### PR TITLE
Remove redundant (Child) casts, ToString() calls, and Fragment() shells

### DIFF
--- a/samples/Rask.Example.Shared/Demos/BindingDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/BindingDemos.cs
@@ -202,7 +202,7 @@ public sealed class BindingAfterBindDemo : Component
                     () => _model.City,
                     Id: "bind-after-city",
                     Class: "form-select")[
-                    _cities.Select(c => Option(c)[c])
+                    _cities.Select(c => Option(c, Key: c)[c])
                 ]
             ],
             Pre(Class: "small mb-0 p-3 bg-light border rounded")[
@@ -295,7 +295,7 @@ public sealed class BindingAfterBindAsyncDemo : Component
                     Disabled: _loading || _languages.Length == 0)[
                     _languages.Length == 0
                         ? [Option("")["— pick a track —"]]
-                        : _languages.Select(l => Option(l)[l])
+                        : _languages.Select(l => Option(l, Key: l)[l])
                 ]
             ],
             Pre(Class: "small mb-0 p-3 bg-light border rounded")[

--- a/samples/Rask.Example.Shared/Demos/LiveTicker.cs
+++ b/samples/Rask.Example.Shared/Demos/LiveTicker.cs
@@ -205,8 +205,8 @@ public sealed class LiveTicker : Component
                 ],
                 Div(Class: "d-flex align-items-baseline gap-3 mb-3")[
                     _history.Count == 0
-                        ? (Child)Span(Class: "fs-3 text-secondary", Id: "ticker-price")["Waiting for first tick…"]
-                        : (Child)Span(Class: "fs-2 fw-bold", Id: "ticker-price")[
+                        ? Span(Class: "fs-3 text-secondary", Id: "ticker-price")["Waiting for first tick…"]
+                        : Span(Class: "fs-2 fw-bold", Id: "ticker-price")[
                             $"${current.ToString("N2", CultureInfo.InvariantCulture)}"],
                     _history.Count > 1
                         ? Span(Class: $"fs-6 fw-semibold {changeClass}", Id: "ticker-change")[
@@ -224,7 +224,7 @@ public sealed class LiveTicker : Component
                 Div(Class: "ticker-chart-container", Id: "ticker-chart",
                     Style: "position: relative; height: 160px;")[
                     _history.Count == 0
-                        ? (Child)P(Class: "text-secondary small mb-0")["Waiting for first tick…"]
+                        ? P(Class: "text-secondary small mb-0")["Waiting for first tick…"]
                         : Sparkline(
                             Values: _history.Select(p => (double)p.PriceUsd).ToList(),
                             Class: "ticker-chart-svg")

--- a/samples/Rask.Example.Shared/Demos/ValidationDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/ValidationDemos.cs
@@ -71,8 +71,8 @@ public sealed class ValidationSummaryDemo : Component
             Ul(Class: "mb-0 ps-3")[
                 entries.Select((e, i) => Li(Key: i)[
                     e.Field.Length == 0
-                        ? (Child)e.Message
-                        : (Child)Fragment()[Strong()[e.Field], ": ", e.Message]
+                        ? e.Message
+                        : Fragment()[Strong()[e.Field], ": ", e.Message]
                 ])
             ]
         ];
@@ -574,8 +574,8 @@ public sealed class CrossFieldSummaryDemo : Component
                 Ul(Class: "mb-0 ps-3")[
                     entries.Select((e, i) => Li(Key: i)[
                         e.Field.Length == 0
-                            ? (Child)e.Message
-                            : (Child)Fragment()[Strong()[e.Field], ": ", e.Message]
+                            ? e.Message
+                            : Fragment()[Strong()[e.Field], ": ", e.Message]
                     ])
                 ]
             ];

--- a/samples/Rask.Example.Shared/Pages/BoomPage.cs
+++ b/samples/Rask.Example.Shared/Pages/BoomPage.cs
@@ -82,7 +82,7 @@ public sealed class BoomPage : Component
                         // Intentionally bypass the factory: RenderThrower is [SkipFactory] and
                         // exists only to demonstrate that a descendant whose Render() throws is
                         // caught by the enclosing ErrorBoundary.
-                        _throwOnRender ? (Child)new RenderThrower() : Text(string.Empty)
+                        _throwOnRender ? new RenderThrower() : Text(string.Empty)
 #pragma warning restore RASK014
                     ]
                 ]),

--- a/samples/Rask.Example.Shared/Pages/CancellationPage.cs
+++ b/samples/Rask.Example.Shared/Pages/CancellationPage.cs
@@ -47,9 +47,9 @@ public sealed class CancellationPage : Component
                     _log.Count == 0
                         ? P(Class: "text-secondary small mb-0")["Mount and unmount the probe to populate this log."]
                         : Ol(Class: "list-group list-group-numbered list-group-flush cancel-log")[_log.Select(line =>
-                            (Child)Li(
+                            Li(
                                 Key: line,
-                                Class: "list-group-item ps-2 small")[Code(Class: "small")[line]]).ToArray()]
+                                Class: "list-group-item ps-2 small")[Code(Class: "small")[line]])]
                 ]
             ],
             H2(Class: "h4 mt-4 mb-3")["Source"],

--- a/samples/Rask.Example.Shared/Pages/TablePage.cs
+++ b/samples/Rask.Example.Shared/Pages/TablePage.cs
@@ -136,16 +136,16 @@ public sealed class TablePage(Navigator nav) : Component
                         ],
                         Tbody()[
                             totalFiltered == 0
-                                ? (Child)Tr()[
+                                ? Tr()[
                                     Td(6, Class: "text-center text-secondary py-4")[
                                         I(Class: "bi bi-search me-2"),
                                         "No people match your search."
                                     ]
                                 ]
-                                : (Child)Fragment()[
+                                : Fragment()[
                                     visible.Select(p =>
-                                        (Child)Tr(Key: p.Id)[
-                                            Td(Class: "text-secondary")[p.Id.ToString()],
+                                        Tr(Key: p.Id)[
+                                            Td(Class: "text-secondary")[p.Id],
                                             Td(Class: "fw-semibold")[p.Name],
                                             Td()[p.City],
                                             Td()[
@@ -166,8 +166,8 @@ public sealed class TablePage(Navigator nav) : Component
                             ? "Showing 0 of 0"
                             : $"Showing {from}–{to} of {totalFiltered}",
                         filter.Length > 0
-                            ? (Child)Span(Class: "ms-1")[$"(filtered from {_people.Length} total)"]
-                            : (Child)Fragment()
+                            ? Span(Class: "ms-1")[$"(filtered from {_people.Length} total)"]
+                            : Fragment()
                     ],
                     Nav()[
                         Ul(Class: "pagination pagination-sm mb-0")[BuildPagination(page, totalPages)]
@@ -311,7 +311,7 @@ public sealed class TablePage(Navigator nav) : Component
                 "button",
                 Class: "page-link",
                 OnClick: () => nav.SetQuery("page", n.ToString()))[
-                n.ToString()
+                n
             ]
         ];
     }

--- a/samples/Rask.Example.Shared/Pages/VirtualizePage.cs
+++ b/samples/Rask.Example.Shared/Pages/VirtualizePage.cs
@@ -68,7 +68,7 @@ public sealed class VirtualizePage : Component
                         ],
                         Tbody()[
                             ctx.VisibleItems.Select(item =>
-                                (Child)Tr(
+                                Tr(
                                     Style: $"height:{ctx.ItemSize}px;",
                                     // data-rask-key engages the morph algorithm's keyed
                                     // reconciliation path: scrolling the window moves the
@@ -123,7 +123,7 @@ public sealed class VirtualizePage : Component
                         ],
                         Tbody()[
                             ctx.VisibleItems.Select(item =>
-                                (Child)Tr(
+                                Tr(
                                     Style: $"height:{ctx.ItemSize}px;",
                                     Data: new Dictionary<string, string?>
                                     {
@@ -131,7 +131,7 @@ public sealed class VirtualizePage : Component
                                         ["rask-key"] = item.Index.ToString(),
                                         ["placeholder"] = item.IsPlaceholder ? "true" : null
                                     })[
-                                    Td()[item.IsPlaceholder ? "—" : item.Value!.Index.ToString()],
+                                    Td()[item.IsPlaceholder ? "—" : item.Value!.Index],
                                     Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
                                     Td()[item.IsPlaceholder ? "—" : item.Value!.City],
                                     Td(Style: "text-align:right;")[item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -194,7 +194,7 @@ public sealed class Select : Element
         }
 
         var newChildren = og.Children.Select(c =>
-            c.Component is Option o ? (Child)MarkOption(o, current) : c).ToArray();
+            c.Component is Option o ? MarkOption(o, current) : c).ToArray();
         return new Optgroup
         {
             Disabled = og.Disabled,

--- a/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
@@ -91,7 +91,11 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         //    and `(Child)` cast wrapping it. Its converted type tells us it becomes a sibling Child.
         var outer = ClimbToChildExpression(invocation);
         var typeInfo = model.GetTypeInfo(outer, context.CancellationToken);
-        if (!IsChild(typeInfo.Type, child) && !IsChild(typeInfo.ConvertedType, child))
+        var isChildLike =
+            IsChild(typeInfo.Type, child) || IsChild(typeInfo.ConvertedType, child)
+            || InheritsFrom(typeInfo.Type as INamedTypeSymbol, component)
+            || InheritsFrom(typeInfo.ConvertedType as INamedTypeSymbol, component);
+        if (!isChildLike)
         {
             return;
         }

--- a/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
+++ b/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
@@ -52,7 +52,7 @@ public class ValidationMessageTests
         var view = new StubComponent(() => Form(Context: ctx, Model: p)[
             ValidationSummary(entries =>
                 Ul(Class: "validation-summary")[
-                    entries.Select((e, i) => (Child)Li(Key: i)[e.Message]).ToArray()
+                    entries.Select((e, i) => Li(Key: i)[e.Message])
                 ])
         ]);
         var html = view.RenderAsLiveRoot();

--- a/tests/Rask.Core.Tests/Components/VirtualizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/VirtualizeTests.cs
@@ -198,8 +198,8 @@ public class VirtualizeTests
         var view = new StubComponent(() => Virtualize(
             ctx => Div()[
                 ctx.VisibleItems.Select(item =>
-                    (Child)Div(Data: new Dictionary<string, string?> { ["rask-key"] = item.Index.ToString() })[
-                        item.Value!.ToString()])
+                    Div(Data: new Dictionary<string, string?> { ["rask-key"] = item.Index.ToString() })[
+                        item.Value!])
             ],
             items,
             ItemSize: 20,

--- a/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
+++ b/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
@@ -121,7 +121,7 @@ public class NestedBindingValidationTests
             Input(() => p.Address.Street,
                 _ => new[] { "model-plus-context" }),
             ValidationMessage(() => p.Address.Street,
-                msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Class: "err", Key: i)[m])])
+                msgs => Fragment()[msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -220,7 +220,7 @@ public class NestedBindingValidationTests
                     return v == "99999" ? new[] { "We don't ship to this area." } : Array.Empty<string>();
                 }),
             ValidationMessage(() => m.Address.PostalCode,
-                msgs => Fragment()[msgs.Select((s, i) => (Child)Div(Class: "err", Key: i)[s])])
+                msgs => Fragment()[msgs.Select((s, i) => Div(Class: "err", Key: i)[s])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -272,7 +272,7 @@ public class NestedBindingValidationTests
                     return v == "99999" ? new[] { "We don't ship to this area." } : Array.Empty<string>();
                 }),
             ValidationMessage(() => m.Address.PostalCode,
-                msgs => Fragment()[msgs.Select((s, i) => (Child)Div(Class: "err", Key: i)[s])])
+                msgs => Fragment()[msgs.Select((s, i) => Div(Class: "err", Key: i)[s])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -369,7 +369,7 @@ public class NestedBindingValidationTests
                 v =>
                     string.IsNullOrEmpty(v) ? new[] { "street required" } : Array.Empty<string>()),
             ValidationMessage(() => p.Address.Street,
-                msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Class: "err", Key: i)[m])])
+                msgs => Fragment()[msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();
@@ -395,7 +395,7 @@ public class NestedBindingValidationTests
                 v =>
                     v.Length < 3 ? new[] { "too short" } : Array.Empty<string>()),
             ValidationMessage(() => p.Address.Street,
-                msgs => Fragment()[msgs.Select((m, i) => (Child)Div(Class: "err", Key: i)[m])])
+                msgs => Fragment()[msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
@@ -100,7 +100,7 @@ public class HeadAssetRenderTests
         public PageShell(Component body) => _body = body;
 
         protected override RenderResult Render() =>
-            Fragment()[
+            [
                 Doctype(),
                 Html("en")[
                     // Head() is framework-managed: the serializer auto-inserts the
@@ -126,7 +126,7 @@ public class HeadAssetRenderTests
         protected override RenderResult Head => Title()[_title];
 
         protected override RenderResult Render() =>
-            Fragment()[
+            [
                 Doctype(),
                 Html("en")[
                     // Head() is framework-managed: the serializer auto-inserts the

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -340,12 +340,12 @@ public class FrameDifferTests
         // walk. Mirrors the morph engine's all-or-nothing keyed detection so the diff
         // codec doesn't disagree with the client about which path applied.
         var before = Frames(C.Ul()[
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one"],
-            (Child)C.Li()["two"]
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one"],
+            C.Li()["two"]
         ]);
         var afterFrames = Frames(C.Ul()[
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one!"],
-            (Child)C.Li()["two"]
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one!"],
+            C.Li()["two"]
         ]);
 
         var ops = new List<EditOp>();
@@ -362,12 +362,12 @@ public class FrameDifferTests
     public void Diff_KeyedList_DuplicateKeys_FallsBackToPositional()
     {
         var before = Frames(C.Ul()[
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a"],
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a"],
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
         ]);
         var afterFrames = Frames(C.Ul()[
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a!"],
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a!"],
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
         ]);
 
         var ops = new List<EditOp>();
@@ -385,10 +385,10 @@ public class FrameDifferTests
         // treats this as a fresh node: remove the old, insert the new at the same slot.
         // Both ops carry Trusted so the gate ships them as diff.
         var before = Frames(C.Ul()[
-            (Child)C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["original"]
+            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["original"]
         ]);
         var (afterFrames, afterHtml) = FramesAndHtml(C.Ul()[
-            (Child)C.Span(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["replaced"]
+            C.Span(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["replaced"]
         ]);
 
         var ops = new List<EditOp>();

--- a/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
@@ -30,7 +30,7 @@ public class MissingKeyAnalyzerTests
     public async Task SelectProjection_NoKey_ReportsRask022()
     {
         var d = Assert.Single(await Diagnostics(App(
-            "return Ul()[ _items.Select(i => (Child)Li()[i.ToString()]) ];")));
+            "return Ul()[ _items.Select(i => Li()[i.ToString()]) ];")));
         Assert.Equal("RASK022", d.Id);
         Assert.Contains("Li", d.GetMessage());
     }
@@ -51,14 +51,14 @@ public class MissingKeyAnalyzerTests
     public async Task SelectProjection_WithKey_NoDiagnostic()
     {
         Assert.Empty(await Diagnostics(App(
-            "return Ul()[ _items.Select(i => (Child)Li(Key: i)[i.ToString()]) ];")));
+            "return Ul()[ _items.Select(i => Li(Key: i)[i.ToString()]) ];")));
     }
 
     [Fact]
     public async Task SelectProjection_WithDataRaskKey_NoDiagnostic()
     {
         Assert.Empty(await Diagnostics(App("""
-            return Ul()[ _items.Select(i => (Child)Li(
+            return Ul()[ _items.Select(i => Li(
                 Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[i.ToString()]) ];
             """)));
     }
@@ -79,7 +79,7 @@ public class MissingKeyAnalyzerTests
         // Li is the projected list item (flagged once); the nested Code is Li's child, not a
         // sibling in the reconciled list, so it must NOT be flagged.
         var d = Assert.Single(await Diagnostics(App(
-            "return Ul()[ _items.Select(i => (Child)Li()[ Code()[i.ToString()] ]) ];")));
+            "return Ul()[ _items.Select(i => Li()[ Code()[i.ToString()] ]) ];")));
         Assert.Contains("Li", d.GetMessage());
     }
 

--- a/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
@@ -11,7 +11,7 @@ namespace Rask.Server.Tests.Authentication;
 public sealed class SignInTestApp(AuthSignIn auth, RouteState routeState) : Component
 {
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["auth-test"]],
                 new Body()[new H1()[$"path={routeState.Path}"],

--- a/tests/Rask.Server.Tests/Endpoints/RuntimeScriptInjectionTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/RuntimeScriptInjectionTests.cs
@@ -57,14 +57,14 @@ public sealed class RuntimeScriptInjectionTests
     private sealed class ShellApp(RouteState routeState) : Component
     {
         protected override RenderResult Render() =>
-            Fragment()[Doctype(), new Html()[new Head(), new Body()[new H1()[$"path={routeState.Path}"]]]];
+            [Doctype(), new Html()[new Head(), new Body()[new H1()[$"path={routeState.Path}"]]]];
     }
 
     // Legacy tree that still contains the (now no-op) RaskRuntimeScript().
     private sealed class LegacyShellApp(RouteState routeState) : Component
     {
         protected override RenderResult Render() =>
-            Fragment()[Doctype(), new Html()[new Head(),
+            [Doctype(), new Html()[new Head(),
                 new Body()[new H1()[$"path={routeState.Path}"], RaskRuntimeScript()]]];
     }
 }

--- a/tests/Rask.Server.Tests/Infrastructure/AsyncValidationApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/AsyncValidationApp.cs
@@ -25,7 +25,7 @@ public sealed class AsyncValidationApp : Component
     }
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()["async-validation"]],

--- a/tests/Rask.Server.Tests/Infrastructure/CheckboxJsInvokeApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/CheckboxJsInvokeApp.cs
@@ -19,7 +19,7 @@ public sealed class CheckboxJsInvokeApp(IJSRuntime js) : Component
         await js.InvokeVoidAsync("test.noop", firstRender);
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()["checkbox"]],

--- a/tests/Rask.Server.Tests/Infrastructure/JsInvokeBindingApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/JsInvokeBindingApp.cs
@@ -22,7 +22,7 @@ public sealed class JsInvokeBindingApp(IJSRuntime js) : Component
         await js.InvokeVoidAsync("test.noop", firstRender);
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()["js-invoke-binding"]],

--- a/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
@@ -38,10 +38,10 @@ public sealed class KeyedNavApp : Component
                 new Body()[
                     new H1()[$"path={_route.Path} count={_items.Count}"],
                     Ul()[
-                        _items.Select(i => (Child)Li(
+                        _items.Select(i => Li(
                             Class: "row",
                             Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[
-                            $"item {i}"]).ToArray()
+                            $"item {i}"])
                     ]
                 ]
             ]

--- a/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
@@ -31,7 +31,7 @@ public sealed class KeyedNavApp : Component
     }
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()["keyed-nav"]],

--- a/tests/Rask.Server.Tests/Infrastructure/NavigateInHandlerStateHasChangedApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/NavigateInHandlerStateHasChangedApp.cs
@@ -27,7 +27,7 @@ public sealed class NavigateInHandlerStateHasChangedApp : Component
     protected override void OnUnmount() => _routeState.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()["nav-coalesce"]],

--- a/tests/Rask.Server.Tests/Infrastructure/NoOpApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/NoOpApp.cs
@@ -13,7 +13,7 @@ public sealed class NoOpApp : Component
     public int Hidden;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["noop"]],
                 new Body()[new H1()["static"],

--- a/tests/Rask.Server.Tests/Infrastructure/OrderedDispatchApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/OrderedDispatchApp.cs
@@ -21,7 +21,7 @@ public sealed class OrderedDispatchApp : Component
     public string Sequence { get; private set; } = "";
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()["ordered-dispatch"]],

--- a/tests/Rask.Server.Tests/Infrastructure/RouteTitleNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RouteTitleNavApp.cs
@@ -22,7 +22,7 @@ public sealed class RouteTitleNavApp : Component
     protected override void OnUnmount() => _routeState.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()[$"t-{_routeState.Path}"]],

--- a/tests/Rask.Server.Tests/Infrastructure/RouteTitleStructuralNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RouteTitleStructuralNavApp.cs
@@ -22,7 +22,7 @@ public sealed class RouteTitleStructuralNavApp : Component
     protected override void OnUnmount() => _routeState.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[
                 new Head()[new Title()[$"t-{_routeState.Path}"]],

--- a/tests/Rask.Server.Tests/Infrastructure/TestApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/TestApp.cs
@@ -14,7 +14,7 @@ public sealed class TestApp : Component
     public TestApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["test"]],
                 new Body()[new H1()[$"path={_routeState.Path}"],

--- a/tests/Rask.Server.Tests/Infrastructure/ThrowingApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/ThrowingApp.cs
@@ -10,7 +10,7 @@ public sealed class ThrowingApp : Component
     public int Counter;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["throw"]],
                 new Body()[new P()[$"count={Counter}"],

--- a/tests/Rask.Server.Tests/JSInterop/RaskJSRuntimeTests.cs
+++ b/tests/Rask.Server.Tests/JSInterop/RaskJSRuntimeTests.cs
@@ -229,7 +229,7 @@ internal sealed class JsRoundTripApp : Component
     }
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]];
 
@@ -265,7 +265,7 @@ internal sealed class JsClickApp : Component
     }
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["t"]],
                 new Body()[
@@ -290,7 +290,7 @@ internal sealed class JsRenderStormApp : Component
     }
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]];
 
@@ -313,7 +313,7 @@ internal sealed class JsErrorApp : Component
     }
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]];
 

--- a/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
@@ -275,7 +275,7 @@ public class NestedValidationTests
             DataAnnotationsValidator(),
             Input(() => p.Address!.Street),
             ValidationMessage(() => p.Address!.Street,
-                msgs => Fragment()[msgs.Select(m => Div(Class: "err")[m])])
+                msgs => Fragment()[msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();

--- a/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
@@ -275,7 +275,7 @@ public class NestedValidationTests
             DataAnnotationsValidator(),
             Input(() => p.Address!.Street),
             ValidationMessage(() => p.Address!.Street,
-                msgs => Fragment()[msgs.Select(m => (Child)Div(Class: "err")[m])])
+                msgs => Fragment()[msgs.Select(m => Div(Class: "err")[m])])
         ]);
 
         var initial = view.RenderAsLiveRoot();

--- a/tests/Rask.Wasm.Tests/Infrastructure/ReactiveTitleStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/ReactiveTitleStubApp.cs
@@ -14,7 +14,7 @@ internal sealed class ReactiveTitleStubApp : Component
     private int _count;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             Html()[
                 Head()[Title()[$"count-{_count}"]],

--- a/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStructuralStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStructuralStubApp.cs
@@ -17,7 +17,7 @@ internal sealed class RouteTitleStructuralStubApp : Component
     public RouteTitleStructuralStubApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             Html()[
                 Head()[Title()[$"title-{_routeState.Path}"]],

--- a/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStubApp.cs
@@ -16,7 +16,7 @@ internal sealed class RouteTitleStubApp : Component
     public RouteTitleStubApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             Html()[
                 Head()[Title()[$"title-{_routeState.Path}"]],

--- a/tests/Rask.Wasm.Tests/Infrastructure/StubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/StubApp.cs
@@ -14,7 +14,7 @@ internal sealed class StubApp : Component
     public StubApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             Html()[
                 Head()[Title()["stub"]],

--- a/tests/Rask.Wasm.Tests/Infrastructure/ThrowingStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/ThrowingStubApp.cs
@@ -8,7 +8,7 @@ namespace Rask.Wasm.Tests.Infrastructure;
 internal sealed class ThrowingStubApp : Component
 {
     protected override RenderResult Render() =>
-        Fragment()[
+        [
             Doctype(),
             Html()[
                 Head()[Title()["throw"]],

--- a/tests/Rask.Wasm.Tests/Session/DownloadTokenPullTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DownloadTokenPullTests.cs
@@ -93,7 +93,7 @@ public class DownloadTokenPullTests : ResettingTestBase
         }
 
         protected override RenderResult Render() =>
-            Fragment()[
+            [
                 Doctype(),
                 Html()[
                     Head()[Title()["dl"]],

--- a/tests/Rask.Wasm.Tests/Session/ScopedStylesAbsenceTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/ScopedStylesAbsenceTests.cs
@@ -57,7 +57,7 @@ public class ScopedStylesAbsenceTests : ResettingTestBase
         protected override RenderResult Head => Title()["wasm-stub"];
 
         protected override RenderResult Render() =>
-            Fragment()[
+            [
                 Doctype(),
                 Html()[
                     Head(),


### PR DESCRIPTION
Cleanup that leans on existing framework affordances to drop boilerplate, plus the analyzer change that makes the cast removal safe.

## What changed

**1. Redundant `(Child)` casts removed** — the children indexer's `IEnumerable<Component>` overload and C# target-typed conditional expressions make explicit casts unnecessary:
- `.Select(...)` projections returning `Component` route through the indexer's `IEnumerable<Component>` overload (now-redundant trailing `.ToArray()` dropped too).
- Ternary children target-type each branch to `Child` (the params element type).
- Literal-list `Component` elements convert implicitly per argument.

**2. Redundant `.ToString()` removed** — parameterless `.ToString()` in child position where the value type has an implicit `Child` conversion (`p.Id`, page numbers, `item.Value!.Index`, …). Format-arg (`"N0"`, `"yyyy-MM-dd"`) and `?? ""`-coalescing calls are kept.

**3. `MissingKeyAnalyzer` (RASK022) broadened — the enabler.** The casts in `.Select(...)` projections were *load-bearing* for RASK022: the analyzer gated on the projected expression typing as `Child`, which only happened because of the cast. Removing casts would have silently disabled the warning for the most common keyless-list idiom. The analyzer now also accepts a `Component`-typed projection body, so cast-free `.Select(i => Li()[...])` is still flagged. Three keyless projections this surfaced (`BindingDemos` `Option` lists, a DataAnnotations test) get `Key:`.

**4. `Fragment()` shells converted to collection expressions** — `Render() => Fragment()[Doctype(), Html(...)]` → `Render() => [Doctype(), Html(...)]`. `RenderResult`'s `[CollectionBuilder]` wraps the items in a Fragment, so output is identical (the documented modern idiom). `Fragment()` is kept where genuinely needed: empty `Fragment()` as a "render nothing" ternary branch, and `Fragment()[...]` collapsing a sequence/multiple children into a single `Child` for a ternary branch, a `Component`-typed argument, or a helper returning `Component`.

## Verification
- `dotnet build` succeeds, no `CS` errors, no RASK022 warnings (outside pre-existing benchmark projects).
- Full non-E2E suite: **1985 passed, 0 failed** (1 pre-existing skip), including 125 generator/analyzer tests covering the cast-free RASK022 detection.