### PR TITLE
Make non-nullable value-type factory params required

### DIFF
--- a/src/Rask.Core/Components/Audio.cs
+++ b/src/Rask.Core/Components/Audio.cs
@@ -7,10 +7,10 @@ public sealed class Audio : Element
     protected override string TagName => "audio";
 
     public string? Src { get; set; }
-    public bool Controls { get; set; }
-    public bool Autoplay { get; set; }
-    public bool Loop { get; set; }
-    public bool Muted { get; set; }
+    public bool? Controls { get; set; }
+    public bool? Autoplay { get; set; }
+    public bool? Loop { get; set; }
+    public bool? Muted { get; set; }
     public string? Preload { get; set; }
     public string? CrossOrigin { get; set; }
 
@@ -22,22 +22,22 @@ public sealed class Audio : Element
             AppendAttr(sb, "src", Src);
         }
 
-        if (Controls)
+        if (Controls is true)
         {
             AppendAttr(sb, "controls", null);
         }
 
-        if (Autoplay)
+        if (Autoplay is true)
         {
             AppendAttr(sb, "autoplay", null);
         }
 
-        if (Loop)
+        if (Loop is true)
         {
             AppendAttr(sb, "loop", null);
         }
 
-        if (Muted)
+        if (Muted is true)
         {
             AppendAttr(sb, "muted", null);
         }

--- a/src/Rask.Core/Components/Button.cs
+++ b/src/Rask.Core/Components/Button.cs
@@ -8,7 +8,7 @@ public sealed class Button : Element
     protected override string TagName => "button";
 
     public string? Type { get; set; }
-    public bool Disabled { get; set; }
+    public bool? Disabled { get; set; }
     public string? Name { get; set; }
     public string? Value { get; set; }
     public Action? OnClick { get; set; }
@@ -22,7 +22,7 @@ public sealed class Button : Element
             AppendAttr(sb, "type", Type);
         }
 
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }

--- a/src/Rask.Core/Components/Details.cs
+++ b/src/Rask.Core/Components/Details.cs
@@ -6,12 +6,12 @@ public sealed class Details : Element
 {
     protected override string TagName => "details";
 
-    public bool Open { get; set; }
+    public bool? Open { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Open)
+        if (Open is true)
         {
             AppendAttr(sb, "open", null);
         }

--- a/src/Rask.Core/Components/Dialog.cs
+++ b/src/Rask.Core/Components/Dialog.cs
@@ -6,12 +6,12 @@ public sealed class Dialog : Element
 {
     protected override string TagName => "dialog";
 
-    public bool Open { get; set; }
+    public bool? Open { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Open)
+        if (Open is true)
         {
             AppendAttr(sb, "open", null);
         }

--- a/src/Rask.Core/Components/Fieldset.cs
+++ b/src/Rask.Core/Components/Fieldset.cs
@@ -6,14 +6,14 @@ public sealed class Fieldset : Element
 {
     protected override string TagName => "fieldset";
 
-    public bool Disabled { get; set; }
+    public bool? Disabled { get; set; }
     public string? Form { get; set; }
     public string? Name { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }

--- a/src/Rask.Core/Components/Form.cs
+++ b/src/Rask.Core/Components/Form.cs
@@ -29,7 +29,7 @@ public sealed class Form : Element
     public string? Target { get; set; }
     public string? AcceptCharset { get; set; }
     public string? Autocomplete { get; set; }
-    public bool Novalidate { get; set; }
+    public bool? Novalidate { get; set; }
     public string? Name { get; set; }
     public Action<FormData>? OnSubmit { get; set; }
 
@@ -185,7 +185,7 @@ public sealed class Form : Element
             AppendAttr(sb, "autocomplete", Autocomplete);
         }
 
-        if (Novalidate)
+        if (Novalidate is true)
         {
             AppendAttr(sb, "novalidate", null);
         }

--- a/src/Rask.Core/Components/Img.cs
+++ b/src/Rask.Core/Components/Img.cs
@@ -19,7 +19,7 @@ public sealed class Img : Element
     public string? ReferrerPolicy { get; set; }
     public string? Decoding { get; set; }
     public string? UseMap { get; set; }
-    public bool Ismap { get; set; }
+    public bool? Ismap { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
@@ -79,7 +79,7 @@ public sealed class Img : Element
             AppendAttr(sb, "usemap", UseMap);
         }
 
-        if (Ismap)
+        if (Ismap is true)
         {
             AppendAttr(sb, "ismap", null);
         }

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -17,10 +17,10 @@ public sealed class Input : Element
     public string? Name { get; set; }
     public string? Value { get; set; }
     public string? Placeholder { get; set; }
-    public bool Required { get; set; }
-    public bool Disabled { get; set; }
-    public bool ReadOnly { get; set; }
-    public bool Checked { get; set; }
+    public bool? Required { get; set; }
+    public bool? Disabled { get; set; }
+    public bool? ReadOnly { get; set; }
+    public bool? Checked { get; set; }
     public string? Min { get; set; }
     public string? Max { get; set; }
     public string? Step { get; set; }
@@ -28,16 +28,16 @@ public sealed class Input : Element
     public int? Size { get; set; }
     public int? MaxLength { get; set; }
     public int? MinLength { get; set; }
-    public bool Multiple { get; set; }
+    public bool? Multiple { get; set; }
     public string? Accept { get; set; }
     public string? Alt { get; set; }
     public string? Autocomplete { get; set; }
-    public bool Autofocus { get; set; }
+    public bool? Autofocus { get; set; }
     public string? Form { get; set; }
     public string? FormAction { get; set; }
     public string? FormEnctype { get; set; }
     public string? FormMethod { get; set; }
-    public bool FormNovalidate { get; set; }
+    public bool? FormNovalidate { get; set; }
     public string? FormTarget { get; set; }
     public string? List { get; set; }
     public string? Src { get; set; }
@@ -245,22 +245,22 @@ public sealed class Input : Element
             AppendAttr(sb, "placeholder", Placeholder);
         }
 
-        if (Required)
+        if (Required is true)
         {
             AppendAttr(sb, "required", null);
         }
 
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }
 
-        if (ReadOnly)
+        if (ReadOnly is true)
         {
             AppendAttr(sb, "readonly", null);
         }
 
-        if (Checked)
+        if (Checked is true)
         {
             AppendAttr(sb, "checked", null);
         }
@@ -300,7 +300,7 @@ public sealed class Input : Element
             AppendAttr(sb, "minlength", MinLength.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        if (Multiple)
+        if (Multiple is true)
         {
             AppendAttr(sb, "multiple", null);
         }
@@ -320,7 +320,7 @@ public sealed class Input : Element
             AppendAttr(sb, "autocomplete", Autocomplete);
         }
 
-        if (Autofocus)
+        if (Autofocus is true)
         {
             AppendAttr(sb, "autofocus", null);
         }
@@ -345,7 +345,7 @@ public sealed class Input : Element
             AppendAttr(sb, "formmethod", FormMethod);
         }
 
-        if (FormNovalidate)
+        if (FormNovalidate is true)
         {
             AppendAttr(sb, "formnovalidate", null);
         }

--- a/src/Rask.Core/Components/Link.cs
+++ b/src/Rask.Core/Components/Link.cs
@@ -16,7 +16,7 @@ public sealed class Link : Element
     public string? As { get; set; }
     public string? CrossOrigin { get; set; }
     public string? ReferrerPolicy { get; set; }
-    public bool Disabled { get; set; }
+    public bool? Disabled { get; set; }
     public string? Color { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
@@ -67,7 +67,7 @@ public sealed class Link : Element
             AppendAttr(sb, "referrerpolicy", ReferrerPolicy);
         }
 
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }

--- a/src/Rask.Core/Components/NavLink.cs
+++ b/src/Rask.Core/Components/NavLink.cs
@@ -19,8 +19,8 @@ public sealed class NavLink : Element
     // factory generator. To opt out of active styling, pass an empty string.
     public string? ActiveClass { get; set; }
 
-    // default(NavLinkMatch) == Exact (enum's 0th value), so no initializer is needed here.
-    public NavLinkMatch ActiveMatch { get; set; }
+    // Optional: null is treated as Exact (the default match mode).
+    public NavLinkMatch? ActiveMatch { get; set; }
 
     protected override void OnMount()
     {
@@ -82,7 +82,7 @@ public sealed class NavLink : Element
             return false;
         }
 
-        return ActiveMatch switch
+        return (ActiveMatch ?? NavLinkMatch.Exact) switch
         {
             NavLinkMatch.Exact => MatchExact(route, Href.Value.Path, Href.Value.QueryString),
             NavLinkMatch.Prefix => MatchPrefix(route.Path, Href.Value.Path),

--- a/src/Rask.Core/Components/Ol.cs
+++ b/src/Rask.Core/Components/Ol.cs
@@ -8,7 +8,7 @@ public sealed class Ol : Element
     protected override string TagName => "ol";
 
     public string? Type { get; set; }
-    public bool Reversed { get; set; }
+    public bool? Reversed { get; set; }
     public int? Start { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
@@ -19,7 +19,7 @@ public sealed class Ol : Element
             AppendAttr(sb, "type", Type);
         }
 
-        if (Reversed)
+        if (Reversed is true)
         {
             AppendAttr(sb, "reversed", null);
         }

--- a/src/Rask.Core/Components/Optgroup.cs
+++ b/src/Rask.Core/Components/Optgroup.cs
@@ -6,13 +6,13 @@ public sealed class Optgroup : Element
 {
     protected override string TagName => "optgroup";
 
-    public bool Disabled { get; set; }
+    public bool? Disabled { get; set; }
     public string? Label { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }

--- a/src/Rask.Core/Components/Option.cs
+++ b/src/Rask.Core/Components/Option.cs
@@ -7,8 +7,8 @@ public sealed class Option : Element
     protected override string TagName => "option";
 
     public string? Value { get; set; }
-    public bool Selected { get; set; }
-    public bool Disabled { get; set; }
+    public bool? Selected { get; set; }
+    public bool? Disabled { get; set; }
     public string? Label { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
@@ -19,12 +19,12 @@ public sealed class Option : Element
             AppendAttr(sb, "value", Value);
         }
 
-        if (Selected)
+        if (Selected is true)
         {
             AppendAttr(sb, "selected", null);
         }
 
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }

--- a/src/Rask.Core/Components/Script.cs
+++ b/src/Rask.Core/Components/Script.cs
@@ -8,11 +8,11 @@ public sealed class Script : Element
 
     public string? Src { get; set; }
     public string? Type { get; set; }
-    public bool Async { get; set; }
-    public bool Defer { get; set; }
+    public bool? Async { get; set; }
+    public bool? Defer { get; set; }
     public string? CrossOrigin { get; set; }
     public string? Integrity { get; set; }
-    public bool NoModule { get; set; }
+    public bool? NoModule { get; set; }
     public string? ReferrerPolicy { get; set; }
     public string? Charset { get; set; }
 
@@ -29,12 +29,12 @@ public sealed class Script : Element
             AppendAttr(sb, "type", Type);
         }
 
-        if (Async)
+        if (Async is true)
         {
             AppendAttr(sb, "async", null);
         }
 
-        if (Defer)
+        if (Defer is true)
         {
             AppendAttr(sb, "defer", null);
         }
@@ -49,7 +49,7 @@ public sealed class Script : Element
             AppendAttr(sb, "integrity", Integrity);
         }
 
-        if (NoModule)
+        if (NoModule is true)
         {
             AppendAttr(sb, "nomodule", null);
         }

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -12,12 +12,12 @@ public sealed class Select : Element
     protected override string TagName => "select";
 
     public string? Name { get; set; }
-    public bool Multiple { get; set; }
-    public bool Required { get; set; }
-    public bool Disabled { get; set; }
+    public bool? Multiple { get; set; }
+    public bool? Required { get; set; }
+    public bool? Disabled { get; set; }
     public int? Size { get; set; }
     public string? Form { get; set; }
-    public bool Autofocus { get; set; }
+    public bool? Autofocus { get; set; }
     public string? Autocomplete { get; set; }
     public Action<string>? OnChange { get; set; }
 
@@ -167,7 +167,7 @@ public sealed class Select : Element
 
     private static Option MarkOption(Option opt, string current)
     {
-        if (opt.Selected || opt.Value != current)
+        if (opt.Selected is true || opt.Value != current)
         {
             return opt;
         }
@@ -215,17 +215,17 @@ public sealed class Select : Element
             AppendAttr(sb, "name", Name);
         }
 
-        if (Multiple)
+        if (Multiple is true)
         {
             AppendAttr(sb, "multiple", null);
         }
 
-        if (Required)
+        if (Required is true)
         {
             AppendAttr(sb, "required", null);
         }
 
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }
@@ -240,7 +240,7 @@ public sealed class Select : Element
             AppendAttr(sb, "form", Form);
         }
 
-        if (Autofocus)
+        if (Autofocus is true)
         {
             AppendAttr(sb, "autofocus", null);
         }

--- a/src/Rask.Core/Components/Textarea.cs
+++ b/src/Rask.Core/Components/Textarea.cs
@@ -15,13 +15,13 @@ public sealed class Textarea : Element
     public int? Rows { get; set; }
     public int? Cols { get; set; }
     public string? Placeholder { get; set; }
-    public bool Required { get; set; }
-    public bool Disabled { get; set; }
-    public bool ReadOnly { get; set; }
+    public bool? Required { get; set; }
+    public bool? Disabled { get; set; }
+    public bool? ReadOnly { get; set; }
     public int? MaxLength { get; set; }
     public int? MinLength { get; set; }
     public string? Wrap { get; set; }
-    public bool Autofocus { get; set; }
+    public bool? Autofocus { get; set; }
     public string? Autocomplete { get; set; }
     public string? Form { get; set; }
     public string? Dirname { get; set; }
@@ -175,17 +175,17 @@ public sealed class Textarea : Element
             AppendAttr(sb, "placeholder", Placeholder);
         }
 
-        if (Required)
+        if (Required is true)
         {
             AppendAttr(sb, "required", null);
         }
 
-        if (Disabled)
+        if (Disabled is true)
         {
             AppendAttr(sb, "disabled", null);
         }
 
-        if (ReadOnly)
+        if (ReadOnly is true)
         {
             AppendAttr(sb, "readonly", null);
         }
@@ -205,7 +205,7 @@ public sealed class Textarea : Element
             AppendAttr(sb, "wrap", Wrap);
         }
 
-        if (Autofocus)
+        if (Autofocus is true)
         {
             AppendAttr(sb, "autofocus", null);
         }

--- a/src/Rask.Core/Components/Track.cs
+++ b/src/Rask.Core/Components/Track.cs
@@ -11,7 +11,7 @@ public sealed class Track : Element
     public string? Src { get; set; }
     public string? Srclang { get; set; }
     public string? Label { get; set; }
-    public bool Default { get; set; }
+    public bool? Default { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
@@ -36,7 +36,7 @@ public sealed class Track : Element
             AppendAttr(sb, "label", Label);
         }
 
-        if (Default)
+        if (Default is true)
         {
             AppendAttr(sb, "default", null);
         }

--- a/src/Rask.Core/Components/Video.cs
+++ b/src/Rask.Core/Components/Video.cs
@@ -11,13 +11,13 @@ public sealed class Video : Element
     public string? Poster { get; set; }
     public int? Width { get; set; }
     public int? Height { get; set; }
-    public bool Controls { get; set; }
-    public bool Autoplay { get; set; }
-    public bool Loop { get; set; }
-    public bool Muted { get; set; }
+    public bool? Controls { get; set; }
+    public bool? Autoplay { get; set; }
+    public bool? Loop { get; set; }
+    public bool? Muted { get; set; }
     public string? Preload { get; set; }
     public string? CrossOrigin { get; set; }
-    public bool PlaysInline { get; set; }
+    public bool? PlaysInline { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
@@ -42,22 +42,22 @@ public sealed class Video : Element
             AppendAttr(sb, "height", Height.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        if (Controls)
+        if (Controls is true)
         {
             AppendAttr(sb, "controls", null);
         }
 
-        if (Autoplay)
+        if (Autoplay is true)
         {
             AppendAttr(sb, "autoplay", null);
         }
 
-        if (Loop)
+        if (Loop is true)
         {
             AppendAttr(sb, "loop", null);
         }
 
-        if (Muted)
+        if (Muted is true)
         {
             AppendAttr(sb, "muted", null);
         }
@@ -72,7 +72,7 @@ public sealed class Video : Element
             AppendAttr(sb, "crossorigin", CrossOrigin);
         }
 
-        if (PlaysInline)
+        if (PlaysInline is true)
         {
             AppendAttr(sb, "playsinline", null);
         }

--- a/src/Rask.Core/Components/Virtualize.cs
+++ b/src/Rask.Core/Components/Virtualize.cs
@@ -48,12 +48,12 @@ public sealed class Virtualize : Component
     public Delegate? ItemsProvider { get; set; }
 
     public int ItemSize { get; set; }
-    public int OverscanCount { get; set; }
+    public int? OverscanCount { get; set; }
 
     // Pre-scroll initial viewport guess. Drives the first render's window size before any
     // scroll event has arrived to set _clientHeight. Should be the scrollable container's
     // approximate visible height in px.
-    public int InitialClientHeight { get; set; }
+    public int? InitialClientHeight { get; set; }
 
     // The render fragment. Called with the type-erased VirtualizationState every render;
     // returns the user's chosen root Component for the virtualized region. Stored under the
@@ -135,8 +135,8 @@ public sealed class Virtualize : Component
         var itemSize = ItemSize;
         var clientHeight = _clientHeight > 0
             ? _clientHeight
-            : Math.Max(InitialClientHeight, itemSize);
-        var overscan = Math.Max(0, OverscanCount);
+            : Math.Max(InitialClientHeight ?? 0, itemSize);
+        var overscan = Math.Max(0, OverscanCount ?? 0);
 
         int totalCount;
         if (Items is not null)

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -526,12 +526,6 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                                  || (prop.Type.IsValueType && prop.Type.OriginalDefinition.SpecialType ==
                                      SpecialType.System_Nullable_T);
 
-                // Non-nullable value types (bool, int, enums, etc.) carry an implicit `default(T)`
-                // — emit them as optional factory parameters with `default` as the literal default
-                // rather than forcing the caller to pass a value. Matches the hand-written facade
-                // pattern where `bool Disabled = false`, `int Width = 0`, etc.
-                var hasImplicitDefault = !isNullable && prop.Type.IsValueType;
-
                 var typeFqn = prop.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
                     .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
                                               | SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
@@ -542,7 +536,6 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                     isNullable,
                     hasInitializer,
                     prop.IsRequired,
-                    hasImplicitDefault,
                     depth,
                     filePath,
                     spanStart,
@@ -596,14 +589,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             return "null";
         }
 
-        if (p.HasImplicitDefault)
-        {
-            // Value type: `default` is `false` / `0` / first enum value — same shape the
-            // hand-written facade used (e.g. `bool Disabled = false`).
-            return "default";
-        }
-
-        // Defensive: should not be called for non-nullable reference properties (they're required).
+        // Defensive: should not be called for non-nullable properties (value or reference) without
+        // an initializer — they're required factory parameters with no default.
         return "default";
     }
 
@@ -704,7 +691,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             : typeFqn;
 
     private static bool IsRequiredFactoryParam(PropInfo p) =>
-        !p.IsNullable && !p.HasInitializer && !p.HasImplicitDefault;
+        !p.IsNullable && !p.HasInitializer;
 
     private static bool IsParamProperty(PropInfo p) =>
         !p.HasInitializer; // properties with initializers are excluded entirely
@@ -1274,7 +1261,6 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         bool IsNullable,
         bool HasInitializer,
         bool UserMarkedRequired,
-        bool HasImplicitDefault,
         int InheritanceDepth,
         string DeclaringFilePath,
         int DeclaringSpanStart,

--- a/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
@@ -341,8 +341,10 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Widget(int Count = default, object? Key = null)", output);
+        // Non-nullable value type with no initializer is a required factory parameter (no default).
+        Assert.Contains("Widget(int Count, object? Key = null)", output);
         Assert.DoesNotContain("Count = null", output);
+        Assert.DoesNotContain("Count = default", output);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Makes the component factory generator rule uniform: **only nullable properties are optional; any non-nullable property without an initializer is required.**

Previously a non-nullable value type (`bool`/`int`/enum) without an initializer became an *optional* parameter defaulting to `default(T)` — only non-nullable reference types were required. This removes that value-type exception.

To keep the HTML element library ergonomic, the attributes that relied on the implicit-default behavior are migrated to nullable so they stay optional:
- bool attributes → `bool?` (rendered when `is true`) across `Audio`, `Button`, `Details`, `Dialog`, `Fieldset`, `Form`, `Img`, `Input`, `Link`, `Ol`, `Optgroup`, `Option`, `Script`, `Select`, `Textarea`, `Track`, `Video`
- `NavLink.ActiveMatch` → `NavLinkMatch?` (null ≡ `Exact`)
- `Virtualize.OverscanCount` / `InitialClientHeight` → `int?`
- `Virtualize.ItemSize` stays non-nullable and is now genuinely **required** (it is validated `> 0` and has no sensible default)

Because `bool` binds implicitly to `bool?`, existing factory call sites keep compiling unchanged.

## Changes
- `ComponentFactoryGenerator`: required test is now `!IsNullable && !HasInitializer` (dropped the `HasImplicitDefault` path).
- 18 component files migrated to nullable attributes as above.
- `ComponentFactoryGeneratorTests.ValueTypeNonNullable_IsRequired` updated to assert the required signature `Widget(int Count, object? Key = null)`.

## Verification
- `dotnet build` — clean
- Unit tests — all pass (Core 1346, Generators 125, Server 116, + rest)
- E2E — 442/442
- `dotnet publish -c Release` (WASM sample) — zero IL/trim warnings