### PR TITLE
Adopt Key: on list-rendered sites to clear RASK022 warnings

### DIFF
--- a/benchmarks/Rask.Benchmarks/DataAttributesBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/DataAttributesBenchmarks.cs
@@ -40,9 +40,9 @@ public class DataAttributesBenchmarks
         {
             var data = new Dictionary<string, string?>
             {
-                ["rask-key"] = $"k{i}", ["index"] = i.ToString(), ["state"] = "idle", ["test-id"] = $"row-{i}"
+                ["index"] = i.ToString(), ["state"] = "idle", ["test-id"] = $"row-{i}"
             };
-            rows.Add(C.Div(Class: "row", Data: data)[
+            rows.Add(C.Div(Class: "row", Data: data, Key: $"k{i}")[
                 C.Span(Data: new Dictionary<string, string?> { ["label"] = "x" })[$"Item {i}"]
             ]);
         }

--- a/benchmarks/Rask.Benchmarks/HtmlSerializerBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/HtmlSerializerBenchmarks.cs
@@ -74,7 +74,7 @@ public class HtmlSerializerBenchmarks
         var rows = new List<Child>(rowCount);
         for (var i = 0; i < rowCount; i++)
         {
-            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;", Key: i)[
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", "_blank", "noopener", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32, "lazy"),
@@ -121,7 +121,7 @@ public class HtmlSerializerBenchmarks
             // All values are encoding-free ASCII so the HtmlEncoder.Encode call returns
             // a string allocation that's literally identical to the input. The proposed
             // fast-path (scan-for-special-chars, append verbatim) elides that allocation.
-            rows.Add(C.Div(Class: "row", Id: $"r{i}")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Key: i)[
                 C.Span(Class: "label")[$"item {i}"],
                 C.Span(Class: "value")[$"value {i}"],
                 C.Span(Class: "meta")[$"meta {i}"],

--- a/benchmarks/Rask.Benchmarks/LiveRenderRoundTripBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/LiveRenderRoundTripBenchmarks.cs
@@ -71,7 +71,7 @@ public class LiveRenderRoundTripBenchmarks
         var rows = new List<Child>(20);
         for (var i = 0; i < 20; i++)
         {
-            rows.Add(B.RowItem(i));
+            rows.Add(B.RowItem(i, Key: i));
         }
 
         return C.Fragment()[

--- a/benchmarks/Rask.Benchmarks/PayloadBytesPerUpdate.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesPerUpdate.cs
@@ -107,7 +107,7 @@ public class PayloadBytesPerUpdate
         var rows = new List<Child>(LargePageRowCount);
         for (var i = 0; i < LargePageRowCount; i++)
         {
-            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;", Key: i)[
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),
@@ -161,7 +161,7 @@ public class PayloadBytesPerUpdate
         for (var i = 0; i < LargePageRowCount; i++)
         {
             var text = i == LargePageRowCount / 2 ? $"ticker {counter}" : $"Item {i}";
-            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;", Key: i)[
                 C.Span(Class: "label")[text],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -112,7 +112,7 @@ internal static class PayloadBytesReport
         var rows = new List<Child>(rowCount);
         for (var i = 0; i < rowCount; i++)
         {
-            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;", Key: i)[
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),
@@ -159,7 +159,7 @@ internal static class PayloadBytesReport
         for (var i = 0; i < rowCount; i++)
         {
             var text = i == rowCount / 2 ? $"ticker {counter}" : $"Item {i}";
-            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Style: "display:flex;gap:8px;", Key: i)[
                 C.Span(Class: "label")[text],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),

--- a/benchmarks/Rask.Benchmarks/RenderRoundTripBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/RenderRoundTripBenchmarks.cs
@@ -30,7 +30,7 @@ public class RenderRoundTripBenchmarks
         var rows = new List<Child>(15);
         for (var i = 0; i < 15; i++)
         {
-            rows.Add(C.Div(Class: "row", Id: $"r{i}")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Key: i)[
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Input("text", $"f{i}", $"v{i}")

--- a/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
+++ b/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
@@ -52,7 +52,7 @@ public class ValidationMessageTests
         var view = new StubComponent(() => Form(Context: ctx, Model: p)[
             ValidationSummary(entries =>
                 Ul(Class: "validation-summary")[
-                    entries.Select(e => (Child)Li()[e.Message]).ToArray()
+                    entries.Select((e, i) => (Child)Li(Key: i)[e.Message]).ToArray()
                 ])
         ]);
         var html = view.RenderAsLiveRoot();

--- a/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
+++ b/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
@@ -121,7 +121,7 @@ public class NestedBindingValidationTests
             Input(() => p.Address.Street,
                 _ => new[] { "model-plus-context" }),
             ValidationMessage(() => p.Address.Street,
-                msgs => Fragment()[msgs.Select(m => (Child)Div(Class: "err")[m])])
+                msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -220,7 +220,7 @@ public class NestedBindingValidationTests
                     return v == "99999" ? new[] { "We don't ship to this area." } : Array.Empty<string>();
                 }),
             ValidationMessage(() => m.Address.PostalCode,
-                msgs => Fragment()[msgs.Select(s => (Child)Div(Class: "err")[s])])
+                msgs => Fragment()[msgs.Select((s, i) => (Child)Div(Class: "err", Key: i)[s])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -272,7 +272,7 @@ public class NestedBindingValidationTests
                     return v == "99999" ? new[] { "We don't ship to this area." } : Array.Empty<string>();
                 }),
             ValidationMessage(() => m.Address.PostalCode,
-                msgs => Fragment()[msgs.Select(s => (Child)Div(Class: "err")[s])])
+                msgs => Fragment()[msgs.Select((s, i) => (Child)Div(Class: "err", Key: i)[s])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -369,7 +369,7 @@ public class NestedBindingValidationTests
                 v =>
                     string.IsNullOrEmpty(v) ? new[] { "street required" } : Array.Empty<string>()),
             ValidationMessage(() => p.Address.Street,
-                msgs => Fragment()[msgs.Select(m => (Child)Div(Class: "err")[m])])
+                msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -395,7 +395,7 @@ public class NestedBindingValidationTests
                 v =>
                     v.Length < 3 ? new[] { "too short" } : Array.Empty<string>()),
             ValidationMessage(() => p.Address.Street,
-                msgs => Fragment()[msgs.Select(m => (Child)Div(Class: "err")[m])])
+                msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -586,7 +586,7 @@ public class FrameDifferTests
         var rows = new List<Child>(rowCount);
         for (var i = 0; i < rowCount; i++)
         {
-            rows.Add(C.Div(Class: "row", Id: $"r{i}")[
+            rows.Add(C.Div(Class: "row", Id: $"r{i}", Key: i)[
                 C.Span(Class: "label")[$"Item {i}"]
             ]);
         }

--- a/tests/Rask.Server.Tests/Infrastructure/OrderedDispatchApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/OrderedDispatchApp.cs
@@ -38,7 +38,7 @@ public sealed class OrderedDispatchApp : Component
         for (var i = 0; i < HandlerCount; i++)
         {
             var captured = i;
-            children.Add(Button(OnClickAsync: () => RecordAsync(captured))[$"#{captured}"]);
+            children.Add(Button(OnClickAsync: () => RecordAsync(captured), Key: captured)[$"#{captured}"]);
         }
 
         return Fragment()[children.ToArray()];


### PR DESCRIPTION
## Context

`dotnet build` emitted **17 warnings, all RASK022** ("rendered in a list without a Key"); the build was otherwise clean. All sites were in test and benchmark projects.

## Change

Adopt a stable `Key:` at every flagged site (the analyzer's intended fix) so the diff codec reconciles by identity instead of position:

- **tests** — loop/projection indices as keys in `FrameDifferTests`, `ValidationMessageTests`, `NestedBindingValidationTests`, and `OrderedDispatchApp` (buttons never reorder there, so the positional dispatch-ordering assertion is unaffected).
- **benchmarks** — `Key: i` on loop-built rows. For `DataAttributesBenchmarks` the existing `rask-key` `Data` entry is lifted to `Key:` (Key supersedes it; rendered output stays byte-identical).

Benchmark byte/serialization baselines shift slightly upward (extra `data-rask-key` per keyed row) — expected, not asserted anywhere.

## Verification

- `dotnet build` → **0 warnings, 0 errors** (was 17).
- Full unit suite (E2E excluded) → all green.