### PR TITLE
Code review sweep: bug fixes, docs, DX, and test coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4)
 
-**[Quick start](#-quick-start--server)** · **[Core concepts](#-core-concepts)** · **[Performance](#-performance)** · **[Live demo ↗](https://pal-tamas.github.io/rask/)**
+**[Quick start](#-quick-start--server)** · **[Core concepts](#-core-concepts)** · **[Docs ↗](docs/)** · **[Performance](#-performance)** · **[Live demo ↗](https://pal-tamas.github.io/rask/)**
 
 </div>
 
@@ -366,6 +366,17 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
 - **Live demo** — every push to `main` publishes `Rask.Example.Wasm` to GitHub Pages via
   [`.github/workflows/pages.yml`](.github/workflows/pages.yml), so you can click through a full multi-page Rask app in
   the browser before cloning anything.
+
+## 📚 Documentation
+
+The collapsible sections below are a feature-by-feature tour. For step-by-step guides and reference,
+see **[`docs/`](docs/)**:
+
+- **[Getting started](docs/getting-started.md)** — scaffold, first component, interactivity, routing.
+- **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · **[Authentication](docs/authentication.md)**
+- **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
+- **[Diagnostics (RASK001–022)](docs/diagnostics.md)** — every build error/warning and its fix.
+- **[Live rendering & the diff codec](docs/architecture/live-rendering.md)** — how the runtime works under the hood.
 
 ## 🧩 Core concepts
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,33 @@
+# Rask documentation
+
+Guides and references for building with Rask. New here? Start with the project
+[README](../README.md) for the pitch and a quick demo, then come back for depth.
+
+## Guides
+
+| Guide | What it covers |
+|-------|----------------|
+| [Getting started](getting-started.md) | Install the templates, scaffold an app, write your first component, add interactivity and a route. |
+| [Routing](routing.md) | `[Route]`, route/query params, nested routes, type-safe `Routes.*` URLs, `Navigator`, `RouteState`. |
+| [Forms & validation](forms.md) | Two-way binding, `Form<T>`/`EditContext`, inline / DataAnnotations / FluentValidation / async validators, radio & checkbox groups. |
+| [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |
+| [Authentication](authentication.md) | Production auth: cookie & JWT, Server & WASM, `Authorize`, route guards, Identity / Keycloak / Auth0 / Cognito / Duende. |
+| [Testing](testing.md) | Unit-testing components with `Rask.TestSupport`, driving event handlers, when to reach for E2E. |
+| [Migrating from Blazor](migration-from-blazor.md) | Concept mapping, behavioural gotchas, and what stays the same. |
+
+## Reference
+
+| Reference | What it covers |
+|-----------|----------------|
+| [Diagnostics (RASK001–022)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
+
+## Architecture
+
+| Doc | What it covers |
+|-----|----------------|
+| [Live rendering & the diff codec](architecture/live-rendering.md) | How the render walk, frame stream, edit-op diff, keyed reconciliation, and the two transports (Server WS / WASM JSImport) work. |
+
+---
+
+The in-repo map for contributors lives in [CLAUDE.md](../CLAUDE.md). Runnable feature demos are
+under [`samples/`](../samples).

--- a/docs/architecture/live-rendering.md
+++ b/docs/architecture/live-rendering.md
@@ -1,0 +1,361 @@
+# Live rendering & the diff codec
+
+How a Rask app stays live after first paint, and how it ships the smallest
+possible payload on every state change. This document expands the *Live runtime &
+diff codec* section of [`CLAUDE.md`](../../CLAUDE.md) with code grounding. File
+references point at `src/Rask.Core/Live/`, `src/Rask.Server/`, and
+`src/Rask.Wasm/`.
+
+## Big picture: one component model, two transports
+
+You write components once. The render walk, the frame stream, and the diff codec
+all live in `Rask.Core` and are shared verbatim. Only the *transport* — how a
+re-render reaches the browser DOM — differs by host:
+
+```
+                         Component tree (shared Rask.Core)
+                                     │
+                       HtmlSerializer.Serialize(...)
+                                     │
+              ┌──────────────────────┴──────────────────────┐
+              │ HTML string                  RenderFrame stream │
+              │ (StringBuilder)              (FrameWriter, parallel) │
+              └──────────────────────┬──────────────────────┘
+                                     │
+                          FrameDiffer.Diff → List<EditOp>
+                                     │
+            ┌────────────────────────┴────────────────────────┐
+            │ Server                              WASM         │
+            │ LiveSession over a WebSocket        WasmLiveSession over JSImport/JSExport │
+            │ (src/Rask.Server/LiveSession.cs)    (src/Rask.Wasm/WasmLiveSession.cs)     │
+            └────────────────────────┬────────────────────────┘
+                                     │
+                  rask.js / rask.wasm.js → applyDiff / morph the DOM
+```
+
+- **Server** (`Rask.Server`): the runtime `<script>` opens a WebSocket. Inbound
+  event-handler messages are dispatched in `LiveSession`; each render produces a
+  payload that's pushed back down the socket.
+- **WASM** (`Rask.Wasm`): there is no socket. `WasmLiveSession` is driven through
+  `[JSImport]`/`[JSExport]` boundaries declared in `JSInterop.cs`. JS calls
+  `[JSExport] DispatchAsync(byte[] json)` to deliver an event; .NET pushes the
+  resulting payload back with the `[JSImport("applyRender")] ApplyRender(byte[])`
+  import (the JSExport source generator doesn't support `Task<byte[]>` returns, so
+  the result is *pushed*, not returned — see the comment in `JSInterop.cs`).
+
+### The runtime `<script>` is auto-injected
+
+`HtmlSerializer` injects the runtime as the **last child of `<body>`** — you never
+write `RaskRuntimeScript()`. On serializing the `</body>` close it resolves the
+host-registered `IRaskRuntimeScript` from DI and serializes its tag inline
+(`HtmlSerializer.cs`, the `tagName == "body"` branch):
+
+```csharp
+if (tagName == "body" && live?.Services?.GetService<IRaskRuntimeScript>() is { } runtime
+                      && runtime.Render() is { } runtimeScript)
+{
+    Serialize(runtimeScript, sb);
+}
+```
+
+It is emitted **inline on every render** (not via a post-process sentinel) so its
+bytes are stable across renders — the diff codec therefore never emits ops for it.
+On **WASM no `IRaskRuntimeScript` provider is registered** (the runtime boots from
+the page shell / `main.js`), so nothing is injected there.
+
+## The render walk: HTML + a frame stream in parallel
+
+`HtmlSerializer.Serialize(Component, StringBuilder, FrameWriter?)` does the work.
+It always produces the HTML string. When `FrameSinkScope.Current` is set to a
+`FrameWriter`, it *also* records a parallel `RenderFrame` stream — a compact
+tagged-union modelled on Blazor's `RenderTreeFrame` but trimmed to the variants
+Rask actually diffs (`Live/RenderFrame.cs`):
+
+| `RenderFrameKind` | Role |
+|-------------------|------|
+| `Element` (1)     | Opens an element; close is implicit at `index + SubtreeLength` |
+| `Attribute` (2)   | One name/value attribute on the last-opened element |
+| `Text` (3)        | HTML-encoded text content |
+| `Raw` (4)         | Verbatim markup (`Raw(...)`) |
+| `Doctype` (5)     | The doctype declaration |
+| `Component` (6)   | Marks the start of a user component's rendered subtree (carries the instance ref) |
+
+Key fields on `RenderFrame`:
+
+- `SubtreeLength` — total frames in the subtree (incl. self); `1` is a leaf. Patched
+  in by `FrameWriter.CloseElement`/`CloseComponent`. Lets a consumer skip a subtree
+  without recursion.
+- `HtmlStart`/`HtmlEnd` — UTF-16 offsets into the rendered HTML string marking where
+  this frame's output lives. The codec slices `[HtmlStart..HtmlEnd]` to ship the HTML
+  fragment for an `InsertSubtree` op.
+- `Value` on an `Element` frame holds the active scoped-CSS id, so an inserted element
+  can be re-stamped `data-{scopeId}` client-side.
+
+`FrameWriter` rents its backing `RenderFrame[]` from `ArrayPool`, so steady-state
+appends amortize to zero allocation. `FrameSinkScope` is a `[ThreadStatic]` ambient
+holder so the 48 `WriteAttributes(StringBuilder)` overrides can emit `Attribute`
+frames without a signature change (`Live/RenderFrame.cs`).
+
+> The `Component` frame's instance ref lets the diff short-circuit: an unchanged
+> component instance that still yields a cached subtree can be skipped.
+
+## The diff codec: ship a minimal edit-op list, not full HTML
+
+`FrameDiffer.Diff(oldFrames, newFrames, output, ...)` walks the previous render's
+frame stream against the current one and emits a minimal `List<EditOp>` that
+transforms the old DOM into the new (`Live/FrameDiffer.cs`). Each `EditOp` names its
+target by `Path` — a **child-index sequence from the document root counting only
+DOM-relevant nodes** (Element / Text / Raw / Doctype). Attribute frames are not
+counted; `Component` frames are *transparent* (their body contributes siblings at the
+surrounding level). The op kinds (`EditOpKind`):
+
+| Kind | # | Meaning |
+|------|---|---------|
+| `SetAttribute`     | 1 | set/replace an attribute |
+| `RemoveAttribute`  | 2 | remove an attribute by name |
+| `UpdateText`       | 3 | replace text/raw node content |
+| `InsertSubtree`    | 4 | insert a new subtree (carries pre-serialized HTML fragment) |
+| `RemoveSubtree`    | 5 | remove a contiguous run of `Length` sibling subtrees |
+| `MoveSubtree`      | 6 | move an existing sibling node (detach at source, insert at dest) |
+| `PermutationBatch` | 7 | a batch of sibling moves under one keyed parent (see below) |
+
+### When a diff ships vs full HTML
+
+`LiveDiffMode` (`Live/LiveOptions.cs`) is configured via
+`AddRask(o => o.DiffMode = ...)` / `WasmHostBuilder.CreateDefault(o => ...)`:
+
+- **`Auto`** (default) — *choose-smaller*. Ship the diff whenever it isn't larger
+  than re-sending the body. Fall back to full HTML on the first render (no baseline),
+  on untrusted structural ops, and on out-of-band side effects.
+- **`DisabledFull`** — always full HTML; bit-for-bit pre-codec behaviour.
+- **`Forced`** — always diff when one is computable, even when larger than the body;
+  for tests/benchmarks.
+
+The actual decision lives in `LiveSession.RenderAndSendAsync` (server) and the
+equivalent WASM path. Sketch (`Rask.Server/LiveSession.cs`):
+
+```csharp
+if (_renderCache.TryComputeDiff(_diffOps, html)
+    && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
+    && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
+{
+    LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes, headHtml);
+    var diffBytes = _writeBuffer.WrittenCount;
+    if (diffMode == LiveDiffMode.Forced || diffBytes < html.Length)
+        usedDiff = true;   // ship the diff
+    else
+        _writeBuffer.ResetWrittenCount();   // diff lost on bytes → full HTML
+}
+```
+
+The byte fallback only kicks in for the pathological case where nearly every node
+changed on a tiny page, so the op framing exceeds the body. Any genuine in-place
+state change (counter tick, text edit, attribute, keyed-list edit) is far smaller
+than the body and takes the diff path regardless of page size.
+
+The diff path is **skipped entirely** when there's an out-of-band side effect —
+`auth` or `download` instructions (both transports gate on
+`auth is null && download is null`). Fire-and-forget `IJSRuntime` invokes (e.g. a
+scoped-JS `OnRenderedAsync` hook) and navigation *do* ride the diff — they don't force
+full HTML.
+
+### Wire format
+
+`LivePayload.BuildPayloadUtf8Diff` writes UTF-8 JSON directly (no UTF-16 string
+materialisation), using `UnsafeRelaxedJsonEscaping` to avoid escaping `<`/`>`/`&` —
+pure wire-size win, the client `JSON.parse` is identical. Envelope shape:
+
+```json
+{
+  "kind": "diff",
+  "names": ["class", "style"],
+  "ops": [ ... ],
+  "head": "<head>...</head>",
+  "history": { "action": "push", "url": "/path" }
+}
+```
+
+Each op is a **positional array**, not an object — `[kind, [path...], extra...]`,
+where `extra` depends on the kind (`LivePayload.cs`):
+
+```json
+[1, [0, 2], "class", "active"]      // SetAttribute: name, value
+[2, [0, 2], "class"]                // RemoveAttribute: name
+[3, [1, 0], "new text"]             // UpdateText: value
+[4, [1], "<li>…</li>", 1]           // InsertSubtree: html fragment, length
+[5, [1], 2]                         // RemoveSubtree: length
+[6, [1], 3]                         // MoveSubtree: source slot in Length
+[7, [1], [dst0, src0, dst1, src1]]  // PermutationBatch: flat moves array
+```
+
+> The conceptual shape is `{k, p, n, v, l}` (kind, path, name, value, length); on the
+> wire it's serialized positionally to save bytes.
+
+**Name interning** (`names`): a pass-1 symbol table interns any attribute name that
+appears 3+ times across the ops (break-even with table overhead), so an attribute
+burst sharing one name (e.g. 100 ops on `class`) drops the duplicate name to a single
+integer index per op. Small diffs pay no envelope.
+
+The client (`rask.js` / `rask.wasm.js`) applies these via `applyDiff(ops)`. Its
+`resolvePath` walks `parent.childNodes` **filtered to Element/Text/Doctype only**, so
+the path coordinates line up with the server's DOM-relevant frame counting.
+
+## Keyed reconciliation: trusted structural ops
+
+Give list items a stable `Key:` (Blazor `@key` parity — last optional factory param)
+and the diff reconciles them by *identity* instead of position. This unlocks
+**trusted** Insert/Remove/Move ops that preserve focus, selection, scroll, IDL
+property state, and event listeners on surviving nodes (moving a node via
+`insertBefore` doesn't materialise a new element).
+
+`EditOp.Trusted` marks an op produced by `FrameDiffer`'s keyed-matching branch. The
+gate `LiveDiffGate.DiffOpsAreClientSupported` (`Live/LiveDiffGate.cs`) routes any
+**untrusted** `InsertSubtree`/`RemoveSubtree`/`MoveSubtree`/`PermutationBatch` op to
+the full-HTML morph path:
+
+```csharp
+if ((op.Kind == InsertSubtree || RemoveSubtree || MoveSubtree || PermutationBatch)
+    && !op.Trusted)
+    return false;   // → full HTML
+```
+
+The reasoning (verbatim from the source): positional structural ops can replace
+mid-list elements the morph would have preserved — ungating them unconditionally broke
+83/430 E2E tests in an earlier iteration. So **positional (keyless) structural changes
+fall back to full HTML**; only **keyed/trusted** ops ship as diff. The
+`SessionRenderCache.TryComputeDiff` overload surfaces `usedKeyedPath` so the session
+knows whether the diff touched the keyed branch.
+
+### Minimal moves via LIS
+
+When a keyed list reorders, the keyed branch (`DiffKeyedSiblings` in
+`Live/FrameDiffer.cs`) computes the permutation mapping each surviving item to its new
+position and finds the **longest-increasing-subsequence (LIS)** of that permutation.
+Items *on* the LIS are already in the right relative order and never move; everything
+else is repositioned. This is the same minimal-moves strategy React/Vue/Inferno use:
+
+```csharp
+// targets[i] = new position of surviving[i]; lis = its longest increasing subsequence
+ComputeLisIndexSet(targets, n, lis);
+// walk new indices RIGHT-TO-LEFT, anchoring each off-LIS node before the
+// already-final node at the next index — the standard correct minimal-move reconcile
+```
+
+### `PermutationBatch` (op kind 7)
+
+Rather than emitting one `MoveSubtree` op per moved row — each re-emitting the full
+parent path, which dominates the wire bytes of a large reorder — the run's moves are
+accumulated as a flat `[dst0, src0, dst1, src1, …]` array and shipped as a **single
+`PermutationBatch` op carrying the shared parent path once**. The array order is
+load-bearing: each dst/src pair is computed against the live DOM as mutated by all
+preceding pairs, so the client replays it strictly left-to-right. This is what
+collapsed a 200-row reverse-sort from ~3.9 KB to ~1.1 KB (see the *Performance*
+section of the [README](../../README.md)). Like `MoveSubtree`, it only ever comes from
+the keyed path and is always `Trusted`.
+
+## `SessionRenderCache`: the two-buffer rotator
+
+The per-session diff baseline lives in `SessionRenderCache` (`Live/SessionRenderCache.cs`).
+It owns **two `FrameWriter` buffers** — one holds the "previous" snapshot the client
+currently has, one is the render in flight — and rotates them. Both survive in pooled
+storage, so steady-state allocation across renders is zero. The typical flow:
+
+```csharp
+var writer = cache.PrepareCurrentBuffer();        // reset the in-flight buffer
+using (FrameSinkScope.Push(writer))
+    HtmlSerializer.Serialize(root, htmlOutput);   // populate it during the render
+bool haveDiff = cache.TryComputeDiff(ops, html);  // diff against previous, then ROTATE
+```
+
+> ### Invariant: `TryComputeDiff` rotates on every call
+>
+> `TryComputeDiff` rotates the buffers internally (promotes current → previous) on
+> **every** call — including the first-render `false` return. So you must **never**
+> call `Snapshot()` after it on the same render: `Snapshot()` also rotates, and a
+> second rotation strands `_previous = null` and corrupts the next diff. `LiveSession`
+> tracks this with a `diffPathEntered` flag and only calls `Snapshot()` on the
+> full-HTML branch *when it did not enter the diff branch*:
+>
+> ```csharp
+> if (!usedDiff)
+> {
+>     LivePayload.BuildPayloadUtf8WithRoot(...);
+>     if (!diffPathEntered)            // TryComputeDiff already rotated otherwise
+>         _renderCache?.Snapshot();
+> }
+> ```
+
+`Snapshot()` (rotate without diffing) keeps the cache in lockstep when the session
+ships full HTML for any reason — first paint, oversized diff, structural ops,
+navigation. Skipping it would leave `_previous` stale and the next diff would apply
+edits computed against a DOM the client has already moved past. There's also a
+`rotate: false` overload used by the WASM coalescing loops, which build a payload
+several times within one dispatch but commit exactly once via `Snapshot()` after the
+loop settles (so intermediate builds don't diff against an un-sent render).
+
+## Head changes and query-only navigations
+
+The diff frame stream walks the **body** but suppresses head-asset frames (the head
+registry pushes a `null` `FrameSinkScope`), so a `<title>`/scoped-asset change produces
+zero body ops. Two helpers in `LiveDiffGate` bridge this:
+
+- `HeadUnchanged(html, baseline)` — compares the `<head>…</head>` region of the fresh
+  render against the last sent baseline byte-for-byte. A missing `</head>` returns
+  `false` (treated as changed → safe).
+- `ExtractHead(html)` — slices the full `<head …>…</head>` element out so the diff
+  payload can carry it as the `"head"` field; the client morphs it into
+  `document.head` alongside applying the body ops, instead of falling back to a whole
+  document.
+
+**Query-only / body-unchanged navigations** produce zero ops but still must `pushState`
+the URL. The session ships the diff anyway when there's a `historyUrl` or a head change,
+even with an empty op list (`LiveSession.cs`):
+
+```csharp
+if (_renderCache.TryComputeDiff(_diffOps, html)
+    && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
+    && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
+```
+
+The `"history"` field carries `{ action: "push"|"replace", url }`.
+
+## Handler dispatch ordering
+
+Both transports hold a session-wide lock across the **whole awaited handler**, so an
+async handler's continuation can't interleave with the next handler's start.
+
+### Server: strict WS-arrival order
+
+The WS receive loop is single-threaded per session. Each inbound handler is chained
+onto `LiveSession.LastHandlerTask`: the new dispatch awaits the prior tail before
+running, then stores its own continuation as the new tail
+(`RaskEndpointExtensions.cs`, `ChainHandlerDispatchAsync`):
+
+```csharp
+capturedSession.LastHandlerTask = ChainHandlerDispatchAsync(
+    capturedSession.LastHandlerTask, capturedSession, handlerId, root, ct);
+```
+
+This pins start-of-dispatch to WS-arrival order **without blocking the receive loop**
+(so async handlers can still interleave with the `jsResult`/`dotNetInvoke` frames they
+await). The comment explains why a `Task.Run` + `SemaphoreSlim.WaitAsync` shape was
+wrong: `SemaphoreSlim` is FIFO on *WaitAsync* call order, not `Task.Run` order, so
+under ThreadPool contention an `input`→`submit` pair could acquire the lock
+`submit`→`input` and let `submit` read a stale `EditContext`.
+
+### WASM: a single `SemaphoreSlim`
+
+`WasmLiveSession` guards every dispatch with `_lock = new SemaphoreSlim(1, 1)` held
+across the awaited handler (`WasmLiveSession.cs`). The render walk is single-threaded
+per session; `InHandlerScope` is a plain instance bool (deliberately *not* `AsyncLocal`)
+because the lock is owned by the session as a whole.
+
+## See also
+
+- [`../diagnostics.md`](../diagnostics.md) — **RASK022** (warning) flags a keyless list
+  item that would reconcile positionally; add a `Key:` to get trusted keyed structural
+  ops instead of a full-HTML morph.
+- [`CLAUDE.md`](../../CLAUDE.md) — *Live runtime & diff codec*, *Primitives*,
+  *Children & factories*, *Page head* sections (the authoritative summary).
+- [`../authentication.md`](../authentication.md) — the auth handshake that forces full
+  HTML (the `auth` out-of-band instruction the diff path gates out).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,0 +1,237 @@
+# Rask diagnostics (RASK001–RASK022)
+
+Every Rask diagnostic, what triggers it, and how to fix it. Errors block the build; warnings don't
+but flag a real problem; one is hidden (informational, surfaced only as an IDE suggestion).
+
+These come from the Rask source generator and analyzers (`Rask.Generators`). The generated
+factories don't exist until a build runs, so if an ID below isn't recognised by your IDE yet,
+build once.
+
+| ID | Severity | Summary |
+|----|----------|---------|
+| [RASK001](#rask001) | Hidden | Property is treated as a required factory parameter |
+| [RASK002](#rask002) | Warning | `required` property is incompatible with a DI constructor |
+| [RASK003](#rask003) | Error | Malformed route template |
+| [RASK004](#rask004) | Error | Route segment has no matching property |
+| [RASK005](#rask005) | Error | Property type does not match the route constraint |
+| [RASK006](#rask006) | Error | `[QueryParam]` applied to a path-segment property |
+| [RASK007](#rask007) | Error | `[ParentRoute]` cycle |
+| [RASK008](#rask008) | Error | `[RouteParam]` without a matching path segment |
+| [RASK009](#rask009) | Error | `[RouteParam]` on a non-routed class |
+| [RASK010](#rask010) | Error | `[QueryParam]` on a non-routed class |
+| [RASK011](#rask011) | Error | Route/query param type must implement `IParsable<T>` |
+| [RASK012](#rask012) | Error | Multiple `[NotFound]` components |
+| [RASK013](#rask013) | Error | `[NotFound]` cannot be combined with `[Route]` |
+| [RASK014](#rask014) | Error | Components must be created via factory methods |
+| [RASK015](#rask015) | Error | Orphan scoped-CSS file |
+| [RASK016](#rask016) | Error | Ambiguous scoped-CSS match |
+| [RASK017](#rask017) | Error | Orphan scoped-JS file |
+| [RASK018](#rask018) | Error | Ambiguous scoped-JS match |
+| [RASK019](#rask019) | Error | `<head>` is a framework-managed slot |
+| [RASK020](#rask020) | Warning | Scoped-JS simple-name collision |
+| [RASK021](#rask021) | Warning | Root component must render a complete page shell |
+| [RASK022](#rask022) | Warning | List item is missing a `Key` |
+
+---
+
+## RASK001
+**Property is treated as a required factory parameter** · Hidden
+
+A non-nullable reference-type property with no initializer becomes a **required** parameter on the
+generated factory. This is informational: the generator already enforces it positionally, but the
+property isn't marked `required` at the language level.
+
+```csharp
+public sealed class Badge : Component
+{
+    public string Label { get; set; }   // RASK001 suggestion: add `required`
+}
+```
+
+**Fix (optional):** add `required` for language-level enforcement, or make the property nullable
+(`string? Label`) if it should be optional. HTML-attribute props are intentionally declared nullable
+to stay ergonomic. See [factory generation rules](getting-started.md).
+
+## RASK002
+**`required` property is incompatible with a DI constructor** · Warning
+
+A property is marked `required`, but the component has dependency-injected constructor parameters.
+The factory builds the component with `ActivatorUtilities.CreateInstance`, which can't satisfy a
+`required` member, so the requirement can't be honoured.
+
+**Fix:** remove `required`, **or** move the value to a constructor parameter, **or** drop the DI
+constructor. Framework services (`RouteState`, `Navigator`, `HttpClient`, `IJSRuntime`) should come
+through the constructor, never as settable properties.
+
+## RASK003
+**Malformed route template** · Error
+
+A `[Route("...")]` template can't be parsed (unbalanced braces, empty segment, illegal constraint).
+
+**Fix:** correct the template, e.g. `[Route("/users/{id:int}")]`.
+
+## RASK004
+**Route segment has no matching property** · Error
+
+A `{segment}` in the route has no public settable property to bind to.
+
+**Fix:** add a matching property and annotate it: `[RouteParam] public int Id { get; set; }`.
+
+## RASK005
+**Property type does not match the route constraint** · Error
+
+The route constraint (e.g. `{id:int}`) is incompatible with the bound property's CLR type.
+
+**Fix:** align the types — `{id:int}` ↔ `int Id`, `{slug}` ↔ `string Slug`.
+
+## RASK006
+**`[QueryParam]` applied to a path-segment property** · Error
+
+A property is bound by a `{path}` segment **and** marked `[QueryParam]`. A value can't come from both.
+
+**Fix:** use `[RouteParam]` for path segments; reserve `[QueryParam]` for query-string values.
+
+## RASK007
+**`[ParentRoute]` cycle** · Error
+
+`[ParentRoute(typeof(...))]` links form a cycle, so no root can be established.
+
+**Fix:** break the cycle so the parent chain terminates at a top-level route.
+
+## RASK008
+**`[RouteParam]` without a matching path segment** · Error
+
+A property is `[RouteParam]` but no `{segment}` in the template (or an ancestor's, via
+`[ParentRoute]`) matches its name.
+
+**Fix:** add the segment to the template, or rename the property/segment to match.
+
+## RASK009
+**`[RouteParam]` on a non-routed class** · Error
+
+`[RouteParam]` sits on a class that isn't a valid route target (no `[Route]`, not reachable via
+`[ParentRoute]`).
+
+**Fix:** add `[Route]` to the class, or remove the attribute.
+
+## RASK010
+**`[QueryParam]` on a non-routed class** · Error
+
+As RASK009, for `[QueryParam]`. Query binding only applies to routed pages.
+
+**Fix:** add `[Route]`, or remove `[QueryParam]`.
+
+## RASK011
+**Route/query param type must implement `IParsable<T>`** · Error
+
+A `[RouteParam]`/`[QueryParam]` property's type can't be parsed from a URL string. Bound types must
+be `string` or implement `System.IParsable<T>` (every built-in numeric, `Guid`, `DateTime`, `bool`,
+enums via custom parsing, etc. qualify).
+
+**Fix:** use a parsable type, or accept the value as `string` and convert inside the page.
+
+## RASK012
+**Multiple `[NotFound]` components** · Error
+
+More than one `[NotFound]` catch-all page exists in the assembly; only one is allowed.
+
+**Fix:** keep a single `[NotFound]` page and remove the duplicate.
+
+## RASK013
+**`[NotFound]` cannot be combined with `[Route]`** · Error
+
+A class carries both `[NotFound]` and `[Route]`. `[NotFound]` is the catch-all and matches no
+specific path.
+
+**Fix:** remove `[Route]` from the not-found page.
+
+## RASK014
+**Components must be created via factory methods** · Error
+
+`new SomeComponent()` was used outside `Rask.Core`. Components are constructed through the generated
+factories so keys, children, and DI wiring are handled consistently.
+
+```csharp
+// ✗ new Div()
+// ✓ Div(Class: "card")[ ... ]
+```
+
+**Fix:** call the generated factory (`Div(...)`, `Counter(...)`). In test files that deliberately
+construct components directly, opt out per file with `#pragma warning disable RASK014`.
+
+## RASK015
+**Orphan scoped-CSS file** · Error
+
+A `{Name}.css` sibling has no matching `Component` subclass named `{Name}` in the same folder, so it
+can't be scoped to anything.
+
+**Fix:** rename the file to match its component, move it next to the right component, or exclude it
+with `<RaskScopedCssAutoInclude>false</RaskScopedCssAutoInclude>` if it's a global stylesheet.
+
+## RASK016
+**Ambiguous scoped-CSS match** · Error
+
+A `{Name}.css` file matches more than one component class named `{Name}` (e.g. two `Card` types in
+different namespaces but the same folder).
+
+**Fix:** disambiguate by moving one component/file so each `.css` has exactly one match.
+
+## RASK017
+**Orphan scoped-JS file** · Error
+
+As RASK015, for a `{Name}.js` sibling with no matching component.
+
+**Fix:** rename/move the file, or opt the file out of auto-inclusion.
+
+## RASK018
+**Ambiguous scoped-JS match** · Error
+
+As RASK016, for `{Name}.js` matching multiple component classes.
+
+**Fix:** disambiguate so each `.js` file maps to one component.
+
+## RASK019
+**`<head>` is a framework-managed slot** · Error
+
+Children were passed to `Head()`. Rask collects, dedupes, and splices head content itself, so the
+`<head>` element doesn't take children.
+
+**Fix:** override `protected override RenderResult Head => ...` on any component and return your
+`Title`/`Meta`/`Link`/`Script` — a single tag, or a collection expression like
+`Head => [Title(...)["..."], Meta(...)]`. See [the head guide](getting-started.md).
+
+## RASK020
+**Scoped-JS simple-name collision** · Warning
+
+Two or more components with scoped JS share the same simple type name. The browser-side namespace
+key `window.Rask["Name"]` is shared, and the last registration silently wins.
+
+**Fix:** rename one component, move it to a differently-named sibling, or expose its exports under a
+sub-namespace inside the JS file. Promote to an error with
+`<WarningsAsErrors>RASK020</WarningsAsErrors>`.
+
+## RASK021
+**Root component must render a complete page shell** · Warning
+
+The root `TApp` doesn't render a full shell. A root `Render()` must produce
+`Doctype()`, `Html(...)[ Head(), Body()[ ... ] ]`. A runtime backstop (`ValidateRootShell`) also
+enforces this, so an incomplete shell that slips past the analyzer still fails at render.
+
+**Fix:** make the root render the complete shell — typically `Fragment()[ Doctype(), Html(...)[...] ]`.
+Do **not** add a runtime `<script>`; it's auto-appended to `<body>`.
+
+## RASK022
+**List item is missing a `Key`** · Warning
+
+A Rask factory call appears in a sibling-list context (a `.Select`/`.SelectMany` projection, or
+`.Add` in a loop) without a `Key:`. Keyless items reconcile **by position**, which loses focus and
+input state and emits untrusted structural diffs on insert/remove/move.
+
+```csharp
+// ✗ items.Select(i => Li()[ i.Name ])
+// ✓ items.Select(i => Li(Key: i.Id)[ i.Name ])
+```
+
+**Fix:** pass a stable `Key:` (an entity id, not the loop index). See
+[keyed lists](getting-started.md) and the [live-rendering architecture](architecture/live-rendering.md)
+for why identity beats position.

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -1,0 +1,414 @@
+# Forms & validation
+
+Rask binds inputs two-way with a strongly-typed `Bind` expression, routes submit through
+validators you opt into, and tracks per-field state (touched / modified / messages / in-flight
+validation) on an `EditContext`. The same component code runs server-rendered or on WASM.
+
+This guide builds up in layers: binding → forms → inline validation → DataAnnotations →
+FluentValidation → async → nested models → radio/checkbox groups.
+
+For the analyzer IDs referenced here (`RASK001`, `RASK022`, …) see [diagnostics.md](diagnostics.md).
+
+---
+
+## 1. Two-way binding
+
+The low-level path wires `Value` and an event handler yourself:
+
+```csharp
+Input(Type: "text", Value: _typed, OnInput: v => _typed = v)
+P()[$"Echo: {_typed}"]
+```
+
+The ergonomic path is a `Bind` expression — one call replaces `Value` + `OnInput` + parsing:
+
+```csharp
+Input(Bind: () => _model.Name, Placeholder: "Your name")
+P()[$"Hello, {_model.Name}!"]
+```
+
+`Bind` is an `Expression<Func<TProp>>` (`Input.Bound<TProp>`). The factory reads the expression and
+derives everything from the bound property:
+
+- **Input name** ← the property name (`name="Name"`). Override with `Name:`.
+- **Input type** ← the property's CLR type (`BindingHelpers.DefaultInputType`):
+  `bool → checkbox`, every numeric primitive `→ number`, `DateOnly → date`,
+  `DateTime`/`DateTimeOffset` `→ datetime-local`, `TimeOnly`/`TimeSpan` `→ time`, everything else
+  `→ text`. Override with `Type:`.
+- **Update timing** — `string` fields update on every keystroke (`OnInput`); every other type
+  updates on `OnChange` (blur). `Textarea(Bind: …)` always streams on `OnInput`.
+
+```csharp
+Input(Bind: () => _model.Subscribe)   // bool     → checkbox
+Input(Bind: () => _model.Age)         // int      → number
+Input(Bind: () => _model.StartDate)   // DateOnly → date
+Select(Bind: () => _model.Favorite)[Option("Red")["Red"], Option("Blue")["Blue"]]
+Textarea(Bind: () => _model.Notes, Rows: 3)
+```
+
+### Empty value handling
+
+When the user clears an input, `BindingHelpers.TrySetTyped` decides what the empty string maps to:
+
+| Property kind | Empty input becomes |
+|---|---|
+| `Nullable<T>` value type (`int?`, `DateOnly?`, …) | `null` |
+| NRT-nullable reference type (`string?`) | `null` (detected via `NullabilityInfoContext`) |
+| Non-nullable value type (`int`, `DateOnly`, enum) | `default(T)` — so a number/date/enum input is clearable |
+| Non-nullable `string` | `""` (verbatim) |
+
+A value that fails to parse (`"not-a-number"` into an `int`) leaves the model unchanged.
+
+### Binding lifecycle
+
+Each change handler runs in order: write the value, `NotifyFieldChanged`, run `AfterBind`/
+`AfterBindAsync` (if supplied, only when a write actually happened), `NotifyFieldTouched` (on
+change/blur), then re-validate the field. `string` inputs stay quiet until the field is touched,
+then re-validate on every keystroke so a correction clears the message without a blur.
+
+`AfterBind` / `AfterBindAsync` fire **after** the new value is written and before validators run —
+handy for dependent fields (pick a country, repopulate the city dropdown in the same render):
+
+```csharp
+Select(Bind: () => _model.Country,
+       AfterBind: c => { _cities = Cities[c]; _model.City = _cities[0]; })[ /* options */ ]
+Select(Bind: () => _model.City)[_cities.Select(c => Option(Value: c)[c])]
+```
+
+---
+
+## 2. `Form<TModel>` and the `EditContext`
+
+`Form<TModel>(model, …)` wraps the inputs and owns an `EditContext` — the per-field state store
+plus the validator pipeline. Bound inputs inside the form discover that context automatically.
+
+```csharp
+Form<SignupModel>(_model, OnValidSubmit: m => Console.WriteLine(m.Username))[
+    Input(Bind: () => _model.Username),
+    Button(Type: "submit")["Sign up"]
+]
+```
+
+Submit runs the full validator pipeline (`ValidateAsync`), marks every registered field touched,
+then routes:
+
+- valid → `OnValidSubmit` (or, if unset, `OnSubmit` / `OnSubmitAsync` with the raw `FormData`),
+- invalid → `OnInvalidSubmit`.
+
+`OnValidSubmit` / `OnInvalidSubmit` accept `Action<TModel>` or `Func<TModel, Task>` — the generic
+overload narrows the delegate so you pass a bare lambda with no cast.
+
+### Auto-created vs explicit `Context`
+
+By default the form creates (and caches per model reference) its own `EditContext` — it persists
+across renders of the same model, so field state survives re-renders. Pass `Context:` to own the
+instance yourself when you need to drive validation imperatively, register an
+`IAsyncFieldValidator`, or tune `ValidatingStickyMs`:
+
+```csharp
+_ctx = new EditContext(_model);
+_ctx.AddValidator(new SlowTitleValidator());
+
+Form<TaskModel>(_model, m => _submission = "Saved", Context: _ctx)[
+    Input(Bind: () => _model.Title),
+    Button(Type: "button", OnClickAsync: () => _ctx.ValidateAsync().AsTask())["Validate now"],
+    Button(Type: "submit", Disabled: _ctx.IsValidatingAny)["Save"]
+]
+```
+
+`Form` requires either `Model` or `Context`.
+
+### Rendering messages
+
+Two headless components read the context — both take a required `Template:` so you own the markup,
+and both render nothing when there's nothing to show:
+
+```csharp
+ValidationMessage(For: () => _model.Email,
+    Template: errs => Div(Class: "field-error")[errs[0]])
+
+ValidationSummary(
+    Template: entries => Ul()[entries.Select(e => Li()[Strong()[e.Field], ": ", e.Message])])
+```
+
+`ValidationMessage.For` keys a single field; `ValidationSummary` lists every `ValidationEntry`
+(`Field` + `Message`), with form-level messages carrying an empty `Field`.
+
+---
+
+## 3. Inline validation (no extra package)
+
+The lightest layer ships in `Rask.Core`. Pass a `Validate:` lambda — per-field or per-form. Both
+accept a sync `Func<…, IEnumerable<string>>` or an async
+`Func<…, CancellationToken, ValueTask<IEnumerable<string>>>`; overload resolution picks by arity, no
+cast. An empty sequence means valid.
+
+```csharp
+Form<LoginModel>(_model,
+    OnValidSubmit: m => _submission = "Welcome",
+    Validate: m => m.Password == m.Confirm ? [] : ["Passwords do not match."])[   // cross-field, at submit
+    Input(Bind: () => _model.Email,
+          Validate: v => v.Contains('@') ? [] : ["Email looks wrong."]),          // per-field, per-keystroke
+    ValidationMessage(For: () => _model.Email, Template: errs => Div(Class: "err")[errs[0]]),
+    ValidationSummary(Template: SummaryAlert),
+    Button(Type: "submit")["Sign in"]
+]
+```
+
+Per-field `Validate:` produces field-scoped messages and runs on each keystroke after the field is
+touched. Form-level `Validate:` runs at submit and attaches messages to the form-level slot
+(`FieldIdentifier(model, "")`) — they surface in `ValidationSummary`, never against a specific input.
+
+---
+
+## 4. DataAnnotations
+
+Add the `Rask.Validation.DataAnnotations` package and drop `DataAnnotationsValidator()` inside the
+form. It's a real (headless) component that registers an `IFieldValidator` on the form's
+`EditContext` via `EditContextScope.Current?.AddValidator(...)` — one declaration covers the whole
+reachable model graph. The package adds a global static using, so the factory is in scope.
+
+```csharp
+public sealed class SignupModel
+{
+    [Required, StringLength(20, MinimumLength = 3)] public string Username { get; set; } = "";
+    [Required, EmailAddress]                        public string Email    { get; set; } = "";
+}
+
+Form<SignupModel>(_model, OnValidSubmit: m => Console.WriteLine(m.Username))[
+    DataAnnotationsValidator(),
+    Input(Bind: () => _model.Username),
+    ValidationMessage(For: () => _model.Username, Template: errs => Div(Class: "err")[errs[0]]),
+    Input(Bind: () => _model.Email),
+    ValidationMessage(For: () => _model.Email, Template: errs => Div(Class: "err")[errs[0]]),
+    Button(Type: "submit")["Register"]
+]
+```
+
+Supports `[Required]`, `[EmailAddress]`, `[Range]`, `[StringLength]`, `[RegularExpression]`, custom
+`ValidationAttribute` subclasses, and `IValidatableObject`. Unlike the BCL's
+`Validator.TryValidateObject`, Rask invokes `IValidatableObject.Validate` even when attribute errors
+exist — so attribute and object-level errors surface together (ASP.NET Core MVC parity). The
+`ValidationContext` is built with the render-scoped `IServiceProvider`, so custom attributes can call
+`ctx.GetService<T>()`.
+
+A `ValidationResult` with empty `MemberNames` lands on the form-level slot (`ValidationSummary`); a
+populated one tags the named field.
+
+---
+
+## 5. FluentValidation
+
+Add the `Rask.Validation.FluentValidation` package and drop
+`FluentValidationValidator(new MyValidator())` inside the form. It wraps any
+`FluentValidation.IValidator` into an `IAsyncFieldValidator` (so async `MustAsync` rules work too).
+
+```csharp
+public sealed class OrderValidator : AbstractValidator<OrderModel>
+{
+    public OrderValidator()
+    {
+        RuleFor(x => x.Product).NotEmpty();
+        RuleFor(x => x.Quantity).GreaterThanOrEqualTo(1).WithMessage("Quantity must be at least 1.");
+    }
+}
+
+Form<OrderModel>(_model, m => _submission = "Ordered")[
+    FluentValidationValidator(new OrderValidator()),
+    Input(Bind: () => _model.Product),
+    ValidationMessage(For: () => _model.Product, Template: errs => Div(Class: "err")[errs[0]]),
+    Input(Bind: () => _model.Quantity),
+    ValidationMessage(For: () => _model.Quantity, Template: errs => Div(Class: "err")[errs[0]]),
+    Button(Type: "submit")["Order"]
+]
+```
+
+Per-keystroke validation on a root-model field scopes FluentValidation to that single property
+(`MemberNameValidatorSelector`, fast path); submit runs every rule. FluentValidation's own
+`Cascade(CascadeMode.Stop)` mirrors Rask's first-error-wins gating.
+
+---
+
+## 6. Async validators and the validating indicator
+
+Three ways to validate asynchronously:
+
+1. **Inline async `Validate:`** — return a `ValueTask<IEnumerable<string>>`. The `CancellationToken`
+   cancels the in-flight check on the next keystroke (latest-wins).
+2. **`IAsyncFieldValidator`** — reach for this when the rule needs DI (an `HttpClient`, a
+   repository) or you want to reuse it across forms. Add it to an `EditContext` you own:
+
+   ```csharp
+   public sealed class UniqueUsernameValidator : IAsyncFieldValidator
+   {
+       public async ValueTask ValidateFieldAsync(EditContext ctx, FieldIdentifier field, CancellationToken ct)
+       {
+           if (ctx.Model is SignupModel m && field.FieldName == nameof(SignupModel.Username))
+           {
+               await Task.Delay(400, ct);            // pretend it's an API call
+               if (await IsTakenAsync(m.Username))
+                   ctx.AddValidationMessage(field, "Already taken.");
+           }
+       }
+       public ValueTask ValidateAsync(EditContext c, CancellationToken ct) => default;
+   }
+
+   _ctx = new EditContext(_model);
+   _ctx.AddValidator(new UniqueUsernameValidator());
+   // Form<…>(_model, Context: _ctx)[ … ]
+   ```
+3. **FluentValidation `MustAsync`** — async rules ride the same `FluentValidationValidator` wrapper.
+
+Each `await` in a handler triggers a re-render, so a `ValidatingIndicator` can surface while a
+check is in flight:
+
+```csharp
+ValidatingIndicator(For: () => _model.Username,
+    Template: () => Span(Class: "spinner")["Checking…"])
+```
+
+### `IsValidating` vs `ShouldShowValidatingIndicator`
+
+- `EditContext.IsValidating(field)` / `IsValidatingAny` — the exact "a validator is in flight right
+  now" answer. Use it for control flow (e.g. `Disabled: _ctx.IsValidatingAny` on a submit button).
+- `ShouldShowValidatingIndicator(field)` — `IsValidating` extended with a short **sticky tail**
+  (`EditContext.ValidatingStickyMs`, default 200ms). A sub-second check still reads as "showing" for
+  the sticky window so the indicator has a footprint screen-readers and Playwright can observe. This
+  is what `ValidatingIndicator` renders against. The sticky dismissal is a single timer-driven
+  re-render at window expiry. Set `ValidatingStickyMs = 0` on a context you own to opt out; it does
+  not delay submit or validator completion.
+
+### First-error-wins
+
+The pipeline runs inline → form-level inline → sync `IFieldValidator` → async
+`IAsyncFieldValidator`. Once any stage flags a field, later stages stay quiet on that **same** field
+— so fixing one error reveals the next rule's message. A validator that throws mid-check surfaces a
+generic `"Validation could not be completed."` rather than killing the submit pipeline.
+
+---
+
+## 7. Nested / complex models
+
+`Bind` and validation extend transparently through sub-objects and collections. A single
+`DataAnnotationsValidator()` or `FluentValidationValidator(...)` at the top of the form covers the
+whole reachable graph — no per-level opt-in. `FieldIdentifier` is **reference-based** (keyed off the
+owner sub-instance, not a dotted path from the root), so removing or replacing a row drops its error
+state with it.
+
+```csharp
+public sealed class CheckoutModel
+{
+    [Required] public string Name { get; set; } = "";
+    public AddressModel Address { get; set; } = new();
+    public List<LineItem> Items { get; set; } = new();
+}
+public sealed class AddressModel
+{
+    [Required] public string Street { get; set; } = "";
+    [Required, RegularExpression("^[A-Z]{2}$")] public string Country { get; set; } = "";
+}
+```
+
+**Sub-object binding** uses the same `Bind: () => …` shape:
+
+```csharp
+Input(Bind: () => _model.Address.Street),
+ValidationMessage(For: () => _model.Address.Street, Template: errs => Div(Class: "err")[errs[0]]),
+```
+
+**Collection binding — `foreach` + per-item capture** (the canonical pattern). Each iteration closes
+over a distinct `item`, so each row's lambda targets its own instance:
+
+```csharp
+foreach (var item in _model.Items)
+{
+    rows.Add(Tr()[
+        Td()[Input(Bind: () => item.Description)],
+        Td()[Input(Bind: () => item.Quantity)],
+        Td()[Button(Type: "button", OnClick: () => _model.Items.Remove(item))["×"]]
+    ]);
+}
+```
+
+**Collection binding — indexer style** when you need the row number, or for records that get
+replaced rather than mutated (`() => model.Items[i].Name` re-resolves the slot every render). Watch
+the classic `for` closure trap — copy the index into a per-iteration local:
+
+```csharp
+for (var idx = 0; idx < _model.Items.Count; idx++)
+{
+    var i = idx;                                  // per-iteration capture, NOT idx
+    rows.Add(Tr()[
+        Td()[$"#{i + 1}"],
+        Td()[Input(Bind: () => _model.Items[i].Description)],
+        Td()[Input(Bind: () => _model.Items[i].Quantity)]
+    ]);
+}
+```
+
+`foreach` has no closure trap. Records with init-only properties can't be auto-bound through the
+setter — declare them `{ get; set; }`, or use the indexer pattern with a manual handler that replaces
+the slot (`_model.Items[i] = _model.Items[i] with { Field = newValue }`).
+
+**FluentValidation nesting** uses `SetValidator(...)` and `RuleForEach(...).SetValidator(...)`; Rask
+routes the dotted `error.PropertyName` (`Address.Street`, `Lines[0].Quantity`) back to the runtime
+sub-instance so `ValidationMessage(For: () => _model.Address.Street, …)` reads the right slot.
+
+> **Trimming.** Validating a nested graph reflects over every reachable model type. Whatever
+> preserves the root model's public properties (`[DynamicallyAccessedMembers]`, a routed page, or a
+> trimmer descriptor) must extend to every nested type.
+
+See `samples/Rask.Example.Shared/Pages/NestedFormPage.cs` for all four patterns side by side.
+
+---
+
+## 8. Radio & checkbox groups
+
+`RadioGroup<TValue>` binds one value from a set of options; `CheckboxGroup<TItem>` binds an
+`ICollection<TItem>`, toggling each item in place. Both are transparent `Fragment`s built on the same
+binding machinery, so changes flow through the `EditContext` (validation, touched-tracking) like any
+bound field.
+
+```csharp
+public static Component RadioGroup<TValue>(
+    Expression<Func<TValue>> Bind,
+    IEnumerable<TValue> Options,
+    Func<TValue, Child>? OptionLabel = null,
+    string? Name = null,
+    string? ItemClass = null,
+    bool Disabled = false)
+
+public static Component CheckboxGroup<TItem>(
+    Expression<Func<ICollection<TItem>>> Bind,
+    IEnumerable<TItem> Options,
+    Func<TItem, Child>? OptionLabel = null,
+    string? Name = null,
+    string? ItemClass = null,
+    bool Disabled = false)
+```
+
+```csharp
+Form(_prefs)[
+    RadioGroup(() => _prefs.Plan,                       // single value
+        Options: new[] { Plan.Free, Plan.Pro, Plan.Team },
+        OptionLabel: p => Span()[p.ToString()]),
+
+    CheckboxGroup<string>(() => _prefs.Interests,       // a collection — toggles in place
+        Options: new[] { "Web", "Mobile", "AI", "Games" },
+        OptionLabel: t => Span()[t])
+]
+```
+
+- The first positional argument is the `Bind` expression.
+- `RadioGroup` renders the option equal to the current value `checked`; the change handler sets the
+  bound property.
+- `CheckboxGroup` mutates the bound collection in place; membership is compared with
+  `EqualityComparer<TItem>.Default`. You usually need the explicit type argument
+  (`CheckboxGroup<string>`) when the bound collection is a concrete `List<T>`.
+- Each renders a transparent `Fragment` of `<label><input>…</label>` — control layout with
+  `OptionLabel` and `ItemClass`.
+- Changing an option re-renders the component that declared the group, so a live summary updates
+  immediately. Each change calls `NotifyFieldChanged` + `NotifyFieldTouched` + `ValidateFieldAsync`,
+  so DataAnnotations / FluentValidation rules on the bound property apply.
+
+See `samples/Rask.Example.Shared/Pages/FormGroupsPage.cs`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,259 @@
+# Getting started with Rask
+
+This is a zero-to-running tutorial. By the end you'll have a Rask app on screen, a
+component of your own, an event handler that updates the UI, and a route.
+
+Rask requires the **.NET 10 SDK**. Check with `dotnet --version` (≥ `10.0`). WASM
+projects also need the WebAssembly tooling — install it once with
+`dotnet workload install wasm-tools`.
+
+## 1. Install the templates and scaffold
+
+`Rask.Templates` ships three `dotnet new` templates, one per host model:
+
+```bash
+dotnet new install Rask.Templates
+
+dotnet new rask-server       -o MyApp    # ASP.NET live-server app (SSR over WebSockets)
+dotnet new rask-wasm         -o MyApp    # standalone browser-WASM SPA (static bundle)
+dotnet new rask-wasm-hosted  -o MyApp    # browser-WASM client + ASP.NET host project
+```
+
+Which one to pick:
+
+- **`rask-server`** — a single ASP.NET project. Components render on the server and
+  live updates ship over a WebSocket. Good default for apps that already have a
+  backend or want server-side secrets.
+- **`rask-wasm`** — a single `net10.0-browser` project that publishes to a static
+  `wwwroot/` you can host anywhere (GitHub Pages, S3, nginx). No server process for
+  the framework itself; bring your own API for whatever the client calls.
+- **`rask-wasm-hosted`** — two projects: the WASM client plus an ASP.NET host that
+  serves the published bundle and your own `/api/...` endpoints, pre-wired with the
+  cross-TFM `ProjectReference`.
+
+All three accept a `--auth` switch that scaffolds a working login flow
+(`rask-server` / `rask-wasm-hosted` scaffold a **cookie** login; `rask-wasm`, having
+no host, scaffolds a **JWT** bearer login against an external API). See
+[authentication](authentication.md) for the full picture.
+
+Each template emits a runnable solution with `App`, `HomePage`, `Counter`, and a
+`Weather` page that demonstrates async data through constructor DI.
+
+## 2. Run it
+
+```bash
+cd MyApp
+dotnet run            # rask-server / rask-wasm
+# rask-wasm-hosted: run the host project
+dotnet run --project MyApp.Host
+```
+
+Open the URL printed in the console.
+
+> The first build is also when the source generators run. The IDE may flag
+> `HomePage()`, `Counter()`, or `NavLink(...)` as undefined until then — they're
+> **generated** factories. Build once, then reload the solution so IntelliSense
+> picks them up.
+
+## 3. Your first component
+
+Every component is a `sealed class : Component`. Override `Render()` and return a
+tree of HTML built from generated factories. Children attach through an **indexer**
+on every component — `Div()[ ... ]` — and strings, `Component`s, and value types
+all convert implicitly to a child node:
+
+```csharp
+public sealed class Greeting : Component
+{
+    protected override RenderResult Render() =>
+        Div(Class: "greeting")[
+            H1()["Hello, world!"],
+            P()["Welcome to your new Rask app — ", Strong()["it's all C#"], "."],
+            Span()[42]                          // value types convert too — no .ToString()
+        ];
+}
+```
+
+`Render()` returns `RenderResult`, which accepts three shapes:
+
+- a single component — `Render() => Div()[...]`;
+- a **collection expression** for several top-level nodes with no wrapper —
+  `Render() => [H1()["Title"], P()["Body"]]` (sugar for `Fragment()[...]`);
+- `default` — render nothing.
+
+### Text vs. Raw
+
+A plain string becomes a `Text` node, which **HTML-encodes** its content (safe by
+default). When you genuinely need to emit verbatim markup, use `Raw`:
+
+```csharp
+P()["<b>encoded</b> — shows the angle brackets as text"],   // string → Text, encoded
+Div()[Raw("<b>bold</b>")]                                    // emitted verbatim
+```
+
+## 4. Add interactivity
+
+Keep local state in fields and wire event handlers as plain delegates. A click does
+a server round-trip (server host) or a local re-render (WASM host) — the same code.
+After the handler runs, **the component that owns the handler re-renders
+automatically**; you never call `StateHasChanged()` by hand for a local update.
+
+```csharp
+[Route("/counter")]
+public sealed class Counter : Component
+{
+    private int _count;
+
+    protected override RenderResult Render() =>
+        [
+            H1()["Counter"],
+            P()[$"Current count: {_count}"],
+            Button(OnClick: () => _count++)["Click me"]
+        ];
+}
+```
+
+Child → parent communication uses the same idea: a child declares a plain delegate
+property (`Action<int>?`, `Func<Task>?`, …), and the generated factory wraps it so
+invoking it re-renders the **parent** that owns the lambda. There is no
+`EventCallback` type. The child stays oblivious to the parent:
+
+```csharp
+public sealed class RatingStars : Component
+{
+    public int Value { get; set; }
+    public Action<int>? OnRate { get; set; }            // a plain delegate prop
+
+    protected override RenderResult Render() =>
+        Div()[
+            Enumerable.Range(1, 5).Select(i => (Child)Button(
+                OnClick: () => OnRate?.Invoke(i),        // child invokes; parent re-renders
+                Key: i)[i <= Value ? "★" : "☆"])
+        ];
+}
+
+public sealed class RatingDemo : Component
+{
+    private int _rating;
+
+    protected override RenderResult Render() =>
+        [
+            RatingStars(Value: _rating, OnRate: n => _rating = n),   // lambda captures this
+            P()[_rating == 0 ? "Click a star." : $"You rated: {_rating}/5"]
+        ];
+}
+```
+
+## 5. Factory generation rules
+
+You never write a factory by hand. For each concrete `Component`, the generator
+emits a `{Type}(...)` factory and derives its parameters from your public settable
+properties:
+
+| Property shape | In the factory |
+|----------------|----------------|
+| Non-nullable, **no initializer** | **required** parameter |
+| Nullable (`T?` / `Nullable<T>`), no initializer | optional, defaults to `null` |
+| Has an initializer (`= ...`) | **excluded** — your default wins |
+| `[SkipFactory]` (property or class) | **excluded** |
+| `Children` | always excluded (children attach via the indexer) |
+
+```csharp
+public sealed class Card : Component
+{
+    public required string Title { get; set; }   // required factory param
+    public string? Subtitle { get; set; }         // optional, default null
+    public int Elevation { get; set; } = 1;        // excluded — your default wins
+    [SkipFactory] public int Internal { get; set; }// excluded explicitly
+    // → generated: Card(string Title, string? Subtitle = null, ...)
+}
+```
+
+**Inject framework services (`HttpClient`, `Navigator`, `RouteState`, `IJSRuntime`)
+through the constructor, not as properties** — a non-nullable settable property
+would become a required factory parameter:
+
+```csharp
+public sealed class Weather(IWeatherForecastService service) : Component { ... }
+```
+
+## 6. The page-root shell and the `Head` override
+
+Your root component (the `TApp` you pass to the host) must render the **full HTML
+shell** — `Doctype`, `Html`, `Head`, `Body`. Both `<head>` and `<body>` are
+framework-managed: the runtime `<script>` is auto-appended to `<body>`, and `<head>`
+is filled from every mounted component's `Head` override.
+
+```csharp
+public sealed class App : Component
+{
+    // App-level head; pages can override their own Head to set a per-page Title.
+    protected override RenderResult Head => [
+        Title()["My Rask App"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1")
+    ];
+
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),               // framework-managed slot — do NOT pass children
+                Body()[
+                    Router()
+                ]
+            ]
+        ];
+}
+```
+
+Any component can contribute to `<head>` while it's in the tree by overriding
+`protected virtual RenderResult Head`. `<title>` and `<base>` are singleton tags —
+the last contributor wins, so a page's `Title` overrides the App fallback:
+
+```csharp
+protected override RenderResult Head => Title()["Welcome — My Rask App"];
+```
+
+Two compile-time guardrails to know about (full list in [diagnostics](diagnostics.md)):
+
+- **RASK021** — the root doesn't render a complete shell (`Doctype`/`Html`/`Head`/`Body`).
+- **RASK019** — you passed children to `Head()`. Use the `Head` override instead.
+
+## 7. Add a route
+
+Put `[Route("/path")]` on a component to register it as a page (`Rask.Core.Routing`
+is the one namespace you bring in explicitly). `[RouteParam]` and `[QueryParam]` bind
+URL pieces to properties, and every route gets a generated, type-safe URL builder:
+
+```csharp
+using Rask.Core.Routing;
+
+[Route("/users/{id}")]
+public sealed class UserPage : Component
+{
+    [RouteParam] public int Id { get; set; }
+    [QueryParam] public string? Tab { get; set; }
+
+    protected override RenderResult Render() =>
+        Span()[$"User #{Id} — {Tab ?? "overview"}"];
+}
+
+// elsewhere — type-safe, refactor-proof:
+NavLink(UserPage(id: 42))["View user"];
+```
+
+The `Router()` in your shell matches the current path and renders the page. To
+navigate from an event handler, inject the `Navigator` service through the
+constructor and call `nav.Navigate(HomePage())`, `nav.SetQuery("tab", "settings")`,
+and so on. For nested layouts (`[ParentRoute]` + `Outlet()`), 404 pages
+(`[NotFound]`), and the full routing model, see [routing](routing.md).
+
+## Next steps
+
+- [routing](routing.md) — nested layouts, route/query params, `Navigator`.
+- [forms](forms.md) — `Form<T>`, `Input(Bind: ...)`, validation.
+- [lifecycle](lifecycle.md) — `OnMount*` / `OnPropsChanged*` / `OnRendered*`, async hooks.
+- [testing](testing.md) — unit-testing components and rendered HTML.
+- [diagnostics](diagnostics.md) — every RASK0xx analyzer ID and how to fix it.
+- [authentication](authentication.md) — cookie/JWT/OIDC on Server and WASM.

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -1,0 +1,157 @@
+# Lifecycle
+
+Every `Component` can override a small set of lifecycle hooks. They fire at well-defined points around each render, in
+both synchronous and asynchronous flavours, and are identical on the Server and WASM hosts (only the transport
+differs). This page documents the exact hooks, their order, the async rules, and the gotchas.
+
+See also: [routing.md](routing.md) for how route/query params drive `OnPropsChanged*`, and the README *Lifecycle
+reference* table for a one-glance summary.
+
+## The hooks
+
+All hooks are `protected virtual` on `Component`. Each has a sync and an async variant; you can override either or
+both, and they run in pairs (sync first, then async):
+
+```csharp
+protected virtual void OnMount() { }
+protected virtual Task OnMountAsync() => Task.CompletedTask;
+
+protected virtual void OnPropsChanged() { }
+protected virtual Task OnPropsChangedAsync() => Task.CompletedTask;
+
+protected virtual void OnRendered(bool firstRender) { }
+protected virtual Task OnRenderedAsync(bool firstRender) => Task.CompletedTask;
+
+protected virtual void OnUnmount() { }
+protected virtual Task OnUnmountAsync() => Task.CompletedTask;
+```
+
+## Order
+
+| Hook                                     | When                                                                                     |
+|------------------------------------------|------------------------------------------------------------------------------------------|
+| `OnMount` / `OnMountAsync`               | **Once**, on first creation of the instance (first render only).                         |
+| `OnPropsChanged` / `OnPropsChangedAsync` | On the **first render**, and on any later render where a bound prop / route or query param **actually changed**. |
+| `OnRendered` / `OnRenderedAsync`         | After **every** render commit, with a `firstRender` flag.                                |
+| `OnUnmount` / `OnUnmountAsync`           | **Once**, on disposal (navigation away, parent subtree torn down, session teardown). Children unmount before parents (depth-first). |
+
+So on the first render of a component you get, in order: `OnMount` → `OnMountAsync` → `OnPropsChanged` →
+`OnPropsChangedAsync` → (render) → `OnRendered(firstRender: true)` → `OnRenderedAsync(firstRender: true)`. On disposal:
+`OnUnmount` → `OnUnmountAsync`.
+
+A typical async-data page uses `OnMountAsync` to fetch once and renders a placeholder until it lands:
+
+```csharp
+[Route("/weather")]
+public sealed class Weather(IWeatherForecastService service) : Component
+{
+    private WeatherForecast[]? _forecasts;
+
+    protected override async Task OnMountAsync() =>
+        _forecasts = await service.GetForecastsAsync();
+
+    protected override RenderResult Render() =>
+        _forecasts is null
+            ? P()[Em()["Loading..."]]
+            : Table()[/* render rows */];
+}
+```
+
+### When `OnPropsChanged*` refires
+
+`OnPropsChanged*` fires on the first render and whenever a value the component is bound to **actually changes** —
+including:
+
+- A parent passing a different value for a factory parameter (a prop).
+- A `[RouteParam]` / `[QueryParam]` value changing because the URL changed.
+- A **reused routed page** whose URL **path** changes (the router keeps the instance and re-binds it rather than
+  remounting).
+
+What does **not** refire it: a bare event-handler re-render. Clicking a button that mutates a local field re-renders
+the component but does **not** re-fire `OnPropsChanged*` — nothing the component is bound to changed. (`Key` is a
+reconciliation identity, not a reactive prop, so a key change doesn't fire `OnPropsChanged` either; it mounts a fresh
+instance.)
+
+## Sync vs async rules
+
+The async hooks install a synchronization context so each `await` inside a hook triggers an automatic re-render after
+the continuation, plus one terminal re-render on completion — you get "mutate state after the await and it paints"
+without calling `StateHasChanged()` by hand. The runtime coalesces these into one payload per handler dispatch.
+
+```csharp
+protected override async Task OnMountAsync()
+{
+    // placeholder shows here
+    _data = await LoadAsync();
+    // auto re-render after the await → real data paints, no StateHasChanged()
+}
+```
+
+**`OnRenderedAsync` is loop-safe.** The terminal auto re-render is a *publish-only* walk: it does **not** re-fire
+`OnRendered` / `OnRenderedAsync` on components that have already rendered at least once. That's what keeps an
+`OnRenderedAsync` hook which awaits a next-frame side effect (e.g. drawing a chart, or a scoped-JS call) from looping
+on itself. Newly-mounted children on the same walk still get their first `OnRendered(firstRender: true)`.
+
+```csharp
+protected override async Task OnRenderedAsync(bool firstRender) =>
+    await js.InvokeVoidAsync("Rask.CodeSample.rendered", firstRender);
+    // re-render from another component won't re-fire this — no loop
+```
+
+## Gotcha: faulted async hooks are silent
+
+**If an async hook faults, the framework logs the exception to `Console.Error` and does NOT trigger a re-render.** It
+does not surface as an error page or a thrown exception up the render stack. The practical symptom: a component stuck
+on a loading placeholder that never resolves is almost always an `OnMountAsync` / `OnPropsChangedAsync` /
+`OnRenderedAsync` that threw. Check `Console.Error`. (Wrap risky work in `try/catch` if you want to render an error
+state yourself, or use an `ErrorBoundary` around the subtree for render/handler faults.)
+
+## Gotcha: don't `StateHasChanged()` in unmount
+
+When `OnUnmount` / `OnUnmountAsync` runs, the component's lifetime `CancellationToken` is still **live** — it's
+cancelled immediately *after* the hook returns. But the component is already leaving the tree, so calling
+`StateHasChanged()` from inside an unmount hook is a **no-op** by design (it's been flagged unmounted before the hook
+fires). Don't request a render from unmount.
+
+```csharp
+protected override void OnUnmount()
+{
+    route.Changed -= StateHasChanged;   // typical: tear down subscriptions
+    // do NOT call StateHasChanged() here — the component is leaving the tree
+}
+```
+
+## Cancellation tied to component lifetime
+
+Every component exposes a `protected CancellationToken CancellationToken`. It's allocated lazily (a component that
+never reads it pays nothing) and cancelled exactly once when the component is unmounted. Pass it into `HttpClient`
+calls, `Task.Delay`, or any cancellable async work started in a lifecycle hook so it aborts cleanly when the user
+navigates away:
+
+```csharp
+public sealed class CancellationProbe : Component
+{
+    public required Action<string> Log { get; set; }
+    public required int InstanceId { get; set; }
+
+    protected override async Task OnMountAsync()
+    {
+        try
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(2500), CancellationToken);
+            Log($"#{InstanceId} completed");
+        }
+        catch (OperationCanceledException)
+        {
+            Log($"#{InstanceId} cancelled");
+        }
+    }
+}
+```
+
+The framework cancels the token **before** disposing the subtree, so awaits unwind via `OperationCanceledException`
+before `Dispose` runs and the unmount hooks fire. Cooperation is required: the framework only *signals* the token — it
+doesn't abort blocking calls. Thread the token through anything you want cancelled.
+
+(See `samples/Rask.Example.Shared/Pages/CancellationPage.cs` and `LifecyclePage.cs` for runnable probes that log every
+hook invocation, and `PropsPage.cs` for the props-binding demo.)

--- a/docs/migration-from-blazor.md
+++ b/docs/migration-from-blazor.md
@@ -1,0 +1,218 @@
+# Migrating from Blazor
+
+Rask isn't a Blazor replacement so much as a different take on the same problem
+space. If you know Blazor, most concepts transfer directly — they just move from
+`.razor` markup into plain C#. This guide maps the day-to-day APIs and calls out the
+behavioural differences that trip people up.
+
+New to Rask entirely? Start with [getting started](getting-started.md).
+
+## Concept mapping
+
+| Blazor | Rask |
+|--------|------|
+| `.razor` component (markup + `@code`) | `sealed class : Component` with `Render()` returning a tree |
+| `RenderFragment` / Razor markup | A factory tree — `Div()[Span(...), "hi"]`, children via an indexer |
+| `@onclick="Handler"` | `OnClick: () => ...` (a plain delegate parameter) |
+| `[Parameter] public T X { get; set; }` | `public T X { get; set; }` — becomes a factory parameter (required if non-nullable) |
+| `EventCallback` / `EventCallback<T>` | **No such type.** A plain delegate prop (`Action`, `Action<T>`, `Func<Task>`, `Func<T,Task>`) |
+| `[CascadingParameter]` / `CascadingValue` | `Context.Provide<T>(Value:)` / `Context.Get<T>()` / `Context.Required<T>()` |
+| `@key="x"` | `Key: x` (last optional factory parameter) |
+| `OnInitialized` / `OnInitializedAsync` | `OnMount` / `OnMountAsync` (once per instance) |
+| `OnParametersSet` / `OnParametersSetAsync` | `OnPropsChanged` / `OnPropsChangedAsync` |
+| `OnAfterRender(firstRender)` / async | `OnRendered(firstRender)` / `OnRenderedAsync` |
+| `Dispose` / `DisposeAsync` | implement `IDisposable` / `IAsyncDisposable`; or use `OnUnmount` / `OnUnmountAsync` |
+| `NavigationManager` | `Navigator` (event-handler-only) + `RouteState` (current path/params) |
+| `@page "/path"` | `[Route("/path")]` on the class |
+| route/query binding | `[RouteParam]` / `[QueryParam]` on a property |
+| `<EditForm>` + `InputText`/`InputNumber` | `Form<TModel>(model, OnValidSubmit:)` + `Input(Bind: () => model.X)` |
+| `<DataAnnotationsValidator>` | drop `DataAnnotationsValidator()` inside the `Form<T>` |
+| `<AuthorizeView>` / `AuthenticationStateProvider` | `Component.User` + headless `Authorize(...)` component |
+| `[Inject] T Svc { get; set; }` | constructor injection — `class Page(T svc) : Component` |
+| `Component.razor.css` | sibling `{Component}.css` next to `{Component}.cs` |
+| `IJSRuntime` | `IJSRuntime` (injected via the constructor) |
+
+## Side-by-side examples
+
+### A parameterised component
+
+```razor
+@* Blazor: Greeting.razor *@
+<h1>Hello, @Name!</h1>
+@code {
+    [Parameter] public string Name { get; set; } = "";
+}
+```
+
+```csharp
+// Rask
+public sealed class Greeting : Component
+{
+    public required string Name { get; set; }   // non-nullable → required factory param
+    protected override RenderResult Render() => H1()[$"Hello, {Name}!"];
+}
+// call site: Greeting(Name: "Ada")
+```
+
+### Event handler + local state
+
+```razor
+@* Blazor *@
+<button @onclick="() => count++">Count: @count</button>
+@code { int count; }
+```
+
+```csharp
+// Rask — owner re-renders automatically after the handler
+Button(OnClick: () => _count++)[$"Count: {_count}"]
+```
+
+### Child → parent callback (no `EventCallback`)
+
+This is the biggest API difference. Blazor wraps child events in `EventCallback` so
+the parent re-renders. **Rask has no `Callback`/`EventCallback` type** — the child
+declares a plain delegate prop, and the generated factory wraps it so invoking it
+re-renders the parent that owns the lambda (the lambda's `this`).
+
+```razor
+@* Blazor: child *@
+<button @onclick="() => OnRate.InvokeAsync(5)">Rate</button>
+@code { [Parameter] public EventCallback<int> OnRate { get; set; } }
+```
+
+```csharp
+// Rask: child declares a plain delegate; parent passes a lambda over its own state
+public sealed class RatingStars : Component
+{
+    public Action<int>? OnRate { get; set; }
+    protected override RenderResult Render() =>
+        Button(OnClick: () => OnRate?.Invoke(5))["Rate"];
+}
+
+// parent — the lambda captures `this`, so invoking OnRate re-renders the parent
+RatingStars(OnRate: n => _rating = n)
+```
+
+A static method, or a lambda closing over a local instead of `this`, has no
+component target, so **no auto re-render fires** — write the lambda inside the
+component that should update.
+
+### Cascading value → Context
+
+```razor
+@* Blazor *@
+<CascadingValue Value="theme"><Child /></CascadingValue>
+@* in Child: *@ [CascadingParameter] Theme Theme { get; set; }
+```
+
+```csharp
+// Rask — provide high, read deep (nearest provider wins, matched by type)
+Context.Provide<Theme>(Value: _theme)[ ThemeCard() ]
+// in any descendant's Render():
+var theme = Context.Required<Theme>();   // or Context.Get<T>() (null if absent)
+```
+
+### Routing + navigation
+
+```razor
+@* Blazor *@
+@page "/users/{Id:int}"
+@inject NavigationManager Nav
+@code { [Parameter] public int Id { get; set; } }
+```
+
+```csharp
+// Rask
+[Route("/users/{id}")]
+public sealed class UserPage(Navigator nav) : Component   // Navigator via ctor
+{
+    [RouteParam] public int Id { get; set; }
+    [QueryParam] public string? Tab { get; set; }
+    // navigate from a handler: nav.Navigate(HomePage()), nav.SetQuery("tab", "x")
+}
+
+// type-safe link (generated URL builder) instead of a "/users/42" string:
+NavLink(UserPage(id: 42))["View user"]
+```
+
+### Forms
+
+```razor
+@* Blazor *@
+<EditForm Model="model" OnValidSubmit="Save">
+    <DataAnnotationsValidator />
+    <InputText @bind-Value="model.Name" />
+</EditForm>
+```
+
+```csharp
+// Rask
+Form<SignupModel>(_model, OnValidSubmit: m => Save(m))[
+    DataAnnotationsValidator(),                  // from Rask.Validation.DataAnnotations
+    Input(Bind: () => _model.Name),              // input type inferred from the CLR type
+    ValidationMessage(For: () => _model.Name,
+        Template: errs => Div(Class: "field-error")[errs[0]]),
+    Button(Type: "submit")["Sign up"]
+]
+```
+
+`Input`/`Select`/`Textarea` infer their type from the bound property (`string` →
+text, `bool` → checkbox, `int` → number, `DateOnly` → date). `ValidationMessage` and
+`ValidationSummary` are headless — you pass a `Template:` lambda for the markup. See
+[forms](forms.md) for nested models, collections, and async validation.
+
+### Scoped CSS
+
+Identical idea, no association ceremony. Drop a sibling `{Component}.css` next to
+`{Component}.cs` and it's auto-globbed, scoped to that type, and hot-reloaded under
+`dotnet watch` — Blazor-parity descendant scoping, with `:global(...)` to opt a
+selector out (use it for shell tags like `body`/`html`).
+
+## Behavioural gotchas
+
+- **Children come through an indexer, not a `Children` parameter.** Write
+  `Div()[Span(...), "hi"]`. There is no `ChildContent` factory param, and `Children`
+  is always excluded from generated factories.
+
+- **The `..` spread fails inside `[...]`.** The C# spread element parses as a
+  `Range` inside the indexer. Pass enumerables **directly** instead:
+
+  ```csharp
+  Ul()[items.Select(i => (Child)Li(Key: i.Id)[i.Name])]   // ✓ pass the sequence
+  // Ul()[.. items.Select(...)]                            // ✗ parses as Range
+  ```
+
+- **F12 / Go-to-Definition on `Foo(...)` lands on the *generated* factory, not your
+  component class.** Stock Roslyn/ReSharper navigate a generated symbol to its
+  generated document. Use the IDE's **"Navigate to Type of Symbol"** for a one-action
+  jump to the component class. (Every generated factory carries a `<see cref>`
+  breadcrumb and `[DebuggerStepThrough]`, so hover/Quick-Doc offers a navigable link
+  and the debugger steps over the factory into your code.)
+
+- **Keyed lists matter — and Rask warns when you forget.** Like Blazor's `@key`,
+  pass `Key:` on list items so inserts/removes/reorders reconcile by identity
+  (preserving focus and input state). A Rask factory call in a list-projection
+  context (`.Select`/`.SelectMany`, or `.Add` in a loop) without a `Key:` raises
+  **RASK022** — keyless items reconcile positionally.
+
+- **`Navigator` is event-handler-only.** Calling it outside a handler throws. Read
+  the current route from `RouteState`; mutate it via `Navigator` from a handler.
+
+- **Lifecycle re-fire rules differ.** `OnPropsChanged*` fires on first render and
+  whenever a bound prop or route/query param actually changes — a bare
+  event-handler re-render does **not** re-fire it. Don't call `StateHasChanged()` in
+  `OnUnmount*`. Faulted async hooks log to `Console.Error` and don't re-render (a
+  placeholder that never resolves usually means an async hook threw).
+
+## What stays the same
+
+- **DI through the constructor** — exactly like the rest of .NET. Framework services
+  (`Navigator`, `RouteState`, `HttpClient`, `IJSRuntime`) inject the same way as your
+  own services. (No `[Inject]` properties — a non-nullable settable property would
+  become a required factory parameter instead.)
+- **Scoped CSS parity** — sibling `{Component}.css`, descendant-combinator scoping,
+  hot reload.
+- **`IJSRuntime`** — the same interop surface (`InvokeAsync`, `InvokeVoidAsync`).
+  Rask adds element refs (`ElementRef.New()` + a `Ref:` parameter on every element)
+  and a sibling `{Component}.js` convention bundled and dispatched as
+  `window.Rask["{TypeName}"]`.

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,0 +1,283 @@
+# Routing
+
+Rask routing is attribute-driven and source-generated. You annotate a component with `[Route("/path")]`; a module
+initializer (emitted by the `RoutesGenerator`) registers it at startup, and the `Router()` in your `App` tree matches
+the current URL against the registry and renders the matching page. The same generator also emits a **type-safe URL
+builder** for every route, so links and navigation never carry stringly-typed paths that rot.
+
+Bring in the routing namespace where you use these APIs:
+
+```csharp
+using Rask.Core.Routing;
+```
+
+See also: [lifecycle.md](lifecycle.md) for hook timing on routed pages, [authentication.md](authentication.md) for
+auth gating, and [diagnostics.md](diagnostics.md) for the routing analyzers (RASK003–RASK013).
+
+## Registering routes
+
+Put `[Route("/path")]` on a `Component`. That's the whole registration:
+
+```csharp
+[Route("/about")]
+public sealed class AboutPage : Component
+{
+    protected override RenderResult Render() => H1()["About"];
+}
+```
+
+Routes use Blazor-style `{param}` placeholders, support optional segments (`{name?}`), and accept type constraints
+(`{id:int}`). The generator validates the template at compile time:
+
+- A malformed template raises [RASK003](diagnostics.md#rask003).
+- A segment with no matching property raises [RASK004](diagnostics.md#rask004).
+
+A route only matters once a `Router()` is somewhere in the tree to match against it. The standard place is the page
+root (`App`):
+
+```csharp
+public sealed class App : Component
+{
+    protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[
+                    Router()        // matches RouteState.Path and renders the page
+                ]
+            ]
+        ];
+}
+```
+
+`Router()` matches `RouteState.Path`, builds the route chain, instantiates each page via DI, binds URL pieces to
+properties, and fires the page lifecycle.
+
+### Type-safe URLs (`Routes.Page(...)`)
+
+For each routed component `Foo`, the generator emits a static formatter `Routes.Foo(...)` returning a `RouteUrl`. The
+formatter's parameters mirror the route's bound properties:
+
+```csharp
+[Route("/")]
+public sealed class HomePage : Component { /* ... */ }
+// → Routes.HomePage()  returns a RouteUrl for "/"
+
+[Route("/users/{id:int}")]
+public sealed class UserPage : Component
+{
+    [RouteParam] public int Id { get; set; }
+}
+// → Routes.UserPage(int Id)  — the path param becomes a required argument
+```
+
+`RouteUrl` is a small `readonly record struct` carrying `Path` and an optional `QueryString`. It converts implicitly
+to and from `string`, so you can pass it straight to `NavLink`, `Navigator.Navigate`, or anywhere a path string is
+expected:
+
+```csharp
+NavLink(Href: Routes.UserPage(Id: 42))["View user"];
+```
+
+Path values are formatted through `RouteValueFormatter.Format`, so an `int`, `Guid`, `DateOnly`, etc. round-trips
+correctly without a manual `.ToString()`. There is also a generic `Route<T>(...)` helper in
+`Rask.Core.Routing.Generated` used by the registry machinery; in app code you almost always reach for the named
+`Routes.Foo(...)` formatter.
+
+> The generated `Routes.*` and component factory symbols don't exist until the generator runs. If the IDE flags them
+> as undefined, run `dotnet build` once and reload the solution.
+
+## Route and query parameters
+
+Two attributes bind URL pieces to properties on the page:
+
+- `[RouteParam]` — binds a **path segment** (`{id}` in the template) to a property.
+- `[QueryParam]` — binds a **query-string** value to a property.
+
+```csharp
+[Route("/users/{id}")]
+public sealed class UserPage : Component
+{
+    [RouteParam] public int Id { get; set; }       // /users/42  → Id = 42
+    [QueryParam] public string? Tab { get; set; }   // ?tab=profile → Tab = "profile"
+
+    protected override RenderResult Render() => Span()[$"User #{Id} — {Tab ?? "overview"}"];
+}
+```
+
+Both attributes take an optional name to bind a segment/key whose name differs from the property:
+`[RouteParam("id")]`, `[QueryParam("page")]`.
+
+**Supported types.** A bound property must be `string` or implement `IParsable<T>` (covers `int`, `long`, `double`,
+`bool`, `Guid`, `DateOnly`, `DateTime`, enums, and your own `IParsable<T>` types). A non-parsable type raises
+[RASK011](diagnostics.md#rask011). When a route template constrains a segment (`{id:int}`), the bound property's CLR
+type must match the constraint, or you get [RASK005](diagnostics.md#rask005).
+
+Other binding-related analyzers worth knowing:
+
+- [RASK006](diagnostics.md#rask006) — `[QueryParam]` placed on a property that's actually a path segment.
+- [RASK008](diagnostics.md#rask008) — `[RouteParam]` with no matching path segment in the template.
+- [RASK009](diagnostics.md#rask009) / [RASK010](diagnostics.md#rask010) — `[RouteParam]` / `[QueryParam]` on a class
+  that isn't a routed page (no `[Route]`).
+
+Route/query binding feeds the lifecycle: `OnPropsChanged*` fires on first render and whenever a bound param actually
+changes value. See [lifecycle.md](lifecycle.md).
+
+## Nested routes — `[ParentRoute]` + `Outlet()`
+
+A page can declare a parent layout with `[ParentRoute(typeof(Parent))]`. The child's template is joined onto the
+parent's, and the parent renders the matched child wherever it places an `Outlet()`:
+
+```csharp
+[Route("/")]
+public sealed class Layout : Component
+{
+    protected override RenderResult Render() =>
+        Div()[
+            Nav()[ /* sidebar */ ],
+            Main()[Outlet()]        // the matched child page renders here
+        ];
+}
+
+[Route("about"), ParentRoute(typeof(Layout))]
+public sealed class AboutPage : Component
+{
+    protected override RenderResult Render() => H1()["About"];
+}
+
+// /about now matches Layout → AboutPage, with AboutPage rendered into Layout's Outlet().
+```
+
+An empty child template (`[Route("")]`) means "the default child for this layout". The showcase app is built this way:
+every page declares `[ParentRoute(typeof(ShowcaseLayout))]` and the layout hosts the `Outlet()`.
+
+`Outlet()` must be called inside a `Router()` render tree (it throws otherwise). A `[ParentRoute]` cycle raises
+[RASK007](diagnostics.md#rask007).
+
+## Programmatic navigation — `Navigator`
+
+`Navigator` is the scoped service for imperative navigation and query mutation. Inject it through the **constructor**
+like any other framework service:
+
+```csharp
+public sealed class ProductsPage(Navigator nav) : Component
+{
+    protected override RenderResult Render() =>
+        Button(OnClick: () => nav.Navigate("/dashboard"))["Open dashboard"];
+}
+```
+
+**Event-handler only.** Every `Navigator` method throws `InvalidOperationException` if called outside an event
+handler — calling it during `Render()` or the initial GET would mid-render the page out from under itself. Navigate
+from button clicks, form submits, or lifecycle hooks that ran in response to an event. Navigation that must happen on
+load belongs in a redirect/route, not in `Render()`.
+
+`Navigator` mutates the shared `RouteState`; after the handler returns, the live runtime pushes (or replaces) the
+resulting URL into browser history.
+
+### Methods
+
+```csharp
+// Path navigation — CLEARS any existing query string:
+nav.Navigate("/users/42");
+nav.Navigate(Routes.UserPage(Id: 42));     // type-safe RouteUrl overload
+
+// Path + a complete new query in one step (REPLACES the whole query):
+nav.Navigate("/users/ada",
+    new[] { KeyValuePair.Create<string, string?>("tab", "profile") });
+
+// Single-param mutations on the CURRENT path (path unchanged):
+nav.SetQuery("page", "2");                  // set/update; null value removes the key
+nav.SetQuery(                               // several at once
+    KeyValuePair.Create<string, string?>("page", "2"),
+    KeyValuePair.Create<string, string?>("sort", "asc"));
+nav.RemoveQuery("page");                    // remove one key (missing key = no-op)
+nav.ClearQuery();                           // drop all query params, keep the path
+```
+
+Key behaviours:
+
+- `Navigate(path)` and `Navigate(RouteUrl)` **clear the query** unless the `RouteUrl` itself carries one. To navigate
+  to a path and keep params, use the `Navigate(path, query)` overload or follow up with `SetQuery`.
+- `Navigate(path, query)` **replaces** the entire query string with the supplied pairs. Pairs with a `null` value are
+  dropped; repeated keys concatenate into a multi-value param.
+- `SetQuery` / `RemoveQuery` / `ClearQuery` operate on the **current** path and leave it unchanged — they're for
+  partial query updates (`?page=2&sort=asc`).
+
+### The `replace` flag
+
+`Navigate(...)` overloads take an optional `replace` parameter (default `false`). `true` replaces the current history
+entry instead of pushing a new one, so it adds no extra Back-button stop:
+
+```csharp
+nav.Navigate("/login", replace: true);   // redirect without a back-stack entry
+```
+
+`Navigator` also exposes `Download(...)` for pushing files to the browser (same event-handler-only rule); that lives in
+the Files section of the README.
+
+## Reading the current URL — `RouteState`
+
+`RouteState` is the scoped, per-session source of truth for the current location. Inject it to read the live URL:
+
+```csharp
+public sealed class CurrentLocation(RouteState route) : Component
+{
+    protected override RenderResult Render() =>
+        Div()[
+            "path: ", Code()[route.Path],
+            " query count: ", route.Query.Count
+        ];
+}
+```
+
+- `route.Path` — the current path, always starting with `/` (defaults to `"/"`).
+- `route.Query` — the parsed query string as an `IQueryCollection` (defaults to empty).
+
+Mutate `RouteState` through `Navigator`, not by setting `Path`/`Query` directly, so browser history stays in sync.
+
+### Reacting to navigation — `RouteState.Changed`
+
+`RouteState` raises an `event Action? Changed` whenever `Path` or `Query` actually changes (`Path` is compared by
+value, `Query` by reference, so a no-op set doesn't fire). Components **inside** the routed page subtree usually don't
+need it — the router re-renders them on navigation. But a component rendered **above** the `Router()` (a sidebar,
+breadcrumb, header path display) won't be re-rendered by the router, so it must subscribe explicitly. Subscribe in
+`OnMount`, unsubscribe in `OnUnmount`:
+
+```csharp
+public sealed class PathDisplay(RouteState route) : Component
+{
+    protected override void OnMount() => route.Changed += StateHasChanged;
+    protected override void OnUnmount() => route.Changed -= StateHasChanged;
+
+    protected override RenderResult Render() =>
+        Span()["path: ", Code()[route.Path]];
+}
+```
+
+The handler is just `StateHasChanged` — the framework coalesces the resulting render with whatever the dispatcher is
+already processing. **Always pair the subscribe with the unsubscribe**, or `RouteState` keeps a strong reference to the
+unmounted component. (`NavLink` and `Outlet` do this subscription internally so they stay current even outside the
+router subtree.)
+
+## Not-found and auth gating
+
+**404 / catch-all.** Mark a component `[NotFound]` to register it as the catch-all page when no route matches; the
+framework falls back to a minimal built-in page if no app-defined one exists.
+
+```csharp
+[NotFound]
+public sealed class NotFoundPage : Component
+{
+    protected override RenderResult Render() => H1()["Page not found"];
+}
+```
+
+Only one `[NotFound]` component is allowed ([RASK012](diagnostics.md#rask012)), and `[NotFound]` cannot be combined
+with `[Route]` on the same class ([RASK013](diagnostics.md#rask013)).
+
+**Route-level authorization.** Put `[Authorize]` (optionally `[Authorize(Roles = "admin")]`) or `[AllowAnonymous]` on
+a page component; the `RouteAuthorizationGuard` enforces it before the page renders. Auth is configured entirely on
+ASP.NET's own `AddCookie` / `AddJwtBearer` / `AddAuthorization` — Rask adds no parallel options. Full flows for
+cookie/JWT on Server and WASM are in [authentication.md](authentication.md).

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,219 @@
+# Testing Rask components
+
+Rask components are plain C# classes that render to HTML, so most behaviour is reachable from fast
+in-process unit tests — no browser, no server. This guide covers the test stack, rendering and
+asserting on output, driving event handlers, testing forms and validation, the build/test commands,
+and when to reach for end-to-end (E2E) tests instead.
+
+> Unit-test first. Add an E2E test only when a unit test genuinely can't reach the path (E2E is
+> heavy — see the last section).
+
+---
+
+## 1. The test stack
+
+Tests run on **xUnit**. The `Rask.TestSupport` project (`tests/Rask.TestSupport/`) collects the
+helpers that render components and pull values out of the output:
+
+- **`RenderHarness`** — `Render<T>(component, services)` begins a `LiveRenderContext`, resolves the
+  component, and fires `NotifyParameters`; `EmptyServices()` builds an empty `IServiceProvider` for
+  components that need no registrations.
+- **`Markup`** — string helpers over rendered HTML / live payloads: `Attr(html, name)` (or
+  `RequireAttr`), `SessionId`, `FirstHandlerId`.
+- **`Stubs`** — `StubComponent` (a live-render root that forwards to the component under test, which
+  often can't itself be a root) and `ContextCapture` (captures the ambient `EditContext` during
+  render so a test can assert against what a form/validator pushed).
+
+The internal render entry points (`RenderAsLiveRoot`, `TryInvokeHandlerAsync`) are exposed to test
+projects through `[InternalsVisibleTo]` on `Rask.Core` (`Rask.Core.Tests`,
+`Rask.Example.Shared.Tests`, the validation test projects, …).
+
+The `Rask.Core.Tests` project imports the generated factory namespaces as `global using static`, so
+tag factories (`Button(...)`, `Div(...)`), form factories (`Form(...)`, `Input(...)`), and
+`Rask.TestSupport` are all in scope unqualified.
+
+### Rendering a component
+
+For a standalone component, `ToHtml()` serializes it directly (no live context):
+
+```csharp
+Assert.Equal("<button></button>", Button().ToHtml());
+```
+
+For anything that needs a live context (event handlers, forms, DI services), wrap it in a
+`StubComponent` and call `RenderAsLiveRoot()`:
+
+```csharp
+var view = new StubComponent(() => Button(OnClick: () => { })["x"]);
+Assert.Equal("<button data-rask-on-click=\"h0\">x</button>", view.RenderAsLiveRoot());
+```
+
+`RenderAsLiveRoot(IServiceProvider)` takes a service provider when the component needs DI
+(`RenderHarness.EmptyServices()`, or a project-specific builder like the example suite's
+`TestServices.Default(...)`).
+
+---
+
+## 2. Unit-testing HTML output
+
+The per-tag convention (`tests/Rask.Core.Tests/Components/{Tag}Tests.cs`) pairs a `Render_NullProps_…`
+case with a `Render_AllPropsSet_…` case that asserts the **exact attribute order**: `id`, `class`,
+`style`, `data-*`, then the tag-specific attributes. Tests pin this with full-string equality.
+
+```csharp
+[Fact]
+public void Render_NullProps_ReturnsEmptyButtonTags() =>
+    Assert.Equal("<button></button>", Button().ToHtml());
+
+[Fact]
+public void Render_AllPropsSet_EmitsBaseThenDerivedAttributesInOrder() =>
+    Assert.Equal(
+        "<button id=\"go\" class=\"btn\" style=\"color:red\" data-test-id=\"primary\" type=\"submit\" disabled name=\"action\" value=\"save\"></button>",
+        Button("submit", true, "action", "save", Id: "go", Class: "btn", Style: "color:red",
+            Data: new Dictionary<string, string?> { ["test-id"] = "primary" }).ToHtml());
+```
+
+Useful patterns from the suite:
+
+- Boolean HTML attributes emit bare (`disabled`, not `disabled="true"`) when `true`, and are omitted
+  when `false`/`null`.
+- `Text` HTML-encodes (`Button()["<click>"]` → `&lt;click&gt;`); `Raw(...)` emits verbatim.
+- When adding a new tag, add the matching `{Tag}Tests.cs` with both cases (see the project CLAUDE.md
+  conventions). Test files opt out of the `RASK014` "use the factory" analyzer with
+  `#pragma warning disable RASK014` since they define their own `Component` subclasses.
+
+---
+
+## 3. Driving event handlers
+
+Event handlers are registered against the live context at render time and surface as
+`data-rask-on-*` attributes whose value is a handler id. To drive one in a test:
+
+1. `RenderAsLiveRoot()` to get the HTML.
+2. Pull the handler id with `Markup.Attr(html, "data-rask-on-click")` (or `-on-input`, `-on-change`,
+   `-on-submit`, `-on-files`).
+3. Invoke it with `view.TryInvokeHandlerAsync(id, jsonPayload)`, passing a `JsonElement` payload that
+   mirrors what the client sends.
+
+```csharp
+var p = new Person { Name = "Ada", Age = 30 };
+var view = new StubComponent(() => Form(p)[Input(() => p.Name)]);
+var html = view.RenderAsLiveRoot();
+
+var inputId = Markup.Attr(html, "data-rask-on-input");
+Assert.NotNull(inputId);
+
+using var doc = JsonDocument.Parse("{\"value\":\"Bea\"}");
+var ok = await view.TryInvokeHandlerAsync(inputId!, doc.RootElement);
+
+Assert.True(ok);
+Assert.Equal("Bea", p.Name);   // bound model was updated
+```
+
+Payload shapes by event:
+
+- input / change → `{"value":"…"}`
+- submit → `{"form":{"FieldName":"value", …}}`
+
+`TryInvokeHandlerAsync` returns `false` when no handler matches the id.
+
+---
+
+## 4. Forms and validation
+
+Form tests follow the same render-then-invoke loop. Mirror the browser's input→change ordering when
+testing per-keystroke vs blur behaviour:
+
+```csharp
+[Fact]
+public async Task Submit_InvalidModel_CallsOnInvalidSubmit_NotOnValidSubmit()
+{
+    var p = new Person { Name = "", Age = 0 };
+    var validCalled = 0; var invalidCalled = 0;
+
+    var view = new StubComponent(() => Form<Person>(p,
+        OnValidSubmit:   _ => validCalled++,
+        OnInvalidSubmit: _ => invalidCalled++,
+        Validate: m => string.IsNullOrEmpty(m.Name) ? new[] { "Name required" } : Array.Empty<string>())[
+        Input(() => p.Name), Input(() => p.Age)
+    ]);
+    var html = view.RenderAsLiveRoot();
+
+    var submitId = Markup.Attr(html, "data-rask-on-submit");
+    using var doc = JsonDocument.Parse("{\"form\":{\"Name\":\"\",\"Age\":\"0\"}}");
+    await view.TryInvokeHandlerAsync(submitId!, doc.RootElement);
+
+    Assert.Equal(0, validCalled);
+    Assert.Equal(1, invalidCalled);
+}
+```
+
+For validation state, capture the form's `EditContext` with `ContextCapture` and assert on its
+messages / flags directly:
+
+```csharp
+var model = new SignupModel { Username = "ada" };
+var ctx = new EditContext(model);
+ctx.AddValidator(new RejectIfEqualsValidator("admin", "Already taken."));
+
+var view = new StubComponent(() => Form<SignupModel>(model, Context: ctx)[Input(() => model.Username)]);
+var html = view.RenderAsLiveRoot();
+
+using var inputDoc  = JsonDocument.Parse("{\"value\":\"admin\"}");
+await view.TryInvokeHandlerAsync(Markup.Attr(html, "data-rask-on-input")!,  inputDoc.RootElement);
+using var changeDoc = JsonDocument.Parse("{\"value\":\"admin\"}");
+await view.TryInvokeHandlerAsync(Markup.Attr(html, "data-rask-on-change")!, changeDoc.RootElement);
+
+var fid = new FieldIdentifier(model, "Username");
+Assert.Equal(new[] { "Already taken." }, ctx.GetValidationMessages(fid));
+```
+
+For **async** flows, drive validation across the await boundary with a gated validator: invoke the
+handler without awaiting it, assert `ctx.IsValidating(fid)` is `true` mid-flight, release the
+validator, then await the dispatch task and assert it flips back to `false`. You can also call
+`ctx.ValidateAsync()` directly to exercise the pipeline without going through submit.
+
+See `tests/Rask.Core.Tests/Forms/FormBindingTests.cs` and `AsyncFormBindingTests.cs` for the full
+set. See [forms.md](forms.md) for the framework-side validation semantics.
+
+### Page-level tests
+
+A page is just a component rendered through the app root with a routed `RouteState` and the services
+it needs, then asserted on the resulting HTML:
+
+```csharp
+var routeState = new RouteState { Path = "/" };
+var html = new App().RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+Assert.Contains("Hello, world!", html);
+```
+
+`tests/Rask.Example.Shared.Tests/Pages/` shows page tests for routing, lifecycle, forms, uploads, and
+more.
+
+---
+
+## 5. Build & test commands
+
+```bash
+dotnet build
+dotnet test                                                   # everything
+
+dotnet test --filter "FullyQualifiedName!~Rask.Examples.E2E"  # skip e2e (faster inner loop)
+dotnet test --filter FullyQualifiedName~ButtonTests           # one class
+```
+
+---
+
+## 6. When to reach for E2E
+
+Prefer a unit test. The Playwright E2E suite (`tests/Rask.Examples.E2E.Tests/`) is heavy — it spins
+up a real host and a browser — so reserve it for paths a unit test genuinely can't reach:
+
+- the actual JS transports (WebSocket dispatch on Server; JSImport/JSExport on WASM),
+- `rask.js` / `rask.wasm.js` client behaviour (DOM diff application, focus/IDL preservation on keyed
+  reorders, scoped-asset delivery),
+- real auth handshakes (cookie redeem, WS reconnect after sign-in),
+- anything depending on real browser layout (e.g. `Virtualize` scroll windowing).
+
+Everything else — rendering, attribute order, binding, validation, lifecycle ordering, event-handler
+dispatch — is faster and more reliable as a unit test.

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -871,8 +871,29 @@ public abstract class Component
                     return true;
                 }
                 default:
-                    handler.DynamicInvoke();
+                {
+                    // Delegate signatures outside the fast-path list above can still arrive through
+                    // the untyped `Delegate?` slots (Element.OnDragStart/OnDragOver/OnDrop/OnDragEnd),
+                    // e.g. a method group typed Func<Task<T>> or Func<ValueTask>. Invoke reflectively;
+                    // if the result is an awaitable, pump it through the render path so exceptions reach
+                    // the ErrorBoundary and post-await state changes re-render — matching the explicit
+                    // Func<…, Task> cases. Without this, a returned Task is fire-and-forget: a fault is
+                    // unobserved and post-await mutations never render.
+                    var result = handler.DynamicInvoke();
+                    var pending = result switch
+                    {
+                        Task t => t,
+                        ValueTask vt => vt.AsTask(),
+                        _ => null,
+                    };
+                    if (pending is not null)
+                    {
+                        await InvokeWithRenderingAsync(() => pending).ConfigureAwait(false);
+                        owner.Live.StateDirty = true;
+                    }
+
                     return true;
+                }
             }
         }
         catch (Exception ex) when (ex is not OperationCanceledException && ResolveHandlerBoundary(owner) is not null)
@@ -1058,9 +1079,44 @@ public abstract class Component
         // Swap: the dict we wrote into this frame becomes next frame's `previous`;
         // the now-stale previous becomes the pool that next frame will Clear and reuse.
         var snapshot = ctx.SnapshotEditContexts();
+        // Dispose EditContexts that were alive last frame but weren't re-resolved this frame —
+        // i.e. the form they back was unmounted. Their sticky-dismissal timers would otherwise
+        // fire once more after teardown (pinning the context + render handle for the sticky
+        // tail). Compare by instance, not key: a Form shares one EditContext across its root
+        // model plus every sub-model key, so a context is dead only when no surviving key still
+        // points at it. Guarded on Count so the common form-free page pays nothing.
+        DisposeUnmountedEditContexts(previousEditContexts, snapshot);
         Live.EditContextsPool = Live.PersistedEditContexts;
         Live.PersistedEditContexts = snapshot;
         return html;
+    }
+
+    // Disposes EditContexts present in `previous` (last frame's set) whose instance no longer
+    // appears in `current` (this frame's set) — the forms they back were unmounted. Compares by
+    // reference identity because one EditContext is shared across a Form's many model keys, so a
+    // context survives if ANY current key still references it. No-ops when there's nothing to do.
+    private static void DisposeUnmountedEditContexts(
+        Dictionary<LiveRenderContext.ObjectKey, EditContext> previous,
+        Dictionary<LiveRenderContext.ObjectKey, EditContext> current)
+    {
+        if (previous.Count == 0)
+        {
+            return;
+        }
+
+        var survivors = new HashSet<EditContext>(ReferenceEqualityComparer.Instance);
+        foreach (var ctx in current.Values)
+        {
+            survivors.Add(ctx);
+        }
+
+        foreach (var ctx in previous.Values)
+        {
+            if (!survivors.Contains(ctx))
+            {
+                ctx.Dispose();
+            }
+        }
     }
 
     // Page-shell tokens a root render must produce, paired with the factory that emits each.

--- a/src/Rask.Core/Forms/BindingHelpers.cs
+++ b/src/Rask.Core/Forms/BindingHelpers.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Reflection;
@@ -20,6 +21,12 @@ internal static class BindingHelpers
     // that NullabilityInfoContext reads off the PropertyInfo. Unknown (NRT disabled in the
     // model's compilation context) is treated as non-nullable, matching pre-NRT behavior.
     private static readonly NullabilityInfoContext _nullabilityCtx = new();
+
+    // Memoizes the (reference-type) nullable-annotation verdict per PropertyInfo. The verdict is a
+    // pure function of the stable PropertyInfo, and NullabilityInfoContext is both reflection-heavy
+    // and not thread-safe (hence the lock around Create). Caching keeps the lock off the steady-state
+    // bind path — it's only ever taken once per property, on the first empty-value bind to it.
+    private static readonly ConcurrentDictionary<PropertyInfo, bool> _refTypeNullableCache = new();
 
     public static EditContext? ResolveBindingContext(object model) =>
         EditContextScope.Current ?? LiveRenderContext.Current?.GetOrCreateEditContext(model);
@@ -295,12 +302,12 @@ internal static class BindingHelpers
             return false;
         }
 
-        NullabilityInfo info;
-        lock (_nullabilityCtx)
+        return _refTypeNullableCache.GetOrAdd(prop, static p =>
         {
-            info = _nullabilityCtx.Create(prop);
-        }
-
-        return info.WriteState == NullabilityState.Nullable;
+            lock (_nullabilityCtx)
+            {
+                return _nullabilityCtx.Create(p).WriteState == NullabilityState.Nullable;
+            }
+        });
     }
 }

--- a/src/Rask.Core/Forms/EditContext.cs
+++ b/src/Rask.Core/Forms/EditContext.cs
@@ -2,7 +2,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Rask.Core.Forms;
 
-public sealed class EditContext
+public sealed class EditContext : IDisposable
 {
     // Default sticky window for the ValidatingIndicator. After PendingCount
     // drops to 0, the field stays "validating" for this many milliseconds —
@@ -84,6 +84,35 @@ public sealed class EditContext
     ///     it just won't proactively re-render on its own.
     /// </summary>
     internal Action? RequestRender { get; set; }
+
+    // True once Dispose has released this context's per-field timers/CTS. Set by the live render
+    // when the backing form unmounts. Purely diagnostic — nothing gates behaviour on it, and a
+    // disposed context re-arms its resources cleanly if the same instance is re-mounted.
+    internal bool IsDisposed { get; private set; }
+
+    /// <summary>
+    ///     Releases the per-field background resources this context owns: the one-shot
+    ///     sticky-dismissal <see cref="System.Threading.Timer" />s and any in-flight
+    ///     async-validation <see cref="CancellationTokenSource" />. The live render calls
+    ///     this when the form backing the context is unmounted, so a sticky timer that
+    ///     would otherwise outlive the form (default 200&#160;ms tail) can neither fire a
+    ///     stale render nor pin the context graph alive. Nulling <see cref="RequestRender" />
+    ///     additionally makes any timer callback already in flight no-op its render request.
+    ///     Idempotent — <see cref="System.Threading.Timer" /> / <see cref="CancellationTokenSource" />
+    ///     disposal is safe to repeat.
+    /// </summary>
+    public void Dispose()
+    {
+        IsDisposed = true;
+        RequestRender = null;
+        foreach (var s in _states.Values)
+        {
+            s.StickyTimer?.Dispose();
+            s.StickyTimer = null;
+            s.Cts?.Dispose();
+            s.Cts = null;
+        }
+    }
 
     public void AddValidator(IFieldValidator validator)
     {
@@ -390,6 +419,13 @@ public sealed class EditContext
         var state = GetOrCreate(field);
 
         // Latest-wins: cancel any prior in-flight run for this field.
+        // Note on the CTS lifecycle (looks racy, isn't): the live transports serialize handler
+        // execution end to end — the Server WS dispatcher and the WASM session each hold their
+        // lock across the whole awaited handler (which is where validation runs), so two
+        // ValidateFieldAsync calls for the same field never overlap. By the time a later call
+        // reaches here, the earlier one has already nulled state.Cts (sync + finally paths), so
+        // these Cancel/Dispose calls only ever touch a still-owned CTS — no double-dispose, no
+        // ObjectDisposedException. Keep validation off background threads to preserve this.
         state.Cts?.Cancel();
         state.Cts?.Dispose();
         var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 
 namespace Rask.Core.Live;
 
@@ -929,6 +930,10 @@ public static class FrameDiffer
                 }
             }
 
+            // len > 0 (guarded above) and every iteration sets tails[lo] with lo <= tailsLen,
+            // bumping tailsLen on the first extension — so tailsLen is now >= 1 and the
+            // back-walk start index is in range.
+            Debug.Assert(tailsLen >= 1, "LIS tails must be non-empty for non-empty input");
             var cur = tails[tailsLen - 1];
             while (cur >= 0)
             {

--- a/src/Rask.Core/Routing/Navigator.cs
+++ b/src/Rask.Core/Routing/Navigator.cs
@@ -2,12 +2,37 @@ using Microsoft.Extensions.Primitives;
 
 namespace Rask.Core.Routing;
 
+/// <summary>
+///     Imperative client-side navigation and query-string mutation, plus file downloads.
+///     Inject it through a component constructor (<c>public MyPage(Navigator nav)</c>) and call
+///     it from <b>event handlers only</b>.
+///     <para>
+///         Every method throws <see cref="InvalidOperationException" /> if called outside an event
+///         handler — e.g. during <c>Render()</c> or the initial GET. Navigation that needs to happen
+///         on load belongs in a lifecycle hook that runs a handler-equivalent path, or should be
+///         expressed as a route/redirect, not driven from render.
+///     </para>
+///     <para>
+///         Changes are applied to the shared <see cref="RouteState" /> and the resulting URL is
+///         pushed (or replaced) into browser history by the live runtime after the handler returns.
+///     </para>
+/// </summary>
 public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink = null)
 {
     private bool _dirty;
     private bool _inHandler;
     private bool _replace;
 
+    /// <summary>
+    ///     Navigates to <paramref name="url" /> (path + query together). Pass a type-safe
+    ///     <see cref="RouteUrl" /> from a generated <c>Routes.Page(...)</c> formatter.
+    /// </summary>
+    /// <param name="url">Target path and query string.</param>
+    /// <param name="replace">
+    ///     <c>true</c> replaces the current history entry instead of pushing a new one (no extra
+    ///     Back-button stop).
+    /// </param>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void Navigate(RouteUrl url, bool replace = false)
     {
         EnsureInHandler();
@@ -19,6 +44,13 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>
+    ///     Navigates to <paramref name="path" />, <b>clearing any existing query string</b>. Use
+    ///     <see cref="SetQuery(string, string?)" /> afterwards, or the query overload, to keep params.
+    /// </summary>
+    /// <param name="path">Target path (e.g. <c>"/users/42"</c>).</param>
+    /// <param name="replace"><c>true</c> replaces the current history entry instead of pushing.</param>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void Navigate(string path, bool replace = false)
     {
         EnsureInHandler();
@@ -29,6 +61,15 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>
+    ///     Navigates to <paramref name="path" /> and <b>replaces</b> the query string with
+    ///     <paramref name="query" /> in one step. Entries with a <c>null</c> value are dropped;
+    ///     repeated keys are concatenated into a multi-value param.
+    /// </summary>
+    /// <param name="path">Target path.</param>
+    /// <param name="query">The complete new query string as key/value pairs.</param>
+    /// <param name="replace"><c>true</c> replaces the current history entry instead of pushing.</param>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void Navigate(string path, IEnumerable<KeyValuePair<string, string?>> query, bool replace = false)
     {
         EnsureInHandler();
@@ -40,6 +81,14 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>
+    ///     Sets or updates a single query parameter on the <b>current</b> path (the path is left
+    ///     unchanged). A <c>null</c> <paramref name="value" /> removes the key — equivalent to
+    ///     <see cref="RemoveQuery" />.
+    /// </summary>
+    /// <param name="key">Query parameter name (case-insensitive).</param>
+    /// <param name="value">New value, or <c>null</c> to remove the parameter.</param>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void SetQuery(string key, string? value)
     {
         EnsureInHandler();
@@ -58,6 +107,12 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>
+    ///     Sets or updates several query parameters on the current path in one update. Pairs with a
+    ///     <c>null</c> value remove that key; all other params are preserved.
+    /// </summary>
+    /// <param name="values">Parameters to set or remove.</param>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void SetQuery(params KeyValuePair<string, string?>[] values)
     {
         EnsureInHandler();
@@ -79,6 +134,9 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>Removes a single query parameter from the current path. Missing keys are a no-op.</summary>
+    /// <param name="key">Query parameter name (case-insensitive).</param>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void RemoveQuery(string key)
     {
         EnsureInHandler();
@@ -89,6 +147,8 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>Removes all query parameters from the current path, keeping the path.</summary>
+    /// <exception cref="InvalidOperationException">Called outside an event handler.</exception>
     public void ClearQuery()
     {
         EnsureInHandler();
@@ -96,6 +156,17 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         _dirty = true;
     }
 
+    /// <summary>
+    ///     Pushes a file to the browser as a download, from an in-memory byte array. Delivered over
+    ///     the live channel by the host's <see cref="IDownloadSink" /> (registered by
+    ///     <c>AddRask()</c> on the server and by the WASM host builder).
+    /// </summary>
+    /// <param name="filename">Suggested file name shown in the browser's save dialog.</param>
+    /// <param name="bytes">File contents.</param>
+    /// <param name="contentType">MIME type; defaults to <c>application/octet-stream</c> when null.</param>
+    /// <exception cref="InvalidOperationException">
+    ///     Called outside an event handler, or no <see cref="IDownloadSink" /> is registered.
+    /// </exception>
     public void Download(string filename, byte[] bytes, string? contentType = null)
     {
         EnsureInHandler();
@@ -104,6 +175,16 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         ResolveSink().Stage(filename, bytes, contentType);
     }
 
+    /// <summary>
+    ///     Pushes a file to the browser as a download, streaming from <paramref name="stream" />
+    ///     (the sink reads and disposes it). Prefer this overload for large payloads.
+    /// </summary>
+    /// <param name="filename">Suggested file name shown in the browser's save dialog.</param>
+    /// <param name="stream">Readable stream of file contents.</param>
+    /// <param name="contentType">MIME type; defaults to <c>application/octet-stream</c> when null.</param>
+    /// <exception cref="InvalidOperationException">
+    ///     Called outside an event handler, or no <see cref="IDownloadSink" /> is registered.
+    /// </exception>
     public void Download(string filename, Stream stream, string? contentType = null)
     {
         EnsureInHandler();

--- a/src/Rask.Core/Routing/Navigator.cs
+++ b/src/Rask.Core/Routing/Navigator.cs
@@ -232,8 +232,10 @@ public sealed class Navigator(RouteState routeState, IDownloadSink? downloadSink
         if (!_inHandler)
         {
             throw new InvalidOperationException(
-                "Navigator can only be used from event handlers. " +
-                "Calling it during component Render() or initial GET is not supported.");
+                "Navigator can only be used from event handlers (e.g. Button(OnClick: ...)). " +
+                "It cannot run during component Render() or the initial GET. To navigate on load, " +
+                "express it as a route/redirect or drive it from a lifecycle hook; to redirect an " +
+                "unauthenticated user, use [Authorize]. See docs/routing.md.");
         }
     }
 

--- a/src/Rask.Core/Routing/RouteState.cs
+++ b/src/Rask.Core/Routing/RouteState.cs
@@ -1,10 +1,27 @@
 namespace Rask.Core.Routing;
 
+/// <summary>
+///     The current location — path plus query string — for the live session, shared by the
+///     <see cref="Router" />, <see cref="Navigator" />, and any component that injects it. Scoped
+///     per session/circuit. Inject it (<c>public MyPage(RouteState route)</c>) to read the live
+///     URL; mutate it through <see cref="Navigator" /> rather than by setting these properties
+///     directly so browser history stays in sync.
+///     <para>
+///         Setting <see cref="Path" /> or <see cref="Query" /> raises <see cref="Changed" /> only
+///         when the value actually differs, which is what drives the router to re-match. Components
+///         that render off the URL outside the routed page subtree should subscribe to
+///         <see cref="Changed" /> in <c>OnMount</c> and unsubscribe in <c>OnUnmount</c>.
+///     </para>
+/// </summary>
 public sealed class RouteState
 {
     private string _path = "/";
     private IQueryCollection _query = QueryCollection.Empty;
 
+    /// <summary>
+    ///     The current path (no query string), always starting with <c>/</c>. Defaults to <c>"/"</c>.
+    ///     Setting a new value raises <see cref="Changed" />.
+    /// </summary>
     public string Path
     {
         get => _path;
@@ -20,6 +37,11 @@ public sealed class RouteState
         }
     }
 
+    /// <summary>
+    ///     The current parsed query string. Defaults to an empty collection. Setting a new instance
+    ///     raises <see cref="Changed" /> (compared by reference, so reuse the same instance for a
+    ///     no-op).
+    /// </summary>
     public IQueryCollection Query
     {
         get => _query;
@@ -35,5 +57,10 @@ public sealed class RouteState
         }
     }
 
+    /// <summary>
+    ///     Raised whenever <see cref="Path" /> or <see cref="Query" /> changes. Subscribe in
+    ///     <c>OnMount</c> and unsubscribe in <c>OnUnmount</c>. Components inside the routed page
+    ///     subtree usually don't need this — the router re-renders them on navigation.
+    /// </summary>
     public event Action? Changed;
 }

--- a/src/Rask.Generators/Analyzers/ComponentConstructionAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/ComponentConstructionAnalyzer.cs
@@ -19,7 +19,8 @@ public sealed class ComponentConstructionAnalyzer : DiagnosticAnalyzer
         "Do not instantiate '{0}' with 'new'; use the generated {1}Components.{0}(...) factory instead",
         "Usage",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK014"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rask014);

--- a/src/Rask.Generators/Analyzers/HeadChildrenAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/HeadChildrenAnalyzer.cs
@@ -26,10 +26,11 @@ public sealed class HeadChildrenAnalyzer : DiagnosticAnalyzer
     private static readonly DiagnosticDescriptor Rask019 = new(
         "RASK019",
         "<head> is a framework-managed slot — declare contents via Component.Head",
-        "Do not pass children to '<head>'; declare head content by overriding the 'Component? Head' property on any component instead. The framework collects, dedupes, and splices contributions automatically.",
+        "Do not pass children to '<head>'; declare head content by overriding the 'RenderResult Head' property on any component instead. The framework collects, dedupes, and splices contributions automatically.",
         "Usage",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK019"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rask019);

--- a/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
@@ -36,7 +36,8 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         "Elements/components produced in a .Select(...) projection or added to a Child collection in "
         + "a loop should carry a stable Key (Blazor @key parity). Without it, insert/remove/reorder "
         + "falls back to a positional full-HTML morph and loses DOM identity (focus, input state) on "
-        + "surviving nodes.");
+        + "surviving nodes.",
+        helpLinkUri: DiagnosticHelp.Link("RASK022"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rask022);

--- a/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
@@ -47,7 +47,8 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
         "The Rask root component '{0}' does not render a complete page shell; missing: {1}. A root Render() should produce Doctype(), Html(...)[Head(), Body()[...]].",
         "Usage",
         DiagnosticSeverity.Warning,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK021"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rask021);

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -28,7 +28,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         "Property '{0}.{1}' is treated as a required factory parameter; consider also marking it 'required' for language-level enforcement",
         "Rask.Generators",
         DiagnosticSeverity.Hidden,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK001"));
 
     private static readonly DiagnosticDescriptor Rask002 = new(
         "RASK002",
@@ -36,7 +37,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         "Property '{0}.{1}' is marked 'required', but '{0}' has dependency-injected constructor parameters; the generated factory cannot honor 'required' through ActivatorUtilities.CreateInstance. Remove 'required' or remove DI parameters.",
         "Rask.Generators",
         DiagnosticSeverity.Warning,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK002"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {

--- a/src/Rask.Generators/ComponentScopedCssGenerator.cs
+++ b/src/Rask.Generators/ComponentScopedCssGenerator.cs
@@ -28,7 +28,8 @@ public sealed class ComponentScopedCssGenerator : IIncrementalGenerator
         "Scoped-CSS file '{0}' has no matching component class. Expected a Component subclass named '{1}' in the same folder.",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK015"));
 
     private static readonly DiagnosticDescriptor Rask016 = new(
         "RASK016",
@@ -36,7 +37,8 @@ public sealed class ComponentScopedCssGenerator : IIncrementalGenerator
         "Scoped-CSS file '{0}' matches multiple component classes named '{1}': {2}. Move one to disambiguate.",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK016"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {

--- a/src/Rask.Generators/ComponentScopedJsGenerator.cs
+++ b/src/Rask.Generators/ComponentScopedJsGenerator.cs
@@ -29,7 +29,8 @@ public sealed class ComponentScopedJsGenerator : IIncrementalGenerator
         "Scoped-JS file '{0}' has no matching component class. Expected a Component subclass named '{1}' in the same folder.",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK017"));
 
     private static readonly DiagnosticDescriptor Rask018 = new(
         "RASK018",
@@ -37,7 +38,8 @@ public sealed class ComponentScopedJsGenerator : IIncrementalGenerator
         "Scoped-JS file '{0}' matches multiple component classes named '{1}': {2}. Move one to disambiguate.",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK018"));
 
     private static readonly DiagnosticDescriptor Rask020 = new(
         "RASK020",
@@ -45,7 +47,8 @@ public sealed class ComponentScopedJsGenerator : IIncrementalGenerator
         "Two or more components with scoped JS share the simple type name '{0}': {1}. The browser-side namespace key window.Rask[\"{0}\"] is shared by all of them and the last registration silently wins. Rename one, move it to a differently-named sibling, or expose your exports under a sub-namespace inside the JS file. Promote to error in csproj with <WarningsAsErrors>RASK020</WarningsAsErrors>.",
         "Rask.Generators",
         DiagnosticSeverity.Warning,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK020"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {

--- a/src/Rask.Generators/DiagnosticHelp.cs
+++ b/src/Rask.Generators/DiagnosticHelp.cs
@@ -1,0 +1,12 @@
+namespace Rask.Generators;
+
+// Builds the help-link URI an IDE opens when you click a Rask diagnostic id (RASKxxx). Points at
+// the per-diagnostic anchor in the docs, so every error/warning links straight to its cause + fix.
+// Single source of truth for the docs base URL across all generators/analyzers.
+internal static class DiagnosticHelp
+{
+    private const string DocBase = "https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md";
+
+    // GitHub lowercases heading anchors, and the docs use "## RASKxxx" headings → "#raskxxx".
+    public static string Link(string id) => $"{DocBase}#{id.ToLowerInvariant()}";
+}

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -31,7 +31,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Route template '{0}' on '{1}' is malformed: {2}",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK003"));
 
     private static readonly DiagnosticDescriptor Rask004 = new(
         "RASK004",
@@ -39,7 +40,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Route segment '{{{0}}}' on '{1}' has no matching public settable property",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK004"));
 
     private static readonly DiagnosticDescriptor Rask005 = new(
         "RASK005",
@@ -47,7 +49,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' has type '{2}', incompatible with route constraint '{3}'",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK005"));
 
     private static readonly DiagnosticDescriptor Rask006 = new(
         "RASK006",
@@ -55,7 +58,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' has [QueryParam] but is also bound by path segment '{{{2}}}'",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK006"));
 
     private static readonly DiagnosticDescriptor Rask007 = new(
         "RASK007",
@@ -63,7 +67,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "[ParentRoute] forms a cycle starting at '{0}'",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK007"));
 
     private static readonly DiagnosticDescriptor Rask008 = new(
         "RASK008",
@@ -71,7 +76,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' has [RouteParam] but no path segment matches '{2}'",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK008"));
 
     private static readonly DiagnosticDescriptor Rask009 = new(
         "RASK009",
@@ -79,7 +85,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' has [RouteParam] but '{0}' is not a valid route target ({2})",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK009"));
 
     private static readonly DiagnosticDescriptor Rask010 = new(
         "RASK010",
@@ -87,7 +94,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' has [QueryParam] but '{0}' is not a valid route target ({2})",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK010"));
 
     private static readonly DiagnosticDescriptor Rask011 = new(
         "RASK011",
@@ -95,7 +103,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' of type '{2}' must be 'string' or implement 'System.IParsable<{2}>' to be bound by [RouteParam]/[QueryParam]",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK011"));
 
     private static readonly DiagnosticDescriptor Rask012 = new(
         "RASK012",
@@ -103,7 +112,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Multiple [NotFound] components found in this assembly; only one is allowed ('{0}' is a duplicate)",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK012"));
 
     private static readonly DiagnosticDescriptor Rask013 = new(
         "RASK013",
@@ -111,7 +121,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Class '{0}' has both [NotFound] and [Route]; remove [Route] (NotFound is the catch-all)",
         "Rask.Generators",
         DiagnosticSeverity.Error,
-        true);
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK013"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {

--- a/tests/Rask.Core.Tests/Components/VirtualizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/VirtualizeTests.cs
@@ -308,4 +308,60 @@ public class VirtualizeTests
         var html = view.RenderAsLiveRoot();
         Assert.DoesNotContain("loaded", html);
     }
+
+    [Fact]
+    public void ItemsProvider_ProviderThrows_IsSwallowed_RenderSucceeds()
+    {
+        // FetchAsync wraps the provider call in try/catch(Exception): a throwing provider must be
+        // logged and dropped, never surfaced out of render. The window stays empty (count unknown).
+        VirtualizationContext<int>? captured = null;
+        var view = new StubComponent(() => Virtualize<int>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            ItemsProvider: _ => throw new InvalidOperationException("provider boom"),
+            ItemSize: 20,
+            InitialClientHeight: 100));
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.NotNull(html);
+        Assert.Equal(0, captured!.TotalCount);
+        Assert.Empty(captured.VisibleItems);
+    }
+
+    [Fact]
+    public void Items_NonIListEnumerable_WindowsViaStreamingPath()
+    {
+        // A lazy iterator is neither IList nor ICollection, so CountItems and FillFromItems both
+        // take their streaming foreach branches rather than the indexed fast paths.
+        IEnumerable<int> Lazy()
+        {
+            for (var i = 0; i < 100; i++)
+            {
+                yield return i;
+            }
+        }
+
+        VirtualizationContext<int>? captured = null;
+        var view = new StubComponent(() => Virtualize(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Lazy(),
+            ItemSize: 20,
+            OverscanCount: 0,
+            InitialClientHeight: 100));
+
+        view.RenderAsLiveRoot();
+
+        Assert.NotNull(captured);
+        Assert.Equal(100, captured!.TotalCount);
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, captured.VisibleItems.Select(v => v.Index));
+        Assert.Equal(new[] { 0, 1, 2, 3, 4 }, captured.VisibleItems.Select(v => v.Value));
+    }
 }

--- a/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
+++ b/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
@@ -1,0 +1,91 @@
+using Rask.Core.Forms;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Forms;
+
+// Covers EditContext disposal on form unmount. A field's sticky-dismissal timer (default 200ms
+// tail after async validation) is a one-shot Timer that would otherwise fire once after the form
+// is torn down — pinning the context + render handle and possibly requesting a stale render. The
+// live render now disposes EditContexts that don't survive a root re-render.
+public class EditContextDisposalTests
+{
+    [Fact]
+    public void FormUnmount_DisposesEditContext()
+    {
+        var model = new Model { Name = "ada" };
+        var ctx = new EditContext(model);
+        var show = true;
+
+        var view = new StubComponent(() => show
+            ? Form<Model>(model, Context: ctx)[Input(() => model.Name)]
+            : Div()[Text("gone")]);
+
+        view.RenderAsLiveRoot();
+        Assert.False(ctx.IsDisposed);
+
+        show = false;
+        view.RenderAsLiveRoot();      // form unmounted → ctx not re-resolved this frame
+        Assert.True(ctx.IsDisposed);
+    }
+
+    [Fact]
+    public void SurvivingForm_AcrossReRender_IsNotDisposed()
+    {
+        var model = new Model { Name = "ada" };
+        var ctx = new EditContext(model);
+        var view = new StubComponent(() => Form<Model>(model, Context: ctx)[Input(() => model.Name)]);
+
+        view.RenderAsLiveRoot();
+        view.RenderAsLiveRoot();
+
+        Assert.False(ctx.IsDisposed);
+    }
+
+    [Fact]
+    public async Task Dispose_CancelsPendingStickyTimer()
+    {
+        var model = new Model { Name = "ada" };
+        var ctx = new EditContext(model) { ValidatingStickyMs = 100 };
+        var renderRequests = 0;
+        ctx.RequestRender = () => Interlocked.Increment(ref renderRequests);
+        ctx.AddValidator(new NoOpAsyncValidator());
+
+        // Completes immediately but takes the async path (an async validator is registered),
+        // so the finally arms the 100ms sticky timer.
+        await ctx.ValidateFieldAsync(new FieldIdentifier(model, "Name"));
+
+        ctx.Dispose();                // must dispose the armed timer before it fires
+        await Task.Delay(250);        // well past the sticky window
+
+        Assert.Equal(0, renderRequests);
+        Assert.True(ctx.IsDisposed);
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent_AndClearsRequestRender()
+    {
+        var ctx = new EditContext(new Model());
+        ctx.RequestRender = () => { };
+
+        ctx.Dispose();
+        Assert.True(ctx.IsDisposed);
+        Assert.Null(ctx.RequestRender);
+
+        ctx.Dispose();                // second dispose must not throw
+        Assert.True(ctx.IsDisposed);
+    }
+
+    private sealed class Model
+    {
+        public string Name { get; set; } = "";
+    }
+
+    private sealed class NoOpAsyncValidator : IAsyncFieldValidator
+    {
+        public ValueTask ValidateAsync(EditContext context, CancellationToken cancellationToken) => default;
+
+        public ValueTask ValidateFieldAsync(EditContext context, FieldIdentifier field,
+            CancellationToken cancellationToken) => default;
+    }
+}

--- a/tests/Rask.Core.Tests/Live/DefaultHandlerAsyncTests.cs
+++ b/tests/Rask.Core.Tests/Live/DefaultHandlerAsyncTests.cs
@@ -1,0 +1,84 @@
+using Rask.Core.Live;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+// Covers the handler-dispatch switch `default:` arm in Component.TryInvokeHandlerAsync — the path
+// taken by a delegate whose signature isn't in the fast-path list (realistically a drag handler
+// assigned through the untyped Element.OnDrag* `Delegate?` slot, e.g. a method group typed
+// Func<Task<T>>). The arm must await a returned awaitable so faults route to the ErrorBoundary
+// and post-await state changes still render — not fire-and-forget it.
+public class DefaultHandlerAsyncTests
+{
+    [Fact]
+    public async Task UnmatchedAsyncSignature_IsAwaited_BeforeDispatchReturns()
+    {
+        var sp = RenderHarness.EmptyServices();
+        var owner = new UnmatchedAsyncOwner(throws: false);
+
+        using var ctx = LiveRenderContext.Begin(owner, sp);
+        _ = owner.ToHtml();
+
+        var handlerId = owner.RegisteredHandlerId
+                        ?? throw new InvalidOperationException("handler never registered");
+
+        await owner.TryInvokeHandlerAsync(handlerId, default);
+
+        // The continuation after `await Task.Yield()` only runs if the dispatcher awaited the
+        // returned Task. Fire-and-forget would let TryInvokeHandlerAsync return first, leaving
+        // this false.
+        Assert.True(owner.ContinuationRan, "dispatcher must await the returned Task");
+    }
+
+    [Fact]
+    public async Task UnmatchedAsyncSignature_Throw_TripsAncestorBoundary()
+    {
+        var sp = RenderHarness.EmptyServices();
+        var owner = new UnmatchedAsyncOwner(throws: true);
+        var boundary = ErrorBoundary();
+        boundary.SetProps(new Child[] { owner }, null);
+
+        using var ctx = LiveRenderContext.Begin(boundary, sp);
+        _ = boundary.ToHtml();
+
+        var handlerId = owner.RegisteredHandlerId
+                        ?? throw new InvalidOperationException("handler never registered");
+
+        var invoked = await boundary.TryInvokeHandlerAsync(handlerId, default);
+
+        Assert.True(invoked);
+        Assert.NotNull(boundary.Error);
+        Assert.Equal("default-async", boundary.Error!.Message);
+    }
+
+    private sealed class UnmatchedAsyncOwner : Component
+    {
+        private readonly bool _throws;
+
+        public UnmatchedAsyncOwner(bool throws) => _throws = throws;
+        public string? RegisteredHandlerId { get; private set; }
+        public bool ContinuationRan { get; private set; }
+
+        protected override RenderResult Render()
+        {
+            var live = LiveRenderContext.Current!;
+            // Func<Task<bool>> is NOT in the dispatch fast-path (only Func<Task> is), so it lands
+            // on the `default:` arm — the realistic shape of a drag handler bound via Delegate?.
+            Func<Task<bool>> handler = async () =>
+            {
+                await Task.Yield();
+                if (_throws)
+                {
+                    throw new InvalidOperationException("default-async");
+                }
+
+                ContinuationRan = true;
+                return true;
+            };
+
+            RegisteredHandlerId = live.RegisterHandler(handler);
+            return Span()[Text("owner")];
+        }
+    }
+}

--- a/tests/Rask.Generators.Tests/TemplateConfigTests.cs
+++ b/tests/Rask.Generators.Tests/TemplateConfigTests.cs
@@ -1,0 +1,102 @@
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+
+namespace Rask.Generators.Tests;
+
+// Guards the `dotnet new` template configs (src/Rask.Templates/content/*). These aren't compiled,
+// so a renamed symbol, a broken template.json, or a dropped Auth exclusion would otherwise only be
+// caught by a human running `dotnet new`. These checks are fast and need no pack/restore — they
+// validate the metadata, not a generated build.
+public class TemplateConfigTests
+{
+    private static readonly string TemplatesRoot =
+        Path.Combine(RepoRoot(), "src", "Rask.Templates", "content");
+
+    public static IEnumerable<object[]> Templates =>
+    [
+        ["rask-server", "Company.RaskServer"],
+        ["rask-wasm", "Company.RaskWasm"],
+        ["rask-wasm-hosted", "Company.RaskWasmHosted"],
+    ];
+
+    [Theory]
+    [MemberData(nameof(Templates))]
+    public void TemplateJson_IsValid_WithExpectedIdentity(string shortName, string sourceName)
+    {
+        var dir = Path.Combine(TemplatesRoot, shortName);
+        Assert.True(Directory.Exists(dir), $"template directory missing: {dir}");
+
+        using var doc = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(dir, ".template.config", "template.json")));
+        var root = doc.RootElement;
+
+        var shortNames = root.GetProperty("shortName").EnumerateArray().Select(e => e.GetString());
+        Assert.Contains(shortName, shortNames);
+        Assert.Equal(sourceName, root.GetProperty("sourceName").GetString());
+        Assert.Equal("project", root.GetProperty("tags").GetProperty("type").GetString());
+    }
+
+    [Theory]
+    [MemberData(nameof(Templates))]
+    public void AuthSymbol_IsBoolean_DefaultsFalse(string shortName, string _)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(TemplatesRoot, shortName, ".template.config", "template.json")));
+
+        var auth = doc.RootElement.GetProperty("symbols").GetProperty("auth");
+        Assert.Equal("parameter", auth.GetProperty("type").GetString());
+        Assert.Equal("bool", auth.GetProperty("datatype").GetString());
+        Assert.Equal("false", auth.GetProperty("defaultValue").GetString());
+    }
+
+    [Theory]
+    [MemberData(nameof(Templates))]
+    public void Sources_ExcludeAuthFolder_WhenAuthOff(string shortName, string _)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(TemplatesRoot, shortName, ".template.config", "template.json")));
+
+        var modifiers = doc.RootElement.GetProperty("sources")
+            .EnumerateArray()
+            .SelectMany(s => s.GetProperty("modifiers").EnumerateArray());
+
+        var authExclusion = modifiers.FirstOrDefault(m =>
+            m.TryGetProperty("condition", out var c) && c.GetString() == "(!auth)");
+
+        Assert.True(authExclusion.ValueKind == JsonValueKind.Object,
+            "expected a (!auth) source modifier");
+        var excludes = authExclusion.GetProperty("exclude").EnumerateArray().Select(e => e.GetString());
+        Assert.Contains(excludes, e => e!.Contains("Auth", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [MemberData(nameof(Templates))]
+    public void AuthScaffolding_Exists_AndProgramHasAuthConditionals(string shortName, string _)
+    {
+        var dir = Path.Combine(TemplatesRoot, shortName);
+
+        // The Auth/** sources excluded by (!auth) must actually be present.
+        Assert.NotEmpty(Directory.GetDirectories(dir, "Auth", SearchOption.AllDirectories));
+
+        // Program.cs wires auth behind //#if (auth) blocks that the engine strips when auth is off.
+        var hasAuthConditional = Directory
+            .GetFiles(dir, "Program.cs", SearchOption.AllDirectories)
+            .Any(f => File.ReadAllText(f).Contains("#if (auth)", StringComparison.Ordinal));
+        Assert.True(hasAuthConditional, $"{shortName}: no Program.cs with a //#if (auth) block");
+    }
+
+    // Walks up from the test assembly to the repo root (the directory holding Rask.slnx) so the
+    // tests find the template sources regardless of the bin/ depth they run from.
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException(
+            "Could not locate repo root (Rask.slnx) from " + AppContext.BaseDirectory);
+    }
+}


### PR DESCRIPTION
A broad review sweep across four areas. A skeptical verification pass came first: of six flagged bug candidates, **three were false positives** (the two "critical" `EditContext` CTS races are guarded by strict handler serialization; the head-asset offset is guarded by `ApplyTo` short-circuiting), so only the three real ones were fixed.

Split into four phase commits for review.

## Phase 1 — Bug fixes (verified only)
- **Async-handler drop** — the handler-dispatch `default:` arm fire-and-forgot a returned awaitable. A drag handler bound via Element's untyped `Delegate?` slot with an unmatched async signature (e.g. `Func<Task<T>>`) lost its faults and skipped the post-await re-render. Now awaited through the render pump, so exceptions reach the `ErrorBoundary`.
- **`EditContext` sticky-timer leak** — `EditContext` is now `IDisposable`; the live render disposes contexts that don't survive a root re-render (compared by instance, since a `Form` shares one context across model keys). Stops a field's one-shot sticky-dismissal timer firing after the form unmounts.
- **Nullability lock** — `BindingHelpers` memoizes the per-`PropertyInfo` nullable-annotation verdict, taking `NullabilityInfoContext`'s process-wide lock off the steady-state bind path.
- Clarifying comment on the (refuted) CTS path + a LIS invariant `Debug.Assert`.

## Phase 2 — Documentation
New `docs/` guides grounded in real source/samples: getting-started, routing, forms, lifecycle, testing, migration-from-blazor, a **diagnostics index (RASK001–022)**, and `architecture/live-rendering.md`, plus a `docs/` index and README links. Added XML docs to the previously undocumented public API (`Navigator`, `RouteState`). Caught and fixed a stale API along the way — `Head` is `RenderResult Head => default`, not `Component? Head`.

## Phase 3 — End-user DX
- `helpLinkUri` on **all 22 diagnostics** → each IDE error/warning links to its fix in `docs/diagnostics.md` (via a shared `DiagnosticHelp` helper).
- Fixed RASK019's stale message wording.
- `Navigator`'s event-handler-only exception is now actionable (names the constraint + on-load alternatives + doc pointer).

## Phase 4 — Test coverage
Virtualize and drag-drop turned out to be well-covered already; filled the genuine gaps: Virtualize throwing-provider + non-IList streaming paths, and `dotnet new` template-config validation (identity, `auth` symbol, `(!auth)` Auth exclusion, `//#if (auth)` blocks) — previously untested.

## Verification
All suites green, no regressions: Core 1446 (+1 skip), Generators 148, Server 159, Shared 237, Wasm/Hosting/Validation pass, **E2E 483**. Build clean apart from pre-existing, documented RASK022 warnings in benchmarks (which intentionally mirror keyless behavior for fair Blazor comparison).