### PR TITLE
Swallow browser-abort fetch in HttpClient demo on fast refresh

### DIFF
--- a/samples/Rask.Example.Shared/Pages/HttpPage.cs
+++ b/samples/Rask.Example.Shared/Pages/HttpPage.cs
@@ -19,6 +19,11 @@ public sealed class HttpPage(HttpClient http) : Component
     {
         try { _post = await http.GetFromJsonAsync("data/posts-1.json", HttpJsonContext.Default.Post, CancellationToken); }
         catch (OperationCanceledException) { }
+        // On WASM a hard browser refresh kills the in-flight fetch outside the
+        // AbortController, so it surfaces as an HttpRequestException with no StatusCode
+        // ("TypeError: Load failed") rather than an OperationCanceledException. That's a
+        // teardown artifact, not a real error — ignore it like a cancellation.
+        catch (HttpRequestException ex) when (ex.StatusCode is null) { }
         catch (Exception ex) { _error = ex.Message; }
     }
 

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -4,6 +4,19 @@
     var root = document.querySelector("[data-rask-root]");
     if (!root) return;
 
+    // Serializes render application across messages. A navigation diff may defer its
+    // body swap until the new page's scoped CSS loads (applyHeadThenWaitForCss), which
+    // opens a microtask/timer gap during which the next WS message could arrive. Both
+    // the diff and full-HTML paths chain through this tail promise so a deferred body
+    // always commits before the following message's ops — paths in a later diff are
+    // computed against the render this one produces, so they must not be applied first.
+    var _renderQueue = Promise.resolve();
+    // Hard cap on how long a navigation diff defers the body swap waiting for a newly
+    // mounted page's scoped stylesheet to load. A warm content-addressed
+    // /_rask/a/{hash}.css load resolves in a few ms; the cap only ever applies to a
+    // genuinely slow/failed sheet, where we'd rather show the page than stall nav.
+    var CSS_FOUC_GUARD_MS = 500;
+
     // Read once from an explicit <base href> element so the runtime can host
     // under a sub-path like /appA/ on a reverse proxy without the .NET side ever
     // seeing the prefix. Resolves to the directory portion of the base href.
@@ -74,113 +87,17 @@
                 location.reload();
                 return;
             }
-            // Diff-mode payload (kind:"diff"): apply ops directly against the live
-            // DOM instead of morphing a fresh document. Wire format matches
-            // LivePayload.BuildPayloadUtf8Diff (C# side). Each op carries a Path
-            // (sequence of childNodes indices from the document root) and an op-
-            // specific payload. Falls through to history/auth/download handling
-            // afterwards so navigation + side effects still flow.
+            // Diff-mode payload (kind:"diff"): apply ops directly against the live DOM.
+            // Both render paths chain through _renderQueue so a diff that defers its body
+            // for a scoped-CSS load (see applyDiffReply) can't be overtaken by the next
+            // message — paths in a later diff are computed against this render's output.
             if (data.kind === "diff" && Array.isArray(data.ops)) {
-                applyDiff(data.ops, Array.isArray(data.names) ? data.names : null);
-                // The head isn't in the diff frame stream (user Head contributions are
-                // collected + spliced server-side), so a head change rides the payload as a
-                // <head> fragment. Morph it into document.head — keyed reconciliation
-                // (data-rask-key) keeps unchanged scoped-CSS links so there's no flash — then
-                // re-scan so newly-added scoped <script>/<link> feed the Rask.* invoke gate.
-                if (typeof data.head === "string") {
-                    var freshHead = new DOMParser().parseFromString(data.head, "text/html").head;
-                    if (freshHead) morph(document.head, freshHead);
-                    scanHeadAssets();
-                }
-                if (data.history && typeof data.history.url === "string") {
-                    var diffTarget = prependBase(data.history.url);
-                    if (data.history.action === "replace") {
-                        history.replaceState({rask: true}, "", diffTarget);
-                    } else {
-                        history.pushState({rask: true}, "", diffTarget);
-                    }
-                }
-                // Fire-and-forget IJSRuntime invokes now ride the diff payload too
-                // (e.g. a scoped-JS OnRenderedAsync hook). Drain them via the same
-                // dispatchJsInvoke path the full-HTML branch uses so the Rask.*
-                // per-namespace deferral queue keeps working on the diff path.
-                if (Array.isArray(data.jsInvokes)) {
-                    for (var ji = 0; ji < data.jsInvokes.length; ji++) {
-                        dispatchJsInvoke(data.jsInvokes[ji]);
-                    }
-                }
-                if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
+                _renderQueue = _renderQueue.then(function () { return applyDiffReply(data); },
+                                                 function () { return applyDiffReply(data); });
                 return;
             }
-            var freshHtml = null;
-            if (typeof data.html === "string") {
-                var doc = new DOMParser().parseFromString(data.html, "text/html");
-                // Morph the whole <html> element so head changes (title, per-page Head
-                // asset contributions, scoped-css/scoped-js hash bumps) propagate too.
-                // Server now sends the full document via BuildPayloadUtf8WithRoot —
-                // matching the WASM runtime's morph target.
-                freshHtml = doc.documentElement;
-            }
-            // All post-morph work (history push, scoped CSS/JS apply, scoped-JS
-            // dispatch, raskAfterMorph hook) runs inside the applyDom callback so
-            // dispatch reads the freshly-morphed DOM rather than the pre-morph one.
-            function applyDom() {
-                if (freshHtml) {
-                    morph(document.documentElement, freshHtml);
-                    root = document.querySelector("[data-rask-root]") || root;
-                    // Pick up any newly-inserted Head-declared external assets
-                    // (e.g., a page-specific Script in Component.Head) so their
-                    // load events feed into the Rask.* invoke gate.
-                    scanHeadAssets();
-                }
-                if (data.history && typeof data.history.url === "string") {
-                    var fullTarget = prependBase(data.history.url);
-                    if (data.history.action === "replace") {
-                        history.replaceState({rask: true}, "", fullTarget);
-                    } else {
-                        history.pushState({rask: true}, "", fullTarget);
-                    }
-                }
-                // Scoped CSS/JS arrives in the rendered HTML as
-                // <link href="/_rask/a/{hash}.css"> / <script src="/_rask/a/{hash}.js" defer>
-                // tags, served by the per-component asset endpoint and morphed into <head>
-                // by the standard keyed-morph path. No payload-side cssHash/jsHash anymore.
-
-                // IJSRuntime.InvokeAsync<T> dispatch: each entry resolves a dotted
-                // identifier on `window` (e.g. `sessionStorage.getItem` or
-                // `Rask.{TypeName}.{method}`), invokes it with the JSON-decoded args,
-                // and ships the result back as a jsResult message keyed by taskId.
-                // Rask.*-prefixed identifiers are deferred via dispatchJsInvoke's
-                // pendingScopedInvokes queue until the scoped-JS bundle has loaded.
-                if (Array.isArray(data.jsInvokes)) {
-                    for (var ji = 0; ji < data.jsInvokes.length; ji++) {
-                        dispatchJsInvoke(data.jsInvokes[ji]);
-                    }
-                }
-                // dotNetResult: reply to a JS-initiated DotNet.invokeMethodAsync call.
-                // Routed by the DotNet shim's pending-call table to resolve/reject
-                // the matching JS Promise.
-                if (data.type === "dotNetResult" && typeof data.callId === "string") {
-                    window.DotNet._endInvokeDotNet(data);
-                }
-                if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
-            }
-
-            applyDom();
-            // Out-of-band frames carry no html — process the supplemental fields and
-            // bail before any morph-related work runs.
-            if (data.type === "dotNetResult" && typeof data.callId === "string"
-                && typeof data.html !== "string") {
-                window.DotNet._endInvokeDotNet(data);
-                return;
-            }
-            if (data.auth && typeof data.auth.ticket === "string") {
-                redeemAuthTicket(data.auth);
-            }
-            if (data.download && typeof data.download.url === "string"
-                && typeof data.download.filename === "string") {
-                triggerDownload(data.download.url, data.download.filename);
-            }
+            _renderQueue = _renderQueue.then(function () { return applyFullReply(data); },
+                                             function () { return applyFullReply(data); });
         });
 
         ws.addEventListener("close", scheduleReconnect);
@@ -336,6 +253,123 @@
 
     function headAssetsReady() {
         return pendingHeadAssets.size === 0;
+    }
+
+    // Morph the incoming <head> into the live one, then return a Promise that resolves
+    // once every *newly added* stylesheet has reached a terminal state (load / error /
+    // CSS_FOUC_GUARD_MS timeout). On a navigation diff the body ops must not be applied
+    // until the new page's scoped CSS (<link href="/_rask/a/{hash}.css">) is in place,
+    // or the freshly-swapped body paints unstyled for a beat (FOUC). Stylesheets already
+    // present + loaded before the morph — the warm-cache case — are skipped via
+    // isAssetAlreadyLoaded, so a return of null means "nothing to wait for, apply the
+    // body synchronously" and warm navigations keep today's instant timing.
+    function applyHeadThenWaitForCss(freshHead) {
+        var before = new Set();
+        document.head.querySelectorAll('link[rel="stylesheet"]').forEach(function (l) {
+            if (l.href && isAssetAlreadyLoaded(l.href)) before.add(l.href);
+        });
+        morph(document.head, freshHead);
+        var pending = [];
+        document.head.querySelectorAll('link[rel="stylesheet"]').forEach(function (l) {
+            if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
+            pending.push(new Promise(function (resolve) {
+                var done = function () { resolve(); };
+                l.addEventListener("load", done, {once: true});
+                l.addEventListener("error", done, {once: true});
+                setTimeout(done, CSS_FOUC_GUARD_MS);
+            }));
+        });
+        return pending.length ? Promise.all(pending) : null;
+    }
+
+    // Diff-mode render application (wire format matches LivePayload.BuildPayloadUtf8Diff).
+    // The head rides the payload as a <head> fragment (user Head contributions are
+    // collected + spliced server-side, so they're not in the frame stream). Morph the
+    // head FIRST — keyed reconciliation (data-rask-key) keeps unchanged scoped-CSS links —
+    // and when the new page adds a not-yet-cached scoped stylesheet, defer the body ops
+    // until it loads so the swapped body never paints unstyled (FOUC). Returns the wait
+    // Promise so _renderQueue holds the next message until the body has committed.
+    function applyDiffReply(data) {
+        var applyBody = function () {
+            // Each op carries a Path (childNodes indices from the document root) and an
+            // op-specific payload.
+            applyDiff(data.ops, Array.isArray(data.names) ? data.names : null);
+            if (data.history && typeof data.history.url === "string") {
+                var diffTarget = prependBase(data.history.url);
+                if (data.history.action === "replace") {
+                    history.replaceState({rask: true}, "", diffTarget);
+                } else {
+                    history.pushState({rask: true}, "", diffTarget);
+                }
+            }
+            // Re-scan so newly-added scoped <script>/<link> feed the Rask.* invoke gate.
+            scanHeadAssets();
+            // Fire-and-forget IJSRuntime invokes ride the diff payload too (e.g. a
+            // scoped-JS OnRenderedAsync hook); drain them via the same dispatchJsInvoke
+            // path the full-HTML branch uses so the per-namespace deferral keeps working.
+            if (Array.isArray(data.jsInvokes)) {
+                for (var ji = 0; ji < data.jsInvokes.length; ji++) {
+                    dispatchJsInvoke(data.jsInvokes[ji]);
+                }
+            }
+            if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
+        };
+        if (typeof data.head === "string") {
+            var freshHead = new DOMParser().parseFromString(data.head, "text/html").head;
+            var wait = freshHead ? applyHeadThenWaitForCss(freshHead) : null;
+            if (wait) return wait.then(applyBody);
+        }
+        applyBody();
+    }
+
+    // Full-document render application: morph the whole <html> element so head changes
+    // (title, per-page Head asset contributions, scoped-css/scoped-js hash bumps)
+    // propagate atomically with the body — no FOUC, so no CSS wait needed here.
+    function applyFullReply(data) {
+        var freshHtml = null;
+        if (typeof data.html === "string") {
+            var doc = new DOMParser().parseFromString(data.html, "text/html");
+            freshHtml = doc.documentElement;
+        }
+        if (freshHtml) {
+            morph(document.documentElement, freshHtml);
+            root = document.querySelector("[data-rask-root]") || root;
+            // Pick up any newly-inserted Head-declared external assets (e.g., a
+            // page-specific Script in Component.Head) so their load events feed the gate.
+            scanHeadAssets();
+        }
+        if (data.history && typeof data.history.url === "string") {
+            var fullTarget = prependBase(data.history.url);
+            if (data.history.action === "replace") {
+                history.replaceState({rask: true}, "", fullTarget);
+            } else {
+                history.pushState({rask: true}, "", fullTarget);
+            }
+        }
+        if (Array.isArray(data.jsInvokes)) {
+            for (var ji = 0; ji < data.jsInvokes.length; ji++) {
+                dispatchJsInvoke(data.jsInvokes[ji]);
+            }
+        }
+        // dotNetResult: reply to a JS-initiated DotNet.invokeMethodAsync call, routed by
+        // the DotNet shim's pending-call table to resolve/reject the matching JS Promise.
+        if (data.type === "dotNetResult" && typeof data.callId === "string") {
+            window.DotNet._endInvokeDotNet(data);
+        }
+        if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
+        // Out-of-band frames carry no html — process supplemental fields and bail.
+        if (data.type === "dotNetResult" && typeof data.callId === "string"
+            && typeof data.html !== "string") {
+            window.DotNet._endInvokeDotNet(data);
+            return;
+        }
+        if (data.auth && typeof data.auth.ticket === "string") {
+            redeemAuthTicket(data.auth);
+        }
+        if (data.download && typeof data.download.url === "string"
+            && typeof data.download.filename === "string") {
+            triggerDownload(data.download.url, data.download.filename);
+        }
     }
 
     function maybeDrainPendingInvokes() {

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -6,6 +6,14 @@ let dotnetExports = null;
 let root = null;
 let basePath = null;
 
+// Serializes render application across payloads. A navigation diff may defer its
+// body swap until the new page's scoped CSS loads (applyHeadThenWaitForCss), which
+// opens a microtask/timer gap during which .NET could deliver the next render. Both
+// the diff and full-HTML paths chain through this tail promise so a deferred body
+// always commits before the following payload's ops — paths in a later diff are
+// computed against the render this one produces, so they must not be applied first.
+let _renderQueue = Promise.resolve();
+
 // scopedJsReady starts true: per-component scripts ship as
 // <script src="/_rask/a/{hash}.js" defer> tags in the initial HTML's <head> (and
 // are morphed in/out as components mount/unmount). The browser's defer semantics
@@ -50,6 +58,12 @@ const HEAD_ASSET_LOAD_TIMEOUT_MS = 5000;
 // (404) still surfaces fast: its <script> fires an 'error' event that drains the gate
 // immediately, so the long window only ever applies to a slow-but-loading asset.
 const SCOPED_ASSET_LOAD_TIMEOUT_MS = 30000;
+// Hard cap on how long a navigation diff defers the body swap waiting for a newly
+// mounted page's scoped stylesheet to load (see applyHeadThenWaitForCss). A warm,
+// content-addressed /_rask/a/{hash}.css load resolves in a few ms; the cap only ever
+// applies to a genuinely slow/failed sheet, where we'd rather show the (briefly
+// unstyled) page than stall navigation.
+const CSS_FOUC_GUARD_MS = 500;
 
 function isAssetAlreadyLoaded(url) {
     if (!url || !window.performance || !performance.getEntriesByName) return false;
@@ -121,6 +135,33 @@ function scanHeadAssets() {
 
 function headAssetsReady() {
     return pendingHeadAssets.size === 0;
+}
+
+// Morph the incoming <head> into the live one, then return a Promise that resolves
+// once every *newly added* stylesheet has reached a terminal state (load / error /
+// CSS_FOUC_GUARD_MS timeout). On a navigation diff the body ops must not be applied
+// until the new page's scoped CSS (<link href="/_rask/a/{hash}.css">) is in place,
+// or the freshly-swapped body paints unstyled for a beat (FOUC). Stylesheets already
+// present + loaded before the morph — the warm-cache case — are skipped via
+// isAssetAlreadyLoaded, so a return of null means "nothing to wait for, apply the
+// body synchronously" and warm navigations keep today's instant timing.
+function applyHeadThenWaitForCss(freshHead) {
+    const before = new Set();
+    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
+        if (l.href && isAssetAlreadyLoaded(l.href)) before.add(l.href);
+    });
+    morph(document.head, freshHead);
+    const pending = [];
+    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
+        if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
+        pending.push(new Promise((resolve) => {
+            const done = () => resolve();
+            l.addEventListener("load", done, {once: true});
+            l.addEventListener("error", done, {once: true});
+            setTimeout(done, CSS_FOUC_GUARD_MS);
+        }));
+    });
+    return pending.length ? Promise.all(pending) : null;
 }
 
 function maybeDrainPendingInvokes() {
@@ -770,29 +811,42 @@ function applyDiff(ops, names) {
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
-    // Diff-mode payload: apply ops directly against the live DOM. Still flow
-    // history below so SPA navigation continues to work alongside the diff.
+    // Diff-mode payload: apply ops directly against the live DOM. Both paths chain
+    // through _renderQueue so a diff that defers its body for a CSS load can't be
+    // overtaken by the next payload (see _renderQueue).
     if (reply.kind === "diff" && Array.isArray(reply.ops)) {
+        _renderQueue = _renderQueue.then(() => applyDiffReply(reply), () => applyDiffReply(reply));
+        return;
+    }
+    _renderQueue = _renderQueue.then(() => applyFullReply(reply), () => applyFullReply(reply));
+}
+
+function applyDiffReply(reply) {
+    // The head isn't in the diff frame stream (user Head contributions are collected +
+    // spliced render-side), so a head change rides the payload as a <head> fragment.
+    // Morph it into document.head FIRST — keyed reconciliation (data-rask-key) keeps
+    // unchanged scoped-CSS links, and morph skips data-rask-managed boot bundles so they
+    // survive. When the new page adds a not-yet-cached scoped stylesheet, defer the body
+    // ops until it loads so the swapped body never paints unstyled (FOUC).
+    const applyBody = () => {
         applyDiff(reply.ops, Array.isArray(reply.names) ? reply.names : null);
-        // The head isn't in the diff frame stream (user Head contributions are collected +
-        // spliced render-side), so a head change rides the payload as a <head> fragment.
-        // Morph it into document.head — keyed reconciliation (data-rask-key) keeps unchanged
-        // scoped-CSS links so there's no flash, and morph skips data-rask-managed boot
-        // bundles so they survive. The scanHeadAssets() below then tracks any new assets.
-        if (typeof reply.head === "string") {
-            const freshHead = new DOMParser().parseFromString(reply.head, "text/html").head;
-            if (freshHead) morph(document.head, freshHead);
-        }
         applyHistory(reply.history);
         // A diff can insert Head-declared external <script>/<link> and scoped-JS tags
         // (keyed InsertSubtree). Track them so their load events feed the Rask.* invoke
-        // gate, then drain anything now unblocked — the full-HTML morph path (applyDom)
-        // does the same after morph().
+        // gate, then drain anything now unblocked — the full-HTML morph path does the same.
         scanHeadAssets();
         maybeDrainPendingInvokes();
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
-        return;
+    };
+    if (typeof reply.head === "string") {
+        const freshHead = new DOMParser().parseFromString(reply.head, "text/html").head;
+        const wait = freshHead ? applyHeadThenWaitForCss(freshHead) : null;
+        if (wait) return wait.then(applyBody);
     }
+    applyBody();
+}
+
+function applyFullReply(reply) {
     let freshHtml = null;
     if (typeof reply.html === "string" && reply.html.length > 0) {
         const doc = new DOMParser().parseFromString(reply.html, "text/html");

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -6,6 +6,14 @@ let dotnetExports = null;
 let root = null;
 let basePath = null;
 
+// Serializes render application across payloads. A navigation diff may defer its
+// body swap until the new page's scoped CSS loads (applyHeadThenWaitForCss), which
+// opens a microtask/timer gap during which .NET could deliver the next render. Both
+// the diff and full-HTML paths chain through this tail promise so a deferred body
+// always commits before the following payload's ops — paths in a later diff are
+// computed against the render this one produces, so they must not be applied first.
+let _renderQueue = Promise.resolve();
+
 // scopedJsReady starts true: per-component scripts ship as
 // <script src="/_rask/a/{hash}.js" defer> tags in the initial HTML's <head> (and
 // are morphed in/out as components mount/unmount). The browser's defer semantics
@@ -50,6 +58,12 @@ const HEAD_ASSET_LOAD_TIMEOUT_MS = 5000;
 // (404) still surfaces fast: its <script> fires an 'error' event that drains the gate
 // immediately, so the long window only ever applies to a slow-but-loading asset.
 const SCOPED_ASSET_LOAD_TIMEOUT_MS = 30000;
+// Hard cap on how long a navigation diff defers the body swap waiting for a newly
+// mounted page's scoped stylesheet to load (see applyHeadThenWaitForCss). A warm,
+// content-addressed /_rask/a/{hash}.css load resolves in a few ms; the cap only ever
+// applies to a genuinely slow/failed sheet, where we'd rather show the (briefly
+// unstyled) page than stall navigation.
+const CSS_FOUC_GUARD_MS = 500;
 
 function isAssetAlreadyLoaded(url) {
     if (!url || !window.performance || !performance.getEntriesByName) return false;
@@ -121,6 +135,33 @@ function scanHeadAssets() {
 
 function headAssetsReady() {
     return pendingHeadAssets.size === 0;
+}
+
+// Morph the incoming <head> into the live one, then return a Promise that resolves
+// once every *newly added* stylesheet has reached a terminal state (load / error /
+// CSS_FOUC_GUARD_MS timeout). On a navigation diff the body ops must not be applied
+// until the new page's scoped CSS (<link href="/_rask/a/{hash}.css">) is in place,
+// or the freshly-swapped body paints unstyled for a beat (FOUC). Stylesheets already
+// present + loaded before the morph — the warm-cache case — are skipped via
+// isAssetAlreadyLoaded, so a return of null means "nothing to wait for, apply the
+// body synchronously" and warm navigations keep today's instant timing.
+function applyHeadThenWaitForCss(freshHead) {
+    const before = new Set();
+    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
+        if (l.href && isAssetAlreadyLoaded(l.href)) before.add(l.href);
+    });
+    morph(document.head, freshHead);
+    const pending = [];
+    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
+        if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
+        pending.push(new Promise((resolve) => {
+            const done = () => resolve();
+            l.addEventListener("load", done, {once: true});
+            l.addEventListener("error", done, {once: true});
+            setTimeout(done, CSS_FOUC_GUARD_MS);
+        }));
+    });
+    return pending.length ? Promise.all(pending) : null;
 }
 
 function maybeDrainPendingInvokes() {
@@ -558,29 +599,42 @@ function applyDiff(ops, names) {
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
-    // Diff-mode payload: apply ops directly against the live DOM. Still flow
-    // history below so SPA navigation continues to work alongside the diff.
+    // Diff-mode payload: apply ops directly against the live DOM. Both paths chain
+    // through _renderQueue so a diff that defers its body for a CSS load can't be
+    // overtaken by the next payload (see _renderQueue).
     if (reply.kind === "diff" && Array.isArray(reply.ops)) {
+        _renderQueue = _renderQueue.then(() => applyDiffReply(reply), () => applyDiffReply(reply));
+        return;
+    }
+    _renderQueue = _renderQueue.then(() => applyFullReply(reply), () => applyFullReply(reply));
+}
+
+function applyDiffReply(reply) {
+    // The head isn't in the diff frame stream (user Head contributions are collected +
+    // spliced render-side), so a head change rides the payload as a <head> fragment.
+    // Morph it into document.head FIRST — keyed reconciliation (data-rask-key) keeps
+    // unchanged scoped-CSS links, and morph skips data-rask-managed boot bundles so they
+    // survive. When the new page adds a not-yet-cached scoped stylesheet, defer the body
+    // ops until it loads so the swapped body never paints unstyled (FOUC).
+    const applyBody = () => {
         applyDiff(reply.ops, Array.isArray(reply.names) ? reply.names : null);
-        // The head isn't in the diff frame stream (user Head contributions are collected +
-        // spliced render-side), so a head change rides the payload as a <head> fragment.
-        // Morph it into document.head — keyed reconciliation (data-rask-key) keeps unchanged
-        // scoped-CSS links so there's no flash, and morph skips data-rask-managed boot
-        // bundles so they survive. The scanHeadAssets() below then tracks any new assets.
-        if (typeof reply.head === "string") {
-            const freshHead = new DOMParser().parseFromString(reply.head, "text/html").head;
-            if (freshHead) morph(document.head, freshHead);
-        }
         applyHistory(reply.history);
         // A diff can insert Head-declared external <script>/<link> and scoped-JS tags
         // (keyed InsertSubtree). Track them so their load events feed the Rask.* invoke
-        // gate, then drain anything now unblocked — the full-HTML morph path (applyDom)
-        // does the same after morph().
+        // gate, then drain anything now unblocked — the full-HTML morph path does the same.
         scanHeadAssets();
         maybeDrainPendingInvokes();
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
-        return;
+    };
+    if (typeof reply.head === "string") {
+        const freshHead = new DOMParser().parseFromString(reply.head, "text/html").head;
+        const wait = freshHead ? applyHeadThenWaitForCss(freshHead) : null;
+        if (wait) return wait.then(applyBody);
     }
+    applyBody();
+}
+
+function applyFullReply(reply) {
     let freshHtml = null;
     if (typeof reply.html === "string" && reply.html.length > 0) {
         const doc = new DOMParser().parseFromString(reply.html, "text/html");

--- a/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
@@ -32,7 +32,10 @@ public sealed class HttpPageTests
     [Fact]
     public async Task OnMountAsync_HttpFailure_SetsErrorPath()
     {
-        var (http, _) = FakeHttp.Throwing(new HttpRequestException("boom"));
+        // A genuine HTTP-status failure carries a StatusCode and must still surface the
+        // error banner (the demo's error handling is a real feature).
+        var (http, _) = FakeHttp.Throwing(
+            new HttpRequestException("boom", inner: null, statusCode: HttpStatusCode.InternalServerError));
         var routeState = new RouteState { Path = "/http" };
         var services = TestServices.Default(http: http, routeState: routeState);
 
@@ -41,8 +44,26 @@ public sealed class HttpPageTests
         await Task.Delay(120);
         var html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
 
-        // Either error banner or loading spinner is acceptable as long as the page didn't throw.
-        Assert.True(html.Contains("alert-danger") || html.Contains("Loading"));
+        Assert.Contains("alert-danger", html);
+    }
+
+    [Fact]
+    public async Task OnMountAsync_BrowserAbort_DoesNotShowError()
+    {
+        // A hard browser refresh kills the in-flight fetch outside the AbortController, so it
+        // surfaces as an HttpRequestException with no StatusCode ("TypeError: Load failed").
+        // That's a teardown artifact and must not render the error banner.
+        var (http, _) = FakeHttp.Throwing(new HttpRequestException("TypeError: Load failed"));
+        var routeState = new RouteState { Path = "/http" };
+        var services = TestServices.Default(http: http, routeState: routeState);
+
+        new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        await Task.Delay(120);
+        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+
+        // No error banner — the swallowed abort leaves the page on its loading state.
+        Assert.DoesNotContain("alert-danger", html);
+        Assert.Contains("Loading", html);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

On the GitHub Pages WASM deploy, refreshing the **HttpClient + DI** page (`/http`, the "Inject and fetch" section) very fast sometimes shows a red alert box:

> **Error:** TypeError: Load failed

## Root cause

`HttpPage.OnMountAsync` fetches a static JSON file with `HttpClient.GetFromJsonAsync(..., CancellationToken)`. On WASM, `HttpClient` is backed by the browser `fetch`, and there are two distinct teardown paths:

- **Cooperative cancel** (navigate away in-app): `Component.CancellationToken` fires → `AbortController.abort()` → `OperationCanceledException` → already swallowed.
- **Hard browser refresh**: the browser kills the in-flight socket itself, *without* going through the AbortController. The fetch rejects with a JS `TypeError` ("Load failed" on WebKit, "Failed to fetch" on Chrome), surfaced by the .NET WASM HTTP handler as an `HttpRequestException` with **no `StatusCode`** (no HTTP response was ever received). That's *not* an `OperationCanceledException`, so it fell through to the generic `catch` and rendered as the error banner.

## Fix

Add `catch (HttpRequestException ex) when (ex.StatusCode is null) { }` before the generic catch, treating the transport-level failure like a cancellation. `StatusCode` is populated only when a response is received, so `null` ⇒ transport/connection failure (the refresh-abort case). Genuine 4xx/5xx failures carry a `StatusCode` and still surface the error banner; malformed JSON throws `JsonException` and is also still surfaced — the demo's error handling stays a real feature.

## Tests

- Updated `OnMountAsync_HttpFailure_SetsErrorPath` to throw a status-bearing exception (the old `HttpRequestException("boom")` has a null StatusCode and would now correctly be swallowed); assertion tightened to require `alert-danger`.
- Added `OnMountAsync_BrowserAbort_DoesNotShowError` covering the swallowed `TypeError: Load failed`-shaped exception — the page stays on its loading state with no error banner.

All 4 `HttpPageTests` pass.