### PR TITLE
Emit DebuggerStepThrough + <see cref> breadcrumb on generated factories

### DIFF
--- a/src/Rask.Core/build/Rask.Core.targets
+++ b/src/Rask.Core/build/Rask.Core.targets
@@ -22,9 +22,19 @@
     packed into the .nupkg.
   -->
 
+  <!--
+    RaskFactoryNavigation (default true) — exposed to the source generator. When true, each
+    generated factory carries a `<see cref>` doc breadcrumb linking to its component type, so
+    Quick-Doc / hover on `Foo(...)` offers a navigable link to `Foo`. (F12 still lands on the
+    generated method — Roslyn/ReSharper navigate generated symbols to the generated file; use
+    "Navigate to Type of Symbol" for a one-action jump to the component.) `[DebuggerStepThrough]`
+    is always emitted regardless. Set <RaskFactoryNavigation>false</RaskFactoryNavigation> to drop
+    the doc breadcrumb (e.g. if a project with documentation-file generation flags the crefs).
+  -->
   <ItemGroup>
     <CompilerVisibleProperty Include="RaskGlobalUsings"/>
     <CompilerVisibleProperty Include="RaskScopedJsAutoInclude"/>
+    <CompilerVisibleProperty Include="RaskFactoryNavigation"/>
   </ItemGroup>
 
   <ItemGroup Condition=" '$(RaskScopedCssAutoInclude)' != 'false' ">

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -50,7 +50,18 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
         var grouped = candidates.Collect();
 
-        context.RegisterSourceOutput(grouped, static (spc, list) => Emit(spc, list));
+        // RaskFactoryNavigation (default true) gates the per-factory `<see cref>` doc breadcrumb
+        // that links each generated factory to its component type (Quick-Doc / hover navigation;
+        // F12 still resolves to the generated method — Roslyn/ReSharper navigate generated symbols
+        // to the generated file, so use "Navigate to Type of Symbol" for a one-action jump to the
+        // component). `[DebuggerStepThrough]` is emitted unconditionally so the debugger always
+        // steps over the factory into user code.
+        var navigationEnabled = context.AnalyzerConfigOptionsProvider.Select(static (p, _) =>
+            !p.GlobalOptions.TryGetValue("build_property.RaskFactoryNavigation", out var v)
+            || !string.Equals(v, "false", StringComparison.OrdinalIgnoreCase));
+
+        context.RegisterSourceOutput(grouped.Combine(navigationEnabled),
+            static (spc, t) => Emit(spc, t.Left, t.Right));
 
         var globalUsingsEnabled = context.AnalyzerConfigOptionsProvider.Select(static (p, _) =>
             !p.GlobalOptions.TryGetValue("build_property.RaskGlobalUsings", out var v)
@@ -640,7 +651,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         return p.IsNullable ? "null" : "default";
     }
 
-    private static void Emit(SourceProductionContext spc, ImmutableArray<Candidate> candidates)
+    private static void Emit(SourceProductionContext spc, ImmutableArray<Candidate> candidates, bool emitNavigation)
     {
         if (candidates.IsDefaultOrEmpty)
         {
@@ -693,18 +704,18 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                     continue;
                 }
 
-                EmitFactory(sb, c);
+                EmitFactory(sb, c, emitNavigation);
                 sb.AppendLine();
 
                 if (c.GenericFactory is { } gf)
                 {
-                    EmitGenericFactoryOverload(sb, c, gf);
+                    EmitGenericFactoryOverload(sb, c, gf, emitNavigation);
                     sb.AppendLine();
                 }
 
                 foreach (var f in c.Forwarders)
                 {
-                    EmitForwarderFactory(sb, c, f);
+                    EmitForwarderFactory(sb, c, f, emitNavigation);
                     sb.AppendLine();
                 }
             }
@@ -742,7 +753,26 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     private static bool IsParamProperty(PropInfo p) =>
         !p.HasInitializer; // properties with initializers are excluded entirely
 
-    private static void EmitFactory(StringBuilder sb, Candidate c)
+    // Emits the per-factory header trivia: a `<see cref>` doc breadcrumb that links to the
+    // component type (Quick-Doc / hover navigation; gated by RaskFactoryNavigation) and an
+    // always-on `[DebuggerStepThrough]` so the debugger steps over the factory into user code.
+    // F12 still lands on the generated method — stock Roslyn/ReSharper navigate a generated
+    // symbol to its generated document; "Navigate to Type of Symbol" jumps to the component.
+    private static void EmitMethodHeader(StringBuilder sb, Candidate c, bool emitNavigation)
+    {
+        if (emitNavigation)
+        {
+            // cref uses `{T}` (not `<T>`) for generic arity — the doc-comment cref syntax — so it
+            // resolves to the component type and renders as a navigable link.
+            var cref = c.FullyQualifiedName.Replace('<', '{').Replace('>', '}');
+            sb.Append("    /// <summary>Factory for the <see cref=\"").Append(cref)
+                .AppendLine("\"/> component.</summary>");
+        }
+
+        sb.AppendLine("    [global::System.Diagnostics.DebuggerStepThrough]");
+    }
+
+    private static void EmitFactory(StringBuilder sb, Candidate c, bool emitNavigation)
     {
         var visibility = c.IsPublic ? "public" : "internal";
         var paramProps = c.Properties.Where(IsParamProperty).ToList();
@@ -772,6 +802,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         var canUseObjectInit = c.HasParameterlessCtor || !c.HasDIConstructor;
 
         // Signature.
+        EmitMethodHeader(sb, c, emitNavigation);
         sb.Append("    ").Append(visibility).Append(" static ").Append(c.FullyQualifiedName).Append(' ')
             .Append(c.TypeName).Append(c.TypeParameters).Append('(');
         var first = true;
@@ -897,11 +928,12 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         sb.AppendLine("    }");
     }
 
-    private static void EmitForwarderFactory(StringBuilder sb, Candidate c, ForwarderInfo f)
+    private static void EmitForwarderFactory(StringBuilder sb, Candidate c, ForwarderInfo f, bool emitNavigation)
     {
         var visibility = c.IsPublic ? "public" : "internal";
 
         // Signature: `public static {Component} {ComponentName}<...>(<params>) <constraints>`
+        EmitMethodHeader(sb, c, emitNavigation);
         sb.Append("    ").Append(visibility).Append(" static ").Append(c.FullyQualifiedName).Append(' ')
             .Append(c.TypeName).Append(f.TypeParameters).Append('(');
         for (var i = 0; i < f.Parameters.Count; i++)
@@ -942,7 +974,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         sb.AppendLine(");");
     }
 
-    private static void EmitGenericFactoryOverload(StringBuilder sb, Candidate c, GenericFactoryConfig gf)
+    private static void EmitGenericFactoryOverload(StringBuilder sb, Candidate c, GenericFactoryConfig gf, bool emitNavigation)
     {
         var visibility = c.IsPublic ? "public" : "internal";
         var typedSet = new HashSet<string>(StringComparer.Ordinal);
@@ -976,7 +1008,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         if (typedValidators.Count == 0)
         {
             EmitOneOverload(sb, c, gf, visibility, typedSet, typedDelegates, typedValidators, validatorSet,
-                modelProperty, paramProps, ValidatorShape.None);
+                modelProperty, paramProps, ValidatorShape.None, emitNavigation);
             return;
         }
 
@@ -987,11 +1019,11 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         // Both Sync and Async overloads make the validator parameter required so the No
         // overload remains the unambiguous match when the caller passes neither.
         EmitOneOverload(sb, c, gf, visibility, typedSet, typedDelegates, typedValidators, validatorSet,
-            modelProperty, paramProps, ValidatorShape.None);
+            modelProperty, paramProps, ValidatorShape.None, emitNavigation);
         EmitOneOverload(sb, c, gf, visibility, typedSet, typedDelegates, typedValidators, validatorSet,
-            modelProperty, paramProps, ValidatorShape.Sync);
+            modelProperty, paramProps, ValidatorShape.Sync, emitNavigation);
         EmitOneOverload(sb, c, gf, visibility, typedSet, typedDelegates, typedValidators, validatorSet,
-            modelProperty, paramProps, ValidatorShape.Async);
+            modelProperty, paramProps, ValidatorShape.Async, emitNavigation);
     }
 
     private static void EmitOneOverload(
@@ -1005,8 +1037,10 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         HashSet<string> validatorSet,
         string modelProperty,
         List<PropInfo> paramProps,
-        ValidatorShape validatorShape)
+        ValidatorShape validatorShape,
+        bool emitNavigation)
     {
+        EmitMethodHeader(sb, c, emitNavigation);
         sb.Append("    ").Append(visibility).Append(" static ").Append(c.FullyQualifiedName).Append(' ')
             .Append(c.TypeName).Append('<').Append(gf.TypeParameter).Append(">(");
 

--- a/tests/Rask.Generators.Tests/FactoryNavigationEmissionTests.cs
+++ b/tests/Rask.Generators.Tests/FactoryNavigationEmissionTests.cs
@@ -1,0 +1,125 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Tests;
+
+public class FactoryNavigationEmissionTests
+{
+    private const string Src = """
+                               using Rask.Core;
+                               namespace Demo;
+                               public sealed class Widget : Component
+                               {
+                                   public string Name { get; set; }
+                                   public override RenderResult Render() => this;
+                               }
+                               """;
+
+    [Fact]
+    public void DefaultOn_EmitsDebuggerStepThroughAndSeeCrefBreadcrumb()
+    {
+        var run = GeneratorDriverFixture.Run(Src);
+        var output = run.GeneratedSource("Demo.Generated.g.cs");
+
+        // Debugger skips the factory into user code.
+        Assert.Contains("[global::System.Diagnostics.DebuggerStepThrough]", output);
+        // Quick-Doc / hover breadcrumb links to the component type.
+        Assert.Contains("<see cref=\"global::Demo.Widget\"/>", output);
+        // No #line: it does nothing for navigation in stock Roslyn/ReSharper.
+        Assert.DoesNotContain("#line", output);
+        // Signature unchanged.
+        Assert.Contains("Widget(string Name, object? Key = null)", output);
+    }
+
+    [Fact]
+    public void GenericComponent_CrefUsesBraceArity()
+    {
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed class Box<T> : Component where T : class
+                  {
+                      public override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.Run(src);
+        var output = run.GeneratedSource("Demo.Generated.g.cs");
+
+        // Generic arity uses `{T}` (doc-comment cref syntax), not `<T>`, so the cref resolves.
+        Assert.Contains("<see cref=\"global::Demo.Box{T}\"/>", output);
+    }
+
+    [Fact]
+    public void OptOut_DropsBreadcrumbButKeepsDebuggerStepThrough()
+    {
+        var output = Run(Src,
+            new Dictionary<string, string> { ["build_property.RaskFactoryNavigation"] = "false" });
+
+        Assert.DoesNotContain("<see cref", output);
+        Assert.Contains("[global::System.Diagnostics.DebuggerStepThrough]", output);
+    }
+
+    private static string Run(string source, Dictionary<string, string> buildProps)
+    {
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest));
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { syntaxTree },
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var driver = (CSharpGeneratorDriver)CSharpGeneratorDriver
+            .Create(new ComponentFactoryGenerator())
+            .WithUpdatedParseOptions(new CSharpParseOptions(LanguageVersion.Latest))
+            .WithUpdatedAnalyzerConfigOptions(new TestAnalyzerConfigOptionsProvider(buildProps));
+
+        var generated = driver.RunGenerators(compilation).GetRunResult()
+            .Results.SelectMany(r => r.GeneratedSources)
+            .ToImmutableArray();
+        var match = generated.FirstOrDefault(s =>
+            s.HintName.Contains("Demo.Generated.g.cs", StringComparison.Ordinal));
+        if (match.SourceText is null)
+        {
+            var available = string.Join(", ", generated.Select(s => s.HintName));
+            throw new InvalidOperationException(
+                $"No Demo.Generated.g.cs generated. Available: [{available}]");
+        }
+
+        return match.SourceText.ToString();
+    }
+
+    private sealed class TestAnalyzerConfigOptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        public TestAnalyzerConfigOptionsProvider(Dictionary<string, string> values) =>
+            GlobalOptions = new DictOptions(values);
+
+        public override AnalyzerConfigOptions GlobalOptions { get; }
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => GlobalOptions;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) => GlobalOptions;
+
+        private sealed class DictOptions : AnalyzerConfigOptions
+        {
+            private readonly Dictionary<string, string> _values;
+
+            public DictOptions(Dictionary<string, string> values) => _values = values;
+
+            public override bool TryGetValue(string key, out string value)
+            {
+                if (_values.TryGetValue(key, out var v))
+                {
+                    value = v;
+                    return true;
+                }
+
+                value = string.Empty;
+                return false;
+            }
+        }
+    }
+}

--- a/tests/Rask.Generators.Tests/ForwarderFactoryEmissionTests.cs
+++ b/tests/Rask.Generators.Tests/ForwarderFactoryEmissionTests.cs
@@ -98,5 +98,7 @@ public class ForwarderFactoryEmissionTests
         // No `<...>` after the component name; forwarder body delegates to the source method.
         Assert.Contains("public static global::Demo.Widget Widget(string? Class = null)", output);
         Assert.Contains("=> global::Demo.Widget.Convenience(Class);", output);
+        // Forwarders also carry the debugger-skip attribute (keeps stepping out of generated code).
+        Assert.Contains("[global::System.Diagnostics.DebuggerStepThrough]", output);
     }
 }


### PR DESCRIPTION
## What

Improves the IDE experience around the generated component factories (`Div(...)`, `CodeSample(...)`, etc.). Each generated factory now carries two IDE aids:

- **`[DebuggerStepThrough]`** (always emitted) — the debugger steps *over* the factory straight into user code instead of the `GetOrCreate`/`NotifyParameters` scaffolding.
- **A `<see cref>` doc breadcrumb** linking each factory to its component type, so Quick-Doc / hover on `Foo(...)` offers a navigable link to `Foo`. Gated by a new `RaskFactoryNavigation` build property (default `true`; set `false` to drop the breadcrumb, e.g. if a project with documentation-file generation would flag the crefs). Generic components use `{T}` cref arity so the cref resolves cleanly.

## Why not F12?

The original goal was for **Go-to-Definition on `Foo(...)` to land on the component class**. That isn't achievable from a source generator: stock Roslyn/ReSharper navigate a generated symbol to its generated document, and neither `#line` directives nor attributes redirect navigation (`#line` only affects debugging). The `<see cref>` breadcrumb is the portable near-equivalent; the IDE's **"Navigate to Type of Symbol"** action is the one-action jump to the component class.

## Changes

- `src/Rask.Generators/ComponentFactoryGenerator.cs` — emit the header trivia across all three factory shapes (standard, forwarder, generic); thread the `RaskFactoryNavigation` flag through the existing config-options plumbing.
- `src/Rask.Core/build/Rask.Core.targets` — expose `RaskFactoryNavigation` as a `CompilerVisibleProperty`.
- `tests/Rask.Generators.Tests/FactoryNavigationEmissionTests.cs` (new) + `ForwarderFactoryEmissionTests.cs` — assert the breadcrumb, generic `{T}` cref arity, opt-out behavior, and always-on `[DebuggerStepThrough]`.

## Verification

- `dotnet build` clean (no CS1574/CS1591 cref warnings; crefs resolve across all sample/benchmark components).
- Full non-E2E suite green (~2,100 tests, 0 failures), including the new generator tests.