### PR TITLE
Add first-class Component.Key with auto-forward and a missing-key warning (RASK022)

### DIFF
--- a/Rask.Core.Tests/KeyTests.cs
+++ b/Rask.Core.Tests/KeyTests.cs
@@ -1,0 +1,93 @@
+using System.Text;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests;
+
+// Component-level Key (Blazor @key parity): emits data-rask-key on an element, and is
+// auto-forwarded onto the first rendered element of a transparent component / Fragment.
+public class KeyTests
+{
+    [Fact]
+    public void Key_OnElement_EmitsDataRaskKeyInDataGroup()
+    {
+        // Order is id, class, style, data-*, then data-rask-key (still inside the data-* run).
+        Assert.Equal(
+            "<div id=\"i\" class=\"c\" style=\"s\" data-rask-key=\"k1\"></div>",
+            Div(Id: "i", Class: "c", Style: "s", Key: "k1").ToHtml());
+    }
+
+    [Fact]
+    public void Key_NonStringValue_StringifiedOnEmit()
+    {
+        Assert.Equal("<li data-rask-key=\"42\"></li>", Li(Key: 42).ToHtml());
+    }
+
+    [Fact]
+    public void Key_Null_EmitsNothing()
+    {
+        Assert.Equal("<div></div>", Div().ToHtml());
+    }
+
+    [Fact]
+    public void Key_AfterUserData_NoDuplicate()
+    {
+        // data-rask-key follows other data-* entries; a literal Data["rask-key"] is dropped
+        // in favour of the canonical Key so there's exactly one data-rask-key.
+        Assert.Equal(
+            "<li data-row=\"7\" data-rask-key=\"k\"></li>",
+            Li(Data: new Dictionary<string, string?> { ["row"] = "7", ["rask-key"] = "from-data" }, Key: "k")
+                .ToHtml());
+    }
+
+    [Fact]
+    public void DataRaskKey_WithoutKeyProp_StillEmits_BackCompat()
+    {
+        // VirtualizePage-style keying via Data continues to work when Key isn't set.
+        Assert.Equal(
+            "<tr data-rask-key=\"3\"></tr>",
+            Tr(Data: new Dictionary<string, string?> { ["rask-key"] = "3" }).ToHtml());
+    }
+
+    [Fact]
+    public void Key_OnFragment_ForwardsToFirstElementOnly()
+    {
+        var sb = new StringBuilder();
+        HtmlSerializer.Serialize(Fragment(Key: "k1")[Div(Class: "row")[Text("x")], Div()[Text("y")]], sb);
+        Assert.Equal("<div class=\"row\" data-rask-key=\"k1\">x</div><div>y</div>", sb.ToString());
+    }
+
+    [Fact]
+    public void Key_OnTransparentComponent_ForwardsToRootElement()
+    {
+        var sb = new StringBuilder();
+        HtmlSerializer.Serialize(new KeyWrapper(Tr()[Td()["cell"]]) { Key = "row-7" }, sb);
+        Assert.Equal("<tr data-rask-key=\"row-7\"><td>cell</td></tr>", sb.ToString());
+    }
+
+    [Fact]
+    public void Key_ElementOwnKey_WinsOverForwarded()
+    {
+        var sb = new StringBuilder();
+        HtmlSerializer.Serialize(new KeyWrapper(Div(Key: "inner")[Text("x")]) { Key = "outer" }, sb);
+        Assert.Equal("<div data-rask-key=\"inner\">x</div>", sb.ToString());
+    }
+
+    [Fact]
+    public void Key_OnComponentRenderingNoElement_DoesNotLeakToSibling()
+    {
+        // The inner keyed Fragment renders only text — its key must NOT spill onto the
+        // following sibling Div (the slot is cleared after the keyed body serializes).
+        var sb = new StringBuilder();
+        HtmlSerializer.Serialize(
+            Fragment()[Fragment(Key: "k")[Text("t")], Div()[Text("x")]], sb);
+        Assert.Equal("t<div>x</div>", sb.ToString());
+    }
+
+    private sealed class KeyWrapper : Component
+    {
+        private readonly Component _body;
+        public KeyWrapper(Component body) => _body = body;
+        protected override RenderResult Render() => _body;
+    }
+}

--- a/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -228,6 +228,23 @@ public class FrameDifferTests
     }
 
     [Fact]
+    public void Diff_KeyedList_ViaKeyProperty_UsesKeyedPathWithTrustedRemove()
+    {
+        // The first-class Key property emits the same data-rask-key the differ keys on, so a
+        // middle-row delete takes the trusted keyed path exactly like the Data["rask-key"] form.
+        var before = Frames(BuildKeyedRowsViaKeyProp(0, 1, 2, 3, 4));
+        var afterFrames = Frames(BuildKeyedRowsViaKeyProp(0, 1, 3, 4));
+
+        var ops = new List<EditOp>();
+        FrameDiffer.Diff(before, afterFrames, ops, out var usedKeyed);
+
+        Assert.True(usedKeyed);
+        var remove = Assert.Single(ops);
+        Assert.Equal(EditOpKind.RemoveSubtree, remove.Kind);
+        Assert.True(remove.Trusted);
+    }
+
+    [Fact]
     public void Diff_KeyedList_MiddleRowDeleted_EmitsSingleTrustedRemove()
     {
         var before = Frames(BuildKeyedRows(0, 1, 2, 3, 4));
@@ -470,6 +487,19 @@ public class FrameDifferTests
             rows.Add(C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = k.ToString() })[
                 $"Item {k}"
             ]);
+        }
+
+        return C.Ul()[rows];
+    }
+
+    // Same shape as BuildKeyedRows but keyed via the first-class Key property instead of a
+    // Data["rask-key"] entry — the differ should treat them identically.
+    private static Component BuildKeyedRowsViaKeyProp(params int[] keys)
+    {
+        var rows = new List<Child>(keys.Length);
+        foreach (var k in keys)
+        {
+            rows.Add(C.Li(Key: k)[$"Item {k}"]);
         }
 
         return C.Ul()[rows];

--- a/Rask.Core/Component.cs
+++ b/Rask.Core/Component.cs
@@ -60,6 +60,18 @@ public abstract class Component
     // parameter — `Div()[Span(...), "hi"]` is the canonical call shape.
     public IEnumerable<Child>? Children { get; set; }
 
+    // Stable identity for keyed list reconciliation (Blazor `@key` parity). When set on an
+    // element it emits `data-rask-key`; when set on a transparent component (a custom
+    // component / Fragment) the serializer forwards it onto that component's FIRST rendered
+    // element (see HtmlSerializer + KeyForwardScope). The diff codec reads the attribute
+    // (FrameDiffer.ExtractRaskKey) to match siblings by identity and ship TRUSTED structural
+    // ops (Insert/Remove/Move) instead of a positional full-HTML morph. `object?` so callers
+    // pass a Guid/int/string directly; stringified on emit. Nullable + no initializer ⇒ the
+    // factory generator exposes it as an optional `Key:` parameter on every factory.
+    // NOTE: keyed insert/append during a navigation currently renders the new row with wrong
+    // content (a known framework bug); delete/move/in-place keyed edits are correct.
+    public object? Key { get; set; }
+
     // Primary children indexer. `Div()[Span(...), "hi"]` is the call shape: literal lists of
     // Components/strings (each implicitly Child via Child's converters). Overload resolution
     // prefers this `params Child[]` form over the IEnumerable<…> variants below — the compiler

--- a/Rask.Core/Element.cs
+++ b/Rask.Core/Element.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Rask.Core.Live;
 
 namespace Rask.Core;
 
@@ -35,14 +36,31 @@ public abstract class Element : Component
             AppendAttr(sb, "style", Style);
         }
 
-        if (Data is null)
+        // Effective keyed-list identity: this element's own Key, else a key forwarded from a
+        // transparent ancestor component (Consume clears the slot so only the FIRST element
+        // adopts it). Emitted in the data-* group below so FrameDiffer.ExtractRaskKey finds it
+        // among the leading attribute frames, same as a Data["rask-key"] entry.
+        var forwarded = KeyForwardScope.Consume();
+        var key = Key?.ToString() ?? forwarded;
+
+        if (Data is not null)
         {
-            return;
+            foreach (var kv in Data)
+            {
+                // A literal Data["rask-key"] is superseded by an effective Key to avoid a
+                // duplicate attribute — Key is the canonical API; Data stays for back-compat.
+                if (key is not null && string.Equals(kv.Key, "rask-key", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                AppendAttr(sb, "data-", kv.Key, kv.Value);
+            }
         }
 
-        foreach (var kv in Data)
+        if (key is not null)
         {
-            AppendAttr(sb, "data-", kv.Key, kv.Value);
+            AppendAttr(sb, "data-", "rask-key", key);
         }
     }
 }

--- a/Rask.Core/HtmlSerializer.cs
+++ b/Rask.Core/HtmlSerializer.cs
@@ -97,22 +97,42 @@ internal static class HtmlSerializer
             }
 
             case Fragment fragment:
-                if (fragment.ChildrenArray is { } fragmentArray)
+            {
+                // A keyed Fragment forwards its Key onto the first element it renders (the
+                // first child's first element); Consume in WriteAttributes claims it once.
+                var fragKey = fragment.Key?.ToString();
+                if (fragKey is not null)
                 {
-                    for (var i = 0; i < fragmentArray.Length; i++)
+                    KeyForwardScope.Arm(fragKey);
+                }
+
+                try
+                {
+                    if (fragment.ChildrenArray is { } fragmentArray)
                     {
-                        Serialize(fragmentArray[i].Component, sb);
+                        for (var i = 0; i < fragmentArray.Length; i++)
+                        {
+                            Serialize(fragmentArray[i].Component, sb);
+                        }
+                    }
+                    else if (fragment.Children is { } fragmentChildren)
+                    {
+                        foreach (var child in fragmentChildren)
+                        {
+                            Serialize(child.Component, sb);
+                        }
                     }
                 }
-                else if (fragment.Children is { } fragmentChildren)
+                finally
                 {
-                    foreach (var child in fragmentChildren)
+                    if (fragKey is not null)
                     {
-                        Serialize(child.Component, sb);
+                        KeyForwardScope.Clear();
                     }
                 }
 
                 break;
+            }
 
             case ErrorBoundary boundary:
                 SerializeErrorBoundary(boundary, sb);
@@ -229,7 +249,28 @@ internal static class HtmlSerializer
                 using (LiveRenderContext.EnterParentScopeOrNone(liveCtx, component))
                 using (component.EnterChildrenScopeInternal())
                 {
-                    Serialize(component.RenderForLive(), sb);
+                    // Component-level Key (Blazor @key parity): a transparent user component
+                    // emits no tag, so forward its Key onto the first element of its rendered
+                    // body (the component's root element), which Consumes it in WriteAttributes.
+                    // Only the first element claims it; Clear in finally stops it leaking to a
+                    // following sibling when the body renders no element at all.
+                    var fwdKey = component.Key?.ToString();
+                    if (fwdKey is not null)
+                    {
+                        KeyForwardScope.Arm(fwdKey);
+                    }
+
+                    try
+                    {
+                        Serialize(component.RenderForLive(), sb);
+                    }
+                    finally
+                    {
+                        if (fwdKey is not null)
+                        {
+                            KeyForwardScope.Clear();
+                        }
+                    }
                 }
                 break;
         }

--- a/Rask.Core/Live/KeyForwardScope.cs
+++ b/Rask.Core/Live/KeyForwardScope.cs
@@ -1,0 +1,44 @@
+namespace Rask.Core.Live;
+
+/// <summary>
+///     Ambient single-slot holder for a <see cref="Component.Key" /> being forwarded onto the
+///     FIRST rendered element of a transparent component (a custom component / Fragment that
+///     emits no tag of its own). Blazor's <c>@key</c> works on any component; the diff codec
+///     only sees element frames, so a Component-level key has to land on the component's root
+///     element. The serializer <see cref="Arm" />s the slot around a keyed transparent
+///     component's body; the first element's <c>WriteAttributes</c> <see cref="Consume" />s it
+///     and emits <c>data-rask-key</c>.
+///     <para>
+///         Single-threaded per render walk (same as <see cref="FrameSinkScope" />), so a
+///         <see cref="ThreadStaticAttribute" /> is the right shape. The slot is cleared (not
+///         restored) on dispose: a keyed component that renders no element simply drops its key
+///         rather than leaking it onto a following sibling, and a nested keyed transparent
+///         component's key wins over an outer one (innermost-to-the-element).
+///     </para>
+/// </summary>
+public static class KeyForwardScope
+{
+    [ThreadStatic] private static string? _pending;
+
+    /// <summary>
+    ///     Arm the slot so the next element adopts <paramref name="key" /> as its
+    ///     <c>data-rask-key</c>. The serializer calls this ONLY for a keyed transparent
+    ///     component (never with a null key for a non-keyed one — that would wipe an ancestor's
+    ///     armed key as it passes through), and pairs it with <see cref="Clear" /> in a finally.
+    /// </summary>
+    public static void Arm(string key) => _pending = key;
+
+    /// <summary>Clear the slot. Paired with <see cref="Arm" /> after a keyed body serializes.</summary>
+    public static void Clear() => _pending = null;
+
+    /// <summary>
+    ///     Return the pending forwarded key (or <c>null</c>) and clear the slot, so exactly one
+    ///     element adopts it. Called by every element's attribute-writing path.
+    /// </summary>
+    public static string? Consume()
+    {
+        var k = _pending;
+        _pending = null;
+        return k;
+    }
+}

--- a/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
+++ b/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
@@ -17,7 +17,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("public static global::Demo.Widget Widget()", output);
+        Assert.Contains("public static global::Demo.Widget Widget(object? Key = null)", output);
         // Widget has a parameterless ctor and no DI ctor, so the factory uses object-init
         // rather than ActivatorUtilities — avoids NRE when the LiveRenderContext was created
         // without a service provider (tests calling RenderAsLiveRoot() with no DI).
@@ -41,7 +41,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(string Name)", output);
+        Assert.Contains("Widget(string Name, object? Key = null)", output);
         Assert.DoesNotContain("Name = null", output);
         Assert.Contains("__c.Name = Name;", output);
     }
@@ -62,7 +62,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(string? Subtitle = null)", output);
+        Assert.Contains("Widget(string? Subtitle = null, object? Key = null)", output);
         Assert.Contains("__c.Subtitle = Subtitle;", output);
     }
 
@@ -105,7 +105,7 @@ public class ComponentFactoryGeneratorTests
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
         // Required before optional, declaration order within group.
-        Assert.Contains("Widget(string Name, string Title, int? Age = null)", output);
+        Assert.Contains("Widget(string Name, string Title, int? Age = null, object? Key = null)", output);
     }
 
     [Fact]
@@ -282,7 +282,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(string Name)", output);
+        Assert.Contains("Widget(string Name, object? Key = null)", output);
     }
 
     [Fact]
@@ -341,7 +341,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(int Count = default)", output);
+        Assert.Contains("Widget(int Count = default, object? Key = null)", output);
         Assert.DoesNotContain("Count = null", output);
     }
 
@@ -365,7 +365,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("CounterPage(string? Name = null, string? Greeting = null, string? Other = null)", output);
+        Assert.Contains("CounterPage(string? Name = null, string? Greeting = null, string? Other = null, object? Key = null)", output);
     }
 
     [Fact]
@@ -408,7 +408,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("public static global::Demo.Foo<TProp> Foo<TProp>(TProp Value)", output);
+        Assert.Contains("public static global::Demo.Foo<TProp> Foo<TProp>(TProp Value, object? Key = null)", output);
         Assert.Contains("new global::Demo.Foo<TProp>()", output);
         Assert.Contains("__c.Value = Value;", output);
     }
@@ -431,7 +431,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Bound<TProp>(global::System.Linq.Expressions.Expression<global::System.Func<TProp>> Bind)",
+        Assert.Contains("Bound<TProp>(global::System.Linq.Expressions.Expression<global::System.Func<TProp>> Bind, object? Key = null)",
             output);
     }
 
@@ -451,7 +451,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Card<T>(T Model) where T : class", output);
+        Assert.Contains("Card<T>(T Model, object? Key = null) where T : class", output);
     }
 
     [Fact]
@@ -606,7 +606,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(string? DerivedProp = null, string? BaseProp = null)", output);
+        Assert.Contains("Widget(string? DerivedProp = null, string? BaseProp = null, object? Key = null)", output);
     }
 
     [Fact]
@@ -629,7 +629,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(string? Title = null)", output);
+        Assert.Contains("Widget(string? Title = null, object? Key = null)", output);
         // No duplicate assignment.
         var firstAssign = output.IndexOf("__c.Title = Title;", StringComparison.Ordinal);
         Assert.True(firstAssign > 0);
@@ -656,7 +656,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(string Name)", output);
+        Assert.Contains("Widget(string Name, object? Key = null)", output);
         Assert.DoesNotContain("Name = null", output);
     }
 
@@ -725,7 +725,7 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Card(string? Children = null)", output);
+        Assert.Contains("Card(string? Children = null, object? Key = null)", output);
         Assert.DoesNotContain("params", output);
     }
 
@@ -757,7 +757,7 @@ public class ComponentFactoryGeneratorTests
         Assert.Contains(
             "Widget(string? P00 = null, string? P01 = null, string? P02 = null, string? P03 = null, " +
             "string? P04 = null, string? P05 = null, string? P06 = null, string? P07 = null, " +
-            "string? P08 = null, string? P09 = null)",
+            "string? P08 = null, string? P09 = null, object? Key = null)",
             output);
     }
 }

--- a/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
+++ b/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+
+namespace Rask.Generators.Tests;
+
+public class MissingKeyAnalyzerTests
+{
+    // Wraps a Render() body in a component. Real Rask.Core factories (Generated.Li/Tr/Ul/...) are
+    // referenced via BuildReferences(), so the analyzer resolves genuine factory symbols.
+    private static string App(string body) => $$"""
+        using System.Collections.Generic;
+        using System.Linq;
+        using Rask.Core;
+        using static Rask.Core.Components.Generated;
+        namespace Demo;
+        public sealed class App : Component
+        {
+            private readonly int[] _items = { 1, 2, 3 };
+            protected override RenderResult Render()
+            {
+                {{body}}
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task SelectProjection_NoKey_ReportsRask022()
+    {
+        var d = Assert.Single(await Diagnostics(App(
+            "return Ul()[ _items.Select(i => (Child)Li()[i.ToString()]) ];")));
+        Assert.Equal("RASK022", d.Id);
+        Assert.Contains("Li", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task ForeachAddToChildList_NoKey_ReportsRask022()
+    {
+        var d = Assert.Single(await Diagnostics(App("""
+            var rows = new List<Child>();
+            foreach (var i in _items) rows.Add(Tr()[i.ToString()]);
+            return Ul()[rows];
+            """)));
+        Assert.Equal("RASK022", d.Id);
+        Assert.Contains("Tr", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task SelectProjection_WithKey_NoDiagnostic()
+    {
+        Assert.Empty(await Diagnostics(App(
+            "return Ul()[ _items.Select(i => (Child)Li(Key: i)[i.ToString()]) ];")));
+    }
+
+    [Fact]
+    public async Task SelectProjection_WithDataRaskKey_NoDiagnostic()
+    {
+        Assert.Empty(await Diagnostics(App("""
+            return Ul()[ _items.Select(i => (Child)Li(
+                Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[i.ToString()]) ];
+            """)));
+    }
+
+    [Fact]
+    public async Task ForeachAddToChildList_WithKey_NoDiagnostic()
+    {
+        Assert.Empty(await Diagnostics(App("""
+            var rows = new List<Child>();
+            foreach (var i in _items) rows.Add(Tr(Key: i)[i.ToString()]);
+            return Ul()[rows];
+            """)));
+    }
+
+    [Fact]
+    public async Task NestedChildOfProjectedItem_OnlyOuterItemFlagged()
+    {
+        // Li is the projected list item (flagged once); the nested Code is Li's child, not a
+        // sibling in the reconciled list, so it must NOT be flagged.
+        var d = Assert.Single(await Diagnostics(App(
+            "return Ul()[ _items.Select(i => (Child)Li()[ Code()[i.ToString()] ]) ];")));
+        Assert.Contains("Li", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task SingleStaticChild_NotAList_NoDiagnostic()
+    {
+        Assert.Empty(await Diagnostics(App("return Div()[ Span()[\"hi\"] ];")));
+    }
+
+    [Fact]
+    public async Task AddOutsideLoop_NoDiagnostic()
+    {
+        // A one-off Add (not in a loop) isn't a reconciled list — don't warn.
+        Assert.Empty(await Diagnostics(App("""
+            var rows = new List<Child>();
+            rows.Add(Tr()["one"]);
+            return Ul()[rows];
+            """)));
+    }
+
+    private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new MissingKeyAnalyzer());
+        var all = await compilation.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+        return all.Where(d => d.Id == "RASK022").ToImmutableArray();
+    }
+}

--- a/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
+++ b/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
@@ -1,0 +1,233 @@
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Analyzers;
+
+// RASK022 — warn when a Rask factory call (an HTML element or a custom component) is produced
+// in a sibling-list context without a Key. Two idioms are flagged:
+//   * a `.Select(...)`/`.SelectMany(...)` projection whose body becomes a Child, and
+//   * an element/component added to a Child collection (`List<Child>.Add(...)`) inside a loop.
+// Keyless list items reconcile by POSITION: an insert/remove/reorder falls back to a full-HTML
+// morph and loses DOM identity (focus, input state) on surviving nodes. A stable `Key:` lets
+// the diff codec match by identity and ship trusted keyed structural ops instead. Best-effort:
+// the heuristics aim for the common idioms; the warning is suppressible.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
+{
+    private const string ComponentFullName = "Rask.Core.Component";
+    private const string ChildFullName = "Rask.Core.Child";
+    private const string RaskCoreAssembly = "Rask.Core";
+    private const string GeneratedClassName = "Generated";
+
+    private static readonly DiagnosticDescriptor Rask022 = new(
+        "RASK022",
+        "List item is missing a Key",
+        "'{0}' is rendered in a list without a Key — set Key: so the diff codec reconciles it by "
+        + "identity (trusted keyed structural ops) instead of by position",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        true,
+        "Elements/components produced in a .Select(...) projection or added to a Child collection in "
+        + "a loop should carry a stable Key (Blazor @key parity). Without it, insert/remove/reorder "
+        + "falls back to a positional full-HTML morph and loses DOM identity (focus, input state) on "
+        + "surviving nodes.");
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rask022);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(static start =>
+        {
+            if (string.Equals(start.Compilation.AssemblyName, RaskCoreAssembly, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var component = start.Compilation.GetTypeByMetadataName(ComponentFullName);
+            var child = start.Compilation.GetTypeByMetadataName(ChildFullName);
+            if (component is null || child is null)
+            {
+                return;
+            }
+
+            start.RegisterSyntaxNodeAction(
+                ctx => Analyze(ctx, component, child),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol component,
+        INamedTypeSymbol child)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        var model = context.SemanticModel;
+
+        // 1) Is this a Rask factory call? Generated factories are static methods on a class named
+        //    `Generated` (namespace varies per component) returning a Component-derived type.
+        if (model.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method
+            || !method.IsStatic
+            || !string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
+            || !InheritsFrom(method.ReturnType as INamedTypeSymbol, component))
+        {
+            return;
+        }
+
+        // 2) Already keyed — a Key: argument, or a Data argument carrying rask-key (back-compat).
+        if (HasKeyArgument(invocation))
+        {
+            return;
+        }
+
+        // 3) The produced "child expression": the call plus any `[...]` children indexer, paren,
+        //    and `(Child)` cast wrapping it. Its converted type tells us it becomes a sibling Child.
+        var outer = ClimbToChildExpression(invocation);
+        var typeInfo = model.GetTypeInfo(outer, context.CancellationToken);
+        if (!IsChild(typeInfo.Type, child) && !IsChild(typeInfo.ConvertedType, child))
+        {
+            return;
+        }
+
+        // 4) Sibling-LIST context: a Select/SelectMany projection, or an Add to a Child collection
+        //    inside a loop. A single static child (e.g. Div()[ Span() ]) is not flagged.
+        if (!IsInSelectProjection(outer)
+            && !IsCollectionAddInLoop(outer, model, child, context.CancellationToken))
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rask022, NameLocation(invocation), method.Name));
+    }
+
+    private static bool InheritsFrom(INamedTypeSymbol? type, INamedTypeSymbol target)
+    {
+        for (var t = type; t is not null; t = t.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, target))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsChild(ITypeSymbol? type, INamedTypeSymbol child) =>
+        type is not null && SymbolEqualityComparer.Default.Equals(type, child);
+
+    private static bool HasKeyArgument(InvocationExpressionSyntax invocation)
+    {
+        foreach (var arg in invocation.ArgumentList.Arguments)
+        {
+            if (string.Equals(arg.NameColon?.Name.Identifier.ValueText, "Key", StringComparison.Ordinal))
+            {
+                return true;
+            }
+
+            // A Data: argument that mentions rask-key keeps VirtualizePage-style keying quiet.
+            if (arg.ToString().IndexOf("rask-key", StringComparison.Ordinal) >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Climb past the children indexer (`[...]`), parens, and `(Child)` casts to reach the
+    // expression that actually flows into the surrounding list/projection context.
+    private static ExpressionSyntax ClimbToChildExpression(ExpressionSyntax node)
+    {
+        while (true)
+        {
+            switch (node.Parent)
+            {
+                case ElementAccessExpressionSyntax eae when eae.Expression == node:
+                    node = eae;
+                    continue;
+                case ParenthesizedExpressionSyntax pe:
+                    node = pe;
+                    continue;
+                case CastExpressionSyntax ce when ce.Expression == node:
+                    node = ce;
+                    continue;
+                default:
+                    return node;
+            }
+        }
+    }
+
+    private static bool IsInSelectProjection(ExpressionSyntax outer)
+    {
+        // `outer` must be the DIRECTLY projected value — the lambda's expression body or a
+        // returned expression — not a nested descendant element (e.g. a Code inside a projected
+        // Li). Only the top-level projected item is the reconciled sibling that needs a Key.
+        LambdaExpressionSyntax? lambda = outer.Parent switch
+        {
+            LambdaExpressionSyntax direct => direct,
+            ReturnStatementSyntax ret => EnclosingLambda(ret),
+            _ => null
+        };
+
+        return lambda?.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax inv } }
+               && IsLinqProjection(inv);
+    }
+
+    private static LambdaExpressionSyntax? EnclosingLambda(SyntaxNode node)
+    {
+        for (var n = node.Parent; n is not null; n = n.Parent)
+        {
+            switch (n)
+            {
+                case LambdaExpressionSyntax lambda:
+                    return lambda;
+                case MethodDeclarationSyntax:
+                case LocalFunctionStatementSyntax:
+                case AccessorDeclarationSyntax:
+                    return null;
+            }
+        }
+
+        return null;
+    }
+
+    private static bool IsLinqProjection(InvocationExpressionSyntax inv)
+    {
+        var name = inv.Expression is MemberAccessExpressionSyntax m ? m.Name.Identifier.ValueText : null;
+        return string.Equals(name, "Select", StringComparison.Ordinal)
+               || string.Equals(name, "SelectMany", StringComparison.Ordinal);
+    }
+
+    private static bool IsCollectionAddInLoop(SyntaxNode outer, SemanticModel model,
+        INamedTypeSymbol child, CancellationToken ct)
+    {
+        // outer must be the single argument to a `.Add(<Child>)` call ...
+        if (outer.Parent is not ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax inv } }
+            || inv.Expression is not MemberAccessExpressionSyntax ma
+            || !string.Equals(ma.Name.Identifier.ValueText, "Add", StringComparison.Ordinal)
+            || model.GetSymbolInfo(inv, ct).Symbol is not IMethodSymbol add
+            || add.Parameters.Length != 1
+            || !IsChild(add.Parameters[0].Type, child))
+        {
+            return false;
+        }
+
+        // ... lexically inside a loop (the foreach/for/while list-building idiom).
+        return outer.Ancestors().Any(a =>
+            a is ForEachStatementSyntax or ForStatementSyntax or WhileStatementSyntax or DoStatementSyntax);
+    }
+
+    private static Location NameLocation(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.GetLocation(),
+        _ => inv.Expression.GetLocation()
+    };
+}

--- a/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/Rask.Generators/ComponentFactoryGenerator.cs
@@ -716,6 +716,14 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         var requiredProps = paramProps.Where(IsRequiredFactoryParam).ToList();
         var optionalProps = paramProps.Where(p => !IsRequiredFactoryParam(p)).ToList();
 
+        // Key (Component-level, Blazor @key parity) is a reconciliation IDENTITY, not a reactive
+        // prop: it's a factory param and is assigned to the instance, but it's excluded from the
+        // propsChanged diff. That keeps a propertyless component on the `propsChanged: false` fast
+        // path, and means a Key change never fires OnPropsChanged (a different key is a different
+        // logical item, which mounts fresh rather than re-rendering the old instance).
+        var hasKeyProp = paramProps.Any(IsKeyProp);
+        var diffProps = paramProps.Where(p => !IsKeyProp(p)).ToList();
+
         // Prefer the parameterless ctor + object-initializer path whenever it's available.
         // Even if the component declares additional ctors that take services (DI) or
         // primitives (Text/Raw's string-arg ctor), the generated factory only needs the
@@ -752,9 +760,10 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         sb.Append(')').AppendLine(c.TypeParameterConstraints);
         sb.AppendLine("    {");
 
-        if (paramProps.Count == 0)
+        if (diffProps.Count == 0)
         {
-            // Legacy parameterless factory shape preserved.
+            // Legacy parameterless factory shape preserved (Key, if present, is assigned but not
+            // diffed — so this fast path still emits propsChanged: false).
             sb.Append("        if (").Append(ContextFullName).AppendLine(".Current is { } __ctx)");
             sb.AppendLine("        {");
             sb.Append("            var __c = __ctx.GetOrCreate<").Append(c.FullyQualifiedName).AppendLine(">(");
@@ -773,12 +782,26 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                     .Append(c.FullyQualifiedName).AppendLine(">(__sp));");
             }
 
+            if (hasKeyProp)
+            {
+                sb.AppendLine("            __c.Key = Key;");
+            }
+
             sb.AppendLine("            __ctx.NotifyParameters(__c, propsChanged: false);");
             sb.AppendLine("            return __c;");
             sb.AppendLine("        }");
             if (c.HasParameterlessCtor)
             {
-                sb.Append("        return new ").Append(c.FullyQualifiedName).AppendLine("();");
+                if (hasKeyProp)
+                {
+                    sb.Append("        var __cf = new ").Append(c.FullyQualifiedName).AppendLine("();");
+                    sb.AppendLine("        __cf.Key = Key;");
+                    sb.AppendLine("        return __cf;");
+                }
+                else
+                {
+                    sb.Append("        return new ").Append(c.FullyQualifiedName).AppendLine("();");
+                }
             }
             else
             {
@@ -826,7 +849,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                     "' has no parameterless constructor; it can only be instantiated inside a LiveRenderContext (e.g. via MapRask<TApp>).\");");
         }
 
-        EmitSnapshotsAndAssignments(sb, paramProps);
+        EmitSnapshotsAndAssignments(sb, paramProps, diffProps);
         sb.Append("        if (").Append(ContextFullName).AppendLine(".Current is { } __ctx2)");
         sb.AppendLine("            __ctx2.NotifyParameters(__c, __propsChanged);");
         sb.AppendLine("        return __c;");
@@ -1110,26 +1133,37 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         sb.Append("            }");
     }
 
-    private static void EmitSnapshotsAndAssignments(StringBuilder sb, IReadOnlyList<PropInfo> props)
+    // assignProps: every factory param re-applied to the (possibly cached) instance each render —
+    // includes Key. foldProps: the subset that participates in the propsChanged diff — excludes
+    // Key (a reconciliation identity, not a reactive prop).
+    private static void EmitSnapshotsAndAssignments(StringBuilder sb,
+        IReadOnlyList<PropInfo> assignProps, IReadOnlyList<PropInfo> foldProps)
     {
-        // Snapshot prior values (typed via the property's FQN so nullable annotations round-trip).
-        foreach (var p in props)
+        // Snapshot prior values of the diff-participating props (typed via the property's FQN so
+        // nullable annotations round-trip).
+        foreach (var p in foldProps)
         {
             sb.Append("        var __old_").Append(p.Name).Append(" = __c.").Append(p.Name).AppendLine(";");
         }
 
-        // Re-apply props so cached instances see fresh values.
-        foreach (var p in props)
+        // Re-apply ALL params (including Key) so cached instances see fresh values.
+        foreach (var p in assignProps)
         {
             sb.Append("        __c.").Append(p.Name).Append(" = ").Append(p.Name).AppendLine(";");
+        }
+
+        if (foldProps.Count == 0)
+        {
+            sb.AppendLine("        var __propsChanged = false;");
+            return;
         }
 
         // Fold per-prop equality into a single __propsChanged bool. EqualityComparer<T>.Default
         // gives ref-equality for ref types unless the type overrides Equals, and structural for
         // primitives — same semantics Blazor uses for [Parameter] equality.
-        if (props.Count == 1)
+        if (foldProps.Count == 1)
         {
-            var p = props[0];
+            var p = foldProps[0];
             sb.Append("        var __propsChanged = !global::System.Collections.Generic.EqualityComparer<")
                 .Append(p.TypeFqn).Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Name)
                 .AppendLine(");");
@@ -1137,14 +1171,16 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         }
 
         sb.AppendLine("        var __propsChanged =");
-        for (var i = 0; i < props.Count; i++)
+        for (var i = 0; i < foldProps.Count; i++)
         {
-            var p = props[i];
+            var p = foldProps[i];
             sb.Append("            !global::System.Collections.Generic.EqualityComparer<").Append(p.TypeFqn)
                 .Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Name).Append(')');
-            sb.AppendLine(i < props.Count - 1 ? " ||" : ";");
+            sb.AppendLine(i < foldProps.Count - 1 ? " ||" : ";");
         }
     }
+
+    private static bool IsKeyProp(PropInfo p) => string.Equals(p.Name, "Key", StringComparison.Ordinal);
 
     private static void EmitGlobalUsings(
         SourceProductionContext spc,


### PR DESCRIPTION
## Summary
Keyed list reconciliation previously required the verbose `Data: new Dictionary<string,string?>{ ["rask-key"] = ... }`. This adds a Blazor `@key`-style `Key` on the **Component** base, plus a compile-time warning when a list item is missing one.

## What's included
- **`Component.Key` (`object?`)** — becomes an optional `Key:` factory param on every generated factory (HTML tags *and* custom components), sorted last so existing positional calls are unaffected.
- **Emission + auto-forward** — an element emits `data-rask-key` (in the data-* group); a transparent component/`Fragment` forwards its `Key` onto its **first rendered element** via the new `KeyForwardScope` ambient (`HtmlSerializer`), cleared after the body so it can't leak to a sibling. `FrameDiffer.ExtractRaskKey` reads it unchanged → trusted keyed structural ops. `Data["rask-key"]` still works (back-compat); `Key` wins if both are set.
- **Excluded from `propsChanged`** — the generator assigns `Key` but keeps it out of the props-diff and the propertyless fast-path gate, so a propertyless component still emits `propsChanged: false` and a `Key` change never fires `OnPropsChanged`.
- **RASK022 analyzer** — warns when a Rask factory is produced in a sibling-list context (a `.Select`/`.SelectMany` projection that becomes a `Child`, or a `List<Child>.Add(...)` inside a loop) without a `Key`. Only the top-level item is flagged; `Key:`/`Data` rask-key suppress it. Suppressible; promotable via `<WarningsAsErrors>RASK022</WarningsAsErrors>`.

## Dependency
Keyed **inserts** rely on the diff-codec fix in #8 (the `InsertSubtree` HTML fragment was sliced with stale byte-offsets after the head-asset sentinel splice). Merge #8 first; this PR's `Key` comment notes the limitation until then. Delete/move/in-place keyed edits are correct without #8.

## Tests
`KeyTests` (emission, forwarding, own-key-wins, no-leak), a FrameDiffer keyed-via-`Key` test, 8 `MissingKeyAnalyzerTests`, and 124 updated generator-signature tests. Core (1278), Generators (124), Server, and e2e (454/454) all pass.