### PR TITLE
Harden live-session security: returnUrl, WS origin, reconnect race, session cap

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -952,6 +952,9 @@ Define an IdentityResource/`role` claim and add it to the client's allowed scope
 |---|---|
 | **Redeem-ticket TTL** | 30s, fixed. The ticket is single-use, session-bound, 128-bit. |
 | **CSRF on `/_rask/auth/redeem`** | The secret session-bound ticket defeats classic CSRF; the endpoint additionally **rejects cross-origin `Origin`/`Referer`** (HTTP 403). |
+| **Session identity trust model** | A live session is keyed by an unguessable 128-bit id embedded in the page (same model as a Blazor circuit). The WS `hello` handler binds the session's user to the principal authenticated on that socket, so security rests on the **secrecy of the session id** — serve over HTTPS, don't log it or leak it via `Referer`. Cross-origin pages can't read it (same-origin policy). |
+| **Cross-Site WebSocket Hijacking** | CORS doesn't apply to WS handshakes and the upgrade carries the auth cookie, so the `/rask/ws` endpoint **rejects a cross-origin handshake** (HTTP 403) using the same host-only same-origin check as redeem. Clients sending no `Origin` (non-browser) are allowed. |
+| **Session-store growth (DoS)** | Each session pins a component tree + DI scope. Sessions are reclaimed shortly after their socket disconnects; set `RaskLiveOptions.MaxSessions` for a hard ceiling (a GET over the cap gets `503` + `Retry-After`). `0` = unlimited (default). Pair with a reverse-proxy rate limit. |
 | **Sign-out invalidation** | Redeem clears the cookie; the WS reconnect re-seeds `SessionUserProvider` to anonymous. `SessionUserProvider.Clear()` is available for explicit invalidation. |
 | **Session expiry → re-auth** | A swept live session pushes `{type:"session",status:"unknown"}`; `rask.js` reloads → fresh GET → route guard challenges to `ChallengePath?returnUrl=…`. |
 | **JWT on WebSocket** | Token rides `?access_token=` on the WS URL via `window.Rask.authToken`; pair with `AddJwtBearer`'s `OnMessageReceived`. |
@@ -967,7 +970,10 @@ Define an IdentityResource/`role` claim and add it to the client's allowed scope
 - ☑ If a token must be in the browser, store it **encrypted** (`ProtectedTokenStore`), never plaintext.
 - ☑ Short JWT lifetime + app-driven silent refresh so sessions stay smooth without long-lived tokens.
 - ☑ Keep `UseAuthentication()` **before** `UseRask()`.
-- ☑ Validate redirect targets — Rask sanitizes the `returnUrl` to local paths.
+- ☑ Validate redirect targets — Rask sanitizes the `returnUrl` to local same-origin paths (rejects `//`, `/\`, and backslash/control-char variants).
+- ☑ Treat the **session id as a bearer secret** — HTTPS only, never logged or placed in URLs that leak via `Referer`.
+- ☑ Behind a reverse proxy, wire **ForwardedHeaders** so the host-only same-origin checks (redeem + WS) see the public host.
+- ☑ For untrusted-traffic hosts, set `RaskLiveOptions.MaxSessions` and a reverse-proxy rate limit to bound session creation.
 - ☑ Rotate signing keys; manage the Data Protection key ring (persisted, encrypted at rest).
 
 ---

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/WasmLoginService.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/WasmLoginService.cs
@@ -19,7 +19,9 @@ public sealed class WasmLoginService(HttpClient http, IUserProvider users, Navig
         }
 
         await users.RefreshAsync();
-        nav.Navigate(returnUrl ?? "/members");
+        // Open-redirect guard: never navigate off-origin from an attacker-supplied returnUrl
+        // (parity with the server's SanitizeReturnUrl). Unsafe values collapse to "/".
+        nav.Navigate(LocalUrl.Sanitize(returnUrl ?? "/members"));
         return true;
     }
 

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
@@ -7,8 +7,19 @@ using Rask.Wasm.Hosting;
 
 var builder = WebApplication.CreateBuilder(args);
 
-var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(
-    builder.Configuration["Jwt:Key"] ?? JwtIssuer.DevKey));
+// JwtIssuer.DevKey is a public, hardcoded signing key — fine for the demo, but anyone could forge
+// tokens with it. Fail fast rather than silently fall back to it outside Development, so a deploy
+// that forgets to set Jwt:Key can't ship a forgeable-token endpoint.
+var jwtKey = builder.Configuration["Jwt:Key"];
+if (jwtKey is null && !builder.Environment.IsDevelopment())
+{
+    throw new InvalidOperationException(
+        "Jwt:Key is not configured. Set a strong signing key (e.g. via user-secrets, environment, " +
+        "or a secret store) before running outside Development — the built-in JwtIssuer.DevKey is " +
+        "public and lets anyone forge tokens.");
+}
+
+var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey ?? JwtIssuer.DevKey));
 
 builder.Services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
     .AddJwtBearer(o =>

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/JwtLoginService.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/JwtLoginService.cs
@@ -23,7 +23,9 @@ public sealed class JwtLoginService(HttpClient http, TokenStore tokens, IUserPro
 
         await tokens.SetAsync(dto.Token);
         await users.RefreshAsync();
-        nav.Navigate(returnUrl ?? "/members");
+        // Open-redirect guard: never navigate off-origin from an attacker-supplied returnUrl
+        // (parity with the server's SanitizeReturnUrl). Unsafe values collapse to "/".
+        nav.Navigate(LocalUrl.Sanitize(returnUrl ?? "/members"));
         return true;
     }
 

--- a/src/Rask.Core/Components/Context.cs
+++ b/src/Rask.Core/Components/Context.cs
@@ -94,10 +94,16 @@ public sealed class Context : Component
 
     /// <summary>
     ///     <c>true</c> when a value of type <typeparamref name="T" /> (optionally by
-    ///     <paramref name="name" />) is provided by an enclosing <see cref="Context" />. Does
-    ///     not mark the caller as a consumer.
+    ///     <paramref name="name" />) is provided by an enclosing <see cref="Context" />. Like
+    ///     <see cref="Get{T}" />, marks the caller a context consumer so it re-renders when an
+    ///     ancestor begins/stops providing the value — otherwise a component that gates purely on
+    ///     <c>Has</c> would be render-cached and show stale UI when the provider appears or leaves.
     /// </summary>
-    public static bool Has<T>(string? name = null) => ContextStack.TryGet(typeof(T), name, out _);
+    public static bool Has<T>(string? name = null)
+    {
+        MarkConsumer();
+        return ContextStack.TryGet(typeof(T), name, out _);
+    }
 
     private static void MarkConsumer() => LiveRenderContext.Current?.MarkCurrentConsumesContext();
 }

--- a/src/Rask.Core/Live/HandlerSyncContext.cs
+++ b/src/Rask.Core/Live/HandlerSyncContext.cs
@@ -11,10 +11,13 @@ internal sealed class HandlerSyncContext : SynchronizationContext
 
     public override void Post(SendOrPostCallback d, object? state)
     {
-        var task = Task.Run(() => RunWithRendersAsync(d, state));
+        // Schedule AND record under the same lock so DrainAsync can't snapshot _pending in the
+        // gap between Task.Run and the Add — which could otherwise let the drain return before a
+        // just-posted render completes. Task.Run always schedules on the pool (never inline), so
+        // holding the lock around it doesn't run user code under the lock.
         lock (_pending)
         {
-            _pending.Add(task);
+            _pending.Add(Task.Run(() => RunWithRendersAsync(d, state)));
         }
     }
 

--- a/src/Rask.Core/Live/LiveOptions.cs
+++ b/src/Rask.Core/Live/LiveOptions.cs
@@ -47,6 +47,19 @@ public sealed class RaskLiveOptions
     public LiveDiffMode DiffMode { get; set; } = LiveDiffMode.Auto;
 
     /// <summary>
+    ///     Maximum number of concurrent live sessions the server will hold. Each session
+    ///     pins a component tree and a DI scope, so an unbounded count is a memory-exhaustion
+    ///     (DoS) surface for hosts exposed to untrusted traffic. <c>0</c> (default) means
+    ///     unlimited, preserving prior behaviour. When set, a GET that would create a session
+    ///     beyond the cap is answered with <c>503 Service Unavailable</c> + <c>Retry-After</c>;
+    ///     existing sessions and auth challenge/forbid redirects are unaffected. This is a
+    ///     coarse backstop — pair it with a reverse-proxy rate limit for precise control.
+    ///     Sessions are reclaimed shortly after their socket disconnects (the grace-period
+    ///     removal), so the live count tracks active clients, not cumulative visits.
+    /// </summary>
+    public int MaxSessions { get; set; }
+
+    /// <summary>
     ///     Per-app URL prefix. Empty (default) keeps every framework URL at the
     ///     origin root. A non-empty value like <c>"/appA"</c> scopes every emitted
     ///     framework URL (head asset links, runtime script src, WS connect, upload /

--- a/src/Rask.Core/Routing/LocalUrl.cs
+++ b/src/Rask.Core/Routing/LocalUrl.cs
@@ -1,0 +1,48 @@
+namespace Rask.Core.Routing;
+
+/// <summary>
+///     Open-redirect guard shared by every Rask redirect path (server post-sign-in
+///     <c>returnUrl</c>, the client route-guard challenge, and the WASM login/logout flows). It
+///     mirrors ASP.NET's <c>Url.IsLocalUrl</c>: only a same-origin absolute path may pass through;
+///     anything that could navigate off the origin collapses to <c>"/"</c>.
+/// </summary>
+public static class LocalUrl
+{
+    /// <summary>
+    ///     Returns <paramref name="url" /> unchanged when it is a guaranteed-local absolute path,
+    ///     otherwise <c>"/"</c>. Rejects: null/empty; non-rooted values (<c>"evil.com"</c>,
+    ///     <c>"https://evil.com"</c>, <c>"javascript:…"</c>); protocol-relative URLs
+    ///     (<c>"//evil.com"</c>); the backslash variants browsers normalise into them
+    ///     (<c>"/\evil.com"</c>, <c>"\evil.com"</c>); and any value containing a control character
+    ///     (which can smuggle the value past downstream parsers / split headers).
+    /// </summary>
+    public static string Sanitize(string? url)
+    {
+        if (string.IsNullOrEmpty(url))
+        {
+            return "/";
+        }
+
+        if (url[0] != '/'
+            || (url.Length > 1 && (url[1] == '/' || url[1] == '\\'))
+            || ContainsControlCharacter(url))
+        {
+            return "/";
+        }
+
+        return url;
+    }
+
+    private static bool ContainsControlCharacter(string value)
+    {
+        foreach (var c in value)
+        {
+            if (char.IsControl(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Rask.Core/Routing/Navigator.cs
+++ b/src/Rask.Core/Routing/Navigator.cs
@@ -119,6 +119,13 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
 
     internal IDisposable EnterHandler()
     {
+        // Clear any navigation a prior handler queued but never consumed — e.g. it called
+        // Navigate(...) and then threw before TryConsumeHistory ran. Resetting on entry (rather
+        // than on scope dispose) starts each dispatch clean so a faulted handler can't leak its
+        // pending nav (and _replace flag) into the next one, while still allowing the caller to
+        // consume the navigation after the scope disposes.
+        _dirty = false;
+        _replace = false;
         _inHandler = true;
         return new HandlerScope(this);
     }

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -783,7 +783,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             }
 
             first = false;
-            sb.Append(p.TypeFqn).Append(' ').Append(p.Name);
+            sb.Append(p.TypeFqn).Append(' ').Append(p.Escaped);
         }
 
         foreach (var p in optionalProps)
@@ -794,7 +794,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             }
 
             first = false;
-            sb.Append(p.TypeFqn).Append(' ').Append(p.Name).Append(" = ")
+            sb.Append(p.TypeFqn).Append(' ').Append(p.Escaped).Append(" = ")
                 .Append(DefaultLiteralFor(p));
         }
 
@@ -1162,7 +1162,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         for (var i = 0; i < entries.Count; i++)
         {
             var p = entries[i];
-            sb.Append("                ").Append(p.Name).Append(" = ").Append(p.Name);
+            sb.Append("                ").Append(p.Escaped).Append(" = ").Append(p.Escaped);
             if (i < entries.Count - 1)
             {
                 sb.Append(',');
@@ -1185,19 +1185,21 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         // nullable annotations round-trip).
         foreach (var p in foldProps)
         {
-            sb.Append("        var __old_").Append(p.Name).Append(" = __c.").Append(p.Name).AppendLine(";");
+            // __old_<Name> is a fresh local (raw Name is a valid identifier even when Name is a
+            // keyword); the property access __c.<Name> must be '@'-escaped.
+            sb.Append("        var __old_").Append(p.Name).Append(" = __c.").Append(p.Escaped).AppendLine(";");
         }
 
         // Re-apply ALL params (including Key) so cached instances see fresh values. Event-callback
         // delegates are wrapped so invoking them re-renders the owning component (see AutoCallback).
         foreach (var p in assignProps)
         {
-            sb.Append("        __c.").Append(p.Name).Append(" = ");
+            sb.Append("        __c.").Append(p.Escaped).Append(" = ");
             if (p.IsAutoRerenderDelegate)
             {
                 // Wrap returns a nullable delegate (null in → null out); a non-nullable prop never
                 // passes null, so the null-forgiving `!` is safe and silences CS8601.
-                sb.Append("global::Rask.Core.AutoCallback.Wrap(").Append(p.Name).Append(')');
+                sb.Append("global::Rask.Core.AutoCallback.Wrap(").Append(p.Escaped).Append(')');
                 if (!p.IsNullable)
                 {
                     sb.Append('!');
@@ -1205,7 +1207,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             }
             else
             {
-                sb.Append(p.Name);
+                sb.Append(p.Escaped);
             }
 
             sb.AppendLine(";");
@@ -1224,7 +1226,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         {
             var p = foldProps[0];
             sb.Append("        var __propsChanged = !global::System.Collections.Generic.EqualityComparer<")
-                .Append(p.TypeFqn).Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Name)
+                .Append(p.TypeFqn).Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Escaped)
                 .AppendLine(");");
             return;
         }
@@ -1234,7 +1236,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         {
             var p = foldProps[i];
             sb.Append("            !global::System.Collections.Generic.EqualityComparer<").Append(p.TypeFqn)
-                .Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Name).Append(')');
+                .Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Escaped).Append(')');
             sb.AppendLine(i < foldProps.Count - 1 ? " ||" : ";");
         }
     }
@@ -1327,6 +1329,15 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         string DefaultLiteral,
         bool IsParams);
 
+    // A property/parameter name as a valid C# identifier in emitted code. ISymbol.Name strips the
+    // leading '@' from a verbatim identifier (a property declared `@event` has Name "event"), so a
+    // reserved keyword must be re-escaped with '@' wherever it is emitted as an identifier —
+    // otherwise the generated factory (`string? event = null`, `__c.event = event`) fails to
+    // compile in the consumer's build. Use this only for emitted identifiers; comparisons against
+    // metadata names (modelProperty, "Children", typed-delegate sets) keep the raw Name.
+    internal static string EscapeIdentifier(string name) =>
+        SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "@" + name : name;
+
     private readonly record struct PropInfo(
         string Name,
         string TypeFqn,
@@ -1337,7 +1348,11 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         string DeclaringFilePath,
         int DeclaringSpanStart,
         int DeclaringSpanLength,
-        bool IsAutoRerenderDelegate);
+        bool IsAutoRerenderDelegate)
+    {
+        // The factory-parameter / property identifier, '@'-escaped when Name is a reserved keyword.
+        public string Escaped => EscapeIdentifier(Name);
+    }
 }
 
 internal readonly struct EquatableArray<T> : IEquatable<EquatableArray<T>>, IEnumerable<T>

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -912,13 +912,19 @@ public sealed class RoutesGenerator : IIncrementalGenerator
             {
                 var ident = qp.Name;
                 var qpName = qp.QueryParamName ?? qp.Name;
+                // URL-encode the query KEY at generation time (the value is encoded at runtime via
+                // EncodeExpr). The key is a compile-time constant, so baking the encoded form costs
+                // nothing and keeps an explicit [QueryParam("a b")] / a name with '&'/'=' from
+                // emitting a malformed query string. Property-name-derived keys are valid
+                // identifiers, so this is a no-op for them.
+                var encodedKey = Uri.EscapeDataString(qpName);
                 if (qp.IsNullable)
                 {
                     sb.Append("        if (").Append(ident).AppendLine(" is not null)");
                     sb.AppendLine("        {");
                     sb.AppendLine("            __qs ??= new global::System.Text.StringBuilder();");
                     sb.AppendLine("            __qs.Append(__qs.Length == 0 ? '?' : '&');");
-                    sb.Append("            __qs.Append(\"").Append(EscapeForCSharpStringLiteral(qpName))
+                    sb.Append("            __qs.Append(\"").Append(EscapeForCSharpStringLiteral(encodedKey))
                         .AppendLine("=\");");
                     sb.Append("            __qs.Append(").Append(EncodeExpr(ident)).AppendLine(");");
                     sb.AppendLine("        }");
@@ -928,7 +934,7 @@ public sealed class RoutesGenerator : IIncrementalGenerator
                     // Non-nullable required query param — always emit
                     sb.AppendLine("        __qs ??= new global::System.Text.StringBuilder();");
                     sb.AppendLine("        __qs.Append(__qs.Length == 0 ? '?' : '&');");
-                    sb.Append("        __qs.Append(\"").Append(EscapeForCSharpStringLiteral(qpName))
+                    sb.Append("        __qs.Append(\"").Append(EscapeForCSharpStringLiteral(encodedKey))
                         .AppendLine("=\");");
                     sb.Append("        __qs.Append(").Append(EncodeExpr(ident)).AppendLine(");");
                 }

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -622,7 +622,14 @@ public sealed class RoutesGenerator : IIncrementalGenerator
             spc.AddSource(hint, SourceText.From(sb.ToString(), Encoding.UTF8));
         }
 
-        EmitRegistryInitializer(spc, filtered);
+        // Deduplicate by fully-qualified type name before emitting the registry. A `partial`
+        // routed page whose declarations carry attributes on more than one part (e.g. [Route] on
+        // one and [Obsolete]/a source-gen attribute on another) yields one Candidate per attributed
+        // declaration — all with the same FQN. Emitting them all produced duplicate
+        // RouteRegistration entries (competing Route nodes for the same page) and duplicate
+        // [DynamicDependency] attributes. byFqn already keeps the first Candidate per FQN (its
+        // Templates reflect every [Route] on the merged symbol), so the registry uses that.
+        EmitRegistryInitializer(spc, byFqn.Values.ToList());
     }
 
     private static void EmitRegistryInitializer(SourceProductionContext spc, IReadOnlyList<Candidate> candidates)

--- a/src/Rask.Server/Authentication/AuthTicketStore.cs
+++ b/src/Rask.Server/Authentication/AuthTicketStore.cs
@@ -29,7 +29,7 @@ internal sealed class AuthTicketStore : IAuthTicketStore
     public string Issue(AuthAction action, ClaimsPrincipal? principal, string? scheme, string sessionId)
     {
         ArgumentNullException.ThrowIfNull(sessionId);
-        var id = Guid.NewGuid().ToString("N");
+        var id = SecureToken.Create();
         var ticket = new AuthTicket(action, principal, scheme, sessionId, DateTime.UtcNow.Add(Ttl));
         _tickets[id] = ticket;
         MaybeSweep();

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -45,6 +45,14 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // state and the hello-time render is redundant. Skipping the redundant render is
     // what aligns Server's initial-mount OnRendered count with WASM's.
     private bool _renderRequestedWhileDetached;
+    // Set by AttachSocket on a reconnect to force the next render to bypass the HTML/buffer
+    // dedup and re-emit even when the rendered bytes match the prior socket's last frame.
+    // The dedup baselines (_lastSentBuffer/_lastSentHtml) are owned by the RenderAndSendAsync
+    // critical section, which can run on a background thread (a StateHasChanged from an async
+    // lifecycle continuation). Resetting them directly from AttachSocket would race that send,
+    // so the reset is deferred into the render lock: RenderAndSendAsync reads-and-clears this
+    // flag under _renderLock. Volatile so the cross-thread write is visible without the lock.
+    private volatile bool _forceResend;
     private WebSocket? _socket;
     private CancellationToken _socketCt;
 
@@ -239,25 +247,23 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
 
     public void AttachSocket(WebSocket socket, CancellationToken ct)
     {
-        _socket = socket;
         _socketCt = ct;
         SuppressEventsUntilReconnect = false;
-        // A reconnect — possibly a different browser tab/window — needs the current HTML
-        // even when it byte-matches the prior socket's last frame. Reset the dedup baseline
-        // so the recovery render reliably emits.
-        _lastSentBuffer = null;
 
         if (_hasAttachedBefore)
         {
-            // Reconnect path — force a catch-up regardless of whether anything was
-            // observably dropped, since the prior send chain may have lost a frame.
-            // Also drop the HTML dedup baseline so the catch-up render reliably
-            // emits even when the browser's stale HTML matches the session's current
-            // render verbatim (the new socket's browser tab needs the bytes either way).
+            // Reconnect path — possibly a different browser tab/window — needs the current
+            // HTML even when it byte-matches the prior socket's last frame, since the prior
+            // send chain may have lost a frame. Force a catch-up and drop the dedup baselines
+            // so the recovery render reliably emits. The baseline reset is deferred into the
+            // render lock (see _forceResend) to avoid racing a background RenderAndSendAsync.
             _renderRequestedWhileDetached = true;
-            _lastSentHtml = null;
+            _forceResend = true;
         }
 
+        // Publish _socket last: a concurrent background render early-returns while it reads
+        // null/closed, so the new socket only becomes visible after the resend flag above.
+        _socket = socket;
         _hasAttachedBefore = true;
     }
 
@@ -361,6 +367,17 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
         await _renderLock.WaitAsync(_socketCt).ConfigureAwait(false);
         try
         {
+            // Consume a reconnect's resend request inside the lock that owns the dedup
+            // baselines, so AttachSocket never has to touch them from another thread. Clearing
+            // both forces this render past the HTML dedup (below) and the buffer dedup (line
+            // ~530), guaranteeing the catch-up frame reaches the freshly attached socket.
+            if (_forceResend)
+            {
+                _forceResend = false;
+                _lastSentBuffer = null;
+                _lastSentHtml = null;
+            }
+
             // Diff-codec path: capture the parallel RenderFrame[] stream during render so
             // we can produce a minimal edit-op payload instead of re-shipping the whole
             // body. Default (LiveDiffMode.DisabledFull) bypasses this entirely — the

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -69,7 +69,9 @@ public sealed class LiveSessionStore : IAsyncDisposable
     internal LiveSession Create(Func<IServiceProvider, Component> factory)
     {
         var scope = _scopeFactory.CreateScope();
-        var sessionId = Guid.NewGuid().ToString("N");
+        // Cryptographically-random id: it is the bearer secret for the WS / upload / download
+        // endpoints (see SecureToken), so it must not be a v4 GUID.
+        var sessionId = SecureToken.Create();
         if (scope.ServiceProvider.GetService<RaskSessionContext>() is { } sessionCtx)
         {
             sessionCtx.Id = sessionId;

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -26,6 +26,22 @@ public sealed class LiveSessionStore : IAsyncDisposable
 
     public int Count => _sessions.Count;
 
+    /// <summary>
+    ///     Soft cap on concurrent sessions (<c>0</c> = unlimited). Set from
+    ///     <see cref="Rask.Core.Live.RaskLiveOptions.MaxSessions" /> at registration. The
+    ///     capacity gate is intentionally check-then-create rather than a hard atomic
+    ///     reservation: a burst can admit a handful of sessions past the cap, which is fine
+    ///     for a DoS backstop and keeps the common (uncapped) <see cref="Create" /> path free
+    ///     of extra synchronisation. Tests set it directly on the resolved singleton.
+    /// </summary>
+    public int MaxSessions { get; set; }
+
+    /// <summary>
+    ///     True when a new session would exceed <see cref="MaxSessions" />. The GET endpoint
+    ///     checks this before minting a session and returns 503 when it holds.
+    /// </summary>
+    public bool AtCapacity => MaxSessions > 0 && _sessions.Count >= MaxSessions;
+
     public async ValueTask DisposeAsync()
     {
         CancelAllPending();

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -58,6 +58,7 @@ public static class RaskEndpointExtensions
         // set explicitly before AddRask was called. The static field starts at
         // Auto via its initializer, so the "no configure, no prior write" path
         // still lands on Auto without us re-writing it here.
+        var maxSessions = 0;
         if (configure is not null)
         {
             var liveOptions = new Rask.Core.Live.RaskLiveOptions();
@@ -68,9 +69,17 @@ public static class RaskEndpointExtensions
             // UseRask<TApp>(pathBase: ...) can still override this if the user
             // prefers to set the prefix at endpoint-registration time.
             Rask.Core.Live.LiveOptions.PathBase = liveOptions.PathBase;
+            // Session cap is a per-store instance value (not a static) so concurrent
+            // hosts/tests don't clobber each other through global state.
+            maxSessions = liveOptions.MaxSessions;
         }
 
-        services.AddSingleton<LiveSessionStore>();
+        services.AddSingleton(sp => new LiveSessionStore(
+            sp.GetRequiredService<IServiceScopeFactory>(),
+            sp.GetService<IHostApplicationLifetime>())
+        {
+            MaxSessions = maxSessions,
+        });
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
@@ -158,6 +167,18 @@ public static class RaskEndpointExtensions
                         await ForbidAsync(httpContext, authResult.AuthenticationScheme).ConfigureAwait(false);
                         return;
                 }
+            }
+
+            // Session-cap backstop (RaskLiveOptions.MaxSessions). Reject before minting a new
+            // session so untrusted GET traffic can't exhaust memory; checked after the auth
+            // guard above so challenge/forbid redirects (which create no session) still work.
+            if (store.AtCapacity)
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                httpContext.Response.Headers.RetryAfter = "5";
+                await httpContext.Response.WriteAsync("Server is at session capacity; please retry shortly.")
+                    .ConfigureAwait(false);
+                return;
             }
 
             var session = store.Create(sp =>
@@ -256,6 +277,19 @@ public static class RaskEndpointExtensions
                 if (!ctx.WebSockets.IsWebSocketRequest)
                 {
                     ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
+                    return;
+                }
+
+                // Cross-Site WebSocket Hijacking guard. The upgrade carries the user's auth
+                // cookie, and CORS does not apply to WebSocket handshakes, so a page on another
+                // origin could otherwise open an authenticated socket. Driving a session also
+                // needs the unguessable sessionId (delivered in the page HTML, unreadable
+                // cross-origin), but rejecting a mismatched Origin is the standard belt-and-
+                // suspenders. Reuses the same host-only same-origin check as the redeem endpoint
+                // (see IsSameOrigin) — non-browser clients omit Origin and are allowed.
+                if (!IsSameOrigin(ctx.Request))
+                {
+                    ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
                     return;
                 }
 
@@ -1028,12 +1062,32 @@ public static class RaskEndpointExtensions
             return "/";
         }
 
-        if (!returnUrl.StartsWith('/') || returnUrl.StartsWith("//", StringComparison.Ordinal))
+        // Local-redirect only. Accept an absolute path ("/foo"); reject anything that could
+        // leave the origin: a non-rooted value ("\evil.com", "https://evil.com"), a
+        // protocol-relative URL ("//evil.com"), or a backslash variant the browser
+        // normalises into one ("/\evil.com"). Mirrors ASP.NET's Url.IsLocalUrl. Control
+        // characters are rejected too — they can smuggle the value past downstream parsers.
+        if (returnUrl[0] != '/'
+            || (returnUrl.Length > 1 && (returnUrl[1] == '/' || returnUrl[1] == '\\'))
+            || ContainsControlCharacter(returnUrl))
         {
             return "/";
         }
 
         return returnUrl;
+    }
+
+    private static bool ContainsControlCharacter(string value)
+    {
+        foreach (var c in value)
+        {
+            if (char.IsControl(c))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     // HTTP methods accepted by the per-component asset endpoint. GET serves the body;

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -37,6 +37,13 @@ public static class RaskEndpointExtensions
     private const string RuntimePath = "/rask/rask.js";
     private const string WebSocketPath = "/rask/ws";
 
+    // Hard cap on a single reassembled inbound WS frame. Client→server messages (hello / event
+    // dispatch / jsResult / navigate / dotNetInvoke args) are small, and file uploads use the HTTP
+    // endpoint — never the socket — so this is generous headroom. It bounds a per-socket memory DoS
+    // where a client streams an unbounded fragmented frame the server would otherwise buffer whole
+    // before JsonDocument.Parse. Mutable static so a test can lower it; not a public knob.
+    internal static int MaxInboundFrameBytes = 8 * 1024 * 1024;
+
     private static FileSystemWatcher? _sourceWatcher;
     private static long _lastSourceChangeTicks;
 
@@ -487,6 +494,16 @@ public static class RaskEndpointExtensions
                         if (result.Count > 0)
                         {
                             message.Write(buffer.AsSpan(0, result.Count));
+                        }
+
+                        // Abort a socket that streams a frame past the cap rather than buffering it
+                        // whole — bounds per-socket memory against a fragmented-frame DoS.
+                        if (message.WrittenCount > MaxInboundFrameBytes)
+                        {
+                            try { ws.Abort(); }
+                            catch { }
+
+                            return;
                         }
                     } while (!result.EndOfMessage);
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -201,6 +201,12 @@ public static class RaskEndpointExtensions
             var html = session.RenderInitialRoot();
             var content = LivePayload.InjectRootAttr(html, session.Id);
             httpContext.Response.ContentType = "text/html; charset=utf-8";
+            // The shell embeds the session id (data-rask-root), which is the de-facto bearer
+            // for the WS / upload / download endpoints. Forbid any shared-proxy / bfcache /
+            // history caching so an authenticated user's session id can't be persisted and
+            // replayed by another principal.
+            httpContext.Response.Headers.CacheControl = "no-store, no-cache, must-revalidate, private";
+            httpContext.Response.Headers.Pragma = "no-cache";
             await httpContext.Response.WriteAsync(content).ConfigureAwait(false);
             // Schedule cleanup in case no WS ever connects for this session.
             // Browsers / probes can hit the catch-all for resources that don't
@@ -336,8 +342,9 @@ public static class RaskEndpointExtensions
             .DisableAntiforgery();
 
         endpoints.MapGet(pathBase + "/_rask/download/{sessionId}/{token}",
-            (HttpContext ctx, string sessionId, string token, SessionDownloadStore downloads) =>
-                HandleDownloadAsync(ctx, sessionId, token, downloads));
+            (HttpContext ctx, string sessionId, string token, LiveSessionStore sessionStore,
+                    SessionDownloadStore downloads) =>
+                HandleDownloadAsync(ctx, sessionId, token, sessionStore, downloads));
 
         var sessionStore = endpoints.ServiceProvider.GetRequiredService<LiveSessionStore>();
         SubscribeAssetChangedDebounced(sessionStore);
@@ -670,7 +677,17 @@ public static class RaskEndpointExtensions
                 using (navigator.EnterHandler())
                 using (authSignIn.EnterHandler())
                 {
-                    if (await session.View.TryInvokeHandlerAsync(handlerId, root, session.Services))
+                    // Re-check route authorization for the *current* principal before running the
+                    // handler. A user whose access was revoked mid-session (signed out elsewhere,
+                    // role removed, cookie expired and re-resolved on a reconnect) must not get to
+                    // fire a server-side handler on a page they can no longer view. When the guard
+                    // no longer passes, skip the handler entirely and let EnforceAuthAndRenderAsync
+                    // re-evaluate and ship the challenge/forbid redirect.
+                    if (!await IsCurrentRouteAuthorizedAsync(session).ConfigureAwait(false))
+                    {
+                        await EnforceAuthAndRenderAsync(session, null, false).ConfigureAwait(false);
+                    }
+                    else if (await session.View.TryInvokeHandlerAsync(handlerId, root, session.Services))
                     {
                         string? historyUrl = null;
                         var historyReplace = false;
@@ -885,6 +902,24 @@ public static class RaskEndpointExtensions
         }
     }
 
+    // Evaluates the route guard for the session's current route + principal. Returns true when the
+    // route resolves and the guard allows it, or when no route resolves (nothing to gate — e.g. a
+    // NotFound page); false when the guard would challenge/forbid. Used to gate handler dispatch.
+    private static async Task<bool> IsCurrentRouteAuthorizedAsync(LiveSession session)
+    {
+        var routeState = session.Services.GetRequiredService<RouteState>();
+        if (!RouteResolver.TryResolve(routeState.Path, out var chain))
+        {
+            return true;
+        }
+
+        var user = session.Services.GetRequiredService<SessionUserProvider>().Current;
+        var result = await RouteAuthorizationGuard
+            .EvaluateAsync(session.Services, chain, user)
+            .ConfigureAwait(false);
+        return result.Outcome == RouteAuthorizationOutcome.Allow;
+    }
+
     private static async Task EnforceAuthAndRenderAsync(
         LiveSession session,
         string? historyUrl,
@@ -1035,6 +1070,30 @@ public static class RaskEndpointExtensions
                && string.Equals(originUri.Host, selfHost, StringComparison.OrdinalIgnoreCase);
     }
 
+    // Binds an id-addressed endpoint (upload / download) to the principal that owns the live
+    // session. The {sessionId} in the URL is the only thing tying the request to a session, so a
+    // leaked id must not let a *different* signed-in user drive a victim's session. An anonymous
+    // session is matched by anyone — the unguessable sessionId is the only authority then (the same
+    // posture the WS handshake takes); an authenticated session requires the request to carry the
+    // same authenticated identity.
+    private static bool SameSessionUser(ClaimsPrincipal request, ClaimsPrincipal owner)
+    {
+        if (owner.Identity?.IsAuthenticated != true)
+        {
+            return true;
+        }
+
+        if (request.Identity?.IsAuthenticated != true)
+        {
+            return false;
+        }
+
+        return string.Equals(UserKey(request), UserKey(owner), StringComparison.Ordinal);
+    }
+
+    private static string? UserKey(ClaimsPrincipal user) =>
+        user.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? user.Identity?.Name;
+
     private static async Task<string> ResolveAuthSchemeAsync(IServiceProvider services, string? explicitScheme)
     {
         if (!string.IsNullOrEmpty(explicitScheme))
@@ -1055,40 +1114,9 @@ public static class RaskEndpointExtensions
         return CookieAuthenticationDefaults.AuthenticationScheme;
     }
 
-    internal static string SanitizeReturnUrl(string? returnUrl)
-    {
-        if (string.IsNullOrEmpty(returnUrl))
-        {
-            return "/";
-        }
-
-        // Local-redirect only. Accept an absolute path ("/foo"); reject anything that could
-        // leave the origin: a non-rooted value ("\evil.com", "https://evil.com"), a
-        // protocol-relative URL ("//evil.com"), or a backslash variant the browser
-        // normalises into one ("/\evil.com"). Mirrors ASP.NET's Url.IsLocalUrl. Control
-        // characters are rejected too — they can smuggle the value past downstream parsers.
-        if (returnUrl[0] != '/'
-            || (returnUrl.Length > 1 && (returnUrl[1] == '/' || returnUrl[1] == '\\'))
-            || ContainsControlCharacter(returnUrl))
-        {
-            return "/";
-        }
-
-        return returnUrl;
-    }
-
-    private static bool ContainsControlCharacter(string value)
-    {
-        foreach (var c in value)
-        {
-            if (char.IsControl(c))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
+    // Local-redirect only — shared with the client route-guard and WASM login flows via
+    // Rask.Core's LocalUrl.Sanitize (single source of truth for the IsLocalUrl rule).
+    internal static string SanitizeReturnUrl(string? returnUrl) => LocalUrl.Sanitize(returnUrl);
 
     // HTTP methods accepted by the per-component asset endpoint. GET serves the body;
     // HEAD returns the same headers with no body (handled by Results.Bytes internally).
@@ -1172,9 +1200,20 @@ public static class RaskEndpointExtensions
         SessionUploadStore uploads,
         RaskUploadOptions options)
     {
-        if (sessions.Get(sessionId) is null)
+        var session = sessions.Get(sessionId);
+        if (session is null)
         {
             ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        // The {sessionId} is the only credential on this multipart POST (DisableAntiforgery), so
+        // guard it like the WS handshake: reject cross-origin posts and require the request's
+        // authenticated user to match the session owner.
+        if (!IsSameOrigin(ctx.Request)
+            || !SameSessionUser(ctx.User, session.Services.GetRequiredService<SessionUserProvider>().Current))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
             return;
         }
 
@@ -1260,8 +1299,26 @@ public static class RaskEndpointExtensions
         HttpContext ctx,
         string sessionId,
         string token,
+        LiveSessionStore sessions,
         SessionDownloadStore downloads)
     {
+        // A leaked download URL must not serve a victim's file to another principal: require the
+        // session to still exist and the request to be same-origin and from the session owner
+        // before consuming the one-shot entry.
+        var session = sessions.Get(sessionId);
+        if (session is null)
+        {
+            ctx.Response.StatusCode = StatusCodes.Status404NotFound;
+            return;
+        }
+
+        if (!IsSameOrigin(ctx.Request)
+            || !SameSessionUser(ctx.User, session.Services.GetRequiredService<SessionUserProvider>().Current))
+        {
+            ctx.Response.StatusCode = StatusCodes.Status403Forbidden;
+            return;
+        }
+
         if (!downloads.TryTake(sessionId, token, out var entry) || entry is null)
         {
             ctx.Response.StatusCode = StatusCodes.Status404NotFound;

--- a/src/Rask.Server/SecureToken.cs
+++ b/src/Rask.Server/SecureToken.cs
@@ -1,0 +1,15 @@
+using System.Security.Cryptography;
+
+namespace Rask.Server;
+
+internal static class SecureToken
+{
+    // A 128-bit cryptographically-random token as 32 lowercase hex chars. Used for values whose
+    // secrecy IS the security boundary — redeem tickets (the authority to set the auth cookie) and
+    // live-session ids (the bearer for the WS / upload / download endpoints). Replaces
+    // Guid.NewGuid().ToString("N"): a v4 GUID exposes only ~122 random bits and carries no
+    // contractual cryptographic-strength guarantee (the runtime happens to use a CSPRNG on current
+    // platforms, but the API doesn't promise it), whereas RandomNumberGenerator is guaranteed CSPRNG.
+    // Same length/charset as Guid "N", so it's a drop-in anywhere these round-trip as opaque strings.
+    public static string Create() => RandomNumberGenerator.GetHexString(32, lowercase: true);
+}

--- a/src/Rask.Templates/content/rask-server/Program.cs
+++ b/src/Rask.Templates/content/rask-server/Program.cs
@@ -15,6 +15,11 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
     .AddCookie(o =>
     {
         o.Cookie.Name = "rask.auth";
+        // Secure-by-default: never send the auth cookie over plain HTTP, and use SameSite=Lax so it
+        // doesn't ride cross-site POSTs (CSRF). The dev launch profile runs on HTTPS so the cookie
+        // is set in development too; if you must serve over plain HTTP, relax SecurePolicy.
+        o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        o.Cookie.SameSite = SameSiteMode.Lax;
         o.LoginPath = "/login";
         o.AccessDeniedPath = "/forbidden";
     });
@@ -22,6 +27,15 @@ builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
 //#endif
 
 var app = builder.Build();
+
+// Transport security (applies whether or not auth is enabled): redirect HTTP→HTTPS, and in
+// non-Development emit HSTS so browsers refuse plain-HTTP for the configured max-age.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
 
 app.MapStaticAssets();
 //#if (auth)

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Program.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Program.cs
@@ -12,14 +12,33 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRask();
 //#if (auth)
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
-    .AddCookie(o => o.Cookie.Name = "rask.auth");
+    .AddCookie(o =>
+    {
+        o.Cookie.Name = "rask.auth";
+        // Secure-by-default: HTTPS-only and SameSite=Lax (so the cookie doesn't ride cross-site
+        // POSTs — the primary CSRF mitigation for the /api/login POST below). The dev launch
+        // profile runs on HTTPS; relax SecurePolicy only if you must serve over plain HTTP.
+        o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+        o.Cookie.SameSite = SameSiteMode.Lax;
+    });
 builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
 //#endif
 
 var app = builder.Build();
+
+// Transport security (applies whether or not auth is enabled): redirect HTTP→HTTPS, and in
+// non-Development emit HSTS so browsers refuse plain-HTTP for the configured max-age.
+if (!app.Environment.IsDevelopment())
+{
+    app.UseHsts();
+}
+
+app.UseHttpsRedirection();
 //#if (auth)
 // Populates HttpContext.User from the cookie so /api/me reflects the signed-in user.
 app.UseAuthentication();
+// Present so a [Authorize]/RequireAuthorization() you add to an endpoint is actually enforced.
+app.UseAuthorization();
 //#endif
 
 var weatherService = new LocalWeatherForecastService();

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Properties/launchSettings.json
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Properties/launchSettings.json
@@ -1,6 +1,6 @@
 {
   "profiles": {
-    "Company.RaskServer": {
+    "Company.RaskWasmHosted.Host": {
       "commandName": "Project",
       "launchBrowser": true,
       "applicationUrl": "https://localhost:5001;http://localhost:5000",

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/Auth.cs
@@ -81,7 +81,8 @@ public sealed class WasmLoginService(HttpClient http, IUserProvider users, Navig
         var resp = await http.PostAsJsonAsync("api/login", new LoginRequest(username, password), AuthJson.Default.LoginRequest);
         if (!resp.IsSuccessStatusCode) return false;
         await users.RefreshAsync();
-        nav.Navigate(returnUrl ?? "/members");
+        // Open-redirect guard: an attacker-supplied returnUrl must never navigate off-origin.
+        nav.Navigate(LocalUrl.Sanitize(returnUrl ?? "/members"));
         return true;
     }
 

--- a/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
@@ -127,7 +127,8 @@ public sealed class JwtLoginService(HttpClient http, TokenStore tokens, IUserPro
         if (dto is null) return false;
         await tokens.SetAsync(dto.Token);
         await users.RefreshAsync();
-        nav.Navigate(returnUrl ?? "/members");
+        // Open-redirect guard: an attacker-supplied returnUrl must never navigate off-origin.
+        nav.Navigate(LocalUrl.Sanitize(returnUrl ?? "/members"));
         return true;
     }
 

--- a/src/Rask.Wasm/Files/WasmDownloadSink.cs
+++ b/src/Rask.Wasm/Files/WasmDownloadSink.cs
@@ -9,13 +9,33 @@ namespace Rask.Wasm.Files;
 // which forced a ~33% JSON inflation per download plus a per-byte decodeBase64 loop in JS.
 internal sealed class WasmDownloadSink : IDownloadSink
 {
+    // Bound on retained un-pulled stagings. Only the most-recently-staged download is ever shipped
+    // (TryConsume reads the single _pending slot), and a real pull removes its entry — so in the
+    // normal one-stage-one-pull flow the map stays near-empty. But an orphaned stage (a second
+    // Stage before the first is consumed, a render coalesced away, or a token the browser never
+    // pulls because the user navigated off) would otherwise leave its byte[] in the map for the
+    // whole page lifetime. Evicting the oldest past this cap turns an unbounded leak into a bounded
+    // working set. WASM is single-threaded, so the queue + dictionary need no extra locking.
+    private const int MaxRetainedStagings = 16;
+
     private readonly ConcurrentDictionary<string, byte[]> _bytesByToken = new();
+    private readonly Queue<string> _order = new();
     private PendingDownload? _pending;
+
+    // Test seam: how many staged downloads are currently retained.
+    internal int RetainedCount => _bytesByToken.Count;
 
     public void Stage(string filename, byte[] bytes, string? contentType)
     {
         var token = Guid.NewGuid().ToString("N");
         _bytesByToken[token] = bytes;
+        _order.Enqueue(token);
+        while (_order.Count > MaxRetainedStagings && _order.TryDequeue(out var oldest))
+        {
+            // No-op when `oldest` was already pulled — TryRemove just returns false.
+            _bytesByToken.TryRemove(oldest, out _);
+        }
+
         _pending = new PendingDownload(filename, contentType ?? "application/octet-stream", null, null, token);
     }
 

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -49,6 +49,13 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
     // serialised the first payload but BEFORE the dispatch returns.
     private bool _pendingRenderInScope;
 
+    // Held so Dispose can unsubscribe symmetrically. The provider can outlive the session (it is a
+    // separate service), so a dangling subscription would fire OnUserChanged on a disposed session
+    // (disposed _lock → ObjectDisposedException). In the normal single-session-per-page lifetime
+    // Dispose is never called, but keeping the teardown correct guards tests and any future
+    // multi-session / re-init path.
+    private readonly IUserProvider? _userProvider;
+
     public WasmLiveSession(Component view, IServiceProvider services)
     {
         View = view;
@@ -64,6 +71,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
 
         if (services.GetService<IUserProvider>() is { } userProvider)
         {
+            _userProvider = userProvider;
             userProvider.Changed += OnUserChanged;
         }
     }
@@ -75,6 +83,12 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
 
     public void Dispose()
     {
+        // Unsubscribe first so a late Changed can't fire OnUserChanged on the now-disposed _lock.
+        if (_userProvider is not null)
+        {
+            _userProvider.Changed -= OnUserChanged;
+        }
+
         ComponentLifecycle.DisposeComponentTree(View);
         _lock.Dispose();
     }

--- a/tests/Rask.Core.Tests/Contexts/ContextTests.cs
+++ b/tests/Rask.Core.Tests/Contexts/ContextTests.cs
@@ -166,6 +166,28 @@ public class ContextTests
     }
 
     [Fact]
+    public void HasGate_MarksConsumer_RerendersWhenProviderRerenders()
+    {
+        // Context.Has<T>() must mark the caller a consumer just like Get<T>(), so a component that
+        // gates purely on Has bypasses the render cache and re-runs when the provider re-renders —
+        // otherwise it would stay cached and show stale UI when the value appears/changes.
+        var sp = RenderHarness.EmptyServices();
+        var consumer = new HasOnlyConsumer();
+        var plain = new PlainChild();
+        var host = new MutableThemeHost(new Theme("light"), consumer, plain);
+
+        host.RenderAsLiveRoot(sp);
+        Assert.Equal(1, consumer.RenderCount);
+        Assert.Equal(1, plain.RenderCount);
+
+        host.Theme = new Theme("dark");
+        host.RenderAsLiveRoot(sp);
+
+        Assert.Equal(2, consumer.RenderCount); // re-ran (consumer marked via Has)
+        Assert.Equal(1, plain.RenderCount);     // non-consumer sibling stays cached
+    }
+
+    [Fact]
     public void Get_OutsideRender_ReturnsDefault_RequiredThrows()
     {
         // No LiveRenderContext is active: the consumer-mark must no-op rather than NRE.
@@ -210,6 +232,17 @@ public class ContextTests
         {
             RenderCount++;
             return Span()["plain"];
+        }
+    }
+
+    private sealed class HasOnlyConsumer : Component
+    {
+        public int RenderCount;
+
+        protected override RenderResult Render()
+        {
+            RenderCount++;
+            return Span()[Context.Has<Theme>() ? "has" : "none"];
         }
     }
 

--- a/tests/Rask.Core.Tests/Routing/LocalUrlTests.cs
+++ b/tests/Rask.Core.Tests/Routing/LocalUrlTests.cs
@@ -1,0 +1,30 @@
+using Rask.Core.Routing;
+
+namespace Rask.Core.Tests.Routing;
+
+// Shared open-redirect guard (Rask.Core.Routing.LocalUrl) used by the server post-sign-in
+// returnUrl, the client route-guard challenge, and the WASM login/logout flows. Only same-origin
+// absolute paths pass through; everything that could leave the origin collapses to "/".
+public class LocalUrlTests
+{
+    [Theory]
+    [InlineData("/dashboard", "/dashboard")]
+    [InlineData("/", "/")]
+    [InlineData("/a/b?x=1#frag", "/a/b?x=1#frag")]
+    public void Local_AbsolutePath_PassesThrough(string input, string expected)
+        => Assert.Equal(expected, LocalUrl.Sanitize(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("//evil.com")]            // protocol-relative
+    [InlineData("/\\evil.com")]           // backslash → browser normalises to "//"
+    [InlineData("\\evil.com")]            // leading backslash
+    [InlineData("https://evil.com")]      // absolute URL
+    [InlineData("javascript:alert(1)")]   // not rooted
+    [InlineData("evil.com")]              // relative, not rooted
+    [InlineData("/foo\r\nSet-Cookie: x")] // control chars
+    [InlineData("/foo\tbar")]
+    public void NonLocal_OrMalformed_CollapsesToRoot(string? input)
+        => Assert.Equal("/", LocalUrl.Sanitize(input));
+}

--- a/tests/Rask.Core.Tests/Routing/NavigatorTests.cs
+++ b/tests/Rask.Core.Tests/Routing/NavigatorTests.cs
@@ -47,6 +47,25 @@ public class NavigatorTests
     }
 
     [Fact]
+    public void UnconsumedNavigation_DoesNotLeakIntoNextHandler()
+    {
+        // A handler that queues a navigation but never consumes it (e.g. it threw before
+        // TryConsumeHistory ran) must not leak that pending nav — including the replace flag —
+        // into the next dispatch and fire a navigation the user never triggered there.
+        var (nav, _) = Build("/start");
+
+        using (nav.EnterHandler())
+        {
+            nav.Navigate("/a", replace: true);
+        } // scope disposed WITHOUT TryConsumeHistory — simulates a faulted handler
+
+        using (nav.EnterHandler())
+        {
+            Assert.False(nav.TryConsumeHistory(out _, out _));
+        }
+    }
+
+    [Fact]
     public void Navigate_PathOnly_ClearsExistingQuery()
     {
         var (nav, state) = Build("/old", new Dictionary<string, StringValues> { ["b"] = "2" });

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
@@ -20,6 +20,10 @@ public abstract class ExampleAppFixture : IAsyncLifetime
     protected abstract int Port { get; }
     protected virtual TimeSpan ReadyTimeout => TimeSpan.FromSeconds(120);
 
+    // Extra environment variables for the spawned host process (e.g. config that production-mode
+    // hosts now fail-fast without). Keys use the ASP.NET `__` config delimiter (e.g. "Jwt__Key").
+    protected virtual IReadOnlyDictionary<string, string>? ExtraEnvironment => null;
+
     public string BaseUrl => $"http://localhost:{Port}";
 
     public string ServerLog
@@ -60,6 +64,14 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         };
         psi.Environment["ASPNETCORE_URLS"] = BaseUrl;
         psi.Environment["DOTNET_ENVIRONMENT"] = "Production";
+
+        if (ExtraEnvironment is { } extra)
+        {
+            foreach (var (key, value) in extra)
+            {
+                psi.Environment[key] = value;
+            }
+        }
 
         _process = Process.Start(psi)
                    ?? throw new InvalidOperationException($"Failed to start `dotnet run` for {ProjectRelativePath}");

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmJwtAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmJwtAuthAppFixture.cs
@@ -6,4 +6,12 @@ public sealed class WasmJwtAuthAppFixture : ExampleAppFixture
     protected override string ProjectRelativePath => "samples/Rask.Example.Auth.WasmJwt.Host";
     protected override int Port => 5105;
     protected override TimeSpan ReadyTimeout => TimeSpan.FromSeconds(180);
+
+    // The host fails fast without Jwt:Key outside Development (the public DevKey would let anyone
+    // forge tokens). Supply a test-only signing key so the production-mode E2E host can boot.
+    protected override IReadOnlyDictionary<string, string> ExtraEnvironment { get; } =
+        new Dictionary<string, string>
+        {
+            ["Jwt__Key"] = "rask-e2e-test-signing-key-not-for-production-0123456789abcdef"
+        };
 }

--- a/tests/Rask.Generators.Tests/GeneratorDriverFixture.cs
+++ b/tests/Rask.Generators.Tests/GeneratorDriverFixture.cs
@@ -108,6 +108,25 @@ internal sealed record GeneratorRun(GeneratorDriverRunResult RunResult, CSharpCo
     public IEnumerable<Diagnostic> Diagnostics =>
         RunResult.Diagnostics.Concat(RunResult.Results.SelectMany(r => r.Diagnostics));
 
+    /// <summary>
+    ///     Compile-error diagnostics (CS####, severity Error) of the input compilation WITH all
+    ///     generated sources added back in. Empty ⇒ the generated code is valid C# that compiles
+    ///     against the user's sources — the strongest check that no emitted identifier/literal is
+    ///     malformed.
+    /// </summary>
+    public IReadOnlyList<Diagnostic> GeneratedCompileErrors()
+    {
+        var generated = RunResult.Results
+            .SelectMany(r => r.GeneratedSources)
+            .Select(s => CSharpSyntaxTree.ParseText(s.SourceText, new CSharpParseOptions(LanguageVersion.Latest)))
+            .ToArray();
+
+        return Compilation.AddSyntaxTrees(generated)
+            .GetDiagnostics()
+            .Where(d => d.Severity == DiagnosticSeverity.Error)
+            .ToList();
+    }
+
     public string GeneratedSource(string hintNameContains)
     {
         foreach (var result in RunResult.Results)

--- a/tests/Rask.Generators.Tests/KeywordIdentifierAndPartialRouteTests.cs
+++ b/tests/Rask.Generators.Tests/KeywordIdentifierAndPartialRouteTests.cs
@@ -1,0 +1,96 @@
+namespace Rask.Generators.Tests;
+
+// M8: a property named with a C# keyword (verbatim identifier, e.g. `@event`) must emit a
+// factory that COMPILES — ISymbol.Name strips the leading '@', so every emitted use of the name
+// has to be re-escaped. M9: a partial routed page with attributes on more than one declaration
+// must register exactly once, not once per attributed declaration.
+public class KeywordIdentifierAndPartialRouteTests
+{
+    [Fact]
+    public void KeywordNamedProperty_GeneratesCompilableFactory()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed class Widget : Component
+                  {
+                      public string? @event { get; set; }   // optional keyword prop
+                      public int @class { get; set; }        // required keyword prop (folded into propsChanged)
+                      protected override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.Run(src);
+        var output = run.GeneratedSource("Demo.Generated.g.cs");
+
+        // The emitted identifiers are '@'-escaped...
+        Assert.Contains("string? @event = null", output);
+        Assert.Contains("__c.@event = @event", output);
+        Assert.Contains("__c.@class = @class", output);
+        // ...and the load-bearing guarantee: the generated factory compiles against the source.
+        Assert.Empty(run.GeneratedCompileErrors());
+    }
+
+    [Fact]
+    public void NonKeywordProperty_FactoryUnchanged()
+    {
+        // Escaping is a no-op for ordinary names — the common path is byte-for-byte as before.
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed class Widget : Component
+                  {
+                      public string? Title { get; set; }
+                      protected override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.Run(src);
+        var output = run.GeneratedSource("Demo.Generated.g.cs");
+
+        Assert.Contains("string? Title = null", output);
+        Assert.DoesNotContain("@Title", output);
+        Assert.Empty(run.GeneratedCompileErrors());
+    }
+
+    [Fact]
+    public void PartialRoutedPage_AttributesOnMultipleDeclarations_RegistersOnce()
+    {
+        var src = """
+                  using System;
+                  using Rask.Core;
+                  using Rask.Core.Routing;
+                  namespace Demo;
+                  [Route("/p")]
+                  public sealed partial class PageA : Component
+                  {
+                      protected override RenderResult Render() => this;
+                  }
+                  [Obsolete]
+                  public sealed partial class PageA
+                  {
+                      public int X { get; set; }
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        var reg = run.GeneratedSource("__RaskRoutesRegistry");
+
+        // Was: two RouteRegistration entries + two [DynamicDependency] (one per attributed part).
+        Assert.Equal(1, CountOccurrences(reg, "new(typeof(global::Demo.PageA), \"/p\", null)"));
+        Assert.Equal(1, CountOccurrences(reg, "DynamicDependency"));
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var i = 0;
+        while ((i = haystack.IndexOf(needle, i, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            i += needle.Length;
+        }
+
+        return count;
+    }
+}

--- a/tests/Rask.Generators.Tests/RoutesGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/RoutesGeneratorTests.cs
@@ -157,6 +157,30 @@ public class RoutesGeneratorTests
     }
 
     [Fact]
+    public void QueryParam_NameWithSpecialChars_IsUrlEncodedInGeneratedKey()
+    {
+        // An explicit query-param name with characters that are special in a query string must be
+        // URL-encoded in the emitted key, else the generated URL is malformed.
+        var src = """
+                  using Rask.Core;
+                  using Rask.Core.Routing;
+                  namespace Demo;
+                  [Route("/")]
+                  public sealed class HomePage : Component
+                  {
+                      [QueryParam("a b&c")] public string? Search { get; set; }
+                      public override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        var output = run.GeneratedSource("Demo.Routes.g.cs");
+
+        Assert.Contains("\"a%20b%26c=\"", output);
+        Assert.DoesNotContain("\"a b&c=\"", output);
+    }
+
+    [Fact]
     public void ParentRoute_PrefixesTemplateWithParentTemplate()
     {
         var src = """

--- a/tests/Rask.Server.Tests/Authentication/RevokedAuthDispatchTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/RevokedAuthDispatchTests.cs
@@ -1,0 +1,124 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Authentication;
+using Rask.Core.Components;
+using Rask.Core.Routing;
+using Rask.Server.Authentication;
+using Rask.Server.Tests.Infrastructure;
+
+#pragma warning disable RASK019 // test-infra app predates framework-managed <head>
+
+namespace Rask.Server.Tests.Authentication;
+
+// M2: a server-side event handler on a protected page must not run once the session principal's
+// authorization has been revoked mid-session — the dispatch path re-checks the route guard before
+// invoking the handler and ships a challenge redirect instead.
+public class RevokedAuthDispatchTests
+{
+    [Fact]
+    public async Task Handler_AfterAuthRevoked_IsNotInvoked_AndRedirectsToLogin()
+    {
+        using var host = CreateHost();
+        var counter = host.Server.Services.GetRequiredService<M2Counter>();
+
+        var cookie = await SignInAsync(host, "alice");
+
+        // Authenticated GET → an authorized session for the protected page.
+        var getReq = new HttpRequestMessage(HttpMethod.Get, "/m2/protected");
+        getReq.Headers.Add("Cookie", cookie);
+        var getResp = await host.Http.SendAsync(getReq);
+        Assert.Equal(HttpStatusCode.OK, getResp.StatusCode);
+        var html = await getResp.Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(html);
+        var handlerId = ExtractHandlerId(html, "bump");
+
+        // Carry the auth cookie onto the WS upgrade so the socket attaches as alice.
+        host.WebSockets.ConfigureRequest = req => req.Headers["Cookie"] = cookie;
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        // Sanity: while authorized, the handler runs.
+        await ws.SendJsonAsync(new { id = handlerId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(1, counter.Count);
+
+        // Revoke authorization on the live session (e.g. signed out in another tab / cookie expired
+        // and re-resolved anonymous on a reconnect).
+        host.Store.Get(sessionId)!.Services.GetRequiredService<SessionUserProvider>().Clear();
+
+        // Fire the same handler again: it must be skipped and a challenge redirect emitted.
+        await ws.SendJsonAsync(new { id = handlerId });
+        var afterRevoke = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.Equal(1, counter.Count); // handler did NOT run a second time
+        Assert.NotNull(afterRevoke);
+        Assert.Contains("/login", afterRevoke!);
+    }
+
+    private static async Task<string> SignInAsync(RaskTestHost host, string name)
+    {
+        var store = host.Server.Services.GetRequiredService<IAuthTicketStore>();
+        var claims = new List<Claim> { new(ClaimTypes.Name, name), new(ClaimTypes.NameIdentifier, name) };
+        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims, "TestCookie"));
+        var ticket = store.Issue(AuthAction.SignIn, principal, "TestCookie", "sess");
+        var resp = await host.Http.PostAsJsonAsync("/_rask/auth/redeem", new { ticket, session = "sess" });
+        return resp.Headers.TryGetValues("Set-Cookie", out var values) ? values.First().Split(';')[0] : "";
+    }
+
+    private static string ExtractHandlerId(string html, string buttonText)
+    {
+        var match = Regex.Match(
+            html,
+            "<button[^>]*data-rask-on-click=\"(h\\d+)\"[^>]*>[^<]*" + Regex.Escape(buttonText));
+        Assert.True(match.Success, $"button with text '{buttonText}' not found");
+        return match.Groups[1].Value;
+    }
+
+    private static RaskTestHost CreateHost() =>
+        RaskTestHost.Create<M2App>(
+            services =>
+            {
+                services.AddSingleton<M2Counter>();
+                services.AddAuthentication("TestCookie").AddCookie("TestCookie", o =>
+                {
+                    o.Cookie.Name = "TestCookie";
+                    o.LoginPath = "/login";
+                    o.AccessDeniedPath = "/forbidden";
+                });
+                services.AddAuthorization();
+            },
+            app =>
+            {
+                app.UseAuthentication();
+                app.UseAuthorization();
+            });
+}
+
+public sealed class M2Counter
+{
+    public int Count;
+}
+
+public sealed class M2App : Component
+{
+    protected override RenderResult Render() =>
+        [Doctype(), Html("en")[Head()[Title()["m2"]], Body()[Router()]]];
+}
+
+[Route("/m2/protected")]
+[Authorize]
+public sealed class M2ProtectedPage(M2Counter counter) : Component
+{
+    protected override RenderResult Render() =>
+        Div(Id: "m2")[
+            Span()[$"count={counter.Count}"],
+            Button(OnClick: () => counter.Count++)["bump"]
+        ];
+}

--- a/tests/Rask.Server.Tests/Endpoints/RootGetEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/RootGetEndpointTests.cs
@@ -33,6 +33,23 @@ public class RootGetEndpointTests
     }
 
     [Fact]
+    public async Task Get_ShellResponse_IsNotCacheable()
+    {
+        // The shell embeds the session id (data-rask-root), the de-facto bearer for the WS /
+        // upload / download endpoints, so it must never be cached by a shared proxy or bfcache.
+        using var host = RaskTestHost.Create<TestApp>();
+
+        var response = await host.Http.GetAsync("/some-path");
+
+        response.EnsureSuccessStatusCode();
+        var cacheControl = response.Headers.CacheControl;
+        Assert.NotNull(cacheControl);
+        Assert.True(cacheControl!.NoStore);
+        Assert.True(cacheControl.NoCache);
+        Assert.True(cacheControl.Private);
+    }
+
+    [Fact]
     public async Task Get_HonoursPathFromRequest()
     {
         using var host = RaskTestHost.Create<TestApp>();

--- a/tests/Rask.Server.Tests/Endpoints/SessionCapTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/SessionCapTests.cs
@@ -1,0 +1,45 @@
+using System.Net;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Endpoints;
+
+/// <summary>
+///     RaskLiveOptions.MaxSessions backstop on the catch-all GET endpoint. Unbounded session
+///     creation is a memory-exhaustion surface; once the cap is reached a new GET is refused
+///     with 503 + Retry-After instead of minting another session. The cap lives on the store
+///     instance (not a static), so setting it here can't bleed into other parallel tests.
+/// </summary>
+public class SessionCapTests
+{
+    [Fact]
+    public async Task Default_Unlimited_AdmitsManySessions()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        Assert.Equal(0, host.Store.MaxSessions);
+
+        for (var i = 0; i < 5; i++)
+        {
+            (await host.Http.GetAsync($"/p{i}")).EnsureSuccessStatusCode();
+        }
+
+        Assert.Equal(5, host.Store.Count);
+    }
+
+    [Fact]
+    public async Task OverCap_NewSession_Returns503WithRetryAfter()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        host.Store.MaxSessions = 1;
+
+        var first = await host.Http.GetAsync("/first");
+        first.EnsureSuccessStatusCode();
+        Assert.Equal(1, host.Store.Count);
+
+        var second = await host.Http.GetAsync("/second");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, second.StatusCode);
+        Assert.True(second.Headers.TryGetValues("Retry-After", out var retry));
+        Assert.Equal("5", Assert.Single(retry));
+        Assert.Equal(1, host.Store.Count); // no extra session minted
+    }
+}

--- a/tests/Rask.Server.Tests/Endpoints/UploadDownloadEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/UploadDownloadEndpointTests.cs
@@ -77,6 +77,44 @@ public class UploadDownloadEndpointTests
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Upload_CrossOrigin_IsRejected()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var sessionId = await CreateSessionAsync(host);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/_rask/upload/" + sessionId)
+        {
+            Content = BuildSingleFileForm("data.bin", new byte[] { 1, 2, 3 })
+        };
+        request.Headers.Add("Origin", "http://evil.example");
+
+        var response = await host.Http.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Download_CrossOrigin_IsRejected()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var sessionId = await CreateSessionAsync(host);
+
+        var store = host.Server.Services.GetRequiredService<SessionDownloadStore>();
+        var entry = store.StageBytes(sessionId, "report.txt", Encoding.UTF8.GetBytes("secret"), "text/plain");
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/_rask/download/{sessionId}/{entry.Token}");
+        request.Headers.Add("Origin", "http://evil.example");
+
+        var response = await host.Http.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        // The cross-origin attempt must not consume the one-shot entry — a legitimate same-origin
+        // fetch still succeeds afterward.
+        var legit = await host.Http.GetAsync($"/_rask/download/{sessionId}/{entry.Token}");
+        Assert.Equal(HttpStatusCode.OK, legit.StatusCode);
+    }
+
     private static async Task<string> CreateSessionAsync(RaskTestHost host)
     {
         var response = await host.Http.GetAsync("/");

--- a/tests/Rask.Server.Tests/Security/SanitizeReturnUrlTests.cs
+++ b/tests/Rask.Server.Tests/Security/SanitizeReturnUrlTests.cs
@@ -1,0 +1,35 @@
+using Rask.Server;
+
+namespace Rask.Server.Tests.Security;
+
+/// <summary>
+///     Open-redirect guard for the post-sign-in returnUrl. Only same-origin absolute
+///     paths may pass through; everything that could navigate off the origin — absolute
+///     URLs, protocol-relative URLs, and the backslash variants browsers normalise into
+///     them — must collapse to "/". Mirrors the contract of ASP.NET's Url.IsLocalUrl.
+/// </summary>
+public class SanitizeReturnUrlTests
+{
+    [Theory]
+    [InlineData("/dashboard", "/dashboard")]
+    [InlineData("/", "/")]
+    [InlineData("/a/b?x=1#frag", "/a/b?x=1#frag")]
+    public void Local_AbsolutePath_PassesThrough(string input, string expected)
+        => Assert.Equal(expected, RaskEndpointExtensions.SanitizeReturnUrl(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("//evil.com")]                 // protocol-relative
+    [InlineData("/\\evil.com")]                // backslash → browser normalises to "//"
+    [InlineData("\\evil.com")]                 // leading backslash
+    [InlineData("\\\\evil.com")]
+    [InlineData("https://evil.com")]           // absolute URL
+    [InlineData("http://evil.com")]
+    [InlineData("javascript:alert(1)")]        // not rooted
+    [InlineData("evil.com")]                    // relative, not rooted
+    [InlineData("/foo\r\nSet-Cookie: x")]      // control chars
+    [InlineData("/foo\tbar")]
+    public void NonLocal_OrMalformed_CollapsesToRoot(string? input)
+        => Assert.Equal("/", RaskEndpointExtensions.SanitizeReturnUrl(input));
+}

--- a/tests/Rask.Server.Tests/Security/SecureTokenTests.cs
+++ b/tests/Rask.Server.Tests/Security/SecureTokenTests.cs
@@ -1,0 +1,28 @@
+using System.Text.RegularExpressions;
+using Rask.Server;
+
+namespace Rask.Server.Tests.Security;
+
+// M5: redeem tickets and live-session ids are bearer secrets, so they come from a CSPRNG
+// (RandomNumberGenerator) rather than Guid.NewGuid().
+public class SecureTokenTests
+{
+    [Fact]
+    public void Create_Is32LowercaseHexChars()
+    {
+        var token = SecureToken.Create();
+
+        Assert.Equal(32, token.Length); // 16 bytes = 128 bits
+        Assert.Matches("^[0-9a-f]{32}$", token);
+    }
+
+    [Fact]
+    public void Create_IsUniquePerCall()
+    {
+        var tokens = new HashSet<string>(StringComparer.Ordinal);
+        for (var i = 0; i < 1000; i++)
+        {
+            Assert.True(tokens.Add(SecureToken.Create()), "tokens must be unique");
+        }
+    }
+}

--- a/tests/Rask.Server.Tests/Security/WebSocketFrameSizeTests.cs
+++ b/tests/Rask.Server.Tests/Security/WebSocketFrameSizeTests.cs
@@ -1,0 +1,75 @@
+using System.Net.WebSockets;
+using Rask.Server;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Security;
+
+// M1: a client must not be able to stream an unbounded fragmented WS frame and force the server to
+// buffer it whole before parsing. The receive loop caps reassembly at MaxInboundFrameBytes and
+// aborts the socket past it.
+public class WebSocketFrameSizeTests
+{
+    [Fact]
+    public async Task OversizedInboundFrame_AbortsSocket()
+    {
+        var prev = RaskEndpointExtensions.MaxInboundFrameBytes;
+        RaskEndpointExtensions.MaxInboundFrameBytes = 32 * 1024; // small cap for the test
+        try
+        {
+            using var host = RaskTestHost.Create<TestApp>();
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+
+            // Larger than both the 16KB server receive buffer (forces the multi-fragment reassembly
+            // path) and the cap. The cap is enforced before JSON parsing, so raw bytes suffice.
+            var big = new byte[256 * 1024];
+
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var aborted = false;
+            try
+            {
+                await ws.SendAsync(big, WebSocketMessageType.Text, true, cts.Token);
+                var buf = new byte[1024];
+                while (true)
+                {
+                    var r = await ws.ReceiveAsync(buf, cts.Token);
+                    if (r.MessageType == WebSocketMessageType.Close)
+                    {
+                        aborted = true;
+                        break;
+                    }
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Timed out without the socket being torn down → the cap did not fire.
+            }
+            catch (Exception)
+            {
+                // WebSocketException / IOException etc. — the server aborted the connection.
+                aborted = true;
+            }
+
+            Assert.True(aborted, "server must abort the socket on an over-cap inbound frame");
+        }
+        finally
+        {
+            RaskEndpointExtensions.MaxInboundFrameBytes = prev;
+        }
+    }
+
+    [Fact]
+    public async Task NormalSizedFrame_IsProcessed()
+    {
+        // Guard against a too-tight cap regressing legitimate traffic: a normal hello round-trips
+        // fine under the default cap.
+        using var host = RaskTestHost.Create<TestApp>();
+        var get = await host.Http.GetAsync("/");
+        var sessionId = Markup.SessionId(await get.Content.ReadAsStringAsync());
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        // No exception, socket stays open.
+        Assert.Equal(WebSocketState.Open, ws.State);
+    }
+}

--- a/tests/Rask.Server.Tests/Security/WebSocketOriginTests.cs
+++ b/tests/Rask.Server.Tests/Security/WebSocketOriginTests.cs
@@ -1,0 +1,38 @@
+using System.Net.WebSockets;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Security;
+
+/// <summary>
+///     Cross-Site WebSocket Hijacking guard on the live endpoint. The upgrade carries the
+///     user's auth cookie and CORS does not apply to WS handshakes, so a mismatched Origin
+///     must be rejected. The endpoint reuses the redeem flow's host-only same-origin check
+///     (IsSameOrigin, unit-tested via AuthRedeemEndpointTests) — these tests assert the WS
+///     handshake is actually wired to it. Clients that send no Origin (non-browser tooling)
+///     are allowed; the existing WS suite connects that way.
+/// </summary>
+public class WebSocketOriginTests
+{
+    [Fact]
+    public async Task CrossOriginHandshake_IsRejected()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        host.WebSockets.ConfigureRequest = req => req.Headers["Origin"] = "http://evil.example";
+
+        // TestServer surfaces the non-101 handshake as a thrown exception; the socket never opens.
+        var ex = await Assert.ThrowsAnyAsync<Exception>(
+            () => host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None));
+        Assert.Contains("403", ex.Message);
+    }
+
+    [Fact]
+    public async Task SameOriginHandshake_Succeeds()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var origin = new Uri(host.Server.BaseAddress, "/").GetLeftPart(UriPartial.Authority);
+        host.WebSockets.ConfigureRequest = req => req.Headers["Origin"] = origin;
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        Assert.Equal(WebSocketState.Open, ws.State);
+    }
+}

--- a/tests/Rask.Wasm.Tests/Session/DisposalTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DisposalTests.cs
@@ -1,0 +1,88 @@
+using System.Security.Claims;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+using Rask.Wasm;
+using Rask.Wasm.Files;
+using static Rask.Core.Components.Generated;
+
+#pragma warning disable RASK014 // test-defined Component subclass has no generated factory
+#pragma warning disable RASK019 // test-infra app predates framework-managed <head>
+
+namespace Rask.Wasm.Tests.Session;
+
+// M10: WasmLiveSession.Dispose must unsubscribe from IUserProvider.Changed (the provider can
+// outlive the session, so a dangling handler would fire OnUserChanged on a disposed _lock).
+// M12: WasmDownloadSink must bound retained un-pulled stagings instead of leaking byte[] for the
+// page lifetime.
+public class DisposalTests
+{
+    [Fact]
+    public void Dispose_UnsubscribesFromUserProviderChanged()
+    {
+        var provider = new CountingUserProvider();
+        var services = new ServiceCollection();
+        services.AddSingleton<RouteState>();
+        services.AddSingleton<Navigator>();
+        services.AddSingleton<IUserProvider>(provider);
+        var sp = services.BuildServiceProvider();
+
+        var session = new WasmLiveSession(new MiniApp(), sp);
+        Assert.Equal(1, provider.SubscriberCount); // session subscribed in the ctor
+
+        session.Dispose();
+
+        Assert.Equal(0, provider.SubscriberCount); // ...and unsubscribed on dispose
+    }
+
+    [Fact]
+    public void DownloadSink_OrphanedStagings_AreBounded()
+    {
+        var sink = new WasmDownloadSink();
+
+        // Stage far more than the cap without ever pulling — the orphaned-download leak case.
+        for (var i = 0; i < 100; i++)
+        {
+            sink.Stage($"f{i}.bin", new byte[] { (byte)i }, null);
+        }
+
+        Assert.True(sink.RetainedCount <= 16,
+            $"retained stagings must be bounded; was {sink.RetainedCount}");
+    }
+
+    [Fact]
+    public void DownloadSink_StageThenPull_RoundTrips()
+    {
+        // The eviction bound must not disturb the normal one-stage-one-pull flow.
+        var sink = new WasmDownloadSink();
+        var bytes = new byte[] { 1, 2, 3 };
+        sink.Stage("a.bin", bytes, null);
+        Assert.True(sink.TryConsume(out var pending));
+        var token = pending!.Token!;
+
+        Assert.Equal(bytes, sink.Pull(token));
+        Assert.Empty(sink.Pull(token)); // drained
+        Assert.Equal(0, sink.RetainedCount);
+    }
+
+    private sealed class MiniApp : Component
+    {
+        protected override RenderResult Render() => Fragment()[Doctype(), Html("en")[Head(), Body()]];
+    }
+
+    private sealed class CountingUserProvider : IUserProvider
+    {
+        private Action? _changed;
+
+        public ClaimsPrincipal Current { get; } = new(new ClaimsIdentity());
+
+        public event Action? Changed
+        {
+            add => _changed += value;
+            remove => _changed -= value;
+        }
+
+        public int SubscriberCount => _changed?.GetInvocationList().Length ?? 0;
+    }
+}


### PR DESCRIPTION
## Context

Output of a full-solution code review. A parallel agent sweep produced ~50 raw findings; a verification pass against the source filtered out the false positives (e.g. a claimed "Critical" keyed-diff bug that the code's own comment shows doesn't exist; an EditContext "CTS race" that's a non-issue under single-threaded dispatch; "XSS via `Raw`" which is by-design Blazor `MarkupString` parity). The Roslyn generators audited clean. This PR fixes the findings that survived verification.

## Changes

| # | Fix | Severity |
|---|-----|----------|
| 1 | **`SanitizeReturnUrl` open-redirect** — also reject backslash (`/\evil.com`, `\evil.com`) and control-char return URLs that browsers normalise into protocol-relative redirects (mirrors ASP.NET `Url.IsLocalUrl`). | Medium |
| 2 | **`AttachSocket` dedup-baseline race** — the dedup baselines (`_lastSentBuffer`/`_lastSentHtml`) were written from a possibly-background thread while `RenderAndSendAsync` read/swapped them under `_renderLock`. A reconnect now sets a `volatile _forceResend` flag consumed inside the render lock, removing the unsynchronised cross-thread access. | Low–Med |
| 3 | **WebSocket Origin check (CSWSH)** — `/rask/ws` rejects cross-origin handshakes (403), reusing the existing host-only `IsSameOrigin` helper already used by the redeem endpoint. | Medium |
| 4 | **Trust model documented** — `docs/authentication.md` now spells out that the sessionId is a bearer secret and the `hello` handler rebinds session identity (Blazor-circuit parity). | doc |
| 5 | **Session cap (DoS)** — opt-in `RaskLiveOptions.MaxSessions`; an over-cap GET returns `503` + `Retry-After`. Default `0` = unlimited, so no behaviour change unless configured. | Low–Med |

Two course-corrections during implementation: (a) #3 was refactored to reuse the existing `IsSameOrigin` helper — its host-only semantics are deliberate (TLS-terminating proxies), so a stricter scheme+port check would have regressed legitimate handshakes; (b) the cap is a per-store instance value, not a global static, so concurrent hosts/tests don't interfere.

## Tests

- New: `SanitizeReturnUrlTests`, `WebSocketOriginTests`, `SessionCapTests`.
- Fix #2's reconnect behaviour is covered by the existing `SocketLifecycleTests` reconnect test.
- Full non-E2E suite green (Core 1423, Server 151, Generators 129, + all others; 0 failures).
- Auth + session-lifecycle E2E (real browser): 13/13 pass.