### PR TITLE
Seed the diff baseline at GET so the first server interaction ships a diff

### DIFF
--- a/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
+++ b/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
@@ -6,8 +6,9 @@ namespace Rask.Server.Tests.Infrastructure;
 /// <summary>
 ///     A connected live session for WebSocket tests: hosts <typeparamref name="TApp" />, GETs the
 ///     shell, opens the socket, sends <c>hello</c>, and drains the post-attach catch-up frame so
-///     per-test assertions observe only the traffic they trigger (and the diff/head baseline is
-///     seeded). Disposes the socket and host on teardown. Consolidates the per-file copies.
+///     per-test assertions observe only the traffic they trigger. The GET render already seeded
+///     the diff/head baseline, so the first interaction a test triggers diffs against it.
+///     Disposes the socket and host on teardown. Consolidates the per-file copies.
 /// </summary>
 internal sealed class ConnectedSession : IAsyncDisposable
 {

--- a/Rask.Server.Tests/WebSockets/HelloMessageTests.cs
+++ b/Rask.Server.Tests/WebSockets/HelloMessageTests.cs
@@ -63,9 +63,12 @@ public class HelloMessageTests
 
         var text = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
         Assert.NotNull(text);
-        using var doc = JsonDocument.Parse(text!);
-        Assert.True(doc.RootElement.TryGetProperty("html", out var htmlProp));
-        Assert.Contains("loaded", htmlProp.GetString());
+        // The catch-up frame must carry the post-GET "loaded" state. Its wire shape depends
+        // on the active diff mode: with the diff codec on, the GET render seeded the baseline
+        // (<p>loading</p>) so this ships a minimal text diff (loading -> loaded) the browser
+        // applies against the GET HTML; under DisabledFull it ships full HTML. Either way the
+        // new text must reach the browser, which is what this test guards.
+        Assert.Contains("loaded", text);
     }
 
     [Fact]

--- a/Rask.Server.Tests/WebSockets/InitialRenderDiffTests.cs
+++ b/Rask.Server.Tests/WebSockets/InitialRenderDiffTests.cs
@@ -1,0 +1,46 @@
+using System.Text.Json;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// The HTTP-GET render now seeds the diff-codec FRAME baseline (not just the HTML dedup
+// string), so the FIRST interactive WS render diffs against the HTML the browser already
+// holds instead of re-shipping the whole document. Previously the frame cache was seeded
+// only by the first full-HTML interactive send, so the first state change after page load
+// always shipped the body in full.
+//
+// In SessionGracePeriod so the static LiveOptions.DiffMode write serialises with the other
+// DiffMode-mutating WS test classes.
+[Collection("SessionGracePeriod")]
+public class InitialRenderDiffTests
+{
+    // Auto is the framework default; a counter's text diff is far smaller than the body, so
+    // it takes the diff path under the choose-smaller heuristic.
+    public InitialRenderDiffTests() => LiveOptions.DiffMode = LiveDiffMode.Auto;
+
+    [Fact]
+    public async Task FirstInteraction_TextOnlyChange_ShipsDiffNotFullHtml()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(initialHtml);
+        var handlerId = Markup.FirstHandlerId(initialHtml);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        // The VERY FIRST interaction: bump the counter (count=0 -> count=1, a pure text-node
+        // change). With the GET-seeded frame baseline this ships a diff, not full HTML.
+        await ws.SendJsonAsync(new { id = handlerId });
+        var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(frame);
+        using var doc = JsonDocument.Parse(frame!);
+        Assert.Equal("diff", doc.RootElement.GetProperty("kind").GetString());
+        Assert.False(doc.RootElement.TryGetProperty("html", out _),
+            $"First interaction must not ship full HTML. Got: {frame![..Math.Min(300, frame!.Length)]}");
+        Assert.NotEmpty(doc.RootElement.GetProperty("ops").EnumerateArray());
+    }
+}

--- a/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
+++ b/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
@@ -26,10 +26,9 @@ public class NavigationDiffGateTests
     {
         await using var fixture = await ConnectedSession.Connect<NavigateInHandlerStateHasChangedApp>();
 
-        // First nav seeds the render-cache baseline: a fresh attach dedups its catch-up
-        // render against the GET-time HTML, so _renderCache._previous is null until a
-        // non-deduped render rotates it through. (Same reason the first post-attach
-        // interaction always ships full HTML.) This first nav ships full HTML and snapshots.
+        // Navigate to /seed first so the asserted transition below is /seed -> /destination
+        // (a same-<head> change). The GET render already seeded the diff baseline, so this
+        // nav itself diffs against it; we drain and ignore it.
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/seed", query = "" });
         _ = await DrainToLastFrame(fixture.Ws);
 
@@ -52,7 +51,7 @@ public class NavigationDiffGateTests
     {
         await using var fixture = await ConnectedSession.Connect<NavigateInHandlerStateHasChangedApp>();
 
-        // First nav seeds the render-cache baseline (see note above).
+        // Navigate to /page first so the re-navigation below is a same-path query-only change.
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/page", query = "" });
         _ = await DrainToLastFrame(fixture.Ws);
 
@@ -77,7 +76,7 @@ public class NavigationDiffGateTests
     {
         await using var fixture = await ConnectedSession.Connect<RouteTitleNavApp>();
 
-        // First nav seeds the render-cache baseline (see Navigate_SameHead note).
+        // Navigate to /seed first so the asserted transition below is /seed -> /destination.
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/seed", query = "" });
         _ = await DrainToLastFrame(fixture.Ws);
 

--- a/Rask.Server/LiveSession.cs
+++ b/Rask.Server/LiveSession.cs
@@ -195,6 +195,39 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     /// </summary>
     internal void SeedInitialHtml(string html) => _lastSentHtml = html;
 
+    /// <summary>
+    ///     Render the initial root for the HTTP-GET response, seeding BOTH the dedup
+    ///     baseline (<c>_lastSentHtml</c> via <see cref="SeedInitialHtml" />) and — when the
+    ///     diff codec is on — the render-cache FRAME baseline. Capturing the GET render's
+    ///     <c>RenderFrame</c> stream and <see cref="SessionRenderCache.Snapshot" />-ing it
+    ///     means the FIRST interactive WS render diffs against the HTML the browser already
+    ///     holds, instead of re-shipping the whole document. Without this the frame cache is
+    ///     seeded only by the first full-HTML interactive send, so the first state change
+    ///     after page load always ships the body in full.
+    /// </summary>
+    internal string RenderInitialRoot()
+    {
+        string html;
+        if (LiveOptions.DiffMode != LiveDiffMode.DisabledFull)
+        {
+            _renderCache ??= new SessionRenderCache();
+            var frameWriter = _renderCache.PrepareCurrentBuffer();
+            using (FrameSinkScope.Push(frameWriter))
+            {
+                html = View.RenderAsLiveRoot(Services);
+            }
+
+            _renderCache.Snapshot(); // promote GET frames to the diff baseline
+        }
+        else
+        {
+            html = View.RenderAsLiveRoot(Services);
+        }
+
+        SeedInitialHtml(html);
+        return html;
+    }
+
     // True after the first socket has ever attached to this session. Lets AttachSocket
     // distinguish the GET→hello first attach (where the browser's HTML is guaranteed to
     // match the session's state because the browser literally just rendered the GET

--- a/Rask.Server/RaskEndpointExtensions.cs
+++ b/Rask.Server/RaskEndpointExtensions.cs
@@ -184,12 +184,12 @@ public static class RaskEndpointExtensions
             var routeState = session.Services.GetRequiredService<RouteState>();
             routeState.Path = path;
             routeState.Query = AdaptQuery(httpContext.Request.Query);
-            var html = session.View.RenderAsLiveRoot(session.Services);
-            // Seed the dedup baseline so the first post-hello WS frame can dedup against
-            // the HTML the browser already has from this GET response (mirroring WASM's
-            // InitialRenderAsync, which populates `_lastAppliedHtml` for the same reason).
-            // Without this, a no-op click after hello would re-send the GET HTML verbatim.
-            session.SeedInitialHtml(html);
+            // Render the GET shell and seed both baselines: the dedup baseline so a no-op
+            // click after hello dedups against the HTML the browser already has (mirroring
+            // WASM's InitialRenderAsync / `_lastAppliedHtml`), AND the diff-codec frame
+            // baseline so the FIRST interactive WS render ships a diff instead of the whole
+            // document. See LiveSession.RenderInitialRoot.
+            var html = session.RenderInitialRoot();
             var content = LivePayload.InjectRootAttr(html, session.Id);
             httpContext.Response.ContentType = "text/html; charset=utf-8";
             await httpContext.Response.WriteAsync(content).ConfigureAwait(false);


### PR DESCRIPTION
## Problem
On the server, the HTTP-GET render never seeded the diff codec's **frame** baseline (only the HTML-dedup string). So `SessionRenderCache._hasPrevious` stayed false and the **first** state-changing interaction after page load always shipped full HTML — only the 2nd+ interaction diffed. (Even documented as a known quirk in the WS tests, which worked around it with a throwaway "seed" nav.)

## Fix
`LiveSession.RenderInitialRoot` renders the GET shell **through a `FrameSinkScope`** into the render cache and `Snapshot()`s it as the baseline (alongside the existing `_lastSentHtml` seed). The first interactive WS render now diffs against the HTML the browser already holds. Renders once — no extra lifecycle.

- `Rask.Server/LiveSession.cs` — add `RenderInitialRoot`
- `Rask.Server/RaskEndpointExtensions.cs` — call it from the GET endpoint

## Tests
- New `InitialRenderDiffTests`: the first interaction ships `kind:"diff"` (no `html`).
- `HelloMessageTests` catch-up frame now ships a minimal diff; assertion made shape-agnostic.
- Refreshed now-stale "first interaction always ships full HTML" comments in `NavigationDiffGateTests` and `ConnectedSession`.

Full server suite (115) + Core + e2e (454/454) pass; null-key/no-op renders are byte-identical.