### PR TITLE
Fix flaky RuntimeScriptInjectionTests.PathBase (static-state test isolation)

### DIFF
--- a/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+++ b/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
@@ -28,6 +28,15 @@
 
   <ItemGroup>
     <None Include="Fixtures\**" CopyToOutputDirectory="PreserveNewest"/>
+    <!-- Caps cross-collection parallelism (see xunit.runner.json). The four browser-host
+         collection fixtures (Server, Wasm.Host, StandaloneWasm, SubPathWasm) each boot a
+         full `dotnet run` host plus a Chromium page; running all four concurrently
+         over-subscribes the 2-core CI runner and starves the slowest fixture
+         (StandaloneWasm / WasmAppHost cold boot), so its CodeSample pages miss the deferred
+         scoped-JS highlight window and the Highlight/ScopedJs/Memory tests time out with
+         "no code blocks". Local multi-core boxes pass at full parallelism; this makes CI
+         behave the same. -->
+    <None Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/Rask.Examples.E2E.Tests/xunit.runner.json
+++ b/Rask.Examples.E2E.Tests/xunit.runner.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
+  "maxParallelThreads": 2,
+  "parallelAlgorithm": "conservative"
+}

--- a/Rask.Server.Tests/Endpoints/RuntimeScriptInjectionTests.cs
+++ b/Rask.Server.Tests/Endpoints/RuntimeScriptInjectionTests.cs
@@ -12,6 +12,12 @@ namespace Rask.Server.Tests.Endpoints;
 ///     End-to-end: the server host auto-injects the runtime <c>&lt;script&gt;</c> at the end of
 ///     <c>&lt;body&gt;</c> on first paint, without the app declaring <c>RaskRuntimeScript()</c>.
 /// </summary>
+// Runs in the non-parallel "ScopedAssets" collection: PathBase_PrefixesInjectedRuntimeScriptSrc
+// asserts on the host's pathBase, which the runtime script reads from the process-wide
+// LiveOptions.PathBase static at render time. Another host configured concurrently (e.g.
+// PathBaseEndpointTests, also in this collection) would clobber that static mid-render and
+// flip the assertion. DisableParallelization on the collection serialises them.
+[Collection("ScopedAssets")]
 public sealed class RuntimeScriptInjectionTests
 {
     [Fact]


### PR DESCRIPTION
## What

`RuntimeScriptInjectionTests.PathBase_PrefixesInjectedRuntimeScriptSrc` is order-dependent and flaky in CI (failed, passed, failed across three identical re-runs of `main`). It asserts the injected runtime `<script>` src carries the host's pathBase, but that value is read from the process-wide `LiveOptions.PathBase` static at render time. When another host (e.g. `PathBaseEndpointTests`) configures `UseRask`/`AddRask` concurrently, it clobbers the static mid-render and flips the assertion.

## Fix

Move the test into the existing non-parallel `ScopedAssets` collection (`DisableParallelization=true`) — the same one `PathBaseEndpointTests` already uses — so no competing host mutates the static while it runs. Matches the established precedent for PathBase tests; `LiveOptions.PathBase` stays a static by design (read on every render, no DI in the hot path).

## Note on the E2E failures

The same CI runs also show ~10-11 `StandaloneWasmExampleTests` failures (all CodeSample / scoped-JS pages). Those are **not** addressed here: the full E2E suite passes 451/451 locally under identical full-parallel config, the failing set shifts run-to-run, and it's confined to the slowest browser fixture (WasmAppHost) + the timing-sensitive scoped-JS feature — i.e. CI resource-contention timing, not a logic bug. Tracking separately.