### PR TITLE
Key the example-page lists (clears RASK022)

### DIFF
--- a/Rask.Example.Shared/Demos/LifecycleProbe.cs
+++ b/Rask.Example.Shared/Demos/LifecycleProbe.cs
@@ -37,7 +37,7 @@ public sealed class LifecycleProbe : Component
             ],
             H3(Class: "h6 text-secondary text-uppercase small")["Hook log"],
             Ol(Class: "list-group list-group-numbered list-group-flush")[
-                _log.Select(l => (Child)Li(Class: "list-group-item ps-2 small")[Code(Class: "small")[l]]).ToArray()]
+                _log.Select(l => (Child)Li(Key: l, Class: "list-group-item ps-2 small")[Code(Class: "small")[l]]).ToArray()]
         ];
     }
 }

--- a/Rask.Example.Shared/Demos/NestedFormDemos.cs
+++ b/Rask.Example.Shared/Demos/NestedFormDemos.cs
@@ -11,7 +11,7 @@ public sealed class NestedSubObjectDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
         [
@@ -77,7 +77,7 @@ public sealed class NestedListForeachDemo : Component
         _model.Items.Add(new LineItem { Description = "Coffee beans (250g)", Quantity = 2 });
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render()
     {
@@ -85,7 +85,7 @@ public sealed class NestedListForeachDemo : Component
         foreach (var item in _model.Items)
         {
             var captured = item; // foreach already captures per-iteration but make it loud.
-            rows.Add(Tr()[
+            rows.Add(Tr(Key: captured.Id)[
                 Td()[
                     Input(() => captured.Description, Class: "form-control form-control-sm"),
                     ValidationMessage(() => captured.Description, FieldError)
@@ -141,7 +141,7 @@ public sealed class NestedListIndexerDemo : Component
     public NestedListIndexerDemo() => _model.Skus.Add(new SkuRow { Code = "WIDGET-1", Price = 9.99m });
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render()
     {
@@ -149,7 +149,7 @@ public sealed class NestedListIndexerDemo : Component
         for (var idx = 0; idx < _model.Skus.Count; idx++)
         {
             var i = idx; // Per-iteration capture — without this every lambda closes over Skus.Count.
-            rows.Add(Tr()[
+            rows.Add(Tr(Key: _model.Skus[i].Id)[
                 Td(Class: "text-secondary small")[$"#{i + 1}"],
                 Td()[
                     Input(() => _model.Skus[i].Code, Class: "form-control form-control-sm"),
@@ -211,7 +211,7 @@ public sealed class NestedFluentValidationDemo : Component
     public NestedFluentValidationDemo() => _model.Lines.Add(new NestedOrderLine { Sku = "BOX-1", Quantity = 3 });
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render()
     {
@@ -219,7 +219,7 @@ public sealed class NestedFluentValidationDemo : Component
         foreach (var line in _model.Lines)
         {
             var captured = line;
-            rows.Add(Tr()[
+            rows.Add(Tr(Key: captured.Id)[
                 Td()[
                     Input(() => captured.Sku, Class: "form-control form-control-sm"),
                     ValidationMessage(() => captured.Sku, FieldError)
@@ -315,6 +315,9 @@ public sealed class CartModel
 
 public sealed class LineItem
 {
+    // Stable per-instance key for keyed row diffing (not bound to any input, no validation attrs).
+    public Guid Id { get; } = Guid.NewGuid();
+
     [Required(ErrorMessage = "Description is required.")]
     [StringLength(80)]
     public string Description { get; set; } = "";
@@ -330,6 +333,9 @@ public sealed class InvoiceModel
 
 public sealed class SkuRow
 {
+    // Stable per-instance key for keyed row diffing — survives the up/down reorder.
+    public Guid Id { get; } = Guid.NewGuid();
+
     [Required(ErrorMessage = "SKU is required.")]
     [RegularExpression("^[A-Z0-9-]{3,12}$", ErrorMessage = "Use uppercase letters, digits, and dashes (3-12 chars).")]
     public string Code { get; set; } = "";
@@ -353,6 +359,9 @@ public sealed class NestedOrderAddress
 
 public sealed class NestedOrderLine
 {
+    // Stable per-instance key for keyed row diffing.
+    public Guid Id { get; } = Guid.NewGuid();
+
     public string Sku { get; set; } = "";
     public int Quantity { get; set; } = 1;
 }

--- a/Rask.Example.Shared/Demos/ValidationDemos.cs
+++ b/Rask.Example.Shared/Demos/ValidationDemos.cs
@@ -13,7 +13,7 @@ public sealed class ValidationFieldsDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
         [
@@ -69,7 +69,7 @@ public sealed class ValidationSummaryDemo : Component
                 $"Please fix {entries.Count} error{(entries.Count == 1 ? "" : "s")}:"
             ],
             Ul(Class: "mb-0 ps-3")[
-                entries.Select(e => (Child)Li()[
+                entries.Select((e, i) => (Child)Li(Key: i)[
                     e.Field.Length == 0
                         ? (Child)e.Message
                         : (Child)Fragment()[Strong()[e.Field], ": ", e.Message]
@@ -122,7 +122,7 @@ public sealed class InlineValidateDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     private static Component SummaryAlert(IReadOnlyList<ValidationEntry> entries)
     {
@@ -135,7 +135,7 @@ public sealed class InlineValidateDemo : Component
 
         return Div(Class: "alert alert-danger small mb-0")[
             Ul(Class: "mb-0 ps-3")[
-                formOnly.Select(e => (Child)Li()[e.Message])
+                formOnly.Select((e, i) => (Child)Li(Key: i)[e.Message])
             ]
         ];
     }
@@ -213,7 +213,7 @@ public sealed class NestedAsyncWithLiveTotalsDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     private static Component Checking() =>
         Span(Class: "validating-indicator text-muted small mt-1")[
@@ -384,7 +384,7 @@ public sealed class InlineAsyncValidateDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     private static Component Checking() =>
         Span(Class: "validating-indicator text-muted small mt-1")[
@@ -400,7 +400,7 @@ public sealed class InlineAsyncValidateDemo : Component
         }
 
         return Div(Class: "alert alert-danger small mb-0")[
-            Ul(Class: "mb-0 ps-3")[formOnly.Select(e => (Child)Li()[e.Message])]
+            Ul(Class: "mb-0 ps-3")[formOnly.Select((e, i) => (Child)Li(Key: i)[e.Message])]
         ];
     }
 
@@ -481,7 +481,7 @@ public sealed class AsyncValidationDemo : Component
                     Input(() => _model.Username, Id: "v3-username", Class: "form-control"),
                     ValidatingIndicator(() => _model.Username, Checking),
                     ValidationMessage(() => _model.Username,
-                        msgs => Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])])
+                        msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])])
                 ],
                 Div()[
                     Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Sign up"]
@@ -572,7 +572,7 @@ public sealed class CrossFieldSummaryDemo : Component
             ? Fragment()
             : Div(Class: "alert alert-danger small mb-0")[
                 Ul(Class: "mb-0 ps-3")[
-                    entries.Select(e => (Child)Li()[
+                    entries.Select((e, i) => (Child)Li(Key: i)[
                         e.Field.Length == 0
                             ? (Child)e.Message
                             : (Child)Fragment()[Strong()[e.Field], ": ", e.Message]
@@ -625,7 +625,7 @@ public sealed class ValidatableObjectDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     private static Component SummaryAlert(IReadOnlyList<ValidationEntry> entries)
     {
@@ -636,7 +636,7 @@ public sealed class ValidatableObjectDemo : Component
         }
 
         return Div(Class: "alert alert-danger small mb-0")[
-            Ul(Class: "mb-0 ps-3")[formOnly.Select(e => (Child)Li()[e.Message])]
+            Ul(Class: "mb-0 ps-3")[formOnly.Select((e, i) => (Child)Li(Key: i)[e.Message])]
         ];
     }
 
@@ -711,7 +711,7 @@ public sealed class ProgrammaticValidateDemo : Component
     }
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     private static Component Checking() =>
         Span(Class: "validating-indicator text-muted small mt-1")[
@@ -803,7 +803,7 @@ public sealed class FluentValidationDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
         [
@@ -856,7 +856,7 @@ public sealed class FirstErrorWinsDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
         [
@@ -899,7 +899,7 @@ public sealed class FluentValidationAsyncDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     private static Component Checking() =>
         Span(Class: "validating-indicator text-muted small mt-1")[
@@ -969,7 +969,7 @@ public sealed class CustomAttributeDemo : Component
     private string? _submission;
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
         [

--- a/Rask.Example.Shared/Pages/CancellationPage.cs
+++ b/Rask.Example.Shared/Pages/CancellationPage.cs
@@ -48,6 +48,7 @@ public sealed class CancellationPage : Component
                         ? P(Class: "text-secondary small mb-0")["Mount and unmount the probe to populate this log."]
                         : Ol(Class: "list-group list-group-numbered list-group-flush cancel-log")[_log.Select(line =>
                             (Child)Li(
+                                Key: line,
                                 Class: "list-group-item ps-2 small")[Code(Class: "small")[line]]).ToArray()]
                 ]
             ],

--- a/Rask.Example.Shared/Pages/DisposalPage.cs
+++ b/Rask.Example.Shared/Pages/DisposalPage.cs
@@ -169,7 +169,7 @@ public sealed class DisposalPage : Component
             entries.Count == 0
                 ? P(Class: "text-secondary small mb-0")["Empty — mount and unmount the probe."]
                 : Ol(Class: "list-group list-group-numbered list-group-flush",
-                    Id: id)[entries.Select(line => (Child)Li(
+                    Id: id)[entries.Select(line => (Child)Li(Key: line, 
                     Class: "list-group-item ps-2 small")[Code(Class: "small")[line]]).ToArray()]];
 
     private void MountSync()

--- a/Rask.Example.Shared/Pages/LifecyclePage.cs
+++ b/Rask.Example.Shared/Pages/LifecyclePage.cs
@@ -54,7 +54,7 @@ public sealed class LifecyclePage : Component
                         : Ol(
                             Class: "list-group list-group-numbered list-group-flush",
                             Id: "lifecycle-cycle-log")[
-                            _cycleLog.Select(l => (Child)Li(
+                            _cycleLog.Select(l => (Child)Li(Key: l, 
                                 Class: "list-group-item ps-2 small")[Code(Class: "small")[l]]).ToArray()]
                 ]
             ],

--- a/Rask.Example.Shared/Pages/LiveTickerPage.cs
+++ b/Rask.Example.Shared/Pages/LiveTickerPage.cs
@@ -45,7 +45,7 @@ public sealed class LiveTickerPage(Navigator nav) : Component
                                     Class: "list-group list-group-numbered list-group-flush",
                                     Id: "ticker-log",
                                     Style: "max-height: 360px; overflow-y: auto;")[
-                                    _log.Select(l => (Child)Li(
+                                    _log.Select(l => (Child)Li(Key: l, 
                                         Class: "list-group-item ps-2 small bg-transparent")[
                                         Code(Class: "small")[l]]).ToArray()]
                         ]

--- a/Rask.Example.Shared/Pages/TablePage.cs
+++ b/Rask.Example.Shared/Pages/TablePage.cs
@@ -144,7 +144,7 @@ public sealed class TablePage(Navigator nav) : Component
                                 ]
                                 : (Child)Fragment()[
                                     visible.Select(p =>
-                                        (Child)Tr()[
+                                        (Child)Tr(Key: p.Id)[
                                             Td(Class: "text-secondary")[p.Id.ToString()],
                                             Td(Class: "fw-semibold")[p.Name],
                                             Td()[p.City],

--- a/Rask.Example.Shared/Pages/TodosPage.cs
+++ b/Rask.Example.Shared/Pages/TodosPage.cs
@@ -77,7 +77,7 @@ public sealed class TodosPage(Navigator nav, RouteState route) : Component
             _todos.Count == 0
                 ? Div(Class: "text-muted small")["No todos yet — click \"New todo\" to add one."]
                 : Ul(Class: "list-group")[
-                    _todos.Select(item => (Child)Li(Class: "list-group-item d-flex align-items-center gap-2")[
+                    _todos.Select(item => (Child)Li(Key: item.Id, Class: "list-group-item d-flex align-items-center gap-2")[
                         Input(
                             () => item.Completed,
                             Id: $"todo-done-{item.Id}",
@@ -116,7 +116,7 @@ public sealed class TodoFormDialog : Component
     public required Action<TodoForm> OnSave { get; set; }
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
-        Fragment()[msgs.Select(m => (Child)Div(Class: "text-danger small mt-1")[m])];
+        Fragment()[msgs.Select((m, i) => (Child)Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
         Dialog(Open: Open)[


### PR DESCRIPTION
Migrates the showcase lists to `Key:` now that keyed inserts are correct (depends on the head-sentinel offset fix in #8). Result: `Rask.Example.Shared` builds with **zero RASK022 warnings** and the examples demonstrate keyed reconciliation.

## Changes
- **Data rows by domain id** — `TodosPage` `<li>` (`item.Id`), `TablePage` `<tr>` (`p.Id`), and the three nested-form row tables (added a stable `Guid Id` to `LineItem`/`SkuRow`/`NestedOrderLine`, invisible to the form/validator).
- **Logs by content** — LiveTicker / Lifecycle / Cancellation / Disposal / LifecycleProbe log lists.
- **Validation/error-message lists by index** — the repeated `FieldError` / `SummaryAlert` helpers.

## Tests
`Rask.Example.Shared` builds warning-free; `Example.Shared.Tests` (231) and the interactive-page e2e (245 across Server + both WASM) pass.

## Stacking
Based on `fix/keyed-insert-offset` (#8) — keyed inserts render the wrong row content without that fix. Merge #8 first; this PR's base will retarget to `main` after.