### PR TITLE
Code review sweep: async upload fix, docs, examples, UI polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to Rask are documented here. The format is based on
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versions are stamped at pack
+time (`$(PackageVersion)`); this log groups changes by the pull request that introduced
+them until tagged releases begin.
+
+## [Unreleased]
+
+### Fixed
+- `SessionUploadStore` no longer blocks a thread-pool thread with sync-over-async
+  (`.GetAwaiter().GetResult()`) while staging an upload — the copy is now awaited.
+
+### Documentation
+- New [Composition](docs/composition.md) guide: children & fragments, callbacks, context,
+  `Virtualize`, drag-and-drop.
+- New [JS interop](docs/js-interop.md) guide: scoped CSS/JS, `IJSRuntime`, element refs,
+  asset delivery.
+- XML `<summary>` docs on the public host entry points (`AddRask`, `UseRask`,
+  `WasmHostBuilder` / `RunAsync`).
+- Added `CONTRIBUTING.md` and this changelog.
+- Per-sample and per-template `README.md` files; clearer `--auth` template descriptions.
+
+### Changed
+- Showcase sample: the home page is now a grouped feature index, with light UI polish.
+
+---
+
+## Earlier history
+
+Condensed from the commit log; see GitHub PRs for detail.
+
+### Authentication & security
+- Production authentication: `Authorize` component, route guards, cookie & JWT for Server
+  and WASM, runnable samples, templates and the [authentication guide](docs/authentication.md) (#33).
+- Hardened the live session: `returnUrl` handling, WebSocket origin checks, reconnect race
+  fix, and a concurrent-session cap (#34).
+
+### Components & DX
+- Replaced the `Callback` type with automatic generator-managed parent re-render (#31),
+  building on Context, element refs, form groups, and user-gating (#30).
+- Added a headless drag-and-drop primitive (#26) and typed SVG components with a showcase (#16).
+- Made non-nullable value-type factory parameters required (#25).
+- First-class `Component.Key` with auto-forward and the RASK022 missing-key warning (#7).
+- Emit `[DebuggerStepThrough]` + a `<see cref>` breadcrumb on generated factories (#35).
+
+### Live runtime & diff codec
+- `PermutationBatch` diff op to close the keyed-reorder byte soft spot (#20).
+- Pooled the keyed-diff scratch so `FrameDiffer` is allocation-free per session (#17).
+- Ship a `<head>` fragment / history-only diff on head- or query-only navigations.
+
+### Infrastructure
+- Restructured to `src` / `tests` / `samples` / `benchmarks` with `.slnx` and Central
+  Package Management (#14).
+- Consolidated shared test helpers into `Rask.TestSupport` (#4).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to Rask
+
+Thanks for your interest in Rask — a C# component framework (Blazor-like) with a Roslyn
+factory generator, scoped CSS/JS, routing, and a live diff runtime over WebSockets
+(Server) or `JSImport`/`JSExport` (WASM).
+
+## Prerequisites
+
+- .NET 10 SDK (`net10.0`; `net10.0-browser` for the WASM projects).
+- For the E2E suite: Playwright browsers (`pwsh tests/Rask.Examples.E2E.Tests/bin/.../playwright.ps1 install`).
+
+## Build & test loop
+
+```bash
+dotnet build
+dotnet test
+
+# Faster inner loop — skip the heavy Playwright E2E suite:
+dotnet test --filter "FullyQualifiedName!~Rask.Examples.E2E"
+
+# A single class:
+dotnet test --filter FullyQualifiedName~SessionUploadStoreTests
+
+# Run a sample app:
+dotnet run --project samples/Rask.Example.Server
+dotnet run --project samples/Rask.Example.Wasm.Host
+```
+
+The WASM trimming path is load-bearing: `samples/Rask.Example.Wasm` must
+`dotnet publish -c Release` with **zero IL trim warnings**. Any new reflection there needs
+a `[DynamicallyAccessedMembers]` annotation or a justified `[UnconditionalSuppressMessage]`.
+
+## Testing expectations
+
+- **Unit-test first.** Every bug fix and new feature gets a unit test; reach for E2E only
+  when a unit test genuinely can't reach the path (the Playwright suite is heavy).
+- New tests mirror the layout and style of the sibling `+ Tests` project.
+- `Highlight_DeepLinkToCodeSamplePage_HighlightsOnFirstPaint` is a known first-paint flake
+  — rerun before assuming a regression.
+
+## Repository layout
+
+| Path | What lives there |
+|------|------------------|
+| `src/Rask.Core/` | Rendering, live diff codec, routing, lifecycle, scoped CSS/JS, primitives. |
+| `src/Rask.Generators/` | Roslyn factory/route generators and analyzers (RASK001–022). |
+| `src/Rask.Server/`, `src/Rask.Wasm/`, `src/Rask.Wasm.Hosting/` | The three hosts. |
+| `src/Rask.Templates/` | `dotnet new` templates (`rask-server`, `rask-wasm`, `rask-wasm-hosted`). |
+| `samples/` | Runnable feature showcases. | 
+| `tests/`, `benchmarks/` | Test suites and render hot-path baselines. |
+
+Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
+[`docs/`](docs/README.md) and the [architecture notes](docs/architecture/live-rendering.md).
+
+## Conventions
+
+- **Adding an HTML tag:** add `src/Rask.Core/Components/{Tag}.cs`
+  (`sealed class {Tag} : Element`, `TagName` override, `WriteAttributes` calling `base`
+  then `AppendAttr` per attribute; void elements set `SelfClosing => true`) plus a
+  `tests/Rask.Core.Tests/Components/{Tag}Tests.cs` asserting exact attribute order
+  (id, class, style, data-*, then tag-specific). The factory is generated automatically.
+- **Don't `new` a `Component`** outside `Rask.Core` — use the generated factory (RASK014).
+- Diagnostics RASK001–022 are documented in [docs/diagnostics.md](docs/diagnostics.md);
+  the analyzer descriptors are the source of truth.
+
+## Commits & pull requests
+
+- Keep PRs focused; include tests; ensure `dotnet build` and `dotnet test` are green.
+- **Do not** append `Co-Authored-By` or `Generated-with` footers to commits or PR
+  descriptions.
+- Add a note to [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` for user-visible changes.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,16 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4)
 
-**[Quick start](#-quick-start--server)** · **[Core concepts](#-core-concepts)** · **[Docs ↗](docs/)** · **[Performance](#-performance)** · **[Live demo ↗](https://pal-tamas.github.io/rask/)**
+**[Quick start](#-quick-start--server)** · **[Core concepts](#-core-concepts)** · **[Docs ↗](docs/)** · *
+*[Performance](#-performance)** · **[Live demo ↗](https://pal-tamas.github.io/rask/)**
 
 </div>
 
 ---
 
-Write components as plain C# classes. Return a tree of HTML from `Render()`. **No `.razor`, no JSX, no JavaScript to write** — and the *same* component code runs server-rendered with live WebSocket updates or fully client-side on WebAssembly.
+Write components as plain C# classes. Return a tree of HTML from `Render()`. **No `.razor`, no JSX, no JavaScript to
+write** — and the *same* component code runs server-rendered with live WebSocket updates or fully client-side on
+WebAssembly.
 
 ```csharp
 [Route("/counter")]
@@ -52,7 +55,9 @@ public sealed class Counter : Component
 - [Troubleshooting](#-troubleshooting)
 - [Sub-path hosting & side-by-side apps](#-sub-path-hosting--side-by-side-apps)
 - [Examples](#-examples)
-- [Core concepts](#-core-concepts) — Components · Interactivity · Context · Async data · Routing · Auth · Head · Error boundaries · Forms & validation · Files · Virtualization · Scoped CSS · Scoped JS · Element refs · Keyed lists · Live diff codec · Lifecycle
+- [Core concepts](#-core-concepts) — Components · Interactivity · Context · Async data · Routing · Auth · Head · Error
+  boundaries · Forms & validation · Files · Virtualization · Scoped CSS · Scoped JS · Element refs · Keyed lists · Live
+  diff codec · Lifecycle
 - [Performance](#-performance)
 - [Status](#-status)
 - [License](#-license)
@@ -66,32 +71,32 @@ plain C# classes, return a tree of HTML from `Render()`, and host the result one
 live updates over a WebSocket, fully client-side in the browser via WebAssembly, or an ASP.NET app that serves a
 published WASM bundle. The **same component code runs under any host** — only the hosting glue changes.
 
-|     | Feature | What it means |
-|:---:|---------|---------------|
-| 🧩 | **Text-first DSL** | No `.razor`, no JSX. Call `Div(...)[Span(...), "hi"]`, `Button(...)["click"]`, `H1()["title"]` from C# — children attach through an indexer on every component, so the tree reads top-down like HTML and stays type-checked, refactor-safe, and IDE-friendly. |
-| ⚙️ | **Source-generated factories** | Define `class Counter : Component` and a `Counter()` factory is generated for you. Required vs. optional parameters fall out of property nullability automatically. |
-| 🔗 | **Type-safe URLs** | Every `[Route]` becomes a generated URL builder — `NavLink(HomePage(), ...)` instead of `"/"` strings that rot. |
-| 🎨 | **Scoped CSS, colocated** | Drop a sibling `{Component}.css` next to `{Component}.cs` and selectors are auto-scoped to that type and hot-reloaded — no class-name discipline, no BEM, no leaks. |
-| 💉 | **Constructor DI** | `class Weather(IWeatherForecastService svc) : Component` works directly — no `[Inject]` properties, no boilerplate. |
-| 🛡️ | **Error boundaries** | `ErrorBoundary(...)` catches render-time, lifecycle, and event-handler faults in its subtree and renders a fallback with a one-shot `recover` callback — no app-wide crashes from a bad descendant. |
-| ✅ | **Forms with async validation** | `Form<TModel>(model, OnValidSubmit: …)` routes submit through validators you opt into by dropping `DataAnnotationsValidator()` or `FluentValidationValidator(...)` inside the form. Implement `IAsyncFieldValidator` for ad-hoc server-side rules — the submit bridge awaits async checks before routing, and rapid keystrokes cancel any prior in-flight validation (latest-wins). |
-| ⚡ | **Live diff codec** | After first paint, a small state change ships a minimal edit-op payload instead of re-serializing the page — a counter tick on a 50 KB page goes from ~50 KB to ~57 bytes on the wire. On by default. |
-| 🔑 | **Keyed lists** | Add a `Key:` to list items (Blazor `@key` parity) and inserts/removes/reorders reconcile by identity — shipping trusted structural diffs that preserve focus and input state on the survivors. A `RASK022` analyzer flags a list item that's missing a key. |
-| 🔐 | **Authentication, ASP.NET-native** | `Component.User` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
+|     | Feature                            | What it means                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+|:---:|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| 🧩  | **Text-first DSL**                 | No `.razor`, no JSX. Call `Div(...)[Span(...), "hi"]`, `Button(...)["click"]`, `H1()["title"]` from C# — children attach through an indexer on every component, so the tree reads top-down like HTML and stays type-checked, refactor-safe, and IDE-friendly.                                                                                                                                                                                                                     |
+| ⚙️  | **Source-generated factories**     | Define `class Counter : Component` and a `Counter()` factory is generated for you. Required vs. optional parameters fall out of property nullability automatically.                                                                                                                                                                                                                                                                                                               |
+| 🔗  | **Type-safe URLs**                 | Every `[Route]` becomes a generated URL builder — `NavLink(HomePage(), ...)` instead of `"/"` strings that rot.                                                                                                                                                                                                                                                                                                                                                                   |
+| 🎨  | **Scoped CSS, colocated**          | Drop a sibling `{Component}.css` next to `{Component}.cs` and selectors are auto-scoped to that type and hot-reloaded — no class-name discipline, no BEM, no leaks.                                                                                                                                                                                                                                                                                                               |
+| 💉  | **Constructor DI**                 | `class Weather(IWeatherForecastService svc) : Component` works directly — no `[Inject]` properties, no boilerplate.                                                                                                                                                                                                                                                                                                                                                               |
+| 🛡️ | **Error boundaries**               | `ErrorBoundary(...)` catches render-time, lifecycle, and event-handler faults in its subtree and renders a fallback with a one-shot `recover` callback — no app-wide crashes from a bad descendant.                                                                                                                                                                                                                                                                               |
+|  ✅  | **Forms with async validation**    | `Form<TModel>(model, OnValidSubmit: …)` routes submit through validators you opt into by dropping `DataAnnotationsValidator()` or `FluentValidationValidator(...)` inside the form. Implement `IAsyncFieldValidator` for ad-hoc server-side rules — the submit bridge awaits async checks before routing, and rapid keystrokes cancel any prior in-flight validation (latest-wins).                                                                                               |
+|  ⚡  | **Live diff codec**                | After first paint, a small state change ships a minimal edit-op payload instead of re-serializing the page — a counter tick on a 50 KB page goes from ~50 KB to ~57 bytes on the wire. On by default.                                                                                                                                                                                                                                                                             |
+| 🔑  | **Keyed lists**                    | Add a `Key:` to list items (Blazor `@key` parity) and inserts/removes/reorders reconcile by identity — shipping trusted structural diffs that preserve focus and input state on the survivors. A `RASK022` analyzer flags a list item that's missing a key.                                                                                                                                                                                                                       |
+| 🔐  | **Authentication, ASP.NET-native** | `Component.User` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
 
 ## ⚖️ Compared to Blazor
 
 If you've worked in Blazor, here's how the day-to-day differs in Rask:
 
-| In Blazor | In Rask |
-|-----------|---------|
-| `.razor` files mixing markup + code | Plain C# classes with an indexer for children — `Div(...)[Span(...), "hi"]`. The whole tree is C# expressions, so refactors, find-references, and IDE navigation just work. |
-| `[Inject]` properties | Services come in through the **constructor** (`Counter(IClock clock) : Component`), like anywhere else in .NET. Framework services (`Navigator`, `RouteState`, `HttpClient`) inject the same way. |
-| `@page "/path"` | `[Route("/path")]` on the class, and every route gets a generated **type-safe URL builder** — `NavLink(UserPage(id: 42))` instead of `"/users/42"` strings that rot when the route changes. |
-| `RenderFragment` / `EventCallback` | Children are `IEnumerable<Child>`; event handlers are plain delegates (`OnClick: () => _count++`). Child→parent callbacks are plain delegate props too (`Action<T>?` / `Func<T,Task>?`) — invoking one auto-re-renders the parent that owns it, no `EventCallback` wrapper. No specialised types, no `@bind-Value:event`. |
-| `.razor.css` association ceremony | Scoped CSS via a sibling `{Component}.css` (Blazor-parity descendant combinators) — auto-globbed at build time, hot-reloaded under `dotnet watch`. Same idea for JS: a sibling `{Component}.js` is bundled and dispatched by the framework. |
-| Separate render modes to wire up | **Same component code on Server or WASM.** Pick the host package per project; you don't rewrite components when switching render mode. Server-only (multipart upload) and WASM-only (chunked file reads, inline downloads) behaviours live in the hosts, not in your tree. |
-| `<AuthorizeView>` + `AuthenticationStateProvider` | `Component.User` everywhere (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface. |
+| In Blazor                                         | In Rask                                                                                                                                                                                                                                                                                                                   |
+|---------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `.razor` files mixing markup + code               | Plain C# classes with an indexer for children — `Div(...)[Span(...), "hi"]`. The whole tree is C# expressions, so refactors, find-references, and IDE navigation just work.                                                                                                                                               |
+| `[Inject]` properties                             | Services come in through the **constructor** (`Counter(IClock clock) : Component`), like anywhere else in .NET. Framework services (`Navigator`, `RouteState`, `HttpClient`) inject the same way.                                                                                                                         |
+| `@page "/path"`                                   | `[Route("/path")]` on the class, and every route gets a generated **type-safe URL builder** — `NavLink(UserPage(id: 42))` instead of `"/users/42"` strings that rot when the route changes.                                                                                                                               |
+| `RenderFragment` / `EventCallback`                | Children are `IEnumerable<Child>`; event handlers are plain delegates (`OnClick: () => _count++`). Child→parent callbacks are plain delegate props too (`Action<T>?` / `Func<T,Task>?`) — invoking one auto-re-renders the parent that owns it, no `EventCallback` wrapper. No specialised types, no `@bind-Value:event`. |
+| `.razor.css` association ceremony                 | Scoped CSS via a sibling `{Component}.css` (Blazor-parity descendant combinators) — auto-globbed at build time, hot-reloaded under `dotnet watch`. Same idea for JS: a sibling `{Component}.js` is bundled and dispatched by the framework.                                                                               |
+| Separate render modes to wire up                  | **Same component code on Server or WASM.** Pick the host package per project; you don't rewrite components when switching render mode. Server-only (multipart upload) and WASM-only (chunked file reads, inline downloads) behaviours live in the hosts, not in your tree.                                                |
+| `<AuthorizeView>` + `AuthenticationStateProvider` | `Component.User` everywhere (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface.                       |
 
 Rask isn't a Blazor replacement so much as a different take on the same problem space. If those trade-offs appeal, the
 rest of this README walks through what they look like in practice.
@@ -300,7 +305,8 @@ First-run snags and their fixes:
   is a build error: `RASK015`/`RASK016` for CSS, `RASK017`/`RASK018` for JS. Two components with scoped JS that share a
   simple type name warn with `RASK020` (they'd collide at `window.Rask[Name]`). Check the build output.
 - **Blank page or 404s on `/_rask/...` assets behind a reverse proxy or sub-path.** The app is almost certainly running
-  under a URL prefix the framework doesn't know about — set `PathBase`. See *Sub-path hosting & side-by-side apps* below.
+  under a URL prefix the framework doesn't know about — set `PathBase`. See *Sub-path hosting & side-by-side apps*
+  below.
 
 ## 🌐 Sub-path hosting & side-by-side apps
 
@@ -344,19 +350,24 @@ default — unchanged behaviour). The CI workflow shipping `Rask.Example.Wasm` t
 
 Beyond the quick starts, the repo ships runnable showcase apps that exercise every feature end-to-end:
 
-- **`samples/Rask.Example.Server`** / **`samples/Rask.Example.Wasm`** / **`samples/Rask.Example.Wasm.Host`** — the same showcase under each
-  host model. Run one with `dotnet run --project samples/Rask.Example.Server` (or `samples/Rask.Example.Wasm.Host`) and open the printed
+- **`samples/Rask.Example.Server`** / **`samples/Rask.Example.Wasm`** / **`samples/Rask.Example.Wasm.Host`** — the same
+  showcase under each
+  host model. Run one with `dotnet run --project samples/Rask.Example.Server` (or `samples/Rask.Example.Wasm.Host`) and
+  open the printed
   URL.
-- **`samples/Rask.Example.Shared/Pages/`** — the feature-by-feature pages those hosts share: forms & validation, nested-form
+- **`samples/Rask.Example.Shared/Pages/`** — the feature-by-feature pages those hosts share: forms & validation,
+  nested-form
   binding, routing, JS interop, virtualization (a 10K-row table), file upload/download, and **auth gating** (the `/user`
   page shows both imperative `Component.User` and the declarative `Authorize` component). These are the canonical
-  references cited throughout *Core concepts* below. For production auth flows see **[docs/authentication.md](docs/authentication.md)**.
+  references cited throughout *Core concepts* below. For production auth flows see *
+  *[docs/authentication.md](docs/authentication.md)**.
 - **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
   (`/login`, a protected `/members`, role-gated admin content, sign-out) backed by a browser E2E:
-  - **`Rask.Example.Auth`** — cookie + Server (the redeem handshake).
-  - **`Rask.Example.Auth.Jwt`** — JWT + Server; the token rides in **`ProtectedSessionStorage`** (encrypted, never in the URL or JS).
-  - **`Rask.Example.Auth.WasmCookie(.Host)`** — cookie + WASM (HttpOnly cookie, `/api/me` hydration).
-  - **`Rask.Example.Auth.WasmJwt(.Host)`** — JWT + WASM (bearer in localStorage, `Authorization: Bearer`).
+    - **`Rask.Example.Auth`** — cookie + Server (the redeem handshake).
+    - **`Rask.Example.Auth.Jwt`** — JWT + Server; the token rides in **`ProtectedSessionStorage`** (encrypted, never in
+      the URL or JS).
+    - **`Rask.Example.Auth.WasmCookie(.Host)`** — cookie + WASM (HttpOnly cookie, `/api/me` hydration).
+    - **`Rask.Example.Auth.WasmJwt(.Host)`** — JWT + WASM (bearer in localStorage, `Authorization: Bearer`).
 
   Run a server cell directly — `dotnet run --project samples/Rask.Example.Auth.Jwt` — and a WASM cell via its host —
   `dotnet run --project samples/Rask.Example.Auth.WasmCookie.Host` — then visit `/members`. Sign in with
@@ -373,7 +384,8 @@ The collapsible sections below are a feature-by-feature tour. For step-by-step g
 see **[`docs/`](docs/)**:
 
 - **[Getting started](docs/getting-started.md)** — scaffold, first component, interactivity, routing.
-- **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · **[Authentication](docs/authentication.md)**
+- **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · *
+  *[Authentication](docs/authentication.md)**
 - **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
 - **[Diagnostics (RASK001–022)](docs/diagnostics.md)** — every build error/warning and its fix.
 - **[Live rendering & the diff codec](docs/architecture/live-rendering.md)** — how the runtime works under the hood.
@@ -398,8 +410,10 @@ binds straight to the indexer (an `IEnumerable<Component>` overload handles the 
 `Render()` (and the `Head` override) return `RenderResult`, which accepts three shapes:
 
 - **A single component** — `Render() => Div()[...]` (converts implicitly).
-- **A collection expression** — `Render() => [Doctype(), Html(...)]` for multiple top-level nodes, with no wrapper element. (This is sugar for `Fragment()[...]`; the items are grouped into a `Fragment` internally.)
-- **`default`** — render nothing / no contribution. Conditionals target-type each branch, so `Render() => ready ? [Doctype(), Html(...)] : default;` works.
+- **A collection expression** — `Render() => [Doctype(), Html(...)]` for multiple top-level nodes, with no wrapper
+  element. (This is sugar for `Fragment()[...]`; the items are grouped into a `Fragment` internally.)
+- **`default`** — render nothing / no contribution. Conditionals target-type each branch, so
+  `Render() => ready ? [Doctype(), Html(...)] : default;` works.
 
 ```csharp
 public sealed class Greeting : Component
@@ -641,7 +655,8 @@ auth configured through ASP.NET's own AddCookie/AddJwtBearer, and a security che
 <summary><b>📑 Page head contributions</b></summary>
 <br>
 
-Any component can override `protected virtual RenderResult Head` to declare what belongs in `<head>` while that component
+Any component can override `protected virtual RenderResult Head` to declare what belongs in `<head>` while that
+component
 is in the tree. The default is `default` — no contribution; a single tag, a collection expression of several tags, or
 `default` for "nothing" are all valid (e.g. `Head => loggedIn ? [Meta(...)] : default`):
 
@@ -772,7 +787,8 @@ The inline `Validate:` lambda already covers async per-field rules — return a 
 submit bridge awaits it before routing, with rapid keystrokes cancelling any prior in-flight check (latest-wins). Reach
 for a full **`IAsyncFieldValidator`** when the rule needs DI (an `HttpClient`, a repository) or you want to reuse it
 across forms: implement it and add it to a manually built `EditContext`. `ValidatingIndicator` is headless too — pass a
-`Template:` lambda for whatever should show while the field is being checked (e.g. `Template: () => Span()["Checking..."]`).
+`Template:` lambda for whatever should show while the field is being checked (e.g.
+`Template: () => Span()["Checking..."]`).
 
 ```csharp
 public sealed class UniqueUsernameValidator : IAsyncFieldValidator
@@ -1081,7 +1097,8 @@ The wrapper is stripped at compile time and the rule emits exactly the inner sel
 
 Drop a sibling `{Component}.js` file next to `{Component}.cs` to colocate behavior with markup. The file exports any
 number of named functions; the framework wraps each file as
-`window.Rask["{TypeName}"] = (function () { /* exports */ return { … }; })();` — so each `export function rendered(...) { ... }`
+`window.Rask["{TypeName}"] = (function () { /* exports */ return { … }; })();` — so each
+`export function rendered(...) { ... }`
 becomes `window.Rask.{TypeName}.rendered`. Delivery mirrors scoped CSS: per-component and content-addressed, identical
 on Server and WASM. The framework auto-emits one `<script src="/_rask/a/{hash}.js" defer data-rask-key="rsk-js-{hash}">`
 per mounted component type with a registered script. `defer` means scoped JS runs after parse, so any CDN scripts you
@@ -1230,7 +1247,8 @@ projection whose body becomes a `Child`, or an element `.Add(...)`-ed to a `List
 (or a `Data` `rask-key`) to clear it. Suppress per-site with `#pragma warning disable RASK022`, or promote it to an
 error with `<WarningsAsErrors>RASK022</WarningsAsErrors>` in the `.csproj`.
 
-See `samples/Rask.Example.Shared/Pages/KeyedListsPage.cs` for an interactive demo — type into a row, then reorder with keys
+See `samples/Rask.Example.Shared/Pages/KeyedListsPage.cs` for an interactive demo — type into a row, then reorder with
+keys
 on vs off to watch DOM state follow (or not follow) its row.
 
 </details>
@@ -1297,24 +1315,25 @@ Headline numbers from `Rask.Benchmarks.VsBlazor` — Rask vs Blazor's
 `HtmlRenderer` (Scope 1, render hot path), `RenderTreeBuilder` parameter
 churn (Scope 2, live-diff payload). Measured 2026-05-27 on **Apple M4 Pro
 (14 logical cores, .NET 10.0.5)** with BenchmarkDotNet ShortRun (3 warmup
-+ 3 iteration + 1 launch, `[MemoryDiagnoser]`). Lower-is-better for both
-columns; bold marks the winner.
 
-| Scenario                                          | Rask time      | Blazor time    | Rask alloc    | Blazor alloc  |
-|---------------------------------------------------|----------------|----------------|---------------|---------------|
-| Counter render (1 button, 1 span)                 | **246 ns**     | 1 030 ns       | **1.59 KB**   | 3.37 KB       |
-| AttributeHeavy 100 elements × 20 attrs            | **88 µs**      | 147 µs         | **273 KB**    | 436 KB        |
-| AttributeHeavy 100 elements × 50 attrs            | **256 µs**     | 314 µs         | **842 KB**    | 1 028 KB      |
-| LiveDiff: counter on 200-row page                 | **49 µs**      | 136 µs         | **87 KB**     | 229 KB        |
-| LiveDiff: attribute update on 100 × 20 page       | **131 µs**     | 242 µs         | **343 KB**    | 589 KB        |
-| LiveDiff: input-typing burst (3-field form)       | **1.2 µs**     | 2.9 µs         | **5.81 KB**   | 5.84 KB       |
-| LiveDiff: multi-attribute (5 attrs on root)       | **1.1 µs**     | 3.1 µs         | **4.47 KB**   | 6.63 KB       |
-| Realistic: dashboard counter tick                 | **8.9 µs**     | 23.7 µs        | **27 KB**     | 49 KB         |
-| Realistic: navigation tab switch                  | **15.9 µs**    | 34.1 µs        | **25.7 KB**   | 56.7 KB       |
-| Virtualize 1000 items vs render-all (Rask wins)   | **1.9 µs**     | 163 µs         | **11.2 KB**   | 609 KB        |
-| Scale: keyed-list reorder (1 000 rows)            | **269 µs** (0.93×) | 290 µs     | 658 KB        | **464 KB**    |
-| Scale: keyed-list reorder (5 000 rows)            | 1 625 µs (1.08×) | **1 505 µs** | 3 391 KB      | **3 266 KB**  |
-| Scale: random permutation 1 000 keyed rows        | 477 µs (1.39×) | **343 µs**     | 632 KB        | **457 KB**    |
++ 3 iteration + 1 launch, `[MemoryDiagnoser]`). Lower-is-better for both
+  columns; bold marks the winner.
+
+| Scenario                                        | Rask time          | Blazor time  | Rask alloc  | Blazor alloc |
+|-------------------------------------------------|--------------------|--------------|-------------|--------------|
+| Counter render (1 button, 1 span)               | **246 ns**         | 1 030 ns     | **1.59 KB** | 3.37 KB      |
+| AttributeHeavy 100 elements × 20 attrs          | **88 µs**          | 147 µs       | **273 KB**  | 436 KB       |
+| AttributeHeavy 100 elements × 50 attrs          | **256 µs**         | 314 µs       | **842 KB**  | 1 028 KB     |
+| LiveDiff: counter on 200-row page               | **49 µs**          | 136 µs       | **87 KB**   | 229 KB       |
+| LiveDiff: attribute update on 100 × 20 page     | **131 µs**         | 242 µs       | **343 KB**  | 589 KB       |
+| LiveDiff: input-typing burst (3-field form)     | **1.2 µs**         | 2.9 µs       | **5.81 KB** | 5.84 KB      |
+| LiveDiff: multi-attribute (5 attrs on root)     | **1.1 µs**         | 3.1 µs       | **4.47 KB** | 6.63 KB      |
+| Realistic: dashboard counter tick               | **8.9 µs**         | 23.7 µs      | **27 KB**   | 49 KB        |
+| Realistic: navigation tab switch                | **15.9 µs**        | 34.1 µs      | **25.7 KB** | 56.7 KB      |
+| Virtualize 1000 items vs render-all (Rask wins) | **1.9 µs**         | 163 µs       | **11.2 KB** | 609 KB       |
+| Scale: keyed-list reorder (1 000 rows)          | **269 µs** (0.93×) | 290 µs       | 658 KB      | **464 KB**   |
+| Scale: keyed-list reorder (5 000 rows)          | 1 625 µs (1.08×)   | **1 505 µs** | 3 391 KB    | **3 266 KB** |
+| Scale: random permutation 1 000 keyed rows      | 477 µs (1.39×)     | **343 µs**   | 632 KB      | **457 KB**   |
 
 **Where Rask wins (wire bytes):** the [diff codec](#live-rendering--the-diff-codec)
 is the main lever — a counter tick on a 200-row page ships ~41 bytes over the wire
@@ -1324,7 +1343,8 @@ latest to cross over: the move run collapses into one `PermutationBatch` op carr
 the shared parent path once, so a 200-row reverse-sort drops from 3.9 KB to **1.1 KB
 (2.99× vs Blazor)** — the last like-for-like byte loss, now a win. See the full
 per-scenario table and methodology in
-[`benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md`](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md).
+[
+`benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md`](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md).
 
 **Where Rask wins (CPU/alloc):** small-tree renders, attribute-heavy markup, live diffs
 that touch only a few nodes on a large page, virtualised lists, and the "realistic"
@@ -1385,7 +1405,8 @@ Rask is pre-1.0. APIs may change between minor versions. It targets **.NET 10** 
   example hosts.
 - **Benchmarks:** baselines for the render hot path live in `Rask.Benchmarks` (BenchmarkDotNet); committed reports
   under `BenchmarkDotNet.Artifacts/results/`. `Rask.Benchmarks.VsBlazor` adds a head-to-head suite measuring Rask
-  against Blazor on shared scenarios — render throughput and the wire-efficiency the [diff codec](#live-rendering--the-diff-codec)
+  against Blazor on shared scenarios — render throughput and the wire-efficiency
+  the [diff codec](#live-rendering--the-diff-codec)
   buys on live updates.
 - **Trimming:** `Rask.Example.Wasm` publishes with zero IL warnings. See `CLAUDE.md` for the contract that keeps it
   that way.
@@ -1400,7 +1421,8 @@ Rask is released under the [MIT License](LICENSE).
 
 ⚡ **Rask** — *Norwegian/Danish/Swedish for "fast".*
 
-**[Live demo ↗](https://pal-tamas.github.io/rask/)** · **[NuGet ↗](https://www.nuget.org/packages/Rask.Server)** · **[License](LICENSE)**
+**[Live demo ↗](https://pal-tamas.github.io/rask/)** · **[NuGet ↗](https://www.nuget.org/packages/Rask.Server)** · *
+*[License](LICENSE)**
 
 Built with .NET 10. Issues and PRs welcome.
 

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -1,45 +1,45 @@
 <Solution>
-  <Folder Name="/benchmarks/">
-    <Project Path="benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj" />
-    <Project Path="benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj" />
-  </Folder>
-  <Folder Name="/samples/">
-    <Project Path="samples/Rask.Example.Auth/Rask.Example.Auth.csproj" />
-    <Project Path="samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj" />
-    <Project Path="samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj" />
-    <Project Path="samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj" />
-    <Project Path="samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj" />
-    <Project Path="samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj" />
-    <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj" />
-    <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj" />
-    <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj" />
-    <Project Path="samples/Rask.Example.Wasm/Rask.Example.Wasm.csproj" />
-  </Folder>
-  <Folder Name="/src/">
-    <Project Path="src/Rask.Core/Rask.Core.csproj" />
-    <Project Path="src/Rask.Generators/Rask.Generators.csproj" />
-    <Project Path="src/Rask.Server/Rask.Server.csproj" />
-    <Project Path="src/Rask.Templates/Rask.Templates.csproj" />
-    <Project Path="src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj" />
-    <Project Path="src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj" />
-    <Project Path="src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj" />
-    <Project Path="src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj" />
-    <Project Path="src/Rask.Wasm/Rask.Wasm.csproj" />
-  </Folder>
-  <Folder Name="/tests/">
-    <Project Path="tests/Rask.Core.Tests/Rask.Core.Tests.csproj" />
-    <Project Path="tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj" />
-    <Project Path="tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj" />
-    <Project Path="tests/Rask.Example.Wasm.Host.Tests/Rask.Example.Wasm.Host.Tests.csproj" />
-    <Project Path="tests/Rask.Example.Wasm.Tests/Rask.Example.Wasm.Tests.csproj" />
-    <Project Path="tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj" />
-    <Project Path="tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj" />
-    <Project Path="tests/Rask.Server.Tests/Rask.Server.Tests.csproj" />
-    <Project Path="tests/Rask.TestSupport/Rask.TestSupport.csproj" />
-    <Project Path="tests/Rask.Validation.DataAnnotations.Tests/Rask.Validation.DataAnnotations.Tests.csproj" />
-    <Project Path="tests/Rask.Validation.FluentValidation.Tests/Rask.Validation.FluentValidation.Tests.csproj" />
-    <Project Path="tests/Rask.Wasm.Hosting.Tests/Rask.Wasm.Hosting.Tests.csproj" />
-    <Project Path="tests/Rask.Wasm.Tasks.Tests/Rask.Wasm.Tasks.Tests.csproj" />
-    <Project Path="tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj" />
-  </Folder>
+    <Folder Name="/benchmarks/">
+        <Project Path="benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj"/>
+        <Project Path="benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj"/>
+    </Folder>
+    <Folder Name="/samples/">
+        <Project Path="samples/Rask.Example.Auth/Rask.Example.Auth.csproj"/>
+        <Project Path="samples/Rask.Example.Auth.Jwt/Rask.Example.Auth.Jwt.csproj"/>
+        <Project Path="samples/Rask.Example.Auth.WasmCookie/Rask.Example.Auth.WasmCookie.csproj"/>
+        <Project Path="samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj"/>
+        <Project Path="samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj"/>
+        <Project Path="samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj"/>
+        <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj"/>
+        <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj"/>
+        <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj"/>
+        <Project Path="samples/Rask.Example.Wasm/Rask.Example.Wasm.csproj"/>
+    </Folder>
+    <Folder Name="/src/">
+        <Project Path="src/Rask.Core/Rask.Core.csproj"/>
+        <Project Path="src/Rask.Generators/Rask.Generators.csproj"/>
+        <Project Path="src/Rask.Server/Rask.Server.csproj"/>
+        <Project Path="src/Rask.Templates/Rask.Templates.csproj"/>
+        <Project Path="src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj"/>
+        <Project Path="src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj"/>
+        <Project Path="src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj"/>
+        <Project Path="src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj"/>
+        <Project Path="src/Rask.Wasm/Rask.Wasm.csproj"/>
+    </Folder>
+    <Folder Name="/tests/">
+        <Project Path="tests/Rask.Core.Tests/Rask.Core.Tests.csproj"/>
+        <Project Path="tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj"/>
+        <Project Path="tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj"/>
+        <Project Path="tests/Rask.Example.Wasm.Host.Tests/Rask.Example.Wasm.Host.Tests.csproj"/>
+        <Project Path="tests/Rask.Example.Wasm.Tests/Rask.Example.Wasm.Tests.csproj"/>
+        <Project Path="tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj"/>
+        <Project Path="tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj"/>
+        <Project Path="tests/Rask.Server.Tests/Rask.Server.Tests.csproj"/>
+        <Project Path="tests/Rask.TestSupport/Rask.TestSupport.csproj"/>
+        <Project Path="tests/Rask.Validation.DataAnnotations.Tests/Rask.Validation.DataAnnotations.Tests.csproj"/>
+        <Project Path="tests/Rask.Validation.FluentValidation.Tests/Rask.Validation.FluentValidation.Tests.csproj"/>
+        <Project Path="tests/Rask.Wasm.Hosting.Tests/Rask.Wasm.Hosting.Tests.csproj"/>
+        <Project Path="tests/Rask.Wasm.Tasks.Tests/Rask.Wasm.Tasks.Tests.csproj"/>
+        <Project Path="tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj"/>
+    </Folder>
 </Solution>

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md
@@ -18,34 +18,34 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- payload-bytes
 Deterministic — no measurement noise. Each row is one incremental update from the
 "before" state to the "after" state for an identically-shaped scenario.
 
-| Scenario | Rask Full | Rask Diff | Blazor batch | Rask diff vs Rask full | Rask diff vs Blazor |
-|---|---:|---:|---:|---:|---:|
-| CounterOnLargePage | 24,114 | **41** | 186 | 588× | **4.54×** Rask wins |
-| TextNodeUpdate | 23,997 | **50** | 193 | 480× | **3.86×** Rask wins |
-| DeepTreeCounterUpdate | 1,283 | **137** | 1,722 | 9.4× | **12.57×** Rask wins |
-| InputTypingBurst | 296 | **48** | 135 | 6.2× | **2.81×** Rask wins |
-| AttributeUpdate | 38,364 | **54** | 140 | 710× | **2.59×** Rask wins |
-| ClassToggle | 1,236 | **92** | 227 | 13.4× | **2.47×** Rask wins |
-| DeleteMiddleRow | 6,551 | **36** | 96 | 182× | **2.67×** Rask wins |
-| MultiAttributeUpdate | 317 | **269** | 576 | 1.2× | **2.14×** Rask wins |
-| KeyedList100Reorder | 6,617 | **43** | 128 | 154× | **2.98×** Rask wins⁵ |
-| NestedKeyedReorder | 9,257 | **43** | 128 | 215× | **2.98×** Rask wins⁵ |
-| AppendRow | 6,685 | **108** | 224 | 62× | **2.07×** Rask wins |
-| AttributeBurstUpdate | 6,527 | **2,037** | 4,596 | 3.2× | **2.26×** Rask wins |
-| KeyedListLargeAppend | 10,017 | **4,273** | 5,957 | 2.3× | **1.39×** Rask wins |
-| KeyedList50Reversal | 3,317 | **269** | 896 | 12.3× | **3.33×** Rask wins⁵ |
-| ConditionalRenderingToggle | **2,040** | 2,032 | 4,588 | 1.0× | **2.26×** Rask wins¹ |
-| Lifecycle_Insert100 | **7,517** | 9,093 | 24,604 | 0.8× | **3.27×** Rask wins¹ |
-| Lifecycle_Remove100 | **37** | 1,223 | 2,080 | 0.0× | **56.2×** Rask wins¹ |
-| VirtualizationScroll | 620 | 440 | 193³ | 1.4× | 0.44×³ |
-| Scale_KeyedReorder_5000 | 347,817 | **47** | 128 | 7,400× | **2.72×** Rask wins⁵ |
-| Scale_KeyedRandomPermutation_1000 | 67,817 | **6,669** | 16,096 | 10.2× | **2.41×** Rask wins⁵ |
-| Scale_KeyedAppendMiddle_2000 | 137,887 | **111** | 225 | 1,242× | **2.03×** Rask wins |
-| Scale_DeepTreeMutationByDepth_200 | 5,207 | **441** | 6,522 | 11.8× | **14.79×** Rask wins |
-| Realistic_DashboardWidgets_Tick | 4,003 | **43** | 218 | 93× | **5.07×** Rask wins |
-| Realistic_TableSort_Reverse | 17,267 | **1,123** | 3,360 | 15.4× | **2.99×** Rask wins⁵ |
-| Realistic_FormValidationChurn_Field0 | 1,369 | **109** | 310 | 12.6× | **2.84×** Rask wins |
-| Realistic_NavSwitch_0to1 | 4,265 | **2,526** | 7,003 | 1.7× | **2.77×** Rask wins |
+| Scenario                             | Rask Full | Rask Diff | Blazor batch | Rask diff vs Rask full |  Rask diff vs Blazor |
+|--------------------------------------|----------:|----------:|-------------:|-----------------------:|---------------------:|
+| CounterOnLargePage                   |    24,114 |    **41** |          186 |                   588× |  **4.54×** Rask wins |
+| TextNodeUpdate                       |    23,997 |    **50** |          193 |                   480× |  **3.86×** Rask wins |
+| DeepTreeCounterUpdate                |     1,283 |   **137** |        1,722 |                   9.4× | **12.57×** Rask wins |
+| InputTypingBurst                     |       296 |    **48** |          135 |                   6.2× |  **2.81×** Rask wins |
+| AttributeUpdate                      |    38,364 |    **54** |          140 |                   710× |  **2.59×** Rask wins |
+| ClassToggle                          |     1,236 |    **92** |          227 |                  13.4× |  **2.47×** Rask wins |
+| DeleteMiddleRow                      |     6,551 |    **36** |           96 |                   182× |  **2.67×** Rask wins |
+| MultiAttributeUpdate                 |       317 |   **269** |          576 |                   1.2× |  **2.14×** Rask wins |
+| KeyedList100Reorder                  |     6,617 |    **43** |          128 |                   154× | **2.98×** Rask wins⁵ |
+| NestedKeyedReorder                   |     9,257 |    **43** |          128 |                   215× | **2.98×** Rask wins⁵ |
+| AppendRow                            |     6,685 |   **108** |          224 |                    62× |  **2.07×** Rask wins |
+| AttributeBurstUpdate                 |     6,527 | **2,037** |        4,596 |                   3.2× |  **2.26×** Rask wins |
+| KeyedListLargeAppend                 |    10,017 | **4,273** |        5,957 |                   2.3× |  **1.39×** Rask wins |
+| KeyedList50Reversal                  |     3,317 |   **269** |          896 |                  12.3× | **3.33×** Rask wins⁵ |
+| ConditionalRenderingToggle           | **2,040** |     2,032 |        4,588 |                   1.0× | **2.26×** Rask wins¹ |
+| Lifecycle_Insert100                  | **7,517** |     9,093 |       24,604 |                   0.8× | **3.27×** Rask wins¹ |
+| Lifecycle_Remove100                  |    **37** |     1,223 |        2,080 |                   0.0× | **56.2×** Rask wins¹ |
+| VirtualizationScroll                 |       620 |       440 |         193³ |                   1.4× |               0.44×³ |
+| Scale_KeyedReorder_5000              |   347,817 |    **47** |          128 |                 7,400× | **2.72×** Rask wins⁵ |
+| Scale_KeyedRandomPermutation_1000    |    67,817 | **6,669** |       16,096 |                  10.2× | **2.41×** Rask wins⁵ |
+| Scale_KeyedAppendMiddle_2000         |   137,887 |   **111** |          225 |                 1,242× |  **2.03×** Rask wins |
+| Scale_DeepTreeMutationByDepth_200    |     5,207 |   **441** |        6,522 |                  11.8× | **14.79×** Rask wins |
+| Realistic_DashboardWidgets_Tick      |     4,003 |    **43** |          218 |                    93× |  **5.07×** Rask wins |
+| Realistic_TableSort_Reverse          |    17,267 | **1,123** |        3,360 |                  15.4× | **2.99×** Rask wins⁵ |
+| Realistic_FormValidationChurn_Field0 |     1,369 |   **109** |          310 |                  12.6× |  **2.84×** Rask wins |
+| Realistic_NavSwitch_0to1             |     4,265 | **2,526** |        7,003 |                   1.7× |  **2.77×** Rask wins |
 
 ¹ `Lifecycle_Insert100` / `Lifecycle_Remove100` / `ConditionalRenderingToggle`: the
 diff codec emits positional structural ops (untrusted `Insert/Remove`) on these
@@ -77,6 +77,7 @@ emits a **single** `PermutationBatch` op `[7, parentPath[], [dst0,src0,…]]` th
 carries the shared parent path once (`src/Rask.Core/Live/FrameDiffer.cs`,
 `LivePayload.cs`, and both client `applyDiff` interpreters). Results vs the previous
 baseline:
+
 - `Realistic_TableSort_Reverse`: 3,873 B → **1,123 B**, 0.87× → **2.99×** (the loss is closed).
 - `KeyedList50Reversal`: 685 B → **269 B**, 1.31× → **3.33×**.
 - `Scale_KeyedRandomPermutation_1000`: 14,936 B → **6,669 B**, 1.08× → **2.41×**.
@@ -129,9 +130,9 @@ Blazor Server uses to put bytes onto the SignalR hub. See methodology below.
 ### What's measured
 
 - **Rask side:** drive the same `SessionRenderCache` + `FrameSinkScope` + `HtmlSerializer`
-  + `LivePayload.BuildPayloadUtf8Diff` pipeline that `LiveSession` uses to put bytes
-  onto the WebSocket. Reuses pooled buffers across iterations so steady-state
-  allocations match production.
+    + `LivePayload.BuildPayloadUtf8Diff` pipeline that `LiveSession` uses to put bytes
+      onto the WebSocket. Reuses pooled buffers across iterations so steady-state
+      allocations match production.
 - **Blazor side:** subclass `Microsoft.AspNetCore.Components.RenderTree.Renderer`,
   capture `RenderBatch` inside `UpdateDisplayAsync`, serialize it via reflection on
   the internal `RenderBatchWriter` (the same writer the SignalR circuit uses), report
@@ -191,6 +192,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*RenderHot
 ```
 
 Benchmark classes (one per scenario so BDN can assign Blazor as the [Baseline]):
+
 - `RenderHotPath_StaticListBenchmarks` with `[Params(5, 100, 1000)]`
 - `RenderHotPath_TextHeavyBenchmarks` with `[Params(5, 100, 1000)]`
 - `RenderHotPath_CounterBenchmarks`
@@ -201,9 +203,9 @@ Benchmark classes (one per scenario so BDN can assign Blazor as the [Baseline]):
 
 Smoke-run numbers (`--job short`):
 
-| Scenario | Blazor mean | Rask mean | Ratio |
-|---|---:|---:|---:|
-| Counter | 1,052 ns | **598 ns** | **0.57× — Rask 1.76× faster** |
+| Scenario | Blazor mean |  Rask mean |                         Ratio |
+|----------|------------:|-----------:|------------------------------:|
+| Counter  |    1,052 ns | **598 ns** | **0.57× — Rask 1.76× faster** |
 
 Re-run with the default job (no `--job short`) and pin the rest into this table when
 the suite stabilises.
@@ -217,19 +219,29 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*LiveDiffP
 ```
 
 Benchmark classes (one per scenario):
+
 - `LiveDiffPayload_CounterOnLargePageBenchmarks` — stateful Rask root mutates one counter cell
 - `LiveDiffPayload_TextNodeUpdateBenchmarks`
 - `LiveDiffPayload_AttributeUpdateBenchmarks` — single `data-*` flip on a 20-attr × 100-element tree
 - `LiveDiffPayload_KeyedList100ReorderBenchmarks` — two keyed rows swapped (one `PermutationBatch` op carrying 2 moves)
-- `LiveDiffPayload_NestedKeyedReorderBenchmarks` — 20 keyed cards × 5 inner keyed rows, swap two outer cards (validates the keyed path recurses into kept cards with zero inner ops)
-- `LiveDiffPayload_InputTypingBurstBenchmarks` — three-field form, single keystroke into field A's value (validates attribute-diff scoping; sibling inputs and labels stay quiet)
-- `LiveDiffPayload_ConditionalRenderingToggleBenchmarks` — show/hide a 50-row panel between header and footer (validates the positional Insert/Remove → full-HTML fallback path; production ships full HTML, still beats Blazor's batch)
-- `LiveDiffPayload_KeyedListReversalBenchmarks` — reverse a 50-row keyed list (LIS worst case: 49 moves, now shipped as one `PermutationBatch` op carrying the shared parent path once — the case that motivated the batch op)
-- `LiveDiffPayload_ClassToggleBenchmarks` — move "active" class between sidebar items (the most common UI mutation; two `SetAttribute` ops)
-- `LiveDiffPayload_DeepTreeCounterUpdateBenchmarks` — counter at the bottom of a 50-deep div nest (measures the path-encoding tax explicitly; 11.25× Rask win — biggest gap in the suite)
-- `LiveDiffPayload_MultiAttributeUpdateBenchmarks` — theme switch flips 5 attrs on the root in one render (5 `SetAttribute` ops; descendants stay quiet)
-- `LiveDiffPayload_AttributeBurstUpdateBenchmarks` — 100 rows each gain `data-loaded` when a state bit flips (100 `SetAttribute` ops sharing one attr name; baselines the case for the attribute-interning optimisation)
-- `LiveDiffPayload_KeyedListLargeAppendBenchmarks` — append 50 rows to a 100-row keyed list (50 keyed `InsertSubtree` ops carrying HTML fragments)
+- `LiveDiffPayload_NestedKeyedReorderBenchmarks` — 20 keyed cards × 5 inner keyed rows, swap two outer cards (validates
+  the keyed path recurses into kept cards with zero inner ops)
+- `LiveDiffPayload_InputTypingBurstBenchmarks` — three-field form, single keystroke into field A's value (validates
+  attribute-diff scoping; sibling inputs and labels stay quiet)
+- `LiveDiffPayload_ConditionalRenderingToggleBenchmarks` — show/hide a 50-row panel between header and footer (validates
+  the positional Insert/Remove → full-HTML fallback path; production ships full HTML, still beats Blazor's batch)
+- `LiveDiffPayload_KeyedListReversalBenchmarks` — reverse a 50-row keyed list (LIS worst case: 49 moves, now shipped as
+  one `PermutationBatch` op carrying the shared parent path once — the case that motivated the batch op)
+- `LiveDiffPayload_ClassToggleBenchmarks` — move "active" class between sidebar items (the most common UI mutation; two
+  `SetAttribute` ops)
+- `LiveDiffPayload_DeepTreeCounterUpdateBenchmarks` — counter at the bottom of a 50-deep div nest (measures the
+  path-encoding tax explicitly; 11.25× Rask win — biggest gap in the suite)
+- `LiveDiffPayload_MultiAttributeUpdateBenchmarks` — theme switch flips 5 attrs on the root in one render (5
+  `SetAttribute` ops; descendants stay quiet)
+- `LiveDiffPayload_AttributeBurstUpdateBenchmarks` — 100 rows each gain `data-loaded` when a state bit flips (100
+  `SetAttribute` ops sharing one attr name; baselines the case for the attribute-interning optimisation)
+- `LiveDiffPayload_KeyedListLargeAppendBenchmarks` — append 50 rows to a 100-row keyed list (50 keyed `InsertSubtree`
+  ops carrying HTML fragments)
 - `LiveDiffPayload_AppendRowBenchmarks` — append one row at end of 100-row keyed list
 - `LiveDiffPayload_DeleteMiddleRowBenchmarks` — remove row index 50 from 100-row keyed list (single `RemoveSubtree`)
 - `LiveDiffPayload_VirtualizationScrollBenchmarks` — Rask scroll shift vs Blazor one-row text change
@@ -240,9 +252,9 @@ All bench methods return `long` (byte count) so BDN reports wire bytes as "Mean"
 End-to-end cost of producing one diff payload — `LiveDiffPayload_CounterOnLargePage`
 after the stateful-counter harness fix (default job):
 
-| Scenario | Blazor mean | Rask mean | Blazor allocs | Rask allocs |
-|---|---:|---:|---:|---:|
-| CounterOnLargePage | 138.7 μs | **45.2 μs** (0.33×) | 228 KB | **95.5 KB** (0.42×) |
+| Scenario           | Blazor mean |           Rask mean | Blazor allocs |         Rask allocs |
+|--------------------|------------:|--------------------:|--------------:|--------------------:|
+| CounterOnLargePage |    138.7 μs | **45.2 μs** (0.33×) |        228 KB | **95.5 KB** (0.42×) |
 
 **Rask 3.07× faster end-to-end and allocates 0.42× of Blazor.** Pre-Step 1 the Rask
 side was at 98 μs / 621 KB, but the 621 KB measured tree rebuild rather than the
@@ -263,6 +275,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*Dispatch_
 ```
 
 Benchmarks:
+
 - `Dispatch_ButtonClickCounterPinnedBenchmarks.{Blazor,Rask}_Dispatch_ButtonClick_Counter`
 - `Dispatch_ButtonClickLargePagePinnedBenchmarks.{Blazor,Rask}_Dispatch_ButtonClick_LargePage`
 
@@ -291,10 +304,10 @@ also runs synchronously on the BDN iteration thread. Validation gate: determinis
 Smoke-run numbers (`--job short`, retained from pre-fix pin for `Counter` — to be
 re-pinned at default job alongside the new `LargePage` row):
 
-| Method | Mean | Allocated |
-|---|---:|---:|
-| Blazor_Dispatch_ButtonClick_Counter | 2,331 ns | 5.77 KB |
-| Rask_Dispatch_ButtonClick_Counter | **875 ns** | **5.48 KB** |
+| Method                              |       Mean |   Allocated |
+|-------------------------------------|-----------:|------------:|
+| Blazor_Dispatch_ButtonClick_Counter |   2,331 ns |     5.77 KB |
+| Rask_Dispatch_ButtonClick_Counter   | **875 ns** | **5.48 KB** |
 
 **Rask 2.66× faster** on the dispatch + small-tree diff, slightly fewer allocations.
 
@@ -305,6 +318,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*Startup_*
 ```
 
 Benchmarks:
+
 - `Startup_ActivateCounterPinnedBenchmarks.{Blazor,Rask}_Activate_Counter`
 - `Startup_FirstRenderCounterPinnedBenchmarks.{Blazor,Rask}_FirstRender_Counter`
 - `Startup_FirstRenderLargePagePinnedBenchmarks.{Blazor,Rask}_FirstRender_LargePage` (200 rows cold)
@@ -447,6 +461,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*Micro_*'
 ```
 
 Benchmark classes:
+
 - `Micro_HtmlSerializerAppendEncodedBenchmarks` — `[Params]` safe-ascii-16,
   safe-ascii-200, encoder-fallback, utf-8-multibyte. Baseline = direct
   `HtmlEncoder.Default.Encode`. Validates the `SearchValues<char>` fast path stays
@@ -479,6 +494,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*Scale_*'
 ```
 
 Benchmark classes:
+
 - `Scale_StaticListLargeBenchmarks` — `[Params(1000, 5000, 10000)]` render hot path
   vs `StaticList.BlazorStaticList`.
 - `Scale_KeyedReorderLargeBenchmarks` — `[Params(1000, 5000)]` two-element keyed
@@ -510,6 +526,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*Realistic
 ```
 
 Benchmark classes:
+
 - `Realistic_DashboardWidgetsBenchmarks` — header + nav sidebar + 6 widgets
   (counter, chart, table summary, alerts, status grid, footer). One counter widget
   ticks per iteration; the diff codec must keep the other five widget subtrees out
@@ -544,6 +561,7 @@ dotnet run -c Release --project Rask.Benchmarks.VsBlazor -- --filter '*MemoryGc_
 ```
 
 Benchmark classes:
+
 - `MemoryGc_SustainedCounterChurnBenchmarks` — 10,000 counter increments on the
   200-row `StatefulLargePageWithCounter` per op. Headline pressure test; matches
   the production busy-dashboard ticker shape.
@@ -584,16 +602,16 @@ Apple M4 Pro.
 
 **Allocation per incremental update** (steady-state, production-relevant — lower is better):
 
-| Scenario | Rask /update | Blazor /update | Rask vs Blazor |
-|---|---:|---:|---:|
-| CounterOnLargePage | 69,598 B | **31,470 B** | 0.45× — Blazor allocates less |
+| Scenario           | Rask /update | Blazor /update |                Rask vs Blazor |
+|--------------------|-------------:|---------------:|------------------------------:|
+| CounterOnLargePage |     69,598 B |   **31,470 B** | 0.45× — Blazor allocates less |
 
 **Retained heap per rendered tree** (architectural tradeoff):
 
-| Scenario | Rask /tree | Blazor /tree | Rask vs Blazor |
-|---|---:|---:|---:|
-| LargePage_200Rows | 326,685 B | **222,798 B** | 0.68× |
-| KeyedList_100Rows | 158,029 B | **57,790 B** | 0.37× |
+| Scenario          | Rask /tree |  Blazor /tree | Rask vs Blazor |
+|-------------------|-----------:|--------------:|---------------:|
+| LargePage_200Rows |  326,685 B | **222,798 B** |          0.68× |
+| KeyedList_100Rows |  158,029 B |  **57,790 B** |          0.37× |
 
 **Read this honestly — it is a tradeoff, not a clean Rask win.** Rask's optimisation
 target is *bytes on the wire* (the headline table: 2–15× fewer, now with no
@@ -633,6 +651,7 @@ basis is a noted follow-up.)
 
 Resolved since the previous baseline (no longer losses), all sharpened further by the
 `PermutationBatch` op kind:
+
 - **`Realistic_TableSort_Reverse`** — was the sole loss at 0.87× (3,873 B); now
   **2.99×** (1,123 B). Closed by `PermutationBatch`.
 - **`Scale_KeyedRandomPermutation_1000`** — was 0.86× (18.7 KB vs 16.1 KB); the

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/Dispatch_PinnedBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/Dispatch_PinnedBenchmarks.cs
@@ -19,9 +19,9 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 [MemoryDiagnoser]
 public class Dispatch_ButtonClickCounterPinnedBenchmarks
 {
-    private RaskHarness _rask = null!;
     private BlazorRenderBatchCapture _blazor = null!;
     private int _counter;
+    private RaskHarness _rask = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -64,13 +64,15 @@ public class Dispatch_ButtonClickCounterPinnedBenchmarks
 [MemoryDiagnoser]
 public class Dispatch_ButtonClickLargePagePinnedBenchmarks
 {
+    private BlazorRenderBatchCapture _blazor = null!;
+
+    private int _blazorCounter;
+
     // Stateful 200-row root: one event handler ticks the counter cell, the rest of
     // the page (200 rows) is unchanged across renders. This is the production shape
     // where the diff codec earns its keep — one mutation deep inside a quiet tree.
     private RaskHarness _rask = null!;
-    private BlazorRenderBatchCapture _blazor = null!;
     private StatefulLargePageWithCounter _stateful = null!;
-    private int _blazorCounter;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/LiveDiffPayloadBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/LiveDiffPayloadBenchmarks.cs
@@ -12,8 +12,8 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 
 public abstract class LiveDiffPayloadBase
 {
-    protected RaskHarness Rask = null!;
     protected BlazorRenderBatchCapture Blazor = null!;
+    protected RaskHarness Rask = null!;
 
     [GlobalCleanup]
     public void Cleanup()
@@ -26,13 +26,14 @@ public abstract class LiveDiffPayloadBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_CounterOnLargePageBenchmarks : LiveDiffPayloadBase
 {
+    private int _blazorCounter;
+
     // Stateful Rask root: 200 rows built once in Render(), only the counter cell
     // mutates across renders. Mirrors Blazor's "re-render with new parameters" path
     // where the unchanged subtree is not rebuilt. Before the switch the Rask side
     // allocated 621 KB / iter rebuilding the 200-row tree on every call; now it
     // measures the diff codec itself.
     private StatefulLargePageWithCounter _stateful = null!;
-    private int _blazorCounter;
 
     [GlobalSetup]
     public void Setup()
@@ -80,11 +81,12 @@ public class LiveDiffPayload_CounterOnLargePageBenchmarks : LiveDiffPayloadBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_TextNodeUpdateBenchmarks : LiveDiffPayloadBase
 {
+    private int _counter;
+
     // Stateful Rask root: 199 of 200 rows cached, only the mutating-cell row is
     // rebuilt per Tick. Mirrors Blazor's parameter update which also only touches
     // the changed cell's frame slot.
     private StatefulLargePageWithDeepTextCell _stateful = null!;
-    private int _counter;
 
     [GlobalSetup]
     public void Setup()
@@ -171,6 +173,11 @@ public class LiveDiffPayload_AttributeUpdateBenchmarks : LiveDiffPayloadBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_KeyedList100ReorderBenchmarks : LiveDiffPayloadBase
 {
+    private int[] _blazorOrder = null!;
+    private int _blazorSwapA;
+
+    private int _blazorSwapB;
+
     // Stateful Rask root: 100 rows wrapped as Child instances once on first render and
     // cached by key. The benchmark Tick swaps two slots of the order array and calls
     // StateHasChanged — the next render returns a reordered list pointing at the SAME
@@ -179,9 +186,6 @@ public class LiveDiffPayload_KeyedList100ReorderBenchmarks : LiveDiffPayloadBase
     // update. Without this, the prior rebuild-per-iter Rask version was unfairly
     // allocating 100 fresh elements every call vs Blazor's 0.
     private KeyedList.StatefulKeyedList _stateful = null!;
-    private int[] _blazorOrder = null!;
-    private int _blazorSwapA;
-    private int _blazorSwapB;
 
     [GlobalSetup]
     public void Setup()
@@ -208,7 +212,8 @@ public class LiveDiffPayload_KeyedList100ReorderBenchmarks : LiveDiffPayloadBase
     public long Blazor_KeyedList100Reorder()
     {
         var beforeOrder = (int[])_blazorOrder.Clone();
-        (_blazorOrder[_blazorSwapA], _blazorOrder[_blazorSwapB]) = (_blazorOrder[_blazorSwapB], _blazorOrder[_blazorSwapA]);
+        (_blazorOrder[_blazorSwapA], _blazorOrder[_blazorSwapB]) =
+            (_blazorOrder[_blazorSwapB], _blazorOrder[_blazorSwapA]);
         _blazorSwapA = (_blazorSwapA + 1) % _blazorOrder.Length;
         _blazorSwapB = (_blazorSwapB + 1) % _blazorOrder.Length;
 
@@ -234,13 +239,15 @@ public class LiveDiffPayload_KeyedList100ReorderBenchmarks : LiveDiffPayloadBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_AppendRowBenchmarks : LiveDiffPayloadBase
 {
+    private bool _appendedIsNext;
+    private int[] _appendedOrder = null!;
+
+    private int[] _baseOrder = null!;
+
     // Stateful Rask root: rows cached by key, only the visible-order array swaps each
     // tick. Mirrors Blazor's ParameterView-update path so the comparison measures
     // the diff codec, not Rask paying for 100+ fresh elements per call.
     private AppendDeleteRowChurn.StatefulAppendDeleteList _stateful = null!;
-    private int[] _baseOrder = null!;
-    private int[] _appendedOrder = null!;
-    private bool _appendedIsNext;
 
     [GlobalSetup]
     public void Setup()
@@ -308,12 +315,14 @@ public class LiveDiffPayload_AppendRowBenchmarks : LiveDiffPayloadBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_DeleteMiddleRowBenchmarks : LiveDiffPayloadBase
 {
+    private int[] _fullOrder = null!;
+    private bool _missingIsNext;
+
+    private int[] _missingMiddleOrder = null!;
+
     // Stateful Rask root: same caching pattern as AppendRow above. Order array toggles
     // between 100 and 99 entries; rows themselves are reused across the swap.
     private AppendDeleteRowChurn.StatefulAppendDeleteList _stateful = null!;
-    private int[] _fullOrder = null!;
-    private int[] _missingMiddleOrder = null!;
-    private bool _missingIsNext;
 
     [GlobalSetup]
     public void Setup()
@@ -517,10 +526,10 @@ public class LiveDiffPayload_KeyedListLargeAppendBenchmarks : LiveDiffPayloadBas
     // way back. Row HTML is reused across the toggle — only the order array changes.
     private const int BaseRowCount = 100;
     private const int AppendCount = 50;
-    private KeyedList.StatefulKeyedList _stateful = null!;
     private int[] _baseOrder = null!;
-    private int[] _largeOrder = null!;
     private bool _largeIsNext;
+    private int[] _largeOrder = null!;
+    private KeyedList.StatefulKeyedList _stateful = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -588,10 +597,10 @@ public class LiveDiffPayload_KeyedListReversalBenchmarks : LiveDiffPayloadBase
     // LIS worst case — every element off the LIS, but row instances are reused so the
     // diff path measures only the move-emission cost (and the patience-sort LIS).
     private const int RowCount = 50;
-    private KeyedList.StatefulKeyedList _stateful = null!;
     private int[] _forwardOrder = null!;
-    private int[] _reverseOrder = null!;
     private bool _reverseIsNext;
+    private int[] _reverseOrder = null!;
+    private KeyedList.StatefulKeyedList _stateful = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -794,6 +803,11 @@ public class LiveDiffPayload_InputTypingBurstBenchmarks : LiveDiffPayloadBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_NestedKeyedReorderBenchmarks : LiveDiffPayloadBase
 {
+    private int[] _blazorOrder = null!;
+    private int _blazorSwapA;
+
+    private int _blazorSwapB;
+
     // Outer keyed list (20 cards) × inner keyed list (5 rows each). Swap two outer
     // cards; inner content is identical post-swap. The keyed differ must (a) emit
     // two MoveSubtree ops at the outer level and (b) recurse into kept cards without
@@ -804,9 +818,6 @@ public class LiveDiffPayload_NestedKeyedReorderBenchmarks : LiveDiffPayloadBase
     // Outer-order toggles per tick; rows reused across the swap. Mirrors Blazor's
     // ParameterView path so the diff codec is what's measured, not tree construction.
     private NestedKeyedList.StatefulNestedKeyedList _stateful = null!;
-    private int[] _blazorOrder = null!;
-    private int _blazorSwapA;
-    private int _blazorSwapB;
 
     [GlobalSetup]
     public void Setup()
@@ -832,7 +843,8 @@ public class LiveDiffPayload_NestedKeyedReorderBenchmarks : LiveDiffPayloadBase
     public long Blazor_NestedKeyedReorder()
     {
         var beforeOrder = (int[])_blazorOrder.Clone();
-        (_blazorOrder[_blazorSwapA], _blazorOrder[_blazorSwapB]) = (_blazorOrder[_blazorSwapB], _blazorOrder[_blazorSwapA]);
+        (_blazorOrder[_blazorSwapA], _blazorOrder[_blazorSwapB]) =
+            (_blazorOrder[_blazorSwapB], _blazorOrder[_blazorSwapA]);
         _blazorSwapA = (_blazorSwapA + 1) % _blazorOrder.Length;
         _blazorSwapB = (_blazorSwapB + 1) % _blazorOrder.Length;
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/MemoryGc_Benchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/MemoryGc_Benchmarks.cs
@@ -3,7 +3,9 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Components;
 using Rask.Benchmarks.VsBlazor.Components;
 using Rask.Benchmarks.VsBlazor.Infrastructure;
+using Rask.Core;
 using Rask.Core.Live;
+using Generated = Rask.Core.Components.Generated;
 
 namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 
@@ -17,8 +19,8 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 
 public abstract class MemoryGcBase
 {
-    protected RaskHarness Rask = null!;
     protected BlazorRenderBatchCapture Blazor = null!;
+    protected RaskHarness Rask = null!;
 
     [GlobalCleanup]
     public void Cleanup()
@@ -35,9 +37,9 @@ public class MemoryGc_SustainedCounterChurnBenchmarks : MemoryGcBase
     // test: this is exactly the load pattern a production live page sees on a busy
     // dashboard (a once-per-frame ticker, a real-time counter, telemetry stream).
     public const int Cycles = 10_000;
+    private int _seedCounter;
 
     private StatefulLargePageWithCounter _stateful = null!;
-    private int _seedCounter;
 
     [GlobalSetup]
     public void Setup()
@@ -73,6 +75,7 @@ public class MemoryGc_SustainedCounterChurnBenchmarks : MemoryGcBase
             _stateful.Tick();
             total += Rask.RenderAndBuildDiffPayloadBytes(_stateful);
         }
+
         return total;
     }
 }
@@ -81,12 +84,11 @@ public class MemoryGc_SustainedCounterChurnBenchmarks : MemoryGcBase
 public class MemoryGc_KeyedListShufflePressureBenchmarks : MemoryGcBase
 {
     public const int Cycles = 5_000;
-
-    [Params(500, 2000)]
-    public int N { get; set; }
+    private ulong _state;
 
     private KeyedList.StatefulKeyedList _stateful = null!;
-    private ulong _state;
+
+    [Params(500, 2000)] public int N { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -119,9 +121,10 @@ public class MemoryGc_KeyedListShufflePressureBenchmarks : MemoryGcBase
                         [nameof(KeyedList.BlazorKeyedList.Order)] = beforeArr
                     });
                 }
-                localState = localState * 6364136223846793005UL + 1442695040888963407UL;
+
+                localState = (localState * 6364136223846793005UL) + 1442695040888963407UL;
                 var a = (int)((localState >> 33) % (uint)n);
-                localState = localState * 6364136223846793005UL + 1442695040888963407UL;
+                localState = (localState * 6364136223846793005UL) + 1442695040888963407UL;
                 var b = (int)((localState >> 33) % (uint)n);
                 (workingOrder[a], workingOrder[b]) = (workingOrder[b], workingOrder[a]);
                 return ParameterView.FromDictionary(new Dictionary<string, object?>
@@ -138,13 +141,14 @@ public class MemoryGc_KeyedListShufflePressureBenchmarks : MemoryGcBase
         long total = 0;
         for (var i = 0; i < Cycles; i++)
         {
-            _state = _state * 6364136223846793005UL + 1442695040888963407UL;
+            _state = (_state * 6364136223846793005UL) + 1442695040888963407UL;
             var a = (int)((_state >> 33) % (uint)n);
-            _state = _state * 6364136223846793005UL + 1442695040888963407UL;
+            _state = (_state * 6364136223846793005UL) + 1442695040888963407UL;
             var b = (int)((_state >> 33) % (uint)n);
             _stateful.SwapAt(a, b);
             total += Rask.RenderAndBuildDiffPayloadBytes(_stateful);
         }
+
         return total;
     }
 }
@@ -153,13 +157,12 @@ public class MemoryGc_KeyedListShufflePressureBenchmarks : MemoryGcBase
 public class MemoryGc_AppendDeletePressureBenchmarks : MemoryGcBase
 {
     public const int Cycles = 1_000;
-
-    [Params(100, 500)]
-    public int N { get; set; }
+    private int[] _baseOrder = null!;
 
     private AppendDeleteRowChurn.StatefulAppendDeleteList _stateful = null!;
-    private int[] _baseOrder = null!;
     private int[] _withInsert = null!;
+
+    [Params(100, 500)] public int N { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -167,9 +170,17 @@ public class MemoryGc_AppendDeletePressureBenchmarks : MemoryGcBase
         Rask = new RaskHarness();
         Blazor = new BlazorRenderBatchCapture();
         _baseOrder = new int[N];
-        for (var i = 0; i < N; i++) _baseOrder[i] = i;
+        for (var i = 0; i < N; i++)
+        {
+            _baseOrder[i] = i;
+        }
+
         _withInsert = new int[N + 1];
-        for (var i = 0; i < N; i++) _withInsert[i] = i;
+        for (var i = 0; i < N; i++)
+        {
+            _withInsert[i] = i;
+        }
+
         _withInsert[N] = N + 1000;
 #pragma warning disable RASK014
         _stateful = new AppendDeleteRowChurn.StatefulAppendDeleteList { Capacity = N + 1001 };
@@ -204,6 +215,7 @@ public class MemoryGc_AppendDeletePressureBenchmarks : MemoryGcBase
             _stateful.SetOrder(_baseOrder);
             total += Rask.RenderAndBuildDiffPayloadBytes(_stateful);
         }
+
         return total;
     }
 }
@@ -232,13 +244,15 @@ public class MemoryGc_DeepTreeMutationPressureBenchmarks : MemoryGcBase
     {
         var startCounter = _seedCounter;
         _seedCounter += Cycles;
-        return Blazor.MeasureSustainedIncrementalUpdates<Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree>(
-            Cycles,
-            i => ParameterView.FromDictionary(new Dictionary<string, object?>
-            {
-                [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Counter)] = startCounter + i,
-                [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Depth)] = Depth
-            }));
+        return Blazor
+            .MeasureSustainedIncrementalUpdates<Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree>(
+                Cycles,
+                i => ParameterView.FromDictionary(new Dictionary<string, object?>
+                {
+                    [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Counter)] =
+                        startCounter + i,
+                    [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Depth)] = Depth
+                }));
     }
 
     [Benchmark]
@@ -248,21 +262,24 @@ public class MemoryGc_DeepTreeMutationPressureBenchmarks : MemoryGcBase
         for (var i = 0; i < Cycles; i++)
         {
             _seedCounter++;
-            total += Rask.RenderAndBuildDiffPayloadBytes(Scale_DeepTreeMutationByDepthBenchmarks_BuildHelper(_seedCounter));
+            total += Rask.RenderAndBuildDiffPayloadBytes(
+                Scale_DeepTreeMutationByDepthBenchmarks_BuildHelper(_seedCounter));
         }
+
         return total;
     }
 
-    private static global::Rask.Core.Component Scale_DeepTreeMutationByDepthBenchmarks_BuildHelper(int counter)
+    private static Component Scale_DeepTreeMutationByDepthBenchmarks_BuildHelper(int counter)
     {
         // Mirror the Blazor side exactly: 100-deep div nest wrapping a leaf span,
         // no page shell. Blazor's BuildRenderTree emits no doctype/html/body either.
-        global::Rask.Core.Component leaf =
-            global::Rask.Core.Components.Generated.Span(Class: "counter")[counter.ToString()];
+        var leaf =
+            Generated.Span(Class: "counter")[counter.ToString()];
         for (var i = 0; i < Depth; i++)
         {
-            leaf = global::Rask.Core.Components.Generated.Div(Class: $"d{i}")[leaf];
+            leaf = Generated.Div(Class: $"d{i}")[leaf];
         }
+
         return leaf;
     }
 }
@@ -275,9 +292,9 @@ public class MemoryGc_PayloadEnvelopePressureBenchmarks
     // engage the symbol-table path at LivePayload.cs:279). Catches accumulating
     // dictionary allocations or temp buffer leaks in the encode preamble.
     public const int Cycles = 10_000;
+    private ArrayBufferWriter<byte> _buffer = null!;
 
     private List<EditOp> _ops = null!;
-    private ArrayBufferWriter<byte> _buffer = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -312,6 +329,7 @@ public class MemoryGc_PayloadEnvelopePressureBenchmarks
             LivePayload.BuildPayloadUtf8Diff(_buffer, _ops);
             total += _buffer.WrittenCount;
         }
+
         return total;
     }
 }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/MicroBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/MicroBenchmarks.cs
@@ -20,18 +20,15 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 [MemoryDiagnoser]
 public class Micro_HtmlSerializerAppendEncodedBenchmarks
 {
-    [ParamsSource(nameof(Inputs))]
-    public InputCase Input { get; set; } = null!;
+    private StringBuilder _sb = null!;
+
+    [ParamsSource(nameof(Inputs))] public InputCase Input { get; set; } = null!;
 
     public static IEnumerable<InputCase> Inputs => new[]
     {
-        new InputCase("safe-ascii-16", "data-test-row-42"),
-        new InputCase("safe-ascii-200", new string('x', 200)),
-        new InputCase("encoder-fallback", "tom&jerry"),
-        new InputCase("utf-8-multibyte", "árvíztűrő")
+        new InputCase("safe-ascii-16", "data-test-row-42"), new InputCase("safe-ascii-200", new string('x', 200)),
+        new InputCase("encoder-fallback", "tom&jerry"), new InputCase("utf-8-multibyte", "árvíztűrő")
     };
-
-    private StringBuilder _sb = null!;
 
     [GlobalSetup]
     public void Setup() => _sb = new StringBuilder(1024);
@@ -40,16 +37,10 @@ public class Micro_HtmlSerializerAppendEncodedBenchmarks
     public void Reset() => _sb.Clear();
 
     [Benchmark(Baseline = true)]
-    public void Baseline_HtmlEncoderDefault()
-    {
-        _sb.Append(HtmlEncoder.Default.Encode(Input.Value));
-    }
+    public void Baseline_HtmlEncoderDefault() => _sb.Append(HtmlEncoder.Default.Encode(Input.Value));
 
     [Benchmark]
-    public void Rask_AppendEncoded()
-    {
-        HtmlSerializer.AppendEncoded(_sb, Input.Value);
-    }
+    public void Rask_AppendEncoded() => HtmlSerializer.AppendEncoded(_sb, Input.Value);
 
     public sealed record InputCase(string Label, string Value)
     {
@@ -67,13 +58,14 @@ public class Micro_FrameDifferDiffBenchmarks
         KeyedSwap50Rows
     }
 
-    [Params(Scenario.IdentityZeroOps, Scenario.SingleTextChange, Scenario.KeyedSwap50Rows)]
-    public Scenario Case { get; set; }
+    private RenderFrame[] _after = null!;
 
     private RenderFrame[] _before = null!;
-    private RenderFrame[] _after = null!;
     private string? _newHtml;
     private List<EditOp> _output = null!;
+
+    [Params(Scenario.IdentityZeroOps, Scenario.SingleTextChange, Scenario.KeyedSwap50Rows)]
+    public Scenario Case { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -92,7 +84,12 @@ public class Micro_FrameDifferDiffBenchmarks
             case Scenario.KeyedSwap50Rows:
                 var orderBefore = new int[50];
                 var orderAfter = new int[50];
-                for (var i = 0; i < 50; i++) { orderBefore[i] = i; orderAfter[i] = i; }
+                for (var i = 0; i < 50; i++)
+                {
+                    orderBefore[i] = i;
+                    orderAfter[i] = i;
+                }
+
                 (orderAfter[10], orderAfter[20]) = (orderAfter[20], orderAfter[10]);
                 _before = MicroBenchHarness.BuildFrames(KeyedList.BuildRask(orderBefore));
                 var pair = MicroBenchHarness.BuildFramesAndHtml(KeyedList.BuildRask(orderAfter));
@@ -113,19 +110,18 @@ public class Micro_FrameDifferDiffBenchmarks
 [MemoryDiagnoser]
 public class Micro_FrameDifferLisBenchmarks
 {
+    private int[] _input = null!;
+
     // O(n²) LIS for keyed reorders. Reverse is the worst case (every pair inversion);
     // the LIS itself is length 1, so the whole array enters the diff as MoveSubtree ops.
     // Identity is the best case (LIS = full array; zero moves). RandomPermutation is the
     // average-case scaling baseline. OneOutOfOrder is the typical real-world shape
     // (a single swap inside an otherwise-sorted list).
-    [Params(10, 100, 500, 2000)]
-    public int N { get; set; }
+    [Params(10, 100, 500, 2000)] public int N { get; set; }
 
     [Params(MicroBenchHarness.LisShape.Identity, MicroBenchHarness.LisShape.Reverse,
         MicroBenchHarness.LisShape.RandomPermutation, MicroBenchHarness.LisShape.OneOutOfOrder)]
     public MicroBenchHarness.LisShape Shape { get; set; }
-
-    private int[] _input = null!;
 
     [GlobalSetup]
     public void Setup() => _input = MicroBenchHarness.BuildLisInput(N, Shape);
@@ -137,11 +133,11 @@ public class Micro_FrameDifferLisBenchmarks
 [MemoryDiagnoser]
 public class Micro_LivePayloadBuildDiffBenchmarks
 {
-    [Params(1, 10, 100, 500)]
-    public int OpCount { get; set; }
+    private ArrayBufferWriter<byte> _buffer = null!;
 
     private List<EditOp> _ops = null!;
-    private ArrayBufferWriter<byte> _buffer = null!;
+
+    [Params(1, 10, 100, 500)] public int OpCount { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -189,20 +185,19 @@ public class Micro_FrameWriterGrowthBenchmarks
     // re-rents the growth path triggers. Re-instantiating per iteration is intentional —
     // measures the cold-rent + grow pattern, not steady-state pooled reuse (which is
     // already covered by RaskHarness throughput).
-    [Params(10, 100, 1000)]
-    public int Cycles { get; set; }
+    [Params(10, 100, 1000)] public int Cycles { get; set; }
 
     [Benchmark]
     public int Rask_FrameWriterGrow()
     {
-        var w = new FrameWriter(initialCapacity: 16);
+        var w = new FrameWriter(16);
         for (var i = 0; i < Cycles; i++)
         {
-            var idx = w.OpenElement("div", scopeId: null, selfClosing: false, htmlStart: 0);
+            var idx = w.OpenElement("div", null, false, 0);
             w.Attribute("class", "row");
             w.Attribute("id", "r");
             w.Text("text", 0, 4);
-            w.CloseElement(idx, htmlEnd: 0);
+            w.CloseElement(idx, 0);
         }
 
         return w.Count;
@@ -218,9 +213,9 @@ public class Micro_SessionRenderCacheRotateBenchmarks
     // itself (the high-water-mark path of the diff codec — the part that has to stay
     // free of per-render allocation).
     private SessionRenderCache _cache = null!;
-    private Component _trivial = null!;
-    private StringBuilder _sb = null!;
     private List<EditOp> _ops = null!;
+    private StringBuilder _sb = null!;
+    private Component _trivial = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/Realistic_Benchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/Realistic_Benchmarks.cs
@@ -13,8 +13,8 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 
 public abstract class RealisticDiffBase
 {
-    protected RaskHarness Rask = null!;
     protected BlazorRenderBatchCapture Blazor = null!;
+    protected RaskHarness Rask = null!;
 
     [GlobalCleanup]
     public void Cleanup()
@@ -27,8 +27,8 @@ public abstract class RealisticDiffBase
 [MemoryDiagnoser]
 public class Realistic_DashboardWidgetsBenchmarks : RealisticDiffBase
 {
-    private DashboardWidgets.StatefulDashboard _stateful = null!;
     private int _blazorCounter;
+    private DashboardWidgets.StatefulDashboard _stateful = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -67,10 +67,10 @@ public class Realistic_DashboardWidgetsBenchmarks : RealisticDiffBase
 [MemoryDiagnoser]
 public class Realistic_TableSortFilterBenchmarks : RealisticDiffBase
 {
-    private TableSortFilter.StatefulTableSortFilter _stateful = null!;
     private int[] _initialOrder = null!;
-    private int[] _reversedOrder = null!;
     private bool _reversed;
+    private int[] _reversedOrder = null!;
+    private TableSortFilter.StatefulTableSortFilter _stateful = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -81,9 +81,17 @@ public class Realistic_TableSortFilterBenchmarks : RealisticDiffBase
         _stateful = new TableSortFilter.StatefulTableSortFilter();
 #pragma warning restore RASK014
         _initialOrder = new int[TableSortFilter.InitialRowCount];
-        for (var i = 0; i < TableSortFilter.InitialRowCount; i++) _initialOrder[i] = i;
+        for (var i = 0; i < TableSortFilter.InitialRowCount; i++)
+        {
+            _initialOrder[i] = i;
+        }
+
         _reversedOrder = new int[TableSortFilter.InitialRowCount];
-        for (var i = 0; i < TableSortFilter.InitialRowCount; i++) _reversedOrder[i] = TableSortFilter.InitialRowCount - 1 - i;
+        for (var i = 0; i < TableSortFilter.InitialRowCount; i++)
+        {
+            _reversedOrder[i] = TableSortFilter.InitialRowCount - 1 - i;
+        }
+
         Rask.SeedPrevious(_stateful);
     }
 
@@ -114,10 +122,10 @@ public class Realistic_TableSortFilterBenchmarks : RealisticDiffBase
 [MemoryDiagnoser]
 public class Realistic_FormValidationChurnBenchmarks : RealisticDiffBase
 {
-    private FormValidationChurn.StatefulForm _stateful = null!;
-    private string?[] _blazorValues = null!;
     private bool[] _blazorInvalid = null!;
+    private string?[] _blazorValues = null!;
     private int _cursor;
+    private FormValidationChurn.StatefulForm _stateful = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -168,8 +176,8 @@ public class Realistic_FormValidationChurnBenchmarks : RealisticDiffBase
 [MemoryDiagnoser]
 public class Realistic_NavSwitchBenchmarks : RealisticDiffBase
 {
-    private NavSwitch.StatefulNavSwitch _stateful = null!;
     private int _blazorActive;
+    private NavSwitch.StatefulNavSwitch _stateful = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/RenderHotPathBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/RenderHotPathBenchmarks.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
 using Rask.Benchmarks.VsBlazor.Components;
-using Rask.Core;
 
 namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 
@@ -99,10 +98,8 @@ public class RenderHotPath_NestedTreeBenchmarks : RenderHotPathBase
 public class RenderHotPath_LargePageBenchmarks : RenderHotPathBase
 {
     [Benchmark(Baseline = true)]
-    public string Blazor_Render() => RenderBlazor<LargePageWithCounter.BlazorLargePageWithCounter>(new Dictionary<string, object?>
-    {
-        [nameof(LargePageWithCounter.BlazorLargePageWithCounter.Counter)] = 1
-    });
+    public string Blazor_Render() => RenderBlazor<LargePageWithCounter.BlazorLargePageWithCounter>(
+        new Dictionary<string, object?> { [nameof(LargePageWithCounter.BlazorLargePageWithCounter.Counter)] = 1 });
 
     [Benchmark]
     public string Rask_Render() => LargePageWithCounter.BuildRask(1).ToHtml();
@@ -118,10 +115,11 @@ public class RenderHotPath_AttributeHeavyBenchmarks : RenderHotPathBase
     [Params(20, 50)] public int AttrCount { get; set; }
 
     [Benchmark(Baseline = true)]
-    public string Blazor_Render() => RenderBlazor<AttributeHeavyElements.BlazorAttributeHeavy>(new Dictionary<string, object?>
-    {
-        [nameof(AttributeHeavyElements.BlazorAttributeHeavy.AttrCount)] = AttrCount
-    });
+    public string Blazor_Render() => RenderBlazor<AttributeHeavyElements.BlazorAttributeHeavy>(
+        new Dictionary<string, object?>
+        {
+            [nameof(AttributeHeavyElements.BlazorAttributeHeavy.AttrCount)] = AttrCount
+        });
 
     [Benchmark]
     public string Rask_Render() => AttributeHeavyElements.BuildRask(AttrCount).ToHtml();

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/Scale_Benchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/Scale_Benchmarks.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Rendering;
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -19,10 +20,9 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 [MemoryDiagnoser]
 public class Scale_StaticListLargeBenchmarks
 {
-    [Params(1000, 5000, 10000)]
-    public int RowCount { get; set; }
-
     private HtmlRenderer _blazor = null!;
+
+    [Params(1000, 5000, 10000)] public int RowCount { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -54,8 +54,8 @@ public class Scale_StaticListLargeBenchmarks
 
 public abstract class ScaleDiffBase
 {
-    protected RaskHarness Rask = null!;
     protected BlazorRenderBatchCapture Blazor = null!;
+    protected RaskHarness Rask = null!;
 
     [GlobalCleanup]
     public void Cleanup()
@@ -68,13 +68,13 @@ public abstract class ScaleDiffBase
 [MemoryDiagnoser]
 public class Scale_KeyedReorderLargeBenchmarks : ScaleDiffBase
 {
-    [Params(1000, 5000)]
-    public int N { get; set; }
+    private int[] _blazorOrder = null!;
 
     private KeyedList.StatefulKeyedList _stateful = null!;
-    private int[] _blazorOrder = null!;
     private int _swapA;
     private int _swapB;
+
+    [Params(1000, 5000)] public int N { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -124,13 +124,13 @@ public class Scale_KeyedReorderLargeBenchmarks : ScaleDiffBase
 [MemoryDiagnoser]
 public class Scale_KeyedRandomPermutationBenchmarks : ScaleDiffBase
 {
-    [Params(100, 500, 1000)]
-    public int N { get; set; }
-
-    private KeyedList.StatefulKeyedList _stateful = null!;
     private int[] _identity = null!;
     private int[] _permuted = null!;
+
+    private KeyedList.StatefulKeyedList _stateful = null!;
     private bool _useIdentity = true;
+
+    [Params(100, 500, 1000)] public int N { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -138,7 +138,11 @@ public class Scale_KeyedRandomPermutationBenchmarks : ScaleDiffBase
         Rask = new RaskHarness();
         Blazor = new BlazorRenderBatchCapture();
         _identity = new int[N];
-        for (var i = 0; i < N; i++) _identity[i] = i;
+        for (var i = 0; i < N; i++)
+        {
+            _identity[i] = i;
+        }
+
         _permuted = MicroBenchHarness.BuildLisInput(N, MicroBenchHarness.LisShape.RandomPermutation);
 #pragma warning disable RASK014
         _stateful = new KeyedList.StatefulKeyedList { InitialRowCount = N };
@@ -175,13 +179,13 @@ public class Scale_KeyedRandomPermutationBenchmarks : ScaleDiffBase
 [MemoryDiagnoser]
 public class Scale_KeyedAppendMiddleBenchmarks : ScaleDiffBase
 {
-    [Params(100, 500, 2000)]
-    public int N { get; set; }
+    private int[] _long = null!;
+    private int[] _short = null!;
 
     private KeyedList.StatefulKeyedList _stateful = null!;
-    private int[] _short = null!;
-    private int[] _long = null!;
     private bool _useShort = true;
+
+    [Params(100, 500, 2000)] public int N { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -189,12 +193,23 @@ public class Scale_KeyedAppendMiddleBenchmarks : ScaleDiffBase
         Rask = new RaskHarness();
         Blazor = new BlazorRenderBatchCapture();
         _short = new int[N];
-        for (var i = 0; i < N; i++) _short[i] = i;
+        for (var i = 0; i < N; i++)
+        {
+            _short[i] = i;
+        }
+
         _long = new int[N + 1];
         var inserted = N + 1000; // unique key not present in _short
-        for (var i = 0; i < N / 2; i++) _long[i] = _short[i];
+        for (var i = 0; i < N / 2; i++)
+        {
+            _long[i] = _short[i];
+        }
+
         _long[N / 2] = inserted;
-        for (var i = N / 2; i < N; i++) _long[i + 1] = _short[i];
+        for (var i = N / 2; i < N; i++)
+        {
+            _long[i + 1] = _short[i];
+        }
 #pragma warning disable RASK014
         _stateful = new KeyedList.StatefulKeyedList { InitialRowCount = N };
 #pragma warning restore RASK014
@@ -230,10 +245,9 @@ public class Scale_KeyedAppendMiddleBenchmarks : ScaleDiffBase
 [MemoryDiagnoser]
 public class Scale_DeepTreeMutationByDepthBenchmarks : ScaleDiffBase
 {
-    [Params(10, 50, 100, 200)]
-    public int Depth { get; set; }
-
     private int _counter;
+
+    [Params(10, 50, 100, 200)] public int Depth { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -269,11 +283,12 @@ public class Scale_DeepTreeMutationByDepthBenchmarks : ScaleDiffBase
 
     private static Component BuildDeepTreeRask(int counter, int depth)
     {
-        Component leaf = C.Span(Class: "counter")[counter.ToString()];
+        var leaf = C.Span(Class: "counter")[counter.ToString()];
         for (var i = 0; i < depth; i++)
         {
             leaf = C.Div(Class: $"d{i}")[leaf];
         }
+
         return C.Fragment()[C.Doctype(), C.Html()[C.Body()[leaf]]];
     }
 
@@ -286,18 +301,22 @@ public class Scale_DeepTreeMutationByDepthBenchmarks : ScaleDiffBase
         [Parameter] public int Counter { get; set; }
         [Parameter] public int Depth { get; set; }
 
-        protected override void BuildRenderTree(Microsoft.AspNetCore.Components.Rendering.RenderTreeBuilder b)
+        protected override void BuildRenderTree(RenderTreeBuilder b)
         {
             for (var i = 0; i < Depth; i++)
             {
                 b.OpenElement(0, "div");
                 b.AddAttribute(1, "class", $"d{i}");
             }
+
             b.OpenElement(2, "span");
             b.AddAttribute(3, "class", "counter");
             b.AddContent(4, Counter.ToString());
             b.CloseElement();
-            for (var i = 0; i < Depth; i++) b.CloseElement();
+            for (var i = 0; i < Depth; i++)
+            {
+                b.CloseElement();
+            }
         }
     }
 }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/VirtualizationScrollBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/VirtualizationScrollBenchmarks.cs
@@ -2,6 +2,7 @@ using BenchmarkDotNet.Attributes;
 using Microsoft.AspNetCore.Components;
 using Rask.Benchmarks.VsBlazor.Components;
 using Rask.Benchmarks.VsBlazor.Infrastructure;
+using Rask.Core;
 using RaskVirtualize = Rask.Core.Components.Virtualize;
 
 namespace Rask.Benchmarks.VsBlazor.Benchmarks;
@@ -14,8 +15,8 @@ namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 [MemoryDiagnoser]
 public class RenderHotPath_VirtualizedListBenchmarks : RenderHotPathBase
 {
+    private Component _raskRoot = null!;
     private RaskVirtualize _raskVirt = null!;
-    private Rask.Core.Component _raskRoot = null!;
 
     public override void Setup()
     {
@@ -42,10 +43,10 @@ public class RenderHotPath_VirtualizedListBenchmarks : RenderHotPathBase
 [MemoryDiagnoser]
 public class LiveDiffPayload_VirtualizationScrollBenchmarks : LiveDiffPayloadBase
 {
-    private RaskVirtualize _raskVirt = null!;
-    private Rask.Core.Component _raskRoot = null!;
-    private int _scrollStep;
     private int _blazorSalt;
+    private Component _raskRoot = null!;
+    private RaskVirtualize _raskVirt = null!;
+    private int _scrollStep;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/AppendDeleteRowChurn.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/AppendDeleteRowChurn.cs
@@ -6,7 +6,7 @@ using C = Rask.Core.Components.Generated;
 namespace Rask.Benchmarks.VsBlazor.Components;
 
 /// <summary>
-///     Companion scenarios to <see cref="KeyedList"/> reorder: one row appended at
+///     Companion scenarios to <see cref="KeyedList" /> reorder: one row appended at
 ///     the end of a 100-row keyed list (or, in the delete variant, one row removed
 ///     from the middle). Stresses the <c>InsertSubtree</c> / <c>RemoveSubtree</c>
 ///     diff op kinds — the cases the live-diff gate explicitly checks for before
@@ -18,7 +18,7 @@ internal static class AppendDeleteRowChurn
 
     /// <summary>
     ///     Build a Rask tree from a row id sequence. Identical row shape to
-    ///     <see cref="KeyedList"/> so the differ can match them across renders by
+    ///     <see cref="KeyedList" /> so the differ can match them across renders by
     ///     the <c>rask-key</c> data attribute.
     /// </summary>
     public static Component BuildRask(int[] order)
@@ -46,13 +46,14 @@ internal static class AppendDeleteRowChurn
     public sealed class StatefulAppendDeleteList : Component
 #pragma warning restore RASK014
     {
+        private readonly Dictionary<int, Child> _rowsByKey = new();
+        private int[]? _currentOrder;
+
+        private List<Child>? _scratch;
+
         // Capacity is kept for the seeded-initial-order branch; sparse keys (e.g. N+1000)
         // work transparently because rows are lazy-built into the dictionary on demand.
         public int Capacity { get; init; } = InitialRowCount + 1;
-
-        private readonly Dictionary<int, Child> _rowsByKey = new();
-        private int[]? _currentOrder;
-        private List<Child>? _scratch;
 
         public int[] CurrentOrder
         {
@@ -80,12 +81,17 @@ internal static class AppendDeleteRowChurn
             {
                 _scratch.Add(GetOrCreateRow(order[i]));
             }
+
             return C.Div(Class: "list")[_scratch];
         }
 
         private Child GetOrCreateRow(int key)
         {
-            if (_rowsByKey.TryGetValue(key, out var row)) return row;
+            if (_rowsByKey.TryGetValue(key, out var row))
+            {
+                return row;
+            }
+
             row = C.Div(
                 Class: "row",
                 Data: new Dictionary<string, string?> { ["rask-key"] = key.ToString() })[
@@ -97,9 +103,16 @@ internal static class AppendDeleteRowChurn
 
         private void EnsureSeeded()
         {
-            if (_currentOrder is not null) return;
+            if (_currentOrder is not null)
+            {
+                return;
+            }
+
             _currentOrder = new int[InitialRowCount];
-            for (var i = 0; i < InitialRowCount; i++) _currentOrder[i] = i;
+            for (var i = 0; i < InitialRowCount; i++)
+            {
+                _currentOrder[i] = i;
+            }
         }
     }
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/AttributeBurstUpdate.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/AttributeBurstUpdate.cs
@@ -23,7 +23,7 @@ internal static class AttributeBurstUpdate
         var rows = new List<Child>(RowCount);
         for (var i = 0; i < RowCount; i++)
         {
-            Component row = loaded
+            var row = loaded
                 ? C.Div(Class: "row", Data: new Dictionary<string, string?> { ["loaded"] = "true" })[
                     C.Span()[$"Row {i}"]
                 ]
@@ -59,6 +59,7 @@ internal static class AttributeBurstUpdate
 
                 b.CloseElement();
             }
+
             b.CloseElement();
         }
     }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/AttributeHeavyElements.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/AttributeHeavyElements.cs
@@ -6,7 +6,7 @@ using C = Rask.Core.Components.Generated;
 namespace Rask.Benchmarks.VsBlazor.Components;
 
 /// <summary>
-///     <see cref="ElementCount"/> div elements, each carrying <c>Class</c>, <c>Id</c>,
+///     <see cref="ElementCount" /> div elements, each carrying <c>Class</c>, <c>Id</c>,
 ///     <c>Style</c>, and <c>(attrCount - 3)</c> data-* attributes. Stresses
 ///     <c>Component.WriteAttributes</c> and the safe-ASCII fast path in
 ///     <c>HtmlSerializer.AppendEncoded</c> — the per-attribute encode + StringBuilder
@@ -41,7 +41,7 @@ internal static class AttributeHeavyElements
     }
 
     /// <summary>
-    ///     Same shape as <see cref="BuildRask"/> but element index 50 has one of its
+    ///     Same shape as <see cref="BuildRask" /> but element index 50 has one of its
     ///     data-* values flipped — gives the diff codec one <c>SetAttribute</c> op to
     ///     emit.
     /// </summary>

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/ClassToggle.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/ClassToggle.cs
@@ -26,7 +26,7 @@ internal static class ClassToggle
         {
             var cls = i == activeIndex ? "nav-item active" : "nav-item";
             items.Add(C.Li(Class: cls)[
-                C.A(Href: $"/page/{i}")[$"Page {i}"]
+                C.A($"/page/{i}")[$"Page {i}"]
             ]);
         }
 
@@ -54,6 +54,7 @@ internal static class ClassToggle
 
                 b.CloseElement();
             }
+
             b.CloseElement();
             b.CloseElement();
         }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/ConditionalPanel.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/ConditionalPanel.cs
@@ -30,14 +30,12 @@ internal static class ConditionalPanel
             rows.Add(C.Li(Class: "panel-row")[$"Detail {i}"]);
         }
 
-        var body = new List<Child>(3)
-        {
-            C.Header()[C.H1()["Dashboard"]]
-        };
+        var body = new List<Child>(3) { C.Header()[C.H1()["Dashboard"]] };
         if (showPanel)
         {
             body.Add(C.Div(Class: "panel")[C.Ul()[rows]]);
         }
+
         body.Add(C.Footer()[C.Span()["© Rask"]]);
 
         return C.Div(Class: "shell")[body];
@@ -70,6 +68,7 @@ internal static class ConditionalPanel
                     b.AddContent(10, $"Detail {i}");
                     b.CloseElement();
                 }
+
                 b.CloseElement();
                 b.CloseElement();
             }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/DashboardWidgets.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/DashboardWidgets.cs
@@ -22,16 +22,15 @@ internal static class DashboardWidgets
     public sealed class StatefulDashboard : Component
 #pragma warning restore RASK014
     {
-        private List<Child>? _staticSidebar;
         private List<Child>? _staticAlerts;
+        private List<Child>? _staticSidebar;
         private List<Child>? _staticStatusGrid;
-        private int _counter;
 
-        public int Counter => _counter;
+        public int Counter { get; private set; }
 
         public void Tick()
         {
-            _counter++;
+            Counter++;
             StateHasChanged();
         }
 
@@ -77,7 +76,7 @@ internal static class DashboardWidgets
                     // Widget 1: counter — the only mutating widget
                     C.Div(Class: "widget counter-widget", Id: "w-counter")[
                         C.Span(Class: "widget-title")["Live count"],
-                        C.Span(Class: "widget-value")[_counter.ToString()]
+                        C.Span(Class: "widget-value")[Counter.ToString()]
                     ],
                     // Widget 2: chart placeholder
                     C.Div(Class: "widget chart-widget", Id: "w-chart")[
@@ -136,7 +135,8 @@ internal static class DashboardWidgets
             b.OpenElement(10, "aside");
             b.AddAttribute(11, "class", "sidebar");
             b.OpenElement(12, "ul");
-            string[] navItems = ["/dashboard:Dashboard", "/reports:Reports", "/users:Users", "/settings:Settings", "/help:Help"];
+            string[] navItems =
+                ["/dashboard:Dashboard", "/reports:Reports", "/users:Users", "/settings:Settings", "/help:Help"];
             foreach (var item in navItems)
             {
                 var parts = item.Split(':');
@@ -148,6 +148,7 @@ internal static class DashboardWidgets
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
             b.CloseElement();
 
@@ -203,6 +204,7 @@ internal static class DashboardWidgets
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
 
             // Widget 4: alerts
@@ -230,6 +232,7 @@ internal static class DashboardWidgets
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
             b.CloseElement();
 
@@ -258,6 +261,7 @@ internal static class DashboardWidgets
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
             b.CloseElement();
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/DeepTreeCounter.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/DeepTreeCounter.cs
@@ -20,7 +20,7 @@ internal static class DeepTreeCounter
 
     public static Component BuildRask(int counter)
     {
-        Component leaf = C.Span(Class: "counter")[counter.ToString()];
+        var leaf = C.Span(Class: "counter")[counter.ToString()];
         for (var i = 0; i < Depth; i++)
         {
             leaf = C.Div(Class: $"d{i}")[leaf];

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/FormInputTyping.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/FormInputTyping.cs
@@ -21,12 +21,12 @@ internal static class FormInputTyping
     {
         return C.Form()[
             C.Label()["Field A"],
-            C.Input(Type: "text", Name: "a", Value: a),
+            C.Input("text", "a", a),
             C.Label()["Field B"],
-            C.Input(Type: "text", Name: "b", Value: b),
+            C.Input("text", "b", b),
             C.Label()["Field C"],
-            C.Input(Type: "text", Name: "c", Value: c),
-            C.Button(Type: "submit")["Save"]
+            C.Input("text", "c", c),
+            C.Button("submit")["Save"]
         ];
     }
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/FormValidationChurn.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/FormValidationChurn.cs
@@ -20,8 +20,8 @@ internal static class FormValidationChurn
     public sealed class StatefulForm : Component
 #pragma warning restore RASK014
     {
-        private readonly string[] _values = new string[FieldCount];
         private readonly bool[] _invalid = new bool[FieldCount];
+        private readonly string[] _values = new string[FieldCount];
 
         public void MutateField(int index)
         {
@@ -32,19 +32,20 @@ internal static class FormValidationChurn
 
         protected override RenderResult Render()
         {
-            var children = new List<Child>(FieldCount * 2 + 1);
+            var children = new List<Child>((FieldCount * 2) + 1);
             for (var i = 0; i < FieldCount; i++)
             {
                 var fieldClass = _invalid[i] ? "field invalid" : "field";
                 children.Add(C.Div(Class: fieldClass, Id: $"f{i}")[
                     C.Label()[$"Field {i}"],
-                    C.Input(Type: "text", Value: _values[i] ?? string.Empty),
+                    C.Input("text", Value: _values[i] ?? string.Empty),
                     _invalid[i]
                         ? C.Div(Class: "validation-msg")["required"]
                         : C.Div(Class: "validation-msg")
                 ]);
             }
-            children.Add(C.Button(Type: "submit")["Save"]);
+
+            children.Add(C.Button("submit")["Save"]);
 
             return C.Form()[children];
         }
@@ -73,10 +74,15 @@ internal static class FormValidationChurn
                 b.CloseElement();
                 b.OpenElement(9, "div");
                 b.AddAttribute(10, "class", "validation-msg");
-                if (Invalid[i]) b.AddContent(11, "required");
+                if (Invalid[i])
+                {
+                    b.AddContent(11, "required");
+                }
+
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.OpenElement(12, "button");
             b.AddAttribute(13, "type", "submit");
             b.AddContent(14, "Save");

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/KeyedList.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/KeyedList.cs
@@ -37,17 +37,18 @@ internal static class KeyedList
     public sealed class StatefulKeyedList : Component
 #pragma warning restore RASK014
     {
+        private readonly Dictionary<int, Child> _rowsByKey = new();
+        private int[]? _order;
+        private List<Child>? _scratch;
+        private int _swapA = 5;
+
+        private int _swapB;
+
         // Default visible-row count for the initial order; benchmarks needing a non-zero
         // pre-seeded population set this (e.g. 100 for KeyedList100Reorder). Sparse-key
         // scenarios (Scale_KeyedAppendMiddle with inserted = N+1000) work transparently
         // because rows are lazy-allocated by key on demand into the dictionary below.
         public int InitialRowCount { get; init; } = 100;
-
-        private readonly Dictionary<int, Child> _rowsByKey = new();
-        private int[]? _order;
-        private List<Child>? _scratch;
-        private int _swapA = 5;
-        private int _swapB;
 
         public int[] CurrentOrder
         {
@@ -92,12 +93,17 @@ internal static class KeyedList
             {
                 _scratch.Add(GetOrCreateRow(order[i]));
             }
+
             return C.Div(Class: "list")[_scratch];
         }
 
         private Child GetOrCreateRow(int key)
         {
-            if (_rowsByKey.TryGetValue(key, out var row)) return row;
+            if (_rowsByKey.TryGetValue(key, out var row))
+            {
+                return row;
+            }
+
             row = C.Div(
                 Class: "row",
                 Data: new Dictionary<string, string?> { ["rask-key"] = key.ToString() })[
@@ -109,9 +115,16 @@ internal static class KeyedList
 
         private void EnsureSeeded()
         {
-            if (_order is not null) return;
+            if (_order is not null)
+            {
+                return;
+            }
+
             _order = new int[InitialRowCount];
-            for (var i = 0; i < InitialRowCount; i++) _order[i] = i;
+            for (var i = 0; i < InitialRowCount; i++)
+            {
+                _order[i] = i;
+            }
         }
     }
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/LifecycleChurn.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/LifecycleChurn.cs
@@ -26,18 +26,6 @@ internal static class LifecycleChurn
 {
     public const int MaxActiveCount = 100;
 
-#pragma warning disable RASK014
-    public sealed class RaskChild : Component
-#pragma warning restore RASK014
-    {
-        public int Index { get; set; }
-
-        protected override RenderResult Render() =>
-            C.Div(Class: "child", Id: $"c{Index}")[
-                C.Span(Class: "label")[$"Child {Index}"]
-            ];
-    }
-
     public static Component BuildRask(int activeCount)
     {
         var children = new List<Child>(activeCount);
@@ -49,6 +37,18 @@ internal static class LifecycleChurn
         }
 
         return C.Div(Class: "host")[children];
+    }
+
+#pragma warning disable RASK014
+    public sealed class RaskChild : Component
+#pragma warning restore RASK014
+    {
+        public int Index { get; set; }
+
+        protected override RenderResult Render() =>
+            C.Div(Class: "child", Id: $"c{Index}")[
+                C.Span(Class: "label")[$"Child {Index}"]
+            ];
     }
 
     public sealed class BlazorChild : ComponentBase

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/NavSwitch.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/NavSwitch.cs
@@ -40,7 +40,7 @@ internal static class NavSwitch
 
         return C.Div(Class: "nav-shell")[
             C.Nav()[C.Ul()[tabs]],
-            C.Main(Id: $"tab-{activeTab}")[contentRows]
+            C.Main($"tab-{activeTab}")[contentRows]
         ];
     }
 
@@ -48,14 +48,13 @@ internal static class NavSwitch
     public sealed class StatefulNavSwitch : Component
 #pragma warning restore RASK014
     {
-        private List<Child>?[] _tabContentCache = new List<Child>?[TabCount];
-        private int _activeTab;
+        private readonly List<Child>?[] _tabContentCache = new List<Child>?[TabCount];
 
-        public int ActiveTab => _activeTab;
+        public int ActiveTab { get; private set; }
 
         public void Switch(int tab)
         {
-            _activeTab = tab;
+            ActiveTab = tab;
             StateHasChanged();
         }
 
@@ -64,29 +63,30 @@ internal static class NavSwitch
             var tabs = new List<Child>(TabCount);
             for (var t = 0; t < TabCount; t++)
             {
-                var isActive = t == _activeTab;
+                var isActive = t == ActiveTab;
                 tabs.Add(C.Li(Class: isActive ? "tab active" : "tab")[
                     C.A($"#t{t}")[$"Tab {t}"]
                 ]);
             }
 
-            var content = _tabContentCache[_activeTab];
+            var content = _tabContentCache[ActiveTab];
             if (content is null)
             {
                 content = new List<Child>(RowsPerTab);
                 for (var i = 0; i < RowsPerTab; i++)
                 {
                     content.Add(C.Div(Class: "row")[
-                        C.Span(Class: "label")[$"Tab {_activeTab} row {i}"],
-                        C.A($"/tab/{_activeTab}/{i}")[$"open {i}"]
+                        C.Span(Class: "label")[$"Tab {ActiveTab} row {i}"],
+                        C.A($"/tab/{ActiveTab}/{i}")[$"open {i}"]
                     ]);
                 }
-                _tabContentCache[_activeTab] = content;
+
+                _tabContentCache[ActiveTab] = content;
             }
 
             return C.Div(Class: "nav-shell")[
                 C.Nav()[C.Ul()[tabs]],
-                C.Main(Id: $"tab-{_activeTab}")[content]
+                C.Main($"tab-{ActiveTab}")[content]
             ];
         }
     }
@@ -113,6 +113,7 @@ internal static class NavSwitch
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
             b.CloseElement();
 
@@ -132,6 +133,7 @@ internal static class NavSwitch
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
 
             b.CloseElement();

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/NestedKeyedList.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/NestedKeyedList.cs
@@ -52,13 +52,12 @@ internal static class NestedKeyedList
     public sealed class StatefulNestedKeyedList : Component
 #pragma warning restore RASK014
     {
-        public int OuterCapacity { get; init; } = OuterCardCount;
-
         private Child[]? _cardsByKey;
         private int[]? _order;
         private List<Child>? _scratch;
         private int _swapA = 3;
         private int _swapB;
+        public int OuterCapacity { get; init; } = OuterCardCount;
 
         public int[] CurrentOrder
         {
@@ -88,12 +87,17 @@ internal static class NestedKeyedList
             {
                 _scratch.Add(_cardsByKey![_order[i]]);
             }
+
             return C.Div(Class: "deck")[_scratch];
         }
 
         private void EnsureSeeded()
         {
-            if (_cardsByKey is not null) return;
+            if (_cardsByKey is not null)
+            {
+                return;
+            }
+
             _cardsByKey = new Child[OuterCapacity];
             for (var k = 0; k < OuterCapacity; k++)
             {
@@ -106,6 +110,7 @@ internal static class NestedKeyedList
                         C.Span()[$"Card {k} · row {r}"]
                     ]);
                 }
+
                 _cardsByKey[k] = C.Div(
                     Class: "card",
                     Data: new Dictionary<string, string?> { ["rask-key"] = k.ToString() })[
@@ -113,10 +118,14 @@ internal static class NestedKeyedList
                     C.Ul()[rows]
                 ];
             }
+
             if (_order is null)
             {
                 _order = new int[OuterCapacity];
-                for (var i = 0; i < OuterCapacity; i++) _order[i] = i;
+                for (var i = 0; i < OuterCapacity; i++)
+                {
+                    _order[i] = i;
+                }
             }
         }
     }
@@ -153,6 +162,7 @@ internal static class NestedKeyedList
 
                     b.CloseElement();
                 }
+
                 b.CloseElement();
 
                 b.CloseElement();

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/NestedTree.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/NestedTree.cs
@@ -13,7 +13,7 @@ internal static class NestedTree
 {
     public static Component BuildRask(int depth)
     {
-        Component leaf = C.Span()["leaf"];
+        var leaf = C.Span()["leaf"];
         for (var i = 0; i < depth; i++)
         {
             leaf = C.Div(Class: $"d{i}")[leaf];

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/StatefulLargePageWithCounter.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/StatefulLargePageWithCounter.cs
@@ -26,13 +26,12 @@ public sealed class StatefulLargePageWithCounter : Component
     public const int LargePageRowCount = 200;
 
     private List<Child>? _rows;
-    private int _counter;
 
-    public int Counter => _counter;
+    public int Counter { get; private set; }
 
     public void Tick()
     {
-        _counter++;
+        Counter++;
         StateHasChanged();
     }
 
@@ -52,7 +51,7 @@ public sealed class StatefulLargePageWithCounter : Component
 
         return C.Div(Class: "container", Id: "root")[
             C.Div(Class: "counter", Id: "counter")[
-                C.Span(Class: "value")[_counter.ToString()]
+                C.Span(Class: "value")[Counter.ToString()]
             ],
             C.Div(Class: "body")[_rows]
         ];
@@ -73,13 +72,12 @@ public sealed class StatefulLargePageWithDeepTextCell : Component
 
     private Child[]? _rowsByIndex;
     private List<Child>? _scratch;
-    private int _counter;
 
-    public int Counter => _counter;
+    public int Counter { get; private set; }
 
     public void Tick()
     {
-        _counter++;
+        Counter++;
         StateHasChanged();
     }
 
@@ -90,7 +88,11 @@ public sealed class StatefulLargePageWithDeepTextCell : Component
             _rowsByIndex = new Child[LargePageRowCount];
             for (var i = 0; i < LargePageRowCount; i++)
             {
-                if (i == MutatingIndex) continue; // built fresh each render
+                if (i == MutatingIndex)
+                {
+                    continue; // built fresh each render
+                }
+
                 _rowsByIndex[i] = C.Div(Class: "row", Id: $"r{i}")[
                     C.Span(Class: "label")[$"Item {i}"],
                     C.A($"/item/{i}", Class: "lnk")[$"open {i}"]
@@ -99,7 +101,7 @@ public sealed class StatefulLargePageWithDeepTextCell : Component
         }
 
         _rowsByIndex[MutatingIndex] = C.Div(Class: "row", Id: $"r{MutatingIndex}")[
-            C.Span(Class: "label")[$"ticker {_counter}"],
+            C.Span(Class: "label")[$"ticker {Counter}"],
             C.A($"/item/{MutatingIndex}", Class: "lnk")[$"open {MutatingIndex}"]
         ];
 
@@ -109,6 +111,7 @@ public sealed class StatefulLargePageWithDeepTextCell : Component
         {
             _scratch.Add(_rowsByIndex[i]);
         }
+
         return C.Div(Class: "body")[_scratch];
     }
 }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/TableSortFilter.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/TableSortFilter.cs
@@ -8,8 +8,12 @@ namespace Rask.Benchmarks.VsBlazor.Components;
 /// <summary>
 ///     200-row keyed table. Two state transitions per iteration:
 ///     <list type="number">
-///         <item><description>Column sort flips the row order (reverse).</description></item>
-///         <item><description>Filter halves the visible rows (drops the second half).</description></item>
+///         <item>
+///             <description>Column sort flips the row order (reverse).</description>
+///         </item>
+///         <item>
+///             <description>Filter halves the visible rows (drops the second half).</description>
+///         </item>
 ///     </list>
 ///     Combined keyed reorder + structural remove pattern — the most challenging
 ///     compound diff scenario. Keyed reorder produces MoveSubtree ops (trusted);
@@ -24,48 +28,53 @@ internal static class TableSortFilter
     public sealed class StatefulTableSortFilter : Component
 #pragma warning restore RASK014
     {
-        private int[] _visibleOrder;
+        private readonly Dictionary<int, Child> _rowCache = new();
+        private List<Child>? _scratch;
 
         public StatefulTableSortFilter()
         {
-            _visibleOrder = new int[InitialRowCount];
-            for (var i = 0; i < InitialRowCount; i++) _visibleOrder[i] = i;
+            VisibleOrder = new int[InitialRowCount];
+            for (var i = 0; i < InitialRowCount; i++)
+            {
+                VisibleOrder[i] = i;
+            }
         }
 
-        public int[] VisibleOrder => _visibleOrder;
+        public int[] VisibleOrder { get; private set; }
 
         public void ReverseSort()
         {
-            Array.Reverse(_visibleOrder);
+            Array.Reverse(VisibleOrder);
             StateHasChanged();
         }
 
         public void HalveFilter()
         {
-            var keep = _visibleOrder.Length / 2;
+            var keep = VisibleOrder.Length / 2;
             var trimmed = new int[keep];
-            Array.Copy(_visibleOrder, trimmed, keep);
-            _visibleOrder = trimmed;
+            Array.Copy(VisibleOrder, trimmed, keep);
+            VisibleOrder = trimmed;
             StateHasChanged();
         }
 
         public void Reset()
         {
-            _visibleOrder = new int[InitialRowCount];
-            for (var i = 0; i < InitialRowCount; i++) _visibleOrder[i] = i;
+            VisibleOrder = new int[InitialRowCount];
+            for (var i = 0; i < InitialRowCount; i++)
+            {
+                VisibleOrder[i] = i;
+            }
+
             StateHasChanged();
         }
 
-        private readonly Dictionary<int, Child> _rowCache = new();
-        private List<Child>? _scratch;
-
         protected override RenderResult Render()
         {
-            _scratch ??= new List<Child>(_visibleOrder.Length);
+            _scratch ??= new List<Child>(VisibleOrder.Length);
             _scratch.Clear();
-            for (var i = 0; i < _visibleOrder.Length; i++)
+            for (var i = 0; i < VisibleOrder.Length; i++)
             {
-                _scratch.Add(GetOrCreateRow(_visibleOrder[i]));
+                _scratch.Add(GetOrCreateRow(VisibleOrder[i]));
             }
 
             return C.Div(Class: "table-shell")[
@@ -83,12 +92,16 @@ internal static class TableSortFilter
 
         private Child GetOrCreateRow(int id)
         {
-            if (_rowCache.TryGetValue(id, out var row)) return row;
+            if (_rowCache.TryGetValue(id, out var row))
+            {
+                return row;
+            }
+
             row = C.Tr(
                 Data: new Dictionary<string, string?> { ["rask-key"] = id.ToString() })[
                 C.Td()[$"{id}"],
                 C.Td()[$"Item {id}"],
-                C.Td()[$"${id * 7 + 13}"],
+                C.Td()[$"${(id * 7) + 13}"],
                 C.Td()[id % 2 == 0 ? "active" : "idle"]
             ];
             _rowCache[id] = row;
@@ -116,6 +129,7 @@ internal static class TableSortFilter
                 b.AddContent(6, h);
                 b.CloseElement();
             }
+
             b.CloseElement();
             b.CloseElement();
 
@@ -132,13 +146,14 @@ internal static class TableSortFilter
                 b.AddContent(12, $"Item {id}");
                 b.CloseElement();
                 b.OpenElement(13, "td");
-                b.AddContent(14, $"${id * 7 + 13}");
+                b.AddContent(14, $"${(id * 7) + 13}");
                 b.CloseElement();
                 b.OpenElement(15, "td");
                 b.AddContent(16, id % 2 == 0 ? "active" : "idle");
                 b.CloseElement();
                 b.CloseElement();
             }
+
             b.CloseElement();
 
             b.CloseElement(); // table

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/ThemeSwitch.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/ThemeSwitch.cs
@@ -33,7 +33,7 @@ internal static class ThemeSwitch
                 C.H2()["Welcome"],
                 C.P()["Pick a theme to taste."]
             ],
-            C.Button(Type: "button")[$"Toggle ({(dark ? "dark" : "light")})"]
+            C.Button("button")[$"Toggle ({(dark ? "dark" : "light")})"]
         ];
     }
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/VirtualizationScroll.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/VirtualizationScroll.cs
@@ -29,13 +29,15 @@ internal static class VirtualizationScroll
     public const int ViewportHeightPx = 240;
 
     private static readonly FieldInfo ScrollTopField = typeof(RaskVirtualize)
-        .GetField("_scrollTop", BindingFlags.Instance | BindingFlags.NonPublic)
-        ?? throw new InvalidOperationException("Rask.Core.Components.Virtualize._scrollTop field not found");
+                                                           .GetField("_scrollTop",
+                                                               BindingFlags.Instance | BindingFlags.NonPublic)
+                                                       ?? throw new InvalidOperationException(
+                                                           "Rask.Core.Components.Virtualize._scrollTop field not found");
 
     /// <summary>
     ///     Construct the Rask tree once. The returned root holds a reference to the
     ///     internal Virtualize instance so the caller can advance the simulated
-    ///     scroll position via <see cref="SetScrollTop"/> between renders.
+    ///     scroll position via <see cref="SetScrollTop" /> between renders.
     /// </summary>
     public static (Component Root, RaskVirtualize Instance) BuildRask()
     {
@@ -45,8 +47,8 @@ internal static class VirtualizationScroll
             items[i] = i;
         }
 
-        var virt = C.Virtualize<int>(
-            Render: ctx =>
+        var virt = C.Virtualize(
+            ctx =>
             {
                 var rows = new List<Child>(ctx.VisibleItems.Count);
                 foreach (var item in ctx.VisibleItems)
@@ -58,7 +60,7 @@ internal static class VirtualizationScroll
 
                 return C.Div(Class: "viewport", Style: $"height:{ViewportHeightPx}px;overflow:auto")[rows];
             },
-            Items: items,
+            items,
             ItemSize: ItemSizePx,
             OverscanCount: 0,
             InitialClientHeight: ViewportHeightPx);

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/BlazorBatchByteSizer.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/BlazorBatchByteSizer.cs
@@ -1,18 +1,19 @@
 using System.Reflection;
 using Microsoft.AspNetCore.Components.RenderTree;
+using Microsoft.AspNetCore.Components.Server;
 
 namespace Rask.Benchmarks.VsBlazor.Infrastructure;
 
 /// <summary>
-///     Serializes a <see cref="RenderBatch"/> to its on-the-wire byte sequence using
+///     Serializes a <see cref="RenderBatch" /> to its on-the-wire byte sequence using
 ///     the same internal <c>RenderBatchWriter</c> that Blazor Server's SignalR circuit
 ///     uses, and returns the byte count. We reach the internal type via reflection
 ///     because Blazor doesn't expose it; the cost of reflection is borne once at
 ///     setup (delegate cached) so per-iteration overhead is one virtual call plus the
 ///     real serializer body.
 ///     <para>
-///         If the type ever moves or is removed, <see cref="Measure"/> throws
-///         <see cref="InvalidOperationException"/> with a hint to switch to the
+///         If the type ever moves or is removed, <see cref="Measure" /> throws
+///         <see cref="InvalidOperationException" /> with a hint to switch to the
 ///         handwritten fallback. We pin the framework version against which the suite
 ///         was validated in <c>Baselines/vs-blazor.md</c>.
 ///     </para>
@@ -21,16 +22,13 @@ internal static class BlazorBatchByteSizer
 {
     private static readonly Lazy<RenderBatchWriterAdapter> Adapter = new(BuildAdapter);
 
-    public static long Measure(in RenderBatch batch)
-    {
-        return Adapter.Value.Measure(in batch);
-    }
+    public static long Measure(in RenderBatch batch) => Adapter.Value.Measure(in batch);
 
     private static RenderBatchWriterAdapter BuildAdapter()
     {
         // RenderBatchWriter lives in Microsoft.AspNetCore.Components.Server. Find it via
         // a known public type from the same assembly so we don't depend on Assembly.Load.
-        var serverAssembly = typeof(Microsoft.AspNetCore.Components.Server.ServerComponentsEndpointOptions).Assembly;
+        var serverAssembly = typeof(ServerComponentsEndpointOptions).Assembly;
         var writerType = serverAssembly.GetType(
                              "Microsoft.AspNetCore.Components.Server.Circuits.RenderBatchWriter")
                          ?? throw new InvalidOperationException(
@@ -38,15 +36,16 @@ internal static class BlazorBatchByteSizer
                              "fall back to the handwritten serializer (see vs-blazor.md methodology).");
 
         var allCtors = writerType.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
-        var allMethods = writerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly)
+        var allMethods = writerType.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance |
+                                               BindingFlags.DeclaredOnly)
             .Where(m => m.Name == "Write")
             .ToArray();
 
         var ctor = writerType.GetConstructor(
                        BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                       binder: null,
-                       types: [typeof(Stream), typeof(bool)],
-                       modifiers: null)
+                       null,
+                       [typeof(Stream), typeof(bool)],
+                       null)
                    ?? throw new InvalidOperationException(
                        "RenderBatchWriter(Stream, bool) ctor not found. Available ctors: " +
                        string.Join(" | ", allCtors.Select(c => c.ToString())));
@@ -54,9 +53,9 @@ internal static class BlazorBatchByteSizer
         var writeMethod = writerType.GetMethod(
                               "Write",
                               BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance,
-                              binder: null,
-                              types: [typeof(RenderBatch).MakeByRefType()],
-                              modifiers: null)
+                              null,
+                              [typeof(RenderBatch).MakeByRefType()],
+                              null)
                           ?? throw new InvalidOperationException(
                               "RenderBatchWriter.Write(in RenderBatch) not found. Available Write methods: " +
                               string.Join(" | ", allMethods.Select(m => m.ToString())));
@@ -72,8 +71,8 @@ internal static class BlazorBatchByteSizer
     private sealed class RenderBatchWriterAdapter
     {
         private readonly ConstructorInfo _ctor;
+        private readonly MemoryStream _stream = new(8 * 1024);
         private readonly MethodInfo _write;
-        private readonly MemoryStream _stream = new(capacity: 8 * 1024);
         private readonly object[] _writeArgs = new object[1];
 
         public RenderBatchWriterAdapter(ConstructorInfo ctor, MethodInfo write)

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/BlazorRenderBatchCapture.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/BlazorRenderBatchCapture.cs
@@ -7,12 +7,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 namespace Rask.Benchmarks.VsBlazor.Infrastructure;
 
 /// <summary>
-///     Subclass of <see cref="Renderer"/> that captures the byte count of each
-///     <see cref="RenderBatch"/> as it would be serialized over a Blazor Server SignalR
-///     circuit. Bytes are measured inside <see cref="UpdateDisplayAsync"/> (synchronously,
+///     Subclass of <see cref="Renderer" /> that captures the byte count of each
+///     <see cref="RenderBatch" /> as it would be serialized over a Blazor Server SignalR
+///     circuit. Bytes are measured inside <see cref="UpdateDisplayAsync" /> (synchronously,
 ///     before returning) so the pooled arrays underlying the batch are still valid.
 ///     <para>
-///         The serialization itself happens in <see cref="BlazorBatchByteSizer.Measure"/>,
+///         The serialization itself happens in <see cref="BlazorBatchByteSizer.Measure" />,
 ///         which reflects on the internal <c>RenderBatchWriter</c> type from
 ///         <c>Microsoft.AspNetCore.Components.Server</c>.
 ///     </para>
@@ -82,7 +82,7 @@ public sealed class BlazorRenderBatchCapture : Renderer
     ///     Two-shot: attach root with the first parameters and discard the initial-attach
     ///     batch, then re-render with the second parameters and return that batch's bytes.
     ///     This is the apples-to-apples shape against
-    ///     <see cref="RaskHarness.SeedPrevious"/> + <see cref="RaskHarness.RenderAndBuildDiffPayloadBytes"/>:
+    ///     <see cref="RaskHarness.SeedPrevious" /> + <see cref="RaskHarness.RenderAndBuildDiffPayloadBytes" />:
     ///     the returned bytes describe ONE incremental update, not the initial mount.
     /// </summary>
     public long MeasureIncrementalUpdate<TComponent>(ParameterView before, ParameterView after)
@@ -99,9 +99,9 @@ public sealed class BlazorRenderBatchCapture : Renderer
     }
 
     /// <summary>
-    ///     Sustained-load counterpart to <see cref="MeasureIncrementalUpdate{TComponent}"/>.
-    ///     Attaches the root ONCE, then drives <paramref name="cycles"/> re-renders each
-    ///     using parameters from <paramref name="parametersFor"/>. Returns the SUM of all
+    ///     Sustained-load counterpart to <see cref="MeasureIncrementalUpdate{TComponent}" />.
+    ///     Attaches the root ONCE, then drives <paramref name="cycles" /> re-renders each
+    ///     using parameters from <paramref name="parametersFor" />. Returns the SUM of all
     ///     per-cycle batch byte counts. Used by <c>MemoryGc_*</c> benches so root
     ///     attachment isn't paid per cycle (Rask's stateful root also pays it only once).
     /// </summary>
@@ -120,6 +120,7 @@ public sealed class BlazorRenderBatchCapture : Renderer
                 await RenderRootComponentAsync(componentId, parametersFor(i));
                 total += LastBatchByteCount;
             }
+
             return total;
         }).GetAwaiter().GetResult();
     }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/IgnoresAccessChecks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/IgnoresAccessChecks.cs
@@ -14,7 +14,7 @@ namespace System.Runtime.CompilerServices;
 ///         checks. Calls into internal Blazor types still go through reflection
 ///         (see <c>BlazorBatchByteSizer</c>). The attribute is here so that, if a future
 ///         reflection-emit / source-generator path replaces the reflection calls, the
-///         JIT will not throw <see cref="MemberAccessException"/> at runtime.
+///         JIT will not throw <see cref="MemberAccessException" /> at runtime.
 ///     </para>
 /// </summary>
 [AttributeUsage(AttributeTargets.Assembly, AllowMultiple = true)]

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/InlineDispatcher.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/InlineDispatcher.cs
@@ -5,18 +5,18 @@ namespace Rask.Benchmarks.VsBlazor.Infrastructure;
 /// <summary>
 ///     Dispatcher that runs every work item synchronously on the calling thread.
 ///     <para>
-///         Replaces <see cref="Dispatcher.CreateDefault"/> inside benchmarks. The default
+///         Replaces <see cref="Dispatcher.CreateDefault" /> inside benchmarks. The default
 ///         dispatcher posts continuations through a <c>RendererSynchronizationContext</c>
 ///         queue. Under BDN's default job — many tight iterations on a single thread —
 ///         the queued continuations from <c>Renderer.RenderRootComponentAsync</c> stack
 ///         up and the wait inside <c>InvokeAsync(...).GetAwaiter().GetResult()</c>
-///         deadlocks. Forcing <see cref="CheckAccess"/> to <c>true</c> makes every
+///         deadlocks. Forcing <see cref="CheckAccess" /> to <c>true</c> makes every
 ///         internal <c>Dispatcher.InvokeAsync</c> Renderer call run inline, so the whole
 ///         render completes synchronously on the BDN iteration thread with no queuing.
 ///     </para>
 ///     <para>
 ///         Safe because benchmarks are single-threaded by construction; no concurrent
-///         dispatch happens against a single <see cref="BlazorRenderBatchCapture"/>.
+///         dispatch happens against a single <see cref="BlazorRenderBatchCapture" />.
 ///     </para>
 /// </summary>
 public sealed class InlineDispatcher : Dispatcher
@@ -29,10 +29,7 @@ public sealed class InlineDispatcher : Dispatcher
         return Task.CompletedTask;
     }
 
-    public override Task<TResult> InvokeAsync<TResult>(Func<TResult> workItem)
-    {
-        return Task.FromResult(workItem());
-    }
+    public override Task<TResult> InvokeAsync<TResult>(Func<TResult> workItem) => Task.FromResult(workItem());
 
     public override Task InvokeAsync(Func<Task> workItem) => workItem();
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/MicroBenchHarness.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/MicroBenchHarness.cs
@@ -8,13 +8,28 @@ namespace Rask.Benchmarks.VsBlazor.Infrastructure;
 ///     Pre-built-input helpers for the Micro_* benchmarks. Each call here belongs in
 ///     <c>[GlobalSetup]</c> so the per-iteration body executes only the hot path under
 ///     test (no Component construction, no FrameSinkScope plumbing, no HTML build).
-///     Same intent as the rest of the suite's harness pattern in <see cref="RaskHarness"/>,
+///     Same intent as the rest of the suite's harness pattern in <see cref="RaskHarness" />,
 ///     just lowered to the layer below the render pipeline.
 /// </summary>
 public static class MicroBenchHarness
 {
+    public enum LisShape
+    {
+        /// <summary>arr[i] = i — already-sorted; LIS = full array. Best case.</summary>
+        Identity,
+
+        /// <summary>arr[i] = n - 1 - i — reverse sorted; LIS = 1. Worst case.</summary>
+        Reverse,
+
+        /// <summary>Seeded LCG permutation. Average case.</summary>
+        RandomPermutation,
+
+        /// <summary>Identity with element[1] swapped with element[n-2]. Realistic single-move shape.</summary>
+        OneOutOfOrder
+    }
+
     /// <summary>
-    ///     Serialize <paramref name="tree"/> once under a fresh FrameSinkScope and
+    ///     Serialize <paramref name="tree" /> once under a fresh FrameSinkScope and
     ///     return a stable copy of the resulting RenderFrame stream. The returned
     ///     array survives the FrameWriter's pooled buffer being returned, so callers
     ///     can hold it across iterations without aliasing trouble.
@@ -35,7 +50,7 @@ public static class MicroBenchHarness
     }
 
     /// <summary>
-    ///     Serialize <paramref name="tree"/> once and return both the frame stream and
+    ///     Serialize <paramref name="tree" /> once and return both the frame stream and
     ///     the HTML the diff codec would attach to InsertSubtree ops (via the
     ///     frame-level HtmlStart/HtmlEnd offsets).
     /// </summary>
@@ -55,7 +70,9 @@ public static class MicroBenchHarness
     }
 
     /// <summary>
-    ///     Run <see cref="FrameDiffer.Diff(System.ReadOnlySpan{RenderFrame},System.ReadOnlySpan{RenderFrame},List{EditOp},string?)"/>
+    ///     Run
+    ///     <see
+    ///         cref="FrameDiffer.Diff(System.ReadOnlySpan{RenderFrame},System.ReadOnlySpan{RenderFrame},List{EditOp},string?)" />
     ///     once and return the materialized op list. Used to seed Micro_LivePayloadBuildDiff
     ///     so the payload benchmark measures only the JSON encoder, not the differ.
     /// </summary>
@@ -64,21 +81,6 @@ public static class MicroBenchHarness
         var ops = new List<EditOp>(32);
         FrameDiffer.Diff(before, after, ops, newHtml);
         return ops;
-    }
-
-    public enum LisShape
-    {
-        /// <summary>arr[i] = i — already-sorted; LIS = full array. Best case.</summary>
-        Identity,
-
-        /// <summary>arr[i] = n - 1 - i — reverse sorted; LIS = 1. Worst case.</summary>
-        Reverse,
-
-        /// <summary>Seeded LCG permutation. Average case.</summary>
-        RandomPermutation,
-
-        /// <summary>Identity with element[1] swapped with element[n-2]. Realistic single-move shape.</summary>
-        OneOutOfOrder
     }
 
     /// <summary>
@@ -93,30 +95,48 @@ public static class MicroBenchHarness
         switch (shape)
         {
             case LisShape.Identity:
-                for (var i = 0; i < n; i++) arr[i] = i;
+                for (var i = 0; i < n; i++)
+                {
+                    arr[i] = i;
+                }
+
                 break;
             case LisShape.Reverse:
-                for (var i = 0; i < n; i++) arr[i] = n - 1 - i;
+                for (var i = 0; i < n; i++)
+                {
+                    arr[i] = n - 1 - i;
+                }
+
                 break;
             case LisShape.OneOutOfOrder:
-                for (var i = 0; i < n; i++) arr[i] = i;
+                for (var i = 0; i < n; i++)
+                {
+                    arr[i] = i;
+                }
+
                 if (n >= 3)
                 {
                     (arr[1], arr[n - 2]) = (arr[n - 2], arr[1]);
                 }
+
                 break;
             case LisShape.RandomPermutation:
-                for (var i = 0; i < n; i++) arr[i] = i;
+                for (var i = 0; i < n; i++)
+                {
+                    arr[i] = i;
+                }
+
                 // Fisher-Yates with a fixed-seed LCG for determinism. Same seed as
                 // KeyedListDiffDump uses so the LIS micro numbers can be cross-referenced
                 // against the keyed-list wire-bytes dump.
-                ulong state = 0xC0FFEE_DEADBEEFUL;
+                var state = 0xC0FFEE_DEADBEEFUL;
                 for (var i = n - 1; i > 0; i--)
                 {
-                    state = state * 6364136223846793005UL + 1442695040888963407UL;
+                    state = (state * 6364136223846793005UL) + 1442695040888963407UL;
                     var j = (int)((state >> 33) % (uint)(i + 1));
                     (arr[i], arr[j]) = (arr[j], arr[i]);
                 }
+
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(shape));

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/ParityCheck.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/ParityCheck.cs
@@ -37,10 +37,10 @@ internal static class ParityCheck
     public static HtmlRenderer SharedBlazorRenderer => SharedHtmlRenderer.Value;
 
     /// <summary>
-    ///     Render <paramref name="raskTree"/> via Rask and a <typeparamref name="TBlazor"/>
-    ///     instance with <paramref name="blazorParameters"/> via Blazor's
-    ///     <see cref="HtmlRenderer"/>, normalize both outputs, and throw
-    ///     <see cref="ParityException"/> if their structural fingerprints diverge.
+    ///     Render <paramref name="raskTree" /> via Rask and a <typeparamref name="TBlazor" />
+    ///     instance with <paramref name="blazorParameters" /> via Blazor's
+    ///     <see cref="HtmlRenderer" />, normalize both outputs, and throw
+    ///     <see cref="ParityException" /> if their structural fingerprints diverge.
     /// </summary>
     public static void Assert<TBlazor>(
         string scenarioName,
@@ -75,7 +75,7 @@ internal static class ParityCheck
     ///     Asserts two Rask trees produce structurally equivalent HTML. Used by the
     ///     stateful-counter scenario to confirm the cached-rows variant renders the
     ///     same output as the rebuild-each-time factory — without that check, a
-    ///     regression in <see cref="StatefulLargePageWithCounter"/> would silently
+    ///     regression in <see cref="StatefulLargePageWithCounter" /> would silently
     ///     ship better diff-codec numbers against a divergent tree.
     /// </summary>
     public static void AssertRaskTreesMatch(string scenarioName, Component left, Component right)
@@ -115,9 +115,18 @@ internal static class ParityCheck
         var inTag = false;
         foreach (var c in stripped)
         {
-            if (c == '<') inTag = true;
-            else if (c == '>') inTag = false;
-            else if (!inTag && !char.IsWhiteSpace(c)) textLen++;
+            if (c == '<')
+            {
+                inTag = true;
+            }
+            else if (c == '>')
+            {
+                inTag = false;
+            }
+            else if (!inTag && !char.IsWhiteSpace(c))
+            {
+                textLen++;
+            }
         }
 
         var summary = string.Join(",",
@@ -126,10 +135,8 @@ internal static class ParityCheck
         return new Fp(summary, textLen);
     }
 
-    private static bool FingerprintMatches(Fp a, Fp b)
-    {
-        return a.TagSummary == b.TagSummary && a.TotalTextLength == b.TotalTextLength;
-    }
+    private static bool FingerprintMatches(Fp a, Fp b) =>
+        a.TagSummary == b.TagSummary && a.TotalTextLength == b.TotalTextLength;
 
     private readonly record struct Fp(string TagSummary, int TotalTextLength);
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/RaskHarness.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/RaskHarness.cs
@@ -8,8 +8,8 @@ namespace Rask.Benchmarks.VsBlazor.Infrastructure;
 /// <summary>
 ///     Drives a single "previous-state → new-state" render cycle through the same code
 ///     path <c>LiveSession</c> uses on the wire: capture both renders' RenderFrame
-///     streams via the framework's <see cref="SessionRenderCache"/>, build the diff
-///     payload via <see cref="LivePayload.BuildPayloadUtf8Diff"/>. Reuses buffers across
+///     streams via the framework's <see cref="SessionRenderCache" />, build the diff
+///     payload via <see cref="LivePayload.BuildPayloadUtf8Diff" />. Reuses buffers across
 ///     invocations so steady-state allocations match production.
 ///     <para>
 ///         Mirrors the workflow in <c>Rask.Benchmarks/PayloadBytesPerUpdate.cs</c> and
@@ -25,12 +25,14 @@ public sealed class RaskHarness : IDisposable
     private readonly List<EditOp> _ops = new(32);
     private readonly ArrayBufferWriter<byte> _payloadBuffer = new(64 * 1024);
 
+    public void Dispose() => _cache.Dispose();
+
     /// <summary>
-    ///     Render <paramref name="tree"/>, populating the cache's "previous" slot. Call
-    ///     once at <c>[GlobalSetup]</c> to seed the before-state. <see cref="TryComputeDiff"/>
+    ///     Render <paramref name="tree" />, populating the cache's "previous" slot. Call
+    ///     once at <c>[GlobalSetup]</c> to seed the before-state. <see cref="TryComputeDiff" />
     ///     will return <c>false</c> on the very next call only if you call it directly on
     ///     this same render with no further frames; in normal use, call this then call
-    ///     <see cref="RenderAndBuildDiffPayloadBytes"/> with the new tree.
+    ///     <see cref="RenderAndBuildDiffPayloadBytes" /> with the new tree.
     /// </summary>
     public void SeedPrevious(Component tree)
     {
@@ -46,7 +48,7 @@ public sealed class RaskHarness : IDisposable
     }
 
     /// <summary>
-    ///     Render <paramref name="tree"/>, diff against the previous capture, build the
+    ///     Render <paramref name="tree" />, diff against the previous capture, build the
     ///     UTF-8 diff payload, and return its byte count. After this call, the cache
     ///     holds this render as the new "previous", so the next call diffs against it.
     /// </summary>
@@ -66,7 +68,7 @@ public sealed class RaskHarness : IDisposable
         _cache.TryComputeDiff(_ops, _htmlBuffer.ToString());
 
         _payloadBuffer.ResetWrittenCount();
-        LivePayload.BuildPayloadUtf8Diff(_payloadBuffer, _ops, null, false);
+        LivePayload.BuildPayloadUtf8Diff(_payloadBuffer, _ops);
         return _payloadBuffer.WrittenCount;
     }
 
@@ -85,7 +87,7 @@ public sealed class RaskHarness : IDisposable
 
     /// <summary>
     ///     Render-to-HTML only — no live root, no payload wrap. Equivalent to calling
-    ///     <see cref="Component.ToHtml"/> but with a pooled writer (matches the same
+    ///     <see cref="Component.ToHtml" /> but with a pooled writer (matches the same
     ///     pool path the framework uses internally).
     /// </summary>
     public string RenderHtml(Component tree)
@@ -94,6 +96,4 @@ public sealed class RaskHarness : IDisposable
         HtmlSerializer.Serialize(tree, _htmlBuffer);
         return _htmlBuffer.ToString();
     }
-
-    public void Dispose() => _cache.Dispose();
 }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Program.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Program.cs
@@ -1,4 +1,5 @@
 using BenchmarkDotNet.Running;
+using Rask.Benchmarks.VsBlazor.Reports;
 
 // Mirror Rask.Benchmarks/Program.cs: subcommands first, then default to BDN.
 //   payload-bytes   — deterministic wire-bytes-per-update report (no measurement noise), CSV
@@ -7,17 +8,17 @@ using BenchmarkDotNet.Running;
 // Anything else passes straight through to BenchmarkDotNet.
 if (args.Length >= 1 && args[0] == "payload-bytes")
 {
-    return Rask.Benchmarks.VsBlazor.Reports.VsBlazorPayloadBytesReport.Run(args);
+    return VsBlazorPayloadBytesReport.Run(args);
 }
 
 if (args.Length >= 1 && args[0] == "keyed-list-dump")
 {
-    return Rask.Benchmarks.VsBlazor.Reports.KeyedListDiffDump.Run(args);
+    return KeyedListDiffDump.Run(args);
 }
 
 if (args.Length >= 1 && args[0] == "mem-footprint")
 {
-    return Rask.Benchmarks.VsBlazor.Reports.VsBlazorMemFootprintReport.Run(args);
+    return VsBlazorMemFootprintReport.Run(args);
 }
 
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj
@@ -16,8 +16,11 @@
       CS0618: Microsoft.AspNetCore.Components.RenderTree.Renderer carries Obsolete[ messages
               warning non-framework code away from inheriting it. Benchmarks deliberately do.
       BL0006: Blazor analyzer that fires on use of low-level RenderTree APIs. Intentional here.
+      RASK022: these benchmarks deliberately render keyless lists to measure the raw render
+               hot path against Blazor's equally-keyless BuildRenderTree. Adding Key: would
+               add per-row key handling and skew the comparison — keep them keyless on purpose.
     -->
-    <NoWarn>$(NoWarn);0436;0618;BL0006</NoWarn>
+    <NoWarn>$(NoWarn);0436;0618;BL0006;RASK022</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/Justifications.md
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/Justifications.md
@@ -17,6 +17,7 @@ constructing the tree per call — `Scope_StaticListLarge`,
 
 **Root cause:** Rask elements are heap-allocated `class Component` instances
 (`Rask.Core/Component.cs`). Each instance carries roughly:
+
 - 16 B object header
 - ~10 nullable reference slots (handlers, children dict, edit-context pool,
   parent map, …) — held as `_field?` and lazy-instantiated, but the slot
@@ -49,6 +50,7 @@ across every RenderHotPath scenario (0.29×–0.83×). The remaining gap is the 
 footprint plus the per-call `Child[]` array on multi-child elements.
 
 **Further mitigation paths (not pursued in this program):**
+
 - Replace the `params Child[]` indexer with a small inline struct-buffer (≤2 slots)
   for the common one/two-child element. Evaluated and **declined**: it adds ~16 B to
   *every* Element (including the leaf-heavy static-list/text scenarios where it doesn't
@@ -85,11 +87,11 @@ dominant constant factor. The move count and wire bytes are unchanged (still
 LIS-minimal); only the computation got correct and cheaper. Measured on
 `Scale_KeyedRandomPermutation` (Apple M4 Pro, short-run, directional):
 
-| N    | Before (buggy) | After (correct) |
-|------|----------------|-----------------|
+| N    | Before (buggy) | After (correct)         |
+|------|----------------|-------------------------|
 | 100  | 1.17× Blazor   | **0.79×** (Rask faster) |
-| 500  | 3.16×          | **1.06×** (parity) |
-| 1000 | 5.87×          | **~1.4×** |
+| 500  | 3.16×          | **1.06×** (parity)      |
+| 1000 | 5.87×          | **~1.4×**               |
 
 Realistic keyed-list sizes (≤500 rows) are now at or below Blazor parity. The residual
 ~1.4× on a 1000-element *random* permutation is the leftover O(N²) of the

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/KeyedListDiffDump.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/KeyedListDiffDump.cs
@@ -140,7 +140,7 @@ internal static class KeyedListDiffDump
         }
 
         var fullPayload = new ArrayBufferWriter<byte>(8 * 1024);
-        LivePayload.BuildPayloadUtf8Diff(fullPayload, ops, null, false);
+        LivePayload.BuildPayloadUtf8Diff(fullPayload, ops);
         var envelope = fullPayload.WrittenCount - totalBytes;
         Console.WriteLine();
         Console.WriteLine($"# Full diff payload: {fullPayload.WrittenCount} bytes");
@@ -154,7 +154,7 @@ internal static class KeyedListDiffDump
         // from `wholePayloadBytes` then attributes the JSON-envelope overhead
         // explicitly. Cheap and deterministic.
         var buf = new ArrayBufferWriter<byte>(256);
-        LivePayload.BuildPayloadUtf8Diff(buf, new[] { op }, null, false);
+        LivePayload.BuildPayloadUtf8Diff(buf, new[] { op });
         return buf.WrittenCount;
     }
 }

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorMemFootprintReport.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorMemFootprintReport.cs
@@ -8,7 +8,7 @@ namespace Rask.Benchmarks.VsBlazor.Reports;
 
 /// <summary>
 ///     Deterministic "memory usage" report — the counterpart to the wire-bytes
-///     <see cref="VsBlazorPayloadBytesReport"/>. Emits two CSV blocks, both measured with
+///     <see cref="VsBlazorPayloadBytesReport" />. Emits two CSV blocks, both measured with
 ///     precise GC counters (no BenchmarkDotNet, no timing jitter):
 ///     <list type="number">
 ///         <item>
@@ -23,7 +23,7 @@ namespace Rask.Benchmarks.VsBlazor.Reports;
 ///         </item>
 ///         <item>
 ///             <b>Retained heap per rendered tree</b> — the architectural tradeoff, NOT
-///             Rask's production memory profile. Rask retains its <see cref="Component"/>
+///             Rask's production memory profile. Rask retains its <see cref="Component" />
 ///             object graph (one heap object per element) where Blazor packs dense
 ///             <c>RenderTreeFrame</c> structs, so a tree HELD in memory costs Rask more.
 ///             But Rask rebuilds-and-discards element trees per render in production rather
@@ -78,10 +78,19 @@ internal static class VsBlazorMemFootprintReport
 #pragma warning restore RASK014
         rask.SeedPrevious(stateful);
         // Warm up: first updates allocate the pooled buffers + cached rows once.
-        for (var i = 0; i < 64; i++) { stateful.Tick(); rask.RenderAndBuildDiffPayloadBytes(stateful); }
+        for (var i = 0; i < 64; i++)
+        {
+            stateful.Tick();
+            rask.RenderAndBuildDiffPayloadBytes(stateful);
+        }
 
         var raskBefore = GC.GetAllocatedBytesForCurrentThread();
-        for (var i = 0; i < Updates; i++) { stateful.Tick(); rask.RenderAndBuildDiffPayloadBytes(stateful); }
+        for (var i = 0; i < Updates; i++)
+        {
+            stateful.Tick();
+            rask.RenderAndBuildDiffPayloadBytes(stateful);
+        }
+
         var raskPerUpdate = (GC.GetAllocatedBytesForCurrentThread() - raskBefore) / Updates;
 
         // Blazor: attach once, then re-render with one changed parameter per update. The
@@ -110,8 +119,8 @@ internal static class VsBlazorMemFootprintReport
     private static void ReportFootprintLargePage()
     {
         var raskPerTree = MeasureRaskFootprint(() => LargePageWithCounter.BuildRask(0));
-        var blazorPerTree = MeasureBlazorFootprint(
-            renderer => () => renderer.RenderAsRootAndMeasure<LargePageWithCounter.BlazorLargePageWithCounter>(
+        var blazorPerTree = MeasureBlazorFootprint(renderer => () =>
+            renderer.RenderAsRootAndMeasure<LargePageWithCounter.BlazorLargePageWithCounter>(
                 CounterParams(0)));
 
         EmitFootprintRow("LargePage_200Rows", raskPerTree, blazorPerTree);
@@ -120,11 +129,14 @@ internal static class VsBlazorMemFootprintReport
     private static void ReportFootprintKeyedList100()
     {
         var order = new int[100];
-        for (var i = 0; i < order.Length; i++) order[i] = i;
+        for (var i = 0; i < order.Length; i++)
+        {
+            order[i] = i;
+        }
 
         var raskPerTree = MeasureRaskFootprint(() => KeyedList.BuildRask(order));
-        var blazorPerTree = MeasureBlazorFootprint(
-            renderer => () => renderer.RenderAsRootAndMeasure<KeyedList.BlazorKeyedList>(
+        var blazorPerTree = MeasureBlazorFootprint(renderer => () =>
+            renderer.RenderAsRootAndMeasure<KeyedList.BlazorKeyedList>(
                 ParameterView.FromDictionary(new Dictionary<string, object?>
                 {
                     [nameof(KeyedList.BlazorKeyedList.Order)] = order
@@ -174,11 +186,11 @@ internal static class VsBlazorMemFootprintReport
     {
         for (var i = 0; i < 3; i++)
         {
-            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, blocking: true);
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true);
             GC.WaitForPendingFinalizers();
         }
 
-        return GC.GetTotalMemory(forceFullCollection: true);
+        return GC.GetTotalMemory(true);
     }
 
     private static void EmitAllocRow(string scenario, long raskPerUpdate, long blazorPerUpdate)

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorPayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorPayloadBytesReport.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
+using Rask.Benchmarks.VsBlazor.Benchmarks;
 using Rask.Benchmarks.VsBlazor.Components;
 using Rask.Benchmarks.VsBlazor.Infrastructure;
 using Rask.Core;
+using Generated = Rask.Core.Components.Generated;
 
 namespace Rask.Benchmarks.VsBlazor.Reports;
 
@@ -60,7 +62,12 @@ internal static class VsBlazorPayloadBytesReport
         const int n = 5000;
         var before = new int[n];
         var after = new int[n];
-        for (var i = 0; i < n; i++) { before[i] = i; after[i] = i; }
+        for (var i = 0; i < n; i++)
+        {
+            before[i] = i;
+            after[i] = i;
+        }
+
         (after[0], after[n - 1]) = (after[n - 1], after[0]);
 
         using var rask = new RaskHarness();
@@ -86,7 +93,11 @@ internal static class VsBlazorPayloadBytesReport
     {
         const int n = 1000;
         var identity = new int[n];
-        for (var i = 0; i < n; i++) identity[i] = i;
+        for (var i = 0; i < n; i++)
+        {
+            identity[i] = i;
+        }
+
         var permuted = MicroBenchHarness.BuildLisInput(n, MicroBenchHarness.LisShape.RandomPermutation);
 
         using var rask = new RaskHarness();
@@ -112,11 +123,22 @@ internal static class VsBlazorPayloadBytesReport
     {
         const int n = 2000;
         var shortArr = new int[n];
-        for (var i = 0; i < n; i++) shortArr[i] = i;
+        for (var i = 0; i < n; i++)
+        {
+            shortArr[i] = i;
+        }
+
         var longArr = new int[n + 1];
-        for (var i = 0; i < n / 2; i++) longArr[i] = shortArr[i];
+        for (var i = 0; i < n / 2; i++)
+        {
+            longArr[i] = shortArr[i];
+        }
+
         longArr[n / 2] = n + 1000;
-        for (var i = n / 2; i < n; i++) longArr[i + 1] = shortArr[i];
+        for (var i = n / 2; i < n; i++)
+        {
+            longArr[i + 1] = shortArr[i];
+        }
 
         using var rask = new RaskHarness();
         rask.SeedPrevious(KeyedList.BuildRask(shortArr));
@@ -143,15 +165,16 @@ internal static class VsBlazorPayloadBytesReport
 
         Component Build(int counter)
         {
-            Component leaf = global::Rask.Core.Components.Generated.Span(Class: "counter")[counter.ToString()];
+            var leaf = Generated.Span(Class: "counter")[counter.ToString()];
             for (var i = 0; i < depth; i++)
             {
-                leaf = global::Rask.Core.Components.Generated.Div(Class: $"d{i}")[leaf];
+                leaf = Generated.Div(Class: $"d{i}")[leaf];
             }
-            return global::Rask.Core.Components.Generated.Fragment()[
-                global::Rask.Core.Components.Generated.Doctype(),
-                global::Rask.Core.Components.Generated.Html()[
-                    global::Rask.Core.Components.Generated.Body()[leaf]]];
+
+            return Generated.Fragment()[
+                Generated.Doctype(),
+                Generated.Html()[
+                    Generated.Body()[leaf]]];
         }
 
         using var rask = new RaskHarness();
@@ -160,17 +183,18 @@ internal static class VsBlazorPayloadBytesReport
         var raskFull = rask.RenderAndBuildFullPayloadBytes(Build(1));
 
         using var blazor = new BlazorRenderBatchCapture();
-        var blazorBytes = blazor.MeasureIncrementalUpdate<Benchmarks.Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree>(
-            ParameterView.FromDictionary(new Dictionary<string, object?>
-            {
-                [nameof(Benchmarks.Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Counter)] = 0,
-                [nameof(Benchmarks.Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Depth)] = depth
-            }),
-            ParameterView.FromDictionary(new Dictionary<string, object?>
-            {
-                [nameof(Benchmarks.Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Counter)] = 1,
-                [nameof(Benchmarks.Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Depth)] = depth
-            }));
+        var blazorBytes =
+            blazor.MeasureIncrementalUpdate<Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree>(
+                ParameterView.FromDictionary(new Dictionary<string, object?>
+                {
+                    [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Counter)] = 0,
+                    [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Depth)] = depth
+                }),
+                ParameterView.FromDictionary(new Dictionary<string, object?>
+                {
+                    [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Counter)] = 1,
+                    [nameof(Scale_DeepTreeMutationByDepthBenchmarks.ParameterizedBlazorDeepTree.Depth)] = depth
+                }));
 
         EmitRow("Scale_DeepTreeMutationByDepth_200", raskFull, raskDiff, blazorBytes);
     }
@@ -678,7 +702,8 @@ internal static class VsBlazorPayloadBytesReport
             [nameof(AttributeHeavyElements.BlazorAttributeHeavyMutateOne.AttrCount)] = attrCount,
             [nameof(AttributeHeavyElements.BlazorAttributeHeavyMutateOne.MutationSalt)] = 1
         });
-        var blazorBytes = blazor.MeasureIncrementalUpdate<AttributeHeavyElements.BlazorAttributeHeavyMutateOne>(before, after);
+        var blazorBytes =
+            blazor.MeasureIncrementalUpdate<AttributeHeavyElements.BlazorAttributeHeavyMutateOne>(before, after);
 
         EmitRow("AttributeUpdate", raskFull, raskDiff, blazorBytes);
     }
@@ -699,7 +724,8 @@ internal static class VsBlazorPayloadBytesReport
         {
             [nameof(LargePageWithCounter.BlazorLargePageWithCounter.Counter)] = 1
         });
-        var blazorBytes = blazor.MeasureIncrementalUpdate<LargePageWithCounter.BlazorLargePageWithCounter>(before, after);
+        var blazorBytes =
+            blazor.MeasureIncrementalUpdate<LargePageWithCounter.BlazorLargePageWithCounter>(before, after);
 
         EmitRow("CounterOnLargePage", raskFull, raskDiff, blazorBytes);
     }
@@ -720,7 +746,8 @@ internal static class VsBlazorPayloadBytesReport
         {
             [nameof(LargePageWithCounter.BlazorLargePageWithDeepTextCell.Counter)] = 1
         });
-        var blazorBytes = blazor.MeasureIncrementalUpdate<LargePageWithCounter.BlazorLargePageWithDeepTextCell>(before, after);
+        var blazorBytes =
+            blazor.MeasureIncrementalUpdate<LargePageWithCounter.BlazorLargePageWithDeepTextCell>(before, after);
 
         EmitRow("TextNodeUpdate", raskFull, raskDiff, blazorBytes);
     }

--- a/benchmarks/Rask.Benchmarks/AssetLoadingBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AssetLoadingBenchmarks.cs
@@ -46,14 +46,15 @@ public class AssetLoadingBenchmarks
         typeof(AssetRow016), typeof(AssetRow017), typeof(AssetRow018), typeof(AssetRow019)
     ];
 
-    private string[] _cssHashes = null!;
-    private string[] _jsHashes = null!;
+    private readonly HashSet<Type> _mounted200 = new();
 
     // Pre-built mounted-type sets at two scales. EmitMountedAssets allocates a
     // StringBuilder each call — the bench captures both the alloc and the per-entry
     // append cost.
     private readonly HashSet<Type> _mounted50 = new();
-    private readonly HashSet<Type> _mounted200 = new();
+
+    private string[] _cssHashes = null!;
+    private string[] _jsHashes = null!;
 
     [GlobalSetup]
     public void Setup()
@@ -76,8 +77,15 @@ public class AssetLoadingBenchmarks
         // mounted-type-set size capped at 20 (page reuses component types heavily).
         // EmitMountedAssets iterates the HashSet directly, so the cost is bounded by
         // distinct types, not source instances.
-        for (var i = 0; i < 50; i++) _mounted50.Add(_types[i % _types.Length]);
-        for (var i = 0; i < 200; i++) _mounted200.Add(_types[i % _types.Length]);
+        for (var i = 0; i < 50; i++)
+        {
+            _mounted50.Add(_types[i % _types.Length]);
+        }
+
+        for (var i = 0; i < 200; i++)
+        {
+            _mounted200.Add(_types[i % _types.Length]);
+        }
     }
 
     // ──────────────────────────────────────────────────────────────────────
@@ -91,7 +99,10 @@ public class AssetLoadingBenchmarks
         var hits = 0;
         for (var i = 0; i < 200; i++)
         {
-            if (ScopedAssetRegistry.TryGetCss(_types[i % _types.Length], out _)) hits++;
+            if (ScopedAssetRegistry.TryGetCss(_types[i % _types.Length], out _))
+            {
+                hits++;
+            }
         }
 
         return hits;
@@ -103,7 +114,10 @@ public class AssetLoadingBenchmarks
         var hits = 0;
         for (var i = 0; i < 200; i++)
         {
-            if (ScopedAssetRegistry.TryGetJs(_types[i % _types.Length], out _)) hits++;
+            if (ScopedAssetRegistry.TryGetJs(_types[i % _types.Length], out _))
+            {
+                hits++;
+            }
         }
 
         return hits;
@@ -115,7 +129,10 @@ public class AssetLoadingBenchmarks
         var hits = 0;
         for (var i = 0; i < 200; i++)
         {
-            if (ScopedAssetRegistry.TryGetScopeId(_types[i % _types.Length], out _)) hits++;
+            if (ScopedAssetRegistry.TryGetScopeId(_types[i % _types.Length], out _))
+            {
+                hits++;
+            }
         }
 
         return hits;
@@ -134,7 +151,10 @@ public class AssetLoadingBenchmarks
         var hits = 0;
         for (var i = 0; i < 200; i++)
         {
-            if (ScopedAssetRegistry.GetByHash(_cssHashes[i % _types.Length], AssetKind.Css) is not null) hits++;
+            if (ScopedAssetRegistry.GetByHash(_cssHashes[i % _types.Length], AssetKind.Css) is not null)
+            {
+                hits++;
+            }
         }
 
         return hits;
@@ -146,7 +166,10 @@ public class AssetLoadingBenchmarks
         var hits = 0;
         for (var i = 0; i < 200; i++)
         {
-            if (ScopedAssetRegistry.GetByHash(_jsHashes[i % _types.Length], AssetKind.Js) is not null) hits++;
+            if (ScopedAssetRegistry.GetByHash(_jsHashes[i % _types.Length], AssetKind.Js) is not null)
+            {
+                hits++;
+            }
         }
 
         return hits;
@@ -203,7 +226,11 @@ public class AssetLoadingBenchmarks
     public int EnumerateAll()
     {
         var n = 0;
-        foreach (var _ in ScopedAssetRegistry.EnumerateAll()) n++;
+        foreach (var _ in ScopedAssetRegistry.EnumerateAll())
+        {
+            n++;
+        }
+
         return n;
     }
 }
@@ -213,23 +240,102 @@ public class AssetLoadingBenchmarks
 // hits a different bucket — defeating any same-type cache that would mask real
 // per-key lookup cost.
 #pragma warning disable RASK014
-public sealed class AssetRow000 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow001 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow002 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow003 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow004 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow005 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow006 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow007 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow008 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow009 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow010 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow011 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow012 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow013 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow014 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow015 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow016 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow017 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow018 : Component { protected override RenderResult Render() => this; }
-public sealed class AssetRow019 : Component { protected override RenderResult Render() => this; }
+public sealed class AssetRow000 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow001 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow002 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow003 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow004 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow005 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow006 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow007 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow008 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow009 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow010 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow011 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow012 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow013 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow014 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow015 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow016 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow017 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow018 : Component
+{
+    protected override RenderResult Render() => this;
+}
+
+public sealed class AssetRow019 : Component
+{
+    protected override RenderResult Render() => this;
+}

--- a/benchmarks/Rask.Benchmarks/Baselines/README.md
+++ b/benchmarks/Rask.Benchmarks/Baselines/README.md
@@ -28,19 +28,19 @@ dotnet run -c Release --project Rask.Benchmarks -- payload-bytes
 
 ### Current numbers (default `LiveDiffMode.Auto` on both Server and WASM)
 
-| Scenario             | Full payload | Diff payload | Diff ops |   Reduction |
-|----------------------|-------------:|-------------:|---------:|------------:|
-| CounterOnLargePage   |      62,577  |          45  |        1 |   **1,391×** |
-| KeyedList100Reorder  |       6,720  |          57  |        2 |      **118×** |
-| TextNodeUpdate       |      62,460  |          54  |        1 |   **1,157×** |
-| AppendRowToList100   |       6,788  |         112  |        1 |       **61×** |
+| Scenario            | Full payload | Diff payload | Diff ops |  Reduction |
+|---------------------|-------------:|-------------:|---------:|-----------:|
+| CounterOnLargePage  |       62,577 |           45 |        1 | **1,391×** |
+| KeyedList100Reorder |        6,720 |           57 |        2 |   **118×** |
+| TextNodeUpdate      |       62,460 |           54 |        1 | **1,157×** |
+| AppendRowToList100  |        6,788 |          112 |        1 |    **61×** |
 
 All four scenarios beat the plan's targets:
 
-- `CounterOnLargePage`  target ≤ **200** bytes  → **45**  ✓ (positional per-op JSON shaved ~12 B)
-- `KeyedList100Reorder` target ≤ **500** bytes  → **57**  ✓ (LIS-minimal `MoveSubtree` pair, positional encoded)
-- `TextNodeUpdate`      target ≤ **100** bytes  → **54**  ✓
-- `AppendRowToList100`  target ≤ **300** bytes  → **112** ✓ (UnsafeRelaxedJsonEscaping halved the HTML-fragment bytes)
+- `CounterOnLargePage`  target ≤ **200** bytes → **45**  ✓ (positional per-op JSON shaved ~12 B)
+- `KeyedList100Reorder` target ≤ **500** bytes → **57**  ✓ (LIS-minimal `MoveSubtree` pair, positional encoded)
+- `TextNodeUpdate`      target ≤ **100** bytes → **54**  ✓
+- `AppendRowToList100`  target ≤ **300** bytes → **112** ✓ (UnsafeRelaxedJsonEscaping halved the HTML-fragment bytes)
 
 Full-payload bytes also dropped ~40% across the board after the WS writer switched
 to `UnsafeRelaxedJsonEscaping` — the default `Utf8JsonWriter` escaping rewrites
@@ -142,24 +142,24 @@ default" and the README updates to cite this CSV.
 Five of the eight planned micro-wins are landed; the remaining three are larger
 refactors or observability-only. All ship unconditionally (no flag gate).
 
-| # | Item | Status | Where |
-|---|------|--------|-------|
-| 1 | `Text` / attribute encoding fast-path (skip `HtmlEncoder` for plain ASCII) | ✓ done | `HtmlSerializer.AppendEncoded` |
-| 2 | Scope poppers as `ref struct` (3 popper classes → 1 `ContextScope`) | ✓ done | `LiveRenderContext.cs` |
-| 3 | `ScopedCssRegistry` lock-free read cache (`ConcurrentDictionary` front) | ✓ done | `ScopedCssRegistry.TryRegister` |
-| 4 | Skip scope push/pop for handler-free cached subtrees | deferred | needs `_cachedRenderResult` metadata |
-| 5 | Single-pass UTF-8 write in `BuildPayloadUtf8Spliced` (eliminate 2nd rent) | ✓ done | already single `ArrayPool.Rent` + 3× `GetBytes` into one buffer (`LivePayload.cs`) |
-| 6 | Coalesce-loop budget telemetry + worst-case bench | deferred | observability-only |
-| 7 | Children-indexer specialisation (drop `.Select(c => (Child)c)`) | ✓ done | `Component[IEnumerable<Component>]` |
-| 8 | Handler-id `string.Concat` cliff (prebake 1024 + stackalloc overflow) | ✓ done | `Component.RegisterHandler` |
-| 9 | Keyed-diff scratch pooling (per-session `DiffScratch`: pooled key maps / child lists / LIS set + `ArrayPool` permutation buffers) | ✓ done | `FrameDiffer.DiffScratch`, `SessionRenderCache._scratch` |
+| # | Item                                                                                                                              | Status   | Where                                                                              |
+|---|-----------------------------------------------------------------------------------------------------------------------------------|----------|------------------------------------------------------------------------------------|
+| 1 | `Text` / attribute encoding fast-path (skip `HtmlEncoder` for plain ASCII)                                                        | ✓ done   | `HtmlSerializer.AppendEncoded`                                                     |
+| 2 | Scope poppers as `ref struct` (3 popper classes → 1 `ContextScope`)                                                               | ✓ done   | `LiveRenderContext.cs`                                                             |
+| 3 | `ScopedCssRegistry` lock-free read cache (`ConcurrentDictionary` front)                                                           | ✓ done   | `ScopedCssRegistry.TryRegister`                                                    |
+| 4 | Skip scope push/pop for handler-free cached subtrees                                                                              | deferred | needs `_cachedRenderResult` metadata                                               |
+| 5 | Single-pass UTF-8 write in `BuildPayloadUtf8Spliced` (eliminate 2nd rent)                                                         | ✓ done   | already single `ArrayPool.Rent` + 3× `GetBytes` into one buffer (`LivePayload.cs`) |
+| 6 | Coalesce-loop budget telemetry + worst-case bench                                                                                 | deferred | observability-only                                                                 |
+| 7 | Children-indexer specialisation (drop `.Select(c => (Child)c)`)                                                                   | ✓ done   | `Component[IEnumerable<Component>]`                                                |
+| 8 | Handler-id `string.Concat` cliff (prebake 1024 + stackalloc overflow)                                                             | ✓ done   | `Component.RegisterHandler`                                                        |
+| 9 | Keyed-diff scratch pooling (per-session `DiffScratch`: pooled key maps / child lists / LIS set + `ArrayPool` permutation buffers) | ✓ done   | `FrameDiffer.DiffScratch`, `SessionRenderCache._scratch`                           |
 
 ### Quick allocation deltas (HtmlSerializerBenchmarks, --job=short)
 
-| Method | Allocated (before Phase 2) | Allocated (after) | Reduction |
-|--------|--------------------------:|------------------:|----------:|
-| RenderTextHeavyTree     | 108.57 KB | 97.58 KB | **-10%** |
-| RenderTreeWithScopedCss |  54.70 KB | 45.32 KB | **-17%** |
+| Method                  | Allocated (before Phase 2) | Allocated (after) | Reduction |
+|-------------------------|---------------------------:|------------------:|----------:|
+| RenderTextHeavyTree     |                  108.57 KB |          97.58 KB |  **-10%** |
+| RenderTreeWithScopedCss |                   54.70 KB |          45.32 KB |  **-17%** |
 
 (ShortRun timing noise hides the time impact; allocation numbers are
 deterministic. A longer run will pin the time delta.)
@@ -180,11 +180,11 @@ dotnet run -c Release --project Rask.Benchmarks -- --filter '*PayloadBytesPerUpd
 
 A quick smoke run (`--job short`) over `PayloadBytesPerUpdate` produced:
 
-| Method              |     Mean | Allocated |
-|---------------------|---------:|----------:|
-| CounterOnLargePage  | 258 µs   |  999 KB   |
-| KeyedList100Reorder |  39 µs   |  195 KB   |
-| TextNodeUpdate      | 261 µs   |  997 KB   |
+| Method              |   Mean | Allocated |
+|---------------------|-------:|----------:|
+| CounterOnLargePage  | 258 µs |    999 KB |
+| KeyedList100Reorder |  39 µs |    195 KB |
+| TextNodeUpdate      | 261 µs |    997 KB |
 
 `Allocated` includes the per-iteration tree build (List<Child>, components,
 attribute dictionaries) + the payload build. The wire-bytes column above is the
@@ -204,9 +204,9 @@ allocates a `DiffScratch` per call (the pre-pooling profile).
 
 | Method                | Rows |     Mean | Allocated | Alloc ratio |
 |-----------------------|-----:|---------:|----------:|------------:|
-| Reorder_ReusedScratch |  100 |  10.7 µs |  7.13 KB  | 1.00 (base) |
-| Reorder_FreshScratch  |  100 |  13.5 µs | 54.35 KB  |   **7.63×** |
-| Reorder_ReusedScratch | 1000 | 128.6 µs | 70.41 KB  | 1.00 (base) |
+| Reorder_ReusedScratch |  100 |  10.7 µs |   7.13 KB | 1.00 (base) |
+| Reorder_FreshScratch  |  100 |  13.5 µs |  54.35 KB |   **7.63×** |
+| Reorder_ReusedScratch | 1000 | 128.6 µs |  70.41 KB | 1.00 (base) |
 | Reorder_FreshScratch  | 1000 | 159.4 µs | 504.31 KB |   **7.16×** |
 
 Pooling the keyed working set cuts the keyed-reconcile allocation ~7× and the

--- a/benchmarks/Rask.Benchmarks/BundleSizeReport.cs
+++ b/benchmarks/Rask.Benchmarks/BundleSizeReport.cs
@@ -141,9 +141,11 @@ internal static class BundleSizeReport
         [
             Path.Combine(root, "samples", "Rask.Example.Wasm.Host", "bin", "Release", "net10.0", "publish", "wwwroot",
                 "_framework"),
-            Path.Combine(root, "samples", "Rask.Example.Wasm", "bin", "Release", "net10.0-browser", "publish", "wwwroot",
+            Path.Combine(root, "samples", "Rask.Example.Wasm", "bin", "Release", "net10.0-browser", "publish",
+                "wwwroot",
                 "_framework"),
-            Path.Combine(root, "samples", "Rask.Example.Wasm", "bin", "Release", "net10.0-browser", "browser-wasm", "publish",
+            Path.Combine(root, "samples", "Rask.Example.Wasm", "bin", "Release", "net10.0-browser", "browser-wasm",
+                "publish",
                 "wwwroot", "_framework")
         ];
 

--- a/benchmarks/Rask.Benchmarks/DownloadPayloadBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/DownloadPayloadBenchmarks.cs
@@ -60,7 +60,7 @@ public class DownloadPayloadBenchmarks
     {
         _writer.ResetWrittenCount();
         var dl = new PendingDownload("f.bin", "application/octet-stream", null, bytes);
-        LivePayload.BuildPayloadUtf8WithRoot(_writer, Html, "wasm", null, false, auth: null, download: dl);
+        LivePayload.BuildPayloadUtf8WithRoot(_writer, Html, "wasm", null, false, null, dl);
         return _writer.WrittenCount;
     }
 
@@ -71,7 +71,7 @@ public class DownloadPayloadBenchmarks
         // download sink keyed by this token until JS pulls them.
         var dl = new PendingDownload("f.bin", "application/octet-stream", null, null,
             "8c7eaa6c6c5d4d97a3b04ea5a3c2f1cd");
-        LivePayload.BuildPayloadUtf8WithRoot(_writer, Html, "wasm", null, false, auth: null, download: dl);
+        LivePayload.BuildPayloadUtf8WithRoot(_writer, Html, "wasm", null, false, null, dl);
         return _writer.WrittenCount;
     }
 }

--- a/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
@@ -21,14 +21,14 @@ namespace Rask.Benchmarks;
 [MemoryDiagnoser]
 public class FrameDifferBenchmarks
 {
-    [Params(100, 1000)] public int RowCount { get; set; }
-
-    private RenderFrame[] _before = null!;
-    private RenderFrame[] _afterReorder = null!;
-    private RenderFrame[] _afterText = null!;
-    private string _afterReorderHtml = "";
     private readonly List<EditOp> _ops = new(64);
     private readonly FrameDiffer.DiffScratch _scratch = new();
+    private RenderFrame[] _afterReorder = null!;
+    private string _afterReorderHtml = "";
+    private RenderFrame[] _afterText = null!;
+
+    private RenderFrame[] _before = null!;
+    [Params(100, 1000)] public int RowCount { get; set; }
 
     [GlobalSetup]
     public void Setup()
@@ -39,16 +39,16 @@ public class FrameDifferBenchmarks
             order[i] = i;
         }
 
-        _before = FramesOf(BuildKeyedList(order, textRow: -1));
+        _before = FramesOf(BuildKeyedList(order, -1));
 
         // Reorder: swap two entries (same shape as PayloadBytesPerUpdate.KeyedList100Reorder).
         var reordered = (int[])order.Clone();
         (reordered[5], reordered[RowCount - 5]) = (reordered[RowCount - 5], reordered[5]);
-        (_afterReorder, _afterReorderHtml) = FramesAndHtmlOf(BuildKeyedList(reordered, textRow: -1));
+        (_afterReorder, _afterReorderHtml) = FramesAndHtmlOf(BuildKeyedList(reordered, -1));
 
         // Same key order, one kept row's inner text changed — exercises the keyed step-5
         // inner-diff recursion (the path that re-enters DiffSiblings under a keyed parent).
-        _afterText = FramesOf(BuildKeyedList(order, textRow: RowCount / 2));
+        _afterText = FramesOf(BuildKeyedList(order, RowCount / 2));
     }
 
     [Benchmark(Baseline = true)]

--- a/benchmarks/Rask.Benchmarks/HtmlSerializerBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/HtmlSerializerBenchmarks.cs
@@ -16,9 +16,9 @@ public class HtmlSerializerBenchmarks
 {
     private Component _large = null!;
     private Component _medium = null!;
-    private Component _tiny = null!;
     private Component _scopedCss = null!;
     private Component _textHeavy = null!;
+    private Component _tiny = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks/LivePayloadUtf8Benchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/LivePayloadUtf8Benchmarks.cs
@@ -16,8 +16,8 @@ public class LivePayloadUtf8Benchmarks
 {
     private string _html = null!;
     private string _largeHtml = null!;
-    private ArrayBufferWriter<byte> _pooledWriter = null!;
     private ArrayBufferWriter<byte> _largeWriter = null!;
+    private ArrayBufferWriter<byte> _pooledWriter = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks/PayloadBytesPerUpdate.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesPerUpdate.cs
@@ -30,8 +30,6 @@ public class PayloadBytesPerUpdate
 {
     private const string SessionId = "session-bench";
 
-    private ArrayBufferWriter<byte> _writer = null!;
-
     // CounterOnLargePage: ~200 static rows + one counter cell. The static rows are the
     // "50 KB of unchanged DOM" payload-size-dominator that the diff codec must elide.
     private const int LargePageRowCount = 200;
@@ -49,6 +47,8 @@ public class PayloadBytesPerUpdate
     // diff — single UpdateText op, all surrounding bytes stable. Today's baseline still
     // re-ships the whole body because rendered HTML differs.
     private int _textCounter;
+
+    private ArrayBufferWriter<byte> _writer = null!;
 
     [GlobalSetup]
     public void Setup()

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Globalization;
+using System.Text;
 using Rask.Core;
 using Rask.Core.Live;
 using C = Rask.Core.Components.Generated;
@@ -68,7 +69,7 @@ internal static class PayloadBytesReport
         FrameDiffer.Diff(beforeFrames, afterFrames, ops, html);
 
         writer.ResetWrittenCount();
-        LivePayload.BuildPayloadUtf8Diff(writer, ops, null, false);
+        LivePayload.BuildPayloadUtf8Diff(writer, ops);
         var diffBytes = writer.WrittenCount;
 
         Console.WriteLine(string.Format(
@@ -79,7 +80,7 @@ internal static class PayloadBytesReport
 
     private static RenderFrame[] CaptureFrames(Component tree)
     {
-        var sb = new System.Text.StringBuilder();
+        var sb = new StringBuilder();
         var fw = new FrameWriter();
         using (FrameSinkScope.Push(fw))
         {

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,8 @@ Guides and references for building with Rask. New here? Start with the project
 |-------|----------------|
 | [Getting started](getting-started.md) | Install the templates, scaffold an app, write your first component, add interactivity and a route. |
 | [Routing](routing.md) | `[Route]`, route/query params, nested routes, type-safe `Routes.*` URLs, `Navigator`, `RouteState`. |
+| [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), `Virtualize`, drag-and-drop. |
+| [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), asset delivery. |
 | [Forms & validation](forms.md) | Two-way binding, `Form<T>`/`EditContext`, inline / DataAnnotations / FluentValidation / async validators, radio & checkbox groups. |
 | [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |
 | [Authentication](authentication.md) | Production auth: cookie & JWT, Server & WASM, `Authorize`, route guards, Identity / Keycloak / Auth0 / Cognito / Duende. |

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -1,0 +1,189 @@
+# Composition: context, callbacks, children & lists
+
+How Rask components talk to each other — passing data down without prop drilling,
+sending events up, nesting children, and rendering windowed or reorderable lists.
+
+- [Children & fragments](#children--fragments)
+- [Callbacks: child → parent](#callbacks-child--parent)
+- [Context: provide / consume](#context-provide--consume)
+- [Virtualize: windowed lists](#virtualize-windowed-lists)
+- [Drag and drop](#drag-and-drop)
+
+---
+
+## Children & fragments
+
+Children attach through the **indexer**, not a `Children:` parameter:
+
+```csharp
+Div(Class: "card")[
+    Span(Class: "title")["Hello"],
+    "plain text becomes a Text node",   // string → Text (HTML-encoded)
+    items.Select(i => (Child)Li(Key: i.Id)[i.Name])
+]
+```
+
+`Fragment()` renders its children with **no wrapping element** — use it for a list of
+siblings, or as the conditional "render nothing" branch:
+
+```csharp
+show ? Panel() : (Child)Fragment()    // Fragment() renders nothing
+```
+
+> The `..` spread fails inside `[…]` (the compiler parses it as a `Range`). Pass the
+> enumerable directly — `Div()[items]` — instead of `Div()[..items]`.
+
+The page root is itself a fragment that renders the full shell:
+
+```csharp
+protected override RenderResult Render() =>
+    Fragment()[Doctype(), Html()[Head()[Title()["My app"]], Body()[ /* … */ ]]];
+```
+
+---
+
+## Callbacks: child → parent
+
+**Rask has no `Callback` / `EventCallback` type.** A child raises an event up to its
+parent with a plain delegate property — `Action`, `Action<T>`, `Func<Task>`, or
+`Func<T, Task>`. The generated factory wraps the delegate so that **invoking it
+re-renders the parent that owns it**, with no `StateHasChanged` threaded through by hand.
+
+```csharp
+// Child: declares the event as a delegate prop and invokes it.
+public sealed class RatingStars : Component
+{
+    public int Value { get; set; }
+    public Action<int>? OnRate { get; set; }
+
+    protected override RenderResult Render() =>
+        Div(Class: "d-inline-flex gap-1")[
+            Enumerable.Range(1, 5).Select(i => (Child)Button(
+                OnClick: () => OnRate?.Invoke(i),   // raise the event
+                Key: i)[i <= Value ? "★" : "☆"])
+        ];
+}
+
+// Parent: passes a lambda that mutates its own state.
+public sealed class RatingDemo : Component
+{
+    private int _rating;
+
+    protected override RenderResult Render() =>
+        Div()[
+            RatingStars(Value: _rating, OnRate: n => _rating = n),   // re-renders the parent
+            P()[_rating == 0 ? "Click a star." : $"You rated {_rating}/5"]
+        ];
+}
+```
+
+**When a delegate is auto-wrapped** (so invoking it re-renders the owner): its `Invoke`
+returns `void` or `Task`, it takes **0 or 1** arguments, and the declaring component is
+**not** an `Element` subclass (so DOM handlers like `Button.OnClick` stay on the free
+fast path). It must also be over a member of a `Component` — write the lambda *inside*
+the component so it captures `this`. A lambda over a plain local, or a static method,
+returns unchanged and does **not** trigger a re-render.
+
+Auto-wrapped delegates are excluded from the `propsChanged` diff — changing only the
+lambda identity between renders does not refire `OnPropsChanged`.
+
+---
+
+## Context: provide / consume
+
+Context passes a value from high in the tree to a deep consumer **without prop
+drilling** — React's provide/consume, type-erased so it stays trim-safe.
+
+```csharp
+// Provide near the top. `Provide<T>` is a transparent node; children render under it.
+Context.Provide<Theme>(Value: _theme)[
+    ThemeCard()        // knows nothing about Theme — no prop passed through it
+]
+
+// Consume anywhere below, in Render():
+public sealed class ThemeBadge : Component
+{
+    protected override RenderResult Render()
+    {
+        var theme = Context.Required<Theme>();   // throws if no provider
+        return Span(Class: theme.IsDark ? "badge bg-dark" : "badge bg-light")[theme.Name];
+    }
+}
+```
+
+Read APIs (call inside `Render()`):
+
+| Call | Behaviour |
+|------|-----------|
+| `Context.Get<T>()` | nearest value, or `null` if no provider |
+| `Context.Required<T>()` | nearest value, or throws |
+| `Context.Has<T>()` | `true` if a provider exists |
+
+**Nearest provider wins**, matched by optional `Name:` plus `IsAssignableFrom` — so you
+can **provide a concrete type and consume by an interface**. A provider supplying `null`
+still resolves (it is a real provider of `null`).
+
+**Reactivity:** reading a context value latches the consumer out of the render cache, so
+it re-reads when the provider re-renders — *even through a render-cached intermediate*
+that never re-renders itself. That is the whole point: `ThemeCard` above is cached after
+first paint, yet the `ThemeBadge` it nests still updates on every toggle.
+
+Runnable demo: [`samples/Rask.Example.Shared/Demos/ContextDemos.cs`](../samples/Rask.Example.Shared/Demos/ContextDemos.cs).
+
+---
+
+## Virtualize — windowed lists
+
+`Virtualize<T>` is **headless**: *you* render the scroll container and rows from a
+`VirtualizationState ctx`, and it tells you which slice is visible. The first argument is
+the body builder; pass **exactly one** of `Items` (positional or named) or `ItemsProvider`,
+plus `ItemSize` (row height in px, required) and optional `OverscanCount`.
+
+```csharp
+Virtualize<Row>(
+    ctx => Div(Style: "height:400px; overflow:auto;", OnScroll: ctx.OnScroll)[
+        Div(Style: $"height:{ctx.OffsetBefore}px"),          // top spacer
+        Table()[Tbody()[
+            ctx.VisibleItems.Select(item => Tr(
+                Style: $"height:{ctx.ItemSize}px;",
+                Data: new() { ["rask-key"] = item.Index.ToString() })[  // key → reuse <tr> on scroll
+                Td()[item.IsPlaceholder ? "—" : item.Value!.Name])
+        ]],
+        Div(Style: $"height:{ctx.OffsetAfter}px")             // bottom spacer
+    ],
+    _rows,                 // Items (in memory)
+    ItemSize: 32,
+    OverscanCount: 4)
+```
+
+For lazy / server-paged data pass `ItemsProvider:` instead of the items list. **The
+provider must propagate the `CancellationToken` it receives** or it will leak in-flight
+requests:
+
+```csharp
+ItemsProvider: async req =>
+{
+    var page = await _api.GetRowsAsync(req.StartIndex, req.Count, req.CancellationToken);
+    return new ItemsProviderResult<Row>(page.Items, page.TotalCount);
+}
+```
+
+Provider mode caches by index, marks rows `IsPlaceholder` while a page is in flight, and
+cancels + disposes superseded requests (and on unmount).
+
+Runnable demo: [`samples/Rask.Example.Shared/Pages/VirtualizePage.cs`](../samples/Rask.Example.Shared/Pages/VirtualizePage.cs).
+
+---
+
+## Drag and drop
+
+A headless drag-and-drop primitive lives in `Rask.Core/DragAndDrop`. It tracks the
+dragged item and the drop target and raises a callback when an item is dropped; you own
+the visuals. See the runnable demo:
+[`samples/Rask.Example.Shared/Pages/DragDropPage.cs`](../samples/Rask.Example.Shared/Pages/DragDropPage.cs)
+(+ `DragDropPage.css`).
+
+---
+
+See also: [Lifecycle](lifecycle.md) for when `OnPropsChanged` refires, and
+[JS interop](js-interop.md) for element refs and scoped JS.

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -1,0 +1,133 @@
+# JavaScript interop: element refs, scoped CSS & JS
+
+Reaching the DOM and shipping component-scoped styles and scripts. The same code runs on
+both transports — Server (WebSocket) and WASM (`JSImport`/`JSExport`).
+
+- [Scoped CSS](#scoped-css)
+- [Scoped JS](#scoped-js)
+- [Calling JS from C# (`IJSRuntime`)](#calling-js-from-c-ijsruntime)
+- [Element refs](#element-refs)
+- [Delivery & caching](#delivery--caching)
+
+---
+
+## Scoped CSS
+
+Drop a `{Component}.css` next to `{Component}.cs` and it is **auto-included** and scoped to
+that component — Blazor-parity isolation, no build step:
+
+```
+Pages/HomePage.cs
+Pages/HomePage.css      ← styles here only apply to HomePage's elements
+```
+
+Each component gets a stable `r-{8hex}` scope id. The serializer stamps `data-{scopeId}`
+on the component's elements and rewrites every selector to `selector[data-{scopeId}]`. To
+opt a whole selector out of scoping (e.g. to style a shell tag like `body`), wrap it in
+`:global(...)`:
+
+```css
+.card { padding: 1rem; }            /* scoped to this component */
+:global(body) { margin: 0; }        /* applies globally */
+```
+
+`@media` / `@supports` / `@container` / `@layer` recurse into their bodies; `@keyframes`,
+`@font-face`, and `@import` pass through unscoped. Opt a project out of auto-globbing with
+`<RaskScopedCssAutoInclude>false</RaskScopedCssAutoInclude>`.
+
+> An orphan `.css` with no matching component, or two that match ambiguously, raises
+> **RASK015 / RASK016**. See [diagnostics](diagnostics.md).
+
+---
+
+## Scoped JS
+
+A sibling `{Component}.js` is wrapped onto `window.Rask["{TypeName}"]`, with every
+`export function NAME` becoming a method:
+
+```js
+// ElementRefDemo.js
+export function width(el) {
+    return el ? el.getBoundingClientRect().width : 0;
+}
+```
+
+becomes callable as `Rask.ElementRefDemo.width`. Two scoped-JS components that share a
+simple type name collide at `window.Rask[Name]` — **RASK020** warns about this
+(RASK017 / RASK018 cover orphan / ambiguous `.js`).
+
+---
+
+## Calling JS from C# (`IJSRuntime`)
+
+Inject `IJSRuntime` through the **constructor** (not a property — a non-nullable settable
+property would become a required factory parameter) and dispatch from a lifecycle hook or
+event handler:
+
+```csharp
+public sealed class CodeSample : Component
+{
+    private readonly IJSRuntime _js;
+    public CodeSample(IJSRuntime js) => _js = js;
+
+    protected override async Task OnRenderedAsync(bool firstRender) =>
+        await _js.InvokeVoidAsync("Rask.CodeSample.rendered", firstRender);
+}
+```
+
+Nothing (no `el`) is passed automatically — pass what the function needs. For a return
+value use `InvokeAsync<T>`. On WASM a non-primitive `T` must be rooted for the trimmer
+(DAM annotation or a `JsonSerializerContext`).
+
+---
+
+## Element refs
+
+Every element exposes a `Ref:` parameter. Mint a ref with `ElementRef.New()` and store it
+in a **field** (so its id is stable across renders), then hand it to JS — it serializes as
+`{"__raskRef__":"id"}` and both clients revive it to the live DOM element before your
+function runs:
+
+```csharp
+public sealed class FocusDemo : Component
+{
+    private readonly IJSRuntime _js;
+    private readonly ElementRef _input = ElementRef.New();
+    private readonly ElementRef _box = ElementRef.New();
+
+    public FocusDemo(IJSRuntime js) => _js = js;
+
+    protected override RenderResult Render() =>
+        Div()[
+            Input(Type: "text", Ref: _input),
+            Div(Ref: _box)["measure me"],
+            Button(OnClickAsync: Focus)["Focus"],
+            Button(OnClickAsync: Measure)["Measure"]
+        ];
+
+    // Built-in helpers: ElementRefInterop.{FocusAsync, BlurAsync, ScrollIntoViewAsync}.
+    private async Task Focus() => await _input.FocusAsync(_js);
+
+    // Hand the ref to your own scoped JS — it resolves to the element before width() runs.
+    private async Task Measure() => await _js.InvokeAsync<double>("Rask.FocusDemo.width", _box);
+}
+```
+
+Runnable demo:
+[`samples/Rask.Example.Shared/Demos/ElementRefDemo.cs`](../samples/Rask.Example.Shared/Demos/ElementRefDemo.cs)
+(+ `ElementRefDemo.js`).
+
+---
+
+## Delivery & caching
+
+Both scoped CSS and JS are **content-addressed**. The generator registers each asset; it
+is served at `/_rask/a/{hash}.{ext}` with `Cache-Control: immutable`, an `ETag`,
+`nosniff`, and `.AllowAnonymous()`. The page `<head>` emits exactly one `<link>` /
+`<script defer>` per mounted component type that has a registered asset. Static-file and
+WASM hosts get the same files baked to disk by the `BakeScopedAssetsTask` MSBuild task.
+
+---
+
+See also: [Composition](composition.md) for component-to-component communication, and the
+[architecture notes](architecture/live-rendering.md) for how the live runtime ships these.

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,38 @@
+# Rask samples
+
+Runnable apps that demonstrate Rask end to end. The **showcase** (Server / WASM) is the
+feature tour; the **auth** samples are focused, production-shaped login flows.
+
+## Showcase
+
+| Project | What it is | Run |
+|---------|------------|-----|
+| [`Rask.Example.Shared`](Rask.Example.Shared) | The component library — every demo page and primitive lives here. Referenced by both hosts; not run directly. | — |
+| [`Rask.Example.Server`](Rask.Example.Server) | The showcase served **server-side** over the WebSocket live runtime. | `dotnet run --project samples/Rask.Example.Server` |
+| [`Rask.Example.Wasm`](Rask.Example.Wasm) | The same showcase compiled to **browser-WASM** (standalone SPA). Published, then served by the host below. | (published) |
+| [`Rask.Example.Wasm.Host`](Rask.Example.Wasm.Host) | ASP.NET static-file host that serves the published WASM showcase. | `dotnet run --project samples/Rask.Example.Wasm.Host` |
+
+The same `Rask.Example.Shared` components run unchanged under both the Server and WASM
+transports — that is the point of the pairing.
+
+## Authentication
+
+Each pairs a login flow with a protected `/members` page. See the
+[authentication guide](../docs/authentication.md) for the full production walkthrough.
+
+| Project | Scheme | Host model | Run |
+|---------|--------|-----------|-----|
+| [`Rask.Example.Auth`](Rask.Example.Auth) | Cookie | Server-side | `dotnet run --project samples/Rask.Example.Auth` |
+| [`Rask.Example.Auth.Jwt`](Rask.Example.Auth.Jwt) | JWT (server) | Server-side | `dotnet run --project samples/Rask.Example.Auth.Jwt` |
+| `Rask.Example.Auth.WasmCookie` + [`.Host`](Rask.Example.Auth.WasmCookie.Host) | Cookie | WASM client + ASP.NET host | `dotnet run --project samples/Rask.Example.Auth.WasmCookie.Host` |
+| `Rask.Example.Auth.WasmJwt` + [`.Host`](Rask.Example.Auth.WasmJwt.Host) | JWT (bearer) | WASM client + ASP.NET host | `dotnet run --project samples/Rask.Example.Auth.WasmJwt.Host` |
+
+For the WASM auth pairs, run the **`.Host`** project — it serves the published WASM client
+and exposes the login/API endpoints. The client project is referenced by its host and is
+not launched on its own.
+
+## Notes
+
+- All commands run from the repository root.
+- Auth is configured on ASP.NET's own `AddCookie` / `AddJwtBearer` — Rask has no auth
+  options object. The samples are wired with demo credentials; do not ship them as-is.

--- a/samples/Rask.Example.Auth.Jwt/App.cs
+++ b/samples/Rask.Example.Auth.Jwt/App.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Components;
-
 namespace Rask.Example.Auth.Jwt;
 
 // App shell. JwtBootstrap (headless) re-establishes the principal from ProtectedSessionStorage on a
@@ -7,7 +5,8 @@ namespace Rask.Example.Auth.Jwt;
 // App.css layers the Rask purple palette on top.
 public sealed class App : Component
 {
-    protected override RenderResult Head => [
+    protected override RenderResult Head =>
+    [
         Title()["Rask — JWT auth sample"],
         Meta("utf-8"),
         Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
@@ -18,21 +17,21 @@ public sealed class App : Component
     ];
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head(),
-                Body(Class: "bg-body-tertiary")[
-                    JwtBootstrap(),
-                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
-                        Div(Class: "container")[
-                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · JWT auth"],
-                            A("https://github.com/pal-tamas/rask", "_blank",
-                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
-                        ]
-                    ],
-                    Main(Class: "container py-4")[Router()]
-                ]
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                JwtBootstrap(),
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container")[
+                        NavLink("/", Class: "navbar-brand fw-bold")["Rask · JWT auth"],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container py-4")[Router()]
             ]
-        ];
+        ]
+    ];
 }

--- a/samples/Rask.Example.Auth.Jwt/Auth/CredentialStore.cs
+++ b/samples/Rask.Example.Auth.Jwt/Auth/CredentialStore.cs
@@ -47,9 +47,9 @@ public sealed class JwtIssuer(IConfiguration config)
         }
 
         var token = new JwtSecurityToken(
-            issuer: "rask-jwt-demo",
-            audience: "rask-jwt-demo",
-            claims: claims,
+            "rask-jwt-demo",
+            "rask-jwt-demo",
+            claims,
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: new SigningCredentials(KeyFrom(config), SecurityAlgorithms.HmacSha256));
 

--- a/samples/Rask.Example.Auth.Jwt/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/HomePage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.Jwt.Pages;
@@ -16,7 +15,7 @@ public sealed class HomePage : Component
                     "The JWT authenticates the live WebSocket — it rides the upgrade as ", Code()["?access_token="],
                     " (set via ", Code()["window.Rask.authToken"], "). The members page gates content with the ",
                     Code()["Authorize"], " component over that authenticated socket."],
-                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                NavLink("/members", Id: "go-members", Class: "btn btn-primary")[
                     "Go to the members area →"]
             ]
         ];

--- a/samples/Rask.Example.Auth.Jwt/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/LoginPage.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 using Rask.Server.Authentication;
 

--- a/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 using Rask.Server.Authentication;
 
@@ -16,8 +15,8 @@ public sealed class MembersPage : Component
         Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
             Div(Class: "card-body")[
                 Authorize(
-                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
-                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    NotAuthorized: P("members-anon", "mb-0")[
+                        "Please ", NavLink("/login")["sign in"], "."],
                     Authorized: MemberContent())
             ]
         ];
@@ -28,11 +27,11 @@ public sealed class MemberContent(ProtectedSessionStorage store, SessionUserProv
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
             P(Class: "text-secondary")["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
                 " — encrypted at rest, decrypted only server-side."],
             Authorize(
-                Roles: ["admin"],
+                ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
             Button(Id: "logout", OnClickAsync: SignOutAsync, Class: "btn btn-outline-primary")["Sign out"]

--- a/samples/Rask.Example.Auth.Jwt/README.md
+++ b/samples/Rask.Example.Auth.Jwt/README.md
@@ -1,0 +1,21 @@
+# Rask.Example.Auth.Jwt
+
+**JWT** authentication, server-side. The login issues a signed JWT (held in protected
+browser storage) instead of an auth cookie; a protected `/members` page is gated behind it.
+
+```bash
+dotnet run --project samples/Rask.Example.Auth.Jwt
+```
+
+Sign in with the demo credentials shown on the login page.
+
+## Key files
+
+- `Program.cs` — `AddAuthentication().AddJwtBearer(...)` + `AddRask()` / `UseRask<App>()`.
+- `JwtBootstrap.cs` — token issuance / signing key setup.
+- `Auth/CredentialStore.cs` — the demo user store (replace with your own).
+- `Pages/LoginPage.cs`, `Pages/MembersPage.cs` — the sign-in form and the gated page.
+
+For cookie auth instead, see [`Rask.Example.Auth`](../Rask.Example.Auth); for the
+browser-WASM JWT flow, see `Rask.Example.Auth.WasmJwt.Host`. Full walkthrough in the
+[authentication guide](../../docs/authentication.md). **Demo credentials only — do not ship.**

--- a/samples/Rask.Example.Auth.WasmCookie.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/Program.cs
@@ -53,6 +53,7 @@ app.UseRask(); // serve the published WASM AppBundle
 app.Run();
 
 public sealed record LoginRequest(string Username, string Password);
+
 public sealed record MeDto(string Name, string[] Roles);
 
 public interface ICredentialStore

--- a/samples/Rask.Example.Auth.WasmCookie.Host/README.md
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/README.md
@@ -1,0 +1,21 @@
+# Rask.Example.Auth.WasmCookie.Host
+
+**Cookie** authentication for a **browser-WASM** client. This ASP.NET host serves the
+published `Rask.Example.Auth.WasmCookie` SPA and exposes the login / `me` / logout
+endpoints; the client hydrates the current user and gates a protected `/members` page.
+
+```bash
+dotnet run --project samples/Rask.Example.Auth.WasmCookie.Host
+```
+
+Run **this** host project (not the client) — it serves the WASM bundle and the auth API.
+
+## How it fits together
+
+- `Rask.Example.Auth.WasmCookie` (`net10.0-browser`) — the SPA: login page, user provider,
+  member gate. Referenced by this host; not launched on its own.
+- This host (`net10.0`) — `Program.cs` wires `AddCookie(...)`, the credential endpoints,
+  and `UseRask<TApp>()` from `Rask.Wasm.Hosting`.
+
+JWT variant: `Rask.Example.Auth.WasmJwt.Host`. See the
+[authentication guide](../../docs/authentication.md). **Demo credentials only — do not ship.**

--- a/samples/Rask.Example.Auth.WasmCookie/App.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/App.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Components;
-
 namespace Rask.Example.Auth.WasmCookie;
 
 public sealed class App : Component
@@ -7,7 +5,8 @@ public sealed class App : Component
     // Bootstrap + Bootstrap Icons via CDN keep the showcase look without vendoring wwwroot/lib
     // per sample. App.css (scoped sibling) layers the Rask purple palette on top — user <head>
     // contributions splice in before the scoped-css link so the palette overrides Bootstrap.
-    protected override RenderResult Head => [
+    protected override RenderResult Head =>
+    [
         Title()["Rask — Cookie + WASM auth"],
         Meta("utf-8"),
         Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
@@ -18,20 +17,20 @@ public sealed class App : Component
     ];
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head(),
-                Body(Class: "bg-body-tertiary")[
-                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
-                        Div(Class: "container")[
-                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · cookie + WASM auth"],
-                            A("https://github.com/pal-tamas/rask", "_blank",
-                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
-                        ]
-                    ],
-                    Main(Class: "container py-4")[Router()]
-                ]
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container")[
+                        NavLink("/", Class: "navbar-brand fw-bold")["Rask · cookie + WASM auth"],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container py-4")[Router()]
             ]
-        ];
+        ]
+    ];
 }

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/ApiUserProvider.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text.Json;
 using Rask.Core.Authentication;
 
 namespace Rask.Example.Auth.WasmCookie;
@@ -9,9 +11,8 @@ namespace Rask.Example.Auth.WasmCookie;
 // before the first render, so there's no anonymous flash.
 public sealed class ApiUserProvider(HttpClient http) : IUserProvider
 {
-    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+    public ClaimsPrincipal Current { get; private set; } = new(new ClaimsIdentity());
 
-    public ClaimsPrincipal Current => _current;
     public bool IsLoading { get; private set; }
     public event Action? Changed;
 
@@ -37,18 +38,18 @@ public sealed class ApiUserProvider(HttpClient http) : IUserProvider
             // (its try/catch only caught HttpRequestException). Treat anything but a 200-with-body
             // as anonymous.
             using var resp = await http.GetAsync("api/me");
-            var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+            var me = resp.StatusCode == HttpStatusCode.OK
                 ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
                 : null;
-            _current = me is { Name: { } name }
+            Current = me is { Name: { } name }
                 ? new ClaimsPrincipal(new ClaimsIdentity(
                     [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))],
                     "api"))
                 : new ClaimsPrincipal(new ClaimsIdentity());
         }
-        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
+        catch (Exception ex) when (ex is HttpRequestException or JsonException)
         {
-            _current = new ClaimsPrincipal(new ClaimsIdentity());
+            Current = new ClaimsPrincipal(new ClaimsIdentity());
         }
         finally
         {

--- a/samples/Rask.Example.Auth.WasmCookie/Auth/Dtos.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Auth/Dtos.cs
@@ -3,8 +3,10 @@ using System.Text.Json.Serialization;
 namespace Rask.Example.Auth.WasmCookie;
 
 public sealed record LoginRequest(
-    [property: JsonPropertyName("username")] string Username,
-    [property: JsonPropertyName("password")] string Password);
+    [property: JsonPropertyName("username")]
+    string Username,
+    [property: JsonPropertyName("password")]
+    string Password);
 
 public sealed record MeDto(
     [property: JsonPropertyName("name")] string Name,

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/HomePage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmCookie.Pages;
@@ -15,7 +14,7 @@ public sealed class HomePage : Component
                 P(Class: "card-text text-secondary")[
                     "A browser-WASM SPA that signs in against its host's ", Code()["/api/login"],
                     " (HttpOnly cookie) and hydrates the user from ", Code()["/api/me"], "."],
-                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                NavLink("/members", Id: "go-members", Class: "btn btn-primary")[
                     "Go to the members area →"]
             ]
         ];

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/LoginPage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmCookie.Pages;

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmCookie.Pages;
@@ -15,9 +14,9 @@ public sealed class MembersPage : Component
         Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
             Div(Class: "card-body")[
                 Authorize(
-                    Authorizing: P(Id: "members-authorizing", Class: "text-secondary mb-0")["Loading…"],
-                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
-                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorizing: P("members-authorizing", "text-secondary mb-0")["Loading…"],
+                    NotAuthorized: P("members-anon", "mb-0")[
+                        "Please ", NavLink("/login")["sign in"], "."],
                     Authorized: MemberContent())
             ]
         ];
@@ -27,9 +26,9 @@ public sealed class MemberContent(WasmLoginService login) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
             Authorize(
-                Roles: ["admin"],
+                ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
             Button(Id: "logout", OnClickAsync: login.LogoutAsync, Class: "btn btn-outline-primary")["Sign out"]

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
@@ -66,7 +66,9 @@ app.UseRask(); // serve the published WASM AppBundle
 app.Run();
 
 public sealed record LoginRequest(string Username, string Password);
+
 public sealed record TokenResponse(string Token);
+
 public sealed record MeDto(string Name, string[] Roles);
 
 public interface ICredentialStore
@@ -98,9 +100,9 @@ public sealed class JwtIssuer(SymmetricSecurityKey key)
         }
 
         var token = new JwtSecurityToken(
-            issuer: "rask-jwt-demo",
-            audience: "rask-jwt-demo",
-            claims: claims,
+            "rask-jwt-demo",
+            "rask-jwt-demo",
+            claims,
             expires: DateTime.UtcNow.AddHours(1),
             signingCredentials: new SigningCredentials(key, SecurityAlgorithms.HmacSha256));
 

--- a/samples/Rask.Example.Auth.WasmJwt.Host/README.md
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/README.md
@@ -1,0 +1,23 @@
+# Rask.Example.Auth.WasmJwt.Host
+
+**JWT** (bearer) authentication for a **browser-WASM** client. This ASP.NET host serves the
+published `Rask.Example.Auth.WasmJwt` SPA and issues JWTs from a login endpoint; the client
+stores the token, attaches it as `Authorization: Bearer`, and gates a protected `/members`
+page.
+
+```bash
+dotnet run --project samples/Rask.Example.Auth.WasmJwt.Host
+```
+
+Run **this** host project (not the client) — it serves the WASM bundle and issues tokens.
+
+## How it fits together
+
+- `Rask.Example.Auth.WasmJwt` (`net10.0-browser`) — the SPA: login page, token store, user
+  provider, member gate. Referenced by this host; not launched on its own.
+- This host (`net10.0`) — `Program.cs` signs and issues JWTs and serves the client via
+  `UseRask<TApp>()` from `Rask.Wasm.Hosting`. The token rides the live-runtime WebSocket as
+  `?access_token=`.
+
+Cookie variant: `Rask.Example.Auth.WasmCookie.Host`. See the
+[authentication guide](../../docs/authentication.md). **Demo credentials only — do not ship.**

--- a/samples/Rask.Example.Auth.WasmJwt/App.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/App.cs
@@ -1,12 +1,11 @@
-using Rask.Core.Components;
-
 namespace Rask.Example.Auth.WasmJwt;
 
 public sealed class App : Component
 {
     // Bootstrap + Bootstrap Icons via CDN keep the showcase look without vendoring wwwroot/lib
     // per sample. App.css (scoped sibling) layers the Rask purple palette on top.
-    protected override RenderResult Head => [
+    protected override RenderResult Head =>
+    [
         Title()["Rask — JWT + WASM auth"],
         Meta("utf-8"),
         Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
@@ -17,20 +16,20 @@ public sealed class App : Component
     ];
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head(),
-                Body(Class: "bg-body-tertiary")[
-                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
-                        Div(Class: "container")[
-                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · JWT + WASM auth"],
-                            A("https://github.com/pal-tamas/rask", "_blank",
-                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
-                        ]
-                    ],
-                    Main(Class: "container py-4")[Router()]
-                ]
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container")[
+                        NavLink("/", Class: "navbar-brand fw-bold")["Rask · JWT + WASM auth"],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container py-4")[Router()]
             ]
-        ];
+        ]
+    ];
 }

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/Dtos.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/Dtos.cs
@@ -3,8 +3,10 @@ using System.Text.Json.Serialization;
 namespace Rask.Example.Auth.WasmJwt;
 
 public sealed record LoginRequest(
-    [property: JsonPropertyName("username")] string Username,
-    [property: JsonPropertyName("password")] string Password);
+    [property: JsonPropertyName("username")]
+    string Username,
+    [property: JsonPropertyName("password")]
+    string Password);
 
 public sealed record TokenResponse([property: JsonPropertyName("token")] string Token);
 

--- a/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Auth/JwtUserProvider.cs
@@ -1,5 +1,7 @@
+using System.Net;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Text.Json;
 using Rask.Core.Authentication;
 
 namespace Rask.Example.Auth.WasmJwt;
@@ -8,9 +10,8 @@ namespace Rask.Example.Auth.WasmJwt;
 // BearerTokenHandler). Only calls /api/me when a token is present, so anonymous never hits a 401.
 public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserProvider
 {
-    private ClaimsPrincipal _current = new(new ClaimsIdentity());
+    public ClaimsPrincipal Current { get; private set; } = new(new ClaimsIdentity());
 
-    public ClaimsPrincipal Current => _current;
     public bool IsLoading { get; private set; }
     public event Action? Changed;
 
@@ -34,25 +35,25 @@ public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserP
         {
             if (tokens.Token is null)
             {
-                _current = new ClaimsPrincipal(new ClaimsIdentity());
+                Current = new ClaimsPrincipal(new ClaimsIdentity());
                 return;
             }
 
             // GetAsync (not GetFromJsonAsync): a 204 No Content would make GetFromJsonAsync throw a
             // JsonException on the empty body; treat anything but a 200-with-body as anonymous.
             using var resp = await http.GetAsync("api/me");
-            var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+            var me = resp.StatusCode == HttpStatusCode.OK
                 ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
                 : null;
-            _current = me is { Name: { } name }
+            Current = me is { Name: { } name }
                 ? new ClaimsPrincipal(new ClaimsIdentity(
                     [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))],
                     "jwt"))
                 : new ClaimsPrincipal(new ClaimsIdentity());
         }
-        catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
+        catch (Exception ex) when (ex is HttpRequestException or JsonException)
         {
-            _current = new ClaimsPrincipal(new ClaimsIdentity());
+            Current = new ClaimsPrincipal(new ClaimsIdentity());
         }
         finally
         {

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/HomePage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmJwt.Pages;
@@ -16,7 +15,7 @@ public sealed class HomePage : Component
                     "A browser-WASM SPA that signs in against ", Code()["/api/login"],
                     ", stores the bearer JWT in localStorage, and sends it as ", Code()["Authorization: Bearer"],
                     " on every API call. ", Code()["/api/me"], " validates it server-side."],
-                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                NavLink("/members", Id: "go-members", Class: "btn btn-primary")[
                     "Go to the members area →"]
             ]
         ];

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/LoginPage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmJwt.Pages;

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmJwt.Pages;
@@ -12,9 +11,9 @@ public sealed class MembersPage : Component
         Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
             Div(Class: "card-body")[
                 Authorize(
-                    Authorizing: P(Id: "members-authorizing", Class: "text-secondary mb-0")["Loading…"],
-                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
-                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorizing: P("members-authorizing", "text-secondary mb-0")["Loading…"],
+                    NotAuthorized: P("members-anon", "mb-0")[
+                        "Please ", NavLink("/login")["sign in"], "."],
                     Authorized: MemberContent())
             ]
         ];
@@ -24,9 +23,9 @@ public sealed class MemberContent(JwtLoginService login) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
             Authorize(
-                Roles: ["admin"],
+                ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
             Button(Id: "logout", OnClickAsync: login.LogoutAsync, Class: "btn btn-outline-primary")["Sign out"]

--- a/samples/Rask.Example.Auth.WasmJwt/Program.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Program.cs
@@ -8,7 +8,8 @@ var host = WasmHostBuilder.CreateDefault();
 host.Services.AddSingleton<TokenStore>();
 // HttpClient with a BearerTokenHandler that attaches the JWT from the TokenStore to every request.
 host.Services.AddSingleton(sp =>
-    new HttpClient(new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
+    new HttpClient(
+        new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
     {
         BaseAddress = new Uri(WasmHostBuilder.BaseAddress)
     });

--- a/samples/Rask.Example.Auth/App.cs
+++ b/samples/Rask.Example.Auth/App.cs
@@ -1,12 +1,11 @@
-using Rask.Core.Components;
-
 namespace Rask.Example.Auth;
 
 // App shell: the framework-managed <head> (Bootstrap via CDN + the Rask purple palette in App.css),
 // a sticky navbar, and a Router that renders the matched page.
 public sealed class App : Component
 {
-    protected override RenderResult Head => [
+    protected override RenderResult Head =>
+    [
         Title()["Rask — cookie auth sample"],
         Meta("utf-8"),
         Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
@@ -17,20 +16,20 @@ public sealed class App : Component
     ];
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head(),
-                Body(Class: "bg-body-tertiary")[
-                    Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
-                        Div(Class: "container")[
-                            NavLink(Href: "/", Class: "navbar-brand fw-bold")["Rask · cookie auth"],
-                            A("https://github.com/pal-tamas/rask", "_blank",
-                                Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
-                        ]
-                    ],
-                    Main(Class: "container py-4")[Router()]
-                ]
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container")[
+                        NavLink("/", Class: "navbar-brand fw-bold")["Rask · cookie auth"],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container py-4")[Router()]
             ]
-        ];
+        ]
+    ];
 }

--- a/samples/Rask.Example.Auth/Pages/HomePage.cs
+++ b/samples/Rask.Example.Auth/Pages/HomePage.cs
@@ -1,5 +1,4 @@
 using Microsoft.AspNetCore.Authorization;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.Pages;
@@ -15,7 +14,7 @@ public sealed class HomePage : Component
                 P(Class: "card-text text-secondary")[
                     "A minimal, real cookie login: a protected ", Code()["/members"],
                     " page, a ", Code()["/login"], " form, and sign-out — all over Rask's live runtime."],
-                NavLink(Href: "/members", Id: "go-members", Class: "btn btn-primary")[
+                NavLink("/members", Id: "go-members", Class: "btn btn-primary")[
                     "Go to the members area →"]
             ]
         ];

--- a/samples/Rask.Example.Auth/Pages/LoginPage.cs
+++ b/samples/Rask.Example.Auth/Pages/LoginPage.cs
@@ -2,7 +2,6 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
 using Rask.Core.Authentication;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.Pages;
@@ -51,6 +50,6 @@ public sealed class LoginPage(IAuthSignIn auth, ICredentialStore creds) : Compon
 
         var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
         // SignInAsync drives the redeem handshake; the returnUrl lands the user back on the protected page.
-        await auth.SignInAsync(new ClaimsPrincipal(identity), returnUrl: ReturnUrl ?? "/members");
+        await auth.SignInAsync(new ClaimsPrincipal(identity), ReturnUrl ?? "/members");
     }
 }

--- a/samples/Rask.Example.Auth/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth/Pages/MembersPage.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
 using Rask.Core.Authentication;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.Pages;
@@ -18,9 +17,9 @@ public sealed class MembersPage : Component
         Div(Id: "members", Class: "card shadow-sm mx-auto", Style: "max-width:34rem")[
             Div(Class: "card-body")[
                 Authorize(
-                    Authorizing: P(Id: "members-authorizing", Class: "text-secondary mb-0")["Signing you in…"],
-                    NotAuthorized: P(Id: "members-anon", Class: "mb-0")[
-                        "Please ", NavLink(Href: "/login")["sign in"], "."],
+                    Authorizing: P("members-authorizing", "text-secondary mb-0")["Signing you in…"],
+                    NotAuthorized: P("members-anon", "mb-0")[
+                        "Please ", NavLink("/login")["sign in"], "."],
                     Authorized: MemberContent())
             ]
         ];
@@ -32,15 +31,15 @@ public sealed class MemberContent(IAuthSignIn auth) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1(Id: "members-greeting", Class: "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
             P(Class: "text-secondary")["This page is gated by ", Code()["[Authorize]"],
                 " plus the Authorize component."],
             // Role gate: only an admin sees this.
             Authorize(
-                Roles: ["admin"],
+                ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
                 NotAuthorized: (Child)Fragment()),
-            Button(Id: "logout", OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"),
+            Button(Id: "logout", OnClickAsync: () => auth.SignOutAsync("/login"),
                 Class: "btn btn-outline-primary")["Sign out"]
         ];
 }

--- a/samples/Rask.Example.Auth/README.md
+++ b/samples/Rask.Example.Auth/README.md
@@ -1,0 +1,21 @@
+# Rask.Example.Auth
+
+**Cookie** authentication, server-side. A `/login` form signs the user in with an ASP.NET
+auth cookie; a protected `/members` page is gated behind it.
+
+```bash
+dotnet run --project samples/Rask.Example.Auth
+```
+
+Sign in with the demo credentials shown on the login page.
+
+## Key files
+
+- `Program.cs` — `AddAuthentication().AddCookie(...)` + `AddRask()` / `UseRask<App>()`.
+  Rask has no auth options object; the cookie scheme is configured on ASP.NET directly.
+- `CredentialStore.cs` — the demo user store (replace with your own).
+- `Pages/LoginPage.cs`, `Pages/MembersPage.cs` — the sign-in form and the gated page.
+
+Other auth flavours: [`Rask.Example.Auth.Jwt`](../Rask.Example.Auth.Jwt) (server JWT),
+and the WASM pairs under `Rask.Example.Auth.Wasm*`. See the
+[authentication guide](../../docs/authentication.md). **Demo credentials only — do not ship.**

--- a/samples/Rask.Example.Server/Program.cs
+++ b/samples/Rask.Example.Server/Program.cs
@@ -10,7 +10,7 @@ using Rask.Server;
 // developers) flip modes without recompiling — useful for diff-vs-morph A/B
 // debugging.
 if (Environment.GetEnvironmentVariable("RASK_DIFF_MODE") is { } diffModeName
-    && Enum.TryParse<LiveDiffMode>(diffModeName, ignoreCase: true, out var diffMode))
+    && Enum.TryParse<LiveDiffMode>(diffModeName, true, out var diffMode))
 {
     LiveOptions.DiffMode = diffMode;
 }
@@ -54,7 +54,7 @@ app.MapGet("/_diag", (LiveSessionStore store) =>
     return Results.Json(new
     {
         sessions = store.Count,
-        gcMemoryBytes = GC.GetTotalMemory(forceFullCollection: true),
+        gcMemoryBytes = GC.GetTotalMemory(true),
         gen0 = GC.CollectionCount(0),
         gen1 = GC.CollectionCount(1),
         gen2 = GC.CollectionCount(2)

--- a/samples/Rask.Example.Server/README.md
+++ b/samples/Rask.Example.Server/README.md
@@ -1,0 +1,18 @@
+# Rask.Example.Server
+
+The showcase served **server-side**. The browser holds a thin client; renders and events
+flow over a WebSocket, and Rask ships a minimal edit-op diff per update.
+
+```bash
+dotnet run --project samples/Rask.Example.Server
+```
+
+Then open the printed URL. Every page in the left nav is a runnable demo with its source.
+
+## Key files
+
+- `Program.cs` — `AddRask()` + `UseRask<ShowcaseLayout>()`; the whole host wiring.
+- The pages and components come from [`Rask.Example.Shared`](../Rask.Example.Shared).
+
+For the same app in the browser instead, see
+[`Rask.Example.Wasm.Host`](../Rask.Example.Wasm.Host).

--- a/samples/Rask.Example.Server/wwwroot/img/rask-mark.svg
+++ b/samples/Rask.Example.Server/wwwroot/img/rask-mark.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="22 6 80 108" width="64" height="64" role="img" aria-label="Rask">
-  <defs>
-    <linearGradient id="bolt" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#7C3AED"/>
-      <stop offset="100%" stop-color="#512BD4"/>
-    </linearGradient>
-  </defs>
-  <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#bolt)"/>
+    <defs>
+        <linearGradient id="bolt" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#7C3AED"/>
+            <stop offset="100%" stop-color="#512BD4"/>
+        </linearGradient>
+    </defs>
+    <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#bolt)"/>
 </svg>

--- a/samples/Rask.Example.Server/wwwroot/img/rask-placeholder.svg
+++ b/samples/Rask.Example.Server/wwwroot/img/rask-placeholder.svg
@@ -1,10 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60" role="img" aria-label="Rask">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#7C3AED"/>
-      <stop offset="100%" stop-color="#512BD4"/>
-    </linearGradient>
-  </defs>
-  <rect width="120" height="60" fill="url(#bg)"/>
-  <text x="60" y="30" fill="#ffffff" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="18" font-weight="600" text-anchor="middle" dominant-baseline="central">Rask</text>
+    <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#7C3AED"/>
+            <stop offset="100%" stop-color="#512BD4"/>
+        </linearGradient>
+    </defs>
+    <rect width="120" height="60" fill="url(#bg)"/>
+    <text x="60" y="30" fill="#ffffff" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+          font-size="18" font-weight="600" text-anchor="middle" dominant-baseline="central">Rask
+    </text>
 </svg>

--- a/samples/Rask.Example.Shared/App.cs
+++ b/samples/Rask.Example.Shared/App.cs
@@ -11,7 +11,8 @@ public sealed class App : Component
     // (<title>, <base>) so the latest contributor wins, and auto-appends the
     // scoped-css <link> + scoped-js <script>. User contributions splice in BEFORE
     // the scoped-css link so App.css's brand palette overrides Bootstrap.
-    protected override RenderResult Head => [
+    protected override RenderResult Head =>
+    [
         Title()["Rask — feature showcase"],
         Meta("utf-8"),
         Meta(Name: "viewport", Content: "width=device-width, initial-scale=1, viewport-fit=cover"),
@@ -31,13 +32,13 @@ public sealed class App : Component
     // Brand palette and global cascade live in App.css (sibling scoped-CSS file).
     // The runtime <script> is injected into <body> automatically — no RaskRuntimeScript().
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head(),
-                Body(Class: "bg-body-tertiary")[
-                    Router()
-                ]
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Router()
             ]
-        ];
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Demos/AuthorizeDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/AuthorizeDemo.cs
@@ -26,7 +26,7 @@ public sealed class AuthorizeDemo : Component
             ],
             // admin → admin slot; any other signed-in user → inner "authorized" slot; anonymous → inner fallback.
             Authorize(
-                Roles: ["admin"],
+                ["admin"],
                 Authorized: Div(Class: "alert alert-warning py-2 mb-0")["🔑 Admin-only content."],
                 NotAuthorized: Authorize(
                     Authorized: Div(Class: "alert alert-success py-2 mb-0")["✅ Signed in — standard access."],

--- a/samples/Rask.Example.Shared/Demos/BindingDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/BindingDemos.cs
@@ -10,17 +10,18 @@ public sealed class BindingManualDemo : Component
     private string _typed = "";
 
     protected override RenderResult Render() =>
-        [
-            Input(
-                "text",
-                Class: "form-control mb-2",
-                Placeholder: "Type something",
-                Value: _typed,
-                OnInput: v => _typed = v),
-            P(Class: "small mb-0")[
-                "Echo: ",
-                Code()[string.IsNullOrEmpty(_typed) ? "\"\"" : $"\"{_typed}\""]
-            ]];
+    [
+        Input(
+            "text",
+            Class: "form-control mb-2",
+            Placeholder: "Type something",
+            Value: _typed,
+            OnInput: v => _typed = v),
+        P(Class: "small mb-0")[
+            "Echo: ",
+            Code()[string.IsNullOrEmpty(_typed) ? "\"\"" : $"\"{_typed}\""]
+        ]
+    ];
 }
 
 public sealed class BindingTypedDemo : Component
@@ -28,16 +29,17 @@ public sealed class BindingTypedDemo : Component
     private readonly Holder _model = new();
 
     protected override RenderResult Render() =>
-        [
-            Input(
-                () => _model.Name,
-                Class: "form-control mb-2",
-                Placeholder: "Your name"),
-            P(Class: "small mb-0")[
-                "Hello, ",
-                Strong()[string.IsNullOrEmpty(_model.Name) ? "stranger" : _model.Name],
-                "!"
-            ]];
+    [
+        Input(
+            () => _model.Name,
+            Class: "form-control mb-2",
+            Placeholder: "Your name"),
+        P(Class: "small mb-0")[
+            "Hello, ",
+            Strong()[string.IsNullOrEmpty(_model.Name) ? "stranger" : _model.Name],
+            "!"
+        ]
+    ];
 
     private sealed class Holder
     {
@@ -50,19 +52,20 @@ public sealed class BindingTextareaDemo : Component
     private readonly Holder _model = new();
 
     protected override RenderResult Render() =>
-        [
-            Textarea(
-                () => _model.Notes,
-                Id: "bind-textarea",
-                Class: "form-control mb-2",
-                Rows: 3,
-                Placeholder: "Jot something down…"),
-            Pre(Class: "small mb-0 p-3 bg-light border rounded")[
-                Code()[
-                    $"Notes  = \"{_model.Notes}\"\n" +
-                    $"Length = {_model.Notes.Length}"
-                ]
-            ]];
+    [
+        Textarea(
+            () => _model.Notes,
+            Id: "bind-textarea",
+            Class: "form-control mb-2",
+            Rows: 3,
+            Placeholder: "Jot something down…"),
+        Pre(Class: "small mb-0 p-3 bg-light border rounded")[
+            Code()[
+                $"Notes  = \"{_model.Notes}\"\n" +
+                $"Length = {_model.Notes.Length}"
+            ]
+        ]
+    ];
 
     private sealed class Holder
     {
@@ -77,50 +80,50 @@ public sealed class BindingNullableDemo : Component
     private readonly Holder _model = new();
 
     protected override RenderResult Render() =>
-        [
-            Div(Class: "mb-3")[
-                Label("bind-null-age", Class: "form-label small")["Optional age (int?)"],
-                Input(
-                    () => _model.OptionalAge,
-                    Id: "bind-null-age",
-                    Class: "form-control",
-                    Placeholder: "leave empty for null")
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-null-start", Class: "form-label small")["Optional start date (DateOnly?)"],
-                Input(
-                    () => _model.StartDate,
-                    Id: "bind-null-start",
-                    Class: "form-control")
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-null-color", Class: "form-label small")["Optional colour (Color?)"],
-                Select(
-                    () => _model.Favorite,
-                    Id: "bind-null-color",
-                    Class: "form-select",
-                    Children: new Child[]
-                    {
-                        Option("")["— none —"], Option("Red")["Red"], Option("Green")["Green"],
-                        Option("Blue")["Blue"]
-                    })
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-null-nick", Class: "form-label small")["Nickname (string?)"],
-                Input(
-                    () => _model.Nickname,
-                    Id: "bind-null-nick",
-                    Class: "form-control",
-                    Placeholder: "clear me for null")
-            ],
-            Pre(Class: "small mb-0 p-3 bg-light border rounded")[
-                Code()[
-                    $"OptionalAge = {_model.OptionalAge?.ToString() ?? "null"}\n" +
-                    $"StartDate   = {_model.StartDate?.ToString("yyyy-MM-dd") ?? "null"}\n" +
-                    $"Favorite    = {_model.Favorite?.ToString() ?? "null"}\n" +
-                    $"Nickname    = {(_model.Nickname is null ? "null" : "\"" + _model.Nickname + "\"")}"
-                ]
-            ]];
+    [
+        Div(Class: "mb-3")[
+            Label("bind-null-age", Class: "form-label small")["Optional age (int?)"],
+            Input(
+                () => _model.OptionalAge,
+                Id: "bind-null-age",
+                Class: "form-control",
+                Placeholder: "leave empty for null")
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-null-start", Class: "form-label small")["Optional start date (DateOnly?)"],
+            Input(
+                () => _model.StartDate,
+                Id: "bind-null-start",
+                Class: "form-control")
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-null-color", Class: "form-label small")["Optional colour (Color?)"],
+            Select(
+                () => _model.Favorite,
+                Id: "bind-null-color",
+                Class: "form-select",
+                Children: new Child[]
+                {
+                    Option("")["— none —"], Option("Red")["Red"], Option("Green")["Green"], Option("Blue")["Blue"]
+                })
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-null-nick", Class: "form-label small")["Nickname (string?)"],
+            Input(
+                () => _model.Nickname,
+                Id: "bind-null-nick",
+                Class: "form-control",
+                Placeholder: "clear me for null")
+        ],
+        Pre(Class: "small mb-0 p-3 bg-light border rounded")[
+            Code()[
+                $"OptionalAge = {_model.OptionalAge?.ToString() ?? "null"}\n" +
+                $"StartDate   = {_model.StartDate?.ToString("yyyy-MM-dd") ?? "null"}\n" +
+                $"Favorite    = {_model.Favorite?.ToString() ?? "null"}\n" +
+                $"Nickname    = {(_model.Nickname is null ? "null" : "\"" + _model.Nickname + "\"")}"
+            ]
+        ]
+    ];
 
     private sealed class Holder
     {
@@ -136,28 +139,29 @@ public sealed class BindingClearDefaultDemo : Component
     private readonly Holder _model = new();
 
     protected override RenderResult Render() =>
-        [
-            Div(Class: "mb-3")[
-                Label("bind-clear-age", Class: "form-label small")["Age (non-nullable int) — clear → 0"],
-                Input(
-                    () => _model.Age,
-                    Id: "bind-clear-age",
-                    Class: "form-control")
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-clear-optage", Class: "form-label small")["Optional age (int?) — clear → null"],
-                Input(
-                    () => _model.OptionalAge,
-                    Id: "bind-clear-optage",
-                    Class: "form-control",
-                    Placeholder: "leave empty for null")
-            ],
-            Pre(Class: "small mb-0 p-3 bg-light border rounded")[
-                Code("bind-clear-echo")[
-                    $"Age         = {_model.Age}\n" +
-                    $"OptionalAge = {_model.OptionalAge?.ToString() ?? "null"}"
-                ]
-            ]];
+    [
+        Div(Class: "mb-3")[
+            Label("bind-clear-age", Class: "form-label small")["Age (non-nullable int) — clear → 0"],
+            Input(
+                () => _model.Age,
+                Id: "bind-clear-age",
+                Class: "form-control")
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-clear-optage", Class: "form-label small")["Optional age (int?) — clear → null"],
+            Input(
+                () => _model.OptionalAge,
+                Id: "bind-clear-optage",
+                Class: "form-control",
+                Placeholder: "leave empty for null")
+        ],
+        Pre(Class: "small mb-0 p-3 bg-light border rounded")[
+            Code("bind-clear-echo")[
+                $"Age         = {_model.Age}\n" +
+                $"OptionalAge = {_model.OptionalAge?.ToString() ?? "null"}"
+            ]
+        ]
+    ];
 
     private sealed class Holder
     {
@@ -179,38 +183,39 @@ public sealed class BindingAfterBindDemo : Component
     private string[] _cities = Cities["US"];
 
     protected override RenderResult Render() =>
-        [
-            Div(Class: "mb-3")[
-                Label("bind-after-country", Class: "form-label small")["Country"],
-                Select(
-                    () => _model.Country,
-                    c =>
-                    {
-                        _cities = Cities[c];
-                        _model.City = _cities[0];
-                    },
-                    Id: "bind-after-country",
-                    Class: "form-select")[
-                    Option("US")["United States"],
-                    Option("DE")["Germany"],
-                    Option("JP")["Japan"]
-                ]
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-after-city", Class: "form-label small")["City"],
-                Select(
-                    () => _model.City,
-                    Id: "bind-after-city",
-                    Class: "form-select")[
-                    _cities.Select(c => Option(c, Key: c)[c])
-                ]
-            ],
-            Pre(Class: "small mb-0 p-3 bg-light border rounded")[
-                Code("bind-after-echo")[
-                    $"Country = {_model.Country}\n" +
-                    $"City    = {_model.City}"
-                ]
-            ]];
+    [
+        Div(Class: "mb-3")[
+            Label("bind-after-country", Class: "form-label small")["Country"],
+            Select(
+                () => _model.Country,
+                c =>
+                {
+                    _cities = Cities[c];
+                    _model.City = _cities[0];
+                },
+                Id: "bind-after-country",
+                Class: "form-select")[
+                Option("US")["United States"],
+                Option("DE")["Germany"],
+                Option("JP")["Japan"]
+            ]
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-after-city", Class: "form-label small")["City"],
+            Select(
+                () => _model.City,
+                Id: "bind-after-city",
+                Class: "form-select")[
+                _cities.Select(c => Option(c, Key: c)[c])
+            ]
+        ],
+        Pre(Class: "small mb-0 p-3 bg-light border rounded")[
+            Code("bind-after-echo")[
+                $"Country = {_model.Country}\n" +
+                $"City    = {_model.City}"
+            ]
+        ]
+    ];
 
     private sealed class Holder
     {
@@ -233,77 +238,78 @@ public sealed class BindingAfterBindAsyncDemo : Component
     private bool _loading;
 
     protected override RenderResult Render() =>
-        [
-            Div(Class: "mb-3")[
-                Label("bind-async-track", Class: "form-label small")["Track"],
-                Select(
-                    () => _model.Track,
-                    AfterBindAsync: async track =>
+    [
+        Div(Class: "mb-3")[
+            Label("bind-async-track", Class: "form-label small")["Track"],
+            Select(
+                () => _model.Track,
+                AfterBindAsync: async track =>
+                {
+                    // Re-selecting the placeholder (or any unknown track) clears the
+                    // dependent list instead of throwing on _catalog[track].
+                    if (!_catalog.ContainsKey(track))
                     {
-                        // Re-selecting the placeholder (or any unknown track) clears the
-                        // dependent list instead of throwing on _catalog[track].
-                        if (!_catalog.ContainsKey(track))
-                        {
-                            _languages = [];
-                            _model.Language = "";
-                            _loading = false;
-                            return;
-                        }
-
-                        // Rask re-renders at every await suspension inside an async handler, so
-                        // flipping _loading before the await below is enough to surface the
-                        // "loading…" UI — a manual StateHasChanged() here would only set a deferred
-                        // in-handler flag and push no frame.
-                        _loading = true;
-                        // Simulated remote fetch — swap for HttpClient.GetFromJsonAsync in real code.
-                        // Pass the component's CancellationToken so unmount-during-fetch aborts
-                        // the simulated work cleanly instead of mutating state on a stale instance.
-                        try
-                        {
-                            await Task.Delay(300, CancellationToken);
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            return;
-                        }
-
-                        _languages = _catalog[track];
-                        _model.Language = _languages[0];
+                        _languages = [];
+                        _model.Language = "";
                         _loading = false;
-                    },
-                    Id: "bind-async-track",
-                    Class: "form-select")[
-                    // Placeholder matching the empty initial Track. Without it the <select>
-                    // visually defaults to "Frontend" while the model is still "" — and
-                    // re-picking the already-shown first option fires no change event, so the
-                    // async load never triggers. A selected placeholder keeps the initial
-                    // display honest and makes every track pick a real change.
-                    Option("")["— pick a track —"],
-                    Option("frontend")["Frontend"],
-                    Option("backend")["Backend"],
-                    Option("data")["Data"]
-                ]
+                        return;
+                    }
+
+                    // Rask re-renders at every await suspension inside an async handler, so
+                    // flipping _loading before the await below is enough to surface the
+                    // "loading…" UI — a manual StateHasChanged() here would only set a deferred
+                    // in-handler flag and push no frame.
+                    _loading = true;
+                    // Simulated remote fetch — swap for HttpClient.GetFromJsonAsync in real code.
+                    // Pass the component's CancellationToken so unmount-during-fetch aborts
+                    // the simulated work cleanly instead of mutating state on a stale instance.
+                    try
+                    {
+                        await Task.Delay(300, CancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        return;
+                    }
+
+                    _languages = _catalog[track];
+                    _model.Language = _languages[0];
+                    _loading = false;
+                },
+                Id: "bind-async-track",
+                Class: "form-select")[
+                // Placeholder matching the empty initial Track. Without it the <select>
+                // visually defaults to "Frontend" while the model is still "" — and
+                // re-picking the already-shown first option fires no change event, so the
+                // async load never triggers. A selected placeholder keeps the initial
+                // display honest and makes every track pick a real change.
+                Option("")["— pick a track —"],
+                Option("frontend")["Frontend"],
+                Option("backend")["Backend"],
+                Option("data")["Data"]
+            ]
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-async-lang", Class: "form-label small")[
+                _loading ? "Language (loading…)" : "Language"
             ],
-            Div(Class: "mb-3")[
-                Label("bind-async-lang", Class: "form-label small")[
-                    _loading ? "Language (loading…)" : "Language"
-                ],
-                Select(
-                    () => _model.Language,
-                    Id: "bind-async-lang",
-                    Class: "form-select",
-                    Disabled: _loading || _languages.Length == 0)[
-                    _languages.Length == 0
-                        ? [Option("")["— pick a track —"]]
-                        : _languages.Select(l => Option(l, Key: l)[l])
-                ]
-            ],
-            Pre(Class: "small mb-0 p-3 bg-light border rounded")[
-                Code("bind-async-echo")[
-                    $"Track    = {_model.Track}\n" +
-                    $"Language = {_model.Language}"
-                ]
-            ]];
+            Select(
+                () => _model.Language,
+                Id: "bind-async-lang",
+                Class: "form-select",
+                Disabled: _loading || _languages.Length == 0)[
+                _languages.Length == 0
+                    ? [Option("")["— pick a track —"]]
+                    : _languages.Select(l => Option(l, Key: l)[l])
+            ]
+        ],
+        Pre(Class: "small mb-0 p-3 bg-light border rounded")[
+            Code("bind-async-echo")[
+                $"Track    = {_model.Track}\n" +
+                $"Language = {_model.Language}"
+            ]
+        ]
+    ];
 
     private sealed class Holder
     {
@@ -319,49 +325,50 @@ public sealed class BindingMultiDemo : Component
     private readonly Holder _model = new();
 
     protected override RenderResult Render() =>
-        [
-            Div(Class: "mb-3 form-check")[
-                Input(
-                    () => _model.Subscribe,
-                    Id: "bind-subscribe",
-                    Class: "form-check-input"),
-                Label("bind-subscribe", Class: "form-check-label ms-1")["Subscribe to the newsletter"]
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-age", Class: "form-label small")["Age"],
-                Input(
-                    () => _model.Age,
-                    Id: "bind-age",
-                    Class: "form-control",
-                    Min: "0",
-                    Max: "120")
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-start", Class: "form-label small")["Start date"],
-                Input(
-                    () => _model.StartDate,
-                    Id: "bind-start",
-                    Class: "form-control")
-            ],
-            Div(Class: "mb-3")[
-                Label("bind-favorite", Class: "form-label small")["Favourite colour"],
-                Select(
-                    () => _model.Favorite,
-                    Id: "bind-favorite",
-                    Class: "form-select")[
-                    Option("Red")["Red"],
-                    Option("Green")["Green"],
-                    Option("Blue")["Blue"]
-                ]
-            ],
-            Pre(Class: "small mb-0 p-3 bg-light border rounded")[
-                Code()[
-                    $"Subscribe = {(_model.Subscribe ? "true" : "false")}\n" +
-                    $"Age       = {_model.Age}\n" +
-                    $"StartDate = {_model.StartDate:yyyy-MM-dd}\n" +
-                    $"Favorite  = {_model.Favorite}"
-                ]
-            ]];
+    [
+        Div(Class: "mb-3 form-check")[
+            Input(
+                () => _model.Subscribe,
+                Id: "bind-subscribe",
+                Class: "form-check-input"),
+            Label("bind-subscribe", Class: "form-check-label ms-1")["Subscribe to the newsletter"]
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-age", Class: "form-label small")["Age"],
+            Input(
+                () => _model.Age,
+                Id: "bind-age",
+                Class: "form-control",
+                Min: "0",
+                Max: "120")
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-start", Class: "form-label small")["Start date"],
+            Input(
+                () => _model.StartDate,
+                Id: "bind-start",
+                Class: "form-control")
+        ],
+        Div(Class: "mb-3")[
+            Label("bind-favorite", Class: "form-label small")["Favourite colour"],
+            Select(
+                () => _model.Favorite,
+                Id: "bind-favorite",
+                Class: "form-select")[
+                Option("Red")["Red"],
+                Option("Green")["Green"],
+                Option("Blue")["Blue"]
+            ]
+        ],
+        Pre(Class: "small mb-0 p-3 bg-light border rounded")[
+            Code()[
+                $"Subscribe = {(_model.Subscribe ? "true" : "false")}\n" +
+                $"Age       = {_model.Age}\n" +
+                $"StartDate = {_model.StartDate:yyyy-MM-dd}\n" +
+                $"Favorite  = {_model.Favorite}"
+            ]
+        ]
+    ];
 
     private sealed class Holder
     {

--- a/samples/Rask.Example.Shared/Demos/CallbackDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/CallbackDemos.cs
@@ -1,6 +1,3 @@
-using System.Linq;
-using Rask.Core;
-
 namespace Rask.Example.Shared.Demos;
 
 // A reusable child component that knows nothing about its parent's state. It renders clickable
@@ -33,7 +30,7 @@ public sealed class CallbackRatingDemo : Component
         Div()[
             // The lambda captures `this`, so it owns this demo — the framework wraps it so clicking
             // a star in the child re-renders the line below, with no extra ceremony.
-            RatingStars(Value: _rating, OnRate: n => _rating = n),
+            RatingStars(_rating, n => _rating = n),
             P(Class: "mt-2 mb-0 small text-secondary")[
                 _rating == 0 ? "Click a star to rate." : $"You rated: {_rating}/5"
             ]

--- a/samples/Rask.Example.Shared/Demos/CodeSample.css
+++ b/samples/Rask.Example.Shared/Demos/CodeSample.css
@@ -68,16 +68,44 @@
    .sample-code so the generic class names don't leak page-wide. Fresh simple dark
    palette tuned to the #1f1d2b background / #e7e3ff base text. */
 :global(.sample-code .keyword),
-:global(.sample-code .preprocessorKeyword) { color: #c792ea; }
+:global(.sample-code .preprocessorKeyword) {
+    color: #c792ea;
+}
+
 :global(.sample-code .string),
-:global(.sample-code .stringCSharpVerbatim) { color: #c3e88d; }
-:global(.sample-code .stringEscape) { color: #89ddff; }
-:global(.sample-code .comment) { color: #6b6786; font-style: italic; }
-:global(.sample-code .xmlDocComment) { color: #6b6786; font-style: italic; }
-:global(.sample-code .xmlDocTag) { color: #8b87a8; }
-:global(.sample-code .number) { color: #f78c6c; }
-:global(.sample-code .className) { color: #82aaff; }
-:global(.sample-code .plainText) { color: #e7e3ff; }
+:global(.sample-code .stringCSharpVerbatim) {
+    color: #c3e88d;
+}
+
+:global(.sample-code .stringEscape) {
+    color: #89ddff;
+}
+
+:global(.sample-code .comment) {
+    color: #6b6786;
+    font-style: italic;
+}
+
+:global(.sample-code .xmlDocComment) {
+    color: #6b6786;
+    font-style: italic;
+}
+
+:global(.sample-code .xmlDocTag) {
+    color: #8b87a8;
+}
+
+:global(.sample-code .number) {
+    color: #f78c6c;
+}
+
+:global(.sample-code .className) {
+    color: #82aaff;
+}
+
+:global(.sample-code .plainText) {
+    color: #e7e3ff;
+}
 
 .sample-result-col {
     background: #fff;

--- a/samples/Rask.Example.Shared/Demos/ContextDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/ContextDemos.cs
@@ -19,7 +19,7 @@ public sealed class ContextThemeDemo : Component
 
     protected override RenderResult Render() =>
         // Provide the current theme to the whole subtree below.
-        Context.Provide<Theme>(Value: _theme)[
+        Context.Provide<Theme>(_theme)[
             Div(
                 Class: "border rounded p-3",
                 Style: _theme.IsDark ? "background:#212529;color:#e9ecef" : "background:#f8f9fa")[

--- a/samples/Rask.Example.Shared/Demos/DemoUserProvider.cs
+++ b/samples/Rask.Example.Shared/Demos/DemoUserProvider.cs
@@ -9,9 +9,7 @@ namespace Rask.Example.Shared.Demos;
 // both itself (so the demo can sign in/out) and IUserProvider (so Component.User resolves it).
 public sealed class DemoUserProvider : IUserProvider
 {
-    private ClaimsPrincipal _current = new(new ClaimsIdentity());
-
-    public ClaimsPrincipal Current => _current;
+    public ClaimsPrincipal Current { get; private set; } = new(new ClaimsIdentity());
 
     public event Action? Changed;
 
@@ -24,13 +22,13 @@ public sealed class DemoUserProvider : IUserProvider
         }
 
         // A ClaimsIdentity with a non-null authenticationType is treated as authenticated.
-        _current = new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "demo"));
+        Current = new ClaimsPrincipal(new ClaimsIdentity(claims, "demo"));
         Changed?.Invoke();
     }
 
     public void SignOut()
     {
-        _current = new ClaimsPrincipal(new ClaimsIdentity());
+        Current = new ClaimsPrincipal(new ClaimsIdentity());
         Changed?.Invoke();
     }
 }

--- a/samples/Rask.Example.Shared/Demos/ElementRefDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/ElementRefDemo.cs
@@ -1,5 +1,4 @@
 using Microsoft.JSInterop;
-using Rask.Core;
 
 namespace Rask.Example.Shared.Demos;
 
@@ -8,9 +7,9 @@ namespace Rask.Example.Shared.Demos;
 // their ids stay stable across renders.
 public sealed class ElementRefDemo : Component
 {
-    private readonly IJSRuntime _js;
-    private readonly ElementRef _input = ElementRef.New();
     private readonly ElementRef _box = ElementRef.New();
+    private readonly ElementRef _input = ElementRef.New();
+    private readonly IJSRuntime _js;
     private string _measured = "";
 
     public ElementRefDemo(IJSRuntime js) => _js = js;
@@ -18,7 +17,7 @@ public sealed class ElementRefDemo : Component
     protected override RenderResult Render() =>
         Div()[
             Input(
-                Type: "text",
+                "text",
                 Class: "form-control mb-2",
                 Placeholder: "Focus me from C#",
                 Ref: _input),

--- a/samples/Rask.Example.Shared/Demos/FormGroupsDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/FormGroupsDemo.cs
@@ -13,16 +13,16 @@ public sealed class FormGroupsDemo : Component
                 Label(Class: "form-label fw-semibold d-block")["Plan"],
                 RadioGroup(
                     () => _prefs.Plan,
-                    Options: new[] { Plan.Free, Plan.Pro, Plan.Team },
-                    OptionLabel: p => Span(Class: "ms-1 me-3")[p.ToString()],
+                    new[] { Plan.Free, Plan.Pro, Plan.Team },
+                    p => Span(Class: "ms-1 me-3")[p.ToString()],
                     ItemClass: "form-check-label")
             ],
             Div(Class: "mb-3")[
                 Label(Class: "form-label fw-semibold d-block")["Interests"],
                 CheckboxGroup<string>(
                     () => _prefs.Interests,
-                    Options: new[] { "Web", "Mobile", "AI", "Games" },
-                    OptionLabel: t => Span(Class: "ms-1 me-3")[t],
+                    new[] { "Web", "Mobile", "AI", "Games" },
+                    t => Span(Class: "ms-1 me-3")[t],
                     ItemClass: "form-check-label")
             ],
             P(Class: "small text-secondary mb-0", Id: "groups-summary")[

--- a/samples/Rask.Example.Shared/Demos/LifecycleProbe.cs
+++ b/samples/Rask.Example.Shared/Demos/LifecycleProbe.cs
@@ -28,7 +28,8 @@ public sealed class LifecycleProbe : Component
     protected override RenderResult Render()
     {
         _renderCount++;
-        return [
+        return
+        [
             Div(Class: "d-flex align-items-center gap-3 mb-3")[
                 Span(Class: "badge text-bg-primary fs-6")[$"Render #{_renderCount}"],
                 Button(
@@ -37,7 +38,8 @@ public sealed class LifecycleProbe : Component
             ],
             H3(Class: "h6 text-secondary text-uppercase small")["Hook log"],
             Ol(Class: "list-group list-group-numbered list-group-flush")[
-                _log.Select((l, i) => Li(Key: i, Class: "list-group-item ps-2 small")[Code(Class: "small")[l]]).ToArray()]
+                _log.Select((l, i) => Li(Key: i, Class: "list-group-item ps-2 small")[Code(Class: "small")[l]])
+                    .ToArray()]
         ];
     }
 }

--- a/samples/Rask.Example.Shared/Demos/LiveTicker.cs
+++ b/samples/Rask.Example.Shared/Demos/LiveTicker.cs
@@ -201,7 +201,8 @@ public sealed class LiveTicker : Component
             Div(Class: "card-body")[
                 Div(Class: "d-flex align-items-baseline justify-content-between mb-3")[
                     H3(Class: "h4 mb-0 fw-semibold", Id: "ticker-symbol")[Symbol],
-                    Span(Class: "text-secondary small")[$"poll {IntervalMs} ms · {_history.Count}/{HistoryCapacity} pts"]
+                    Span(Class: "text-secondary small")[
+                        $"poll {IntervalMs} ms · {_history.Count}/{HistoryCapacity} pts"]
                 ],
                 Div(Class: "d-flex align-items-baseline gap-3 mb-3")[
                     _history.Count == 0
@@ -226,7 +227,7 @@ public sealed class LiveTicker : Component
                     _history.Count == 0
                         ? P(Class: "text-secondary small mb-0")["Waiting for first tick…"]
                         : Sparkline(
-                            Values: _history.Select(p => (double)p.PriceUsd).ToList(),
+                            _history.Select(p => (double)p.PriceUsd).ToList(),
                             Class: "ticker-chart-svg")
                 ]
             ]
@@ -259,7 +260,7 @@ public sealed class LiveTicker : Component
             }
 
             _error = null;
-            StateHasChanged();                      // the one render per tick
+            StateHasChanged(); // the one render per tick
         }
         catch (OperationCanceledException)
         {
@@ -268,7 +269,7 @@ public sealed class LiveTicker : Component
         catch (Exception ex)
         {
             _error = ex.Message;
-            StateHasChanged();                      // surface the #ticker-error alert
+            StateHasChanged(); // surface the #ticker-error alert
         }
     }
 

--- a/samples/Rask.Example.Shared/Demos/NestedFormDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/NestedFormDemos.cs
@@ -14,56 +14,57 @@ public sealed class NestedSubObjectDemo : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        [
-            Form<CheckoutModel>(
-                _model,
-                m => _submission =
-                    $"Checked out as {m.Name} to {m.Address.Street}, {m.Address.City} ({m.Address.Country}).",
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                Div()[
-                    Label("nf-name", Class: "form-label small mb-1")["Name"],
-                    Input(() => _model.Name, Id: "nf-name", Class: "form-control"),
-                    ValidationMessage(() => _model.Name, FieldError)
-                ],
-                Div()[
-                    Label("nf-email", Class: "form-label small mb-1")["Email"],
-                    Input(() => _model.Email, Id: "nf-email", Type: "email",
-                        Class: "form-control"),
-                    ValidationMessage(() => _model.Email, FieldError)
-                ],
-                Fieldset(Class: "border rounded p-3 mt-2")[
-                    Legend(Class: "h6 fw-semibold")["Shipping address"],
-                    Div(Class: "vstack gap-3")[
-                        Div()[
-                            Label("nf-street", Class: "form-label small mb-1")["Street"],
-                            Input(() => _model.Address.Street, Id: "nf-street",
-                                Class: "form-control"),
-                            ValidationMessage(() => _model.Address.Street, FieldError)
-                        ],
-                        Div()[
-                            Label("nf-city", Class: "form-label small mb-1")["City"],
-                            Input(() => _model.Address.City, Id: "nf-city",
-                                Class: "form-control"),
-                            ValidationMessage(() => _model.Address.City, FieldError)
-                        ],
-                        Div()[
-                            Label("nf-country", Class: "form-label small mb-1")["Country (ISO)"],
-                            Input(() => _model.Address.Country, Id: "nf-country",
-                                Class: "form-control", MaxLength: 2),
-                            ValidationMessage(() => _model.Address.Country, FieldError)
-                        ]
+    [
+        Form<CheckoutModel>(
+            _model,
+            m => _submission =
+                $"Checked out as {m.Name} to {m.Address.Street}, {m.Address.City} ({m.Address.Country}).",
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            Div()[
+                Label("nf-name", Class: "form-label small mb-1")["Name"],
+                Input(() => _model.Name, Id: "nf-name", Class: "form-control"),
+                ValidationMessage(() => _model.Name, FieldError)
+            ],
+            Div()[
+                Label("nf-email", Class: "form-label small mb-1")["Email"],
+                Input(() => _model.Email, Id: "nf-email", Type: "email",
+                    Class: "form-control"),
+                ValidationMessage(() => _model.Email, FieldError)
+            ],
+            Fieldset(Class: "border rounded p-3 mt-2")[
+                Legend(Class: "h6 fw-semibold")["Shipping address"],
+                Div(Class: "vstack gap-3")[
+                    Div()[
+                        Label("nf-street", Class: "form-label small mb-1")["Street"],
+                        Input(() => _model.Address.Street, Id: "nf-street",
+                            Class: "form-control"),
+                        ValidationMessage(() => _model.Address.Street, FieldError)
+                    ],
+                    Div()[
+                        Label("nf-city", Class: "form-label small mb-1")["City"],
+                        Input(() => _model.Address.City, Id: "nf-city",
+                            Class: "form-control"),
+                        ValidationMessage(() => _model.Address.City, FieldError)
+                    ],
+                    Div()[
+                        Label("nf-country", Class: "form-label small mb-1")["Country (ISO)"],
+                        Input(() => _model.Address.Country, Id: "nf-country",
+                            Class: "form-control", MaxLength: 2),
+                        ValidationMessage(() => _model.Address.Country, FieldError)
                     ]
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary", Id: "nf-submit")[
-                        I(Class: "bi bi-check2-circle me-1"), "Place order"]
                 ]
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-result")[
-                    I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Button("submit", Class: "btn btn-primary", Id: "nf-submit")[
+                    I(Class: "bi bi-check2-circle me-1"), "Place order"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-result")[
+                I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 // Collection binding via foreach-capture — the canonical pattern.
@@ -102,7 +103,8 @@ public sealed class NestedListForeachDemo : Component
             ]);
         }
 
-        return [
+        return
+        [
             Form<CartModel>(
                 _model,
                 m => _submission = $"Submitted {m.Items.Count} line item(s).",
@@ -125,7 +127,8 @@ public sealed class NestedListForeachDemo : Component
             ],
             _submission is null
                 ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-list-result")[_submission]];
+                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-list-result")[_submission]
+        ];
     }
 }
 
@@ -172,7 +175,8 @@ public sealed class NestedListIndexerDemo : Component
             ]);
         }
 
-        return [
+        return
+        [
             Form<InvoiceModel>(
                 _model,
                 m => _submission =
@@ -195,7 +199,8 @@ public sealed class NestedListIndexerDemo : Component
             ],
             _submission is null
                 ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-idx-result")[_submission]];
+                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-idx-result")[_submission]
+        ];
     }
 }
 
@@ -236,7 +241,8 @@ public sealed class NestedFluentValidationDemo : Component
             ]);
         }
 
-        return [
+        return
+        [
             Form<NestedOrderModel>(
                 _model,
                 m => _submission = $"Order routed: {m.CustomerName} → {m.Address.Street}, {m.Lines.Count} line(s)",
@@ -276,7 +282,8 @@ public sealed class NestedFluentValidationDemo : Component
             ],
             _submission is null
                 ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-fv-result")[_submission]];
+                : Div(Class: "alert alert-success small mt-3 mb-0", Id: "nf-fv-result")[_submission]
+        ];
     }
 }
 

--- a/samples/Rask.Example.Shared/Demos/RaskLogo.cs
+++ b/samples/Rask.Example.Shared/Demos/RaskLogo.cs
@@ -14,17 +14,17 @@ internal static class RaskLogo
     public static Component Mark(double size, string gradientId)
     {
         var s = size.ToString(CultureInfo.InvariantCulture);
-        return Svg(Width: s, Height: s, ViewBox: "22 6 80 108", Xmlns: "http://www.w3.org/2000/svg")[
+        return Svg(s, s, "22 6 80 108", Xmlns: "http://www.w3.org/2000/svg")[
             // A <title> child gives the mark its accessible name (the SVG-native equivalent of
             // aria-label) and demonstrates nesting under a shape/container element.
             SvgTitle()["Rask"],
             Defs()[
                 LinearGradient(Id: gradientId, X1: "0", Y1: "0", X2: "1", Y2: "1")[
-                    Stop(Offset: "0%", StopColor: "#7C3AED"),
-                    Stop(Offset: "100%", StopColor: "#512BD4")
+                    Stop("0%", "#7C3AED"),
+                    Stop("100%", "#512BD4")
                 ]
             ],
-            SvgPath(D: "M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z", Fill: $"url(#{gradientId})")
+            SvgPath("M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z", Fill: $"url(#{gradientId})")
         ];
     }
 }

--- a/samples/Rask.Example.Shared/Demos/Sparkline.cs
+++ b/samples/Rask.Example.Shared/Demos/Sparkline.cs
@@ -50,7 +50,7 @@ public sealed class Sparkline : Component
         if (n == 0)
         {
             return Frame()[
-                SvgText(X: Num(W / 2), Y: Num(H / 2), TextAnchor: "middle",
+                SvgText(Num(W / 2), Num(H / 2), TextAnchor: "middle",
                     DominantBaseline: "middle", FontFamily: "sans-serif", FontSize: "12",
                     Fill: "#adb5bd")["No data"]
             ];
@@ -71,13 +71,14 @@ public sealed class Sparkline : Component
             }
         }
 
-        var plotW = W - 2 * PadX;
+        var plotW = W - (2 * PadX);
         var plotH = H - PadTop - PadBottom;
         var baseY = H - PadBottom;
 
-        double X(int i) => n == 1 ? PadX + plotW / 2 : PadX + plotW * i / (n - 1);
+        double X(int i) => n == 1 ? PadX + (plotW / 2) : PadX + (plotW * i / (n - 1));
+
         // Higher value ⇒ smaller y (SVG y grows downward). Flat series ⇒ centre the line.
-        double Y(double v) => max <= min ? PadTop + plotH / 2 : PadTop + plotH * (1 - (v - min) / (max - min));
+        double Y(double v) => max <= min ? PadTop + (plotH / 2) : PadTop + (plotH * (1 - ((v - min) / (max - min))));
 
         var sb = new StringBuilder();
         for (var i = 0; i < n; i++)
@@ -98,33 +99,33 @@ public sealed class Sparkline : Component
         var children = new List<Child>
         {
             // Light horizontal gridlines (top / middle / baseline).
-            Line(X1: Num(PadX), Y1: Num(PadTop), X2: Num(W - PadX), Y2: Num(PadTop),
+            Line(Num(PadX), Num(PadTop), Num(W - PadX), Num(PadTop),
                 Stroke: "rgba(0,0,0,0.05)", StrokeWidth: "1"),
-            Line(X1: Num(PadX), Y1: Num(PadTop + plotH / 2), X2: Num(W - PadX), Y2: Num(PadTop + plotH / 2),
+            Line(Num(PadX), Num(PadTop + (plotH / 2)), Num(W - PadX), Num(PadTop + (plotH / 2)),
                 Stroke: "rgba(0,0,0,0.05)", StrokeWidth: "1"),
-            Line(X1: Num(PadX), Y1: Num(baseY), X2: Num(W - PadX), Y2: Num(baseY),
+            Line(Num(PadX), Num(baseY), Num(W - PadX), Num(baseY),
                 Stroke: "rgba(0,0,0,0.05)", StrokeWidth: "1"),
 
             // Filled area under the line: the trend points closed down to the baseline.
-            Polygon(Points: $"{Num(X(0))},{Num(baseY)} {points} {Num(lastX)},{Num(baseY)}",
+            Polygon($"{Num(X(0))},{Num(baseY)} {points} {Num(lastX)},{Num(baseY)}",
                 Fill: AreaColor, Stroke: "none")
         };
 
         // A single point has no line to draw; skip the polyline and just mark the point.
         if (n > 1)
         {
-            children.Add(Polyline(Points: points, Fill: "none", Stroke: StrokeColor,
+            children.Add(Polyline(points, Fill: "none", Stroke: StrokeColor,
                 StrokeWidth: "2", StrokeLinejoin: "round", StrokeLinecap: "round"));
         }
 
         // Min / max value labels on the y-axis.
-        children.Add(SvgText(X: Num(PadX + 2), Y: Num(PadTop + 10), FontFamily: "sans-serif",
+        children.Add(SvgText(Num(PadX + 2), Num(PadTop + 10), FontFamily: "sans-serif",
             FontSize: "11", Fill: "#6c757d")[Money(max)]);
-        children.Add(SvgText(X: Num(PadX + 2), Y: Num(baseY - 3), FontFamily: "sans-serif",
+        children.Add(SvgText(Num(PadX + 2), Num(baseY - 3), FontFamily: "sans-serif",
             FontSize: "11", Fill: "#6c757d")[Money(min)]);
 
         // Last-point marker carrying a native SVG <title> tooltip (no JS).
-        children.Add(Circle(Cx: Num(lastX), Cy: Num(lastY), R: "3.5", Fill: StrokeColor)[
+        children.Add(Circle(Num(lastX), Num(lastY), "3.5", Fill: StrokeColor)[
             SvgTitle()[Money(values[n - 1])]
         ]);
 
@@ -132,8 +133,8 @@ public sealed class Sparkline : Component
     }
 
     private Component Frame() =>
-        Svg(Width: "100%", Height: "100%", ViewBox: $"0 0 {Num(W)} {Num(H)}",
-            PreserveAspectRatio: "none", Class: Class);
+        Svg("100%", "100%", $"0 0 {Num(W)} {Num(H)}",
+            "none", Class: Class);
 
     private static string Num(double v) => v.ToString("0.##", Inv);
 

--- a/samples/Rask.Example.Shared/Demos/UserGateDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/UserGateDemo.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Authentication;
-
 namespace Rask.Example.Shared.Demos;
 
 // Auth-gating with the built-in Component.User — no AuthorizeView component. The demo injects the

--- a/samples/Rask.Example.Shared/Demos/ValidationDemos.cs
+++ b/samples/Rask.Example.Shared/Demos/ValidationDemos.cs
@@ -16,45 +16,46 @@ public sealed class ValidationFieldsDemo : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        [
-            Form<RegistrationModel>(
-                _model,
-                m => _submission = $"Registered: {m.Name} <{m.Email}>",
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                Div()[
-                    Label("v1-name", Class: "form-label small mb-1")["Name"],
-                    Input(() => _model.Name, Id: "v1-name", Class: "form-control"),
-                    ValidationMessage(() => _model.Name, FieldError)
-                ],
-                Div()[
-                    Label("v1-email", Class: "form-label small mb-1")["Email"],
-                    Input(() => _model.Email, Id: "v1-email", Type: "email",
-                        Class: "form-control"),
-                    ValidationMessage(() => _model.Email, FieldError)
-                ],
-                Div()[
-                    Label("v1-age", Class: "form-label small mb-1")["Age"],
-                    Input(() => _model.Age, Id: "v1-age", Class: "form-control"),
-                    ValidationMessage(() => _model.Age, FieldError)
-                ],
-                Div()[
-                    Label("v1-plan", Class: "form-label small mb-1")["Plan"],
-                    Select(() => _model.Plan, Id: "v1-plan", Class: "form-select")[
-                        Option("")["— choose —"],
-                        Option("free")["Free"],
-                        Option("pro")["Pro"],
-                        Option("team")["Team"]
-                    ],
-                    ValidationMessage(() => _model.Plan, FieldError)
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Register"]
-                ]
+    [
+        Form<RegistrationModel>(
+            _model,
+            m => _submission = $"Registered: {m.Name} <{m.Email}>",
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            Div()[
+                Label("v1-name", Class: "form-label small mb-1")["Name"],
+                Input(() => _model.Name, Id: "v1-name", Class: "form-control"),
+                ValidationMessage(() => _model.Name, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Label("v1-email", Class: "form-label small mb-1")["Email"],
+                Input(() => _model.Email, Id: "v1-email", Type: "email",
+                    Class: "form-control"),
+                ValidationMessage(() => _model.Email, FieldError)
+            ],
+            Div()[
+                Label("v1-age", Class: "form-label small mb-1")["Age"],
+                Input(() => _model.Age, Id: "v1-age", Class: "form-control"),
+                ValidationMessage(() => _model.Age, FieldError)
+            ],
+            Div()[
+                Label("v1-plan", Class: "form-label small mb-1")["Plan"],
+                Select(() => _model.Plan, Id: "v1-plan", Class: "form-select")[
+                    Option("")["— choose —"],
+                    Option("free")["Free"],
+                    Option("pro")["Pro"],
+                    Option("team")["Team"]
+                ],
+                ValidationMessage(() => _model.Plan, FieldError)
+            ],
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Register"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class ValidationSummaryDemo : Component
@@ -78,42 +79,43 @@ public sealed class ValidationSummaryDemo : Component
         ];
 
     protected override RenderResult Render() =>
-        [
-            Form<RegistrationModel>(
-                _model,
-                m => _submission = $"Registered: {m.Name} <{m.Email}>",
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                ValidationSummary(SummaryAlert),
-                Div()[
-                    Label("v2-name", Class: "form-label small mb-1")["Name"],
-                    Input(() => _model.Name, Id: "v2-name", Class: "form-control")
-                ],
-                Div()[
-                    Label("v2-email", Class: "form-label small mb-1")["Email"],
-                    Input(() => _model.Email, Id: "v2-email", Type: "email",
-                        Class: "form-control")
-                ],
-                Div()[
-                    Label("v2-age", Class: "form-label small mb-1")["Age"],
-                    Input(() => _model.Age, Id: "v2-age", Class: "form-control")
-                ],
-                Div()[
-                    Label("v2-plan", Class: "form-label small mb-1")["Plan"],
-                    Select(() => _model.Plan, Id: "v2-plan", Class: "form-select")[
-                        Option("")["— choose —"],
-                        Option("free")["Free"],
-                        Option("pro")["Pro"],
-                        Option("team")["Team"]
-                    ]
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Register"]
+    [
+        Form<RegistrationModel>(
+            _model,
+            m => _submission = $"Registered: {m.Name} <{m.Email}>",
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            ValidationSummary(SummaryAlert),
+            Div()[
+                Label("v2-name", Class: "form-label small mb-1")["Name"],
+                Input(() => _model.Name, Id: "v2-name", Class: "form-control")
+            ],
+            Div()[
+                Label("v2-email", Class: "form-label small mb-1")["Email"],
+                Input(() => _model.Email, Id: "v2-email", Type: "email",
+                    Class: "form-control")
+            ],
+            Div()[
+                Label("v2-age", Class: "form-label small mb-1")["Age"],
+                Input(() => _model.Age, Id: "v2-age", Class: "form-control")
+            ],
+            Div()[
+                Label("v2-plan", Class: "form-label small mb-1")["Plan"],
+                Select(() => _model.Plan, Id: "v2-plan", Class: "form-select")[
+                    Option("")["— choose —"],
+                    Option("free")["Free"],
+                    Option("pro")["Pro"],
+                    Option("team")["Team"]
                 ]
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Register"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class InlineValidateDemo : Component
@@ -141,38 +143,39 @@ public sealed class InlineValidateDemo : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            Form(
-                _model,
-                OnValidSubmit: m => _submission = $"Welcome, {m.Email}",
-                Class: "vstack gap-3",
-                Validate: m =>
-                    m.Password == m.Confirm ? Array.Empty<string>() : new[] { "Passwords do not match." })[
-                Div()[
-                    Label("v4-email", Class: "form-label small mb-1")["Email"],
-                    Input(() => _model.Email, Id: "v4-email", Type: "email", Class: "form-control",
-                        Validate: v =>
-                            v.Contains('@')
-                                ? Array.Empty<string>()
-                                : new[] { "Email looks wrong." }),
-                    ValidationMessage(() => _model.Email, FieldError)
-                ],
-                Div()[
-                    Label("v4-password", Class: "form-label small mb-1")["Password"],
-                    Input(() => _model.Password, Id: "v4-password", Type: "password", Class: "form-control")
-                ],
-                Div()[
-                    Label("v4-confirm", Class: "form-label small mb-1")["Confirm"],
-                    Input(() => _model.Confirm, Id: "v4-confirm", Type: "password", Class: "form-control")
-                ],
-                ValidationSummary(SummaryAlert),
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Sign in"]
-                ]
+    [
+        Form(
+            _model,
+            OnValidSubmit: m => _submission = $"Welcome, {m.Email}",
+            Class: "vstack gap-3",
+            Validate: m =>
+                m.Password == m.Confirm ? Array.Empty<string>() : new[] { "Passwords do not match." })[
+            Div()[
+                Label("v4-email", Class: "form-label small mb-1")["Email"],
+                Input(() => _model.Email, Id: "v4-email", Type: "email", Class: "form-control",
+                    Validate: v =>
+                        v.Contains('@')
+                            ? Array.Empty<string>()
+                            : new[] { "Email looks wrong." }),
+                ValidationMessage(() => _model.Email, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Label("v4-password", Class: "form-label small mb-1")["Password"],
+                Input(() => _model.Password, Id: "v4-password", Type: "password", Class: "form-control")
+            ],
+            Div()[
+                Label("v4-confirm", Class: "form-label small mb-1")["Confirm"],
+                Input(() => _model.Confirm, Id: "v4-confirm", Type: "password", Class: "form-control")
+            ],
+            ValidationSummary(SummaryAlert),
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Sign in"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class LoginModel
@@ -256,7 +259,8 @@ public sealed class NestedAsyncWithLiveTotalsDemo : Component
         var tax = Math.Round(afterDiscount * 0.08m, 2);
         var total = afterDiscount + tax;
 
-        return [
+        return
+        [
             Form(
                 _model,
                 m => _submission = $"Charged ${total.ToString("F2", CultureInfo.InvariantCulture)} to {m.CustomerName}",
@@ -416,34 +420,35 @@ public sealed class InlineAsyncValidateDemo : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            Form<PromoModel>(
-                _model,
-                OnValidSubmit: m => _submission = $"Redeemed: {m.Code}",
-                Class: "vstack gap-3",
-                Validate: async (m, ct) =>
-                {
-                    await Task.Yield();
-                    ct.ThrowIfCancellationRequested();
-                    return string.IsNullOrWhiteSpace(m.Code)
-                        ? new[] { "Code is required." }
-                        : Array.Empty<string>();
-                })[
-                Div()[
-                    Label("v10-code", Class: "form-label small mb-1")["Promo code"],
-                    Input(() => _model.Code, Id: "v10-code", Class: "form-control",
-                        Validate: CheckCodeAsync),
-                    ValidatingIndicator(() => _model.Code, Checking),
-                    ValidationMessage(() => _model.Code, FieldError)
-                ],
-                ValidationSummary(SummaryAlert),
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-gift me-1"), "Redeem"]
-                ]
+    [
+        Form<PromoModel>(
+            _model,
+            OnValidSubmit: m => _submission = $"Redeemed: {m.Code}",
+            Class: "vstack gap-3",
+            Validate: async (m, ct) =>
+            {
+                await Task.Yield();
+                ct.ThrowIfCancellationRequested();
+                return string.IsNullOrWhiteSpace(m.Code)
+                    ? new[] { "Code is required." }
+                    : Array.Empty<string>();
+            })[
+            Div()[
+                Label("v10-code", Class: "form-label small mb-1")["Promo code"],
+                Input(() => _model.Code, Id: "v10-code", Class: "form-control",
+                    Validate: CheckCodeAsync),
+                ValidatingIndicator(() => _model.Code, Checking),
+                ValidationMessage(() => _model.Code, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            ValidationSummary(SummaryAlert),
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-gift me-1"), "Redeem"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class PromoModel
@@ -469,27 +474,28 @@ public sealed class AsyncValidationDemo : Component
         ];
 
     protected override RenderResult Render() =>
-        [
-            Form<SignupModel>(
-                _model,
-                m => _submission = $"Signed up: {m.Username}",
-                Context: _ctx,
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                Div()[
-                    Label("v3-username", Class: "form-label small mb-1")["Username"],
-                    Input(() => _model.Username, Id: "v3-username", Class: "form-control"),
-                    ValidatingIndicator(() => _model.Username, Checking),
-                    ValidationMessage(() => _model.Username,
-                        msgs => Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])])
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Sign up"]
-                ]
+    [
+        Form<SignupModel>(
+            _model,
+            m => _submission = $"Signed up: {m.Username}",
+            Context: _ctx,
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            Div()[
+                Label("v3-username", Class: "form-label small mb-1")["Username"],
+                Input(() => _model.Username, Id: "v3-username", Class: "form-control"),
+                ValidatingIndicator(() => _model.Username, Checking),
+                ValidationMessage(() => _model.Username,
+                    msgs => Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])])
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Sign up"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class SignupModel
@@ -581,31 +587,32 @@ public sealed class CrossFieldSummaryDemo : Component
             ];
 
     protected override RenderResult Render() =>
-        [
-            Form<TripModel>(
-                _model,
-                OnValidSubmit: m => _submission = $"Booked: {m.Depart:yyyy-MM-dd} → {m.Return:yyyy-MM-dd}",
-                Class: "vstack gap-3",
-                Validate: m =>
-                    m.Return > m.Depart
-                        ? Array.Empty<string>()
-                        : new[] { "Return date must be after departure." })[
-                ValidationSummary(SummaryAlert),
-                Div()[
-                    Label("v5-depart", Class: "form-label small mb-1")["Departure"],
-                    Input(() => _model.Depart, Id: "v5-depart", Class: "form-control")
-                ],
-                Div()[
-                    Label("v5-return", Class: "form-label small mb-1")["Return"],
-                    Input(() => _model.Return, Id: "v5-return", Class: "form-control")
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-airplane me-1"), "Book"]
-                ]
+    [
+        Form<TripModel>(
+            _model,
+            OnValidSubmit: m => _submission = $"Booked: {m.Depart:yyyy-MM-dd} → {m.Return:yyyy-MM-dd}",
+            Class: "vstack gap-3",
+            Validate: m =>
+                m.Return > m.Depart
+                    ? Array.Empty<string>()
+                    : new[] { "Return date must be after departure." })[
+            ValidationSummary(SummaryAlert),
+            Div()[
+                Label("v5-depart", Class: "form-label small mb-1")["Departure"],
+                Input(() => _model.Depart, Id: "v5-depart", Class: "form-control")
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Label("v5-return", Class: "form-label small mb-1")["Return"],
+                Input(() => _model.Return, Id: "v5-return", Class: "form-control")
+            ],
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-airplane me-1"), "Book"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class TripModel
@@ -641,35 +648,36 @@ public sealed class ValidatableObjectDemo : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            Form<BookingModel>(
-                _model,
-                m => _submission = $"Booked: {m.Name} {m.Departure:yyyy-MM-dd} → {m.Arrival:yyyy-MM-dd}",
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                ValidationSummary(SummaryAlert),
-                Div()[
-                    Label("v11-name", Class: "form-label small mb-1")["Name"],
-                    Input(() => _model.Name, Id: "v11-name", Class: "form-control"),
-                    ValidationMessage(() => _model.Name, FieldError)
-                ],
-                Div()[
-                    Label("v11-departure", Class: "form-label small mb-1")["Departure"],
-                    Input(() => _model.Departure, Id: "v11-departure", Class: "form-control"),
-                    ValidationMessage(() => _model.Departure, FieldError)
-                ],
-                Div()[
-                    Label("v11-arrival", Class: "form-label small mb-1")["Arrival"],
-                    Input(() => _model.Arrival, Id: "v11-arrival", Class: "form-control"),
-                    ValidationMessage(() => _model.Arrival, FieldError)
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-calendar-check me-1"), "Book"]
-                ]
+    [
+        Form<BookingModel>(
+            _model,
+            m => _submission = $"Booked: {m.Name} {m.Departure:yyyy-MM-dd} → {m.Arrival:yyyy-MM-dd}",
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            ValidationSummary(SummaryAlert),
+            Div()[
+                Label("v11-name", Class: "form-label small mb-1")["Name"],
+                Input(() => _model.Name, Id: "v11-name", Class: "form-control"),
+                ValidationMessage(() => _model.Name, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Label("v11-departure", Class: "form-label small mb-1")["Departure"],
+                Input(() => _model.Departure, Id: "v11-departure", Class: "form-control"),
+                ValidationMessage(() => _model.Departure, FieldError)
+            ],
+            Div()[
+                Label("v11-arrival", Class: "form-label small mb-1")["Arrival"],
+                Input(() => _model.Arrival, Id: "v11-arrival", Class: "form-control"),
+                ValidationMessage(() => _model.Arrival, FieldError)
+            ],
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-calendar-check me-1"), "Book"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class BookingModel : IValidatableObject
@@ -721,36 +729,37 @@ public sealed class ProgrammaticValidateDemo : Component
     private async Task ValidateNowAsync() => await _ctx.ValidateAsync().ConfigureAwait(false);
 
     protected override RenderResult Render() =>
-        [
-            Form<TaskModel>(
-                _model,
-                m => _submission = $"Saved task: {m.Title}",
-                Context: _ctx,
-                Class: "vstack gap-3")[
-                Div()[
-                    Label("v6-title", Class: "form-label small mb-1")["Title"],
-                    Input(() => _model.Title, Id: "v6-title", Class: "form-control"),
-                    ValidatingIndicator(() => _model.Title, Checking),
-                    ValidationMessage(() => _model.Title, FieldError)
-                ],
-                Div(Class: "d-flex gap-2")[
-                    Button(
-                        "button",
-                        Id: "v6-validate-now",
-                        Class: "btn btn-outline-secondary",
-                        OnClickAsync: ValidateNowAsync)[
-                        I(Class: "bi bi-search me-1"), "Validate now"
-                    ],
-                    Button(
-                        "submit",
-                        Id: "v6-submit",
-                        Disabled: _ctx.IsValidatingAny,
-                        Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Save"]
-                ]
+    [
+        Form<TaskModel>(
+            _model,
+            m => _submission = $"Saved task: {m.Title}",
+            Context: _ctx,
+            Class: "vstack gap-3")[
+            Div()[
+                Label("v6-title", Class: "form-label small mb-1")["Title"],
+                Input(() => _model.Title, Id: "v6-title", Class: "form-control"),
+                ValidatingIndicator(() => _model.Title, Checking),
+                ValidationMessage(() => _model.Title, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div(Class: "d-flex gap-2")[
+                Button(
+                    "button",
+                    Id: "v6-validate-now",
+                    Class: "btn btn-outline-secondary",
+                    OnClickAsync: ValidateNowAsync)[
+                    I(Class: "bi bi-search me-1"), "Validate now"
+                ],
+                Button(
+                    "submit",
+                    Id: "v6-submit",
+                    Disabled: _ctx.IsValidatingAny,
+                    Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Save"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class TaskModel
@@ -806,29 +815,30 @@ public sealed class FluentValidationDemo : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        [
-            Form<OrderModel>(
-                _model,
-                m => _submission = $"Ordered {m.Quantity} × {m.Product}",
-                Class: "vstack gap-3")[
-                FluentValidationValidator(new OrderValidator()),
-                Div()[
-                    Label("v7-product", Class: "form-label small mb-1")["Product"],
-                    Input(() => _model.Product, Id: "v7-product", Class: "form-control"),
-                    ValidationMessage(() => _model.Product, FieldError)
-                ],
-                Div()[
-                    Label("v7-quantity", Class: "form-label small mb-1")["Quantity"],
-                    Input(() => _model.Quantity, Id: "v7-quantity", Class: "form-control"),
-                    ValidationMessage(() => _model.Quantity, FieldError)
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-bag-check me-1"), "Order"]
-                ]
+    [
+        Form<OrderModel>(
+            _model,
+            m => _submission = $"Ordered {m.Quantity} × {m.Product}",
+            Class: "vstack gap-3")[
+            FluentValidationValidator(new OrderValidator()),
+            Div()[
+                Label("v7-product", Class: "form-label small mb-1")["Product"],
+                Input(() => _model.Product, Id: "v7-product", Class: "form-control"),
+                ValidationMessage(() => _model.Product, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Label("v7-quantity", Class: "form-label small mb-1")["Quantity"],
+                Input(() => _model.Quantity, Id: "v7-quantity", Class: "form-control"),
+                ValidationMessage(() => _model.Quantity, FieldError)
+            ],
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-bag-check me-1"), "Order"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class OrderModel
@@ -859,28 +869,29 @@ public sealed class FirstErrorWinsDemo : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        [
-            Form<LicenseModel>(
-                _model,
-                m => _submission = $"Activated: {m.Code}",
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                Div()[
-                    Label("v8-code", Class: "form-label small mb-1")["License code"],
-                    Input(() => _model.Code, Id: "v8-code", Class: "form-control",
-                        Validate: v =>
-                            string.IsNullOrWhiteSpace(v)
-                                ? new[] { "Code is required." }
-                                : Array.Empty<string>()),
-                    ValidationMessage(() => _model.Code, FieldError)
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-unlock me-1"), "Activate"]
-                ]
+    [
+        Form<LicenseModel>(
+            _model,
+            m => _submission = $"Activated: {m.Code}",
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            Div()[
+                Label("v8-code", Class: "form-label small mb-1")["License code"],
+                Input(() => _model.Code, Id: "v8-code", Class: "form-control",
+                    Validate: v =>
+                        string.IsNullOrWhiteSpace(v)
+                            ? new[] { "Code is required." }
+                            : Array.Empty<string>()),
+                ValidationMessage(() => _model.Code, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-unlock me-1"), "Activate"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class LicenseModel
@@ -907,25 +918,26 @@ public sealed class FluentValidationAsyncDemo : Component
         ];
 
     protected override RenderResult Render() =>
-        [
-            Form<TicketModel>(
-                _model,
-                m => _submission = $"Reserved: {m.Code}",
-                Class: "vstack gap-3")[
-                FluentValidationValidator(new TicketValidator()),
-                Div()[
-                    Label("v9-code", Class: "form-label small mb-1")["Ticket code"],
-                    Input(() => _model.Code, Id: "v9-code", Class: "form-control"),
-                    ValidatingIndicator(() => _model.Code, Checking),
-                    ValidationMessage(() => _model.Code, FieldError)
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-ticket-perforated me-1"), "Reserve"]
-                ]
+    [
+        Form<TicketModel>(
+            _model,
+            m => _submission = $"Reserved: {m.Code}",
+            Class: "vstack gap-3")[
+            FluentValidationValidator(new TicketValidator()),
+            Div()[
+                Label("v9-code", Class: "form-label small mb-1")["Ticket code"],
+                Input(() => _model.Code, Id: "v9-code", Class: "form-control"),
+                ValidatingIndicator(() => _model.Code, Checking),
+                ValidationMessage(() => _model.Code, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-ticket-perforated me-1"), "Reserve"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class TicketModel
@@ -972,34 +984,35 @@ public sealed class CustomAttributeDemo : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        [
-            Form<CustomAttributeModel>(
-                _model,
-                m => _submission = $"Welcome, {m.Username}!",
-                Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                Div()[
-                    Label("v12-username", Class: "form-label small mb-1")["Username"],
-                    Input(() => _model.Username, Id: "v12-username", Class: "form-control"),
-                    ValidationMessage(() => _model.Username, FieldError)
-                ],
-                Div()[
-                    Label("v12-password", Class: "form-label small mb-1")["Password"],
-                    Input(() => _model.Password, Id: "v12-password", Type: "password", Class: "form-control"),
-                    ValidationMessage(() => _model.Password, FieldError)
-                ],
-                Div()[
-                    Label("v12-confirm", Class: "form-label small mb-1")["Confirm password"],
-                    Input(() => _model.ConfirmPassword, Id: "v12-confirm", Type: "password", Class: "form-control"),
-                    ValidationMessage(() => _model.ConfirmPassword, FieldError)
-                ],
-                Div()[
-                    Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-shield-check me-1"), "Create account"]
-                ]
+    [
+        Form<CustomAttributeModel>(
+            _model,
+            m => _submission = $"Welcome, {m.Username}!",
+            Class: "vstack gap-3")[
+            DataAnnotationsValidator(),
+            Div()[
+                Label("v12-username", Class: "form-label small mb-1")["Username"],
+                Input(() => _model.Username, Id: "v12-username", Class: "form-control"),
+                ValidationMessage(() => _model.Username, FieldError)
             ],
-            _submission is null
-                ? Fragment()
-                : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]];
+            Div()[
+                Label("v12-password", Class: "form-label small mb-1")["Password"],
+                Input(() => _model.Password, Id: "v12-password", Type: "password", Class: "form-control"),
+                ValidationMessage(() => _model.Password, FieldError)
+            ],
+            Div()[
+                Label("v12-confirm", Class: "form-label small mb-1")["Confirm password"],
+                Input(() => _model.ConfirmPassword, Id: "v12-confirm", Type: "password", Class: "form-control"),
+                ValidationMessage(() => _model.ConfirmPassword, FieldError)
+            ],
+            Div()[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-shield-check me-1"), "Create account"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
 }
 
 public sealed class CustomAttributeModel

--- a/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
@@ -1,6 +1,5 @@
 using Rask.Core.Routing;
 using Rask.Example.Shared.Demos;
-using static Rask.Example.Shared.Layout.Generated;
 
 namespace Rask.Example.Shared.Layout;
 
@@ -60,51 +59,51 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
     protected override void OnUnmount() => route.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        [
-            Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm sticky-top")[
-                Div(Class: "container-fluid")[
-                    Button(
-                        Class: "hamburger-btn",
-                        Type: "button",
-                        OnClick: () => _drawerOpen = !_drawerOpen)[
-                        I(Class: _drawerOpen ? "bi bi-x-lg" : "bi bi-list")
-                    ],
-                    Button(
-                        Class: "navbar-brand fw-semibold border-0 bg-transparent d-inline-flex align-items-center gap-2",
-                        OnClick: () =>
-                        {
-                            _drawerOpen = false;
-                            nav.Navigate("/");
-                        })[
-                        RaskLogo.Mark(24, "brandBolt"),
-                        Span()["Rask"],
-                        Span(Class: "badge rounded-pill rask-badge")["showcase"]
-                    ],
-                    Div(Class: "d-flex align-items-center gap-2 ms-auto")[
-                        PathDisplay(),
-                        A("https://github.com/pal-tamas/rask",
-                            "_blank",
-                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
-                    ]
-                ]
-            ],
-            Button(
-                Class: _drawerOpen ? "nav-backdrop drawer-open" : "nav-backdrop",
-                Type: "button",
-                OnClick: () => _drawerOpen = false),
+    [
+        Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm sticky-top")[
             Div(Class: "container-fluid")[
-                Div(Class: "row")[
-                    Aside(Class: _drawerOpen
-                        ? "col-12 col-md-4 col-lg-3 col-xl-2 bg-white border-end side-nav drawer-open"
-                        : "col-12 col-md-4 col-lg-3 col-xl-2 bg-white border-end side-nav")[
-                        Div(Class: "position-sticky pt-3 pb-4 px-2", Style: "top: 56px;")[BuildGroups()]
-                    ],
-                    Main(Class: "col-12 col-md-8 col-lg-9 col-xl-10 py-4 px-md-5")[
-                        Div(Class: "mx-auto", Style: "max-width: 1280px;")[Outlet()]
-                    ]
+                Button(
+                    Class: "hamburger-btn",
+                    Type: "button",
+                    OnClick: () => _drawerOpen = !_drawerOpen)[
+                    I(Class: _drawerOpen ? "bi bi-x-lg" : "bi bi-list")
+                ],
+                Button(
+                    Class: "navbar-brand fw-semibold border-0 bg-transparent d-inline-flex align-items-center gap-2",
+                    OnClick: () =>
+                    {
+                        _drawerOpen = false;
+                        nav.Navigate("/");
+                    })[
+                    RaskLogo.Mark(24, "brandBolt"),
+                    Span()["Rask"],
+                    Span(Class: "badge rounded-pill rask-badge")["showcase"]
+                ],
+                Div(Class: "d-flex align-items-center gap-2 ms-auto")[
+                    PathDisplay(),
+                    A("https://github.com/pal-tamas/rask",
+                        "_blank",
+                        Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
                 ]
             ]
-        ];
+        ],
+        Button(
+            Class: _drawerOpen ? "nav-backdrop drawer-open" : "nav-backdrop",
+            Type: "button",
+            OnClick: () => _drawerOpen = false),
+        Div(Class: "container-fluid")[
+            Div(Class: "row")[
+                Aside(Class: _drawerOpen
+                    ? "col-12 col-md-4 col-lg-3 col-xl-2 bg-white border-end side-nav drawer-open"
+                    : "col-12 col-md-4 col-lg-3 col-xl-2 bg-white border-end side-nav")[
+                    Div(Class: "position-sticky pt-3 pb-4 px-2", Style: "top: 56px;")[BuildGroups()]
+                ],
+                Main(Class: "col-12 col-md-8 col-lg-9 col-xl-10 py-4 px-md-5")[
+                    Div(Class: "mx-auto", Style: "max-width: 1280px;")[Outlet()]
+                ]
+            ]
+        ]
+    ];
 
     private List<Child> BuildGroups()
     {
@@ -156,6 +155,6 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
 
         var trimmedPrefix = matchPrefix.TrimEnd('/');
         return string.Equals(trimmed, trimmedPrefix, StringComparison.OrdinalIgnoreCase)
-            || trimmed.StartsWith(trimmedPrefix + "/", StringComparison.OrdinalIgnoreCase);
+               || trimmed.StartsWith(trimmedPrefix + "/", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/samples/Rask.Example.Shared/Pages/AssetLoading/AssetLoadingPage.cs
+++ b/samples/Rask.Example.Shared/Pages/AssetLoading/AssetLoadingPage.cs
@@ -29,26 +29,21 @@ public sealed class AssetLoadingPage : Component
                 Code()["Cache-Control: public, max-age=31536000, immutable"],
                 ". Open DevTools → Network and observe each section below."
             ],
-
             Section("Basic scoped CSS",
                 "One component with a sibling .css file. Exactly one <link> request.",
                 BasicScopedCss()),
-
             Section("JS-only component",
                 "Sibling .js, no .css. Used to regress when the mounted-set only tracked CSS components. " +
                 "Click the button — it dispatches via IJSRuntime to the scoped JS module.",
                 JsOnlyDemo()),
-
             Section("Two components, two URLs",
                 "Different rewritten content → different content hash → two independent <link>s. " +
                 "Either component edited in isolation only re-fetches its own bytes.",
                 Div(Class: "d-flex gap-2 flex-wrap")[TwinA(), TwinB()]),
-
             Section("Lazy mount / unmount",
                 "Toggle the button. On mount, the framework adds the child's <link> via the head morph; " +
                 "on unmount, the tag is removed. The browser keeps the CSS bytes cached, so re-mounting is instant.",
                 LazyMount()),
-
             Div(Class: "alert alert-info d-flex align-items-start mt-5")[
                 I(Class: "bi bi-info-circle-fill me-3 fs-4"),
                 Div()[

--- a/samples/Rask.Example.Shared/Pages/AssetLoading/LazyMount.cs
+++ b/samples/Rask.Example.Shared/Pages/AssetLoading/LazyMount.cs
@@ -8,6 +8,7 @@ namespace Rask.Example.Shared.Pages.AssetLoading;
 /// </summary>
 public sealed class LazyMount : Component
 {
+    private static readonly Component Empty = Div();
     private bool _shown;
 
     protected override RenderResult Render() =>
@@ -19,6 +20,4 @@ public sealed class LazyMount : Component
             ],
             _shown ? LazyChild() : Empty
         ];
-
-    private static readonly Component Empty = Div();
 }

--- a/samples/Rask.Example.Shared/Pages/BindingPage.cs
+++ b/samples/Rask.Example.Shared/Pages/BindingPage.cs
@@ -11,112 +11,112 @@ public sealed class BindingPage : Component
     protected override RenderResult Head => Title()["Two-way binding — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Two-way binding",
-                "Inputs can be wired with plain Value + OnInput, or with a strongly-typed Bind expression that resolves the input name, type, and update timing for you."),
-            H2(Class: "h4 mt-4 mb-3")["Manual — Value + OnInput"],
-            CodeSample(
-                """
-                Input(Type: "text",
-                      Value: _typed,
-                      OnInput: v => _typed = v)
-                P()[$"Echo: {_typed}"]
-                """,
-                Notes:
-                "The low-level path: wire Value and the event handler yourself. Works for any input type, but you parse and re-render manually.",
-                Result: BindingManualDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — Input<TProp>(Bind: ...)"],
-            CodeSample(
-                """
-                Input(Bind: () => _model.Name,
-                      Placeholder: "Your name")
-                P()[$"Hello, {_model.Name}!"]
-                """,
-                Notes:
-                "Bind reads the expression — the property name becomes the input name, the property type picks the input type, and string fields update on every keystroke. One call replaces Value + OnInput + parsing.",
-                Result: BindingTypedDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — across primitive types"],
-            CodeSample(
-                """
-                Input(Bind: () => _model.Subscribe)   // bool   → checkbox
-                Input(Bind: () => _model.Age)         // int    → number
-                Input(Bind: () => _model.StartDate)   // DateOnly → date
-                Select(Bind: () => _model.Favorite)[
-                    Option("Red")["Red"],
-                    Option("Green")["Green"],
-                    Option("Blue")["Blue"]
-                ]
-                """,
-                Notes:
-                "The same Bind helper picks the right input type from the property's CLR type and wires immediate (string) or change-deferred (everything else) update timing automatically.",
-                Result: BindingMultiDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — nullable properties"],
-            CodeSample(
-                """
-                Input(Bind: () => _model.OptionalAge)   // int?    → empty → null
-                Input(Bind: () => _model.StartDate)     // DateOnly? → empty → null
-                Select(Bind: () => _model.Favorite)[    // Color?
-                    Option("")["— none —"],
-                    Option("Red")["Red"], ...
-                ]
-                Input(Bind: () => _model.Nickname)      // string? (NRT) → empty → null
-                """,
-                Notes:
-                "BindingHelpers.TrySetTyped routes empty input to null when the property is nullable — either Nullable<T> for value types or NRT-annotated for reference types (detected via NullabilityInfoContext). Non-nullable string still becomes \"\" when emptied; non-nullable value types clear to default(T) — see the next section.",
-                Result: BindingNullableDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — clearing a non-nullable value-type input"],
-            CodeSample(
-                """
-                Input(Bind: () => _model.Age)         // int      → clear → 0
-                Input(Bind: () => _model.OptionalAge) // int?     → clear → null
-                """,
-                Notes:
-                "Clearing a number/date/enum input on a non-nullable value type now snaps the model to default(T) instead of silently reverting. The nullable companion still routes empty → null, so the two paths stay distinguishable.",
-                Result: BindingClearDefaultDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — Textarea<TProp>(Bind: ...)"],
-            CodeSample(
-                """
-                Textarea(Bind: () => _model.Notes,
-                         Rows: 3,
-                         Placeholder: "Jot something down…")
-                Pre()[$"Notes = \"{_model.Notes}\""]
-                """,
-                Notes:
-                "Textareas always stream — Textarea.Bound wires OnInputAsync for every keystroke so the echo updates without blur or submit, no matter how long the text is.",
-                Result: BindingTextareaDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — AfterBind (sync)"],
-            CodeSample(
-                """
-                Select(Bind: () => _model.Country,
-                       AfterBind: c => {
-                           _cities = Cities[c];
-                           _model.City = _cities[0];
-                       })[ ... ]
-                Select(Bind: () => _model.City)[
-                    _cities.Select(c => Option(Value: c)[c])
-                ]
-                """,
-                Notes:
-                "AfterBind fires after TrySetTyped has written the new value to the model and before validators run. The dependent dropdown rebinds in the same render — no extra round-trip.",
-                Result: BindingAfterBindDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Typed — AfterBindAsync (async)"],
-            CodeSample(
-                """
-                Select(Bind: () => _model.Track,
-                       AfterBindAsync: async track => {
-                           _loading = true;            // Rask renders at the await below — no StateHasChanged needed
-                           await Task.Delay(300);      // simulated fetch
-                           _languages = Catalog[track];
-                           _model.Language = _languages[0];
-                           _loading = false;
-                       })[
-                    Option("")["— pick a track —"],    // placeholder = empty initial value
-                    Option("frontend")["Frontend"], ...
-                ]
-                """,
-                Notes:
-                "Rask re-renders at every await suspension inside an async handler, so setting _loading before the await surfaces the \"loading…\" UI on its own — no manual StateHasChanged() is required. AfterBindAsync is still awaited before the post-handler render, so validators see the new dependent state. Note the empty-value placeholder option: it matches the initial model so the dropdown doesn't falsely show the first track, and so picking any track (including the first) fires a real change.",
-                Result: BindingAfterBindAsyncDemo())
-        ];
+    [
+        PageHeader.Render(
+            "Two-way binding",
+            "Inputs can be wired with plain Value + OnInput, or with a strongly-typed Bind expression that resolves the input name, type, and update timing for you."),
+        H2(Class: "h4 mt-4 mb-3")["Manual — Value + OnInput"],
+        CodeSample(
+            """
+            Input(Type: "text",
+                  Value: _typed,
+                  OnInput: v => _typed = v)
+            P()[$"Echo: {_typed}"]
+            """,
+            Notes:
+            "The low-level path: wire Value and the event handler yourself. Works for any input type, but you parse and re-render manually.",
+            Result: BindingManualDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — Input<TProp>(Bind: ...)"],
+        CodeSample(
+            """
+            Input(Bind: () => _model.Name,
+                  Placeholder: "Your name")
+            P()[$"Hello, {_model.Name}!"]
+            """,
+            Notes:
+            "Bind reads the expression — the property name becomes the input name, the property type picks the input type, and string fields update on every keystroke. One call replaces Value + OnInput + parsing.",
+            Result: BindingTypedDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — across primitive types"],
+        CodeSample(
+            """
+            Input(Bind: () => _model.Subscribe)   // bool   → checkbox
+            Input(Bind: () => _model.Age)         // int    → number
+            Input(Bind: () => _model.StartDate)   // DateOnly → date
+            Select(Bind: () => _model.Favorite)[
+                Option("Red")["Red"],
+                Option("Green")["Green"],
+                Option("Blue")["Blue"]
+            ]
+            """,
+            Notes:
+            "The same Bind helper picks the right input type from the property's CLR type and wires immediate (string) or change-deferred (everything else) update timing automatically.",
+            Result: BindingMultiDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — nullable properties"],
+        CodeSample(
+            """
+            Input(Bind: () => _model.OptionalAge)   // int?    → empty → null
+            Input(Bind: () => _model.StartDate)     // DateOnly? → empty → null
+            Select(Bind: () => _model.Favorite)[    // Color?
+                Option("")["— none —"],
+                Option("Red")["Red"], ...
+            ]
+            Input(Bind: () => _model.Nickname)      // string? (NRT) → empty → null
+            """,
+            Notes:
+            "BindingHelpers.TrySetTyped routes empty input to null when the property is nullable — either Nullable<T> for value types or NRT-annotated for reference types (detected via NullabilityInfoContext). Non-nullable string still becomes \"\" when emptied; non-nullable value types clear to default(T) — see the next section.",
+            Result: BindingNullableDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — clearing a non-nullable value-type input"],
+        CodeSample(
+            """
+            Input(Bind: () => _model.Age)         // int      → clear → 0
+            Input(Bind: () => _model.OptionalAge) // int?     → clear → null
+            """,
+            Notes:
+            "Clearing a number/date/enum input on a non-nullable value type now snaps the model to default(T) instead of silently reverting. The nullable companion still routes empty → null, so the two paths stay distinguishable.",
+            Result: BindingClearDefaultDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — Textarea<TProp>(Bind: ...)"],
+        CodeSample(
+            """
+            Textarea(Bind: () => _model.Notes,
+                     Rows: 3,
+                     Placeholder: "Jot something down…")
+            Pre()[$"Notes = \"{_model.Notes}\""]
+            """,
+            Notes:
+            "Textareas always stream — Textarea.Bound wires OnInputAsync for every keystroke so the echo updates without blur or submit, no matter how long the text is.",
+            Result: BindingTextareaDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — AfterBind (sync)"],
+        CodeSample(
+            """
+            Select(Bind: () => _model.Country,
+                   AfterBind: c => {
+                       _cities = Cities[c];
+                       _model.City = _cities[0];
+                   })[ ... ]
+            Select(Bind: () => _model.City)[
+                _cities.Select(c => Option(Value: c)[c])
+            ]
+            """,
+            Notes:
+            "AfterBind fires after TrySetTyped has written the new value to the model and before validators run. The dependent dropdown rebinds in the same render — no extra round-trip.",
+            Result: BindingAfterBindDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Typed — AfterBindAsync (async)"],
+        CodeSample(
+            """
+            Select(Bind: () => _model.Track,
+                   AfterBindAsync: async track => {
+                       _loading = true;            // Rask renders at the await below — no StateHasChanged needed
+                       await Task.Delay(300);      // simulated fetch
+                       _languages = Catalog[track];
+                       _model.Language = _languages[0];
+                       _loading = false;
+                   })[
+                Option("")["— pick a track —"],    // placeholder = empty initial value
+                Option("frontend")["Frontend"], ...
+            ]
+            """,
+            Notes:
+            "Rask re-renders at every await suspension inside an async handler, so setting _loading before the await surfaces the \"loading…\" UI on its own — no manual StateHasChanged() is required. AfterBindAsync is still awaited before the post-handler render, so validators see the new dependent state. Note the empty-value placeholder option: it matches the initial model so the dropdown doesn't falsely show the first track, and so picking any track (including the first) fires a real change.",
+            Result: BindingAfterBindAsyncDemo())
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/BoomPage.cs
+++ b/samples/Rask.Example.Shared/Pages/BoomPage.cs
@@ -13,113 +13,113 @@ public sealed class BoomPage : Component
     protected override RenderResult Head => Title()["Error boundary — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Error boundary",
-                "ErrorBoundary catches exceptions thrown by descendants — render-time, sync lifecycle, async lifecycle, and event handlers — and renders a fallback in their place. The fallback receives a Recover() callback so the boundary can be reset from a button click."),
-            H2(Class: "h4 mt-4 mb-3")["Handler throw — boundary catches and renders fallback"],
-            CodeSample(
-                """
-                ErrorBoundary(
-                    Fallback: (ex, recover) => Div()[
-                        Strong()["Caught: "], ex.Message,
-                        Button(OnClick: recover)["Reset"]
-                    ])[
-                        Button(OnClick: () => throw new InvalidOperationException("kaboom"))["Throw"]
-                    ]
-                """,
-                Result: ErrorBoundary(
-                    BoundaryFallback)[
-                    Div(Class: "p-3 border rounded bg-white", Id: "boom-handler-host")[
-                        P(Class: "text-secondary small mb-2")["Healthy subtree — click to throw."],
-                        Button(
-                            Class: "btn btn-danger",
-                            Id: "boom-throw",
-                            OnClick: ThrowFromHandler)[I(Class: "bi bi-exclamation-triangle me-2"),
-                            "Throw a handler exception"]
-                    ]
-                ]),
-            H2(Class: "h4 mt-5 mb-3")["Render-time throw"],
-            CodeSample(
-                """
-                ErrorBoundary(
-                    Fallback: (ex, recover) => ...)[_throwOnRender ? new RenderThrower() : Div(...)]
-                """,
-                Notes:
-                "The same boundary catches synchronous exceptions thrown inside a descendant's Render(). Click below to flip a flag; the next render of the child throws and the fallback replaces it.",
-                Result: ErrorBoundary(
-                    // Recover for the render-throw demo must ALSO reset _throwOnRender —
-                    // otherwise the boundary clears its error, re-walks its cached Children
-                    // (still containing the RenderThrower built last frame), and trips
-                    // again on the same exception. Two cooperating dirty-marks are needed:
-                    //   - recover()         → clears boundary._error, marks boundary dirty
-                    //   - StateHasChanged() → marks THIS BoomPage dirty so its Render re-
-                    //                         executes with _throwOnRender=false and the
-                    //                         boundary receives fresh Children without the
-                    //                         RenderThrower.
-                    // The handler-throw demo above doesn't need this because the underlying
-                    // state isn't stale across the trip.
-                    (ex, recover) => BoundaryFallback(ex, () =>
-                    {
-                        // Order matters: dirty-mark BoomPage FIRST so its re-render calls
-                        // the ErrorBoundary factory → boundary.SetProps with fresh Children
-                        // that no longer include the RenderThrower. THEN clear the boundary's
-                        // error. Calling recover() before that would synchronously re-render
-                        // the boundary against the stale cached Children (still containing
-                        // RenderThrower) — the boundary would trip again on the same
-                        // exception and the recovery would appear to do nothing.
-                        _throwOnRender = false;
-                        StateHasChanged();
-                        recover();
-                    }))[
-                    Div(Class: "p-3 border rounded bg-white", Id: "boom-render-host")[
-                        P(Class: "text-secondary small mb-2")["Healthy. Click below to make my next render throw."],
-                        Button(
-                            Class: "btn btn-warning",
-                            Id: "boom-render-trigger",
-                            OnClick: () => _throwOnRender = true)[I(Class: "bi bi-bug me-2"), "Throw on next render"],
+    [
+        PageHeader.Render(
+            "Error boundary",
+            "ErrorBoundary catches exceptions thrown by descendants — render-time, sync lifecycle, async lifecycle, and event handlers — and renders a fallback in their place. The fallback receives a Recover() callback so the boundary can be reset from a button click."),
+        H2(Class: "h4 mt-4 mb-3")["Handler throw — boundary catches and renders fallback"],
+        CodeSample(
+            """
+            ErrorBoundary(
+                Fallback: (ex, recover) => Div()[
+                    Strong()["Caught: "], ex.Message,
+                    Button(OnClick: recover)["Reset"]
+                ])[
+                    Button(OnClick: () => throw new InvalidOperationException("kaboom"))["Throw"]
+                ]
+            """,
+            Result: ErrorBoundary(
+                BoundaryFallback)[
+                Div(Class: "p-3 border rounded bg-white", Id: "boom-handler-host")[
+                    P(Class: "text-secondary small mb-2")["Healthy subtree — click to throw."],
+                    Button(
+                        Class: "btn btn-danger",
+                        Id: "boom-throw",
+                        OnClick: ThrowFromHandler)[I(Class: "bi bi-exclamation-triangle me-2"),
+                        "Throw a handler exception"]
+                ]
+            ]),
+        H2(Class: "h4 mt-5 mb-3")["Render-time throw"],
+        CodeSample(
+            """
+            ErrorBoundary(
+                Fallback: (ex, recover) => ...)[_throwOnRender ? new RenderThrower() : Div(...)]
+            """,
+            Notes:
+            "The same boundary catches synchronous exceptions thrown inside a descendant's Render(). Click below to flip a flag; the next render of the child throws and the fallback replaces it.",
+            Result: ErrorBoundary(
+                // Recover for the render-throw demo must ALSO reset _throwOnRender —
+                // otherwise the boundary clears its error, re-walks its cached Children
+                // (still containing the RenderThrower built last frame), and trips
+                // again on the same exception. Two cooperating dirty-marks are needed:
+                //   - recover()         → clears boundary._error, marks boundary dirty
+                //   - StateHasChanged() → marks THIS BoomPage dirty so its Render re-
+                //                         executes with _throwOnRender=false and the
+                //                         boundary receives fresh Children without the
+                //                         RenderThrower.
+                // The handler-throw demo above doesn't need this because the underlying
+                // state isn't stale across the trip.
+                (ex, recover) => BoundaryFallback(ex, () =>
+                {
+                    // Order matters: dirty-mark BoomPage FIRST so its re-render calls
+                    // the ErrorBoundary factory → boundary.SetProps with fresh Children
+                    // that no longer include the RenderThrower. THEN clear the boundary's
+                    // error. Calling recover() before that would synchronously re-render
+                    // the boundary against the stale cached Children (still containing
+                    // RenderThrower) — the boundary would trip again on the same
+                    // exception and the recovery would appear to do nothing.
+                    _throwOnRender = false;
+                    StateHasChanged();
+                    recover();
+                }))[
+                Div(Class: "p-3 border rounded bg-white", Id: "boom-render-host")[
+                    P(Class: "text-secondary small mb-2")["Healthy. Click below to make my next render throw."],
+                    Button(
+                        Class: "btn btn-warning",
+                        Id: "boom-render-trigger",
+                        OnClick: () => _throwOnRender = true)[I(Class: "bi bi-bug me-2"), "Throw on next render"],
 #pragma warning disable RASK014
-                        // Intentionally bypass the factory: RenderThrower is [SkipFactory] and
-                        // exists only to demonstrate that a descendant whose Render() throws is
-                        // caught by the enclosing ErrorBoundary.
-                        _throwOnRender ? new RenderThrower() : Text(string.Empty)
+                    // Intentionally bypass the factory: RenderThrower is [SkipFactory] and
+                    // exists only to demonstrate that a descendant whose Render() throws is
+                    // caught by the enclosing ErrorBoundary.
+                    _throwOnRender ? new RenderThrower() : Text(string.Empty)
 #pragma warning restore RASK014
-                    ]
-                ]),
-            H2(Class: "h4 mt-5 mb-3")["Nested boundaries — inner catches first"],
-            CodeSample(
-                """
-                ErrorBoundary(  // outer
-                    Fallback: outerFallback)[
-                        Div()[
-                            P()["Outer healthy region — survives inner throws."],
-                            ErrorBoundary(  // inner
-                                Fallback: innerFallback)[
-                                    Button(OnClick: () => throw new InvalidOperationException("inner kaboom"))["Throw inside inner boundary"]
-                                ]
-                        ]
-                    ]
-                """,
-                Notes:
-                "The inner boundary catches first — the outer healthy region (and its sibling paragraph) stays mounted. If the inner fallback itself throws, the outer boundary catches the escalation.",
-                Result: ErrorBoundary((ex, _) => OuterFallback(ex))[
-                    Div(Class: "p-3 border rounded bg-white", Id: "boom-nested-host")[
-                        P(Class: "mb-2 small text-secondary",
-                            Id: "boom-nested-outer-healthy")[
-                            "Outer healthy region — stays mounted while the inner boundary trips."],
-                        ErrorBoundary((ex, recover) => InnerFallback(ex, recover))[
-                            Div(Class: "p-3 border rounded bg-light")[
-                                P(Class: "small text-secondary mb-2")["Inner boundary subtree."],
-                                Button(
-                                    Class: "btn btn-danger btn-sm",
-                                    Id: "boom-nested-throw",
-                                    OnClick: ThrowFromInnerHandler)[I(Class: "bi bi-exclamation-triangle me-2"),
-                                    "Throw inside inner boundary"]
+                ]
+            ]),
+        H2(Class: "h4 mt-5 mb-3")["Nested boundaries — inner catches first"],
+        CodeSample(
+            """
+            ErrorBoundary(  // outer
+                Fallback: outerFallback)[
+                    Div()[
+                        P()["Outer healthy region — survives inner throws."],
+                        ErrorBoundary(  // inner
+                            Fallback: innerFallback)[
+                                Button(OnClick: () => throw new InvalidOperationException("inner kaboom"))["Throw inside inner boundary"]
                             ]
+                    ]
+                ]
+            """,
+            Notes:
+            "The inner boundary catches first — the outer healthy region (and its sibling paragraph) stays mounted. If the inner fallback itself throws, the outer boundary catches the escalation.",
+            Result: ErrorBoundary((ex, _) => OuterFallback(ex))[
+                Div(Class: "p-3 border rounded bg-white", Id: "boom-nested-host")[
+                    P(Class: "mb-2 small text-secondary",
+                        Id: "boom-nested-outer-healthy")[
+                        "Outer healthy region — stays mounted while the inner boundary trips."],
+                    ErrorBoundary((ex, recover) => InnerFallback(ex, recover))[
+                        Div(Class: "p-3 border rounded bg-light")[
+                            P(Class: "small text-secondary mb-2")["Inner boundary subtree."],
+                            Button(
+                                Class: "btn btn-danger btn-sm",
+                                Id: "boom-nested-throw",
+                                OnClick: ThrowFromInnerHandler)[I(Class: "bi bi-exclamation-triangle me-2"),
+                                "Throw inside inner boundary"]
                         ]
                     ]
-                ])
-        ];
+                ]
+            ])
+    ];
 
     private static Child InnerFallback(Exception ex, Action recover) =>
         Div(Class: "alert alert-warning d-flex align-items-start",

--- a/samples/Rask.Example.Shared/Pages/CallbackPage.cs
+++ b/samples/Rask.Example.Shared/Pages/CallbackPage.cs
@@ -11,36 +11,40 @@ public sealed class CallbackPage : Component
     protected override RenderResult Head => Title()["Callbacks — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Callback",
-                "Child→parent events are plain delegate props — no special type. Invoking one re-renders the parent that owns it, automatically."),
-            H2(Class: "h4 mt-4 mb-3")["Child emits, parent re-renders"],
-            CodeSample(
-                """
-                // reusable child — declares a plain Action<int>? prop
-                public sealed class RatingStars : Component
-                {
-                    public int Value { get; set; }
-                    public Action<int>? OnRate { get; set; }
+    [
+        PageHeader.Render(
+            "Callback",
+            "Child→parent events are plain delegate props — no special type. Invoking one re-renders the parent that owns it, automatically."),
+        H2(Class: "h4 mt-4 mb-3")["Child emits, parent re-renders"],
+        CodeSample(
+            """
+            // reusable child — declares a plain Action<int>? prop
+            public sealed class RatingStars : Component
+            {
+                public int Value { get; set; }
+                public Action<int>? OnRate { get; set; }
 
-                    protected override RenderResult Render() => /* clickable stars */
-                        Button(OnClick: () => OnRate?.Invoke(i))[ "★" ];
-                }
+                protected override RenderResult Render() => /* clickable stars */
+                    Button(OnClick: () => OnRate?.Invoke(i))[ "★" ];
+            }
 
-                // parent — passes a plain lambda that mutates its own state
-                RatingStars(Value: _rating, OnRate: n => _rating = n)
-                P()[ $"You rated: {_rating}/5" ]
-                """,
-                Notes:
-                "The star button's handler belongs to RatingStars, so the DOM dispatch only dirties the child — and the child invokes OnRate off that path. The parent still re-renders because the framework wraps the delegate to re-render its owner (the parent, captured from the lambda's `this`). RatingStars never knows the parent exists, and the parent never wires StateHasChanged by hand.",
-                Result: CallbackRatingDemo()),
-            H2(Class: "h4 mt-5 mb-3")["How it works"],
-            Ul(Class: "text-secondary")[
-                Li()["An event-callback prop is any Action / Action<T> / Func<Task> / Func<T,Task> on a component. The generated factory wraps it so invoking it runs your delegate and then re-renders the component that owns it."],
-                Li()["The owner is the delegate's Target — the component you wrote the lambda inside (it captures `this`). A static method, or a lambda closing over a local instead of `this`, has no component target, so no auto re-render fires."],
-                Li()["When a child forwards a parent's delegate straight onto a DOM element, handler-owner resolution already re-renders the parent; the wrapper covers the cases the child wraps, transforms, or fires off the DOM path."],
-                Li()["HTML element handlers (Button.OnClick, …) are not wrapped — they reach the DOM directly, where re-render is already free. Wrapping is confined to your own components, keeping the render hot path allocation-free."]
-            ]
-        ];
+            // parent — passes a plain lambda that mutates its own state
+            RatingStars(Value: _rating, OnRate: n => _rating = n)
+            P()[ $"You rated: {_rating}/5" ]
+            """,
+            Notes:
+            "The star button's handler belongs to RatingStars, so the DOM dispatch only dirties the child — and the child invokes OnRate off that path. The parent still re-renders because the framework wraps the delegate to re-render its owner (the parent, captured from the lambda's `this`). RatingStars never knows the parent exists, and the parent never wires StateHasChanged by hand.",
+            Result: CallbackRatingDemo()),
+        H2(Class: "h4 mt-5 mb-3")["How it works"],
+        Ul(Class: "text-secondary")[
+            Li()[
+                "An event-callback prop is any Action / Action<T> / Func<Task> / Func<T,Task> on a component. The generated factory wraps it so invoking it runs your delegate and then re-renders the component that owns it."],
+            Li()[
+                "The owner is the delegate's Target — the component you wrote the lambda inside (it captures `this`). A static method, or a lambda closing over a local instead of `this`, has no component target, so no auto re-render fires."],
+            Li()[
+                "When a child forwards a parent's delegate straight onto a DOM element, handler-owner resolution already re-renders the parent; the wrapper covers the cases the child wraps, transforms, or fires off the DOM path."],
+            Li()[
+                "HTML element handlers (Button.OnClick, …) are not wrapped — they reach the DOM directly, where re-render is already free. Wrapping is confined to your own components, keeping the render hot path allocation-free."]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/CancellationPage.cs
+++ b/samples/Rask.Example.Shared/Pages/CancellationPage.cs
@@ -15,77 +15,77 @@ public sealed class CancellationPage : Component
     protected override RenderResult Head => Title()["Cancellation — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Cancellation",
-                "Every Component exposes a protected CancellationToken that fires exactly once when the component is unmounted. Pass it into HttpClient calls, Task.Delay, or any other cancellable async work started inside a lifecycle hook."),
-            H2(Class: "h4 mt-4 mb-3")["Live probe"],
-            P(Class: "text-secondary")[
-                "Mount the probe to start a 2.5-second ",
-                Code()["Task.Delay"],
-                " inside ", Code()["OnMountAsync"],
-                ". Click Unmount before it settles to cancel — the probe records what happened into the log below."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "d-flex gap-2 mb-3")[
-                        Button(
-                            Class: "btn btn-primary btn-sm",
-                            Id: "cancel-mount",
-                            Disabled: _mounted,
-                            OnClick: Mount)[I(Class: "bi bi-play-circle me-1"), "Mount probe"],
-                        Button(
-                            Class: "btn btn-outline-secondary btn-sm",
-                            Id: "cancel-unmount",
-                            Disabled: !_mounted,
-                            OnClick: Unmount)[I(Class: "bi bi-stop-circle me-1"), "Unmount probe"]
-                    ],
-                    _mounted
-                        ? CancellationProbe(AppendLog, _nextInstance)
-                        : P(Class: "text-secondary fst-italic mb-0")["Probe is not mounted."],
-                    H3(Class: "h6 text-secondary text-uppercase small mt-4")["Log"],
-                    _log.Count == 0
-                        ? P(Class: "text-secondary small mb-0")["Mount and unmount the probe to populate this log."]
-                        : Ol(Class: "list-group list-group-numbered list-group-flush cancel-log")[_log.Select(line =>
-                            Li(
-                                Key: line,
-                                Class: "list-group-item ps-2 small")[Code(Class: "small")[line]])]
-                ]
-            ],
-            H2(Class: "h4 mt-4 mb-3")["Source"],
-            CodeSample(
-                """
-                public sealed class CancellationProbe : Component
-                {
-                    public required Action<string> Log { get; set; }
-                    public required int InstanceId { get; set; }
+    [
+        PageHeader.Render(
+            "Cancellation",
+            "Every Component exposes a protected CancellationToken that fires exactly once when the component is unmounted. Pass it into HttpClient calls, Task.Delay, or any other cancellable async work started inside a lifecycle hook."),
+        H2(Class: "h4 mt-4 mb-3")["Live probe"],
+        P(Class: "text-secondary")[
+            "Mount the probe to start a 2.5-second ",
+            Code()["Task.Delay"],
+            " inside ", Code()["OnMountAsync"],
+            ". Click Unmount before it settles to cancel — the probe records what happened into the log below."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 mb-3")[
+                    Button(
+                        Class: "btn btn-primary btn-sm",
+                        Id: "cancel-mount",
+                        Disabled: _mounted,
+                        OnClick: Mount)[I(Class: "bi bi-play-circle me-1"), "Mount probe"],
+                    Button(
+                        Class: "btn btn-outline-secondary btn-sm",
+                        Id: "cancel-unmount",
+                        Disabled: !_mounted,
+                        OnClick: Unmount)[I(Class: "bi bi-stop-circle me-1"), "Unmount probe"]
+                ],
+                _mounted
+                    ? CancellationProbe(AppendLog, _nextInstance)
+                    : P(Class: "text-secondary fst-italic mb-0")["Probe is not mounted."],
+                H3(Class: "h6 text-secondary text-uppercase small mt-4")["Log"],
+                _log.Count == 0
+                    ? P(Class: "text-secondary small mb-0")["Mount and unmount the probe to populate this log."]
+                    : Ol(Class: "list-group list-group-numbered list-group-flush cancel-log")[_log.Select(line =>
+                        Li(
+                            Key: line,
+                            Class: "list-group-item ps-2 small")[Code(Class: "small")[line]])]
+            ]
+        ],
+        H2(Class: "h4 mt-4 mb-3")["Source"],
+        CodeSample(
+            """
+            public sealed class CancellationProbe : Component
+            {
+                public required Action<string> Log { get; set; }
+                public required int InstanceId { get; set; }
 
-                    protected override async Task OnMountAsync()
+                protected override async Task OnMountAsync()
+                {
+                    try
                     {
-                        try
-                        {
-                            await Task.Delay(TimeSpan.FromMilliseconds(2500), CancellationToken);
-                            Log($"#{InstanceId} completed");
-                        }
-                        catch (OperationCanceledException)
-                        {
-                            Log($"#{InstanceId} cancelled");
-                        }
+                        await Task.Delay(TimeSpan.FromMilliseconds(2500), CancellationToken);
+                        Log($"#{InstanceId} completed");
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        Log($"#{InstanceId} cancelled");
                     }
                 }
-                """,
-                Notes:
-                "Component.CancellationToken is allocated lazily — components that don't read it never pay the CTS cost. The framework cancels the token before disposing the subtree, so awaits unwind via OperationCanceledException before Dispose runs."),
-            Div(Class: "alert alert-info d-flex align-items-start mt-3")[
-                I(Class: "bi bi-info-circle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Cooperation required:"],
-                    " the framework does not abort blocking calls — it only signals the token. Pass it into ",
-                    Code()["HttpClient"], ", ", Code()["Task.Delay"],
-                    ", and any cancellable API you call from a lifecycle hook so they unwind cleanly when the user navigates away."
-                ]
+            }
+            """,
+            Notes:
+            "Component.CancellationToken is allocated lazily — components that don't read it never pay the CTS cost. The framework cancels the token before disposing the subtree, so awaits unwind via OperationCanceledException before Dispose runs."),
+        Div(Class: "alert alert-info d-flex align-items-start mt-3")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Cooperation required:"],
+                " the framework does not abort blocking calls — it only signals the token. Pass it into ",
+                Code()["HttpClient"], ", ", Code()["Task.Delay"],
+                ", and any cancellable API you call from a lifecycle hook so they unwind cleanly when the user navigates away."
             ]
-        ];
+        ]
+    ];
 
     private void Mount()
     {

--- a/samples/Rask.Example.Shared/Pages/ComponentsPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ComponentsPage.cs
@@ -11,96 +11,96 @@ public sealed class ComponentsPage : Component
     protected override RenderResult Head => Title()["User components — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "User components",
-                "Subclass Component, override Render. The Rask source generator emits a Namespace.Generated.TypeName(...) factory for every concrete user component, with parameters derived from your public settable properties."),
-            H2(Class: "h4 mt-4 mb-3")["A component and its generated factory"],
-            CodeSample(
-                """
-                public sealed class Greeting : Component
-                {
-                    public required string Name { get; set; }
-                    public string? Title { get; set; }
+    [
+        PageHeader.Render(
+            "User components",
+            "Subclass Component, override Render. The Rask source generator emits a Namespace.Generated.TypeName(...) factory for every concrete user component, with parameters derived from your public settable properties."),
+        H2(Class: "h4 mt-4 mb-3")["A component and its generated factory"],
+        CodeSample(
+            """
+            public sealed class Greeting : Component
+            {
+                public required string Name { get; set; }
+                public string? Title { get; set; }
 
-                    public override RenderResult Render() =>
-                        P()[
-                            Title is null ? "" : $"{Title} ",
-                            "Hello, ", Strong()[Name], "!"
-                        ];
-                }
+                public override RenderResult Render() =>
+                    P()[
+                        Title is null ? "" : $"{Title} ",
+                        "Hello, ", Strong()[Name], "!"
+                    ];
+            }
 
-                // call site (generated factory):
-                Generated.Greeting(Name: "Ada", Title: "Dr.")
-                """,
-                Notes:
-                "Non-nullable property without an initializer → required factory parameter. Nullable property → optional with default null. Property with an initializer → excluded from the factory.",
-                Result: Greeting("Ada", "Dr.")),
-            H2(Class: "h4 mt-5 mb-3")["DI via constructor"],
-            CodeSample(
-                """
-                // Inject services like HttpClient/Navigator/RouteState through the
-                // primary constructor — never as a public settable property:
-                public sealed class WeatherCard(HttpClient http) : Component
-                {
-                    public required string City { get; set; }
-                    // ... uses `http` to fetch
-                }
+            // call site (generated factory):
+            Generated.Greeting(Name: "Ada", Title: "Dr.")
+            """,
+            Notes:
+            "Non-nullable property without an initializer → required factory parameter. Nullable property → optional with default null. Property with an initializer → excluded from the factory.",
+            Result: Greeting("Ada", "Dr.")),
+        H2(Class: "h4 mt-5 mb-3")["DI via constructor"],
+        CodeSample(
+            """
+            // Inject services like HttpClient/Navigator/RouteState through the
+            // primary constructor — never as a public settable property:
+            public sealed class WeatherCard(HttpClient http) : Component
+            {
+                public required string City { get; set; }
+                // ... uses `http` to fetch
+            }
 
-                // call site is unchanged — ActivatorUtilities resolves `http`:
-                Generated.WeatherCard(City: "Helsinki")
-                """,
-                Notes:
-                "ActivatorUtilities.CreateInstance constructs the component each time; constructor parameters resolve from DI, properties are then re-applied so cached private state survives across renders while props stay fresh."),
-            H2(Class: "h4 mt-5 mb-3")["[SkipFactory] hides a property"],
-            CodeSample(
-                """
-                public sealed class SkipFactoryCounter : Component
-                {
-                    private int _count;
+            // call site is unchanged — ActivatorUtilities resolves `http`:
+            Generated.WeatherCard(City: "Helsinki")
+            """,
+            Notes:
+            "ActivatorUtilities.CreateInstance constructs the component each time; constructor parameters resolve from DI, properties are then re-applied so cached private state survives across renders while props stay fresh."),
+        H2(Class: "h4 mt-5 mb-3")["[SkipFactory] hides a property"],
+        CodeSample(
+            """
+            public sealed class SkipFactoryCounter : Component
+            {
+                private int _count;
 
-                    // [SkipFactory] excludes this property from the generated factory.
-                    // The initializer seeds the cached instance — the factory call site
-                    // doesn't have to (and can't) pass Initial through.
-                    [SkipFactory] public int Initial { get; set; } = 7;
+                // [SkipFactory] excludes this property from the generated factory.
+                // The initializer seeds the cached instance — the factory call site
+                // doesn't have to (and can't) pass Initial through.
+                [SkipFactory] public int Initial { get; set; } = 7;
 
-                    protected override void OnMount() => _count = Initial;
+                protected override void OnMount() => _count = Initial;
 
-                    protected override RenderResult Render() =>
-                        Button(OnClick: () => _count++)[$"Clicks: {_count}"];
-                }
+                protected override RenderResult Render() =>
+                    Button(OnClick: () => _count++)[$"Clicks: {_count}"];
+            }
 
-                // The generated factory has NO Initial parameter — the call site stays
-                // clean. Framework caches the instance by tree position, so _count
-                // survives re-renders just like any other private state.
-                SkipFactoryCounter()
-                """,
-                Notes:
-                "[SkipFactory] keeps a property settable in code while removing it from the generated factory signature. The counter below started at 7 — click it and the state persists across re-renders.",
-                Result: SkipFactoryCounter()),
-            H2(Class: "h4 mt-5 mb-3")["Diagnostics"],
-            Div(Class: "list-group mb-3")[
-                Div(Class: "list-group-item d-flex align-items-start")[
-                    Span(Class: "badge text-bg-secondary me-3")["RASK001"],
-                    Div()[
-                        Strong()["Hidden suggestion."],
-                        " A property is treated as a required factory parameter — consider also marking it ",
-                        Code()["required"],
-                        " for language-level enforcement."
-                    ]
-                ],
-                Div(Class: "list-group-item d-flex align-items-start")[
-                    Span(Class: "badge text-bg-warning me-3")["RASK002"],
-                    Div()[
-                        Strong()["Warning."],
-                        " ", Code()["required"],
-                        " on a property combined with DI-injected constructor parameters: ",
-                        Code()["ActivatorUtilities"],
-                        " cannot satisfy ", Code()["required"], " members. Drop one or the other."
-                    ]
+            // The generated factory has NO Initial parameter — the call site stays
+            // clean. Framework caches the instance by tree position, so _count
+            // survives re-renders just like any other private state.
+            SkipFactoryCounter()
+            """,
+            Notes:
+            "[SkipFactory] keeps a property settable in code while removing it from the generated factory signature. The counter below started at 7 — click it and the state persists across re-renders.",
+            Result: SkipFactoryCounter()),
+        H2(Class: "h4 mt-5 mb-3")["Diagnostics"],
+        Div(Class: "list-group mb-3")[
+            Div(Class: "list-group-item d-flex align-items-start")[
+                Span(Class: "badge text-bg-secondary me-3")["RASK001"],
+                Div()[
+                    Strong()["Hidden suggestion."],
+                    " A property is treated as a required factory parameter — consider also marking it ",
+                    Code()["required"],
+                    " for language-level enforcement."
+                ]
+            ],
+            Div(Class: "list-group-item d-flex align-items-start")[
+                Span(Class: "badge text-bg-warning me-3")["RASK002"],
+                Div()[
+                    Strong()["Warning."],
+                    " ", Code()["required"],
+                    " on a property combined with DI-injected constructor parameters: ",
+                    Code()["ActivatorUtilities"],
+                    " cannot satisfy ", Code()["required"], " members. Drop one or the other."
                 ]
             ]
-        ];
+        ]
+    ];
 }
 
 public sealed class SkipFactoryCounter : Component

--- a/samples/Rask.Example.Shared/Pages/ContextPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ContextPage.cs
@@ -11,32 +11,36 @@ public sealed class ContextPage : Component
     protected override RenderResult Head => Title()["Context — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Context",
-                "Supply a value to a whole subtree and read it deep down — no prop drilling. Rask's analogue of React Context / Blazor CascadingValue, with the provider and readers on one Context type."),
-            H2(Class: "h4 mt-4 mb-3")["Provide once, consume anywhere below"],
-            CodeSample(
-                """
-                // provide — high in the tree
-                Context.Provide<Theme>(Value: _theme)[
-                    ThemeCard()          // knows nothing about the theme
-                ]
-
-                // consume — anywhere below, no prop passed down
-                var theme = Context.Required<Theme>();   // throws if no provider
-                var maybe = Context.Get<Theme>();        // null if no provider
-                if (Context.Has<Theme>()) { ... }
-                """,
-                Notes:
-                "The badge sits inside ThemeCard, which receives no theme parameter and is render-cached after first paint. Reading the value with Context.Required opts the badge out of the render cache, so each toggle re-renders only the badge — straight through the cached intermediate, with nothing threaded between them.",
-                Result: ContextThemeDemo()),
-            H2(Class: "h4 mt-5 mb-3")["How it works"],
-            Ul(Class: "text-secondary")[
-                Li()["Context.Provide<T>(value) is a transparent node — it renders its children with no wrapper and pushes the value onto an ambient stack for the duration of that subtree."],
-                Li()["Nested providers of the same type resolve nearest-first; an optional Name lets two providers of one type coexist."],
-                Li()["Reading is explicit (like React's useContext) rather than an attribute, so it composes anywhere a component renders — even outside a form or route."],
-                Li()["Change detection rides the normal render walk: when the value changes the providing component re-renders, and consumers (which bypass the cache) re-read on the way down."]
+    [
+        PageHeader.Render(
+            "Context",
+            "Supply a value to a whole subtree and read it deep down — no prop drilling. Rask's analogue of React Context / Blazor CascadingValue, with the provider and readers on one Context type."),
+        H2(Class: "h4 mt-4 mb-3")["Provide once, consume anywhere below"],
+        CodeSample(
+            """
+            // provide — high in the tree
+            Context.Provide<Theme>(Value: _theme)[
+                ThemeCard()          // knows nothing about the theme
             ]
-        ];
+
+            // consume — anywhere below, no prop passed down
+            var theme = Context.Required<Theme>();   // throws if no provider
+            var maybe = Context.Get<Theme>();        // null if no provider
+            if (Context.Has<Theme>()) { ... }
+            """,
+            Notes:
+            "The badge sits inside ThemeCard, which receives no theme parameter and is render-cached after first paint. Reading the value with Context.Required opts the badge out of the render cache, so each toggle re-renders only the badge — straight through the cached intermediate, with nothing threaded between them.",
+            Result: ContextThemeDemo()),
+        H2(Class: "h4 mt-5 mb-3")["How it works"],
+        Ul(Class: "text-secondary")[
+            Li()[
+                "Context.Provide<T>(value) is a transparent node — it renders its children with no wrapper and pushes the value onto an ambient stack for the duration of that subtree."],
+            Li()[
+                "Nested providers of the same type resolve nearest-first; an optional Name lets two providers of one type coexist."],
+            Li()[
+                "Reading is explicit (like React's useContext) rather than an attribute, so it composes anywhere a component renders — even outside a form or route."],
+            Li()[
+                "Change detection rides the normal render walk: when the value changes the providing component re-renders, and consumers (which bypass the cache) re-read on the way down."]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/DisposalPage.cs
+++ b/samples/Rask.Example.Shared/Pages/DisposalPage.cs
@@ -21,147 +21,147 @@ public sealed class DisposalPage : Component
     protected override RenderResult Head => Title()["Disposal — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Disposal",
-                "Components that implement IDisposable or IAsyncDisposable get their Dispose method called by the framework when they leave the render tree. Use it to release timers, subscriptions, or any handle you took out in OnMount."),
-            H2(Class: "h4 mt-4 mb-3")["IDisposable (sync)"],
-            P(Class: "text-secondary")[
-                "Mount, then unmount. The probe's ", Code()["Dispose()"],
-                " runs synchronously as the parent's diff removes it from the tree."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "d-flex gap-2 mb-3")[
-                        Button(
-                            Class: "btn btn-primary btn-sm",
-                            Id: "dispose-sync-mount",
-                            Disabled: _syncMounted,
-                            OnClick: MountSync)[I(Class: "bi bi-play-circle me-1"), "Mount sync probe"],
-                        Button(
-                            Class: "btn btn-outline-secondary btn-sm",
-                            Id: "dispose-sync-unmount",
-                            Disabled: !_syncMounted,
-                            OnClick: UnmountSync)[I(Class: "bi bi-stop-circle me-1"), "Unmount sync probe"]
-                    ],
-                    _syncMounted
-                        ? DisposableTimerProbe(AppendSyncLog, _nextSyncId)
-                        : P(Class: "text-secondary fst-italic mb-0")["Probe not mounted."],
-                    LogList(_syncLog, "dispose-sync-log")
-                ]
-            ],
-            CodeSample(
-                """
-                public sealed class DisposableTimerProbe : Component, IDisposable
+    [
+        PageHeader.Render(
+            "Disposal",
+            "Components that implement IDisposable or IAsyncDisposable get their Dispose method called by the framework when they leave the render tree. Use it to release timers, subscriptions, or any handle you took out in OnMount."),
+        H2(Class: "h4 mt-4 mb-3")["IDisposable (sync)"],
+        P(Class: "text-secondary")[
+            "Mount, then unmount. The probe's ", Code()["Dispose()"],
+            " runs synchronously as the parent's diff removes it from the tree."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 mb-3")[
+                    Button(
+                        Class: "btn btn-primary btn-sm",
+                        Id: "dispose-sync-mount",
+                        Disabled: _syncMounted,
+                        OnClick: MountSync)[I(Class: "bi bi-play-circle me-1"), "Mount sync probe"],
+                    Button(
+                        Class: "btn btn-outline-secondary btn-sm",
+                        Id: "dispose-sync-unmount",
+                        Disabled: !_syncMounted,
+                        OnClick: UnmountSync)[I(Class: "bi bi-stop-circle me-1"), "Unmount sync probe"]
+                ],
+                _syncMounted
+                    ? DisposableTimerProbe(AppendSyncLog, _nextSyncId)
+                    : P(Class: "text-secondary fst-italic mb-0")["Probe not mounted."],
+                LogList(_syncLog, "dispose-sync-log")
+            ]
+        ],
+        CodeSample(
+            """
+            public sealed class DisposableTimerProbe : Component, IDisposable
+            {
+                public required Action<string> Log { get; set; }
+                public required int InstanceId { get; set; }
+
+                protected override void OnMount() => Log($"#{InstanceId} mounted");
+
+                public void Dispose() => Log($"#{InstanceId} disposed");
+
+                protected override RenderResult Render() =>
+                    Div()[/* ... */];
+            }
+            """,
+            Notes:
+            "Dispose runs once when the component leaves the render tree — either because its parent stopped including it, the route changed, or the live session is being torn down. The framework walks children depth-first, so nested IDisposables dispose bottom-up."),
+        H2(Class: "h4 mt-5 mb-3")["IAsyncDisposable"],
+        P(Class: "text-secondary")[
+            "The async variant: the framework awaits ", Code()["DisposeAsync()"],
+            " on its own dispatch path. The log entry shows up after the next render cycle resolves the continuation."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 mb-3")[
+                    Button(
+                        Class: "btn btn-primary btn-sm",
+                        Id: "dispose-async-mount",
+                        Disabled: _asyncMounted,
+                        OnClick: MountAsync)[I(Class: "bi bi-play-circle me-1"), "Mount async probe"],
+                    Button(
+                        Class: "btn btn-outline-secondary btn-sm",
+                        Id: "dispose-async-unmount",
+                        Disabled: !_asyncMounted,
+                        OnClick: UnmountAsync)[I(Class: "bi bi-stop-circle me-1"), "Unmount async probe"]
+                ],
+                _asyncMounted
+                    ? DisposableAsyncProbe(AppendAsyncLog, _nextAsyncId)
+                    : P(Class: "text-secondary fst-italic mb-0")["Probe not mounted."],
+                LogList(_asyncLog, "dispose-async-log")
+            ]
+        ],
+        Div(Class: "alert alert-warning d-flex align-items-start mt-3")[
+            I(Class: "bi bi-exclamation-triangle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Order:"],
+                " disposal walks children depth-first, then cancels the parent's lifetime token, then invokes Dispose / DisposeAsync on the parent. ",
+                "If you need to observe the cancellation token from inside Dispose, it is already in the cancelled state by then — see ",
+                Code()["/cancellation"], "."
+            ]
+        ],
+        H2(Class: "h4 mt-5 mb-3")["OnUnmount vs IDisposable"],
+        P(Class: "text-secondary")[
+            Code()["OnUnmount"], " / ", Code()["OnUnmountAsync"],
+            " is the framework-side cleanup signal. It fires before the lifetime ",
+            Code()["CancellationToken"],
+            " is cancelled, so cleanup code can still observe the token. Reach for it when the resource is conceptually a ",
+            Em()["lifecycle hook"],
+            " (unsubscribe from an event, stop a timer you started in ", Code()["OnMount"],
+            ") and reserve ", Code()["IDisposable"],
+            " for things you would dispose anyway in non-Rask code (file handles, HTTP responses, DB connections)."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 mb-3")[
+                    Button(
+                        Class: "btn btn-primary btn-sm",
+                        Id: "unmount-hook-mount",
+                        Disabled: _hookMounted,
+                        OnClick: MountHook)[I(Class: "bi bi-play-circle me-1"), "Start ticker"],
+                    Button(
+                        Class: "btn btn-outline-secondary btn-sm",
+                        Id: "unmount-hook-unmount",
+                        Disabled: !_hookMounted,
+                        OnClick: UnmountHook)[I(Class: "bi bi-stop-circle me-1"), "Stop ticker"]
+                ],
+                _hookMounted
+                    ? UnmountTimerProbe(AppendHookLog, _nextHookId)
+                    : P(Class: "text-secondary fst-italic mb-0")["Ticker not running."],
+                LogList(_hookLog, "unmount-hook-log")
+            ]
+        ],
+        CodeSample(
+            """
+            public sealed class UnmountTimerProbe : Component
+            {
+                public required Action<string> Log { get; set; }
+                private Timer? _timer;
+                private int _ticks;
+
+                protected override void OnMount()
                 {
-                    public required Action<string> Log { get; set; }
-                    public required int InstanceId { get; set; }
-
-                    protected override void OnMount() => Log($"#{InstanceId} mounted");
-
-                    public void Dispose() => Log($"#{InstanceId} disposed");
-
-                    protected override RenderResult Render() =>
-                        Div()[/* ... */];
+                    Log("ticker started");
+                    _timer = new Timer(_ => {
+                        _ticks++;
+                        StateHasChanged();
+                    }, null, 1000, 1000);
                 }
-                """,
-                Notes:
-                "Dispose runs once when the component leaves the render tree — either because its parent stopped including it, the route changed, or the live session is being torn down. The framework walks children depth-first, so nested IDisposables dispose bottom-up."),
-            H2(Class: "h4 mt-5 mb-3")["IAsyncDisposable"],
-            P(Class: "text-secondary")[
-                "The async variant: the framework awaits ", Code()["DisposeAsync()"],
-                " on its own dispatch path. The log entry shows up after the next render cycle resolves the continuation."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "d-flex gap-2 mb-3")[
-                        Button(
-                            Class: "btn btn-primary btn-sm",
-                            Id: "dispose-async-mount",
-                            Disabled: _asyncMounted,
-                            OnClick: MountAsync)[I(Class: "bi bi-play-circle me-1"), "Mount async probe"],
-                        Button(
-                            Class: "btn btn-outline-secondary btn-sm",
-                            Id: "dispose-async-unmount",
-                            Disabled: !_asyncMounted,
-                            OnClick: UnmountAsync)[I(Class: "bi bi-stop-circle me-1"), "Unmount async probe"]
-                    ],
-                    _asyncMounted
-                        ? DisposableAsyncProbe(AppendAsyncLog, _nextAsyncId)
-                        : P(Class: "text-secondary fst-italic mb-0")["Probe not mounted."],
-                    LogList(_asyncLog, "dispose-async-log")
-                ]
-            ],
-            Div(Class: "alert alert-warning d-flex align-items-start mt-3")[
-                I(Class: "bi bi-exclamation-triangle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Order:"],
-                    " disposal walks children depth-first, then cancels the parent's lifetime token, then invokes Dispose / DisposeAsync on the parent. ",
-                    "If you need to observe the cancellation token from inside Dispose, it is already in the cancelled state by then — see ",
-                    Code()["/cancellation"], "."
-                ]
-            ],
-            H2(Class: "h4 mt-5 mb-3")["OnUnmount vs IDisposable"],
-            P(Class: "text-secondary")[
-                Code()["OnUnmount"], " / ", Code()["OnUnmountAsync"],
-                " is the framework-side cleanup signal. It fires before the lifetime ",
-                Code()["CancellationToken"],
-                " is cancelled, so cleanup code can still observe the token. Reach for it when the resource is conceptually a ",
-                Em()["lifecycle hook"],
-                " (unsubscribe from an event, stop a timer you started in ", Code()["OnMount"],
-                ") and reserve ", Code()["IDisposable"],
-                " for things you would dispose anyway in non-Rask code (file handles, HTTP responses, DB connections)."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "d-flex gap-2 mb-3")[
-                        Button(
-                            Class: "btn btn-primary btn-sm",
-                            Id: "unmount-hook-mount",
-                            Disabled: _hookMounted,
-                            OnClick: MountHook)[I(Class: "bi bi-play-circle me-1"), "Start ticker"],
-                        Button(
-                            Class: "btn btn-outline-secondary btn-sm",
-                            Id: "unmount-hook-unmount",
-                            Disabled: !_hookMounted,
-                            OnClick: UnmountHook)[I(Class: "bi bi-stop-circle me-1"), "Stop ticker"]
-                    ],
-                    _hookMounted
-                        ? UnmountTimerProbe(AppendHookLog, _nextHookId)
-                        : P(Class: "text-secondary fst-italic mb-0")["Ticker not running."],
-                    LogList(_hookLog, "unmount-hook-log")
-                ]
-            ],
-            CodeSample(
-                """
-                public sealed class UnmountTimerProbe : Component
+
+                protected override void OnUnmount()
                 {
-                    public required Action<string> Log { get; set; }
-                    private Timer? _timer;
-                    private int _ticks;
-
-                    protected override void OnMount()
-                    {
-                        Log("ticker started");
-                        _timer = new Timer(_ => {
-                            _ticks++;
-                            StateHasChanged();
-                        }, null, 1000, 1000);
-                    }
-
-                    protected override void OnUnmount()
-                    {
-                        _timer?.Dispose();
-                        Log($"ticker stopped after {_ticks} tick(s)");
-                    }
-
-                    protected override RenderResult Render() =>
-                        Span()[$"tick {_ticks}"];
+                    _timer?.Dispose();
+                    Log($"ticker stopped after {_ticks} tick(s)");
                 }
-                """,
-                Notes:
-                "No IDisposable on the component. The timer is owned by a render hook, so its cleanup belongs in OnUnmount — symmetric with OnMount. The lifetime CancellationToken is still live here, so you could also pass it to any pending awaits if you wanted to fan out cancellation.")
-        ];
+
+                protected override RenderResult Render() =>
+                    Span()[$"tick {_ticks}"];
+            }
+            """,
+            Notes:
+            "No IDisposable on the component. The timer is owned by a render hook, so its cleanup belongs in OnUnmount — symmetric with OnMount. The lifetime CancellationToken is still live here, so you could also pass it to any pending awaits if you wanted to fan out cancellation.")
+    ];
 
     private static Component LogList(IReadOnlyList<string> entries, string id) =>
         Fragment()[

--- a/samples/Rask.Example.Shared/Pages/DownloadPage.cs
+++ b/samples/Rask.Example.Shared/Pages/DownloadPage.cs
@@ -23,34 +23,34 @@ public sealed class DownloadPage(Navigator nav) : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "File download",
-                "Navigator.Download stages bytes (or a stream) on the active session. On the server they're served from /_rask/download/{sid}/{token}; on WASM they're handed to JS as a base64 payload. The component code is the same."),
-            H2(Class: "h4 mt-4 mb-3")["Generated report"],
-            CodeSample(
-                """
-                public sealed class DownloadPage(Navigator nav) : Component
+    [
+        PageHeader.Render(
+            "File download",
+            "Navigator.Download stages bytes (or a stream) on the active session. On the server they're served from /_rask/download/{sid}/{token}; on WASM they're handed to JS as a base64 payload. The component code is the same."),
+        H2(Class: "h4 mt-4 mb-3")["Generated report"],
+        CodeSample(
+            """
+            public sealed class DownloadPage(Navigator nav) : Component
+            {
+                private int _count;
+
+                private void DownloadReport()
                 {
-                    private int _count;
-
-                    private void DownloadReport()
-                    {
-                        _count++;
-                        var report = $"Generated at {DateTimeOffset.UtcNow}\nCount: {_count}";
-                        nav.Download("report.txt",
-                                     Encoding.UTF8.GetBytes(report),
-                                     "text/plain");
-                    }
-
-                    protected override RenderResult Render() =>
-                        Button(OnClick: DownloadReport)["Download report"];
+                    _count++;
+                    var report = $"Generated at {DateTimeOffset.UtcNow}\nCount: {_count}";
+                    nav.Download("report.txt",
+                                 Encoding.UTF8.GetBytes(report),
+                                 "text/plain");
                 }
-                """,
-                Notes:
-                "Navigator.Download must be called from an event handler — outside that scope it throws, because there's no live render round-trip to attach the download to. The handler can do other state changes too (here, bump a counter); both ship in the same render.",
-                Result: RenderReport())
-        ];
+
+                protected override RenderResult Render() =>
+                    Button(OnClick: DownloadReport)["Download report"];
+            }
+            """,
+            Notes:
+            "Navigator.Download must be called from an event handler — outside that scope it throws, because there's no live render round-trip to attach the download to. The handler can do other state changes too (here, bump a counter); both ship in the same render.",
+            Result: RenderReport())
+    ];
 
     private Component RenderReport() =>
         Div()[

--- a/samples/Rask.Example.Shared/Pages/DragDropPage.cs
+++ b/samples/Rask.Example.Shared/Pages/DragDropPage.cs
@@ -9,7 +9,21 @@ namespace Rask.Example.Shared.Pages;
 [ParentRoute(typeof(ShowcaseLayout))]
 public sealed class DragDropPage : Component
 {
-    private sealed record Card(int Id, string Title);
+    // Demo B — Kanban board. One drop zone per column.
+    private static readonly string[] _columns = ["todo", "doing", "done"];
+
+    private static readonly Dictionary<string, string> _columnLabels = new()
+    {
+        ["todo"] = "To do", ["doing"] = "In progress", ["done"] = "Done"
+    };
+
+    private readonly Dictionary<string, List<Card>> _board = new()
+    {
+        ["todo"] =
+            [new Card(1, "Sketch the API"), new Card(2, "Write the primitive"), new Card(3, "Add the events")],
+        ["doing"] = [new Card(4, "Wire the client JS")],
+        ["done"] = [new Card(5, "Read the codebase")]
+    };
 
     // Demo A — single-list reorder. One drop zone ("list").
     private readonly List<string> _fruits =
@@ -17,60 +31,43 @@ public sealed class DragDropPage : Component
         "Apple", "Banana", "Cherry", "Date", "Elderberry"
     ];
 
-    // Demo B — Kanban board. One drop zone per column.
-    private static readonly string[] _columns = ["todo", "doing", "done"];
-
-    private static readonly Dictionary<string, string> _columnLabels = new()
-    {
-        ["todo"] = "To do",
-        ["doing"] = "In progress",
-        ["done"] = "Done"
-    };
-
-    private readonly Dictionary<string, List<Card>> _board = new()
-    {
-        ["todo"] = [new(1, "Sketch the API"), new(2, "Write the primitive"), new(3, "Add the events")],
-        ["doing"] = [new(4, "Wire the client JS")],
-        ["done"] = [new(5, "Read the codebase")]
-    };
-
     protected override RenderResult Head => Title()["Drag & drop — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Headless drag & drop",
-                "DragDrop is a headless primitive: it owns no DOM and tracks only the in-flight drag, handing your Body delegate a DragDropContext. You draw the items and drop zones, wire the context's DragStart/DragOver/Drop/DragEnd onto them, and move your own data when OnDrop reports where the drag landed. Zones are arbitrary string keys — one zone is a sortable list, several are a Kanban board."),
+    [
+        PageHeader.Render(
+            "Headless drag & drop",
+            "DragDrop is a headless primitive: it owns no DOM and tracks only the in-flight drag, handing your Body delegate a DragDropContext. You draw the items and drop zones, wire the context's DragStart/DragOver/Drop/DragEnd onto them, and move your own data when OnDrop reports where the drag landed. Zones are arbitrary string keys — one zone is a sortable list, several are a Kanban board."),
 
-            SortableDemo(),
-            KanbanDemo(),
+        SortableDemo(),
+        KanbanDemo(),
 
-            CodeSample(
-                """
-                // Headless: DragDrop renders no DOM. You draw the items, wire the
-                // context's delegates, and move your own data when OnDrop fires.
-                DragDrop(
-                    Body: ctx => Ul()[
-                        _fruits.Select((fruit, i) => Li(
-                            Key: fruit,
-                            Draggable: true,
-                            Class: ctx.IsDropTarget("list", i) ? "drop-target" : null,
-                            OnDragStart: ctx.DragStart("list", i),
-                            OnDragOver: ctx.DragOver("list", i),  // optional live highlight
-                            OnDrop: ctx.Drop("list", i),
-                            OnDragEnd: ctx.DragEnd)[fruit])
-                    ],
-                    // move.ApplyTo(list) does the reorder: dragging down lands the item
-                    // after the target, dragging up before it, so either end is reachable.
-                    OnDrop: m => m.ApplyTo(_fruits));
+        CodeSample(
+            """
+            // Headless: DragDrop renders no DOM. You draw the items, wire the
+            // context's delegates, and move your own data when OnDrop fires.
+            DragDrop(
+                Body: ctx => Ul()[
+                    _fruits.Select((fruit, i) => Li(
+                        Key: fruit,
+                        Draggable: true,
+                        Class: ctx.IsDropTarget("list", i) ? "drop-target" : null,
+                        OnDragStart: ctx.DragStart("list", i),
+                        OnDragOver: ctx.DragOver("list", i),  // optional live highlight
+                        OnDrop: ctx.Drop("list", i),
+                        OnDragEnd: ctx.DragEnd)[fruit])
+                ],
+                // move.ApplyTo(list) does the reorder: dragging down lands the item
+                // after the target, dragging up before it, so either end is reachable.
+                OnDrop: m => m.ApplyTo(_fruits));
 
-                // A Kanban board is the same primitive with one zone per column —
-                // OnDrop reports (FromZone, FromIndex) -> (ToZone, ToIndex) so a single
-                // handler moves the card across lists: m.ApplyTo(_board[m.FromZone], _board[m.ToZone]).
-                """,
-                Notes:
-                "Drag handlers are parameterless (like OnClick) — the dragged item's identity rides the handler closure, not the event payload, so no custom wire type is needed. DragDropMove.ApplyTo handles the direction-aware insert math (down-after, up-before) for both same-list and cross-list moves. Items carry a stable Key: so reorders ship trusted keyed structural diff ops that preserve survivors' DOM state.")
-        ];
+            // A Kanban board is the same primitive with one zone per column —
+            // OnDrop reports (FromZone, FromIndex) -> (ToZone, ToIndex) so a single
+            // handler moves the card across lists: m.ApplyTo(_board[m.FromZone], _board[m.ToZone]).
+            """,
+            Notes:
+            "Drag handlers are parameterless (like OnClick) — the dragged item's identity rides the handler closure, not the event payload, so no custom wire type is needed. DragDropMove.ApplyTo handles the direction-aware insert math (down-after, up-before) for both same-list and cross-list moves. Items carry a stable Key: so reorders ship trusted keyed structural diff ops that preserve survivors' DOM state.")
+    ];
 
     // ----- Demo A: sortable list ---------------------------------------------
 
@@ -80,8 +77,8 @@ public sealed class DragDropPage : Component
                 H5(Class: "fw-semibold mb-1")["Sortable list"],
                 P(Class: "text-secondary small")["Drag a fruit and drop it onto another to reorder. One drop zone."],
                 DragDrop(
-                    Body: SortableBody,
-                    OnDrop: ReorderFruit)
+                    SortableBody,
+                    ReorderFruit)
             ]
         ];
 
@@ -129,10 +126,11 @@ public sealed class DragDropPage : Component
         Div(Class: "card shadow-sm border-0 mb-4")[
             Div(Class: "card-body")[
                 H5(Class: "fw-semibold mb-1")["Kanban board"],
-                P(Class: "text-secondary small")["Drag cards between columns, or reorder within one. Each column is a drop zone."],
+                P(Class: "text-secondary small")[
+                    "Drag cards between columns, or reorder within one. Each column is a drop zone."],
                 DragDrop(
-                    Body: KanbanBody,
-                    OnDrop: MoveCard)
+                    KanbanBody,
+                    MoveCard)
             ]
         ];
 
@@ -210,4 +208,6 @@ public sealed class DragDropPage : Component
             move.ApplyTo(from, to);
         }
     }
+
+    private sealed record Card(int Id, string Title);
 }

--- a/samples/Rask.Example.Shared/Pages/ElementRefPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ElementRefPage.cs
@@ -11,33 +11,36 @@ public sealed class ElementRefPage : Component
     protected override RenderResult Head => Title()["Element refs — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Element refs",
-                "Hand a rendered DOM element to JavaScript — for third-party widgets (charts, datepickers, editors) that need the raw node, or for focus and measurement. Rask's analogue of Blazor's ElementReference."),
-            H2(Class: "h4 mt-4 mb-3")["Attach a ref, pass it to JS"],
-            CodeSample(
-                """
-                private readonly ElementRef _input = ElementRef.New();
-                private readonly ElementRef _box   = ElementRef.New();
+    [
+        PageHeader.Render(
+            "Element refs",
+            "Hand a rendered DOM element to JavaScript — for third-party widgets (charts, datepickers, editors) that need the raw node, or for focus and measurement. Rask's analogue of Blazor's ElementReference."),
+        H2(Class: "h4 mt-4 mb-3")["Attach a ref, pass it to JS"],
+        CodeSample(
+            """
+            private readonly ElementRef _input = ElementRef.New();
+            private readonly ElementRef _box   = ElementRef.New();
 
-                Input(Ref: _input)                     // stamps data-rask-ref="…"
-                Div(Ref: _box)[ "…" ]
+            Input(Ref: _input)                     // stamps data-rask-ref="…"
+            Div(Ref: _box)[ "…" ]
 
-                // built-in helper — resolves the ref to the element, then focuses it
-                await _input.FocusAsync(js);
+            // built-in helper — resolves the ref to the element, then focuses it
+            await _input.FocusAsync(js);
 
-                // hand the element to your own scoped JS (it receives the DOM node)
-                var w = await js.InvokeAsync<double>("Rask.ElementRefDemo.width", _box);
-                """,
-                Notes:
-                "An ElementRef stamps data-rask-ref on the element. When you pass it to IJSRuntime, the client's JSON reviver swaps it for document.querySelector('[data-rask-ref=…]'), so your JS function receives the live element — no marker-class convention needed. FocusAsync/BlurAsync/ScrollIntoViewAsync are built in.",
-                Result: ElementRefDemo()),
-            H2(Class: "h4 mt-5 mb-3")["How it works"],
-            Ul(Class: "text-secondary")[
-                Li()["ElementRef is a reference type minted by ElementRef.New() — allocated once (typically a field), so refs cost nothing on the render hot path; the Ref: parameter is a cheap nullable-reference factory param on every element."],
-                Li()["It serializes to {\"__raskRef__\":\"id\"}; both runtimes' revivers resolve that to the DOM element by [data-rask-ref], on Server (over the WS jsInvokes path) and WASM alike."],
-                Li()["The built-in __raskEl helpers (focus/blur/scrollIntoView) receive the resolved element, so common operations need no user JS at all."]
-            ]
-        ];
+            // hand the element to your own scoped JS (it receives the DOM node)
+            var w = await js.InvokeAsync<double>("Rask.ElementRefDemo.width", _box);
+            """,
+            Notes:
+            "An ElementRef stamps data-rask-ref on the element. When you pass it to IJSRuntime, the client's JSON reviver swaps it for document.querySelector('[data-rask-ref=…]'), so your JS function receives the live element — no marker-class convention needed. FocusAsync/BlurAsync/ScrollIntoViewAsync are built in.",
+            Result: ElementRefDemo()),
+        H2(Class: "h4 mt-5 mb-3")["How it works"],
+        Ul(Class: "text-secondary")[
+            Li()[
+                "ElementRef is a reference type minted by ElementRef.New() — allocated once (typically a field), so refs cost nothing on the render hot path; the Ref: parameter is a cheap nullable-reference factory param on every element."],
+            Li()[
+                "It serializes to {\"__raskRef__\":\"id\"}; both runtimes' revivers resolve that to the DOM element by [data-rask-ref], on Server (over the WS jsInvokes path) and WASM alike."],
+            Li()[
+                "The built-in __raskEl helpers (focus/blur/scrollIntoView) receive the resolved element, so common operations need no user JS at all."]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/EventsPage.cs
+++ b/samples/Rask.Example.Shared/Pages/EventsPage.cs
@@ -17,79 +17,79 @@ public sealed class EventsPage : Component
     protected override RenderResult Head => Title()["Events — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Events",
-                "Event handlers are plain delegates on the factory call site — OnClick, OnInput, OnChange, OnSubmit. Each handler triggers a re-render after it runs."),
-            H2(Class: "h4 mt-4 mb-3")["Click"],
-            CodeSample(
-                """
-                Button(OnClick: () => _clicks++)[$"Clicks: {_clicks}"]
-                """,
-                Result: Button(
-                    Class: "btn btn-primary",
-                    OnClick: () => _clicks++)[I(Class: "bi bi-hand-index me-2"), $"Clicks: {_clicks}"]),
-            H2(Class: "h4 mt-5 mb-3")["Input — onInput"],
-            CodeSample(
-                """
-                Input(Type: "text",
-                      Placeholder: "Type something",
-                      OnInput: v => _typed = v)
-                P()[$"You typed: {_typed}"]
-                """,
-                Result: Fragment()[
-                    Input(
-                        "text",
-                        Class: "form-control mb-2",
-                        Placeholder: "Type something",
-                        Value: _typed,
-                        OnInput: v => _typed = v),
-                    P(Class: "small mb-0")[
-                        "You typed: ",
-                        Code()[string.IsNullOrEmpty(_typed) ? "\"\"" : $"\"{_typed}\""]
-                    ]]),
-            H2(Class: "h4 mt-5 mb-3")["Select — onChange"],
-            CodeSample(
-                """
-                Select(OnChange: v => _pick = v)[
-                    Option(Value: "rask")["Rask"],
-                    Option(Value: "blazor")["Blazor"],
-                    Option(Value: "htmx")["htmx"]
-                ]
-                """,
-                Result: Fragment()[
-                    Select(
-                        Class: "form-select mb-2",
-                        OnChange: v => _pick = v)[
-                        Option("rask", _pick == "rask")["Rask"],
-                        Option("blazor", _pick == "blazor")["Blazor"],
-                        Option("htmx", _pick == "htmx")["htmx"]
-                    ],
-                    P(Class: "small mb-0")["Picked: ", Strong()[_pick]]]),
-            H2(Class: "h4 mt-5 mb-3")["Form — onSubmit"],
-            CodeSample(
-                """
-                Form(OnSubmit: fd => _submitted = fd.Get("name"))[
-                         Input(Type: "text", Name: "name", Placeholder: "Your name"),
-                         Button(Type: "submit")["Send"]
-                     ]
-                """,
-                Notes: "OnSubmit receives a FormData object collected from all named form fields.",
-                Result: Fragment()[
-                    Form(OnSubmit: OnSubmit, Class: "mb-2")[
-                        Div(Class: "input-group")[
-                            Input(
-                                "text",
-                                "name",
-                                Class: "form-control",
-                                Placeholder: "Your name"),
-                            Button(
-                                "submit",
-                                Class: "btn btn-primary")[I(Class: "bi bi-send me-1"), "Send"]
-                        ]
-                    ],
-                    P(Class: "small mb-0")["Last submitted: ", Strong()[_submitted]]])
-        ];
+    [
+        PageHeader.Render(
+            "Events",
+            "Event handlers are plain delegates on the factory call site — OnClick, OnInput, OnChange, OnSubmit. Each handler triggers a re-render after it runs."),
+        H2(Class: "h4 mt-4 mb-3")["Click"],
+        CodeSample(
+            """
+            Button(OnClick: () => _clicks++)[$"Clicks: {_clicks}"]
+            """,
+            Result: Button(
+                Class: "btn btn-primary",
+                OnClick: () => _clicks++)[I(Class: "bi bi-hand-index me-2"), $"Clicks: {_clicks}"]),
+        H2(Class: "h4 mt-5 mb-3")["Input — onInput"],
+        CodeSample(
+            """
+            Input(Type: "text",
+                  Placeholder: "Type something",
+                  OnInput: v => _typed = v)
+            P()[$"You typed: {_typed}"]
+            """,
+            Result: Fragment()[
+                Input(
+                    "text",
+                    Class: "form-control mb-2",
+                    Placeholder: "Type something",
+                    Value: _typed,
+                    OnInput: v => _typed = v),
+                P(Class: "small mb-0")[
+                    "You typed: ",
+                    Code()[string.IsNullOrEmpty(_typed) ? "\"\"" : $"\"{_typed}\""]
+                ]]),
+        H2(Class: "h4 mt-5 mb-3")["Select — onChange"],
+        CodeSample(
+            """
+            Select(OnChange: v => _pick = v)[
+                Option(Value: "rask")["Rask"],
+                Option(Value: "blazor")["Blazor"],
+                Option(Value: "htmx")["htmx"]
+            ]
+            """,
+            Result: Fragment()[
+                Select(
+                    Class: "form-select mb-2",
+                    OnChange: v => _pick = v)[
+                    Option("rask", _pick == "rask")["Rask"],
+                    Option("blazor", _pick == "blazor")["Blazor"],
+                    Option("htmx", _pick == "htmx")["htmx"]
+                ],
+                P(Class: "small mb-0")["Picked: ", Strong()[_pick]]]),
+        H2(Class: "h4 mt-5 mb-3")["Form — onSubmit"],
+        CodeSample(
+            """
+            Form(OnSubmit: fd => _submitted = fd.Get("name"))[
+                     Input(Type: "text", Name: "name", Placeholder: "Your name"),
+                     Button(Type: "submit")["Send"]
+                 ]
+            """,
+            Notes: "OnSubmit receives a FormData object collected from all named form fields.",
+            Result: Fragment()[
+                Form(OnSubmit: OnSubmit, Class: "mb-2")[
+                    Div(Class: "input-group")[
+                        Input(
+                            "text",
+                            "name",
+                            Class: "form-control",
+                            Placeholder: "Your name"),
+                        Button(
+                            "submit",
+                            Class: "btn btn-primary")[I(Class: "bi bi-send me-1"), "Send"]
+                    ]
+                ],
+                P(Class: "small mb-0")["Last submitted: ", Strong()[_submitted]]])
+    ];
 
     private void OnSubmit(FormData fd)
     {

--- a/samples/Rask.Example.Shared/Pages/FormGroupsPage.cs
+++ b/samples/Rask.Example.Shared/Pages/FormGroupsPage.cs
@@ -11,29 +11,32 @@ public sealed class FormGroupsPage : Component
     protected override RenderResult Head => Title()["Radio & checkbox groups — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Radio & checkbox groups",
-                "Bind a set of radios to one value, or a set of checkboxes to a collection — one call each, wired into the same EditContext as Input(Bind: …)."),
-            H2(Class: "h4 mt-4 mb-3")["RadioGroup + CheckboxGroup"],
-            CodeSample(
-                """
-                // one value across mutually-exclusive radios
-                RadioGroup(() => _prefs.Plan,
-                           Options: new[] { Plan.Free, Plan.Pro, Plan.Team })
+    [
+        PageHeader.Render(
+            "Radio & checkbox groups",
+            "Bind a set of radios to one value, or a set of checkboxes to a collection — one call each, wired into the same EditContext as Input(Bind: …)."),
+        H2(Class: "h4 mt-4 mb-3")["RadioGroup + CheckboxGroup"],
+        CodeSample(
+            """
+            // one value across mutually-exclusive radios
+            RadioGroup(() => _prefs.Plan,
+                       Options: new[] { Plan.Free, Plan.Pro, Plan.Team })
 
-                // a collection across checkboxes — toggling add/removes the item
-                CheckboxGroup<string>(() => _prefs.Interests,
-                                      Options: new[] { "Web", "Mobile", "AI", "Games" })
-                """,
-                Notes:
-                "Both parse the bind expression, resolve the ambient EditContext, and wire each input's change handler to set the value (radios) or add/remove the item (checkboxes), then re-validate. They render a transparent Fragment of <label><input>…</label>, so you control layout with OptionLabel and ItemClass.",
-                Result: FormGroupsDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Notes"],
-            Ul(Class: "text-secondary")[
-                Li()["RadioGroup binds a single TValue; the option equal to the current value renders checked. CheckboxGroup binds an ICollection<TItem>; the collection is mutated in place on toggle."],
-                Li()["Changing an option re-renders the component that declared the group (the change handler's owner), so a summary like the one above updates immediately."],
-                Li()["Validation rides the same field: each change calls NotifyFieldChanged + ValidateFieldAsync, so DataAnnotations/FluentValidation rules on the bound property apply."]
-            ]
-        ];
+            // a collection across checkboxes — toggling add/removes the item
+            CheckboxGroup<string>(() => _prefs.Interests,
+                                  Options: new[] { "Web", "Mobile", "AI", "Games" })
+            """,
+            Notes:
+            "Both parse the bind expression, resolve the ambient EditContext, and wire each input's change handler to set the value (radios) or add/remove the item (checkboxes), then re-validate. They render a transparent Fragment of <label><input>…</label>, so you control layout with OptionLabel and ItemClass.",
+            Result: FormGroupsDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Notes"],
+        Ul(Class: "text-secondary")[
+            Li()[
+                "RadioGroup binds a single TValue; the option equal to the current value renders checked. CheckboxGroup binds an ICollection<TItem>; the collection is mutated in place on toggle."],
+            Li()[
+                "Changing an option re-renders the component that declared the group (the change handler's owner), so a summary like the one above updates immediately."],
+            Li()[
+                "Validation rides the same field: each change calls NotifyFieldChanged + ValidateFieldAsync, so DataAnnotations/FluentValidation rules on the bound property apply."]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/HomePage.cs
+++ b/samples/Rask.Example.Shared/Pages/HomePage.cs
@@ -1,4 +1,3 @@
-using System.Linq;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Layout;
@@ -9,8 +8,6 @@ namespace Rask.Example.Shared.Pages;
 [ParentRoute(typeof(ShowcaseLayout))]
 public sealed class HomePage(Navigator nav) : Component
 {
-    protected override RenderResult Head => Title()["Welcome — Rask"];
-
     // The showcase index, grouped to mirror the left-hand nav. Every runnable demo page is
     // surfaced here so the home page doubles as a feature map.
     private static readonly string[] SectionOrder =
@@ -50,7 +47,8 @@ public sealed class HomePage(Navigator nav) : Component
         ("Styling", "bi-palette", "Scoped CSS", "Co-located, isolated component styles.", "/scoped-css"),
         ("Styling", "bi-link-45deg", "Asset loading", "Content-addressed scoped assets.", "/asset-loading"),
 
-        ("Data & files", "bi-cloud-arrow-down", "HttpClient + DI", "Inject HttpClient, fetch in OnMountAsync.", "/http"),
+        ("Data & files", "bi-cloud-arrow-down", "HttpClient + DI", "Inject HttpClient, fetch in OnMountAsync.",
+            "/http"),
         ("Data & files", "bi-upload", "File upload", "Staged multipart uploads.", "/upload"),
         ("Data & files", "bi-cloud-download", "File download", "One-shot secure downloads.", "/download"),
 
@@ -58,65 +56,67 @@ public sealed class HomePage(Navigator nav) : Component
         ("Apps", "bi-braces", "IJSRuntime", "Dispatch to scoped JS modules.", "/jsruntime")
     ];
 
+    protected override RenderResult Head => Title()["Welcome — Rask"];
+
     protected override RenderResult Render() =>
-        [
-            Div(Class: "p-4 p-md-5 mb-4 rounded-3 hero-card")[
-                Div(Class: "container-fluid py-3")[
-                    Div(Class: "hero-logo mb-4")[RaskLogo.Mark(76, "heroBolt")],
-                    H1(Class: "display-5 fw-bold mb-3")[
-                        "The Rask framework, ",
-                        Span(Class: "hero-accent")["one page at a time."]
-                    ],
-                    P(Class: "fs-5 col-md-10 hero-lead mb-4")[
-                        "A small C# DSL for HTML — components, routing, lifecycle, scoped CSS, ",
-                        "and a browser-WASM client. This site is itself a Rask WASM app; ",
-                        "every example below renders live in your browser."
-                    ],
-                    Div(Class: "d-flex flex-wrap gap-2")[
-                        Button(
-                            Class: "btn btn-light btn-lg fw-semibold",
-                            OnClick: () => nav.Navigate("/tags"))[I(Class: "bi bi-arrow-right me-2"),
-                            "Start with Tags"],
-                        A("https://github.com/pal-tamas/rask",
-                            "_blank",
-                            Class: "btn btn-outline-light btn-lg")[I(Class: "bi bi-github me-2"),
-                            "Source on GitHub"]
-                    ]
-                ]
-            ],
-            CodeSample(
-                """
-                Fragment(
-                    Doctype(),
-                    Html("en")[
-                        Head()[Title()["Hi"]],
-                        Body()[
-                            H1()["Hello, world!"],
-                            P()["A page rendered with Rask."]
-                        ]
-                    ]
-                );
-                """,
-                "The minimal page",
-                Notes:
-                "Generator-emitted factories build a tree. Strings convert implicitly to Child. Component.ToHtml() produces the final HTML.",
-                Result: Fragment()[
-                    H1(Class: "h3 mb-2")["Hello, world!"],
-                    P(Class: "text-secondary mb-0")["A page rendered with Rask."]
-                ]),
-            H2(Class: "h4 mt-5 mb-1")["Explore the showcase"],
-            P(Class: "text-secondary mb-4")[
-                "Every page on the left has a runnable demo and the C# source that produced it."
-            ],
-            Div()[FeatureIndex()],
-            Div(Class: "alert alert-info d-flex align-items-start")[
-                I(Class: "bi bi-info-circle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Tip:"],
-                    " copy/paste any demo and its source into a fresh Rask project to follow along."
+    [
+        Div(Class: "p-4 p-md-5 mb-4 rounded-3 hero-card")[
+            Div(Class: "container-fluid py-3")[
+                Div(Class: "hero-logo mb-4")[RaskLogo.Mark(76, "heroBolt")],
+                H1(Class: "display-5 fw-bold mb-3")[
+                    "The Rask framework, ",
+                    Span(Class: "hero-accent")["one page at a time."]
+                ],
+                P(Class: "fs-5 col-md-10 hero-lead mb-4")[
+                    "A small C# DSL for HTML — components, routing, lifecycle, scoped CSS, ",
+                    "and a browser-WASM client. This site is itself a Rask WASM app; ",
+                    "every example below renders live in your browser."
+                ],
+                Div(Class: "d-flex flex-wrap gap-2")[
+                    Button(
+                        Class: "btn btn-light btn-lg fw-semibold",
+                        OnClick: () => nav.Navigate("/tags"))[I(Class: "bi bi-arrow-right me-2"),
+                        "Start with Tags"],
+                    A("https://github.com/pal-tamas/rask",
+                        "_blank",
+                        Class: "btn btn-outline-light btn-lg")[I(Class: "bi bi-github me-2"),
+                        "Source on GitHub"]
                 ]
             ]
-        ];
+        ],
+        CodeSample(
+            """
+            Fragment(
+                Doctype(),
+                Html("en")[
+                    Head()[Title()["Hi"]],
+                    Body()[
+                        H1()["Hello, world!"],
+                        P()["A page rendered with Rask."]
+                    ]
+                ]
+            );
+            """,
+            "The minimal page",
+            Notes:
+            "Generator-emitted factories build a tree. Strings convert implicitly to Child. Component.ToHtml() produces the final HTML.",
+            Result: Fragment()[
+                H1(Class: "h3 mb-2")["Hello, world!"],
+                P(Class: "text-secondary mb-0")["A page rendered with Rask."]
+            ]),
+        H2(Class: "h4 mt-5 mb-1")["Explore the showcase"],
+        P(Class: "text-secondary mb-4")[
+            "Every page on the left has a runnable demo and the C# source that produced it."
+        ],
+        Div()[FeatureIndex()],
+        Div(Class: "alert alert-info d-flex align-items-start")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Tip:"],
+                " copy/paste any demo and its source into a fresh Rask project to follow along."
+            ]
+        ]
+    ];
 
     // Yields, per section in display order, a heading followed by a row of feature cards.
     private IEnumerable<Child> FeatureIndex()

--- a/samples/Rask.Example.Shared/Pages/HomePage.cs
+++ b/samples/Rask.Example.Shared/Pages/HomePage.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Layout;
@@ -9,6 +10,53 @@ namespace Rask.Example.Shared.Pages;
 public sealed class HomePage(Navigator nav) : Component
 {
     protected override RenderResult Head => Title()["Welcome — Rask"];
+
+    // The showcase index, grouped to mirror the left-hand nav. Every runnable demo page is
+    // surfaced here so the home page doubles as a feature map.
+    private static readonly string[] SectionOrder =
+        ["DSL", "Components", "Forms", "Styling", "Data & files", "Apps"];
+
+    private static readonly (string Section, string Icon, string Title, string Blurb, string Path)[] Features =
+    [
+        ("DSL", "bi-code-slash", "Tag factories", "Every HTML element, strongly typed.", "/tags"),
+        ("DSL", "bi-asterisk", "Primitives", "Text, Raw, Fragment, Doctype, Child.", "/primitives"),
+        ("DSL", "bi-gear", "Universal props", "Id, Class, Style, Data, Ref on every tag.", "/props"),
+        ("DSL", "bi-vector-pen", "SVG", "Typed SVG components.", "/svg"),
+
+        ("Components", "bi-boxes", "User components", "Sealed classes with generated factories.", "/components"),
+        ("Components", "bi-signpost-2", "Routing", "Attributes, nested layouts, Outlet().", "/routing"),
+        ("Components", "bi-link-45deg", "Route + query params", "Bind URL segments and query.", "/users/42"),
+        ("Components", "bi-compass", "Navigator", "Programmatic navigation.", "/navigator"),
+        ("Components", "bi-arrow-repeat", "Lifecycle", "Mount, props-changed, rendered hooks.", "/lifecycle"),
+        ("Components", "bi-diagram-2", "Context", "Provide and consume without prop drilling.", "/context"),
+        ("Components", "bi-arrow-up-right-circle", "Callbacks", "Child→parent events, auto re-render.", "/callback"),
+        ("Components", "bi-bullseye", "Element refs", "Reach the live DOM from C#.", "/element-ref"),
+        ("Components", "bi-x-circle", "Cancellation", "A token that fires on unmount.", "/cancellation"),
+        ("Components", "bi-trash", "Disposal", "IDisposable / IAsyncDisposable cleanup.", "/disposal"),
+        ("Components", "bi-mouse", "Events", "DOM event handlers.", "/events"),
+        ("Components", "bi-list-ol", "Virtualize", "Headless windowed lists.", "/virtualize"),
+        ("Components", "bi-table", "Data table", "Sortable, paginated table.", "/table"),
+        ("Components", "bi-key", "Keyed lists", "Stable identity for trusted diffs.", "/keyed-lists"),
+        ("Components", "bi-arrows-move", "Drag & drop", "Headless reordering primitive.", "/drag-drop"),
+        ("Components", "bi-graph-up-arrow", "Live ticker", "Server-pushed live updates.", "/realtime/BTC"),
+        ("Components", "bi-person-lock", "User & auth", "Gate UI on the current user.", "/user"),
+        ("Components", "bi-shield-exclamation", "Error boundary", "Catch render and lifecycle errors.", "/boom"),
+
+        ("Forms", "bi-arrow-left-right", "Two-way binding", "() => model.X bindings.", "/binding"),
+        ("Forms", "bi-shield-check", "Validation", "Inline, DataAnnotations, FluentValidation.", "/validation"),
+        ("Forms", "bi-diagram-3", "Complex models", "Nested objects and collections.", "/nested-forms"),
+        ("Forms", "bi-ui-radios", "Radio & checkbox", "RadioGroup and CheckboxGroup.", "/form-groups"),
+
+        ("Styling", "bi-palette", "Scoped CSS", "Co-located, isolated component styles.", "/scoped-css"),
+        ("Styling", "bi-link-45deg", "Asset loading", "Content-addressed scoped assets.", "/asset-loading"),
+
+        ("Data & files", "bi-cloud-arrow-down", "HttpClient + DI", "Inject HttpClient, fetch in OnMountAsync.", "/http"),
+        ("Data & files", "bi-upload", "File upload", "Staged multipart uploads.", "/upload"),
+        ("Data & files", "bi-cloud-download", "File download", "One-shot secure downloads.", "/download"),
+
+        ("Apps", "bi-check2-square", "Todos", "A small end-to-end app.", "/todos"),
+        ("Apps", "bi-braces", "IJSRuntime", "Dispatch to scoped JS modules.", "/jsruntime")
+    ];
 
     protected override RenderResult Render() =>
         [
@@ -56,43 +104,40 @@ public sealed class HomePage(Navigator nav) : Component
                     H1(Class: "h3 mb-2")["Hello, world!"],
                     P(Class: "text-secondary mb-0")["A page rendered with Rask."]
                 ]),
-            H2(Class: "h4 mt-5 mb-3")["What's covered"],
-            Div(Class: "row g-3 mb-4")[
-                FeatureCard("bi-code-slash", "DSL",
-                    "Every HTML element as a strongly-typed factory. Universal Id/Class/Style/Data on every tag.",
-                    "/tags"),
-                FeatureCard("bi-boxes", "Components",
-                    "Sealed classes with Render(). Source-generated factories with required and optional params, DI through the constructor.",
-                    "/components"),
-                FeatureCard("bi-signpost-2", "Routing",
-                    "[Route], [ParentRoute], [RouteParam], [QueryParam]. Nested layouts via Outlet().", "/routing"),
-                FeatureCard("bi-arrow-repeat", "Lifecycle",
-                    "OnMount, OnPropsChanged, OnRendered — sync and async, with auto re-render after each await.",
-                    "/lifecycle"),
-                FeatureCard("bi-x-circle", "Cancellation",
-                    "Every Component exposes a protected CancellationToken that fires on unmount. Pass it into HttpClient or Task.Delay and in-flight work aborts cleanly.",
-                    "/cancellation"),
-                FeatureCard("bi-trash", "Disposal",
-                    "Components that implement IDisposable / IAsyncDisposable get Dispose called when removed from the tree. Use it for timers, subscriptions, or DI handles.",
-                    "/disposal"),
-                FeatureCard("bi-palette", "Scoped CSS",
-                    "Co-locate styles on the component. Rask hashes the type name and rewrites selectors so two components can share .box.",
-                    "/scoped-css"),
-                FeatureCard("bi-cloud-arrow-down", "HttpClient + DI",
-                    "Standard ServiceCollection. Inject HttpClient via the primary constructor and fetch in OnMountAsync.",
-                    "/http")
+            H2(Class: "h4 mt-5 mb-1")["Explore the showcase"],
+            P(Class: "text-secondary mb-4")[
+                "Every page on the left has a runnable demo and the C# source that produced it."
             ],
+            Div()[FeatureIndex()],
             Div(Class: "alert alert-info d-flex align-items-start")[
                 I(Class: "bi bi-info-circle-fill me-3 fs-4"),
                 Div()[
                     Strong()["Tip:"],
-                    " every page on the left has both a runnable demo and the C# source that produced it — copy/paste them into a fresh Rask project to follow along."
+                    " copy/paste any demo and its source into a fresh Rask project to follow along."
                 ]
             ]
         ];
 
+    // Yields, per section in display order, a heading followed by a row of feature cards.
+    private IEnumerable<Child> FeatureIndex()
+    {
+        foreach (var section in SectionOrder)
+        {
+            var cards = Features.Where(f => f.Section == section).ToArray();
+            if (cards.Length == 0)
+            {
+                continue;
+            }
+
+            yield return H3(Class: "h6 fw-bold text-uppercase text-secondary mt-4 mb-3 feature-section")[section];
+            yield return Div(Class: "row g-3")[
+                cards.Select(f => (Child)FeatureCard(f.Icon, f.Title, f.Blurb, f.Path))
+            ];
+        }
+    }
+
     private Component FeatureCard(string icon, string title, string body, string path) =>
-        Div(Class: "col-md-6 col-lg-4")[
+        Div(Class: "col-md-6 col-lg-4", Key: path)[
             Div(Class: "card h-100 border-0 shadow-sm feature-card")[
                 Div(Class: "card-body p-4")[
                     Div(Class: "feature-icon mb-3")[I(Class: $"bi {icon}")],

--- a/samples/Rask.Example.Shared/Pages/HomePage.css
+++ b/samples/Rask.Example.Shared/Pages/HomePage.css
@@ -43,12 +43,30 @@
     color: rgba(255, 255, 255, 0.85);
 }
 
+/* Section dividers in the showcase index. A short accent rule sits to the left of the
+   uppercase label so the grouped grid reads as distinct bands. */
+.feature-section {
+    letter-spacing: 0.06em;
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
+.feature-section::before {
+    content: "";
+    width: 1.5rem;
+    height: 2px;
+    border-radius: 2px;
+    background: var(--rask-accent);
+}
+
 .feature-card {
     transition: transform 140ms ease, box-shadow 140ms ease;
 }
 
 .feature-card:hover {
     transform: translateY(-2px);
+    box-shadow: 0 12px 24px -14px rgba(81, 43, 212, 0.55) !important;
 }
 
 .feature-icon {

--- a/samples/Rask.Example.Shared/Pages/HttpPage.cs
+++ b/samples/Rask.Example.Shared/Pages/HttpPage.cs
@@ -20,11 +20,12 @@ public sealed class HttpPage(HttpClient http) : Component
 
     protected override async Task OnMountAsync()
     {
-        for (var attempt = 0; ; attempt++)
+        for (var attempt = 0;; attempt++)
         {
             try
             {
-                _post = await http.GetFromJsonAsync("data/posts-1.json", HttpJsonContext.Default.Post, CancellationToken);
+                _post = await http.GetFromJsonAsync("data/posts-1.json", HttpJsonContext.Default.Post,
+                    CancellationToken);
                 return;
             }
             // Navigating away unmounts the page and cancels the token — the page is gone, nothing to show.
@@ -40,64 +41,68 @@ public sealed class HttpPage(HttpClient http) : Component
                 catch (OperationCanceledException) { return; }
             }
             // A real HTTP-status failure, or a transport failure that never recovers, surfaces the error banner.
-            catch (Exception ex) { _error = ex.Message; return; }
+            catch (Exception ex)
+            {
+                _error = ex.Message;
+                return;
+            }
         }
     }
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "HttpClient + DI",
-                "HttpClient is registered as a service in Program.cs and injected into pages through their primary constructor. This demo fetches data/posts-1.json — a static JSON file the app serves from its own origin, so the showcase stays self-contained and offline-safe."),
-            H2(Class: "h4 mt-4 mb-3")["Register"],
-            CodeSample(
-                """
-                // Program.cs — point HttpClient at the app's own origin so relative
-                // fetches resolve to the static files it serves itself.
-                var host = WasmHostBuilder.CreateDefault();
-                host.Services.AddSingleton(_ =>
-                    new HttpClient {
-                        BaseAddress = new Uri(WasmHostBuilder.BaseAddress)
-                    });
-                await host.RunAsync<App>();
-                """,
-                Notes:
-                "Relative URLs require BaseAddress. WasmHostBuilder.BaseAddress is the page origin (and carries any sub-path) — read it lazily inside the factory so it fires after the JS module imports."),
-            H2(Class: "h4 mt-5 mb-3")["Inject and fetch"],
-            CodeSample(
-                """
-                [Route("/http")]
-                public sealed class HttpPage(HttpClient http) : Component
-                {
-                    private Post? _post;
+    [
+        PageHeader.Render(
+            "HttpClient + DI",
+            "HttpClient is registered as a service in Program.cs and injected into pages through their primary constructor. This demo fetches data/posts-1.json — a static JSON file the app serves from its own origin, so the showcase stays self-contained and offline-safe."),
+        H2(Class: "h4 mt-4 mb-3")["Register"],
+        CodeSample(
+            """
+            // Program.cs — point HttpClient at the app's own origin so relative
+            // fetches resolve to the static files it serves itself.
+            var host = WasmHostBuilder.CreateDefault();
+            host.Services.AddSingleton(_ =>
+                new HttpClient {
+                    BaseAddress = new Uri(WasmHostBuilder.BaseAddress)
+                });
+            await host.RunAsync<App>();
+            """,
+            Notes:
+            "Relative URLs require BaseAddress. WasmHostBuilder.BaseAddress is the page origin (and carries any sub-path) — read it lazily inside the factory so it fires after the JS module imports."),
+        H2(Class: "h4 mt-5 mb-3")["Inject and fetch"],
+        CodeSample(
+            """
+            [Route("/http")]
+            public sealed class HttpPage(HttpClient http) : Component
+            {
+                private Post? _post;
 
-                    protected override async Task OnMountAsync() =>
-                        _post = await http.GetFromJsonAsync<Post>("data/posts-1.json", CancellationToken);
+                protected override async Task OnMountAsync() =>
+                    _post = await http.GetFromJsonAsync<Post>("data/posts-1.json", CancellationToken);
 
-                    public override RenderResult Render() =>
-                        _post is null
-                            ? P()[Em()["Loading…"]]
-                            : Article()[
-                                H3()[_post.Title],
-                                P()[_post.Body]
-                            ];
-                }
-                """,
-                Notes:
-                "OnMountAsync runs once on first render. The framework's async lifecycle handler triggers a re-render when the awaited task completes. Component.CancellationToken cancels on unmount — navigate away mid-fetch and the in-flight request aborts.",
-                Result: RenderResult()),
-            Div(Class: "alert alert-info d-flex align-items-start mt-4")[
-                I(Class: "bi bi-info-circle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Same demo, two hosts."],
-                    " Under ", Code()["Rask.Example.Server"],
-                    " the request is a loopback call to the server's own static file. Under ",
-                    Code()["Rask.Example.Wasm"],
-                    " (and the GitHub Pages deploy) the browser fetches the same file from the AppBundle. ",
-                    "The page code is identical — only the BaseAddress differs per host."
-                ]
+                public override RenderResult Render() =>
+                    _post is null
+                        ? P()[Em()["Loading…"]]
+                        : Article()[
+                            H3()[_post.Title],
+                            P()[_post.Body]
+                        ];
+            }
+            """,
+            Notes:
+            "OnMountAsync runs once on first render. The framework's async lifecycle handler triggers a re-render when the awaited task completes. Component.CancellationToken cancels on unmount — navigate away mid-fetch and the in-flight request aborts.",
+            Result: RenderResult()),
+        Div(Class: "alert alert-info d-flex align-items-start mt-4")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Same demo, two hosts."],
+                " Under ", Code()["Rask.Example.Server"],
+                " the request is a loopback call to the server's own static file. Under ",
+                Code()["Rask.Example.Wasm"],
+                " (and the GitHub Pages deploy) the browser fetches the same file from the AppBundle. ",
+                "The page code is identical — only the BaseAddress differs per host."
             ]
-        ];
+        ]
+    ];
 
     private Component RenderResult()
     {

--- a/samples/Rask.Example.Shared/Pages/JsRuntimePage.cs
+++ b/samples/Rask.Example.Shared/Pages/JsRuntimePage.cs
@@ -1,5 +1,6 @@
 using Microsoft.JSInterop;
 using Rask.Core.Routing;
+using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Layout;
 
 namespace Rask.Example.Shared.Pages;
@@ -40,7 +41,9 @@ public sealed class JsRuntimePage(IJSRuntime js) : Component
 
     protected override RenderResult Render() =>
         [
-            H1(Class: "h3 mt-2 mb-3")["IJSRuntime — sessionStorage round-trip"],
+            PageHeader.Render(
+                "IJSRuntime — sessionStorage round-trip",
+                "Call into window APIs from C# and await the result, identically on Server and WASM."),
             P(Class: "text-secondary")[
                 "Type a value, click ", Strong()["Set"], " to write it to ",
                 Code()["sessionStorage"], " via ", Code()["IJSRuntime.InvokeVoidAsync"],

--- a/samples/Rask.Example.Shared/Pages/JsRuntimePage.cs
+++ b/samples/Rask.Example.Shared/Pages/JsRuntimePage.cs
@@ -40,55 +40,55 @@ public sealed class JsRuntimePage(IJSRuntime js) : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "IJSRuntime — sessionStorage round-trip",
-                "Call into window APIs from C# and await the result, identically on Server and WASM."),
-            P(Class: "text-secondary")[
-                "Type a value, click ", Strong()["Set"], " to write it to ",
-                Code()["sessionStorage"], " via ", Code()["IJSRuntime.InvokeVoidAsync"],
-                ". Click ", Strong()["Read"], " to read it back. Refresh the page — ",
-                Code()["OnRendered"], " reads the saved value automatically on the next mount."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "mb-3")[
-                        Label(Class: "form-label", For: "demo-input")["sessionStorage value"],
-                        Input(
-                            Id: "demo-input",
-                            Class: "form-control",
-                            Value: _input,
-                            OnInput: v => _input = v)
-                    ],
-                    Div(Class: "d-flex gap-2 flex-wrap mb-3")[
-                        Button(Class: "btn btn-primary btn-sm", Id: "demo-set", OnClickAsync: SetAsync)[
-                            I(Class: "bi bi-save me-1"), "Set"],
-                        Button(Class: "btn btn-outline-primary btn-sm", Id: "demo-read", OnClickAsync: ReadAsync)[
-                            I(Class: "bi bi-arrow-clockwise me-1"), "Read"],
-                        Button(Class: "btn btn-outline-danger btn-sm", Id: "demo-remove", OnClickAsync: RemoveAsync)[
-                            I(Class: "bi bi-trash me-1"), "Remove"]
-                    ],
-                    Div(Class: "mb-2")[
-                        Span(Class: "text-secondary small text-uppercase")["Last read"],
-                        Div()[Code(Class: "fs-6", Id: "demo-last-read")[_lastRead ?? "(null)"]]
-                    ],
-                    Div()[
-                        Span(Class: "text-secondary small text-uppercase")["Status"],
-                        Div()[Code(Class: "fs-6", Id: "demo-status")[_status ?? "(idle)"]]
-                    ]
-                ]
-            ],
-            Div(Class: "alert alert-info d-flex align-items-start")[
-                I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+    [
+        PageHeader.Render(
+            "IJSRuntime — sessionStorage round-trip",
+            "Call into window APIs from C# and await the result, identically on Server and WASM."),
+        P(Class: "text-secondary")[
+            "Type a value, click ", Strong()["Set"], " to write it to ",
+            Code()["sessionStorage"], " via ", Code()["IJSRuntime.InvokeVoidAsync"],
+            ". Click ", Strong()["Read"], " to read it back. Refresh the page — ",
+            Code()["OnRendered"], " reads the saved value automatically on the next mount."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "mb-3")[
+                    Label(Class: "form-label", For: "demo-input")["sessionStorage value"],
+                    Input(
+                        Id: "demo-input",
+                        Class: "form-control",
+                        Value: _input,
+                        OnInput: v => _input = v)
+                ],
+                Div(Class: "d-flex gap-2 flex-wrap mb-3")[
+                    Button(Class: "btn btn-primary btn-sm", Id: "demo-set", OnClickAsync: SetAsync)[
+                        I(Class: "bi bi-save me-1"), "Set"],
+                    Button(Class: "btn btn-outline-primary btn-sm", Id: "demo-read", OnClickAsync: ReadAsync)[
+                        I(Class: "bi bi-arrow-clockwise me-1"), "Read"],
+                    Button(Class: "btn btn-outline-danger btn-sm", Id: "demo-remove", OnClickAsync: RemoveAsync)[
+                        I(Class: "bi bi-trash me-1"), "Remove"]
+                ],
+                Div(Class: "mb-2")[
+                    Span(Class: "text-secondary small text-uppercase")["Last read"],
+                    Div()[Code(Class: "fs-6", Id: "demo-last-read")[_lastRead ?? "(null)"]]
+                ],
                 Div()[
-                    Strong()["What's happening:"],
-                    " On Server each call queues a global-JS invoke onto the next outbound WS frame; on WASM the call goes through the in-process JS bridge. ",
-                    "Either runtime resolves the dotted identifier on ", Code()["window"], " (e.g. ",
-                    Code()["sessionStorage.getItem"], "), invokes it, then ships the result back ",
-                    "to the awaiting ", Code()["ValueTask<T>"], "."
+                    Span(Class: "text-secondary small text-uppercase")["Status"],
+                    Div()[Code(Class: "fs-6", Id: "demo-status")[_status ?? "(idle)"]]
                 ]
             ]
-        ];
+        ],
+        Div(Class: "alert alert-info d-flex align-items-start")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["What's happening:"],
+                " On Server each call queues a global-JS invoke onto the next outbound WS frame; on WASM the call goes through the in-process JS bridge. ",
+                "Either runtime resolves the dotted identifier on ", Code()["window"], " (e.g. ",
+                Code()["sessionStorage.getItem"], "), invokes it, then ships the result back ",
+                "to the awaiting ", Code()["ValueTask<T>"], "."
+            ]
+        ]
+    ];
 
     private async Task SetAsync()
     {

--- a/samples/Rask.Example.Shared/Pages/KeyedListsPage.cs
+++ b/samples/Rask.Example.Shared/Pages/KeyedListsPage.cs
@@ -8,8 +8,6 @@ namespace Rask.Example.Shared.Pages;
 [ParentRoute(typeof(ShowcaseLayout))]
 public sealed class KeyedListsPage : Component
 {
-    private sealed record Fruit(int Id, string Name);
-
     private readonly List<Fruit> _items =
     [
         new(1, "Apple"),
@@ -19,91 +17,92 @@ public sealed class KeyedListsPage : Component
         new(5, "Elderberry")
     ];
 
-    private bool _useKeys = true;
     private int _nextId = 6;
+
+    private bool _useKeys = true;
 
     protected override RenderResult Head => Title()["Keyed lists — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Keyed lists & reconciliation",
-                "Give each list item a stable Key: and the diff codec reconciles by identity — inserts, removals, and reorders ship as trusted structural ops that preserve the survivors' DOM state (focus, selection, uncommitted input text) instead of rewriting rows by position."),
+    [
+        PageHeader.Render(
+            "Keyed lists & reconciliation",
+            "Give each list item a stable Key: and the diff codec reconciles by identity — inserts, removals, and reorders ship as trusted structural ops that preserve the survivors' DOM state (focus, selection, uncommitted input text) instead of rewriting rows by position."),
 
-            Div(Class: "alert alert-primary d-flex align-items-start")[
-                I(Class: "bi bi-lightbulb-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Try it:"],
-                    " type something into a couple of the inputs below, then press ", Strong()["Rotate"],
-                    " or ", Strong()["Reverse"], ". With keys ", Strong()["on"],
-                    ", your typed text travels with its fruit (the row's DOM node is moved). Turn keys ",
-                    Strong()["off"], " and repeat — the labels reorder but the inputs stay put, so your text ends up next to the wrong fruit (positional reconciliation)."
-                ]
-            ],
-
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "d-flex flex-wrap align-items-center gap-2 mb-3")[
-                        Button(
-                            Class: _useKeys ? "btn btn-success btn-sm" : "btn btn-outline-secondary btn-sm",
-                            Id: "kl-toggle-keys",
-                            OnClick: () => _useKeys = !_useKeys)[
-                            I(Class: _useKeys ? "bi bi-key-fill me-1" : "bi bi-key me-1"),
-                            _useKeys ? "Keys: ON" : "Keys: OFF"
-                        ],
-                        Span(Class: "vr mx-1"),
-                        Button(Class: "btn btn-outline-primary btn-sm", Id: "kl-rotate", OnClick: Rotate)[
-                            I(Class: "bi bi-arrow-down-up me-1"), "Rotate"
-                        ],
-                        Button(Class: "btn btn-outline-primary btn-sm", Id: "kl-reverse", OnClick: Reverse)[
-                            I(Class: "bi bi-arrow-repeat me-1"), "Reverse"
-                        ],
-                        Button(Class: "btn btn-outline-primary btn-sm", Id: "kl-add", OnClick: AddTop)[
-                            I(Class: "bi bi-plus-lg me-1"), "Add to top"
-                        ],
-                        Button(
-                            Class: "btn btn-outline-danger btn-sm",
-                            Id: "kl-remove",
-                            Disabled: _items.Count == 0,
-                            OnClick: RemoveTop)[
-                            I(Class: "bi bi-dash-lg me-1"), "Remove top"
-                        ]
-                    ],
-
-                    Ul(Class: "list-group", Id: "kl-list")[BuildRows()]
-                ]
-            ],
-
-            CodeSample(
-                """
-                // Keyed: a stable Key: per row. Reorders ship trusted Move ops, so the DOM
-                // node (and its focus / uncommitted input value) follows its logical row.
-                Ul()[
-                    _items.Select(f => Li(Key: f.Id, Class: "list-group-item")[
-                        Span()[f.Name],
-                        Input(Type: "text")          // unbound — its value lives only in the DOM
-                    ])
-                ]
-
-                // Keyless: the same list with no Key reconciles by position — an insert or
-                // reorder rewrites each slot in place, so DOM state does not follow the row.
-                // (The analyzer flags this with RASK022.)
-                """,
-                Notes:
-                "Key is an identity, not a reactive prop: a Key change mounts a fresh instance and never fires OnPropsChanged. On an element Key emits data-rask-key; on a transparent component or Fragment it auto-forwards onto the first rendered element. RASK022 warns when a projected/looped list item is missing a Key."),
-
-            Div(Class: "alert alert-warning d-flex align-items-start mt-3")[
-                I(Class: "bi bi-exclamation-triangle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["RASK022:"],
-                    " a list item produced by ", Code()["Select(...)"], " / ", Code()["SelectMany(...)"],
-                    " or added to a ", Code()["List<Child>"], " in a loop without a ", Code()["Key:"],
-                    " raises a build warning. The keyless branch on this page suppresses it on purpose with ",
-                    Code()["#pragma warning disable RASK022"], " — promote it to an error in your own project with ",
-                    Code()["<WarningsAsErrors>RASK022</WarningsAsErrors>"], "."
-                ]
+        Div(Class: "alert alert-primary d-flex align-items-start")[
+            I(Class: "bi bi-lightbulb-fill me-3 fs-4"),
+            Div()[
+                Strong()["Try it:"],
+                " type something into a couple of the inputs below, then press ", Strong()["Rotate"],
+                " or ", Strong()["Reverse"], ". With keys ", Strong()["on"],
+                ", your typed text travels with its fruit (the row's DOM node is moved). Turn keys ",
+                Strong()["off"],
+                " and repeat — the labels reorder but the inputs stay put, so your text ends up next to the wrong fruit (positional reconciliation)."
             ]
-        ];
+        ],
+
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex flex-wrap align-items-center gap-2 mb-3")[
+                    Button(
+                        Class: _useKeys ? "btn btn-success btn-sm" : "btn btn-outline-secondary btn-sm",
+                        Id: "kl-toggle-keys",
+                        OnClick: () => _useKeys = !_useKeys)[
+                        I(Class: _useKeys ? "bi bi-key-fill me-1" : "bi bi-key me-1"),
+                        _useKeys ? "Keys: ON" : "Keys: OFF"
+                    ],
+                    Span(Class: "vr mx-1"),
+                    Button(Class: "btn btn-outline-primary btn-sm", Id: "kl-rotate", OnClick: Rotate)[
+                        I(Class: "bi bi-arrow-down-up me-1"), "Rotate"
+                    ],
+                    Button(Class: "btn btn-outline-primary btn-sm", Id: "kl-reverse", OnClick: Reverse)[
+                        I(Class: "bi bi-arrow-repeat me-1"), "Reverse"
+                    ],
+                    Button(Class: "btn btn-outline-primary btn-sm", Id: "kl-add", OnClick: AddTop)[
+                        I(Class: "bi bi-plus-lg me-1"), "Add to top"
+                    ],
+                    Button(
+                        Class: "btn btn-outline-danger btn-sm",
+                        Id: "kl-remove",
+                        Disabled: _items.Count == 0,
+                        OnClick: RemoveTop)[
+                        I(Class: "bi bi-dash-lg me-1"), "Remove top"
+                    ]
+                ],
+                Ul(Class: "list-group", Id: "kl-list")[BuildRows()]
+            ]
+        ],
+
+        CodeSample(
+            """
+            // Keyed: a stable Key: per row. Reorders ship trusted Move ops, so the DOM
+            // node (and its focus / uncommitted input value) follows its logical row.
+            Ul()[
+                _items.Select(f => Li(Key: f.Id, Class: "list-group-item")[
+                    Span()[f.Name],
+                    Input(Type: "text")          // unbound — its value lives only in the DOM
+                ])
+            ]
+
+            // Keyless: the same list with no Key reconciles by position — an insert or
+            // reorder rewrites each slot in place, so DOM state does not follow the row.
+            // (The analyzer flags this with RASK022.)
+            """,
+            Notes:
+            "Key is an identity, not a reactive prop: a Key change mounts a fresh instance and never fires OnPropsChanged. On an element Key emits data-rask-key; on a transparent component or Fragment it auto-forwards onto the first rendered element. RASK022 warns when a projected/looped list item is missing a Key."),
+
+        Div(Class: "alert alert-warning d-flex align-items-start mt-3")[
+            I(Class: "bi bi-exclamation-triangle-fill me-3 fs-4"),
+            Div()[
+                Strong()["RASK022:"],
+                " a list item produced by ", Code()["Select(...)"], " / ", Code()["SelectMany(...)"],
+                " or added to a ", Code()["List<Child>"], " in a loop without a ", Code()["Key:"],
+                " raises a build warning. The keyless branch on this page suppresses it on purpose with ",
+                Code()["#pragma warning disable RASK022"], " — promote it to an error in your own project with ",
+                Code()["<WarningsAsErrors>RASK022</WarningsAsErrors>"], "."
+            ]
+        ]
+    ];
 
     private List<Child> BuildRows()
     {
@@ -128,7 +127,7 @@ public sealed class KeyedListsPage : Component
         Span(Class: "badge bg-secondary rounded-pill")[index + 1],
         Span(Class: "fw-semibold", Style: "min-width: 7rem;")[f.Name],
         Input(
-            Type: "text",
+            "text",
             Class: "form-control form-control-sm kl-note",
             Placeholder: "type here, then reorder…")
     ];
@@ -160,4 +159,6 @@ public sealed class KeyedListsPage : Component
             _items.RemoveAt(0);
         }
     }
+
+    private sealed record Fruit(int Id, string Name);
 }

--- a/samples/Rask.Example.Shared/Pages/LifecyclePage.cs
+++ b/samples/Rask.Example.Shared/Pages/LifecyclePage.cs
@@ -15,110 +15,110 @@ public sealed class LifecyclePage : Component
     protected override RenderResult Head => Title()["Lifecycle — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Lifecycle hooks",
-                "Every Component can override the lifecycle hooks below. Async hooks install a synchronization context that triggers a re-render after each in-method await, plus one terminal render on completion."),
-            H2(Class: "h4 mt-4 mb-3")["Live probe"],
-            P(Class: "text-secondary")[
-                "The component below records every hook invocation into a list and re-renders so you can watch the order."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[LifecycleProbe()]
-            ],
-            H2(Class: "h4 mt-5 mb-3")["Mount / unmount cycle"],
-            P(Class: "text-secondary")[
-                "Toggle the probe in and out of the tree to watch ", Code()["OnUnmount"],
-                " and ", Code()["OnUnmountAsync"], " fire. The log is held by the parent so it survives the unmount."
-            ],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "d-flex gap-2 mb-3")[
-                        Button(
-                            Class: "btn btn-primary btn-sm",
-                            Id: "lifecycle-cycle-mount",
-                            Disabled: _cycleMounted,
-                            OnClick: MountCycle)[I(Class: "bi bi-play-circle me-1"), "Mount probe"],
-                        Button(
-                            Class: "btn btn-outline-secondary btn-sm",
-                            Id: "lifecycle-cycle-unmount",
-                            Disabled: !_cycleMounted,
-                            OnClick: UnmountCycle)[I(Class: "bi bi-stop-circle me-1"), "Unmount probe"]
-                    ],
-                    _cycleMounted
-                        ? LifecycleCycleProbe(AppendCycleLog, _nextCycleId)
-                        : P(Class: "text-secondary fst-italic mb-0")["Probe not mounted."],
-                    H3(Class: "h6 text-secondary text-uppercase small mt-4")["Log"],
-                    _cycleLog.Count == 0
-                        ? P(Class: "text-secondary small mb-0")["Empty — mount and unmount the probe."]
-                        : Ol(
-                            Class: "list-group list-group-numbered list-group-flush",
-                            Id: "lifecycle-cycle-log")[
-                            _cycleLog.Select((l, i) => Li(Key: i,
-                                Class: "list-group-item ps-2 small")[Code(Class: "small")[l]]).ToArray()]
-                ]
-            ],
-            H2(Class: "h4 mt-5 mb-3")["Source"],
-            CodeSample(
-                """
-                public sealed class LifecycleProbe : Component
-                {
-                    private readonly List<string> _log = new();
-                    private int _renderCount;
-
-                    protected override void OnMount() =>
-                        _log.Add("OnMount");
-
-                    protected override async Task OnMountAsync()
-                    {
-                        _log.Add("OnMountAsync (start)");
-                        await Task.Delay(450);
-                        _log.Add("OnMountAsync (after 450ms await)");
-                    }
-
-                    protected override void OnPropsChanged() =>
-                        _log.Add($"OnPropsChanged (render #{_renderCount + 1})");
-
-                    protected override Task OnPropsChangedAsync()
-                    {
-                        _log.Add("OnPropsChangedAsync");
-                        return Task.CompletedTask;
-                    }
-
-                    protected override void OnRendered(bool firstRender) =>
-                        _log.Add($"OnRendered(firstRender: {firstRender})");
-
-                    // Symmetric with OnMount — fires once when the component leaves the
-                    // tree (navigation, parent diff, session teardown). The lifetime
-                    // CancellationToken is still live; it cancels right after.
-                    protected override void OnUnmount() =>
-                        _log.Add("OnUnmount");
-
-                    protected override Task OnUnmountAsync()
-                    {
-                        _log.Add("OnUnmountAsync");
-                        return Task.CompletedTask;
-                    }
-
-                    public override RenderResult Render()
-                    {
-                        _renderCount++;
-                        return /* ... */;
-                    }
-                }
-                """,
-                Notes:
-                "OnMount* fires once on first creation; OnPropsChanged* on first render and whenever a bound prop or route/query param actually changes — a bare event-handler re-render (like the Trigger button above) does NOT refire it; OnRendered* after every render commits; OnUnmount* once on disposal (children before parents). StateHasChanged() inside OnUnmount* is a no-op — the component is already leaving the tree."),
-            Div(Class: "alert alert-danger d-flex align-items-start mt-3")[
-                I(Class: "bi bi-exclamation-triangle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Failure model:"],
-                    " if an async hook faults, the framework logs the exception to ",
-                    Code()["Console.Error"],
-                    " and does NOT trigger a re-render — so a component stuck on a loading placeholder is usually a hook that threw."
-                ]
+    [
+        PageHeader.Render(
+            "Lifecycle hooks",
+            "Every Component can override the lifecycle hooks below. Async hooks install a synchronization context that triggers a re-render after each in-method await, plus one terminal render on completion."),
+        H2(Class: "h4 mt-4 mb-3")["Live probe"],
+        P(Class: "text-secondary")[
+            "The component below records every hook invocation into a list and re-renders so you can watch the order."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[LifecycleProbe()]
+        ],
+        H2(Class: "h4 mt-5 mb-3")["Mount / unmount cycle"],
+        P(Class: "text-secondary")[
+            "Toggle the probe in and out of the tree to watch ", Code()["OnUnmount"],
+            " and ", Code()["OnUnmountAsync"], " fire. The log is held by the parent so it survives the unmount."
+        ],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 mb-3")[
+                    Button(
+                        Class: "btn btn-primary btn-sm",
+                        Id: "lifecycle-cycle-mount",
+                        Disabled: _cycleMounted,
+                        OnClick: MountCycle)[I(Class: "bi bi-play-circle me-1"), "Mount probe"],
+                    Button(
+                        Class: "btn btn-outline-secondary btn-sm",
+                        Id: "lifecycle-cycle-unmount",
+                        Disabled: !_cycleMounted,
+                        OnClick: UnmountCycle)[I(Class: "bi bi-stop-circle me-1"), "Unmount probe"]
+                ],
+                _cycleMounted
+                    ? LifecycleCycleProbe(AppendCycleLog, _nextCycleId)
+                    : P(Class: "text-secondary fst-italic mb-0")["Probe not mounted."],
+                H3(Class: "h6 text-secondary text-uppercase small mt-4")["Log"],
+                _cycleLog.Count == 0
+                    ? P(Class: "text-secondary small mb-0")["Empty — mount and unmount the probe."]
+                    : Ol(
+                        Class: "list-group list-group-numbered list-group-flush",
+                        Id: "lifecycle-cycle-log")[
+                        _cycleLog.Select((l, i) => Li(Key: i,
+                            Class: "list-group-item ps-2 small")[Code(Class: "small")[l]]).ToArray()]
             ]
-        ];
+        ],
+        H2(Class: "h4 mt-5 mb-3")["Source"],
+        CodeSample(
+            """
+            public sealed class LifecycleProbe : Component
+            {
+                private readonly List<string> _log = new();
+                private int _renderCount;
+
+                protected override void OnMount() =>
+                    _log.Add("OnMount");
+
+                protected override async Task OnMountAsync()
+                {
+                    _log.Add("OnMountAsync (start)");
+                    await Task.Delay(450);
+                    _log.Add("OnMountAsync (after 450ms await)");
+                }
+
+                protected override void OnPropsChanged() =>
+                    _log.Add($"OnPropsChanged (render #{_renderCount + 1})");
+
+                protected override Task OnPropsChangedAsync()
+                {
+                    _log.Add("OnPropsChangedAsync");
+                    return Task.CompletedTask;
+                }
+
+                protected override void OnRendered(bool firstRender) =>
+                    _log.Add($"OnRendered(firstRender: {firstRender})");
+
+                // Symmetric with OnMount — fires once when the component leaves the
+                // tree (navigation, parent diff, session teardown). The lifetime
+                // CancellationToken is still live; it cancels right after.
+                protected override void OnUnmount() =>
+                    _log.Add("OnUnmount");
+
+                protected override Task OnUnmountAsync()
+                {
+                    _log.Add("OnUnmountAsync");
+                    return Task.CompletedTask;
+                }
+
+                public override RenderResult Render()
+                {
+                    _renderCount++;
+                    return /* ... */;
+                }
+            }
+            """,
+            Notes:
+            "OnMount* fires once on first creation; OnPropsChanged* on first render and whenever a bound prop or route/query param actually changes — a bare event-handler re-render (like the Trigger button above) does NOT refire it; OnRendered* after every render commits; OnUnmount* once on disposal (children before parents). StateHasChanged() inside OnUnmount* is a no-op — the component is already leaving the tree."),
+        Div(Class: "alert alert-danger d-flex align-items-start mt-3")[
+            I(Class: "bi bi-exclamation-triangle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Failure model:"],
+                " if an async hook faults, the framework logs the exception to ",
+                Code()["Console.Error"],
+                " and does NOT trigger a re-render — so a component stuck on a loading placeholder is usually a hook that threw."
+            ]
+        ]
+    ];
 
     private void MountCycle()
     {

--- a/samples/Rask.Example.Shared/Pages/LiveTickerPage.cs
+++ b/samples/Rask.Example.Shared/Pages/LiveTickerPage.cs
@@ -15,115 +15,117 @@ public sealed class LiveTickerPage(Navigator nav) : Component
     protected override RenderResult Head => Title()[$"{Symbol} live ticker — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                $"{Symbol} live ticker",
-                "A widget that exercises the lifecycle hooks. The Symbol comes from the [RouteParam] in the URL; switching it flips the route param and exercises OnPropsChanged. The poll loop in OnMountAsync drifts a synthetic price each tick (so the demo is deterministic and offline-safe). The chart is a server-rendered SVG drawn straight from the rolling buffer — no Chart.js, no canvas, and no JavaScript at all."),
-            Div(Class: "btn-group mb-3", Id: "ticker-symbol-switcher")[
-                SwitchButton("BTC"),
-                SwitchButton("ETH"),
-                SwitchButton("SOL")
+    [
+        PageHeader.Render(
+            $"{Symbol} live ticker",
+            "A widget that exercises the lifecycle hooks. The Symbol comes from the [RouteParam] in the URL; switching it flips the route param and exercises OnPropsChanged. The poll loop in OnMountAsync drifts a synthetic price each tick (so the demo is deterministic and offline-safe). The chart is a server-rendered SVG drawn straight from the rolling buffer — no Chart.js, no canvas, and no JavaScript at all."),
+        Div(Class: "btn-group mb-3", Id: "ticker-symbol-switcher")[
+            SwitchButton("BTC"),
+            SwitchButton("ETH"),
+            SwitchButton("SOL")
+        ],
+        Div(Class: "row g-4")[
+            Div(Class: "col-lg-7")[
+                LiveTicker(Symbol, Log: AppendLog)
             ],
-            Div(Class: "row g-4")[
-                Div(Class: "col-lg-7")[
-                    LiveTicker(Symbol: Symbol, Log: AppendLog)
-                ],
-                Div(Class: "col-lg-5")[
-                    Div(Class: "card border-0 bg-light h-100")[
-                        Div(Class: "card-body")[
-                            Div(Class: "d-flex justify-content-between align-items-baseline mb-3")[
-                                H3(Class: "h6 text-secondary text-uppercase small mb-0")["Hook activity"],
-                                Button(
-                                    Class: "btn btn-sm btn-link p-0 text-decoration-none",
-                                    Id: "ticker-clear-log",
-                                    OnClick: ClearLog)["clear"]
-                            ],
-                            _log.Count == 0
-                                ? P(Class: "text-secondary fst-italic small mb-0")[
-                                    "Empty — hooks will fire as the component mounts and ticks."]
-                                : (Component)Ol(
-                                    Class: "list-group list-group-numbered list-group-flush",
-                                    Id: "ticker-log",
-                                    Style: "max-height: 360px; overflow-y: auto;")[
-                                    _log.Select((l, i) => Li(Key: i,
-                                        Class: "list-group-item ps-2 small bg-transparent")[
-                                        Code(Class: "small")[l]]).ToArray()]
-                        ]
+            Div(Class: "col-lg-5")[
+                Div(Class: "card border-0 bg-light h-100")[
+                    Div(Class: "card-body")[
+                        Div(Class: "d-flex justify-content-between align-items-baseline mb-3")[
+                            H3(Class: "h6 text-secondary text-uppercase small mb-0")["Hook activity"],
+                            Button(
+                                Class: "btn btn-sm btn-link p-0 text-decoration-none",
+                                Id: "ticker-clear-log",
+                                OnClick: ClearLog)["clear"]
+                        ],
+                        _log.Count == 0
+                            ? P(Class: "text-secondary fst-italic small mb-0")[
+                                "Empty — hooks will fire as the component mounts and ticks."]
+                            : (Component)Ol(
+                                Class: "list-group list-group-numbered list-group-flush",
+                                Id: "ticker-log",
+                                Style: "max-height: 360px; overflow-y: auto;")[
+                                _log.Select((l, i) => Li(Key: i,
+                                    Class: "list-group-item ps-2 small bg-transparent")[
+                                    Code(Class: "small")[l]]).ToArray()]
                     ]
                 ]
-            ],
-            H2(Class: "h4 mt-5 mb-3")["What each hook does here"],
-            P(Class: "text-secondary")[
-                "Every override in ", Code()["LiveTicker"], " has a natural production job. Click ",
-                Code()["ETH"], " or ", Code()["SOL"], " above to watch the OnPropsChanged + OnPropsChangedAsync entries fire, then click ",
-                A("/lifecycle", "_self", Class: "")["Lifecycle"], " in the sidebar to navigate away and see ",
-                Code()["OnUnmount"], " + ", Code()["OnUnmountAsync"], " (the log lives on the page, so unmount entries survive)."
-            ],
-            CodeSample(
-                """
-                public sealed class LiveTicker : Component
-                {
-                    public string Symbol { get; set; } = "BTC";
-                    public int Interval { get; set; } = 1000;
-
-                    protected override void OnMount() { /* record _mountedAt */ }
-
-                    protected override async Task OnMountAsync()
-                    {
-                        var ct = CancellationToken;   // cancels on unmount
-                        try
-                        {
-                            while (!ct.IsCancellationRequested)
-                            {
-                                var wake = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                                Interlocked.Exchange(ref _wake, wake)?.Dispose();
-                                await PollOnceAsync(ct).ConfigureAwait(false);  // synthetic feed → history
-                                try { await Task.Delay(Interval, wake.Token).ConfigureAwait(false); }
-                                catch (OperationCanceledException) when (!ct.IsCancellationRequested) { }
-                            }
-                        }
-                        catch (OperationCanceledException) { /* unmount */ }
-                    }
-
-                    protected override void OnPropsChanged() { /* detect Symbol change */ }
-
-                    protected override Task OnPropsChangedAsync()
-                    {
-                        if (_lastSymbol is not null && _lastSymbol != Symbol)
-                        {
-                            _history.Clear();         // start the new symbol fresh
-                            _wake?.Cancel();          // poll the new symbol immediately
-                        }
-                        _lastSymbol = Symbol;
-                        return Task.CompletedTask;
-                    }
-
-                    protected override void OnRendered(bool firstRender) { /* paint latency */ }
-
-                    protected override void OnUnmount() { /* sync log */ }
-
-                    protected override async Task OnUnmountAsync() =>
-                        await Task.Delay(50); // stand-in for POST /stats/session-end
-
-                    protected override RenderResult Render() =>
-                        // The chart is just SVG — no Chart.js, no canvas, no JS round-trip.
-                        Sparkline(Values: _history.Select(p => (double)p.PriceUsd).ToList());
-                }
-                """,
-                Notes:
-                "OnMountAsync runs a long-lived poll loop. Every await uses ConfigureAwait(false) so the loop doesn't auto-render on each yield; instead it calls StateHasChanged() once per real data change — one render per tick. The inter-tick delay is interruptible: a Symbol switch cancels _wake so the new asset polls immediately. CancellationToken cancels on unmount, breaking the loop. There is no OnRenderedAsync: the chart is a server-rendered SVG (the Sparkline component) emitted straight from Render(), so the framework ships the updated <svg> over the same transport as the rest of the page — zero JavaScript."),
-            Div(Class: "alert alert-info d-flex align-items-start mt-3")[
-                I(Class: "bi bi-info-circle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Synthetic feed."],
-                    " The poll loop generates a random-walk price locally (with a 50 ms ",
-                    Code()["Task.Delay"], " to simulate latency) so the demo is offline-safe. ",
-                    "Switching to a real HTTP source is a one-line change in ",
-                    Code()["PollOnceAsync"], "; the rest of the component — lifecycle, ",
-                    "cancellation, the SVG chart — is identical."
-                ]
             ]
-        ];
+        ],
+        H2(Class: "h4 mt-5 mb-3")["What each hook does here"],
+        P(Class: "text-secondary")[
+            "Every override in ", Code()["LiveTicker"], " has a natural production job. Click ",
+            Code()["ETH"], " or ", Code()["SOL"],
+            " above to watch the OnPropsChanged + OnPropsChangedAsync entries fire, then click ",
+            A("/lifecycle", "_self", Class: "")["Lifecycle"], " in the sidebar to navigate away and see ",
+            Code()["OnUnmount"], " + ", Code()["OnUnmountAsync"],
+            " (the log lives on the page, so unmount entries survive)."
+        ],
+        CodeSample(
+            """
+            public sealed class LiveTicker : Component
+            {
+                public string Symbol { get; set; } = "BTC";
+                public int Interval { get; set; } = 1000;
+
+                protected override void OnMount() { /* record _mountedAt */ }
+
+                protected override async Task OnMountAsync()
+                {
+                    var ct = CancellationToken;   // cancels on unmount
+                    try
+                    {
+                        while (!ct.IsCancellationRequested)
+                        {
+                            var wake = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                            Interlocked.Exchange(ref _wake, wake)?.Dispose();
+                            await PollOnceAsync(ct).ConfigureAwait(false);  // synthetic feed → history
+                            try { await Task.Delay(Interval, wake.Token).ConfigureAwait(false); }
+                            catch (OperationCanceledException) when (!ct.IsCancellationRequested) { }
+                        }
+                    }
+                    catch (OperationCanceledException) { /* unmount */ }
+                }
+
+                protected override void OnPropsChanged() { /* detect Symbol change */ }
+
+                protected override Task OnPropsChangedAsync()
+                {
+                    if (_lastSymbol is not null && _lastSymbol != Symbol)
+                    {
+                        _history.Clear();         // start the new symbol fresh
+                        _wake?.Cancel();          // poll the new symbol immediately
+                    }
+                    _lastSymbol = Symbol;
+                    return Task.CompletedTask;
+                }
+
+                protected override void OnRendered(bool firstRender) { /* paint latency */ }
+
+                protected override void OnUnmount() { /* sync log */ }
+
+                protected override async Task OnUnmountAsync() =>
+                    await Task.Delay(50); // stand-in for POST /stats/session-end
+
+                protected override RenderResult Render() =>
+                    // The chart is just SVG — no Chart.js, no canvas, no JS round-trip.
+                    Sparkline(Values: _history.Select(p => (double)p.PriceUsd).ToList());
+            }
+            """,
+            Notes:
+            "OnMountAsync runs a long-lived poll loop. Every await uses ConfigureAwait(false) so the loop doesn't auto-render on each yield; instead it calls StateHasChanged() once per real data change — one render per tick. The inter-tick delay is interruptible: a Symbol switch cancels _wake so the new asset polls immediately. CancellationToken cancels on unmount, breaking the loop. There is no OnRenderedAsync: the chart is a server-rendered SVG (the Sparkline component) emitted straight from Render(), so the framework ships the updated <svg> over the same transport as the rest of the page — zero JavaScript."),
+        Div(Class: "alert alert-info d-flex align-items-start mt-3")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Synthetic feed."],
+                " The poll loop generates a random-walk price locally (with a 50 ms ",
+                Code()["Task.Delay"], " to simulate latency) so the demo is offline-safe. ",
+                "Switching to a real HTTP source is a one-line change in ",
+                Code()["PollOnceAsync"], "; the rest of the component — lifecycle, ",
+                "cancellation, the SVG chart — is identical."
+            ]
+        ]
+    ];
 
     private Component SwitchButton(string symbol) =>
         Button(
@@ -146,10 +148,7 @@ public sealed class LiveTickerPage(Navigator nav) : Component
         _ = DeferredRerenderAsync();
     }
 
-    private void ClearLog()
-    {
-        _log.Clear();
-    }
+    private void ClearLog() => _log.Clear();
 
     // Same trick LifecyclePage uses: an unmount-time StateHasChanged lands in
     // the in-handler guard and gets dropped on WASM. Yielding to the event loop

--- a/samples/Rask.Example.Shared/Pages/NavigatorPage.cs
+++ b/samples/Rask.Example.Shared/Pages/NavigatorPage.cs
@@ -11,73 +11,73 @@ public sealed class NavigatorPage(Navigator nav, RouteState route) : Component
     protected override RenderResult Head => Title()["Navigator — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Navigator",
-                "A scoped service that lets event-handler code change the route. It throws if you call it from Render() or during an initial GET — navigation belongs in event handlers."),
-            H2(Class: "h4 mt-4 mb-3")["Current location"],
-            Div(Class: "card shadow-sm border-0 mb-4")[
-                Div(Class: "card-body")[
-                    Div(Class: "row g-3")[
-                        Div(Class: "col-md-6")[
-                            Span(Class: "text-secondary small text-uppercase")["Path"],
-                            Div()[Code(Class: "fs-6")[route.Path]]
-                        ],
-                        Div(Class: "col-md-6")[
-                            Span(Class: "text-secondary small text-uppercase")["Query"],
-                            Div()[
-                                Code(Class: "fs-6")[
-                                    route.Query.Count == 0 ? "(empty)" : BuildQuery(route)
-                                ]
+    [
+        PageHeader.Render(
+            "Navigator",
+            "A scoped service that lets event-handler code change the route. It throws if you call it from Render() or during an initial GET — navigation belongs in event handlers."),
+        H2(Class: "h4 mt-4 mb-3")["Current location"],
+        Div(Class: "card shadow-sm border-0 mb-4")[
+            Div(Class: "card-body")[
+                Div(Class: "row g-3")[
+                    Div(Class: "col-md-6")[
+                        Span(Class: "text-secondary small text-uppercase")["Path"],
+                        Div()[Code(Class: "fs-6")[route.Path]]
+                    ],
+                    Div(Class: "col-md-6")[
+                        Span(Class: "text-secondary small text-uppercase")["Query"],
+                        Div()[
+                            Code(Class: "fs-6")[
+                                route.Query.Count == 0 ? "(empty)" : BuildQuery(route)
                             ]
                         ]
                     ]
                 ]
-            ],
-            H2(Class: "h4 mt-4 mb-3")["Query mutators"],
-            P(Class: "text-secondary")[
-                "Watch the URL bar — every button below mutates state and the page re-renders to reflect it."
-            ],
-            Div(Class: "btn-group flex-wrap mb-3")[
-                Button(Class: "btn btn-outline-primary btn-sm", OnClick: () => nav.SetQuery("page", "1"))[
-                    "SetQuery page=1"],
-                Button(Class: "btn btn-outline-primary btn-sm", OnClick: () => nav.SetQuery("page", "2"))[
-                    "SetQuery page=2"],
-                Button(Class: "btn btn-outline-primary btn-sm", OnClick: () => nav.SetQuery("sort", "asc"))[
-                    "SetQuery sort=asc"],
-                Button(Class: "btn btn-outline-secondary btn-sm", OnClick: () => nav.RemoveQuery("page"))[
-                    "RemoveQuery page"],
-                Button(Class: "btn btn-outline-danger btn-sm", OnClick: () => nav.ClearQuery())["ClearQuery"]
-            ],
-            H2(Class: "h4 mt-4 mb-3")["Path navigation"],
-            Div(Class: "d-flex flex-wrap gap-2 mb-4")[
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () => nav.Navigate("/navigator"))[I(Class: "bi bi-arrow-counterclockwise me-1"),
-                    "Navigate(\"/navigator\")"],
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () =>
-                        nav.Navigate("/navigator", new[] { KeyValuePair.Create<string, string?>("from", "button") }))[
-                    I(Class: "bi bi-arrow-up-right me-1"), "Navigate(path, query)"]
-            ],
-            Div(Class: "alert alert-info d-flex align-items-start")[
-                I(Class: "bi bi-info-circle-fill me-3 fs-4"),
-                Div()[
-                    Strong()["Why event-handler only:"],
-                    " Navigator mutates RouteState and asks the dispatcher to push history. Doing that during Render() would mid-render the page out from under itself. Use it from button clicks, form submits, or lifecycle hooks that ran in response to an event."
-                ]
-            ],
-            CodeSample(
-                """
-                Button(
-                    OnClick: () => nav.Navigate("/dashboard"))["Open dashboard"]
+            ]
+        ],
+        H2(Class: "h4 mt-4 mb-3")["Query mutators"],
+        P(Class: "text-secondary")[
+            "Watch the URL bar — every button below mutates state and the page re-renders to reflect it."
+        ],
+        Div(Class: "btn-group flex-wrap mb-3")[
+            Button(Class: "btn btn-outline-primary btn-sm", OnClick: () => nav.SetQuery("page", "1"))[
+                "SetQuery page=1"],
+            Button(Class: "btn btn-outline-primary btn-sm", OnClick: () => nav.SetQuery("page", "2"))[
+                "SetQuery page=2"],
+            Button(Class: "btn btn-outline-primary btn-sm", OnClick: () => nav.SetQuery("sort", "asc"))[
+                "SetQuery sort=asc"],
+            Button(Class: "btn btn-outline-secondary btn-sm", OnClick: () => nav.RemoveQuery("page"))[
+                "RemoveQuery page"],
+            Button(Class: "btn btn-outline-danger btn-sm", OnClick: () => nav.ClearQuery())["ClearQuery"]
+        ],
+        H2(Class: "h4 mt-4 mb-3")["Path navigation"],
+        Div(Class: "d-flex flex-wrap gap-2 mb-4")[
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () => nav.Navigate("/navigator"))[I(Class: "bi bi-arrow-counterclockwise me-1"),
+                "Navigate(\"/navigator\")"],
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () =>
+                    nav.Navigate("/navigator", new[] { KeyValuePair.Create<string, string?>("from", "button") }))[
+                I(Class: "bi bi-arrow-up-right me-1"), "Navigate(path, query)"]
+        ],
+        Div(Class: "alert alert-info d-flex align-items-start")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Why event-handler only:"],
+                " Navigator mutates RouteState and asks the dispatcher to push history. Doing that during Render() would mid-render the page out from under itself. Use it from button clicks, form submits, or lifecycle hooks that ran in response to an event."
+            ]
+        ],
+        CodeSample(
+            """
+            Button(
+                OnClick: () => nav.Navigate("/dashboard"))["Open dashboard"]
 
-                // Or update just the query, keeping the same path:
-                Select(
-                    OnChange: v => nav.SetQuery("sort", v))[...]
-                """)
-        ];
+            // Or update just the query, keeping the same path:
+            Select(
+                OnChange: v => nav.SetQuery("sort", v))[...]
+            """)
+    ];
 
     private static string BuildQuery(RouteState route)
     {

--- a/samples/Rask.Example.Shared/Pages/NestedFormPage.cs
+++ b/samples/Rask.Example.Shared/Pages/NestedFormPage.cs
@@ -11,101 +11,101 @@ public sealed class NestedFormPage : Component
     protected override RenderResult Head => Title()["Complex models — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Complex models",
-                "Forms aren't always flat. Drop a single DataAnnotationsValidator() or FluentValidationValidator(...) at the top of the Form and the same Input(Bind: ...) syntax binds through sub-objects, lists, and dictionaries. The reference-based FieldIdentifier means each sub-instance owns its own validation state, so add/remove/reorder works without re-keying."),
-            H2(Class: "h4 mt-4 mb-3")["Sub-object — () => model.Address.Street"],
-            CodeSample(
-                """
-                public sealed class CheckoutModel {
-                    [Required, StringLength(60)] public string Name { get; set; } = "";
-                    [Required, EmailAddress]    public string Email { get; set; } = "";
-                    public AddressModel Address { get; set; } = new();
-                }
+    [
+        PageHeader.Render(
+            "Complex models",
+            "Forms aren't always flat. Drop a single DataAnnotationsValidator() or FluentValidationValidator(...) at the top of the Form and the same Input(Bind: ...) syntax binds through sub-objects, lists, and dictionaries. The reference-based FieldIdentifier means each sub-instance owns its own validation state, so add/remove/reorder works without re-keying."),
+        H2(Class: "h4 mt-4 mb-3")["Sub-object — () => model.Address.Street"],
+        CodeSample(
+            """
+            public sealed class CheckoutModel {
+                [Required, StringLength(60)] public string Name { get; set; } = "";
+                [Required, EmailAddress]    public string Email { get; set; } = "";
+                public AddressModel Address { get; set; } = new();
+            }
 
-                public sealed class AddressModel {
-                    [Required]                                  public string Street { get; set; } = "";
-                    [Required]                                  public string City   { get; set; } = "";
-                    [Required, RegularExpression("^[A-Z]{2}$",
-                        ErrorMessage = "Use the ISO 2-letter code.")]
-                                                                public string Country { get; set; } = "";
-                }
+            public sealed class AddressModel {
+                [Required]                                  public string Street { get; set; } = "";
+                [Required]                                  public string City   { get; set; } = "";
+                [Required, RegularExpression("^[A-Z]{2}$",
+                    ErrorMessage = "Use the ISO 2-letter code.")]
+                                                            public string Country { get; set; } = "";
+            }
 
-                Form<CheckoutModel>(_model, OnValidSubmit: m => ...)[
-                    DataAnnotationsValidator(),
-                    Input(() => _model.Name),
-                    Input(() => _model.Email),
-                    // Sub-object fields — same Bind syntax, no extra validator declaration:
-                    Input(() => _model.Address.Street),
-                    Input(() => _model.Address.City),
-                    Input(() => _model.Address.Country)
-                ]
-                """,
-                Notes:
-                "The graph walker in DataAnnotationsValidator visits the Address sub-object automatically, so [Required] / [RegularExpression] on its properties fire just like the root model's. ValidationMessage(() => _model.Address.Street, ...) reads the message off the Address instance — not off the root — so reassigning _model.Address = new(...) between renders rewires the bindings without leftover errors.",
-                Result: NestedSubObjectDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Collection — foreach + per-item capture"],
-            CodeSample(
-                """
-                public sealed class LineItem {
-                    [Required, StringLength(80)] public string Description { get; set; } = "";
-                    [Range(1, int.MaxValue, ErrorMessage = "Quantity must be at least 1.")]
-                    public int Quantity { get; set; } = 1;
-                }
+            Form<CheckoutModel>(_model, OnValidSubmit: m => ...)[
+                DataAnnotationsValidator(),
+                Input(() => _model.Name),
+                Input(() => _model.Email),
+                // Sub-object fields — same Bind syntax, no extra validator declaration:
+                Input(() => _model.Address.Street),
+                Input(() => _model.Address.City),
+                Input(() => _model.Address.Country)
+            ]
+            """,
+            Notes:
+            "The graph walker in DataAnnotationsValidator visits the Address sub-object automatically, so [Required] / [RegularExpression] on its properties fire just like the root model's. ValidationMessage(() => _model.Address.Street, ...) reads the message off the Address instance — not off the root — so reassigning _model.Address = new(...) between renders rewires the bindings without leftover errors.",
+            Result: NestedSubObjectDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Collection — foreach + per-item capture"],
+        CodeSample(
+            """
+            public sealed class LineItem {
+                [Required, StringLength(80)] public string Description { get; set; } = "";
+                [Range(1, int.MaxValue, ErrorMessage = "Quantity must be at least 1.")]
+                public int Quantity { get; set; } = 1;
+            }
 
-                // Inside Render:
-                List<Child> rows = new();
-                foreach (var item in _model.Items) {
-                    rows.Add(Tr()[
-                        Td()[Input(() => item.Description, Class: "form-control")],
-                        Td()[Input(() => item.Quantity,    Class: "form-control")],
-                        Td()[Button(OnClick: () => _model.Items.Remove(item))["×"]]
-                    ]);
+            // Inside Render:
+            List<Child> rows = new();
+            foreach (var item in _model.Items) {
+                rows.Add(Tr()[
+                    Td()[Input(() => item.Description, Class: "form-control")],
+                    Td()[Input(() => item.Quantity,    Class: "form-control")],
+                    Td()[Button(OnClick: () => _model.Items.Remove(item))["×"]]
+                ]);
+            }
+            """,
+            Notes:
+            "Each foreach iteration closes over a different `item` reference, so the resulting lambdas point at distinct instances — each row owns its own validation state. When the user removes a row, that item's FieldIdentifier entries simply stop being read; no key juggling. When they add a row, the new item starts with empty state.",
+            Result: NestedListForeachDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Collection — indexer with the for-loop closure workaround"],
+        CodeSample(
+            """
+            // for (int i = …) captures `i` by reference — without the local copy, every
+            // lambda would close over the loop's final value. Standard C# closure trap.
+            for (var idx = 0; idx < _model.Skus.Count; idx++) {
+                var i = idx;                       // <-- per-iteration capture
+                rows.Add(Tr()[
+                    Td(Class: "text-secondary small")[$"#{i + 1}"],
+                    Td()[Input(() => _model.Skus[i].Code,  Class: "form-control")],
+                    Td()[Input(() => _model.Skus[i].Price, Class: "form-control")]
+                ]);
+            }
+            """,
+            Notes:
+            "Indexer binding compiles to a MethodCallExpression on get_Item (List<T>) or BinaryExpression(ArrayIndex) (T[]). The parser invokes it each render, so reassigning _model.Skus[i] (record replacement, reorder) is picked up next frame without any rebind boilerplate. The catch is the C# `for` closure trap — copy the index into a per-iteration local. `foreach` doesn't have this problem.",
+            Result: NestedListIndexerDemo()),
+        H2(Class: "h4 mt-5 mb-3")["FluentValidation — SetValidator and RuleForEach"],
+        CodeSample(
+            """
+            public sealed class OrderValidator : AbstractValidator<OrderModel> {
+                public OrderValidator() {
+                    RuleFor(x => x.CustomerName).NotEmpty();
+                    // Sub-object — declare a separate validator and SetValidator into it.
+                    RuleFor(x => x.Address).SetValidator(new AddressValidator());
+                    // Collection — RuleForEach + SetValidator per item.
+                    RuleForEach(x => x.Lines).SetValidator(new LineValidator());
                 }
-                """,
-                Notes:
-                "Each foreach iteration closes over a different `item` reference, so the resulting lambdas point at distinct instances — each row owns its own validation state. When the user removes a row, that item's FieldIdentifier entries simply stop being read; no key juggling. When they add a row, the new item starts with empty state.",
-                Result: NestedListForeachDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Collection — indexer with the for-loop closure workaround"],
-            CodeSample(
-                """
-                // for (int i = …) captures `i` by reference — without the local copy, every
-                // lambda would close over the loop's final value. Standard C# closure trap.
-                for (var idx = 0; idx < _model.Skus.Count; idx++) {
-                    var i = idx;                       // <-- per-iteration capture
-                    rows.Add(Tr()[
-                        Td(Class: "text-secondary small")[$"#{i + 1}"],
-                        Td()[Input(() => _model.Skus[i].Code,  Class: "form-control")],
-                        Td()[Input(() => _model.Skus[i].Price, Class: "form-control")]
-                    ]);
-                }
-                """,
-                Notes:
-                "Indexer binding compiles to a MethodCallExpression on get_Item (List<T>) or BinaryExpression(ArrayIndex) (T[]). The parser invokes it each render, so reassigning _model.Skus[i] (record replacement, reorder) is picked up next frame without any rebind boilerplate. The catch is the C# `for` closure trap — copy the index into a per-iteration local. `foreach` doesn't have this problem.",
-                Result: NestedListIndexerDemo()),
-            H2(Class: "h4 mt-5 mb-3")["FluentValidation — SetValidator and RuleForEach"],
-            CodeSample(
-                """
-                public sealed class OrderValidator : AbstractValidator<OrderModel> {
-                    public OrderValidator() {
-                        RuleFor(x => x.CustomerName).NotEmpty();
-                        // Sub-object — declare a separate validator and SetValidator into it.
-                        RuleFor(x => x.Address).SetValidator(new AddressValidator());
-                        // Collection — RuleForEach + SetValidator per item.
-                        RuleForEach(x => x.Lines).SetValidator(new LineValidator());
-                    }
-                }
+            }
 
-                Form<OrderModel>(_model, OnValidSubmit: m => ...)[
-                    FluentValidationValidator(new OrderValidator()),
-                    Input(() => _model.CustomerName),
-                    Input(() => _model.Address.Street),     // Address.Street routes to AddressValidator
-                    // foreach line in _model.Lines: Input(() => line.Description)  → LineValidator
-                ]
-                """,
-                Notes:
-                "FluentValidation already walks nested rules via .SetValidator(...) and RuleForEach(...). Rask's job is just to route the dotted PropertyName (\"Address.Street\", \"Lines[0].Description\") back to the runtime sub-instance so the message lands where ValidationMessage(For: () => _model.Address.Street, ...) is reading. Per-keystroke validation on a root-model field uses MemberNameValidatorSelector (fast path); on a nested field it runs the full validator and filters by resolved owner.",
-                Result: NestedFluentValidationDemo())
-        ];
+            Form<OrderModel>(_model, OnValidSubmit: m => ...)[
+                FluentValidationValidator(new OrderValidator()),
+                Input(() => _model.CustomerName),
+                Input(() => _model.Address.Street),     // Address.Street routes to AddressValidator
+                // foreach line in _model.Lines: Input(() => line.Description)  → LineValidator
+            ]
+            """,
+            Notes:
+            "FluentValidation already walks nested rules via .SetValidator(...) and RuleForEach(...). Rask's job is just to route the dotted PropertyName (\"Address.Street\", \"Lines[0].Description\") back to the runtime sub-instance so the message lands where ValidationMessage(For: () => _model.Address.Street, ...) is reading. Per-keystroke validation on a root-model field uses MemberNameValidatorSelector (fast path); on a nested field it runs the full validator and filters by resolved owner.",
+            Result: NestedFluentValidationDemo())
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/NotFoundPage.cs
+++ b/samples/Rask.Example.Shared/Pages/NotFoundPage.cs
@@ -11,14 +11,14 @@ public sealed class NotFoundPage(Navigator nav, RouteState route) : Component
     protected override RenderResult Head => Title()["Not found — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Page not found",
-                $"No route is registered for {route.Path}. Pick a section from the sidebar — every showcase page is reachable from there."),
-            Div(Class: "d-flex gap-2 mt-3")[
-                Button(
-                    Class: "btn btn-primary",
-                    OnClick: () => nav.Navigate("/"))[I(Class: "bi bi-house me-2"), "Back to welcome"]
-            ]
-        ];
+    [
+        PageHeader.Render(
+            "Page not found",
+            $"No route is registered for {route.Path}. Pick a section from the sidebar — every showcase page is reachable from there."),
+        Div(Class: "d-flex gap-2 mt-3")[
+            Button(
+                Class: "btn btn-primary",
+                OnClick: () => nav.Navigate("/"))[I(Class: "bi bi-house me-2"), "Back to welcome"]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/PrimitivesPage.cs
+++ b/samples/Rask.Example.Shared/Pages/PrimitivesPage.cs
@@ -11,77 +11,77 @@ public sealed class PrimitivesPage : Component
     protected override RenderResult Head => Title()["Primitives — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Primitives",
-                "Four primitives sit beneath every Rask page: Text, Raw, Fragment, and Doctype. Everything else is built out of them."),
-            H2(Class: "h4 mt-4 mb-3")["Text — auto-escaped strings"],
-            CodeSample(
-                """
-                // Strings implicitly convert to Child (wrapped as Text):
-                P()["1 < 2 && \"safe\""]
-                """,
-                Notes:
-                "Text HTML-encodes its value. The < and & above render as literal characters, not parsed as markup.",
-                Result: P(Class: "mb-0")["1 < 2 && \"safe\""]),
-            H2(Class: "h4 mt-5 mb-3")["Raw — verbatim HTML"],
-            CodeSample(
-                """
-                // new Raw(...) bypasses encoding. Use deliberately.
-                P()[Raw("Already <strong>safe</strong> HTML")]
-                """,
-                Notes:
-                "Raw is the escape hatch. Use when you control the source (markdown output, sanitized snippets); never on user input.",
-                Result: P(Class: "mb-0")[Raw("Already <strong>safe</strong> HTML")]),
-            Div(Class: "alert alert-warning d-flex align-items-start mt-3")[
-                I(Class: "bi bi-shield-exclamation me-3 fs-4"),
-                Div()[
-                    Strong()["Security:"],
-                    " ", Code()["Raw"],
-                    " skips all HTML encoding. Never feed it untrusted strings — sanitize or use ",
-                    Code()["Text"], " instead."
-                ]
-            ],
-            H2(Class: "h4 mt-5 mb-3")["Fragment — siblings without a wrapper"],
-            CodeSample(
-                """
-                Fragment(
-                    H3()["A heading"],
-                    P()["A paragraph"]
-                )
-                """,
-                Notes:
-                "Fragment renders its children with no surrounding tag — handy for siblings at the root, especially Fragment(Doctype(), Html(...)) as the page entry.",
-                Result: Fragment()[
-                    H3(Class: "h5")["A heading"],
-                    P(Class: "mb-0")["A paragraph"]
-                ]),
-            H2(Class: "h4 mt-5 mb-3")["Doctype"],
-            CodeSample(
-                """
-                // The recommended page-root pattern:
-                Fragment(
-                    Doctype(),
-                    Html("en")[ /* head + body */ ]
-                )
-                """,
-                Notes:
-                "Doctype() emits exactly <!DOCTYPE html>. Special-cased — no attributes, no children, no wrapping tag.",
-                Result: Span(Class: "text-secondary")["(emits ", Code()["<!DOCTYPE html>"], ")"]),
-            H2(Class: "h4 mt-5 mb-3")["Children from strings"],
-            CodeSample(
-                """
-                // Child has implicit conversions from string and Component:
-                Div()[
-                    "plain text, ",
-                    Strong()["bold text, "],
-                    $"interpolated: {DateTime.Today:yyyy-MM-dd}"
-                ]
-                """,
-                Result: Div(Class: "mb-0")[
-                    "plain text, ",
-                    Strong()["bold text, "],
-                    $"interpolated: {DateTime.Today:yyyy-MM-dd}"
-                ])
-        ];
+    [
+        PageHeader.Render(
+            "Primitives",
+            "Four primitives sit beneath every Rask page: Text, Raw, Fragment, and Doctype. Everything else is built out of them."),
+        H2(Class: "h4 mt-4 mb-3")["Text — auto-escaped strings"],
+        CodeSample(
+            """
+            // Strings implicitly convert to Child (wrapped as Text):
+            P()["1 < 2 && \"safe\""]
+            """,
+            Notes:
+            "Text HTML-encodes its value. The < and & above render as literal characters, not parsed as markup.",
+            Result: P(Class: "mb-0")["1 < 2 && \"safe\""]),
+        H2(Class: "h4 mt-5 mb-3")["Raw — verbatim HTML"],
+        CodeSample(
+            """
+            // new Raw(...) bypasses encoding. Use deliberately.
+            P()[Raw("Already <strong>safe</strong> HTML")]
+            """,
+            Notes:
+            "Raw is the escape hatch. Use when you control the source (markdown output, sanitized snippets); never on user input.",
+            Result: P(Class: "mb-0")[Raw("Already <strong>safe</strong> HTML")]),
+        Div(Class: "alert alert-warning d-flex align-items-start mt-3")[
+            I(Class: "bi bi-shield-exclamation me-3 fs-4"),
+            Div()[
+                Strong()["Security:"],
+                " ", Code()["Raw"],
+                " skips all HTML encoding. Never feed it untrusted strings — sanitize or use ",
+                Code()["Text"], " instead."
+            ]
+        ],
+        H2(Class: "h4 mt-5 mb-3")["Fragment — siblings without a wrapper"],
+        CodeSample(
+            """
+            Fragment(
+                H3()["A heading"],
+                P()["A paragraph"]
+            )
+            """,
+            Notes:
+            "Fragment renders its children with no surrounding tag — handy for siblings at the root, especially Fragment(Doctype(), Html(...)) as the page entry.",
+            Result: Fragment()[
+                H3(Class: "h5")["A heading"],
+                P(Class: "mb-0")["A paragraph"]
+            ]),
+        H2(Class: "h4 mt-5 mb-3")["Doctype"],
+        CodeSample(
+            """
+            // The recommended page-root pattern:
+            Fragment(
+                Doctype(),
+                Html("en")[ /* head + body */ ]
+            )
+            """,
+            Notes:
+            "Doctype() emits exactly <!DOCTYPE html>. Special-cased — no attributes, no children, no wrapping tag.",
+            Result: Span(Class: "text-secondary")["(emits ", Code()["<!DOCTYPE html>"], ")"]),
+        H2(Class: "h4 mt-5 mb-3")["Children from strings"],
+        CodeSample(
+            """
+            // Child has implicit conversions from string and Component:
+            Div()[
+                "plain text, ",
+                Strong()["bold text, "],
+                $"interpolated: {DateTime.Today:yyyy-MM-dd}"
+            ]
+            """,
+            Result: Div(Class: "mb-0")[
+                "plain text, ",
+                Strong()["bold text, "],
+                $"interpolated: {DateTime.Today:yyyy-MM-dd}"
+            ])
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/PropsPage.cs
+++ b/samples/Rask.Example.Shared/Pages/PropsPage.cs
@@ -11,52 +11,52 @@ public sealed class PropsPage : Component
     protected override RenderResult Head => Title()["Universal props — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Universal props",
-                "Every tag accepts Id, Class, Style, and Data. They render in that exact order, ahead of any tag-specific attributes."),
-            H2(Class: "h4 mt-4 mb-3")["Id, Class, Style"],
-            CodeSample(
-                """
-                Div(
-                    Id: "card-1",
-                    Class: "card highlighted",
-                    Style: "padding: 0.5rem; border: 1px solid #ccc;")["Three attributes — id then class then style."]
-                """,
-                Result: Div(
-                    Id: "card-1",
-                    Class: "card border-primary",
-                    Style: "padding: 0.6rem 0.8rem;")["Three attributes — id then class then style."]),
-            H2(Class: "h4 mt-5 mb-3")["Data — dictionary expands as data-*"],
-            CodeSample(
-                """
-                Div(
-                    Data: new Dictionary<string, string?> {
-                        ["role"] = "card",
-                        ["index"] = "7",
-                        ["new"] = null   // bare attribute
-                    })["Inspect — data-role, data-index, and a bare data-new."]
-                """,
-                Notes:
-                "Null values render as bare attributes (e.g. data-new). That's also how boolean attrs like disabled work elsewhere.",
-                Result: Div(
-                    Class: "p-2 bg-light rounded border",
-                    Data: new Dictionary<string, string?> { ["role"] = "card", ["index"] = "7", ["new"] = null })[
-                    "Inspect the rendered HTML — data-role, data-index, and a bare data-new."]),
-            H2(Class: "h4 mt-5 mb-3")["Attribute order"],
-            CodeSample(
-                """
-                // Tag-specific (Href) renders AFTER id/class/style/data-*, even though
-                // the factory signature lists Href first.
-                A(Href: "/tags", Id: "out", Class: "link",
-                  Data: new Dictionary<string, string?> { ["external"] = "true" })["See HTML order"]
-                """,
-                Notes:
-                "Render order is base props first (id, class, style, data-*), then tag-specific. Tests enforce it. Predictable for diffing and DOM tooling.",
-                Result: A(
-                    "/tags",
-                    Id: "out",
-                    Class: "link link-primary",
-                    Data: new Dictionary<string, string?> { ["external"] = "true" })["See HTML order"])
-        ];
+    [
+        PageHeader.Render(
+            "Universal props",
+            "Every tag accepts Id, Class, Style, and Data. They render in that exact order, ahead of any tag-specific attributes."),
+        H2(Class: "h4 mt-4 mb-3")["Id, Class, Style"],
+        CodeSample(
+            """
+            Div(
+                Id: "card-1",
+                Class: "card highlighted",
+                Style: "padding: 0.5rem; border: 1px solid #ccc;")["Three attributes — id then class then style."]
+            """,
+            Result: Div(
+                Id: "card-1",
+                Class: "card border-primary",
+                Style: "padding: 0.6rem 0.8rem;")["Three attributes — id then class then style."]),
+        H2(Class: "h4 mt-5 mb-3")["Data — dictionary expands as data-*"],
+        CodeSample(
+            """
+            Div(
+                Data: new Dictionary<string, string?> {
+                    ["role"] = "card",
+                    ["index"] = "7",
+                    ["new"] = null   // bare attribute
+                })["Inspect — data-role, data-index, and a bare data-new."]
+            """,
+            Notes:
+            "Null values render as bare attributes (e.g. data-new). That's also how boolean attrs like disabled work elsewhere.",
+            Result: Div(
+                Class: "p-2 bg-light rounded border",
+                Data: new Dictionary<string, string?> { ["role"] = "card", ["index"] = "7", ["new"] = null })[
+                "Inspect the rendered HTML — data-role, data-index, and a bare data-new."]),
+        H2(Class: "h4 mt-5 mb-3")["Attribute order"],
+        CodeSample(
+            """
+            // Tag-specific (Href) renders AFTER id/class/style/data-*, even though
+            // the factory signature lists Href first.
+            A(Href: "/tags", Id: "out", Class: "link",
+              Data: new Dictionary<string, string?> { ["external"] = "true" })["See HTML order"]
+            """,
+            Notes:
+            "Render order is base props first (id, class, style, data-*), then tag-specific. Tests enforce it. Predictable for diffing and DOM tooling.",
+            Result: A(
+                "/tags",
+                Id: "out",
+                Class: "link link-primary",
+                Data: new Dictionary<string, string?> { ["external"] = "true" })["See HTML order"])
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/RoutingPage.cs
+++ b/samples/Rask.Example.Shared/Pages/RoutingPage.cs
@@ -11,90 +11,90 @@ public sealed class RoutingPage(Navigator nav) : Component
     protected override RenderResult Head => Title()["Routing — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Routing",
-                "Annotate a component with [Route(\"/path\")]. A module initializer registers it; Router() in your App tree matches the current URL and renders the page."),
-            H2(Class: "h4 mt-4 mb-3")["A page is a routed component"],
-            CodeSample(
-                """
-                [Route("/about")]
-                public sealed class AboutPage : Component
-                {
-                    public override RenderResult Render() =>
-                        H1()["About"];
-                }
-                """,
-                Notes:
-                "Routes use Blazor-style {param} placeholders. Optional, catch-all (**rest), and type-constrained variants are all supported."),
-            H2(Class: "h4 mt-5 mb-3")["Nested layouts with [ParentRoute] + Outlet"],
-            CodeSample(
-                """
-                [Route("/")]
-                public sealed class Layout : Component
-                {
-                    public override RenderResult Render() =>
-                        Div()[
-                            Nav(/* sidebar */),
-                            Main()[Outlet()]   // children render here
-                        ];
-                }
+    [
+        PageHeader.Render(
+            "Routing",
+            "Annotate a component with [Route(\"/path\")]. A module initializer registers it; Router() in your App tree matches the current URL and renders the page."),
+        H2(Class: "h4 mt-4 mb-3")["A page is a routed component"],
+        CodeSample(
+            """
+            [Route("/about")]
+            public sealed class AboutPage : Component
+            {
+                public override RenderResult Render() =>
+                    H1()["About"];
+            }
+            """,
+            Notes:
+            "Routes use Blazor-style {param} placeholders. Optional, catch-all (**rest), and type-constrained variants are all supported."),
+        H2(Class: "h4 mt-5 mb-3")["Nested layouts with [ParentRoute] + Outlet"],
+        CodeSample(
+            """
+            [Route("/")]
+            public sealed class Layout : Component
+            {
+                public override RenderResult Render() =>
+                    Div()[
+                        Nav(/* sidebar */),
+                        Main()[Outlet()]   // children render here
+                    ];
+            }
 
-                [Route("about"), ParentRoute(typeof(Layout))]
-                public sealed class AboutPage : Component { ... }
+            [Route("about"), ParentRoute(typeof(Layout))]
+            public sealed class AboutPage : Component { ... }
 
-                // /about now matches Layout → AboutPage.
-                """,
-                Notes:
-                "Child templates are joined to the parent's. An empty child template (\"\") means \"default child for this layout\". This very showcase is built that way — every page declares [ParentRoute(typeof(ShowcaseLayout))]."),
-            H2(Class: "h4 mt-5 mb-3")["Try the live param demo"],
-            P(Class: "text-secondary")[
-                "The page at ",
-                Code()["/users/{id}"],
-                " binds the URL segment to a property. Try one of these:"
-            ],
-            Div(Class: "d-flex flex-wrap gap-2 mb-2")[
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () => nav.Navigate("/users/42"))[I(Class: "bi bi-link-45deg me-1"), "/users/42"],
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () => nav.Navigate("/users/137"))[I(Class: "bi bi-link-45deg me-1"), "/users/137"],
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () =>
-                        nav.Navigate("/users/ada", new[] { KeyValuePair.Create<string, string?>("tab", "profile") }))[
-                    I(Class: "bi bi-link-45deg me-1"), "/users/ada?tab=profile"]
-            ],
-            H2(Class: "h4 mt-5 mb-3")["Reacting to navigation: RouteState.Changed"],
-            P(Class: "text-secondary")[
-                Code()["RouteState"],
-                " raises ",
-                Code()["Changed"],
-                " whenever the path or query actually changes (reference-equality gated). Subscribe in ",
-                Code()["OnMount"],
-                " and unsubscribe in ",
-                Code()["OnUnmount"],
-                ". Useful for components rendered ",
-                Em()["above"],
-                " the ", Code()["Router"],
-                " (sidebars, breadcrumbs, the path display in the showcase header) that need to refresh on every nav, including browser back/forward."
-            ],
-            CodeSample(
-                """
-                public sealed class PathDisplay(RouteState route) : Component
-                {
-                    protected override void OnMount() =>
-                        route.Changed += StateHasChanged;
+            // /about now matches Layout → AboutPage.
+            """,
+            Notes:
+            "Child templates are joined to the parent's. An empty child template (\"\") means \"default child for this layout\". This very showcase is built that way — every page declares [ParentRoute(typeof(ShowcaseLayout))]."),
+        H2(Class: "h4 mt-5 mb-3")["Try the live param demo"],
+        P(Class: "text-secondary")[
+            "The page at ",
+            Code()["/users/{id}"],
+            " binds the URL segment to a property. Try one of these:"
+        ],
+        Div(Class: "d-flex flex-wrap gap-2 mb-2")[
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () => nav.Navigate("/users/42"))[I(Class: "bi bi-link-45deg me-1"), "/users/42"],
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () => nav.Navigate("/users/137"))[I(Class: "bi bi-link-45deg me-1"), "/users/137"],
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () =>
+                    nav.Navigate("/users/ada", new[] { KeyValuePair.Create<string, string?>("tab", "profile") }))[
+                I(Class: "bi bi-link-45deg me-1"), "/users/ada?tab=profile"]
+        ],
+        H2(Class: "h4 mt-5 mb-3")["Reacting to navigation: RouteState.Changed"],
+        P(Class: "text-secondary")[
+            Code()["RouteState"],
+            " raises ",
+            Code()["Changed"],
+            " whenever the path or query actually changes (reference-equality gated). Subscribe in ",
+            Code()["OnMount"],
+            " and unsubscribe in ",
+            Code()["OnUnmount"],
+            ". Useful for components rendered ",
+            Em()["above"],
+            " the ", Code()["Router"],
+            " (sidebars, breadcrumbs, the path display in the showcase header) that need to refresh on every nav, including browser back/forward."
+        ],
+        CodeSample(
+            """
+            public sealed class PathDisplay(RouteState route) : Component
+            {
+                protected override void OnMount() =>
+                    route.Changed += StateHasChanged;
 
-                    protected override void OnUnmount() =>
-                        route.Changed -= StateHasChanged;
+                protected override void OnUnmount() =>
+                    route.Changed -= StateHasChanged;
 
-                    protected override RenderResult Render() =>
-                        Span()["path: ", Code()[route.Path]];
-                }
-                """,
-                Notes:
-                "The handler is just StateHasChanged — the framework already knows how to coalesce the resulting render with whatever else the dispatcher is processing. Always pair the subscribe with the unsubscribe in OnUnmount; otherwise the RouteState keeps a strong reference to the (already-unmounted) component.")
-        ];
+                protected override RenderResult Render() =>
+                    Span()["path: ", Code()[route.Path]];
+            }
+            """,
+            Notes:
+            "The handler is just StateHasChanged — the framework already knows how to coalesce the resulting render with whatever else the dispatcher is processing. Always pair the subscribe with the unsubscribe in OnUnmount; otherwise the RouteState keeps a strong reference to the (already-unmounted) component.")
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/ScopedCssPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ScopedCssPage.cs
@@ -11,83 +11,83 @@ public sealed class ScopedCssPage : Component
     protected override RenderResult Head => Title()["Scoped CSS — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Scoped CSS",
-                "Drop a sibling {Component}.css file next to {Component}.cs and Rask pairs them at compile time. The framework hashes the type's full name into a stable scope id and rewrites every selector to apply only inside that component — no class-name discipline, no BEM, no leaks."),
-            H2(Class: "h4 mt-4 mb-3")["Two components, same selector, no conflict"],
-            CodeSample(
-                """""
-                // ScopedRed.cs
-                public sealed class ScopedRed : Component
-                {
-                    protected override RenderResult Render() =>
-                        Div(Class: "box")[Span(Class: "dot"), "I think .box should be red."];
-                }
+    [
+        PageHeader.Render(
+            "Scoped CSS",
+            "Drop a sibling {Component}.css file next to {Component}.cs and Rask pairs them at compile time. The framework hashes the type's full name into a stable scope id and rewrites every selector to apply only inside that component — no class-name discipline, no BEM, no leaks."),
+        H2(Class: "h4 mt-4 mb-3")["Two components, same selector, no conflict"],
+        CodeSample(
+            """""
+            // ScopedRed.cs
+            public sealed class ScopedRed : Component
+            {
+                protected override RenderResult Render() =>
+                    Div(Class: "box")[Span(Class: "dot"), "I think .box should be red."];
+            }
 
-                /* ScopedRed.css (sibling file) */
-                .box { background: #fdecec; color: #8a1f1f; ... }
-                .dot { width: 0.6rem; height: 0.6rem; background: #d23030; border-radius: 50%; }
+            /* ScopedRed.css (sibling file) */
+            .box { background: #fdecec; color: #8a1f1f; ... }
+            .dot { width: 0.6rem; height: 0.6rem; background: #d23030; border-radius: 50%; }
 
 
-                // ScopedBlue.cs — same .box selector, different sibling .css
-                public sealed class ScopedBlue : Component
-                {
-                    protected override RenderResult Render() =>
-                        Div(Class: "box")[Span(Class: "dot"), "I think .box should be blue."];
-                }
-                """"",
-                Notes:
-                "Both classes use the same .box selector. The framework stamps every rendered body element with data-{scopeId}, then rewrites .box to .box[data-{scopeId}] — same source CSS, isolated outputs.",
-                Result: Div(Class: "d-flex flex-column gap-2")[
-                    ScopedRed(),
-                    ScopedBlue()
-                ]),
-            H2(Class: "h4 mt-5 mb-3")["How it ships"],
-            P()[
-                "Put ", Code()["RaskScopedStyles()"],
-                " in your ", Code()["<head>"],
-                ". The host decides the form: on the server it renders ",
-                Code()["<link href=\"/_rask/scoped.css?v={hash}\">"],
-                " served with ETag + 304 revalidation; in the WASM host the bundle is delivered through the page shell's ",
-                Code()["<style id=\"rask-scoped\">"],
-                " slot instead. Same call site either way. Under ",
-                Code()["dotnet watch"],
-                " a metadata-update handler invalidates the affected type and re-renders every open session with a fresh ",
-                Code()["?v="],
-                " — hot reload without a page refresh."
-            ],
-            H2(Class: "h4 mt-5 mb-3")["What gets rewritten"],
-            Div(Class: "list-group list-group-flush mb-3")[
-                Li(Class: "list-group-item d-flex align-items-start")[
-                    I(Class: "bi bi-check2-circle text-success me-2 mt-1"),
-                    Div()[
-                        Code()[".list li:hover"], " becomes ",
-                        Code()[".list li[data-{scopeId}]:hover"],
-                        " (suffix on the last compound selector — Blazor parity)"
-                    ]
-                ],
-                Li(Class: "list-group-item d-flex align-items-start")[
-                    I(Class: "bi bi-check2-circle text-success me-2 mt-1"),
-                    Div()[Code()["@media / @supports / @container / @layer"], " recurse"]
-                ],
-                Li(Class: "list-group-item d-flex align-items-start")[
-                    I(Class: "bi bi-dash-circle text-secondary me-2 mt-1"),
-                    Div()[Code()["@keyframes / @font-face / @import"], " pass through untouched"]
-                ],
-                Li(Class: "list-group-item d-flex align-items-start")[
-                    I(Class: "bi bi-dash-circle text-secondary me-2 mt-1"),
-                    Div()["Shell tags (html, head, body, title, meta, link, script, style, base) are not stamped"]
+            // ScopedBlue.cs — same .box selector, different sibling .css
+            public sealed class ScopedBlue : Component
+            {
+                protected override RenderResult Render() =>
+                    Div(Class: "box")[Span(Class: "dot"), "I think .box should be blue."];
+            }
+            """"",
+            Notes:
+            "Both classes use the same .box selector. The framework stamps every rendered body element with data-{scopeId}, then rewrites .box to .box[data-{scopeId}] — same source CSS, isolated outputs.",
+            Result: Div(Class: "d-flex flex-column gap-2")[
+                ScopedRed(),
+                ScopedBlue()
+            ]),
+        H2(Class: "h4 mt-5 mb-3")["How it ships"],
+        P()[
+            "Put ", Code()["RaskScopedStyles()"],
+            " in your ", Code()["<head>"],
+            ". The host decides the form: on the server it renders ",
+            Code()["<link href=\"/_rask/scoped.css?v={hash}\">"],
+            " served with ETag + 304 revalidation; in the WASM host the bundle is delivered through the page shell's ",
+            Code()["<style id=\"rask-scoped\">"],
+            " slot instead. Same call site either way. Under ",
+            Code()["dotnet watch"],
+            " a metadata-update handler invalidates the affected type and re-renders every open session with a fresh ",
+            Code()["?v="],
+            " — hot reload without a page refresh."
+        ],
+        H2(Class: "h4 mt-5 mb-3")["What gets rewritten"],
+        Div(Class: "list-group list-group-flush mb-3")[
+            Li(Class: "list-group-item d-flex align-items-start")[
+                I(Class: "bi bi-check2-circle text-success me-2 mt-1"),
+                Div()[
+                    Code()[".list li:hover"], " becomes ",
+                    Code()[".list li[data-{scopeId}]:hover"],
+                    " (suffix on the last compound selector — Blazor parity)"
                 ]
             ],
-            H2(Class: "h4 mt-5 mb-3")["Diagnostics"],
-            P()[
-                "A ", Code()[".css"], " file with no matching ", Code()[".cs"],
-                " component in the same directory raises ", Code()["RASK015"],
-                ". Two ", Code()[".css"], " files claiming the same component (e.g. ",
-                Code()["Counter.css"], " in two folders) raise ", Code()["RASK016"],
-                ". Opt the whole project out with ",
-                Code()["<RaskScopedCssAutoInclude>false</RaskScopedCssAutoInclude>"], "."
+            Li(Class: "list-group-item d-flex align-items-start")[
+                I(Class: "bi bi-check2-circle text-success me-2 mt-1"),
+                Div()[Code()["@media / @supports / @container / @layer"], " recurse"]
+            ],
+            Li(Class: "list-group-item d-flex align-items-start")[
+                I(Class: "bi bi-dash-circle text-secondary me-2 mt-1"),
+                Div()[Code()["@keyframes / @font-face / @import"], " pass through untouched"]
+            ],
+            Li(Class: "list-group-item d-flex align-items-start")[
+                I(Class: "bi bi-dash-circle text-secondary me-2 mt-1"),
+                Div()["Shell tags (html, head, body, title, meta, link, script, style, base) are not stamped"]
             ]
-        ];
+        ],
+        H2(Class: "h4 mt-5 mb-3")["Diagnostics"],
+        P()[
+            "A ", Code()[".css"], " file with no matching ", Code()[".cs"],
+            " component in the same directory raises ", Code()["RASK015"],
+            ". Two ", Code()[".css"], " files claiming the same component (e.g. ",
+            Code()["Counter.css"], " in two folders) raise ", Code()["RASK016"],
+            ". Opt the whole project out with ",
+            Code()["<RaskScopedCssAutoInclude>false</RaskScopedCssAutoInclude>"], "."
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/SvgPage.cs
+++ b/samples/Rask.Example.Shared/Pages/SvgPage.cs
@@ -13,7 +13,7 @@ public sealed class SvgPage : Component
         ("Violet", "#7C3AED"),
         ("Indigo", "#512BD4"),
         ("Teal", "#0D9488"),
-        ("Amber", "#D97706"),
+        ("Amber", "#D97706")
     ];
 
     private int _selected;
@@ -21,91 +21,91 @@ public sealed class SvgPage : Component
     protected override RenderResult Head => Title()["SVG — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "SVG",
-                "SVG elements are first-class core components. svg, g, path, the shapes, text, gradients and filters all have typed factories that flow through scoped CSS, keyed lists, and event handlers — no Raw() required."),
+    [
+        PageHeader.Render(
+            "SVG",
+            "SVG elements are first-class core components. svg, g, path, the shapes, text, gradients and filters all have typed factories that flow through scoped CSS, keyed lists, and event handlers — no Raw() required."),
 
-            H2(Class: "h4 mt-4 mb-3")["Shapes inside an <svg>"],
-            CodeSample(
-                """
-                Svg(Width: "200", Height: "80", ViewBox: "0 0 200 80")[
-                    Rect(X: "5", Y: "5", Width: "60", Height: "70", Rx: "8",
-                        Fill: "#7C3AED"),
-                    Circle(Cx: "105", Cy: "40", R: "35", Fill: "#0D9488"),
-                    Line(X1: "150", Y1: "10", X2: "195", Y2: "70",
-                        Stroke: "#D97706", StrokeWidth: "6", StrokeLinecap: "round")
-                ]
-                """,
-                Notes:
-                "Presentation attributes (Fill, Stroke, StrokeWidth, StrokeLinecap, …) live on the shared SvgElement base, so every shape exposes them as optional factory parameters.",
-                Result: Svg(Width: "200", Height: "80", ViewBox: "0 0 200 80")[
-                    Rect(X: "5", Y: "5", Width: "60", Height: "70", Rx: "8", Fill: "#7C3AED"),
-                    Circle(Cx: "105", Cy: "40", R: "35", Fill: "#0D9488"),
-                    Line(X1: "150", Y1: "10", X2: "195", Y2: "70",
-                        Stroke: "#D97706", StrokeWidth: "6", StrokeLinecap: "round")
-                ]),
+        H2(Class: "h4 mt-4 mb-3")["Shapes inside an <svg>"],
+        CodeSample(
+            """
+            Svg(Width: "200", Height: "80", ViewBox: "0 0 200 80")[
+                Rect(X: "5", Y: "5", Width: "60", Height: "70", Rx: "8",
+                    Fill: "#7C3AED"),
+                Circle(Cx: "105", Cy: "40", R: "35", Fill: "#0D9488"),
+                Line(X1: "150", Y1: "10", X2: "195", Y2: "70",
+                    Stroke: "#D97706", StrokeWidth: "6", StrokeLinecap: "round")
+            ]
+            """,
+            Notes:
+            "Presentation attributes (Fill, Stroke, StrokeWidth, StrokeLinecap, …) live on the shared SvgElement base, so every shape exposes them as optional factory parameters.",
+            Result: Svg("200", "80", "0 0 200 80")[
+                Rect("5", "5", "60", "70", "8", Fill: "#7C3AED"),
+                Circle("105", "40", "35", Fill: "#0D9488"),
+                Line("150", "10", "195", "70",
+                    Stroke: "#D97706", StrokeWidth: "6", StrokeLinecap: "round")
+            ]),
 
-            H2(Class: "h4 mt-5 mb-3")["Gradients via <defs> and <linearGradient>"],
-            CodeSample(
-                """
-                Svg(Width: "120", Height: "120", ViewBox: "22 6 80 108")[
-                    SvgTitle()["Rask"],
-                    Defs()[
-                        LinearGradient(Id: "bolt", X1: "0", Y1: "0", X2: "1", Y2: "1")[
-                            Stop(Offset: "0%", StopColor: "#7C3AED"),
-                            Stop(Offset: "100%", StopColor: "#512BD4")
-                        ]
-                    ],
-                    SvgPath(D: "M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z",
-                        Fill: "url(#bolt)")
-                ]
-                """,
-                Notes:
-                "The Rask brand mark itself is built this way — see Demos/RaskLogo.cs. A nested SvgTitle gives the graphic its accessible name.",
-                Result: RaskLogo.Mark(120, "svgPageBolt")),
-
-            H2(Class: "h4 mt-5 mb-3")["Clickable shapes — OnClick on any element"],
-            CodeSample(
-                """
-                // SvgElement carries OnClick/OnClickAsync, so a shape dispatches
-                // through the same handler path as a Button.
-                Circle(Cx: "20", Cy: "20", R: "18",
-                    Fill: i == _selected ? hex : "#e5e7eb",
-                    Stroke: "#1f2937", StrokeWidth: "2",
-                    OnClick: () => _selected = i)
-                """,
-                Notes:
-                $"Click a swatch — the selection re-renders live over the same transport as the rest of the page. Selected: {Swatches[_selected].Name}.",
-                Result: Fragment()[
-                    Svg(Width: "240", Height: "48", ViewBox: "0 0 240 48")[BuildSwatches()],
-                    P(Class: "mt-2 mb-0 small text-secondary")[
-                        "Selected colour: ",
-                        Strong()[Swatches[_selected].Name]
+        H2(Class: "h4 mt-5 mb-3")["Gradients via <defs> and <linearGradient>"],
+        CodeSample(
+            """
+            Svg(Width: "120", Height: "120", ViewBox: "22 6 80 108")[
+                SvgTitle()["Rask"],
+                Defs()[
+                    LinearGradient(Id: "bolt", X1: "0", Y1: "0", X2: "1", Y2: "1")[
+                        Stop(Offset: "0%", StopColor: "#7C3AED"),
+                        Stop(Offset: "100%", StopColor: "#512BD4")
                     ]
-                ]),
+                ],
+                SvgPath(D: "M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z",
+                    Fill: "url(#bolt)")
+            ]
+            """,
+            Notes:
+            "The Rask brand mark itself is built this way — see Demos/RaskLogo.cs. A nested SvgTitle gives the graphic its accessible name.",
+            Result: RaskLogo.Mark(120, "svgPageBolt")),
 
-            H2(Class: "h4 mt-5 mb-3")["Text with <text> and <tspan>"],
-            CodeSample(
-                """
-                Svg(Width: "220", Height: "60", ViewBox: "0 0 220 60")[
-                    SvgText(X: "10", Y: "38", FontFamily: "sans-serif",
-                        FontSize: "28", FontWeight: "bold", Fill: "#512BD4")[
-                        "Ra",
-                        Tspan(Fill: "#0D9488")["sk"]
-                    ]
+        H2(Class: "h4 mt-5 mb-3")["Clickable shapes — OnClick on any element"],
+        CodeSample(
+            """
+            // SvgElement carries OnClick/OnClickAsync, so a shape dispatches
+            // through the same handler path as a Button.
+            Circle(Cx: "20", Cy: "20", R: "18",
+                Fill: i == _selected ? hex : "#e5e7eb",
+                Stroke: "#1f2937", StrokeWidth: "2",
+                OnClick: () => _selected = i)
+            """,
+            Notes:
+            $"Click a swatch — the selection re-renders live over the same transport as the rest of the page. Selected: {Swatches[_selected].Name}.",
+            Result: Fragment()[
+                Svg("240", "48", "0 0 240 48")[BuildSwatches()],
+                P(Class: "mt-2 mb-0 small text-secondary")[
+                    "Selected colour: ",
+                    Strong()[Swatches[_selected].Name]
                 ]
-                """,
-                Notes:
-                "SvgText is the <text> tag (renamed to avoid colliding with the Text primitive); Tspan styles a run inside it.",
-                Result: Svg(Width: "220", Height: "60", ViewBox: "0 0 220 60")[
-                    SvgText(X: "10", Y: "38", FontFamily: "sans-serif", FontSize: "28",
-                        FontWeight: "bold", Fill: "#512BD4")[
-                        "Ra",
-                        Tspan(Fill: "#0D9488")["sk"]
-                    ]
-                ])
-        ];
+            ]),
+
+        H2(Class: "h4 mt-5 mb-3")["Text with <text> and <tspan>"],
+        CodeSample(
+            """
+            Svg(Width: "220", Height: "60", ViewBox: "0 0 220 60")[
+                SvgText(X: "10", Y: "38", FontFamily: "sans-serif",
+                    FontSize: "28", FontWeight: "bold", Fill: "#512BD4")[
+                    "Ra",
+                    Tspan(Fill: "#0D9488")["sk"]
+                ]
+            ]
+            """,
+            Notes:
+            "SvgText is the <text> tag (renamed to avoid colliding with the Text primitive); Tspan styles a run inside it.",
+            Result: Svg("220", "60", "0 0 220 60")[
+                SvgText("10", "38", FontFamily: "sans-serif", FontSize: "28",
+                    FontWeight: "bold", Fill: "#512BD4")[
+                    "Ra",
+                    Tspan(Fill: "#0D9488")["sk"]
+                ]
+            ])
+    ];
 
     // Keyed so the diff codec reconciles the swatches by identity rather than by position.
     private List<Child> BuildSwatches()
@@ -116,9 +116,9 @@ public sealed class SvgPage : Component
             var index = i;
             var (_, hex) = Swatches[i];
             children.Add(Circle(
-                Cx: (24 + i * 56).ToString(),
-                Cy: "24",
-                R: "18",
+                (24 + (i * 56)).ToString(),
+                "24",
+                "18",
                 Fill: i == _selected ? hex : "#e5e7eb",
                 Stroke: "#1f2937",
                 StrokeWidth: "2",

--- a/samples/Rask.Example.Shared/Pages/TablePage.cs
+++ b/samples/Rask.Example.Shared/Pages/TablePage.cs
@@ -90,7 +90,8 @@ public sealed class TablePage(Navigator nav) : Component
         var from = totalFiltered == 0 ? 0 : ((page - 1) * size) + 1;
         var to = totalFiltered == 0 ? 0 : from + visible.Length - 1;
 
-        return [
+        return
+        [
             PageHeader.Render(
                 "Data table",
                 "Sortable columns, paged rows, search and page-size selector — all driven from the URL query string. Bookmark or share any view."),

--- a/samples/Rask.Example.Shared/Pages/TagsPage.cs
+++ b/samples/Rask.Example.Shared/Pages/TagsPage.cs
@@ -12,93 +12,93 @@ public sealed class TagsPage : Component
     protected override RenderResult Head => Title()["Tag factories — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Tag factories",
-                "Every standard HTML element has a generator-emitted factory in Rask.Core.Components.Generated. " +
-                "Tag-specific attributes come first; the universal Id/Class/Style/Data trail at the end."),
-            H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-fonts text-accent me-2"), "Text & semantic"],
-            CodeSample(
-                """
-                Article()[
-                    H1()["Tags are just methods."],
-                    P()[
-                        "You can ", Strong()["emphasize"], " or ",
-                        Em()["italicize"], " by composing them."
-                    ],
-                    Blockquote()["A small DSL, an honest day's HTML."]
+    [
+        PageHeader.Render(
+            "Tag factories",
+            "Every standard HTML element has a generator-emitted factory in Rask.Core.Components.Generated. " +
+            "Tag-specific attributes come first; the universal Id/Class/Style/Data trail at the end."),
+        H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-fonts text-accent me-2"), "Text & semantic"],
+        CodeSample(
+            """
+            Article()[
+                H1()["Tags are just methods."],
+                P()[
+                    "You can ", Strong()["emphasize"], " or ",
+                    Em()["italicize"], " by composing them."
+                ],
+                Blockquote()["A small DSL, an honest day's HTML."]
+            ]
+            """,
+            Result: Article()[
+                H1(Class: "h4")["Tags are just methods."],
+                P()[
+                    "You can ", Strong()["emphasize"], " or ", Em()["italicize"],
+                    " by composing them."
+                ],
+                Blockquote(Class: "blockquote fs-6")["A small DSL, an honest day's HTML."]
+            ]),
+        H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-input-cursor-text text-accent me-2"), "Forms"],
+        CodeSample(
+            """
+            Form()[
+                Label(For: "n")["Name"],
+                Input(Type: "text", Id: "n", Placeholder: "Jane Doe"),
+                Button(Type: "submit")["Submit"]
+            ]
+            """,
+            Result: Form()[
+                Div(Class: "mb-2")[
+                    Label("n", Class: "form-label small mb-1")["Name"],
+                    Input("text", Id: "n", Class: "form-control form-control-sm", Placeholder: "Jane Doe")
+                ],
+                Button("submit", Class: "btn btn-primary btn-sm")["Submit"]
+            ]),
+        H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-table text-accent me-2"), "Tables"],
+        CodeSample(
+            """
+            Table()[
+                Thead()[Tr()[
+                    Th()["#"],
+                    Th()["Tag"]
+                ]],
+                Tbody()[
+                    Tr()[Td()["1"], Td()["Div"]],
+                    Tr()[Td()["2"], Td()["Span"]]
                 ]
-                """,
-                Result: Article()[
-                    H1(Class: "h4")["Tags are just methods."],
-                    P()[
-                        "You can ", Strong()["emphasize"], " or ", Em()["italicize"],
-                        " by composing them."
-                    ],
-                    Blockquote(Class: "blockquote fs-6")["A small DSL, an honest day's HTML."]
-                ]),
-            H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-input-cursor-text text-accent me-2"), "Forms"],
-            CodeSample(
-                """
-                Form()[
-                    Label(For: "n")["Name"],
-                    Input(Type: "text", Id: "n", Placeholder: "Jane Doe"),
-                    Button(Type: "submit")["Submit"]
+            ]
+            """,
+            Result: Table(Class: "table table-sm mb-0")[
+                Thead()[Tr()[Th()["#"], Th()["Tag"]]],
+                Tbody()[
+                    Tr()[Td()["1"], Td()[Code()["Div"]]],
+                    Tr()[Td()["2"], Td()[Code()["Span"]]]
                 ]
-                """,
-                Result: Form()[
-                    Div(Class: "mb-2")[
-                        Label("n", Class: "form-label small mb-1")["Name"],
-                        Input("text", Id: "n", Class: "form-control form-control-sm", Placeholder: "Jane Doe")
-                    ],
-                    Button("submit", Class: "btn btn-primary btn-sm")["Submit"]
-                ]),
-            H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-table text-accent me-2"), "Tables"],
-            CodeSample(
-                """
-                Table()[
-                    Thead()[Tr()[
-                        Th()["#"],
-                        Th()["Tag"]
-                    ]],
-                    Tbody()[
-                        Tr()[Td()["1"], Td()["Div"]],
-                        Tr()[Td()["2"], Td()["Span"]]
-                    ]
-                ]
-                """,
-                Result: Table(Class: "table table-sm mb-0")[
-                    Thead()[Tr()[Th()["#"], Th()["Tag"]]],
-                    Tbody()[
-                        Tr()[Td()["1"], Td()[Code()["Div"]]],
-                        Tr()[Td()["2"], Td()[Code()["Span"]]]
-                    ]
-                ]),
-            H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-image text-accent me-2"), "Media"],
-            CodeSample(
-                """
-                Img(Src: LiveOptions.PathBase + "/img/rask-placeholder.svg",
-                    Alt: "Rask")
-                """,
-                Result: Img(
-                    LiveOptions.PathBase + "/img/rask-placeholder.svg",
-                    "Rask",
-                    Class: "rounded shadow-sm")),
-            H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-dash-circle text-accent me-2"), "Void elements"],
-            CodeSample(
-                """
-                Fragment(
-                    P()["Above the rule"],
-                    Hr(),
-                    P()["Below the rule"]
-                )
-                """,
-                Notes:
-                "Void elements (Br, Hr, Img, Meta, Link, Input, …) have SelfClosing => true and never accept children.",
-                Result: Fragment()[
-                    P(Class: "mb-2")["Above the rule"],
-                    Hr(),
-                    P(Class: "mb-0")["Below the rule"]
-                ])
-        ];
+            ]),
+        H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-image text-accent me-2"), "Media"],
+        CodeSample(
+            """
+            Img(Src: LiveOptions.PathBase + "/img/rask-placeholder.svg",
+                Alt: "Rask")
+            """,
+            Result: Img(
+                LiveOptions.PathBase + "/img/rask-placeholder.svg",
+                "Rask",
+                Class: "rounded shadow-sm")),
+        H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-dash-circle text-accent me-2"), "Void elements"],
+        CodeSample(
+            """
+            Fragment(
+                P()["Above the rule"],
+                Hr(),
+                P()["Below the rule"]
+            )
+            """,
+            Notes:
+            "Void elements (Br, Hr, Img, Meta, Link, Input, …) have SelfClosing => true and never accept children.",
+            Result: Fragment()[
+                P(Class: "mb-2")["Above the rule"],
+                Hr(),
+                P(Class: "mb-0")["Below the rule"]
+            ])
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/TodosPage.cs
+++ b/samples/Rask.Example.Shared/Pages/TodosPage.cs
@@ -11,7 +11,7 @@ namespace Rask.Example.Shared.Pages;
 [ParentRoute(typeof(ShowcaseLayout))]
 public sealed class TodosPage(Navigator nav, RouteState route) : Component
 {
-    [RouteParam] public Guid? Id { get; set; }
+    private readonly TodoForm _form = new();
 
     private readonly List<TodoItem> _todos =
     [
@@ -19,7 +19,7 @@ public sealed class TodosPage(Navigator nav, RouteState route) : Component
         new() { Title = "Wire up a feature toggle", Completed = true }
     ];
 
-    private readonly TodoForm _form = new();
+    [RouteParam] public Guid? Id { get; set; }
 
     protected override RenderResult Head => Title()["Todos — Rask"];
 
@@ -62,7 +62,8 @@ public sealed class TodosPage(Navigator nav, RouteState route) : Component
     protected override RenderResult Render()
     {
         var done = _todos.Count(t => t.Completed);
-        return [
+        return
+        [
             PageHeader.Render(
                 "Todos",
                 "A small CRUD screen built on top of Rask primitives. The page declares three [Route] attributes — /todos shows the list, /todos/new opens the add dialog, /todos/{id:guid}/edit opens the edit dialog. Browser Back closes the dialog; deep links open it."),
@@ -98,11 +99,11 @@ public sealed class TodosPage(Navigator nav, RouteState route) : Component
                     ])
                 ],
             TodoFormDialog(
-                Open: ShowDialog,
-                Model: _form,
-                IsAdding: IsAdding,
-                OnCancel: Cancel,
-                OnSave: Save)
+                ShowDialog,
+                _form,
+                IsAdding,
+                Cancel,
+                Save)
         ];
     }
 }
@@ -119,7 +120,7 @@ public sealed class TodoFormDialog : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        Dialog(Open: Open)[
+        Dialog(Open)[
             H5(Class: "mb-3")[IsAdding ? "Add todo" : "Edit todo"],
             Form(Model, OnSave, Class: "vstack gap-3")[
                 DataAnnotationsValidator(),

--- a/samples/Rask.Example.Shared/Pages/UploadPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UploadPage.cs
@@ -33,30 +33,30 @@ public sealed class UploadPage : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "File upload",
-                "Input(Type: \"file\", OnFiles: …) wires a file picker to a typed handler. RaskFile carries the metadata; OpenReadStream gives you a Stream for the bytes — over multipart POST on the server, via JS chunked reads on WASM."),
-            H2(Class: "h4 mt-4 mb-3")["Pick a file"],
-            CodeSample(
-                """
-                Input(Type: "file", OnFiles: files => {
-                    var file = files[0];
-                    _name = file.Name;
-                    _size = file.Size;
-                    _contentType = file.ContentType;
-                    _modified = file.LastModified;
-                })
+    [
+        PageHeader.Render(
+            "File upload",
+            "Input(Type: \"file\", OnFiles: …) wires a file picker to a typed handler. RaskFile carries the metadata; OpenReadStream gives you a Stream for the bytes — over multipart POST on the server, via JS chunked reads on WASM."),
+        H2(Class: "h4 mt-4 mb-3")["Pick a file"],
+        CodeSample(
+            """
+            Input(Type: "file", OnFiles: files => {
+                var file = files[0];
+                _name = file.Name;
+                _size = file.Size;
+                _contentType = file.ContentType;
+                _modified = file.LastModified;
+            })
 
-                // Inside the same handler — or any handler that ran while the
-                // file is still alive — read the bytes:
-                // using var s = file.OpenReadStream(maxAllowedSize, CancellationToken);
-                // await s.CopyToAsync(destination);
-                """,
-                Notes:
-                "The handler runs once per change event. RaskFile is only valid while the handler is on the stack — read whatever you need (bytes, metadata) before returning. The same component code runs unchanged on both hosts.",
-                Result: RenderResult())
-        ];
+            // Inside the same handler — or any handler that ran while the
+            // file is still alive — read the bytes:
+            // using var s = file.OpenReadStream(maxAllowedSize, CancellationToken);
+            // await s.CopyToAsync(destination);
+            """,
+            Notes:
+            "The handler runs once per change event. RaskFile is only valid while the handler is on the stack — read whatever you need (bytes, metadata) before returning. The same component code runs unchanged on both hosts.",
+            Result: RenderResult())
+    ];
 
     private Component RenderResult() =>
         Div()[

--- a/samples/Rask.Example.Shared/Pages/UserDetailPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UserDetailPage.cs
@@ -14,57 +14,57 @@ public sealed class UserDetailPage(Navigator nav) : Component
     protected override RenderResult Head => Title()[$"User #{Id} — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                $"User #{Id}",
-                "This page lives at /users/{id}. The Id property is bound from the URL segment and Tab from the ?tab= query string."),
-            H2(Class: "h4 mt-4 mb-3")["Current binding"],
-            Div(Class: "card mb-3 shadow-sm border-0")[
-                Div(Class: "card-body")[
-                    Ul(Class: "list-unstyled mb-0")[
-                        Li(Class: "mb-2")[
-                            Span(Class: "badge text-bg-primary me-2")["RouteParam"],
-                            Code()["Id"], " = ", Strong()[Id]
-                        ],
-                        Li()[
-                            Span(Class: "badge text-bg-secondary me-2")["QueryParam"],
-                            Code()["Tab"], " = ", Strong()[Tab ?? "(none)"]
-                        ]
+    [
+        PageHeader.Render(
+            $"User #{Id}",
+            "This page lives at /users/{id}. The Id property is bound from the URL segment and Tab from the ?tab= query string."),
+        H2(Class: "h4 mt-4 mb-3")["Current binding"],
+        Div(Class: "card mb-3 shadow-sm border-0")[
+            Div(Class: "card-body")[
+                Ul(Class: "list-unstyled mb-0")[
+                    Li(Class: "mb-2")[
+                        Span(Class: "badge text-bg-primary me-2")["RouteParam"],
+                        Code()["Id"], " = ", Strong()[Id]
+                    ],
+                    Li()[
+                        Span(Class: "badge text-bg-secondary me-2")["QueryParam"],
+                        Code()["Tab"], " = ", Strong()[Tab ?? "(none)"]
                     ]
                 ]
-            ],
-            CodeSample(
-                """
-                [Route("users/{id}")]
-                public sealed class UserDetailPage : Component
-                {
-                    [RouteParam] public string Id { get; set; } = string.Empty;
-                    [QueryParam("tab")] public string? Tab { get; set; }
-
-                    public override RenderResult Render() => /* uses Id and Tab */;
-                }
-                """,
-                Notes:
-                "Route templates use {name} for segments. Add a type constraint with {name:int}, optional with {name?}, or a catch-all with {**rest}. [RouteParam] without an argument matches by property name; pass a string to alias."),
-            H2(Class: "h4 mt-5 mb-3")["Switch user"],
-            Div(Class: "btn-group mb-3")[
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () => nav.Navigate("/users/1"))["User #1"],
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () => nav.Navigate("/users/42"))["#42"],
-                Button(
-                    Class: "btn btn-outline-primary btn-sm",
-                    OnClick: () => nav.Navigate("/users/137"))["#137"]
-            ],
-            Div()[
-                Button(
-                    Class: "btn btn-primary btn-sm",
-                    OnClick: () => nav.SetQuery("tab", Tab == "profile" ? "activity" : "profile"))[
-                    I(Class: "bi bi-toggle-on me-1"),
-                    "Toggle ?tab=", Tab == "profile" ? "activity" : "profile"
-                ]
             ]
-        ];
+        ],
+        CodeSample(
+            """
+            [Route("users/{id}")]
+            public sealed class UserDetailPage : Component
+            {
+                [RouteParam] public string Id { get; set; } = string.Empty;
+                [QueryParam("tab")] public string? Tab { get; set; }
+
+                public override RenderResult Render() => /* uses Id and Tab */;
+            }
+            """,
+            Notes:
+            "Route templates use {name} for segments. Add a type constraint with {name:int}, optional with {name?}, or a catch-all with {**rest}. [RouteParam] without an argument matches by property name; pass a string to alias."),
+        H2(Class: "h4 mt-5 mb-3")["Switch user"],
+        Div(Class: "btn-group mb-3")[
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () => nav.Navigate("/users/1"))["User #1"],
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () => nav.Navigate("/users/42"))["#42"],
+            Button(
+                Class: "btn btn-outline-primary btn-sm",
+                OnClick: () => nav.Navigate("/users/137"))["#137"]
+        ],
+        Div()[
+            Button(
+                Class: "btn btn-primary btn-sm",
+                OnClick: () => nav.SetQuery("tab", Tab == "profile" ? "activity" : "profile"))[
+                I(Class: "bi bi-toggle-on me-1"),
+                "Toggle ?tab=", Tab == "profile" ? "activity" : "profile"
+            ]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/UserPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UserPage.cs
@@ -11,53 +11,55 @@ public sealed class UserPage : Component
     protected override RenderResult Head => Title()["User & auth gating — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "User & auth gating",
-                "Gate content on the signed-in user — imperatively with the built-in Component.User (branch in Render() on User.Identity?.IsAuthenticated and User.IsInRole(...)), or declaratively with the headless Authorize component."),
-            H2(Class: "h4 mt-4 mb-3")["Conditional rendering on User"],
-            CodeSample(
-                """
-                // Component.User comes from the registered IUserProvider
-                protected override RenderResult Render() =>
-                    User.Identity?.IsAuthenticated == true
-                        ? Fragment(
-                            P()[$"Signed in as {User.Identity!.Name}"],
-                            User.IsInRole("admin") ? AdminPanel() : Fragment(),
-                            Button(OnClick: _auth.SignOut)["Sign out"])
-                        : Button(OnClick: () => _auth.SignIn("alice", "user"))["Sign in"];
+    [
+        PageHeader.Render(
+            "User & auth gating",
+            "Gate content on the signed-in user — imperatively with the built-in Component.User (branch in Render() on User.Identity?.IsAuthenticated and User.IsInRole(...)), or declaratively with the headless Authorize component."),
+        H2(Class: "h4 mt-4 mb-3")["Conditional rendering on User"],
+        CodeSample(
+            """
+            // Component.User comes from the registered IUserProvider
+            protected override RenderResult Render() =>
+                User.Identity?.IsAuthenticated == true
+                    ? Fragment(
+                        P()[$"Signed in as {User.Identity!.Name}"],
+                        User.IsInRole("admin") ? AdminPanel() : Fragment(),
+                        Button(OnClick: _auth.SignOut)["Sign out"])
+                    : Button(OnClick: () => _auth.SignIn("alice", "user"))["Sign in"];
 
-                // re-render when auth changes (the provider raises Changed)
-                protected override void OnMount()   => _auth.Changed += StateHasChanged;
-                protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
-                """,
-                Notes:
-                "User resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on User subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
-                Result: UserGateDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Declarative gating — the Authorize component"],
-            CodeSample(
-                """
-                // Headless: renders exactly one of three slots, no markup of its own.
-                // The component subscribes to IUserProvider.Changed itself, so it reacts to sign-in/out.
-                Authorize(
-                    Roles: ["admin"],                                  // ANY-of; omit for "any authenticated user"
-                    Authorized:    Div(Class: "alert alert-warning")["🔑 Admin-only content."],
-                    NotAuthorized: Authorize(                        // nest for an authenticated-but-not-admin branch
-                        Authorized:    Div(Class: "alert alert-success")["✅ Signed in — standard access."],
-                        NotAuthorized: Div(Class: "alert alert-secondary")["🔒 Sign in to see member content."]));
+            // re-render when auth changes (the provider raises Changed)
+            protected override void OnMount()   => _auth.Changed += StateHasChanged;
+            protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
+            """,
+            Notes:
+            "User resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on User subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
+            Result: UserGateDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Declarative gating — the Authorize component"],
+        CodeSample(
+            """
+            // Headless: renders exactly one of three slots, no markup of its own.
+            // The component subscribes to IUserProvider.Changed itself, so it reacts to sign-in/out.
+            Authorize(
+                Roles: ["admin"],                                  // ANY-of; omit for "any authenticated user"
+                Authorized:    Div(Class: "alert alert-warning")["🔑 Admin-only content."],
+                NotAuthorized: Authorize(                        // nest for an authenticated-but-not-admin branch
+                    Authorized:    Div(Class: "alert alert-success")["✅ Signed in — standard access."],
+                    NotAuthorized: Div(Class: "alert alert-secondary")["🔒 Sign in to see member content."]));
 
-                // Shorthand — children are the Authorized branch:
-                //   Authorize(Roles: ["admin"])[ AdminPanel() ]
-                // Policy gating resolves via IAuthorizationService; the optional Authorizing slot shows
-                // until it lands (and while a WASM provider's principal is still loading).
-                """,
-                Notes:
-                "Authorize is the declarative counterpart to gating in Render() on User: it picks the Authorized, NotAuthorized, or Authorizing slot off the same Component.User. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
-                Result: AuthorizeDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Notes"],
-            Ul(Class: "text-secondary")[
-                Li()["Component.User never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so User.Identity?.IsAuthenticated is false."],
-                Li()["Role checks use the standard ClaimsPrincipal.IsInRole. For route-level gating use [Authorize]/[AllowAnonymous] on the page (RouteAuthorizationGuard) instead of branching in Render()."]
-            ]
-        ];
+            // Shorthand — children are the Authorized branch:
+            //   Authorize(Roles: ["admin"])[ AdminPanel() ]
+            // Policy gating resolves via IAuthorizationService; the optional Authorizing slot shows
+            // until it lands (and while a WASM provider's principal is still loading).
+            """,
+            Notes:
+            "Authorize is the declarative counterpart to gating in Render() on User: it picks the Authorized, NotAuthorized, or Authorizing slot off the same Component.User. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
+            Result: AuthorizeDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Notes"],
+        Ul(Class: "text-secondary")[
+            Li()[
+                "Component.User never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so User.Identity?.IsAuthenticated is false."],
+            Li()[
+                "Role checks use the standard ClaimsPrincipal.IsInRole. For route-level gating use [Authorize]/[AllowAnonymous] on the page (RouteAuthorizationGuard) instead of branching in Render()."]
+        ]
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/ValidationPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ValidationPage.cs
@@ -11,348 +11,348 @@ public sealed class ValidationPage : Component
     protected override RenderResult Head => Title()["Validation — Rask"];
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Validation",
-                "Validators are opt-in components placed inside the Form. Drop DataAnnotationsValidator() in if your model uses [Required]/[Range]/etc., or FluentValidationValidator(...) if you wired up FluentValidation. Or skip both and pass Validate: directly on Form (cross-field rule) or on Input/Select/Textarea (per-field rule) — the callback is just a Func that returns IEnumerable<string>, sync or async."),
-            H2(Class: "h4 mt-4 mb-3")["Per-field — DataAnnotations + ValidationMessage"],
-            CodeSample(
-                """
-                static Component FieldError(IReadOnlyList<string> msgs) =>
-                    Fragment()[msgs.Select(m => Div(Class: "text-danger small")[m])];
+    [
+        PageHeader.Render(
+            "Validation",
+            "Validators are opt-in components placed inside the Form. Drop DataAnnotationsValidator() in if your model uses [Required]/[Range]/etc., or FluentValidationValidator(...) if you wired up FluentValidation. Or skip both and pass Validate: directly on Form (cross-field rule) or on Input/Select/Textarea (per-field rule) — the callback is just a Func that returns IEnumerable<string>, sync or async."),
+        H2(Class: "h4 mt-4 mb-3")["Per-field — DataAnnotations + ValidationMessage"],
+        CodeSample(
+            """
+            static Component FieldError(IReadOnlyList<string> msgs) =>
+                Fragment()[msgs.Select(m => Div(Class: "text-danger small")[m])];
 
-                Form(Model: _model,
-                     OnValidSubmit: (RegistrationModel m) =>
-                         _submission = $"Registered: {m.Name} <{m.Email}>")[
-                        DataAnnotationsValidator(),
-                        Label(For: "name")["Name"],
-                        Input(Bind: () => _model.Name, Id: "name"),
-                        ValidationMessage(For: () => _model.Name, Template: FieldError),
-                        // ... Email, Age, Plan ...
-                        Button(Type: "submit")["Register"]
-                     ]
-                """,
-                Notes:
-                "DataAnnotationsValidator() is a real component — drop it in to opt into [Required]/[EmailAddress]/[Range]/[StringLength]. ValidationMessage's Template runs only when the field has at least one message — the empty state stays out of the DOM.",
-                Result: ValidationFieldsDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Top-of-form — ValidationSummary"],
-            CodeSample(
-                """
-                static Component SummaryAlert(IReadOnlyList<ValidationEntry> entries) =>
-                    Div(Class: "alert alert-danger small mb-0")[
-                        Ul(Class: "mb-0 ps-3")[
-                            entries.Select(e => Li()[
-                                Strong()[e.Field], ": ", e.Message
-                            ])
-                        ]
-                    ];
-
-                Form(Model: _model,
-                     OnValidSubmit: (RegistrationModel m) => /* ... */)[
-                        DataAnnotationsValidator(),
-                        ValidationSummary(Template: SummaryAlert),
-                        // ... unadorned fields, no per-field ValidationMessage ...
-                        Button(Type: "submit")["Register"]
-                     ]
-                """,
-                Notes:
-                "ValidationSummary's Template receives every current ValidationEntry (Field + Message). The component itself emits nothing — wrapper, list shape, and field formatting are entirely yours.",
-                Result: ValidationSummaryDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Inline — Validate: on field & form"],
-            CodeSample(
-                """
-                Form<LoginModel>(_model,
-                     OnValidSubmit: m => _submission = "Welcome",
-                     Validate: m =>
-                         m.Password == m.Confirm ? [] : ["Passwords do not match."])[
-                        Input(Bind: () => _model.Email,
-                              Validate: v =>
-                                  v.Contains('@') ? [] : ["Email looks wrong."]),
-                        ValidationMessage(For: () => _model.Email, Template: FieldError),
-                        Input(Bind: () => _model.Password, Type: "password"),
-                        Input(Bind: () => _model.Confirm, Type: "password"),
-                        ValidationSummary(Template: SummaryAlert),
-                        Button(Type: "submit")["Sign in"]
-                     ]
-                """,
-                Notes:
-                "No DataAnnotations on the model — every rule lives at the call site. Validate: on Input runs per-keystroke (after the field is touched) and produces field-scoped messages. Validate: on Form runs at submit and produces summary-scoped messages. Both delegates accept either a Func<T, IEnumerable<string>> (sync) or Func<T, CancellationToken, ValueTask<IEnumerable<string>>> (async).",
-                Result: InlineValidateDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Nested test"],
-            CodeSample(
-                """
-                public sealed class StorefrontModel {
-                    public string CustomerName { get; set; } = "";
-                    public StorefrontAddress Address { get; set; } = new();
-                    public List<StorefrontLineItem> Items { get; set; } = new();
-                    public string DiscountCode { get; set; } = "";
-                }
-
-                static async ValueTask<IEnumerable<string>> ValidatePostalAsync(
-                    string code, CancellationToken ct)
-                {
-                    if (!Regex.IsMatch(code ?? "", @"^\d{5}$"))
-                        return new[] { "Postal code must be 5 digits." };
-                    await Task.Delay(300, ct);
-                    return Undeliverable.Contains(code)
-                        ? new[] { "We don't ship to this area." }
-                        : Array.Empty<string>();
-                }
-
-                protected override RenderResult Render() {
-                    // Derived state — recomputed on every render. The dispatcher re-renders
-                    // after each handler completes, so the figures stay in sync automatically.
-                    var subtotal = _model.Items.Sum(i => i.Quantity * i.UnitPrice);
-                    var pct = PromoCodes.GetValueOrDefault(_model.DiscountCode, 0m);
-                    var total = subtotal * (1m - pct) * 1.08m;
-
-                    return Form<StorefrontModel>(_model, OnValidSubmit)[
-                        // Async validation on a NESTED field.
-                        Input(Bind: () => _model.Address.PostalCode, Validate: ValidatePostalAsync),
-                        ValidatingIndicator(For: () => _model.Address.PostalCode, Template: Checking),
-                        ValidationMessage(For: () => _model.Address.PostalCode, Template: FieldError),
-                        Input(Bind: () => _model.Items[0].Quantity),
-                        Input(Bind: () => _model.Items[0].UnitPrice),
-                        Input(Bind: () => _model.DiscountCode),
-                        Div()[ "Total ", total ]
-                    ];
-                }
-                """,
-                Notes:
-                "Combines async validation on a nested field with live derived UI. The Validate: lambda on Input(() => _model.Address.PostalCode, …) routes through the form's EditContext, same as a root field — latest-wins cancellation supersedes the prior in-flight check, ValidatingIndicator surfaces while the await is pending, and OperationCanceledException is swallowed without producing a generic message. Live calcs work because every event handler re-renders the owning component: string fields (DiscountCode) update on every keystroke via OnInput, numeric fields (Quantity / UnitPrice) update on blur via OnChange — both flow through the same dispatcher path. Submit only fires OnValidSubmit when every per-field rule passes; an undeliverable ZIP keeps the form pending until corrected.",
-                Result: NestedAsyncWithLiveTotalsDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Inline async — Validate: as Func<T, CT, ValueTask<IEnumerable<string>>>"],
-            CodeSample(
-                """
-                static async ValueTask<IEnumerable<string>> CheckCodeAsync(string code, CancellationToken ct) {
-                    await Task.Delay(250, ct);
-                    return TakenCodes.Contains(code) ? new[] { $"\"{code}\" is reserved." } : [];
-                }
-
-                Form<PromoModel>(Model: _model, OnValidSubmit: m => ...,
-                     Validate: async (m, ct) =>
-                         string.IsNullOrWhiteSpace(m.Code) ? ["Code is required."] : [])[
-                        Input(Bind: () => _model.Code, Validate: CheckCodeAsync),
-                        ValidatingIndicator(For: () => _model.Code, Template: Checking),
-                        ValidationMessage(For: () => _model.Code, Template: FieldError),
-                        Button(Type: "submit")["Redeem"]
-                     ]
-                """,
-                Notes:
-                "Same call-site shape as the sync Validate above — overload resolution picks the async variant from the lambda's two-parameter arity (or method-group conversion against a `(T, CancellationToken) -> ValueTask<IEnumerable<string>>` method). The ValidatingIndicator surfaces while the 250ms delay runs; rapid typing supersedes the prior in-flight check (latest-wins) and OperationCanceledException is swallowed without producing a generic message.",
-                Result: InlineAsyncValidateDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Async — IAsyncFieldValidator / FluentValidation"],
-            CodeSample(
-                """
-                public sealed class UniqueUsernameValidator : IAsyncFieldValidator {
-                    public async ValueTask ValidateFieldAsync(
-                        EditContext ctx, FieldIdentifier field, CancellationToken ct) {
-                            await Task.Delay(400, ct);   // pretend it's an API call
-                            if (Taken.Contains(ctx.Model.Username))
-                                ctx.AddValidationMessage(field, "Already taken.");
-                    }
-                    /* ValidateAsync similar */
-                }
-
-                Form(Model: _model, OnValidSubmit: ...)[
+            Form(Model: _model,
+                 OnValidSubmit: (RegistrationModel m) =>
+                     _submission = $"Registered: {m.Name} <{m.Email}>")[
                     DataAnnotationsValidator(),
-                    new UniqueUsernameValidator() /* or FluentValidationValidator(new …) */,
-                    Input(Bind: () => _model.Username),
-                    ValidatingIndicator(For: () => _model.Username, Template: Checking),
-                    ValidationMessage(For: () => _model.Username, Template: FieldError)
-                ]
-                """,
-                Notes:
-                "Try \"admin\" or \"taken\" — the ValidatingIndicator shows while the 400ms check runs, then a message appears. Per-keystroke calls cancel any prior in-flight check (latest-wins). Submit awaits all validators before routing to OnValidSubmit vs OnInvalidSubmit. The literal \"explode\" forces the demo validator to throw mid-await so you can see the generic \"Validation could not be completed.\" fallback that the framework surfaces when a validator faults. The indicator stays visible for ~200 ms after the check completes — EditContext.ValidatingStickyMs (default 200) smooths over sub-second validators that would otherwise flash on/off; set it to 0 on a manually-built EditContext to opt out.",
-                Result: AsyncValidationDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Cross-field — Form-level Validate feeding ValidationSummary"],
-            CodeSample(
-                """
-                Form<TripModel>(Model: _model, OnValidSubmit: m => _submission = ...,
-                     Validate: m =>
-                         m.Return > m.Depart
-                             ? Array.Empty<string>()
-                             : new[] { "Return date must be after departure." })[
-                        ValidationSummary(SummaryAlert),
-                        Input(Bind: () => _model.Depart, Id: "v5-depart"),
-                        Input(Bind: () => _model.Return, Id: "v5-return"),
-                        Button(Type: "submit")["Book"]
-                     ]
-                """,
-                Notes:
-                "Form-level Validate runs at submit time and adds its messages to FieldIdentifier(model, \"\") — they surface in ValidationSummary alongside any field-level messages but never tag a specific input.",
-                Result: CrossFieldSummaryDemo()),
-            H2(Class: "h4 mt-5 mb-3")["IValidatableObject — model-level Validate(ctx) alongside attributes"],
-            CodeSample(
-                """
-                public sealed class BookingModel : IValidatableObject {
-                    [Required(ErrorMessage = "Name is required.")]
-                    public string Name { get; set; } = "";
-                    public DateOnly Departure { get; set; }
-                    public DateOnly Arrival { get; set; }
-
-                    public IEnumerable<ValidationResult> Validate(ValidationContext ctx) {
-                        if (Departure < Today)
-                            yield return new ValidationResult(
-                                "Departure cannot be in the past.",
-                                new[] { nameof(Departure) });   // per-field
-                        if (Arrival <= Departure)
-                            yield return new ValidationResult(
-                                "Arrival must be after departure.");   // form-level
-                    }
-                }
-
-                Form<BookingModel>(_model, OnValidSubmit: m => /* ... */)[
-                    DataAnnotationsValidator(),
-                    ValidationSummary(SummaryAlert),
-                    Input(Bind: () => _model.Name, Id: "v11-name"),
+                    Label(For: "name")["Name"],
+                    Input(Bind: () => _model.Name, Id: "name"),
                     ValidationMessage(For: () => _model.Name, Template: FieldError),
-                    Input(Bind: () => _model.Departure, Id: "v11-departure"),
-                    ValidationMessage(For: () => _model.Departure, Template: FieldError),
-                    Input(Bind: () => _model.Arrival, Id: "v11-arrival"),
-                    Button(Type: "submit")["Book"]
-                ]
-                """,
-                Notes:
-                "ASP.NET Core MVC accumulates attribute errors and IValidatableObject errors into the same ModelState — the BCL's own Validator.TryValidateObject silences IValidatableObject as soon as any attribute fails. DataAnnotationsValidator calls the interface directly so both layers always surface together. ValidationResult.MemberNames routes the message: an empty collection lands on FieldIdentifier(model, \"\") (ValidationSummary), a populated one tags a specific field (ValidationMessage). Submit empty to see Name's [Required] and the model's two Validate() results land in the same render.",
-                Result: ValidatableObjectDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Programmatic — EditContext.Validate() and IsValidating"],
-            CodeSample(
-                """
-                _ctx = new EditContext(_model);
-                _ctx.AddValidator(new SlowTitleValidator());   // 600ms async rule
+                    // ... Email, Age, Plan ...
+                    Button(Type: "submit")["Register"]
+                 ]
+            """,
+            Notes:
+            "DataAnnotationsValidator() is a real component — drop it in to opt into [Required]/[EmailAddress]/[Range]/[StringLength]. ValidationMessage's Template runs only when the field has at least one message — the empty state stays out of the DOM.",
+            Result: ValidationFieldsDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Top-of-form — ValidationSummary"],
+        CodeSample(
+            """
+            static Component SummaryAlert(IReadOnlyList<ValidationEntry> entries) =>
+                Div(Class: "alert alert-danger small mb-0")[
+                    Ul(Class: "mb-0 ps-3")[
+                        entries.Select(e => Li()[
+                            Strong()[e.Field], ": ", e.Message
+                        ])
+                    ]
+                ];
 
-                Form<TaskModel>(_model, m => _submission = ..., Context: _ctx)[
-                    Input(Bind: () => _model.Title, Id: "v6-title"),
-                    ValidatingIndicator(For: () => _model.Title, Template: Checking),
-                    ValidationMessage(For: () => _model.Title, Template: FieldError),
-                    Button(Type: "button", Id: "v6-validate-now",
-                           OnClickAsync: () => _ctx.ValidateAsync().AsTask())["Validate now"],
-                    Button(Type: "submit", Id: "v6-submit",
-                           Disabled: _ctx.IsValidatingAny)["Save"]
-                ]
-                """,
-                Notes:
-                "Hold your own EditContext and pass it via Context: on Form to drive validation from anywhere. Calling ctx.ValidateAsync() outside the submit path raises messages without routing through OnValidSubmit/OnInvalidSubmit. ctx.IsValidatingAny flips while async validators run — bind it to a button's Disabled to block submit during in-flight checks.",
-                Result: ProgrammaticValidateDemo()),
-            H2(Class: "h4 mt-5 mb-3")["FluentValidation — AbstractValidator<TModel>"],
-            CodeSample(
-                """
-                public sealed class OrderValidator : AbstractValidator<OrderModel> {
-                    public OrderValidator() {
-                        RuleFor(x => x.Product).NotEmpty();
-                        RuleFor(x => x.Quantity).GreaterThanOrEqualTo(1)
-                            .WithMessage("Quantity must be at least 1.");
-                    }
-                }
-
-                Form<OrderModel>(_model, m => _submission = ...)[
-                    FluentValidationValidator(new OrderValidator()),
-                    Input(Bind: () => _model.Product, Id: "v7-product"),
-                    ValidationMessage(For: () => _model.Product, Template: FieldError),
-                    Input(Bind: () => _model.Quantity, Id: "v7-quantity"),
-                    ValidationMessage(For: () => _model.Quantity, Template: FieldError),
-                    Button(Type: "submit")["Order"]
-                ]
-                """,
-                Notes:
-                "FluentValidationValidator wraps any IValidator into an IAsyncFieldValidator. Per-keystroke runs use MemberNameValidatorSelector to scope FV to a single property; submit runs every rule on the model.",
-                Result: FluentValidationDemo()),
-            H2(Class: "h4 mt-5 mb-3")["First-error-wins — inline gates DataAnnotations"],
-            CodeSample(
-                """
-                public sealed class LicenseModel {
-                    [RegularExpression(@"^[A-Z]{3}-\d{3}$",
-                        ErrorMessage = "Use the ABC-123 format.")]
-                    public string Code { get; set; } = "";
-                }
-
-                Form<LicenseModel>(_model, m => _submission = "Activated")[
+            Form(Model: _model,
+                 OnValidSubmit: (RegistrationModel m) => /* ... */)[
                     DataAnnotationsValidator(),
-                    Input(Bind: () => _model.Code,
+                    ValidationSummary(Template: SummaryAlert),
+                    // ... unadorned fields, no per-field ValidationMessage ...
+                    Button(Type: "submit")["Register"]
+                 ]
+            """,
+            Notes:
+            "ValidationSummary's Template receives every current ValidationEntry (Field + Message). The component itself emits nothing — wrapper, list shape, and field formatting are entirely yours.",
+            Result: ValidationSummaryDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Inline — Validate: on field & form"],
+        CodeSample(
+            """
+            Form<LoginModel>(_model,
+                 OnValidSubmit: m => _submission = "Welcome",
+                 Validate: m =>
+                     m.Password == m.Confirm ? [] : ["Passwords do not match."])[
+                    Input(Bind: () => _model.Email,
                           Validate: v =>
-                              string.IsNullOrWhiteSpace(v)
-                                  ? new[] { "Code is required." }
-                                  : Array.Empty<string>()),
-                    ValidationMessage(For: () => _model.Code, Template: FieldError),
-                    Button(Type: "submit")["Activate"]
-                ]
-                """,
-                Notes:
-                "The chain runs inline → form-level inline → sync IFieldValidator → async IAsyncFieldValidator. EditContext gates each later stage per-field: once any rule has flagged a field, the later rules on the SAME field stay quiet. Type nothing — only \"Code is required.\" shows. Type \"abc\" — the inline rule passes and DataAnnotations' \"Use the ABC-123 format.\" takes over. Type \"ABC-123\" — both pass and the form submits.",
-                Result: FirstErrorWinsDemo()),
-            H2(Class: "h4 mt-5 mb-3")["FluentValidation async — MustAsync inside the RuleFor chain"],
-            CodeSample(
-                """
-                public sealed class TicketValidator : AbstractValidator<TicketModel> {
-                    public TicketValidator() {
-                        RuleFor(x => x.Code).Cascade(CascadeMode.Stop)
-                            .NotEmpty().WithMessage("Code is required.")
-                            .Matches(@"^TKT-\d{3}$").WithMessage("Format must be TKT-123.")
-                            .MustAsync(async (code, ct) => {
-                                await Task.Delay(400, ct); // pretend it's an API
-                                return !Reserved.Contains(code);
-                            }).WithMessage("Code is already reserved.");
-                    }
-                }
+                              v.Contains('@') ? [] : ["Email looks wrong."]),
+                    ValidationMessage(For: () => _model.Email, Template: FieldError),
+                    Input(Bind: () => _model.Password, Type: "password"),
+                    Input(Bind: () => _model.Confirm, Type: "password"),
+                    ValidationSummary(Template: SummaryAlert),
+                    Button(Type: "submit")["Sign in"]
+                 ]
+            """,
+            Notes:
+            "No DataAnnotations on the model — every rule lives at the call site. Validate: on Input runs per-keystroke (after the field is touched) and produces field-scoped messages. Validate: on Form runs at submit and produces summary-scoped messages. Both delegates accept either a Func<T, IEnumerable<string>> (sync) or Func<T, CancellationToken, ValueTask<IEnumerable<string>>> (async).",
+            Result: InlineValidateDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Nested test"],
+        CodeSample(
+            """
+            public sealed class StorefrontModel {
+                public string CustomerName { get; set; } = "";
+                public StorefrontAddress Address { get; set; } = new();
+                public List<StorefrontLineItem> Items { get; set; } = new();
+                public string DiscountCode { get; set; } = "";
+            }
 
-                Form<TicketModel>(_model, m => _submission = ...)[
-                    FluentValidationValidator(new TicketValidator()),
-                    Input(Bind: () => _model.Code),
+            static async ValueTask<IEnumerable<string>> ValidatePostalAsync(
+                string code, CancellationToken ct)
+            {
+                if (!Regex.IsMatch(code ?? "", @"^\d{5}$"))
+                    return new[] { "Postal code must be 5 digits." };
+                await Task.Delay(300, ct);
+                return Undeliverable.Contains(code)
+                    ? new[] { "We don't ship to this area." }
+                    : Array.Empty<string>();
+            }
+
+            protected override RenderResult Render() {
+                // Derived state — recomputed on every render. The dispatcher re-renders
+                // after each handler completes, so the figures stay in sync automatically.
+                var subtotal = _model.Items.Sum(i => i.Quantity * i.UnitPrice);
+                var pct = PromoCodes.GetValueOrDefault(_model.DiscountCode, 0m);
+                var total = subtotal * (1m - pct) * 1.08m;
+
+                return Form<StorefrontModel>(_model, OnValidSubmit)[
+                    // Async validation on a NESTED field.
+                    Input(Bind: () => _model.Address.PostalCode, Validate: ValidatePostalAsync),
+                    ValidatingIndicator(For: () => _model.Address.PostalCode, Template: Checking),
+                    ValidationMessage(For: () => _model.Address.PostalCode, Template: FieldError),
+                    Input(Bind: () => _model.Items[0].Quantity),
+                    Input(Bind: () => _model.Items[0].UnitPrice),
+                    Input(Bind: () => _model.DiscountCode),
+                    Div()[ "Total ", total ]
+                ];
+            }
+            """,
+            Notes:
+            "Combines async validation on a nested field with live derived UI. The Validate: lambda on Input(() => _model.Address.PostalCode, …) routes through the form's EditContext, same as a root field — latest-wins cancellation supersedes the prior in-flight check, ValidatingIndicator surfaces while the await is pending, and OperationCanceledException is swallowed without producing a generic message. Live calcs work because every event handler re-renders the owning component: string fields (DiscountCode) update on every keystroke via OnInput, numeric fields (Quantity / UnitPrice) update on blur via OnChange — both flow through the same dispatcher path. Submit only fires OnValidSubmit when every per-field rule passes; an undeliverable ZIP keeps the form pending until corrected.",
+            Result: NestedAsyncWithLiveTotalsDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Inline async — Validate: as Func<T, CT, ValueTask<IEnumerable<string>>>"],
+        CodeSample(
+            """
+            static async ValueTask<IEnumerable<string>> CheckCodeAsync(string code, CancellationToken ct) {
+                await Task.Delay(250, ct);
+                return TakenCodes.Contains(code) ? new[] { $"\"{code}\" is reserved." } : [];
+            }
+
+            Form<PromoModel>(Model: _model, OnValidSubmit: m => ...,
+                 Validate: async (m, ct) =>
+                     string.IsNullOrWhiteSpace(m.Code) ? ["Code is required."] : [])[
+                    Input(Bind: () => _model.Code, Validate: CheckCodeAsync),
                     ValidatingIndicator(For: () => _model.Code, Template: Checking),
                     ValidationMessage(For: () => _model.Code, Template: FieldError),
-                    Button(Type: "submit")["Reserve"]
-                ]
-                """,
-                Notes:
-                "FluentValidation's own Cascade(CascadeMode.Stop) mirrors Rask's first-error-wins: NotEmpty must pass before Matches, which must pass before the MustAsync API check fires. Type \"TKT-001\" to see the indicator while the await is in flight, then the \"already reserved\" message land. Type a value not in the reserved set (e.g. \"TKT-999\") to submit successfully. FluentValidationValidator is registered as an IAsyncFieldValidator — async rules and sync rules share the one wrapper.",
-                Result: FluentValidationAsyncDemo()),
-            H2(Class: "h4 mt-5 mb-3")["Custom ValidationAttribute — IsValid, GetValidationResult, and DI"],
-            CodeSample(
-                """
-                // IsValid(object?) — the simplest custom-attribute shape.
-                public sealed class StrongPasswordAttribute : ValidationAttribute {
-                    public override bool IsValid(object? value) =>
-                        value is string s && s.Length >= 8
-                            && s.Any(char.IsLetter) && s.Any(char.IsDigit);
+                    Button(Type: "submit")["Redeem"]
+                 ]
+            """,
+            Notes:
+            "Same call-site shape as the sync Validate above — overload resolution picks the async variant from the lambda's two-parameter arity (or method-group conversion against a `(T, CancellationToken) -> ValueTask<IEnumerable<string>>` method). The ValidatingIndicator surfaces while the 250ms delay runs; rapid typing supersedes the prior in-flight check (latest-wins) and OperationCanceledException is swallowed without producing a generic message.",
+            Result: InlineAsyncValidateDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Async — IAsyncFieldValidator / FluentValidation"],
+        CodeSample(
+            """
+            public sealed class UniqueUsernameValidator : IAsyncFieldValidator {
+                public async ValueTask ValidateFieldAsync(
+                    EditContext ctx, FieldIdentifier field, CancellationToken ct) {
+                        await Task.Delay(400, ct);   // pretend it's an API call
+                        if (Taken.Contains(ctx.Model.Username))
+                            ctx.AddValidationMessage(field, "Already taken.");
                 }
+                /* ValidateAsync similar */
+            }
 
-                // GetValidationResult — reads ValidationContext.ObjectInstance for cross-field rules.
-                public sealed class MatchesPropertyAttribute(string otherProperty) : ValidationAttribute {
-                    protected override ValidationResult? IsValid(object? value, ValidationContext ctx) {
-                        var other = ctx.ObjectInstance.GetType().GetProperty(otherProperty)
-                            ?.GetValue(ctx.ObjectInstance);
-                        return Equals(value, other)
-                            ? ValidationResult.Success
-                            : new ValidationResult(ErrorMessage, new[] { ctx.MemberName! });
-                    }
+            Form(Model: _model, OnValidSubmit: ...)[
+                DataAnnotationsValidator(),
+                new UniqueUsernameValidator() /* or FluentValidationValidator(new …) */,
+                Input(Bind: () => _model.Username),
+                ValidatingIndicator(For: () => _model.Username, Template: Checking),
+                ValidationMessage(For: () => _model.Username, Template: FieldError)
+            ]
+            """,
+            Notes:
+            "Try \"admin\" or \"taken\" — the ValidatingIndicator shows while the 400ms check runs, then a message appears. Per-keystroke calls cancel any prior in-flight check (latest-wins). Submit awaits all validators before routing to OnValidSubmit vs OnInvalidSubmit. The literal \"explode\" forces the demo validator to throw mid-await so you can see the generic \"Validation could not be completed.\" fallback that the framework surfaces when a validator faults. The indicator stays visible for ~200 ms after the check completes — EditContext.ValidatingStickyMs (default 200) smooths over sub-second validators that would otherwise flash on/off; set it to 0 on a manually-built EditContext to opt out.",
+            Result: AsyncValidationDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Cross-field — Form-level Validate feeding ValidationSummary"],
+        CodeSample(
+            """
+            Form<TripModel>(Model: _model, OnValidSubmit: m => _submission = ...,
+                 Validate: m =>
+                     m.Return > m.Depart
+                         ? Array.Empty<string>()
+                         : new[] { "Return date must be after departure." })[
+                    ValidationSummary(SummaryAlert),
+                    Input(Bind: () => _model.Depart, Id: "v5-depart"),
+                    Input(Bind: () => _model.Return, Id: "v5-return"),
+                    Button(Type: "submit")["Book"]
+                 ]
+            """,
+            Notes:
+            "Form-level Validate runs at submit time and adds its messages to FieldIdentifier(model, \"\") — they surface in ValidationSummary alongside any field-level messages but never tag a specific input.",
+            Result: CrossFieldSummaryDemo()),
+        H2(Class: "h4 mt-5 mb-3")["IValidatableObject — model-level Validate(ctx) alongside attributes"],
+        CodeSample(
+            """
+            public sealed class BookingModel : IValidatableObject {
+                [Required(ErrorMessage = "Name is required.")]
+                public string Name { get; set; } = "";
+                public DateOnly Departure { get; set; }
+                public DateOnly Arrival { get; set; }
+
+                public IEnumerable<ValidationResult> Validate(ValidationContext ctx) {
+                    if (Departure < Today)
+                        yield return new ValidationResult(
+                            "Departure cannot be in the past.",
+                            new[] { nameof(Departure) });   // per-field
+                    if (Arrival <= Departure)
+                        yield return new ValidationResult(
+                            "Arrival must be after departure.");   // form-level
                 }
+            }
 
-                // ValidationContext.GetService<T>() — resolves services from the render-scoped SP.
-                public sealed class NotBannedAttribute : ValidationAttribute {
-                    protected override ValidationResult? IsValid(object? value, ValidationContext ctx) {
-                        var svc = (IBannedWordService?)ctx.GetService(typeof(IBannedWordService));
-                        return svc is { } s && value is string str && s.Words.Contains(str)
-                            ? new ValidationResult(FormatErrorMessage(str), new[] { ctx.MemberName! })
-                            : ValidationResult.Success;
-                    }
+            Form<BookingModel>(_model, OnValidSubmit: m => /* ... */)[
+                DataAnnotationsValidator(),
+                ValidationSummary(SummaryAlert),
+                Input(Bind: () => _model.Name, Id: "v11-name"),
+                ValidationMessage(For: () => _model.Name, Template: FieldError),
+                Input(Bind: () => _model.Departure, Id: "v11-departure"),
+                ValidationMessage(For: () => _model.Departure, Template: FieldError),
+                Input(Bind: () => _model.Arrival, Id: "v11-arrival"),
+                Button(Type: "submit")["Book"]
+            ]
+            """,
+            Notes:
+            "ASP.NET Core MVC accumulates attribute errors and IValidatableObject errors into the same ModelState — the BCL's own Validator.TryValidateObject silences IValidatableObject as soon as any attribute fails. DataAnnotationsValidator calls the interface directly so both layers always surface together. ValidationResult.MemberNames routes the message: an empty collection lands on FieldIdentifier(model, \"\") (ValidationSummary), a populated one tags a specific field (ValidationMessage). Submit empty to see Name's [Required] and the model's two Validate() results land in the same render.",
+            Result: ValidatableObjectDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Programmatic — EditContext.Validate() and IsValidating"],
+        CodeSample(
+            """
+            _ctx = new EditContext(_model);
+            _ctx.AddValidator(new SlowTitleValidator());   // 600ms async rule
+
+            Form<TaskModel>(_model, m => _submission = ..., Context: _ctx)[
+                Input(Bind: () => _model.Title, Id: "v6-title"),
+                ValidatingIndicator(For: () => _model.Title, Template: Checking),
+                ValidationMessage(For: () => _model.Title, Template: FieldError),
+                Button(Type: "button", Id: "v6-validate-now",
+                       OnClickAsync: () => _ctx.ValidateAsync().AsTask())["Validate now"],
+                Button(Type: "submit", Id: "v6-submit",
+                       Disabled: _ctx.IsValidatingAny)["Save"]
+            ]
+            """,
+            Notes:
+            "Hold your own EditContext and pass it via Context: on Form to drive validation from anywhere. Calling ctx.ValidateAsync() outside the submit path raises messages without routing through OnValidSubmit/OnInvalidSubmit. ctx.IsValidatingAny flips while async validators run — bind it to a button's Disabled to block submit during in-flight checks.",
+            Result: ProgrammaticValidateDemo()),
+        H2(Class: "h4 mt-5 mb-3")["FluentValidation — AbstractValidator<TModel>"],
+        CodeSample(
+            """
+            public sealed class OrderValidator : AbstractValidator<OrderModel> {
+                public OrderValidator() {
+                    RuleFor(x => x.Product).NotEmpty();
+                    RuleFor(x => x.Quantity).GreaterThanOrEqualTo(1)
+                        .WithMessage("Quantity must be at least 1.");
                 }
+            }
 
-                public sealed class CustomAttributeModel {
-                    [Required, NotBanned(ErrorMessage = "\"{0}\" isn't available.")]
-                    public string Username { get; set; } = "";
+            Form<OrderModel>(_model, m => _submission = ...)[
+                FluentValidationValidator(new OrderValidator()),
+                Input(Bind: () => _model.Product, Id: "v7-product"),
+                ValidationMessage(For: () => _model.Product, Template: FieldError),
+                Input(Bind: () => _model.Quantity, Id: "v7-quantity"),
+                ValidationMessage(For: () => _model.Quantity, Template: FieldError),
+                Button(Type: "submit")["Order"]
+            ]
+            """,
+            Notes:
+            "FluentValidationValidator wraps any IValidator into an IAsyncFieldValidator. Per-keystroke runs use MemberNameValidatorSelector to scope FV to a single property; submit runs every rule on the model.",
+            Result: FluentValidationDemo()),
+        H2(Class: "h4 mt-5 mb-3")["First-error-wins — inline gates DataAnnotations"],
+        CodeSample(
+            """
+            public sealed class LicenseModel {
+                [RegularExpression(@"^[A-Z]{3}-\d{3}$",
+                    ErrorMessage = "Use the ABC-123 format.")]
+                public string Code { get; set; } = "";
+            }
 
-                    [Required, StrongPassword(ErrorMessage = "8+ chars, letters and digits.")]
-                    public string Password { get; set; } = "";
-
-                    [Required, MatchesProperty(nameof(Password), ErrorMessage = "Passwords don't match.")]
-                    public string ConfirmPassword { get; set; } = "";
+            Form<LicenseModel>(_model, m => _submission = "Activated")[
+                DataAnnotationsValidator(),
+                Input(Bind: () => _model.Code,
+                      Validate: v =>
+                          string.IsNullOrWhiteSpace(v)
+                              ? new[] { "Code is required." }
+                              : Array.Empty<string>()),
+                ValidationMessage(For: () => _model.Code, Template: FieldError),
+                Button(Type: "submit")["Activate"]
+            ]
+            """,
+            Notes:
+            "The chain runs inline → form-level inline → sync IFieldValidator → async IAsyncFieldValidator. EditContext gates each later stage per-field: once any rule has flagged a field, the later rules on the SAME field stay quiet. Type nothing — only \"Code is required.\" shows. Type \"abc\" — the inline rule passes and DataAnnotations' \"Use the ABC-123 format.\" takes over. Type \"ABC-123\" — both pass and the form submits.",
+            Result: FirstErrorWinsDemo()),
+        H2(Class: "h4 mt-5 mb-3")["FluentValidation async — MustAsync inside the RuleFor chain"],
+        CodeSample(
+            """
+            public sealed class TicketValidator : AbstractValidator<TicketModel> {
+                public TicketValidator() {
+                    RuleFor(x => x.Code).Cascade(CascadeMode.Stop)
+                        .NotEmpty().WithMessage("Code is required.")
+                        .Matches(@"^TKT-\d{3}$").WithMessage("Format must be TKT-123.")
+                        .MustAsync(async (code, ct) => {
+                            await Task.Delay(400, ct); // pretend it's an API
+                            return !Reserved.Contains(code);
+                        }).WithMessage("Code is already reserved.");
                 }
+            }
 
-                // Program.cs: services.AddSingleton<IBannedWordService, BannedWordService>();
-                """,
-                Notes:
-                "Custom ValidationAttribute subclasses flow through DataAnnotationsValidator with no extra opt-in — System.ComponentModel.DataAnnotations.Validator walks every attribute on the property at validation time. ValidationContext is constructed with the render-scoped IServiceProvider, so attributes can resolve services via ctx.GetService<T>() the same way ASP.NET Core / Blazor's DataAnnotationsValidator do it. Try \"admin\" (NotBanned, DI-resolved), a weak password (StrongPassword.IsValid), or mismatched confirm (MatchesProperty reads ObjectInstance).",
-                Result: CustomAttributeDemo())
-        ];
+            Form<TicketModel>(_model, m => _submission = ...)[
+                FluentValidationValidator(new TicketValidator()),
+                Input(Bind: () => _model.Code),
+                ValidatingIndicator(For: () => _model.Code, Template: Checking),
+                ValidationMessage(For: () => _model.Code, Template: FieldError),
+                Button(Type: "submit")["Reserve"]
+            ]
+            """,
+            Notes:
+            "FluentValidation's own Cascade(CascadeMode.Stop) mirrors Rask's first-error-wins: NotEmpty must pass before Matches, which must pass before the MustAsync API check fires. Type \"TKT-001\" to see the indicator while the await is in flight, then the \"already reserved\" message land. Type a value not in the reserved set (e.g. \"TKT-999\") to submit successfully. FluentValidationValidator is registered as an IAsyncFieldValidator — async rules and sync rules share the one wrapper.",
+            Result: FluentValidationAsyncDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Custom ValidationAttribute — IsValid, GetValidationResult, and DI"],
+        CodeSample(
+            """
+            // IsValid(object?) — the simplest custom-attribute shape.
+            public sealed class StrongPasswordAttribute : ValidationAttribute {
+                public override bool IsValid(object? value) =>
+                    value is string s && s.Length >= 8
+                        && s.Any(char.IsLetter) && s.Any(char.IsDigit);
+            }
+
+            // GetValidationResult — reads ValidationContext.ObjectInstance for cross-field rules.
+            public sealed class MatchesPropertyAttribute(string otherProperty) : ValidationAttribute {
+                protected override ValidationResult? IsValid(object? value, ValidationContext ctx) {
+                    var other = ctx.ObjectInstance.GetType().GetProperty(otherProperty)
+                        ?.GetValue(ctx.ObjectInstance);
+                    return Equals(value, other)
+                        ? ValidationResult.Success
+                        : new ValidationResult(ErrorMessage, new[] { ctx.MemberName! });
+                }
+            }
+
+            // ValidationContext.GetService<T>() — resolves services from the render-scoped SP.
+            public sealed class NotBannedAttribute : ValidationAttribute {
+                protected override ValidationResult? IsValid(object? value, ValidationContext ctx) {
+                    var svc = (IBannedWordService?)ctx.GetService(typeof(IBannedWordService));
+                    return svc is { } s && value is string str && s.Words.Contains(str)
+                        ? new ValidationResult(FormatErrorMessage(str), new[] { ctx.MemberName! })
+                        : ValidationResult.Success;
+                }
+            }
+
+            public sealed class CustomAttributeModel {
+                [Required, NotBanned(ErrorMessage = "\"{0}\" isn't available.")]
+                public string Username { get; set; } = "";
+
+                [Required, StrongPassword(ErrorMessage = "8+ chars, letters and digits.")]
+                public string Password { get; set; } = "";
+
+                [Required, MatchesProperty(nameof(Password), ErrorMessage = "Passwords don't match.")]
+                public string ConfirmPassword { get; set; } = "";
+            }
+
+            // Program.cs: services.AddSingleton<IBannedWordService, BannedWordService>();
+            """,
+            Notes:
+            "Custom ValidationAttribute subclasses flow through DataAnnotationsValidator with no extra opt-in — System.ComponentModel.DataAnnotations.Validator walks every attribute on the property at validation time. ValidationContext is constructed with the render-scoped IServiceProvider, so attributes can resolve services via ctx.GetService<T>() the same way ASP.NET Core / Blazor's DataAnnotationsValidator do it. Try \"admin\" (NotBanned, DI-resolved), a weak password (StrongPassword.IsValid), or mismatched confirm (MatchesProperty reads ObjectInstance).",
+            Result: CustomAttributeDemo())
+    ];
 }

--- a/samples/Rask.Example.Shared/Pages/VirtualizePage.cs
+++ b/samples/Rask.Example.Shared/Pages/VirtualizePage.cs
@@ -40,111 +40,113 @@ public sealed class VirtualizePage : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            PageHeader.Render(
-                "Virtualize",
-                $"Headless virtualization. The list below contains {_rows.Length:N0} rows, but the DOM only holds the visible window plus a small overscan."),
-            P(Class: "small text-secondary mb-4")[
-                "Scroll the box below. The two spacer divs (",
-                Code()["OffsetBefore"], " and ", Code()["OffsetAfter"],
-                ") keep the scrollbar consistent with the full row count while ",
-                Code()["VisibleItems"], " only emits the rows currently on screen."
-            ],
-            Virtualize<Row>(
-                ctx => Div(
-                    Class: "border rounded bg-white",
-                    Style: "height:400px; overflow:auto;",
-                    Data: new Dictionary<string, string?> { ["testid"] = "virtualize-scroller" },
-                    OnScroll: ctx.OnScroll)[
-                    Div(Style: $"height:{ctx.OffsetBefore}px"),
-                    Table(Class: "table table-sm mb-0", Style: "table-layout:fixed; width:100%;")[
-                        Thead(Style: "position:sticky; top:0; background:#f8f9fa; z-index:1;")[
-                            Tr()[
-                                Th(Style: "width:80px;")["#"],
-                                Th()["Name"],
-                                Th(Style: "width:140px;")["City"],
-                                Th(Style: "width:120px; text-align:right;")["Balance"]
-                            ]
-                        ],
-                        Tbody()[
-                            ctx.VisibleItems.Select(item =>
-                                Tr(
-                                    Style: $"height:{ctx.ItemSize}px;",
-                                    // data-rask-key engages the morph algorithm's keyed
-                                    // reconciliation path: scrolling the window moves the
-                                    // existing <tr> nodes instead of replacing them, so
-                                    // focus and scroll state survive the re-render.
-                                    Data: new Dictionary<string, string?>
-                                    {
-                                        ["row-index"] = item.Index.ToString(), ["rask-key"] = item.Index.ToString()
-                                    })[
-                                    Td()[item.Value?.Index.ToString() ?? ""],
-                                    Td()[item.Value?.Name ?? ""],
-                                    Td()[item.Value?.City ?? ""],
-                                    Td(Style: "text-align:right;")[item.Value?.Balance.ToString("0.00") ?? ""]
-                                ])
+    [
+        PageHeader.Render(
+            "Virtualize",
+            $"Headless virtualization. The list below contains {_rows.Length:N0} rows, but the DOM only holds the visible window plus a small overscan."),
+        P(Class: "small text-secondary mb-4")[
+            "Scroll the box below. The two spacer divs (",
+            Code()["OffsetBefore"], " and ", Code()["OffsetAfter"],
+            ") keep the scrollbar consistent with the full row count while ",
+            Code()["VisibleItems"], " only emits the rows currently on screen."
+        ],
+        Virtualize<Row>(
+            ctx => Div(
+                Class: "border rounded bg-white",
+                Style: "height:400px; overflow:auto;",
+                Data: new Dictionary<string, string?> { ["testid"] = "virtualize-scroller" },
+                OnScroll: ctx.OnScroll)[
+                Div(Style: $"height:{ctx.OffsetBefore}px"),
+                Table(Class: "table table-sm mb-0", Style: "table-layout:fixed; width:100%;")[
+                    Thead(Style: "position:sticky; top:0; background:#f8f9fa; z-index:1;")[
+                        Tr()[
+                            Th(Style: "width:80px;")["#"],
+                            Th()["Name"],
+                            Th(Style: "width:140px;")["City"],
+                            Th(Style: "width:120px; text-align:right;")["Balance"]
                         ]
                     ],
-                    Div(Style: $"height:{ctx.OffsetAfter}px")
+                    Tbody()[
+                        ctx.VisibleItems.Select(item =>
+                            Tr(
+                                Style: $"height:{ctx.ItemSize}px;",
+                                // data-rask-key engages the morph algorithm's keyed
+                                // reconciliation path: scrolling the window moves the
+                                // existing <tr> nodes instead of replacing them, so
+                                // focus and scroll state survive the re-render.
+                                Data: new Dictionary<string, string?>
+                                {
+                                    ["row-index"] = item.Index.ToString(), ["rask-key"] = item.Index.ToString()
+                                })[
+                                Td()[item.Value?.Index.ToString() ?? ""],
+                                Td()[item.Value?.Name ?? ""],
+                                Td()[item.Value?.City ?? ""],
+                                Td(Style: "text-align:right;")[item.Value?.Balance.ToString("0.00") ?? ""]
+                            ])
+                    ]
                 ],
-                _rows,
-                ItemSize: 32,
-                OverscanCount: 4,
-                InitialClientHeight: 400),
-            P(Class: "small text-secondary mt-3 mb-0")[
-                Code()["data-row-index"],
-                " on each row lets you eyeball which slice is rendered. Open DevTools and inspect — only ~",
-                Strong()["20–30"], " rows live in the DOM at any time."
+                Div(Style: $"height:{ctx.OffsetAfter}px")
             ],
-            H2(Class: "h4 mt-5 mb-3")["Async paging via ItemsProvider"],
-            P(Class: "small text-secondary mb-3")[
-                "The same component, now backed by a provider that simulates a 350 ms API call per window. ",
-                "Visible rows show a placeholder ", Code()["—"],
-                " until the fetch resolves, then morph in. Navigating away mid-fetch cancels the in-flight ",
-                "call: Virtualize cancels its ", Code()["CancellationTokenSource"], " in ",
-                Code()["OnUnmount"], " (and supersedes it whenever a new viewport request arrives). ",
-                "Honour ", Code()["req.CancellationToken"], " in your own providers so the cancellation actually propagates."
-            ],
-            Virtualize<Row>(
-                ctx => Div(
-                    Class: "border rounded bg-white",
-                    Style: "height:400px; overflow:auto;",
-                    Data: new Dictionary<string, string?> { ["testid"] = "virtualize-async-scroller" },
-                    OnScroll: ctx.OnScroll)[
-                    Div(Style: $"height:{ctx.OffsetBefore}px"),
-                    Table(Class: "table table-sm mb-0", Style: "table-layout:fixed; width:100%;")[
-                        Thead(Style: "position:sticky; top:0; background:#f8f9fa; z-index:1;")[
-                            Tr()[
-                                Th(Style: "width:80px;")["#"],
-                                Th()["Name"],
-                                Th(Style: "width:140px;")["City"],
-                                Th(Style: "width:120px; text-align:right;")["Balance"]
-                            ]
-                        ],
-                        Tbody()[
-                            ctx.VisibleItems.Select(item =>
-                                Tr(
-                                    Style: $"height:{ctx.ItemSize}px;",
-                                    Data: new Dictionary<string, string?>
-                                    {
-                                        ["row-index"] = item.Index.ToString(),
-                                        ["rask-key"] = item.Index.ToString(),
-                                        ["placeholder"] = item.IsPlaceholder ? "true" : null
-                                    })[
-                                    Td()[item.IsPlaceholder ? "—" : item.Value!.Index],
-                                    Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
-                                    Td()[item.IsPlaceholder ? "—" : item.Value!.City],
-                                    Td(Style: "text-align:right;")[item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]
-                                ])
+            _rows,
+            ItemSize: 32,
+            OverscanCount: 4,
+            InitialClientHeight: 400),
+        P(Class: "small text-secondary mt-3 mb-0")[
+            Code()["data-row-index"],
+            " on each row lets you eyeball which slice is rendered. Open DevTools and inspect — only ~",
+            Strong()["20–30"], " rows live in the DOM at any time."
+        ],
+        H2(Class: "h4 mt-5 mb-3")["Async paging via ItemsProvider"],
+        P(Class: "small text-secondary mb-3")[
+            "The same component, now backed by a provider that simulates a 350 ms API call per window. ",
+            "Visible rows show a placeholder ", Code()["—"],
+            " until the fetch resolves, then morph in. Navigating away mid-fetch cancels the in-flight ",
+            "call: Virtualize cancels its ", Code()["CancellationTokenSource"], " in ",
+            Code()["OnUnmount"], " (and supersedes it whenever a new viewport request arrives). ",
+            "Honour ", Code()["req.CancellationToken"],
+            " in your own providers so the cancellation actually propagates."
+        ],
+        Virtualize(
+            ctx => Div(
+                Class: "border rounded bg-white",
+                Style: "height:400px; overflow:auto;",
+                Data: new Dictionary<string, string?> { ["testid"] = "virtualize-async-scroller" },
+                OnScroll: ctx.OnScroll)[
+                Div(Style: $"height:{ctx.OffsetBefore}px"),
+                Table(Class: "table table-sm mb-0", Style: "table-layout:fixed; width:100%;")[
+                    Thead(Style: "position:sticky; top:0; background:#f8f9fa; z-index:1;")[
+                        Tr()[
+                            Th(Style: "width:80px;")["#"],
+                            Th()["Name"],
+                            Th(Style: "width:140px;")["City"],
+                            Th(Style: "width:120px; text-align:right;")["Balance"]
                         ]
                     ],
-                    Div(Style: $"height:{ctx.OffsetAfter}px")
+                    Tbody()[
+                        ctx.VisibleItems.Select(item =>
+                            Tr(
+                                Style: $"height:{ctx.ItemSize}px;",
+                                Data: new Dictionary<string, string?>
+                                {
+                                    ["row-index"] = item.Index.ToString(),
+                                    ["rask-key"] = item.Index.ToString(),
+                                    ["placeholder"] = item.IsPlaceholder ? "true" : null
+                                })[
+                                Td()[item.IsPlaceholder ? "—" : item.Value!.Index],
+                                Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
+                                Td()[item.IsPlaceholder ? "—" : item.Value!.City],
+                                Td(Style: "text-align:right;")[
+                                    item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]
+                            ])
+                    ]
                 ],
-                ItemsProvider: FetchRowsAsync,
-                ItemSize: 32,
-                OverscanCount: 4,
-                InitialClientHeight: 400)
-        ];
+                Div(Style: $"height:{ctx.OffsetAfter}px")
+            ],
+            ItemsProvider: FetchRowsAsync,
+            ItemSize: 32,
+            OverscanCount: 4,
+            InitialClientHeight: 400)
+    ];
 
     private static async ValueTask<ItemsProviderResult<Row>> FetchRowsAsync(ItemsProviderRequest req)
     {

--- a/samples/Rask.Example.Shared/README.md
+++ b/samples/Rask.Example.Shared/README.md
@@ -14,11 +14,11 @@ dotnet run --project samples/Rask.Example.Wasm.Host   # browser-WASM
 
 ## Layout
 
-| Folder | Contents |
-|--------|----------|
-| `Pages/` | One routed page per feature (`[Route]`), each pairing a runnable demo with its source. |
-| `Demos/` | Reusable demo components used by the pages (e.g. `ContextDemos`, `CallbackDemos`, `ElementRefDemo`). |
-| `Layout/` | `ShowcaseLayout` — the shell, sidebar nav, and the route table that drives both. |
+| Folder    | Contents                                                                                             |
+|-----------|------------------------------------------------------------------------------------------------------|
+| `Pages/`  | One routed page per feature (`[Route]`), each pairing a runnable demo with its source.               |
+| `Demos/`  | Reusable demo components used by the pages (e.g. `ContextDemos`, `CallbackDemos`, `ElementRefDemo`). |
+| `Layout/` | `ShowcaseLayout` — the shell, sidebar nav, and the route table that drives both.                     |
 
 `Pages/HomePage.cs` is the feature index; its card list mirrors the nav in
 `Layout/ShowcaseLayout.cs`.

--- a/samples/Rask.Example.Shared/README.md
+++ b/samples/Rask.Example.Shared/README.md
@@ -1,0 +1,24 @@
+# Rask.Example.Shared
+
+The heart of the showcase: a component library holding every demo page and primitive. It
+targets `net10.0` and is referenced unchanged by both the
+[Server](../Rask.Example.Server) and [WASM](../Rask.Example.Wasm) hosts — proving the same
+components run under either transport.
+
+Not runnable on its own. Launch it through a host:
+
+```bash
+dotnet run --project samples/Rask.Example.Server      # server-side live runtime
+dotnet run --project samples/Rask.Example.Wasm.Host   # browser-WASM
+```
+
+## Layout
+
+| Folder | Contents |
+|--------|----------|
+| `Pages/` | One routed page per feature (`[Route]`), each pairing a runnable demo with its source. |
+| `Demos/` | Reusable demo components used by the pages (e.g. `ContextDemos`, `CallbackDemos`, `ElementRefDemo`). |
+| `Layout/` | `ShowcaseLayout` — the shell, sidebar nav, and the route table that drives both. |
+
+`Pages/HomePage.cs` is the feature index; its card list mirrors the nav in
+`Layout/ShowcaseLayout.cs`.

--- a/samples/Rask.Example.Wasm.Host/Program.cs
+++ b/samples/Rask.Example.Wasm.Host/Program.cs
@@ -25,7 +25,7 @@ var app = builder.Build();
 // at a re-published AppBundle under a prefix without a dedicated executable.
 // In a real app you'd just hardcode the pathBase you want.
 app.UseRask<App>(
-    bundlePath: Environment.GetEnvironmentVariable("RASK_BUNDLE_DIR"),
-    pathBase: Environment.GetEnvironmentVariable("RASK_PATHBASE") ?? string.Empty);
+    Environment.GetEnvironmentVariable("RASK_BUNDLE_DIR"),
+    Environment.GetEnvironmentVariable("RASK_PATHBASE") ?? string.Empty);
 
 app.Run();

--- a/samples/Rask.Example.Wasm.Host/README.md
+++ b/samples/Rask.Example.Wasm.Host/README.md
@@ -1,0 +1,21 @@
+# Rask.Example.Wasm.Host
+
+Serves the showcase as a **browser-WASM** app. This ASP.NET host publishes and statically
+serves the [`Rask.Example.Wasm`](../Rask.Example.Wasm) client (which compiles the shared
+components to `net10.0-browser`); after first load the app runs entirely in the browser,
+using the `JSImport`/`JSExport` transport instead of a WebSocket.
+
+```bash
+dotnet run --project samples/Rask.Example.Wasm.Host
+```
+
+## Key files
+
+- `Program.cs` — `UseRask<TApp>()` from `Rask.Wasm.Hosting`, generic so the client
+  assembly's `[ModuleInitializer]` (route registration) loads.
+- Client: [`Rask.Example.Wasm`](../Rask.Example.Wasm); components:
+  [`Rask.Example.Shared`](../Rask.Example.Shared).
+
+Building this project bakes scoped CSS/JS assets into the published bundle via
+`BakeScopedAssetsTask`. For the server-side variant, see
+[`Rask.Example.Server`](../Rask.Example.Server).

--- a/samples/Rask.Example.Wasm/wwwroot/img/rask-mark.svg
+++ b/samples/Rask.Example.Wasm/wwwroot/img/rask-mark.svg
@@ -1,9 +1,9 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="22 6 80 108" width="64" height="64" role="img" aria-label="Rask">
-  <defs>
-    <linearGradient id="bolt" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#7C3AED"/>
-      <stop offset="100%" stop-color="#512BD4"/>
-    </linearGradient>
-  </defs>
-  <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#bolt)"/>
+    <defs>
+        <linearGradient id="bolt" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#7C3AED"/>
+            <stop offset="100%" stop-color="#512BD4"/>
+        </linearGradient>
+    </defs>
+    <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#bolt)"/>
 </svg>

--- a/samples/Rask.Example.Wasm/wwwroot/img/rask-placeholder.svg
+++ b/samples/Rask.Example.Wasm/wwwroot/img/rask-placeholder.svg
@@ -1,10 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="120" height="60" viewBox="0 0 120 60" role="img" aria-label="Rask">
-  <defs>
-    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#7C3AED"/>
-      <stop offset="100%" stop-color="#512BD4"/>
-    </linearGradient>
-  </defs>
-  <rect width="120" height="60" fill="url(#bg)"/>
-  <text x="60" y="30" fill="#ffffff" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="18" font-weight="600" text-anchor="middle" dominant-baseline="central">Rask</text>
+    <defs>
+        <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0%" stop-color="#7C3AED"/>
+            <stop offset="100%" stop-color="#512BD4"/>
+        </linearGradient>
+    </defs>
+    <rect width="120" height="60" fill="url(#bg)"/>
+    <text x="60" y="30" fill="#ffffff" font-family="system-ui, -apple-system, Segoe UI, Roboto, sans-serif"
+          font-size="18" font-weight="600" text-anchor="middle" dominant-baseline="central">Rask
+    </text>
 </svg>

--- a/src/Rask.Core/Authentication/IUserProvider.cs
+++ b/src/Rask.Core/Authentication/IUserProvider.cs
@@ -5,6 +5,16 @@ namespace Rask.Core.Authentication;
 public interface IUserProvider
 {
     ClaimsPrincipal Current { get; }
+
+    /// <summary>
+    ///     <c>true</c> while the principal is still being established — e.g. a WASM provider's
+    ///     <see cref="EnsureLoadedAsync" />/<see cref="RefreshAsync" /> is in flight. The declarative
+    ///     <see cref="Rask.Core.Components.Authorize" /> component shows its <c>Authorizing</c> slot
+    ///     while this is true, bridging the anonymous→authenticated flash. Providers with a
+    ///     synchronously-known principal (server cookie, anonymous) leave the default <c>false</c>.
+    /// </summary>
+    bool IsLoading => false;
+
     event Action? Changed;
 
     /// <summary>
@@ -19,13 +29,4 @@ public interface IUserProvider
     ///     Default is a no-op.
     /// </summary>
     Task RefreshAsync() => Task.CompletedTask;
-
-    /// <summary>
-    ///     <c>true</c> while the principal is still being established — e.g. a WASM provider's
-    ///     <see cref="EnsureLoadedAsync" />/<see cref="RefreshAsync" /> is in flight. The declarative
-    ///     <see cref="Rask.Core.Components.Authorize" /> component shows its <c>Authorizing</c> slot
-    ///     while this is true, bridging the anonymous→authenticated flash. Providers with a
-    ///     synchronously-known principal (server cookie, anonymous) leave the default <c>false</c>.
-    /// </summary>
-    bool IsLoading => false;
 }

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1,13 +1,12 @@
 using System.Security.Claims;
 using System.Text;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Forms;
+using Rask.Core.HeadAssets;
 using Rask.Core.Live;
-using Rask.Core.ScopedCss;
 
 namespace Rask.Core;
 
@@ -22,6 +21,22 @@ public abstract class Component
     // saves callers from null checks while keeping the per-instance allocation lazy.
     private static readonly Dictionary<(Type, int), Component> _emptyChildren = new();
 
+    // Page-shell tokens a root render must produce, paired with the factory that emits each.
+    // Doctype writes the literal "<!DOCTYPE html>"; the element tags are matched by their
+    // opening prefix so attributes (e.g. <html lang="en">) don't defeat the check.
+    private static readonly (string Token, string Factory)[] _requiredShell =
+    {
+        ("<!DOCTYPE html>", "Doctype()"), ("<html", "Html(...)"), ("<head", "Head()"), ("<body", "Body()")
+    };
+
+    // Set the first time this component reads a context value (Context.Get/Required/Has-via-Get).
+    // Such a component depends on ambient state the framework doesn't diff, so — like
+    // BypassRenderCache — it must re-execute Render() on every walk to pick up a changed value.
+    // Latched on: once a consumer, always a consumer (its Render path can read different
+    // context types across renders).
+    private bool _consumesContext;
+    private CancellationTokenSource? _lifetimeCts;
+
     // All live-render-only state — handlers, child reconciliation, root alive sets,
     // edit-context pool, the dirty/lifecycle flags — is hoisted off the base Component
     // class into a lazy container. Plain Elements (Div, Span, …) never engage any of
@@ -30,32 +45,8 @@ public abstract class Component
     // User components and live-render roots pay one LiveState allocation on first use;
     // subsequent renders reuse it via the pooled dictionaries inside.
     private LiveState? _live;
-    private CancellationTokenSource? _lifetimeCts;
 
     private LiveState Live => _live ??= new LiveState();
-
-    // The hoisted state — class so it stays out-of-band from each Component instance.
-    // Field grouping mirrors the prior layout for readability of the diff.
-    private sealed class LiveState
-    {
-        public HashSet<Component>? AliveNow;
-        public HashSet<Component>? AlivePrev;
-        public Component? CachedRenderResult;
-        public int ChildPositions;
-        public Dictionary<(Type, int), Component>? Children;
-        public Dictionary<LiveRenderContext.ObjectKey, EditContext>? EditContextsPool;
-        public Dictionary<string, (Component Owner, Delegate Handler)>? Handlers;
-        public ElementRef? ElementRef;
-        public bool HasInitialized;
-        public bool HasRenderedOnce;
-        public bool IsUnmounted;
-        public int NextHandlerId;
-        public Dictionary<Component, Component>? ParentMap;
-        public Dictionary<LiveRenderContext.ObjectKey, EditContext>? PersistedEditContexts;
-        public Dictionary<(Type, int), Component>? PreviousChildren;
-        public bool PropsDirty;
-        public bool StateDirty;
-    }
 
     // Set by the children indexer below. Factories no longer expose Children as a
     // parameter — `Div()[Span(...), "hi"]` is the canonical call shape.
@@ -173,14 +164,6 @@ public abstract class Component
     // call StateHasChanged() instead — only opt in if you genuinely cannot.
     protected virtual bool BypassRenderCache => false;
 
-    // Set the first time this component reads a context value (Context.Get/Required/Has-via-Get).
-    // Such a component depends on ambient state the framework doesn't diff, so — like
-    // BypassRenderCache — it must re-execute Render() on every walk to pick up a changed value.
-    // Latched on: once a consumer, always a consumer (its Render path can read different
-    // context types across renders).
-    private bool _consumesContext;
-    internal void MarkConsumesContextInternal() => _consumesContext = true;
-
     // Backing store for Element.Ref, hoisted into the lazy LiveState so a plain element (the
     // overwhelming majority — refs are opt-in) keeps `_live` null and pays nothing for the
     // feature. The setter only forces a LiveState allocation when an actual ref is assigned;
@@ -238,6 +221,7 @@ public abstract class Component
     protected virtual RenderResult Head => default;
 
     internal Component? HeadInternal => Head.ToComponentOrNull();
+    internal void MarkConsumesContextInternal() => _consumesContext = true;
 
     internal void WriteAttributesInternal(StringBuilder sb) => WriteAttributes(sb);
     internal IEnumerable<Child> RenderChildrenInternal() => RenderChildren();
@@ -601,6 +585,7 @@ public abstract class Component
             (_live.PreviousChildren, _live.Children) = (_live.Children, _live.PreviousChildren);
             _live.Children.Clear();
         }
+
         Live.ChildPositions = 0;
 
         // HtmlSerializer wraps every user-component serialization in an EnterParentScope so
@@ -656,7 +641,8 @@ public abstract class Component
     {
         var key = (type, Live.ChildPositions++);
         Component instance;
-        if (Live.PreviousChildren is not null && Live.PreviousChildren.TryGetValue(key, out var prev) && prev.GetType() == type)
+        if (Live.PreviousChildren is not null && Live.PreviousChildren.TryGetValue(key, out var prev) &&
+            prev.GetType() == type)
         {
             instance = prev;
             // See the generic overload: clear children on reuse so a childless element can't
@@ -884,7 +870,7 @@ public abstract class Component
                     {
                         Task t => t,
                         ValueTask vt => vt.AsTask(),
-                        _ => null,
+                        _ => null
                     };
                     if (pending is not null)
                     {
@@ -955,9 +941,9 @@ public abstract class Component
         }
     }
 
-    internal string RenderAsLiveRoot() => RenderAsLiveRootCore(null, publishOnly: false);
+    internal string RenderAsLiveRoot() => RenderAsLiveRootCore(null, false);
 
-    internal string RenderAsLiveRoot(IServiceProvider services) => RenderAsLiveRootCore(services, publishOnly: false);
+    internal string RenderAsLiveRoot(IServiceProvider services) => RenderAsLiveRootCore(services, false);
 
     internal string RenderAsLiveRoot(IServiceProvider services, bool publishOnly) =>
         RenderAsLiveRootCore(services, publishOnly);
@@ -972,7 +958,8 @@ public abstract class Component
         Live.NextHandlerId = 0;
         // Lazily init on first root render — non-root Component instances (the 99% case for
         // leaf Elements in a page) never touch this field and stay allocation-free.
-        var previousEditContexts = Live.PersistedEditContexts ??= new Dictionary<LiveRenderContext.ObjectKey, EditContext>();
+        var previousEditContexts =
+            Live.PersistedEditContexts ??= new Dictionary<LiveRenderContext.ObjectKey, EditContext>();
         // Recycle the previously-snapshotted dict as the next frame's `current`. First
         // render: pool is null, allocate once. Steady state: Clear and reuse.
         Live.EditContextsPool ??= new Dictionary<LiveRenderContext.ObjectKey, EditContext>();
@@ -1015,13 +1002,13 @@ public abstract class Component
             // HTML, so when a frame stream is being captured (diff path) we must move the
             // offsets past the sentinel by the same delta — otherwise an InsertSubtree fragment
             // (sliced from this post-splice HTML via those offsets) reads the wrong bytes.
-            var sentinelIdx = html.IndexOf(Rask.Core.HeadAssets.HeadAssetRegistry.Sentinel, StringComparison.Ordinal);
+            var sentinelIdx = html.IndexOf(HeadAssetRegistry.Sentinel, StringComparison.Ordinal);
             var preLen = html.Length;
             html = liveCtx.HeadAssets.ApplyTo(html, liveCtx.Services);
             if (sentinelIdx >= 0 && FrameSinkScope.Current is { } frameSink)
             {
                 frameSink.AdjustOffsetsFrom(
-                    sentinelIdx + Rask.Core.HeadAssets.HeadAssetRegistry.Sentinel.Length,
+                    sentinelIdx + HeadAssetRegistry.Sentinel.Length,
                     html.Length - preLen);
             }
         }
@@ -1119,17 +1106,6 @@ public abstract class Component
         }
     }
 
-    // Page-shell tokens a root render must produce, paired with the factory that emits each.
-    // Doctype writes the literal "<!DOCTYPE html>"; the element tags are matched by their
-    // opening prefix so attributes (e.g. <html lang="en">) don't defeat the check.
-    private static readonly (string Token, string Factory)[] _requiredShell =
-    {
-        ("<!DOCTYPE html>", "Doctype()"),
-        ("<html", "Html(...)"),
-        ("<head", "Head()"),
-        ("<body", "Body()")
-    };
-
     private static void ValidateRootShell(string html)
     {
         List<string>? missing = null;
@@ -1164,7 +1140,11 @@ public abstract class Component
                 return;
             }
 
-            if (c._live?.Children is null) return;
+            if (c._live?.Children is null)
+            {
+                return;
+            }
+
             foreach (var child in c._live.Children.Values)
             {
                 Visit(child, seen);
@@ -1186,7 +1166,11 @@ public abstract class Component
                 return;
             }
 
-            if (c._live?.Children is null) return;
+            if (c._live?.Children is null)
+            {
+                return;
+            }
+
             foreach (var child in c._live.Children.Values)
             {
                 parents[child] = c;
@@ -1229,6 +1213,29 @@ public abstract class Component
         }
 
         FileListReader.ResolveBackend()?.Release(files);
+    }
+
+    // The hoisted state — class so it stays out-of-band from each Component instance.
+    // Field grouping mirrors the prior layout for readability of the diff.
+    private sealed class LiveState
+    {
+        public HashSet<Component>? AliveNow;
+        public HashSet<Component>? AlivePrev;
+        public Component? CachedRenderResult;
+        public int ChildPositions;
+        public Dictionary<(Type, int), Component>? Children;
+        public Dictionary<LiveRenderContext.ObjectKey, EditContext>? EditContextsPool;
+        public ElementRef? ElementRef;
+        public Dictionary<string, (Component Owner, Delegate Handler)>? Handlers;
+        public bool HasInitialized;
+        public bool HasRenderedOnce;
+        public bool IsUnmounted;
+        public int NextHandlerId;
+        public Dictionary<Component, Component>? ParentMap;
+        public Dictionary<LiveRenderContext.ObjectKey, EditContext>? PersistedEditContexts;
+        public Dictionary<(Type, int), Component>? PreviousChildren;
+        public bool PropsDirty;
+        public bool StateDirty;
     }
 }
 

--- a/src/Rask.Core/Components/Authorize.cs
+++ b/src/Rask.Core/Components/Authorize.cs
@@ -12,12 +12,16 @@ namespace Rask.Core.Components;
 ///     a named authorization policy), with <b>no markup of its own</b> (transparent like
 ///     <see cref="Fragment" />):
 ///     <list type="bullet">
-///         <item><see cref="Authorized" /> — the user passes the gate. Falls back to the children
-///         indexer when the slot is null, so <c>Authorize(Roles: "admin")[ adminPanel ]</c> works.</item>
+///         <item>
+///             <see cref="Authorized" /> — the user passes the gate. Falls back to the children
+///             indexer when the slot is null, so <c>Authorize(Roles: "admin")[ adminPanel ]</c> works.
+///         </item>
 ///         <item><see cref="NotAuthorized" /> — the user is denied (default: renders nothing).</item>
-///         <item><see cref="Authorizing" /> — the provider is still loading, or a <see cref="Policy" />
-///         evaluation is in flight (default: renders nothing). Bridges the anonymous→authenticated
-///         flash on WASM, where the principal hydrates asynchronously.</item>
+///         <item>
+///             <see cref="Authorizing" /> — the provider is still loading, or a <see cref="Policy" />
+///             evaluation is in flight (default: renders nothing). Bridges the anonymous→authenticated
+///             flash on WASM, where the principal hydrates asynchronously.
+///         </item>
 ///     </list>
 ///     <para>
 ///         <see cref="Roles" /> and the authenticated check are evaluated synchronously in
@@ -30,9 +34,6 @@ namespace Rask.Core.Components;
 /// </summary>
 public sealed class Authorize : Component
 {
-    private IUserProvider? _provider;
-    private IServiceProvider? _services;
-
     // null = "policy not yet evaluated" (or no policy). true/false once resolved. Read in Render to
     // gate the Policy branch and to decide whether to show the Authorizing slot.
     private bool? _policyAllowed;
@@ -41,6 +42,8 @@ public sealed class Authorize : Component
     // evaluation whose token is no longer current must not overwrite a newer verdict (avoids a
     // last-completer-wins race when the principal changes mid-flight).
     private int _policyGen;
+    private IUserProvider? _provider;
+    private IServiceProvider? _services;
 
     // Transparent — Authorize itself emits nothing, it only selects one slot. (Same as the base
     // default; stated explicitly to document the headless contract.)
@@ -167,7 +170,8 @@ public sealed class Authorize : Component
     private async Task RefreshPolicyThenRenderAsync()
     {
         StateHasChanged(); // paint the Authorizing slot immediately
-        await EvaluatePolicyAsync(_provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity())).ConfigureAwait(false);
+        await EvaluatePolicyAsync(_provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity()))
+            .ConfigureAwait(false);
         StateHasChanged(); // paint the resolved verdict
     }
 
@@ -196,7 +200,7 @@ public sealed class Authorize : Component
                 }
                 else
                 {
-                    var result = await authz.AuthorizeAsync(principal, resource: null, policy).ConfigureAwait(false);
+                    var result = await authz.AuthorizeAsync(principal, null, policy).ConfigureAwait(false);
                     allowed = result.Succeeded;
                 }
             }

--- a/src/Rask.Core/Components/CheckboxGroup.cs
+++ b/src/Rask.Core/Components/CheckboxGroup.cs
@@ -32,13 +32,13 @@ public static partial class Generated
         {
             var optionValue = option; // capture per iteration
             var isChecked = selected is not null && Contains(selected, optionValue, comparer);
-            Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
+            var label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
             children.Add(Label(Class: ItemClass)[
                 Input(
-                    Type: "checkbox",
-                    Name: groupName,
-                    Value: BindingHelpers.FormatValue(option),
+                    "checkbox",
+                    groupName,
+                    BindingHelpers.FormatValue(option),
                     Checked: isChecked,
                     Disabled: Disabled,
                     // The checkbox change payload carries the new checked state as a bool string.

--- a/src/Rask.Core/Components/Context.cs
+++ b/src/Rask.Core/Components/Context.cs
@@ -11,7 +11,7 @@ namespace Rask.Core.Components;
 ///     <code>
 ///     // provide (inside a Render)
 ///     Context.Provide&lt;Theme&gt;(Value: dark)[ Sidebar(), Content() ]
-///
+/// 
 ///     // consume (inside any descendant's Render)
 ///     var theme = Context.Required&lt;Theme&gt;();   // throws if no provider
 ///     var maybe = Context.Get&lt;Theme&gt;();        // null if no provider
@@ -53,13 +53,7 @@ public sealed class Context : Component
     ///     it is trim-safe. PascalCase parameter names match the generated-factory call style.
     /// </summary>
     public static Context Provide<TValue>(TValue Value, string? Name = null, object? Key = null) =>
-        new()
-        {
-            Value = Value,
-            ValueType = typeof(TValue),
-            Name = Name,
-            Key = Key
-        };
+        new() { Value = Value, ValueType = typeof(TValue), Name = Name, Key = Key };
 
     /// <summary>
     ///     The nearest provided value of type <typeparamref name="T" /> (optionally matched by

--- a/src/Rask.Core/Components/DragDrop.cs
+++ b/src/Rask.Core/Components/DragDrop.cs
@@ -16,11 +16,6 @@ namespace Rask.Core.Components;
 // `Body` parameter (named so to avoid colliding with Component.Render(), same as Virtualize).
 public sealed class DragDrop : Component
 {
-    private string? _sourceZone;
-    private int _sourceIndex = -1;
-    private string? _targetZone;
-    private int _targetIndex = -1;
-
     // The render fragment. Called with a fresh DragDropContext every render; returns the user's
     // chosen root Component for the drag region. Named "Body" (not "Render") to avoid colliding
     // with Component.Render().
@@ -34,38 +29,42 @@ public sealed class DragDrop : Component
     // observe through props, so every render must re-execute — same reasoning as Virtualize.
     protected override bool BypassRenderCache => true;
 
-    internal string? SourceZoneInternal => _sourceZone;
-    internal int SourceIndexInternal => _sourceIndex;
-    internal string? TargetZoneInternal => _targetZone;
-    internal int TargetIndexInternal => _targetIndex;
+    internal string? SourceZoneInternal { get; private set; }
+
+    internal int SourceIndexInternal { get; private set; } = -1;
+
+    internal string? TargetZoneInternal { get; private set; }
+
+    internal int TargetIndexInternal { get; private set; } = -1;
+
     internal bool HasAsyncDrop => OnDropAsync is not null;
 
     internal void BeginDrag(string zone, int index)
     {
-        _sourceZone = zone;
-        _sourceIndex = index;
-        _targetZone = null;
-        _targetIndex = -1;
+        SourceZoneInternal = zone;
+        SourceIndexInternal = index;
+        TargetZoneInternal = null;
+        TargetIndexInternal = -1;
     }
 
     internal void HoverTarget(string zone, int index)
     {
         // Ignore hover updates when no drag is active (a stray dragover after a drop).
-        if (_sourceZone is null)
+        if (SourceZoneInternal is null)
         {
             return;
         }
 
-        _targetZone = zone;
-        _targetIndex = index;
+        TargetZoneInternal = zone;
+        TargetIndexInternal = index;
     }
 
     internal void EndDrag()
     {
-        _sourceZone = null;
-        _sourceIndex = -1;
-        _targetZone = null;
-        _targetIndex = -1;
+        SourceZoneInternal = null;
+        SourceIndexInternal = -1;
+        TargetZoneInternal = null;
+        TargetIndexInternal = -1;
     }
 
     internal void CommitDrop(string zone, int index)
@@ -89,8 +88,8 @@ public sealed class DragDrop : Component
     // keeps the state consistent if the handler triggers a synchronous re-render.
     private DragDropMove? TryTakeMove(string zone, int index)
     {
-        var sourceZone = _sourceZone;
-        var sourceIndex = _sourceIndex;
+        var sourceZone = SourceZoneInternal;
+        var sourceIndex = SourceIndexInternal;
         EndDrag();
         return sourceZone is null ? null : new DragDropMove(sourceZone, sourceIndex, zone, index);
     }

--- a/src/Rask.Core/Components/RadioGroup.cs
+++ b/src/Rask.Core/Components/RadioGroup.cs
@@ -34,13 +34,13 @@ public static partial class Generated
         {
             var optionValue = option; // capture per iteration for the handler closure
             var isChecked = current is TValue typed && comparer.Equals(option, typed);
-            Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
+            var label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
             children.Add(Label(Class: ItemClass)[
                 Input(
-                    Type: "radio",
-                    Name: groupName,
-                    Value: BindingHelpers.FormatValue(option),
+                    "radio",
+                    groupName,
+                    BindingHelpers.FormatValue(option),
                     Checked: isChecked,
                     Disabled: Disabled,
                     OnChangeAsync: async _ =>

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -9,6 +9,10 @@ namespace Rask.Core.Components;
 
 public sealed class Select : Element
 {
+    // Set by BoundCore; non-bound selects (plain Generated.Select) leave _bound false and
+    // skip the serialize-time marking entirely.
+    private bool _bound;
+    private string _boundValue = "";
     protected override string TagName => "select";
 
     public string? Name { get; set; }
@@ -125,11 +129,6 @@ public sealed class Select : Element
         select._boundValue = BindingHelpers.FormatValue(acc.Getter());
         return select;
     }
-
-    // Set by BoundCore; non-bound selects (plain Generated.Select) leave _bound false and
-    // skip the serialize-time marking entirely.
-    private bool _bound;
-    private string _boundValue = "";
 
     protected override IDisposable? EnterChildrenScope()
     {

--- a/src/Rask.Core/DragAndDrop/DragDropContext.cs
+++ b/src/Rask.Core/DragAndDrop/DragDropContext.cs
@@ -32,6 +32,8 @@ public sealed class DragDropContext
     public string? TargetZone => _owner.TargetZoneInternal;
     public int TargetIndex => _owner.TargetIndexInternal;
 
+    public Action DragEnd => _owner.EndDrag;
+
     // Convenience for the common "highlight the slot under the cursor" case.
     public bool IsDropTarget(string zone, int index) =>
         string.Equals(_owner.TargetZoneInternal, zone, StringComparison.Ordinal)
@@ -52,6 +54,4 @@ public sealed class DragDropContext
         _owner.HasAsyncDrop
             ? (Func<Task>)(() => _owner.CommitDropAsync(zone, index))
             : (Action)(() => _owner.CommitDrop(zone, index));
-
-    public Action DragEnd => _owner.EndDrag;
 }

--- a/src/Rask.Core/Forms/EditContext.cs
+++ b/src/Rask.Core/Forms/EditContext.cs
@@ -12,13 +12,6 @@ public sealed class EditContext : IDisposable
     // <see cref="ValidatingStickyMs" />; set to 0 to opt out.
     public const int DefaultValidatingStickyMs = 200;
 
-    /// <summary>
-    ///     Override the sticky window for this context. Default 200 ms.
-    ///     Set to 0 to disable (the indicator disappears immediately when
-    ///     PendingCount drops to 0 — the pre-sticky behaviour).
-    /// </summary>
-    public int ValidatingStickyMs { get; set; } = DefaultValidatingStickyMs;
-
     private readonly List<IAsyncFieldValidator> _asyncValidators = new();
     private readonly Dictionary<FieldIdentifier, DelegateRegistration> _fieldDelegates = new();
     private readonly Dictionary<FieldIdentifier, FieldState> _states = new();
@@ -26,6 +19,13 @@ public sealed class EditContext : IDisposable
     private Delegate? _formDelegate;
 
     public EditContext(object model) => Model = model ?? throw new ArgumentNullException(nameof(model));
+
+    /// <summary>
+    ///     Override the sticky window for this context. Default 200 ms.
+    ///     Set to 0 to disable (the indicator disappears immediately when
+    ///     PendingCount drops to 0 — the pre-sticky behaviour).
+    /// </summary>
+    public int ValidatingStickyMs { get; set; } = DefaultValidatingStickyMs;
 
     public object Model { get; }
 
@@ -70,9 +70,6 @@ public sealed class EditContext : IDisposable
         }
     }
 
-    public event Action<FieldIdentifier>? FieldChanged;
-    public event Action? ValidationStateChanged;
-
     /// <summary>
     ///     Optional fire-and-forget render-request callback wired by the
     ///     framework (LiveRenderContext) when this context is attached to a
@@ -113,6 +110,9 @@ public sealed class EditContext : IDisposable
             s.Cts = null;
         }
     }
+
+    public event Action<FieldIdentifier>? FieldChanged;
+    public event Action? ValidationStateChanged;
 
     public void AddValidator(IFieldValidator validator)
     {
@@ -794,7 +794,9 @@ public sealed class EditContext : IDisposable
         public List<string> Messages = new();
         public bool Modified;
         public int PendingCount;
-        public bool Touched;
+
+        public Timer? StickyTimer;
+
         // Sticky window. When PendingCount drops to 0 the EditContext stamps
         // a UTC deadline here so IsValidating(field) keeps returning true for
         // a short tail after the validator finishes — gives a 400ms async
@@ -803,7 +805,7 @@ public sealed class EditContext : IDisposable
         // and gets disposed when the next PendingCount > 0 starts or when
         // the field is no longer alive.
         public DateTimeOffset? StickyUntilUtc;
-        public Timer? StickyTimer;
+        public bool Touched;
     }
 
     private readonly struct DelegateRegistration

--- a/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
+++ b/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
@@ -20,6 +20,15 @@ namespace Rask.Core.HeadAssets;
 internal sealed class HeadAssetRegistry
 {
     internal const string Sentinel = "<!--__rask_head_assets__-->";
+
+    /// <summary>
+    ///     Reserved prefix for framework-emitted asset <c>data-rask-key</c> values.
+    ///     User-declared head tags whose key starts with this prefix are rejected (to
+    ///     prevent accidental morph identity collisions with framework tags).
+    /// </summary>
+    internal const string FrameworkAssetKeyPrefix = "rsk-";
+
+    private static readonly char[] _attrSpecials = { '&', '"', '<', '>' };
     private readonly List<string> _orderedHtml = new();
     private readonly List<string> _orderedKeys = new();
 
@@ -257,19 +266,10 @@ internal sealed class HeadAssetRegistry
         }
 
         return s.Replace("&", "&amp;")
-                .Replace("\"", "&quot;")
-                .Replace("<", "&lt;")
-                .Replace(">", "&gt;");
+            .Replace("\"", "&quot;")
+            .Replace("<", "&lt;")
+            .Replace(">", "&gt;");
     }
-
-    private static readonly char[] _attrSpecials = { '&', '"', '<', '>' };
-
-    /// <summary>
-    ///     Reserved prefix for framework-emitted asset <c>data-rask-key</c> values.
-    ///     User-declared head tags whose key starts with this prefix are rejected (to
-    ///     prevent accidental morph identity collisions with framework tags).
-    /// </summary>
-    internal const string FrameworkAssetKeyPrefix = "rsk-";
 
     /// <summary>
     ///     Emits one <c>&lt;link href="/_rask/a/{hash}.css"&gt;</c> per mounted component
@@ -355,7 +355,7 @@ internal sealed class HeadAssetRegistry
     // cause an attribute morph instead of an insert+remove, which is still safe.
     private static string ContentHash(string s)
     {
-        uint hash = 2166136261u;
+        var hash = 2166136261u;
         for (var i = 0; i < s.Length; i++)
         {
             hash ^= s[i];

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -23,6 +23,19 @@ internal static class HtmlSerializer
         "0123456789" +
         " -._/:,?!()*=#%");
 
+    private static readonly HashSet<string> _shellTags = new(StringComparer.Ordinal)
+    {
+        "html",
+        "head",
+        "body",
+        "title",
+        "meta",
+        "link",
+        "script",
+        "style",
+        "base"
+    };
+
     /// <summary>
     ///     Append <paramref name="value" /> to <paramref name="sb" /> HTML-encoded.
     ///     Fast path: when every char is in the safe-ASCII set the
@@ -48,19 +61,6 @@ internal static class HtmlSerializer
 
         sb.Append(HtmlEncoder.Default.Encode(value));
     }
-
-    private static readonly HashSet<string> _shellTags = new(StringComparer.Ordinal)
-    {
-        "html",
-        "head",
-        "body",
-        "title",
-        "meta",
-        "link",
-        "script",
-        "style",
-        "base"
-    };
 
     public static void Serialize(Component component, StringBuilder sb)
     {
@@ -206,6 +206,7 @@ internal static class HtmlSerializer
                     {
                         frames.CloseElement(elementFrameIdx, sb.Length);
                     }
+
                     break;
                 }
 
@@ -259,6 +260,7 @@ internal static class HtmlSerializer
                 {
                     frames.CloseElement(elementFrameIdx, sb.Length);
                 }
+
                 break;
 
             default:
@@ -315,6 +317,7 @@ internal static class HtmlSerializer
                         }
                     }
                 }
+
                 break;
         }
     }

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -10,50 +10,64 @@ namespace Rask.Core.Live;
 /// </summary>
 public enum EditOpKind : byte
 {
-    /// <summary>Set or replace an attribute's value on the element at
-    /// <see cref="EditOp.Path" />. <see cref="EditOp.Name" /> is the attribute name,
-    /// <see cref="EditOp.Value" /> is the new value (null for bare attributes).</summary>
+    /// <summary>
+    ///     Set or replace an attribute's value on the element at
+    ///     <see cref="EditOp.Path" />. <see cref="EditOp.Name" /> is the attribute name,
+    ///     <see cref="EditOp.Value" /> is the new value (null for bare attributes).
+    /// </summary>
     SetAttribute = 1,
 
-    /// <summary>Remove an attribute by name from the element at
-    /// <see cref="EditOp.Path" />.</summary>
+    /// <summary>
+    ///     Remove an attribute by name from the element at
+    ///     <see cref="EditOp.Path" />.
+    /// </summary>
     RemoveAttribute = 2,
 
-    /// <summary>Replace the text content of the text-or-raw node at
-    /// <see cref="EditOp.Path" />.</summary>
+    /// <summary>
+    ///     Replace the text content of the text-or-raw node at
+    ///     <see cref="EditOp.Path" />.
+    /// </summary>
     UpdateText = 3,
 
-    /// <summary>Insert a new subtree at <see cref="EditOp.Path" /> (the index of the
-    /// slot among the parent's existing DOM children; ops further into the same
-    /// parent reference subsequent indices). <see cref="EditOp.Value" /> carries the
-    /// pre-serialized HTML fragment for the inserted subtree (set by the codec at
-    /// wire-format time once HtmlSerializer captures per-frame byte offsets).</summary>
+    /// <summary>
+    ///     Insert a new subtree at <see cref="EditOp.Path" /> (the index of the
+    ///     slot among the parent's existing DOM children; ops further into the same
+    ///     parent reference subsequent indices). <see cref="EditOp.Value" /> carries the
+    ///     pre-serialized HTML fragment for the inserted subtree (set by the codec at
+    ///     wire-format time once HtmlSerializer captures per-frame byte offsets).
+    /// </summary>
     InsertSubtree = 4,
 
-    /// <summary>Remove a contiguous run of <see cref="EditOp.Length" /> sibling
-    /// subtrees starting at <see cref="EditOp.Path" />.</summary>
+    /// <summary>
+    ///     Remove a contiguous run of <see cref="EditOp.Length" /> sibling
+    ///     subtrees starting at <see cref="EditOp.Path" />.
+    /// </summary>
     RemoveSubtree = 5,
 
-    /// <summary>Move an existing sibling DOM node within its parent. <see cref="EditOp.Path" />
-    /// resolves to the destination slot among the parent's DOM-relevant children;
-    /// <see cref="EditOp.Length" /> is the source slot. The client detaches the node at the
-    /// source, then inserts at the destination slot in the post-detach sibling list — both
-    /// indexes are computed against the live DOM as it stands when this op runs (with any
-    /// preceding ops already applied). Preserves DOM identity (focus, IDL property state, event
-    /// listeners, iframe document state) since moving an existing node via
-    /// <c>parent.insertBefore</c> doesn't materialise a new element.</summary>
+    /// <summary>
+    ///     Move an existing sibling DOM node within its parent. <see cref="EditOp.Path" />
+    ///     resolves to the destination slot among the parent's DOM-relevant children;
+    ///     <see cref="EditOp.Length" /> is the source slot. The client detaches the node at the
+    ///     source, then inserts at the destination slot in the post-detach sibling list — both
+    ///     indexes are computed against the live DOM as it stands when this op runs (with any
+    ///     preceding ops already applied). Preserves DOM identity (focus, IDL property state, event
+    ///     listeners, iframe document state) since moving an existing node via
+    ///     <c>parent.insertBefore</c> doesn't materialise a new element.
+    /// </summary>
     MoveSubtree = 6,
 
-    /// <summary>A batch of sibling moves under a single keyed parent. <see cref="EditOp.Path" />
-    /// resolves to the shared parent node; <see cref="EditOp.Moves" /> is a flat
-    /// <c>[dst0, src0, dst1, src1, …]</c> array, replayed in order with identical semantics to a
-    /// run of <see cref="MoveSubtree" /> ops (detach the source slot, then insert at the
-    /// destination slot in the post-detach sibling list). The order is load-bearing: each
-    /// dst/src pair is computed against the live DOM as mutated by all preceding pairs in the
-    /// batch, so it must not be reordered. Collapses N per-row moves (each re-emitting the full
-    /// parent path) into one op + one path — the dominant wire-bytes cost of a keyed-list
-    /// reorder. Like <see cref="MoveSubtree" /> it only ever comes from the keyed path and
-    /// preserves DOM identity.</summary>
+    /// <summary>
+    ///     A batch of sibling moves under a single keyed parent. <see cref="EditOp.Path" />
+    ///     resolves to the shared parent node; <see cref="EditOp.Moves" /> is a flat
+    ///     <c>[dst0, src0, dst1, src1, …]</c> array, replayed in order with identical semantics to a
+    ///     run of <see cref="MoveSubtree" /> ops (detach the source slot, then insert at the
+    ///     destination slot in the post-detach sibling list). The order is load-bearing: each
+    ///     dst/src pair is computed against the live DOM as mutated by all preceding pairs in the
+    ///     batch, so it must not be reordered. Collapses N per-row moves (each re-emitting the full
+    ///     parent path) into one op + one path — the dominant wire-bytes cost of a keyed-list
+    ///     reorder. Like <see cref="MoveSubtree" /> it only ever comes from the keyed path and
+    ///     preserves DOM identity.
+    /// </summary>
     PermutationBatch = 7
 }
 
@@ -69,7 +83,8 @@ public enum EditOpKind : byte
 /// </summary>
 public readonly struct EditOp
 {
-    public EditOp(EditOpKind kind, int[] path, string? name, string? value, int length = 0, bool trusted = false, int[]? moves = null)
+    public EditOp(EditOpKind kind, int[] path, string? name, string? value, int length = 0, bool trusted = false,
+        int[]? moves = null)
     {
         Kind = kind;
         Path = path;
@@ -82,27 +97,33 @@ public readonly struct EditOp
 
     public EditOpKind Kind { get; }
 
-    /// <summary>Child-index sequence from the document root that identifies the
-    /// target DOM node (or, for <see cref="EditOpKind.InsertSubtree" /> /
-    /// <see cref="EditOpKind.RemoveSubtree" /> / <see cref="EditOpKind.MoveSubtree" />,
-    /// the slot among siblings).</summary>
+    /// <summary>
+    ///     Child-index sequence from the document root that identifies the
+    ///     target DOM node (or, for <see cref="EditOpKind.InsertSubtree" /> /
+    ///     <see cref="EditOpKind.RemoveSubtree" /> / <see cref="EditOpKind.MoveSubtree" />,
+    ///     the slot among siblings).
+    /// </summary>
     public int[] Path { get; }
 
     public string? Name { get; }
     public string? Value { get; }
     public int Length { get; }
 
-    /// <summary>For <see cref="EditOpKind.PermutationBatch" /> only: a flat
-    /// <c>[dst0, src0, dst1, src1, …]</c> array of sibling moves under the parent at
-    /// <see cref="Path" />, in apply order. Null for every other op kind.</summary>
+    /// <summary>
+    ///     For <see cref="EditOpKind.PermutationBatch" /> only: a flat
+    ///     <c>[dst0, src0, dst1, src1, …]</c> array of sibling moves under the parent at
+    ///     <see cref="Path" />, in apply order. Null for every other op kind.
+    /// </summary>
     public int[]? Moves { get; }
 
-    /// <summary>True when this structural op was produced by the keyed-matching path
-    /// (where the moved/inserted/removed node is identified by <c>data-rask-key</c>, so the
-    /// surrounding morph-baseline DOM state stays consistent under apply). Positional structural
-    /// ops set this to <c>false</c> and the live-session gates route them through the full-HTML
-    /// morph path. Non-structural ops (SetAttribute, RemoveAttribute, UpdateText) ignore the
-    /// flag — they're always safe to ship.</summary>
+    /// <summary>
+    ///     True when this structural op was produced by the keyed-matching path
+    ///     (where the moved/inserted/removed node is identified by <c>data-rask-key</c>, so the
+    ///     surrounding morph-baseline DOM state stays consistent under apply). Positional structural
+    ///     ops set this to <c>false</c> and the live-session gates route them through the full-HTML
+    ///     morph path. Non-structural ops (SetAttribute, RemoveAttribute, UpdateText) ignore the
+    ///     flag — they're always safe to ship.
+    /// </summary>
     public bool Trusted { get; }
 }
 
@@ -169,88 +190,10 @@ public static class FrameDiffer
         var startCount = output.Count;
         scratch.ResetForDiff();
         DiffSiblings(oldFrames, 0, oldFrames.Length,
-                     newFrames, 0, newFrames.Length,
-                     output, newHtml, scratch);
+            newFrames, 0, newFrames.Length,
+            output, newHtml, scratch);
         usedKeyedPath = scratch.UsedKeyedPath;
         return output.Count - startCount;
-    }
-
-    /// <summary>
-    ///     Reusable scratch for the keyed-diff path. Holds the DOM-path accumulator plus a
-    ///     small free-list of per-parent keyed buffers (key maps, child lists, the LIS set).
-    ///     Reused across renders — cleared, not reallocated — so a keyed list diff allocates
-    ///     nothing in steady state. One instance per session; NOT thread-safe (the render
-    ///     loop is single-threaded per session). Created via the public parameterless ctor.
-    /// </summary>
-    public sealed class DiffScratch
-    {
-        // Accessed only by the enclosing FrameDiffer (which, as the containing type, reaches
-        // these private members). Kept private so DiffScratch's public surface is just "an
-        // opaque reusable token the caller threads back in".
-        private readonly List<int> _path = new(8);
-        private bool _usedKeyedPath;
-
-        // Free-list of keyed-parent buffers. A keyed parent rents one for the lifetime of its
-        // DiffKeyedSiblings call — whose key maps and child lists stay live across the step-5
-        // inner-diff recursion — and returns it after. The pool grows to the maximum keyed
-        // nesting depth, then is reused forever.
-        private readonly Stack<KeyedBundle> _bundles = new();
-
-        internal List<int> Path => _path;
-
-        internal bool UsedKeyedPath
-        {
-            get => _usedKeyedPath;
-            set => _usedKeyedPath = value;
-        }
-
-        internal void ResetForDiff()
-        {
-            _path.Clear();
-            _usedKeyedPath = false;
-        }
-
-        internal KeyedBundle RentBundle() => _bundles.Count > 0 ? _bundles.Pop() : new KeyedBundle();
-
-        internal void ReturnBundle(KeyedBundle bundle)
-        {
-            bundle.Clear();
-            _bundles.Push(bundle);
-        }
-    }
-
-    // One keyed parent's working set. All collections start empty (a rented bundle is always
-    // cleared on return) and are reused across renders. Nested in FrameDiffer so it can name
-    // the private KeyedChild struct. Internal (not private) so DiffScratch's internal
-    // Rent/ReturnBundle members don't trip CS0050/CS0051 — it never appears in a public signature.
-    internal sealed class KeyedBundle
-    {
-        public readonly List<KeyedChild> OldKids = [];
-        public readonly List<KeyedChild> NewKids = [];
-        public readonly HashSet<string> Seen = new(StringComparer.Ordinal);
-        public readonly Dictionary<string, int> OldByKey = new(StringComparer.Ordinal);
-        public readonly Dictionary<string, int> NewByKey = new(StringComparer.Ordinal);
-        public readonly List<KeyedChild> Surviving = [];
-        public readonly List<int> Live = [];
-        public readonly HashSet<int> LisSet = [];
-
-        // Flat [dst0, src0, dst1, src1, …] accumulator for the step-4 move run. Reused across
-        // renders; the emitted PermutationBatch op gets a fresh copy (ToArray) so the consumer
-        // can hold the path/moves past the next render's Clear().
-        public readonly List<int> MovesBuffer = [];
-
-        public void Clear()
-        {
-            OldKids.Clear();
-            NewKids.Clear();
-            Seen.Clear();
-            OldByKey.Clear();
-            NewByKey.Clear();
-            Surviving.Clear();
-            Live.Clear();
-            LisSet.Clear();
-            MovesBuffer.Clear();
-        }
     }
 
     private static void DiffSiblings(
@@ -332,14 +275,14 @@ public static class FrameDiffer
 
                     // Attributes diff against the current element path.
                     DiffAttributes(oldFrames, ref oldChildStart, oldChildEnd,
-                                   newFrames, ref newChildStart, newChildEnd,
-                                   PathPlus(path, domSlot), output);
+                        newFrames, ref newChildStart, newChildEnd,
+                        PathPlus(path, domSlot), output);
 
                     // Recurse into children. Push domSlot onto path, then diff inside.
                     path.Add(domSlot);
                     DiffSiblings(oldFrames, oldChildStart, oldChildEnd,
-                                 newFrames, newChildStart, newChildEnd,
-                                 output, newHtml, scratch);
+                        newFrames, newChildStart, newChildEnd,
+                        output, newHtml, scratch);
                     path.RemoveAt(path.Count - 1);
 
                     oi += oldFrame.SubtreeLength;
@@ -530,12 +473,6 @@ public static class FrameDiffer
         return count;
     }
 
-    internal struct KeyedChild
-    {
-        public string Key;
-        public int FrameIndex;
-    }
-
     /// <summary>
     ///     Probes a sibling range for the all-or-nothing keyed contract: every direct child
     ///     must be an Element carrying a <c>data-rask-key</c> attribute, and the keys must be
@@ -661,7 +598,7 @@ public static class FrameDiffer
                 null,
                 null,
                 DomNodeCount(oldFrames, oc.FrameIndex, oc.FrameIndex + elem.SubtreeLength),
-                trusted: true));
+                true));
         }
 
         // 2) Build tracking list = old children whose keys survived. Note we work with
@@ -695,7 +632,7 @@ public static class FrameDiffer
                 null,
                 html,
                 DomNodeCount(newFrames, nc.FrameIndex, nc.FrameIndex + elem.SubtreeLength),
-                trusted: true));
+                true));
             surviving.Insert(j, nc);
         }
 
@@ -834,14 +771,14 @@ public static class FrameDiffer
                     null,
                     null,
                     DomNodeCount(oldFrames, oc.FrameIndex, oc.FrameIndex + oldElem.SubtreeLength),
-                    trusted: true));
+                    true));
                 output.Add(new EditOp(
                     EditOpKind.InsertSubtree,
                     PathPlus(path, j),
                     null,
                     SliceHtml(newHtml, newElem.HtmlStart, newElem.HtmlEnd),
                     DomNodeCount(newFrames, nc.FrameIndex, nc.FrameIndex + newElem.SubtreeLength),
-                    trusted: true));
+                    true));
                 continue;
             }
 
@@ -851,13 +788,13 @@ public static class FrameDiffer
             var newChildEnd = nc.FrameIndex + newElem.SubtreeLength;
 
             DiffAttributes(oldFrames, ref oldChildStart, oldChildEnd,
-                           newFrames, ref newChildStart, newChildEnd,
-                           PathPlus(path, j), output);
+                newFrames, ref newChildStart, newChildEnd,
+                PathPlus(path, j), output);
 
             path.Add(j);
             DiffSiblings(oldFrames, oldChildStart, oldChildEnd,
-                         newFrames, newChildStart, newChildEnd,
-                         output, newHtml, scratch);
+                newFrames, newChildStart, newChildEnd,
+                output, newHtml, scratch);
             path.RemoveAt(path.Count - 1);
         }
     }
@@ -896,8 +833,8 @@ public static class FrameDiffer
             return;
         }
 
-        var tails = ArrayPool<int>.Shared.Rent(len);   // tails[k] = arr-index of smallest tail of LIS length k+1
-        var prev = ArrayPool<int>.Shared.Rent(len);    // prev[i] = arr-index of LIS predecessor of i (or -1)
+        var tails = ArrayPool<int>.Shared.Rent(len); // tails[k] = arr-index of smallest tail of LIS length k+1
+        var prev = ArrayPool<int>.Shared.Rent(len); // prev[i] = arr-index of LIS predecessor of i (or -1)
         try
         {
             var tailsLen = 0;
@@ -946,5 +883,83 @@ public static class FrameDiffer
             ArrayPool<int>.Shared.Return(tails);
             ArrayPool<int>.Shared.Return(prev);
         }
+    }
+
+    /// <summary>
+    ///     Reusable scratch for the keyed-diff path. Holds the DOM-path accumulator plus a
+    ///     small free-list of per-parent keyed buffers (key maps, child lists, the LIS set).
+    ///     Reused across renders — cleared, not reallocated — so a keyed list diff allocates
+    ///     nothing in steady state. One instance per session; NOT thread-safe (the render
+    ///     loop is single-threaded per session). Created via the public parameterless ctor.
+    /// </summary>
+    public sealed class DiffScratch
+    {
+        // Free-list of keyed-parent buffers. A keyed parent rents one for the lifetime of its
+        // DiffKeyedSiblings call — whose key maps and child lists stay live across the step-5
+        // inner-diff recursion — and returns it after. The pool grows to the maximum keyed
+        // nesting depth, then is reused forever.
+        private readonly Stack<KeyedBundle> _bundles = new();
+
+        // Accessed only by the enclosing FrameDiffer (which, as the containing type, reaches
+        // these private members). Kept private so DiffScratch's public surface is just "an
+        // opaque reusable token the caller threads back in".
+
+        internal List<int> Path { get; } = new(8);
+
+        internal bool UsedKeyedPath { get; set; }
+
+        internal void ResetForDiff()
+        {
+            Path.Clear();
+            UsedKeyedPath = false;
+        }
+
+        internal KeyedBundle RentBundle() => _bundles.Count > 0 ? _bundles.Pop() : new KeyedBundle();
+
+        internal void ReturnBundle(KeyedBundle bundle)
+        {
+            bundle.Clear();
+            _bundles.Push(bundle);
+        }
+    }
+
+    // One keyed parent's working set. All collections start empty (a rented bundle is always
+    // cleared on return) and are reused across renders. Nested in FrameDiffer so it can name
+    // the private KeyedChild struct. Internal (not private) so DiffScratch's internal
+    // Rent/ReturnBundle members don't trip CS0050/CS0051 — it never appears in a public signature.
+    internal sealed class KeyedBundle
+    {
+        public readonly HashSet<int> LisSet = [];
+        public readonly List<int> Live = [];
+
+        // Flat [dst0, src0, dst1, src1, …] accumulator for the step-4 move run. Reused across
+        // renders; the emitted PermutationBatch op gets a fresh copy (ToArray) so the consumer
+        // can hold the path/moves past the next render's Clear().
+        public readonly List<int> MovesBuffer = [];
+        public readonly Dictionary<string, int> NewByKey = new(StringComparer.Ordinal);
+        public readonly List<KeyedChild> NewKids = [];
+        public readonly Dictionary<string, int> OldByKey = new(StringComparer.Ordinal);
+        public readonly List<KeyedChild> OldKids = [];
+        public readonly HashSet<string> Seen = new(StringComparer.Ordinal);
+        public readonly List<KeyedChild> Surviving = [];
+
+        public void Clear()
+        {
+            OldKids.Clear();
+            NewKids.Clear();
+            Seen.Clear();
+            OldByKey.Clear();
+            NewByKey.Clear();
+            Surviving.Clear();
+            Live.Clear();
+            LisSet.Clear();
+            MovesBuffer.Clear();
+        }
+    }
+
+    internal struct KeyedChild
+    {
+        public string Key;
+        public int FrameIndex;
     }
 }

--- a/src/Rask.Core/Live/LiveDiffGate.cs
+++ b/src/Rask.Core/Live/LiveDiffGate.cs
@@ -1,12 +1,12 @@
 namespace Rask.Core.Live;
 
 /// <summary>
-/// Pure diff-codec gating helpers shared by both host sessions
-/// (<c>Rask.Server.LiveSession</c> and <c>Rask.Wasm.WasmLiveSession</c>). These carry no
-/// transport or session state — they decide, from the rendered HTML and the computed edit
-/// ops, whether a diff can be shipped and what slice of <c>&lt;head&gt;</c> rides along.
-/// Kept in one place so a fix to the head-fragment gating or the structural-op safety rule
-/// applies to both transports at once.
+///     Pure diff-codec gating helpers shared by both host sessions
+///     (<c>Rask.Server.LiveSession</c> and <c>Rask.Wasm.WasmLiveSession</c>). These carry no
+///     transport or session state — they decide, from the rendered HTML and the computed edit
+///     ops, whether a diff can be shipped and what slice of <c>&lt;head&gt;</c> rides along.
+///     Kept in one place so a fix to the head-fragment gating or the structural-op safety rule
+///     applies to both transports at once.
 /// </summary>
 internal static class LiveDiffGate
 {
@@ -50,12 +50,24 @@ internal static class LiveDiffGate
     {
         const string headClose = "</head>";
         var a = html.IndexOf(headClose, StringComparison.Ordinal);
-        if (a < 0) return false;
+        if (a < 0)
+        {
+            return false;
+        }
+
         var b = baseline.IndexOf(headClose, StringComparison.Ordinal);
-        if (b < 0) return false;
+        if (b < 0)
+        {
+            return false;
+        }
+
         a += headClose.Length;
         b += headClose.Length;
-        if (a != b) return false;
+        if (a != b)
+        {
+            return false;
+        }
+
         return html.AsSpan(0, a).SequenceEqual(baseline.AsSpan(0, b));
     }
 
@@ -67,10 +79,18 @@ internal static class LiveDiffGate
     internal static string? ExtractHead(string html)
     {
         var open = html.IndexOf("<head", StringComparison.Ordinal);
-        if (open < 0) return null;
+        if (open < 0)
+        {
+            return null;
+        }
+
         const string headClose = "</head>";
         var close = html.IndexOf(headClose, StringComparison.Ordinal);
-        if (close < 0) return null;
+        if (close < 0)
+        {
+            return null;
+        }
+
         close += headClose.Length;
         return close <= open ? null : html.Substring(open, close - open);
     }

--- a/src/Rask.Core/Live/LiveOptions.cs
+++ b/src/Rask.Core/Live/LiveOptions.cs
@@ -6,29 +6,39 @@ namespace Rask.Core.Live;
 /// </summary>
 public enum LiveDiffMode
 {
-    /// <summary>Always ship the full rendered HTML — the behaviour Rask had
-    /// before the diff codec landed. Default; safe; matches existing tests and the
-    /// existing client morph path.</summary>
+    /// <summary>
+    ///     Always ship the full rendered HTML — the behaviour Rask had
+    ///     before the diff codec landed. Default; safe; matches existing tests and the
+    ///     existing client morph path.
+    /// </summary>
     DisabledFull = 0,
 
-    /// <summary>Ship a <see cref="LivePayload.BuildPayloadUtf8Diff" /> payload
-    /// whenever a diff is computable and client-applicable. Falls back to full HTML
-    /// only when the diff would be <em>larger</em> than re-sending the body, on the
-    /// first render (no baseline), on structural ops the client interpreter can't
-    /// apply without morph-quality book-keeping (positional
-    /// <see cref="EditOpKind.InsertSubtree" /> / <see cref="EditOpKind.RemoveSubtree" />
-    /// / <see cref="EditOpKind.MoveSubtree" /> — keyed list edits are diffed), and on
-    /// out-of-band side effects (auth, download, jsInvokes, navigation). This is the
-    /// default: any genuine in-place state change ships as a diff regardless of page
-    /// size.</summary>
+    /// <summary>
+    ///     Ship a <see cref="LivePayload.BuildPayloadUtf8Diff" /> payload
+    ///     whenever a diff is computable and client-applicable. Falls back to full HTML
+    ///     only when the diff would be <em>larger</em> than re-sending the body, on the
+    ///     first render (no baseline), on structural ops the client interpreter can't
+    ///     apply without morph-quality book-keeping (positional
+    ///     <see cref="EditOpKind.InsertSubtree" /> / <see cref="EditOpKind.RemoveSubtree" />
+    ///     / <see cref="EditOpKind.MoveSubtree" /> — keyed list edits are diffed), and on
+    ///     out-of-band side effects (auth, download, jsInvokes, navigation). This is the
+    ///     default: any genuine in-place state change ships as a diff regardless of page
+    ///     size.
+    /// </summary>
     Auto = 1,
 
-    /// <summary>Always ship a diff payload when one is computable, <em>even when it
-    /// would be larger than the full HTML</em>. Mostly useful for tests and
-    /// benchmarks that want to lock in the diff path regardless of byte size.
-    /// Otherwise identical to <see cref="Auto" /> — still falls back to full HTML on
-    /// the first render, on structural ops, and on out-of-band side effects (auth,
-    /// download) that the diff wire format doesn't yet carry.</summary>
+    /// <summary>
+    ///     Always ship a diff payload when one is computable,
+    ///     <em>
+    ///         even when it
+    ///         would be larger than the full HTML
+    ///     </em>
+    ///     . Mostly useful for tests and
+    ///     benchmarks that want to lock in the diff path regardless of byte size.
+    ///     Otherwise identical to <see cref="Auto" /> — still falls back to full HTML on
+    ///     the first render, on structural ops, and on out-of-band side effects (auth,
+    ///     download) that the diff wire format doesn't yet carry.
+    /// </summary>
     Forced = 2
 }
 
@@ -44,6 +54,7 @@ public enum LiveDiffMode
 /// </summary>
 public sealed class RaskLiveOptions
 {
+    private string _pathBase = string.Empty;
     public LiveDiffMode DiffMode { get; set; } = LiveDiffMode.Auto;
 
     /// <summary>
@@ -74,7 +85,6 @@ public sealed class RaskLiveOptions
         get => _pathBase;
         set => _pathBase = RaskPath.Normalize(value);
     }
-    private string _pathBase = string.Empty;
 }
 
 /// <summary>
@@ -87,6 +97,7 @@ public sealed class RaskLiveOptions
 /// </summary>
 public static class LiveOptions
 {
+    private static string _pathBase = string.Empty;
     public static LiveDiffMode DiffMode { get; set; } = LiveDiffMode.Auto;
 
     /// <summary>
@@ -98,7 +109,6 @@ public static class LiveOptions
         get => _pathBase;
         set => _pathBase = RaskPath.Normalize(value);
     }
-    private static string _pathBase = string.Empty;
 }
 
 /// <summary>
@@ -114,11 +124,27 @@ public static class RaskPath
     /// </summary>
     public static string Normalize(string? value)
     {
-        if (string.IsNullOrWhiteSpace(value)) return string.Empty;
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return string.Empty;
+        }
+
         var s = value.Trim();
-        if (s == "/") return string.Empty;
-        if (s[0] != '/') s = "/" + s;
-        while (s.Length > 1 && s[^1] == '/') s = s[..^1];
+        if (s == "/")
+        {
+            return string.Empty;
+        }
+
+        if (s[0] != '/')
+        {
+            s = "/" + s;
+        }
+
+        while (s.Length > 1 && s[^1] == '/')
+        {
+            s = s[..^1];
+        }
+
         return s;
     }
 }

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -9,6 +9,19 @@ namespace Rask.Core.Live;
 
 public static class LivePayload
 {
+    // The Utf8JsonWriter default encoder is HTML-safe — it rewrites `<`, `>`, `&`, `+`,
+    // `'`, and a long list of other characters to `\uXXXX` escapes so the JSON can be
+    // embedded inside an HTML <script> tag without prematurely closing it. Diff payloads
+    // never appear inline in HTML (they flow over the WebSocket and are decoded by
+    // JSON.parse), and InsertSubtree ops carry whole HTML fragments where every `<` and
+    // `>` would otherwise pay a 5× byte tax. UnsafeRelaxedJsonEscaping only escapes the
+    // JSON-required characters (`"`, `\`, control bytes) — JSON.parse on the client
+    // produces the identical string either way, so this is a pure wire-size win.
+    private static readonly JsonWriterOptions DiffWriterOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+    };
+
     public static string InjectRootAttr(string html, string sessionId)
     {
         // Linear scan for the first "<body" (case-insensitive). Faster than a compiled regex
@@ -232,19 +245,6 @@ public static class LivePayload
         writer.WriteStringValue(name);
     }
 
-    // The Utf8JsonWriter default encoder is HTML-safe — it rewrites `<`, `>`, `&`, `+`,
-    // `'`, and a long list of other characters to `\uXXXX` escapes so the JSON can be
-    // embedded inside an HTML <script> tag without prematurely closing it. Diff payloads
-    // never appear inline in HTML (they flow over the WebSocket and are decoded by
-    // JSON.parse), and InsertSubtree ops carry whole HTML fragments where every `<` and
-    // `>` would otherwise pay a 5× byte tax. UnsafeRelaxedJsonEscaping only escapes the
-    // JSON-required characters (`"`, `\`, control bytes) — JSON.parse on the client
-    // produces the identical string either way, so this is a pure wire-size win.
-    private static readonly JsonWriterOptions DiffWriterOptions = new()
-    {
-        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
-    };
-
     public static void BuildPayloadUtf8Diff(
         ArrayBufferWriter<byte> output,
         IReadOnlyList<EditOp> ops,
@@ -266,8 +266,16 @@ public static class LivePayload
         for (var i = 0; i < ops.Count; i++)
         {
             var op = ops[i];
-            if (op.Name is null) continue;
-            if (op.Kind != EditOpKind.SetAttribute && op.Kind != EditOpKind.RemoveAttribute) continue;
+            if (op.Name is null)
+            {
+                continue;
+            }
+
+            if (op.Kind != EditOpKind.SetAttribute && op.Kind != EditOpKind.RemoveAttribute)
+            {
+                continue;
+            }
+
             nameCount ??= new Dictionary<string, int>(StringComparer.Ordinal);
             nameCount.TryGetValue(op.Name, out var c);
             nameCount[op.Name] = c + 1;
@@ -278,7 +286,11 @@ public static class LivePayload
         {
             foreach (var kv in nameCount)
             {
-                if (kv.Value < 3) continue;
+                if (kv.Value < 3)
+                {
+                    continue;
+                }
+
                 nameIndex ??= new Dictionary<string, int>(StringComparer.Ordinal);
                 internedNames ??= new List<string>();
                 nameIndex[kv.Key] = internedNames.Count;
@@ -297,6 +309,7 @@ public static class LivePayload
             {
                 writer.WriteStringValue(n);
             }
+
             writer.WriteEndArray();
         }
 
@@ -311,25 +324,47 @@ public static class LivePayload
             {
                 writer.WriteNumberValue(step);
             }
+
             writer.WriteEndArray();
 
             switch (op.Kind)
             {
                 case EditOpKind.SetAttribute:
                     WriteInternedOrString(writer, op.Name, nameIndex);
-                    if (op.Value is null) writer.WriteNullValue();
-                    else writer.WriteStringValue(op.Value);
+                    if (op.Value is null)
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(op.Value);
+                    }
+
                     break;
                 case EditOpKind.RemoveAttribute:
                     WriteInternedOrString(writer, op.Name, nameIndex);
                     break;
                 case EditOpKind.UpdateText:
-                    if (op.Value is null) writer.WriteNullValue();
-                    else writer.WriteStringValue(op.Value);
+                    if (op.Value is null)
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(op.Value);
+                    }
+
                     break;
                 case EditOpKind.InsertSubtree:
-                    if (op.Value is null) writer.WriteNullValue();
-                    else writer.WriteStringValue(op.Value);
+                    if (op.Value is null)
+                    {
+                        writer.WriteNullValue();
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(op.Value);
+                    }
+
                     writer.WriteNumberValue(op.Length);
                     break;
                 case EditOpKind.RemoveSubtree:
@@ -340,8 +375,12 @@ public static class LivePayload
                     writer.WriteStartArray();
                     if (op.Moves is { } moves)
                     {
-                        foreach (var m in moves) writer.WriteNumberValue(m);
+                        foreach (var m in moves)
+                        {
+                            writer.WriteNumberValue(m);
+                        }
                     }
+
                     writer.WriteEndArray();
                     break;
             }
@@ -405,7 +444,7 @@ public static class LivePayload
             return;
         }
 
-        int sliceStartChar = includeOnlyBody ? bodyOpenChar : 0;
+        var sliceStartChar = includeOnlyBody ? bodyOpenChar : 0;
         int sliceEndChar;
         if (includeOnlyBody)
         {

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -27,8 +27,6 @@ public sealed class LiveRenderContext : IDisposable
     // the using-block exits still observes `Current == this`. Callers that need the
     // narrower meaning (e.g. RaskJSRuntime.BeginInvokeJS deciding whether the current
     // frame will drain a queued invoke for them) check IsActive instead of Current.
-    private bool _active = true;
-    internal bool IsActive => _active;
 
     private LiveRenderContext(
         Component root,
@@ -44,6 +42,8 @@ public sealed class LiveRenderContext : IDisposable
         _previous = _current.Value;
         _current.Value = this;
     }
+
+    internal bool IsActive { get; private set; } = true;
 
     public static LiveRenderContext? Current => _current.Value;
 
@@ -82,7 +82,7 @@ public sealed class LiveRenderContext : IDisposable
 
     public void Dispose()
     {
-        _active = false;
+        IsActive = false;
         _current.Value = _previous;
     }
 
@@ -237,6 +237,19 @@ public sealed class LiveRenderContext : IDisposable
 
     internal Dictionary<ObjectKey, EditContext> SnapshotEditContexts() => _currentEditContexts;
 
+    // Extension-style entry points that handle a null receiver. Lets HtmlSerializer's
+    // `using (liveCtx?.PushScope(...))` pattern survive the rewrite from class-based
+    // pop disposables to a ref struct — `?.` can't return a ref struct (no Nullable<T>
+    // for ref structs), but a non-extension static taking `LiveRenderContext?` can.
+    internal static ContextScope PushScopeOrNone(LiveRenderContext? ctx, Component instance)
+        => ctx is null ? default : ctx.PushScope(instance);
+
+    internal static ContextScope EnterParentScopeOrNone(LiveRenderContext? ctx, Component parent)
+        => ctx is null ? default : ctx.EnterParentScope(parent);
+
+    internal static ContextScope PushBoundaryOrNone(LiveRenderContext? ctx, ErrorBoundary boundary)
+        => ctx is null ? default : ctx.PushBoundary(boundary);
+
     internal readonly struct ObjectKey : IEquatable<ObjectKey>
     {
         public ObjectKey(object value) => Value = value;
@@ -260,19 +273,6 @@ public sealed class LiveRenderContext : IDisposable
         Boundary = 3
     }
 
-    // Extension-style entry points that handle a null receiver. Lets HtmlSerializer's
-    // `using (liveCtx?.PushScope(...))` pattern survive the rewrite from class-based
-    // pop disposables to a ref struct — `?.` can't return a ref struct (no Nullable<T>
-    // for ref structs), but a non-extension static taking `LiveRenderContext?` can.
-    internal static ContextScope PushScopeOrNone(LiveRenderContext? ctx, Component instance)
-        => ctx is null ? default : ctx.PushScope(instance);
-
-    internal static ContextScope EnterParentScopeOrNone(LiveRenderContext? ctx, Component parent)
-        => ctx is null ? default : ctx.EnterParentScope(parent);
-
-    internal static ContextScope PushBoundaryOrNone(LiveRenderContext? ctx, ErrorBoundary boundary)
-        => ctx is null ? default : ctx.PushBoundary(boundary);
-
     internal readonly ref struct ContextScope
     {
         private readonly LiveRenderContext? _ctx;
@@ -294,13 +294,25 @@ public sealed class LiveRenderContext : IDisposable
             switch (_kind)
             {
                 case ContextScopeKind.Scope:
-                    if (ctx._scopeStack.Count > 0) ctx._scopeStack.Pop();
+                    if (ctx._scopeStack.Count > 0)
+                    {
+                        ctx._scopeStack.Pop();
+                    }
+
                     break;
                 case ContextScopeKind.Parent:
-                    if (ctx._parentStack.Count > 0) ctx._parentStack.Pop();
+                    if (ctx._parentStack.Count > 0)
+                    {
+                        ctx._parentStack.Pop();
+                    }
+
                     break;
                 case ContextScopeKind.Boundary:
-                    if (ctx._boundaryStack.Count > 0) ctx._boundaryStack.Pop();
+                    if (ctx._boundaryStack.Count > 0)
+                    {
+                        ctx._boundaryStack.Pop();
+                    }
+
                     break;
             }
         }

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -10,16 +10,20 @@ namespace Rask.Core.Live;
 /// </summary>
 public enum RenderFrameKind : byte
 {
-    /// <summary>Opens an HTML element. The matching closing tag is implicit at
-    /// <c>index + SubtreeLength</c>; there is no <c>CloseElement</c> frame.</summary>
+    /// <summary>
+    ///     Opens an HTML element. The matching closing tag is implicit at
+    ///     <c>index + SubtreeLength</c>; there is no <c>CloseElement</c> frame.
+    /// </summary>
     Element = 1,
 
     /// <summary>A single name/value attribute on the most-recently-opened element.</summary>
     Attribute = 2,
 
-    /// <summary>HTML-encoded text content (the producer is responsible for any encoding
-    /// decisions — the frame stores the raw user-supplied text so a consumer can
-    /// re-encode if it writes to a different sink).</summary>
+    /// <summary>
+    ///     HTML-encoded text content (the producer is responsible for any encoding
+    ///     decisions — the frame stores the raw user-supplied text so a consumer can
+    ///     re-encode if it writes to a different sink).
+    /// </summary>
     Text = 3,
 
     /// <summary>Verbatim markup (no encoding). Corresponds to <see cref="Generated.Raw" />.</summary>
@@ -28,9 +32,11 @@ public enum RenderFrameKind : byte
     /// <summary>Doctype declaration.</summary>
     Doctype = 5,
 
-    /// <summary>Marks the start of a user-component's rendered subtree. The component
-    /// instance reference lets the diff codec short-circuit when an unchanged component
-    /// instance still produces an identical cached subtree.</summary>
+    /// <summary>
+    ///     Marks the start of a user-component's rendered subtree. The component
+    ///     instance reference lets the diff codec short-circuit when an unchanged component
+    ///     instance still produces an identical cached subtree.
+    /// </summary>
     Component = 6
 }
 
@@ -46,12 +52,14 @@ public struct RenderFrame
 {
     public RenderFrameKind Kind;
 
-    /// <summary>For <see cref="RenderFrameKind.Element" /> and
-    /// <see cref="RenderFrameKind.Component" />: total frames in the subtree rooted at
-    /// this frame including itself. <c>1</c> means a leaf element with no children. The
-    /// field is patched in by <see cref="FrameWriter.CloseElement" /> /
-    /// <see cref="FrameWriter.CloseComponent" /> at close time; while the element is
-    /// still open the value is meaningless.</summary>
+    /// <summary>
+    ///     For <see cref="RenderFrameKind.Element" /> and
+    ///     <see cref="RenderFrameKind.Component" />: total frames in the subtree rooted at
+    ///     this frame including itself. <c>1</c> means a leaf element with no children. The
+    ///     field is patched in by <see cref="FrameWriter.CloseElement" /> /
+    ///     <see cref="FrameWriter.CloseComponent" /> at close time; while the element is
+    ///     still open the value is meaningless.
+    /// </summary>
     public int SubtreeLength;
 
     /// <summary>
@@ -61,31 +69,39 @@ public struct RenderFrame
     /// </summary>
     public string? Name;
 
-    /// <summary>For <see cref="RenderFrameKind.Attribute" />: the attribute value.
-    /// For <see cref="RenderFrameKind.Element" />: the active scoped-CSS id when the
-    /// element opened (or null when no scope is active), so consumers that emit edit-ops
-    /// for inserted elements can re-stamp <c>data-{scopeId}</c> client-side.</summary>
+    /// <summary>
+    ///     For <see cref="RenderFrameKind.Attribute" />: the attribute value.
+    ///     For <see cref="RenderFrameKind.Element" />: the active scoped-CSS id when the
+    ///     element opened (or null when no scope is active), so consumers that emit edit-ops
+    ///     for inserted elements can re-stamp <c>data-{scopeId}</c> client-side.
+    /// </summary>
     public string? Value;
 
-    /// <summary>For <see cref="RenderFrameKind.Component" />: the component instance.
-    /// Allows the diff codec to compare by identity, letting cached subtrees
-    /// short-circuit a full frame walk.</summary>
+    /// <summary>
+    ///     For <see cref="RenderFrameKind.Component" />: the component instance.
+    ///     Allows the diff codec to compare by identity, letting cached subtrees
+    ///     short-circuit a full frame walk.
+    /// </summary>
     public Component? ComponentRef;
 
-    /// <summary>For <see cref="RenderFrameKind.Element" />: whether the tag is
-    /// self-closing (<c>&lt;br /&gt;</c>). Persisted on the frame so a consumer
-    /// rendering edit-ops to HTML doesn't need a void-element lookup table.</summary>
+    /// <summary>
+    ///     For <see cref="RenderFrameKind.Element" />: whether the tag is
+    ///     self-closing (<c>&lt;br /&gt;</c>). Persisted on the frame so a consumer
+    ///     rendering edit-ops to HTML doesn't need a void-element lookup table.
+    /// </summary>
     public bool SelfClosing;
 
-    /// <summary>UTF-16 character offset into the rendered HTML string at which this
-    /// frame's serialized output begins. Set by <see cref="FrameWriter" /> at
-    /// <c>Open*</c> time; the matching <see cref="HtmlEnd" /> is set at <c>Close*</c>
-    /// time. The diff codec uses <c>[HtmlStart..HtmlEnd]</c> as the HTML fragment to
-    /// ship with an <see cref="RenderFrameKind"/>-bearing op (specifically
-    /// <see cref="EditOpKind.InsertSubtree" />) so the client interpreter can apply
-    /// structural changes without re-rendering on its own. Frames without a
-    /// meaningful HTML range (e.g. <see cref="RenderFrameKind.Attribute" />) leave
-    /// these as zero.</summary>
+    /// <summary>
+    ///     UTF-16 character offset into the rendered HTML string at which this
+    ///     frame's serialized output begins. Set by <see cref="FrameWriter" /> at
+    ///     <c>Open*</c> time; the matching <see cref="HtmlEnd" /> is set at <c>Close*</c>
+    ///     time. The diff codec uses <c>[HtmlStart..HtmlEnd]</c> as the HTML fragment to
+    ///     ship with an <see cref="RenderFrameKind" />-bearing op (specifically
+    ///     <see cref="EditOpKind.InsertSubtree" />) so the client interpreter can apply
+    ///     structural changes without re-rendering on its own. Frames without a
+    ///     meaningful HTML range (e.g. <see cref="RenderFrameKind.Attribute" />) leave
+    ///     these as zero.
+    /// </summary>
     public int HtmlStart;
 
     /// <summary>Companion to <see cref="HtmlStart" />.</summary>
@@ -102,26 +118,27 @@ public struct RenderFrame
 public sealed class FrameWriter
 {
     private RenderFrame[] _buffer;
-    private int _count;
 
-    public FrameWriter(int initialCapacity = 256)
-    {
+    public FrameWriter(int initialCapacity = 256) =>
         _buffer = ArrayPool<RenderFrame>.Shared.Rent(Math.Max(16, initialCapacity));
-    }
 
     /// <summary>Total frames emitted so far.</summary>
-    public int Count => _count;
+    public int Count { get; private set; }
 
-    /// <summary>View over the emitted frames. Stable for the duration of one render
-    /// — invalidated by the next <c>Open*</c>/<c>Reset</c> call that triggers a resize.</summary>
-    public ReadOnlySpan<RenderFrame> WrittenSpan => _buffer.AsSpan(0, _count);
+    /// <summary>
+    ///     View over the emitted frames. Stable for the duration of one render
+    ///     — invalidated by the next <c>Open*</c>/<c>Reset</c> call that triggers a resize.
+    /// </summary>
+    public ReadOnlySpan<RenderFrame> WrittenSpan => _buffer.AsSpan(0, Count);
 
     /// <summary>Reset the writer for the next render. Re-uses the underlying buffer.</summary>
-    public void Reset() => _count = 0;
+    public void Reset() => Count = 0;
 
-    /// <summary>Open a regular HTML element. Returns the frame index so the caller
-    /// can pass it back to <see cref="CloseElement" /> to patch in the subtree length
-    /// and the HTML byte range.</summary>
+    /// <summary>
+    ///     Open a regular HTML element. Returns the frame index so the caller
+    ///     can pass it back to <see cref="CloseElement" /> to patch in the subtree length
+    ///     and the HTML byte range.
+    /// </summary>
     public int OpenElement(string tag, string? scopeId, bool selfClosing, int htmlStart)
     {
         var idx = Reserve();
@@ -139,7 +156,7 @@ public sealed class FrameWriter
 
     public void CloseElement(int openIndex, int htmlEnd)
     {
-        _buffer[openIndex].SubtreeLength = _count - openIndex;
+        _buffer[openIndex].SubtreeLength = Count - openIndex;
         _buffer[openIndex].HtmlEnd = htmlEnd;
     }
 
@@ -148,17 +165,14 @@ public sealed class FrameWriter
         var idx = Reserve();
         _buffer[idx] = new RenderFrame
         {
-            Kind = RenderFrameKind.Component,
-            ComponentRef = instance,
-            SubtreeLength = 1,
-            HtmlStart = htmlStart
+            Kind = RenderFrameKind.Component, ComponentRef = instance, SubtreeLength = 1, HtmlStart = htmlStart
         };
         return idx;
     }
 
     public void CloseComponent(int openIndex, int htmlEnd)
     {
-        _buffer[openIndex].SubtreeLength = _count - openIndex;
+        _buffer[openIndex].SubtreeLength = Count - openIndex;
         _buffer[openIndex].HtmlEnd = htmlEnd;
     }
 
@@ -167,10 +181,7 @@ public sealed class FrameWriter
         var idx = Reserve();
         _buffer[idx] = new RenderFrame
         {
-            Kind = RenderFrameKind.Attribute,
-            Name = name,
-            Value = value,
-            SubtreeLength = 1
+            Kind = RenderFrameKind.Attribute, Name = name, Value = value, SubtreeLength = 1
         };
     }
 
@@ -205,24 +216,21 @@ public sealed class FrameWriter
         var idx = Reserve();
         _buffer[idx] = new RenderFrame
         {
-            Kind = RenderFrameKind.Doctype,
-            SubtreeLength = 1,
-            HtmlStart = htmlStart,
-            HtmlEnd = htmlEnd
+            Kind = RenderFrameKind.Doctype, SubtreeLength = 1, HtmlStart = htmlStart, HtmlEnd = htmlEnd
         };
     }
 
     private int Reserve()
     {
-        if (_count == _buffer.Length)
+        if (Count == _buffer.Length)
         {
             var bigger = ArrayPool<RenderFrame>.Shared.Rent(_buffer.Length * 2);
-            Array.Copy(_buffer, bigger, _count);
-            ArrayPool<RenderFrame>.Shared.Return(_buffer, clearArray: true);
+            Array.Copy(_buffer, bigger, Count);
+            ArrayPool<RenderFrame>.Shared.Return(_buffer, true);
             _buffer = bigger;
         }
 
-        return _count++;
+        return Count++;
     }
 
     /// <summary>
@@ -240,7 +248,7 @@ public sealed class FrameWriter
             return;
         }
 
-        for (var i = 0; i < _count; i++)
+        for (var i = 0; i < Count; i++)
         {
             if (_buffer[i].HtmlStart >= from)
             {
@@ -266,19 +274,17 @@ public sealed class FrameWriter
 /// </summary>
 public static class FrameSinkScope
 {
-    [ThreadStatic] private static FrameWriter? _current;
-
-    public static FrameWriter? Current => _current;
+    [field: ThreadStatic] public static FrameWriter? Current { get; private set; }
 
     public static Popper Push(FrameWriter? writer)
     {
-        var prev = _current;
-        _current = writer;
+        var prev = Current;
+        Current = writer;
         return new Popper(prev);
     }
 
     public readonly struct Popper(FrameWriter? previous) : IDisposable
     {
-        public void Dispose() => _current = previous;
+        public void Dispose() => Current = previous;
     }
 }

--- a/src/Rask.Core/Live/SessionRenderCache.cs
+++ b/src/Rask.Core/Live/SessionRenderCache.cs
@@ -16,29 +16,41 @@ namespace Rask.Core.Live;
 ///         Two ways to use this:
 ///         <list type="bullet">
 ///             <item>
-///                 <description><see cref="Render" />: the cache drives the render
-///                 directly. Returns the diff (or <c>null</c> on first render).</description>
+///                 <description>
+///                     <see cref="Render" />: the cache drives the render
+///                     directly. Returns the diff (or <c>null</c> on first render).
+///                 </description>
 ///             </item>
 ///             <item>
-///                 <description><see cref="PrepareCurrentBuffer" /> +
-///                 <see cref="TryComputeDiff" />: caller drives the render however it
-///                 likes (typically through <c>RenderAsLiveRoot</c>) while pushing
-///                 the returned buffer onto <see cref="FrameSinkScope" /> first. Use
-///                 this from <c>LiveSession</c>, which has its own render flow.</description>
+///                 <description>
+///                     <see cref="PrepareCurrentBuffer" /> +
+///                     <see cref="TryComputeDiff" />: caller drives the render however it
+///                     likes (typically through <c>RenderAsLiveRoot</c>) while pushing
+///                     the returned buffer onto <see cref="FrameSinkScope" /> first. Use
+///                     this from <c>LiveSession</c>, which has its own render flow.
+///                 </description>
 ///             </item>
 ///         </list>
 ///     </para>
 /// </summary>
 public sealed class SessionRenderCache : IDisposable
 {
-    private FrameWriter? _previous;
     private FrameWriter? _current;
     private bool _hasPrevious;
+    private FrameWriter? _previous;
 
     // Reusable keyed-diff scratch, owned per session so the keyed reconciliation path
     // (FrameDiffer.DiffKeyedSiblings) is allocation-free in steady state. Lazily created
     // on first diff; nulled on Dispose alongside the frame buffers.
     private FrameDiffer.DiffScratch? _scratch;
+
+    public void Dispose()
+    {
+        _previous = null;
+        _current = null;
+        _hasPrevious = false;
+        _scratch = null;
+    }
 
     /// <summary>
     ///     Acquire the buffer the caller should push onto
@@ -86,7 +98,7 @@ public sealed class SessionRenderCache : IDisposable
     ///     ship as diff; positional structural ops still route to the full-HTML morph path.
     /// </summary>
     public bool TryComputeDiff(List<EditOp> output, out bool usedKeyedPath, string? newHtml = null)
-        => TryComputeDiff(output, out usedKeyedPath, newHtml, rotate: true);
+        => TryComputeDiff(output, out usedKeyedPath, newHtml, true);
 
     public bool TryComputeDiff(List<EditOp> output, out bool usedKeyedPath, string? newHtml, bool rotate)
     {
@@ -102,7 +114,8 @@ public sealed class SessionRenderCache : IDisposable
             return false;
         }
 
-        FrameDiffer.Diff(_previous!.WrittenSpan, _current.WrittenSpan, output, _scratch ??= new FrameDiffer.DiffScratch(), out usedKeyedPath, newHtml);
+        FrameDiffer.Diff(_previous!.WrittenSpan, _current.WrittenSpan, output,
+            _scratch ??= new FrameDiffer.DiffScratch(), out usedKeyedPath, newHtml);
         if (rotate)
         {
             RotateBuffers();
@@ -120,10 +133,7 @@ public sealed class SessionRenderCache : IDisposable
     ///     corrupts the next diff: edits computed against an out-of-date snapshot
     ///     applied to a DOM the client has already moved past.
     /// </summary>
-    public void Snapshot()
-    {
-        RotateBuffers();
-    }
+    public void Snapshot() => RotateBuffers();
 
     /// <summary>
     ///     One-shot render + diff. Mostly useful for tests and the
@@ -149,13 +159,5 @@ public sealed class SessionRenderCache : IDisposable
     {
         (_previous, _current) = (_current, _previous);
         _hasPrevious = true;
-    }
-
-    public void Dispose()
-    {
-        _previous = null;
-        _current = null;
-        _hasPrevious = false;
-        _scratch = null;
     }
 }

--- a/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
+++ b/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
@@ -46,6 +46,28 @@ public static class ScopedAssetRegistry
         new(@"(^|\n)\s*export\s+(?:default\s+)?function\s+(\w+)\s*\(",
             RegexOptions.Compiled);
 
+    internal static int CssEntryCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _cssByHash.Count;
+            }
+        }
+    }
+
+    internal static int JsEntryCount
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _jsByHash.Count;
+            }
+        }
+    }
+
     public static event Action<Type, AssetKind>? AssetChanged;
 
     /// <summary>
@@ -278,8 +300,6 @@ public static class ScopedAssetRegistry
         return snapshot;
     }
 
-    public readonly record struct EnumeratedEntry(string Hash, AssetKind Kind, ReadOnlyMemory<byte> Utf8);
-
     /// <summary>
     ///     Looks up the asset hash for a component's CSS. Returns false (with empty out)
     ///     when the type has no scoped CSS registered. Called by head emission to decide
@@ -365,28 +385,6 @@ public static class ScopedAssetRegistry
         return null;
     }
 
-    internal static int CssEntryCount
-    {
-        get
-        {
-            lock (_lock)
-            {
-                return _cssByHash.Count;
-            }
-        }
-    }
-
-    internal static int JsEntryCount
-    {
-        get
-        {
-            lock (_lock)
-            {
-                return _jsByHash.Count;
-            }
-        }
-    }
-
     private static void IncrementOrInsertLocked(
         Dictionary<string, AssetEntry> bucket, string hash, byte[] bytes)
     {
@@ -426,7 +424,7 @@ public static class ScopedAssetRegistry
         {
             var b = hash[i];
             chars[i * 2] = ToLowerHex(b >> 4);
-            chars[i * 2 + 1] = ToLowerHex(b & 0xF);
+            chars[(i * 2) + 1] = ToLowerHex(b & 0xF);
         }
 
         return new string(chars);
@@ -483,10 +481,14 @@ public static class ScopedAssetRegistry
         return sb.ToString();
     }
 
+    public readonly record struct EnumeratedEntry(string Hash, AssetKind Kind, ReadOnlyMemory<byte> Utf8);
+
     public readonly record struct AssetBytes(ReadOnlyMemory<byte> Utf8, string Etag);
 
     private sealed class AssetEntry
     {
+        public int RefCount;
+
         public AssetEntry(byte[] utf8, string etag)
         {
             Utf8 = utf8;
@@ -495,6 +497,5 @@ public static class ScopedAssetRegistry
 
         public byte[] Utf8 { get; }
         public string Etag { get; }
-        public int RefCount;
     }
 }

--- a/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
@@ -37,7 +37,7 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         + "a loop should carry a stable Key (Blazor @key parity). Without it, insert/remove/reorder "
         + "falls back to a positional full-HTML morph and loses DOM identity (focus, input state) on "
         + "surviving nodes.",
-        helpLinkUri: DiagnosticHelp.Link("RASK022"));
+        DiagnosticHelp.Link("RASK022"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
         ImmutableArray.Create(Rask022);
@@ -94,8 +94,8 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         var typeInfo = model.GetTypeInfo(outer, context.CancellationToken);
         var isChildLike =
             IsChild(typeInfo.Type, child) || IsChild(typeInfo.ConvertedType, child)
-            || InheritsFrom(typeInfo.Type as INamedTypeSymbol, component)
-            || InheritsFrom(typeInfo.ConvertedType as INamedTypeSymbol, component);
+                                          || InheritsFrom(typeInfo.Type as INamedTypeSymbol, component)
+                                          || InheritsFrom(typeInfo.ConvertedType as INamedTypeSymbol, component);
         if (!isChildLike)
         {
             return;
@@ -175,14 +175,17 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         // `outer` must be the DIRECTLY projected value — the lambda's expression body or a
         // returned expression — not a nested descendant element (e.g. a Code inside a projected
         // Li). Only the top-level projected item is the reconciled sibling that needs a Key.
-        LambdaExpressionSyntax? lambda = outer.Parent switch
+        var lambda = outer.Parent switch
         {
             LambdaExpressionSyntax direct => direct,
             ReturnStatementSyntax ret => EnclosingLambda(ret),
             _ => null
         };
 
-        return lambda?.Parent is ArgumentSyntax { Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax inv } }
+        return lambda?.Parent is ArgumentSyntax
+               {
+                   Parent: ArgumentListSyntax { Parent: InvocationExpressionSyntax inv }
+               }
                && IsLinqProjection(inv);
     }
 

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -976,7 +976,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         sb.AppendLine(");");
     }
 
-    private static void EmitGenericFactoryOverload(StringBuilder sb, Candidate c, GenericFactoryConfig gf, bool emitNavigation)
+    private static void EmitGenericFactoryOverload(StringBuilder sb, Candidate c, GenericFactoryConfig gf,
+        bool emitNavigation)
     {
         var visibility = c.IsPublic ? "public" : "internal";
         var typedSet = new HashSet<string>(StringComparer.Ordinal);
@@ -1331,6 +1332,15 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             new LinePositionSpan(new LinePosition(0, 0), new LinePosition(0, 0)));
     }
 
+    // A property/parameter name as a valid C# identifier in emitted code. ISymbol.Name strips the
+    // leading '@' from a verbatim identifier (a property declared `@event` has Name "event"), so a
+    // reserved keyword must be re-escaped with '@' wherever it is emitted as an identifier —
+    // otherwise the generated factory (`string? event = null`, `__c.event = event`) fails to
+    // compile in the consumer's build. Use this only for emitted identifiers; comparisons against
+    // metadata names (modelProperty, "Children", typed-delegate sets) keep the raw Name.
+    internal static string EscapeIdentifier(string name) =>
+        SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "@" + name : name;
+
     private enum ValidatorShape { None, Sync, Async }
 
     private sealed record Candidate(
@@ -1364,15 +1374,6 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         string Name,
         string DefaultLiteral,
         bool IsParams);
-
-    // A property/parameter name as a valid C# identifier in emitted code. ISymbol.Name strips the
-    // leading '@' from a verbatim identifier (a property declared `@event` has Name "event"), so a
-    // reserved keyword must be re-escaped with '@' wherever it is emitted as an identifier —
-    // otherwise the generated factory (`string? event = null`, `__c.event = event`) fails to
-    // compile in the consumer's build. Use this only for emitted identifiers; comparisons against
-    // metadata names (modelProperty, "Children", typed-delegate sets) keep the raw Name.
-    internal static string EscapeIdentifier(string name) =>
-        SyntaxFacts.GetKeywordKind(name) != SyntaxKind.None ? "@" + name : name;
 
     private readonly record struct PropInfo(
         string Name,

--- a/src/Rask.Server/Files/SessionDownloadStore.cs
+++ b/src/Rask.Server/Files/SessionDownloadStore.cs
@@ -29,6 +29,13 @@ internal sealed class SessionDownloadStore : IDisposable
     {
         var token = Guid.NewGuid().ToString("N");
         var path = Path.Combine(Path.GetTempPath(), $"rask-download-{token}.bin");
+        // Eagerly copy to a temp file (synchronously) rather than holding the caller's
+        // stream until the download HTTP request arrives. This decouples the file's
+        // lifetime from the source stream — IDownloadSink.Stage / Navigator.Download are
+        // synchronous, fire-and-forget APIs called from an event handler, so the stream
+        // (often a `using` MemoryStream/FileStream) may be disposed the moment the handler
+        // returns. Copying now is the price of that contract; keep it sync to avoid
+        // turning the whole public Download path async.
         using (var f = File.Create(path))
         {
             stream.CopyTo(f);

--- a/src/Rask.Server/Files/SessionUploadStore.cs
+++ b/src/Rask.Server/Files/SessionUploadStore.cs
@@ -17,12 +17,12 @@ internal sealed class SessionUploadStore : IDisposable
         }
     }
 
-    public Entry Stage(string sessionId, string name, string contentType, long size, DateTimeOffset lastModified,
-        Func<string, Task> writeToPath)
+    public async Task<Entry> StageAsync(string sessionId, string name, string contentType, long size,
+        DateTimeOffset lastModified, Func<string, Task> writeToPath)
     {
         var token = Guid.NewGuid().ToString("N");
         var path = Path.Combine(Path.GetTempPath(), $"rask-upload-{token}.bin");
-        writeToPath(path).GetAwaiter().GetResult();
+        await writeToPath(path).ConfigureAwait(false);
         var info = new FileInfo(path);
         var entry = new Entry(sessionId, token, path, name, info.Exists ? info.Length : size, contentType,
             lastModified);

--- a/src/Rask.Server/JSInterop/RaskJSRuntime.cs
+++ b/src/Rask.Server/JSInterop/RaskJSRuntime.cs
@@ -37,10 +37,7 @@ internal sealed class RaskJSRuntime : JSRuntime
 {
     private readonly LiveSessionAccessor _accessor;
 
-    public RaskJSRuntime(LiveSessionAccessor accessor)
-    {
-        _accessor = accessor;
-    }
+    public RaskJSRuntime(LiveSessionAccessor accessor) => _accessor = accessor;
 
     private LiveSession CurrentSession =>
         _accessor.Session ?? throw new InvalidOperationException(

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -15,6 +15,12 @@ namespace Rask.Server;
 
 internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
 {
+    // IJSRuntime queue. Calls land here via RaskJSRuntime.BeginInvokeJS and get drained
+    // into the next outbound payload by RenderAndSendAsync. A plain List under lock —
+    // contention is bounded by the session's outer Lock semaphore (one handler at a time),
+    // so writes only race with the drain at flush time.
+    private readonly List<PendingJsInvoke> _pendingJsInvokes = new();
+
     // Serialises individual RenderAndSendAsync calls within one handler dispatch. The dispatcher's
     // outer Lock pins single-handler-at-a-time; this inner gate keeps the mid-await render (on the
     // handler thread) from racing the HandlerSyncContext.RunWithRendersAsync renders (fired on
@@ -24,27 +30,8 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // wins, dropping the other's payload, or both call _socket.SendAsync on the same WebSocket.
     private readonly SemaphoreSlim _renderLock = new(1, 1);
 
-    // IJSRuntime queue. Calls land here via RaskJSRuntime.BeginInvokeJS and get drained
-    // into the next outbound payload by RenderAndSendAsync. A plain List under lock —
-    // contention is bounded by the session's outer Lock semaphore (one handler at a time),
-    // so writes only race with the drain at flush time.
-    private readonly List<PendingJsInvoke> _pendingJsInvokes = new();
-    private ArrayBufferWriter<byte>? _lastSentBuffer;
-    // Last rendered HTML (the `html` string the framework produced last time we
-    // sent a frame). Used to skip noop publish-renders that would otherwise
-    // re-morph identical HTML and clobber JS-applied DOM state (e.g. the
-    // `.hljs` class hljs added to <code> elements after the previous
-    // OnRenderedAsync invoke completed). Set after a successful send.
-    private string? _lastSentHtml;
-    // Set true whenever a render request lands with no live socket — async lifecycle
-    // continuations from OnMountAsync / OnRenderedAsync that resolve during the HTTP-GET-
-    // to-WS-hello handoff window, or while a session is between sockets across a
-    // reconnect. AttachSocket reads it from the hello handler to decide whether a
-    // catch-up render is actually needed: when nothing was dropped, the HTML the browser
-    // already has from the GET response (or the prior socket) still matches the session
-    // state and the hello-time render is redundant. Skipping the redundant render is
-    // what aligns Server's initial-mount OnRendered count with WASM's.
-    private bool _renderRequestedWhileDetached;
+    private List<EditOp>? _diffOps;
+
     // Set by AttachSocket on a reconnect to force the next render to bypass the HTML/buffer
     // dedup and re-emit even when the rendered bytes match the prior socket's last frame.
     // The dedup baselines (_lastSentBuffer/_lastSentHtml) are owned by the RenderAndSendAsync
@@ -53,8 +40,24 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // so the reset is deferred into the render lock: RenderAndSendAsync reads-and-clears this
     // flag under _renderLock. Volatile so the cross-thread write is visible without the lock.
     private volatile bool _forceResend;
-    private WebSocket? _socket;
-    private CancellationToken _socketCt;
+
+    // True after the first socket has ever attached to this session. Lets AttachSocket
+    // distinguish the GET→hello first attach (where the browser's HTML is guaranteed to
+    // match the session's state because the browser literally just rendered the GET
+    // response) from a subsequent reconnect (where the browser may have missed the prior
+    // socket's last frame due to a partial send, a tab background, or any other transport
+    // gap we can't observe from this side). First-attach skips the redundant render;
+    // reconnect always renders.
+    private bool _hasAttachedBefore;
+
+    private ArrayBufferWriter<byte>? _lastSentBuffer;
+
+    // Last rendered HTML (the `html` string the framework produced last time we
+    // sent a frame). Used to skip noop publish-renders that would otherwise
+    // re-morph identical HTML and clobber JS-applied DOM state (e.g. the
+    // `.hljs` class hljs added to <code> elements after the previous
+    // OnRenderedAsync invoke completed). Set after a successful send.
+    private string? _lastSentHtml;
 
     // Set by RequestRenderInternalAsync when StateHasChanged fires while a handler
     // dispatch is mid-flight (InHandlerScope=true). RenderAndSendCoalescingAsync
@@ -67,17 +70,28 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // Mirrors WasmLiveSession._pendingRenderInScope (Rask.Wasm/WasmLiveSession.cs:41).
     private bool _pendingRenderInScope;
 
+    // Diff-codec state. Populated only when LiveOptions.DiffMode != DisabledFull, so
+    // the default path pays nothing for these. Both fields are lazy because the
+    // common production path today still ships full HTML.
+    private SessionRenderCache? _renderCache;
+
+    // Set true whenever a render request lands with no live socket — async lifecycle
+    // continuations from OnMountAsync / OnRenderedAsync that resolve during the HTTP-GET-
+    // to-WS-hello handoff window, or while a session is between sockets across a
+    // reconnect. AttachSocket reads it from the hello handler to decide whether a
+    // catch-up render is actually needed: when nothing was dropped, the HTML the browser
+    // already has from the GET response (or the prior socket) still matches the session
+    // state and the hello-time render is redundant. Skipping the redundant render is
+    // what aligns Server's initial-mount OnRendered count with WASM's.
+    private bool _renderRequestedWhileDetached;
+    private WebSocket? _socket;
+    private CancellationToken _socketCt;
+
     // Two-buffer swap: `_writeBuffer` receives the next frame, `_lastSentBuffer` holds the
     // previous send (dedup compare target). After SendAsync the references swap so the just-
     // sent buffer becomes the dedup baseline without any byte[] copy. Both writers persist
     // across the session's lifetime; ResetWrittenCount keeps the underlying rented array hot.
     private ArrayBufferWriter<byte> _writeBuffer = new(4096);
-
-    // Diff-codec state. Populated only when LiveOptions.DiffMode != DisabledFull, so
-    // the default path pays nothing for these. Both fields are lazy because the
-    // common production path today still ships full HTML.
-    private SessionRenderCache? _renderCache;
-    private List<EditOp>? _diffOps;
 
     public LiveSession(string id, Component view, IServiceScope scope)
     {
@@ -139,9 +153,11 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
         Scope.Dispose();
     }
 
-    public Task RequestRenderAsync() => RequestRenderInternalAsync(publishOnly: false);
+    public Task RequestRenderAsync() => RequestRenderInternalAsync(false);
 
-    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(publishOnly: true);
+    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(true);
+
+    Task IRenderHandle.RenderInScopeAsync() => RenderAndSendAsync(null, false);
 
     private async Task RequestRenderInternalAsync(bool publishOnly)
     {
@@ -176,8 +192,6 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
             Lock.Release();
         }
     }
-
-    Task IRenderHandle.RenderInScopeAsync() => RenderAndSendAsync(null, false);
 
     private void ReleaseFileStores()
     {
@@ -235,15 +249,6 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
         SeedInitialHtml(html);
         return html;
     }
-
-    // True after the first socket has ever attached to this session. Lets AttachSocket
-    // distinguish the GET→hello first attach (where the browser's HTML is guaranteed to
-    // match the session's state because the browser literally just rendered the GET
-    // response) from a subsequent reconnect (where the browser may have missed the prior
-    // socket's last frame due to a partial send, a tab background, or any other transport
-    // gap we can't observe from this side). First-attach skips the redundant render;
-    // reconnect always renders.
-    private bool _hasAttachedBefore;
 
     public void AttachSocket(WebSocket socket, CancellationToken ct)
     {
@@ -484,7 +489,7 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
             // full HTML (first render, oversized diff, structural ops) the client morphs to
             // match the server's frame snapshot, so the next render diffs cleanly against it.
             if (frameWriter is not null && _renderCache is not null
-                && auth is null && download is null)
+                                        && auth is null && download is null)
             {
                 _diffOps ??= new List<EditOp>();
                 diffPathEntered = true;
@@ -581,8 +586,10 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     ///     single outbound payload. The first send emits the captured navigation/auth
     ///     state; if an in-handler StateHasChanged set <see cref="_pendingRenderInScope" />
     ///     (e.g. <c>RouteState.Changed</c> subscribers on a layout above the Router),
-    ///     rebuild up to twice — re-threading <paramref name="historyUrl" />, <paramref
-    ///     name="replace" />, and <paramref name="auth" /> so the actually-sent payload
+    ///     rebuild up to twice — re-threading <paramref name="historyUrl" />,
+    ///     <paramref
+    ///         name="replace" />
+    ///     , and <paramref name="auth" /> so the actually-sent payload
     ///     still carries them. Dropping any of those on a rebuild silently swallows
     ///     handler-initiated navigation, the c11b61d invariant ported from
     ///     <c>WasmLiveSession.BuildPayloadCoalescingRerendersAsync</c>. The

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -14,6 +14,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Primitives;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
+using Microsoft.Net.Http.Headers;
 using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Core.Authorization;
@@ -52,10 +53,23 @@ public static class RaskEndpointExtensions
     private static readonly byte[] SessionUnknownPayload =
         Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "session", status = "unknown" }));
 
+    // 50ms trailing-edge debounce for ScopedAssetRegistry.AssetChanged. A multi-file edit
+    // (or a single hot-reload UpdateApplication burst that re-registers every component
+    // back-to-back) generates N events; without coalescing each fires its own
+    // RerenderAllAsync. The generation counter snapshot survives only if no newer event
+    // arrived during the quiet window — the trailing change wins and we re-render once.
+    private static long _assetChangeGen;
+
+    // HTTP methods accepted by the per-component asset endpoint. GET serves the body;
+    // HEAD returns the same headers with no body (handled by Results.Bytes internally).
+    // POST/PUT/DELETE/PATCH not listed → ASP.NET returns 405 Method Not Allowed.
+    private static readonly string[] _assetMethods = ["GET", "HEAD"];
+
     /// <summary>
     ///     Registers the Rask server-side live-rendering services (session store, routing,
     ///     authentication, file upload/download, <see cref="IJSRuntime" /> bridge, and the live
-    ///     runtime script). Call this in <c>ConfigureServices</c>, then <see cref="UseRask{TApp}(WebApplication, string, string)" />
+    ///     runtime script). Call this in <c>ConfigureServices</c>, then
+    ///     <see cref="UseRask{TApp}(WebApplication, string, string)" />
     ///     in the pipeline. Authentication itself is configured on ASP.NET's own
     ///     <c>AddAuthentication</c>/<c>AddCookie</c>/<c>AddJwtBearer</c> — Rask has no auth options object.
     /// </summary>
@@ -66,7 +80,7 @@ public static class RaskEndpointExtensions
     /// </param>
     /// <returns>The same <paramref name="services" /> instance, for chaining.</returns>
     public static IServiceCollection AddRask(this IServiceCollection services,
-        Action<Rask.Core.Live.RaskLiveOptions>? configure = null)
+        Action<RaskLiveOptions>? configure = null)
     {
         // Per-app live runtime options. The framework default for DiffMode is
         // LiveDiffMode.Auto (set on the static LiveOptions.DiffMode at class init),
@@ -81,14 +95,14 @@ public static class RaskEndpointExtensions
         var maxSessions = 0;
         if (configure is not null)
         {
-            var liveOptions = new Rask.Core.Live.RaskLiveOptions();
+            var liveOptions = new RaskLiveOptions();
             configure(liveOptions);
-            Rask.Core.Live.LiveOptions.DiffMode = liveOptions.DiffMode;
+            LiveOptions.DiffMode = liveOptions.DiffMode;
             // PathBase normalization happens on assignment to RaskLiveOptions,
             // and a second normalize on the static accessor is a cheap no-op.
             // UseRask<TApp>(pathBase: ...) can still override this if the user
             // prefers to set the prefix at endpoint-registration time.
-            Rask.Core.Live.LiveOptions.PathBase = liveOptions.PathBase;
+            LiveOptions.PathBase = liveOptions.PathBase;
             // Session cap is a per-store instance value (not a static) so concurrent
             // hosts/tests don't clobber each other through global state.
             maxSessions = liveOptions.MaxSessions;
@@ -96,10 +110,7 @@ public static class RaskEndpointExtensions
 
         services.AddSingleton(sp => new LiveSessionStore(
             sp.GetRequiredService<IServiceScopeFactory>(),
-            sp.GetService<IHostApplicationLifetime>())
-        {
-            MaxSessions = maxSessions,
-        });
+            sp.GetService<IHostApplicationLifetime>()) { MaxSessions = maxSessions });
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
@@ -394,13 +405,6 @@ public static class RaskEndpointExtensions
         SubscribeAssetChangedDebounced(sessionStore);
         TryEnableSourceWatcher(sessionStore);
     }
-
-    // 50ms trailing-edge debounce for ScopedAssetRegistry.AssetChanged. A multi-file edit
-    // (or a single hot-reload UpdateApplication burst that re-registers every component
-    // back-to-back) generates N events; without coalescing each fires its own
-    // RerenderAllAsync. The generation counter snapshot survives only if no newer event
-    // arrived during the quiet window — the trailing change wins and we re-render once.
-    private static long _assetChangeGen;
 
     private static void SubscribeAssetChangedDebounced(LiveSessionStore sessionStore)
     {
@@ -846,9 +850,10 @@ public static class RaskEndpointExtensions
             }
             else
             {
-                w.WriteStringValue(root.TryGetProperty("error", out var errEl) && errEl.ValueKind == JsonValueKind.String
-                    ? errEl.GetString()
-                    : "JS invocation failed");
+                w.WriteStringValue(
+                    root.TryGetProperty("error", out var errEl) && errEl.ValueKind == JsonValueKind.String
+                        ? errEl.GetString()
+                        : "JS invocation failed");
             }
 
             w.WriteEndArray();
@@ -1172,11 +1177,6 @@ public static class RaskEndpointExtensions
     // Rask.Core's LocalUrl.Sanitize (single source of truth for the IsLocalUrl rule).
     internal static string SanitizeReturnUrl(string? returnUrl) => LocalUrl.Sanitize(returnUrl);
 
-    // HTTP methods accepted by the per-component asset endpoint. GET serves the body;
-    // HEAD returns the same headers with no body (handled by Results.Bytes internally).
-    // POST/PUT/DELETE/PATCH not listed → ASP.NET returns 405 Method Not Allowed.
-    private static readonly string[] _assetMethods = ["GET", "HEAD"];
-
     /// <summary>
     ///     Serves a single per-component scoped asset by its content hash. The hash and
     ///     extension are validated by routing pattern + a hex/length check here; on miss,
@@ -1214,7 +1214,7 @@ public static class RaskEndpointExtensions
                 bytes.Value.Utf8.ToArray(),
                 contentType,
                 enableRangeProcessing: true,
-                entityTag: new Microsoft.Net.Http.Headers.EntityTagHeaderValue(bytes.Value.Etag))
+                entityTag: new EntityTagHeaderValue(bytes.Value.Etag))
             .ExecuteAsync(ctx);
     }
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -52,6 +52,19 @@ public static class RaskEndpointExtensions
     private static readonly byte[] SessionUnknownPayload =
         Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "session", status = "unknown" }));
 
+    /// <summary>
+    ///     Registers the Rask server-side live-rendering services (session store, routing,
+    ///     authentication, file upload/download, <see cref="IJSRuntime" /> bridge, and the live
+    ///     runtime script). Call this in <c>ConfigureServices</c>, then <see cref="UseRask{TApp}(WebApplication, string, string)" />
+    ///     in the pipeline. Authentication itself is configured on ASP.NET's own
+    ///     <c>AddAuthentication</c>/<c>AddCookie</c>/<c>AddJwtBearer</c> — Rask has no auth options object.
+    /// </summary>
+    /// <param name="services">The service collection to add Rask services to.</param>
+    /// <param name="configure">
+    ///     Optional per-app live-runtime options (diff mode, path base, session cap). When omitted,
+    ///     framework defaults apply (<see cref="Rask.Core.Live.LiveDiffMode.Auto" />, no path base, uncapped).
+    /// </param>
+    /// <returns>The same <paramref name="services" /> instance, for chaining.</returns>
     public static IServiceCollection AddRask(this IServiceCollection services,
         Action<Rask.Core.Live.RaskLiveOptions>? configure = null)
     {
@@ -118,6 +131,20 @@ public static class RaskEndpointExtensions
         return services;
     }
 
+    /// <summary>
+    ///     Maps the Rask live endpoints (root document, WebSocket dispatcher, scoped-asset, auth,
+    ///     and upload/download routes) with <typeparamref name="TApp" /> as the root component, and
+    ///     enables WebSockets. The root must render a complete shell
+    ///     (<c>Doctype</c>/<c>Html</c>/<c>Head</c>/<c>Body</c>) — see RASK021.
+    /// </summary>
+    /// <typeparam name="TApp">The root <see cref="Component" /> rendered for every matched route.</typeparam>
+    /// <param name="app">The web application to map endpoints on.</param>
+    /// <param name="pattern">Catch-all route pattern Rask serves (default <c>/{**path}</c>).</param>
+    /// <param name="pathBase">
+    ///     Optional URL prefix so two Rask servers can share one origin behind a reverse proxy
+    ///     (e.g. <c>/app1</c>). Overrides any path base set via <see cref="AddRask" />.
+    /// </param>
+    /// <returns>The same <paramref name="app" /> instance, for chaining.</returns>
     public static WebApplication UseRask<TApp>(
         this WebApplication app,
         string pattern = "/{**path}",
@@ -129,6 +156,16 @@ public static class RaskEndpointExtensions
         return app;
     }
 
+    /// <summary>
+    ///     Endpoint-routing overload of <see cref="UseRask{TApp}(WebApplication, string, string)" />: maps the
+    ///     Rask live endpoints onto an existing <see cref="IEndpointRouteBuilder" /> without touching the
+    ///     middleware pipeline (the caller is responsible for <c>UseWebSockets()</c>).
+    /// </summary>
+    /// <typeparam name="TApp">The root <see cref="Component" /> rendered for every matched route.</typeparam>
+    /// <param name="endpoints">The endpoint route builder to map Rask routes on.</param>
+    /// <param name="pattern">Catch-all route pattern Rask serves (default <c>/{**path}</c>).</param>
+    /// <param name="pathBase">Optional URL prefix; see the <see cref="WebApplication" /> overload.</param>
+    /// <returns>The same <paramref name="endpoints" /> instance, for chaining.</returns>
     public static IEndpointRouteBuilder UseRask<TApp>(
         this IEndpointRouteBuilder endpoints,
         string pattern = "/{**path}",
@@ -1273,7 +1310,7 @@ public static class RaskEndpointExtensions
                 lastModified = lm;
             }
 
-            var entry = uploads.Stage(
+            var entry = await uploads.StageAsync(
                 sessionId,
                 file.FileName,
                 string.IsNullOrEmpty(file.ContentType) ? "application/octet-stream" : file.ContentType,

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -4,9 +4,15 @@
     // Built-in element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
     // The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
     window.__raskEl = window.__raskEl || {
-        focus: function (el) { if (el) el.focus(); },
-        blur: function (el) { if (el) el.blur(); },
-        scrollIntoView: function (el, opts) { if (el) el.scrollIntoView(opts || { behavior: "smooth", block: "nearest" }); }
+        focus: function (el) {
+            if (el) el.focus();
+        },
+        blur: function (el) {
+            if (el) el.blur();
+        },
+        scrollIntoView: function (el, opts) {
+            if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
+        }
     };
 
     var root = document.querySelector("[data-rask-root]");
@@ -33,6 +39,7 @@
     // the current route URL (e.g. /realtime/BTC), yielding a bogus "/realtime/"
     // base that breaks the WS/asset URLs on every deep route.
     var basePath = null;
+
     function getBasePath() {
         if (basePath !== null) return basePath;
         var baseEl = document.querySelector("base[href]");
@@ -45,12 +52,14 @@
         basePath = last < 0 ? "/" : p.slice(0, last + 1);
         return basePath;
     }
+
     function stripBase(pathname) {
         var b = getBasePath();
         if (b === "/" || !pathname) return pathname;
         if (pathname === b.slice(0, -1) || pathname === b) return "/";
         return pathname.indexOf(b) === 0 ? "/" + pathname.slice(b.length) : pathname;
     }
+
     function prependBase(url) {
         var b = getBasePath();
         if (b === "/" || typeof url !== "string" || url.charAt(0) !== "/" || url.indexOf(b) === 0) return url;
@@ -77,7 +86,9 @@
                 var meta = document.querySelector('meta[name="rask-access-token"]');
                 if (meta) token = meta.getAttribute("content");
             }
-        } catch (e) { token = null; }
+        } catch (e) {
+            token = null;
+        }
         if (!token) return baseWsUrl;
         return baseWsUrl + (baseWsUrl.indexOf("?") >= 0 ? "&" : "?") + "access_token=" + encodeURIComponent(token);
     }
@@ -138,12 +149,20 @@
             // for a scoped-CSS load (see applyDiffReply) can't be overtaken by the next
             // message — paths in a later diff are computed against this render's output.
             if (data.kind === "diff" && Array.isArray(data.ops)) {
-                _renderQueue = _renderQueue.then(function () { return applyDiffReply(data); },
-                                                 function () { return applyDiffReply(data); });
+                _renderQueue = _renderQueue.then(function () {
+                        return applyDiffReply(data);
+                    },
+                    function () {
+                        return applyDiffReply(data);
+                    });
                 return;
             }
-            _renderQueue = _renderQueue.then(function () { return applyFullReply(data); },
-                                             function () { return applyFullReply(data); });
+            _renderQueue = _renderQueue.then(function () {
+                    return applyFullReply(data);
+                },
+                function () {
+                    return applyFullReply(data);
+                });
         });
 
         ws.addEventListener("close", scheduleReconnect);
@@ -283,13 +302,19 @@
             }
             maybeDrainPendingInvokes();
         };
-        el.addEventListener("load", function () { finish("load"); }, {once: true});
-        el.addEventListener("error", function () { finish("error"); }, {once: true});
+        el.addEventListener("load", function () {
+            finish("load");
+        }, {once: true});
+        el.addEventListener("error", function () {
+            finish("error");
+        }, {once: true});
         // Safety: the load/error event may have fired between insertion and
         // our listener attach (cache hit on a CDN). Performance.getEntriesByName
         // covers the common case; the timeout covers everything else so a
         // missed event doesn't hold Rask.* invokes forever.
-        setTimeout(function () { finish("timeout"); }, HEAD_ASSET_LOAD_TIMEOUT_MS);
+        setTimeout(function () {
+            finish("timeout");
+        }, HEAD_ASSET_LOAD_TIMEOUT_MS);
     }
 
     function scanHeadAssets() {
@@ -319,7 +344,9 @@
         document.head.querySelectorAll('link[rel="stylesheet"]').forEach(function (l) {
             if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
             pending.push(new Promise(function (resolve) {
-                var done = function () { resolve(); };
+                var done = function () {
+                    resolve();
+                };
                 l.addEventListener("load", done, {once: true});
                 l.addEventListener("error", done, {once: true});
                 setTimeout(done, CSS_FOUC_GUARD_MS);
@@ -955,7 +982,7 @@
     // Comment nodes shift childNodes indices relative to the server's frame walk.
     // Filter to DOM-relevant nodes only (Element=1, Text=3, Doctype=10) so paths
     // match what FrameDiffer counts.
-    var _relevantNodeTypes = { 1: 1, 3: 1, 10: 1 };
+    var _relevantNodeTypes = {1: 1, 3: 1, 10: 1};
 
     function relevantChild(parent, index) {
         if (!parent || !parent.childNodes) return null;

--- a/src/Rask.Server/SecureToken.cs
+++ b/src/Rask.Server/SecureToken.cs
@@ -11,5 +11,5 @@ internal static class SecureToken
     // contractual cryptographic-strength guarantee (the runtime happens to use a CSPRNG on current
     // platforms, but the API doesn't promise it), whereas RandomNumberGenerator is guaranteed CSPRNG.
     // Same length/charset as Guid "N", so it's a drop-in anywhere these round-trip as opaque strings.
-    public static string Create() => RandomNumberGenerator.GetHexString(32, lowercase: true);
+    public static string Create() => RandomNumberGenerator.GetHexString(32, true);
 }

--- a/src/Rask.Templates/content/rask-server/README.md
+++ b/src/Rask.Templates/content/rask-server/README.md
@@ -1,0 +1,28 @@
+# Company.RaskServer
+
+A server-side [Rask](https://github.com/pal-tamas/rask) app. The browser holds a thin
+client; renders and events flow over a WebSocket and Rask ships a minimal diff per update.
+
+## Run
+
+```bash
+dotnet run
+```
+
+Then open the printed URL.
+
+## Layout
+
+- `Program.cs` — host wiring: `AddRask()` + `UseRask<App>()`.
+- `App.cs` — the root component; renders the full page shell (`Doctype`/`Html`/`Head`/`Body`).
+- `HomePage.cs` (+ `HomePage.css`) — a routed page with co-located scoped styles.
+- `Counter.cs` — an interactive component.
+- `Weather.cs` / `LocalWeatherForecastService.cs` — data via DI.
+
+## Authentication
+
+Scaffolded with `--auth`. This template adds **cookie** auth: a `/login` form, a credential
+store, and a protected `/members` page (under `Auth/`). Without `--auth` those files are
+omitted. Auth is configured on ASP.NET's own `AddCookie` — Rask has no auth options object.
+
+Next steps: the [Rask docs](https://github.com/pal-tamas/rask/tree/main/docs).

--- a/src/Rask.Templates/content/rask-wasm-hosted/README.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/README.md
@@ -1,0 +1,33 @@
+# Company.RaskWasmHosted
+
+A browser-WASM [Rask](https://github.com/pal-tamas/rask) app **with an ASP.NET host** — two
+projects in one solution:
+
+- `Company.RaskWasmHosted.Wasm` (`net10.0-browser`) — the SPA that runs in the browser.
+- `Company.RaskWasmHosted.Host` (`net10.0`) — serves the published WASM client and any
+  server APIs. It references the Wasm project across target frameworks
+  (`SkipGetTargetFrameworkProperties`) and uses a generic `UseRask<TApp>()` so the client
+  assembly's `[ModuleInitializer]` (route registration) loads.
+
+## Run
+
+```bash
+dotnet run --project Company.RaskWasmHosted.Host
+```
+
+Run the **Host** — it publishes and serves the WASM client. Building the host bakes the
+client's scoped CSS/JS assets into the served bundle.
+
+## Publish
+
+```bash
+dotnet publish Company.RaskWasmHosted.Host -c Release
+```
+
+## Authentication
+
+Scaffolded with `--auth`: **cookie** auth. The host serves the login / `me` / logout
+endpoints; the client hydrates the current user and gates a protected `/members` page.
+Auth-related files live under each project's `Auth/` folder and are omitted without `--auth`.
+
+Next steps: the [Rask docs](https://github.com/pal-tamas/rask/tree/main/docs).

--- a/src/Rask.Templates/content/rask-wasm/README.md
+++ b/src/Rask.Templates/content/rask-wasm/README.md
@@ -1,0 +1,38 @@
+# Company.RaskWasm
+
+A standalone browser-WASM [Rask](https://github.com/pal-tamas/rask) SPA (`net10.0-browser`).
+It runs entirely in the browser using the `JSImport`/`JSExport` transport — there is no
+ASP.NET host of its own.
+
+## Run
+
+```bash
+dotnet run
+```
+
+## Publish
+
+```bash
+dotnet publish -c Release
+```
+
+Publishing trims the app and bakes scoped CSS/JS assets into the bundle; serve the output
+from any static-file host. Keep the publish IL-trim-clean — new reflection needs a
+`[DynamicallyAccessedMembers]` annotation or a justified suppression.
+
+## Layout
+
+- `Program.cs` — `WasmHostBuilder.CreateDefault()` + `RunAsync<App>()`.
+- `App.cs` — the root component (renders the full shell).
+- `HomePage.cs` (+ `HomePage.css`), `Counter.cs`, `Weather.cs` — pages and components.
+
+## Authentication
+
+Scaffolded with `--auth`. Because a standalone SPA has no host, this template adds a **JWT
+bearer** login against an *external* API: the token is held in storage and attached as
+`Authorization: Bearer`. Point `BaseAddress` at your auth API. Without `--auth` the `Auth/`
+files are omitted.
+
+> Want the client and its API in one solution instead? Use the `rask-wasm-hosted` template.
+
+Next steps: the [Rask docs](https://github.com/pal-tamas/rask/tree/main/docs).

--- a/src/Rask.Wasm.Hosting/RaskAssetEndpoint.cs
+++ b/src/Rask.Wasm.Hosting/RaskAssetEndpoint.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Net.Http.Headers;
 using Rask.Core.ScopedAssets;
 
 namespace Rask.Wasm.Hosting;
@@ -54,7 +55,7 @@ internal static class RaskAssetEndpoint
                 bytes.Value.Utf8.ToArray(),
                 contentType,
                 enableRangeProcessing: true,
-                entityTag: new Microsoft.Net.Http.Headers.EntityTagHeaderValue(bytes.Value.Etag))
+                entityTag: new EntityTagHeaderValue(bytes.Value.Etag))
             .ExecuteAsync(ctx);
     }
 

--- a/src/Rask.Wasm.Hosting/RaskWasmEndpointExtensions.cs
+++ b/src/Rask.Wasm.Hosting/RaskWasmEndpointExtensions.cs
@@ -69,7 +69,7 @@ public static class RaskWasmEndpointExtensions
         // runtime to resolve and JIT-init the defining assembly, which runs every
         // [ModuleInitializer] in that assembly. Discarded to make the intent obvious.
         _ = typeof(TApp);
-        return UseRask(endpoints, bundlePath, pathBase);
+        return endpoints.UseRask(bundlePath, pathBase);
     }
 
     public static IEndpointRouteBuilder UseRask(
@@ -119,6 +119,7 @@ public static class RaskWasmEndpointExtensions
                         await ctx.Response.WriteAsync($"Rask WASM AppBundle unavailable: {reason}.");
                     });
             }
+
             return endpoints;
         }
 
@@ -151,9 +152,7 @@ public static class RaskWasmEndpointExtensions
 
         app.UseDefaultFiles(new DefaultFilesOptions
         {
-            FileProvider = fileProvider,
-            RequestPath = pathBaseNormalized,
-            DefaultFileNames = new[] { "index.html" }
+            FileProvider = fileProvider, RequestPath = pathBaseNormalized, DefaultFileNames = new[] { "index.html" }
         });
 
         app.UseStaticFiles(new StaticFileOptions

--- a/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
+++ b/src/Rask.Wasm.Tasks/BakeScopedAssetsTask.cs
@@ -1,7 +1,7 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
@@ -122,19 +122,30 @@ public sealed class BakeScopedAssetsTask : Task
         foreach (var item in Assemblies)
         {
             var dir = Path.GetDirectoryName(item.ItemSpec);
-            if (!string.IsNullOrEmpty(dir)) searchDirs.Add(dir);
+            if (!string.IsNullOrEmpty(dir))
+            {
+                searchDirs.Add(dir);
+            }
         }
 
         AppDomain.CurrentDomain.AssemblyResolve += (_, args) =>
         {
             var simpleName = new AssemblyName(args.Name).Name;
-            if (simpleName is null) return null;
+            if (simpleName is null)
+            {
+                return null;
+            }
+
             foreach (var dir in searchDirs)
             {
                 var candidate = Path.Combine(dir, simpleName + ".dll");
                 if (File.Exists(candidate))
                 {
-                    try { return Assembly.LoadFrom(candidate); } catch { /* ignore */ }
+                    try { return Assembly.LoadFrom(candidate); }
+                    catch
+                    {
+                        /* ignore */
+                    }
                 }
             }
 
@@ -167,15 +178,18 @@ public sealed class BakeScopedAssetsTask : Task
 
             if (registryType is null && assembly.GetName().Name == "Rask.Core")
             {
-                registryType = assembly.GetType("Rask.Core.ScopedAssets.ScopedAssetRegistry", throwOnError: false);
+                registryType = assembly.GetType("Rask.Core.ScopedAssets.ScopedAssetRegistry", false);
             }
 
             // Source-generator-emitted registration classes are top-level (no namespace);
             // collect them so we can re-fire RefreshAll after invalidating the registry.
             foreach (var name in new[] { "__RaskScopedCssRegistration", "__RaskScopedJsRegistration" })
             {
-                var t = assembly.GetType(name, throwOnError: false);
-                if (t is not null) registrationTypes.Add(t);
+                var t = assembly.GetType(name, false);
+                if (t is not null)
+                {
+                    registrationTypes.Add(t);
+                }
             }
         }
 
@@ -221,7 +235,7 @@ public sealed class BakeScopedAssetsTask : Task
         Directory.CreateDirectory(outDir);
 
         var written = 0;
-        var entries = (System.Collections.IEnumerable)enumerateAll.Invoke(null, null)!;
+        var entries = (IEnumerable)enumerateAll.Invoke(null, null)!;
         foreach (var entry in entries)
         {
             var entryType = entry.GetType();

--- a/src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj
+++ b/src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj
@@ -28,7 +28,7 @@
       because MSBuild's own assembly resolver provides these at runtime; bundling them
       would clash with the host MSBuild's copy.
     -->
-    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.Build.Utilities.Core" ExcludeAssets="runtime" PrivateAssets="all"/>
   </ItemGroup>
 
   <!--
@@ -39,7 +39,7 @@
     refreshes the deployed task. Cheap: one file, ~20 KB.
   -->
   <Target Name="CopyTaskAssemblyToRaskWasmBuild" AfterTargets="Build">
-    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(MSBuildThisFileDirectory)..\Rask.Wasm\build\" SkipUnchangedFiles="true" />
+    <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(MSBuildThisFileDirectory)..\Rask.Wasm\build\" SkipUnchangedFiles="true"/>
   </Target>
 
 </Project>

--- a/src/Rask.Wasm/Browser/index.html
+++ b/src/Rask.Wasm/Browser/index.html
@@ -27,7 +27,8 @@
     <title>Rask WASM</title>
     <!-- Inline data-URI favicon (the Rask bolt) so the boot screen is branded with no
          external file dependency; the App's <head> morphs in its own <link> on first paint. -->
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E"/>
+    <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E" rel="icon"
+          type="image/svg+xml"/>
     <style id="rask-scoped"></style>
     <style>
         .rask-boot {
@@ -42,21 +43,42 @@
             color: #512BD4;
             background: #faf9fe;
         }
-        .rask-boot svg { width: 64px; height: 64px; animation: rask-pulse 1.4s ease-in-out infinite; }
+
+        .rask-boot svg {
+            width: 64px;
+            height: 64px;
+            animation: rask-pulse 1.4s ease-in-out infinite;
+        }
+
         .rask-boot .rask-spin {
-            width: 26px; height: 26px; border-radius: 50%;
+            width: 26px;
+            height: 26px;
+            border-radius: 50%;
             border: 3px solid rgba(124, 58, 237, 0.22);
             border-top-color: #7C3AED;
             animation: rask-spin 0.8s linear infinite;
         }
-        @keyframes rask-spin { to { transform: rotate(360deg); } }
-        @keyframes rask-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.55; } }
+
+        @keyframes rask-spin {
+            to {
+                transform: rotate(360deg);
+            }
+        }
+
+        @keyframes rask-pulse {
+            0%, 100% {
+                opacity: 1;
+            }
+            50% {
+                opacity: 0.55;
+            }
+        }
     </style>
 </head>
 <body data-rask-root>
 <div class="rask-boot">
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="22 6 80 108" role="img" aria-label="Rask">
-        <linearGradient id="rask-boot-bolt" x1="0" y1="0" x2="1" y2="1">
+    <svg aria-label="Rask" role="img" viewBox="22 6 80 108" xmlns="http://www.w3.org/2000/svg">
+        <linearGradient id="rask-boot-bolt" x1="0" x2="1" y1="0" y2="1">
             <stop offset="0" stop-color="#7C3AED"/>
             <stop offset="1" stop-color="#512BD4"/>
         </linearGradient>

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -9,9 +9,15 @@ let basePath = null;
 // Built-in element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
 // The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
 window.__raskEl = window.__raskEl || {
-    focus: function (el) { if (el) el.focus(); },
-    blur: function (el) { if (el) el.blur(); },
-    scrollIntoView: function (el, opts) { if (el) el.scrollIntoView(opts || { behavior: "smooth", block: "nearest" }); }
+    focus: function (el) {
+        if (el) el.focus();
+    },
+    blur: function (el) {
+        if (el) el.blur();
+    },
+    scrollIntoView: function (el, opts) {
+        if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
+    }
 };
 
 // Serializes render application across payloads. A navigation diff may defer its
@@ -1268,8 +1274,12 @@ window.DotNet = window.DotNet || {
 
 export function endDotNetInvoke(resultJson) {
     let msg;
-    try { msg = JSON.parse(resultJson); }
-    catch (e) { console.error("[Rask] endDotNetInvoke: malformed JSON", e); return; }
+    try {
+        msg = JSON.parse(resultJson);
+    } catch (e) {
+        console.error("[Rask] endDotNetInvoke: malformed JSON", e);
+        return;
+    }
     const pending = dotNetPending.get(msg.callId);
     if (!pending) return;
     dotNetPending.delete(msg.callId);

--- a/src/Rask.Wasm/JSInterop.cs
+++ b/src/Rask.Wasm/JSInterop.cs
@@ -191,10 +191,17 @@ internal static partial class JSInterop
         Task.FromResult(Array.Empty<byte>());
 
     // Records the last BeginInvokeJSImport call so tests can assert dispatch shape.
-    public record BeginInvokeJsCall(string TaskId, string Identifier, string? ArgsJson, int ResultType, string TargetInstanceId);
+    public record BeginInvokeJsCall(
+        string TaskId,
+        string Identifier,
+        string? ArgsJson,
+        int ResultType,
+        string TargetInstanceId);
+
     public static BeginInvokeJsCall? LastBeginInvokeJsCall { get; private set; }
 
-    public static void BeginInvokeJSImport(string taskId, string identifier, string? argsJson, int resultType, string targetInstanceId) =>
+    public static void BeginInvokeJSImport(string taskId, string identifier, string? argsJson, int resultType,
+        string targetInstanceId) =>
         LastBeginInvokeJsCall = new BeginInvokeJsCall(taskId, identifier, argsJson, resultType, targetInstanceId);
 
     public static string? LastEndDotNetInvoke { get; private set; }
@@ -202,13 +209,22 @@ internal static partial class JSInterop
 
     public static void EndInvokeJSResult(string arguments)
     {
-        if (_runtime is null) return;
+        if (_runtime is null)
+        {
+            return;
+        }
+
         DotNetDispatcher.EndInvokeJS(_runtime, arguments);
     }
 
-    public static void BeginDotNetInvoke(string callId, string? assemblyName, string methodIdentifier, int dotNetObjectId, string argsJson)
+    public static void BeginDotNetInvoke(string callId, string? assemblyName, string methodIdentifier,
+        int dotNetObjectId, string argsJson)
     {
-        if (_runtime is null) return;
+        if (_runtime is null)
+        {
+            return;
+        }
+
         var info = new DotNetInvocationInfo(assemblyName, methodIdentifier, dotNetObjectId, callId);
         DotNetDispatcher.BeginInvokeDotNet(_runtime, info, argsJson);
     }

--- a/src/Rask.Wasm/JSInterop/WasmJSRuntime.cs
+++ b/src/Rask.Wasm/JSInterop/WasmJSRuntime.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.JSInterop;
@@ -102,6 +103,6 @@ internal sealed class WasmJSRuntime : JSRuntime
             writer.WriteEndObject();
         }
 
-        return System.Text.Encoding.UTF8.GetString(stream.ToArray());
+        return Encoding.UTF8.GetString(stream.ToArray());
     }
 }

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -9,9 +9,15 @@ let basePath = null;
 // Built-in element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
 // The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
 window.__raskEl = window.__raskEl || {
-    focus: function (el) { if (el) el.focus(); },
-    blur: function (el) { if (el) el.blur(); },
-    scrollIntoView: function (el, opts) { if (el) el.scrollIntoView(opts || { behavior: "smooth", block: "nearest" }); }
+    focus: function (el) {
+        if (el) el.focus();
+    },
+    blur: function (el) {
+        if (el) el.blur();
+    },
+    scrollIntoView: function (el, opts) {
+        if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
+    }
 };
 
 // Serializes render application across payloads. A navigation diff may defer its
@@ -1056,8 +1062,12 @@ window.DotNet = window.DotNet || {
 
 export function endDotNetInvoke(resultJson) {
     let msg;
-    try { msg = JSON.parse(resultJson); }
-    catch (e) { console.error("[Rask] endDotNetInvoke: malformed JSON", e); return; }
+    try {
+        msg = JSON.parse(resultJson);
+    } catch (e) {
+        console.error("[Rask] endDotNetInvoke: malformed JSON", e);
+        return;
+    }
     const pending = dotNetPending.get(msg.callId);
     if (!pending) return;
     dotNetPending.delete(msg.callId);

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -13,6 +13,12 @@ using Rask.Wasm.Files;
 
 namespace Rask.Wasm;
 
+/// <summary>
+///     Entry point for a browser-WASM Rask app. Build with <see cref="CreateDefault()" />, register
+///     app services on <see cref="Services" />, then <c>await</c> <see cref="RunAsync{TApp}" /> with the
+///     root component. Mirrors <c>Rask.Server</c>'s <c>AddRask</c>/<c>UseRask</c> pair for the
+///     JSImport/JSExport transport.
+/// </summary>
 public sealed class WasmHostBuilder
 {
     private WasmHostBuilder()
@@ -32,6 +38,7 @@ public sealed class WasmHostBuilder
         Services.AddSingleton<IJSRuntime>(sp => sp.GetRequiredService<WasmJSRuntime>());
     }
 
+    /// <summary>The DI container for the app. Register your services here before calling <see cref="RunAsync{TApp}" />.</summary>
     public IServiceCollection Services { get; }
 
     /// <summary>
@@ -41,6 +48,7 @@ public sealed class WasmHostBuilder
     /// </summary>
     public static string BaseAddress => JSInterop.GetBaseAddress();
 
+    /// <summary>Creates a builder with framework-default live options (<see cref="LiveDiffMode.Auto" />).</summary>
     public static WasmHostBuilder CreateDefault() => CreateDefault(null);
 
     /// <summary>
@@ -76,6 +84,12 @@ public sealed class WasmHostBuilder
         return new WasmHostBuilder();
     }
 
+    /// <summary>
+    ///     Boots the app: imports the JS bridge, auto-detects the path base from <c>&lt;base href&gt;</c>,
+    ///     builds the service provider, instantiates <typeparamref name="TApp" /> (wrapped in a root error
+    ///     boundary), and performs the first render. Returns once the initial render has been applied.
+    /// </summary>
+    /// <typeparam name="TApp">The root <see cref="Component" /> for the app. Must render a complete shell (RASK021).</typeparam>
     public async Task RunAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>()
         where TApp : Component
     {

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.JSInterop;
 using Rask.Core;
 using Rask.Core.Authentication;
-using Rask.Core.Authorization;
 using Rask.Core.Forms;
 using Rask.Core.Live;
 using Rask.Core.Routing;

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -7,8 +7,6 @@ using Rask.Core.Authentication;
 using Rask.Core.Authorization;
 using Rask.Core.Live;
 using Rask.Core.Routing;
-using Rask.Core.ScopedCss;
-using Rask.Core.ScopedJs;
 
 namespace Rask.Wasm;
 
@@ -16,16 +14,32 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
 {
     private readonly SemaphoreSlim _lock = new(1, 1);
 
+    // Held so Dispose can unsubscribe symmetrically. The provider can outlive the session (it is a
+    // separate service), so a dangling subscription would fire OnUserChanged on a disposed session
+    // (disposed _lock → ObjectDisposedException). In the normal single-session-per-page lifetime
+    // Dispose is never called, but keeping the teardown correct guards tests and any future
+    // multi-session / re-init path.
+    private readonly IUserProvider? _userProvider;
+
     // Pooled across the session lifetime; ResetWrittenCount between frames keeps the rented
     // backing array hot. Eliminates the per-render ArrayBufferWriter allocation that
     // BuildPayloadUtf8WithRoot's byte[]-returning overload would otherwise make.
     private readonly ArrayBufferWriter<byte> _writeBuffer = new(4096);
-    private byte[]? _lastAppliedPayload;
+
+    private List<EditOp>? _diffOps;
+
     // Last rendered HTML string, used to suppress noop publish-renders that
     // would otherwise re-morph identical HTML and strip JS-applied DOM state
     // (e.g. the `.hljs` class hljs added in a prior frame's OnRenderedAsync).
     // Set after a successful ApplyRender.
     private string? _lastAppliedHtml;
+    private byte[]? _lastAppliedPayload;
+
+    // Set by RequestRenderAsync when called while InHandlerScope=true. The dispatch helpers
+    // (BuildPayloadCoalescingRerendersAsync) read and clear it to rebuild the payload before
+    // releasing the lock — catches state mutated by dispose callbacks that fire AFTER ToHtml
+    // serialised the first payload but BEFORE the dispatch returns.
+    private bool _pendingRenderInScope;
 
     // Plain instance bool, NOT AsyncLocal: the dispatch lock is owned by this session as a whole,
     // not by any one async chain. AsyncLocal would flow into Timer/Task captures created during a
@@ -41,20 +55,6 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
     // Diff-codec state, lazily allocated only when LiveOptions.DiffMode opts in.
     // Default path (DisabledFull) pays nothing for these.
     private SessionRenderCache? _renderCache;
-    private List<EditOp>? _diffOps;
-
-    // Set by RequestRenderAsync when called while InHandlerScope=true. The dispatch helpers
-    // (BuildPayloadCoalescingRerendersAsync) read and clear it to rebuild the payload before
-    // releasing the lock — catches state mutated by dispose callbacks that fire AFTER ToHtml
-    // serialised the first payload but BEFORE the dispatch returns.
-    private bool _pendingRenderInScope;
-
-    // Held so Dispose can unsubscribe symmetrically. The provider can outlive the session (it is a
-    // separate service), so a dangling subscription would fire OnUserChanged on a disposed session
-    // (disposed _lock → ObjectDisposedException). In the normal single-session-per-page lifetime
-    // Dispose is never called, but keeping the teardown correct guards tests and any future
-    // multi-session / re-init path.
-    private readonly IUserProvider? _userProvider;
 
     public WasmLiveSession(Component view, IServiceProvider services)
     {
@@ -93,9 +93,43 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
         _lock.Dispose();
     }
 
-    public Task RequestRenderAsync() => RequestRenderInternalAsync(publishOnly: false);
+    public Task RequestRenderAsync() => RequestRenderInternalAsync(false);
 
-    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(publishOnly: true);
+    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(true);
+
+    async Task IRenderHandle.RenderInScopeAsync()
+    {
+        // Mirror Rask.Server LiveSession.RenderAndSendAsync: when the framework asks for a
+        // mid-await render (Component.InvokeWithRenderingAsync), build and push an intermediate
+        // payload directly via JSInterop.ApplyRender so transient UI state — e.g. the async-
+        // validator "Checking…" indicator that lives only during the validator's await window —
+        // reaches the browser before the post-handler payload supersedes it. The dispatcher
+        // already holds _lock and has InHandlerScope=true at this point, so no re-locking.
+        //
+        // Suppress the ambient SynchronizationContext (HandlerSyncContext, installed by
+        // Component.InvokeWithRenderingAsync) for the duration of this call: BuildPayloadAsync's
+        // internal `await Task.Yield()` would otherwise Post its continuation back through
+        // HandlerSyncContext, which re-enters this same method via _render — a render loop on
+        // the WASM JS task queue.
+        var prevCtx = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(null);
+        try
+        {
+            var (payload, html) = await BuildPayloadAsync(null, false).ConfigureAwait(false);
+            if (_lastAppliedPayload is not null && payload.AsSpan().SequenceEqual(_lastAppliedPayload))
+            {
+                return;
+            }
+
+            JSInterop.ApplyRender(payload);
+            _lastAppliedPayload = payload;
+            _lastAppliedHtml = html;
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(prevCtx);
+        }
+    }
 
     private async Task RequestRenderInternalAsync(bool publishOnly)
     {
@@ -145,40 +179,6 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
         {
             InHandlerScope = false;
             _lock.Release();
-        }
-    }
-
-    async Task IRenderHandle.RenderInScopeAsync()
-    {
-        // Mirror Rask.Server LiveSession.RenderAndSendAsync: when the framework asks for a
-        // mid-await render (Component.InvokeWithRenderingAsync), build and push an intermediate
-        // payload directly via JSInterop.ApplyRender so transient UI state — e.g. the async-
-        // validator "Checking…" indicator that lives only during the validator's await window —
-        // reaches the browser before the post-handler payload supersedes it. The dispatcher
-        // already holds _lock and has InHandlerScope=true at this point, so no re-locking.
-        //
-        // Suppress the ambient SynchronizationContext (HandlerSyncContext, installed by
-        // Component.InvokeWithRenderingAsync) for the duration of this call: BuildPayloadAsync's
-        // internal `await Task.Yield()` would otherwise Post its continuation back through
-        // HandlerSyncContext, which re-enters this same method via _render — a render loop on
-        // the WASM JS task queue.
-        var prevCtx = SynchronizationContext.Current;
-        SynchronizationContext.SetSynchronizationContext(null);
-        try
-        {
-            var (payload, html) = await BuildPayloadAsync(null, false).ConfigureAwait(false);
-            if (_lastAppliedPayload is not null && payload.AsSpan().SequenceEqual(_lastAppliedPayload))
-            {
-                return;
-            }
-
-            JSInterop.ApplyRender(payload);
-            _lastAppliedPayload = payload;
-            _lastAppliedHtml = html;
-        }
-        finally
-        {
-            SynchronizationContext.SetSynchronizationContext(prevCtx);
         }
     }
 
@@ -321,7 +321,8 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
 
             try
             {
-                var (payload, html) = await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
+                var (payload, html) =
+                    await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
                 _lastAppliedPayload = payload;
                 _lastAppliedHtml = html;
                 return payload;
@@ -364,12 +365,12 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
         // un-sent render — shipping a tiny stale diff (e.g. a head-only diff after a real page
         // swap) that never updates the body. We commit the final render once, after the loop.
         _pendingRenderInScope = false;
-        var result = await BuildPayloadAsync(historyUrl, replace, publishOnly, commitCache: false).ConfigureAwait(false);
+        var result = await BuildPayloadAsync(historyUrl, replace, publishOnly, false).ConfigureAwait(false);
         var budget = 2;
         while (_pendingRenderInScope && budget-- > 0)
         {
             _pendingRenderInScope = false;
-            result = await BuildPayloadAsync(historyUrl, replace, publishOnly, commitCache: false).ConfigureAwait(false);
+            result = await BuildPayloadAsync(historyUrl, replace, publishOnly, false).ConfigureAwait(false);
         }
 
         // Commit the final, actually-sent render as the new diff baseline exactly once.
@@ -395,7 +396,8 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
     // each other. Only the final, actually-sent build's render becomes the new baseline (the
     // loop calls Snapshot once after it settles). Direct senders (RenderInScopeAsync,
     // InitialRenderAsync) leave it true: their payload reaches the client, so it must commit.
-    internal async Task<(byte[] Payload, string Html)> BuildPayloadAsync(string? historyUrl, bool replace, bool publishOnly = false, bool commitCache = true)
+    internal async Task<(byte[] Payload, string Html)> BuildPayloadAsync(string? historyUrl, bool replace,
+        bool publishOnly = false, bool commitCache = true)
     {
         await Task.Yield();
 
@@ -492,7 +494,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
         // return value) so the fallback Snapshot doesn't double-rotate and strand _previous.
         var diffPathEntered = false;
         if (frameWriter is not null && _renderCache is not null
-            && download is null)
+                                    && download is null)
         {
             _diffOps ??= new List<EditOp>();
             diffPathEntered = true;
@@ -501,7 +503,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
             // navigation or a head change needs to flow — a query-only nav produces zero ops
             // yet must still pushState the URL; a head-only change must still ship the head
             // fragment. Zero ops + no history + unchanged head means nothing to send.
-            if (_renderCache.TryComputeDiff(_diffOps, rotate: commitCache, newHtml: html)
+            if (_renderCache.TryComputeDiff(_diffOps, commitCache, html)
                 && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
                 && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
             {
@@ -534,7 +536,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
             // ToArray at the end is still needed today because the JS interop boundary
             // marshals byte[] (PR6 will swap that for ReadOnlyMemory<byte>).
             LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, html, "wasm", historyUrl, replace,
-                auth: null, download: download);
+                null, download);
             // Only Snapshot when TryComputeDiff was NOT called (it would have rotated) AND we
             // own the commit (commitCache). When commitCache is false the coalescing loop
             // commits once after it settles, so rotating here would strand the baseline.
@@ -546,5 +548,4 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
 
         return (_writeBuffer.WrittenSpan.ToArray(), html);
     }
-
 }

--- a/src/Rask.Wasm/build/Rask.Wasm.Trim.xml
+++ b/src/Rask.Wasm/build/Rask.Wasm.Trim.xml
@@ -19,8 +19,8 @@
       static references without help, so it would drop the Register* method bodies
       (or replace them with throw-stubs).
     -->
-    <type fullname="Rask.Core.ScopedAssets.ScopedAssetRegistry" preserve="all" />
-    <type fullname="Rask.Core.ScopedAssets.ScopedAssetRegistry/EnumeratedEntry" preserve="all" />
-    <type fullname="Rask.Core.ScopedAssets.AssetKind" preserve="all" />
+    <type fullname="Rask.Core.ScopedAssets.ScopedAssetRegistry" preserve="all"/>
+    <type fullname="Rask.Core.ScopedAssets.ScopedAssetRegistry/EnumeratedEntry" preserve="all"/>
+    <type fullname="Rask.Core.ScopedAssets.AssetKind" preserve="all"/>
   </assembly>
 </linker>

--- a/src/Rask.Wasm/build/Rask.Wasm.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.targets
@@ -87,7 +87,7 @@
     across configurations because the source generator is deterministic.
   -->
   <ItemGroup Condition=" '$(WasmGenerateAppBundle)' == 'true' ">
-    <_RaskBakeInputAssemblies Include="$(OutDir)*.dll" Exclude="$(OutDir)publish/**;$(OutDir)AppBundle/**" />
+    <_RaskBakeInputAssemblies Include="$(OutDir)*.dll" Exclude="$(OutDir)publish/**;$(OutDir)AppBundle/**"/>
   </ItemGroup>
 
   <!--

--- a/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
+++ b/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
@@ -42,7 +42,7 @@ public class UserGatingTests
     {
         var html = Render(Principal("alice", "user"));
 
-        Assert.Contains("secret", html);          // authenticated content shows
+        Assert.Contains("secret", html); // authenticated content shows
         Assert.DoesNotContain("admin-panel", html); // but not the admin panel
     }
 

--- a/tests/Rask.Core.Tests/Callbacks/AutoCallbackTests.cs
+++ b/tests/Rask.Core.Tests/Callbacks/AutoCallbackTests.cs
@@ -1,4 +1,3 @@
-using Rask.Core;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
@@ -65,7 +64,7 @@ public class AutoCallbackTests
     public void Wrap_NullDelegate_ReturnsNull()
     {
         Assert.Null(AutoCallback.Wrap((Action?)null));
-        Assert.Null(AutoCallback.Wrap((Func<Task>?)null));
+        Assert.Null(AutoCallback.Wrap(null));
         Assert.Null(AutoCallback.Wrap((Action<int>?)null));
         Assert.Null(AutoCallback.Wrap((Func<int, Task>?)null));
     }
@@ -77,7 +76,7 @@ public class AutoCallbackTests
         // closure, not a Component) have no component to re-render — Wrap returns them unchanged,
         // so there is no extra allocation and no spurious re-render (same limitation Blazor's
         // EventCallback and the old Callback had).
-        Action<int> staticMethod = NoOp;
+        var staticMethod = NoOp;
         Assert.Same(staticMethod, AutoCallback.Wrap(staticMethod));
 
         var local = 0;
@@ -141,11 +140,11 @@ public class AutoCallbackTests
         private readonly Mode _mode;
         public readonly Fireable Child = new();
         public int Count;
-        public string? Text;
-        public int RenderCount;
         public Action<int>? OnAdd;
         public Func<int, Task>? OnAddAsync;
         public Action<string>? OnText;
+        public int RenderCount;
+        public string? Text;
 
         public Receiver(Mode mode) => _mode = mode;
 
@@ -194,7 +193,7 @@ public class AutoCallbackTests
         // path would only dirty the child; the wrapped parent delegate re-renders the parent.
         public ValueTask FireWrappedInOwnLambda(int n)
         {
-            Action wrappedInChildLambda = () => Owner!.OnAdd!(n);
+            var wrappedInChildLambda = () => Owner!.OnAdd!(n);
             wrappedInChildLambda();
             return default;
         }

--- a/tests/Rask.Core.Tests/ChildTests.cs
+++ b/tests/Rask.Core.Tests/ChildTests.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Rask.Core.Tests;
 
 public class ChildTests
@@ -45,18 +47,18 @@ public class ChildTests
     [Fact]
     public void ImplicitConversion_FromDouble_UsesInvariantCulture()
     {
-        var original = System.Threading.Thread.CurrentThread.CurrentCulture;
+        var original = Thread.CurrentThread.CurrentCulture;
         try
         {
             // A comma-decimal culture would render "1,5" if ToString ignored the provider.
-            System.Threading.Thread.CurrentThread.CurrentCulture =
-                new System.Globalization.CultureInfo("de-DE");
+            Thread.CurrentThread.CurrentCulture =
+                new CultureInfo("de-DE");
             Child child = 1.5;
             Assert.Equal("1.5", child.Component.ToHtml());
         }
         finally
         {
-            System.Threading.Thread.CurrentThread.CurrentCulture = original;
+            Thread.CurrentThread.CurrentCulture = original;
         }
     }
 

--- a/tests/Rask.Core.Tests/Components/ATests.cs
+++ b/tests/Rask.Core.Tests/Components/ATests.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Tests.Live;
-
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
 namespace Rask.Core.Tests.Components;

--- a/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Authentication;
 
@@ -55,7 +56,7 @@ public class AuthorizeTests
     public void RoleMatch_RendersAuthorized()
     {
         var html = Render(User("root", "admin"),
-            () => Authorize(Roles: ["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("AUTHED", html);
     }
@@ -64,7 +65,7 @@ public class AuthorizeTests
     public void RoleMiss_RendersNotAuthorized()
     {
         var html = Render(User("alice", "user"),
-            () => Authorize(Roles: ["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("DENIED", html);
         Assert.DoesNotContain("AUTHED", html);
@@ -74,7 +75,7 @@ public class AuthorizeTests
     public void AnyOfRoles_MatchesOnEither()
     {
         var html = Render(User("alice", "editor"),
-            () => Authorize(Roles: ["admin", "editor"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(["admin", "editor"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("AUTHED", html);
     }
@@ -83,7 +84,8 @@ public class AuthorizeTests
     public void ProviderLoading_RendersAuthorizingSlot()
     {
         var html = Render(new LoadingUser(),
-            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"], Authorizing: Span()["LOADING"]));
+            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"],
+                Authorizing: Span()["LOADING"]));
 
         Assert.Contains("LOADING", html);
         Assert.DoesNotContain("AUTHED", html);
@@ -121,7 +123,8 @@ public class AuthorizeTests
         services.AddSingleton<IAuthorizationService>(new SyncRoleAuthz());
     }
 
-    private static string Render(IUserProvider provider, Func<Component> gate, Action<IServiceCollection>? configure = null)
+    private static string Render(IUserProvider provider, Func<Component> gate,
+        Action<IServiceCollection>? configure = null)
     {
         var services = new ServiceCollection().AddSingleton(provider);
         configure?.Invoke(services);
@@ -173,7 +176,7 @@ public class AuthorizeTests
         {
             foreach (var req in requirements)
             {
-                if (req is Microsoft.AspNetCore.Authorization.Infrastructure.RolesAuthorizationRequirement roles
+                if (req is RolesAuthorizationRequirement roles
                     && !roles.AllowedRoles.Any(user.IsInRole))
                 {
                     return Task.FromResult(AuthorizationResult.Failed());

--- a/tests/Rask.Core.Tests/Components/ButtonTests.cs
+++ b/tests/Rask.Core.Tests/Components/ButtonTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Tests.Live;
-
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
 namespace Rask.Core.Tests.Components;

--- a/tests/Rask.Core.Tests/Components/DefaultNotFoundPageTests.cs
+++ b/tests/Rask.Core.Tests/Components/DefaultNotFoundPageTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 using Rask.Core.Routing;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Components/DragDropTests.cs
+++ b/tests/Rask.Core.Tests/Components/DragDropTests.cs
@@ -12,14 +12,14 @@ public class DragDropTests
     [Fact]
     public void Render_HeadlessNoOwnDom_OnlyEmitsBodyMarkup()
     {
-        var view = new StubComponent(() => DragDrop(Body: ctx => Div()["x"]));
+        var view = new StubComponent(() => DragDrop(ctx => Div()["x"]));
         Assert.Equal("<div>x</div>", view.RenderAsLiveRoot());
     }
 
     [Fact]
     public void Render_NullBody_Throws()
     {
-        var view = new StubComponent(() => DragDrop(Body: null!));
+        var view = new StubComponent(() => DragDrop(null!));
         Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot());
     }
 
@@ -28,11 +28,11 @@ public class DragDropTests
     {
         DragDropMove? captured = null;
         var view = new StubComponent(() => DragDrop(
-            Body: ctx => Div()[
+            ctx => Div()[
                 Div(Draggable: true, OnDragStart: ctx.DragStart("zoneA", 2))["src"],
                 Div(OnDrop: ctx.Drop("zoneB", 5))["dst"]
             ],
-            OnDrop: m => captured = m));
+            m => captured = m));
 
         var html = view.RenderAsLiveRoot();
         var startId = Markup.Attr(html, "data-rask-on-dragstart");
@@ -53,8 +53,8 @@ public class DragDropTests
     {
         var fired = false;
         var view = new StubComponent(() => DragDrop(
-            Body: ctx => Div(OnDrop: ctx.Drop("z", 0))["dst"],
-            OnDrop: _ => fired = true));
+            ctx => Div(OnDrop: ctx.Drop("z", 0))["dst"],
+            _ => fired = true));
 
         var dropId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-drop");
         await view.TryInvokeHandlerAsync(dropId!, Empty);
@@ -67,7 +67,7 @@ public class DragDropTests
     {
         DragDropContext? captured = null;
         var view = new StubComponent(() => DragDrop(
-            Body: ctx =>
+            ctx =>
             {
                 captured = ctx;
                 return Div()[
@@ -75,7 +75,7 @@ public class DragDropTests
                     Div(OnDragOver: ctx.DragOver("z", 1))["o"]
                 ];
             },
-            OnDrop: _ => { }));
+            _ => { }));
 
         var html = view.RenderAsLiveRoot();
         var startId = Markup.Attr(html, "data-rask-on-dragstart");
@@ -100,12 +100,12 @@ public class DragDropTests
     {
         DragDropContext? captured = null;
         var view = new StubComponent(() => DragDrop(
-            Body: ctx =>
+            ctx =>
             {
                 captured = ctx;
                 return Div(OnDragOver: ctx.DragOver("z", 1))["o"];
             },
-            OnDrop: _ => { }));
+            _ => { }));
 
         var overId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-dragover");
         await view.TryInvokeHandlerAsync(overId!, Empty);
@@ -120,7 +120,7 @@ public class DragDropTests
     {
         DragDropContext? captured = null;
         var view = new StubComponent(() => DragDrop(
-            Body: ctx =>
+            ctx =>
             {
                 captured = ctx;
                 return Div()[
@@ -128,7 +128,7 @@ public class DragDropTests
                     Div(OnDragEnd: ctx.DragEnd)["e"]
                 ];
             },
-            OnDrop: _ => { }));
+            _ => { }));
 
         var html = view.RenderAsLiveRoot();
         await view.TryInvokeHandlerAsync(Markup.Attr(html, "data-rask-on-dragstart")!, Empty);
@@ -144,7 +144,7 @@ public class DragDropTests
     {
         DragDropMove? captured = null;
         var view = new StubComponent(() => DragDrop(
-            Body: ctx => Div()[
+            ctx => Div()[
                 Div(Draggable: true, OnDragStart: ctx.DragStart("a", 1))["src"],
                 Div(OnDrop: ctx.Drop("b", 0))["dst"]
             ],

--- a/tests/Rask.Core.Tests/Components/ErrorBoundaryTests.cs
+++ b/tests/Rask.Core.Tests/Components/ErrorBoundaryTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Components/FormTests.cs
+++ b/tests/Rask.Core.Tests/Components/FormTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
@@ -18,7 +17,7 @@ public class FormTests
     {
         Assert.Equal(
             "<form id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" enctype=\"multipart/form-data\" target=\"_blank\" accept-charset=\"utf-8\" autocomplete=\"off\" novalidate name=\"n\"></form>",
-            Form(Enctype: "multipart/form-data", "_blank", "utf-8", "off", true, "n", Id: "i", Class: "c", Style: "s",
+            Form("multipart/form-data", "_blank", "utf-8", "off", true, "n", Id: "i", Class: "c", Style: "s",
                 Data: new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
 

--- a/tests/Rask.Core.Tests/Components/InputTests.cs
+++ b/tests/Rask.Core.Tests/Components/InputTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Tests.Live;
-
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
 namespace Rask.Core.Tests.Components;

--- a/tests/Rask.Core.Tests/Components/NavLinkTests.cs
+++ b/tests/Rask.Core.Tests/Components/NavLinkTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using Rask.Core.Live;
 using Rask.Core.Routing;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Components/RaskRuntimeScriptTests.cs
+++ b/tests/Rask.Core.Tests/Components/RaskRuntimeScriptTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Components/SelectTests.cs
+++ b/tests/Rask.Core.Tests/Components/SelectTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Components/Svg/SvgClashNamingTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgClashNamingTests.cs
@@ -16,17 +16,17 @@ public class SvgClashNamingTests
     public void SvgA_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<a href=\"/docs\" target=\"_blank\">link</a>",
-            SvgA(Href: "/docs", Target: "_blank")["link"].ToHtml());
+            SvgA("/docs", "_blank")["link"].ToHtml());
 
     [Fact]
     public void SvgScript_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<script href=\"/a.js\" type=\"text/javascript\"></script>",
-            SvgScript(Href: "/a.js", Type: "text/javascript").ToHtml());
+            SvgScript("/a.js", "text/javascript").ToHtml());
 
     [Fact]
     public void SvgStyle_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<style type=\"text/css\" media=\"screen\">.x{fill:red}</style>",
-            SvgStyle(Type: "text/css", Media: "screen")[Raw(".x{fill:red}")].ToHtml());
+            SvgStyle("text/css", "screen")[Raw(".x{fill:red}")].ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgContainerTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgContainerTests.cs
@@ -24,35 +24,35 @@ public class SvgContainerTests
     public void Use_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<use href=\"#icon\" x=\"1\" y=\"2\" width=\"3\" height=\"4\"></use>",
-            Use(Href: "#icon", X: "1", Y: "2", Width: "3", Height: "4").ToHtml());
+            Use("#icon", "1", "2", "3", "4").ToHtml());
 
     [Fact]
     public void Symbol_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<symbol viewBox=\"0 0 24 24\" preserveAspectRatio=\"xMinYMin\" x=\"1\" y=\"2\" " +
             "width=\"3\" height=\"4\" refX=\"5\" refY=\"6\"></symbol>",
-            Symbol(ViewBox: "0 0 24 24", PreserveAspectRatio: "xMinYMin", X: "1", Y: "2",
-                Width: "3", Height: "4", RefX: "5", RefY: "6").ToHtml());
+            Symbol("0 0 24 24", "xMinYMin", "1", "2",
+                "3", "4", "5", "6").ToHtml());
 
     [Fact]
     public void Marker_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<marker markerWidth=\"10\" markerHeight=\"10\" refX=\"5\" refY=\"5\" orient=\"auto\" " +
             "markerUnits=\"strokeWidth\" viewBox=\"0 0 10 10\" preserveAspectRatio=\"none\"></marker>",
-            Marker(MarkerWidth: "10", MarkerHeight: "10", RefX: "5", RefY: "5", Orient: "auto",
-                MarkerUnits: "strokeWidth", ViewBox: "0 0 10 10", PreserveAspectRatio: "none").ToHtml());
+            Marker("10", "10", "5", "5", "auto",
+                "strokeWidth", "0 0 10 10", "none").ToHtml());
 
     [Fact]
     public void ForeignObject_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<foreignObject x=\"1\" y=\"2\" width=\"3\" height=\"4\"></foreignObject>",
-            ForeignObject(X: "1", Y: "2", Width: "3", Height: "4").ToHtml());
+            ForeignObject("1", "2", "3", "4").ToHtml());
 
     [Fact]
     public void Image_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<image x=\"1\" y=\"2\" width=\"3\" height=\"4\" href=\"/a.png\" " +
             "preserveAspectRatio=\"xMidYMid slice\"></image>",
-            Image(X: "1", Y: "2", Width: "3", Height: "4", Href: "/a.png",
-                PreserveAspectRatio: "xMidYMid slice").ToHtml());
+            Image("1", "2", "3", "4", "/a.png",
+                "xMidYMid slice").ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgElementTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgElementTests.cs
@@ -29,7 +29,7 @@ public class SvgElementTests
             "clip-path=\"cp\" color=\"col\" display=\"d\" visibility=\"vis\" pointer-events=\"pe\" " +
             "cx=\"1\" cy=\"2\" r=\"3\"></circle>",
             Circle(
-                Cx: "1", Cy: "2", R: "3",
+                "1", "2", "3",
                 Fill: "f", FillOpacity: "fo", FillRule: "fr",
                 Stroke: "st", StrokeWidth: "sw", StrokeOpacity: "so",
                 StrokeLinecap: "slc", StrokeLinejoin: "slj",
@@ -61,7 +61,7 @@ public class SvgElementTests
     public void Render_NestedChildren_RendersInsideOpenCloseTags() =>
         Assert.Equal(
             "<svg viewBox=\"0 0 10 10\"><path d=\"M0 0\"></path><circle r=\"5\"></circle></svg>",
-            Svg(ViewBox: "0 0 10 10")[SvgPath(D: "M0 0"), Circle(R: "5")].ToHtml());
+            Svg(ViewBox: "0 0 10 10")[SvgPath("M0 0"), Circle(R: "5")].ToHtml());
 
     [Fact]
     public void Render_ShapeWithTitleChild_AllowsNestingForAccessibility() =>

--- a/tests/Rask.Core.Tests/Components/Svg/SvgFilterTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgFilterTests.cs
@@ -7,56 +7,56 @@ public class SvgFilterTests
         Assert.Equal(
             "<filter x=\"0\" y=\"0\" width=\"1\" height=\"1\" filterUnits=\"objectBoundingBox\" " +
             "primitiveUnits=\"userSpaceOnUse\"></filter>",
-            Filter(X: "0", Y: "0", Width: "1", Height: "1", FilterUnits: "objectBoundingBox",
-                PrimitiveUnits: "userSpaceOnUse").ToHtml());
+            Filter("0", "0", "1", "1", "objectBoundingBox",
+                "userSpaceOnUse").ToHtml());
 
     [Fact]
     public void FeGaussianBlur_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feGaussianBlur in=\"SourceGraphic\" stdDeviation=\"2\" edgeMode=\"duplicate\" result=\"b\"></feGaussianBlur>",
-            FeGaussianBlur(In: "SourceGraphic", StdDeviation: "2", EdgeMode: "duplicate", Result: "b").ToHtml());
+            FeGaussianBlur("SourceGraphic", "2", "duplicate", "b").ToHtml());
 
     [Fact]
     public void FeOffset_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feOffset in=\"b\" dx=\"3\" dy=\"4\" result=\"o\"></feOffset>",
-            FeOffset(In: "b", Dx: "3", Dy: "4", Result: "o").ToHtml());
+            FeOffset("b", "3", "4", "o").ToHtml());
 
     [Fact]
     public void FeBlend_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feBlend in=\"a\" in2=\"b\" mode=\"multiply\" result=\"r\"></feBlend>",
-            FeBlend(In: "a", In2: "b", Mode: "multiply", Result: "r").ToHtml());
+            FeBlend("a", "b", "multiply", "r").ToHtml());
 
     [Fact]
     public void FeColorMatrix_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feColorMatrix in=\"SourceGraphic\" type=\"saturate\" values=\"0.5\" result=\"r\"></feColorMatrix>",
-            FeColorMatrix(In: "SourceGraphic", Type: "saturate", Values: "0.5", Result: "r").ToHtml());
+            FeColorMatrix("SourceGraphic", "saturate", "0.5", "r").ToHtml());
 
     [Fact]
     public void FeComposite_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feComposite in=\"a\" in2=\"b\" operator=\"arithmetic\" k1=\"0\" k2=\"1\" k3=\"1\" k4=\"0\" result=\"r\"></feComposite>",
-            FeComposite(In: "a", In2: "b", Operator: "arithmetic", K1: "0", K2: "1", K3: "1", K4: "0", Result: "r").ToHtml());
+            FeComposite("a", "b", "arithmetic", "0", "1", "1", "0", "r").ToHtml());
 
     [Fact]
     public void FeMerge_WithMergeNodeChildren_NestsCorrectly() =>
         Assert.Equal(
             "<feMerge><feMergeNode in=\"a\"></feMergeNode><feMergeNode in=\"b\"></feMergeNode></feMerge>",
-            FeMerge()[FeMergeNode(In: "a"), FeMergeNode(In: "b")].ToHtml());
+            FeMerge()[FeMergeNode("a"), FeMergeNode("b")].ToHtml());
 
     [Fact]
     public void FeFlood_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feFlood flood-color=\"#000\" flood-opacity=\"0.5\" result=\"r\"></feFlood>",
-            FeFlood(FloodColor: "#000", FloodOpacity: "0.5", Result: "r").ToHtml());
+            FeFlood("#000", "0.5", "r").ToHtml());
 
     [Fact]
     public void FeDropShadow_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<feDropShadow in=\"SourceGraphic\" dx=\"2\" dy=\"2\" stdDeviation=\"1\" " +
             "flood-color=\"#000\" flood-opacity=\"0.3\" result=\"r\"></feDropShadow>",
-            FeDropShadow(In: "SourceGraphic", Dx: "2", Dy: "2", StdDeviation: "1",
-                FloodColor: "#000", FloodOpacity: "0.3", Result: "r").ToHtml());
+            FeDropShadow("SourceGraphic", "2", "2", "1",
+                "#000", "0.3", "r").ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgGradientTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgGradientTests.cs
@@ -7,8 +7,8 @@ public class SvgGradientTests
         Assert.Equal(
             "<linearGradient x1=\"0\" y1=\"0\" x2=\"1\" y2=\"1\" gradientUnits=\"userSpaceOnUse\" " +
             "gradientTransform=\"rotate(45)\" spreadMethod=\"pad\" href=\"#base\"></linearGradient>",
-            LinearGradient(X1: "0", Y1: "0", X2: "1", Y2: "1", GradientUnits: "userSpaceOnUse",
-                GradientTransform: "rotate(45)", SpreadMethod: "pad", Href: "#base").ToHtml());
+            LinearGradient("0", "0", "1", "1", "userSpaceOnUse",
+                "rotate(45)", "pad", "#base").ToHtml());
 
     [Fact]
     public void RadialGradient_AllPropsSet_EmitsExpectedAttributes() =>
@@ -16,15 +16,15 @@ public class SvgGradientTests
             "<radialGradient cx=\"0.5\" cy=\"0.5\" r=\"0.5\" fx=\"0.2\" fy=\"0.3\" fr=\"0.1\" " +
             "gradientUnits=\"objectBoundingBox\" gradientTransform=\"scale(2)\" spreadMethod=\"reflect\" " +
             "href=\"#base\"></radialGradient>",
-            RadialGradient(Cx: "0.5", Cy: "0.5", R: "0.5", Fx: "0.2", Fy: "0.3", Fr: "0.1",
-                GradientUnits: "objectBoundingBox", GradientTransform: "scale(2)",
-                SpreadMethod: "reflect", Href: "#base").ToHtml());
+            RadialGradient("0.5", "0.5", "0.5", "0.2", "0.3", "0.1",
+                "objectBoundingBox", "scale(2)",
+                "reflect", "#base").ToHtml());
 
     [Fact]
     public void Stop_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<stop offset=\"50%\" stop-color=\"blue\" stop-opacity=\"0.5\"></stop>",
-            Stop(Offset: "50%", StopColor: "blue", StopOpacity: "0.5").ToHtml());
+            Stop("50%", "blue", "0.5").ToHtml());
 
     [Fact]
     public void Gradient_WithStopChildren_NestsCorrectly() =>
@@ -32,8 +32,8 @@ public class SvgGradientTests
             "<linearGradient id=\"g\"><stop offset=\"0\" stop-color=\"red\"></stop>" +
             "<stop offset=\"1\" stop-color=\"blue\"></stop></linearGradient>",
             LinearGradient(Id: "g")[
-                Stop(Offset: "0", StopColor: "red"),
-                Stop(Offset: "1", StopColor: "blue")].ToHtml());
+                Stop("0", "red"),
+                Stop("1", "blue")].ToHtml());
 
     [Fact]
     public void Pattern_AllPropsSet_EmitsExpectedAttributes() =>
@@ -41,7 +41,7 @@ public class SvgGradientTests
             "<pattern x=\"0\" y=\"0\" width=\"10\" height=\"10\" patternUnits=\"userSpaceOnUse\" " +
             "patternContentUnits=\"userSpaceOnUse\" patternTransform=\"rotate(10)\" " +
             "viewBox=\"0 0 10 10\" preserveAspectRatio=\"none\" href=\"#p\"></pattern>",
-            Pattern(X: "0", Y: "0", Width: "10", Height: "10", PatternUnits: "userSpaceOnUse",
-                PatternContentUnits: "userSpaceOnUse", PatternTransform: "rotate(10)",
-                ViewBox: "0 0 10 10", PreserveAspectRatio: "none", Href: "#p").ToHtml());
+            Pattern("0", "0", "10", "10", "userSpaceOnUse",
+                "userSpaceOnUse", "rotate(10)",
+                "0 0 10 10", "none", "#p").ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgPaintTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgPaintTests.cs
@@ -6,7 +6,7 @@ public class SvgPaintTests
     public void ClipPath_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<clipPath clipPathUnits=\"userSpaceOnUse\"></clipPath>",
-            ClipPath(ClipPathUnits: "userSpaceOnUse").ToHtml());
+            ClipPath("userSpaceOnUse").ToHtml());
 
     [Fact]
     public void ClipPath_InheritedClipPathPresentationProp_StillAvailable() =>
@@ -21,6 +21,6 @@ public class SvgPaintTests
         Assert.Equal(
             "<mask maskUnits=\"userSpaceOnUse\" maskContentUnits=\"userSpaceOnUse\" " +
             "x=\"0\" y=\"0\" width=\"10\" height=\"10\"></mask>",
-            Mask(MaskUnits: "userSpaceOnUse", MaskContentUnits: "userSpaceOnUse",
-                X: "0", Y: "0", Width: "10", Height: "10").ToHtml());
+            Mask("userSpaceOnUse", "userSpaceOnUse",
+                "0", "0", "10", "10").ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgShapeTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgShapeTests.cs
@@ -10,7 +10,7 @@ public class SvgShapeTests
     public void SvgPath_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<path d=\"M0 0 L10 10\" pathLength=\"100\"></path>",
-            SvgPath(D: "M0 0 L10 10", PathLength: "100").ToHtml());
+            SvgPath("M0 0 L10 10", "100").ToHtml());
 
     [Fact]
     public void Rect_NullProps_ReturnsOpenAndCloseTags() =>
@@ -20,35 +20,35 @@ public class SvgShapeTests
     public void Rect_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<rect x=\"1\" y=\"2\" width=\"3\" height=\"4\" rx=\"5\" ry=\"6\" pathLength=\"7\"></rect>",
-            Rect(X: "1", Y: "2", Width: "3", Height: "4", Rx: "5", Ry: "6", PathLength: "7").ToHtml());
+            Rect("1", "2", "3", "4", "5", "6", "7").ToHtml());
 
     [Fact]
     public void Circle_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<circle cx=\"1\" cy=\"2\" r=\"3\" pathLength=\"4\"></circle>",
-            Circle(Cx: "1", Cy: "2", R: "3", PathLength: "4").ToHtml());
+            Circle("1", "2", "3", "4").ToHtml());
 
     [Fact]
     public void Ellipse_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<ellipse cx=\"1\" cy=\"2\" rx=\"3\" ry=\"4\" pathLength=\"5\"></ellipse>",
-            Ellipse(Cx: "1", Cy: "2", Rx: "3", Ry: "4", PathLength: "5").ToHtml());
+            Ellipse("1", "2", "3", "4", "5").ToHtml());
 
     [Fact]
     public void Line_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<line x1=\"1\" y1=\"2\" x2=\"3\" y2=\"4\" pathLength=\"5\"></line>",
-            Line(X1: "1", Y1: "2", X2: "3", Y2: "4", PathLength: "5").ToHtml());
+            Line("1", "2", "3", "4", "5").ToHtml());
 
     [Fact]
     public void Polyline_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<polyline points=\"0,0 1,1\" pathLength=\"2\"></polyline>",
-            Polyline(Points: "0,0 1,1", PathLength: "2").ToHtml());
+            Polyline("0,0 1,1", "2").ToHtml());
 
     [Fact]
     public void Polygon_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<polygon points=\"0,0 1,1 2,0\" pathLength=\"3\"></polygon>",
-            Polygon(Points: "0,0 1,1 2,0", PathLength: "3").ToHtml());
+            Polygon("0,0 1,1 2,0", "3").ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgTests.cs
@@ -12,9 +12,9 @@ public class SvgTests
             "<svg id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" width=\"100\" height=\"50\" " +
             "viewBox=\"0 0 100 50\" preserveAspectRatio=\"xMidYMid meet\" x=\"1\" y=\"2\" " +
             "xmlns=\"http://www.w3.org/2000/svg\"></svg>",
-            Svg(Width: "100", Height: "50", ViewBox: "0 0 100 50",
-                PreserveAspectRatio: "xMidYMid meet", X: "1", Y: "2",
-                Xmlns: "http://www.w3.org/2000/svg",
+            Svg("100", "50", "0 0 100 50",
+                "xMidYMid meet", "1", "2",
+                "http://www.w3.org/2000/svg",
                 Id: "i", Class: "c", Style: "s",
                 Data: new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/Svg/SvgTextTests.cs
+++ b/tests/Rask.Core.Tests/Components/Svg/SvgTextTests.cs
@@ -12,21 +12,21 @@ public class SvgTextTests
             "<text x=\"1\" y=\"2\" dx=\"3\" dy=\"4\" rotate=\"5\" text-anchor=\"middle\" " +
             "dominant-baseline=\"central\" font-family=\"sans-serif\" font-size=\"12\" " +
             "font-weight=\"bold\" lengthAdjust=\"spacing\" textLength=\"80\">hi</text>",
-            SvgText(X: "1", Y: "2", Dx: "3", Dy: "4", Rotate: "5", TextAnchor: "middle",
-                DominantBaseline: "central", FontFamily: "sans-serif", FontSize: "12",
-                FontWeight: "bold", LengthAdjust: "spacing", TextLength: "80")["hi"].ToHtml());
+            SvgText("1", "2", "3", "4", "5", "middle",
+                "central", "sans-serif", "12",
+                "bold", "spacing", "80")["hi"].ToHtml());
 
     [Fact]
     public void Tspan_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<tspan x=\"1\" y=\"2\" dx=\"3\" dy=\"4\" rotate=\"5\" text-anchor=\"end\" " +
             "lengthAdjust=\"spacingAndGlyphs\" textLength=\"40\">x</tspan>",
-            Tspan(X: "1", Y: "2", Dx: "3", Dy: "4", Rotate: "5", TextAnchor: "end",
-                LengthAdjust: "spacingAndGlyphs", TextLength: "40")["x"].ToHtml());
+            Tspan("1", "2", "3", "4", "5", "end",
+                "spacingAndGlyphs", "40")["x"].ToHtml());
 
     [Fact]
     public void TextPath_AllPropsSet_EmitsExpectedAttributes() =>
         Assert.Equal(
             "<textPath href=\"#p\" startOffset=\"10%\" method=\"align\" spacing=\"auto\">label</textPath>",
-            TextPath(Href: "#p", StartOffset: "10%", Method: "align", Spacing: "auto")["label"].ToHtml());
+            TextPath("#p", "10%", "align", "auto")["label"].ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/TextareaTests.cs
+++ b/tests/Rask.Core.Tests/Components/TextareaTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core.Tests.Live;
-
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
 namespace Rask.Core.Tests.Components;

--- a/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
+++ b/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
@@ -1,5 +1,5 @@
+using System.Linq.Expressions;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
@@ -142,8 +142,8 @@ public class ValidationMessageTests
         gate.SetResult();
         await task;
 
-        view.RenderAsLiveRoot();  // sticky window starts
-        await Task.Delay(80);     // > 30ms sticky window
+        view.RenderAsLiveRoot(); // sticky window starts
+        await Task.Delay(80); // > 30ms sticky window
         var finalHtml = view.RenderAsLiveRoot();
         Assert.DoesNotContain("validating-indicator", finalHtml);
     }
@@ -190,7 +190,7 @@ public class ValidationMessageTests
 
     private static class TestExpressions
     {
-        public static System.Linq.Expressions.Expression<Func<TProp>> For<TProp>(
-            System.Linq.Expressions.Expression<Func<TProp>> expr) => expr;
+        public static Expression<Func<TProp>> For<TProp>(
+            Expression<Func<TProp>> expr) => expr;
     }
 }

--- a/tests/Rask.Core.Tests/Components/VirtualizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/VirtualizeTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Rask.Core.Tests.Live;
 using Rask.Core.Virtualization;
 
 #pragma warning disable RASK014 // test-defined StubComponent has no generated factory
@@ -228,6 +227,7 @@ public class VirtualizeTests
             providerStarted.TrySetResult();
             try { await Task.Delay(Timeout.Infinite, req.CancellationToken); }
             catch (OperationCanceledException) { }
+
             return new ItemsProviderResult<string>(Array.Empty<string>(), 0);
         };
 

--- a/tests/Rask.Core.Tests/Contexts/ContextTests.cs
+++ b/tests/Rask.Core.Tests/Contexts/ContextTests.cs
@@ -12,7 +12,7 @@ public class ContextTests
         var sp = RenderHarness.EmptyServices();
         var consumer = new ThemeConsumer();
         var root = new StubComponent(() =>
-            Context.Provide<Theme>(Value: new Theme("light"))[consumer]);
+            Context.Provide<Theme>(new Theme("light"))[consumer]);
 
         var html = root.RenderAsLiveRoot(sp);
 
@@ -27,9 +27,9 @@ public class ContextTests
         var outer = new ThemeConsumer();
         var inner = new ThemeConsumer();
         var root = new StubComponent(() =>
-            Context.Provide<Theme>(Value: new Theme("outer"))[
+            Context.Provide<Theme>(new Theme("outer"))[
                 outer,
-                Context.Provide<Theme>(Value: new Theme("inner"))[inner]
+                Context.Provide(new Theme("inner"))[inner]
             ]);
 
         root.RenderAsLiveRoot(sp);
@@ -60,7 +60,7 @@ public class ContextTests
         // A provider explicitly supplying a null reference: Has is true, the value is null, and
         // Required returns null rather than throwing — the "no provider" path.
         var root = new StubComponent(() =>
-            Context.Provide<Theme?>(Value: null)[probe]);
+            Context.Provide<Theme?>(null)[probe]);
 
         root.RenderAsLiveRoot(sp);
 
@@ -74,7 +74,7 @@ public class ContextTests
     {
         var sp = RenderHarness.EmptyServices();
         var probe = new IntProbe();
-        var root = new StubComponent(() => Context.Provide<int>(Value: 42)[probe]);
+        var root = new StubComponent(() => Context.Provide(42)[probe]);
 
         root.RenderAsLiveRoot(sp);
 
@@ -87,7 +87,7 @@ public class ContextTests
         var sp = RenderHarness.EmptyServices();
         var probe = new GreeterProbe();
         var root = new StubComponent(() =>
-            Context.Provide<EnGreeter>(Value: new EnGreeter())[probe]);
+            Context.Provide(new EnGreeter())[probe]);
 
         root.RenderAsLiveRoot(sp);
 
@@ -101,8 +101,8 @@ public class ContextTests
         var sp = RenderHarness.EmptyServices();
         var probe = new NamedProbe();
         var root = new StubComponent(() =>
-            Context.Provide<string>(Value: "primary", Name: "a")[
-                Context.Provide<string>(Value: "secondary", Name: "b")[probe]
+            Context.Provide<string>("primary", "a")[
+                Context.Provide<string>("secondary", "b")[probe]
             ]);
 
         root.RenderAsLiveRoot(sp);
@@ -119,13 +119,13 @@ public class ContextTests
         var inner = new ContextProbe();
         var sibling = new ContextProbe();
         var root = new StubComponent(() => new Fragment(
-            Context.Provide<Theme>(Value: new Theme("scoped"))[inner],
+            Context.Provide(new Theme("scoped"))[inner],
             sibling));
 
         root.RenderAsLiveRoot(sp);
 
-        Assert.True(inner.Has);          // inside the provider subtree
-        Assert.False(sibling.Has);       // stack popped before the sibling renders
+        Assert.True(inner.Has); // inside the provider subtree
+        Assert.False(sibling.Has); // stack popped before the sibling renders
     }
 
     [Fact]
@@ -133,7 +133,7 @@ public class ContextTests
     {
         var sp = RenderHarness.EmptyServices();
         var root = new StubComponent(() =>
-            Context.Provide<int>(Value: 1, Key: "k1")[Div()["body"]]);
+            Context.Provide(1, Key: "k1")[Div()["body"]]);
 
         var html = root.RenderAsLiveRoot(sp);
 
@@ -184,7 +184,7 @@ public class ContextTests
         host.RenderAsLiveRoot(sp);
 
         Assert.Equal(2, consumer.RenderCount); // re-ran (consumer marked via Has)
-        Assert.Equal(1, plain.RenderCount);     // non-consumer sibling stays cached
+        Assert.Equal(1, plain.RenderCount); // non-consumer sibling stays cached
     }
 
     [Fact]
@@ -212,8 +212,8 @@ public class ContextTests
 
     private sealed class ThemeConsumer : Component
     {
-        public int RenderCount;
         public string? LastSeen;
+        public int RenderCount;
 
         protected override RenderResult Render()
         {
@@ -248,8 +248,8 @@ public class ContextTests
 
     private sealed class ContextProbe : Component
     {
-        public bool Has;
         public Theme? GotOptional;
+        public bool Has;
         public bool RequiredThrew;
 
         protected override RenderResult Render()
@@ -326,7 +326,7 @@ public class ContextTests
             ctx.NotifyParameters(con, false);
             var pl = ctx.GetOrCreate(_ => _plain);
             ctx.NotifyParameters(pl, false);
-            return Context.Provide<Theme>(Value: Theme)[con, pl];
+            return Context.Provide(Theme)[con, pl];
         }
     }
 }

--- a/tests/Rask.Core.Tests/Forms/AfterBindTests.cs
+++ b/tests/Rask.Core.Tests/Forms/AfterBindTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Forms/AsyncFormBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/AsyncFormBindingTests.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Forms;
 using Rask.Core.Live;
 using Rask.Core.Routing;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014
 

--- a/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
+++ b/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
@@ -25,7 +25,7 @@ public class EditContextDisposalTests
         Assert.False(ctx.IsDisposed);
 
         show = false;
-        view.RenderAsLiveRoot();      // form unmounted → ctx not re-resolved this frame
+        view.RenderAsLiveRoot(); // form unmounted → ctx not re-resolved this frame
         Assert.True(ctx.IsDisposed);
     }
 
@@ -55,8 +55,8 @@ public class EditContextDisposalTests
         // so the finally arms the 100ms sticky timer.
         await ctx.ValidateFieldAsync(new FieldIdentifier(model, "Name"));
 
-        ctx.Dispose();                // must dispose the armed timer before it fires
-        await Task.Delay(250);        // well past the sticky window
+        ctx.Dispose(); // must dispose the armed timer before it fires
+        await Task.Delay(250); // well past the sticky window
 
         Assert.Equal(0, renderRequests);
         Assert.True(ctx.IsDisposed);
@@ -72,7 +72,7 @@ public class EditContextDisposalTests
         Assert.True(ctx.IsDisposed);
         Assert.Null(ctx.RequestRender);
 
-        ctx.Dispose();                // second dispose must not throw
+        ctx.Dispose(); // second dispose must not throw
         Assert.True(ctx.IsDisposed);
     }
 

--- a/tests/Rask.Core.Tests/Forms/FormBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/FormBindingTests.cs
@@ -1,7 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Forms/InputDelegateValidateTests.cs
+++ b/tests/Rask.Core.Tests/Forms/InputDelegateValidateTests.cs
@@ -1,6 +1,5 @@
 using System.Text.Json;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
+++ b/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Forms/RadioCheckboxGroupTests.cs
+++ b/tests/Rask.Core.Tests/Forms/RadioCheckboxGroupTests.cs
@@ -6,29 +6,12 @@ namespace Rask.Core.Tests.Forms;
 
 public class RadioCheckboxGroupTests
 {
-    private enum Color
-    {
-        Red,
-        Green,
-        Blue
-    }
-
-    private sealed class ColorModel
-    {
-        public Color Choice { get; set; } = Color.Red;
-    }
-
-    private sealed class TagsModel
-    {
-        public List<string> Tags { get; } = new();
-    }
-
     [Fact]
     public void RadioGroup_RendersOnePerOption_CurrentChecked()
     {
         var m = new ColorModel { Choice = Color.Green };
         var view = new StubComponent(() =>
-            Form(m)[RadioGroup(() => m.Choice, Options: new[] { Color.Red, Color.Green, Color.Blue })]);
+            Form(m)[RadioGroup(() => m.Choice, new[] { Color.Red, Color.Green, Color.Blue })]);
 
         var html = view.RenderAsLiveRoot();
 
@@ -47,7 +30,7 @@ public class RadioCheckboxGroupTests
     {
         var m = new ColorModel { Choice = Color.Red };
         var view = new StubComponent(() =>
-            Form(m)[RadioGroup(() => m.Choice, Options: new[] { Color.Red, Color.Green, Color.Blue })]);
+            Form(m)[RadioGroup(() => m.Choice, new[] { Color.Red, Color.Green, Color.Blue })]);
 
         var html = view.RenderAsLiveRoot();
         var ids = AllChangeIds(html);
@@ -74,7 +57,7 @@ public class RadioCheckboxGroupTests
         var m = new TagsModel();
         m.Tags.Add("b");
         var view = new StubComponent(() =>
-            Form(m)[CheckboxGroup<string>(() => m.Tags, Options: new[] { "a", "b", "c" })]);
+            Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })]);
 
         var html = view.RenderAsLiveRoot();
 
@@ -91,7 +74,7 @@ public class RadioCheckboxGroupTests
     {
         var m = new TagsModel();
         var view = new StubComponent(() =>
-            Form(m)[CheckboxGroup<string>(() => m.Tags, Options: new[] { "a", "b", "c" })]);
+            Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })]);
 
         var html = view.RenderAsLiveRoot();
         var ids = AllChangeIds(html);
@@ -110,7 +93,7 @@ public class RadioCheckboxGroupTests
         m.Tags.Add("a");
         m.Tags.Add("b");
         var view = new StubComponent(() =>
-            Form(m)[CheckboxGroup<string>(() => m.Tags, Options: new[] { "a", "b", "c" })]);
+            Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })]);
 
         var html = view.RenderAsLiveRoot();
         var ids = AllChangeIds(html);
@@ -149,5 +132,22 @@ public class RadioCheckboxGroupTests
         }
 
         return ids;
+    }
+
+    private enum Color
+    {
+        Red,
+        Green,
+        Blue
+    }
+
+    private sealed class ColorModel
+    {
+        public Color Choice { get; set; } = Color.Red;
+    }
+
+    private sealed class TagsModel
+    {
+        public List<string> Tags { get; } = new();
     }
 }

--- a/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
+++ b/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Forms;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014
 

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetEmissionTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetEmissionTests.cs
@@ -162,10 +162,8 @@ public class HeadAssetEmissionTests
     [Fact]
     public void NullArguments_Throw()
     {
-        Assert.Throws<ArgumentNullException>(
-            () => HeadAssetRegistry.EmitMountedAssets(null!, Array.Empty<Type>()));
-        Assert.Throws<ArgumentNullException>(
-            () => HeadAssetRegistry.EmitMountedAssets(new StringBuilder(), null!));
+        Assert.Throws<ArgumentNullException>(() => HeadAssetRegistry.EmitMountedAssets(null!, Array.Empty<Type>()));
+        Assert.Throws<ArgumentNullException>(() => HeadAssetRegistry.EmitMountedAssets(new StringBuilder(), null!));
     }
 
     // ─── User Head × per-component asset coexistence ─────────────────────
@@ -196,7 +194,7 @@ public class HeadAssetEmissionTests
     public void UserCdnScript_AppearsBeforePerComponentScript()
     {
         var registry = new HeadAssetRegistry();
-        registry.Add(Script(Src: "https://cdn.example/chartjs.js"));
+        registry.Add(Script("https://cdn.example/chartjs.js"));
 
         ScopedAssetRegistry.RegisterJs(typeof(JsOnly), "export function f() {}");
 
@@ -299,8 +297,8 @@ public class HeadAssetEmissionTests
         var registry = new HeadAssetRegistry();
         registry.Add(Title("First"));
         registry.Add(Title("Second"));
-        registry.Add(Base(Href: "/old/"));
-        registry.Add(Base(Href: "/new/"));
+        registry.Add(Base("/old/"));
+        registry.Add(Base("/new/"));
 
         var html = registry.ApplyTo("<head><!--__rask_head_assets__--></head>");
         Assert.Equal(1, CountOccurrences(html, "<title"));
@@ -340,11 +338,38 @@ public class HeadAssetEmissionTests
         return count;
     }
 
-    private sealed class NoAssets : Component { protected override RenderResult Render() => this; }
-    private sealed class CssOnly : Component { protected override RenderResult Render() => this; }
-    private sealed class JsOnly : Component { protected override RenderResult Render() => this; }
-    private sealed class BothAssets : Component { protected override RenderResult Render() => this; }
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
-    private sealed class WidgetB : Component { protected override RenderResult Render() => this; }
-    private sealed class WidgetC : Component { protected override RenderResult Render() => this; }
+    private sealed class NoAssets : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class CssOnly : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class JsOnly : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class BothAssets : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class WidgetB : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class WidgetC : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetPathBaseTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetPathBaseTests.cs
@@ -101,5 +101,8 @@ public sealed class HeadAssetPathBaseTests : IDisposable
         Assert.Contains($"href=\"/a/b/_rask/a/{hash}.css\"", html);
     }
 
-    private sealed class Widget : Component { protected override RenderResult Render() => this; }
+    private sealed class Widget : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetRegistryTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetRegistryTests.cs
@@ -151,7 +151,11 @@ public class HeadAssetRegistryTests
     {
         const string needle = "data-rask-key=\"";
         var start = html.IndexOf(needle, StringComparison.Ordinal);
-        if (start < 0) return null;
+        if (start < 0)
+        {
+            return null;
+        }
+
         start += needle.Length;
         var end = html.IndexOf('"', start);
         return end < 0 ? null : html.Substring(start, end - start);

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
@@ -100,16 +100,16 @@ public class HeadAssetRenderTests
         public PageShell(Component body) => _body = body;
 
         protected override RenderResult Render() =>
-            [
-                Doctype(),
-                Html("en")[
-                    // Head() is framework-managed: the serializer auto-inserts the
-                    // head-asset sentinel inside, so contributions splice in without
-                    // any explicit placeholder.
-                    Head(),
-                    Body()[_body]
-                ]
-            ];
+        [
+            Doctype(),
+            Html("en")[
+                // Head() is framework-managed: the serializer auto-inserts the
+                // head-asset sentinel inside, so contributions splice in without
+                // any explicit placeholder.
+                Head(),
+                Body()[_body]
+            ]
+        ];
     }
 
     private sealed class ShellWithTitle : Component
@@ -126,16 +126,16 @@ public class HeadAssetRenderTests
         protected override RenderResult Head => Title()[_title];
 
         protected override RenderResult Render() =>
-            [
-                Doctype(),
-                Html("en")[
-                    // Head() is framework-managed: the serializer auto-inserts the
-                    // head-asset sentinel inside, so contributions splice in without
-                    // any explicit placeholder.
-                    Head(),
-                    Body()[_body]
-                ]
-            ];
+        [
+            Doctype(),
+            Html("en")[
+                // Head() is framework-managed: the serializer auto-inserts the
+                // head-asset sentinel inside, so contributions splice in without
+                // any explicit placeholder.
+                Head(),
+                Body()[_body]
+            ]
+        ];
     }
 
     private sealed class NoHeadComponent : Component

--- a/tests/Rask.Core.Tests/Interop/ElementRefTests.cs
+++ b/tests/Rask.Core.Tests/Interop/ElementRefTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using Rask.Core;
 
 namespace Rask.Core.Tests.Interop;
 

--- a/tests/Rask.Core.Tests/KeyTests.cs
+++ b/tests/Rask.Core.Tests/KeyTests.cs
@@ -18,16 +18,11 @@ public class KeyTests
     }
 
     [Fact]
-    public void Key_NonStringValue_StringifiedOnEmit()
-    {
+    public void Key_NonStringValue_StringifiedOnEmit() =>
         Assert.Equal("<li data-rask-key=\"42\"></li>", Li(Key: 42).ToHtml());
-    }
 
     [Fact]
-    public void Key_Null_EmitsNothing()
-    {
-        Assert.Equal("<div></div>", Div().ToHtml());
-    }
+    public void Key_Null_EmitsNothing() => Assert.Equal("<div></div>", Div().ToHtml());
 
     [Fact]
     public void Key_AfterUserData_NoDuplicate()

--- a/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleErrorBoundaryTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleErrorBoundaryTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleRenderingTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/AsyncLifecycleRenderingTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
@@ -180,7 +179,11 @@ public class AsyncLifecycleRenderingTests
 
         protected override async Task OnRenderedAsync(bool firstRender)
         {
-            if (!firstRender) return;
+            if (!firstRender)
+            {
+                return;
+            }
+
             await Gate.Task;
         }
 
@@ -207,10 +210,10 @@ public class AsyncLifecycleRenderingTests
     // both continuations fire, exercising the multi-component cascade path.
     private sealed class MultiAwaitProbe : Component
     {
-        public int AOnRenderedCount;
-        public int BOnRenderedCount;
         private readonly AlwaysAwaitsProbe _a = new();
         private readonly AlwaysAwaitsProbe _b = new();
+        public int AOnRenderedCount;
+        public int BOnRenderedCount;
 
         public void ReleaseAll()
         {
@@ -224,8 +227,15 @@ public class AsyncLifecycleRenderingTests
         {
             // Tally hook re-entries on the root too — if the publishOnly walk is broken,
             // this counter pegs at hundreds.
-            if (firstRender) AOnRenderedCount++;
-            else BOnRenderedCount++;
+            if (firstRender)
+            {
+                AOnRenderedCount++;
+            }
+            else
+            {
+                BOnRenderedCount++;
+            }
+
             return Task.CompletedTask;
         }
     }
@@ -284,8 +294,8 @@ public class AsyncLifecycleRenderingTests
 
     private sealed class RecordingHandle : IRenderHandle
     {
-        public int RequestRenderCount;
         public int RequestPublishRenderCount;
+        public int RequestRenderCount;
 
         public Task RequestRenderAsync()
         {

--- a/tests/Rask.Core.Tests/Lifecycle/ComponentCancellationTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/ComponentCancellationTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Lifecycle/DiffGatedLifecycleTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/DiffGatedLifecycleTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Lifecycle/MountTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/MountTests.cs
@@ -44,7 +44,7 @@ public class MountTests
 
         for (var i = 0; i < 3; i++)
         {
-            using (RenderHarness.Render(c, sp, propsChanged: false)) { }
+            using (RenderHarness.Render(c, sp, false)) { }
         }
 
         Assert.Equal(1, c.PropsChangedCount);

--- a/tests/Rask.Core.Tests/Lifecycle/RenderSkipTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/RenderSkipTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
@@ -46,7 +45,7 @@ public class RenderSkipTests
         var sp = RenderHarness.EmptyServices();
         var c = new LifecycleTrackingComponent();
 
-        using (RenderHarness.Render(c, sp, propsChanged: false))
+        using (RenderHarness.Render(c, sp, false))
         {
             c.ToHtml();
         }

--- a/tests/Rask.Core.Tests/Lifecycle/StateHasChangedAfterUnmountTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/StateHasChangedAfterUnmountTests.cs
@@ -102,8 +102,8 @@ public class StateHasChangedAfterUnmountTests
 
     private sealed class RecordingHandle : IRenderHandle
     {
-        public int RequestRenderCount;
         public int RequestPublishRenderCount;
+        public int RequestRenderCount;
 
         public Task RequestRenderAsync()
         {

--- a/tests/Rask.Core.Tests/Live/ComponentFactoryIntegrationTests.cs
+++ b/tests/Rask.Core.Tests/Live/ComponentFactoryIntegrationTests.cs
@@ -1,5 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 
 namespace Rask.Core.Tests.Live;

--- a/tests/Rask.Core.Tests/Live/CrossParentKeyedMoveTests.cs
+++ b/tests/Rask.Core.Tests/Live/CrossParentKeyedMoveTests.cs
@@ -1,45 +1,9 @@
-using C = Rask.Core.Components.Generated;
-using Rask.Core;
-
 #pragma warning disable RASK014
 
 namespace Rask.Core.Tests.Live;
 
 public class CrossParentKeyedMoveTests
 {
-    private sealed class Board : Component
-    {
-        public Dictionary<string, List<int>> Cols = new()
-        {
-            ["todo"] = new() { 1, 2, 3 },
-            ["doing"] = new() { 4 },
-            ["done"] = new() { 5 },
-        };
-        private static readonly string[] Zones = { "todo", "doing", "done" };
-
-        private Child Column(string zone)
-        {
-            var cards = Cols[zone];
-            var children = new List<Child>();
-            foreach (var id in cards)
-                children.Add(C.Div(Key: id, Class: "card")[C.Div(Class: "card-body")[C.Span()[$"card{id}"]]]);
-            children.Add(C.Div(Key: $"{zone}-end", Class: "tail"));
-            return C.Div(Key: zone, Class: "col")[
-                C.Div(Class: "dd-column")[
-                    C.Div(Class: "dd-column-header")[C.Span()[zone], C.Span()[cards.Count.ToString()]],
-                    C.Div(Class: "dd-column-body")[children]
-                ]
-            ];
-        }
-
-        protected override RenderResult Render()
-        {
-            var cols = new List<Child>();
-            foreach (var z in Zones) cols.Add(Column(z));
-            return C.Div(Class: "board")[cols];
-        }
-    }
-
     [Fact]
     public void CrossParentKeyedMove_DoesNotCycle()
     {
@@ -53,5 +17,44 @@ public class CrossParentKeyedMoveTests
         var html2 = board.RenderAsLiveRoot();
         var count = html2.Split("card2").Length - 1;
         Assert.True(count == 1, $"expected card2 once, got {count}");
+    }
+
+    private sealed class Board : Component
+    {
+        private static readonly string[] Zones = { "todo", "doing", "done" };
+
+        public readonly Dictionary<string, List<int>> Cols = new()
+        {
+            ["todo"] = new List<int> { 1, 2, 3 }, ["doing"] = new List<int> { 4 }, ["done"] = new List<int> { 5 }
+        };
+
+        private Child Column(string zone)
+        {
+            var cards = Cols[zone];
+            var children = new List<Child>();
+            foreach (var id in cards)
+            {
+                children.Add(Div(Key: id, Class: "card")[Div(Class: "card-body")[Span()[$"card{id}"]]]);
+            }
+
+            children.Add(Div(Key: $"{zone}-end", Class: "tail"));
+            return Div(Key: zone, Class: "col")[
+                Div(Class: "dd-column")[
+                    Div(Class: "dd-column-header")[Span()[zone], Span()[cards.Count.ToString()]],
+                    Div(Class: "dd-column-body")[children]
+                ]
+            ];
+        }
+
+        protected override RenderResult Render()
+        {
+            var cols = new List<Child>();
+            foreach (var z in Zones)
+            {
+                cols.Add(Column(z));
+            }
+
+            return Div(Class: "board")[cols];
+        }
     }
 }

--- a/tests/Rask.Core.Tests/Live/DefaultHandlerAsyncTests.cs
+++ b/tests/Rask.Core.Tests/Live/DefaultHandlerAsyncTests.cs
@@ -15,7 +15,7 @@ public class DefaultHandlerAsyncTests
     public async Task UnmatchedAsyncSignature_IsAwaited_BeforeDispatchReturns()
     {
         var sp = RenderHarness.EmptyServices();
-        var owner = new UnmatchedAsyncOwner(throws: false);
+        var owner = new UnmatchedAsyncOwner(false);
 
         using var ctx = LiveRenderContext.Begin(owner, sp);
         _ = owner.ToHtml();
@@ -35,7 +35,7 @@ public class DefaultHandlerAsyncTests
     public async Task UnmatchedAsyncSignature_Throw_TripsAncestorBoundary()
     {
         var sp = RenderHarness.EmptyServices();
-        var owner = new UnmatchedAsyncOwner(throws: true);
+        var owner = new UnmatchedAsyncOwner(true);
         var boundary = ErrorBoundary();
         boundary.SetProps(new Child[] { owner }, null);
 

--- a/tests/Rask.Core.Tests/Live/EventHandlerErrorBoundaryTests.cs
+++ b/tests/Rask.Core.Tests/Live/EventHandlerErrorBoundaryTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Rask.Core.Live;
-using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Tests.Live;
 
@@ -14,8 +13,8 @@ public class FrameDifferTests
     [Fact]
     public void Diff_IdenticalTrees_ProducesZeroOps()
     {
-        var before = Frames(C.Div(Class: "row")[C.Span()["Item 5"]]);
-        var after = Frames(C.Div(Class: "row")[C.Span()["Item 5"]]);
+        var before = Frames(Div(Class: "row")[Span()["Item 5"]]);
+        var after = Frames(Div(Class: "row")[Span()["Item 5"]]);
 
         var ops = new List<EditOp>();
         var count = FrameDiffer.Diff(before, after, ops);
@@ -31,8 +30,8 @@ public class FrameDifferTests
         // text node changes deep in an otherwise-identical tree. The diff should be
         // a single UpdateText op — not a full RemoveSubtree + InsertSubtree of the
         // surrounding element.
-        var before = Frames(C.Div(Class: "counter")[C.Span()["5"]]);
-        var after = Frames(C.Div(Class: "counter")[C.Span()["6"]]);
+        var before = Frames(Div(Class: "counter")[Span()["5"]]);
+        var after = Frames(Div(Class: "counter")[Span()["6"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -45,8 +44,8 @@ public class FrameDifferTests
     [Fact]
     public void Diff_AttributeValueChanged_ProducesSingleSetAttributeOp()
     {
-        var before = Frames(C.Input("text", "f", "old", "edit"));
-        var after = Frames(C.Input("text", "f", "new", "edit"));
+        var before = Frames(Input("text", "f", "old", "edit"));
+        var after = Frames(Input("text", "f", "new", "edit"));
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -68,8 +67,8 @@ public class FrameDifferTests
         // checkbox losing its event handler (so it stopped responding after a click) and
         // gaining a spurious value="". Name-keyed diffing emits exactly one op for the
         // toggled attribute and leaves `list` (emitted AFTER `checked`) untouched.
-        var unchecked_ = Frames(C.Input("checkbox", "n", List: "dl"));
-        var checked_ = Frames(C.Input("checkbox", "n", Checked: true, List: "dl"));
+        var unchecked_ = Frames(Input("checkbox", "n", List: "dl"));
+        var checked_ = Frames(Input("checkbox", "n", Checked: true, List: "dl"));
 
         var on = new List<EditOp>();
         FrameDiffer.Diff(unchecked_, checked_, on);
@@ -87,8 +86,8 @@ public class FrameDifferTests
     [Fact]
     public void Diff_ChildAdded_ProducesInsertSubtreeOp()
     {
-        var before = Frames(C.Ul()[C.Li()["a"], C.Li()["b"]]);
-        var after = Frames(C.Ul()[C.Li()["a"], C.Li()["b"], C.Li()["c"]]);
+        var before = Frames(Ul()[Li()["a"], Li()["b"]]);
+        var after = Frames(Ul()[Li()["a"], Li()["b"], Li()["c"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -100,8 +99,8 @@ public class FrameDifferTests
     [Fact]
     public void Diff_ChildRemoved_ProducesRemoveSubtreeOp()
     {
-        var before = Frames(C.Ul()[C.Li()["a"], C.Li()["b"], C.Li()["c"]]);
-        var after = Frames(C.Ul()[C.Li()["a"], C.Li()["b"]]);
+        var before = Frames(Ul()[Li()["a"], Li()["b"], Li()["c"]]);
+        var after = Frames(Ul()[Li()["a"], Li()["b"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -117,8 +116,8 @@ public class FrameDifferTests
         // span produces an UpdateText op whose Path walks: root-fragment-omitted →
         // div(0) → span(0) → text(0). The client uses this exact path to descend its
         // DOM tree and update the right node.
-        var before = Frames(C.Div()[C.Span()["one"]]);
-        var after = Frames(C.Div()[C.Span()["two"]]);
+        var before = Frames(Div()[Span()["one"]]);
+        var after = Frames(Div()[Span()["two"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -136,8 +135,8 @@ public class FrameDifferTests
     {
         // The element being changed is the SECOND div of the parent. Verifies the
         // sibling slot counter advances correctly past the first sibling.
-        var before = Frames(C.Div()[C.Div(Class: "a")["one"], C.Div(Class: "b")["two"]]);
-        var after = Frames(C.Div()[C.Div(Class: "a")["one"], C.Div(Class: "z")["two"]]);
+        var before = Frames(Div()[Div(Class: "a")["one"], Div(Class: "b")["two"]]);
+        var after = Frames(Div()[Div(Class: "a")["one"], Div(Class: "z")["two"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -174,8 +173,8 @@ public class FrameDifferTests
         // When the caller passes newHtml, FrameDiffer attaches the HTML slice for the
         // inserted subtree to op.Value. This is what makes the client-side InsertSubtree
         // applicable without a follow-up full render: the op carries everything needed.
-        var before = Frames(C.Ul()[C.Li()["a"], C.Li()["b"]]);
-        var (afterFrames, afterHtml) = FramesAndHtml(C.Ul()[C.Li()["a"], C.Li()["b"], C.Li()["c"]]);
+        var before = Frames(Ul()[Li()["a"], Li()["b"]]);
+        var (afterFrames, afterHtml) = FramesAndHtml(Ul()[Li()["a"], Li()["b"], Li()["c"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, afterFrames, ops, afterHtml);
@@ -189,8 +188,8 @@ public class FrameDifferTests
     [Fact]
     public void Diff_WithoutNewHtml_InsertSubtreeOmitsFragment()
     {
-        var before = Frames(C.Ul()[C.Li()["a"]]);
-        var afterFrames = Frames(C.Ul()[C.Li()["a"], C.Li()["b"]]);
+        var before = Frames(Ul()[Li()["a"]]);
+        var afterFrames = Frames(Ul()[Li()["a"], Li()["b"]]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, afterFrames, ops);
@@ -223,7 +222,8 @@ public class FrameDifferTests
         // bounds the move count at <= N - LIS = 2 pairs (4 ints), flattened into op.Moves.
         var batch = Assert.Single(ops);
         Assert.Equal(EditOpKind.PermutationBatch, batch.Kind);
-        Assert.True(batch.Trusted, "Keyed moves must be marked Trusted so the live-session gate doesn't divert to full HTML.");
+        Assert.True(batch.Trusted,
+            "Keyed moves must be marked Trusted so the live-session gate doesn't divert to full HTML.");
         Assert.NotNull(batch.Moves);
         Assert.True(batch.Moves!.Length is 2 or 4, "Expected 1–2 (dst,src) pairs.");
         Assert.Equal(0, batch.Moves.Length % 2);
@@ -356,13 +356,13 @@ public class FrameDifferTests
         // One child without data-rask-key drops the whole parent back to the positional
         // walk. Mirrors the morph engine's all-or-nothing keyed detection so the diff
         // codec doesn't disagree with the client about which path applied.
-        var before = Frames(C.Ul()[
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one"],
-            C.Li()["two"]
+        var before = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one"],
+            Li()["two"]
         ]);
-        var afterFrames = Frames(C.Ul()[
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one!"],
-            C.Li()["two"]
+        var afterFrames = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["one!"],
+            Li()["two"]
         ]);
 
         var ops = new List<EditOp>();
@@ -378,13 +378,13 @@ public class FrameDifferTests
     [Fact]
     public void Diff_KeyedList_DuplicateKeys_FallsBackToPositional()
     {
-        var before = Frames(C.Ul()[
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a"],
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
+        var before = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a"],
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
         ]);
-        var afterFrames = Frames(C.Ul()[
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a!"],
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
+        var afterFrames = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["a!"],
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "dup" })["b"]
         ]);
 
         var ops = new List<EditOp>();
@@ -401,11 +401,11 @@ public class FrameDifferTests
         // Same data-rask-key but the element kind changed (Li → Span). The keyed branch
         // treats this as a fresh node: remove the old, insert the new at the same slot.
         // Both ops carry Trusted so the gate ships them as diff.
-        var before = Frames(C.Ul()[
-            C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["original"]
+        var before = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["original"]
         ]);
-        var (afterFrames, afterHtml) = FramesAndHtml(C.Ul()[
-            C.Span(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["replaced"]
+        var (afterFrames, afterHtml) = FramesAndHtml(Ul()[
+            Span(Data: new Dictionary<string, string?> { ["rask-key"] = "x" })["replaced"]
         ]);
 
         var ops = new List<EditOp>();
@@ -432,6 +432,7 @@ public class FrameDifferTests
             orderBefore[i] = i;
             orderAfter[i] = i;
         }
+
         (orderAfter[5], orderAfter[95]) = (orderAfter[95], orderAfter[5]);
 
         var before = Frames(BuildKeyedRows(orderBefore));
@@ -519,14 +520,14 @@ public class FrameDifferTests
         // single trusted PermutationBatch, at the right parent depths and non-interleaved.
         static Child Row(int key, bool innerSwapped)
         {
-            Child a = C.Span(Key: $"{key}a")["A"];
-            Child b = C.Span(Key: $"{key}b")["B"];
-            var li = C.Li(Key: key);
+            Child a = Span(Key: $"{key}a")["A"];
+            Child b = Span(Key: $"{key}b")["B"];
+            var li = Li(Key: key);
             return innerSwapped ? li[b, a] : li[a, b];
         }
 
-        var before = Frames(C.Ul()[new List<Child> { Row(0, false), Row(1, false) }]);
-        var (afterFrames, afterHtml) = FramesAndHtml(C.Ul()[new List<Child> { Row(1, false), Row(0, true) }]);
+        var before = Frames(Ul()[new List<Child> { Row(0, false), Row(1, false) }]);
+        var (afterFrames, afterHtml) = FramesAndHtml(Ul()[new List<Child> { Row(1, false), Row(0, true) }]);
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, afterFrames, ops, out var usedKeyed, afterHtml);
@@ -537,8 +538,8 @@ public class FrameDifferTests
         Assert.All(ops, op => Assert.True(op.Trusted));
         // The batch op's Path is the PARENT (no trailing dst slot — that now lives in Moves).
         // Outer batch is emitted first (step 4 precedes the step-5 inner recursion).
-        Assert.Equal(new[] { 0 }, ops[0].Path);          // outer: rows reordered under the Ul (slot 0)
-        Assert.Equal(new[] { 0, 1 }, ops[1].Path);       // inner: spans reordered inside row 0 at its new slot 1
+        Assert.Equal(new[] { 0 }, ops[0].Path); // outer: rows reordered under the Ul (slot 0)
+        Assert.Equal(new[] { 0, 1 }, ops[1].Path); // inner: spans reordered inside row 0 at its new slot 1
         Assert.All(ops, op => Assert.Equal(2, op.Moves!.Length)); // one (dst,src) pair each
     }
 
@@ -547,12 +548,12 @@ public class FrameDifferTests
         var rows = new List<Child>(keys.Length);
         foreach (var k in keys)
         {
-            rows.Add(C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = k.ToString() })[
+            rows.Add(Li(Data: new Dictionary<string, string?> { ["rask-key"] = k.ToString() })[
                 $"Item {k}"
             ]);
         }
 
-        return C.Ul()[rows];
+        return Ul()[rows];
     }
 
     private static Component BuildMixedRows(params (int Key, bool Keyed)[] rows)
@@ -561,11 +562,11 @@ public class FrameDifferTests
         foreach (var (key, keyed) in rows)
         {
             children.Add(keyed
-                ? C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = key.ToString() })[$"Item {key}"]
-                : C.Li()[$"Item {key}"]);
+                ? Li(Data: new Dictionary<string, string?> { ["rask-key"] = key.ToString() })[$"Item {key}"]
+                : Li()[$"Item {key}"]);
         }
 
-        return C.Ul()[children];
+        return Ul()[children];
     }
 
     // Same shape as BuildKeyedRows but keyed via the first-class Key property instead of a
@@ -575,10 +576,10 @@ public class FrameDifferTests
         var rows = new List<Child>(keys.Length);
         foreach (var k in keys)
         {
-            rows.Add(C.Li(Key: k)[$"Item {k}"]);
+            rows.Add(Li(Key: k)[$"Item {k}"]);
         }
 
-        return C.Ul()[rows];
+        return Ul()[rows];
     }
 
     private static Component BuildKeyedRowsWithLabel(params (string Key, string Label)[] rows)
@@ -586,10 +587,10 @@ public class FrameDifferTests
         var items = new List<Child>(rows.Length);
         foreach (var (key, label) in rows)
         {
-            items.Add(C.Li(Data: new Dictionary<string, string?> { ["rask-key"] = key })[label]);
+            items.Add(Li(Data: new Dictionary<string, string?> { ["rask-key"] = key })[label]);
         }
 
-        return C.Ul()[items];
+        return Ul()[items];
     }
 
     private static RenderFrame[] Frames(Component tree)
@@ -616,14 +617,14 @@ public class FrameDifferTests
         var rows = new List<Child>(rowCount);
         for (var i = 0; i < rowCount; i++)
         {
-            rows.Add(C.Div(Class: "row", Id: $"r{i}", Key: i)[
-                C.Span(Class: "label")[$"Item {i}"]
+            rows.Add(Div(Class: "row", Id: $"r{i}", Key: i)[
+                Span(Class: "label")[$"Item {i}"]
             ]);
         }
 
-        return C.Div(Class: "container")[
-            C.Div(Class: "counter")[C.Span(Class: "value")[counter.ToString()]],
-            C.Div(Class: "body")[rows]
+        return Div(Class: "container")[
+            Div(Class: "counter")[Span(Class: "value")[counter.ToString()]],
+            Div(Class: "body")[rows]
         ];
     }
 }

--- a/tests/Rask.Core.Tests/Live/LisAlgorithmTests.cs
+++ b/tests/Rask.Core.Tests/Live/LisAlgorithmTests.cs
@@ -12,11 +12,11 @@ public class LisAlgorithmTests
     [Theory]
     [InlineData(new int[0], 0)]
     [InlineData(new[] { 5 }, 1)]
-    [InlineData(new[] { 1, 2, 3, 4, 5 }, 5)]                       // already sorted
-    [InlineData(new[] { 5, 4, 3, 2, 1 }, 1)]                       // reversed
-    [InlineData(new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5 }, 4)]     // classic test
-    [InlineData(new[] { 10, 22, 9, 33, 21, 50, 41, 60, 80 }, 6)]   // Wikipedia LIS example
-    [InlineData(new[] { 0, 2, 4, 1, 3, 5 }, 4)]                    // interleaved
+    [InlineData(new[] { 1, 2, 3, 4, 5 }, 5)] // already sorted
+    [InlineData(new[] { 5, 4, 3, 2, 1 }, 1)] // reversed
+    [InlineData(new[] { 3, 1, 4, 1, 5, 9, 2, 6, 5, 3, 5 }, 4)] // classic test
+    [InlineData(new[] { 10, 22, 9, 33, 21, 50, 41, 60, 80 }, 6)] // Wikipedia LIS example
+    [InlineData(new[] { 0, 2, 4, 1, 3, 5 }, 4)] // interleaved
     public void ComputeLisIndexSet_ReturnsOptimalLengthIncreasingSubsequence(int[] input, int expectedLisLength)
     {
         var lisIndexes = FrameDiffer.ComputeLisIndexSet(input);
@@ -51,7 +51,11 @@ public class LisAlgorithmTests
     private static int NaiveLisLength(int[] arr)
     {
         var n = arr.Length;
-        if (n == 0) return 0;
+        if (n == 0)
+        {
+            return 0;
+        }
+
         var dp = new int[n];
         Array.Fill(dp, 1);
         var best = 1;
@@ -64,8 +68,13 @@ public class LisAlgorithmTests
                     dp[i] = dp[j] + 1;
                 }
             }
-            if (dp[i] > best) best = dp[i];
+
+            if (dp[i] > best)
+            {
+                best = dp[i];
+            }
         }
+
         return best;
     }
 }

--- a/tests/Rask.Core.Tests/Live/LiveDiffGateTests.cs
+++ b/tests/Rask.Core.Tests/Live/LiveDiffGateTests.cs
@@ -10,7 +10,7 @@ namespace Rask.Core.Tests.Live;
 public class LiveDiffGateTests
 {
     private static EditOp Op(EditOpKind kind, bool trusted = false) =>
-        new(kind, [0], name: null, value: null, length: 0, trusted: trusted);
+        new(kind, [0], null, null, 0, trusted);
 
     // --- HeadUnchanged -----------------------------------------------------
 
@@ -75,16 +75,12 @@ public class LiveDiffGateTests
     }
 
     [Fact]
-    public void ExtractHead_NoHeadOpen_ReturnsNull()
-    {
+    public void ExtractHead_NoHeadOpen_ReturnsNull() =>
         Assert.Null(LiveDiffGate.ExtractHead("<html><body>x</body></html>"));
-    }
 
     [Fact]
-    public void ExtractHead_NoHeadClose_ReturnsNull()
-    {
+    public void ExtractHead_NoHeadClose_ReturnsNull() =>
         Assert.Null(LiveDiffGate.ExtractHead("<html><head><title>A</title><body>x</body></html>"));
-    }
 
     [Fact]
     public void ExtractHead_CloseBeforeOpen_ReturnsNull()
@@ -96,10 +92,8 @@ public class LiveDiffGateTests
     // --- DiffOpsAreClientSupported -----------------------------------------
 
     [Fact]
-    public void DiffOpsAreClientSupported_EmptyList_ReturnsTrue()
-    {
+    public void DiffOpsAreClientSupported_EmptyList_ReturnsTrue() =>
         Assert.True(LiveDiffGate.DiffOpsAreClientSupported([]));
-    }
 
     [Fact]
     public void DiffOpsAreClientSupported_OnlyAttributeAndTextOps_ReturnsTrue()
@@ -108,7 +102,7 @@ public class LiveDiffGateTests
         [
             Op(EditOpKind.SetAttribute),
             Op(EditOpKind.RemoveAttribute),
-            Op(EditOpKind.UpdateText),
+            Op(EditOpKind.UpdateText)
         ];
 
         Assert.True(LiveDiffGate.DiffOpsAreClientSupported(ops));
@@ -119,10 +113,8 @@ public class LiveDiffGateTests
     [InlineData(EditOpKind.RemoveSubtree)]
     [InlineData(EditOpKind.MoveSubtree)]
     [InlineData(EditOpKind.PermutationBatch)]
-    public void DiffOpsAreClientSupported_UntrustedStructuralOp_ReturnsFalse(EditOpKind kind)
-    {
-        Assert.False(LiveDiffGate.DiffOpsAreClientSupported([Op(kind, trusted: false)]));
-    }
+    public void DiffOpsAreClientSupported_UntrustedStructuralOp_ReturnsFalse(EditOpKind kind) =>
+        Assert.False(LiveDiffGate.DiffOpsAreClientSupported([Op(kind, false)]));
 
     [Theory]
     [InlineData(EditOpKind.InsertSubtree)]
@@ -132,7 +124,7 @@ public class LiveDiffGateTests
     public void DiffOpsAreClientSupported_TrustedStructuralOp_ReturnsTrue(EditOpKind kind)
     {
         // Keyed-matching path marks structural ops Trusted=true; those are safe to apply.
-        Assert.True(LiveDiffGate.DiffOpsAreClientSupported([Op(kind, trusted: true)]));
+        Assert.True(LiveDiffGate.DiffOpsAreClientSupported([Op(kind, true)]));
     }
 
     [Fact]
@@ -141,8 +133,8 @@ public class LiveDiffGateTests
         List<EditOp> ops =
         [
             Op(EditOpKind.SetAttribute),
-            Op(EditOpKind.InsertSubtree, trusted: false),
-            Op(EditOpKind.UpdateText),
+            Op(EditOpKind.InsertSubtree, false),
+            Op(EditOpKind.UpdateText)
         ];
 
         Assert.False(LiveDiffGate.DiffOpsAreClientSupported(ops));

--- a/tests/Rask.Core.Tests/Live/LivePayloadDiffTests.cs
+++ b/tests/Rask.Core.Tests/Live/LivePayloadDiffTests.cs
@@ -60,14 +60,10 @@ public class LivePayloadDiffTests
         // Fire-and-forget IJSRuntime invokes ride the diff payload the same way they
         // ride the full-HTML payload, so a per-render js.InvokeVoidAsync no longer
         // forces the whole page onto the full-HTML path on the server runtime.
-        var ops = new List<EditOp>
-        {
-            new(EditOpKind.UpdateText, new[] { 0, 1 }, null, "echo")
-        };
+        var ops = new List<EditOp> { new(EditOpKind.UpdateText, new[] { 0, 1 }, null, "echo") };
         var invokes = new List<PendingJsInvoke>
         {
-            new(7, "Rask.CodeSample.rendered", "[false]", 1, 0),
-            new(8, "sessionStorage.getItem", "[\"k\"]", 0, 42)
+            new(7, "Rask.CodeSample.rendered", "[false]", 1, 0), new(8, "sessionStorage.getItem", "[\"k\"]", 0, 42)
         };
 
         var output = new ArrayBufferWriter<byte>(256);
@@ -144,8 +140,8 @@ public class LivePayloadDiffTests
         // pick the wrong source.
         var ops = new List<EditOp>
         {
-            new(EditOpKind.MoveSubtree, new[] { 1, 0 }, null, null, length: 7, trusted: true),
-            new(EditOpKind.MoveSubtree, new[] { 1, 3 }, null, null, length: 0, trusted: true)
+            new(EditOpKind.MoveSubtree, new[] { 1, 0 }, null, null, 7, true),
+            new(EditOpKind.MoveSubtree, new[] { 1, 3 }, null, null, 0, true)
         };
 
         var output = new ArrayBufferWriter<byte>(128);
@@ -191,10 +187,7 @@ public class LivePayloadDiffTests
     [Fact]
     public void BuildPayloadUtf8Diff_InsertSubtree_EncodesHtmlAndDomCount()
     {
-        var ops = new List<EditOp>
-        {
-            new(EditOpKind.InsertSubtree, new[] { 0, 2 }, null, "<li>new</li>", length: 1, trusted: true)
-        };
+        var ops = new List<EditOp> { new(EditOpKind.InsertSubtree, new[] { 0, 2 }, null, "<li>new</li>", 1, true) };
 
         var output = new ArrayBufferWriter<byte>(128);
         LivePayload.BuildPayloadUtf8Diff(output, ops);
@@ -215,10 +208,7 @@ public class LivePayloadDiffTests
         // Bare HTML attributes (`disabled`, `required`) carry no value. The positional
         // format must still emit a slot so the client reads name and value from the
         // expected indices.
-        var ops = new List<EditOp>
-        {
-            new(EditOpKind.SetAttribute, new[] { 0 }, "disabled", null)
-        };
+        var ops = new List<EditOp> { new(EditOpKind.SetAttribute, new[] { 0 }, "disabled", null) };
 
         var output = new ArrayBufferWriter<byte>(64);
         LivePayload.BuildPayloadUtf8Diff(output, ops);
@@ -273,7 +263,7 @@ public class LivePayloadDiffTests
         {
             new(EditOpKind.SetAttribute, new[] { 0, 0 }, "class", "a"),
             new(EditOpKind.SetAttribute, new[] { 0, 1 }, "class", "b"),
-            new(EditOpKind.SetAttribute, new[] { 0, 2 }, "style", "color:red"),
+            new(EditOpKind.SetAttribute, new[] { 0, 2 }, "style", "color:red")
         };
 
         var output = new ArrayBufferWriter<byte>(256);
@@ -306,7 +296,7 @@ public class LivePayloadDiffTests
     public void BuildPayloadUtf8Diff_IncludesHistory_WhenProvided()
     {
         var output = new ArrayBufferWriter<byte>(128);
-        LivePayload.BuildPayloadUtf8Diff(output, new List<EditOp>(), "/page/2", replace: true);
+        LivePayload.BuildPayloadUtf8Diff(output, new List<EditOp>(), "/page/2", true);
 
         var json = Encoding.UTF8.GetString(output.WrittenSpan);
         using var doc = JsonDocument.Parse(json);

--- a/tests/Rask.Core.Tests/Live/MorphValueGuardFixture.mjs
+++ b/tests/Rask.Core.Tests/Live/MorphValueGuardFixture.mjs
@@ -12,7 +12,7 @@
 //
 // The C# test (MorphValueGuardTests) runs this in a node subprocess and asserts
 // the single JSON line on stdout. Exits non-zero on an internal stub failure.
-import { readFileSync } from "node:fs";
+import {readFileSync} from "node:fs";
 
 const morphPath = process.argv[2];
 if (!morphPath) {
@@ -41,7 +41,7 @@ function makeInput(attrs) {
         setAttribute: (n, v) => a.set(n, String(v)),
         removeAttribute: (n) => a.delete(n),
         get attributes() {
-            return [...a.entries()].map(([name, value]) => ({ name, value }));
+            return [...a.entries()].map(([name, value]) => ({name, value}));
         }
     };
     return el;
@@ -49,7 +49,7 @@ function makeInput(attrs) {
 
 // A spectator element that owns focus, so morph's focus guard (activeElement !==
 // from) lets the value-sync path run — the realistic post-blur state.
-const elsewhere = { nodeType: 1, nodeName: "BODY", tagName: "BODY" };
+const elsewhere = {nodeType: 1, nodeName: "BODY", tagName: "BODY"};
 
 globalThis.window = globalThis;
 globalThis.document = {
@@ -61,7 +61,7 @@ globalThis.document = {
 const src = readFileSync(morphPath, "utf8");
 const factory = new Function(
     src + "\n;return { morph, raskNotePendingValue, raskShouldSuppressValue };");
-const { morph, raskNotePendingValue, raskShouldSuppressValue } = factory();
+const {morph, raskNotePendingValue, raskShouldSuppressValue} = factory();
 
 // Change-only inputs: data-rask-on-change present, NO data-rask-on-input, so morph
 // treats the server value as canonical (the pre-fix clobber path). The runtime
@@ -71,7 +71,7 @@ const DEFAULT = "2026-07-05";
 const LATER = "2030-01-01";
 
 // ---- Scenario 1: lagging stale render must not clobber a committed edit ----
-const dateInput = makeInput({ "data-rask-on-change": "h78", "value": DEFAULT });
+const dateInput = makeInput({"data-rask-on-change": "h78", "value": DEFAULT});
 dateInput.value = DEFAULT;
 
 // User edits to COMMITTED. Dispatch records the pre-edit attribute (DEFAULT).
@@ -79,26 +79,26 @@ raskNotePendingValue(dateInput, dateInput.getAttribute("value"));
 dateInput.value = COMMITTED;
 
 // A render the server computed BEFORE the change lands, carrying the stale DEFAULT.
-morph(dateInput, makeInput({ "data-rask-on-change": "h78", "value": DEFAULT }));
+morph(dateInput, makeInput({"data-rask-on-change": "h78", "value": DEFAULT}));
 const afterStale = dateInput.value;
 
 // The authoritative echo of the user's value lands — applies, releases the guard.
-morph(dateInput, makeInput({ "data-rask-on-change": "h78", "value": COMMITTED }));
+morph(dateInput, makeInput({"data-rask-on-change": "h78", "value": COMMITTED}));
 const afterEcho = dateInput.value;
 
 // A genuine later server-driven change wins (guard already released).
-morph(dateInput, makeInput({ "data-rask-on-change": "h78", "value": LATER }));
+morph(dateInput, makeInput({"data-rask-on-change": "h78", "value": LATER}));
 const afterLater = dateInput.value;
 
 // ---- Scenario 2: server CORRECTION must apply (the int-clear regression) ----
 // User clears a non-nullable int (value="") whose model snaps to 0. The server's
 // authoritative response is "0" — different from the user's "" AND from the pre-edit
 // "30" — so it must win, not be suppressed.
-const intInput = makeInput({ "data-rask-on-change": "h99", "value": "30" });
+const intInput = makeInput({"data-rask-on-change": "h99", "value": "30"});
 intInput.value = "30";
 raskNotePendingValue(intInput, intInput.getAttribute("value")); // records "30"
 intInput.value = "";                                            // user cleared
-morph(intInput, makeInput({ "data-rask-on-change": "h99", "value": "0" }));
+morph(intInput, makeInput({"data-rask-on-change": "h99", "value": "0"}));
 const afterCorrection = intInput.value;
 
 process.stdout.write(JSON.stringify({

--- a/tests/Rask.Core.Tests/Live/ReconciliationTests.cs
+++ b/tests/Rask.Core.Tests/Live/ReconciliationTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Live/RenderFrameTests.cs
+++ b/tests/Rask.Core.Tests/Live/RenderFrameTests.cs
@@ -1,6 +1,5 @@
 using System.Text;
 using Rask.Core.Live;
-using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Tests.Live;
 
@@ -17,7 +16,7 @@ public class RenderFrameTests
         //                    Attribute(class, x)
         //                    Element(span) [SubtreeLength=2]
         //                      Text(hi)
-        var tree = C.Div(Class: "x")[C.Span()["hi"]];
+        var tree = Div(Class: "x")[Span()["hi"]];
 
         var frames = RenderAndCaptureFrames(tree);
 
@@ -41,7 +40,7 @@ public class RenderFrameTests
         // Sanity: the frame-producing path must be invisible when no scope is active.
         // If a future change inadvertently activates the scope unconditionally, this
         // test catches the leak.
-        var tree = C.Div(Class: "x", Id: "y")[C.Span()["hi"]];
+        var tree = Div(Class: "x", Id: "y")[Span()["hi"]];
 
         var sb = new StringBuilder();
         HtmlSerializer.Serialize(tree, sb);
@@ -54,7 +53,7 @@ public class RenderFrameTests
     [Fact]
     public void Serialize_DoctypeAndFragment_EmitsDoctypeFrameAndWalksFragmentChildren()
     {
-        var tree = C.Fragment()[C.Doctype(), C.Div()["hi"]];
+        var tree = Fragment()[Doctype(), Div()["hi"]];
 
         var frames = RenderAndCaptureFrames(tree);
 
@@ -69,7 +68,7 @@ public class RenderFrameTests
     [Fact]
     public void Serialize_SelfClosingElement_SubtreeLengthIsOne_AndSelfClosingFlagSet()
     {
-        var tree = C.Br();
+        var tree = Br();
 
         var frames = RenderAndCaptureFrames(tree);
 
@@ -85,7 +84,7 @@ public class RenderFrameTests
     {
         // Element + multiple attributes: SubtreeLength must include all of them so a
         // diff consumer can skip the whole element by jumping (i + SubtreeLength).
-        var tree = C.A("https://example.com", "_blank", "noopener", Class: "lnk", Id: "go")["open"];
+        var tree = A("https://example.com", "_blank", "noopener", Class: "lnk", Id: "go")["open"];
 
         var frames = RenderAndCaptureFrames(tree);
 

--- a/tests/Rask.Core.Tests/Live/RootShellValidationTests.cs
+++ b/tests/Rask.Core.Tests/Live/RootShellValidationTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories

--- a/tests/Rask.Core.Tests/Live/RuntimeScriptInjectionTests.cs
+++ b/tests/Rask.Core.Tests/Live/RuntimeScriptInjectionTests.cs
@@ -1,6 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Core.Components;
-using Rask.Core.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Live/SessionRenderCacheTests.cs
+++ b/tests/Rask.Core.Tests/Live/SessionRenderCacheTests.cs
@@ -1,7 +1,5 @@
 using System.Text;
-using Rask.Core;
 using Rask.Core.Live;
-using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Tests.Live;
 
@@ -16,7 +14,7 @@ public class SessionRenderCacheTests
         var sb = new StringBuilder();
         var ops = new List<EditOp>();
 
-        var hasDiff = cache.Render(C.Div(Class: "x")["hi"], sb, ops);
+        var hasDiff = cache.Render(Div(Class: "x")["hi"], sb, ops);
 
         Assert.False(hasDiff);
         Assert.Empty(ops);
@@ -30,11 +28,11 @@ public class SessionRenderCacheTests
         var ops = new List<EditOp>();
 
         var sb1 = new StringBuilder();
-        cache.Render(C.Div(Class: "counter")[C.Span()["1"]], sb1, ops);
+        cache.Render(Div(Class: "counter")[Span()["1"]], sb1, ops);
         Assert.Empty(ops);
 
         var sb2 = new StringBuilder();
-        var hasDiff = cache.Render(C.Div(Class: "counter")[C.Span()["2"]], sb2, ops);
+        var hasDiff = cache.Render(Div(Class: "counter")[Span()["2"]], sb2, ops);
 
         Assert.True(hasDiff);
         var op = Assert.Single(ops);
@@ -49,8 +47,8 @@ public class SessionRenderCacheTests
         var ops = new List<EditOp>();
         var sb = new StringBuilder();
 
-        cache.Render(C.Div()["hi"], sb, ops);
-        cache.Render(C.Div()["hi"], sb, ops);
+        cache.Render(Div()["hi"], sb, ops);
+        cache.Render(Div()["hi"], sb, ops);
 
         Assert.Empty(ops);
     }
@@ -65,10 +63,10 @@ public class SessionRenderCacheTests
         var ops = new List<EditOp>();
         var sb = new StringBuilder();
 
-        cache.Render(C.Div()[C.Span()["1"]], sb, ops);  // 1
-        cache.Render(C.Div()[C.Span()["2"]], sb, ops);  // diff vs 1
+        cache.Render(Div()[Span()["1"]], sb, ops); // 1
+        cache.Render(Div()[Span()["2"]], sb, ops); // diff vs 1
         ops.Clear();
-        cache.Render(C.Div()[C.Span()["3"]], sb, ops);  // diff vs 2
+        cache.Render(Div()[Span()["3"]], sb, ops); // diff vs 2
 
         var op = Assert.Single(ops);
         Assert.Equal("3", op.Value);
@@ -86,18 +84,18 @@ public class SessionRenderCacheTests
         var ops = new List<EditOp>();
 
         // Baseline "a" (first render rotates to establish it).
-        Assert.False(RenderInto(cache, C.Div()["a"], ops, rotate: true));
+        Assert.False(RenderInto(cache, Div()["a"], ops, true));
 
         // Two intermediate builds, neither rotating — both diff against "a".
-        Assert.True(RenderInto(cache, C.Div()["b"], ops, rotate: false));
+        Assert.True(RenderInto(cache, Div()["b"], ops, false));
         Assert.NotEmpty(ops);
-        Assert.True(RenderInto(cache, C.Div()["c"], ops, rotate: false));
+        Assert.True(RenderInto(cache, Div()["c"], ops, false));
         Assert.NotEmpty(ops);
 
         // The baseline must still be "a": rendering "a" now (rotate:true) yields zero ops. If a
         // rotate:false call had wrongly promoted _current, the baseline would be "b"/"c" and this
         // would show a spurious diff.
-        Assert.True(RenderInto(cache, C.Div()["a"], ops, rotate: true));
+        Assert.True(RenderInto(cache, Div()["a"], ops, true));
         Assert.Empty(ops);
     }
 
@@ -107,12 +105,12 @@ public class SessionRenderCacheTests
         var cache = new SessionRenderCache();
         var ops = new List<EditOp>();
 
-        RenderInto(cache, C.Div()["a"], ops, rotate: true);  // baseline a
-        RenderInto(cache, C.Div()["b"], ops, rotate: false); // intermediate, no rotate
-        cache.Snapshot();                                    // commit "b" exactly once
+        RenderInto(cache, Div()["a"], ops, true); // baseline a
+        RenderInto(cache, Div()["b"], ops, false); // intermediate, no rotate
+        cache.Snapshot(); // commit "b" exactly once
 
         // Baseline is now "b": rendering "b" yields no diff; rendering "a" would.
-        Assert.True(RenderInto(cache, C.Div()["b"], ops, rotate: true));
+        Assert.True(RenderInto(cache, Div()["b"], ops, true));
         Assert.Empty(ops);
     }
 
@@ -125,8 +123,8 @@ public class SessionRenderCacheTests
         var cache = new SessionRenderCache();
         var ops = new List<EditOp>();
 
-        Assert.False(RenderInto(cache, C.Div()["x"], ops, rotate: true)); // false, but rotates
-        Assert.True(RenderInto(cache, C.Div()["x"], ops, rotate: true));  // has baseline now
+        Assert.False(RenderInto(cache, Div()["x"], ops, true)); // false, but rotates
+        Assert.True(RenderInto(cache, Div()["x"], ops, true)); // has baseline now
         Assert.Empty(ops);
     }
 

--- a/tests/Rask.Core.Tests/Performance/CounterAllocationPinTests.cs
+++ b/tests/Rask.Core.Tests/Performance/CounterAllocationPinTests.cs
@@ -1,6 +1,4 @@
-using Rask.Core.Components;
 using Xunit.Abstractions;
-using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Tests.Performance;
 
@@ -53,22 +51,22 @@ public class CounterAllocationPinTests
     }
 
     private static Component BuildFullPageShell() =>
-        C.Fragment()[
-            C.Doctype(),
-            C.Html()[
-                C.Body()[
-                    C.Div(Class: "counter", Id: "counter")[
-                        C.Span(Class: "value")["42"],
-                        C.Button(Class: "inc")["+"]
+        Fragment()[
+            Doctype(),
+            Html()[
+                Body()[
+                    Div(Class: "counter", Id: "counter")[
+                        Span(Class: "value")["42"],
+                        Button(Class: "inc")["+"]
                     ]
                 ]
             ]
         ];
 
     private static Component BuildInner() =>
-        C.Div(Class: "counter", Id: "counter")[
-            C.Span(Class: "value")["42"],
-            C.Button(Class: "inc")["+"]
+        Div(Class: "counter", Id: "counter")[
+            Span(Class: "value")["42"],
+            Button(Class: "inc")["+"]
         ];
 
     private static void WarmUp(Func<Component> build)
@@ -93,6 +91,7 @@ public class CounterAllocationPinTests
         {
             _ = build().ToHtml();
         }
+
         var after = GC.GetAllocatedBytesForCurrentThread();
 
         return (after - before) / iterations;

--- a/tests/Rask.Core.Tests/Routing/LocalUrlTests.cs
+++ b/tests/Rask.Core.Tests/Routing/LocalUrlTests.cs
@@ -17,12 +17,12 @@ public class LocalUrlTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    [InlineData("//evil.com")]            // protocol-relative
-    [InlineData("/\\evil.com")]           // backslash → browser normalises to "//"
-    [InlineData("\\evil.com")]            // leading backslash
-    [InlineData("https://evil.com")]      // absolute URL
-    [InlineData("javascript:alert(1)")]   // not rooted
-    [InlineData("evil.com")]              // relative, not rooted
+    [InlineData("//evil.com")] // protocol-relative
+    [InlineData("/\\evil.com")] // backslash → browser normalises to "//"
+    [InlineData("\\evil.com")] // leading backslash
+    [InlineData("https://evil.com")] // absolute URL
+    [InlineData("javascript:alert(1)")] // not rooted
+    [InlineData("evil.com")] // relative, not rooted
     [InlineData("/foo\r\nSet-Cookie: x")] // control chars
     [InlineData("/foo\tbar")]
     public void NonLocal_OrMalformed_CollapsesToRoot(string? input)

--- a/tests/Rask.Core.Tests/Routing/NavigatorTests.cs
+++ b/tests/Rask.Core.Tests/Routing/NavigatorTests.cs
@@ -56,7 +56,7 @@ public class NavigatorTests
 
         using (nav.EnterHandler())
         {
-            nav.Navigate("/a", replace: true);
+            nav.Navigate("/a", true);
         } // scope disposed WITHOUT TryConsumeHistory — simulates a faulted handler
 
         using (nav.EnterHandler())

--- a/tests/Rask.Core.Tests/Routing/OutletTests.cs
+++ b/tests/Rask.Core.Tests/Routing/OutletTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Routing;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/Routing/RouterTests.cs
+++ b/tests/Rask.Core.Tests/Routing/RouterTests.cs
@@ -2,7 +2,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Primitives;
 using Rask.Core.Live;
 using Rask.Core.Routing;
-using Rask.Core.Tests.Live;
 
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
 

--- a/tests/Rask.Core.Tests/ScopedAssets/ChaosTests.cs
+++ b/tests/Rask.Core.Tests/ScopedAssets/ChaosTests.cs
@@ -92,8 +92,8 @@ public class ChaosTests
         var roundtrip = Encoding.UTF8.GetBytes(Encoding.UTF8.GetString(bytes));
         Assert.Equal(bytes, roundtrip);
         // And the emoji's UTF-8 sequence (F0 9F 8E A8) survived.
-        Assert.Contains((byte)0xF0, (IEnumerable<byte>)bytes);
-        Assert.Contains((byte)0x9F, (IEnumerable<byte>)bytes);
+        Assert.Contains((byte)0xF0, bytes);
+        Assert.Contains((byte)0x9F, bytes);
     }
 
     [Fact]
@@ -134,5 +134,8 @@ public class ChaosTests
         Assert.False(ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out _));
     }
 
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Core.Tests/ScopedAssets/HotReloadTests.cs
+++ b/tests/Rask.Core.Tests/ScopedAssets/HotReloadTests.cs
@@ -157,18 +157,30 @@ public class HotReloadTests
     private static void InvokeUpdateApplication(string handlerFullName, Type[]? types)
     {
         var handlerType = typeof(ScopedAssetRegistry).Assembly
-            .GetType(handlerFullName, throwOnError: true)!;
+            .GetType(handlerFullName, true)!;
         var update = handlerType.GetMethod(
             "UpdateApplication",
             BindingFlags.Public | BindingFlags.Static)!;
         update.Invoke(null, new object?[] { types });
     }
 
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
-    private sealed class WidgetB : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class WidgetB : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 
     // Sentinel types whose Name matches the generator-emitted classes — the hot-reload
     // handler's gate is name-based, so a stand-in is enough for tests.
-    private sealed class __RaskScopedCssRegistration { }
-    private sealed class __RaskScopedJsRegistration { }
+    private sealed class __RaskScopedCssRegistration
+    {
+    }
+
+    private sealed class __RaskScopedJsRegistration
+    {
+    }
 }

--- a/tests/Rask.Core.Tests/ScopedAssets/ScopedAssetRegistryTests.cs
+++ b/tests/Rask.Core.Tests/ScopedAssets/ScopedAssetRegistryTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reflection;
 using System.Runtime.Loader;
+using System.Security.Cryptography;
 using System.Text;
 using Rask.Core.ScopedAssets;
 
@@ -259,7 +260,7 @@ public class ScopedAssetRegistryTests
             // Use the same hash function the registry uses (via a register/read round-trip
             // against a unique type per iteration would be heavier; here we just want a
             // pre-image-distinct sample to assert post-image distinctness empirically).
-            using var sha = System.Security.Cryptography.SHA256.Create();
+            using var sha = SHA256.Create();
             var full = sha.ComputeHash(bytes);
             var sb = new StringBuilder(12);
             for (var j = 0; j < 6; j++)
@@ -324,10 +325,8 @@ public class ScopedAssetRegistryTests
     }
 
     [Fact]
-    public void GetByHash_UnknownHash_ReturnsNull()
-    {
+    public void GetByHash_UnknownHash_ReturnsNull() =>
         Assert.Null(ScopedAssetRegistry.GetByHash("ffffffffffff", AssetKind.Css));
-    }
 
     [Fact]
     public void AssetBytes_EtagIsHashWrappedInDoubleQuotes()
@@ -345,10 +344,10 @@ public class ScopedAssetRegistryTests
     [Fact]
     public void Concurrent_RegisterDistinctTypes_AllSucceed()
     {
-        var types = new Type[]
+        var types = new[]
         {
-            typeof(P0), typeof(P1), typeof(P2), typeof(P3), typeof(P4),
-            typeof(P5), typeof(P6), typeof(P7), typeof(P8), typeof(P9)
+            typeof(P0), typeof(P1), typeof(P2), typeof(P3), typeof(P4), typeof(P5), typeof(P6), typeof(P7),
+            typeof(P8), typeof(P9)
         };
 
         Parallel.ForEach(types, t =>
@@ -485,23 +484,21 @@ public class ScopedAssetRegistryTests
     [Fact]
     public void RegisterCss_NullType_Throws()
     {
-        Assert.Throws<ArgumentNullException>(
-            () => ScopedAssetRegistry.RegisterCss(null!, ".x {}"));
+        Assert.Throws<ArgumentNullException>(() => ScopedAssetRegistry.RegisterCss(null!, ".x {}"));
     }
 
     [Fact]
     public void RegisterCss_OpenGeneric_Throws()
     {
-        var ex = Assert.Throws<ArgumentException>(
-            () => ScopedAssetRegistry.RegisterCss(typeof(Generic<>), ".x {}"));
+        var ex = Assert.Throws<ArgumentException>(() => ScopedAssetRegistry.RegisterCss(typeof(Generic<>), ".x {}"));
         Assert.Contains("Open generic", ex.Message);
     }
 
     [Fact]
     public void RegisterJs_OpenGeneric_Throws()
     {
-        Assert.Throws<ArgumentException>(
-            () => ScopedAssetRegistry.RegisterJs(typeof(Generic<>), "export function f(){}"));
+        Assert.Throws<ArgumentException>(() =>
+            ScopedAssetRegistry.RegisterJs(typeof(Generic<>), "export function f(){}"));
     }
 
     [Fact]
@@ -562,8 +559,8 @@ public class ScopedAssetRegistryTests
     {
         // A type from a collectible AssemblyLoadContext: while the registry holds it,
         // the ALC cannot collect. This is the documented constraint.
-        var alc = new AssemblyLoadContext("test-alc-" + Guid.NewGuid(), isCollectible: true);
-        WeakReference alcWeak = new WeakReference(alc);
+        var alc = new AssemblyLoadContext("test-alc-" + Guid.NewGuid(), true);
+        var alcWeak = new WeakReference(alc);
 
         // Register the current-assembly type using the same ALC's resolution path.
         // The registry's strong Type reference would keep an actual ALC-loaded assembly
@@ -579,16 +576,13 @@ public class ScopedAssetRegistryTests
         // The registration itself stays valid (its type isn't from the unloaded ALC).
         Assert.True(ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out _));
         _ = alcWeak; // referenced to silence unused warnings; full collectible-ALC test
-                     // would need a runtime-emitted assembly which is heavy for this suite
+        // would need a runtime-emitted assembly which is heavy for this suite
     }
 
     // ─── Enumeration (for publish-time bake) ──────────────────────────────
 
     [Fact]
-    public void EnumerateAll_EmptyRegistry_YieldsNothing()
-    {
-        Assert.Empty(ScopedAssetRegistry.EnumerateAll());
-    }
+    public void EnumerateAll_EmptyRegistry_YieldsNothing() => Assert.Empty(ScopedAssetRegistry.EnumerateAll());
 
     [Fact]
     public void EnumerateAll_YieldsRegisteredCssAndJsEntries_WithDistinctHashesAndKinds()
@@ -631,26 +625,85 @@ public class ScopedAssetRegistryTests
 
     // ─── Test fixture types ───────────────────────────────────────────────
 
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
-    private sealed class WidgetB : Component { protected override RenderResult Render() => this; }
-    private sealed class P0 : Component { protected override RenderResult Render() => this; }
-    private sealed class P1 : Component { protected override RenderResult Render() => this; }
-    private sealed class P2 : Component { protected override RenderResult Render() => this; }
-    private sealed class P3 : Component { protected override RenderResult Render() => this; }
-    private sealed class P4 : Component { protected override RenderResult Render() => this; }
-    private sealed class P5 : Component { protected override RenderResult Render() => this; }
-    private sealed class P6 : Component { protected override RenderResult Render() => this; }
-    private sealed class P7 : Component { protected override RenderResult Render() => this; }
-    private sealed class P8 : Component { protected override RenderResult Render() => this; }
-    private sealed class P9 : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 
-    private sealed class Generic<T> : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetB : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 
-    private class BaseWidget : Component { protected override RenderResult Render() => this; }
-    private sealed class DerivedWidget : BaseWidget { }
+    private sealed class P0 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P1 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P2 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P3 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P4 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P5 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P6 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P7 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P8 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class P9 : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class Generic<T> : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private class BaseWidget : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class DerivedWidget : BaseWidget
+    {
+    }
 
     internal static class Outer
     {
-        internal sealed class Inner : Component { protected override RenderResult Render() => this; }
+        internal sealed class Inner : Component
+        {
+            protected override RenderResult Render() => this;
+        }
     }
 }

--- a/tests/Rask.Example.Server.Tests/Pages/JsRuntimePageTests.cs
+++ b/tests/Rask.Example.Server.Tests/Pages/JsRuntimePageTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using Rask.Core;
+using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
 
@@ -31,7 +31,7 @@ public sealed class JsRuntimePageTests
         js.SetResponse("sessionStorage.getItem", "stored-value");
         var page = new JsRuntimePage(js);
 
-        await InvokeOnRenderedAsync(page, firstRender: true);
+        await InvokeOnRenderedAsync(page, true);
 
         Assert.Equal("stored-value", GetField<string?>(page, "_lastRead"));
         Assert.Equal("Read on mount: stored-value", GetField<string?>(page, "_status"));
@@ -44,7 +44,7 @@ public sealed class JsRuntimePageTests
         // No SetResponse → returns default (null for string?).
         var page = new JsRuntimePage(js);
 
-        await InvokeOnRenderedAsync(page, firstRender: true);
+        await InvokeOnRenderedAsync(page, true);
 
         Assert.Null(GetField<string?>(page, "_lastRead"));
         Assert.Equal("(no value yet — try Set)", GetField<string?>(page, "_status"));
@@ -56,7 +56,7 @@ public sealed class JsRuntimePageTests
         var js = new FakeJsRuntime();
         var page = new JsRuntimePage(js);
 
-        await InvokeOnRenderedAsync(page, firstRender: false);
+        await InvokeOnRenderedAsync(page, false);
 
         // No call should have been made to sessionStorage.getItem.
         Assert.Equal(0, js.CallCount("sessionStorage.getItem"));
@@ -70,7 +70,7 @@ public sealed class JsRuntimePageTests
         js.SetException("sessionStorage.getItem", new InvalidOperationException("boom"));
         var page = new JsRuntimePage(js);
 
-        await InvokeOnRenderedAsync(page, firstRender: true);
+        await InvokeOnRenderedAsync(page, true);
 
         var status = GetField<string?>(page, "_status");
         Assert.NotNull(status);
@@ -173,7 +173,7 @@ public sealed class JsRuntimePageTests
     public void RouteAttribute_RegisteredAt_Jsruntime()
     {
         var attr = typeof(JsRuntimePage)
-            .GetCustomAttribute<Rask.Core.Routing.RouteAttribute>();
+            .GetCustomAttribute<RouteAttribute>();
         Assert.NotNull(attr);
         Assert.Equal("jsruntime", attr!.Template);
     }

--- a/tests/Rask.Example.Shared.Tests/App/AppTests.cs
+++ b/tests/Rask.Example.Shared.Tests/App/AppTests.cs
@@ -1,4 +1,3 @@
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Tests.Infrastructure;
 
@@ -9,7 +8,7 @@ public sealed class AppTests
     [Fact]
     public void LiveRender_StartsWithDoctype_AndHtmlEnLang()
     {
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(TestServices.Default());
+        var html = new Shared.App().RenderAsLiveRoot(TestServices.Default());
 
         Assert.StartsWith("<!DOCTYPE html>", html);
         Assert.Contains("<html lang=\"en\">", html);
@@ -19,7 +18,7 @@ public sealed class AppTests
     [Fact]
     public void LiveRender_EmitsBootstrapLinksAndMeta_InHead()
     {
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(TestServices.Default());
+        var html = new Shared.App().RenderAsLiveRoot(TestServices.Default());
 
         // Title body content is HTML-encoded: literal "—" → "&#x2014;". HomePage
         // overrides App's fallback title via the framework's singleton-key dedupe.
@@ -35,7 +34,7 @@ public sealed class AppTests
     [Fact]
     public void LiveRender_EmitsRouterAndRuntimeScriptSlot_InBody()
     {
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(TestServices.Default());
+        var html = new Shared.App().RenderAsLiveRoot(TestServices.Default());
 
         // Router rendered the matched chain — ShowcaseLayout contributes the navbar.
         Assert.Contains("navbar-brand", html);
@@ -47,7 +46,7 @@ public sealed class AppTests
     public void LiveRender_UnmatchedRoute_StillProducesHtml()
     {
         var routeState = new RouteState { Path = "/__no_such_path" };
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = new Shared.App().RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.StartsWith("<!DOCTYPE html>", html);
         Assert.Contains("<title ", html);

--- a/tests/Rask.Example.Shared.Tests/Demos/AuthorizeDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/AuthorizeDemoTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Example.Shared.Demos;
 

--- a/tests/Rask.Example.Shared.Tests/Demos/BindingDemosTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/BindingDemosTests.cs
@@ -1,5 +1,5 @@
+using System.Collections;
 using System.Reflection;
-using Rask.Core;
 using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
@@ -153,18 +153,18 @@ public sealed class BindingDemosTests
         var live = liveField?.GetValue(parent);
         if (live is null)
         {
-            return null;   // component never rendered children -> _live still null
+            return null; // component never rendered children -> _live still null
         }
 
         var childrenField = live.GetType().GetField("Children",
             BindingFlags.Instance | BindingFlags.Public);
-        var children = childrenField?.GetValue(live) as System.Collections.IDictionary;
+        var children = childrenField?.GetValue(live) as IDictionary;
         if (children is null)
         {
             return null;
         }
 
-        foreach (System.Collections.DictionaryEntry kv in children)
+        foreach (DictionaryEntry kv in children)
         {
             if (kv.Value is T match)
             {

--- a/tests/Rask.Example.Shared.Tests/Demos/CancellationProbeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/CancellationProbeTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core;
-using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -12,7 +10,7 @@ public sealed class CancellationProbeTests
     {
         var log = new LifecycleLog();
         var host = new LiveHost(
-            () => CancellationProbe(Log: log.Add, InstanceId: 1),
+            () => CancellationProbe(log.Add, 1),
             TestServices.Default());
 
         host.RenderAsLiveRoot();
@@ -31,7 +29,7 @@ public sealed class CancellationProbeTests
     {
         var log = new LifecycleLog();
         var host = new LiveHost(
-            () => CancellationProbe(Log: log.Add, InstanceId: 9),
+            () => CancellationProbe(log.Add, 9),
             TestServices.Default());
 
         host.RenderAsLiveRoot();

--- a/tests/Rask.Example.Shared.Tests/Demos/CodeSampleTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/CodeSampleTests.cs
@@ -1,4 +1,3 @@
-using Rask.Core;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -12,8 +11,8 @@ public sealed class CodeSampleTests
         var js = new FakeJsRuntime();
         var host = new LiveHost(
             () => CodeSample(
-                Source: "var x = 1;",
-                Title: "Sample title",
+                "var x = 1;",
+                "Sample title",
                 Notes: "A note",
                 Result: Div()["the result"]),
             TestServices.Default(js: js));
@@ -35,7 +34,7 @@ public sealed class CodeSampleTests
     {
         var js = new FakeJsRuntime();
         var host = new LiveHost(
-            () => CodeSample(Source: "code"),
+            () => CodeSample("code"),
             TestServices.Default(js: js));
 
         var html = host.RenderAsLiveRoot();
@@ -52,7 +51,7 @@ public sealed class CodeSampleTests
         // rendered HTML); there is no longer any highlight.js <link>/<script> in <head>.
         // HomePage's CodeSample source contains C# string literals, so its tokenized
         // output carries a <span class="string">.
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(TestServices.Default());
+        var html = new Shared.App().RenderAsLiveRoot(TestServices.Default());
         Assert.Contains("class=\"string\"", html);
         Assert.DoesNotContain("/lib/highlightjs/", html);
     }

--- a/tests/Rask.Example.Shared.Tests/Demos/DisposableTimerProbeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/DisposableTimerProbeTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core;
-using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -12,7 +10,7 @@ public sealed class DisposableTimerProbeTests
     {
         var log = new LifecycleLog();
         var host = new LiveHost(
-            () => DisposableTimerProbe(Log: log.Add, InstanceId: 1),
+            () => DisposableTimerProbe(log.Add, 1),
             TestServices.Default());
 
         host.RenderAsLiveRoot();
@@ -30,7 +28,7 @@ public sealed class DisposableTimerProbeTests
     {
         var log = new LifecycleLog();
         var host = new LiveHost(
-            () => UnmountTimerProbe(Log: log.Add, InstanceId: 2),
+            () => UnmountTimerProbe(log.Add, 2),
             TestServices.Default());
 
         host.RenderAsLiveRoot();
@@ -48,7 +46,7 @@ public sealed class DisposableTimerProbeTests
     {
         var log = new LifecycleLog();
         var host = new LiveHost(
-            () => DisposableAsyncProbe(Log: log.Add, InstanceId: 3),
+            () => DisposableAsyncProbe(log.Add, 3),
             TestServices.Default());
 
         host.RenderAsLiveRoot();

--- a/tests/Rask.Example.Shared.Tests/Demos/LifecycleProbeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/LifecycleProbeTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core;
-using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -14,7 +12,8 @@ public sealed class LifecycleProbeTests
 
         host.RenderAsLiveRoot();
         // OnMountAsync awaits 450ms; allow time for the full sequence.
-        await WaitFor.True(() => RenderedHtml(host).Contains("OnMountAsync (after 450ms await)"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => RenderedHtml(host).Contains("OnMountAsync (after 450ms await)"),
+            TimeSpan.FromSeconds(2));
 
         var html = host.RenderAsLiveRoot();
         Assert.Contains("OnMount", html);
@@ -30,7 +29,7 @@ public sealed class LifecycleProbeTests
         var log = new LifecycleLog();
         var instanceId = 7;
         var host = new LiveHost(
-            () => LifecycleCycleProbe(Log: log.Add, InstanceId: instanceId),
+            () => LifecycleCycleProbe(log.Add, instanceId),
             TestServices.Default());
 
         host.RenderAsLiveRoot();
@@ -44,7 +43,7 @@ public sealed class LifecycleProbeTests
     {
         var log = new LifecycleLog();
         var host = new LiveHost(
-            () => LifecycleCycleProbe(Log: log.Add, InstanceId: 1),
+            () => LifecycleCycleProbe(log.Add, 1),
             TestServices.Default());
 
         host.RenderAsLiveRoot();

--- a/tests/Rask.Example.Shared.Tests/Demos/LiveTickerTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/LiveTickerTests.cs
@@ -1,7 +1,5 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
-using Rask.Core;
-using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -19,7 +17,7 @@ public sealed class LiveTickerTests
     public async Task OnMountAsync_PopulatesHistoryFromSyntheticFeed()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, interval: 30);
+        var host = BuildHost(symbol, 30);
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
@@ -38,7 +36,7 @@ public sealed class LiveTickerTests
     public async Task OnPropsChanged_LogsSymbolSwitch()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, interval: 30);
+        var host = BuildHost(symbol, 30);
 
         host.RenderAsLiveRoot();
         await WaitFor.True(() => host.Log.Contains("OnPropsChangedAsync"), TimeSpan.FromSeconds(2));
@@ -55,7 +53,7 @@ public sealed class LiveTickerTests
     public async Task OnUnmount_FiresOnRemovalFromTree()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, interval: 30);
+        var host = BuildHost(symbol, 30);
 
         host.RenderAsLiveRoot();
         await WaitFor.True(() => host.Log.Contains("OnMountAsync"), TimeSpan.FromSeconds(2));
@@ -75,7 +73,7 @@ public sealed class LiveTickerTests
     public async Task PollLoop_StopsAfterUnmount()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, interval: 30);
+        var host = BuildHost(symbol, 30);
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
@@ -100,7 +98,7 @@ public sealed class LiveTickerTests
     {
         var symbol = new Box<string>("BTC");
         var counter = 0;
-        var host = BuildHost(symbol, interval: 1, priceSource: _ => 10_000m + counter++);
+        var host = BuildHost(symbol, 1, _ => 10_000m + counter++);
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
@@ -130,7 +128,7 @@ public sealed class LiveTickerTests
         // Large interval ⇒ steady-state polling is gated; the symbol switch is what
         // drives the next poll (via the wake). The first BTC poll parks in the 50 ms
         // simulated-latency Task.Delay while we flip the symbol underneath it.
-        var host = BuildHost(symbol, interval: 5000);
+        var host = BuildHost(symbol, 5000);
 
         host.RenderAsLiveRoot();
         // The flip lands within microseconds — well inside the 50 ms in-flight window,
@@ -156,7 +154,7 @@ public sealed class LiveTickerTests
         var symbol = new Box<string>("BTC");
         // Large interval: without the wake the next poll wouldn't run for 5 s. The
         // assertion is that switching symbols polls the new asset well inside that.
-        var host = BuildHost(symbol, interval: 5000);
+        var host = BuildHost(symbol, 5000);
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
@@ -184,8 +182,8 @@ public sealed class LiveTickerTests
     {
         var symbol = new Box<string>("BTC");
         var host = BuildHost(
-            symbol, interval: 30,
-            priceSource: _ => throw new InvalidOperationException("feed offline"));
+            symbol, 30,
+            _ => throw new InvalidOperationException("feed offline"));
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
@@ -214,32 +212,13 @@ public sealed class LiveTickerTests
         Assert.Equal(2, Regex.Matches(html, "ticker-chart-container").Count);
     }
 
-    // Full-shell root hosting two LiveTickers so the head pipeline runs (same
-    // RenderAsLiveRoot path App uses). [SkipFactory] keeps the generator from
-    // emitting a colliding Generated.TwoTickerRoot() factory.
-    [SkipFactory]
-    private sealed class TwoTickerRoot(Action<string> log) : Component
-    {
-        protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head(),
-                Body()[
-                    LiveTicker(Symbol: "BTC", Interval: 5000, Log: log),
-                    LiveTicker(Symbol: "ETH", Interval: 5000, Log: log)
-                ]
-            ]
-        ];
-    }
-
     private static LiveHost BuildHost(
         Box<string> symbol, int interval, Func<string, decimal>? priceSource = null)
     {
         LiveHost? host = null;
         host = new LiveHost(
             () => LiveTicker(
-                Symbol: symbol.Value, Interval: interval, Log: host!.Log.Add, PriceSource: priceSource),
+                symbol.Value, interval, host!.Log.Add, priceSource),
             LiveHost.Services());
         return host;
     }
@@ -258,6 +237,25 @@ public sealed class LiveTickerTests
         return m.Success
             ? decimal.Parse(m.Groups[1].Value, NumberStyles.Number, CultureInfo.InvariantCulture)
             : 0m;
+    }
+
+    // Full-shell root hosting two LiveTickers so the head pipeline runs (same
+    // RenderAsLiveRoot path App uses). [SkipFactory] keeps the generator from
+    // emitting a colliding Generated.TwoTickerRoot() factory.
+    [SkipFactory]
+    private sealed class TwoTickerRoot(Action<string> log) : Component
+    {
+        protected override RenderResult Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[
+                    LiveTicker("BTC", 5000, log),
+                    LiveTicker("ETH", 5000, log)
+                ]
+            ]
+        ];
     }
 
     private sealed class Box<T>(T initial)

--- a/tests/Rask.Example.Shared.Tests/Demos/NestedFormDemosTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/NestedFormDemosTests.cs
@@ -1,6 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using FluentValidation;
-using Rask.Core;
 using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
@@ -136,11 +134,11 @@ public sealed class NestedFormDemosTests
         Assert.Contains(result.Errors, e => e.PropertyName == "City");
     }
 
-    private static List<System.ComponentModel.DataAnnotations.ValidationResult> Validate(object instance)
+    private static List<ValidationResult> Validate(object instance)
     {
         var ctx = new ValidationContext(instance);
-        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
-        Validator.TryValidateObject(instance, ctx, results, validateAllProperties: true);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(instance, ctx, results, true);
         return results;
     }
 }

--- a/tests/Rask.Example.Shared.Tests/Demos/PageHeaderTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/PageHeaderTests.cs
@@ -1,4 +1,3 @@
-using Rask.Core;
 using Rask.Example.Shared.Demos;
 
 namespace Rask.Example.Shared.Tests.Demos;

--- a/tests/Rask.Example.Shared.Tests/Demos/ScopedDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/ScopedDemoTests.cs
@@ -1,5 +1,3 @@
-using Rask.Core;
-using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 

--- a/tests/Rask.Example.Shared.Tests/Demos/SparklineTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/SparklineTests.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Text.RegularExpressions;
-using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -66,7 +65,7 @@ public sealed class SparklineTests
     }
 
     private static string Render(params double[] values) =>
-        new LiveHost(() => Sparkline(Values: values), LiveHost.Services()).RenderAsLiveRoot();
+        new LiveHost(() => Sparkline(values), LiveHost.Services()).RenderAsLiveRoot();
 
     private static (double X, double Y)[] PolylinePoints(string html)
     {

--- a/tests/Rask.Example.Shared.Tests/Demos/ValidationDemosTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/ValidationDemosTests.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
-using FluentValidation;
-using Rask.Core;
+using System.Diagnostics;
+using System.Reflection;
 using Rask.Core.Forms;
 using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -172,10 +172,7 @@ public sealed class ValidationDemosTests
     }
 
     [Fact]
-    public void LicenseModel_ValidCode_NoErrors()
-    {
-        Assert.Empty(Validate(new LicenseModel { Code = "RAS-001" }));
-    }
+    public void LicenseModel_ValidCode_NoErrors() => Assert.Empty(Validate(new LicenseModel { Code = "RAS-001" }));
 
     [Fact]
     public void TripModel_DefaultDates_IsEdgeCase_ReturnEqualsDepart()
@@ -191,14 +188,12 @@ public sealed class ValidationDemosTests
     {
         var m = new BookingModel
         {
-            Name = "X",
-            Departure = new DateOnly(2020, 1, 1),
-            Arrival = new DateOnly(2020, 1, 5)
+            Name = "X", Departure = new DateOnly(2020, 1, 1), Arrival = new DateOnly(2020, 1, 5)
         };
         var ctx = new ValidationContext(m);
         var results = m.Validate(ctx).ToList();
         Assert.Contains(results, r => r.MemberNames.Contains("Departure")
-            && r.ErrorMessage!.Contains("past"));
+                                      && r.ErrorMessage!.Contains("past"));
     }
 
     [Fact]
@@ -206,14 +201,12 @@ public sealed class ValidationDemosTests
     {
         var m = new BookingModel
         {
-            Name = "X",
-            Departure = new DateOnly(2026, 8, 1),
-            Arrival = new DateOnly(2026, 8, 1)
+            Name = "X", Departure = new DateOnly(2026, 8, 1), Arrival = new DateOnly(2026, 8, 1)
         };
         var ctx = new ValidationContext(m);
         var results = m.Validate(ctx).ToList();
         Assert.Contains(results, r => !r.MemberNames.Any()
-            && r.ErrorMessage!.Contains("after departure"));
+                                      && r.ErrorMessage!.Contains("after departure"));
     }
 
     [Fact]
@@ -221,9 +214,7 @@ public sealed class ValidationDemosTests
     {
         var errors = Validate(new CustomAttributeModel
         {
-            Username = "pat",
-            Password = "short",
-            ConfirmPassword = "short"
+            Username = "pat", Password = "short", ConfirmPassword = "short"
         });
         Assert.Contains(errors, e => e.MemberNames.Contains("Password"));
     }
@@ -233,9 +224,7 @@ public sealed class ValidationDemosTests
     {
         var errors = Validate(new CustomAttributeModel
         {
-            Username = "pat",
-            Password = "Pass1word",
-            ConfirmPassword = "DIFFERENT"
+            Username = "pat", Password = "Pass1word", ConfirmPassword = "DIFFERENT"
         });
         Assert.Contains(errors, e => e.MemberNames.Contains("ConfirmPassword"));
     }
@@ -245,9 +234,7 @@ public sealed class ValidationDemosTests
     {
         var errors = Validate(new CustomAttributeModel
         {
-            Username = "pat",
-            Password = "Pass1word",
-            ConfirmPassword = "Pass1word"
+            Username = "pat", Password = "Pass1word", ConfirmPassword = "Pass1word"
         });
         Assert.Empty(errors);
     }
@@ -443,7 +430,7 @@ public sealed class ValidationDemosTests
         var v = new UniqueUsernameValidator();
         var model = new SignupModel { Username = "" };
         var ctx = new EditContext(model);
-        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var sw = Stopwatch.StartNew();
         await v.ValidateAsync(ctx, CancellationToken.None);
         sw.Stop();
         Assert.True(sw.ElapsedMilliseconds < 200,
@@ -455,8 +442,8 @@ public sealed class ValidationDemosTests
     {
         var v = new UniqueUsernameValidator();
         var ctx = new EditContext(new SignupModel { Username = "explode" });
-        await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await v.ValidateAsync(ctx, CancellationToken.None));
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await v.ValidateAsync(ctx, CancellationToken.None));
     }
 
     [Fact]
@@ -475,7 +462,7 @@ public sealed class ValidationDemosTests
     {
         var v = new SlowTitleValidator();
         var ctx = new EditContext(new TaskModel { Title = "" });
-        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var sw = Stopwatch.StartNew();
         await v.ValidateAsync(ctx, CancellationToken.None);
         sw.Stop();
         Assert.True(sw.ElapsedMilliseconds < 200);
@@ -487,14 +474,14 @@ public sealed class ValidationDemosTests
     {
         var ctx = new ValidationContext(instance);
         var results = new List<ValidationResult>();
-        Validator.TryValidateObject(instance, ctx, results, validateAllProperties: true);
+        Validator.TryValidateObject(instance, ctx, results, true);
         return results;
     }
 
     private static ValidationResult? InvokeIsValid(ValidationAttribute attr, object? value, ValidationContext ctx)
     {
         var mi = typeof(ValidationAttribute).GetMethod("IsValid",
-            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+            BindingFlags.Instance | BindingFlags.NonPublic,
             null, [typeof(object), typeof(ValidationContext)], null);
         return (ValidationResult?)mi!.Invoke(attr, [value, ctx]);
     }

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/FakeHttp.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/FakeHttp.cs
@@ -6,8 +6,8 @@ namespace Rask.Example.Shared.Tests.Infrastructure;
 
 internal sealed class FakeHttp : HttpMessageHandler
 {
-    public Func<HttpRequestMessage, Task<HttpResponseMessage>>? Handler { get; set; }
     public int RequestCount;
+    public Func<HttpRequestMessage, Task<HttpResponseMessage>>? Handler { get; set; }
     public List<HttpRequestMessage> Requests { get; } = [];
 
     public static (HttpClient Client, FakeHttp Handler) WithPrices(params (string Asset, decimal Price)[] prices)

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/FakeJsRuntime.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/FakeJsRuntime.cs
@@ -6,17 +6,8 @@ namespace Rask.Example.Shared.Tests.Infrastructure;
 internal sealed class FakeJsRuntime : IJSRuntime
 {
     private readonly ConcurrentBag<(string Identifier, object?[]? Args)> _calls = new();
-    private readonly Dictionary<string, object?> _responses = new();
     private readonly Dictionary<string, Exception> _exceptions = new();
-
-    public void SetResponse(string identifier, object? response) => _responses[identifier] = response;
-
-    public void SetException(string identifier, Exception ex) => _exceptions[identifier] = ex;
-
-    public IReadOnlyList<object?[]?> GetCalls(string identifier) =>
-        _calls.Where(c => c.Identifier == identifier).Select(c => c.Args).ToArray();
-
-    public int CallCount(string identifier) => _calls.Count(c => c.Identifier == identifier);
+    private readonly Dictionary<string, object?> _responses = new();
 
     public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
     {
@@ -40,4 +31,13 @@ internal sealed class FakeJsRuntime : IJSRuntime
     public ValueTask<TValue> InvokeAsync<TValue>(
         string identifier, CancellationToken cancellationToken, object?[]? args) =>
         InvokeAsync<TValue>(identifier, args);
+
+    public void SetResponse(string identifier, object? response) => _responses[identifier] = response;
+
+    public void SetException(string identifier, Exception ex) => _exceptions[identifier] = ex;
+
+    public IReadOnlyList<object?[]?> GetCalls(string identifier) =>
+        _calls.Where(c => c.Identifier == identifier).Select(c => c.Args).ToArray();
+
+    public int CallCount(string identifier) => _calls.Count(c => c.Identifier == identifier);
 }

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/LifecycleLog.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/LifecycleLog.cs
@@ -7,6 +7,17 @@ internal sealed class LifecycleLog
 {
     private readonly List<string> _entries = [];
 
+    public int Count
+    {
+        get
+        {
+            lock (_entries)
+            {
+                return _entries.Count;
+            }
+        }
+    }
+
     public void Add(string entry)
     {
         lock (_entries)
@@ -36,17 +47,6 @@ internal sealed class LifecycleLog
             }
 
             return false;
-        }
-    }
-
-    public int Count
-    {
-        get
-        {
-            lock (_entries)
-            {
-                return _entries.Count;
-            }
         }
     }
 }

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/LiveHost.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/LiveHost.cs
@@ -1,6 +1,5 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop;
-using Rask.Core;
 
 namespace Rask.Example.Shared.Tests.Infrastructure;
 
@@ -37,7 +36,7 @@ internal sealed class LiveHost : Component
     internal new string RenderAsLiveRoot() => base.RenderAsLiveRoot(_services);
 
     protected override RenderResult Render() =>
-        Mounted ? _factory() : (Component)Fragment();
+        Mounted ? _factory() : Fragment();
 
     public static IServiceProvider Services(params (Type Service, object Instance)[] singletons)
     {

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/RecordingHandle.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/RecordingHandle.cs
@@ -4,8 +4,8 @@ namespace Rask.Example.Shared.Tests.Infrastructure;
 
 internal sealed class RecordingHandle : IRenderHandle
 {
-    public int RequestRenderCount;
     public int RequestPublishRenderCount;
+    public int RequestRenderCount;
 
     public Task RequestRenderAsync()
     {

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/TestServices.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/TestServices.cs
@@ -26,8 +26,8 @@ internal static class TestServices
 
         sc.AddSingleton(http ?? new HttpClient { BaseAddress = new Uri("https://example.test/") });
         sc.AddSingleton<IJSRuntime>(js ?? new FakeJsRuntime());
-        sc.AddSingleton<IDownloadSink>(downloadSink ?? new CapturingDownloadSink());
-        sc.AddSingleton<IBannedWordService>(bannedWords ?? new BannedWordService());
+        sc.AddSingleton(downloadSink ?? new CapturingDownloadSink());
+        sc.AddSingleton(bannedWords ?? new BannedWordService());
 
         return sc.BuildServiceProvider();
     }

--- a/tests/Rask.Example.Shared.Tests/Layout/PathDisplayTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Layout/PathDisplayTests.cs
@@ -1,4 +1,3 @@
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Layout;
 using Rask.Example.Shared.Tests.Infrastructure;

--- a/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
@@ -1,5 +1,5 @@
 using System.Reflection;
-using Rask.Core;
+using System.Text.RegularExpressions;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Layout;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -15,7 +15,7 @@ public sealed class ShowcaseLayoutTests
     public void RenderThroughApp_EmitsNavbarAndAside()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("navbar navbar-dark bg-dark", html);
@@ -28,7 +28,7 @@ public sealed class ShowcaseLayoutTests
     public void RenderThroughApp_GroupsLinks_UnderGroupHeaders()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         // BuildGroups emits an H6 per group label before the buttons in that group.
@@ -42,7 +42,7 @@ public sealed class ShowcaseLayoutTests
     public void RenderThroughApp_RootPath_MarksAtLeastOneNavItemActive()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("nav-item-btn-active", html);
@@ -61,8 +61,8 @@ public sealed class ShowcaseLayoutTests
 
     [Theory]
     [InlineData("/tags", "/tags", true)]
-    [InlineData("/tags/", "/tags", true)]      // trailing slash trimmed
-    [InlineData("/TAGS", "/tags", true)]       // case-insensitive
+    [InlineData("/tags/", "/tags", true)] // trailing slash trimmed
+    [InlineData("/TAGS", "/tags", true)] // case-insensitive
     [InlineData("/binding", "/tags", false)]
     public void IsActive_NonRootHref_MatchesPathIgnoringCaseAndTrailingSlash(string path, string href, bool expected)
     {
@@ -84,7 +84,7 @@ public sealed class ShowcaseLayoutTests
     [InlineData("/realtime/BTC/", "/realtime/BTC", "/realtime", true)]
     [InlineData("/users/42", "/users/42", "/users", true)]
     [InlineData("/users/99", "/users/42", "/users", true)]
-    [InlineData("/realtimes/BTC", "/realtime/BTC", "/realtime", false)]    // prefix must be a full segment
+    [InlineData("/realtimes/BTC", "/realtime/BTC", "/realtime", false)] // prefix must be a full segment
     [InlineData("/lifecycle", "/realtime/BTC", "/realtime", false)]
     public void IsActive_HrefWithMatchPrefix_TrueForAnyPathUnderPrefix(
         string path, string href, string? matchPrefix, bool expected)
@@ -101,7 +101,7 @@ public sealed class ShowcaseLayoutTests
         // from BTC inside the LiveTickerPage), the sidebar's "Live ticker" item
         // must still render with the active class.
         var routeState = new RouteState { Path = "/realtime/ETH" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Matches("nav-item-btn-active[^>]*>[^<]*<i class=\"bi bi-graph-up-arrow",
@@ -131,7 +131,7 @@ public sealed class ShowcaseLayoutTests
         // With BypassRenderCache=true the layout always re-rendered (working but
         // wasteful); with RouteState.Changed subscription it re-renders just on nav.
         var routeState = new RouteState { Path = "/" };
-        var app = new Rask.Example.Shared.App();
+        var app = new Shared.App();
         var services = TestServices.Default(routeState: routeState);
 
         var htmlAtRoot = app.RenderAsLiveRoot(services);
@@ -147,7 +147,7 @@ public sealed class ShowcaseLayoutTests
     }
 
     private static string CollapseWhitespace(string s) =>
-        System.Text.RegularExpressions.Regex.Replace(s, @"\s+", " ");
+        Regex.Replace(s, @"\s+", " ");
 
     private static bool InvokePrivateIsActive(ShowcaseLayout layout, string href, string? matchPrefix = null)
     {

--- a/tests/Rask.Example.Shared.Tests/Pages/BoomPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/BoomPageTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -11,7 +10,7 @@ public sealed class BoomPageTests
     [Fact]
     public void Render_AtRest_EmitsAllThreeHostDivs()
     {
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(
+        var html = new Shared.App().RenderAsLiveRoot(
             TestServices.Default(routeState: new RouteState { Path = "/boom" }));
 
         Assert.Contains("boom-handler-host", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/DownloadPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/DownloadPageTests.cs
@@ -12,7 +12,7 @@ public sealed class DownloadPageTests
     public void Render_EmitsDownloadButton_AndZeroCount()
     {
         var routeState = new RouteState { Path = "/download" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("download-report", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/HomePageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/HomePageTests.cs
@@ -1,6 +1,4 @@
-using Rask.Core;
 using Rask.Core.Routing;
-using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Shared.Tests.Pages;
@@ -11,7 +9,7 @@ public sealed class HomePageTests
     public void Render_AtRoot_EmitsHeroAndAllFeatureCards()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("The Rask framework", html);
@@ -34,7 +32,7 @@ public sealed class HomePageTests
     public void Render_EmitsHelloWorldSnippet()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("Hello, world!", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
@@ -1,8 +1,6 @@
 using System.Net;
 using System.Text;
-using Rask.Core;
 using Rask.Core.Routing;
-using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Shared.Tests.Pages;
@@ -16,14 +14,14 @@ public sealed class HttpPageTests
             "{\"id\":1,\"title\":\"hello\",\"body\":\"the body text\"}";
         var (http, fakeHttp) = FakeHttp.WithJson(body);
         var routeState = new RouteState { Path = "/http" };
-        var services = TestServices.Default(http: http, routeState: routeState);
+        var services = TestServices.Default(http, routeState: routeState);
 
         // Render via App so OnMountAsync fires. Wait for at least one fetch to complete.
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        var html = new Shared.App().RenderAsLiveRoot(services);
         await WaitFor.True(() => fakeHttp.RequestCount >= 1, TimeSpan.FromSeconds(2));
         // Re-render so the post is visible.
         await Task.Delay(50);
-        html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        html = new Shared.App().RenderAsLiveRoot(services);
 
         Assert.True(fakeHttp.RequestCount >= 1);
         // Verify the fetch went to the expected relative path.
@@ -36,14 +34,14 @@ public sealed class HttpPageTests
         // A genuine HTTP-status failure carries a StatusCode and must still surface the
         // error banner (the demo's error handling is a real feature).
         var (http, _) = FakeHttp.Throwing(
-            new HttpRequestException("boom", inner: null, statusCode: HttpStatusCode.InternalServerError));
+            new HttpRequestException("boom", null, HttpStatusCode.InternalServerError));
         var routeState = new RouteState { Path = "/http" };
-        var services = TestServices.Default(http: http, routeState: routeState);
+        var services = TestServices.Default(http, routeState: routeState);
 
-        new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        new Shared.App().RenderAsLiveRoot(services);
         // Loading shows initially; after the fetch faults the error banner should appear on next render.
         await Task.Delay(120);
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        var html = new Shared.App().RenderAsLiveRoot(services);
 
         Assert.Contains("alert-danger", html);
     }
@@ -69,11 +67,11 @@ public sealed class HttpPageTests
         };
         var http = new HttpClient(handler) { BaseAddress = new Uri("https://test.local/") };
         var routeState = new RouteState { Path = "/http" };
-        var services = TestServices.Default(http: http, routeState: routeState);
+        var services = TestServices.Default(http, routeState: routeState);
 
         // Re-render the SAME app instance: the retried fetch resolves on a continuation after
         // the first render returns, and only the same HttpPage instance retains the result.
-        var app = new Rask.Example.Shared.App();
+        var app = new Shared.App();
         app.RenderAsLiveRoot(services);
         await WaitFor.True(() => handler.RequestCount >= 2, TimeSpan.FromSeconds(2));
         await Task.Delay(50);
@@ -91,11 +89,11 @@ public sealed class HttpPageTests
         // never leave the page spinning forever.
         var (http, handler) = FakeHttp.Throwing(new HttpRequestException("TypeError: Load failed"));
         var routeState = new RouteState { Path = "/http" };
-        var services = TestServices.Default(http: http, routeState: routeState);
+        var services = TestServices.Default(http, routeState: routeState);
 
         // Re-render the SAME app instance so the retry loop's terminal error (set on a
         // continuation) is observed; the loop makes MaxTransientRetries + 1 attempts then stops.
-        var app = new Rask.Example.Shared.App();
+        var app = new Shared.App();
         app.RenderAsLiveRoot(services);
         await WaitFor.True(() => handler.RequestCount > 3, TimeSpan.FromSeconds(3));
         await Task.Delay(50);
@@ -113,11 +111,11 @@ public sealed class HttpPageTests
     {
         var (http, _) = FakeHttp.WithStatus(HttpStatusCode.NotFound);
         var routeState = new RouteState { Path = "/http" };
-        var services = TestServices.Default(http: http, routeState: routeState);
+        var services = TestServices.Default(http, routeState: routeState);
 
-        var html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        var html = new Shared.App().RenderAsLiveRoot(services);
         await Task.Delay(120);
-        html = new Rask.Example.Shared.App().RenderAsLiveRoot(services);
+        html = new Shared.App().RenderAsLiveRoot(services);
         Assert.Contains("HttpClient", html);
     }
 }

--- a/tests/Rask.Example.Shared.Tests/Pages/KeyedListsPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/KeyedListsPageTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -12,7 +11,7 @@ public sealed class KeyedListsPageTests
     public void Route_KeyedLists_RendersSeededRows()
     {
         var routeState = new RouteState { Path = "/keyed-lists" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("Apple", html);
@@ -25,7 +24,7 @@ public sealed class KeyedListsPageTests
     [Fact]
     public void KeysOn_ByDefault_EmitsDataRaskKeyPerRow()
     {
-        var html = RenderRows(useKeys: true);
+        var html = RenderRows(true);
 
         Assert.Contains("data-rask-key=\"1\"", html);
         Assert.Contains("data-rask-key=\"5\"", html);
@@ -35,7 +34,7 @@ public sealed class KeyedListsPageTests
     [Fact]
     public void KeysOff_OmitsDataRaskKey_ButStillRendersRows()
     {
-        var html = RenderRows(useKeys: false);
+        var html = RenderRows(false);
 
         Assert.DoesNotContain("data-rask-key", html);
         Assert.Contains("Apple", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/LifecyclePageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/LifecyclePageTests.cs
@@ -1,5 +1,4 @@
 using System.Reflection;
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -12,7 +11,7 @@ public sealed class LifecyclePageTests
     public void Render_AtRest_ShowsProbeNotMounted_AndEmptyLog()
     {
         var routeState = new RouteState { Path = "/lifecycle" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("Probe not mounted.", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/LiveTickerPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/LiveTickerPageTests.cs
@@ -1,6 +1,4 @@
-using Rask.Core;
 using Rask.Core.Routing;
-using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Shared.Tests.Pages;
@@ -14,7 +12,7 @@ public sealed class LiveTickerPageTests
     public void RouteParam_Symbol_BindsFromUrl_AndRendersTitle(string path, string expectedSymbol)
     {
         var routeState = new RouteState { Path = path };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains($"{expectedSymbol} live ticker", html);
@@ -26,7 +24,7 @@ public sealed class LiveTickerPageTests
     public void Render_EmitsAllThreeSwitchButtons()
     {
         var routeState = new RouteState { Path = "/realtime/BTC" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("ticker-switch-BTC", html);
@@ -38,7 +36,7 @@ public sealed class LiveTickerPageTests
     public void Render_HookActivityCard_Present()
     {
         var routeState = new RouteState { Path = "/realtime/BTC" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         // The card may show the empty-hint OR an already-populated log depending on

--- a/tests/Rask.Example.Shared.Tests/Pages/NavigatorPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/NavigatorPageTests.cs
@@ -1,7 +1,5 @@
-using Rask.Core;
-using Rask.Core.Routing;
 using Microsoft.Extensions.Primitives;
-using Rask.Example.Shared.Pages;
+using Rask.Core.Routing;
 using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Shared.Tests.Pages;
@@ -12,7 +10,7 @@ public sealed class NavigatorPageTests
     public void Render_EmptyQuery_ShowsEmptyPlaceholder()
     {
         var routeState = new RouteState { Path = "/navigator" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
         Assert.Contains("(empty)", html);
     }
@@ -22,11 +20,10 @@ public sealed class NavigatorPageTests
     {
         var query = new QueryCollection(new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
         {
-            ["page"] = "2",
-            ["sort"] = "asc"
+            ["page"] = "2", ["sort"] = "asc"
         });
         var routeState = new RouteState { Path = "/navigator", Query = query };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
         Assert.Contains("page=2", html);
         Assert.Contains("sort=asc", html);
@@ -44,10 +41,9 @@ public sealed class NavigatorPageTests
     [Fact]
     public void RemoveQuery_FromHandler_DropsKey()
     {
-        var initial = new QueryCollection(new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
-        {
-            ["page"] = "2"
-        });
+        var initial =
+            new QueryCollection(
+                new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase) { ["page"] = "2" });
         var routeState = new RouteState { Path = "/navigator", Query = initial };
         var nav = new Navigator(routeState);
 
@@ -60,8 +56,7 @@ public sealed class NavigatorPageTests
     {
         var initial = new QueryCollection(new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase)
         {
-            ["a"] = "1",
-            ["b"] = "2"
+            ["a"] = "1", ["b"] = "2"
         });
         var routeState = new RouteState { Path = "/navigator", Query = initial };
         var nav = new Navigator(routeState);

--- a/tests/Rask.Example.Shared.Tests/Pages/NotFoundPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/NotFoundPageTests.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using Rask.Core.Routing;
+using Rask.Example.Shared.Layout;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
 
@@ -11,7 +12,7 @@ public sealed class NotFoundPageTests
     public void Render_ShowsRouteInBody()
     {
         var routeState = new RouteState { Path = "/__unknown" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("Page not found", html);
@@ -20,16 +21,14 @@ public sealed class NotFoundPageTests
     }
 
     [Fact]
-    public void NotFoundAttribute_AppliedToType()
-    {
+    public void NotFoundAttribute_AppliedToType() =>
         Assert.NotNull(typeof(NotFoundPage).GetCustomAttribute<NotFoundAttribute>());
-    }
 
     [Fact]
     public void HasParentRoute_ShowcaseLayout()
     {
         var parent = typeof(NotFoundPage).GetCustomAttribute<ParentRouteAttribute>();
         Assert.NotNull(parent);
-        Assert.Equal(typeof(Rask.Example.Shared.Layout.ShowcaseLayout), parent!.Parent);
+        Assert.Equal(typeof(ShowcaseLayout), parent!.Parent);
     }
 }

--- a/tests/Rask.Example.Shared.Tests/Pages/PageBaselineTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/PageBaselineTests.cs
@@ -1,6 +1,4 @@
 using System.Reflection;
-using Microsoft.Extensions.DependencyInjection;
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -39,7 +37,7 @@ public sealed class PageBaselineTests
     public void Page_RenderedAtRegisteredPath_EmitsTitleAndPageMarker(Type pageType, string path, string marker)
     {
         var routeState = new RouteState { Path = path };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.NotNull(pageType);
@@ -84,16 +82,14 @@ public sealed class PageBaselineTests
     }
 
     [Fact]
-    public void NotFoundPage_HasNotFoundAttribute()
-    {
+    public void NotFoundPage_HasNotFoundAttribute() =>
         Assert.True(typeof(NotFoundPage).GetCustomAttributes<NotFoundAttribute>().Any());
-    }
 
     [Fact]
     public void UnmatchedRoute_RendersNotFoundPage()
     {
         var routeState = new RouteState { Path = "/__no_such_route" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
         Assert.Contains("Page not found", html);
     }

--- a/tests/Rask.Example.Shared.Tests/Pages/TodosPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/TodosPageTests.cs
@@ -1,5 +1,5 @@
+using System.ComponentModel.DataAnnotations;
 using System.Reflection;
-using Rask.Core;
 using Rask.Core.Routing;
 using Rask.Example.Shared.Pages;
 using Rask.Example.Shared.Tests.Infrastructure;
@@ -12,7 +12,7 @@ public sealed class TodosPageTests
     public void Route_TodosList_RendersSeededItems()
     {
         var routeState = new RouteState { Path = "/todos" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("Read the Rask README", html);
@@ -24,7 +24,7 @@ public sealed class TodosPageTests
     public void Route_TodosNew_OpensDialogInAddMode()
     {
         var routeState = new RouteState { Path = "/todos/new" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains(">Add todo<", html);
@@ -165,10 +165,10 @@ public sealed class TodosPageTests
     public void TodoForm_EmptyTitle_FailsRequired()
     {
         var instance = new TodoForm();
-        var ctx = new System.ComponentModel.DataAnnotations.ValidationContext(instance);
-        var results = new List<System.ComponentModel.DataAnnotations.ValidationResult>();
-        System.ComponentModel.DataAnnotations.Validator.TryValidateObject(
-            instance, ctx, results, validateAllProperties: true);
+        var ctx = new ValidationContext(instance);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(
+            instance, ctx, results, true);
         Assert.NotEmpty(results);
     }
 

--- a/tests/Rask.Example.Shared.Tests/Pages/UploadPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/UploadPageTests.cs
@@ -12,7 +12,7 @@ public sealed class UploadPageTests
     public void Render_BeforeFileChosen_ShowsNoFileSelected()
     {
         var routeState = new RouteState { Path = "/upload" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains("upload-input", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/UserDetailPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/UserDetailPageTests.cs
@@ -1,7 +1,5 @@
-using Rask.Core;
-using Rask.Core.Routing;
 using Microsoft.Extensions.Primitives;
-using Rask.Example.Shared.Pages;
+using Rask.Core.Routing;
 using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Shared.Tests.Pages;
@@ -15,7 +13,7 @@ public sealed class UserDetailPageTests
     public void RouteParam_Id_BindsFromUrl(string path, string expectedId)
     {
         var routeState = new RouteState { Path = path };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         Assert.Contains($"User #{expectedId}", html);
@@ -32,7 +30,7 @@ public sealed class UserDetailPageTests
             ["tab"] = "profile"
         });
         var routeState = new RouteState { Path = "/users/42", Query = query };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
 
         // PageBinder runs through the Router and walks RouteState.Query, mapping
@@ -47,7 +45,7 @@ public sealed class UserDetailPageTests
     public void NoQueryParam_RendersNonePlaceholder()
     {
         var routeState = new RouteState { Path = "/users/42" };
-        var html = new Rask.Example.Shared.App()
+        var html = new Shared.App()
             .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
         Assert.Contains("(none)", html);
     }

--- a/tests/Rask.Example.Wasm.Host.Tests/Hosting/ProgramTests.cs
+++ b/tests/Rask.Example.Wasm.Host.Tests/Hosting/ProgramTests.cs
@@ -1,8 +1,6 @@
 using System.Net;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.AspNetCore.ResponseCompression;
+using Microsoft.Extensions.DependencyInjection;
 using Rask.Example.Wasm.Host.Tests.Infrastructure;
 using Rask.Wasm.Hosting;
 

--- a/tests/Rask.Example.Wasm.Host.Tests/Infrastructure/ExampleHostTestServer.cs
+++ b/tests/Rask.Example.Wasm.Host.Tests/Infrastructure/ExampleHostTestServer.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Wasm.Hosting;
 
 namespace Rask.Example.Wasm.Host.Tests.Infrastructure;

--- a/tests/Rask.Example.Wasm.Host.Tests/Infrastructure/FakeBundle.cs
+++ b/tests/Rask.Example.Wasm.Host.Tests/Infrastructure/FakeBundle.cs
@@ -25,6 +25,9 @@ internal sealed class FakeBundle : IDisposable
     public void Dispose()
     {
         try { Directory.Delete(Path, true); }
-        catch { /* best effort */ }
+        catch
+        {
+            /* best effort */
+        }
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/AuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/AuthExampleTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
@@ -33,9 +34,10 @@ public sealed class AuthExampleTests : IAsyncLifetime
     {
         // 1. Anonymous deep-link to a [Authorize] page → cookie challenge → lands on /login with ReturnUrl.
         await _page.GotoAsync("/members");
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login\?ReturnUrl=.*members"),
-            new() { Timeout = 30_000 });
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/login\?ReturnUrl=.*members"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
 
         // 2. Sign in as the admin user. The form submit drives the redeem handshake + reconnect.
         await _page.Locator("#username").FillAsync("root");
@@ -43,33 +45,37 @@ public sealed class AuthExampleTests : IAsyncLifetime
         await _page.Locator("#login-submit").ClickAsync();
 
         // 3. Handshake completes → returnUrl lands us back on the protected page, now authenticated.
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
-            new() { Timeout = 30_000 });
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 15_000 });
-        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 }); // role gate
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/members$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("root", new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
+        await Expect(_page.Locator("#admin-note"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 }); // role gate
 
         // 4. Sign out → handshake clears the cookie → back to /login.
         await _page.Locator("#logout").ClickAsync();
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
-            new() { Timeout = 30_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/login"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
 
         // 5. The protected page is gated again now that we're signed out.
         await _page.GotoAsync("/members");
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login\?ReturnUrl=.*members"),
-            new() { Timeout = 30_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/login\?ReturnUrl=.*members"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
     }
 
     [Fact]
     public async Task NonAdmin_DoesNotSeeAdminNote()
     {
         await _page.GotoAsync("/login?ReturnUrl=%2Fmembers");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
 
         await _page.Locator("#username").FillAsync("alice");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("alice", new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
         await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0); // alice is not an admin
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.HighlightJs.cs
+++ b/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.HighlightJs.cs
@@ -18,11 +18,8 @@ public abstract partial class ExampleSmokeTests
         // spans as soon as the page paints (highlighting is part of the server render).
         var pages = new[]
         {
-            ("/validation", "Validation"),
-            ("/routing", "Routing"),
-            ("/navigator", "Navigator"),
-            ("/nested-forms", "Complex models"),
-            ("/http", "HttpClient + DI")
+            ("/validation", "Validation"), ("/routing", "Routing"), ("/navigator", "Navigator"),
+            ("/nested-forms", "Complex models"), ("/http", "HttpClient + DI")
         };
 
         foreach (var (path, heading) in pages)
@@ -31,7 +28,7 @@ public abstract partial class ExampleSmokeTests
             await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync(heading,
                 new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
-            await WaitForHighlightedSpansAsync(timeoutMs: HighlightSettleTimeoutMs);
+            await WaitForHighlightedSpansAsync(HighlightSettleTimeoutMs);
             var total = await Page.Locator("pre code[class*='language-']").CountAsync();
             var highlighted = await Page.Locator("pre code[class*='language-']:has(span[class])").CountAsync();
             Assert.True(total > 0, $"{path}: no code blocks found. [{await HighlightDiagnosticsAsync()}]");
@@ -52,7 +49,7 @@ public abstract partial class ExampleSmokeTests
         await Page.GotoAsync("/validation");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await WaitForHighlightedSpansAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await WaitForHighlightedSpansAsync(HighlightSettleTimeoutMs);
 
         await Page.ReloadAsync();
 
@@ -61,7 +58,7 @@ public abstract partial class ExampleSmokeTests
 
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await WaitForHighlightedSpansAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await WaitForHighlightedSpansAsync(HighlightSettleTimeoutMs);
         var total = await Page.Locator("pre code[class*='language-']").CountAsync();
         var highlighted = await Page.Locator("pre code[class*='language-']:has(span[class])").CountAsync();
         Assert.True(total > 0,

--- a/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.JsRuntime.cs
+++ b/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.JsRuntime.cs
@@ -19,7 +19,7 @@ public abstract partial class ExampleSmokeTests
         await Page.EvaluateAsync(
             "() => { try { sessionStorage.removeItem('rask.jsruntime.demo'); } catch (_) {} }").ContinueWith(_ => { });
         await Page.GotoAsync("/jsruntime");
-        await Expect(Page.Locator("main h1.h3")).ToContainTextAsync("IJSRuntime",
+        await Expect(Page.Locator("main h1.h2")).ToContainTextAsync("IJSRuntime",
             new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
 
         await Page.Locator("#demo-input").FillAsync("after-reload");
@@ -28,7 +28,7 @@ public abstract partial class ExampleSmokeTests
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         await Page.ReloadAsync();
-        await Expect(Page.Locator("main h1.h3")).ToContainTextAsync("IJSRuntime",
+        await Expect(Page.Locator("main h1.h2")).ToContainTextAsync("IJSRuntime",
             new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
 
         await Expect(Page.Locator("#demo-status")).ToContainTextAsync("Read on mount: after-reload",

--- a/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.Todos.cs
+++ b/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.Todos.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
@@ -47,7 +48,7 @@ public abstract partial class ExampleSmokeTests
             new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
 
         await Page.GoBackAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/todos$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
         await Expect(Page.Locator("#todo-title")).Not.ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });

--- a/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/ExampleSmokeTests.cs
@@ -687,7 +687,7 @@ public abstract partial class ExampleSmokeTests : SharedSmokeTests
         Assert.NotNull(logText);
         // Exactly one "OnMount:" entry — multiple would mean the previous page's
         // log leaked into the new one (a leak the framework forbids).
-        var mountCount = System.Text.RegularExpressions.Regex.Matches(logText!, "OnMount: ").Count;
+        var mountCount = Regex.Matches(logText!, "OnMount: ").Count;
         Assert.Equal(1, mountCount);
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/StandaloneWasmAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/StandaloneWasmAppFixture.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
 
@@ -117,7 +118,7 @@ public sealed class StandaloneWasmAppFixture : IAsyncLifetime
         var assetUrl = $"{url}/_rask/a/{Path.GetFileName(jsFile)}";
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(5) };
         using var resp = await http.GetAsync(assetUrl, ct);
-        if (resp.StatusCode != System.Net.HttpStatusCode.OK)
+        if (resp.StatusCode != HttpStatusCode.OK)
         {
             throw new InvalidOperationException(
                 $"{ProjectRelativePath} served {assetUrl} with HTTP {(int)resp.StatusCode} (expected 200). " +

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/SubPathWasmAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/SubPathWasmAppFixture.cs
@@ -9,7 +9,7 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 ///     so the bundled <c>index.html</c> already has <c>&lt;base href="/sub/"&gt;</c>.
 ///     The host process reads <c>RASK_BUNDLE_DIR</c> + <c>RASK_PATHBASE</c> at startup
 ///     (see <c>Rask.Example.Wasm.Host/Program.cs</c>) and threads them into
-///     <c>UseRask&lt;App&gt;(bundlePath, pathBase)</c>. Exposes <see cref="BaseUrl"/>
+///     <c>UseRask&lt;App&gt;(bundlePath, pathBase)</c>. Exposes <see cref="BaseUrl" />
 ///     pointing at the prefix root (<c>http://localhost:{port}/sub</c>) so tests can
 ///     navigate via Playwright without rewriting every path.
 /// </summary>
@@ -80,6 +80,7 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
             throw new InvalidOperationException(
                 "Failed to rewrite <base href=\"/\"> in copied index.html — bundle layout drift?");
         }
+
         await File.WriteAllTextAsync(indexHtmlPath, rewritten);
 
         var psi = new ProcessStartInfo("dotnet")
@@ -87,11 +88,15 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
             ArgumentList =
             {
                 "run",
-                "--project", Path.Combine(repoRoot, "samples", "Rask.Example.Wasm.Host"),
+                "--project",
+                Path.Combine(repoRoot, "samples", "Rask.Example.Wasm.Host"),
                 "--no-launch-profile",
                 "--no-build",
-                "-c", Configuration,
-                "--", "--urls", OriginUrl
+                "-c",
+                Configuration,
+                "--",
+                "--urls",
+                OriginUrl
             },
             RedirectStandardOutput = true,
             RedirectStandardError = true,
@@ -104,7 +109,8 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
         psi.Environment["RASK_PATHBASE"] = PathBase;
 
         _process = Process.Start(psi)
-                   ?? throw new InvalidOperationException("Failed to start Rask.Example.Wasm.Host with sub-path env vars");
+                   ?? throw new InvalidOperationException(
+                       "Failed to start Rask.Example.Wasm.Host with sub-path env vars");
 
         _ = Task.Run(() => DrainAsync(_process.StandardOutput, _stdout));
         _ = Task.Run(() => DrainAsync(_process.StandardError, _stderr));
@@ -119,21 +125,32 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
             if (!_process.HasExited)
             {
                 try { _process.Kill(true); }
-                catch { /* race: already exited */ }
+                catch
+                {
+                    /* race: already exited */
+                }
             }
+
             try
             {
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
                 await _process.WaitForExitAsync(cts.Token);
             }
-            catch { /* best effort */ }
+            catch
+            {
+                /* best effort */
+            }
+
             _process.Dispose();
         }
 
         if (_bundleDir is not null)
         {
-            try { Directory.Delete(_bundleDir, recursive: true); }
-            catch { /* best effort */ }
+            try { Directory.Delete(_bundleDir, true); }
+            catch
+            {
+                /* best effort */
+            }
         }
     }
 
@@ -144,9 +161,10 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
         {
             Directory.CreateDirectory(dir.Replace(source, destination));
         }
+
         foreach (var file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
         {
-            File.Copy(file, file.Replace(source, destination), overwrite: true);
+            File.Copy(file, file.Replace(source, destination), true);
         }
     }
 
@@ -161,15 +179,27 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
                 throw new InvalidOperationException(
                     $"Sub-path host exited before becoming ready (code {_process.ExitCode}).\n{ServerLog}");
             }
+
             try
             {
                 using var resp = await http.GetAsync($"{BaseUrl}/");
-                if ((int)resp.StatusCode < 500) return;
+                if ((int)resp.StatusCode < 500)
+                {
+                    return;
+                }
             }
-            catch (HttpRequestException) { /* not yet listening */ }
-            catch (TaskCanceledException) { /* per-request timeout */ }
+            catch (HttpRequestException)
+            {
+                /* not yet listening */
+            }
+            catch (TaskCanceledException)
+            {
+                /* per-request timeout */
+            }
+
             await Task.Delay(250);
         }
+
         throw new TimeoutException(
             $"Sub-path host did not respond on {BaseUrl} within {timeout}.\n{ServerLog}");
     }
@@ -190,9 +220,14 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
         while (dir is not null)
         {
-            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx"))) return dir.FullName;
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
             dir = dir.Parent;
         }
+
         throw new InvalidOperationException(
             $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
     }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/TestArtifacts.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/TestArtifacts.cs
@@ -6,7 +6,8 @@ internal static class TestArtifacts
 {
     private static readonly string Root = Path.Combine(LocateRepoRoot(), "TestResults", "E2E");
 
-    public static async Task DumpAsync(IPage page, string fixtureName, string testName, string serverLog, string[]? console = null)
+    public static async Task DumpAsync(IPage page, string fixtureName, string testName, string serverLog,
+        string[]? console = null)
     {
         var safeName = string.Concat(testName.Select(c => char.IsLetterOrDigit(c) || c is '_' or '-' ? c : '_'));
         var dir = Path.Combine(Root, fixtureName, safeName);

--- a/tests/Rask.Examples.E2E.Tests/JwtServerAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/JwtServerAuthExampleTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
@@ -33,20 +34,24 @@ public sealed class JwtServerAuthExampleTests : IAsyncLifetime
     {
         // Anonymous members page → component gate shows the sign-in prompt.
         await _page.GotoAsync("/members");
-        await Expect(_page.Locator("#members-anon")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-anon"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
 
         // Sign in as admin.
         await _page.GotoAsync("/login");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
         await _page.Locator("#username").FillAsync("root");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
         // Lands on /members, authenticated, with the admin note.
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
-            new() { Timeout = 30_000 });
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 30_000 });
-        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/members$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("root", new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
 
         // The raw JWT must NOT be readable in JS — sessionStorage holds only the encrypted blob.
         var stored = await _page.EvaluateAsync<string?>("() => sessionStorage.getItem('rask.jwt')");
@@ -55,20 +60,22 @@ public sealed class JwtServerAuthExampleTests : IAsyncLifetime
 
         // Sign out → back to /login.
         await _page.Locator("#logout").ClickAsync();
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
-            new() { Timeout = 30_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/login"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
     }
 
     [Fact]
     public async Task NonAdmin_DoesNotSeeAdminNote()
     {
         await _page.GotoAsync("/login");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
         await _page.Locator("#username").FillAsync("alice");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 30_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("alice", new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
         await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0);
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/ServerExampleTests.SessionLifecycle.cs
+++ b/tests/Rask.Examples.E2E.Tests/ServerExampleTests.SessionLifecycle.cs
@@ -196,8 +196,8 @@ public sealed partial class ServerExampleTests
 
             // Heap is allowed to grow by some margin (JIT, intern pool, etc.)
             // but should not be 10x baseline. This is a loose canary — a real
-                // leak would be orders of magnitude.
-            Assert.True(after.GcMemoryBytes < baseline.GcMemoryBytes * 10 + 50_000_000,
+            // leak would be orders of magnitude.
+            Assert.True(after.GcMemoryBytes < (baseline.GcMemoryBytes * 10) + 50_000_000,
                 $"GC heap suspect growth. baseline={baseline.GcMemoryBytes} after={after.GcMemoryBytes}");
         }
         finally
@@ -258,8 +258,10 @@ public sealed partial class ServerExampleTests
     }
 
     public sealed record DiagSnapshot(
-        [property: JsonPropertyName("sessions")] int Sessions,
-        [property: JsonPropertyName("gcMemoryBytes")] long GcMemoryBytes,
+        [property: JsonPropertyName("sessions")]
+        int Sessions,
+        [property: JsonPropertyName("gcMemoryBytes")]
+        long GcMemoryBytes,
         [property: JsonPropertyName("gen0")] int Gen0,
         [property: JsonPropertyName("gen1")] int Gen1,
         [property: JsonPropertyName("gen2")] int Gen2);

--- a/tests/Rask.Examples.E2E.Tests/ServerExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/ServerExampleTests.cs
@@ -5,7 +5,8 @@ using static Microsoft.Playwright.Assertions;
 namespace Rask.Examples.E2E.Tests;
 
 [Collection(ServerExampleCollection.Name)]
-public sealed partial class ServerExampleTests(ServerExampleAppFixture app, PlaywrightFixture pw) : ExampleSmokeTests(pw)
+public sealed partial class ServerExampleTests(ServerExampleAppFixture app, PlaywrightFixture pw)
+    : ExampleSmokeTests(pw)
 {
     protected override string BaseUrl => app.BaseUrl;
     protected override string FixtureName => "Server";

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.AuthorizeComponent.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.AuthorizeComponent.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -12,26 +13,30 @@ public abstract partial class SharedSmokeTests
     {
         await NavigateToAsync("/user");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("User & auth gating",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         var demo = Page.Locator("#authorize-demo");
 
         // Anonymous → the NotAuthorized fallback slot.
-        await Expect(demo).ToContainTextAsync("Sign in to see member content", new() { Timeout = 10_000 });
+        await Expect(demo).ToContainTextAsync("Sign in to see member content",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(demo).Not.ToContainTextAsync("Admin-only content");
 
         // Plain user → the authenticated ("standard access") slot, but not the admin slot.
         await demo.Locator("button:has-text('Sign in as user')").ClickAsync();
-        await Expect(demo).ToContainTextAsync("standard access", new() { Timeout = 10_000 });
+        await Expect(demo).ToContainTextAsync("standard access",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(demo).Not.ToContainTextAsync("Admin-only content");
 
         // Sign out → back to the fallback slot.
         await demo.Locator("button:has-text('Sign out')").ClickAsync();
-        await Expect(demo).ToContainTextAsync("Sign in to see member content", new() { Timeout = 10_000 });
+        await Expect(demo).ToContainTextAsync("Sign in to see member content",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Admin → the role-gated Authorized slot.
         await demo.Locator("button:has-text('Sign in as admin')").ClickAsync();
-        await Expect(demo).ToContainTextAsync("Admin-only content", new() { Timeout = 10_000 });
+        await Expect(demo).ToContainTextAsync("Admin-only content",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(demo).Not.ToContainTextAsync("Sign in to see member content");
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Callback.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Callback.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -13,13 +14,15 @@ public abstract partial class SharedSmokeTests
         // re-render were broken, the text would stay at "Click a star to rate."
         await NavigateToAsync("/callback");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Callback",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         var line = Page.Locator("main .sample-result-body p");
-        await Expect(line).ToContainTextAsync("Click a star to rate", new() { Timeout = 10_000 });
+        await Expect(line).ToContainTextAsync("Click a star to rate",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Click the 4th star.
         await Page.Locator("main .sample-result-body button").Nth(3).ClickAsync();
-        await Expect(line).ToContainTextAsync("You rated: 4/5", new() { Timeout = 10_000 });
+        await Expect(line).ToContainTextAsync("You rated: 4/5",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Context.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Context.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -14,16 +15,16 @@ public abstract partial class SharedSmokeTests
         // intermediate. If the bypass/walk were wrong, the badge would freeze at "Light".
         await NavigateToAsync("/context");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Context",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         var badge = Page.Locator("main .badge");
-        await Expect(badge).ToContainTextAsync("Light", new() { Timeout = 10_000 });
+        await Expect(badge).ToContainTextAsync("Light", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         await Page.Locator("button:has-text('Toggle theme')").ClickAsync();
-        await Expect(badge).ToContainTextAsync("Dark", new() { Timeout = 10_000 });
+        await Expect(badge).ToContainTextAsync("Dark", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Toggle back to prove it isn't a one-way latch.
         await Page.Locator("button:has-text('Toggle theme')").ClickAsync();
-        await Expect(badge).ToContainTextAsync("Light", new() { Timeout = 10_000 });
+        await Expect(badge).ToContainTextAsync("Light", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.DragDrop.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.DragDrop.cs
@@ -20,9 +20,7 @@ public abstract partial class SharedSmokeTests
         var dataTransfer = await Page.EvaluateHandleAsync("() => new DataTransfer()");
         var init = new Dictionary<string, object>
         {
-            ["dataTransfer"] = dataTransfer,
-            ["bubbles"] = true,
-            ["cancelable"] = true
+            ["dataTransfer"] = dataTransfer, ["bubbles"] = true, ["cancelable"] = true
         };
 
         await source.DispatchEventAsync("dragstart", init);
@@ -116,7 +114,7 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
         await Expect(Page.Locator("[data-testid='col-done'] .dd-card").Nth(1))
             .ToHaveAttributeAsync("data-testid", "card-4",
-            new LocatorAssertionsToHaveAttributeOptions { Timeout = 10_000 });
+                new LocatorAssertionsToHaveAttributeOptions { Timeout = 10_000 });
         await Expect(Page.Locator("[data-testid='col-doing'] [data-testid='card-4']")).ToHaveCountAsync(0,
             new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
     });

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.ElementRef.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.ElementRef.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -12,13 +13,13 @@ public abstract partial class SharedSmokeTests
         // broken the input would never gain focus.
         await NavigateToAsync("/element-ref");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Element refs",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         var input = Page.Locator("main .sample-result-body input");
-        await Expect(input).Not.ToBeFocusedAsync(new() { Timeout = 10_000 });
+        await Expect(input).Not.ToBeFocusedAsync(new LocatorAssertionsToBeFocusedOptions { Timeout = 10_000 });
 
         await Page.Locator("main .sample-result-body button:has-text('Focus the input')").ClickAsync();
-        await Expect(input).ToBeFocusedAsync(new() { Timeout = 10_000 });
+        await Expect(input).ToBeFocusedAsync(new LocatorAssertionsToBeFocusedOptions { Timeout = 10_000 });
     });
 
     [Fact]
@@ -28,10 +29,10 @@ public abstract partial class SharedSmokeTests
         // the resolved element and returns its width — proving refs reach user JS, not just builtins.
         await NavigateToAsync("/element-ref");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Element refs",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         await Page.Locator("main .sample-result-body button:has-text('Measure the box')").ClickAsync();
         await Expect(Page.Locator("main .sample-result-body p"))
-            .ToContainTextAsync("Box width:", new() { Timeout = 10_000 });
+            .ToContainTextAsync("Box width:", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.FormGroups.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.FormGroups.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -9,25 +10,28 @@ public abstract partial class SharedSmokeTests
     {
         await NavigateToAsync("/form-groups");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Radio & checkbox groups",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         var summary = Page.Locator("#groups-summary");
-        await Expect(summary).ToContainTextAsync("Plan: Free", new() { Timeout = 10_000 });
+        await Expect(summary)
+            .ToContainTextAsync("Plan: Free", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(summary).ToContainTextAsync("Interests: none");
 
         // Pick the Pro radio (single-value bind).
         await Page.Locator("input[type=radio][value='Pro']").CheckAsync();
-        await Expect(summary).ToContainTextAsync("Plan: Pro", new() { Timeout = 10_000 });
+        await Expect(summary)
+            .ToContainTextAsync("Plan: Pro", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Tick two interest checkboxes (collection bind).
         await Page.Locator("input[type=checkbox][value='Web']").CheckAsync();
         await Page.Locator("input[type=checkbox][value='AI']").CheckAsync();
-        await Expect(summary).ToContainTextAsync("Web", new() { Timeout = 10_000 });
+        await Expect(summary).ToContainTextAsync("Web", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(summary).ToContainTextAsync("AI");
 
         // Untick one — it leaves the collection.
         await Page.Locator("input[type=checkbox][value='Web']").UncheckAsync();
-        await Expect(summary).Not.ToContainTextAsync("Web", new() { Timeout = 10_000 });
+        await Expect(summary).Not
+            .ToContainTextAsync("Web", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(summary).ToContainTextAsync("AI");
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.HighlightJs.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.HighlightJs.cs
@@ -28,7 +28,7 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
-        await AssertAllCodeBlocksHighlightedAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await AssertAllCodeBlocksHighlightedAsync(HighlightSettleTimeoutMs);
     });
 
     [Fact]
@@ -55,12 +55,12 @@ public abstract partial class SharedSmokeTests
         await NavigateToAsync("/validation");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await AssertAllCodeBlocksHighlightedAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await AssertAllCodeBlocksHighlightedAsync(HighlightSettleTimeoutMs);
 
         await ClickSidebar("Routing");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Routing",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await AssertAllCodeBlocksHighlightedAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await AssertAllCodeBlocksHighlightedAsync(HighlightSettleTimeoutMs);
     });
 
     [Fact]
@@ -72,7 +72,7 @@ public abstract partial class SharedSmokeTests
         await NavigateToAsync("/validation");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await AssertAllCodeBlocksHighlightedAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await AssertAllCodeBlocksHighlightedAsync(HighlightSettleTimeoutMs);
 
         await ClickSidebar("Welcome");
         await Expect(Page.Locator("h1.display-5")).ToBeVisibleAsync(
@@ -81,7 +81,7 @@ public abstract partial class SharedSmokeTests
         await ClickSidebar("Validation");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await AssertAllCodeBlocksHighlightedAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await AssertAllCodeBlocksHighlightedAsync(HighlightSettleTimeoutMs);
     });
 
     [Fact]
@@ -101,7 +101,7 @@ public abstract partial class SharedSmokeTests
 
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("HttpClient + DI",
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
-        await AssertAllCodeBlocksHighlightedAsync(timeoutMs: HighlightSettleTimeoutMs);
+        await AssertAllCodeBlocksHighlightedAsync(HighlightSettleTimeoutMs);
     });
 
     private async Task AssertAllCodeBlocksHighlightedAsync(int timeoutMs)

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.JsRuntime.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.JsRuntime.cs
@@ -20,7 +20,7 @@ public abstract partial class SharedSmokeTests
         // stays at "(idle)".
         await ClearJsRuntimeStorageAsync();
         await NavigateToAsync("/jsruntime");
-        await Expect(Page.Locator("main h1.h3")).ToContainTextAsync("IJSRuntime",
+        await Expect(Page.Locator("main h1.h2")).ToContainTextAsync("IJSRuntime",
             new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
 
         await Expect(Page.Locator("#demo-status")).ToContainTextAsync("no value yet",
@@ -34,7 +34,7 @@ public abstract partial class SharedSmokeTests
         // pulls it back via InvokeAsync<string?>. Status mirrors each step.
         await ClearJsRuntimeStorageAsync();
         await NavigateToAsync("/jsruntime");
-        await Expect(Page.Locator("main h1.h3")).ToContainTextAsync("IJSRuntime",
+        await Expect(Page.Locator("main h1.h2")).ToContainTextAsync("IJSRuntime",
             new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
 
         await Page.Locator("#demo-input").FillAsync("hello-rask");
@@ -54,7 +54,7 @@ public abstract partial class SharedSmokeTests
     {
         await ClearJsRuntimeStorageAsync();
         await NavigateToAsync("/jsruntime");
-        await Expect(Page.Locator("main h1.h3")).ToContainTextAsync("IJSRuntime",
+        await Expect(Page.Locator("main h1.h2")).ToContainTextAsync("IJSRuntime",
             new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
 
         await Page.Locator("#demo-input").FillAsync("temp");

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.LifecycleAcrossNavigation.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.LifecycleAcrossNavigation.cs
@@ -1,4 +1,5 @@
 using Microsoft.Playwright;
+using Xunit.Sdk;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -136,6 +137,6 @@ public abstract partial class SharedSmokeTests
             await Task.Delay(100);
         }
 
-        throw new Xunit.Sdk.XunitException($"Timed out after {timeoutMs} ms waiting for: {message}");
+        throw new XunitException($"Timed out after {timeoutMs} ms waiting for: {message}");
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.MemoryStability.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.MemoryStability.cs
@@ -48,7 +48,7 @@ public abstract partial class SharedSmokeTests
         var after = await SampleJsHeapAsync();
 
         Assert.True(after > 0, $"No heap reading available on this browser. baseline={baseline} after={after}");
-        Assert.True(after < baseline * 3 + 25_000_000,
+        Assert.True(after < (baseline * 3) + 25_000_000,
             $"JS heap grew unexpectedly. baseline={baseline:N0} after={after:N0} bytes. " +
             "Suspect: leaked component subscriptions, retained event handlers, or uncancelled lifecycle hooks.");
 
@@ -86,7 +86,7 @@ public abstract partial class SharedSmokeTests
 
         var after = await SampleJsHeapAsync();
 
-        Assert.True(after < baseline * 4 + 30_000_000,
+        Assert.True(after < (baseline * 4) + 30_000_000,
             $"Heap grew across CodeSample-heavy navs. baseline={baseline:N0} after={after:N0}. " +
             "Likely culprit: highlight-cache or head-asset cache growth OR CodeSample lifecycle closures.");
     });

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.NavigationFlicker.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.NavigationFlicker.cs
@@ -3,6 +3,7 @@
 // NavigateToAsync waits for window.location to match /realtime/{Symbol},
 // which is timing-flaky on WasmAppHost. Kept as a placeholder so the future
 // addition of cross-host nav-flicker assertions has an obvious home.
+
 namespace Rask.Examples.E2E.Tests;
 
 public abstract partial class SharedSmokeTests

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Navigator.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Navigator.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
@@ -14,13 +15,13 @@ public abstract partial class SharedSmokeTests
 
         await Page.Locator("button:has-text('SetQuery page=1')").ClickAsync();
         await Page.Locator("button:has-text('SetQuery sort=asc')").ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]sort=asc"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]sort=asc"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
 
         await Page.Locator("button:has-text('RemoveQuery page')").ClickAsync();
-        await Expect(Page).Not.ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]page="),
+        await Expect(Page).Not.ToHaveURLAsync(new Regex(".*[\\?&]page="),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]sort=asc"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]sort=asc"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
     });
 
@@ -35,7 +36,7 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("button:has-text('SetQuery sort=asc')").ClickAsync();
         await Page.Locator("button:has-text('ClearQuery')").ClickAsync();
 
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/navigator$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/navigator$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
     });
 
@@ -60,7 +61,7 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
         await Expect(Page).ToHaveTitleAsync("User #137 — Rask",
             new PageAssertionsToHaveTitleOptions { Timeout = 5_000 });
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/users/137$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/users/137$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
     });
 
@@ -78,11 +79,11 @@ public abstract partial class SharedSmokeTests
         // Navigate(path, query) — should drop sort/page, keep only from=button.
         await Page.Locator("button:has-text('Navigate(path, query)')").ClickAsync();
 
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]from=button"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]from=button"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        await Expect(Page).Not.ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]sort="),
+        await Expect(Page).Not.ToHaveURLAsync(new Regex(".*[\\?&]sort="),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        await Expect(Page).Not.ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]page="),
+        await Expect(Page).Not.ToHaveURLAsync(new Regex(".*[\\?&]page="),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.RenderCountStability.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.RenderCountStability.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
@@ -81,12 +82,8 @@ public abstract partial class SharedSmokeTests
         // is invisible by construction — see comment above.
         var expected = new[]
         {
-            "OnMount",
-            "OnMountAsync (start)",
-            "OnPropsChanged (render #1)",
-            "OnPropsChangedAsync",
-            "OnRendered(firstRender: True)",
-            "OnMountAsync (after 450ms await)"
+            "OnMount", "OnMountAsync (start)", "OnPropsChanged (render #1)", "OnPropsChangedAsync",
+            "OnRendered(firstRender: True)", "OnMountAsync (after 450ms await)"
         };
 
         Assert.Equal(expected, entries);
@@ -198,11 +195,11 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         await Page.Locator("button:has-text('SetQuery page=1')").ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]page=1"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]page=1"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
 
         await Page.Locator("button:has-text('SetQuery page=2')").ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]page=2"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]page=2"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
     });
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Table.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Table.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
@@ -33,21 +34,21 @@ public abstract partial class SharedSmokeTests
 
         // Click 1: ascending.
         await nameHeader.ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]sort=name"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]sort=name"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]dir=asc"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]dir=asc"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
 
         // Click 2: descending.
         await nameHeader.ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]dir=desc"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]dir=desc"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
 
         // Click 3: cleared (sort= empty, dir=asc).
         await nameHeader.ClickAsync();
         // URL still has dir=asc but sort= empty. Asserting absence of dir=desc
         // and presence of dir=asc.
-        await Expect(Page).Not.ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]dir=desc"),
+        await Expect(Page).Not.ToHaveURLAsync(new Regex(".*[\\?&]dir=desc"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
     });
 
@@ -61,7 +62,7 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("input[type='search']").FillAsync("Linus");
         await Page.WaitForTimeoutAsync(300);
 
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]filter=Linus"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]filter=Linus"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
 
         var rowCount = await Page.Locator("tbody tr").CountAsync();
@@ -92,7 +93,7 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("select.form-select-sm").SelectOptionAsync("25");
         await Page.WaitForTimeoutAsync(200);
 
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]size=25"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]size=25"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
         await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
             new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
@@ -109,7 +110,7 @@ public abstract partial class SharedSmokeTests
 
         // Click the numbered page-2 item.
         await Page.Locator(".page-item .page-link:has-text('2')").First.ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*[\\?&]page=2"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]page=2"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
 
         var firstRowIdAfter = await Page.Locator("tbody tr td").First.InnerTextAsync();

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Todos.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Todos.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
@@ -30,7 +31,7 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         await Page.Locator("button:has-text('New todo')").ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/todos/new$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos/new$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
         await Expect(Page.Locator("#todo-title")).ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
@@ -52,11 +53,11 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("#todo-title").FillAsync("Wire up reconnect");
         await Page.Locator("button:has-text('Add')").ClickAsync();
 
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/todos$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
         await Expect(Page.Locator(".list-group .list-group-item")).ToHaveCountAsync(baseRows + 1,
             new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
-        await Expect(Page.Locator(".todo-title", new() { HasTextString = "Wire up reconnect" }))
+        await Expect(Page.Locator(".todo-title", new PageLocatorOptions { HasTextString = "Wire up reconnect" }))
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
     });
 
@@ -76,9 +77,9 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("#todo-title").FillAsync("Read the new README");
         await Page.Locator("button:has-text('Save')").ClickAsync();
 
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/todos$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        await Expect(Page.Locator(".todo-title", new() { HasTextString = "Read the new README" }))
+        await Expect(Page.Locator(".todo-title", new PageLocatorOptions { HasTextString = "Read the new README" }))
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
     });
 
@@ -114,7 +115,7 @@ public abstract partial class SharedSmokeTests
         // Scope the Cancel selector to the dialog — otherwise it matches the
         // sidebar's "Cancellation" entry which also contains the substring "Cancel".
         await Page.Locator("dialog[open] button:has-text('Cancel')").ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(".*/todos$"),
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
         await Expect(Page.Locator("#todo-title")).Not.ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
@@ -148,7 +149,7 @@ public abstract partial class SharedSmokeTests
         var firstRowCheckbox = Page.Locator(".list-group-item").First.Locator("input[type='checkbox']");
         await firstRowCheckbox.CheckAsync();
         await Page.WaitForTimeoutAsync(200);
-        await Expect(Page.Locator(".todo-title.completed", new() { HasTextString = titleText }))
+        await Expect(Page.Locator(".todo-title.completed", new PageLocatorOptions { HasTextString = titleText }))
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.UserGate.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.UserGate.cs
@@ -1,3 +1,4 @@
+using Microsoft.Playwright;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -9,21 +10,25 @@ public abstract partial class SharedSmokeTests
     {
         await NavigateToAsync("/user");
         await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("User & auth gating",
-            new() { Timeout = 30_000 });
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
 
         var gate = Page.Locator("#user-gate");
-        await Expect(gate).ToContainTextAsync("signed out", new() { Timeout = 10_000 });
+        await Expect(gate)
+            .ToContainTextAsync("signed out", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Sign in as a plain user — authenticated content shows, admin panel does not.
         await gate.Locator("button:has-text('Sign in as user')").ClickAsync();
-        await Expect(gate).ToContainTextAsync("Signed in as", new() { Timeout = 10_000 });
+        await Expect(gate)
+            .ToContainTextAsync("Signed in as", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Expect(gate).Not.ToContainTextAsync("Admin-only panel");
 
         await gate.Locator("button:has-text('Sign out')").ClickAsync();
-        await Expect(gate).ToContainTextAsync("signed out", new() { Timeout = 10_000 });
+        await Expect(gate)
+            .ToContainTextAsync("signed out", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Sign in as admin — now the role-gated panel appears.
         await gate.Locator("button:has-text('Sign in as admin')").ClickAsync();
-        await Expect(gate).ToContainTextAsync("Admin-only panel", new() { Timeout = 10_000 });
+        await Expect(gate).ToContainTextAsync("Admin-only panel",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     });
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
@@ -15,9 +15,9 @@ namespace Rask.Examples.E2E.Tests;
 // SPA fallback (deep links 404).
 public abstract partial class SharedSmokeTests : IAsyncLifetime
 {
+    private readonly List<string> _console = new();
     private readonly PlaywrightFixture _pw;
     private IBrowserContext _ctx = default!;
-    private readonly List<string> _console = new();
 
     protected IPage Page = default!;
 
@@ -35,8 +35,20 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
         // the real client-side cause (e.g. a scoped-JS "Could not find … on target" force-fault
         // that trips RootErrorBoundary) in the CI log — the C# stack alone only shows the wait
         // timeout, not why the app never became interactive.
-        Page.Console += (_, msg) => { lock (_console) _console.Add($"[{msg.Type}] {msg.Text}"); };
-        Page.PageError += (_, err) => { lock (_console) _console.Add($"[pageerror] {err}"); };
+        Page.Console += (_, msg) =>
+        {
+            lock (_console)
+            {
+                _console.Add($"[{msg.Type}] {msg.Text}");
+            }
+        };
+        Page.PageError += (_, err) =>
+        {
+            lock (_console)
+            {
+                _console.Add($"[pageerror] {err}");
+            }
+        };
     }
 
     public async Task DisposeAsync() => await _ctx.DisposeAsync();
@@ -62,7 +74,11 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
         finally
         {
             string[] console;
-            lock (_console) console = _console.ToArray();
+            lock (_console)
+            {
+                console = _console.ToArray();
+            }
+
             await TestArtifacts.DumpAsync(Page, FixtureName, testName, ServerLog, console);
         }
     }
@@ -73,22 +89,38 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
     private async Task DumpDiagnosticsAsync(string testName)
     {
         string[] console;
-        lock (_console) console = _console.ToArray();
+        lock (_console)
+        {
+            console = _console.ToArray();
+        }
 
         string? boundary = null;
         try
         {
             var html = await Page.ContentAsync();
             if (html.Contains("Something went wrong", StringComparison.Ordinal))
+            {
                 boundary = "RootErrorBoundary fallback PRESENT (\"Something went wrong\") — the app crashed";
+            }
         }
-        catch { /* page may be closed */ }
+        catch
+        {
+            /* page may be closed */
+        }
 
         Console.WriteLine($"===== E2E DIAG {FixtureName}.{testName} =====");
         Console.WriteLine($"  url: {Page.Url}");
-        if (boundary is not null) Console.WriteLine($"  {boundary}");
+        if (boundary is not null)
+        {
+            Console.WriteLine($"  {boundary}");
+        }
+
         Console.WriteLine($"  browser console ({console.Length} msgs):");
-        foreach (var line in console.TakeLast(40)) Console.WriteLine($"    {line}");
+        foreach (var line in console.TakeLast(40))
+        {
+            Console.WriteLine($"    {line}");
+        }
+
         Console.WriteLine($"===== /E2E DIAG {FixtureName}.{testName} =====");
     }
 
@@ -1940,5 +1972,4 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
             .ToContainTextAsync("Generated 1 time(s).",
                 new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     });
-
 }

--- a/tests/Rask.Examples.E2E.Tests/StandaloneWasmExampleTests.LiveTickerNav.cs
+++ b/tests/Rask.Examples.E2E.Tests/StandaloneWasmExampleTests.LiveTickerNav.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
@@ -50,7 +51,7 @@ public sealed partial class StandaloneWasmExampleTests
         }
         finally
         {
-            await Infrastructure.TestArtifacts.DumpAsync(
+            await TestArtifacts.DumpAsync(
                 Page, FixtureName, nameof(LiveTickerSidebarNav_UpdatesBrowserUrl), ServerLog);
         }
     }

--- a/tests/Rask.Examples.E2E.Tests/WasmCookieAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmCookieAuthExampleTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
@@ -33,35 +34,41 @@ public sealed class WasmCookieAuthExampleTests : IAsyncLifetime
     {
         // Anonymous → /api/me 204 → the gate shows the sign-in prompt (WASM cold boot can be slow).
         await _page.GotoAsync("/members");
-        await Expect(_page.Locator("#members-anon")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+        await Expect(_page.Locator("#members-anon"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 90_000 });
 
         await _page.GotoAsync("/login");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
         await _page.Locator("#username").FillAsync("root");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
         // /api/login set the cookie, RefreshAsync re-hydrated from /api/me, navigated to /members.
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
-            new() { Timeout = 60_000 });
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 30_000 });
-        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/members$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 60_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("root", new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
 
         await _page.Locator("#logout").ClickAsync();
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
-            new() { Timeout = 30_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/login"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
     }
 
     [Fact]
     public async Task NonAdmin_DoesNotSeeAdminNote()
     {
         await _page.GotoAsync("/login");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 90_000 });
         await _page.Locator("#username").FillAsync("alice");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("alice", new LocatorAssertionsToContainTextOptions { Timeout = 60_000 });
         await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0);
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/WasmJwtAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmJwtAuthExampleTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
@@ -32,18 +33,22 @@ public sealed class WasmJwtAuthExampleTests : IAsyncLifetime
     public async Task Login_RoundTrip_TokenInLocalStorage_AdminSeesAdminNote_ThenSignOut()
     {
         await _page.GotoAsync("/members");
-        await Expect(_page.Locator("#members-anon")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+        await Expect(_page.Locator("#members-anon"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 90_000 });
 
         await _page.GotoAsync("/login");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
         await _page.Locator("#username").FillAsync("root");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/members$"),
-            new() { Timeout = 60_000 });
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("root", new() { Timeout = 30_000 });
-        await Expect(_page.Locator("#admin-note")).ToBeVisibleAsync(new() { Timeout = 15_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/members$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 60_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("root", new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
+        await Expect(_page.Locator("#admin-note"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
 
         // The bearer JWT is in localStorage (this sample's choice).
         var stored = await _page.EvaluateAsync<string?>("() => localStorage.getItem('rask.jwt')");
@@ -51,8 +56,8 @@ public sealed class WasmJwtAuthExampleTests : IAsyncLifetime
         Assert.StartsWith("eyJ", stored); // a raw JWT begins with the base64url "eyJ" header
 
         await _page.Locator("#logout").ClickAsync();
-        await Expect(_page).ToHaveURLAsync(new System.Text.RegularExpressions.Regex(@"/login"),
-            new() { Timeout = 30_000 });
+        await Expect(_page).ToHaveURLAsync(new Regex(@"/login"),
+            new PageAssertionsToHaveURLOptions { Timeout = 30_000 });
         var cleared = await _page.EvaluateAsync<string?>("() => localStorage.getItem('rask.jwt')");
         Assert.True(string.IsNullOrEmpty(cleared));
     }
@@ -61,12 +66,14 @@ public sealed class WasmJwtAuthExampleTests : IAsyncLifetime
     public async Task NonAdmin_DoesNotSeeAdminNote()
     {
         await _page.GotoAsync("/login");
-        await Expect(_page.Locator("#login-submit")).ToBeVisibleAsync(new() { Timeout = 90_000 });
+        await Expect(_page.Locator("#login-submit"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 90_000 });
         await _page.Locator("#username").FillAsync("alice");
         await _page.Locator("#password").FillAsync("password");
         await _page.Locator("#login-submit").ClickAsync();
 
-        await Expect(_page.Locator("#members-greeting")).ToContainTextAsync("alice", new() { Timeout = 60_000 });
+        await Expect(_page.Locator("#members-greeting"))
+            .ToContainTextAsync("alice", new LocatorAssertionsToContainTextOptions { Timeout = 60_000 });
         await Expect(_page.Locator("#admin-note")).ToHaveCountAsync(0);
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/WasmSubPathExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmSubPathExampleTests.cs
@@ -1,4 +1,4 @@
-using System.Text.RegularExpressions;
+using System.Net;
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
 using static Microsoft.Playwright.Assertions;
@@ -29,7 +29,7 @@ public sealed class WasmSubPathExampleTests : IAsyncLifetime
     }
 
     private IPage Page => _page
-        ?? throw new InvalidOperationException("Test page accessed before InitializeAsync ran");
+                          ?? throw new InvalidOperationException("Test page accessed before InitializeAsync ran");
 
     public async Task InitializeAsync()
     {
@@ -37,10 +37,7 @@ public sealed class WasmSubPathExampleTests : IAsyncLifetime
         // Playwright's absolute-path resolution doesn't drop the prefix — calling
         // Page.GotoAsync("/") with BaseURL "http://host/sub" goes to "http://host/"
         // (the leading "/" is absolute, not relative to the base path).
-        _context = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions
-        {
-            BaseURL = _app.OriginUrl
-        });
+        _context = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = _app.OriginUrl });
         _page = await _context.NewPageAsync();
     }
 
@@ -49,10 +46,18 @@ public sealed class WasmSubPathExampleTests : IAsyncLifetime
         if (_page is not null)
         {
             try { await TestArtifacts.DumpAsync(_page, "SubPathWasm", "after-test", _app.ServerLog); }
-            catch { /* best effort */ }
+            catch
+            {
+                /* best effort */
+            }
+
             await _page.CloseAsync();
         }
-        if (_context is not null) await _context.DisposeAsync();
+
+        if (_context is not null)
+        {
+            await _context.DisposeAsync();
+        }
     }
 
     [Fact]
@@ -88,7 +93,7 @@ public sealed class WasmSubPathExampleTests : IAsyncLifetime
         // The host moved every framework endpoint under /sub. A direct fetch to the
         // origin root must not be served — confirms endpoints aren't double-mapped.
         var response = await Page.APIRequest.GetAsync(_app.OriginUrl + "/");
-        Assert.Equal((int)System.Net.HttpStatusCode.NotFound, response.Status);
+        Assert.Equal((int)HttpStatusCode.NotFound, response.Status);
     }
 
     [Fact]
@@ -108,6 +113,6 @@ public sealed class WasmSubPathExampleTests : IAsyncLifetime
 
         var url = new Uri(new Uri(_app.OriginUrl), firstHref);
         var response = await Page.APIRequest.GetAsync(url.ToString());
-        Assert.Equal((int)System.Net.HttpStatusCode.OK, response.Status);
+        Assert.Equal((int)HttpStatusCode.OK, response.Status);
     }
 }

--- a/tests/Rask.Generators.Tests/ComponentConstructionAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentConstructionAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
@@ -470,7 +470,9 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("CounterPage(string? Name = null, string? Greeting = null, string? Other = null, object? Key = null)", output);
+        Assert.Contains(
+            "CounterPage(string? Name = null, string? Greeting = null, string? Other = null, object? Key = null)",
+            output);
     }
 
     [Fact]
@@ -536,7 +538,8 @@ public class ComponentFactoryGeneratorTests
         var run = GeneratorDriverFixture.Run(src);
         var output = run.GeneratedSource("Demo.Generated.g.cs");
 
-        Assert.Contains("Bound<TProp>(global::System.Linq.Expressions.Expression<global::System.Func<TProp>> Bind, object? Key = null)",
+        Assert.Contains(
+            "Bound<TProp>(global::System.Linq.Expressions.Expression<global::System.Func<TProp>> Bind, object? Key = null)",
             output);
     }
 

--- a/tests/Rask.Generators.Tests/ComponentScopedCssGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentScopedCssGeneratorTests.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Rask.Generators.Tests;
 

--- a/tests/Rask.Generators.Tests/ComponentScopedJsGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentScopedJsGeneratorTests.cs
@@ -1,8 +1,4 @@
-using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Text;
 
 namespace Rask.Generators.Tests;
 

--- a/tests/Rask.Generators.Tests/GlobalUsingsEmissionTests.cs
+++ b/tests/Rask.Generators.Tests/GlobalUsingsEmissionTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/MissingKeyAnalyzerTests.cs
@@ -11,20 +11,20 @@ public class MissingKeyAnalyzerTests
     // Wraps a Render() body in a component. Real Rask.Core factories (Generated.Li/Tr/Ul/...) are
     // referenced via BuildReferences(), so the analyzer resolves genuine factory symbols.
     private static string App(string body) => $$"""
-        using System.Collections.Generic;
-        using System.Linq;
-        using Rask.Core;
-        using static Rask.Core.Components.Generated;
-        namespace Demo;
-        public sealed class App : Component
-        {
-            private readonly int[] _items = { 1, 2, 3 };
-            protected override RenderResult Render()
-            {
-                {{body}}
-            }
-        }
-        """;
+                                                using System.Collections.Generic;
+                                                using System.Linq;
+                                                using Rask.Core;
+                                                using static Rask.Core.Components.Generated;
+                                                namespace Demo;
+                                                public sealed class App : Component
+                                                {
+                                                    private readonly int[] _items = { 1, 2, 3 };
+                                                    protected override RenderResult Render()
+                                                    {
+                                                        {{body}}
+                                                    }
+                                                }
+                                                """;
 
     [Fact]
     public async Task SelectProjection_NoKey_ReportsRask022()
@@ -39,10 +39,10 @@ public class MissingKeyAnalyzerTests
     public async Task ForeachAddToChildList_NoKey_ReportsRask022()
     {
         var d = Assert.Single(await Diagnostics(App("""
-            var rows = new List<Child>();
-            foreach (var i in _items) rows.Add(Tr()[i.ToString()]);
-            return Ul()[rows];
-            """)));
+                                                    var rows = new List<Child>();
+                                                    foreach (var i in _items) rows.Add(Tr()[i.ToString()]);
+                                                    return Ul()[rows];
+                                                    """)));
         Assert.Equal("RASK022", d.Id);
         Assert.Contains("Tr", d.GetMessage());
     }
@@ -58,19 +58,19 @@ public class MissingKeyAnalyzerTests
     public async Task SelectProjection_WithDataRaskKey_NoDiagnostic()
     {
         Assert.Empty(await Diagnostics(App("""
-            return Ul()[ _items.Select(i => Li(
-                Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[i.ToString()]) ];
-            """)));
+                                           return Ul()[ _items.Select(i => Li(
+                                               Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[i.ToString()]) ];
+                                           """)));
     }
 
     [Fact]
     public async Task ForeachAddToChildList_WithKey_NoDiagnostic()
     {
         Assert.Empty(await Diagnostics(App("""
-            var rows = new List<Child>();
-            foreach (var i in _items) rows.Add(Tr(Key: i)[i.ToString()]);
-            return Ul()[rows];
-            """)));
+                                           var rows = new List<Child>();
+                                           foreach (var i in _items) rows.Add(Tr(Key: i)[i.ToString()]);
+                                           return Ul()[rows];
+                                           """)));
     }
 
     [Fact]
@@ -84,20 +84,18 @@ public class MissingKeyAnalyzerTests
     }
 
     [Fact]
-    public async Task SingleStaticChild_NotAList_NoDiagnostic()
-    {
+    public async Task SingleStaticChild_NotAList_NoDiagnostic() =>
         Assert.Empty(await Diagnostics(App("return Div()[ Span()[\"hi\"] ];")));
-    }
 
     [Fact]
     public async Task AddOutsideLoop_NoDiagnostic()
     {
         // A one-off Add (not in a loop) isn't a reconciled list — don't warn.
         Assert.Empty(await Diagnostics(App("""
-            var rows = new List<Child>();
-            rows.Add(Tr()["one"]);
-            return Ul()[rows];
-            """)));
+                                           var rows = new List<Child>();
+                                           rows.Add(Tr()["one"]);
+                                           return Ul()[rows];
+                                           """)));
     }
 
     private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)

--- a/tests/Rask.Generators.Tests/Rask020CollisionTests.cs
+++ b/tests/Rask.Generators.Tests/Rask020CollisionTests.cs
@@ -1,7 +1,4 @@
-using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
 
 namespace Rask.Generators.Tests;
 
@@ -19,8 +16,10 @@ public class Rask020CollisionTests
         var run = Run(
             new[]
             {
-                ("/proj/PageA/Counter.cs", "namespace A; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
-                ("/proj/PageB/Counter.cs", "namespace B; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
+                ("/proj/PageA/Counter.cs",
+                    "namespace A; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
+                ("/proj/PageB/Counter.cs",
+                    "namespace B; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
             },
             new[]
             {
@@ -43,8 +42,10 @@ public class Rask020CollisionTests
         var run = Run(
             new[]
             {
-                ("/proj/PageA/Counter.cs", "namespace A; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
-                ("/proj/PageB/Counter.cs", "namespace B; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
+                ("/proj/PageA/Counter.cs",
+                    "namespace A; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
+                ("/proj/PageB/Counter.cs",
+                    "namespace B; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
             },
             new[]
             {
@@ -61,14 +62,16 @@ public class Rask020CollisionTests
         var run = Run(
             new[]
             {
-                ("/proj/A/Widget.cs", "namespace A; public sealed class Widget : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
-                ("/proj/B/Widget.cs", "namespace B; public sealed class Widget : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
-                ("/proj/C/Widget.cs", "namespace C; public sealed class Widget : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
+                ("/proj/A/Widget.cs",
+                    "namespace A; public sealed class Widget : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
+                ("/proj/B/Widget.cs",
+                    "namespace B; public sealed class Widget : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
+                ("/proj/C/Widget.cs",
+                    "namespace C; public sealed class Widget : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
             },
             new[]
             {
-                ("/proj/A/Widget.js", "export function f() {}"),
-                ("/proj/B/Widget.js", "export function g() {}"),
+                ("/proj/A/Widget.js", "export function f() {}"), ("/proj/B/Widget.js", "export function g() {}"),
                 ("/proj/C/Widget.js", "export function h() {}")
             });
 
@@ -93,13 +96,14 @@ public class Rask020CollisionTests
         var run = Run(
             new[]
             {
-                ("/proj/A/Counter.cs", "namespace A; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
-                ("/proj/B/Toggle.cs", "namespace B; public sealed class Toggle : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
+                ("/proj/A/Counter.cs",
+                    "namespace A; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }"),
+                ("/proj/B/Toggle.cs",
+                    "namespace B; public sealed class Toggle : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
             },
             new[]
             {
-                ("/proj/A/Counter.js", "export function f() {}"),
-                ("/proj/B/Toggle.js", "export function g() {}")
+                ("/proj/A/Counter.js", "export function f() {}"), ("/proj/B/Toggle.js", "export function g() {}")
             });
 
         Assert.DoesNotContain(run.Diagnostics, d => d.Id == "RASK020");
@@ -109,11 +113,16 @@ public class Rask020CollisionTests
     public void Generator_EmitsScopedAssetRegistryRegistration()
     {
         var run = Run(
-            new[] { ("/proj/Counter.cs", "namespace Foo; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }") },
+            new[]
+            {
+                ("/proj/Counter.cs",
+                    "namespace Foo; public sealed class Counter : Rask.Core.Component { protected override Rask.Core.RenderResult Render() => this; }")
+            },
             new[] { ("/proj/Counter.js", "export function rendered(el) {}") });
 
         var generated = run.GeneratedSource("__RaskScopedJsRegistration");
-        Assert.Contains("global::Rask.Core.ScopedAssets.ScopedAssetRegistry.RegisterJs(typeof(global::Foo.Counter)", generated);
+        Assert.Contains("global::Rask.Core.ScopedAssets.ScopedAssetRegistry.RegisterJs(typeof(global::Foo.Counter)",
+            generated);
         Assert.DoesNotContain("ScopedJsRegistry", generated);
         Assert.DoesNotContain(run.Diagnostics, d => d.Severity == DiagnosticSeverity.Error);
     }

--- a/tests/Rask.Generators.Tests/RootShellAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/RootShellAnalyzerTests.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -14,31 +13,31 @@ public class RootShellAnalyzerTests
     // the tests don't need to reference the host assemblies. The shell factories (Doctype/Html/
     // Head/Body) are matched by name, so the App declares same-named local helpers.
     private const string EntryStubs = """
-        using Rask.Core;
-        namespace Rask.Server { public static class RaskEndpointExtensions {
-            public static void UseRask<TApp>(object app) where TApp : Component { } } }
-        namespace Rask.Wasm { public sealed class WasmHostBuilder {
-            public void RunAsync<TApp>() where TApp : Component { } } }
-        """;
+                                      using Rask.Core;
+                                      namespace Rask.Server { public static class RaskEndpointExtensions {
+                                          public static void UseRask<TApp>(object app) where TApp : Component { } } }
+                                      namespace Rask.Wasm { public sealed class WasmHostBuilder {
+                                          public void RunAsync<TApp>() where TApp : Component { } } }
+                                      """;
 
     private static string App(string renderBody) => $$"""
-        using Rask.Core;
-        namespace Demo;
-        public sealed class App : Component
-        {
-            private static object Doctype() => null!;
-            private static object Html(string lang) => null!;
-            private static object Head() => null!;
-            private static object Body() => null!;
-            protected override RenderResult Render() { {{renderBody}} return this; }
-        }
-        """;
+                                                      using Rask.Core;
+                                                      namespace Demo;
+                                                      public sealed class App : Component
+                                                      {
+                                                          private static object Doctype() => null!;
+                                                          private static object Html(string lang) => null!;
+                                                          private static object Head() => null!;
+                                                          private static object Body() => null!;
+                                                          protected override RenderResult Render() { {{renderBody}} return this; }
+                                                      }
+                                                      """;
 
     [Fact]
     public async Task UseRask_RootMissingBody_ReportsRask021()
     {
         var src = EntryStubs + App("Doctype(); Html(\"en\"); Head();")
-                  + "namespace Demo { class Host { void M() { Rask.Server.RaskEndpointExtensions.UseRask<App>(null!); } } }";
+                             + "namespace Demo { class Host { void M() { Rask.Server.RaskEndpointExtensions.UseRask<App>(null!); } } }";
 
         var d = Assert.Single(await GetDiagnosticsAsync(src));
         Assert.Equal("RASK021", d.Id);
@@ -50,7 +49,7 @@ public class RootShellAnalyzerTests
     public async Task UseRask_FullShell_NoDiagnostic()
     {
         var src = EntryStubs + App("Doctype(); Html(\"en\"); Head(); Body();")
-                  + "namespace Demo { class Host { void M() { Rask.Server.RaskEndpointExtensions.UseRask<App>(null!); } } }";
+                             + "namespace Demo { class Host { void M() { Rask.Server.RaskEndpointExtensions.UseRask<App>(null!); } } }";
 
         Assert.Empty(await GetDiagnosticsAsync(src));
     }
@@ -59,7 +58,7 @@ public class RootShellAnalyzerTests
     public async Task RunAsync_WasmEntry_RootMissingShell_ReportsRask021()
     {
         var src = EntryStubs + App("Body();")
-                  + "namespace Demo { class Host { void M() { new Rask.Wasm.WasmHostBuilder().RunAsync<App>(); } } }";
+                             + "namespace Demo { class Host { void M() { new Rask.Wasm.WasmHostBuilder().RunAsync<App>(); } } }";
 
         var d = Assert.Single(await GetDiagnosticsAsync(src));
         Assert.Equal("RASK021", d.Id);

--- a/tests/Rask.Generators.Tests/RoutesGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/RoutesGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 
 namespace Rask.Generators.Tests;
@@ -585,7 +586,7 @@ public class RoutesGeneratorTests
         Assert.Contains("new(typeof(global::Demo.TodosPage), \"/todos/{id:guid}/edit\", null)", registry);
 
         // DynamicDependency is per-type, not per-template — exactly one entry per type.
-        var dynDepCount = System.Text.RegularExpressions.Regex
+        var dynDepCount = Regex
             .Matches(registry, "typeof\\(global::Demo\\.TodosPage\\)\\)\\]").Count;
         Assert.Equal(1, dynDepCount);
     }

--- a/tests/Rask.Generators.Tests/TemplateConfigTests.cs
+++ b/tests/Rask.Generators.Tests/TemplateConfigTests.cs
@@ -1,5 +1,3 @@
-using System.IO;
-using System.Linq;
 using System.Text.Json;
 
 namespace Rask.Generators.Tests;
@@ -17,7 +15,7 @@ public class TemplateConfigTests
     [
         ["rask-server", "Company.RaskServer"],
         ["rask-wasm", "Company.RaskWasm"],
-        ["rask-wasm-hosted", "Company.RaskWasmHosted"],
+        ["rask-wasm-hosted", "Company.RaskWasmHosted"]
     ];
 
     [Theory]

--- a/tests/Rask.Server.Tests/Authentication/RevokedAuthDispatchTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/RevokedAuthDispatchTests.cs
@@ -7,7 +7,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Authentication;
-using Rask.Core.Components;
 using Rask.Core.Routing;
 using Rask.Server.Authentication;
 using Rask.Server.Tests.Infrastructure;

--- a/tests/Rask.Server.Tests/Authentication/RouteGuardPipelineTests.cs
+++ b/tests/Rask.Server.Tests/Authentication/RouteGuardPipelineTests.cs
@@ -90,10 +90,10 @@ public class RouteGuardPipelineTests
         var cookie = await SignInAsync(host, "alice");
         Assert.Equal(HttpStatusCode.OK, (await GetWithCookieAsync(host, "/e2e/members", cookie)).StatusCode);
 
-        var cleared = await SignOutAsync(host);                 // ctx.SignOutAsync emits an emptied cookie
+        var cleared = await SignOutAsync(host); // ctx.SignOutAsync emits an emptied cookie
         var resp = await GetWithCookieAsync(host, "/e2e/members", cleared);
 
-        Assert.Equal(HttpStatusCode.Found, resp.StatusCode);    // back to the challenge
+        Assert.Equal(HttpStatusCode.Found, resp.StatusCode); // back to the challenge
     }
 
     private static async Task<string> SignInAsync(RaskTestHost host, string name, params string[] roles)

--- a/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
@@ -11,13 +11,13 @@ namespace Rask.Server.Tests.Authentication;
 public sealed class RouteGuardTestApp : Component
 {
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html("en")[
-                Head()[Title()["route-guard-e2e"]],
-                Body()[Router()]
-            ]
-        ];
+    [
+        Doctype(),
+        Html("en")[
+            Head()[Title()["route-guard-e2e"]],
+            Body()[Router()]
+        ]
+    ];
 }
 
 [Route("/e2e/public")]

--- a/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
@@ -11,13 +11,14 @@ namespace Rask.Server.Tests.Authentication;
 public sealed class SignInTestApp(AuthSignIn auth, RouteState routeState) : Component
 {
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["auth-test"]],
-                new Body()[new H1()[$"path={routeState.Path}"],
-                    new P()[$"user={(User.Identity?.IsAuthenticated == true ? User.Identity.Name : "anon")}"],
-                    Button(OnClickAsync: SignInAsync)["sign-in"],
-                    Button(OnClickAsync: SignOutAsync)["sign-out"]]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["auth-test"]],
+            new Body()[new H1()[$"path={routeState.Path}"],
+                new P()[$"user={(User.Identity?.IsAuthenticated == true ? User.Identity.Name : "anon")}"],
+                Button(OnClickAsync: SignInAsync)["sign-in"],
+                Button(OnClickAsync: SignOutAsync)["sign-out"]]]
+    ];
 
     private Task SignInAsync()
     {

--- a/tests/Rask.Server.Tests/Endpoints/AssetEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/AssetEndpointTests.cs
@@ -327,6 +327,7 @@ public class AssetEndpointTests
             bigSource.Append(".class").Append(i).Append(" { color: rgb(")
                 .Append(i % 256).Append(",0,0); padding: 1px 2px 3px 4px; margin: 0; }\n");
         }
+
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), bigSource.ToString());
         ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hash);
         using var host = RaskTestHost.Create<TestApp>();
@@ -351,7 +352,10 @@ public class AssetEndpointTests
 
     // ─── Test fixtures ───────────────────────────────────────────────────
 
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }
 
 [CollectionDefinition("ScopedAssets", DisableParallelization = true)]

--- a/tests/Rask.Server.Tests/Endpoints/PathBaseEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/PathBaseEndpointTests.cs
@@ -144,5 +144,8 @@ public sealed class PathBaseEndpointTests
         Assert.Contains("path=/foo", body);
     }
 
-    private sealed class Widget : Component { protected override RenderResult Render() => this; }
+    private sealed class Widget : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Server.Tests/Endpoints/RootGetEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/RootGetEndpointTests.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Routing;
 using Rask.Server.Tests.Infrastructure;

--- a/tests/Rask.Server.Tests/Endpoints/RuntimeScriptInjectionTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/RuntimeScriptInjectionTests.cs
@@ -64,7 +64,9 @@ public sealed class RuntimeScriptInjectionTests
     private sealed class LegacyShellApp(RouteState routeState) : Component
     {
         protected override RenderResult Render() =>
-            [Doctype(), new Html()[new Head(),
-                new Body()[new H1()[$"path={routeState.Path}"], RaskRuntimeScript()]]];
+        [
+            Doctype(), new Html()[new Head(),
+                new Body()[new H1()[$"path={routeState.Path}"], RaskRuntimeScript()]]
+        ];
     }
 }

--- a/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
+++ b/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
@@ -47,7 +47,7 @@ public class SessionUploadStoreTests
 
         // Callback writes nothing; the entry size falls back to the declared size.
         var entry = await store.StageAsync(
-            "session-1", "empty.bin", "text/plain", size: 42, DateTimeOffset.UnixEpoch,
+            "session-1", "empty.bin", "text/plain", 42, DateTimeOffset.UnixEpoch,
             _ => Task.CompletedTask);
 
         Assert.Equal(42, entry.Size);

--- a/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
+++ b/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
@@ -1,0 +1,56 @@
+using Rask.Server.Files;
+
+namespace Rask.Server.Tests.Files;
+
+public class SessionUploadStoreTests
+{
+    [Fact]
+    public async Task StageAsync_AwaitsWriteCallback_BeforeRecordingEntry()
+    {
+        using var store = new SessionUploadStore();
+        var gate = new TaskCompletionSource();
+        var observedDuringWrite = (Entry: (SessionUploadStore.Entry?)null, Completed: false);
+
+        var writeBytes = new byte[] { 1, 2, 3, 4 };
+        var stageTask = store.StageAsync(
+            "session-1", "data.bin", "application/octet-stream", writeBytes.Length, DateTimeOffset.UnixEpoch,
+            async path =>
+            {
+                // The write must still be in flight here — StageAsync should not have
+                // recorded the entry or returned yet (no sync-over-async block).
+                await gate.Task.ConfigureAwait(false);
+                await File.WriteAllBytesAsync(path, writeBytes).ConfigureAwait(false);
+            });
+
+        // StageAsync is genuinely async: it has not completed while the write is gated.
+        observedDuringWrite.Completed = stageTask.IsCompleted;
+        observedDuringWrite.Entry = store.Get("session-1", "ignored");
+        Assert.False(observedDuringWrite.Completed);
+        Assert.Null(observedDuringWrite.Entry);
+
+        gate.SetResult();
+        var entry = await stageTask;
+
+        Assert.Equal("data.bin", entry.Name);
+        Assert.Equal(writeBytes.Length, entry.Size);
+        var staged = await File.ReadAllBytesAsync(entry.Path);
+        Assert.Equal(writeBytes, staged);
+
+        store.Release("session-1", entry.Token);
+        Assert.False(File.Exists(entry.Path));
+    }
+
+    [Fact]
+    public async Task StageAsync_FallsBackToProvidedSize_WhenFileMissing()
+    {
+        using var store = new SessionUploadStore();
+
+        // Callback writes nothing; the entry size falls back to the declared size.
+        var entry = await store.StageAsync(
+            "session-1", "empty.bin", "text/plain", size: 42, DateTimeOffset.UnixEpoch,
+            _ => Task.CompletedTask);
+
+        Assert.Equal(42, entry.Size);
+        store.Release("session-1", entry.Token);
+    }
+}

--- a/tests/Rask.Server.Tests/Infrastructure/AsyncValidationApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/AsyncValidationApp.cs
@@ -25,23 +25,23 @@ public sealed class AsyncValidationApp : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()["async-validation"]],
-                new Body()[
-                    Form<SignupModel>(_model, Context: _ctx)[
-                        Input(() => _model.Username),
-                        ValidatingIndicator(
-                            () => _model.Username,
-                            () => Span(Class: "spinner")["Checking..."]),
-                        ValidationMessage(
-                            () => _model.Username,
-                            msgs => Div(Class: "text-danger")[msgs[0]])
-                    ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()["async-validation"]],
+            new Body()[
+                Form<SignupModel>(_model, Context: _ctx)[
+                    Input(() => _model.Username),
+                    ValidatingIndicator(
+                        () => _model.Username,
+                        () => Span(Class: "spinner")["Checking..."]),
+                    ValidationMessage(
+                        () => _model.Username,
+                        msgs => Div(Class: "text-danger")[msgs[0]])
                 ]
             ]
-        ];
+        ]
+    ];
 
     public sealed class SignupModel
     {

--- a/tests/Rask.Server.Tests/Infrastructure/CheckboxJsInvokeApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/CheckboxJsInvokeApp.cs
@@ -1,7 +1,6 @@
 using Microsoft.JSInterop;
 using Rask.Core;
 using Rask.Core.Components;
-using Rask.Core.Forms;
 
 #pragma warning disable RASK019 // test-infra app predates framework-managed <head>
 
@@ -19,16 +18,16 @@ public sealed class CheckboxJsInvokeApp(IJSRuntime js) : Component
         await js.InvokeVoidAsync("test.noop", firstRender);
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()["checkbox"]],
-                new Body()[
-                    Form(_m)[Input(() => _m.Subscribe, Id: "sub")],
-                    new P()[$"S={_m.Subscribe}"]
-                ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()["checkbox"]],
+            new Body()[
+                Form(_m)[Input(() => _m.Subscribe, Id: "sub")],
+                new P()[$"S={_m.Subscribe}"]
             ]
-        ];
+        ]
+    ];
 
     private sealed class Model
     {

--- a/tests/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
@@ -1,5 +1,5 @@
 using System.Net.WebSockets;
-using Rask.TestSupport;
+using Rask.Core;
 
 namespace Rask.Server.Tests.Infrastructure;
 
@@ -23,18 +23,6 @@ internal sealed class ConnectedSession : IAsyncDisposable
     public WebSocket Ws { get; }
     public LiveSession Session { get; }
 
-    public static async Task<ConnectedSession> Connect<TApp>() where TApp : Rask.Core.Component
-    {
-        var host = RaskTestHost.Create<TApp>();
-        var initial = await host.Http.GetAsync("/start");
-        var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
-        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-        var session = host.Store.Get(sessionId)!;
-        return new ConnectedSession(host, ws, session);
-    }
-
     public async ValueTask DisposeAsync()
     {
         try
@@ -50,5 +38,17 @@ internal sealed class ConnectedSession : IAsyncDisposable
 
         Ws.Dispose();
         Host.Dispose();
+    }
+
+    public static async Task<ConnectedSession> Connect<TApp>() where TApp : Component
+    {
+        var host = RaskTestHost.Create<TApp>();
+        var initial = await host.Http.GetAsync("/start");
+        var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        var session = host.Store.Get(sessionId)!;
+        return new ConnectedSession(host, ws, session);
     }
 }

--- a/tests/Rask.Server.Tests/Infrastructure/JsInvokeBindingApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/JsInvokeBindingApp.cs
@@ -22,14 +22,14 @@ public sealed class JsInvokeBindingApp(IJSRuntime js) : Component
         await js.InvokeVoidAsync("test.noop", firstRender);
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()["js-invoke-binding"]],
-                new Body()[
-                    Input(Value: _typed, OnInput: v => _typed = v),
-                    new P()[$"Echo: {_typed}"]
-                ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()["js-invoke-binding"]],
+            new Body()[
+                Input(Value: _typed, OnInput: v => _typed = v),
+                new P()[$"Echo: {_typed}"]
             ]
-        ];
+        ]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
@@ -12,8 +12,8 @@ namespace Rask.Server.Tests.Infrastructure;
 // coalescing send loop). The rows are keyed via data-rask-key.
 public sealed class KeyedNavApp : Component
 {
-    private readonly RouteState _route;
     private readonly List<int> _items = [1, 2];
+    private readonly RouteState _route;
 
     public KeyedNavApp(RouteState route) => _route = route;
 
@@ -31,19 +31,19 @@ public sealed class KeyedNavApp : Component
     }
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()["keyed-nav"]],
-                new Body()[
-                    new H1()[$"path={_route.Path} count={_items.Count}"],
-                    Ul()[
-                        _items.Select(i => Li(
-                            Class: "row",
-                            Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[
-                            $"item {i}"])
-                    ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()["keyed-nav"]],
+            new Body()[
+                new H1()[$"path={_route.Path} count={_items.Count}"],
+                Ul()[
+                    _items.Select(i => Li(
+                        Class: "row",
+                        Data: new Dictionary<string, string?> { ["rask-key"] = i.ToString() })[
+                        $"item {i}"])
                 ]
             ]
-        ];
+        ]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/NavigateInHandlerStateHasChangedApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/NavigateInHandlerStateHasChangedApp.cs
@@ -27,13 +27,13 @@ public sealed class NavigateInHandlerStateHasChangedApp : Component
     protected override void OnUnmount() => _routeState.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()["nav-coalesce"]],
-                new Body()[
-                    new H1()[$"path={_routeState.Path}"]
-                ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()["nav-coalesce"]],
+            new Body()[
+                new H1()[$"path={_routeState.Path}"]
             ]
-        ];
+        ]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/NoOpApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/NoOpApp.cs
@@ -13,9 +13,10 @@ public sealed class NoOpApp : Component
     public int Hidden;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["noop"]],
-                new Body()[new H1()["static"],
-                    Button(OnClick: () => Hidden++)["noop"]]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["noop"]],
+            new Body()[new H1()["static"],
+                Button(OnClick: () => Hidden++)["noop"]]]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/OrderedDispatchApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/OrderedDispatchApp.cs
@@ -1,6 +1,5 @@
 using Rask.Core;
 using Rask.Core.Components;
-using Rask.Core.Routing;
 
 #pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
 
@@ -21,16 +20,16 @@ public sealed class OrderedDispatchApp : Component
     public string Sequence { get; private set; } = "";
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()["ordered-dispatch"]],
-                new Body()[
-                    new P()[$"Sequence={Sequence}"],
-                    Buttons()
-                ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()["ordered-dispatch"]],
+            new Body()[
+                new P()[$"Sequence={Sequence}"],
+                Buttons()
             ]
-        ];
+        ]
+    ];
 
     private Component Buttons()
     {

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
+using Rask.Core.Live;
 
 namespace Rask.Server.Tests.Infrastructure;
 
@@ -32,7 +33,7 @@ internal sealed class RaskTestHost : IDisposable
         // Reset the static PathBase so a pathBase-configured host doesn't leak
         // into subsequent tests in the same AppDomain. Cheap; matches the
         // existing Diff-mode reset convention.
-        Rask.Core.Live.LiveOptions.PathBase = string.Empty;
+        LiveOptions.PathBase = string.Empty;
     }
 
     public static RaskTestHost Create<TApp>(

--- a/tests/Rask.Server.Tests/Infrastructure/RouteTitleNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RouteTitleNavApp.cs
@@ -22,13 +22,13 @@ public sealed class RouteTitleNavApp : Component
     protected override void OnUnmount() => _routeState.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()[$"t-{_routeState.Path}"]],
-                new Body()[
-                    new H1()[$"path={_routeState.Path}"]
-                ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()[$"t-{_routeState.Path}"]],
+            new Body()[
+                new H1()[$"path={_routeState.Path}"]
             ]
-        ];
+        ]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/RouteTitleStructuralNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RouteTitleStructuralNavApp.cs
@@ -22,15 +22,15 @@ public sealed class RouteTitleStructuralNavApp : Component
     protected override void OnUnmount() => _routeState.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[
-                new Head()[new Title()[$"t-{_routeState.Path}"]],
-                new Body()[
-                    _routeState.Path == "/destination"
-                        ? new Ul()[new Li()["a"], new Li()["b"], new Li()["c"]]
-                        : new Div()["plain"]
-                ]
+    [
+        Doctype(),
+        new Html()[
+            new Head()[new Title()[$"t-{_routeState.Path}"]],
+            new Body()[
+                _routeState.Path == "/destination"
+                    ? new Ul()[new Li()["a"], new Li()["b"], new Li()["c"]]
+                    : new Div()["plain"]
             ]
-        ];
+        ]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/TestApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/TestApp.cs
@@ -14,10 +14,11 @@ public sealed class TestApp : Component
     public TestApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["test"]],
-                new Body()[new H1()[$"path={_routeState.Path}"],
-                    new P()[$"count={Counter}"],
-                    Button(OnClick: () => Counter++)["bump"]]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["test"]],
+            new Body()[new H1()[$"path={_routeState.Path}"],
+                new P()[$"count={Counter}"],
+                Button(OnClick: () => Counter++)["bump"]]]
+    ];
 }

--- a/tests/Rask.Server.Tests/Infrastructure/ThrowingApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/ThrowingApp.cs
@@ -10,10 +10,11 @@ public sealed class ThrowingApp : Component
     public int Counter;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["throw"]],
-                new Body()[new P()[$"count={Counter}"],
-                    Button(OnClick: () => throw new InvalidOperationException("boom"))["throw"],
-                    Button(OnClick: () => Counter++)["bump"]]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["throw"]],
+            new Body()[new P()[$"count={Counter}"],
+                Button(OnClick: () => throw new InvalidOperationException("boom"))["throw"],
+                Button(OnClick: () => Counter++)["bump"]]]
+    ];
 }

--- a/tests/Rask.Server.Tests/JSInterop/RaskJSRuntimeTests.cs
+++ b/tests/Rask.Server.Tests/JSInterop/RaskJSRuntimeTests.cs
@@ -44,13 +44,7 @@ public class RaskJSRuntimeTests
 
             var taskId = invoke.GetProperty("id").GetInt64();
             // Send jsResult: emulate JS-side returning "stored-value" for sessionStorage.getItem.
-            await ws.SendJsonAsync(new
-            {
-                type = "jsResult",
-                id = taskId,
-                success = true,
-                result = "stored-value"
-            });
+            await ws.SendJsonAsync(new { type = "jsResult", id = taskId, success = true, result = "stored-value" });
         }
 
         // Wait for the TCS to be completed by the await-continuation in the component.
@@ -72,13 +66,7 @@ public class RaskJSRuntimeTests
         using var doc = JsonDocument.Parse(first!);
         var invoke = doc.RootElement.GetProperty("jsInvokes")[0];
         var taskId = invoke.GetProperty("id").GetInt64();
-        await ws.SendJsonAsync(new
-        {
-            type = "jsResult",
-            id = taskId,
-            success = false,
-            error = "TypeError: nope"
-        });
+        await ws.SendJsonAsync(new { type = "jsResult", id = taskId, success = false, error = "TypeError: nope" });
 
         var ex = await JsErrorApp.Caught.Task.WaitAsync(TimeSpan.FromSeconds(2));
         Assert.IsType<JSException>(ex);
@@ -182,7 +170,11 @@ public class RaskJSRuntimeTests
         while (DateTime.UtcNow < deadline)
         {
             var frame = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100));
-            if (frame is null) continue;
+            if (frame is null)
+            {
+                continue;
+            }
+
             trailing++;
             using var doc = JsonDocument.Parse(frame);
             if (doc.RootElement.TryGetProperty("jsInvokes", out var arr))
@@ -210,8 +202,8 @@ public class RaskJSRuntimeTests
         using var scope = sp.CreateScope();
 
         var js = scope.ServiceProvider.GetRequiredService<IJSRuntime>();
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
-            async () => await js.InvokeAsync<string>("anything", "arg").AsTask());
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await js.InvokeAsync<string>("anything", "arg").AsTask());
         Assert.Contains("Rask session", ex.Message);
     }
 }
@@ -219,19 +211,18 @@ public class RaskJSRuntimeTests
 #pragma warning disable RASK014 // private test-helper Component subclasses
 internal sealed class JsRoundTripApp : Component
 {
-    public static TaskCompletionSource<string?> LastResult { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
     private readonly IJSRuntime _js;
 
-    public JsRoundTripApp(IJSRuntime js)
-    {
-        _js = js;
-    }
+    public JsRoundTripApp(IJSRuntime js) => _js = js;
+
+    public static TaskCompletionSource<string?> LastResult { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]
+    ];
 
     protected override async Task OnRenderedAsync(bool firstRender)
     {
@@ -254,23 +245,21 @@ internal sealed class JsRoundTripApp : Component
 
 internal sealed class JsClickApp : Component
 {
-    public static TaskCompletionSource Completed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
     public static string? LastStatus;
 
     private readonly IJSRuntime _js;
 
-    public JsClickApp(IJSRuntime js)
-    {
-        _js = js;
-    }
+    public JsClickApp(IJSRuntime js) => _js = js;
+    public static TaskCompletionSource Completed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["t"]],
-                new Body()[
-                    Button(OnClickAsync: SetAsync)["set"]
-                ]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["t"]],
+            new Body()[
+                Button(OnClickAsync: SetAsync)["set"]
+            ]]
+    ];
 
     private async Task SetAsync()
     {
@@ -284,15 +273,13 @@ internal sealed class JsRenderStormApp : Component
 {
     private readonly IJSRuntime _js;
 
-    public JsRenderStormApp(IJSRuntime js)
-    {
-        _js = js;
-    }
+    public JsRenderStormApp(IJSRuntime js) => _js = js;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]
+    ];
 
     // Intentionally NO firstRender guard — the whole point is to assert the framework
     // doesn't loop even with this anti-pattern. Mirrors the original CodeSample shape
@@ -303,19 +290,18 @@ internal sealed class JsRenderStormApp : Component
 
 internal sealed class JsErrorApp : Component
 {
-    public static TaskCompletionSource<Exception> Caught { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
     private readonly IJSRuntime _js;
 
-    public JsErrorApp(IJSRuntime js)
-    {
-        _js = js;
-    }
+    public JsErrorApp(IJSRuntime js) => _js = js;
+
+    public static TaskCompletionSource<Exception> Caught { get; } =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]];
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["t"]], new Body()[Text("ready")]]
+    ];
 
     protected override async Task OnRenderedAsync(bool firstRender)
     {

--- a/tests/Rask.Server.Tests/Security/AssetEndpointSecurityTests.cs
+++ b/tests/Rask.Server.Tests/Security/AssetEndpointSecurityTests.cs
@@ -1,5 +1,4 @@
 using System.Net;
-using System.Text;
 using Rask.Core;
 using Rask.Core.ScopedAssets;
 using Rask.Server.Tests.Infrastructure;
@@ -185,5 +184,8 @@ public class AssetEndpointSecurityTests
         Assert.NotEqual(HttpStatusCode.Found, response.StatusCode); // not redirected to login
     }
 
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Server.Tests/Security/SanitizeReturnUrlTests.cs
+++ b/tests/Rask.Server.Tests/Security/SanitizeReturnUrlTests.cs
@@ -1,5 +1,3 @@
-using Rask.Server;
-
 namespace Rask.Server.Tests.Security;
 
 /// <summary>
@@ -20,15 +18,15 @@ public class SanitizeReturnUrlTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    [InlineData("//evil.com")]                 // protocol-relative
-    [InlineData("/\\evil.com")]                // backslash → browser normalises to "//"
-    [InlineData("\\evil.com")]                 // leading backslash
+    [InlineData("//evil.com")] // protocol-relative
+    [InlineData("/\\evil.com")] // backslash → browser normalises to "//"
+    [InlineData("\\evil.com")] // leading backslash
     [InlineData("\\\\evil.com")]
-    [InlineData("https://evil.com")]           // absolute URL
+    [InlineData("https://evil.com")] // absolute URL
     [InlineData("http://evil.com")]
-    [InlineData("javascript:alert(1)")]        // not rooted
-    [InlineData("evil.com")]                    // relative, not rooted
-    [InlineData("/foo\r\nSet-Cookie: x")]      // control chars
+    [InlineData("javascript:alert(1)")] // not rooted
+    [InlineData("evil.com")] // relative, not rooted
+    [InlineData("/foo\r\nSet-Cookie: x")] // control chars
     [InlineData("/foo\tbar")]
     public void NonLocal_OrMalformed_CollapsesToRoot(string? input)
         => Assert.Equal("/", RaskEndpointExtensions.SanitizeReturnUrl(input));

--- a/tests/Rask.Server.Tests/Security/SecureTokenTests.cs
+++ b/tests/Rask.Server.Tests/Security/SecureTokenTests.cs
@@ -1,6 +1,3 @@
-using System.Text.RegularExpressions;
-using Rask.Server;
-
 namespace Rask.Server.Tests.Security;
 
 // M5: redeem tickets and live-session ids are bearer secrets, so they come from a CSPRNG

--- a/tests/Rask.Server.Tests/Security/WebSocketFrameSizeTests.cs
+++ b/tests/Rask.Server.Tests/Security/WebSocketFrameSizeTests.cs
@@ -1,5 +1,4 @@
 using System.Net.WebSockets;
-using Rask.Server;
 using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.Security;

--- a/tests/Rask.Server.Tests/Security/WebSocketOriginTests.cs
+++ b/tests/Rask.Server.Tests/Security/WebSocketOriginTests.cs
@@ -20,8 +20,8 @@ public class WebSocketOriginTests
         host.WebSockets.ConfigureRequest = req => req.Headers["Origin"] = "http://evil.example";
 
         // TestServer surfaces the non-101 handshake as a thrown exception; the socket never opens.
-        var ex = await Assert.ThrowsAnyAsync<Exception>(
-            () => host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None));
+        var ex = await Assert.ThrowsAnyAsync<Exception>(() =>
+            host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None));
         Assert.Contains("403", ex.Message);
     }
 

--- a/tests/Rask.Server.Tests/WebSockets/AsyncValidationDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/AsyncValidationDispatchTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Rask.Core.Live;
 using Rask.Server.Tests.Infrastructure;
 

--- a/tests/Rask.Server.Tests/WebSockets/CheckboxBindingDiffTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/CheckboxBindingDiffTests.cs
@@ -1,4 +1,3 @@
-using System.Net.WebSockets;
 using System.Text.RegularExpressions;
 using Rask.Server.Tests.Infrastructure;
 

--- a/tests/Rask.Server.Tests/WebSockets/DiffWithJsInvokesTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/DiffWithJsInvokesTests.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;

--- a/tests/Rask.Server.Tests/WebSockets/HandlerOrderingTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerOrderingTests.cs
@@ -41,7 +41,7 @@ public class HandlerOrderingTests
         // bug stays latent — which is exactly why the failure only surfaces
         // on loaded CI runners. Make the test fail deterministically when
         // chaining is broken by injecting that contention here.
-        using var stress = new ThreadPoolStress(workers: 8);
+        using var stress = new ThreadPoolStress(8);
 
         using var host = RaskTestHost.Create<OrderedDispatchApp>();
         var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
@@ -94,7 +94,7 @@ public class HandlerOrderingTests
         // "01010101…" alternating is if a later h1 dispatched before its
         // paired h0. With chained dispatch the sequence is always strictly
         // alternating in arrival order.
-        using var stress = new ThreadPoolStress(workers: 8);
+        using var stress = new ThreadPoolStress(8);
 
         using var host = RaskTestHost.Create<OrderedDispatchApp>();
         var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
@@ -176,6 +176,7 @@ public class HandlerOrderingTests
             _cts.Cancel();
             try { Task.WaitAll(_tasks, TimeSpan.FromSeconds(2)); }
             catch { }
+
             _cts.Dispose();
         }
     }

--- a/tests/Rask.Server.Tests/WebSockets/HelloMessageTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HelloMessageTests.cs
@@ -1,7 +1,8 @@
 using System.Net.WebSockets;
 using System.Text.Json;
-using System.Text.RegularExpressions;
+using Rask.Core;
 using Rask.Server.Tests.Infrastructure;
+using Generated = Rask.Core.Components.Generated;
 
 namespace Rask.Server.Tests.WebSockets;
 
@@ -85,7 +86,7 @@ public class HelloMessageTests
         var ws1 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
         await ws1.SendJsonAsync(new { type = "hello", session = sessionId });
         _ = await ws1.TryReceiveTextAsync(TimeSpan.FromMilliseconds(200));
-        await ws1.CloseAsync(System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, "bye",
+        await ws1.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye",
             CancellationToken.None);
 
         using var ws2 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
@@ -114,7 +115,7 @@ public class HelloMessageTests
     // render completes — exercises the "drop happened before hello" branch of
     // FlushPendingRenderAsync.
 #pragma warning disable RASK019 // test-helper Components predate framework-managed <head>
-    private sealed class MountAsyncApp : Rask.Core.Component
+    private sealed class MountAsyncApp : Component
     {
         public static readonly TaskCompletionSource AwaitCompleted =
             new(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -129,14 +130,14 @@ public class HelloMessageTests
             AwaitCompleted.TrySetResult();
         }
 
-        protected override Rask.Core.RenderResult Render() =>
-            Rask.Core.Components.Generated.Fragment()[
-                Rask.Core.Components.Generated.Doctype(),
-                Rask.Core.Components.Generated.Html()[
-                    Rask.Core.Components.Generated.Head()[
-                        Rask.Core.Components.Generated.Title()["mount-async-app"]],
-                    Rask.Core.Components.Generated.Body()[
-                        Rask.Core.Components.Generated.P()[_loaded ? "loaded" : "loading"]]]];
+        protected override RenderResult Render() =>
+            Fragment()[
+                Doctype(),
+                Html()[
+                    Head()[
+                        Title()["mount-async-app"]],
+                    Body()[
+                        P()[_loaded ? "loaded" : "loading"]]]];
     }
 #pragma warning restore RASK019
 }

--- a/tests/Rask.Server.Tests/WebSockets/NavigateMessageTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/NavigateMessageTests.cs
@@ -1,6 +1,4 @@
-using System.Net.WebSockets;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Routing;
 using Rask.Server.Tests.Infrastructure;

--- a/tests/Rask.Server.Tests/WebSockets/NavigationCoalescingTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/NavigationCoalescingTests.cs
@@ -1,6 +1,4 @@
-using System.Net.WebSockets;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Routing;
 using Rask.Server.Tests.Infrastructure;

--- a/tests/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
@@ -1,6 +1,5 @@
 using System.Net.WebSockets;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Rask.Core.Live;
 using Rask.Server.Tests.Infrastructure;
 

--- a/tests/Rask.Server.Tests/WebSockets/PayloadDedupTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/PayloadDedupTests.cs
@@ -1,4 +1,3 @@
-using System.Text.RegularExpressions;
 using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;

--- a/tests/Rask.TestSupport/RenderHarness.cs
+++ b/tests/Rask.TestSupport/RenderHarness.cs
@@ -31,17 +31,16 @@ public static class RenderHarness
     public readonly struct RenderScope<T> : IDisposable
         where T : Component
     {
-        private readonly LiveRenderContext _ctx;
-
         internal RenderScope(LiveRenderContext ctx, T resolved)
         {
-            _ctx = ctx;
+            Context = ctx;
             Resolved = resolved;
         }
 
-        public LiveRenderContext Context => _ctx;
+        public LiveRenderContext Context { get; }
+
         public T Resolved { get; }
 
-        public void Dispose() => _ctx.Dispose();
+        public void Dispose() => Context.Dispose();
     }
 }

--- a/tests/Rask.Validation.DataAnnotations.Tests/DataAnnotationsValidatorTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/DataAnnotationsValidatorTests.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
-using Rask.Core;
 using Rask.Core.Forms;
 
 #pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory

--- a/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
-using Rask.Core;
 using Rask.Core.Forms;
 
 #pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory

--- a/tests/Rask.Validation.FluentValidation.Tests/NestedValidationTests.cs
+++ b/tests/Rask.Validation.FluentValidation.Tests/NestedValidationTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using FluentValidation;
 using FluentValidation.Results;
-using Rask.Core;
 using Rask.Core.Forms;
 
 #pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory

--- a/tests/Rask.Wasm.Hosting.Tests/AssetEndpointParityTests.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/AssetEndpointParityTests.cs
@@ -166,5 +166,8 @@ public class AssetEndpointParityTests
         Assert.Equal("text/css", response.Content.Headers.ContentType?.MediaType);
     }
 
-    private sealed class WidgetA : Component { protected override RenderResult Render() => this; }
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Wasm.Hosting.Tests/Infrastructure/WasmHostingTestServer.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/Infrastructure/WasmHostingTestServer.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.TestHost;
+using Rask.Core.Live;
 
 namespace Rask.Wasm.Hosting.Tests.Infrastructure;
 
@@ -24,7 +25,7 @@ internal sealed class WasmHostingTestServer : IAsyncDisposable
         await _app.DisposeAsync();
         // Reset the static PathBase so tests configuring a prefix don't leak into
         // subsequent tests sharing the AppDomain.
-        Rask.Core.Live.LiveOptions.PathBase = string.Empty;
+        LiveOptions.PathBase = string.Empty;
     }
 
     public static async Task<WasmHostingTestServer> CreateAsync(
@@ -42,7 +43,7 @@ internal sealed class WasmHostingTestServer : IAsyncDisposable
 
         var app = builder.Build();
         app.UseRouting();
-        app.UseRask(bundlePath, pathBase: pathBase);
+        app.UseRask(bundlePath, pathBase);
 
         await app.StartAsync();
         return new WasmHostingTestServer(app);

--- a/tests/Rask.Wasm.Hosting.Tests/PathBaseEndpointTests.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/PathBaseEndpointTests.cs
@@ -154,5 +154,8 @@ public sealed class PathBaseEndpointTests
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
-    private sealed class Widget : Component { protected override RenderResult Render() => this; }
+    private sealed class Widget : Component
+    {
+        protected override RenderResult Render() => this;
+    }
 }

--- a/tests/Rask.Wasm.Hosting.Tests/UseRaskTests.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/UseRaskTests.cs
@@ -185,7 +185,7 @@ public class UseRaskTests
     public async Task AddRaskNotRegistered_BrotliRequested_NoCompression()
     {
         using var bundle = new FakeBundleDirectory(8 * 1024);
-        await using var host = await WasmHostingTestServer.CreateAsync(bundle.Path, false);
+        await using var host = await WasmHostingTestServer.CreateAsync(bundle.Path);
 
         var req = new HttpRequestMessage(HttpMethod.Get, "/_framework/foo.wasm");
         req.Headers.AcceptEncoding.ParseAdd("br");

--- a/tests/Rask.Wasm.Tasks.Tests/BakeScopedAssetsTaskTests.cs
+++ b/tests/Rask.Wasm.Tasks.Tests/BakeScopedAssetsTaskTests.cs
@@ -1,7 +1,8 @@
+using System.Collections;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 using Rask.Core.ScopedAssets;
-using Rask.Wasm.Tasks;
+using Rask.Example.Shared;
 
 namespace Rask.Wasm.Tasks.Tests;
 
@@ -25,17 +26,15 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
 
     public void Dispose()
     {
-        try { Directory.Delete(_bundleDir, recursive: true); }
-        catch { /* best effort */ }
+        try { Directory.Delete(_bundleDir, true); }
+        catch
+        {
+            /* best effort */
+        }
     }
 
     private static BakeScopedAssetsTask NewTask(string bundleDir, ITaskItem[] assemblies)
-        => new()
-        {
-            BundleDir = bundleDir,
-            Assemblies = assemblies,
-            BuildEngine = new StubBuildEngine()
-        };
+        => new() { BundleDir = bundleDir, Assemblies = assemblies, BuildEngine = new StubBuildEngine() };
 
     [Fact]
     public void EmptyBundleDir_ReturnsTrue_NoOutput()
@@ -67,10 +66,8 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
     [Fact]
     public void AssembliesPointToNothing_ReturnsTrue_NoFilesWritten()
     {
-        var task = NewTask(_bundleDir, new ITaskItem[]
-        {
-            new TaskItem(Path.Combine(_bundleDir, "does-not-exist.dll"))
-        });
+        var task = NewTask(_bundleDir,
+            new ITaskItem[] { new TaskItem(Path.Combine(_bundleDir, "does-not-exist.dll")) });
 
         Assert.True(task.Execute());
         // _rask/a/ may or may not get created (registry still scanned); critical is no .css/.js files.
@@ -90,15 +87,11 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
         // already contains its entries. The task RefreshAll-loops over those registration
         // classes, then writes one file per (hash, kind) entry.
         var raskCoreDll = typeof(ScopedAssetRegistry).Assembly.Location;
-        var exampleSharedDll = typeof(Rask.Example.Shared.App).Assembly.Location;
+        var exampleSharedDll = typeof(App).Assembly.Location;
         Assert.True(File.Exists(raskCoreDll), $"Rask.Core.dll not at {raskCoreDll}");
         Assert.True(File.Exists(exampleSharedDll), $"Rask.Example.Shared.dll not at {exampleSharedDll}");
 
-        var task = NewTask(_bundleDir, new ITaskItem[]
-        {
-            new TaskItem(raskCoreDll),
-            new TaskItem(exampleSharedDll),
-        });
+        var task = NewTask(_bundleDir, new ITaskItem[] { new TaskItem(raskCoreDll), new TaskItem(exampleSharedDll) });
 
         Assert.True(task.Execute());
 
@@ -116,13 +109,9 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
     public void RealAssemblies_BakedFilenamesMatchHashAndExtension()
     {
         var raskCoreDll = typeof(ScopedAssetRegistry).Assembly.Location;
-        var exampleSharedDll = typeof(Rask.Example.Shared.App).Assembly.Location;
+        var exampleSharedDll = typeof(App).Assembly.Location;
 
-        var task = NewTask(_bundleDir, new ITaskItem[]
-        {
-            new TaskItem(raskCoreDll),
-            new TaskItem(exampleSharedDll),
-        });
+        var task = NewTask(_bundleDir, new ITaskItem[] { new TaskItem(raskCoreDll), new TaskItem(exampleSharedDll) });
         task.Execute();
 
         var outDir = Path.Combine(_bundleDir, "_rask", "a");
@@ -142,11 +131,12 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
     {
         // The real assemblies register a non-empty scoped-asset set, so even with the
         // fail-fast guard armed the bake succeeds.
-        var task = NewTask(_bundleDir, new ITaskItem[]
-        {
-            new TaskItem(typeof(ScopedAssetRegistry).Assembly.Location),
-            new TaskItem(typeof(Rask.Example.Shared.App).Assembly.Location),
-        });
+        var task = NewTask(_bundleDir,
+            new ITaskItem[]
+            {
+                new TaskItem(typeof(ScopedAssetRegistry).Assembly.Location),
+                new TaskItem(typeof(App).Assembly.Location)
+            });
         task.FailOnEmpty = true;
 
         Assert.True(task.Execute());
@@ -164,10 +154,7 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
         ScopedAssetRegistry.InvalidateAllCss();
         ScopedAssetRegistry.InvalidateAllJs();
 
-        var task = NewTask(_bundleDir, new ITaskItem[]
-        {
-            new TaskItem(typeof(ScopedAssetRegistry).Assembly.Location),
-        });
+        var task = NewTask(_bundleDir, new ITaskItem[] { new TaskItem(typeof(ScopedAssetRegistry).Assembly.Location) });
         task.FailOnEmpty = true;
 
         Assert.False(task.Execute());
@@ -179,10 +166,8 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
     {
         // No Rask.Core in the assembly set → registry never resolves → silent no-op even
         // with the guard armed (a non-Rask WASM project must not be failed by the bake).
-        var task = NewTask(_bundleDir, new ITaskItem[]
-        {
-            new TaskItem(Path.Combine(_bundleDir, "does-not-exist.dll")),
-        });
+        var task = NewTask(_bundleDir,
+            new ITaskItem[] { new TaskItem(Path.Combine(_bundleDir, "does-not-exist.dll")) });
         task.FailOnEmpty = true;
 
         Assert.True(task.Execute());
@@ -193,12 +178,8 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
     public void Rerun_OverwritesSameFiles_Idempotent()
     {
         var raskCoreDll = typeof(ScopedAssetRegistry).Assembly.Location;
-        var exampleSharedDll = typeof(Rask.Example.Shared.App).Assembly.Location;
-        var assemblies = new ITaskItem[]
-        {
-            new TaskItem(raskCoreDll),
-            new TaskItem(exampleSharedDll),
-        };
+        var exampleSharedDll = typeof(App).Assembly.Location;
+        var assemblies = new ITaskItem[] { new TaskItem(raskCoreDll), new TaskItem(exampleSharedDll) };
 
         NewTask(_bundleDir, assemblies).Execute();
         var outDir = Path.Combine(_bundleDir, "_rask", "a");
@@ -234,7 +215,7 @@ public sealed class BakeScopedAssetsTaskTests : IDisposable
         public bool BuildProjectFile(
             string projectFileName,
             string[] targetNames,
-            System.Collections.IDictionary globalProperties,
-            System.Collections.IDictionary targetOutputs) => false;
+            IDictionary globalProperties,
+            IDictionary targetOutputs) => false;
     }
 }

--- a/tests/Rask.Wasm.Tests/Infrastructure/NavigateWithPublishRenderApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/NavigateWithPublishRenderApp.cs
@@ -14,8 +14,8 @@ namespace Rask.Wasm.Tests.Infrastructure;
 // path the bug fix is about.
 internal sealed class NavigateWithPublishRenderApp : Component
 {
-    private readonly RouteState _routeState;
     private readonly Navigator _nav;
+    private readonly RouteState _routeState;
 
     public NavigateWithPublishRenderApp(RouteState routeState, Navigator nav)
     {

--- a/tests/Rask.Wasm.Tests/Infrastructure/ReactiveTitleStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/ReactiveTitleStubApp.cs
@@ -1,5 +1,4 @@
 using Rask.Core;
-using Rask.Core.Routing;
 using static Rask.Core.Components.Generated;
 
 #pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
@@ -14,13 +13,14 @@ internal sealed class ReactiveTitleStubApp : Component
     private int _count;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html()[
-                Head()[Title()[$"count-{_count}"]],
-                Body()[
-                    H1()[$"count={_count}"],
-                    Button(OnClick: () => _count++)["bump"]
-                ]
-            ]];
+    [
+        Doctype(),
+        Html()[
+            Head()[Title()[$"count-{_count}"]],
+            Body()[
+                H1()[$"count={_count}"],
+                Button(OnClick: () => _count++)["bump"]
+            ]
+        ]
+    ];
 }

--- a/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStructuralStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStructuralStubApp.cs
@@ -17,14 +17,15 @@ internal sealed class RouteTitleStructuralStubApp : Component
     public RouteTitleStructuralStubApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html()[
-                Head()[Title()[$"title-{_routeState.Path}"]],
-                Body()[
-                    _routeState.Path == "/destination"
-                        ? Ul()[Li()["a"], Li()["b"], Li()["c"]]
-                        : Div()["plain"]
-                ]
-            ]];
+    [
+        Doctype(),
+        Html()[
+            Head()[Title()[$"title-{_routeState.Path}"]],
+            Body()[
+                _routeState.Path == "/destination"
+                    ? Ul()[Li()["a"], Li()["b"], Li()["c"]]
+                    : Div()["plain"]
+            ]
+        ]
+    ];
 }

--- a/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/RouteTitleStubApp.cs
@@ -16,12 +16,13 @@ internal sealed class RouteTitleStubApp : Component
     public RouteTitleStubApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html()[
-                Head()[Title()[$"title-{_routeState.Path}"]],
-                Body()[
-                    H1()[$"path={_routeState.Path}"]
-                ]
-            ]];
+    [
+        Doctype(),
+        Html()[
+            Head()[Title()[$"title-{_routeState.Path}"]],
+            Body()[
+                H1()[$"path={_routeState.Path}"]
+            ]
+        ]
+    ];
 }

--- a/tests/Rask.Wasm.Tests/Infrastructure/StubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/StubApp.cs
@@ -14,14 +14,15 @@ internal sealed class StubApp : Component
     public StubApp(RouteState routeState) => _routeState = routeState;
 
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html()[
-                Head()[Title()["stub"]],
-                Body()[
-                    H1()[$"path={_routeState.Path}"],
-                    P()[$"count={Counter}"],
-                    Button(OnClick: () => Counter++)["bump"]
-                ]
-            ]];
+    [
+        Doctype(),
+        Html()[
+            Head()[Title()["stub"]],
+            Body()[
+                H1()[$"path={_routeState.Path}"],
+                P()[$"count={Counter}"],
+                Button(OnClick: () => Counter++)["bump"]
+            ]
+        ]
+    ];
 }

--- a/tests/Rask.Wasm.Tests/Infrastructure/ThrowingStubApp.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/ThrowingStubApp.cs
@@ -8,13 +8,14 @@ namespace Rask.Wasm.Tests.Infrastructure;
 internal sealed class ThrowingStubApp : Component
 {
     protected override RenderResult Render() =>
-        [
-            Doctype(),
-            Html()[
-                Head()[Title()["throw"]],
-                Body()[
-                    P()["throwing app"],
-                    Button(OnClick: () => throw new InvalidOperationException("boom"))["go"]
-                ]
-            ]];
+    [
+        Doctype(),
+        Html()[
+            Head()[Title()["throw"]],
+            Body()[
+                P()["throwing app"],
+                Button(OnClick: () => throw new InvalidOperationException("boom"))["go"]
+            ]
+        ]
+    ];
 }

--- a/tests/Rask.Wasm.Tests/JSInterop/HeadAssetGateBugReproductionTests.cs
+++ b/tests/Rask.Wasm.Tests/JSInterop/HeadAssetGateBugReproductionTests.cs
@@ -53,6 +53,7 @@ public sealed class HeadAssetGateBugReproductionTests
             // user-observable side of the same bug under Playwright.
             return;
         }
+
         var repoRoot = LocateRepoRoot();
         var fixtureScript = Path.Combine(repoRoot, "tests", "Rask.Wasm.Tests", "JSInterop", "HeadAssetGateFixture.mjs");
         var bundlePath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "rask.wasm.js");

--- a/tests/Rask.Wasm.Tests/JSInterop/HeadAssetGateFixture.mjs
+++ b/tests/Rask.Wasm.Tests/JSInterop/HeadAssetGateFixture.mjs
@@ -26,7 +26,7 @@
 // line on stdout and asserts the recorded values match the bug pattern.
 // When the bug is fixed (gate stops draining on 'error'/timeout), the
 // expectations flip and the test reads as a regression guard.
-import { readFileSync } from "node:fs";
+import {readFileSync} from "node:fs";
 
 const bundlePath = process.argv[2];
 if (!bundlePath) {
@@ -44,13 +44,27 @@ function makeStubElement(tagName) {
         _children: [],
         parentNode: null,
         textContent: "",
-        get rel() { return attrs.get("rel") ?? ""; },
-        get src() { return attrs.get("src") ?? ""; },
-        get href() { return attrs.get("href") ?? ""; },
-        get id() { return attrs.get("id") ?? ""; },
-        set id(v) { attrs.set("id", String(v)); },
-        get text() { return el.textContent; },
-        set text(v) { el.textContent = String(v); },
+        get rel() {
+            return attrs.get("rel") ?? "";
+        },
+        get src() {
+            return attrs.get("src") ?? "";
+        },
+        get href() {
+            return attrs.get("href") ?? "";
+        },
+        get id() {
+            return attrs.get("id") ?? "";
+        },
+        set id(v) {
+            attrs.set("id", String(v));
+        },
+        get text() {
+            return el.textContent;
+        },
+        set text(v) {
+            el.textContent = String(v);
+        },
         hasAttribute: (name) => attrs.has(name),
         getAttribute: (name) => (attrs.has(name) ? attrs.get(name) : null),
         setAttribute: (name, value) => attrs.set(name, String(value)),
@@ -61,7 +75,7 @@ function makeStubElement(tagName) {
         },
         _dispatch: (type) => {
             const fns = listeners.get(type) || [];
-            for (const fn of fns.slice()) fn({ type, target: el });
+            for (const fn of fns.slice()) fn({type, target: el});
         },
         appendChild: (child) => {
             el._children.push(child);
@@ -69,7 +83,7 @@ function makeStubElement(tagName) {
             return child;
         },
         get attributes() {
-            return [...attrs.entries()].map(([name, value]) => ({ name, value }));
+            return [...attrs.entries()].map(([name, value]) => ({name, value}));
         }
     };
     return el;
@@ -98,30 +112,37 @@ body.setAttribute("data-rask-root", "");
 globalThis.document = {
     head,
     body,
-    documentElement: { tagName: "HTML" },
+    documentElement: {tagName: "HTML"},
     getElementById: (id) => head._children.find(c => c.getAttribute("id") === id) || null,
     createElement: (tag) => makeStubElement(tag),
     querySelector: (sel) => {
         if (sel === "[data-rask-root]") return body;
         return null;
     },
-    addEventListener: () => {}
+    addEventListener: () => {
+    }
 };
 globalThis.window = globalThis;
 // The bundle wires top-level `window.addEventListener("popstate", ...)` and a
 // few `document.addEventListener(...)` handlers at module init. Provide
 // no-op stubs so the import doesn't fault — the gate scenarios under test
 // never dispatch any of these events.
-globalThis.addEventListener = () => {};
-globalThis.performance = { getEntriesByName: () => [] };
-globalThis.location = { pathname: "/", search: "" };
-globalThis.history = { replaceState: () => {}, pushState: () => {} };
-globalThis.cancelAnimationFrame = () => {};
+globalThis.addEventListener = () => {
+};
+globalThis.performance = {getEntriesByName: () => []};
+globalThis.location = {pathname: "/", search: ""};
+globalThis.history = {
+    replaceState: () => {
+    }, pushState: () => {
+    }
+};
+globalThis.cancelAnimationFrame = () => {
+};
 globalThis.requestAnimationFrame = () => 0;
 // Node already exposes a (getter-only) `crypto` global on v19+; skip the
 // override if one is present so the assignment doesn't fault here.
 if (typeof globalThis.crypto === "undefined") {
-    globalThis.crypto = { randomUUID: () => "stub-uuid" };
+    globalThis.crypto = {randomUUID: () => "stub-uuid"};
 }
 
 // Capture the gate's 5-second safety timeout so the test can fire it on
@@ -143,6 +164,7 @@ const mod = await import(moduleUrl);
 
 // ----- Helpers -----
 const encoder = new TextEncoder();
+
 function applyRenderJson(reply) {
     mod.applyRender(encoder.encode(JSON.stringify(reply)));
 }
@@ -169,11 +191,13 @@ mod.setExports({
     Rask: {
         Wasm: {
             JSInterop: {
-                Dispatch: () => {},
+                Dispatch: () => {
+                },
                 // Production wires EndInvokeJSResult to a [JSExport]. The gate
                 // calls it after running a queued invoke; without the stub the
                 // bundle logs a noisy error to stderr.
-                EndInvokeJSResult: () => {}
+                EndInvokeJSResult: () => {
+                }
             }
         }
     }
@@ -181,7 +205,7 @@ mod.setExports({
 
 // Open the scoped-JS half of the gate. Without html the runtime skips
 // morph + the post-morph scanHeadAssets re-run — only applyScopedJs fires.
-applyRenderJson({ jsHash: "test-hash", jsText: "// scoped-js bundle stub" });
+applyRenderJson({jsHash: "test-hash", jsText: "// scoped-js bundle stub"});
 
 // Capture console.warn so we can assert the gate emits a diagnostic when
 // a Head asset terminates without successfully defining its global.

--- a/tests/Rask.Wasm.Tests/JSInterop/WasmJSRuntimeTests.cs
+++ b/tests/Rask.Wasm.Tests/JSInterop/WasmJSRuntimeTests.cs
@@ -16,17 +16,17 @@ public sealed class WasmJSRuntimeTests
     public async Task InvokeAsync_RoundTrip_CompletesWithJsResult()
     {
         var runtime = new WasmJSRuntime();
-        Rask.Wasm.JSInterop.Init(runtime);
+        JSInterop.Init(runtime);
 
         var task = runtime.InvokeAsync<string>("sessionStorage.getItem", "my-key").AsTask();
 
-        var call = Rask.Wasm.JSInterop.LastBeginInvokeJsCall;
+        var call = JSInterop.LastBeginInvokeJsCall;
         Assert.NotNull(call);
         Assert.Equal("sessionStorage.getItem", call!.Identifier);
         Assert.Equal("[\"my-key\"]", call.ArgsJson);
 
         var taskId = long.Parse(call.TaskId);
-        Rask.Wasm.JSInterop.EndInvokeJSResult(BuildResult(taskId, success: true, resultJson: "\"stored-value\""));
+        JSInterop.EndInvokeJSResult(BuildResult(taskId, true, "\"stored-value\""));
 
         var observed = await task.WaitAsync(TimeSpan.FromSeconds(2));
         Assert.Equal("stored-value", observed);
@@ -36,12 +36,12 @@ public sealed class WasmJSRuntimeTests
     public async Task InvokeAsync_ErrorReply_PropagatesAsJSException()
     {
         var runtime = new WasmJSRuntime();
-        Rask.Wasm.JSInterop.Init(runtime);
+        JSInterop.Init(runtime);
 
         var task = runtime.InvokeAsync<string>("nonexistent.method").AsTask();
 
-        var taskId = long.Parse(Rask.Wasm.JSInterop.LastBeginInvokeJsCall!.TaskId);
-        Rask.Wasm.JSInterop.EndInvokeJSResult(BuildResult(taskId, success: false, error: "TypeError: boom"));
+        var taskId = long.Parse(JSInterop.LastBeginInvokeJsCall!.TaskId);
+        JSInterop.EndInvokeJSResult(BuildResult(taskId, false, error: "TypeError: boom"));
 
         var ex = await Assert.ThrowsAsync<JSException>(() => task.WaitAsync(TimeSpan.FromSeconds(2)));
         Assert.Contains("TypeError: boom", ex.Message);
@@ -51,18 +51,18 @@ public sealed class WasmJSRuntimeTests
     public async Task InvokeVoidAsync_VoidResult_Completes()
     {
         var runtime = new WasmJSRuntime();
-        Rask.Wasm.JSInterop.Init(runtime);
+        JSInterop.Init(runtime);
 
         var task = runtime.InvokeVoidAsync("sessionStorage.setItem", "k", "v").AsTask();
 
-        var call = Rask.Wasm.JSInterop.LastBeginInvokeJsCall;
+        var call = JSInterop.LastBeginInvokeJsCall;
         Assert.NotNull(call);
         // JSCallResultType.JSVoidResult == 3 — verifies the void overload routes through
         // the same dispatch surface without expecting a serializable result.
         Assert.Equal(3, call!.ResultType);
 
         var taskId = long.Parse(call.TaskId);
-        Rask.Wasm.JSInterop.EndInvokeJSResult(BuildResult(taskId, success: true, resultJson: "null"));
+        JSInterop.EndInvokeJSResult(BuildResult(taskId, true, "null"));
 
         await task.WaitAsync(TimeSpan.FromSeconds(2));
     }

--- a/tests/Rask.Wasm.Tests/Session/DispatchAsyncRoutingTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DispatchAsyncRoutingTests.cs
@@ -1,10 +1,8 @@
-using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
 using Rask.Core.Routing;
-using Rask.Core.ScopedAssets;
 using Rask.Wasm.Tests.Infrastructure;
 
 namespace Rask.Wasm.Tests.Session;

--- a/tests/Rask.Wasm.Tests/Session/DisposalTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DisposalTests.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Core.Routing;
-using Rask.Wasm;
 using Rask.Wasm.Files;
 using static Rask.Core.Components.Generated;
 
@@ -44,7 +43,7 @@ public class DisposalTests
         // Stage far more than the cap without ever pulling — the orphaned-download leak case.
         for (var i = 0; i < 100; i++)
         {
-            sink.Stage($"f{i}.bin", new byte[] { (byte)i }, null);
+            sink.Stage($"f{i}.bin", new[] { (byte)i }, null);
         }
 
         Assert.True(sink.RetainedCount <= 16,
@@ -75,6 +74,8 @@ public class DisposalTests
     {
         private Action? _changed;
 
+        public int SubscriberCount => _changed?.GetInvocationList().Length ?? 0;
+
         public ClaimsPrincipal Current { get; } = new(new ClaimsIdentity());
 
         public event Action? Changed
@@ -82,7 +83,5 @@ public class DisposalTests
             add => _changed += value;
             remove => _changed -= value;
         }
-
-        public int SubscriberCount => _changed?.GetInvocationList().Length ?? 0;
     }
 }

--- a/tests/Rask.Wasm.Tests/Session/DownloadTokenPullTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DownloadTokenPullTests.cs
@@ -1,10 +1,8 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Routing;
-using Rask.Core.ScopedAssets;
 using Rask.Wasm.Files;
 using static Rask.Core.Components.Generated;
 
@@ -15,7 +13,6 @@ namespace Rask.Wasm.Tests.Session;
 [Collection("WasmSession")]
 public class DownloadTokenPullTests : ResettingTestBase
 {
-
     [Fact]
     public async Task DownloadTriggeredFromHandler_PayloadCarriesTokenNotBase64Bytes()
     {
@@ -68,8 +65,8 @@ public class DownloadTokenPullTests : ResettingTestBase
     private static (WasmLiveSession session, IServiceProvider services) NewSessionWithDownloadOnClick(
         string filename, byte[] bytes, string? contentType) =>
         NewSession<DownloadStubApp>(
-            appFactory: p => new DownloadStubApp(p.GetRequiredService<Navigator>(), filename, bytes, contentType),
-            configure: s => s.AddSingleton<IDownloadSink, WasmDownloadSink>());
+            p => new DownloadStubApp(p.GetRequiredService<Navigator>(), filename, bytes, contentType),
+            s => s.AddSingleton<IDownloadSink, WasmDownloadSink>());
 
     private static string ExtractToken(byte[] payload)
     {
@@ -93,13 +90,14 @@ public class DownloadTokenPullTests : ResettingTestBase
         }
 
         protected override RenderResult Render() =>
-            [
-                Doctype(),
-                Html()[
-                    Head()[Title()["dl"]],
-                    Body()[
-                        Button(OnClick: () => _nav.Download(_filename, _bytes, _contentType))["go"]
-                    ]
-                ]];
+        [
+            Doctype(),
+            Html()[
+                Head()[Title()["dl"]],
+                Body()[
+                    Button(OnClick: () => _nav.Download(_filename, _bytes, _contentType))["go"]
+                ]
+            ]
+        ];
     }
 }

--- a/tests/Rask.Wasm.Tests/Session/HandlerScopeTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/HandlerScopeTests.cs
@@ -1,7 +1,3 @@
-using Microsoft.Extensions.DependencyInjection;
-using Rask.Core.Routing;
-using Rask.Wasm.Tests.Infrastructure;
-
 namespace Rask.Wasm.Tests.Session;
 
 [Collection("WasmSession")]

--- a/tests/Rask.Wasm.Tests/Session/NavigationDiffGateTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/NavigationDiffGateTests.cs
@@ -1,10 +1,6 @@
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Rask.Core;
 using Rask.Core.Live;
-using Rask.Core.Routing;
-using Rask.Core.ScopedAssets;
 using Rask.Wasm.Tests.Infrastructure;
 
 namespace Rask.Wasm.Tests.Session;
@@ -20,7 +16,6 @@ namespace Rask.Wasm.Tests.Session;
 // write is safe.
 public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
 {
-
     [Fact]
     public async Task Navigate_SameHead_ShipsDiffWithHistory()
     {
@@ -134,7 +129,8 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
 
         using var doc = JsonDocument.Parse(result.AsMemory());
         Assert.Equal("diff", doc.RootElement.GetProperty("kind").GetString());
-        Assert.True(doc.RootElement.TryGetProperty("head", out var head), "reactive title change must ship a head fragment");
+        Assert.True(doc.RootElement.TryGetProperty("head", out var head),
+            "reactive title change must ship a head fragment");
         Assert.Contains("count-1", head.GetString());
         Assert.NotEmpty(doc.RootElement.GetProperty("ops").EnumerateArray());
         Assert.False(doc.RootElement.TryGetProperty("history", out _), "no navigation → no history");

--- a/tests/Rask.Wasm.Tests/Session/NavigationPublishRerenderTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/NavigationPublishRerenderTests.cs
@@ -1,9 +1,6 @@
-using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Routing;
-using Rask.Core.ScopedAssets;
 using Rask.Wasm.Tests.Infrastructure;
 
 namespace Rask.Wasm.Tests.Session;

--- a/tests/Rask.Wasm.Tests/Session/PayloadShapeTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/PayloadShapeTests.cs
@@ -1,11 +1,6 @@
 using System.Text;
 using System.Text.Json;
-using System.Text.RegularExpressions;
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Live;
-using Rask.Core.Routing;
-using Rask.Core.ScopedAssets;
-using Rask.Wasm.Tests.Infrastructure;
 
 namespace Rask.Wasm.Tests.Session;
 
@@ -14,7 +9,6 @@ namespace Rask.Wasm.Tests.Session;
 // (framework default is LiveDiffMode.Auto).
 public class PayloadShapeTests() : ResettingTestBase(LiveDiffMode.DisabledFull)
 {
-
     [Fact]
     public async Task InitialRender_AlwaysIncludesDataRaskRootEqualsWasm()
     {

--- a/tests/Rask.Wasm.Tests/Session/ScopedStylesAbsenceTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/ScopedStylesAbsenceTests.cs
@@ -1,8 +1,5 @@
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
-using Rask.Core.Components;
-using Rask.Core.Routing;
 using Rask.Core.ScopedAssets;
 using static Rask.Core.Components.Generated;
 
@@ -57,12 +54,12 @@ public class ScopedStylesAbsenceTests : ResettingTestBase
         protected override RenderResult Head => Title()["wasm-stub"];
 
         protected override RenderResult Render() =>
-            [
-                Doctype(),
-                Html()[
-                    Head(),
-                    Body()[Div(Class: "tag")["hi"]]
-                ]
-            ];
+        [
+            Doctype(),
+            Html()[
+                Head(),
+                Body()[Div(Class: "tag")["hi"]]
+            ]
+        ];
     }
 }

--- a/tests/Rask.Wasm.Tests/Session/WasmDiffPathTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/WasmDiffPathTests.cs
@@ -1,11 +1,6 @@
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Rask.Core;
 using Rask.Core.Live;
-using Rask.Core.Routing;
-using Rask.Core.ScopedAssets;
-using Rask.Wasm.Tests.Infrastructure;
 
 namespace Rask.Wasm.Tests.Session;
 
@@ -20,7 +15,6 @@ namespace Rask.Wasm.Tests.Session;
 // re-sending the body); Forced just removes that last size comparison from the equation.
 public class WasmDiffPathTests() : ResettingTestBase(LiveDiffMode.Forced)
 {
-
     [Fact]
     public async Task ClickCounter_ThreeIncrements_ProducesDiffsWithCorrectUpdateText()
     {


### PR DESCRIPTION
A curated, verified sweep across four areas. Three parallel review passes plus targeted code reads were used to separate real issues from false positives — only verified changes ship here.

## Bug fixes
- **`SessionUploadStore`**: was blocking a thread-pool thread with sync-over-async (`.GetAwaiter().GetResult()`) for the whole upload copy. Now `StageAsync`, awaited at the `HandleUploadAsync` call site. Adds a focused unit test.
- Documented why `SessionDownloadStore.StageStream` copies eagerly (it decouples the temp file's lifetime from the synchronous public `Navigator.Download` / `IDownloadSink.Stage` API — making it async would change that public seam).
- Rejected as false positives (no change): the `ScheduleRemoval` "race" (removal is atomic via `ICollection.Remove` + `TryRemove`), `Fragment(null)` semantics (intentional `[]` normalization), and the Content-Disposition "header injection" (`Uri.EscapeDataString` already percent-encodes `"`/CR/LF).

## Docs
- XML `<summary>` on the public host entry points: `AddRask`, both `UseRask` overloads, and the `Rask.Wasm` `WasmHostBuilder` surface (class, `Services`, `CreateDefault()`, `RunAsync`).
- New [`docs/composition.md`](docs/composition.md) (children & fragments, callbacks, context, `Virtualize`, drag-drop) and [`docs/js-interop.md`](docs/js-interop.md) (scoped CSS/JS, `IJSRuntime`, element refs), both indexed in `docs/README.md`.
- New `CONTRIBUTING.md` and `CHANGELOG.md`.

## Examples
- `samples/README.md` index plus a README in each runnable sample/host, and a README in each `dotnet new` template (`rask-server` / `-wasm` / `-wasm-hosted`).
- Suppressed the 15 RASK022 warnings in `Rask.Benchmarks.VsBlazor` with rationale: those lists are deliberately keyless to match Blazor's keyless `BuildRenderTree`; adding `Key:` would skew the comparison.

## UI / DX
- Showcase `HomePage` is now a grouped feature index surfacing **every** demo page (was 8 of ~33), with section-divider + card-hover polish in `HomePage.css`.
- `JsRuntimePage` adopts `PageHeader`, matching the other 32 pages.

## Verification
- `dotnet build` — 0 warnings, 0 errors (benchmark RASK022 noise gone).
- `dotnet test` (non-E2E) — ~2,160 passing, 0 failing, incl. the new test.
- WASM `dotnet publish -c Release` — zero IL trim warnings.
- Template smoke: `dotnet new rask-server --auth` scaffolds the README (name-substituted) and `Auth/`.
- Server sample renders the new home page server-side; all new internal doc links resolve.