### PR TITLE
Pre-select bound <select> options supplied via the indexer

### DIFF
--- a/Rask.Core.Tests/Components/SelectTests.cs
+++ b/Rask.Core.Tests/Components/SelectTests.cs
@@ -7,10 +7,42 @@ namespace Rask.Core.Tests.Components;
 
 public class SelectTests
 {
-    // Preselection (MarkSelected) only runs over children passed through the factory's
-    // `params IEnumerable<Child> Children` slot — children attached via the indexer
-    // overwrite the preselected list. These tests therefore use the `Children:` named
-    // arg form rather than `Select(...)[Option(...)]`.
+    // Preselection (MarkSelected) marks the <option> whose value matches the bound model
+    // value at serialize time (Select.EnterChildrenScope), so it works whether options are
+    // supplied via the `Children:` factory argument OR the `[...]` indexer. The indexer
+    // cases below pin the latter (it used to silently fail — the indexer overwrote the
+    // factory-time preselection).
+
+    [Fact]
+    public void BoundSelect_IndexerChildren_PreselectsMatchingNonFirstOption()
+    {
+        // The exact shape that used to break: idiomatic indexer syntax, bound value matching
+        // a non-first option. Factory-time MarkSelected never saw these children.
+        var model = new ColorPicker { Color = "red" };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Color)[Option(""), Option("red"), Option("blue")]
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.Contains("<option value=\"red\" selected>", html);
+        Assert.DoesNotContain("<option value=\"\" selected>", html);
+        Assert.DoesNotContain("<option value=\"blue\" selected>", html);
+    }
+
+    [Fact]
+    public void BoundSelect_IndexerChildren_NullValue_PreselectsEmptyOption()
+    {
+        var model = new ColorPicker { Color = null };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Color)[Option(""), Option("red")]
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.Contains("<option value=\"\" selected>", html);
+        Assert.DoesNotContain("<option value=\"red\" selected>", html);
+    }
 
     [Fact]
     public void BoundSelect_NullValue_Preselects_EmptyValueOption()

--- a/Rask.Core/Components/Select.cs
+++ b/Rask.Core/Components/Select.cs
@@ -109,14 +109,36 @@ public sealed class Select : Element
         var name = Name ?? acc.PropertyName;
         ctx?.RegisterFieldValidator(fid, validate, () => acc.Getter());
         var afterBind = BindingHelpers.BuildAfterBind(acc, afterBindSync, afterBindAsync);
-        var current = BindingHelpers.FormatValue(acc.Getter());
-        var preselected = MarkSelected(Children, current);
 
-        return (Select)C.Select(
+        var select = (Select)C.Select(
             name, Required: Required, Disabled: Disabled, Size: Size,
             Autofocus: Autofocus, Autocomplete: Autocomplete,
             OnChangeAsync: BindingHelpers.TouchAndValidateHandler(acc, ctx, fid, true, afterBind),
-            Id: Id, Class: Class, Style: Style, Data: Data)[preselected];
+            Id: Id, Class: Class, Style: Style, Data: Data)[Children];
+
+        // Defer option pre-selection to serialize time. Options supplied via the [...] indexer
+        // (the idiomatic `Select(Bind: …)[Option(…)…]` form) replace Children *after* this
+        // factory returns, so marking them here would be discarded. EnterChildrenScope marks
+        // the matching <option> just before the serializer reads Children — covering both the
+        // indexer and the Children: argument forms.
+        select._bound = true;
+        select._boundValue = BindingHelpers.FormatValue(acc.Getter());
+        return select;
+    }
+
+    // Set by BoundCore; non-bound selects (plain Generated.Select) leave _bound false and
+    // skip the serialize-time marking entirely.
+    private bool _bound;
+    private string _boundValue = "";
+
+    protected override IDisposable? EnterChildrenScope()
+    {
+        if (_bound && Children is not null)
+        {
+            Children = MarkSelected(Children, _boundValue);
+        }
+
+        return base.EnterChildrenScope();
     }
 
     private static IEnumerable<Child> MarkSelected(IEnumerable<Child> children, string current)
@@ -138,7 +160,9 @@ public sealed class Select : Element
             }
         }
 
-        return list;
+        // Return an array so Children stays a Child[] and the serializer's zero-allocation
+        // fast path (ChildrenArray => Children as Child[]) still applies after marking.
+        return list.ToArray();
     }
 
     private static Option MarkOption(Option opt, string current)

--- a/Rask.Example.Shared/Demos/BindingDemos.cs
+++ b/Rask.Example.Shared/Demos/BindingDemos.cs
@@ -240,8 +240,21 @@ public sealed class BindingAfterBindAsyncDemo : Component
                     () => _model.Track,
                     AfterBindAsync: async track =>
                     {
+                        // Re-selecting the placeholder (or any unknown track) clears the
+                        // dependent list instead of throwing on _catalog[track].
+                        if (!_catalog.ContainsKey(track))
+                        {
+                            _languages = [];
+                            _model.Language = "";
+                            _loading = false;
+                            return;
+                        }
+
+                        // Rask re-renders at every await suspension inside an async handler, so
+                        // flipping _loading before the await below is enough to surface the
+                        // "loading…" UI — a manual StateHasChanged() here would only set a deferred
+                        // in-handler flag and push no frame.
                         _loading = true;
-                        await StateHasChangedAsync();
                         // Simulated remote fetch — swap for HttpClient.GetFromJsonAsync in real code.
                         // Pass the component's CancellationToken so unmount-during-fetch aborts
                         // the simulated work cleanly instead of mutating state on a stale instance.
@@ -260,6 +273,12 @@ public sealed class BindingAfterBindAsyncDemo : Component
                     },
                     Id: "bind-async-track",
                     Class: "form-select")[
+                    // Placeholder matching the empty initial Track. Without it the <select>
+                    // visually defaults to "Frontend" while the model is still "" — and
+                    // re-picking the already-shown first option fires no change event, so the
+                    // async load never triggers. A selected placeholder keeps the initial
+                    // display honest and makes every track pick a real change.
+                    Option("")["— pick a track —"],
                     Option("frontend")["Frontend"],
                     Option("backend")["Backend"],
                     Option("data")["Data"]

--- a/Rask.Example.Shared/Pages/BindingPage.cs
+++ b/Rask.Example.Shared/Pages/BindingPage.cs
@@ -105,16 +105,18 @@ public sealed class BindingPage : Component
                 """
                 Select(Bind: () => _model.Track,
                        AfterBindAsync: async track => {
-                           _loading = true;
-                           StateHasChanged();          // surface "loading…" mid-await
+                           _loading = true;            // Rask renders at the await below — no StateHasChanged needed
                            await Task.Delay(300);      // simulated fetch
                            _languages = Catalog[track];
                            _model.Language = _languages[0];
                            _loading = false;
-                       })[ ... ]
+                       })[
+                    Option("")["— pick a track —"],    // placeholder = empty initial value
+                    Option("frontend")["Frontend"], ...
+                ]
                 """,
                 Notes:
-                "AfterBindAsync is awaited before the post-handler render, so validators see the new dependent state. A mid-await StateHasChanged() pushes the \"loading…\" UI before the simulated fetch completes; the dispatcher's per-await rendering picks it up.",
+                "Rask re-renders at every await suspension inside an async handler, so setting _loading before the await surfaces the \"loading…\" UI on its own — no manual StateHasChanged() is required. AfterBindAsync is still awaited before the post-handler render, so validators see the new dependent state. Note the empty-value placeholder option: it matches the initial model so the dropdown doesn't falsely show the first track, and so picking any track (including the first) fires a real change.",
                 Result: BindingAfterBindAsyncDemo())
         ];
 }


### PR DESCRIPTION
## Problem

`Select.Bound`'s `MarkSelected` ran at **factory time** over the `Children:` parameter only. The `[...]` indexer assigns `Children` *after* the factory returns, overwriting the marked options — so options written in the idiomatic `Select(Bind: …)[Option(…)…]` form were **never pre-selected**.

It only looked correct when the bound value happened to be the *first* option (the browser displays the first option by default). Auto-selecting any **non-first** value silently displayed the wrong option, and the model/display disagreed.

## Fix

Defer marking to **serialize time**:
- `BoundCore` stops marking eagerly and stashes the bound value (`_bound` / `_boundValue`).
- A new `Select.EnterChildrenScope()` override runs `MarkSelected` against the **final** `Children`. `HtmlSerializer` calls `EnterChildrenScopeInternal()` *before* it reads `ChildrenArray`, so this covers **both** the `[...]` indexer and the `Children:` argument forms.
- `MarkSelected` now returns a `Child[]` so the serializer's zero-allocation fast path (`Children as Child[]`) still applies.

## Example fix (how the bug surfaced)

The `AfterBindAsync` binding demo exposed this. Alongside the framework fix:
- Added an empty-value placeholder so the initial `Track` display matches the empty model and picking the first track fires a real `change` event (previously the dropdown showed "Frontend" while the model was `""`, and re-picking the shown option fired no change — so nothing loaded).
- Guarded the callback so re-selecting the placeholder clears the dependent list instead of throwing on `_catalog[track]`.
- Dropped the redundant `StateHasChanged()` (Rask already renders at every `await` suspension inside an async handler) and corrected the page note.

## Verification

- 2 new `SelectTests` pin the indexer path, including a **non-first** match.
- Full `Rask.Core.Tests` passes (**1280**, 0 failed).
- Confirmed in the running example server: bound selects now emit `selected` on the matching option (`<option value="US" selected>`, `<option value="" selected>`) where they previously emitted none.