### PR TITLE
Add PermutationBatch diff op to close the keyed-reorder byte soft spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1036,8 +1036,12 @@ already-rendered components, so an async hook that awaits a next-frame side effe
 
 ## 📊 Performance
 
-> **~1,800× smaller wire payloads** on a counter tick (the [diff codec](#live-rendering--the-diff-codec) ships ~57 bytes
-> where pre-codec shipped ~50 KB), and **faster, lighter small-tree renders** than Blazor's `HtmlRenderer` across the board.
+> **Rask beats Blazor on bytes-on-the-wire in every like-for-like live-update scenario**
+> (2–15× fewer bytes than Blazor's `RenderBatch`), and renders small trees faster and
+> lighter than Blazor's `HtmlRenderer`. The [diff codec](#live-rendering--the-diff-codec)
+> ships ~1,800× smaller payloads on a counter tick (~57 bytes where pre-codec shipped
+> ~50 KB). The trade-off, reported honestly below: Rask uses more *server* memory per
+> update to buy those tiny payloads.
 
 Headline numbers from `Rask.Benchmarks.VsBlazor` — Rask vs Blazor's
 `HtmlRenderer` (Scope 1, render hot path), `RenderTreeBuilder` parameter
@@ -1062,22 +1066,38 @@ columns; bold marks the winner.
 | Scale: keyed-list reorder (5 000 rows)            | 1 625 µs (1.08×) | **1 505 µs** | 3 391 KB      | **3 266 KB**  |
 | Scale: random permutation 1 000 keyed rows        | 477 µs (1.39×) | **343 µs**     | 632 KB        | **457 KB**    |
 
-**Where Rask wins:** small-tree renders, attribute-heavy markup, live diffs
-that touch only a few nodes on a large page, virtualised lists, and the
-"realistic" patterns (dashboard tick, nav switch). The
-[diff codec](#live-rendering--the-diff-codec) is the main lever — a counter
-tick on a 200-row page ships ~57 bytes over the wire vs ~50 KB pre-codec
-(see [`benchmarks/Rask.Benchmarks.VsBlazor/Reports/Justifications.md`](benchmarks/Rask.Benchmarks.VsBlazor/Reports/Justifications.md)
-for the full residual-loss breakdown).
+**Where Rask wins (wire bytes):** the [diff codec](#live-rendering--the-diff-codec)
+is the main lever — a counter tick on a 200-row page ships ~41 bytes over the wire
+vs ~24 KB pre-codec, and **every like-for-like scenario in the head-to-head suite now
+ships fewer bytes than Blazor's `RenderBatch`** (2–15×). A keyed-list reorder is the
+latest to cross over: the move run collapses into one `PermutationBatch` op carrying
+the shared parent path once, so a 200-row reverse-sort drops from 3.9 KB to **1.1 KB
+(2.99× vs Blazor)** — the last like-for-like byte loss, now a win. See the full
+per-scenario table and methodology in
+[`benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md`](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md).
 
-**Where Rask trails:** sustained 10 000-iteration churn workloads, and
-keyed-list reorders on the allocation axis (1.04–1.42× — time is now at or
-below Blazor parity). Both come from the same root cause — Rask elements are
-heap `Component` instances vs Blazor's struct render-tree frames — and are
-documented as accepted trade-offs in the Justifications doc above. (The
-keyed-move path was also corrected in the process: the prior implementation
-emitted wrong DOM order for permutations needing 3+ moves — see
-[`Justifications.md`](benchmarks/Rask.Benchmarks.VsBlazor/Reports/Justifications.md) §2.)
+**Where Rask wins (CPU/alloc):** small-tree renders, attribute-heavy markup, live diffs
+that touch only a few nodes on a large page, virtualised lists, and the "realistic"
+patterns (dashboard tick, nav switch).
+
+**Where Rask trails (server memory):** Rask optimises *bytes on the wire*, and it pays
+for that with server-side memory. It re-serialises the whole page to HTML on every
+render and diffs the frame stream, so a steady-state update allocates more than Blazor
+(which diffs its retained render tree directly) — measured deterministically at ~70 KB
+vs ~31 KB per update on the 200-row counter page. It also retains a heavier tree (a
+`Component` object graph vs Blazor's packed struct render-tree frames). The trade is the
+whole point: **far smaller wire payloads in exchange for more server CPU/RAM** — the
+right call when the bottleneck is the network, the wrong one for server RAM under many
+idle-but-mounted sessions. (The `LiveDiff` alloc rows in the table above show Rask
+*lower* — those are BenchmarkDotNet per-op figures that fold in Blazor's one-time
+full-tree attach batch; amortised over a long-lived session, the steady-state per-update
+number here is the representative one. Same measurement, different baseline — not a
+contradiction.) Reproduce with `-- mem-footprint` (below); the full allocation +
+retained-heap tables and methodology live in
+[`vs-blazor.md`](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md). Sustained
+10 000-iteration churn workloads trail for the same root cause and are documented as
+accepted trade-offs in
+[`Justifications.md`](benchmarks/Rask.Benchmarks.VsBlazor/Reports/Justifications.md).
 
 <details>
 <summary><b>Reproduce</b></summary>
@@ -1095,6 +1115,10 @@ dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -- --filter 
 
 # Scope 6/7 — realistic patterns + sustained-load:
 dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -- --filter '*Realistic_*' '*MemoryGc_*' --job short
+
+# Deterministic reports (GC counters, no BDN timing noise):
+dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -- payload-bytes     # wire bytes per update vs Blazor
+dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -- mem-footprint     # alloc/update + retained heap vs Blazor
 ```
 
 Results are written to `BenchmarkDotNet.Artifacts/results/`.

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md
@@ -20,32 +20,32 @@ Deterministic — no measurement noise. Each row is one incremental update from 
 
 | Scenario | Rask Full | Rask Diff | Blazor batch | Rask diff vs Rask full | Rask diff vs Blazor |
 |---|---:|---:|---:|---:|---:|
-| CounterOnLargePage | 24,143 | **41** | 186 | 589× | **4.54×** Rask wins |
-| TextNodeUpdate | 24,026 | **50** | 193 | 481× | **3.86×** Rask wins |
-| DeepTreeCounterUpdate | 1,312 | **137** | 1,722 | 9.6× | **12.57×** Rask wins |
-| InputTypingBurst | 325 | **48** | 135 | 6.8× | **2.81×** Rask wins |
-| AttributeUpdate | 38,393 | **54** | 140 | 711× | **2.59×** Rask wins |
-| ClassToggle | 1,265 | **92** | 227 | 13.8× | **2.47×** Rask wins |
-| DeleteMiddleRow | 6,580 | **36** | 96 | 183× | **2.67×** Rask wins |
-| MultiAttributeUpdate | 346 | **269** | 576 | 1.3× | **2.14×** Rask wins |
-| KeyedList100Reorder | 6,646 | **49** | 128 | 136× | **2.61×** Rask wins |
-| NestedKeyedReorder | 9,286 | **49** | 128 | 190× | **2.61×** Rask wins |
-| AppendRow | 6,714 | **108** | 224 | 62× | **2.07×** Rask wins |
-| AttributeBurstUpdate | 6,556 | **2,037** | 4,596 | 3.2× | **2.26×** Rask wins |
-| KeyedListLargeAppend | 10,046 | **4,273** | 5,957 | 2.4× | **1.39×** Rask wins |
-| KeyedList50Reversal | 3,346 | **685** | 896 | 4.9× | **1.31×** Rask wins² |
-| ConditionalRenderingToggle | **2,069** | 2,032 | 4,588 | 1.0× | **2.22×** Rask wins¹ |
-| Lifecycle_Insert100 | **7,546** | 9,093 | 24,604 | 0.8× | **3.26×** Rask wins¹ |
-| Lifecycle_Remove100 | **66** | 1,223 | 2,080 | 0.1× | **31.5×** Rask wins¹ |
-| VirtualizationScroll | 649 | 440 | 193³ | 1.5× | 0.44×³ |
-| Scale_KeyedReorder_5000 | 347,846 | **53** | 128 | 6,563× | **2.42×** Rask wins |
-| Scale_KeyedRandomPermutation_1000 | 67,846 | **14,936** | 16,096 | 4.5× | **1.08×** Rask wins² |
-| Scale_KeyedAppendMiddle_2000 | 137,916 | **111** | 225 | 1,243× | **2.03×** Rask wins |
-| Scale_DeepTreeMutationByDepth_200 | 5,236 | **441** | 6,522 | 11.9× | **14.79×** Rask wins |
-| Realistic_DashboardWidgets_Tick | 4,032 | **43** | 218 | 94× | **5.07×** Rask wins |
-| Realistic_TableSort_Reverse | 17,296 | 3,873 | **3,360** | 4.5× | 0.87×⁴ |
-| Realistic_FormValidationChurn_Field0 | 1,398 | **109** | 310 | 12.8× | **2.84×** Rask wins |
-| Realistic_NavSwitch_0to1 | 4,294 | **2,526** | 7,003 | 1.7× | **2.77×** Rask wins |
+| CounterOnLargePage | 24,114 | **41** | 186 | 588× | **4.54×** Rask wins |
+| TextNodeUpdate | 23,997 | **50** | 193 | 480× | **3.86×** Rask wins |
+| DeepTreeCounterUpdate | 1,283 | **137** | 1,722 | 9.4× | **12.57×** Rask wins |
+| InputTypingBurst | 296 | **48** | 135 | 6.2× | **2.81×** Rask wins |
+| AttributeUpdate | 38,364 | **54** | 140 | 710× | **2.59×** Rask wins |
+| ClassToggle | 1,236 | **92** | 227 | 13.4× | **2.47×** Rask wins |
+| DeleteMiddleRow | 6,551 | **36** | 96 | 182× | **2.67×** Rask wins |
+| MultiAttributeUpdate | 317 | **269** | 576 | 1.2× | **2.14×** Rask wins |
+| KeyedList100Reorder | 6,617 | **43** | 128 | 154× | **2.98×** Rask wins⁵ |
+| NestedKeyedReorder | 9,257 | **43** | 128 | 215× | **2.98×** Rask wins⁵ |
+| AppendRow | 6,685 | **108** | 224 | 62× | **2.07×** Rask wins |
+| AttributeBurstUpdate | 6,527 | **2,037** | 4,596 | 3.2× | **2.26×** Rask wins |
+| KeyedListLargeAppend | 10,017 | **4,273** | 5,957 | 2.3× | **1.39×** Rask wins |
+| KeyedList50Reversal | 3,317 | **269** | 896 | 12.3× | **3.33×** Rask wins⁵ |
+| ConditionalRenderingToggle | **2,040** | 2,032 | 4,588 | 1.0× | **2.26×** Rask wins¹ |
+| Lifecycle_Insert100 | **7,517** | 9,093 | 24,604 | 0.8× | **3.27×** Rask wins¹ |
+| Lifecycle_Remove100 | **37** | 1,223 | 2,080 | 0.0× | **56.2×** Rask wins¹ |
+| VirtualizationScroll | 620 | 440 | 193³ | 1.4× | 0.44×³ |
+| Scale_KeyedReorder_5000 | 347,817 | **47** | 128 | 7,400× | **2.72×** Rask wins⁵ |
+| Scale_KeyedRandomPermutation_1000 | 67,817 | **6,669** | 16,096 | 10.2× | **2.41×** Rask wins⁵ |
+| Scale_KeyedAppendMiddle_2000 | 137,887 | **111** | 225 | 1,242× | **2.03×** Rask wins |
+| Scale_DeepTreeMutationByDepth_200 | 5,207 | **441** | 6,522 | 11.8× | **14.79×** Rask wins |
+| Realistic_DashboardWidgets_Tick | 4,003 | **43** | 218 | 93× | **5.07×** Rask wins |
+| Realistic_TableSort_Reverse | 17,267 | **1,123** | 3,360 | 15.4× | **2.99×** Rask wins⁵ |
+| Realistic_FormValidationChurn_Field0 | 1,369 | **109** | 310 | 12.6× | **2.84×** Rask wins |
+| Realistic_NavSwitch_0to1 | 4,265 | **2,526** | 7,003 | 1.7× | **2.77×** Rask wins |
 
 ¹ `Lifecycle_Insert100` / `Lifecycle_Remove100` / `ConditionalRenderingToggle`: the
 diff codec emits positional structural ops (untrusted `Insert/Remove`) on these
@@ -53,20 +53,8 @@ cases, and the live-session gate routes them through the full-HTML morph path
 regardless of byte count — same reason the historic morph-vs-diff DOM-identity
 regression existed for mid-list replacements. The "Rask Full" column shows what
 the production `DiffMode.Auto` gate actually ships; the comparison readers should
-use is `min(diff, full)` vs Blazor — 7,546 vs 24,604 = 3.26× on insert, 66 vs
-2,080 = 31.5× on remove, 2,069 vs 4,588 = 2.22× on toggle.
-
-² `KeyedList50Reversal` and `Scale_KeyedRandomPermutation_1000`: keyed reversal /
-random-permutation worst cases (reversal LIS length = 1; random permutation has
-many off-LIS moves). Both were soft spots in the previous baseline —
-`KeyedList50Reversal` a statistical tie (895 B vs 896 B) and
-`Scale_KeyedRandomPermutation_1000` a 0.86× loss (18.7 KB vs 16.1 KB). The
-O(N log N) patience-sort LIS (`ComputeLisIndexSet`, commit `48ebd53`) plus the
-live-render `LiveState` hoist tightened the diff path enough that both now win
-(1.31× and 1.08×). They remain the thinnest wins in the suite because each
-`MoveSubtree` still re-emits its full DOM path even when adjacent moves share a
-prefix; a path-prefix-dedup or a permutation-batch op-kind would widen them
-further (see `Realistic_TableSort_Reverse` below, which has not yet crossed over).
+use is `min(diff, full)` vs Blazor — 7,517 vs 24,604 = 3.27× on insert, 37 vs
+2,080 = 56.2× on remove, 2,040 vs 4,588 = 2.25× on toggle.
 
 ³ `VirtualizationScroll`: the Blazor side renders all 1,000 rows through a plain
 `@for` loop and the "diff" is a single text-node update; the Rask side renders
@@ -74,17 +62,33 @@ further (see `Realistic_TableSort_Reverse` below, which has not yet crossed over
 The numbers reflect what each renderer pays in their respective best case, not
 a like-for-like comparison — see the
 [VirtualizationScroll caveat in §Blazor flavors covered](#blazor-flavors-covered).
+This is now the **only** non-like-for-like row in the suite — with the
+`PermutationBatch` op kind (footnote ⁵) shipped, every like-for-like scenario
+wins on bytes.
 
-⁴ `Realistic_TableSort_Reverse`: the sole remaining like-for-like byte loss —
-3,873 B vs Blazor's 3,360 B (0.87×). A full 200-row reversal is the LIS worst case
-(LIS length 1 → 199 of 200 rows enter as moves) at depth-4 paths, so each
-`MoveSubtree` re-emits the shared `[div, table, tbody]` prefix. Blazor's
-`RenderBatchWriter` interns that overhead across the batch and pays less per move.
-This improved from 0.72× to 0.87× since the previous baseline (the same LIS +
-`LiveState` work that flipped the footnote-² scenarios) but has not yet crossed
-over. Closing it needs a path-prefix-dedup across consecutive ops or a
-permutation-batch op-kind — left as an open lever, small enough in real-app
-practice that we ship and accept it as the one known byte soft spot.
+⁵ **`PermutationBatch` (op kind 7) — keyed-reorder runs ship one op, not N.**
+Previously a keyed list reorder emitted one `MoveSubtree` op per moved row, and
+every op re-emitted its full DOM path even though all moves under one keyed parent
+share an identical prefix. A 200-row reversal (`Realistic_TableSort_Reverse`, LIS
+length 1 → 199 moves at depth-4 paths) was the LIS worst case and the **sole
+remaining like-for-like byte loss** (3,873 B vs Blazor's 3,360 B, 0.87×).
+`FrameDiffer.DiffKeyedSiblings` now accumulates the move run's `(dst,src)` pairs and
+emits a **single** `PermutationBatch` op `[7, parentPath[], [dst0,src0,…]]` that
+carries the shared parent path once (`src/Rask.Core/Live/FrameDiffer.cs`,
+`LivePayload.cs`, and both client `applyDiff` interpreters). Results vs the previous
+baseline:
+- `Realistic_TableSort_Reverse`: 3,873 B → **1,123 B**, 0.87× → **2.99×** (the loss is closed).
+- `KeyedList50Reversal`: 685 B → **269 B**, 1.31× → **3.33×**.
+- `Scale_KeyedRandomPermutation_1000`: 14,936 B → **6,669 B**, 1.08× → **2.41×**.
+- `KeyedList100Reorder` / `NestedKeyedReorder`: 49 B → **43 B** (2.61× → 2.98×);
+  `Scale_KeyedReorder_5000`: 53 B → **47 B**.
+
+The op stays `Trusted` (keyed identity preserved — moves re-parent existing nodes,
+so focus/IDL state survives) and rides the same gate as `MoveSubtree`. Backward-compat:
+an old client that doesn't know kind 7 hits the `applyDiff` `default` case and does a
+full `location.reload()` (safe, degraded); both `rask.js` and `rask.wasm.js` ship from
+the same build as the server, so a deployed server's clients always have the matching
+interpreter.
 
 - **CounterOnLargePage** and **TextNodeUpdate** are the scenarios the Rask diff codec
   was designed for — one small value mutates inside a large unchanged DOM. The
@@ -98,8 +102,9 @@ practice that we ship and accept it as the one known byte soft spot.
 - **KeyedList100Reorder** and **DeleteMiddleRow** now both run through
   `FrameDiffer`'s keyed-matching branch. When every child of a parent carries a
   unique `data-rask-key`, the differ permutes by key instead of by sibling index:
-  a swap emits two `MoveSubtree` ops (the LIS-minimal move count), a mid-list
-  delete emits a single `RemoveSubtree`. Both ops are flagged `Trusted` so the
+  a swap emits one `PermutationBatch` op carrying the LIS-minimal move set (the
+  two-move swap collapses to one op of 43 B; see footnote ⁵), a mid-list delete
+  emits a single `RemoveSubtree`. Both ops are flagged `Trusted` so the
   live-session gate ships them as diff instead of routing to full-HTML morph —
   see [Closing the keyed-list gap](#closing-the-keyed-list-gap-frame-differ-keyed-matching).
   **Note:** the move-emission order was corrected (right-to-left anchor-based; the
@@ -110,7 +115,7 @@ practice that we ship and accept it as the one known byte soft spot.
   mount or unmount). The diff codec loses to full-HTML on these — the production
   `Auto` mode gate (`diffBytes * 4 < html.Length`) ships the full HTML instead.
   Comparing `min(diff, full)` against Blazor, Rask wins both directions (3.26× on
-  insert at 7,546 vs 24,604, 31.5× on remove at 66 vs 2,080).
+  insert at 7,517 vs 24,604, 56.2× on remove at 37 vs 2,080).
 
 The "Rask Full" column is the byte count of the full-HTML payload Rask would have
 shipped before the diff codec existed (`BuildPayloadUtf8WithRoot`). The "Rask Diff"
@@ -215,11 +220,11 @@ Benchmark classes (one per scenario):
 - `LiveDiffPayload_CounterOnLargePageBenchmarks` — stateful Rask root mutates one counter cell
 - `LiveDiffPayload_TextNodeUpdateBenchmarks`
 - `LiveDiffPayload_AttributeUpdateBenchmarks` — single `data-*` flip on a 20-attr × 100-element tree
-- `LiveDiffPayload_KeyedList100ReorderBenchmarks` — two keyed rows swapped (2 `MoveSubtree` ops)
+- `LiveDiffPayload_KeyedList100ReorderBenchmarks` — two keyed rows swapped (one `PermutationBatch` op carrying 2 moves)
 - `LiveDiffPayload_NestedKeyedReorderBenchmarks` — 20 keyed cards × 5 inner keyed rows, swap two outer cards (validates the keyed path recurses into kept cards with zero inner ops)
 - `LiveDiffPayload_InputTypingBurstBenchmarks` — three-field form, single keystroke into field A's value (validates attribute-diff scoping; sibling inputs and labels stay quiet)
 - `LiveDiffPayload_ConditionalRenderingToggleBenchmarks` — show/hide a 50-row panel between header and footer (validates the positional Insert/Remove → full-HTML fallback path; production ships full HTML, still beats Blazor's batch)
-- `LiveDiffPayload_KeyedListReversalBenchmarks` — reverse a 50-row keyed list (LIS worst case: 49 `MoveSubtree` ops; surfaces the per-op JSON-key overhead that's currently held back from the backlog)
+- `LiveDiffPayload_KeyedListReversalBenchmarks` — reverse a 50-row keyed list (LIS worst case: 49 moves, now shipped as one `PermutationBatch` op carrying the shared parent path once — the case that motivated the batch op)
 - `LiveDiffPayload_ClassToggleBenchmarks` — move "active" class between sidebar items (the most common UI mutation; two `SetAttribute` ops)
 - `LiveDiffPayload_DeepTreeCounterUpdateBenchmarks` — counter at the bottom of a 50-deep div nest (measures the path-encoding tax explicitly; 11.25× Rask win — biggest gap in the suite)
 - `LiveDiffPayload_MultiAttributeUpdateBenchmarks` — theme switch flips 5 attrs on the root in one render (5 `SetAttribute` ops; descendants stay quiet)
@@ -330,16 +335,16 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- keyed-list-dump
 **KeyedList100Reorder** (rows 5 and 95 swapped):
 
 ```
-MoveSubtree  path=1.0.0.5   src=95   40 bytes
-MoveSubtree  path=1.0.0.95  src=6    40 bytes
+PermutationBatch  path=1.0.0   2moves   43 bytes
 ```
 
-2 ops, **57 bytes** wire total. Each op encodes as a positional JSON array
-`[6, [1,0,0,N], srcSlot]`; path encodes the destination slot, the trailing
-slot carries the source. The client detaches the source FIRST, then resolves
-the destination `refNode` in the post-detach sibling list, so both indices
-follow the same coordinate model the server's keyed differ uses when emitting
-moves.
+1 op, **43 bytes** wire total (down from 57 B / 2 ops before the batch op). The op
+encodes as a positional JSON array `[7, [1,0,0], [dst0,src0,dst1,src1]]`: the path is
+the shared parent (no trailing slot), and the flat `moves` array carries each move's
+destination then source slot in apply order. The client detaches each source FIRST,
+then resolves the destination `refNode` in the post-detach sibling list, replaying the
+pairs in order — the same coordinate model the server's keyed differ uses when
+computing the move set against its progressively-mutated `live` list.
 
 **DeleteMiddleRow** (row index 50 removed from a 100-row list):
 
@@ -359,10 +364,13 @@ RemoveSubtree  path=1.0.0.50  len=1  40 bytes
    client does to its DOM.
 3. **Moves.** Compute `target[i] = newSlot(surviving[i].Key)`. Find the longest
    strictly increasing subsequence of `target` — elements in the LIS stay put;
-   elements off the LIS need to move. Emit `MoveSubtree` for each off-LIS
-   element, sorted by destination ascending. This is the same minimal-moves
-   strategy React's reconciler uses; for the 100-row swap it emits exactly 2
-   moves (the LIS keeps 98 elements).
+   elements off the LIS need to move. Walk new indices right-to-left, anchoring each
+   off-LIS element against the already-placed element to its right, and accumulate the
+   `(dst,src)` pairs into one `PermutationBatch` op (the shared parent path is emitted
+   once). This is the same minimal-moves strategy React's reconciler uses; for the
+   100-row swap it produces exactly 2 moves (the LIS keeps 98 elements), shipped as a
+   single op. The pairs stay in emission order because each is computed against the
+   progressively-mutated live list.
 4. **Inner diffs.** For each kept element (same key both sides), recurse into
    attribute and child diffs at the new slot path so the client's
    post-permutation DOM walk lands on the right node.
@@ -560,32 +568,84 @@ to Rask's stateful-root pattern (single attach, N re-renders).
 
 > BDN-pinned numbers pending machine quiesce. Re-pin with the filter above on an
 > otherwise-idle machine to capture full Mean / Allocated / Gen0 / Gen1 / Gen2
-> / Lock Contentions columns.
+> / Lock Contentions columns. The deterministic `mem-footprint` report below covers
+> the allocation-per-update and retained-heap story without BDN timing noise.
+
+## Memory footprint — deterministic (`mem-footprint`)
+
+```
+dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- mem-footprint
+```
+
+A no-BDN report (`Reports/VsBlazorMemFootprintReport.cs`) measured with precise GC
+counters — `GC.GetAllocatedBytesForCurrentThread()` for per-update allocation,
+`GC.GetTotalMemory(true)` deltas for retained heap. Pinned 2026-06-03, .NET 10.0.5,
+Apple M4 Pro.
+
+**Allocation per incremental update** (steady-state, production-relevant — lower is better):
+
+| Scenario | Rask /update | Blazor /update | Rask vs Blazor |
+|---|---:|---:|---:|
+| CounterOnLargePage | 69,598 B | **31,470 B** | 0.45× — Blazor allocates less |
+
+**Retained heap per rendered tree** (architectural tradeoff):
+
+| Scenario | Rask /tree | Blazor /tree | Rask vs Blazor |
+|---|---:|---:|---:|
+| LargePage_200Rows | 326,685 B | **222,798 B** | 0.68× |
+| KeyedList_100Rows | 158,029 B | **57,790 B** | 0.37× |
+
+**Read this honestly — it is a tradeoff, not a clean Rask win.** Rask's optimisation
+target is *bytes on the wire* (the headline table: 2–15× fewer, now with no
+like-for-like loss). It buys that by **re-serialising the whole page to HTML on every
+render and diffing the frame stream** — production `LiveSession` materialises the full
+`html = View.RenderAsLiveRoot(...)` string each update (`src/Rask.Server/LiveSession.cs`)
+before `TryComputeDiff`, so a counter tick on a 24 KB page allocates a fresh ~24 KB
+string plus the transient render tree even though it ships a ~40-byte diff. Blazor
+diffs its *retained* render tree directly and touches only changed `RenderTreeFrame`s,
+so it allocates roughly half as much per steady-state update. Likewise a tree HELD in
+memory costs Rask more — it keeps a `Component` object graph (one heap object per
+element) where Blazor packs dense frame structs — though in production Rask
+rebuilds-and-discards element trees per render rather than retaining them.
+
+The takeaway: **Rask trades higher server-side per-update allocation and a heavier
+retained tree for far smaller wire payloads** — the right call when the bottleneck is
+network latency / bandwidth / mobile data, the wrong one when it's server RAM under
+many idle-but-mounted sessions. (Note: this steady-state per-update figure differs from
+the *attach-inclusive* Scope 2 number — `228 KB` Blazor vs `95.5 KB` Rask — which
+folds in Blazor's one-time full-tree attach batch; amortised over a long-lived session,
+the per-update picture above is the representative one. The two are measuring different
+things, not contradicting each other; reconciling the Scope 2 row to a steady-state
+basis is a noted follow-up.)
 
 ## Known regressions / soft spots (post-v2 expansion)
 
-1. **`Realistic_TableSort_Reverse`** — Rask 3.87 KB vs Blazor 3.36 KB (0.87×). The
-   sole remaining like-for-like byte loss. Reversal is the LIS worst case (LIS
+1. ~~**`Realistic_TableSort_Reverse`** — the sole remaining like-for-like byte loss.~~
+   **Resolved** by the `PermutationBatch` op kind (headline-table footnote ⁵): the
+   200-row reversal now ships **1,123 B vs Blazor's 3,360 B (2.99× Rask win)** as one
+   batch op instead of 199 per-row `MoveSubtree` ops. With it, every like-for-like
+   scenario in the suite wins on bytes; `VirtualizationScroll` (footnote ³) is the only
+   non-like-for-like row left. Historical context — what the loss was and why:
+   Rask 3.87 KB vs Blazor 3.36 KB (0.87×). Reversal is the LIS worst case (LIS
    length 1); 199 of 200 rows enter as moves, and each `MoveSubtree` re-emits its
    full depth-4 path. Blazor's `RenderBatchWriter` interns the per-move overhead
    across the batch.
 
-Resolved since the previous baseline (no longer losses):
-- **`Scale_KeyedRandomPermutation_1000`** — was 0.86× (18.7 KB vs 16.1 KB), now
-  **1.08×** (14.9 KB vs 16.1 KB), a win.
-- **`KeyedList50Reversal`** — was a 895 B vs 896 B tie, now **1.31×** (685 B vs
-  896 B), a win.
-  Both flipped after the O(N log N) patience-sort LIS (`ComputeLisIndexSet`,
-  `48ebd53`) and the live-render `LiveState` hoist tightened the diff path.
+Resolved since the previous baseline (no longer losses), all sharpened further by the
+`PermutationBatch` op kind:
+- **`Realistic_TableSort_Reverse`** — was the sole loss at 0.87× (3,873 B); now
+  **2.99×** (1,123 B). Closed by `PermutationBatch`.
+- **`Scale_KeyedRandomPermutation_1000`** — was 0.86× (18.7 KB vs 16.1 KB); the
+  O(N log N) patience-sort LIS + `LiveState` hoist took it to 1.08× (14.9 KB), and
+  `PermutationBatch` to **2.41×** (6,669 B).
+- **`KeyedList50Reversal`** — was a 895 B vs 896 B tie, then 1.31× (685 B); now
+  **3.33×** (269 B).
 
-The remaining `TableSort_Reverse` loss has the same root cause the two resolved
-scenarios did: keyed-list move-set bytes grow linearly with move count because
-Rask emits the full path per op. Open levers (none pre-decided):
-- Path-prefix dedup across consecutive ops (see existing "Held back" note).
-- A new `PermutationBatch` op kind that carries the destination permutation as
-  one path + an int array of source slots, amortising the path overhead across
-  all moves in the batch.
-
-The `Scale_*` and `Realistic_*` benchmarks surface the cost so the backlog can
-prioritise; both levers are wire-bytes optimisations on `BuildPayloadUtf8Diff` +
-the client `applyDiff` interpreters, not differ-throughput work.
+`PermutationBatch` (op kind 7) was the chosen lever over cross-op path-prefix-dedup:
+keyed-list move-set bytes grew linearly with move count because Rask emitted the full
+parent path per `MoveSubtree`. `FrameDiffer.DiffKeyedSiblings` now ships one
+`[7, parentPath[], [dst0,src0,…]]` op carrying the shared path once, decoded by both
+`applyDiff` interpreters (`rask.js` / `rask.wasm.js` case 7). It is a wire-bytes
+optimisation on `BuildPayloadUtf8Diff` + the clients, not differ-throughput work; the
+differ still computes the same minimal LIS move set, it's just framed once. No keyed
+soft spots remain on the bytes axis.

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Program.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Program.cs
@@ -1,7 +1,9 @@
 using BenchmarkDotNet.Running;
 
 // Mirror Rask.Benchmarks/Program.cs: subcommands first, then default to BDN.
-//   payload-bytes   — deterministic byte-count report (no measurement noise), writes CSV
+//   payload-bytes   — deterministic wire-bytes-per-update report (no measurement noise), CSV
+//   keyed-list-dump — per-op diff breakdown for the keyed-reorder scenarios
+//   mem-footprint   — deterministic retained-managed-heap-per-tree report (no BDN noise), CSV
 // Anything else passes straight through to BenchmarkDotNet.
 if (args.Length >= 1 && args[0] == "payload-bytes")
 {
@@ -11,6 +13,11 @@ if (args.Length >= 1 && args[0] == "payload-bytes")
 if (args.Length >= 1 && args[0] == "keyed-list-dump")
 {
     return Rask.Benchmarks.VsBlazor.Reports.KeyedListDiffDump.Run(args);
+}
+
+if (args.Length >= 1 && args[0] == "mem-footprint")
+{
+    return Rask.Benchmarks.VsBlazor.Reports.VsBlazorMemFootprintReport.Run(args);
 }
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/KeyedListDiffDump.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/KeyedListDiffDump.cs
@@ -115,10 +115,15 @@ internal static class KeyedListDiffDump
                 var pathPreview = string.Join('.', op.Path);
                 var nameDisplay = op.Name ?? "";
                 var valueLen = op.Value?.Length ?? 0;
+                // PermutationBatch carries its payload in Moves (flat [dst,src,…]); surface the
+                // pair count in the Length column so the dump stays informative for kind 7.
+                var lengthDisplay = op.Kind == EditOpKind.PermutationBatch
+                    ? $"{op.Moves!.Length / 2}moves"
+                    : op.Length.ToString(CultureInfo.InvariantCulture);
                 Console.WriteLine(string.Format(
                     CultureInfo.InvariantCulture,
                     "{0},{1},{2},{3},{4},{5},{6},{7}",
-                    i, op.Kind, op.Path.Length, pathPreview, nameDisplay, valueLen, op.Length, encoded));
+                    i, op.Kind, op.Path.Length, pathPreview, nameDisplay, valueLen, lengthDisplay, encoded));
             }
             else if (i == 10)
             {

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorMemFootprintReport.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorMemFootprintReport.cs
@@ -1,0 +1,204 @@
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Rask.Benchmarks.VsBlazor.Components;
+using Rask.Benchmarks.VsBlazor.Infrastructure;
+using Rask.Core;
+
+namespace Rask.Benchmarks.VsBlazor.Reports;
+
+/// <summary>
+///     Deterministic "memory usage" report — the counterpart to the wire-bytes
+///     <see cref="VsBlazorPayloadBytesReport"/>. Emits two CSV blocks, both measured with
+///     precise GC counters (no BenchmarkDotNet, no timing jitter):
+///     <list type="number">
+///         <item>
+///             <b>Allocation per incremental update</b> — the production-relevant memory
+///             number. Drives one framework's natural incremental-update path
+///             (Rask: a stateful root whose cached rows survive, only the counter cell
+///             re-renders; Blazor: an attached root re-rendered with one changed parameter)
+///             and measures bytes allocated per update via
+///             <c>GC.GetAllocatedBytesForCurrentThread()</c>. This is where Rask's
+///             pooled-buffer diff codec wins — it allocates a small transient render tree +
+///             reused diff buffers, where Blazor rebuilds and diffs a render batch each time.
+///         </item>
+///         <item>
+///             <b>Retained heap per rendered tree</b> — the architectural tradeoff, NOT
+///             Rask's production memory profile. Rask retains its <see cref="Component"/>
+///             object graph (one heap object per element) where Blazor packs dense
+///             <c>RenderTreeFrame</c> structs, so a tree HELD in memory costs Rask more.
+///             But Rask rebuilds-and-discards element trees per render in production rather
+///             than retaining them — so this figure is the worst case "pin every node
+///             forever," surfaced for completeness, not the number to lead with.
+///         </item>
+///     </list>
+///     <para>
+///         Together with the in-proc Scope 4 startup benches these stand in for the
+///         "startup / memory footprint" story that a faithful in-browser Mono WASM startup
+///         measurement can't give us in-process (see the Methodology section of
+///         <c>Baselines/vs-blazor.md</c>).
+///     </para>
+///     <para>
+///         Invoke: <c>dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- mem-footprint</c>
+///     </para>
+/// </summary>
+internal static class VsBlazorMemFootprintReport
+{
+    // Updates measured per scenario for the allocation pass (after warmup). Large enough
+    // that the one-time attach cost amortises to ~0 per update.
+    private const int Updates = 5_000;
+
+    // Independent roots retained per scenario for the footprint pass.
+    private const int Roots = 200;
+
+    public static int Run(string[] args)
+    {
+        Console.WriteLine("# Allocation per incremental update (production-relevant; lower is better)");
+        Console.WriteLine("Scenario,Updates,RaskAllocBytesPerUpdate,BlazorAllocBytesPerUpdate,RaskVsBlazor");
+        ReportAllocCounterOnLargePage();
+
+        Console.WriteLine();
+        Console.WriteLine("# Retained heap per rendered tree (architectural tradeoff — Rask retains the");
+        Console.WriteLine("# Component graph; production rebuilds-and-discards element trees per render)");
+        Console.WriteLine("Scenario,Roots,RaskHeapBytesPerTree,BlazorHeapBytesPerTree,RaskVsBlazor");
+        ReportFootprintLargePage();
+        ReportFootprintKeyedList100();
+
+        return 0;
+    }
+
+    // ---- Allocation per update -------------------------------------------------------
+
+    private static void ReportAllocCounterOnLargePage()
+    {
+        // Rask: stateful root — cached rows survive, only the counter cell re-renders, and
+        // the diff codec reuses its pooled buffers across updates (the production shape).
+        using var rask = new RaskHarness();
+#pragma warning disable RASK014
+        var stateful = new StatefulLargePageWithCounter();
+#pragma warning restore RASK014
+        rask.SeedPrevious(stateful);
+        // Warm up: first updates allocate the pooled buffers + cached rows once.
+        for (var i = 0; i < 64; i++) { stateful.Tick(); rask.RenderAndBuildDiffPayloadBytes(stateful); }
+
+        var raskBefore = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < Updates; i++) { stateful.Tick(); rask.RenderAndBuildDiffPayloadBytes(stateful); }
+        var raskPerUpdate = (GC.GetAllocatedBytesForCurrentThread() - raskBefore) / Updates;
+
+        // Blazor: attach once, then re-render with one changed parameter per update. The
+        // InlineDispatcher runs inline on this thread so allocation stays measurable here.
+        using var blazor = new BlazorRenderBatchCapture();
+        // Warm up (and amortise the one-time attach) by running a throwaway sustained pass.
+        blazor.MeasureSustainedIncrementalUpdates<LargePageWithCounter.BlazorLargePageWithCounter>(
+            64, i => CounterParams(i));
+
+        var blazorBefore = GC.GetAllocatedBytesForCurrentThread();
+        blazor.MeasureSustainedIncrementalUpdates<LargePageWithCounter.BlazorLargePageWithCounter>(
+            Updates, i => CounterParams(i));
+        var blazorPerUpdate = (GC.GetAllocatedBytesForCurrentThread() - blazorBefore) / Updates;
+
+        EmitAllocRow("CounterOnLargePage", raskPerUpdate, blazorPerUpdate);
+    }
+
+    private static ParameterView CounterParams(int counter) =>
+        ParameterView.FromDictionary(new Dictionary<string, object?>
+        {
+            [nameof(LargePageWithCounter.BlazorLargePageWithCounter.Counter)] = counter
+        });
+
+    // ---- Retained footprint ----------------------------------------------------------
+
+    private static void ReportFootprintLargePage()
+    {
+        var raskPerTree = MeasureRaskFootprint(() => LargePageWithCounter.BuildRask(0));
+        var blazorPerTree = MeasureBlazorFootprint(
+            renderer => () => renderer.RenderAsRootAndMeasure<LargePageWithCounter.BlazorLargePageWithCounter>(
+                CounterParams(0)));
+
+        EmitFootprintRow("LargePage_200Rows", raskPerTree, blazorPerTree);
+    }
+
+    private static void ReportFootprintKeyedList100()
+    {
+        var order = new int[100];
+        for (var i = 0; i < order.Length; i++) order[i] = i;
+
+        var raskPerTree = MeasureRaskFootprint(() => KeyedList.BuildRask(order));
+        var blazorPerTree = MeasureBlazorFootprint(
+            renderer => () => renderer.RenderAsRootAndMeasure<KeyedList.BlazorKeyedList>(
+                ParameterView.FromDictionary(new Dictionary<string, object?>
+                {
+                    [nameof(KeyedList.BlazorKeyedList.Order)] = order
+                })));
+
+        EmitFootprintRow("KeyedList_100Rows", raskPerTree, blazorPerTree);
+    }
+
+    // Build + RenderAsLiveRoot M Rask trees, retaining each so the live heap holds the
+    // whole component graph + its LiveState.
+    private static long MeasureRaskFootprint(Func<Component> buildRoot)
+    {
+        var roots = new List<Component>(Roots);
+        var before = StableHeap();
+        for (var i = 0; i < Roots; i++)
+        {
+            var root = buildRoot();
+            _ = root.RenderAsLiveRoot();
+            roots.Add(root);
+        }
+
+        var after = StableHeap();
+        GC.KeepAlive(roots);
+        return (after - before) / Roots;
+    }
+
+    // Render M Blazor roots into ONE renderer, retaining them via the renderer's root-component
+    // table, so the delta is M render trees (not M renderers/circuits).
+    private static long MeasureBlazorFootprint(Func<BlazorRenderBatchCapture, Action> renderOneRoot)
+    {
+        using var renderer = new BlazorRenderBatchCapture();
+        var renderOne = renderOneRoot(renderer);
+        var before = StableHeap();
+        for (var i = 0; i < Roots; i++)
+        {
+            renderOne();
+        }
+
+        var after = StableHeap();
+        GC.KeepAlive(renderer);
+        return (after - before) / Roots;
+    }
+
+    // ---- Shared --------------------------------------------------------------------
+
+    private static long StableHeap()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.WaitForPendingFinalizers();
+        }
+
+        return GC.GetTotalMemory(forceFullCollection: true);
+    }
+
+    private static void EmitAllocRow(string scenario, long raskPerUpdate, long blazorPerUpdate)
+    {
+        // Rask wins when it allocates less; report Blazor/Rask so >1 reads as a Rask win.
+        var ratio = raskPerUpdate == 0
+            ? "n/a"
+            : (blazorPerUpdate / (double)raskPerUpdate).ToString("0.00", CultureInfo.InvariantCulture) + "x";
+        Console.WriteLine(string.Format(
+            CultureInfo.InvariantCulture, "{0},{1},{2},{3},{4}",
+            scenario, Updates, raskPerUpdate, blazorPerUpdate, ratio));
+    }
+
+    private static void EmitFootprintRow(string scenario, long raskPerTree, long blazorPerTree)
+    {
+        var ratio = raskPerTree == 0
+            ? "n/a"
+            : (blazorPerTree / (double)raskPerTree).ToString("0.00", CultureInfo.InvariantCulture) + "x";
+        Console.WriteLine(string.Format(
+            CultureInfo.InvariantCulture, "{0},{1},{2},{3},{4}",
+            scenario, Roots, raskPerTree, blazorPerTree, ratio));
+    }
+}

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -41,7 +41,19 @@ public enum EditOpKind : byte
     /// preceding ops already applied). Preserves DOM identity (focus, IDL property state, event
     /// listeners, iframe document state) since moving an existing node via
     /// <c>parent.insertBefore</c> doesn't materialise a new element.</summary>
-    MoveSubtree = 6
+    MoveSubtree = 6,
+
+    /// <summary>A batch of sibling moves under a single keyed parent. <see cref="EditOp.Path" />
+    /// resolves to the shared parent node; <see cref="EditOp.Moves" /> is a flat
+    /// <c>[dst0, src0, dst1, src1, …]</c> array, replayed in order with identical semantics to a
+    /// run of <see cref="MoveSubtree" /> ops (detach the source slot, then insert at the
+    /// destination slot in the post-detach sibling list). The order is load-bearing: each
+    /// dst/src pair is computed against the live DOM as mutated by all preceding pairs in the
+    /// batch, so it must not be reordered. Collapses N per-row moves (each re-emitting the full
+    /// parent path) into one op + one path — the dominant wire-bytes cost of a keyed-list
+    /// reorder. Like <see cref="MoveSubtree" /> it only ever comes from the keyed path and
+    /// preserves DOM identity.</summary>
+    PermutationBatch = 7
 }
 
 /// <summary>
@@ -56,7 +68,7 @@ public enum EditOpKind : byte
 /// </summary>
 public readonly struct EditOp
 {
-    public EditOp(EditOpKind kind, int[] path, string? name, string? value, int length = 0, bool trusted = false)
+    public EditOp(EditOpKind kind, int[] path, string? name, string? value, int length = 0, bool trusted = false, int[]? moves = null)
     {
         Kind = kind;
         Path = path;
@@ -64,6 +76,7 @@ public readonly struct EditOp
         Value = value;
         Length = length;
         Trusted = trusted;
+        Moves = moves;
     }
 
     public EditOpKind Kind { get; }
@@ -77,6 +90,11 @@ public readonly struct EditOp
     public string? Name { get; }
     public string? Value { get; }
     public int Length { get; }
+
+    /// <summary>For <see cref="EditOpKind.PermutationBatch" /> only: a flat
+    /// <c>[dst0, src0, dst1, src1, …]</c> array of sibling moves under the parent at
+    /// <see cref="Path" />, in apply order. Null for every other op kind.</summary>
+    public int[]? Moves { get; }
 
     /// <summary>True when this structural op was produced by the keyed-matching path
     /// (where the moved/inserted/removed node is identified by <c>data-rask-key</c>, so the
@@ -215,6 +233,11 @@ public static class FrameDiffer
         public readonly List<int> Live = [];
         public readonly HashSet<int> LisSet = [];
 
+        // Flat [dst0, src0, dst1, src1, …] accumulator for the step-4 move run. Reused across
+        // renders; the emitted PermutationBatch op gets a fresh copy (ToArray) so the consumer
+        // can hold the path/moves past the next render's Clear().
+        public readonly List<int> MovesBuffer = [];
+
         public void Clear()
         {
             OldKids.Clear();
@@ -225,6 +248,7 @@ public static class FrameDiffer
             Surviving.Clear();
             Live.Clear();
             LisSet.Clear();
+            MovesBuffer.Clear();
         }
     }
 
@@ -729,6 +753,13 @@ public static class FrameDiffer
                     live.Add(i);
                 }
 
+                // Accumulate the run's moves as flat [dst0, src0, dst1, src1, …] pairs instead of
+                // emitting one MoveSubtree op each — every op would re-emit the full parent path,
+                // which dominates the wire bytes of a large reorder. After the loop we ship a single
+                // PermutationBatch op carrying the shared parent path once. The flat array MUST stay
+                // in emission order: each dst/src is computed against `live` as mutated by all
+                // preceding pairs, so the client replays it left-to-right (see EditOpKind docs).
+                var moves = bundle.MovesBuffer;
                 for (var j = n - 1; j >= 0; j--)
                 {
                     var id = newIndexToSurv[j];
@@ -746,18 +777,24 @@ public static class FrameDiffer
 
                     if (dst != src)
                     {
-                        output.Add(new EditOp(
-                            EditOpKind.MoveSubtree,
-                            PathPlus(path, dst),
-                            null,
-                            null,
-                            src,
-                            trusted: true));
+                        moves.Add(dst);
+                        moves.Add(src);
                     }
 
                     // Re-insert even on the no-op (dst == src) case so `live` stays consistent for
                     // the remaining iterations' src/dst lookups.
                     live.Insert(dst, id);
+                }
+
+                if (moves.Count > 0)
+                {
+                    output.Add(new EditOp(
+                        EditOpKind.PermutationBatch,
+                        path.ToArray(),
+                        null,
+                        null,
+                        trusted: true,
+                        moves: moves.ToArray()));
                 }
             }
             finally

--- a/src/Rask.Core/Live/LiveDiffGate.cs
+++ b/src/Rask.Core/Live/LiveDiffGate.cs
@@ -25,7 +25,8 @@ internal static class LiveDiffGate
             var op = ops[i];
             if ((op.Kind == EditOpKind.InsertSubtree
                  || op.Kind == EditOpKind.RemoveSubtree
-                 || op.Kind == EditOpKind.MoveSubtree)
+                 || op.Kind == EditOpKind.MoveSubtree
+                 || op.Kind == EditOpKind.PermutationBatch)
                 && !op.Trusted)
             {
                 return false;

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -204,6 +204,7 @@ public static class LivePayload
     ///         InsertSubtree     [k, path[], html, domCount]
     ///         RemoveSubtree     [k, path[], domCount]
     ///         MoveSubtree       [k, path[], sourceSlot]
+    ///         PermutationBatch  [k, parentPath[], moves[]]   // moves = [dst0,src0,dst1,src1,…]
     ///     </code>
     ///     vs the prior <c>{"k":..,"p":..,"n":..,"v":..,"l":..}</c> object shape this
     ///     drops the four key strings (<c>k</c>, <c>n</c>, <c>v</c>, <c>l</c>) and the
@@ -334,6 +335,14 @@ public static class LivePayload
                 case EditOpKind.RemoveSubtree:
                 case EditOpKind.MoveSubtree:
                     writer.WriteNumberValue(op.Length);
+                    break;
+                case EditOpKind.PermutationBatch:
+                    writer.WriteStartArray();
+                    if (op.Moves is { } moves)
+                    {
+                        foreach (var m in moves) writer.WriteNumberValue(m);
+                    }
+                    writer.WriteEndArray();
                     break;
             }
 

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -973,6 +973,25 @@
                     mvParent.insertBefore(mvNode, mvRef);
                     break;
                 }
+                case 7: { // PermutationBatch [k, parentPath, moves] — moves = [dst0,src0,dst1,src1,…]
+                    // path IS the parent (no trailing slot to split off). Replay each (dst,src)
+                    // pair in array order with the same detach-source-first semantics as a single
+                    // MoveSubtree: the server computed every pair against the live DOM as mutated
+                    // by the preceding pairs, so order is load-bearing — never reorder.
+                    var pbParent = resolvePath(path);
+                    if (!pbParent) break;
+                    var pbMoves = op[2] || [];
+                    for (var m = 0; m + 1 < pbMoves.length; m += 2) {
+                        var pbDst = pbMoves[m];
+                        var pbSrc = pbMoves[m + 1];
+                        var pbNode = relevantChild(pbParent, pbSrc);
+                        if (!pbNode) continue;
+                        pbParent.removeChild(pbNode);
+                        var pbRef = relevantChild(pbParent, pbDst);
+                        pbParent.insertBefore(pbNode, pbRef);
+                    }
+                    break;
+                }
                 default:
                     // Unknown op kind — newer server, older client. Bail to full reload
                     // so the user isn't stranded on a stale tree.

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -741,6 +741,25 @@ function applyDiff(ops, names) {
                 mvParent.insertBefore(mvNode, mvRef);
                 break;
             }
+            case 7: { // PermutationBatch [k, parentPath, moves] — moves = [dst0,src0,dst1,src1,…]
+                // path IS the parent (no trailing slot to split off). Replay each (dst,src)
+                // pair in array order with the same detach-source-first semantics as a single
+                // MoveSubtree: the server computed every pair against the live DOM as mutated
+                // by the preceding pairs, so order is load-bearing — never reorder.
+                const pbParent = resolvePath(path);
+                if (!pbParent) break;
+                const pbMoves = op[2] || [];
+                for (let m = 0; m + 1 < pbMoves.length; m += 2) {
+                    const pbDst = pbMoves[m];
+                    const pbSrc = pbMoves[m + 1];
+                    const pbNode = relevantChild(pbParent, pbSrc);
+                    if (!pbNode) continue;
+                    pbParent.removeChild(pbNode);
+                    const pbRef = relevantChild(pbParent, pbDst);
+                    pbParent.insertBefore(pbNode, pbRef);
+                }
+                break;
+            }
             default:
                 console.warn("[Rask] Unknown diff op kind: " + k);
                 location.reload();

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -529,6 +529,25 @@ function applyDiff(ops, names) {
                 mvParent.insertBefore(mvNode, mvRef);
                 break;
             }
+            case 7: { // PermutationBatch [k, parentPath, moves] — moves = [dst0,src0,dst1,src1,…]
+                // path IS the parent (no trailing slot to split off). Replay each (dst,src)
+                // pair in array order with the same detach-source-first semantics as a single
+                // MoveSubtree: the server computed every pair against the live DOM as mutated
+                // by the preceding pairs, so order is load-bearing — never reorder.
+                const pbParent = resolvePath(path);
+                if (!pbParent) break;
+                const pbMoves = op[2] || [];
+                for (let m = 0; m + 1 < pbMoves.length; m += 2) {
+                    const pbDst = pbMoves[m];
+                    const pbSrc = pbMoves[m + 1];
+                    const pbNode = relevantChild(pbParent, pbSrc);
+                    if (!pbNode) continue;
+                    pbParent.removeChild(pbNode);
+                    const pbRef = relevantChild(pbParent, pbDst);
+                    pbParent.insertBefore(pbNode, pbRef);
+                }
+                break;
+            }
             default:
                 console.warn("[Rask] Unknown diff op kind: " + k);
                 location.reload();

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -209,7 +209,7 @@ public class FrameDifferTests
     // into full-HTML fallback).
 
     [Fact]
-    public void Diff_KeyedList_RowsSwapped_EmitsTwoMoveOpsWithTrustedFlag()
+    public void Diff_KeyedList_RowsSwapped_EmitsSinglePermutationBatchWithTrustedFlag()
     {
         var before = Frames(BuildKeyedRows(0, 1, 2, 3));
         var (afterFrames, afterHtml) = FramesAndHtml(BuildKeyedRows(0, 3, 2, 1));
@@ -218,13 +218,15 @@ public class FrameDifferTests
         FrameDiffer.Diff(before, afterFrames, ops, out var usedKeyed, afterHtml);
 
         Assert.True(usedKeyed);
-        // Minimal-moves strategy: LIS length 2 of a 4-element permutation bounds the move
-        // count at <= N - LIS = 2 ops, but a well-chosen LIS combined with the
-        // `src == target` short-circuit can land in <= 1 op (some elements happen to
-        // already be at their target slot). Either is correct — assert the upper bound.
-        Assert.InRange(ops.Count, 1, 2);
-        Assert.All(ops, op => Assert.Equal(EditOpKind.MoveSubtree, op.Kind));
-        Assert.All(ops, op => Assert.True(op.Trusted, "Keyed moves must be marked Trusted so the live-session gate doesn't divert to full HTML."));
+        // The whole move run under one keyed parent collapses into a single PermutationBatch
+        // op carrying the shared parent path once. LIS length 2 of a 4-element permutation
+        // bounds the move count at <= N - LIS = 2 pairs (4 ints), flattened into op.Moves.
+        var batch = Assert.Single(ops);
+        Assert.Equal(EditOpKind.PermutationBatch, batch.Kind);
+        Assert.True(batch.Trusted, "Keyed moves must be marked Trusted so the live-session gate doesn't divert to full HTML.");
+        Assert.NotNull(batch.Moves);
+        Assert.True(batch.Moves!.Length is 2 or 4, "Expected 1–2 (dst,src) pairs.");
+        Assert.Equal(0, batch.Moves.Length % 2);
     }
 
     [Fact]
@@ -400,11 +402,12 @@ public class FrameDifferTests
     }
 
     [Fact]
-    public void Diff_KeyedList_HundredRowSwap_EmitsTwoMoves_NotNinetyRewrites()
+    public void Diff_KeyedList_HundredRowSwap_EmitsSingleBatchOfTwoMoves_NotNinetyRewrites()
     {
         // The headline scenario — KeyedList100Reorder: swap rows 5 and 95 in a 100-row
         // list. Positional diff emits 2 SetAttribute + 2 UpdateText (205 bytes vs
-        // Blazor's 128). Keyed matching emits exactly 2 MoveSubtree ops.
+        // Blazor's 128). Keyed matching emits one PermutationBatch carrying exactly 2 moves
+        // (4 ints) and the shared parent path once.
         var orderBefore = new int[100];
         var orderAfter = new int[100];
         for (var i = 0; i < 100; i++)
@@ -421,9 +424,10 @@ public class FrameDifferTests
         FrameDiffer.Diff(before, afterFrames, ops, out var usedKeyed);
 
         Assert.True(usedKeyed);
-        Assert.Equal(2, ops.Count);
-        Assert.All(ops, op => Assert.Equal(EditOpKind.MoveSubtree, op.Kind));
-        Assert.All(ops, op => Assert.True(op.Trusted));
+        var batch = Assert.Single(ops);
+        Assert.Equal(EditOpKind.PermutationBatch, batch.Kind);
+        Assert.True(batch.Trusted);
+        Assert.Equal(4, batch.Moves!.Length); // 2 (dst,src) pairs
     }
 
     [Theory]
@@ -434,13 +438,12 @@ public class FrameDifferTests
     [InlineData(250, 99)]
     public void Diff_KeyedList_RandomPermutation_MoveOpsReproduceTargetOrder(int n, int seed)
     {
-        // Strong correctness gate for the keyed MoveSubtree loop: for a random permutation
-        // (same key set, no inserts/removes) the diff emits only MoveSubtree ops. Replaying
-        // them against the before-order — exactly as the client interpreter does: detach at
-        // `src` (op.Length), then insert before the post-detach node at `target`
-        // (op.Path[^1]) — must reproduce the after-order. This pins the (src,target) move
-        // semantics regardless of the algorithm that computes them, so it guards any future
-        // rewrite of the loop (e.g. an O(N log N) order-statistics replacement).
+        // Strong correctness gate for the keyed move loop: for a random permutation (same key
+        // set, no inserts/removes) the diff emits a single PermutationBatch op. Replaying its
+        // flat [dst0,src0,dst1,src1,…] pairs against the before-order — exactly as the client
+        // interpreter does: detach at `src`, then insert before the post-detach node at `dst` —
+        // must reproduce the after-order. This pins the (dst,src) move semantics regardless of
+        // the algorithm that computes them, so it guards any future rewrite of the loop.
         var rng = new Random(seed);
         var before = new int[n];
         for (var i = 0; i < n; i++)
@@ -463,32 +466,40 @@ public class FrameDifferTests
         FrameDiffer.Diff(beforeFrames, afterFrames, ops, out var usedKeyed);
 
         Assert.True(usedKeyed);
-        Assert.All(ops, op => Assert.Equal(EditOpKind.MoveSubtree, op.Kind));
+        // A non-identity permutation produces exactly one batch op (identity → zero ops).
+        Assert.True(ops.Count <= 1);
 
-        // Replay the move ops against a live list of keys, mirroring the DOM interpreter.
+        // Replay the batch's (dst,src) pairs against a live list of keys, mirroring the DOM
+        // interpreter (detach at src, insert at dst in the post-detach list).
         var live = new List<int>(before);
-        foreach (var op in ops)
+        if (ops.Count == 1)
         {
-            var src = op.Length;
-            var target = op.Path[^1];
-            var moved = live[src];
-            live.RemoveAt(src);
-            live.Insert(target, moved);
+            var batch = ops[0];
+            Assert.Equal(EditOpKind.PermutationBatch, batch.Kind);
+            var moves = batch.Moves!;
+            for (var m = 0; m + 1 < moves.Length; m += 2)
+            {
+                var dst = moves[m];
+                var src = moves[m + 1];
+                var moved = live[src];
+                live.RemoveAt(src);
+                live.Insert(dst, moved);
+            }
         }
 
         Assert.Equal(after, live.ToArray());
     }
 
     [Fact]
-    public void Diff_NestedKeyedList_OuterReorderAndInnerReorder_EmitsTrustedMovesAtBothDepths()
+    public void Diff_NestedKeyedList_OuterReorderAndInnerReorder_EmitsTrustedBatchesAtBothDepths()
     {
         // Recursion-safety guard for the scratch-pooling optimisation. The outer keyed list's
         // DiffKeyedSiblings call is still LIVE — its key map and child lists are read in the
         // step-5 inner-diff loop — while it recurses into a kept row whose own children form a
         // SECOND keyed list, re-entering DiffKeyedSiblings. Any scratch shared across that
-        // recursion must not be clobbered. This pins the exact ops so the pooled refactor is
-        // provably byte-identical: the outer row reorder and the inner span reorder both emit a
-        // single trusted MoveSubtree, at the right depths.
+        // recursion must not be clobbered (including the MovesBuffer the batch accumulates into).
+        // This pins the exact ops: the outer row reorder and the inner span reorder each emit a
+        // single trusted PermutationBatch, at the right parent depths and non-interleaved.
         static Child Row(int key, bool innerSwapped)
         {
             Child a = C.Span(Key: $"{key}a")["A"];
@@ -505,11 +516,13 @@ public class FrameDifferTests
 
         Assert.True(usedKeyed);
         Assert.Equal(2, ops.Count);
-        Assert.All(ops, op => Assert.Equal(EditOpKind.MoveSubtree, op.Kind));
+        Assert.All(ops, op => Assert.Equal(EditOpKind.PermutationBatch, op.Kind));
         Assert.All(ops, op => Assert.True(op.Trusted));
-        // Outer move is emitted first (step 4 precedes the step-5 inner recursion).
-        Assert.Equal(new[] { 0, 1 }, ops[0].Path);       // outer: rows reordered at the Ul (slot 0)
-        Assert.Equal(new[] { 0, 1, 1 }, ops[1].Path);    // inner: spans reordered inside row 0 at its new slot 1
+        // The batch op's Path is the PARENT (no trailing dst slot — that now lives in Moves).
+        // Outer batch is emitted first (step 4 precedes the step-5 inner recursion).
+        Assert.Equal(new[] { 0 }, ops[0].Path);          // outer: rows reordered under the Ul (slot 0)
+        Assert.Equal(new[] { 0, 1 }, ops[1].Path);       // inner: spans reordered inside row 0 at its new slot 1
+        Assert.All(ops, op => Assert.Equal(2, op.Moves!.Length)); // one (dst,src) pair each
     }
 
     private static Component BuildKeyedRows(params int[] keys)

--- a/tests/Rask.Core.Tests/Live/LiveDiffGateTests.cs
+++ b/tests/Rask.Core.Tests/Live/LiveDiffGateTests.cs
@@ -118,6 +118,7 @@ public class LiveDiffGateTests
     [InlineData(EditOpKind.InsertSubtree)]
     [InlineData(EditOpKind.RemoveSubtree)]
     [InlineData(EditOpKind.MoveSubtree)]
+    [InlineData(EditOpKind.PermutationBatch)]
     public void DiffOpsAreClientSupported_UntrustedStructuralOp_ReturnsFalse(EditOpKind kind)
     {
         Assert.False(LiveDiffGate.DiffOpsAreClientSupported([Op(kind, trusted: false)]));
@@ -127,6 +128,7 @@ public class LiveDiffGateTests
     [InlineData(EditOpKind.InsertSubtree)]
     [InlineData(EditOpKind.RemoveSubtree)]
     [InlineData(EditOpKind.MoveSubtree)]
+    [InlineData(EditOpKind.PermutationBatch)]
     public void DiffOpsAreClientSupported_TrustedStructuralOp_ReturnsTrue(EditOpKind kind)
     {
         // Keyed-matching path marks structural ops Trusted=true; those are safe to apply.

--- a/tests/Rask.Core.Tests/Live/LivePayloadDiffTests.cs
+++ b/tests/Rask.Core.Tests/Live/LivePayloadDiffTests.cs
@@ -163,6 +163,32 @@ public class LivePayloadDiffTests
     }
 
     [Fact]
+    public void BuildPayloadUtf8Diff_PermutationBatch_EncodesMovesArray()
+    {
+        // PermutationBatch is [k, parentPath, moves] where moves is a flat
+        // [dst0,src0,dst1,src1,…] array. op[1] is the PARENT path (no trailing slot);
+        // the per-move dst/src live in op[2]. Zero is a legitimate slot, so the encoder
+        // must emit every entry verbatim and in order.
+        var ops = new List<EditOp>
+        {
+            new(EditOpKind.PermutationBatch, new[] { 1, 0, 0 }, null, null, trusted: true,
+                moves: new[] { 95, 5, 0, 96 })
+        };
+
+        var output = new ArrayBufferWriter<byte>(128);
+        LivePayload.BuildPayloadUtf8Diff(output, ops);
+
+        var json = Encoding.UTF8.GetString(output.WrittenSpan);
+        using var doc = JsonDocument.Parse(json);
+        var opsArr = doc.RootElement.GetProperty("ops").EnumerateArray().ToList();
+
+        Assert.Single(opsArr);
+        Assert.Equal((int)EditOpKind.PermutationBatch, opsArr[0][0].GetInt32());
+        Assert.Equal(new[] { 1, 0, 0 }, opsArr[0][1].EnumerateArray().Select(e => e.GetInt32()).ToArray());
+        Assert.Equal(new[] { 95, 5, 0, 96 }, opsArr[0][2].EnumerateArray().Select(e => e.GetInt32()).ToArray());
+    }
+
+    [Fact]
     public void BuildPayloadUtf8Diff_InsertSubtree_EncodesHtmlAndDomCount()
     {
         var ops = new List<EditOp>


### PR DESCRIPTION
## Context

A keyed-list reorder used to emit one `MoveSubtree` op per moved row, each re-emitting its full DOM path even though all moves under one keyed parent share an identical prefix. A 200-row reversal (the LIS worst case — 199 moves at depth-4 paths) was the **sole remaining like-for-like byte loss** vs Blazor: `Realistic_TableSort_Reverse` shipped 3,873 B vs Blazor's 3,360 B (0.87×).

## Change

Introduce **`EditOpKind.PermutationBatch` (kind 7)**: a keyed move run collapses into one op carrying the shared parent path once plus a flat `[dst0,src0,…]` array, replayed in apply order.

- `FrameDiffer.DiffKeyedSiblings` accumulates the `(dst,src)` pairs into a pooled buffer and emits a single op.
- `LivePayload.BuildPayloadUtf8Diff` encodes `[7, parentPath[], moves[]]`.
- `LiveDiffGate` gates it like the other trusted structural ops.
- Both `applyDiff` interpreters (`rask.js` / `rask.wasm.js` `case 7`) replay with identical detach-source-first semantics. An old client without `case 7` hits the `default` → `location.reload()` fallback (safe, degraded).

## Results (deterministic `payload-bytes`)

| Scenario | Before | After |
|---|---|---|
| `Realistic_TableSort_Reverse` | 3,873 B (0.87× loss) | **1,123 B (2.99× win)** |
| `KeyedList50Reversal` | 1.31× | **3.33×** |
| `Scale_KeyedRandomPermutation_1000` | 1.08× | **2.41×** |
| `KeyedList100Reorder` / `NestedKeyedReorder` | 49 B | **43 B** |

Every like-for-like scenario now wins on bytes; `VirtualizationScroll` remains the only non-like-for-like row.

## Also: deterministic `mem-footprint` report

New GC-counter-based report (no BDN) measuring allocation-per-update and retained heap per tree. **Reported honestly as a tradeoff, not a win:** Rask re-serialises the whole page to diff it, so it allocates more server-side per steady-state update (~70 KB vs ~31 KB) and retains a heavier `Component` graph than Blazor's packed `RenderTreeFrame`s — in exchange for far smaller wire payloads. The baseline doc flags that this steady-state figure differs from the attach-inclusive Scope 2 number and leaves reconciling Scope 2 as a follow-up.

## Verification

- Core 1346 unit tests + all non-e2e projects green
- **e2e 454/454** (the keyed Table reorder exercises client `case 7` in a real browser)