### PR TITLE
Retry transient fetch failure on the HttpClient demo instead of hanging

### DIFF
--- a/samples/Rask.Example.Shared/Pages/HttpPage.cs
+++ b/samples/Rask.Example.Shared/Pages/HttpPage.cs
@@ -10,6 +10,9 @@ namespace Rask.Example.Shared.Pages;
 [ParentRoute(typeof(ShowcaseLayout))]
 public sealed class HttpPage(HttpClient http) : Component
 {
+    private const int MaxTransientRetries = 3;
+    private static readonly TimeSpan RetryDelay = TimeSpan.FromMilliseconds(150);
+
     private string? _error;
     private Post? _post;
 
@@ -17,14 +20,28 @@ public sealed class HttpPage(HttpClient http) : Component
 
     protected override async Task OnMountAsync()
     {
-        try { _post = await http.GetFromJsonAsync("data/posts-1.json", HttpJsonContext.Default.Post, CancellationToken); }
-        catch (OperationCanceledException) { }
-        // On WASM a hard browser refresh kills the in-flight fetch outside the
-        // AbortController, so it surfaces as an HttpRequestException with no StatusCode
-        // ("TypeError: Load failed") rather than an OperationCanceledException. That's a
-        // teardown artifact, not a real error — ignore it like a cancellation.
-        catch (HttpRequestException ex) when (ex.StatusCode is null) { }
-        catch (Exception ex) { _error = ex.Message; }
+        for (var attempt = 0; ; attempt++)
+        {
+            try
+            {
+                _post = await http.GetFromJsonAsync("data/posts-1.json", HttpJsonContext.Default.Post, CancellationToken);
+                return;
+            }
+            // Navigating away unmounts the page and cancels the token — the page is gone, nothing to show.
+            catch (OperationCanceledException) { return; }
+            // On WASM a hard browser refresh kills the in-flight fetch outside the AbortController, so it
+            // surfaces as an HttpRequestException with no StatusCode ("TypeError: Load failed") rather than
+            // an OperationCanceledException. The same null-status failure also fires transiently on the
+            // freshly-booted page when its first fetch races the discarded page's network teardown — so retry
+            // a few times and the page self-heals instead of hanging on the spinner forever.
+            catch (HttpRequestException ex) when (ex.StatusCode is null && attempt < MaxTransientRetries)
+            {
+                try { await Task.Delay(RetryDelay, CancellationToken); }
+                catch (OperationCanceledException) { return; }
+            }
+            // A real HTTP-status failure, or a transport failure that never recovers, surfaces the error banner.
+            catch (Exception ex) { _error = ex.Message; return; }
+        }
     }
 
     protected override RenderResult Render() =>

--- a/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Text;
 using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
@@ -48,22 +49,63 @@ public sealed class HttpPageTests
     }
 
     [Fact]
-    public async Task OnMountAsync_BrowserAbort_DoesNotShowError()
+    public async Task OnMountAsync_TransientTransportFailure_RetriesAndLoads()
     {
-        // A hard browser refresh kills the in-flight fetch outside the AbortController, so it
-        // surfaces as an HttpRequestException with no StatusCode ("TypeError: Load failed").
-        // That's a teardown artifact and must not render the error banner.
-        var (http, _) = FakeHttp.Throwing(new HttpRequestException("TypeError: Load failed"));
+        // A fast browser refresh produces a transport-level HttpRequestException with no
+        // StatusCode ("TypeError: Load failed") that can fire transiently on the surviving
+        // page when its first fetch races the discarded page's network teardown. The page
+        // must retry and self-heal rather than hang on the spinner — and must not flash the
+        // error banner for a failure that recovers.
+        const string body = "{\"id\":1,\"title\":\"hello\",\"body\":\"the body text\"}";
+        var attempts = 0;
+        var handler = new FakeHttp
+        {
+            Handler = _ => Interlocked.Increment(ref attempts) <= 1
+                ? throw new HttpRequestException("TypeError: Load failed")
+                : Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new StringContent(body, Encoding.UTF8, "application/json")
+                })
+        };
+        var http = new HttpClient(handler) { BaseAddress = new Uri("https://test.local/") };
         var routeState = new RouteState { Path = "/http" };
         var services = TestServices.Default(http: http, routeState: routeState);
 
-        new Rask.Example.Shared.App().RenderAsLiveRoot(services);
-        await Task.Delay(120);
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        // Re-render the SAME app instance: the retried fetch resolves on a continuation after
+        // the first render returns, and only the same HttpPage instance retains the result.
+        var app = new Rask.Example.Shared.App();
+        app.RenderAsLiveRoot(services);
+        await WaitFor.True(() => handler.RequestCount >= 2, TimeSpan.FromSeconds(2));
+        await Task.Delay(50);
+        var html = app.RenderAsLiveRoot(services);
 
-        // No error banner — the swallowed abort leaves the page on its loading state.
         Assert.DoesNotContain("alert-danger", html);
-        Assert.Contains("Loading", html);
+        Assert.Contains("the body text", html);
+    }
+
+    [Fact]
+    public async Task OnMountAsync_PersistentTransportFailure_ShowsErrorAfterRetries()
+    {
+        // A transport failure that never recovers (every attempt throws a null-status
+        // HttpRequestException) must surface the error banner once retries are exhausted —
+        // never leave the page spinning forever.
+        var (http, handler) = FakeHttp.Throwing(new HttpRequestException("TypeError: Load failed"));
+        var routeState = new RouteState { Path = "/http" };
+        var services = TestServices.Default(http: http, routeState: routeState);
+
+        // Re-render the SAME app instance so the retry loop's terminal error (set on a
+        // continuation) is observed; the loop makes MaxTransientRetries + 1 attempts then stops.
+        var app = new Rask.Example.Shared.App();
+        app.RenderAsLiveRoot(services);
+        await WaitFor.True(() => handler.RequestCount > 3, TimeSpan.FromSeconds(3));
+        await Task.Delay(50);
+        var html = app.RenderAsLiveRoot(services);
+
+        Assert.Contains("alert-danger", html);
+        // The spinner is gone — the page no longer hangs on the loading state.
+        // ("Loading…" still appears verbatim inside the page's code sample, so assert on the
+        // spinner-border indicator class instead.)
+        Assert.DoesNotContain("spinner-border", html);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

On the `/http` HttpClient demo, a fast browser refresh leaves the loading spinner spinning forever — the page hangs and never shows the post.

A hard refresh kills the in-flight fetch in `HttpPage.OnMountAsync` *outside* the `AbortController`, so it surfaces as an `HttpRequestException` with a **null** `StatusCode` ("TypeError: Load failed" on WebKit) rather than an `OperationCanceledException`. #28 added `catch (HttpRequestException ex) when (ex.StatusCode is null) { }` to drop the resulting error banner — but that same null-status failure also fires *transiently* on the **surviving** page when its first fetch races the discarded page load's network teardown. The swallow then leaves both `_post` and `_error` null, and since `OnMountAsync` runs exactly once with no retry, the spinner shows forever.

(The client-side render queue in `rask.js`/`rask.wasm.js` was ruled out: every deferred CSS wait resolves within the 500 ms `setTimeout` cap, and the WS message handler recovers from rejections, so the JS can't hang permanently.)

## Fix

Replace the blanket swallow in `HttpPage.OnMountAsync` with a bounded retry loop:

- A null-status transport failure retries up to 3 times (150 ms apart) so the page **self-heals** on the common transient case.
- Cancellation (navigation/unmount) returns quietly.
- A status-bearing failure, or a transport failure that never recovers, falls through to `_error` and surfaces the existing red banner — never a permanent spinner.

## Tests

- Replaced `OnMountAsync_BrowserAbort_DoesNotShowError` with `OnMountAsync_TransientTransportFailure_RetriesAndLoads` (fails once, then loads, no banner).
- Added `OnMountAsync_PersistentTransportFailure_ShowsErrorAfterRetries` — the direct regression guard for the hang (banner appears, `spinner-border` gone).
- Kept the status-failure and happy-path tests unchanged.

Both new tests re-render the **same** `App` instance, since the retried result is set on a continuation after the first render returns and only the same `HttpPage` instance retains it. The "not spinning" assertion targets the `spinner-border` class, not the word "Loading" (the page's code sample renders `"Loading…"` verbatim).

Full non-E2E suite green (0 failures across all 12 test projects).