### PR TITLE
Production authentication: Authorize component, hardening, runnable samples, templates & docs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,6 +40,14 @@
   <PropertyGroup>
     <_RaskInRepoImplicitUsings>false</_RaskInRepoImplicitUsings>
     <_RaskInRepoImplicitUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.')) ">true</_RaskInRepoImplicitUsings>
+    <!--
+      The validation packages inject their own global usings (Rask.Validation.* below). Downstream
+      consumers only get them by referencing the validation NuGet package; in-repo we'd otherwise force
+      every Rask.Example.* project to reference the validation libs just to satisfy the generated usings.
+      The auth samples (Rask.Example.Auth*) don't use validation, so skip those usings for them.
+    -->
+    <_RaskExampleValidationUsings>$(_RaskInRepoImplicitUsings)</_RaskExampleValidationUsings>
+    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) ">false</_RaskExampleValidationUsings>
   </PropertyGroup>
 
   <!--
@@ -60,8 +68,8 @@
   <Import Project="$(MSBuildThisFileDirectory)src\Rask.Wasm\build\Rask.Wasm.props"
           Condition=" '$(_RaskInRepoImplicitUsings)' == 'true' AND Exists('$(MSBuildThisFileDirectory)src\Rask.Wasm\build\Rask.Wasm.props') "/>
   <Import Project="$(MSBuildThisFileDirectory)src\Rask.Validation.DataAnnotations\build\Rask.Validation.DataAnnotations.props"
-          Condition=" '$(_RaskInRepoImplicitUsings)' == 'true' AND Exists('$(MSBuildThisFileDirectory)src\Rask.Validation.DataAnnotations\build\Rask.Validation.DataAnnotations.props') "/>
+          Condition=" '$(_RaskExampleValidationUsings)' == 'true' AND Exists('$(MSBuildThisFileDirectory)src\Rask.Validation.DataAnnotations\build\Rask.Validation.DataAnnotations.props') "/>
   <Import Project="$(MSBuildThisFileDirectory)src\Rask.Validation.FluentValidation\build\Rask.Validation.FluentValidation.props"
-          Condition=" '$(_RaskInRepoImplicitUsings)' == 'true' AND Exists('$(MSBuildThisFileDirectory)src\Rask.Validation.FluentValidation\build\Rask.Validation.FluentValidation.props') "/>
+          Condition=" '$(_RaskExampleValidationUsings)' == 'true' AND Exists('$(MSBuildThisFileDirectory)src\Rask.Validation.FluentValidation\build\Rask.Validation.FluentValidation.props') "/>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="ColorCode.HTML" Version="2.0.15" />
     <PackageVersion Include="coverlet.collector" Version="10.0.0" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.8" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.8" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="17.13.9" />

--- a/README.md
+++ b/README.md
@@ -349,10 +349,13 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
   binding, routing, JS interop, virtualization (a 10K-row table), file upload/download, and **auth gating** (the `/user`
   page shows both imperative `Component.User` and the declarative `Authorize` component). These are the canonical
   references cited throughout *Core concepts* below. For production auth flows see **[docs/authentication.md](docs/authentication.md)**.
-- **`samples/Rask.Example.Auth`** — a minimal, runnable **cookie-login** app: a `/login` form, a protected
-  `/members` page (`[Authorize]` + the `Authorize` component), role-gated admin content, and sign-out over the live
-  runtime. `dotnet run --project samples/Rask.Example.Auth` and visit `/members`. The full login round trip is covered
-  by a browser E2E (`AuthExampleTests`).
+- **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
+  (`/login`, protected `/members`, role-gated admin, sign-out) with a browser E2E:
+  - **`Rask.Example.Auth`** — cookie + Server (the redeem handshake).
+  - **`Rask.Example.Auth.Jwt`** — JWT + Server; the token rides in **`ProtectedSessionStorage`** (encrypted, never in the URL or JS).
+  - **`Rask.Example.Auth.WasmCookie(.Host)`** — cookie + WASM (HttpOnly cookie, `/api/me` hydration).
+  - **`Rask.Example.Auth.WasmJwt(.Host)`** — JWT + WASM (bearer in localStorage, `Authorization: Bearer`).
+  Run a server cell with `dotnet run --project samples/Rask.Example.Auth.Jwt`; a WASM cell via its `.Host`. Full guide: **[docs/authentication.md](docs/authentication.md)**.
 - **Live demo** — every push to `main` publishes `Rask.Example.Wasm` to GitHub Pages via
   [`.github/workflows/pages.yml`](.github/workflows/pages.yml), so you can click through a full multi-page Rask app in
   the browser before cloning anything.

--- a/README.md
+++ b/README.md
@@ -346,8 +346,13 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
   host model. Run one with `dotnet run --project samples/Rask.Example.Server` (or `samples/Rask.Example.Wasm.Host`) and open the printed
   URL.
 - **`samples/Rask.Example.Shared/Pages/`** — the feature-by-feature pages those hosts share: forms & validation, nested-form
-  binding, routing, JS interop, virtualization (a 10K-row table), and file upload/download. These are the canonical
-  references cited throughout *Core concepts* below.
+  binding, routing, JS interop, virtualization (a 10K-row table), file upload/download, and **auth gating** (the `/user`
+  page shows both imperative `Component.User` and the declarative `Authorize` component). These are the canonical
+  references cited throughout *Core concepts* below. For production auth flows see **[docs/authentication.md](docs/authentication.md)**.
+- **`samples/Rask.Example.Auth`** — a minimal, runnable **cookie-login** app: a `/login` form, a protected
+  `/members` page (`[Authorize]` + the `Authorize` component), role-gated admin content, and sign-out over the live
+  runtime. `dotnet run --project samples/Rask.Example.Auth` and visit `/members`. The full login round trip is covered
+  by a browser E2E (`AuthExampleTests`).
 - **Live demo** — every push to `main` publishes `Rask.Example.Wasm` to GitHub Pages via
   [`.github/workflows/pages.yml`](.github/workflows/pages.yml), so you can click through a full multi-page Rask app in
   the browser before cloning anything.
@@ -568,9 +573,9 @@ built-in page if no app-defined one exists.
 <summary><b>🔐 Auth gating (built-in <code>User</code>)</b></summary>
 <br>
 
-There is no `AuthorizeView` component. Every component exposes `Component.User` — a never-null `ClaimsPrincipal` resolved
-from the scoped `IUserProvider` (back it with a cookie/JWT on Server, or `/api/me` on WASM). Gate in `Render()` with
-plain C#, and subscribe to the provider's `Changed` event so a sign-in originating anywhere re-renders the gate:
+Every component exposes `Component.User` — a never-null `ClaimsPrincipal` resolved from the scoped `IUserProvider`
+(back it with a cookie/JWT on Server, or `/api/me` on WASM). Gate **imperatively** in `Render()` with plain C#, and
+subscribe to the provider's `Changed` event so a sign-in originating anywhere re-renders the gate:
 
 ```csharp
 public sealed class AccountPanel : Component
@@ -592,8 +597,22 @@ public sealed class AccountPanel : Component
 }
 ```
 
+Or gate **declaratively** with the headless `Authorize` component — three slots, no markup of its own:
+
+```csharp
+Authorize(
+    Roles: ["admin"],
+    Authorized:    Div()["🔑 Admin tools"],
+    NotAuthorized: A(Href: "/login")["Sign in"],
+    Authorizing:   Spinner());                 // shown while the principal/policy resolves
+```
+
 For whole-page gating, put `[Authorize]` (optionally `[Authorize(Roles = "admin")]`) or `[AllowAnonymous]` on the page
 component — the `RouteAuthorizationGuard` enforces it before the page renders.
+
+**Going to production?** See **[docs/authentication.md](docs/authentication.md)** for complete, copy-pasteable flows:
+cookie & JWT on both Server and WASM, ASP.NET Identity, Keycloak/OIDC, protected token storage, the
+auth configured through ASP.NET's own AddCookie/AddJwtBearer, and a security checklist.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ published WASM bundle. The **same component code runs under any host** — only 
 | ✅ | **Forms with async validation** | `Form<TModel>(model, OnValidSubmit: …)` routes submit through validators you opt into by dropping `DataAnnotationsValidator()` or `FluentValidationValidator(...)` inside the form. Implement `IAsyncFieldValidator` for ad-hoc server-side rules — the submit bridge awaits async checks before routing, and rapid keystrokes cancel any prior in-flight validation (latest-wins). |
 | ⚡ | **Live diff codec** | After first paint, a small state change ships a minimal edit-op payload instead of re-serializing the page — a counter tick on a 50 KB page goes from ~50 KB to ~57 bytes on the wire. On by default. |
 | 🔑 | **Keyed lists** | Add a `Key:` to list items (Blazor `@key` parity) and inserts/removes/reorders reconcile by identity — shipping trusted structural diffs that preserve focus and input state on the survivors. A `RASK022` analyzer flags a list item that's missing a key. |
+| 🔐 | **Authentication, ASP.NET-native** | `Component.User` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
 
 ## ⚖️ Compared to Blazor
 
@@ -90,6 +91,7 @@ If you've worked in Blazor, here's how the day-to-day differs in Rask:
 | `RenderFragment` / `EventCallback` | Children are `IEnumerable<Child>`; event handlers are plain delegates (`OnClick: () => _count++`). Child→parent callbacks are plain delegate props too (`Action<T>?` / `Func<T,Task>?`) — invoking one auto-re-renders the parent that owns it, no `EventCallback` wrapper. No specialised types, no `@bind-Value:event`. |
 | `.razor.css` association ceremony | Scoped CSS via a sibling `{Component}.css` (Blazor-parity descendant combinators) — auto-globbed at build time, hot-reloaded under `dotnet watch`. Same idea for JS: a sibling `{Component}.js` is bundled and dispatched by the framework. |
 | Separate render modes to wire up | **Same component code on Server or WASM.** Pick the host package per project; you don't rewrite components when switching render mode. Server-only (multipart upload) and WASM-only (chunked file reads, inline downloads) behaviours live in the hosts, not in your tree. |
+| `<AuthorizeView>` + `AuthenticationStateProvider` | `Component.User` everywhere (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface. |
 
 Rask isn't a Blazor replacement so much as a different take on the same problem space. If those trade-offs appeal, the
 rest of this README walks through what they look like in practice.
@@ -350,12 +352,17 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
   page shows both imperative `Component.User` and the declarative `Authorize` component). These are the canonical
   references cited throughout *Core concepts* below. For production auth flows see **[docs/authentication.md](docs/authentication.md)**.
 - **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
-  (`/login`, protected `/members`, role-gated admin, sign-out) with a browser E2E:
+  (`/login`, a protected `/members`, role-gated admin content, sign-out) backed by a browser E2E:
   - **`Rask.Example.Auth`** — cookie + Server (the redeem handshake).
   - **`Rask.Example.Auth.Jwt`** — JWT + Server; the token rides in **`ProtectedSessionStorage`** (encrypted, never in the URL or JS).
   - **`Rask.Example.Auth.WasmCookie(.Host)`** — cookie + WASM (HttpOnly cookie, `/api/me` hydration).
   - **`Rask.Example.Auth.WasmJwt(.Host)`** — JWT + WASM (bearer in localStorage, `Authorization: Bearer`).
-  Run a server cell with `dotnet run --project samples/Rask.Example.Auth.Jwt`; a WASM cell via its `.Host`. Full guide: **[docs/authentication.md](docs/authentication.md)**.
+
+  Run a server cell directly — `dotnet run --project samples/Rask.Example.Auth.Jwt` — and a WASM cell via its host —
+  `dotnet run --project samples/Rask.Example.Auth.WasmCookie.Host` — then visit `/members`. Sign in with
+  `alice` / `password` (user) or `root` / `password` (admin). To scaffold the same in a new project:
+  `dotnet new rask-server --auth`, `dotnet new rask-wasm-hosted --auth`, or `dotnet new rask-wasm --auth`. Full
+  guide: **[docs/authentication.md](docs/authentication.md)**.
 - **Live demo** — every push to `main` publishes `Rask.Example.Wasm` to GitHub Pages via
   [`.github/workflows/pages.yml`](.github/workflows/pages.yml), so you can click through a full multi-page Rask app in
   the browser before cloning anything.

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -5,6 +5,11 @@
   </Folder>
   <Folder Name="/samples/">
     <Project Path="samples/Rask.Example.Auth/Rask.Example.Auth.csproj" />
+    <Project Path="samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj" />
+    <Project Path="samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj" />
+    <Project Path="samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj" />
+    <Project Path="samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj" />
+    <Project Path="samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj" />
     <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj" />
     <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj" />
     <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj" />

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -4,6 +4,7 @@
     <Project Path="benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj" />
   </Folder>
   <Folder Name="/samples/">
+    <Project Path="samples/Rask.Example.Auth/Rask.Example.Auth.csproj" />
     <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj" />
     <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj" />
     <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj" />

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,912 @@
+# Authentication in Rask
+
+Rask ships the *plumbing* for authentication — a scoped current-user, a sign-in/out handshake, route
+guards, and a declarative gate — and lets you bring any backing store (a cookie, a JWT, ASP.NET Identity,
+Keycloak/OIDC, …). This guide shows the complete, copy-pasteable flow for each combination.
+
+- [Concepts](#concepts)
+- [Configuration](#configuration)
+- [Declarative gating — the `Authorize` component](#declarative-gating)
+- [Cookie + Server](#cookie--server)
+- [Cookie + WASM](#cookie--wasm)
+- [JWT + Server](#jwt--server)
+- [JWT + WASM (protected storage)](#jwt--wasm-protected-storage)
+- [Standalone WASM (no host)](#standalone-wasm-no-host)
+- [ASP.NET Identity](#aspnet-identity)
+- [Keycloak / OpenID Connect](#keycloak--openid-connect)
+- [Other OIDC providers — Auth0, AWS Cognito, Duende IdentityServer](#other-oidc-providers)
+- [Hardening reference](#hardening-reference)
+- [Security checklist](#security-checklist)
+- [Decision table](#decision-table)
+
+---
+
+## Concepts
+
+| Piece | What it is |
+|---|---|
+| `IUserProvider` | Scoped source of the current `ClaimsPrincipal` (`Current`), a `Changed` event, optional `EnsureLoadedAsync`/`RefreshAsync`, and `IsLoading`. Server: `SessionUserProvider` (seeded from `HttpContext.User`). WASM: you supply one (or the anonymous default). |
+| `Component.User` | The never-null `ClaimsPrincipal` resolved from `IUserProvider` in the active render scope. Gate in `Render()` on `User.Identity?.IsAuthenticated` / `User.IsInRole(...)`. |
+| `Authorize` component | Headless declarative gate with `Authorized` / `NotAuthorized` / `Authorizing` slots (see below). |
+| `IAuthSignIn` | Event-handler-only `SignInAsync(principal, returnUrl)` / `SignOutAsync(returnUrl)`. Server drives the cookie handshake; WASM signs out via `/auth/logout`. |
+| `[Authorize]` / `[AllowAnonymous]` | Route-level gating evaluated by `RouteAuthorizationGuard` → redirect to the auth scheme's `LoginPath` (401) or `AccessDeniedPath` (403). |
+
+**The Server cookie handshake.** A WebSocket can't write a `Set-Cookie`, so sign-in is a four-step relay:
+`IAuthSignIn.SignInAsync(principal)` (in an event handler) → the framework issues a single-use,
+session-bound ticket → the browser `POST`s it to `/_rask/auth/redeem` → the endpoint calls
+`HttpContext.SignInAsync` (sets the cookie) → the WS reconnects and re-seeds `SessionUserProvider` from the
+now-authenticated `HttpContext.User`. You never touch this directly — just call `SignInAsync`.
+
+---
+
+## Configuration
+
+**Rask has no auth options object of its own** — authentication is configured entirely through ASP.NET's
+own primitives. You set the cookie name/flags/expiry and login path on `AddCookie(...)`, the JWT signing key
+and token lifetimes on `AddJwtBearer(...)`, and roles/policies on `AddAuthorization(...)`. `AddRask()` takes
+no auth configuration.
+
+A few framework defaults are fixed (not configurable knobs):
+
+| Behaviour | Value |
+|---|---|
+| Initial HTTP GET challenge / forbid | the configured auth scheme's own `LoginPath` / `AccessDeniedPath` (e.g. on `AddCookie`) |
+| Client-side route-guard redirect (an in-app nav to a protected route) | `/login` / `/forbidden` — name your login route `/login` to match |
+| Sign-in/out redeem ticket lifetime | 30 seconds |
+
+```csharp
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(o =>
+    {
+        o.LoginPath = "/login";          // ← where unauthenticated users are challenged (HTTP GET)
+        o.AccessDeniedPath = "/forbidden";
+        o.Cookie.Name = "rask.auth";
+        o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+    });
+builder.Services.AddRask();              // no auth config here — it's all on AddCookie/AddJwtBearer
+```
+
+---
+
+## Declarative gating
+
+The headless `Authorize` component renders exactly one of three slots — no markup of its own — off
+`Component.User`:
+
+```csharp
+// Shorthand: children are the "authorized" branch.
+Authorize(Roles: ["admin"])[ AdminPanel() ]
+
+// Full three-slot form.
+Authorize(
+    Roles: ["admin", "editor"],                       // ANY-of; omit for "any authenticated user"
+    Authorized:    Div(Class: "card")[ "Members-only content" ],
+    NotAuthorized: A(Href: "/login")[ "Please sign in" ],
+    Authorizing:   Spinner())                     // shown while the principal/policy resolves
+```
+
+- **`Roles`** and the authenticated check are synchronous → no flicker.
+- **`Policy`** (e.g. `Authorize(Policy: "over-18")`) resolves via `IAuthorizationService` in the background;
+  the `Authorizing` slot shows until it lands.
+- **`Authorizing`** also covers the WASM bootstrap window: while a provider's `EnsureLoadedAsync`/`RefreshAsync`
+  is in flight (`IUserProvider.IsLoading == true`), the slot bridges the anonymous→authenticated flash.
+
+Use `Authorize` for *content* gating; use `[Authorize]` on a page for *route* gating; use `Component.User`
+directly when you need imperative logic.
+
+---
+
+## Cookie + Server
+
+The lowest-friction, most secure option for the Server (WS) host — the token lives in an HttpOnly cookie and
+never reaches JavaScript.
+
+> **Scaffold it:** `dotnet new rask-server --auth` generates exactly this — a `/login` form, a
+> `DemoCredentialStore`, a protected `/members` page, and the `AddCookie` + `UseAuthentication` wiring below.
+> A runnable reference also lives in `samples/Rask.Example.Auth`.
+
+**A credential store (demo — swap for your real one):**
+
+```csharp
+public interface ICredentialStore
+{
+    IReadOnlyList<Claim>? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public IReadOnlyList<Claim>? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => [new Claim(ClaimTypes.Name, "alice"), new Claim(ClaimTypes.Role, "user")],
+            ("root",  "password") => [new Claim(ClaimTypes.Name, "root"),  new Claim(ClaimTypes.Role, "admin")],
+            _ => null
+        };
+}
+```
+
+**The login page** — a normal Rask page; `SignInAsync` runs inside the form's submit handler:
+
+```csharp
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(IAuthSignIn auth, ICredentialStore creds) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Class: "mx-auto", Style: "max-width:24rem")[
+            H1()["Sign in"],
+            _error is null ? Fragment() : Div(Class: "alert alert-danger")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
+                Input(() => _model.Username, Id: "username", Class: "form-control"),
+                Input(() => _model.Password, Id: "password", Type: "password", Class: "form-control"),
+                Button("submit", Class: "btn btn-primary")["Sign in"]
+            ]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        var claims = creds.Validate(m.Username, m.Password);
+        if (claims is null) { _error = "Invalid username or password."; return; }
+
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await auth.SignInAsync(new ClaimsPrincipal(identity), returnUrl: ReturnUrl ?? "/");
+    }
+}
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+```
+
+**A protected page** redirects to `/login?returnUrl=/secure` for anonymous users (handled by the route
+guard). Gate the *content* with the `Authorize` component and keep the user-dependent view in a child
+component in the `Authorized` slot — see the reactivity note below for why:
+
+```csharp
+[Route("secure")]
+[Authorize]
+public sealed class SecurePage : Component
+{
+    protected override RenderResult Render() =>
+        Authorize(
+            Authorizing:   P()["Signing you in…"],
+            NotAuthorized: P()["Please sign in."],
+            Authorized:    SecureContent());     // child component → renders fresh when the gate opens
+}
+
+public sealed class SecureContent : Component
+{
+    protected override RenderResult Render() =>
+        Div()[
+            H1()[$"Hello, {User.Identity!.Name}"],
+            Authorize(Roles: ["admin"],
+                Authorized:    Div(Class: "alert alert-warning")["🔑 Admin tools"],
+                NotAuthorized: P()["You have standard access."])
+        ];
+}
+```
+
+> **Reactivity.** Sign-in on the Server completes over a WS reconnect that re-seeds the principal and fires
+> `IUserProvider.Changed`. The `Authorize` component subscribes to that event and re-renders — but a page
+> that reads `User` *directly in its own `Render`* won't re-execute (it didn't subscribe), so a greeting
+> built there can go stale after a mid-session sign-in. Two fixes: put `User`-dependent markup inside a
+> **child component** in the `Authorized` slot (it first renders only once the gate opens, as above), or
+> subscribe the page itself: `OnMount() => users.Changed += StateHasChanged;`. The child-component form
+> needs no manual subscription.
+
+**`Program.cs` — wire cookie auth *before* `UseRask`:**
+
+```csharp
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(o =>
+    {
+        o.Cookie.Name = "rask.auth";
+        o.Cookie.HttpOnly = true;
+        o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        o.Cookie.SameSite = SameSiteMode.Lax;
+        o.ExpireTimeSpan = TimeSpan.FromHours(8);
+        o.SlidingExpiration = true;
+        o.LoginPath = "/login";
+    });
+builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+builder.Services.AddRask(); // no auth config on AddRask — it's all on AddCookie above
+
+var app = builder.Build();
+
+app.UseAuthentication();   // ⚠️ MUST precede UseRask — populates HttpContext.User on GET and WS upgrade
+app.UseAuthorization();
+app.UseRask<App>();
+app.Run();
+```
+
+> **Ordering matters.** If `UseAuthentication` runs *after* `UseRask`, `HttpContext.User` is empty when the
+> session is seeded and every `[Authorize]` page challenges. Keep it before `UseRask`.
+
+Sign out from any event handler: `await auth.SignOutAsync(returnUrl: "/");`
+
+---
+
+## Cookie + WASM
+
+The WASM client has no server pipeline of its own, so the **API host** owns the cookie. The client hydrates
+its principal from `/api/me`.
+
+**On the API host** (`Rask.Wasm.Host` / your ASP.NET server):
+
+```csharp
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie();
+builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+// ... build app ...
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapPost("/api/login", async (HttpContext ctx, LoginDto dto, ICredentialStore creds) =>
+{
+    var claims = creds.Validate(dto.Username, dto.Password);
+    if (claims is null) return Results.Unauthorized();
+    var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+    await ctx.SignInAsync(new ClaimsPrincipal(identity));   // sets the HttpOnly cookie
+    return Results.Ok(new MeDto(dto.Username, claims.Where(c => c.Type == ClaimTypes.Role).Select(c => c.Value).ToArray()));
+});
+
+app.MapGet("/api/me", (HttpContext ctx) =>
+    ctx.User.Identity?.IsAuthenticated == true
+        ? Results.Ok(new MeDto(ctx.User.Identity!.Name!, ctx.User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray()))
+        : Results.NoContent());
+
+app.MapPost("/auth/logout", async (HttpContext ctx) => { await ctx.SignOutAsync(); return Results.Ok(); });
+
+public sealed record LoginDto(string Username, string Password);
+public sealed record MeDto(string Name, string[] Roles);
+```
+
+**The client `IUserProvider`** bootstraps from `/api/me`:
+
+```csharp
+public sealed class ApiUserProvider(HttpClient http) : IUserProvider
+{
+    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+    public ClaimsPrincipal Current => _current;
+    public bool IsLoading { get; private set; }
+    public event Action? Changed;
+
+    public Task EnsureLoadedAsync() => LoadAsync();
+
+    public async Task RefreshAsync()
+    {
+        IsLoading = true; Changed?.Invoke();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            _current = me is { Name: { } name }
+                ? new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))], "api"))
+                : new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        catch (HttpRequestException) { _current = new ClaimsPrincipal(new ClaimsIdentity()); }
+        finally { IsLoading = false; Changed?.Invoke(); }
+    }
+}
+
+// Source-generated JSON keeps the WASM trim-clean (zero IL warnings).
+[JsonSerializable(typeof(MeDto))]
+[JsonSerializable(typeof(LoginDto))]
+public partial class AuthJson : JsonSerializerContext { }
+```
+
+**Client login** posts credentials, then refreshes the provider (WASM `SignInAsync` is intentionally
+unsupported — the cookie is set by the server):
+
+```csharp
+public sealed class WasmLoginService(HttpClient http, IUserProvider users, Navigator nav)
+{
+    public async Task<bool> LoginAsync(LoginModel m, string? returnUrl)
+    {
+        var resp = await http.PostAsJsonAsync("api/login", new LoginDto(m.Username, m.Password), AuthJson.Default.Options);
+        if (!resp.IsSuccessStatusCode) return false;
+        await users.RefreshAsync();
+        nav.Navigate(returnUrl ?? "/");
+        return true;
+    }
+}
+```
+
+**`Program.cs` (client):**
+
+```csharp
+var builder = WasmHostBuilder.CreateDefault(args);
+builder.Services.AddSingleton(new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddSingleton<ApiUserProvider>();
+builder.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<ApiUserProvider>()); // overrides the anonymous default
+builder.Services.AddSingleton<WasmLoginService>();
+await builder.RunAsync<App>();
+```
+
+Sign out with the built-in WASM signer (POSTs `/auth/logout`, refreshes, navigates):
+`await auth.SignOutAsync(returnUrl: "/");`
+
+---
+
+## JWT + Server
+
+Use this when you want a bearer-token API the same identity serves. Because browsers can't set an
+`Authorization` header on a WebSocket upgrade, Rask carries the token on the WS URL as `?access_token=`
+(the SignalR pattern).
+
+**Issue + validate the token:**
+
+```csharp
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme).AddJwtBearer(o =>
+{
+    o.TokenValidationParameters = new TokenValidationParameters
+    {
+        ValidateIssuer = true, ValidIssuer = "rask-demo",
+        ValidateAudience = true, ValidAudience = "rask-demo",
+        ValidateIssuerSigningKey = true,
+        IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!)),
+        ValidateLifetime = true
+    };
+
+    // Read the bearer token off the Rask WS upgrade query string.
+    o.Events = new JwtBearerEvents
+    {
+        OnMessageReceived = ctx =>
+        {
+            var token = ctx.Request.Query["access_token"];
+            if (!string.IsNullOrEmpty(token) && ctx.HttpContext.Request.Path.StartsWithSegments("/_rask/ws"))
+                ctx.Token = token;
+            return Task.CompletedTask;
+        }
+    };
+});
+builder.Services.AddRask(); // the JWT scheme is configured on AddJwtBearer above, not on Rask
+
+app.MapPost("/api/login", (LoginDto dto, ICredentialStore creds, IConfiguration cfg) =>
+{
+    var claims = creds.Validate(dto.Username, dto.Password);
+    if (claims is null) return Results.Unauthorized();
+    var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(cfg["Jwt:Key"]!));
+    var jwt = new JwtSecurityToken("rask-demo", "rask-demo", claims,
+        expires: DateTime.UtcNow.AddMinutes(15),
+        signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+    return Results.Ok(new { token = new JwtSecurityTokenHandler().WriteToken(jwt) });
+});
+```
+
+**On the client**, store the token and publish it to the WS hook so every (re)connect carries it:
+
+```javascript
+// after a successful /api/login on the client:
+window.Rask = window.Rask || {};
+window.Rask.authToken = () => sessionStorage.getItem("rask.jwt"); // read fresh each reconnect
+```
+
+When `window.Rask.authToken` returns a token, `rask.js` appends `?access_token=…` to the WS URL and
+`AddJwtBearer`'s `OnMessageReceived` picks it up — `HttpContext.User` is then populated on the WS upgrade
+exactly as for cookies.
+
+> The token appears in the WS URL (and thus server access logs). Keep the JWT lifetime short (set on `AddJwtBearer`), require
+> HTTPS, and prefer the cookie scheme for the Server host when you can.
+
+---
+
+## JWT + WASM (protected storage)
+
+For a bearer-token SPA, the token rides the `Authorization` header on every `HttpClient` call. Per the
+"never store a plaintext token" rule, the token is **encrypted with ASP.NET Data Protection** before it
+touches browser storage.
+
+**`ProtectedTokenStore` (reference implementation of `ITokenStore`):**
+
+```csharp
+public sealed class ProtectedTokenStore(IJSRuntime js, IDataProtectionProvider dp) : ITokenStore
+{
+    private readonly IDataProtector _protector = dp.CreateProtector("Rask.Auth.Token");
+    private const string Key = "rask.jwt";
+
+    public async ValueTask<string?> GetAsync()
+    {
+        var cipher = await js.InvokeAsync<string?>("localStorage.getItem", Key)
+                     ?? await js.InvokeAsync<string?>("sessionStorage.getItem", Key);
+        if (string.IsNullOrEmpty(cipher)) return null;
+        try { return _protector.Unprotect(cipher); }
+        catch (CryptographicException) { await ClearAsync(); return null; } // tampered / key rotated
+    }
+
+    public async ValueTask SetAsync(string token, bool persist)
+    {
+        var cipher = _protector.Protect(token);                     // ← ciphertext, never the raw JWT
+        var store = persist ? "localStorage" : "sessionStorage";    // remember-me vs tab-scoped
+        await js.InvokeVoidAsync($"{store}.setItem", Key, cipher);
+    }
+
+    public async ValueTask ClearAsync()
+    {
+        await js.InvokeVoidAsync("localStorage.removeItem", Key);
+        await js.InvokeVoidAsync("sessionStorage.removeItem", Key);
+    }
+}
+```
+
+> On WASM, ASP.NET Data Protection needs a key ring. For a browser-only SPA, deliver the protected blob from
+> the server (protect in the API, unprotect on `/api/me`), or — simpler and stronger — use the **HttpOnly
+> cookie** scheme so the token never reaches JS at all. Protected storage is the right call when you must
+> hold a bearer token client-side for a non-cookie API.
+
+**Attach the bearer token to outgoing calls:**
+
+```csharp
+public sealed class BearerTokenHandler(ITokenStore tokens) : DelegatingHandler
+{
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+    {
+        if (await tokens.GetAsync() is { } token)
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return await base.SendAsync(req, ct);
+    }
+}
+```
+
+The `ApiUserProvider` from the cookie section works unchanged — it hydrates from `/api/me`, which is now
+validated by `AddJwtBearer`. Silent refresh is an **app responsibility** (Rask doesn't run a refresh timer):
+from a timer in a long-lived component, refresh the token before it expires and call `users.RefreshAsync()`
+— the provider raises `Changed` and the session re-renders.
+
+---
+
+## Standalone WASM (no host)
+
+A standalone `rask-wasm` app is published as **static files** and has **no server of its own** — the Rask
+runtime is entirely in-browser (no WebSocket back to a Rask host). So there's no cookie handshake, no
+`/api/me` you own, and no `?access_token=` WS hook. Auth is purely: **POST credentials to an external API,
+store the JWT client-side, decode it to a principal, and attach it to your `HttpClient` calls.** The external
+API must enable **CORS** for your app's origin and allow the `Authorization` header.
+
+> No host means no ASP.NET Data Protection key ring, so the encrypted "protected storage" option isn't
+> available here. Use a **short-lived** JWT in `sessionStorage` (cleared on tab close) with refresh, a strict
+> **CSP** to reduce XSS exposure, and HTTPS. If you need the token to never touch JS, you need a host — see
+> [JWT + WASM](#jwt--wasm-protected-storage) or the cookie flows.
+
+**A token store** (in-memory + `sessionStorage`, read synchronously by the handler):
+
+```csharp
+public sealed class TokenStore(IJSRuntime js)
+{
+    public string? Token { get; private set; }
+
+    public async Task InitAsync() => Token = await js.InvokeAsync<string?>("sessionStorage.getItem", "rask.jwt");
+    public async Task SetAsync(string t) { Token = t; await js.InvokeVoidAsync("sessionStorage.setItem", "rask.jwt", t); }
+    public async Task ClearAsync() { Token = null; await js.InvokeVoidAsync("sessionStorage.removeItem", "rask.jwt"); }
+}
+
+public sealed class BearerTokenHandler(TokenStore tokens) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+    {
+        if (tokens.Token is { } token)
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return base.SendAsync(req, ct);
+    }
+}
+```
+
+**A provider that decodes the JWT to a principal** (no `/api/me` round-trip needed):
+
+```csharp
+public sealed class JwtUserProvider(TokenStore tokens) : IUserProvider
+{
+    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+    public ClaimsPrincipal Current => _current;
+    public bool IsLoading { get; private set; }
+    public event Action? Changed;
+
+    // Awaited by WasmHostBuilder before the first render → no anonymous flash.
+    public async Task EnsureLoadedAsync()
+    {
+        IsLoading = true;
+        await tokens.InitAsync();
+        Apply(tokens.Token);
+        IsLoading = false;
+        Changed?.Invoke();
+    }
+
+    public void SignedIn()  => Apply(tokens.Token);
+    public void SignedOut() => Apply(null);
+
+    private void Apply(string? jwt)
+    {
+        _current = jwt is null
+            ? new ClaimsPrincipal(new ClaimsIdentity())
+            : new ClaimsPrincipal(new ClaimsIdentity(DecodeClaims(jwt), "jwt"));
+        Changed?.Invoke();
+    }
+
+    private static IEnumerable<Claim> DecodeClaims(string jwt)
+    {
+        var json = Encoding.UTF8.GetString(Base64Url(jwt.Split('.')[1]));
+        using var doc = JsonDocument.Parse(json);
+        foreach (var p in doc.RootElement.EnumerateObject())
+        {
+            if (p.Name is "name" or "unique_name" or "sub")
+                yield return new Claim(ClaimTypes.Name, p.Value.ToString());
+            else if (p.Name is "role" or "roles")
+            {
+                if (p.Value.ValueKind == JsonValueKind.Array)
+                    foreach (var r in p.Value.EnumerateArray()) yield return new Claim(ClaimTypes.Role, r.GetString()!);
+                else yield return new Claim(ClaimTypes.Role, p.Value.GetString()!);
+            }
+        }
+    }
+
+    private static byte[] Base64Url(string s)
+    {
+        s = s.Replace('-', '+').Replace('_', '/');
+        s += (s.Length % 4) switch { 2 => "==", 3 => "=", _ => "" };
+        return Convert.FromBase64String(s);
+    }
+}
+```
+
+**A login service** posting to the external API:
+
+```csharp
+public sealed class LoginService(HttpClient http, TokenStore tokens, JwtUserProvider users, Navigator nav)
+{
+    public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
+    {
+        var resp = await http.PostAsJsonAsync("api/login", new LoginDto(username, password), AuthJson.Default.Options);
+        if (!resp.IsSuccessStatusCode) return false;
+        var dto = await resp.Content.ReadFromJsonAsync(AuthJson.Default.TokenDto);
+        await tokens.SetAsync(dto!.Token);
+        users.SignedIn();
+        nav.Navigate(returnUrl ?? "/");
+        return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        await tokens.ClearAsync();
+        users.SignedOut();
+        nav.Navigate("/");
+    }
+}
+
+public sealed record LoginDto(string Username, string Password);
+public sealed record TokenDto(string Token);
+
+[JsonSerializable(typeof(LoginDto)), JsonSerializable(typeof(TokenDto))]
+public partial class AuthJson : JsonSerializerContext { } // keeps the WASM publish trim-clean
+```
+
+**`Program.cs`:**
+
+```csharp
+var builder = WasmHostBuilder.CreateDefault(args);
+
+builder.Services.AddSingleton<TokenStore>();
+builder.Services.AddSingleton(sp => new HttpClient(
+        new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
+    { BaseAddress = new Uri("https://api.example.com/") });   // ← your external API (CORS-enabled)
+builder.Services.AddSingleton<JwtUserProvider>();
+builder.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>()); // overrides the anonymous default
+builder.Services.AddSingleton<LoginService>();
+
+await builder.RunAsync<App>();
+```
+
+`Component.User`, the `Authorize` component, and `[Authorize]` route gating all work against the decoded
+principal exactly as everywhere else — they just resolve from `JwtUserProvider` instead of a server-backed
+one. (Route-level `[Authorize]` redirects work client-side too, since the guard runs in the WASM session.)
+
+### Cookie variant (static-file SPA + cookie)
+
+You can keep the token out of JS entirely with an **HttpOnly cookie** even for a static-file SPA — but the
+cookie is now **cross-origin** (your `app.example.com` SPA calls an `api.example.com` server), which has
+hard browser constraints:
+
+> ⚠️ **Cross-site cookies are increasingly blocked.** Safari and Brave block third-party cookies by default,
+> and Chrome is phasing them out. A cross-site cookie needs `SameSite=None; Secure`, which many browsers
+> drop for "third-party" contexts. **This is only reliable when the SPA and API share a registrable domain**
+> (e.g. `app.example.com` + `api.example.com` — same site, so `SameSite=Lax`/`None` works). For truly
+> different domains, use the [JWT approach above](#standalone-wasm-no-host) instead.
+
+**On the API server:**
+
+```csharp
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme).AddCookie(o =>
+{
+    o.Cookie.HttpOnly = true;
+    o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+    o.Cookie.SameSite = SameSiteMode.None;            // required for cross-site; needs Secure + HTTPS
+});
+builder.Services.AddCors(p => p.AddDefaultPolicy(b => b
+    .WithOrigins("https://app.example.com")           // the SPA origin — never "*" with credentials
+    .AllowAnyHeader().AllowAnyMethod()
+    .AllowCredentials()));                            // lets the browser carry the cookie cross-site
+
+var app = builder.Build();
+app.UseCors();
+app.UseAuthentication();
+app.UseAuthorization();
+// /api/login → ctx.SignInAsync(...);  /api/me → reads ctx.User;  /auth/logout → ctx.SignOutAsync()
+//   (identical endpoint bodies to the "Cookie + WASM" section)
+```
+
+**On the client**, the browser only attaches a cross-site cookie when the fetch uses `credentials: include`.
+Set that per request with a handler, then reuse the `ApiUserProvider` (hydrates from `/api/me`) from the
+[Cookie + WASM](#cookie--wasm) section unchanged:
+
+```csharp
+public sealed class CookieCredentialsHandler : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+    {
+        // .NET WASM BrowserHttpHandler honors this option (Blazor's SetBrowserRequestCredentials wraps it).
+        req.Options.Set(
+            new HttpRequestOptionsKey<IDictionary<string, object>>("WebAssemblyFetchOptions"),
+            new Dictionary<string, object> { ["credentials"] = "include" });
+        return base.SendAsync(req, ct);
+    }
+}
+
+// Program.cs
+builder.Services.AddSingleton(sp => new HttpClient(
+        new CookieCredentialsHandler { InnerHandler = new HttpClientHandler() })
+    { BaseAddress = new Uri("https://api.example.com/") });
+builder.Services.AddSingleton<ApiUserProvider>();
+builder.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<ApiUserProvider>());
+```
+
+No token store, no `Authorization` header — the cookie rides every credentialed request automatically, and
+`ApiUserProvider.EnsureLoadedAsync()` hydrates the principal from `/api/me` before the first render.
+
+---
+
+## ASP.NET Identity
+
+ASP.NET Identity is just a richer `ICredentialStore` + cookie. Wire Identity for storage/password hashing,
+then sign in through Rask's handshake.
+
+```csharp
+builder.Services
+    .AddIdentityCore<IdentityUser>(o => o.Password.RequiredLength = 8)
+    .AddRoles<IdentityRole>()
+    .AddEntityFrameworkStores<AppDbContext>()
+    .AddSignInManager();
+
+builder.Services.AddAuthentication(IdentityConstants.ApplicationScheme)
+    .AddCookie(IdentityConstants.ApplicationScheme);
+builder.Services.AddRask();
+// app: UseAuthentication(); UseAuthorization(); UseRask<App>();
+```
+
+In the login page, validate with `SignInManager` / `UserManager` and build the principal Identity provides:
+
+```csharp
+[Route("login"), AllowAnonymous]
+public sealed class LoginPage(
+    SignInManager<IdentityUser> signIn,
+    UserManager<IdentityUser> users,
+    IAuthSignIn auth) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() => /* same form as Cookie + Server */ ...;
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        var user = await users.FindByNameAsync(m.Username);
+        if (user is null || !await signIn.CanSignInAsync(user) ||
+            !(await signIn.CheckPasswordSignInAsync(user, m.Password, lockoutOnFailure: true)).Succeeded)
+        {
+            _error = "Invalid credentials."; return;
+        }
+
+        var principal = await signIn.CreateUserPrincipalAsync(user); // includes Identity's claims + roles
+        await auth.SignInAsync(principal, returnUrl: ReturnUrl ?? "/", scheme: IdentityConstants.ApplicationScheme);
+    }
+}
+```
+
+Everything else (`Component.User`, `Authorize`, `[Authorize(Roles = "...")]`) works against the Identity
+principal unchanged. Registration/2FA/lockout are standard Identity APIs called from your pages.
+
+---
+
+## Keycloak / OpenID Connect
+
+For an external IdP, let ASP.NET's OIDC handler own the login redirect; Rask reads the resulting cookie.
+
+```csharp
+builder.Services.AddAuthentication(o =>
+    {
+        o.DefaultScheme = CookieAuthenticationDefaults.AuthenticationScheme;
+        o.DefaultChallengeScheme = OpenIdConnectDefaults.AuthenticationScheme;
+    })
+    .AddCookie()
+    .AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, o =>
+    {
+        o.Authority = "https://keycloak.example.com/realms/rask"; // your realm
+        o.ClientId = "rask-app";
+        o.ClientSecret = builder.Configuration["Keycloak:ClientSecret"];
+        o.ResponseType = "code";
+        o.SaveTokens = true;
+        o.GetClaimsFromUserInfoEndpoint = true;
+        o.Scope.Add("roles");
+        o.TokenValidationParameters.RoleClaimType = "roles"; // map Keycloak realm roles → User.IsInRole
+        o.TokenValidationParameters.NameClaimType = "preferred_username";
+    });
+builder.Services.AddRask(auth => auth.ChallengePath = "/login");
+// app: UseAuthentication(); UseAuthorization(); UseRask<App>();
+```
+
+Because the challenge is an HTTP redirect to Keycloak (not an in-app form), expose plain endpoints for the
+round trip and point users at them:
+
+```csharp
+app.MapGet("/login", (string? returnUrl, HttpContext ctx) =>
+    Results.Challenge(new AuthenticationProperties { RedirectUri = returnUrl ?? "/" },
+        [OpenIdConnectDefaults.AuthenticationScheme]));
+
+app.MapPost("/logout", (HttpContext ctx) =>
+    Results.SignOut(new AuthenticationProperties { RedirectUri = "/" },
+        [CookieAuthenticationDefaults.AuthenticationScheme, OpenIdConnectDefaults.AuthenticationScheme]));
+```
+
+A "Sign in" link (`A(Href: "/login?returnUrl=/secure")`) sends the user through Keycloak; on return the
+cookie is set and the next Rask GET/WS sees the authenticated `User`. Route `[Authorize]` pages now
+challenge straight to Keycloak via `ChallengePath`.
+
+---
+
+## Other OIDC providers
+
+Auth0, AWS Cognito, and Duende IdentityServer integrate exactly like [Keycloak](#keycloak--openid-connect):
+ASP.NET's OIDC handler owns the login redirect, Rask reads the resulting cookie, and the
+`/login` + `/logout` endpoints and "Sign in" link are **identical**. Only the `AddOpenIdConnect(...)` block
+and the provider's logout quirk differ. Swap the relevant block into the Keycloak setup.
+
+### Auth0
+
+```csharp
+.AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, o =>
+{
+    o.Authority = $"https://{builder.Configuration["Auth0:Domain"]}";        // e.g. dev-abc123.us.auth0.com
+    o.ClientId = builder.Configuration["Auth0:ClientId"];
+    o.ClientSecret = builder.Configuration["Auth0:ClientSecret"];
+    o.ResponseType = "code";
+    o.SaveTokens = true;
+    o.Scope.Clear(); o.Scope.Add("openid"); o.Scope.Add("profile"); o.Scope.Add("email");
+    o.CallbackPath = "/callback";
+    o.TokenValidationParameters.NameClaimType = "name";
+    // Auth0 emits roles only if an Action/Rule adds a namespaced claim:
+    o.TokenValidationParameters.RoleClaimType = "https://your-app.example.com/roles";
+
+    // Auth0 logout needs its own endpoint (clears the Auth0 session, then returnTo):
+    o.Events.OnRedirectToIdentityProviderForSignOut = ctx =>
+    {
+        var returnTo = Uri.EscapeDataString($"{ctx.Request.Scheme}://{ctx.Request.Host}/");
+        ctx.Response.Redirect($"https://{builder.Configuration["Auth0:Domain"]}/v2/logout" +
+            $"?client_id={builder.Configuration["Auth0:ClientId"]}&returnTo={returnTo}");
+        ctx.HandleResponse();
+        return Task.CompletedTask;
+    };
+});
+```
+
+Add an `audience` (and `o.Scope.Add("...")`) only if you also call an Auth0-protected API. Define roles with
+an Auth0 **Action** that adds `event.authorization.roles` to the ID token under your namespace.
+
+### AWS Cognito
+
+```csharp
+.AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, o =>
+{
+    var region = builder.Configuration["Cognito:Region"];        // e.g. eu-west-1
+    var poolId = builder.Configuration["Cognito:UserPoolId"];    // e.g. eu-west-1_AbCdEf
+    o.Authority = $"https://cognito-idp.{region}.amazonaws.com/{poolId}";
+    o.MetadataAddress = $"{o.Authority}/.well-known/openid-configuration";
+    o.ClientId = builder.Configuration["Cognito:ClientId"];
+    o.ClientSecret = builder.Configuration["Cognito:ClientSecret"];
+    o.ResponseType = "code";
+    o.SaveTokens = true;
+    o.Scope.Clear(); o.Scope.Add("openid"); o.Scope.Add("profile"); o.Scope.Add("email");
+    o.TokenValidationParameters.NameClaimType = "cognito:username";
+    o.TokenValidationParameters.RoleClaimType = "cognito:groups";  // User Pool groups → User.IsInRole
+
+    // Cognito uses its own Hosted-UI logout endpoint:
+    o.Events.OnRedirectToIdentityProviderForSignOut = ctx =>
+    {
+        var domain = builder.Configuration["Cognito:Domain"];      // your-app.auth.{region}.amazoncognito.com
+        var logoutUri = Uri.EscapeDataString($"{ctx.Request.Scheme}://{ctx.Request.Host}/");
+        ctx.Response.Redirect($"https://{domain}/logout" +
+            $"?client_id={builder.Configuration["Cognito:ClientId"]}&logout_uri={logoutUri}");
+        ctx.HandleResponse();
+        return Task.CompletedTask;
+    };
+});
+```
+
+Map users to roles by assigning them to **Cognito User Pool groups** — they arrive in the `cognito:groups`
+claim.
+
+### Duende IdentityServer
+
+```csharp
+.AddOpenIdConnect(OpenIdConnectDefaults.AuthenticationScheme, o =>
+{
+    o.Authority = builder.Configuration["Duende:Authority"];      // e.g. https://ids.example.com
+    o.ClientId = "rask-app";
+    o.ClientSecret = builder.Configuration["Duende:ClientSecret"];
+    o.ResponseType = "code";
+    o.UsePkce = true;
+    o.SaveTokens = true;
+    o.GetClaimsFromUserInfoEndpoint = true;
+    o.Scope.Clear(); o.Scope.Add("openid"); o.Scope.Add("profile"); o.Scope.Add("roles");
+    o.TokenValidationParameters.NameClaimType = "name";
+    o.TokenValidationParameters.RoleClaimType = "role";
+    o.SignedOutCallbackPath = "/signout-callback-oidc"; // Duende honors standard RP-initiated logout
+});
+```
+
+Duende supports standard RP-initiated logout, so the `/logout` endpoint from the Keycloak section works as-is
+(no provider-specific redirect needed) — `Results.SignOut(... [Cookie, OpenIdConnect])` clears both sessions.
+Define an IdentityResource/`role` claim and add it to the client's allowed scopes on the Duende side.
+
+---
+
+## Hardening reference
+
+| Concern | How Rask handles it |
+|---|---|
+| **Redeem-ticket TTL** | 30s, fixed. The ticket is single-use, session-bound, 128-bit. |
+| **CSRF on `/_rask/auth/redeem`** | The secret session-bound ticket defeats classic CSRF; the endpoint additionally **rejects cross-origin `Origin`/`Referer`** (HTTP 403). |
+| **Sign-out invalidation** | Redeem clears the cookie; the WS reconnect re-seeds `SessionUserProvider` to anonymous. `SessionUserProvider.Clear()` is available for explicit invalidation. |
+| **Session expiry → re-auth** | A swept live session pushes `{type:"session",status:"unknown"}`; `rask.js` reloads → fresh GET → route guard challenges to `ChallengePath?returnUrl=…`. |
+| **JWT on WebSocket** | Token rides `?access_token=` on the WS URL via `window.Rask.authToken`; pair with `AddJwtBearer`'s `OnMessageReceived`. |
+| **Token at rest (JWT/WASM)** | `ProtectedTokenStore` encrypts with Data Protection before storage; the HttpOnly-cookie scheme keeps it out of JS entirely. |
+
+---
+
+## Security checklist
+
+- ☑ Serve auth over **HTTPS** only (`Cookie.SecurePolicy = Always` on `AddCookie`).
+- ☑ Cookies: `HttpOnly`, `Secure`, `SameSite=Lax` (or `Strict`).
+- ☑ Prefer the **cookie scheme** — the token never reaches JavaScript (immune to XSS token theft).
+- ☑ If a token must be in the browser, store it **encrypted** (`ProtectedTokenStore`), never plaintext.
+- ☑ Short JWT lifetime + app-driven silent refresh so sessions stay smooth without long-lived tokens.
+- ☑ Keep `UseAuthentication()` **before** `UseRask()`.
+- ☑ Validate redirect targets — Rask sanitizes the `returnUrl` to local paths.
+- ☑ Rotate signing keys; manage the Data Protection key ring (persisted, encrypted at rest).
+
+---
+
+## Decision table
+
+| Question | Choose |
+|---|---|
+| Server (WS) app, simplest + safest | **Cookie + Server** |
+| WASM SPA talking to your own ASP.NET API, simplest + safest | **Cookie + WASM** |
+| Static-file WASM SPA against a separate API (no host of your own) | **Standalone WASM** (JWT in `sessionStorage`) |
+| Need a bearer-token API the same identity serves | **JWT** (cookie storage if you can, protected storage if not) |
+| Existing user database, password hashing, 2FA | **ASP.NET Identity** (+ cookie) |
+| Central SSO / social login / corporate IdP | **OIDC** (+ cookie) — Keycloak, Auth0, AWS Cognito, Duende IdentityServer |
+
+See the [`Authorize`](#declarative-gating) component and [Configuration](#configuration) for how each of
+these gates content and is configured.

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -343,9 +343,19 @@ Sign out with the built-in WASM signer (POSTs `/auth/logout`, refreshes, navigat
 
 ## JWT + Server
 
-Use this when you want a bearer-token API the same identity serves. Because browsers can't set an
-`Authorization` header on a WebSocket upgrade, Rask carries the token on the WS URL as `?access_token=`
-(the SignalR pattern).
+Use this when you want a bearer-token API the same identity serves.
+
+> **Recommended (and what the runnable sample does): hold the JWT in
+> [`ProtectedSessionStorage`](https://learn.microsoft.com/aspnet/core/blazor/state-management).** It is
+> encrypted at rest via ASP.NET Data Protection and decrypted **only server-side**, so the raw token never
+> appears in the URL, in a cookie, or as a JS-readable value. Login validates the JWT into a principal and
+> sets it on the live session directly (`SessionUserProvider.Set`); a small headless bootstrap re-reads it on
+> refresh. Members pages gate with the `Authorize` component (a JWT bearer challenge returns 401, not a login
+> redirect, so route `[Authorize]` is the wrong tool for an interactive page). See
+> **`samples/Rask.Example.Auth.Jwt`**.
+
+The alternative below carries the token on the WS URL as `?access_token=` (the SignalR pattern) — simpler,
+but the token lands in server access logs, so keep it short-lived and HTTPS-only.
 
 **Issue + validate the token:**
 

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -503,6 +503,11 @@ host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserPro
 
 > ⚠️ A token in `localStorage` is readable by any script on the page (XSS). For maximum security prefer the
 > **HttpOnly-cookie** scheme — the token never reaches JS at all (see [Cookie + WASM](#cookie--wasm)).
+>
+> Note: the runnable JWT samples and `dotnet new rask-wasm --auth` scaffold this **plaintext-`localStorage`**
+> `TokenStore` as the starting point. Treat it as the floor, not the recommendation — pair it with
+> short-lived access tokens (minutes, not hours), HTTPS, and a strict CSP, or graft on the encrypted-at-rest
+> `ProtectedTokenStore` below before going to production.
 
 **Harden it — encrypted at rest (`ProtectedTokenStore`).** Instead of plain `localStorage`, encrypt the token
 with ASP.NET Data Protection before storing — the browser holds only ciphertext (a server protect/unprotect

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -10,7 +10,7 @@ Keycloak/OIDC, …). This guide shows the complete, copy-pasteable flow for each
 - [Cookie + Server](#cookie--server)
 - [Cookie + WASM](#cookie--wasm)
 - [JWT + Server](#jwt--server)
-- [JWT + WASM (protected storage)](#jwt--wasm-protected-storage)
+- [JWT + WASM](#jwt--wasm)
 - [Standalone WASM (no host)](#standalone-wasm-no-host)
 - [ASP.NET Identity](#aspnet-identity)
 - [Keycloak / OpenID Connect](#keycloak--openid-connect)
@@ -238,7 +238,10 @@ Sign out from any event handler: `await auth.SignOutAsync(returnUrl: "/");`
 ## Cookie + WASM
 
 The WASM client has no server pipeline of its own, so the **API host** owns the cookie. The client hydrates
-its principal from `/api/me`.
+its principal from `/api/me`. Runnable: **`samples/Rask.Example.Auth.WasmCookie(.Host)`** (with a browser E2E).
+
+> **Scaffold it:** `dotnet new rask-wasm-hosted --auth` generates this — the host's `/api/login` + `/api/me` +
+> `/auth/logout`, and a client with `ApiUserProvider`, a login page, and a protected `/members` page.
 
 **On the API host** (`Rask.Wasm.Host` / your ASP.NET server):
 
@@ -314,30 +317,40 @@ unsupported — the cookie is set by the server):
 ```csharp
 public sealed class WasmLoginService(HttpClient http, IUserProvider users, Navigator nav)
 {
-    public async Task<bool> LoginAsync(LoginModel m, string? returnUrl)
+    public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
     {
-        var resp = await http.PostAsJsonAsync("api/login", new LoginDto(m.Username, m.Password), AuthJson.Default.Options);
+        var resp = await http.PostAsJsonAsync("api/login", new LoginDto(username, password), AuthJson.Default.LoginDto);
         if (!resp.IsSuccessStatusCode) return false;
         await users.RefreshAsync();
-        nav.Navigate(returnUrl ?? "/");
+        nav.Navigate(returnUrl ?? "/members");
         return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        await http.PostAsync("auth/logout", null);
+        // Navigate first (still in the click-handler scope), then clear the principal — refreshing first
+        // closes the Authorize gate and unmounts the calling component before the navigation runs.
+        nav.Navigate("/login");
+        await users.RefreshAsync();
     }
 }
 ```
 
-**`Program.cs` (client):**
+**`Program.cs` (client)** — note `WasmHostBuilder.BaseAddress` (not Blazor's `HostEnvironment`):
 
 ```csharp
-var builder = WasmHostBuilder.CreateDefault(args);
-builder.Services.AddSingleton(new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
-builder.Services.AddSingleton<ApiUserProvider>();
-builder.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<ApiUserProvider>()); // overrides the anonymous default
-builder.Services.AddSingleton<WasmLoginService>();
-await builder.RunAsync<App>();
+var host = WasmHostBuilder.CreateDefault();
+host.Services.AddSingleton(_ => new HttpClient { BaseAddress = new Uri(WasmHostBuilder.BaseAddress) });
+host.Services.AddSingleton<ApiUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<ApiUserProvider>()); // overrides the anonymous default
+host.Services.AddSingleton<WasmLoginService>();
+await host.RunAsync<App>();
 ```
 
-Sign out with the built-in WASM signer (POSTs `/auth/logout`, refreshes, navigates):
-`await auth.SignOutAsync(returnUrl: "/");`
+Wire the form to `WasmLoginService.LoginAsync` and the sign-out button to `WasmLoginService.LogoutAsync`.
+(The built-in `WasmAuthSignIn.SignOutAsync` also works, but doing it through your own service keeps the
+navigate-before-refresh ordering explicit.)
 
 ---
 
@@ -354,8 +367,40 @@ Use this when you want a bearer-token API the same identity serves.
 > redirect, so route `[Authorize]` is the wrong tool for an interactive page). See
 > **`samples/Rask.Example.Auth.Jwt`**.
 
-The alternative below carries the token on the WS URL as `?access_token=` (the SignalR pattern) — simpler,
-but the token lands in server access logs, so keep it short-lived and HTTPS-only.
+**Recommended — `ProtectedSessionStorage`:**
+
+```csharp
+// Program.cs
+builder.Services.AddDataProtection();
+builder.Services.AddScoped<ProtectedSessionStorage>();   // Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+builder.Services.AddSingleton<JwtIssuer>();
+builder.Services.AddSingleton<JwtValidator>();           // validates a raw JWT → ClaimsPrincipal
+builder.Services.AddRask();
+// no AddJwtBearer, no UseAuthentication — the principal is held in the live session, not middleware.
+
+// LoginPage submit handler (the WS is up, so JS interop works):
+var jwt = issuer.Issue(name, roles);
+await sessionStore.SetAsync("rask.jwt", jwt);            // encrypted at rest, decrypted only server-side
+if (validator.Validate(jwt) is { } principal)
+    users.Set(principal);                               // SessionUserProvider.Set — authenticated in-session
+nav.Navigate("/members");
+
+// A headless bootstrap re-establishes the principal on a fresh session / refresh:
+protected override async Task OnMountAsync()
+{
+    var result = await sessionStore.GetAsync<string>("rask.jwt");
+    if (result.Success && result.Value is { } jwt && validator.Validate(jwt) is { } principal)
+        users.Set(principal);
+}
+```
+
+The members page gates with the `Authorize` component (not route `[Authorize]`, which would 401). Full code:
+**`samples/Rask.Example.Auth.Jwt`**.
+
+---
+
+**Alternative — `?access_token` on the WS URL** (the SignalR pattern): simpler, but the token lands in
+server access logs, so keep it short-lived and HTTPS-only.
 
 **Issue + validate the token:**
 
@@ -414,13 +459,54 @@ exactly as for cookies.
 
 ---
 
-## JWT + WASM (protected storage)
+## JWT + WASM
 
-For a bearer-token SPA, the token rides the `Authorization` header on every `HttpClient` call. Per the
-"never store a plaintext token" rule, the token is **encrypted with ASP.NET Data Protection** before it
-touches browser storage.
+For a bearer-token SPA, the token rides the `Authorization` header on every `HttpClient` call. The runnable
+sample (**`samples/Rask.Example.Auth.WasmJwt(.Host)`**, with a browser E2E) keeps it simple: a plain
+**`localStorage`** token store (cleared on sign-out), a `BearerTokenHandler` that attaches it, and the host
+validating it with `AddJwtBearer`.
 
-**`ProtectedTokenStore` (reference implementation of `ITokenStore`):**
+**`TokenStore` (localStorage) + `BearerTokenHandler`:**
+
+```csharp
+public sealed class TokenStore(IJSRuntime js)
+{
+    public string? Token { get; private set; }   // in-memory copy the handler reads synchronously
+    public async Task InitAsync()        => Token = await js.InvokeAsync<string?>("localStorage.getItem", "rask.jwt");
+    public async Task SetAsync(string t) { Token = t; await js.InvokeVoidAsync("localStorage.setItem", "rask.jwt", t); }
+    public async Task ClearAsync()       { Token = null; await js.InvokeVoidAsync("localStorage.removeItem", "rask.jwt"); }
+}
+
+public sealed class BearerTokenHandler(TokenStore tokens) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
+    {
+        if (tokens.Token is { } token)
+            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return base.SendAsync(req, ct);
+    }
+}
+```
+
+Register the `HttpClient` with the handler; a `JwtUserProvider` hydrates from `/api/me` **only when a token is
+present** (so anonymous never hits a 401). On the host, `AddJwtBearer` validates the bearer and `/api/login`
+returns the signed JWT.
+
+```csharp
+host.Services.AddSingleton<TokenStore>();
+host.Services.AddSingleton(sp => new HttpClient(
+        new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
+    { BaseAddress = new Uri(WasmHostBuilder.BaseAddress) });
+host.Services.AddSingleton<JwtUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>());
+```
+
+> ⚠️ A token in `localStorage` is readable by any script on the page (XSS). For maximum security prefer the
+> **HttpOnly-cookie** scheme — the token never reaches JS at all (see [Cookie + WASM](#cookie--wasm)).
+
+**Harden it — encrypted at rest (`ProtectedTokenStore`).** Instead of plain `localStorage`, encrypt the token
+with ASP.NET Data Protection before storing — the browser holds only ciphertext (a server protect/unprotect
+round-trip, since a standalone SPA has no key ring):
 
 ```csharp
 public sealed class ProtectedTokenStore(IJSRuntime js, IDataProtectionProvider dp) : ITokenStore
@@ -430,51 +516,22 @@ public sealed class ProtectedTokenStore(IJSRuntime js, IDataProtectionProvider d
 
     public async ValueTask<string?> GetAsync()
     {
-        var cipher = await js.InvokeAsync<string?>("localStorage.getItem", Key)
-                     ?? await js.InvokeAsync<string?>("sessionStorage.getItem", Key);
+        var cipher = await js.InvokeAsync<string?>("localStorage.getItem", Key);
         if (string.IsNullOrEmpty(cipher)) return null;
         try { return _protector.Unprotect(cipher); }
         catch (CryptographicException) { await ClearAsync(); return null; } // tampered / key rotated
     }
 
-    public async ValueTask SetAsync(string token, bool persist)
-    {
-        var cipher = _protector.Protect(token);                     // ← ciphertext, never the raw JWT
-        var store = persist ? "localStorage" : "sessionStorage";    // remember-me vs tab-scoped
-        await js.InvokeVoidAsync($"{store}.setItem", Key, cipher);
-    }
+    public async ValueTask SetAsync(string token, bool persist) =>
+        await js.InvokeVoidAsync($"{(persist ? "localStorage" : "sessionStorage")}.setItem", Key, _protector.Protect(token));
 
-    public async ValueTask ClearAsync()
-    {
-        await js.InvokeVoidAsync("localStorage.removeItem", Key);
-        await js.InvokeVoidAsync("sessionStorage.removeItem", Key);
-    }
+    public async ValueTask ClearAsync() => await js.InvokeVoidAsync("localStorage.removeItem", Key);
 }
 ```
 
-> On WASM, ASP.NET Data Protection needs a key ring. For a browser-only SPA, deliver the protected blob from
-> the server (protect in the API, unprotect on `/api/me`), or — simpler and stronger — use the **HttpOnly
-> cookie** scheme so the token never reaches JS at all. Protected storage is the right call when you must
-> hold a bearer token client-side for a non-cookie API.
-
-**Attach the bearer token to outgoing calls:**
-
-```csharp
-public sealed class BearerTokenHandler(ITokenStore tokens) : DelegatingHandler
-{
-    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage req, CancellationToken ct)
-    {
-        if (await tokens.GetAsync() is { } token)
-            req.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
-        return await base.SendAsync(req, ct);
-    }
-}
-```
-
-The `ApiUserProvider` from the cookie section works unchanged — it hydrates from `/api/me`, which is now
-validated by `AddJwtBearer`. Silent refresh is an **app responsibility** (Rask doesn't run a refresh timer):
-from a timer in a long-lived component, refresh the token before it expires and call `users.RefreshAsync()`
-— the provider raises `Changed` and the session re-renders.
+Silent refresh is an **app responsibility** (Rask doesn't run a refresh timer): from a timer in a long-lived
+component, refresh the token before it expires and call `users.RefreshAsync()` — the provider raises `Changed`
+and the session re-renders.
 
 ---
 
@@ -486,10 +543,13 @@ runtime is entirely in-browser (no WebSocket back to a Rask host). So there's no
 store the JWT client-side, decode it to a principal, and attach it to your `HttpClient` calls.** The external
 API must enable **CORS** for your app's origin and allow the `Authorization` header.
 
+> **Scaffold it:** `dotnet new rask-wasm --auth` generates the client pieces below (`TokenStore`,
+> `BearerTokenHandler`, `JwtUserProvider`, a login page) with a `BaseAddress` stub — point it at your API.
+
 > No host means no ASP.NET Data Protection key ring, so the encrypted "protected storage" option isn't
 > available here. Use a **short-lived** JWT in `sessionStorage` (cleared on tab close) with refresh, a strict
 > **CSP** to reduce XSS exposure, and HTTPS. If you need the token to never touch JS, you need a host — see
-> [JWT + WASM](#jwt--wasm-protected-storage) or the cookie flows.
+> [JWT + WASM](#jwt--wasm) or the cookie flows.
 
 **A token store** (in-memory + `sessionStorage`, read synchronously by the handler):
 
@@ -578,7 +638,7 @@ public sealed class LoginService(HttpClient http, TokenStore tokens, JwtUserProv
 {
     public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
     {
-        var resp = await http.PostAsJsonAsync("api/login", new LoginDto(username, password), AuthJson.Default.Options);
+        var resp = await http.PostAsJsonAsync("api/login", new LoginDto(username, password), AuthJson.Default.LoginDto);
         if (!resp.IsSuccessStatusCode) return false;
         var dto = await resp.Content.ReadFromJsonAsync(AuthJson.Default.TokenDto);
         await tokens.SetAsync(dto!.Token);
@@ -605,17 +665,17 @@ public partial class AuthJson : JsonSerializerContext { } // keeps the WASM publ
 **`Program.cs`:**
 
 ```csharp
-var builder = WasmHostBuilder.CreateDefault(args);
+var host = WasmHostBuilder.CreateDefault();
 
-builder.Services.AddSingleton<TokenStore>();
-builder.Services.AddSingleton(sp => new HttpClient(
+host.Services.AddSingleton<TokenStore>();
+host.Services.AddSingleton(sp => new HttpClient(
         new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
     { BaseAddress = new Uri("https://api.example.com/") });   // ← your external API (CORS-enabled)
-builder.Services.AddSingleton<JwtUserProvider>();
-builder.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>()); // overrides the anonymous default
-builder.Services.AddSingleton<LoginService>();
+host.Services.AddSingleton<JwtUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>()); // overrides the anonymous default
+host.Services.AddSingleton<LoginService>();
 
-await builder.RunAsync<App>();
+await host.RunAsync<App>();
 ```
 
 `Component.User`, the `Authorize` component, and `[Authorize]` route gating all work against the decoded

--- a/samples/Rask.Example.Auth.Jwt/App.cs
+++ b/samples/Rask.Example.Auth.Jwt/App.cs
@@ -1,19 +1,37 @@
+using Rask.Core.Components;
+
 namespace Rask.Example.Auth.Jwt;
 
-// Minimal shell. JwtBootstrap (headless) re-establishes the principal from ProtectedSessionStorage on a
-// fresh session/refresh; Router renders the matched page.
+// App shell. JwtBootstrap (headless) re-establishes the principal from ProtectedSessionStorage on a
+// fresh session/refresh; the navbar + Router render the matched page. Bootstrap rides a CDN link and
+// App.css layers the Rask purple palette on top.
 public sealed class App : Component
 {
-    protected override RenderResult Head => Title()["Rask — JWT auth sample"];
+    protected override RenderResult Head => [
+        Title()["Rask — JWT auth sample"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
 
     protected override RenderResult Render() =>
         [
             Doctype(),
             Html("en")[
                 Head(),
-                Body()[
+                Body(Class: "bg-body-tertiary")[
                     JwtBootstrap(),
-                    Router()
+                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                        Div(Class: "container")[
+                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · JWT auth"],
+                            A("https://github.com/pal-tamas/rask", "_blank",
+                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                        ]
+                    ],
+                    Main(Class: "container py-4")[Router()]
                 ]
             ]
         ];

--- a/samples/Rask.Example.Auth.Jwt/App.cs
+++ b/samples/Rask.Example.Auth.Jwt/App.cs
@@ -1,0 +1,20 @@
+namespace Rask.Example.Auth.Jwt;
+
+// Minimal shell. JwtBootstrap (headless) re-establishes the principal from ProtectedSessionStorage on a
+// fresh session/refresh; Router renders the matched page.
+public sealed class App : Component
+{
+    protected override RenderResult Head => Title()["Rask — JWT auth sample"];
+
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[
+                    JwtBootstrap(),
+                    Router()
+                ]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Auth.Jwt/App.css
+++ b/samples/Rask.Example.Auth.Jwt/App.css
@@ -1,0 +1,40 @@
+/* Rask brand palette layered over Bootstrap. Every rule targets :root, a global Bootstrap
+   class, or a shell tag, so each is wrapped in :global() to opt out of the component
+   scope-suffix rewrite (mirrors samples/Rask.Example.Shared/App.css). */
+:global(:root) {
+    --bs-primary: #7C3AED;
+    --bs-primary-rgb: 124, 58, 237;
+    --bs-link-color: #6D28D9;
+    --bs-link-color-rgb: 109, 40, 217;
+    --bs-link-hover-color: #512BD4;
+    --rask-accent: #7C3AED;
+    --rask-accent-strong: #512BD4;
+    --rask-accent-soft: #f1ebfd;
+}
+
+:global(.btn-primary) {
+    --bs-btn-bg: #7C3AED;
+    --bs-btn-border-color: #7C3AED;
+    --bs-btn-hover-bg: #6D28D9;
+    --bs-btn-hover-border-color: #6D28D9;
+    --bs-btn-active-bg: #512BD4;
+    --bs-btn-active-border-color: #512BD4;
+    --bs-btn-disabled-bg: #7C3AED;
+    --bs-btn-disabled-border-color: #7C3AED;
+}
+
+:global(a) {
+    color: var(--rask-accent);
+}
+
+:global(a:hover) {
+    color: var(--rask-accent-strong);
+}
+
+:global(:not(pre) > code) {
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.08rem 0.32rem;
+    border-radius: 4px;
+    font-size: 0.86em;
+}

--- a/samples/Rask.Example.Auth.Jwt/Auth/CredentialStore.cs
+++ b/samples/Rask.Example.Auth.Jwt/Auth/CredentialStore.cs
@@ -1,0 +1,90 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Rask.Example.Auth.Jwt;
+
+// Demo credential store — replace with your real user store.
+public interface ICredentialStore
+{
+    (string Name, string[] Roles)? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public (string Name, string[] Roles)? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => ("alice", new[] { "user" }),
+            ("root", "password") => ("root", new[] { "admin" }),
+            _ => null
+        };
+}
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+
+// Issues short-lived HMAC-signed JWTs (claims use short "name"/"role" names; MapInboundClaims off on read
+// so they round-trip unchanged).
+public sealed class JwtIssuer(IConfiguration config)
+{
+    // Dev-only default — set Jwt:Key in configuration for anything real.
+    public const string DevKey = "rask-jwt-demo-insecure-dev-signing-key-change-me-please-0123456789";
+
+    public static SymmetricSecurityKey KeyFrom(IConfiguration config) =>
+        new(Encoding.UTF8.GetBytes(config["Jwt:Key"] ?? DevKey));
+
+    public string Issue(string name, string[] roles)
+    {
+        var claims = new List<Claim> { new("name", name) };
+        foreach (var r in roles)
+        {
+            claims.Add(new Claim("role", r));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: "rask-jwt-demo",
+            audience: "rask-jwt-demo",
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(KeyFrom(config), SecurityAlgorithms.HmacSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+// Validates a raw JWT and builds the ClaimsPrincipal. Used by the login handler (issue → validate → set
+// principal, so the JWT is the source of truth) and by the boot read on a fresh session.
+public sealed class JwtValidator(IConfiguration config)
+{
+    public ClaimsPrincipal? Validate(string jwt)
+    {
+        try
+        {
+            var principal = new JwtSecurityTokenHandler { MapInboundClaims = false }.ValidateToken(
+                jwt,
+                new TokenValidationParameters
+                {
+                    ValidateIssuer = true,
+                    ValidIssuer = "rask-jwt-demo",
+                    ValidateAudience = true,
+                    ValidAudience = "rask-jwt-demo",
+                    ValidateIssuerSigningKey = true,
+                    IssuerSigningKey = JwtIssuer.KeyFrom(config),
+                    ValidateLifetime = true,
+                    NameClaimType = "name",
+                    RoleClaimType = "role"
+                },
+                out _);
+            return principal;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/samples/Rask.Example.Auth.Jwt/JwtBootstrap.cs
+++ b/samples/Rask.Example.Auth.Jwt/JwtBootstrap.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Rask.Server.Authentication;
+
+namespace Rask.Example.Auth.Jwt;
+
+// Headless. On a fresh session it reads the stored JWT (ProtectedSessionStorage decrypts it server-side),
+// validates it, and seeds the live principal — so a refresh stays signed in without the token ever being in
+// the URL or readable in JS. JS interop runs once the WebSocket is up; the read completes then and fires a
+// re-render via IUserProvider.Changed.
+public sealed class JwtBootstrap(ProtectedSessionStorage store, JwtValidator validator, SessionUserProvider users)
+    : Component
+{
+    protected override async Task OnMountAsync()
+    {
+        try
+        {
+            var result = await store.GetAsync<string>("rask.jwt");
+            if (result.Success && result.Value is { } jwt && validator.Validate(jwt) is { } principal)
+            {
+                users.Set(principal);
+            }
+        }
+        catch
+        {
+            // No token yet, or JS interop unavailable on the prerender pass — stay anonymous.
+        }
+    }
+
+    protected override RenderResult Render() => default;
+}

--- a/samples/Rask.Example.Auth.Jwt/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/HomePage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.Jwt.Pages;
@@ -8,11 +9,15 @@ namespace Rask.Example.Auth.Jwt.Pages;
 public sealed class HomePage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Rask JWT-auth sample"],
-            P()["The JWT authenticates the live WebSocket — it rides the upgrade as ", Code()["?access_token="],
-                " (set via ", Code()["window.Rask.authToken"], "). The members page gates content with the ",
-                Code()["Authorize"], " component over that authenticated socket."],
-            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        Div(Id: "home", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Rask JWT-auth sample"],
+                P(Class: "card-text text-secondary")[
+                    "The JWT authenticates the live WebSocket — it rides the upgrade as ", Code()["?access_token="],
+                    " (set via ", Code()["window.Rask.authToken"], "). The members page gates content with the ",
+                    Code()["Authorize"], " component over that authenticated socket."],
+                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                    "Go to the members area →"]
+            ]
         ];
 }

--- a/samples/Rask.Example.Auth.Jwt/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/HomePage.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.Jwt.Pages;
+
+[Route("/")]
+[AllowAnonymous]
+public sealed class HomePage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Rask JWT-auth sample"],
+            P()["The JWT authenticates the live WebSocket — it rides the upgrade as ", Code()["?access_token="],
+                " (set via ", Code()["window.Rask.authToken"], "). The members page gates content with the ",
+                Code()["Authorize"], " component over that authenticated socket."],
+            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        ];
+}

--- a/samples/Rask.Example.Auth.Jwt/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/LoginPage.cs
@@ -1,0 +1,62 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+using Rask.Server.Authentication;
+
+namespace Rask.Example.Auth.Jwt.Pages;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(
+    ICredentialStore creds,
+    JwtIssuer issuer,
+    JwtValidator validator,
+    ProtectedSessionStorage store,
+    SessionUserProvider users,
+    Navigator nav) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    protected override RenderResult Render() =>
+        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Sign in"],
+            _error is null
+                ? (Child)Fragment()
+                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div(Style: "margin-bottom:.5rem")[
+                    Label("username")["Username"],
+                    Input(() => _model.Username, Id: "username")
+                ],
+                Div(Style: "margin-bottom:.75rem")[
+                    Label("password")["Password"],
+                    Input(() => _model.Password, Id: "password", Type: "password")
+                ],
+                Button("submit", Id: "login-submit")["Sign in"]
+            ],
+            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        var ok = creds.Validate(m.Username, m.Password);
+        if (ok is null)
+        {
+            _error = "Invalid username or password.";
+            return;
+        }
+
+        // Issue the JWT and stash it encrypted in sessionStorage (decrypted only server-side). Then validate
+        // it into a principal and set it on the live session — no URL token, no cookie, no JS-readable token.
+        var jwt = issuer.Issue(ok.Value.Name, ok.Value.Roles);
+        await store.SetAsync("rask.jwt", jwt);
+        if (validator.Validate(jwt) is { } principal)
+        {
+            users.Set(principal);
+        }
+
+        nav.Navigate("/members");
+    }
+}

--- a/samples/Rask.Example.Auth.Jwt/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/LoginPage.cs
@@ -20,23 +20,26 @@ public sealed class LoginPage(
     private string? _error;
 
     protected override RenderResult Render() =>
-        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Sign in"],
-            _error is null
-                ? (Child)Fragment()
-                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
-            Form(_model, OnValidSubmitAsync: SubmitAsync)[
-                Div(Style: "margin-bottom:.5rem")[
-                    Label("username")["Username"],
-                    Input(() => _model.Username, Id: "username")
+        Div(Id: "login", Class: "card shadow-sm mx-auto", Style: "max-width:24rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Sign in"],
+                _error is null
+                    ? (Child)Fragment()
+                    : Div(Id: "login-error", Class: "alert alert-danger py-2")[_error],
+                Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                    Div(Class: "mb-3")[
+                        Label("username", Class: "form-label")["Username"],
+                        Input(() => _model.Username, Id: "username", Class: "form-control")
+                    ],
+                    Div(Class: "mb-3")[
+                        Label("password", Class: "form-label")["Password"],
+                        Input(() => _model.Password, Id: "password", Type: "password", Class: "form-control")
+                    ],
+                    Button("submit", Id: "login-submit", Class: "btn btn-primary w-100")["Sign in"]
                 ],
-                Div(Style: "margin-bottom:.75rem")[
-                    Label("password")["Password"],
-                    Input(() => _model.Password, Id: "password", Type: "password")
-                ],
-                Button("submit", Id: "login-submit")["Sign in"]
-            ],
-            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+                P(Class: "text-muted small mt-3 mb-0")[
+                    "Try alice / password (user) or root / password (admin)."]
+            ]
         ];
 
     private async Task SubmitAsync(LoginModel m)

--- a/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+using Rask.Server.Authentication;
+
+namespace Rask.Example.Auth.Jwt.Pages;
+
+// Component-gated (not a [Authorize] route attribute): the principal is held in the live session, set from
+// the JWT held in ProtectedSessionStorage. The Authorize component re-renders when that principal changes.
+[Route("members")]
+[AllowAnonymous]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            Authorize(
+                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+public sealed class MemberContent(ProtectedSessionStorage store, SessionUserProvider users, Navigator nav)
+    : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
+            P()["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
+                " — encrypted at rest, decrypted only server-side."],
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(Id: "logout", OnClickAsync: SignOutAsync)["Sign out"]
+        ];
+
+    private async Task SignOutAsync()
+    {
+        await store.DeleteAsync("rask.jwt");
+        users.Clear();
+        nav.Navigate("/login");
+    }
+}

--- a/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
@@ -13,10 +13,13 @@ namespace Rask.Example.Auth.Jwt.Pages;
 public sealed class MembersPage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            Authorize(
-                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+        Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                Authorize(
+                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
+                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorized: MemberContent())
+            ]
         ];
 }
 
@@ -25,14 +28,14 @@ public sealed class MemberContent(ProtectedSessionStorage store, SessionUserProv
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
-            P()["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
+            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            P(Class: "text-secondary")["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
                 " — encrypted at rest, decrypted only server-side."],
             Authorize(
                 Roles: ["admin"],
-                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
-            Button(Id: "logout", OnClickAsync: SignOutAsync)["Sign out"]
+            Button(Id: "logout", OnClickAsync: SignOutAsync, Class: "btn btn-outline-primary")["Sign out"]
         ];
 
     private async Task SignOutAsync()

--- a/samples/Rask.Example.Auth.Jwt/Program.cs
+++ b/samples/Rask.Example.Auth.Jwt/Program.cs
@@ -1,0 +1,23 @@
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
+using Rask.Example.Auth.Jwt;
+using Rask.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// The JWT is held in ProtectedSessionStorage — encrypted at rest via ASP.NET Data Protection, stored in the
+// browser's sessionStorage, decrypted server-side. The raw token never appears in JS, in a cookie, or in the
+// WebSocket URL. Login validates it into a principal and sets it on the live session directly.
+builder.Services.AddDataProtection();
+builder.Services.AddScoped<ProtectedSessionStorage>();
+builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+builder.Services.AddSingleton<JwtIssuer>();
+builder.Services.AddSingleton<JwtValidator>();
+builder.Services.AddRask();
+
+var app = builder.Build();
+
+app.UseStaticFiles();
+app.UseRouting();
+app.UseRask<App>();
+
+app.Run();

--- a/samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj
+++ b/samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj
@@ -7,6 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
@@ -14,7 +18,6 @@
                       ReferenceOutputAssembly="false"/>
   </ItemGroup>
 
-  <!-- The ASP.NET Web SDK requires a wwwroot to exist even when there are no static files. -->
   <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
     <MakeDir Directories="wwwroot"/>
   </Target>

--- a/samples/Rask.Example.Auth.WasmCookie.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/Program.cs
@@ -1,0 +1,72 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Rask.Wasm.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(o =>
+    {
+        o.Cookie.Name = "rask.auth";
+        o.ExpireTimeSpan = TimeSpan.FromHours(8);
+        o.SlidingExpiration = true;
+    });
+builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+builder.Services.AddRask(); // Rask.Wasm.Hosting — response compression for the AppBundle
+
+var app = builder.Build();
+
+// Populates HttpContext.User from the cookie so /api/me reflects the signed-in user. (No UseAuthorization
+// — there are no [Authorize] endpoints; the WASM client gates content with the Authorize component.)
+app.UseAuthentication();
+
+// Auth API consumed by the WASM client (same origin, so the HttpOnly cookie rides every request).
+app.MapPost("/api/login", async (HttpContext ctx, LoginRequest dto, ICredentialStore creds) =>
+{
+    var claims = creds.Validate(dto.Username, dto.Password);
+    if (claims is null)
+    {
+        return Results.Unauthorized();
+    }
+
+    var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+    await ctx.SignInAsync(new ClaimsPrincipal(identity));
+    return Results.Ok();
+});
+
+app.MapGet("/api/me", (HttpContext ctx) =>
+    ctx.User.Identity?.IsAuthenticated == true
+        ? Results.Ok(new MeDto(
+            ctx.User.Identity!.Name!,
+            ctx.User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray()))
+        : Results.NoContent());
+
+app.MapPost("/auth/logout", async (HttpContext ctx) =>
+{
+    await ctx.SignOutAsync();
+    return Results.Ok();
+});
+
+app.UseRask(); // serve the published WASM AppBundle
+
+app.Run();
+
+public sealed record LoginRequest(string Username, string Password);
+public sealed record MeDto(string Name, string[] Roles);
+
+public interface ICredentialStore
+{
+    IReadOnlyList<Claim>? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public IReadOnlyList<Claim>? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => [new Claim(ClaimTypes.Name, "alice"), new Claim(ClaimTypes.Role, "user")],
+            ("root", "password") => [new Claim(ClaimTypes.Name, "root"), new Claim(ClaimTypes.Role, "admin")],
+            _ => null
+        };
+}

--- a/samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Rask.Example.Auth.WasmCookie.Host</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Wasm.Hosting\Rask.Wasm.Hosting.csproj"/>
+    <ProjectReference Include="..\Rask.Example.Auth.WasmCookie\Rask.Example.Auth.WasmCookie.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"/>
+  </ItemGroup>
+
+  <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="wwwroot"/>
+  </Target>
+
+</Project>

--- a/samples/Rask.Example.Auth.WasmCookie/App.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/App.cs
@@ -1,15 +1,37 @@
+using Rask.Core.Components;
+
 namespace Rask.Example.Auth.WasmCookie;
 
 public sealed class App : Component
 {
-    protected override RenderResult Head => Title()["Rask — Cookie + WASM auth"];
+    // Bootstrap + Bootstrap Icons via CDN keep the showcase look without vendoring wwwroot/lib
+    // per sample. App.css (scoped sibling) layers the Rask purple palette on top — user <head>
+    // contributions splice in before the scoped-css link so the palette overrides Bootstrap.
+    protected override RenderResult Head => [
+        Title()["Rask — Cookie + WASM auth"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
 
     protected override RenderResult Render() =>
         [
             Doctype(),
             Html("en")[
                 Head(),
-                Body()[Router()]
+                Body(Class: "bg-body-tertiary")[
+                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                        Div(Class: "container")[
+                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · cookie + WASM auth"],
+                            A("https://github.com/pal-tamas/rask", "_blank",
+                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                        ]
+                    ],
+                    Main(Class: "container py-4")[Router()]
+                ]
             ]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmCookie/App.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/App.cs
@@ -1,0 +1,15 @@
+namespace Rask.Example.Auth.WasmCookie;
+
+public sealed class App : Component
+{
+    protected override RenderResult Head => Title()["Rask — Cookie + WASM auth"];
+
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[Router()]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Auth.WasmCookie/App.css
+++ b/samples/Rask.Example.Auth.WasmCookie/App.css
@@ -1,0 +1,40 @@
+/* Rask brand palette layered over Bootstrap. Every rule targets :root, a global Bootstrap
+   class, or a shell tag, so each is wrapped in :global() to opt out of the component
+   scope-suffix rewrite (mirrors samples/Rask.Example.Shared/App.css). */
+:global(:root) {
+    --bs-primary: #7C3AED;
+    --bs-primary-rgb: 124, 58, 237;
+    --bs-link-color: #6D28D9;
+    --bs-link-color-rgb: 109, 40, 217;
+    --bs-link-hover-color: #512BD4;
+    --rask-accent: #7C3AED;
+    --rask-accent-strong: #512BD4;
+    --rask-accent-soft: #f1ebfd;
+}
+
+:global(.btn-primary) {
+    --bs-btn-bg: #7C3AED;
+    --bs-btn-border-color: #7C3AED;
+    --bs-btn-hover-bg: #6D28D9;
+    --bs-btn-hover-border-color: #6D28D9;
+    --bs-btn-active-bg: #512BD4;
+    --bs-btn-active-border-color: #512BD4;
+    --bs-btn-disabled-bg: #7C3AED;
+    --bs-btn-disabled-border-color: #7C3AED;
+}
+
+:global(a) {
+    color: var(--rask-accent);
+}
+
+:global(a:hover) {
+    color: var(--rask-accent-strong);
+}
+
+:global(:not(pre) > code) {
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.08rem 0.32rem;
+    border-radius: 4px;
+    font-size: 0.86em;
+}

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
@@ -15,7 +15,11 @@ public sealed class ApiUserProvider(HttpClient http) : IUserProvider
     public bool IsLoading { get; private set; }
     public event Action? Changed;
 
-    public Task EnsureLoadedAsync() => LoadAsync();
+    public Task EnsureLoadedAsync()
+    {
+        IsLoading = true; // bridge the anonymous→authed flash (LoadAsync's finally clears it)
+        return LoadAsync();
+    }
 
     public async Task RefreshAsync()
     {

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
@@ -32,14 +32,21 @@ public sealed class ApiUserProvider(HttpClient http) : IUserProvider
     {
         try
         {
-            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            // GetAsync (not GetFromJsonAsync): an anonymous /api/me returns 204 No Content, and
+            // GetFromJsonAsync would throw a JsonException trying to deserialize the empty body
+            // (its try/catch only caught HttpRequestException). Treat anything but a 200-with-body
+            // as anonymous.
+            using var resp = await http.GetAsync("api/me");
+            var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+                ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
+                : null;
             _current = me is { Name: { } name }
                 ? new ClaimsPrincipal(new ClaimsIdentity(
                     [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))],
                     "api"))
                 : new ClaimsPrincipal(new ClaimsIdentity());
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
         {
             _current = new ClaimsPrincipal(new ClaimsIdentity());
         }

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
@@ -1,0 +1,48 @@
+using System.Net.Http.Json;
+using System.Security.Claims;
+using Rask.Core.Authentication;
+
+namespace Rask.Example.Auth.WasmCookie;
+
+// Real WASM IUserProvider: hydrates the principal from the host's /api/me (the HttpOnly cookie rides the
+// same-origin request automatically — the token never touches JS). WasmHostBuilder awaits EnsureLoadedAsync
+// before the first render, so there's no anonymous flash.
+public sealed class ApiUserProvider(HttpClient http) : IUserProvider
+{
+    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+
+    public ClaimsPrincipal Current => _current;
+    public bool IsLoading { get; private set; }
+    public event Action? Changed;
+
+    public Task EnsureLoadedAsync() => LoadAsync();
+
+    public async Task RefreshAsync()
+    {
+        IsLoading = true;
+        Changed?.Invoke();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            _current = me is { Name: { } name }
+                ? new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))],
+                    "api"))
+                : new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        catch (HttpRequestException)
+        {
+            _current = new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        finally
+        {
+            IsLoading = false;
+            Changed?.Invoke();
+        }
+    }
+}

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/Dtos.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/Dtos.cs
@@ -1,0 +1,23 @@
+using System.Text.Json.Serialization;
+
+namespace Rask.Example.Auth.WasmCookie;
+
+public sealed record LoginRequest(
+    [property: JsonPropertyName("username")] string Username,
+    [property: JsonPropertyName("password")] string Password);
+
+public sealed record MeDto(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("roles")] string[] Roles);
+
+// Form-bound model (settable props for two-way binding).
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+
+// Source-generated JSON so the WASM publish stays trim-clean (zero IL warnings).
+[JsonSerializable(typeof(LoginRequest))]
+[JsonSerializable(typeof(MeDto))]
+public partial class AuthJson : JsonSerializerContext;

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/WasmLoginService.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/WasmLoginService.cs
@@ -1,0 +1,34 @@
+using System.Net.Http.Json;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmCookie;
+
+// WASM sign-in: POST credentials to the host's /api/login (it sets the HttpOnly cookie), then refresh the
+// provider from /api/me and navigate. (WasmAuthSignIn.SignInAsync intentionally throws — credentials go to
+// your own endpoint; only sign-out is framework-provided.)
+public sealed class WasmLoginService(HttpClient http, IUserProvider users, Navigator nav)
+{
+    public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
+    {
+        var resp = await http.PostAsJsonAsync("api/login", new LoginRequest(username, password),
+            AuthJson.Default.LoginRequest);
+        if (!resp.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        await users.RefreshAsync();
+        nav.Navigate(returnUrl ?? "/members");
+        return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        await http.PostAsync("auth/logout", null);
+        // Navigate first (while still in the click-handler scope), then clear the principal — refreshing
+        // first would close the Authorize gate and unmount this component before the navigation runs.
+        nav.Navigate("/login");
+        await users.RefreshAsync();
+    }
+}

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/HomePage.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmCookie.Pages;
+
+[Route("/")]
+[AllowAnonymous]
+public sealed class HomePage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Rask cookie + WASM auth sample"],
+            P()["A browser-WASM SPA that signs in against its host's ", Code()["/api/login"],
+                " (HttpOnly cookie) and hydrates the user from ", Code()["/api/me"], "."],
+            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        ];
+}

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/HomePage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmCookie.Pages;
@@ -8,10 +9,14 @@ namespace Rask.Example.Auth.WasmCookie.Pages;
 public sealed class HomePage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Rask cookie + WASM auth sample"],
-            P()["A browser-WASM SPA that signs in against its host's ", Code()["/api/login"],
-                " (HttpOnly cookie) and hydrates the user from ", Code()["/api/me"], "."],
-            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        Div(Id: "home", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Rask cookie + WASM auth sample"],
+                P(Class: "card-text text-secondary")[
+                    "A browser-WASM SPA that signs in against its host's ", Code()["/api/login"],
+                    " (HttpOnly cookie) and hydrates the user from ", Code()["/api/me"], "."],
+                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                    "Go to the members area →"]
+            ]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/LoginPage.cs
@@ -14,23 +14,26 @@ public sealed class LoginPage(WasmLoginService login) : Component
     [QueryParam] public string? ReturnUrl { get; set; }
 
     protected override RenderResult Render() =>
-        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Sign in"],
-            _error is null
-                ? (Child)Fragment()
-                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
-            Form(_model, OnValidSubmitAsync: SubmitAsync)[
-                Div(Style: "margin-bottom:.5rem")[
-                    Label("username")["Username"],
-                    Input(() => _model.Username, Id: "username")
+        Div(Id: "login", Class: "card shadow-sm mx-auto", Style: "max-width:24rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Sign in"],
+                _error is null
+                    ? (Child)Fragment()
+                    : Div(Id: "login-error", Class: "alert alert-danger py-2")[_error],
+                Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                    Div(Class: "mb-3")[
+                        Label("username", Class: "form-label")["Username"],
+                        Input(() => _model.Username, Id: "username", Class: "form-control")
+                    ],
+                    Div(Class: "mb-3")[
+                        Label("password", Class: "form-label")["Password"],
+                        Input(() => _model.Password, Id: "password", Type: "password", Class: "form-control")
+                    ],
+                    Button("submit", Id: "login-submit", Class: "btn btn-primary w-100")["Sign in"]
                 ],
-                Div(Style: "margin-bottom:.75rem")[
-                    Label("password")["Password"],
-                    Input(() => _model.Password, Id: "password", Type: "password")
-                ],
-                Button("submit", Id: "login-submit")["Sign in"]
-            ],
-            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+                P(Class: "text-muted small mt-3 mb-0")[
+                    "Try alice / password (user) or root / password (admin)."]
+            ]
         ];
 
     private async Task SubmitAsync(LoginModel m)

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/LoginPage.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmCookie.Pages;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(WasmLoginService login) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Sign in"],
+            _error is null
+                ? (Child)Fragment()
+                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div(Style: "margin-bottom:.5rem")[
+                    Label("username")["Username"],
+                    Input(() => _model.Username, Id: "username")
+                ],
+                Div(Style: "margin-bottom:.75rem")[
+                    Label("password")["Password"],
+                    Input(() => _model.Password, Id: "password", Type: "password")
+                ],
+                Button("submit", Id: "login-submit")["Sign in"]
+            ],
+            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        if (!await login.LoginAsync(m.Username, m.Password, ReturnUrl))
+        {
+            _error = "Invalid username or password.";
+        }
+    }
+}

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmCookie.Pages;
+
+// On WASM there's no server route guard — the Authorize component gates the content off the ApiUserProvider
+// principal (hydrated from /api/me). The signed-in view is a child component so it reads the fresh principal
+// when the gate opens after sign-in.
+[Route("members")]
+[AllowAnonymous]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            Authorize(
+                Authorizing: P(Id: "members-authorizing")["Loading…"],
+                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+public sealed class MemberContent(WasmLoginService login) : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+        ];
+}

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
@@ -12,11 +12,14 @@ namespace Rask.Example.Auth.WasmCookie.Pages;
 public sealed class MembersPage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            Authorize(
-                Authorizing: P(Id: "members-authorizing")["Loading…"],
-                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+        Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                Authorize(
+                    Authorizing: P(Id: "members-authorizing", Class: "text-secondary mb-0")["Loading…"],
+                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
+                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorized: MemberContent())
+            ]
         ];
 }
 
@@ -24,11 +27,11 @@ public sealed class MemberContent(WasmLoginService login) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
+            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
-                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
-            Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+            Button(Id: "logout", OnClickAsync: login.LogoutAsync, Class: "btn btn-outline-primary")["Sign out"]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmCookie/Program.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Program.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Authentication;
+using Rask.Example.Auth.WasmCookie;
+using Rask.Wasm;
+
+var host = WasmHostBuilder.CreateDefault();
+
+// Same-origin HttpClient (served by the host) — the HttpOnly auth cookie rides every request automatically.
+host.Services.AddSingleton(_ => new HttpClient { BaseAddress = new Uri(WasmHostBuilder.BaseAddress) });
+host.Services.AddSingleton<ApiUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<ApiUserProvider>());
+host.Services.AddSingleton<WasmLoginService>();
+
+await host.RunAsync<App>();

--- a/samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj
+++ b/samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-browser</TargetFramework>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>false</UseAppHost>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <WasmGenerateAppBundle>true</WasmGenerateAppBundle>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Wasm\Rask.Wasm.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+</Project>

--- a/samples/Rask.Example.Auth.WasmCookie/runtimeconfig.template.json
+++ b/samples/Rask.Example.Auth.WasmCookie/runtimeconfig.template.json
@@ -1,0 +1,11 @@
+{
+  "wasmHostProperties": {
+    "perHostConfig": [
+      {
+        "name": "browser",
+        "html-path": "index.html",
+        "Host": "browser"
+      }
+    ]
+  }
+}

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
@@ -1,0 +1,98 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.IdentityModel.Tokens;
+using Rask.Wasm.Hosting;
+
+var builder = WebApplication.CreateBuilder(args);
+
+var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
+    builder.Configuration["Jwt:Key"] ?? JwtIssuer.DevKey));
+
+builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(o =>
+    {
+        o.MapInboundClaims = false;
+        o.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidIssuer = "rask-jwt-demo",
+            ValidateAudience = true,
+            ValidAudience = "rask-jwt-demo",
+            ValidateIssuerSigningKey = true,
+            IssuerSigningKey = signingKey,
+            ValidateLifetime = true,
+            NameClaimType = "name",
+            RoleClaimType = "role"
+        };
+    });
+builder.Services.AddAuthorization();
+builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+builder.Services.AddSingleton(new JwtIssuer(signingKey));
+builder.Services.AddRask(); // Rask.Wasm.Hosting — response compression for the AppBundle
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapPost("/api/login", (LoginRequest dto, ICredentialStore creds, JwtIssuer jwt) =>
+{
+    var ok = creds.Validate(dto.Username, dto.Password);
+    return ok is null
+        ? Results.Unauthorized()
+        : Results.Ok(new TokenResponse(jwt.Issue(ok.Value.Name, ok.Value.Roles)));
+});
+
+app.MapGet("/api/me", (HttpContext ctx) => new MeDto(
+        ctx.User.Identity!.Name!,
+        ctx.User.FindAll("role").Select(c => c.Value).ToArray()))
+    .RequireAuthorization();
+
+app.UseRask(); // serve the published WASM AppBundle
+
+app.Run();
+
+public sealed record LoginRequest(string Username, string Password);
+public sealed record TokenResponse(string Token);
+public sealed record MeDto(string Name, string[] Roles);
+
+public interface ICredentialStore
+{
+    (string Name, string[] Roles)? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public (string Name, string[] Roles)? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => ("alice", new[] { "user" }),
+            ("root", "password") => ("root", new[] { "admin" }),
+            _ => null
+        };
+}
+
+public sealed class JwtIssuer(SymmetricSecurityKey key)
+{
+    public const string DevKey = "rask-jwt-demo-insecure-dev-signing-key-change-me-please-0123456789";
+
+    public string Issue(string name, string[] roles)
+    {
+        var claims = new List<Claim> { new("name", name) };
+        foreach (var r in roles)
+        {
+            claims.Add(new Claim("role", r));
+        }
+
+        var token = new JwtSecurityToken(
+            issuer: "rask-jwt-demo",
+            audience: "rask-jwt-demo",
+            claims: claims,
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>Rask.Example.Auth.WasmJwt.Host</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Wasm.Hosting\Rask.Wasm.Hosting.csproj"/>
+    <ProjectReference Include="..\Rask.Example.Auth.WasmJwt\Rask.Example.Auth.WasmJwt.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"/>
+  </ItemGroup>
+
+  <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="wwwroot"/>
+  </Target>
+
+</Project>

--- a/samples/Rask.Example.Auth.WasmJwt/App.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/App.cs
@@ -1,15 +1,36 @@
+using Rask.Core.Components;
+
 namespace Rask.Example.Auth.WasmJwt;
 
 public sealed class App : Component
 {
-    protected override RenderResult Head => Title()["Rask — JWT + WASM auth"];
+    // Bootstrap + Bootstrap Icons via CDN keep the showcase look without vendoring wwwroot/lib
+    // per sample. App.css (scoped sibling) layers the Rask purple palette on top.
+    protected override RenderResult Head => [
+        Title()["Rask — JWT + WASM auth"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
 
     protected override RenderResult Render() =>
         [
             Doctype(),
             Html("en")[
                 Head(),
-                Body()[Router()]
+                Body(Class: "bg-body-tertiary")[
+                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                        Div(Class: "container")[
+                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · JWT + WASM auth"],
+                            A("https://github.com/pal-tamas/rask", "_blank",
+                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                        ]
+                    ],
+                    Main(Class: "container py-4")[Router()]
+                ]
             ]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmJwt/App.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/App.cs
@@ -1,0 +1,15 @@
+namespace Rask.Example.Auth.WasmJwt;
+
+public sealed class App : Component
+{
+    protected override RenderResult Head => Title()["Rask — JWT + WASM auth"];
+
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[Router()]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Auth.WasmJwt/App.css
+++ b/samples/Rask.Example.Auth.WasmJwt/App.css
@@ -1,0 +1,40 @@
+/* Rask brand palette layered over Bootstrap. Every rule targets :root, a global Bootstrap
+   class, or a shell tag, so each is wrapped in :global() to opt out of the component
+   scope-suffix rewrite (mirrors samples/Rask.Example.Shared/App.css). */
+:global(:root) {
+    --bs-primary: #7C3AED;
+    --bs-primary-rgb: 124, 58, 237;
+    --bs-link-color: #6D28D9;
+    --bs-link-color-rgb: 109, 40, 217;
+    --bs-link-hover-color: #512BD4;
+    --rask-accent: #7C3AED;
+    --rask-accent-strong: #512BD4;
+    --rask-accent-soft: #f1ebfd;
+}
+
+:global(.btn-primary) {
+    --bs-btn-bg: #7C3AED;
+    --bs-btn-border-color: #7C3AED;
+    --bs-btn-hover-bg: #6D28D9;
+    --bs-btn-hover-border-color: #6D28D9;
+    --bs-btn-active-bg: #512BD4;
+    --bs-btn-active-border-color: #512BD4;
+    --bs-btn-disabled-bg: #7C3AED;
+    --bs-btn-disabled-border-color: #7C3AED;
+}
+
+:global(a) {
+    color: var(--rask-accent);
+}
+
+:global(a:hover) {
+    color: var(--rask-accent-strong);
+}
+
+:global(:not(pre) > code) {
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.08rem 0.32rem;
+    border-radius: 4px;
+    font-size: 0.86em;
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/BearerTokenHandler.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/BearerTokenHandler.cs
@@ -1,0 +1,17 @@
+using System.Net.Http.Headers;
+
+namespace Rask.Example.Auth.WasmJwt;
+
+// Attaches Authorization: Bearer <jwt> from the TokenStore to every outgoing request.
+public sealed class BearerTokenHandler(TokenStore tokens) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        if (tokens.Token is { } token)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return base.SendAsync(request, ct);
+    }
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/Dtos.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/Dtos.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace Rask.Example.Auth.WasmJwt;
+
+public sealed record LoginRequest(
+    [property: JsonPropertyName("username")] string Username,
+    [property: JsonPropertyName("password")] string Password);
+
+public sealed record TokenResponse([property: JsonPropertyName("token")] string Token);
+
+public sealed record MeDto(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("roles")] string[] Roles);
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+
+// Source-generated JSON so the WASM publish stays trim-clean.
+[JsonSerializable(typeof(LoginRequest))]
+[JsonSerializable(typeof(TokenResponse))]
+[JsonSerializable(typeof(MeDto))]
+public partial class AuthJson : JsonSerializerContext;

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/JwtLoginService.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/JwtLoginService.cs
@@ -1,0 +1,37 @@
+using System.Net.Http.Json;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmJwt;
+
+public sealed class JwtLoginService(HttpClient http, TokenStore tokens, IUserProvider users, Navigator nav)
+{
+    public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
+    {
+        var resp = await http.PostAsJsonAsync("api/login", new LoginRequest(username, password),
+            AuthJson.Default.LoginRequest);
+        if (!resp.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        var dto = await resp.Content.ReadFromJsonAsync(AuthJson.Default.TokenResponse);
+        if (dto is null)
+        {
+            return false;
+        }
+
+        await tokens.SetAsync(dto.Token);
+        await users.RefreshAsync();
+        nav.Navigate(returnUrl ?? "/members");
+        return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        // Navigate first (still in the handler scope), then clear the token + principal.
+        nav.Navigate("/login");
+        await tokens.ClearAsync();
+        await users.RefreshAsync();
+    }
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
@@ -16,6 +16,7 @@ public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserP
 
     public async Task EnsureLoadedAsync()
     {
+        IsLoading = true; // bridge the anonymous→authed flash (LoadAsync's finally clears it)
         await tokens.InitAsync();
         await LoadAsync();
     }

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
@@ -1,0 +1,57 @@
+using System.Net.Http.Json;
+using System.Security.Claims;
+using Rask.Core.Authentication;
+
+namespace Rask.Example.Auth.WasmJwt;
+
+// Hydrates the principal from /api/me, which the host validates from the Bearer token (attached by
+// BearerTokenHandler). Only calls /api/me when a token is present, so anonymous never hits a 401.
+public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserProvider
+{
+    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+
+    public ClaimsPrincipal Current => _current;
+    public bool IsLoading { get; private set; }
+    public event Action? Changed;
+
+    public async Task EnsureLoadedAsync()
+    {
+        await tokens.InitAsync();
+        await LoadAsync();
+    }
+
+    public async Task RefreshAsync()
+    {
+        IsLoading = true;
+        Changed?.Invoke();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            if (tokens.Token is null)
+            {
+                _current = new ClaimsPrincipal(new ClaimsIdentity());
+                return;
+            }
+
+            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            _current = me is { Name: { } name }
+                ? new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))],
+                    "jwt"))
+                : new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        catch (HttpRequestException)
+        {
+            _current = new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        finally
+        {
+            IsLoading = false;
+            Changed?.Invoke();
+        }
+    }
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
@@ -38,14 +38,19 @@ public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserP
                 return;
             }
 
-            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            // GetAsync (not GetFromJsonAsync): a 204 No Content would make GetFromJsonAsync throw a
+            // JsonException on the empty body; treat anything but a 200-with-body as anonymous.
+            using var resp = await http.GetAsync("api/me");
+            var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+                ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
+                : null;
             _current = me is { Name: { } name }
                 ? new ClaimsPrincipal(new ClaimsIdentity(
                     [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))],
                     "jwt"))
                 : new ClaimsPrincipal(new ClaimsIdentity());
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
         {
             _current = new ClaimsPrincipal(new ClaimsIdentity());
         }

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/TokenStore.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/TokenStore.cs
@@ -1,0 +1,25 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Example.Auth.WasmJwt;
+
+// Holds the bearer JWT in localStorage (survives a refresh) plus an in-memory copy the DelegatingHandler
+// reads synchronously. Plain localStorage per the sample's choice — note the XSS caveat: a token in JS
+// storage is readable by any script on the page. For maximum security prefer an HttpOnly cookie.
+public sealed class TokenStore(IJSRuntime js)
+{
+    public string? Token { get; private set; }
+
+    public async Task InitAsync() => Token = await js.InvokeAsync<string?>("localStorage.getItem", "rask.jwt");
+
+    public async Task SetAsync(string token)
+    {
+        Token = token;
+        await js.InvokeVoidAsync("localStorage.setItem", "rask.jwt", token);
+    }
+
+    public async Task ClearAsync()
+    {
+        Token = null;
+        await js.InvokeVoidAsync("localStorage.removeItem", "rask.jwt");
+    }
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/HomePage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmJwt.Pages;
@@ -8,11 +9,15 @@ namespace Rask.Example.Auth.WasmJwt.Pages;
 public sealed class HomePage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Rask JWT + WASM auth sample"],
-            P()["A browser-WASM SPA that signs in against ", Code()["/api/login"],
-                ", stores the bearer JWT in localStorage, and sends it as ", Code()["Authorization: Bearer"],
-                " on every API call. ", Code()["/api/me"], " validates it server-side."],
-            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        Div(Id: "home", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Rask JWT + WASM auth sample"],
+                P(Class: "card-text text-secondary")[
+                    "A browser-WASM SPA that signs in against ", Code()["/api/login"],
+                    ", stores the bearer JWT in localStorage, and sends it as ", Code()["Authorization: Bearer"],
+                    " on every API call. ", Code()["/api/me"], " validates it server-side."],
+                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                    "Go to the members area →"]
+            ]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/HomePage.cs
@@ -1,0 +1,18 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmJwt.Pages;
+
+[Route("/")]
+[AllowAnonymous]
+public sealed class HomePage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Rask JWT + WASM auth sample"],
+            P()["A browser-WASM SPA that signs in against ", Code()["/api/login"],
+                ", stores the bearer JWT in localStorage, and sends it as ", Code()["Authorization: Bearer"],
+                " on every API call. ", Code()["/api/me"], " validates it server-side."],
+            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        ];
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/LoginPage.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmJwt.Pages;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(JwtLoginService login) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Sign in"],
+            _error is null
+                ? (Child)Fragment()
+                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div(Style: "margin-bottom:.5rem")[
+                    Label("username")["Username"],
+                    Input(() => _model.Username, Id: "username")
+                ],
+                Div(Style: "margin-bottom:.75rem")[
+                    Label("password")["Password"],
+                    Input(() => _model.Password, Id: "password", Type: "password")
+                ],
+                Button("submit", Id: "login-submit")["Sign in"]
+            ],
+            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        if (!await login.LoginAsync(m.Username, m.Password, ReturnUrl))
+        {
+            _error = "Invalid username or password.";
+        }
+    }
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/LoginPage.cs
@@ -14,23 +14,26 @@ public sealed class LoginPage(JwtLoginService login) : Component
     [QueryParam] public string? ReturnUrl { get; set; }
 
     protected override RenderResult Render() =>
-        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Sign in"],
-            _error is null
-                ? (Child)Fragment()
-                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
-            Form(_model, OnValidSubmitAsync: SubmitAsync)[
-                Div(Style: "margin-bottom:.5rem")[
-                    Label("username")["Username"],
-                    Input(() => _model.Username, Id: "username")
+        Div(Id: "login", Class: "card shadow-sm mx-auto", Style: "max-width:24rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Sign in"],
+                _error is null
+                    ? (Child)Fragment()
+                    : Div(Id: "login-error", Class: "alert alert-danger py-2")[_error],
+                Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                    Div(Class: "mb-3")[
+                        Label("username", Class: "form-label")["Username"],
+                        Input(() => _model.Username, Id: "username", Class: "form-control")
+                    ],
+                    Div(Class: "mb-3")[
+                        Label("password", Class: "form-label")["Password"],
+                        Input(() => _model.Password, Id: "password", Type: "password", Class: "form-control")
+                    ],
+                    Button("submit", Id: "login-submit", Class: "btn btn-primary w-100")["Sign in"]
                 ],
-                Div(Style: "margin-bottom:.75rem")[
-                    Label("password")["Password"],
-                    Input(() => _model.Password, Id: "password", Type: "password")
-                ],
-                Button("submit", Id: "login-submit")["Sign in"]
-            ],
-            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+                P(Class: "text-muted small mt-3 mb-0")[
+                    "Try alice / password (user) or root / password (admin)."]
+            ]
         ];
 
     private async Task SubmitAsync(LoginModel m)

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
@@ -9,11 +9,14 @@ namespace Rask.Example.Auth.WasmJwt.Pages;
 public sealed class MembersPage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            Authorize(
-                Authorizing: P(Id: "members-authorizing")["Loading…"],
-                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+        Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                Authorize(
+                    Authorizing: P(Id: "members-authorizing", Class: "text-secondary mb-0")["Loading…"],
+                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
+                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorized: MemberContent())
+            ]
         ];
 }
 
@@ -21,11 +24,11 @@ public sealed class MemberContent(JwtLoginService login) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
+            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
-                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
-            Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+            Button(Id: "logout", OnClickAsync: login.LogoutAsync, Class: "btn btn-outline-primary")["Sign out"]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.WasmJwt.Pages;
+
+[Route("members")]
+[AllowAnonymous]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            Authorize(
+                Authorizing: P(Id: "members-authorizing")["Loading…"],
+                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+public sealed class MemberContent(JwtLoginService login) : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+        ];
+}

--- a/samples/Rask.Example.Auth.WasmJwt/Program.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Program.cs
@@ -1,0 +1,19 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Authentication;
+using Rask.Example.Auth.WasmJwt;
+using Rask.Wasm;
+
+var host = WasmHostBuilder.CreateDefault();
+
+host.Services.AddSingleton<TokenStore>();
+// HttpClient with a BearerTokenHandler that attaches the JWT from the TokenStore to every request.
+host.Services.AddSingleton(sp =>
+    new HttpClient(new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
+    {
+        BaseAddress = new Uri(WasmHostBuilder.BaseAddress)
+    });
+host.Services.AddSingleton<JwtUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>());
+host.Services.AddSingleton<JwtLoginService>();
+
+await host.RunAsync<App>();

--- a/samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj
+++ b/samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-browser</TargetFramework>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>false</UseAppHost>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <WasmGenerateAppBundle>true</WasmGenerateAppBundle>
+    <RunAOTCompilation>false</RunAOTCompilation>
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Wasm\Rask.Wasm.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+</Project>

--- a/samples/Rask.Example.Auth.WasmJwt/runtimeconfig.template.json
+++ b/samples/Rask.Example.Auth.WasmJwt/runtimeconfig.template.json
@@ -1,0 +1,11 @@
+{
+  "wasmHostProperties": {
+    "perHostConfig": [
+      {
+        "name": "browser",
+        "html-path": "index.html",
+        "Host": "browser"
+      }
+    ]
+  }
+}

--- a/samples/Rask.Example.Auth/App.cs
+++ b/samples/Rask.Example.Auth/App.cs
@@ -1,16 +1,36 @@
+using Rask.Core.Components;
+
 namespace Rask.Example.Auth;
 
-// Minimal app shell: the framework-managed <head> plus a Router that renders the matched page.
+// App shell: the framework-managed <head> (Bootstrap via CDN + the Rask purple palette in App.css),
+// a sticky navbar, and a Router that renders the matched page.
 public sealed class App : Component
 {
-    protected override RenderResult Head => Title()["Rask — cookie auth sample"];
+    protected override RenderResult Head => [
+        Title()["Rask — cookie auth sample"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
 
     protected override RenderResult Render() =>
         [
             Doctype(),
             Html("en")[
                 Head(),
-                Body()[Router()]
+                Body(Class: "bg-body-tertiary")[
+                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                        Div(Class: "container")[
+                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · cookie auth"],
+                            A("https://github.com/pal-tamas/rask", "_blank",
+                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                        ]
+                    ],
+                    Main(Class: "container py-4")[Router()]
+                ]
             ]
         ];
 }

--- a/samples/Rask.Example.Auth/App.cs
+++ b/samples/Rask.Example.Auth/App.cs
@@ -1,0 +1,16 @@
+namespace Rask.Example.Auth;
+
+// Minimal app shell: the framework-managed <head> plus a Router that renders the matched page.
+public sealed class App : Component
+{
+    protected override RenderResult Head => Title()["Rask — cookie auth sample"];
+
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[Router()]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Auth/App.css
+++ b/samples/Rask.Example.Auth/App.css
@@ -1,0 +1,40 @@
+/* Rask brand palette layered over Bootstrap. Every rule targets :root, a global Bootstrap
+   class, or a shell tag, so each is wrapped in :global() to opt out of the component
+   scope-suffix rewrite (mirrors samples/Rask.Example.Shared/App.css). */
+:global(:root) {
+    --bs-primary: #7C3AED;
+    --bs-primary-rgb: 124, 58, 237;
+    --bs-link-color: #6D28D9;
+    --bs-link-color-rgb: 109, 40, 217;
+    --bs-link-hover-color: #512BD4;
+    --rask-accent: #7C3AED;
+    --rask-accent-strong: #512BD4;
+    --rask-accent-soft: #f1ebfd;
+}
+
+:global(.btn-primary) {
+    --bs-btn-bg: #7C3AED;
+    --bs-btn-border-color: #7C3AED;
+    --bs-btn-hover-bg: #6D28D9;
+    --bs-btn-hover-border-color: #6D28D9;
+    --bs-btn-active-bg: #512BD4;
+    --bs-btn-active-border-color: #512BD4;
+    --bs-btn-disabled-bg: #7C3AED;
+    --bs-btn-disabled-border-color: #7C3AED;
+}
+
+:global(a) {
+    color: var(--rask-accent);
+}
+
+:global(a:hover) {
+    color: var(--rask-accent-strong);
+}
+
+:global(:not(pre) > code) {
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.08rem 0.32rem;
+    border-radius: 4px;
+    font-size: 0.86em;
+}

--- a/samples/Rask.Example.Auth/CredentialStore.cs
+++ b/samples/Rask.Example.Auth/CredentialStore.cs
@@ -1,0 +1,26 @@
+using System.Security.Claims;
+
+namespace Rask.Example.Auth;
+
+public interface ICredentialStore
+{
+    // Returns the claims for a valid (username, password), or null. Demo only — swap for a real store.
+    IReadOnlyList<Claim>? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public IReadOnlyList<Claim>? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => [new Claim(ClaimTypes.Name, "alice"), new Claim(ClaimTypes.Role, "user")],
+            ("root", "password") => [new Claim(ClaimTypes.Name, "root"), new Claim(ClaimTypes.Role, "admin")],
+            _ => null
+        };
+}
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}

--- a/samples/Rask.Example.Auth/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth/Pages/HomePage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.Pages;
@@ -8,10 +9,14 @@ namespace Rask.Example.Auth.Pages;
 public sealed class HomePage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Rask cookie-auth sample"],
-            P()["A minimal, real cookie login: a protected ", Code()["/members"],
-                " page, a ", Code()["/login"], " form, and sign-out — all over Rask's live runtime."],
-            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        Div(Id: "home", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Rask cookie-auth sample"],
+                P(Class: "card-text text-secondary")[
+                    "A minimal, real cookie login: a protected ", Code()["/members"],
+                    " page, a ", Code()["/login"], " form, and sign-out — all over Rask's live runtime."],
+                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                    "Go to the members area →"]
+            ]
         ];
 }

--- a/samples/Rask.Example.Auth/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth/Pages/HomePage.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.Pages;
+
+[Route("/")]
+[AllowAnonymous]
+public sealed class HomePage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "home", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Rask cookie-auth sample"],
+            P()["A minimal, real cookie login: a protected ", Code()["/members"],
+                " page, a ", Code()["/login"], " form, and sign-out — all over Rask's live runtime."],
+            P()[A(Href: "/members", Id: "go-members")["Go to the members area →"]]
+        ];
+}

--- a/samples/Rask.Example.Auth/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth/Pages/LoginPage.cs
@@ -18,23 +18,26 @@ public sealed class LoginPage(IAuthSignIn auth, ICredentialStore creds) : Compon
     [QueryParam] public string? ReturnUrl { get; set; }
 
     protected override RenderResult Render() =>
-        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
-            H1()["Sign in"],
-            _error is null
-                ? (Child)Fragment()
-                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
-            Form(_model, OnValidSubmitAsync: SubmitAsync)[
-                Div(Style: "margin-bottom:.5rem")[
-                    Label("username")["Username"],
-                    Input(() => _model.Username, Id: "username")
+        Div(Id: "login", Class: "card shadow-sm mx-auto", Style: "max-width:24rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h3 card-title mb-3")["Sign in"],
+                _error is null
+                    ? (Child)Fragment()
+                    : Div(Id: "login-error", Class: "alert alert-danger py-2")[_error],
+                Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                    Div(Class: "mb-3")[
+                        Label("username", Class: "form-label")["Username"],
+                        Input(() => _model.Username, Id: "username", Class: "form-control")
+                    ],
+                    Div(Class: "mb-3")[
+                        Label("password", Class: "form-label")["Password"],
+                        Input(() => _model.Password, Id: "password", Type: "password", Class: "form-control")
+                    ],
+                    Button("submit", Id: "login-submit", Class: "btn btn-primary w-100")["Sign in"]
                 ],
-                Div(Style: "margin-bottom:.75rem")[
-                    Label("password")["Password"],
-                    Input(() => _model.Password, Id: "password", Type: "password")
-                ],
-                Button("submit", Id: "login-submit")["Sign in"]
-            ],
-            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+                P(Class: "text-muted small mt-3 mb-0")[
+                    "Try alice / password (user) or root / password (admin)."]
+            ]
         ];
 
     private async Task SubmitAsync(LoginModel m)

--- a/samples/Rask.Example.Auth/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth/Pages/LoginPage.cs
@@ -1,0 +1,53 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.Pages;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(IAuthSignIn auth, ICredentialStore creds) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    // The cookie middleware appends ?ReturnUrl= on its challenge redirect; QueryParam binds it (case-insensitive).
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Id: "login", Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Sign in"],
+            _error is null
+                ? (Child)Fragment()
+                : Div(Id: "login-error", Style: "color:#b00020;margin-bottom:.5rem")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div(Style: "margin-bottom:.5rem")[
+                    Label("username")["Username"],
+                    Input(() => _model.Username, Id: "username")
+                ],
+                Div(Style: "margin-bottom:.75rem")[
+                    Label("password")["Password"],
+                    Input(() => _model.Password, Id: "password", Type: "password")
+                ],
+                Button("submit", Id: "login-submit")["Sign in"]
+            ],
+            P(Style: "color:#666;font-size:.85rem")["Try alice / password (user) or root / password (admin)."]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        var claims = creds.Validate(m.Username, m.Password);
+        if (claims is null)
+        {
+            _error = "Invalid username or password.";
+            return;
+        }
+
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        // SignInAsync drives the redeem handshake; the returnUrl lands the user back on the protected page.
+        await auth.SignInAsync(new ClaimsPrincipal(identity), returnUrl: ReturnUrl ?? "/members");
+    }
+}

--- a/samples/Rask.Example.Auth/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth/Pages/MembersPage.cs
@@ -1,0 +1,41 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Auth.Pages;
+
+// [Authorize] blocks anonymous *deep-links* (full GET → 302 to /login). The headless Authorize
+// component gates the *content* — it subscribes to IUserProvider.Changed, so when the post-sign-in
+// reconnect re-seeds the principal it re-renders to the Authorized slot. The signed-in view lives in
+// its own component (MemberContent) so it first renders only once the gate opens, reading the
+// freshly-authenticated User — no manual Changed subscription needed on the page.
+[Route("members")]
+[Authorize]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            Authorize(
+                Authorizing: P(Id: "members-authorizing")["Signing you in…"],
+                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+// Rendered only by the Authorize component's Authorized slot, so its Render reads the current
+// (authenticated) User. Injects IAuthSignIn for sign-out.
+public sealed class MemberContent(IAuthSignIn auth) : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
+            P()["This page is gated by ", Code()["[Authorize]"], " plus the Authorize component."],
+            // Role gate: only an admin sees this.
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(Id: "logout", OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"))["Sign out"]
+        ];
+}

--- a/samples/Rask.Example.Auth/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth/Pages/MembersPage.cs
@@ -15,11 +15,14 @@ namespace Rask.Example.Auth.Pages;
 public sealed class MembersPage : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "members", Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
-            Authorize(
-                Authorizing: P(Id: "members-authorizing")["Signing you in…"],
-                NotAuthorized: P(Id: "members-anon")["Please ", A(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+        Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
+            Div(Class: "card-body")[
+                Authorize(
+                    Authorizing: P(Id: "members-authorizing", Class: "text-secondary mb-0")["Signing you in…"],
+                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
+                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorized: MemberContent())
+            ]
         ];
 }
 
@@ -29,13 +32,15 @@ public sealed class MemberContent(IAuthSignIn auth) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting")[$"Welcome, {User.Identity?.Name}"],
-            P()["This page is gated by ", Code()["[Authorize]"], " plus the Authorize component."],
+            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            P(Class: "text-secondary")["This page is gated by ", Code()["[Authorize]"],
+                " plus the Authorize component."],
             // Role gate: only an admin sees this.
             Authorize(
                 Roles: ["admin"],
-                Authorized: Div(Id: "admin-note", Style: "color:#7a5c00")["🔑 You have admin access."],
+                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
-            Button(Id: "logout", OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"))["Sign out"]
+            Button(Id: "logout", OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"),
+                Class: "btn btn-outline-primary")["Sign out"]
         ];
 }

--- a/samples/Rask.Example.Auth/Program.cs
+++ b/samples/Rask.Example.Auth/Program.cs
@@ -1,14 +1,8 @@
-using Company.RaskServer;
-using Rask.Server;
-//#if (auth)
 using Microsoft.AspNetCore.Authentication.Cookies;
-//#endif
+using Rask.Example.Auth;
+using Rask.Server;
 
 var builder = WebApplication.CreateBuilder(args);
-
-builder.Services.AddRask();
-builder.Services.AddScoped<IWeatherForecastService, LocalWeatherForecastService>();
-//#if (auth)
 
 // Cookie auth — Rask reads HttpContext.User; the sign-in handshake sets this cookie on redeem.
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
@@ -17,23 +11,19 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         o.Cookie.Name = "rask.auth";
         o.LoginPath = "/login";
         o.AccessDeniedPath = "/forbidden";
+        o.ExpireTimeSpan = TimeSpan.FromHours(8);
+        o.SlidingExpiration = true;
     });
 builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
-//#endif
+builder.Services.AddRask();
 
 var app = builder.Build();
 
-app.MapStaticAssets();
-//#if (auth)
+app.UseStaticFiles();
+app.UseRouting();
 // Must precede UseRask so HttpContext.User is populated on the GET and the WS upgrade.
 app.UseAuthentication();
 app.UseAuthorization();
-//#endif
-
-// To host this app under a sub-path (e.g. behind a reverse proxy mapping
-// /myapp/* → this server), pass pathBase. Every framework endpoint and
-// emitted URL is scoped under the prefix; user-space routes stay unprefixed.
-//   app.UseRask<App>(pathBase: "/myapp");
 app.UseRask<App>();
 
 app.Run();

--- a/samples/Rask.Example.Auth/Rask.Example.Auth.csproj
+++ b/samples/Rask.Example.Auth/Rask.Example.Auth.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Validation.DataAnnotations\Rask.Validation.DataAnnotations.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Validation.FluentValidation\Rask.Validation.FluentValidation.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <!-- The ASP.NET Web SDK requires a wwwroot to exist even when there are no static files. -->
+  <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="wwwroot"/>
+  </Target>
+
+</Project>

--- a/samples/Rask.Example.Shared/Demos/AuthorizeDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/AuthorizeDemo.cs
@@ -1,0 +1,35 @@
+namespace Rask.Example.Shared.Demos;
+
+// Declarative auth gating with the headless Authorize component (Authorized / NotAuthorized /
+// Authorizing slots). Driven by the same toggleable DemoUserProvider as UserGateDemo — the Authorize
+// component subscribes to IUserProvider.Changed itself, so signing in/out anywhere re-renders the gate.
+// Nesting an inner Authorize() in the outer's NotAuthorized slot yields three distinct states
+// (admin / signed-in / anonymous) with no imperative branching in Render().
+public sealed class AuthorizeDemo : Component
+{
+    private readonly DemoUserProvider _auth;
+
+    public AuthorizeDemo(DemoUserProvider auth) => _auth = auth;
+
+    protected override void OnMount() => _auth.Changed += StateHasChanged;
+
+    protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
+
+    protected override RenderResult Render() =>
+        Div(Id: "authorize-demo")[
+            Div(Class: "d-flex gap-2 mb-3")[
+                Button(Class: "btn btn-sm btn-primary", OnClick: () => _auth.SignIn("alice", "user"))[
+                    "Sign in as user"],
+                Button(Class: "btn btn-sm btn-warning", OnClick: () => _auth.SignIn("rootadmin", "admin"))[
+                    "Sign in as admin"],
+                Button(Class: "btn btn-sm btn-outline-secondary", OnClick: _auth.SignOut)["Sign out"]
+            ],
+            // admin → admin slot; any other signed-in user → inner "authorized" slot; anonymous → inner fallback.
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Class: "alert alert-warning py-2 mb-0")["🔑 Admin-only content."],
+                NotAuthorized: Authorize(
+                    Authorized: Div(Class: "alert alert-success py-2 mb-0")["✅ Signed in — standard access."],
+                    NotAuthorized: Div(Class: "alert alert-secondary py-2 mb-0")["🔒 Sign in to see member content."]))
+        ];
+}

--- a/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
+++ b/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
@@ -24,9 +24,13 @@ public static class ExampleServiceCollectionExtensions
 
         // Toggleable demo auth for the User-gating showcase (/user). Registered as the concrete
         // type (so the demo can sign in/out) and as IUserProvider (so Component.User resolves it).
-        // Defaults to anonymous, so other pages are unaffected.
-        services.AddSingleton<DemoUserProvider>();
-        services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<DemoUserProvider>());
+        // Defaults to anonymous, so other pages are unaffected. Scoped — NOT singleton — so each
+        // live session gets its own principal (matching the framework's own SessionUserProvider,
+        // RaskEndpointExtensions.AddScoped). A singleton would share one signed-in user across every
+        // Server connection, leaking auth state between sessions (and between E2E tests). On WASM
+        // there's a single session, so scoped resolves once from the root provider — same behaviour.
+        services.AddScoped<DemoUserProvider>();
+        services.AddScoped<IUserProvider>(sp => sp.GetRequiredService<DemoUserProvider>());
         return services;
     }
 }

--- a/samples/Rask.Example.Shared/Pages/UserPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UserPage.cs
@@ -14,7 +14,7 @@ public sealed class UserPage : Component
         [
             PageHeader.Render(
                 "User & auth gating",
-                "Gate content on the signed-in user with the built-in Component.User — no AuthorizeView component. Branch in Render() on User.Identity?.IsAuthenticated and User.IsInRole(...)."),
+                "Gate content on the signed-in user — imperatively with the built-in Component.User (branch in Render() on User.Identity?.IsAuthenticated and User.IsInRole(...)), or declaratively with the headless Authorize component."),
             H2(Class: "h4 mt-4 mb-3")["Conditional rendering on User"],
             CodeSample(
                 """
@@ -34,6 +34,26 @@ public sealed class UserPage : Component
                 Notes:
                 "User resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on User subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
                 Result: UserGateDemo()),
+            H2(Class: "h4 mt-5 mb-3")["Declarative gating — the Authorize component"],
+            CodeSample(
+                """
+                // Headless: renders exactly one of three slots, no markup of its own.
+                // The component subscribes to IUserProvider.Changed itself, so it reacts to sign-in/out.
+                Authorize(
+                    Roles: ["admin"],                                  // ANY-of; omit for "any authenticated user"
+                    Authorized:    Div(Class: "alert alert-warning")["🔑 Admin-only content."],
+                    NotAuthorized: Authorize(                        // nest for an authenticated-but-not-admin branch
+                        Authorized:    Div(Class: "alert alert-success")["✅ Signed in — standard access."],
+                        NotAuthorized: Div(Class: "alert alert-secondary")["🔒 Sign in to see member content."]));
+
+                // Shorthand — children are the Authorized branch:
+                //   Authorize(Roles: ["admin"])[ AdminPanel() ]
+                // Policy gating resolves via IAuthorizationService; the optional Authorizing slot shows
+                // until it lands (and while a WASM provider's principal is still loading).
+                """,
+                Notes:
+                "Authorize is the declarative counterpart to gating in Render() on User: it picks the Authorized, NotAuthorized, or Authorizing slot off the same Component.User. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
+                Result: AuthorizeDemo()),
             H2(Class: "h4 mt-5 mb-3")["Notes"],
             Ul(Class: "text-secondary")[
                 Li()["Component.User never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so User.Identity?.IsAuthenticated is false."],

--- a/src/Rask.Core/Authentication/ITokenStore.cs
+++ b/src/Rask.Core/Authentication/ITokenStore.cs
@@ -1,0 +1,29 @@
+namespace Rask.Core.Authentication;
+
+/// <summary>
+///     Optional, app-facing abstraction over where a bearer token lives on the client for a JWT-based
+///     WASM app. The most secure choice is an HttpOnly cookie — the token never reaches JavaScript and no
+///     token store is needed. Use this only when a bearer token must be held client-side.
+///     <para>
+///         The reference implementation (see <c>docs/authentication.md</c>) encrypts the token with ASP.NET
+///         Data Protection before writing it to <c>localStorage</c>/<c>sessionStorage</c> via
+///         <c>IJSRuntime</c>, so the value at rest is ciphertext — useless if exfiltrated by XSS. A
+///         <c>BearerTokenHandler : DelegatingHandler</c> reads it back through this store to attach
+///         <c>Authorization: Bearer</c>, and the WASM <c>IUserProvider</c> uses it to hydrate from
+///         <c>/api/me</c> and to drive silent refresh. Rask does not consume this interface itself.
+///     </para>
+/// </summary>
+public interface ITokenStore
+{
+    /// <summary>Return the stored token, or <c>null</c> when none is present.</summary>
+    ValueTask<string?> GetAsync();
+
+    /// <summary>
+    ///     Persist <paramref name="token" />. When <paramref name="persist" /> is <c>true</c> ("remember me")
+    ///     it survives a browser restart; otherwise it is cleared when the tab/session ends.
+    /// </summary>
+    ValueTask SetAsync(string token, bool persist);
+
+    /// <summary>Remove any stored token (sign-out).</summary>
+    ValueTask ClearAsync();
+}

--- a/src/Rask.Core/Authentication/IUserProvider.cs
+++ b/src/Rask.Core/Authentication/IUserProvider.cs
@@ -19,4 +19,13 @@ public interface IUserProvider
     ///     Default is a no-op.
     /// </summary>
     Task RefreshAsync() => Task.CompletedTask;
+
+    /// <summary>
+    ///     <c>true</c> while the principal is still being established — e.g. a WASM provider's
+    ///     <see cref="EnsureLoadedAsync" />/<see cref="RefreshAsync" /> is in flight. The declarative
+    ///     <see cref="Rask.Core.Components.Authorize" /> component shows its <c>Authorizing</c> slot
+    ///     while this is true, bridging the anonymous→authenticated flash. Providers with a
+    ///     synchronously-known principal (server cookie, anonymous) leave the default <c>false</c>.
+    /// </summary>
+    bool IsLoading => false;
 }

--- a/src/Rask.Core/Authorization/RaskAuthorizationOptions.cs
+++ b/src/Rask.Core/Authorization/RaskAuthorizationOptions.cs
@@ -1,7 +1,0 @@
-namespace Rask.Core.Authorization;
-
-public sealed class RaskAuthorizationOptions
-{
-    public string ChallengePath { get; set; } = "/login";
-    public string ForbidPath { get; set; } = "/forbidden";
-}

--- a/src/Rask.Core/Authorization/RouteAuthorizationGuard.cs
+++ b/src/Rask.Core/Authorization/RouteAuthorizationGuard.cs
@@ -7,6 +7,12 @@ namespace Rask.Core.Authorization;
 
 public static class RouteAuthorizationGuard
 {
+    // Client-side guard redirect targets for an in-app nav to a protected route. (The initial HTTP GET
+    // challenge/forbid goes through the configured auth scheme's own LoginPath/AccessDeniedPath instead.)
+    // Shared by the server (RaskEndpointExtensions) and WASM (WasmLiveSession) guards so the two can't drift.
+    public const string ChallengePath = "/login";
+    public const string ForbidPath = "/forbidden";
+
     public static async Task<RouteAuthorizationResult> EvaluateAsync(
         IServiceProvider services,
         IReadOnlyList<Type> chain,

--- a/src/Rask.Core/Components/Authorize.cs
+++ b/src/Rask.Core/Components/Authorize.cs
@@ -37,6 +37,11 @@ public sealed class Authorize : Component
     // gate the Policy branch and to decide whether to show the Authorizing slot.
     private bool? _policyAllowed;
 
+    // Monotonic token: each policy evaluation captures the current value at entry; a slower in-flight
+    // evaluation whose token is no longer current must not overwrite a newer verdict (avoids a
+    // last-completer-wins race when the principal changes mid-flight).
+    private int _policyGen;
+
     // Transparent — Authorize itself emits nothing, it only selects one slot. (Same as the base
     // default; stated explicitly to document the headless contract.)
     protected override string? TagName => null;
@@ -168,25 +173,46 @@ public sealed class Authorize : Component
 
     private async Task EvaluatePolicyAsync(ClaimsPrincipal principal)
     {
-        // Resolve the named policy through the provider, then authorize against its requirements —
-        // the same path RouteAuthorizationGuard uses for [Authorize(Policy = ...)].
-        var policyProvider = _services?.GetService<IAuthorizationPolicyProvider>();
-        var authz = _services?.GetService<IAuthorizationService>();
-        if (policyProvider is null || authz is null)
+        // Capture the generation at entry (synchronously, before any await). A newer evaluation will
+        // bump it; this one then drops its result rather than clobbering the fresher verdict.
+        var gen = ++_policyGen;
+        bool allowed;
+        try
         {
-            _policyAllowed = false;
-            return;
+            // Resolve the named policy through the provider, then authorize against its requirements —
+            // the same path RouteAuthorizationGuard uses for [Authorize(Policy = ...)].
+            var policyProvider = _services?.GetService<IAuthorizationPolicyProvider>();
+            var authz = _services?.GetService<IAuthorizationService>();
+            if (policyProvider is null || authz is null)
+            {
+                allowed = false;
+            }
+            else
+            {
+                var policy = await policyProvider.GetPolicyAsync(Policy!).ConfigureAwait(false);
+                if (policy is null)
+                {
+                    allowed = false;
+                }
+                else
+                {
+                    var result = await authz.AuthorizeAsync(principal, resource: null, policy).ConfigureAwait(false);
+                    allowed = result.Succeeded;
+                }
+            }
+        }
+        catch
+        {
+            // Fail closed: a throw from policy resolution/evaluation denies rather than leaving the gate
+            // stuck on the Authorizing slot. (This path also runs from a fire-and-forget continuation in
+            // OnUserChanged, where an unobserved throw would otherwise be swallowed silently.)
+            allowed = false;
         }
 
-        var policy = await policyProvider.GetPolicyAsync(Policy!).ConfigureAwait(false);
-        if (policy is null)
+        if (gen == _policyGen)
         {
-            _policyAllowed = false;
-            return;
+            _policyAllowed = allowed;
         }
-
-        var result = await authz.AuthorizeAsync(principal, resource: null, policy).ConfigureAwait(false);
-        _policyAllowed = result.Succeeded;
     }
 
     private static RenderResult RenderSlot(Child? slot) =>

--- a/src/Rask.Core/Components/Authorize.cs
+++ b/src/Rask.Core/Components/Authorize.cs
@@ -1,0 +1,194 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Authentication;
+using Rask.Core.Live;
+
+namespace Rask.Core.Components;
+
+/// <summary>
+///     Declarative auth gating — the headless analogue of Blazor's <c>AuthorizeView</c>. Renders
+///     exactly one of three slots based on the current <see cref="Component.User" /> (and, optionally,
+///     a named authorization policy), with <b>no markup of its own</b> (transparent like
+///     <see cref="Fragment" />):
+///     <list type="bullet">
+///         <item><see cref="Authorized" /> — the user passes the gate. Falls back to the children
+///         indexer when the slot is null, so <c>Authorize(Roles: "admin")[ adminPanel ]</c> works.</item>
+///         <item><see cref="NotAuthorized" /> — the user is denied (default: renders nothing).</item>
+///         <item><see cref="Authorizing" /> — the provider is still loading, or a <see cref="Policy" />
+///         evaluation is in flight (default: renders nothing). Bridges the anonymous→authenticated
+///         flash on WASM, where the principal hydrates asynchronously.</item>
+///     </list>
+///     <para>
+///         <see cref="Roles" /> and the authenticated check are evaluated synchronously in
+///         <see cref="Render" /> (no flicker). <see cref="Policy" /> is the only asynchronous vector:
+///         it is evaluated via <see cref="IAuthorizationService" /> in <see cref="OnPropsChangedAsync" />
+///         (and re-evaluated when the user changes), cached, and surfaced through the
+///         <see cref="Authorizing" /> slot until it resolves. The component subscribes to
+///         <see cref="IUserProvider.Changed" /> so a sign-in/out anywhere re-renders it.
+///     </para>
+/// </summary>
+public sealed class Authorize : Component
+{
+    private IUserProvider? _provider;
+    private IServiceProvider? _services;
+
+    // null = "policy not yet evaluated" (or no policy). true/false once resolved. Read in Render to
+    // gate the Policy branch and to decide whether to show the Authorizing slot.
+    private bool? _policyAllowed;
+
+    // Transparent — Authorize itself emits nothing, it only selects one slot. (Same as the base
+    // default; stated explicitly to document the headless contract.)
+    protected override string? TagName => null;
+
+    /// <summary>
+    ///     Roles the gate accepts; it passes when the user is in <b>any</b> of them. Null/empty means
+    ///     "any authenticated user". Pass a collection expression: <c>Authorize(Roles: ["admin", "editor"])</c>.
+    /// </summary>
+    public string[]? Roles { get; set; }
+
+    /// <summary>
+    ///     A named ASP.NET authorization policy, evaluated via <see cref="IAuthorizationService" />.
+    ///     Composes with <see cref="Roles" /> (both must pass). Requires <c>AddAuthorization()</c>
+    ///     (server) / <c>AddAuthorizationCore()</c> (WASM) in DI.
+    /// </summary>
+    public string? Policy { get; set; }
+
+    /// <summary>Rendered when the gate passes. When null, the children indexer is used instead.</summary>
+    public Child? Authorized { get; set; }
+
+    /// <summary>Rendered when the gate denies. Defaults to nothing.</summary>
+    public Child? NotAuthorized { get; set; }
+
+    /// <summary>Rendered while the provider is loading or a <see cref="Policy" /> is resolving. Defaults to nothing.</summary>
+    public Child? Authorizing { get; set; }
+
+    protected override void OnMount()
+    {
+        _services = LiveRenderContext.Current?.Services;
+        _provider = _services?.GetService<IUserProvider>();
+        if (_provider is not null)
+        {
+            _provider.Changed += OnUserChanged;
+        }
+    }
+
+    protected override void OnUnmount()
+    {
+        if (_provider is not null)
+        {
+            _provider.Changed -= OnUserChanged;
+        }
+    }
+
+    protected override async Task OnPropsChangedAsync()
+    {
+        if (string.IsNullOrEmpty(Policy))
+        {
+            _policyAllowed = null;
+            return;
+        }
+
+        await EvaluatePolicyAsync(User).ConfigureAwait(false);
+    }
+
+    protected override RenderResult Render()
+    {
+        if (IsAuthorizing())
+        {
+            return RenderSlot(Authorizing);
+        }
+
+        if (IsAllowed())
+        {
+            return Authorized is { Component: { } authorized }
+                ? authorized
+                : new Fragment { Children = Children ?? [] };
+        }
+
+        return RenderSlot(NotAuthorized);
+    }
+
+    private bool IsAuthorizing() =>
+        (_provider?.IsLoading ?? false) || (!string.IsNullOrEmpty(Policy) && _policyAllowed is null);
+
+    private bool IsAllowed()
+    {
+        if (User.Identity?.IsAuthenticated != true)
+        {
+            return false;
+        }
+
+        if (Roles is { Length: > 0 } && !InAnyRole())
+        {
+            return false;
+        }
+
+        if (!string.IsNullOrEmpty(Policy) && _policyAllowed != true)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    private bool InAnyRole()
+    {
+        foreach (var role in Roles!)
+        {
+            if (!string.IsNullOrEmpty(role) && User.IsInRole(role))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Re-render on sign-in/out. When a policy is in play the cached verdict is stale against the new
+    // principal, so clear it and re-evaluate — showing the Authorizing slot in between.
+    private void OnUserChanged()
+    {
+        if (!string.IsNullOrEmpty(Policy))
+        {
+            _policyAllowed = null;
+            _ = RefreshPolicyThenRenderAsync();
+            return;
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task RefreshPolicyThenRenderAsync()
+    {
+        StateHasChanged(); // paint the Authorizing slot immediately
+        await EvaluatePolicyAsync(_provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity())).ConfigureAwait(false);
+        StateHasChanged(); // paint the resolved verdict
+    }
+
+    private async Task EvaluatePolicyAsync(ClaimsPrincipal principal)
+    {
+        // Resolve the named policy through the provider, then authorize against its requirements —
+        // the same path RouteAuthorizationGuard uses for [Authorize(Policy = ...)].
+        var policyProvider = _services?.GetService<IAuthorizationPolicyProvider>();
+        var authz = _services?.GetService<IAuthorizationService>();
+        if (policyProvider is null || authz is null)
+        {
+            _policyAllowed = false;
+            return;
+        }
+
+        var policy = await policyProvider.GetPolicyAsync(Policy!).ConfigureAwait(false);
+        if (policy is null)
+        {
+            _policyAllowed = false;
+            return;
+        }
+
+        var result = await authz.AuthorizeAsync(principal, resource: null, policy).ConfigureAwait(false);
+        _policyAllowed = result.Succeeded;
+    }
+
+    private static RenderResult RenderSlot(Child? slot) =>
+        slot is { Component: { } component } ? (RenderResult)component : default;
+}

--- a/src/Rask.Server/Authentication/AuthTicketStore.cs
+++ b/src/Rask.Server/Authentication/AuthTicketStore.cs
@@ -19,6 +19,8 @@ internal sealed record AuthTicket(
 
 internal sealed class AuthTicketStore : IAuthTicketStore
 {
+    // Lifetime of a one-shot sign-in/out redeem ticket. Short by design (the ticket is the authority
+    // for setting the cookie). Mutable static so tests can force expiry; not a public knob.
     internal static TimeSpan Ttl = TimeSpan.FromSeconds(30);
 
     private readonly ConcurrentDictionary<string, AuthTicket> _tickets = new();

--- a/src/Rask.Server/Authentication/SessionUserProvider.cs
+++ b/src/Rask.Server/Authentication/SessionUserProvider.cs
@@ -19,4 +19,17 @@ public sealed class SessionUserProvider : IUserProvider
             Changed?.Invoke();
         }
     }
+
+    /// <summary>
+    ///     Reset to an unauthenticated principal — explicit session invalidation on sign-out. Raises
+    ///     <see cref="Changed" /> (via <see cref="Set" />) only when the session was actually
+    ///     authenticated, so a redundant clear on an already-anonymous session is a no-op.
+    /// </summary>
+    public void Clear()
+    {
+        if (Current.Identity?.IsAuthenticated == true)
+        {
+            Set(new ClaimsPrincipal(new ClaimsIdentity()));
+        }
+    }
 }

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -87,7 +87,6 @@ public static class RaskEndpointExtensions
 
         services.AddScoped<SessionUserProvider>();
         services.AddScoped<IUserProvider>(sp => sp.GetRequiredService<SessionUserProvider>());
-        services.TryAddSingleton<RaskAuthorizationOptions>();
         services.AddAuthorization();
 
         // IJSRuntime compatibility. RaskJSRuntime + LiveSessionAccessor are scoped — one
@@ -101,17 +100,6 @@ public static class RaskEndpointExtensions
         services.AddScoped<RaskJSRuntime>();
         services.AddScoped<IJSRuntime>(sp => sp.GetRequiredService<RaskJSRuntime>());
         return services;
-    }
-
-    public static IServiceCollection AddRask(
-        this IServiceCollection services,
-        Action<RaskAuthorizationOptions> configure)
-    {
-        ArgumentNullException.ThrowIfNull(configure);
-        var options = new RaskAuthorizationOptions();
-        configure(options);
-        services.AddSingleton(options);
-        return services.AddRask();
     }
 
     public static WebApplication UseRask<TApp>(
@@ -883,11 +871,12 @@ public static class RaskEndpointExtensions
                     .ConfigureAwait(false);
                 if (result.Outcome != RouteAuthorizationOutcome.Allow)
                 {
-                    var options = session.Services.GetRequiredService<RaskAuthorizationOptions>();
+                    // Client-side guard redirect targets. (The initial HTTP GET challenge already goes
+                    // through the configured auth scheme's own LoginPath/AccessDeniedPath.)
                     var originalUrl = QueryString.Build(routeState.Path, routeState.Query);
                     var redirectPath = result.Outcome == RouteAuthorizationOutcome.Forbid
-                        ? options.ForbidPath
-                        : options.ChallengePath;
+                        ? "/forbidden"
+                        : "/login";
                     routeState.Path = redirectPath;
                     if (result.Outcome == RouteAuthorizationOutcome.Challenge)
                     {
@@ -923,6 +912,16 @@ public static class RaskEndpointExtensions
 
     private static async Task RedeemAuthTicketAsync(HttpContext ctx, IAuthTicketStore tickets)
     {
+        // Defense-in-depth CSRF: the redeem ticket is a single-use, session-bound, 128-bit secret
+        // delivered only over the authenticated same-origin WS frame, so classic cookie-CSRF can't
+        // forge it. As belt-and-braces we still reject a cross-origin Origin/Referer — a forged POST
+        // from another site is bounced before the (otherwise antiforgery-exempt) ticket is consulted.
+        if (!IsSameOrigin(ctx.Request))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return;
+        }
+
         string? ticketId = null;
         string? sessionId = null;
         try
@@ -967,6 +966,33 @@ public static class RaskEndpointExtensions
         }
 
         ctx.Response.StatusCode = StatusCodes.Status200OK;
+    }
+
+    // True when the request carries no Origin/Referer (same-origin fetches may omit Origin — the
+    // ticket secrecy covers those) or one whose scheme+host+port matches the request's own host.
+    private static bool IsSameOrigin(HttpRequest request)
+    {
+        var origin = request.Headers.Origin.ToString();
+        if (string.IsNullOrEmpty(origin))
+        {
+            var referer = request.Headers.Referer.ToString();
+            if (string.IsNullOrEmpty(referer))
+            {
+                return true;
+            }
+
+            origin = referer;
+        }
+
+        if (!Uri.TryCreate(origin, UriKind.Absolute, out var originUri))
+        {
+            return false;
+        }
+
+        var self = new Uri(request.Scheme + "://" + request.Host.Value);
+        return string.Equals(originUri.Scheme, self.Scheme, StringComparison.OrdinalIgnoreCase)
+               && string.Equals(originUri.Host, self.Host, StringComparison.OrdinalIgnoreCase)
+               && originUri.Port == self.Port;
     }
 
     private static async Task<string> ResolveAuthSchemeAsync(IServiceProvider services, string? explicitScheme)

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -875,8 +875,8 @@ public static class RaskEndpointExtensions
                     // through the configured auth scheme's own LoginPath/AccessDeniedPath.)
                     var originalUrl = QueryString.Build(routeState.Path, routeState.Query);
                     var redirectPath = result.Outcome == RouteAuthorizationOutcome.Forbid
-                        ? "/forbidden"
-                        : "/login";
+                        ? RouteAuthorizationGuard.ForbidPath
+                        : RouteAuthorizationGuard.ChallengePath;
                     routeState.Path = redirectPath;
                     if (result.Outcome == RouteAuthorizationOutcome.Challenge)
                     {
@@ -969,7 +969,13 @@ public static class RaskEndpointExtensions
     }
 
     // True when the request carries no Origin/Referer (same-origin fetches may omit Origin — the
-    // ticket secrecy covers those) or one whose scheme+host+port matches the request's own host.
+    // ticket secrecy covers those) or one whose host matches the request's own host.
+    //
+    // We compare host only — NOT scheme/port. Behind a TLS-terminating reverse proxy the browser's
+    // Origin is https://app (:443) while request.Scheme/Host can be http (:80) unless ForwardedHeaders
+    // is wired, so a scheme/port match would 403 a legitimate sign-in. Host is the CSRF-relevant axis
+    // and the single-use session-bound ticket is the real authority (see RedeemAuthTicketAsync), so a
+    // host-only check is the right belt-and-braces.
     private static bool IsSameOrigin(HttpRequest request)
     {
         var origin = request.Headers.Origin.ToString();
@@ -989,10 +995,10 @@ public static class RaskEndpointExtensions
             return false;
         }
 
-        var self = new Uri(request.Scheme + "://" + request.Host.Value);
-        return string.Equals(originUri.Scheme, self.Scheme, StringComparison.OrdinalIgnoreCase)
-               && string.Equals(originUri.Host, self.Host, StringComparison.OrdinalIgnoreCase)
-               && originUri.Port == self.Port;
+        // request.Host.Host is the host without the port (empty if the Host header is missing/malformed).
+        var selfHost = request.Host.Host;
+        return !string.IsNullOrEmpty(selfHost)
+               && string.Equals(originUri.Host, selfHost, StringComparison.OrdinalIgnoreCase);
     }
 
     private static async Task<string> ResolveAuthSchemeAsync(IServiceProvider services, string? explicitScheme)

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -59,7 +59,28 @@
 
     var sessionId = root.getAttribute("data-rask-root");
     var proto = location.protocol === "https:" ? "wss:" : "ws:";
-    var wsUrl = proto + "//" + location.host + prependBase("/rask/ws");
+    var baseWsUrl = proto + "//" + location.host + prependBase("/rask/ws");
+
+    // JWT-on-WebSocket hook. Browsers can't set Authorization headers on a WS upgrade, so a
+    // bearer-token app carries the access token on the URL as ?access_token= (the SignalR pattern;
+    // pair it with AddJwtBearer's OnMessageReceived reading the query for the Rask WS path). The
+    // token is read fresh on every (re)connect from window.Rask.authToken (string or function) or a
+    // <meta name="rask-access-token"> tag. With no token set this is a no-op — cookie auth is
+    // unaffected and the URL is unchanged.
+    function buildWsUrl() {
+        var token = null;
+        try {
+            var r = window.Rask;
+            if (r && typeof r.authToken === "function") token = r.authToken();
+            else if (r && typeof r.authToken === "string") token = r.authToken;
+            if (!token) {
+                var meta = document.querySelector('meta[name="rask-access-token"]');
+                if (meta) token = meta.getAttribute("content");
+            }
+        } catch (e) { token = null; }
+        if (!token) return baseWsUrl;
+        return baseWsUrl + (baseWsUrl.indexOf("?") >= 0 ? "&" : "?") + "access_token=" + encodeURIComponent(token);
+    }
 
     var ws = null;
     var queue = [];
@@ -68,11 +89,23 @@
     var reconnectTimer = null;
     var suppressEvents = false;
     var overlay = installOverlay();
+    // The reconnect overlay doubles as the auth-handshake indicator. During a sign-in/out the
+    // socket is deliberately closed and reconnected to pick up the new cookie; that reconnect is
+    // an authentication step, not a dropped connection, so the overlay says "Authenticating…"
+    // instead of "Reconnecting…" for its duration.
+    var overlayMsg = overlay.querySelector(".rask-overlay__msg");
+    var authInProgress = false;
+    var RECONNECT_MSG = "Reconnecting…";
+    var AUTH_MSG = "Authenticating…";
+
+    function setOverlayMessage(text) {
+        if (overlayMsg) overlayMsg.textContent = text;
+    }
 
     connect();
 
     function connect() {
-        ws = new WebSocket(wsUrl);
+        ws = new WebSocket(buildWsUrl());
 
         ws.addEventListener("open", function () {
             open = true;
@@ -81,6 +114,11 @@
             ws.send(JSON.stringify({type: "hello", session: sessionId}));
             for (var i = 0; i < queue.length; i++) ws.send(queue[i]);
             queue.length = 0;
+            // Auth reconnect completed — restore the default message for any future drop.
+            if (authInProgress) {
+                authInProgress = false;
+                setOverlayMessage(RECONNECT_MSG);
+            }
             hideOverlay();
         });
 
@@ -154,7 +192,7 @@
         el.innerHTML =
             '<div class="rask-overlay__card">' +
             '<span class="rask-overlay__spinner" aria-hidden="true"></span>' +
-            '<span>Reconnecting…</span>' +
+            '<span class="rask-overlay__msg">Reconnecting…</span>' +
             '</div>';
         document.documentElement.appendChild(el);
         return el;
@@ -454,6 +492,11 @@
 
     function redeemAuthTicket(auth) {
         suppressEvents = true;
+        // The imminent socket close + reconnect is an auth step — show "Authenticating…" up front
+        // so the user never sees "Reconnecting…" for a deliberate sign-in/out.
+        authInProgress = true;
+        setOverlayMessage(AUTH_MSG);
+        showOverlay();
         fetch(prependBase("/_rask/auth/redeem"), {
             method: "POST",
             headers: {"content-type": "application/json"},

--- a/src/Rask.Templates/content/rask-server/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-server/.template.config/template.json
@@ -12,5 +12,23 @@
   },
   "sourceName": "Company.RaskServer",
   "preferNameDirectory": true,
-  "defaultName": "RaskApp"
+  "defaultName": "RaskApp",
+  "symbols": {
+    "auth": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Scaffold a cookie-backed login: a /login form, a credential store, a protected /members page, and the auth wiring."
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!auth)",
+          "exclude": [ "Auth/**" ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/Rask.Templates/content/rask-server/Auth/CredentialStore.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/CredentialStore.cs
@@ -1,0 +1,26 @@
+using System.Security.Claims;
+
+namespace Company.RaskServer;
+
+// Demo credential store — replace with your real user store (ASP.NET Identity, a database, etc.).
+public interface ICredentialStore
+{
+    IReadOnlyList<Claim>? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public IReadOnlyList<Claim>? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => [new Claim(ClaimTypes.Name, "alice"), new Claim(ClaimTypes.Role, "user")],
+            ("root", "password") => [new Claim(ClaimTypes.Name, "root"), new Claim(ClaimTypes.Role, "admin")],
+            _ => null
+        };
+}
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}

--- a/src/Rask.Templates/content/rask-server/Auth/LoginPage.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/LoginPage.cs
@@ -1,0 +1,44 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Company.RaskServer;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(IAuthSignIn auth, ICredentialStore creds) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Class: "welcome-card")[
+            H1()["Sign in"],
+            _error is null ? (Child)Fragment() : Div(Style: "color:#b00020")[_error],
+            // Async submit uses the generated OnValidSubmitAsync sibling (like Button's OnClickAsync).
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div()[Label("username")["Username"], Input(() => _model.Username, Id: "username")],
+                Div()[Label("password")["Password"], Input(() => _model.Password, Id: "password", Type: "password")],
+                Button("submit")["Sign in"]
+            ],
+            P()["Try alice / password (user) or root / password (admin)."]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        var claims = creds.Validate(m.Username, m.Password);
+        if (claims is null)
+        {
+            _error = "Invalid username or password.";
+            return;
+        }
+
+        var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+        await auth.SignInAsync(new ClaimsPrincipal(identity), returnUrl: ReturnUrl ?? "/members");
+    }
+}

--- a/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Company.RaskServer;
+
+// [Authorize] blocks anonymous deep-links (full GET → 302 to /login). The Authorize component gates the
+// content and re-renders when the post-sign-in reconnect re-seeds the principal; the signed-in view lives
+// in its own component so it reads the freshly-authenticated User — no manual Changed subscription.
+[Route("members")]
+[Authorize]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Class: "welcome-card")[
+            Authorize(
+                NotAuthorized: P()["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+public sealed class MemberContent(IAuthSignIn auth) : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1()[$"Welcome, {User.Identity?.Name}"],
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"))["Sign out"]
+        ];
+}

--- a/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
@@ -15,7 +15,7 @@ public sealed class MembersPage : Component
     protected override RenderResult Render() =>
         Div(Class: "welcome-card")[
             Authorize(
-                NotAuthorized: P()["Please ", A(Href: "/login")["sign in"], "."],
+                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."],
                 Authorized: MemberContent())
         ];
 }

--- a/src/Rask.Templates/content/rask-wasm-hosted/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-wasm-hosted/.template.config/template.json
@@ -12,5 +12,23 @@
   },
   "sourceName": "Company.RaskWasmHosted",
   "preferNameDirectory": true,
-  "defaultName": "RaskApp"
+  "defaultName": "RaskApp",
+  "symbols": {
+    "auth": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Scaffold a cookie-backed login: the host serves /api/login + /api/me + /auth/logout, the client hydrates the user and gates a protected /members page."
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!auth)",
+          "exclude": [ "**/Auth/**" ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Auth/CredentialStore.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Auth/CredentialStore.cs
@@ -1,0 +1,23 @@
+using System.Security.Claims;
+
+namespace Company.RaskWasmHosted.Host;
+
+public sealed record LoginRequest(string Username, string Password);
+public sealed record MeDto(string Name, string[] Roles);
+
+// Demo credential store — replace with your real user store (ASP.NET Identity, a database, etc.).
+public interface ICredentialStore
+{
+    IReadOnlyList<Claim>? Validate(string username, string password);
+}
+
+public sealed class DemoCredentialStore : ICredentialStore
+{
+    public IReadOnlyList<Claim>? Validate(string username, string password) =>
+        (username, password) switch
+        {
+            ("alice", "password") => [new Claim(ClaimTypes.Name, "alice"), new Claim(ClaimTypes.Role, "user")],
+            ("root", "password") => [new Claim(ClaimTypes.Name, "root"), new Claim(ClaimTypes.Role, "admin")],
+            _ => null
+        };
+}

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Program.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Program.cs
@@ -1,22 +1,49 @@
 using Company.RaskWasmHosted.Host;
 using Rask.Wasm.Hosting;
+//#if (auth)
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+//#endif
 
 var builder = WebApplication.CreateBuilder(args);
 
 // Opt into brotli + gzip response compression for the AppBundle (.wasm / .dll / .js / .json).
-// UseRask wires UseResponseCompression ahead of UseStaticFiles when this is registered.
 builder.Services.AddRask();
+//#if (auth)
+builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+    .AddCookie(o => o.Cookie.Name = "rask.auth");
+builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+//#endif
 
 var app = builder.Build();
+//#if (auth)
+// Populates HttpContext.User from the cookie so /api/me reflects the signed-in user.
+app.UseAuthentication();
+//#endif
 
 var weatherService = new LocalWeatherForecastService();
 app.MapGet("/api/weatherforecast", async () => await weatherService.GetForecastsAsync());
+//#if (auth)
 
-// To host two WASM AppBundles side-by-side, pass a per-app prefix:
-//   app.UseRask(pathBase: "/appA");
-// or the generic form app.UseRask<App>(pathBase: "/appA"). Pair with
-// /p:RaskPathBase=/appA at WASM publish time so the bundled index.html's
-// <base href> matches.
+// Auth API consumed by the WASM client (same origin, so the HttpOnly cookie rides every request).
+app.MapPost("/api/login", async (HttpContext ctx, LoginRequest dto, ICredentialStore creds) =>
+{
+    var claims = creds.Validate(dto.Username, dto.Password);
+    if (claims is null) return Results.Unauthorized();
+    var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+    await ctx.SignInAsync(new ClaimsPrincipal(identity));
+    return Results.Ok();
+});
+
+app.MapGet("/api/me", (HttpContext ctx) =>
+    ctx.User.Identity?.IsAuthenticated == true
+        ? Results.Ok(new MeDto(ctx.User.Identity!.Name!, ctx.User.FindAll(ClaimTypes.Role).Select(c => c.Value).ToArray()))
+        : Results.NoContent());
+
+app.MapPost("/auth/logout", async (HttpContext ctx) => { await ctx.SignOutAsync(); return Results.Ok(); });
+//#endif
+
 app.UseRask();
 
 app.Run();

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
@@ -33,7 +33,11 @@ public sealed class ApiUserProvider(HttpClient http) : IUserProvider
     public bool IsLoading { get; private set; }
     public event Action? Changed;
 
-    public Task EnsureLoadedAsync() => LoadAsync();
+    public Task EnsureLoadedAsync()
+    {
+        IsLoading = true; // bridge the anonymous→authed flash (LoadAsync's finally clears it)
+        return LoadAsync();
+    }
 
     public async Task RefreshAsync()
     {

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
@@ -1,0 +1,85 @@
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+
+namespace Company.RaskWasmHosted.Wasm;
+
+public sealed record LoginRequest(
+    [property: JsonPropertyName("username")] string Username,
+    [property: JsonPropertyName("password")] string Password);
+
+public sealed record MeDto(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("roles")] string[] Roles);
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+
+// Source-generated JSON keeps the WASM publish trim-clean (zero IL warnings).
+[JsonSerializable(typeof(LoginRequest))]
+[JsonSerializable(typeof(MeDto))]
+public partial class AuthJson : JsonSerializerContext;
+
+// Hydrates the principal from the host's /api/me (the HttpOnly cookie rides the same-origin request).
+public sealed class ApiUserProvider(HttpClient http) : IUserProvider
+{
+    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+    public ClaimsPrincipal Current => _current;
+    public bool IsLoading { get; private set; }
+    public event Action? Changed;
+
+    public Task EnsureLoadedAsync() => LoadAsync();
+
+    public async Task RefreshAsync()
+    {
+        IsLoading = true;
+        Changed?.Invoke();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            _current = me is { Name: { } name }
+                ? new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))], "api"))
+                : new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        catch (HttpRequestException)
+        {
+            _current = new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        finally
+        {
+            IsLoading = false;
+            Changed?.Invoke();
+        }
+    }
+}
+
+public sealed class WasmLoginService(HttpClient http, IUserProvider users, Navigator nav)
+{
+    public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
+    {
+        var resp = await http.PostAsJsonAsync("api/login", new LoginRequest(username, password), AuthJson.Default.LoginRequest);
+        if (!resp.IsSuccessStatusCode) return false;
+        await users.RefreshAsync();
+        nav.Navigate(returnUrl ?? "/members");
+        return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        await http.PostAsync("auth/logout", null);
+        // Navigate first (still in the handler scope), then clear the principal.
+        nav.Navigate("/login");
+        await users.RefreshAsync();
+    }
+}

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
@@ -50,13 +50,19 @@ public sealed class ApiUserProvider(HttpClient http) : IUserProvider
     {
         try
         {
-            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            // GetAsync (not GetFromJsonAsync): an anonymous /api/me returns 204 No Content, and
+            // GetFromJsonAsync would throw a JsonException deserializing the empty body. Treat
+            // anything but a 200-with-body as anonymous.
+            using var resp = await http.GetAsync("api/me");
+            var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+                ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
+                : null;
             _current = me is { Name: { } name }
                 ? new ClaimsPrincipal(new ClaimsIdentity(
                     [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))], "api"))
                 : new ClaimsPrincipal(new ClaimsIdentity());
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
         {
             _current = new ClaimsPrincipal(new ClaimsIdentity());
         }

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/LoginPage.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/LoginPage.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Company.RaskWasmHosted.Wasm;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(WasmLoginService login) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Sign in"],
+            _error is null ? (Child)Fragment() : Div(Style: "color:#b00020")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div()[Label("username")["Username"], Input(() => _model.Username, Id: "username")],
+                Div()[Label("password")["Password"], Input(() => _model.Password, Id: "password", Type: "password")],
+                Button("submit", Id: "login-submit")["Sign in"]
+            ],
+            P()["Try alice / password (user) or root / password (admin)."]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        if (!await login.LoginAsync(m.Username, m.Password, ReturnUrl))
+        {
+            _error = "Invalid username or password.";
+        }
+    }
+}

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
@@ -14,7 +14,7 @@ public sealed class MembersPage : Component
     protected override RenderResult Render() =>
         Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
             Authorize(
-                NotAuthorized: P()["Please ", A(Href: "/login")["sign in"], "."],
+                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."],
                 Authorized: MemberContent())
         ];
 }

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Company.RaskWasmHosted.Wasm;
+
+// On WASM there's no server route guard — the Authorize component gates the content off the principal
+// (hydrated from /api/me). The signed-in view is a child component so it reads the fresh principal when the
+// gate opens after sign-in.
+[Route("members")]
+[AllowAnonymous]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            Authorize(
+                NotAuthorized: P()["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+public sealed class MemberContent(WasmLoginService login) : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1()[$"Welcome, {User.Identity?.Name}"],
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+        ];
+}

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Program.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Program.cs
@@ -1,6 +1,9 @@
 using Company.RaskWasmHosted.Wasm;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Wasm;
+//#if (auth)
+using Rask.Core.Authentication;
+//#endif
 
 // PathBase is auto-detected from <base href>. Publish with /p:RaskPathBase=/myapp
 // for sub-path deploys, or override via CreateDefault(o => o.PathBase = "/myapp").
@@ -8,5 +11,11 @@ var host = WasmHostBuilder.CreateDefault();
 
 host.Services.AddSingleton(_ => new HttpClient { BaseAddress = new Uri(WasmHostBuilder.BaseAddress) });
 host.Services.AddSingleton<IWeatherForecastService, HttpWeatherForecastService>();
+//#if (auth)
+// Hydrates the user from the host's /api/me (HttpOnly cookie); WasmLoginService drives sign-in/out.
+host.Services.AddSingleton<ApiUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<ApiUserProvider>());
+host.Services.AddSingleton<WasmLoginService>();
+//#endif
 
 await host.RunAsync<App>();

--- a/src/Rask.Templates/content/rask-wasm/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-wasm/.template.config/template.json
@@ -12,5 +12,23 @@
   },
   "sourceName": "Company.RaskWasm",
   "preferNameDirectory": true,
-  "defaultName": "RaskApp"
+  "defaultName": "RaskApp",
+  "symbols": {
+    "auth": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Scaffold a JWT bearer login against an external API (token in localStorage, attached as Authorization: Bearer). Point BaseAddress at your auth API — a standalone SPA has no host of its own."
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(!auth)",
+          "exclude": [ "Auth/**" ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
@@ -1,0 +1,134 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.Json.Serialization;
+using Microsoft.JSInterop;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+
+namespace Company.RaskWasm;
+
+public sealed record LoginRequest(
+    [property: JsonPropertyName("username")] string Username,
+    [property: JsonPropertyName("password")] string Password);
+
+public sealed record TokenResponse([property: JsonPropertyName("token")] string Token);
+
+public sealed record MeDto(
+    [property: JsonPropertyName("name")] string Name,
+    [property: JsonPropertyName("roles")] string[] Roles);
+
+public sealed class LoginModel
+{
+    public string Username { get; set; } = "";
+    public string Password { get; set; } = "";
+}
+
+[JsonSerializable(typeof(LoginRequest))]
+[JsonSerializable(typeof(TokenResponse))]
+[JsonSerializable(typeof(MeDto))]
+public partial class AuthJson : JsonSerializerContext;
+
+// Bearer JWT in localStorage (survives refresh) + an in-memory copy the handler reads synchronously.
+// Note: a token in JS storage is readable by any script (XSS). Prefer an HttpOnly cookie where you can.
+public sealed class TokenStore(IJSRuntime js)
+{
+    public string? Token { get; private set; }
+
+    public async Task InitAsync() => Token = await js.InvokeAsync<string?>("localStorage.getItem", "rask.jwt");
+
+    public async Task SetAsync(string token)
+    {
+        Token = token;
+        await js.InvokeVoidAsync("localStorage.setItem", "rask.jwt", token);
+    }
+
+    public async Task ClearAsync()
+    {
+        Token = null;
+        await js.InvokeVoidAsync("localStorage.removeItem", "rask.jwt");
+    }
+}
+
+public sealed class BearerTokenHandler(TokenStore tokens) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+    {
+        if (tokens.Token is { } token)
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return base.SendAsync(request, ct);
+    }
+}
+
+public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserProvider
+{
+    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+    public ClaimsPrincipal Current => _current;
+    public bool IsLoading { get; private set; }
+    public event Action? Changed;
+
+    public async Task EnsureLoadedAsync()
+    {
+        await tokens.InitAsync();
+        await LoadAsync();
+    }
+
+    public async Task RefreshAsync()
+    {
+        IsLoading = true;
+        Changed?.Invoke();
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            if (tokens.Token is null)
+            {
+                _current = new ClaimsPrincipal(new ClaimsIdentity());
+                return;
+            }
+
+            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            _current = me is { Name: { } name }
+                ? new ClaimsPrincipal(new ClaimsIdentity(
+                    [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))], "jwt"))
+                : new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        catch (HttpRequestException)
+        {
+            _current = new ClaimsPrincipal(new ClaimsIdentity());
+        }
+        finally
+        {
+            IsLoading = false;
+            Changed?.Invoke();
+        }
+    }
+}
+
+public sealed class JwtLoginService(HttpClient http, TokenStore tokens, IUserProvider users, Navigator nav)
+{
+    public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
+    {
+        var resp = await http.PostAsJsonAsync("api/login", new LoginRequest(username, password), AuthJson.Default.LoginRequest);
+        if (!resp.IsSuccessStatusCode) return false;
+        var dto = await resp.Content.ReadFromJsonAsync(AuthJson.Default.TokenResponse);
+        if (dto is null) return false;
+        await tokens.SetAsync(dto.Token);
+        await users.RefreshAsync();
+        nav.Navigate(returnUrl ?? "/members");
+        return true;
+    }
+
+    public async Task LogoutAsync()
+    {
+        nav.Navigate("/login");
+        await tokens.ClearAsync();
+        await users.RefreshAsync();
+    }
+}

--- a/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
@@ -94,13 +94,18 @@ public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserP
                 return;
             }
 
-            var me = await http.GetFromJsonAsync("api/me", AuthJson.Default.MeDto);
+            // GetAsync (not GetFromJsonAsync): a 204 No Content would make GetFromJsonAsync throw a
+            // JsonException on the empty body; treat anything but a 200-with-body as anonymous.
+            using var resp = await http.GetAsync("api/me");
+            var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+                ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
+                : null;
             _current = me is { Name: { } name }
                 ? new ClaimsPrincipal(new ClaimsIdentity(
                     [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))], "jwt"))
                 : new ClaimsPrincipal(new ClaimsIdentity());
         }
-        catch (HttpRequestException)
+        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
         {
             _current = new ClaimsPrincipal(new ClaimsIdentity());
         }

--- a/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
@@ -72,6 +72,7 @@ public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserP
 
     public async Task EnsureLoadedAsync()
     {
+        IsLoading = true; // bridge the anonymous→authed flash (LoadAsync's finally clears it)
         await tokens.InitAsync();
         await LoadAsync();
     }

--- a/src/Rask.Templates/content/rask-wasm/Auth/LoginPage.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/LoginPage.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Company.RaskWasm;
+
+[Route("login")]
+[AllowAnonymous]
+public sealed class LoginPage(JwtLoginService login) : Component
+{
+    private readonly LoginModel _model = new();
+    private string? _error;
+
+    [QueryParam] public string? ReturnUrl { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+            H1()["Sign in"],
+            _error is null ? (Child)Fragment() : Div(Style: "color:#b00020")[_error],
+            Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                Div()[Label("username")["Username"], Input(() => _model.Username, Id: "username")],
+                Div()[Label("password")["Password"], Input(() => _model.Password, Id: "password", Type: "password")],
+                Button("submit", Id: "login-submit")["Sign in"]
+            ]
+        ];
+
+    private async Task SubmitAsync(LoginModel m)
+    {
+        if (!await login.LoginAsync(m.Username, m.Password, ReturnUrl))
+        {
+            _error = "Invalid username or password.";
+        }
+    }
+}

--- a/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
@@ -11,7 +11,7 @@ public sealed class MembersPage : Component
     protected override RenderResult Render() =>
         Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
             Authorize(
-                NotAuthorized: P()["Please ", A(Href: "/login")["sign in"], "."],
+                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."],
                 Authorized: MemberContent())
         ];
 }

--- a/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Company.RaskWasm;
+
+[Route("members")]
+[AllowAnonymous]
+public sealed class MembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+            Authorize(
+                NotAuthorized: P()["Please ", A(Href: "/login")["sign in"], "."],
+                Authorized: MemberContent())
+        ];
+}
+
+public sealed class MemberContent(JwtLoginService login) : Component
+{
+    protected override RenderResult Render() =>
+        Fragment()[
+            H1()[$"Welcome, {User.Identity?.Name}"],
+            Authorize(
+                Roles: ["admin"],
+                Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],
+                NotAuthorized: (Child)Fragment()),
+            Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+        ];
+}

--- a/src/Rask.Templates/content/rask-wasm/Program.cs
+++ b/src/Rask.Templates/content/rask-wasm/Program.cs
@@ -1,6 +1,9 @@
 using Company.RaskWasm;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Wasm;
+//#if (auth)
+using Rask.Core.Authentication;
+//#endif
 
 // PathBase is auto-detected at boot from <base href>. For sub-path deploys
 // (e.g. GH Pages at https://<user>.github.io/<repo>/), publish with
@@ -12,5 +15,19 @@ using Rask.Wasm;
 var host = WasmHostBuilder.CreateDefault();
 
 host.Services.AddSingleton<IWeatherForecastService, LocalWeatherForecastService>();
+//#if (auth)
+
+// A standalone SPA has no host of its own — point this at YOUR auth API (CORS-enabled).
+const string authApiBaseAddress = "https://api.example.com/"; // TODO: your auth API
+host.Services.AddSingleton<TokenStore>();
+host.Services.AddSingleton(sp =>
+    new HttpClient(new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
+    {
+        BaseAddress = new Uri(authApiBaseAddress)
+    });
+host.Services.AddSingleton<JwtUserProvider>();
+host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>());
+host.Services.AddSingleton<JwtLoginService>();
+//#endif
 
 await host.RunAsync<App>();

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -24,7 +24,6 @@ public sealed class WasmHostBuilder
         Services.AddSingleton<IDownloadSink, WasmDownloadSink>();
         Services.AddSingleton<Navigator>();
         Services.TryAddSingleton<IUserProvider, AnonymousUserProvider>();
-        Services.TryAddSingleton<RaskAuthorizationOptions>();
         Services.TryAddSingleton<IAuthSignIn, WasmAuthSignIn>();
         Services.AddAuthorizationCore();
         // IJSRuntime backed by the WASM JSImport/JSExport bridge. Singleton — one

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -395,11 +395,10 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
                 .ConfigureAwait(false);
             if (authResult.Outcome != RouteAuthorizationOutcome.Allow)
             {
-                var options = Services.GetRequiredService<RaskAuthorizationOptions>();
                 var originalUrl = QueryString.Build(routeState.Path, routeState.Query);
                 var redirectPath = authResult.Outcome == RouteAuthorizationOutcome.Forbid
-                    ? options.ForbidPath
-                    : options.ChallengePath;
+                    ? "/forbidden"
+                    : "/login";
                 routeState.Path = redirectPath;
                 if (authResult.Outcome == RouteAuthorizationOutcome.Challenge)
                 {

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -397,8 +397,8 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
             {
                 var originalUrl = QueryString.Build(routeState.Path, routeState.Query);
                 var redirectPath = authResult.Outcome == RouteAuthorizationOutcome.Forbid
-                    ? "/forbidden"
-                    : "/login";
+                    ? RouteAuthorizationGuard.ForbidPath
+                    : RouteAuthorizationGuard.ChallengePath;
                 routeState.Path = redirectPath;
                 if (authResult.Outcome == RouteAuthorizationOutcome.Challenge)
                 {

--- a/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
+++ b/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
@@ -7,8 +7,8 @@ using Rask.Core.Authentication;
 namespace Rask.Core.Tests.Authentication;
 
 // The built-in Component.User (resolved from IUserProvider in the active render scope) is the
-// supported way to gate content — no AuthorizeView component. These pin that gating in Render()
-// reflects the provider's principal, including role checks.
+// imperative way to gate content (the declarative counterpart is the Authorize component — see
+// AuthorizeTests). These pin that gating in Render() reflects the provider's principal, incl. roles.
 public class UserGatingTests
 {
     [Fact]

--- a/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
@@ -1,0 +1,190 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Authentication;
+
+#pragma warning disable RASK014 // test harness instantiates StubComponent directly
+
+namespace Rask.Core.Tests.Components;
+
+// The headless Authorize component selects exactly one of three slots (Authorized / NotAuthorized /
+// Authorizing) off Component.User, plus optional role/policy gating. These pin that selection. The
+// gate is built INSIDE a render delegate so its generated factory runs under a live render context
+// (which fires OnMount/OnPropsChangedAsync) — building it eagerly would skip the lifecycle.
+public class AuthorizeTests
+{
+    [Fact]
+    public void Anonymous_WithoutNotAuthorized_RendersNothing()
+    {
+        var html = Render(Anonymous(), () => Authorize(Authorized: Span()["AUTHED"]));
+
+        Assert.DoesNotContain("AUTHED", html);
+        Assert.DoesNotContain("DENIED", html);
+    }
+
+    [Fact]
+    public void Anonymous_RendersNotAuthorizedSlot()
+    {
+        var html = Render(Anonymous(),
+            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+
+        Assert.Contains("DENIED", html);
+        Assert.DoesNotContain("AUTHED", html);
+    }
+
+    [Fact]
+    public void Authenticated_RendersAuthorizedSlot()
+    {
+        var html = Render(User("alice"),
+            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+
+        Assert.Contains("AUTHED", html);
+        Assert.DoesNotContain("DENIED", html);
+    }
+
+    [Fact]
+    public void Authenticated_NoAuthorizedSlot_RendersChildrenShorthand()
+    {
+        // Authorize(Roles: "...")[ content ] — the children indexer is the authorized branch.
+        var html = Render(User("alice"), () => Authorize()[Span()["CHILD"]]);
+
+        Assert.Contains("CHILD", html);
+    }
+
+    [Fact]
+    public void RoleMatch_RendersAuthorized()
+    {
+        var html = Render(User("root", "admin"),
+            () => Authorize(Roles: ["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+
+        Assert.Contains("AUTHED", html);
+    }
+
+    [Fact]
+    public void RoleMiss_RendersNotAuthorized()
+    {
+        var html = Render(User("alice", "user"),
+            () => Authorize(Roles: ["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+
+        Assert.Contains("DENIED", html);
+        Assert.DoesNotContain("AUTHED", html);
+    }
+
+    [Fact]
+    public void AnyOfRoles_MatchesOnEither()
+    {
+        var html = Render(User("alice", "editor"),
+            () => Authorize(Roles: ["admin", "editor"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+
+        Assert.Contains("AUTHED", html);
+    }
+
+    [Fact]
+    public void ProviderLoading_RendersAuthorizingSlot()
+    {
+        var html = Render(new LoadingUser(),
+            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"], Authorizing: Span()["LOADING"]));
+
+        Assert.Contains("LOADING", html);
+        Assert.DoesNotContain("AUTHED", html);
+        Assert.DoesNotContain("DENIED", html);
+    }
+
+    [Fact]
+    public void PolicyAllow_RendersAuthorized()
+    {
+        var html = Render(User("root", "admin"),
+            () => Authorize(Policy: "admins-only", Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]),
+            WithAdminsPolicy);
+
+        Assert.Contains("AUTHED", html);
+    }
+
+    [Fact]
+    public void PolicyDeny_RendersNotAuthorized()
+    {
+        var html = Render(User("alice", "user"),
+            () => Authorize(Policy: "admins-only", Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]),
+            WithAdminsPolicy);
+
+        Assert.Contains("DENIED", html);
+        Assert.DoesNotContain("AUTHED", html);
+    }
+
+    // Register the policy provider (real) but override the authorization service with a synchronous
+    // role evaluator, so the policy verdict resolves within the single test render frame. (The real
+    // DefaultAuthorizationService completes on a continuation; in a live session that triggers a
+    // re-render, but a one-shot RenderAsLiveRoot would only capture the pre-resolution frame.)
+    private static void WithAdminsPolicy(IServiceCollection services)
+    {
+        services.AddAuthorizationCore(o => o.AddPolicy("admins-only", p => p.RequireRole("admin")));
+        services.AddSingleton<IAuthorizationService>(new SyncRoleAuthz());
+    }
+
+    private static string Render(IUserProvider provider, Func<Component> gate, Action<IServiceCollection>? configure = null)
+    {
+        var services = new ServiceCollection().AddSingleton(provider);
+        configure?.Invoke(services);
+        var sp = services.BuildServiceProvider();
+        return new StubComponent(gate).RenderAsLiveRoot(sp);
+    }
+
+    private static IUserProvider Anonymous() => new FixedUser(new ClaimsPrincipal(new ClaimsIdentity()));
+
+    private static IUserProvider User(string name, params string[] roles)
+    {
+        var claims = new List<Claim> { new(ClaimTypes.Name, name) };
+        foreach (var r in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, r));
+        }
+
+        return new FixedUser(new ClaimsPrincipal(new ClaimsIdentity(claims, "test")));
+    }
+
+    private sealed class FixedUser(ClaimsPrincipal principal) : IUserProvider
+    {
+        public ClaimsPrincipal Current { get; } = principal;
+
+        public event Action? Changed
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    private sealed class LoadingUser : IUserProvider
+    {
+        public ClaimsPrincipal Current { get; } = new(new ClaimsIdentity());
+        public bool IsLoading => true;
+
+        public event Action? Changed
+        {
+            add { }
+            remove { }
+        }
+    }
+
+    // Synchronous role-requirement evaluator — faithful to RequireRole policies but completes inline.
+    private sealed class SyncRoleAuthz : IAuthorizationService
+    {
+        public Task<AuthorizationResult> AuthorizeAsync(
+            ClaimsPrincipal user, object? resource, IEnumerable<IAuthorizationRequirement> requirements)
+        {
+            foreach (var req in requirements)
+            {
+                if (req is Microsoft.AspNetCore.Authorization.Infrastructure.RolesAuthorizationRequirement roles
+                    && !roles.AllowedRoles.Any(user.IsInRole))
+                {
+                    return Task.FromResult(AuthorizationResult.Failed());
+                }
+            }
+
+            return Task.FromResult(AuthorizationResult.Success());
+        }
+
+        // Not used by Authorize (it resolves the policy via IAuthorizationPolicyProvider first).
+        public Task<AuthorizationResult> AuthorizeAsync(ClaimsPrincipal user, object? resource, string policyName) =>
+            throw new NotSupportedException();
+    }
+}

--- a/tests/Rask.Example.Shared.Tests/Demos/AuthorizeDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/AuthorizeDemoTests.cs
@@ -1,0 +1,56 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Authentication;
+using Rask.Example.Shared.Demos;
+
+#pragma warning disable RASK014 // test renders the demo component directly as a root
+
+namespace Rask.Example.Shared.Tests.Demos;
+
+// The Authorize-component showcase: the nested Authorize picks one of three states off the toggleable
+// DemoUserProvider (admin / signed-in / anonymous) with no imperative branching.
+public sealed class AuthorizeDemoTests
+{
+    [Fact]
+    public void Anonymous_ShowsSignInPrompt()
+    {
+        var html = Render(new DemoUserProvider());
+
+        Assert.Contains("Sign in to see member content", html);
+        Assert.DoesNotContain("standard access", html);
+        Assert.DoesNotContain("Admin-only", html);
+    }
+
+    [Fact]
+    public void SignedInUser_ShowsStandardAccess()
+    {
+        var provider = new DemoUserProvider();
+        provider.SignIn("alice", "user");
+
+        var html = Render(provider);
+
+        Assert.Contains("standard access", html);
+        Assert.DoesNotContain("Admin-only", html);
+    }
+
+    [Fact]
+    public void Admin_ShowsAdminContent()
+    {
+        var provider = new DemoUserProvider();
+        provider.SignIn("rootadmin", "admin");
+
+        var html = Render(provider);
+
+        Assert.Contains("Admin-only", html);
+        Assert.DoesNotContain("Sign in to see member content", html);
+    }
+
+    private static string Render(DemoUserProvider provider)
+    {
+        var sp = new ServiceCollection()
+            .AddSingleton(provider)
+            .AddSingleton<IUserProvider>(provider)
+            .BuildServiceProvider();
+        return new AuthorizeDemo(provider).RenderAsLiveRoot(sp);
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/AuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/AuthExampleTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+// Full visual cookie-login round trip against the minimal Rask.Example.Auth host:
+// protected page → challenge redirect → sign-in handshake → land on the protected page → sign out.
+[Collection(AuthExampleCollection.Name)]
+public sealed class AuthExampleTests : IAsyncLifetime
+{
+    private readonly AuthExampleAppFixture _app;
+    private readonly PlaywrightFixture _pw;
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public AuthExampleTests(AuthExampleAppFixture app, PlaywrightFixture pw)
+    {
+        _app = app;
+        _pw = pw;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = _app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task CookieLogin_RoundTrip_ChallengeSignInLandSignOut()
+    {
+        // 1. Anonymous deep-link to a [Authorize] page → cookie challenge → lands on /login with ReturnUrl.
+        await _page.GotoAsync("/members");
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login\?ReturnUrl=.*members"),
+            new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+        // 2. Sign in as the admin user. The form submit drives the redeem handshake + reconnect.
+        await _page.Locator("#username").FillAsync("root");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        // 3. Handshake completes → returnUrl lands us back on the protected page, now authenticated.
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
+            new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 15_000 });
+        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 }); // role gate
+
+        // 4. Sign out → handshake clears the cookie → back to /login.
+        await _page.Locator("#logout").ClickAsync();
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
+            new() { Timeout = 30_000 });
+
+        // 5. The protected page is gated again now that we're signed out.
+        await _page.GotoAsync("/members");
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login\?ReturnUrl=.*members"),
+            new() { Timeout = 30_000 });
+    }
+
+    [Fact]
+    public async Task NonAdmin_DoesNotSeeAdminNote()
+    {
+        await _page.GotoAsync("/login?ReturnUrl=%2Fmembers");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+        await _page.Locator("#username").FillAsync("alice");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0); // alice is not an admin
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/AuthExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/AuthExampleAppFixture.cs
@@ -1,0 +1,8 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+// Boots the minimal cookie-auth sample (samples/Rask.Example.Auth) for the login round-trip E2E.
+public sealed class AuthExampleAppFixture : ExampleAppFixture
+{
+    protected override string ProjectRelativePath => "samples/Rask.Example.Auth";
+    protected override int Port => 5102;
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -27,3 +27,10 @@ public sealed class SubPathWasmExampleCollection
 {
     public const string Name = "SubPathWasmExample";
 }
+
+[CollectionDefinition(Name)]
+public sealed class AuthExampleCollection
+    : ICollectionFixture<AuthExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "AuthExample";
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -34,3 +34,24 @@ public sealed class AuthExampleCollection
 {
     public const string Name = "AuthExample";
 }
+
+[CollectionDefinition(Name)]
+public sealed class JwtServerAuthExampleCollection
+    : ICollectionFixture<JwtServerAuthAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "JwtServerAuthExample";
+}
+
+[CollectionDefinition(Name)]
+public sealed class WasmCookieAuthExampleCollection
+    : ICollectionFixture<WasmCookieAuthAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "WasmCookieAuthExample";
+}
+
+[CollectionDefinition(Name)]
+public sealed class WasmJwtAuthExampleCollection
+    : ICollectionFixture<WasmJwtAuthAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "WasmJwtAuthExample";
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/JwtServerAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/JwtServerAuthAppFixture.cs
@@ -1,0 +1,8 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+// Boots the JWT + Server sample (samples/Rask.Example.Auth.Jwt) for the login round-trip E2E.
+public sealed class JwtServerAuthAppFixture : ExampleAppFixture
+{
+    protected override string ProjectRelativePath => "samples/Rask.Example.Auth.Jwt";
+    protected override int Port => 5103;
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmCookieAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmCookieAuthAppFixture.cs
@@ -1,0 +1,9 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+// Boots the Cookie + WASM host (serves the WASM bundle + the cookie auth API) for the login round-trip E2E.
+public sealed class WasmCookieAuthAppFixture : ExampleAppFixture
+{
+    protected override string ProjectRelativePath => "samples/Rask.Example.Auth.WasmCookie.Host";
+    protected override int Port => 5104;
+    protected override TimeSpan ReadyTimeout => TimeSpan.FromSeconds(180);
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmJwtAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmJwtAuthAppFixture.cs
@@ -1,0 +1,9 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+// Boots the JWT + WASM host (serves the WASM bundle + the JWT auth API) for the login round-trip E2E.
+public sealed class WasmJwtAuthAppFixture : ExampleAppFixture
+{
+    protected override string ProjectRelativePath => "samples/Rask.Example.Auth.WasmJwt.Host";
+    protected override int Port => 5105;
+    protected override TimeSpan ReadyTimeout => TimeSpan.FromSeconds(180);
+}

--- a/tests/Rask.Examples.E2E.Tests/JwtServerAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/JwtServerAuthExampleTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+// JWT + Server with the token in ProtectedSessionStorage (no URL token, no JS-readable token). Login sets
+// the principal in-session; the Authorize component gates the members content over the live connection.
+[Collection(JwtServerAuthExampleCollection.Name)]
+public sealed class JwtServerAuthExampleTests : IAsyncLifetime
+{
+    private readonly JwtServerAuthAppFixture _app;
+    private readonly PlaywrightFixture _pw;
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public JwtServerAuthExampleTests(JwtServerAuthAppFixture app, PlaywrightFixture pw)
+    {
+        _app = app;
+        _pw = pw;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = _app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task Login_RoundTrip_AdminSeesAdminNote_ThenSignOut()
+    {
+        // Anonymous members page → component gate shows the sign-in prompt.
+        await _page.GotoAsync("/members");
+        await Expect(_page.Locator("#members-anon")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+
+        // Sign in as admin.
+        await _page.GotoAsync("/login");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await _page.Locator("#username").FillAsync("root");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        // Lands on /members, authenticated, with the admin note.
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
+            new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+        // The raw JWT must NOT be readable in JS — sessionStorage holds only the encrypted blob.
+        var stored = await _page.EvaluateAsync<string?>("() => sessionStorage.getItem('rask.jwt')");
+        Assert.False(string.IsNullOrEmpty(stored));
+        Assert.DoesNotContain("eyJ", stored); // not a raw JWT (which starts with the base64 "eyJ" header)
+
+        // Sign out → back to /login.
+        await _page.Locator("#logout").ClickAsync();
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
+            new() { Timeout = 30_000 });
+    }
+
+    [Fact]
+    public async Task NonAdmin_DoesNotSeeAdminNote()
+    {
+        await _page.GotoAsync("/login");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await _page.Locator("#username").FillAsync("alice");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0);
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+++ b/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
@@ -42,6 +42,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\samples\Rask.Example.Server\Rask.Example.Server.csproj"
                       ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\samples\Rask.Example.Auth\Rask.Example.Auth.csproj"
+                      ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Wasm.Host\Rask.Example.Wasm.Host.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"/>

--- a/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+++ b/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
@@ -44,6 +44,14 @@
                       ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Auth\Rask.Example.Auth.csproj"
                       ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\samples\Rask.Example.Auth.Jwt\Rask.Example.Auth.Jwt.csproj"
+                      ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\samples\Rask.Example.Auth.WasmCookie.Host\Rask.Example.Auth.WasmCookie.Host.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"/>
+    <ProjectReference Include="..\..\samples\Rask.Example.Auth.WasmJwt.Host\Rask.Example.Auth.WasmJwt.Host.csproj"
+                      ReferenceOutputAssembly="false"
+                      SkipGetTargetFrameworkProperties="true"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Wasm.Host\Rask.Example.Wasm.Host.csproj"
                       ReferenceOutputAssembly="false"
                       SkipGetTargetFrameworkProperties="true"/>

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.AuthorizeComponent.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.AuthorizeComponent.cs
@@ -1,0 +1,37 @@
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+public abstract partial class SharedSmokeTests
+{
+    // The headless Authorize component (declarative gate) on the /user page. Its three slots —
+    // Authorized / NotAuthorized / Authorizing — must reflect the signed-in principal as the shared
+    // DemoUserProvider is toggled, with no page reload (live re-render via IUserProvider.Changed).
+    [Fact]
+    public Task AuthorizeComponent_Slots_ReflectRole() => RunAsync(async () =>
+    {
+        await NavigateToAsync("/user");
+        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("User & auth gating",
+            new() { Timeout = 30_000 });
+
+        var demo = Page.Locator("#authorize-demo");
+
+        // Anonymous → the NotAuthorized fallback slot.
+        await Expect(demo).ToContainTextAsync("Sign in to see member content", new() { Timeout = 10_000 });
+        await Expect(demo).Not.ToContainTextAsync("Admin-only content");
+
+        // Plain user → the authenticated ("standard access") slot, but not the admin slot.
+        await demo.Locator("button:has-text('Sign in as user')").ClickAsync();
+        await Expect(demo).ToContainTextAsync("standard access", new() { Timeout = 10_000 });
+        await Expect(demo).Not.ToContainTextAsync("Admin-only content");
+
+        // Sign out → back to the fallback slot.
+        await demo.Locator("button:has-text('Sign out')").ClickAsync();
+        await Expect(demo).ToContainTextAsync("Sign in to see member content", new() { Timeout = 10_000 });
+
+        // Admin → the role-gated Authorized slot.
+        await demo.Locator("button:has-text('Sign in as admin')").ClickAsync();
+        await Expect(demo).ToContainTextAsync("Admin-only content", new() { Timeout = 10_000 });
+        await Expect(demo).Not.ToContainTextAsync("Sign in to see member content");
+    });
+}

--- a/tests/Rask.Examples.E2E.Tests/WasmCookieAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmCookieAuthExampleTests.cs
@@ -1,0 +1,67 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+// Cookie + WASM: a browser-WASM SPA signs in against its host's /api/login (HttpOnly cookie) and hydrates
+// the user from /api/me. The Authorize component gates the members content off that principal.
+[Collection(WasmCookieAuthExampleCollection.Name)]
+public sealed class WasmCookieAuthExampleTests : IAsyncLifetime
+{
+    private readonly WasmCookieAuthAppFixture _app;
+    private readonly PlaywrightFixture _pw;
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public WasmCookieAuthExampleTests(WasmCookieAuthAppFixture app, PlaywrightFixture pw)
+    {
+        _app = app;
+        _pw = pw;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = _app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task Login_RoundTrip_AdminSeesAdminNote_ThenSignOut()
+    {
+        // Anonymous → /api/me 204 → the gate shows the sign-in prompt (WASM cold boot can be slow).
+        await _page.GotoAsync("/members");
+        await Expect(_page.Locator("#members-anon")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+
+        await _page.GotoAsync("/login");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 60_000 });
+        await _page.Locator("#username").FillAsync("root");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        // /api/login set the cookie, RefreshAsync re-hydrated from /api/me, navigated to /members.
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
+            new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+        await _page.Locator("#logout").ClickAsync();
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
+            new() { Timeout = 30_000 });
+    }
+
+    [Fact]
+    public async Task NonAdmin_DoesNotSeeAdminNote()
+    {
+        await _page.GotoAsync("/login");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+        await _page.Locator("#username").FillAsync("alice");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0);
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/WasmJwtAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmJwtAuthExampleTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+// JWT + WASM: the bearer token lives in localStorage and is sent as Authorization: Bearer on every API call;
+// /api/me validates it server-side. The Authorize component gates the members content.
+[Collection(WasmJwtAuthExampleCollection.Name)]
+public sealed class WasmJwtAuthExampleTests : IAsyncLifetime
+{
+    private readonly WasmJwtAuthAppFixture _app;
+    private readonly PlaywrightFixture _pw;
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public WasmJwtAuthExampleTests(WasmJwtAuthAppFixture app, PlaywrightFixture pw)
+    {
+        _app = app;
+        _pw = pw;
+    }
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = _app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task Login_RoundTrip_TokenInLocalStorage_AdminSeesAdminNote_ThenSignOut()
+    {
+        await _page.GotoAsync("/members");
+        await Expect(_page.Locator("#members-anon")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+
+        await _page.GotoAsync("/login");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 60_000 });
+        await _page.Locator("#username").FillAsync("root");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
+            new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+
+        // The bearer JWT is in localStorage (this sample's choice).
+        var stored = await _page.EvaluateAsync<string?>("() => localStorage.getItem('rask.jwt')");
+        Assert.False(string.IsNullOrEmpty(stored));
+        Assert.StartsWith("eyJ", stored); // a raw JWT begins with the base64url "eyJ" header
+
+        await _page.Locator("#logout").ClickAsync();
+        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
+            new() { Timeout = 30_000 });
+        var cleared = await _page.EvaluateAsync<string?>("() => localStorage.getItem('rask.jwt')");
+        Assert.True(string.IsNullOrEmpty(cleared));
+    }
+
+    [Fact]
+    public async Task NonAdmin_DoesNotSeeAdminNote()
+    {
+        await _page.GotoAsync("/login");
+        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+        await _page.Locator("#username").FillAsync("alice");
+        await _page.Locator("#password").FillAsync("password");
+        await _page.Locator("#login-submit").ClickAsync();
+
+        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0);
+    }
+}

--- a/tests/Rask.Server.Tests/Authentication/AuthRedeemEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/AuthRedeemEndpointTests.cs
@@ -103,6 +103,52 @@ public class AuthRedeemEndpointTests
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task Redeem_ForeignOrigin_Returns403()
+    {
+        using var host = CreateHost();
+        var store = host.Server.Services.GetRequiredService<IAuthTicketStore>();
+        var ticketId = store.Issue(
+            AuthAction.SignIn,
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "alice")], "TestCookie")),
+            "TestCookie",
+            "session-1");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+        req.Headers.Add("Origin", "https://evil.example");
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+        // The cross-origin request was bounced before the ticket was consumed — it still redeems.
+        Assert.True(store.TryRedeem(ticketId, "session-1", out _));
+    }
+
+    [Fact]
+    public async Task Redeem_SameOrigin_Succeeds()
+    {
+        using var host = CreateHost();
+        var store = host.Server.Services.GetRequiredService<IAuthTicketStore>();
+        var ticketId = store.Issue(
+            AuthAction.SignIn,
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "alice")], "TestCookie")),
+            "TestCookie",
+            "session-1");
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+        req.Headers.Add("Origin", "http://localhost");
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
     private static RaskTestHost CreateHost() =>
         RaskTestHost.Create<SignInTestApp>(
             services =>

--- a/tests/Rask.Server.Tests/Authentication/AuthRedeemEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/AuthRedeemEndpointTests.cs
@@ -149,6 +149,106 @@ public class AuthRedeemEndpointTests
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
     }
 
+    [Fact]
+    public async Task Redeem_NoOriginNoReferer_Succeeds()
+    {
+        // Same-origin fetch() may omit Origin entirely; with no Referer either, the ticket secrecy is
+        // the authority and the request is allowed.
+        using var host = CreateHost();
+        var ticketId = IssueTicket(host);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Redeem_SameHostRefererFallback_Succeeds()
+    {
+        // No Origin header → fall back to Referer; same host passes.
+        using var host = CreateHost();
+        var ticketId = IssueTicket(host);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+        req.Headers.Add("Referer", "http://localhost/login");
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Redeem_ForeignReferer_Returns403()
+    {
+        using var host = CreateHost();
+        var ticketId = IssueTicket(host);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+        req.Headers.Add("Referer", "https://evil.example/page");
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Redeem_MalformedOrigin_Returns403()
+    {
+        // An Origin that isn't an absolute URI can't be proven same-origin → reject.
+        using var host = CreateHost();
+        var ticketId = IssueTicket(host);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+        req.Headers.TryAddWithoutValidation("Origin", "not-a-valid-origin");
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
+    }
+
+    [Fact]
+    public async Task Redeem_CrossSchemeSameHost_Succeeds()
+    {
+        // TLS-terminating proxy: browser Origin is https (:443) while the request reaches the app as
+        // http (:80). Host matches, so redeem must still succeed (host-only comparison).
+        using var host = CreateHost();
+        var ticketId = IssueTicket(host);
+
+        var req = new HttpRequestMessage(HttpMethod.Post, "/_rask/auth/redeem")
+        {
+            Content = JsonContent.Create(new { ticket = ticketId, session = "session-1" })
+        };
+        req.Headers.Add("Origin", "https://localhost");
+
+        var resp = await host.Http.SendAsync(req);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+    }
+
+    private static string IssueTicket(RaskTestHost host)
+    {
+        var store = host.Server.Services.GetRequiredService<IAuthTicketStore>();
+        return store.Issue(
+            AuthAction.SignIn,
+            new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "alice")], "TestCookie")),
+            "TestCookie",
+            "session-1");
+    }
+
     private static RaskTestHost CreateHost() =>
         RaskTestHost.Create<SignInTestApp>(
             services =>

--- a/tests/Rask.Server.Tests/Authentication/AuthTicketStoreTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/AuthTicketStoreTests.cs
@@ -6,10 +6,12 @@ namespace Rask.Server.Tests.Authentication;
 
 public class AuthTicketStoreTests
 {
+    private static AuthTicketStore Store() => new();
+
     [Fact]
     public void Issue_Then_TryRedeem_ReturnsTicket()
     {
-        var store = new AuthTicketStore();
+        var store = Store();
         var principal = new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "alice")], "Test"));
         var id = store.Issue(AuthAction.SignIn, principal, "Test", "session-1");
 
@@ -23,7 +25,7 @@ public class AuthTicketStoreTests
     [Fact]
     public void TryRedeem_Twice_SecondReturnsFalse()
     {
-        var store = new AuthTicketStore();
+        var store = Store();
         var id = store.Issue(AuthAction.SignIn, new ClaimsPrincipal(new ClaimsIdentity()), null, "session-1");
 
         Assert.True(store.TryRedeem(id, "session-1", out _));
@@ -33,7 +35,7 @@ public class AuthTicketStoreTests
     [Fact]
     public void TryRedeem_WrongSession_ReturnsFalse()
     {
-        var store = new AuthTicketStore();
+        var store = Store();
         var id = store.Issue(AuthAction.SignIn, new ClaimsPrincipal(new ClaimsIdentity()), null, "session-1");
 
         Assert.False(store.TryRedeem(id, "session-2", out _));
@@ -44,31 +46,32 @@ public class AuthTicketStoreTests
     [Fact]
     public void TryRedeem_UnknownTicket_ReturnsFalse()
     {
-        var store = new AuthTicketStore();
+        var store = Store();
         Assert.False(store.TryRedeem("no-such-id", "session-1", out _));
     }
 
     [Fact]
     public void TryRedeem_Expired_ReturnsFalse()
     {
-        var prevTtl = AuthTicketStore.Ttl;
+        // A negative TTL makes every issued ticket already expired by the time it's redeemed.
+        var prev = AuthTicketStore.Ttl;
         AuthTicketStore.Ttl = TimeSpan.FromMilliseconds(-1);
         try
         {
-            var store = new AuthTicketStore();
+            var store = Store();
             var id = store.Issue(AuthAction.SignIn, new ClaimsPrincipal(new ClaimsIdentity()), null, "session-1");
             Assert.False(store.TryRedeem(id, "session-1", out _));
         }
         finally
         {
-            AuthTicketStore.Ttl = prevTtl;
+            AuthTicketStore.Ttl = prev;
         }
     }
 
     [Fact]
     public void TryRedeem_EmptyArgs_ReturnsFalse()
     {
-        var store = new AuthTicketStore();
+        var store = Store();
         Assert.False(store.TryRedeem("", "session-1", out _));
         Assert.False(store.TryRedeem("ticket", "", out _));
     }
@@ -76,7 +79,7 @@ public class AuthTicketStoreTests
     [Fact]
     public void Issue_SignOutAction_AcceptsNullPrincipal()
     {
-        var store = new AuthTicketStore();
+        var store = Store();
         var id = store.Issue(AuthAction.SignOut, null, null, "session-1");
         Assert.True(store.TryRedeem(id, "session-1", out var ticket));
         Assert.Equal(AuthAction.SignOut, ticket.Action);

--- a/tests/Rask.Server.Tests/Authentication/RouteGuardPipelineTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/RouteGuardPipelineTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Authentication;
+using Rask.Server.Authentication;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Authentication;
+
+// End-to-end coverage of every route-guard outcome through the real Rask HTTP pipeline
+// (middleware → cookie auth → RouteAuthorizationGuard → challenge/forbid), plus the cookie
+// established via the genuine sign-in redeem handshake.
+public class RouteGuardPipelineTests
+{
+    [Fact]
+    public async Task PublicPage_Anonymous_Returns200()
+    {
+        using var host = CreateHost();
+        var resp = await host.Http.GetAsync("/e2e/public");
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("public-content", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task ProtectedPage_Anonymous_ChallengesToLogin()
+    {
+        using var host = CreateHost();
+        var resp = await host.Http.GetAsync("/e2e/members");
+
+        Assert.Equal(HttpStatusCode.Found, resp.StatusCode);
+        Assert.Equal("/login", resp.Headers.Location!.AbsolutePath);
+        Assert.Contains("ReturnUrl", resp.Headers.Location!.Query);
+    }
+
+    [Fact]
+    public async Task AdminPage_Anonymous_ChallengesToLogin()
+    {
+        using var host = CreateHost();
+        var resp = await host.Http.GetAsync("/e2e/admin");
+
+        Assert.Equal(HttpStatusCode.Found, resp.StatusCode);
+        Assert.Equal("/login", resp.Headers.Location!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task ProtectedPage_Authenticated_Returns200_WithUserName()
+    {
+        using var host = CreateHost();
+        var cookie = await SignInAsync(host, "alice");
+
+        var resp = await GetWithCookieAsync(host, "/e2e/members", cookie);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        var body = await resp.Content.ReadAsStringAsync();
+        Assert.Contains("members-content", body);
+        Assert.Contains("alice", body); // SessionUserProvider seeded from the cookie principal
+    }
+
+    [Fact]
+    public async Task AdminPage_AuthenticatedNonAdmin_IsForbidden()
+    {
+        using var host = CreateHost();
+        var cookie = await SignInAsync(host, "alice", "user");
+
+        var resp = await GetWithCookieAsync(host, "/e2e/admin", cookie);
+
+        Assert.Equal(HttpStatusCode.Found, resp.StatusCode); // forbid → AccessDeniedPath
+        Assert.Equal("/forbidden", resp.Headers.Location!.AbsolutePath);
+    }
+
+    [Fact]
+    public async Task AdminPage_Admin_Returns200()
+    {
+        using var host = CreateHost();
+        var cookie = await SignInAsync(host, "root", "admin");
+
+        var resp = await GetWithCookieAsync(host, "/e2e/admin", cookie);
+
+        Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
+        Assert.Contains("admin-content", await resp.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task SignOut_ClearedCookie_LosesAccess()
+    {
+        using var host = CreateHost();
+        var cookie = await SignInAsync(host, "alice");
+        Assert.Equal(HttpStatusCode.OK, (await GetWithCookieAsync(host, "/e2e/members", cookie)).StatusCode);
+
+        var cleared = await SignOutAsync(host);                 // ctx.SignOutAsync emits an emptied cookie
+        var resp = await GetWithCookieAsync(host, "/e2e/members", cleared);
+
+        Assert.Equal(HttpStatusCode.Found, resp.StatusCode);    // back to the challenge
+    }
+
+    private static async Task<string> SignInAsync(RaskTestHost host, string name, params string[] roles)
+    {
+        var store = host.Server.Services.GetRequiredService<IAuthTicketStore>();
+        var claims = new List<Claim> { new(ClaimTypes.Name, name), new(ClaimTypes.NameIdentifier, name) };
+        foreach (var r in roles)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, r));
+        }
+
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestCookie"));
+        var ticket = store.Issue(AuthAction.SignIn, principal, "TestCookie", "sess");
+        var resp = await host.Http.PostAsJsonAsync("/_rask/auth/redeem", new { ticket, session = "sess" });
+        return CookieFrom(resp);
+    }
+
+    private static async Task<string> SignOutAsync(RaskTestHost host)
+    {
+        var store = host.Server.Services.GetRequiredService<IAuthTicketStore>();
+        var ticket = store.Issue(AuthAction.SignOut, null, "TestCookie", "sess");
+        var resp = await host.Http.PostAsJsonAsync("/_rask/auth/redeem", new { ticket, session = "sess" });
+        return CookieFrom(resp);
+    }
+
+    private static string CookieFrom(HttpResponseMessage resp) =>
+        resp.Headers.TryGetValues("Set-Cookie", out var values) ? values.First().Split(';')[0] : "";
+
+    private static Task<HttpResponseMessage> GetWithCookieAsync(RaskTestHost host, string path, string cookie)
+    {
+        var req = new HttpRequestMessage(HttpMethod.Get, path);
+        if (!string.IsNullOrEmpty(cookie))
+        {
+            req.Headers.Add("Cookie", cookie);
+        }
+
+        return host.Http.SendAsync(req);
+    }
+
+    private static RaskTestHost CreateHost() =>
+        RaskTestHost.Create<RouteGuardTestApp>(
+            services =>
+            {
+                services.AddAuthentication("TestCookie").AddCookie("TestCookie", o =>
+                {
+                    o.Cookie.Name = "TestCookie";
+                    o.LoginPath = "/login";
+                    o.AccessDeniedPath = "/forbidden";
+                });
+                services.AddAuthorization();
+            },
+            app =>
+            {
+                app.UseAuthentication();
+                app.UseAuthorization();
+            });
+}

--- a/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
@@ -1,0 +1,43 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core;
+using Rask.Core.Routing;
+
+#pragma warning disable RASK019 // test-infra app predates framework-managed <head>
+
+namespace Rask.Server.Tests.Authentication;
+
+// A minimal app whose Router exposes pages with every route-gating shape, so the route-guard
+// pipeline (Allow / Challenge / Forbid) can be exercised end-to-end over real HTTP.
+public sealed class RouteGuardTestApp : Component
+{
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head()[Title()["route-guard-e2e"]],
+                Body()[Router()]
+            ]
+        ];
+}
+
+[Route("/e2e/public")]
+[AllowAnonymous]
+public sealed class E2EPublicPage : Component
+{
+    protected override RenderResult Render() => Div(Id: "public")["public-content"];
+}
+
+[Route("/e2e/members")]
+[Authorize]
+public sealed class E2EMembersPage : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "members")["members-content for ", Span()[User.Identity?.Name ?? "?"]];
+}
+
+[Route("/e2e/admin")]
+[Authorize(Roles = "admin")]
+public sealed class E2EAdminPage : Component
+{
+    protected override RenderResult Render() => Div(Id: "admin")["admin-content"];
+}

--- a/tests/Rask.Server.Tests/Authentication/SessionUserProviderTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/SessionUserProviderTests.cs
@@ -1,0 +1,37 @@
+using System.Security.Claims;
+using Rask.Server.Authentication;
+
+namespace Rask.Server.Tests.Authentication;
+
+public class SessionUserProviderTests
+{
+    [Fact]
+    public void Clear_AfterSignIn_ResetsToAnonymous_AndRaisesChanged()
+    {
+        var provider = new SessionUserProvider();
+        var changes = 0;
+        provider.Changed += () => changes++;
+
+        provider.Set(new ClaimsPrincipal(new ClaimsIdentity([new Claim(ClaimTypes.Name, "alice")], "test")));
+        Assert.True(provider.Current.Identity?.IsAuthenticated);
+        Assert.Equal(1, changes);
+
+        provider.Clear();
+
+        Assert.False(provider.Current.Identity?.IsAuthenticated ?? false);
+        Assert.Equal(2, changes);
+    }
+
+    [Fact]
+    public void Clear_WhenAlreadyAnonymous_IsNoOp()
+    {
+        var provider = new SessionUserProvider();
+        var changes = 0;
+        provider.Changed += () => changes++;
+
+        provider.Clear();
+
+        Assert.False(provider.Current.Identity?.IsAuthenticated ?? false);
+        Assert.Equal(0, changes);
+    }
+}


### PR DESCRIPTION
Adds a complete, end-to-end authentication story for Rask — the declarative gate, sign-in hardening, runnable reference samples for every `{Cookie, JWT} × {Server, WASM}` cell (each with a browser E2E), `dotnet new --auth` scaffolding, and a full guide.

## Framework
- **`Authorize` headless component** (`Authorized` / `NotAuthorized` / `Authorizing` slots, `Roles: string[]`, `Policy` via `IAuthorizationService`) + `IUserProvider.IsLoading`. Reverses the old "no AuthorizeView" stance.
- **Hardening on the sign-in handshake:** cross-origin Origin/Referer check on `/_rask/auth/redeem`, `SessionUserProvider.Clear()`, a JWT-over-WebSocket `?access_token` hook in `rask.js`, and an "Authenticating…" overlay during the auth reconnect.
- Auth is configured entirely through ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization` — no bespoke options object.

## Runnable samples (one per cell, each with a browser E2E)
| Cell | Sample | Token transport |
|---|---|---|
| Cookie + Server | `Rask.Example.Auth` | redeem handshake → HttpOnly cookie |
| JWT + Server | `Rask.Example.Auth.Jwt` | **`ProtectedSessionStorage`** (encrypted, server-side-only; never in the URL or JS) |
| Cookie + WASM | `Rask.Example.Auth.WasmCookie(.Host)` | HttpOnly cookie + `/api/me` hydration |
| JWT + WASM | `Rask.Example.Auth.WasmJwt(.Host)` | bearer in localStorage + `BearerTokenHandler` |

All WASM clients publish trim-clean (zero IL warnings) via source-generated JSON contexts.

## Templates
`dotnet new --auth` on **all three** templates: `rask-server` / `rask-wasm-hosted` scaffold a cookie login; `rask-wasm` (standalone) scaffolds a JWT bearer login against an external API. Verified via `dotnet new install` + instantiate (clean both ways, no orphan directives).

## Tests
- Unit: `Authorize` (10), route-guard pipeline (real HTTP), redeem/Origin, ticket TTL, `SessionUserProvider.Clear`, WS sign-in dispatch, `AuthorizeDemo`.
- Browser E2E (Playwright): the `Authorize` component across 3 hosts, and the login round trip for all four cells.

## Docs
`docs/authentication.md` — copy-pasteable flows for cookie/JWT × Server/WASM, standalone WASM, ASP.NET Identity, Keycloak, Auth0, AWS Cognito, Duende IdentityServer, plus a hardening reference and security checklist. Aligned to the runnable samples.

## Notes
- The in-repo `Directory.Build.props` was auto-injecting `Rask.Validation.*` global usings into every `Rask.Example.*` project; gated to skip `Rask.Example.Auth*` so the auth samples don't reference validation.
- `Microsoft.AspNetCore.Authentication.JwtBearer` added to central package management.

**Verification:** full solution builds clean; non-E2E suite green (Core 1423, Server 127, Shared 237, + all others); the new auth E2E pass live; `Rask.Example.Wasm` + the new WASM samples publish with zero IL trim warnings.