### PR TITLE
Fix corrupted InsertSubtree fragment from the head-sentinel splice

### DIFF
--- a/Rask.Core/Component.cs
+++ b/Rask.Core/Component.cs
@@ -951,7 +951,20 @@ public abstract class Component
         // below) and apply once.
         if (LiveRenderContext.Current is { } liveCtx)
         {
+            // ApplyTo replaces the head-asset sentinel in place, shifting every byte position
+            // after it. The diff codec's frame offsets were captured against the pre-splice
+            // HTML, so when a frame stream is being captured (diff path) we must move the
+            // offsets past the sentinel by the same delta — otherwise an InsertSubtree fragment
+            // (sliced from this post-splice HTML via those offsets) reads the wrong bytes.
+            var sentinelIdx = html.IndexOf(Rask.Core.HeadAssets.HeadAssetRegistry.Sentinel, StringComparison.Ordinal);
+            var preLen = html.Length;
             html = liveCtx.HeadAssets.ApplyTo(html, liveCtx.Services);
+            if (sentinelIdx >= 0 && FrameSinkScope.Current is { } frameSink)
+            {
+                frameSink.AdjustOffsetsFrom(
+                    sentinelIdx + Rask.Core.HeadAssets.HeadAssetRegistry.Sentinel.Length,
+                    html.Length - preLen);
+            }
         }
 
         // Fail-fast backstop for a malformed root: the App must render the full page shell

--- a/Rask.Core/Live/RenderFrame.cs
+++ b/Rask.Core/Live/RenderFrame.cs
@@ -224,6 +224,35 @@ public sealed class FrameWriter
 
         return _count++;
     }
+
+    /// <summary>
+    ///     Shift every recorded HTML offset at or past <paramref name="from" /> by
+    ///     <paramref name="delta" />. Frame offsets are captured against the serialized HTML;
+    ///     when <c>RenderAsLiveRootCore</c> later splices the head-asset sentinel out of (or
+    ///     replaces it within) that HTML, every byte position after the splice moves, so the
+    ///     offsets must move in lockstep — otherwise <c>FrameDiffer</c>'s <c>InsertSubtree</c>
+    ///     fragment (sliced from the post-splice HTML via these offsets) reads the wrong bytes.
+    /// </summary>
+    public void AdjustOffsetsFrom(int from, int delta)
+    {
+        if (delta == 0)
+        {
+            return;
+        }
+
+        for (var i = 0; i < _count; i++)
+        {
+            if (_buffer[i].HtmlStart >= from)
+            {
+                _buffer[i].HtmlStart += delta;
+            }
+
+            if (_buffer[i].HtmlEnd >= from)
+            {
+                _buffer[i].HtmlEnd += delta;
+            }
+        }
+    }
 }
 
 /// <summary>

--- a/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
+++ b/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
@@ -1,0 +1,49 @@
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Infrastructure;
+
+// Reproduces the keyed-insert-during-navigation scenario: a layout-style app subscribes to
+// RouteState.Changed and, when it navigates to "/add", appends an item to a keyed list — so
+// the keyed InsertSubtree rides the navigation diff (which on the server runs through the
+// coalescing send loop). The rows are keyed via data-rask-key.
+public sealed class KeyedNavApp : Component
+{
+    private readonly RouteState _route;
+    private readonly List<int> _items = [1, 2];
+
+    public KeyedNavApp(RouteState route) => _route = route;
+
+    protected override void OnMount() => _route.Changed += OnRouteChanged;
+    protected override void OnUnmount() => _route.Changed -= OnRouteChanged;
+
+    private void OnRouteChanged()
+    {
+        if (_route.Path == "/add" && !_items.Contains(3))
+        {
+            _items.Add(3);
+        }
+
+        StateHasChanged();
+    }
+
+    protected override RenderResult Render() =>
+        Fragment()[
+            Doctype(),
+            new Html()[
+                new Head()[new Title()["keyed-nav"]],
+                new Body()[
+                    new H1()[$"path={_route.Path} count={_items.Count}"],
+                    Ul()[
+                        _items.Select(i => (Child)Li(
+                            Class: "row",
+                            Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[
+                            $"item {i}"]).ToArray()
+                    ]
+                ]
+            ]
+        ];
+}

--- a/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
+++ b/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
@@ -1,0 +1,72 @@
+using System.Net.WebSockets;
+using System.Text.Json;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// Regression: a keyed InsertSubtree fragment is sliced from the rendered HTML using frame
+// byte-offsets. RenderAsLiveRootCore splices the head-asset sentinel out of that HTML AFTER
+// the offsets were captured, shifting every byte position after the head — so without the
+// offset adjustment the inserted row's HTML was garbled (sliced mid-attribute). Keyed insert
+// is the only op that carries an HTML slice, which is why delete/move were unaffected.
+[Collection("SessionGracePeriod")]
+public class KeyedInsertNavTests
+{
+    public KeyedInsertNavTests() => LiveOptions.DiffMode = LiveDiffMode.Forced;
+
+    [Fact]
+    public async Task KeyedInsertDuringNavigation_ShipsCorrectRowHtml()
+    {
+        await using var fixture = await ConnectedSession.Connect<KeyedNavApp>();
+
+        // Seed the diff baseline (first interaction ships full HTML).
+        await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/list", query = "" });
+        _ = await DrainAll(fixture.Ws);
+
+        // Navigate to /add: the RouteState.Changed handler appends keyed item 3 — the keyed
+        // InsertSubtree rides this navigation diff.
+        await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/add", query = "" });
+        var frames = await DrainAll(fixture.Ws);
+
+        var insert = FindInsertSubtree(frames);
+        Assert.NotNull(insert);
+        // The fragment must be the complete, correctly-sliced <li> — not garbled bytes.
+        Assert.Equal("<li class=\"row\" data-rask-key=\"3\">item 3</li>", insert);
+    }
+
+    // Walk every shipped diff frame; return the HTML payload of the first InsertSubtree op
+    // (EditOpKind value 4 → [kind, path, html, domCount]).
+    private static string? FindInsertSubtree(List<string> frames)
+    {
+        foreach (var frame in frames)
+        {
+            using var doc = JsonDocument.Parse(frame);
+            if (!doc.RootElement.TryGetProperty("ops", out var ops))
+            {
+                continue;
+            }
+
+            foreach (var op in ops.EnumerateArray())
+            {
+                if (op.GetArrayLength() >= 3 && op[0].GetInt32() == 4)
+                {
+                    return op[2].GetString();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static async Task<List<string>> DrainAll(WebSocket ws)
+    {
+        var all = new List<string>();
+        while (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500)) is { } frame)
+        {
+            all.Add(frame);
+        }
+
+        return all;
+    }
+}


### PR DESCRIPTION
## Problem
A keyed `InsertSubtree` shipped a **garbled** HTML fragment — the inserted row's markup was sliced mid-attribute. Captured payload:

```
before:  "ey=\"3\">item 3</li></ul><script src=\"/rask/ras"   ← off by 27 bytes
after:   "<li class=\"row\" data-rask-key=\"3\">item 3</li>"   ← correct
```

## Root cause
`FrameDiffer` slices a keyed insert's HTML out of the rendered string using frame **byte-offsets** captured during serialization. `RenderAsLiveRootCore` then replaces the 27-char head-asset sentinel (`<!--__rask_head_assets__-->`) in that string **after** the offsets were captured, shifting every byte position after the head — so the slice read the wrong bytes.

`InsertSubtree` is the only diff op that carries an HTML slice (delete/move don't; positional inserts fall back to full HTML), and only the real `RenderAsLiveRoot` pipeline hits it — the `FrameDiffer` unit tests build trees directly and bypass it, which is why it went unnoticed.

## Fix
`FrameWriter.AdjustOffsetsFrom(from, delta)` shifts the post-sentinel frame offsets by the splice delta right after `ApplyTo`, keeping them consistent with the HTML the differ slices. Handles both the no-asset case (sentinel removed, delta −27) and the with-asset case (sentinel replaced by a longer string).

- `Rask.Core/Live/RenderFrame.cs` — `FrameWriter.AdjustOffsetsFrom`
- `Rask.Core/Component.cs` — call it from `RenderAsLiveRootCore` after `ApplyTo`

## Tests
`KeyedInsertNavTests` reproduces the corruption then asserts the shipped `InsertSubtree` fragment is the exact `<li>` (via `KeyedNavApp`, a keyed list appended during navigation). Core (1268) and Server (115) suites pass.

This is an independent diff-codec correctness fix. It also unblocks keyed inserts for the `Key` feature in #7.