### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+---
+
+## [0.7.0] - 2026-06-10
+
 ### Fixed
 - `SessionUploadStore` no longer blocks a thread-pool thread with sync-over-async
   (`.GetAwaiter().GetResult()`) while staging an upload — the copy is now awaited.


### PR DESCRIPTION
Promote CHANGELOG `[Unreleased]` to v0.7.0 (dated 2026-06-10).

After this merges to main, tag `v0.7.0` on the merge commit to trigger `.github/workflows/release.yml`:
- build + test (Release)
- pack all six NuGet packages
- push to nuget.org
- create the GitHub release with auto-generated notes

Release contents (from the changelog): `SessionUploadStore` sync-over-async fix, new Composition & JS-interop docs, host entry-point XML docs, CONTRIBUTING.md, per-sample/template READMEs, and showcase home-page polish.

Verified locally: `dotnet build -c Release` (0 warnings) and the full non-E2E test suite pass.