### PR TITLE
Harden render hot path, session layer, and URL output (perf/memory/security)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Security
+- URL-bearing attributes (`href`, `src`, `cite`, `formaction`, object `data`, `poster`,
+  SVG `href`) are now **scheme-sanitized by default**: `javascript:`/`vbscript:` and
+  `data:` outside media tags are neutralized to `about:blank`, closing a DOM-XSS hole that
+  HTML-encoding alone left open. Detection defeats whitespace/tab/NUL obfuscation. Opt out
+  per call with `RaskUrl.Trusted(...)` for URLs you control; media tags still allow inline
+  `data:image/*`, `data:video/*`, `data:audio/*`. See the [getting-started guide](docs/getting-started.md#url-attributes-are-scheme-sanitized).
+
+### Performance
+- Scoped-asset registry reads (run per component, per render) are now lock-free
+  (`ConcurrentDictionary`), so concurrent sessions no longer serialize on a process-wide lock.
+- Removed `AsyncLocal` reads from the per-element attribute path via a thread-local
+  render-context mirror, and cache `Component.Key` stringification (no per-render `ToString`
+  allocation on keyed lists).
+- `<head>` splice avoids a second whole-body scan, pools its builders, and appends keys
+  without per-asset string allocation.
+
+### Memory
+- The per-render head-asset collector and mounted-type set are hoisted onto the root and
+  reused (cleared per render) instead of allocating fresh collections every frame.
+- A session minted by the GET shell but never connected over WebSocket is now evicted on a
+  short grace (vs. the 30s reconnect grace), and `MaxSessions` is enforced as a hard atomic
+  reservation — a concurrent GET burst can no longer exceed the cap.
+- The WebSocket handler-dispatch chain is bounded: when handlers back up behind a hung or
+  flooding client, the socket is closed instead of retaining queued payloads without limit.
+
 ---
 
 ## [0.7.0] - 2026-06-10

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -91,6 +91,24 @@ P()["<b>encoded</b> — shows the angle brackets as text"],   // string → Text
 Div()[Raw("<b>bold</b>")]                                    // emitted verbatim
 ```
 
+### URL attributes are scheme-sanitized
+
+URL-bearing attributes — `href` (`A`, `Area`, `Link`, `Base`, SVG), `src`
+(`Iframe`, `Script`, `Embed`, media), `cite`, `formaction`, object `data`, `poster` —
+are **sanitized by default**: HTML-encoding alone does not stop `<a href="javascript:…">`
+from executing on click. A dangerous scheme (`javascript:`, `vbscript:`, and `data:`
+outside media tags) is neutralized to `about:blank`; relative/`http(s)`/`mailto`/`tel`/
+fragment URLs pass through unchanged, and media tags (`img`/`audio`/`video`/`source`/
+`poster`) still allow inline `data:image/*`, `data:video/*`, `data:audio/*`.
+
+```csharp
+A(Href: userSuppliedUrl)["profile"]            // javascript:… → about:blank
+A(Href: RaskUrl.Trusted("javascript:void(0)"))["noop"]   // opt out for URLs you control
+```
+
+`RaskUrl.Trusted(...)` is the per-call escape hatch — the value is still HTML-encoded,
+just not scheme-checked. Use it only for non-attacker-controlled URLs.
+
 ## 4. Add interactivity
 
 Keep local state in fields and wire event handlers as plain delegates. A click does

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -64,6 +64,40 @@ public abstract class Component
     // content (a known framework bug); delete/move/in-place keyed edits are correct.
     public object? Key { get; set; }
 
+    private object? _cachedKeyValue;
+    private string? _cachedKeyString;
+
+    // Stringified Key for emit (data-rask-key) and key-forwarding, computed per render on every
+    // keyed node. A string key needs no allocation (ToString() returns itself); for boxed value
+    // keys (the common int/Guid keyed-list case) the factory re-boxes the same value each render,
+    // so we cache by value-equality and reuse the prior string instead of re-allocating it.
+    internal string? KeyString
+    {
+        get
+        {
+            var k = Key;
+            if (k is null)
+            {
+                return null;
+            }
+
+            if (k is string s)
+            {
+                return s;
+            }
+
+            if (_cachedKeyValue is not null && _cachedKeyValue.Equals(k))
+            {
+                return _cachedKeyString;
+            }
+
+            var str = k.ToString();
+            _cachedKeyValue = k;
+            _cachedKeyString = str;
+            return str;
+        }
+    }
+
     // Primary children indexer. `Div()[Span(...), "hi"]` is the call shape: literal lists of
     // Components/strings (each implicitly Child via Child's converters). Overload resolution
     // prefers this `params Child[]` form over the IEnumerable<…> variants below — the compiler
@@ -270,6 +304,22 @@ public abstract class Component
             // common no-frames path stays zero-allocation.
             fw.Attribute(namePrefix + nameSuffix, value);
         }
+    }
+
+    // URL-bearing attribute (href/cite/action and iframe/script/object sources). Scheme is
+    // sanitized by default — javascript:/vbscript:/data: are neutralized to about:blank — to
+    // close the DOM-XSS hole that plain HTML-encoding leaves open. Wrap a trusted value in
+    // RaskUrl.Trusted(...) to opt out. Otherwise identical to AppendAttr (incl. frame sink).
+    protected static void AppendUrlAttr(StringBuilder sb, string name, string? value)
+    {
+        AppendAttr(sb, name, UrlSanitizer.Sanitize(value));
+    }
+
+    // Media URL attribute (img/audio/video/source src, poster). As AppendUrlAttr but also
+    // allows data:image/*, data:video/*, data:audio/* (inline media is common and inert here).
+    protected static void AppendMediaUrlAttr(StringBuilder sb, string name, string? value)
+    {
+        AppendAttr(sb, name, UrlSanitizer.SanitizeMedia(value));
     }
 
     protected virtual IEnumerable<Child> RenderChildren() => Children ?? [];
@@ -964,7 +1014,14 @@ public abstract class Component
         // render: pool is null, allocate once. Steady state: Clear and reuse.
         Live.EditContextsPool ??= new Dictionary<LiveRenderContext.ObjectKey, EditContext>();
         Live.EditContextsPool.Clear();
-        using var ctx = LiveRenderContext.Begin(this, previousEditContexts, Live.EditContextsPool, services);
+        // Reuse the head-asset collector and mounted-type set across renders (cleared here),
+        // so head emission doesn't allocate fresh lists/sets every frame.
+        Live.HeadAssets ??= new HeadAssetRegistry();
+        Live.HeadAssets.Clear();
+        Live.MountedTypes ??= new HashSet<Type>();
+        Live.MountedTypes.Clear();
+        using var ctx = LiveRenderContext.Begin(
+            this, previousEditContexts, Live.EditContextsPool, services, Live.HeadAssets, Live.MountedTypes);
 
         // Pooled per-frame scratch buffers held on the root component. RenderAsLiveRootCore
         // runs single-threaded per session (the WS dispatcher serializes via the session
@@ -1004,7 +1061,7 @@ public abstract class Component
             // (sliced from this post-splice HTML via those offsets) reads the wrong bytes.
             var sentinelIdx = html.IndexOf(HeadAssetRegistry.Sentinel, StringComparison.Ordinal);
             var preLen = html.Length;
-            html = liveCtx.HeadAssets.ApplyTo(html, liveCtx.Services);
+            html = liveCtx.HeadAssets.ApplyTo(html, sentinelIdx, liveCtx.Services);
             if (sentinelIdx >= 0 && FrameSinkScope.Current is { } frameSink)
             {
                 frameSink.AdjustOffsetsFrom(
@@ -1226,6 +1283,8 @@ public abstract class Component
         public Dictionary<(Type, int), Component>? Children;
         public Dictionary<LiveRenderContext.ObjectKey, EditContext>? EditContextsPool;
         public ElementRef? ElementRef;
+        public HeadAssetRegistry? HeadAssets;
+        public HashSet<Type>? MountedTypes;
         public Dictionary<string, (Component Owner, Delegate Handler)>? Handlers;
         public bool HasInitialized;
         public bool HasRenderedOnce;

--- a/src/Rask.Core/Components/A.cs
+++ b/src/Rask.Core/Components/A.cs
@@ -23,7 +23,7 @@ public sealed class A : Element
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (Target is not null)
@@ -62,7 +62,7 @@ public sealed class A : Element
         }
 
         var click = (Delegate?)OnClick ?? OnClickAsync;
-        if (click is not null && LiveRenderContext.Current is { } ctx)
+        if (click is not null && LiveRenderContext.CurrentSync is { } ctx)
         {
             AppendAttr(sb, "data-rask-on-click", ctx.RegisterHandler(click));
         }

--- a/src/Rask.Core/Components/Area.cs
+++ b/src/Rask.Core/Components/Area.cs
@@ -35,7 +35,7 @@ public sealed class Area : Element
 
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (Target is not null)

--- a/src/Rask.Core/Components/Audio.cs
+++ b/src/Rask.Core/Components/Audio.cs
@@ -19,7 +19,7 @@ public sealed class Audio : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendMediaUrlAttr(sb, "src", Src);
         }
 
         if (Controls is true)

--- a/src/Rask.Core/Components/Base.cs
+++ b/src/Rask.Core/Components/Base.cs
@@ -15,7 +15,7 @@ public sealed class Base : Element
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (Target is not null)

--- a/src/Rask.Core/Components/Blockquote.cs
+++ b/src/Rask.Core/Components/Blockquote.cs
@@ -13,7 +13,7 @@ public sealed class Blockquote : Element
         base.WriteAttributes(sb);
         if (Cite is not null)
         {
-            AppendAttr(sb, "cite", Cite);
+            AppendUrlAttr(sb, "cite", Cite);
         }
     }
 }

--- a/src/Rask.Core/Components/Button.cs
+++ b/src/Rask.Core/Components/Button.cs
@@ -38,7 +38,7 @@ public sealed class Button : Element
         }
 
         var click = (Delegate?)OnClick ?? OnClickAsync;
-        if (click is not null && LiveRenderContext.Current is { } ctx)
+        if (click is not null && LiveRenderContext.CurrentSync is { } ctx)
         {
             AppendAttr(sb, "data-rask-on-click", ctx.RegisterHandler(click));
         }

--- a/src/Rask.Core/Components/Context.cs
+++ b/src/Rask.Core/Components/Context.cs
@@ -99,5 +99,5 @@ public sealed class Context : Component
         return ContextStack.TryGet(typeof(T), name, out _);
     }
 
-    private static void MarkConsumer() => LiveRenderContext.Current?.MarkCurrentConsumesContext();
+    private static void MarkConsumer() => LiveRenderContext.CurrentSync?.MarkCurrentConsumesContext();
 }

--- a/src/Rask.Core/Components/Del.cs
+++ b/src/Rask.Core/Components/Del.cs
@@ -14,7 +14,7 @@ public sealed class Del : Element
         base.WriteAttributes(sb);
         if (Cite is not null)
         {
-            AppendAttr(sb, "cite", Cite);
+            AppendUrlAttr(sb, "cite", Cite);
         }
 
         if (DateTime is not null)

--- a/src/Rask.Core/Components/Div.cs
+++ b/src/Rask.Core/Components/Div.cs
@@ -19,7 +19,7 @@ public sealed class Div : Element
     {
         base.WriteAttributes(sb);
 
-        if (LiveRenderContext.Current is not { } ctx)
+        if (LiveRenderContext.CurrentSync is not { } ctx)
         {
             return;
         }

--- a/src/Rask.Core/Components/Embed.cs
+++ b/src/Rask.Core/Components/Embed.cs
@@ -18,7 +18,7 @@ public sealed class Embed : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendUrlAttr(sb, "src", Src);
         }
 
         if (Type is not null)

--- a/src/Rask.Core/Components/Form.cs
+++ b/src/Rask.Core/Components/Form.cs
@@ -49,7 +49,7 @@ public sealed class Form : Element
         set
         {
             _model = value;
-            if (value is not null && LiveRenderContext.Current is { } live)
+            if (value is not null && LiveRenderContext.CurrentSync is { } live)
             {
                 var ctx = live.GetOrCreateEditContext(value);
                 RegisterSubGraph(live, ctx, value);
@@ -79,7 +79,7 @@ public sealed class Form : Element
             // LiveRenderContext.GetOrCreateEditContext(model). Walk the model graph so nested
             // bindings (acc.Target = a sub-object) also land on this context rather than
             // auto-creating a separate one keyed by the sub-object reference.
-            if (value is not null && LiveRenderContext.Current is { } live)
+            if (value is not null && LiveRenderContext.CurrentSync is { } live)
             {
                 live.RegisterEditContext(value);
                 RegisterSubGraph(live, value, value.Model);
@@ -123,7 +123,7 @@ public sealed class Form : Element
                 throw new InvalidOperationException("Form requires Model or Context.");
             }
 
-            ctx = LiveRenderContext.Current is { } live
+            ctx = LiveRenderContext.CurrentSync is { } live
                 ? live.GetOrCreateEditContext(Model)
                 : new EditContext(Model);
         }
@@ -206,7 +206,7 @@ public sealed class Form : Element
             submit = (Delegate?)OnSubmit ?? OnSubmitAsync;
         }
 
-        if (submit is not null && LiveRenderContext.Current is { } liveCtx)
+        if (submit is not null && LiveRenderContext.CurrentSync is { } liveCtx)
         {
             AppendAttr(sb, "data-rask-on-submit", liveCtx.RegisterHandler(submit));
         }

--- a/src/Rask.Core/Components/HtmlObject.cs
+++ b/src/Rask.Core/Components/HtmlObject.cs
@@ -21,7 +21,7 @@ public sealed class HtmlObject : Element
         base.WriteAttributes(sb);
         if (DataUrl is not null)
         {
-            AppendAttr(sb, "data", DataUrl);
+            AppendUrlAttr(sb, "data", DataUrl);
         }
 
         if (Type is not null)

--- a/src/Rask.Core/Components/Iframe.cs
+++ b/src/Rask.Core/Components/Iframe.cs
@@ -22,7 +22,7 @@ public sealed class Iframe : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendUrlAttr(sb, "src", Src);
         }
 
         if (Srcdoc is not null)

--- a/src/Rask.Core/Components/Img.cs
+++ b/src/Rask.Core/Components/Img.cs
@@ -26,7 +26,7 @@ public sealed class Img : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendMediaUrlAttr(sb, "src", Src);
         }
 
         if (Alt is not null)

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -332,7 +332,7 @@ public sealed class Input : Element
 
         if (FormAction is not null)
         {
-            AppendAttr(sb, "formaction", FormAction);
+            AppendUrlAttr(sb, "formaction", FormAction);
         }
 
         if (FormEnctype is not null)
@@ -362,7 +362,7 @@ public sealed class Input : Element
 
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendMediaUrlAttr(sb, "src", Src);
         }
 
         if (Width is not null)
@@ -375,7 +375,7 @@ public sealed class Input : Element
             AppendAttr(sb, "height", Height.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        if (LiveRenderContext.Current is { } ctx)
+        if (LiveRenderContext.CurrentSync is { } ctx)
         {
             var input = (Delegate?)OnInput ?? OnInputAsync;
             if (input is not null)

--- a/src/Rask.Core/Components/Ins.cs
+++ b/src/Rask.Core/Components/Ins.cs
@@ -14,7 +14,7 @@ public sealed class Ins : Element
         base.WriteAttributes(sb);
         if (Cite is not null)
         {
-            AppendAttr(sb, "cite", Cite);
+            AppendUrlAttr(sb, "cite", Cite);
         }
 
         if (DateTime is not null)

--- a/src/Rask.Core/Components/Link.cs
+++ b/src/Rask.Core/Components/Link.cs
@@ -24,7 +24,7 @@ public sealed class Link : Element
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (Rel is not null)

--- a/src/Rask.Core/Components/NavLink.cs
+++ b/src/Rask.Core/Components/NavLink.cs
@@ -63,7 +63,7 @@ public sealed class NavLink : Element
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href.Value.ToString());
+            AppendUrlAttr(sb, "href", Href.Value.ToString());
         }
 
         AppendAttr(sb, "data-rask-nav", null);

--- a/src/Rask.Core/Components/Q.cs
+++ b/src/Rask.Core/Components/Q.cs
@@ -13,7 +13,7 @@ public sealed class Q : Element
         base.WriteAttributes(sb);
         if (Cite is not null)
         {
-            AppendAttr(sb, "cite", Cite);
+            AppendUrlAttr(sb, "cite", Cite);
         }
     }
 }

--- a/src/Rask.Core/Components/Script.cs
+++ b/src/Rask.Core/Components/Script.cs
@@ -21,7 +21,7 @@ public sealed class Script : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendUrlAttr(sb, "src", Src);
         }
 
         if (Type is not null)

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -250,7 +250,7 @@ public sealed class Select : Element
         }
 
         var change = (Delegate?)OnChange ?? OnChangeAsync;
-        if (change is not null && LiveRenderContext.Current is { } ctx)
+        if (change is not null && LiveRenderContext.CurrentSync is { } ctx)
         {
             AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(change));
         }

--- a/src/Rask.Core/Components/Source.cs
+++ b/src/Rask.Core/Components/Source.cs
@@ -18,7 +18,7 @@ public sealed class Source : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendMediaUrlAttr(sb, "src", Src);
         }
 
         if (Type is not null)

--- a/src/Rask.Core/Components/Svg/Image.cs
+++ b/src/Rask.Core/Components/Svg/Image.cs
@@ -38,7 +38,7 @@ public sealed class Image : SvgElement
 
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendMediaUrlAttr(sb, "href", Href);
         }
 
         if (PreserveAspectRatio is not null)

--- a/src/Rask.Core/Components/Svg/LinearGradient.cs
+++ b/src/Rask.Core/Components/Svg/LinearGradient.cs
@@ -55,7 +55,7 @@ public sealed class LinearGradient : SvgElement
 
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
     }
 }

--- a/src/Rask.Core/Components/Svg/Pattern.cs
+++ b/src/Rask.Core/Components/Svg/Pattern.cs
@@ -67,7 +67,7 @@ public sealed class Pattern : SvgElement
 
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
     }
 }

--- a/src/Rask.Core/Components/Svg/RadialGradient.cs
+++ b/src/Rask.Core/Components/Svg/RadialGradient.cs
@@ -67,7 +67,7 @@ public sealed class RadialGradient : SvgElement
 
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
     }
 }

--- a/src/Rask.Core/Components/Svg/SvgA.cs
+++ b/src/Rask.Core/Components/Svg/SvgA.cs
@@ -15,7 +15,7 @@ public sealed class SvgA : SvgElement
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (Target is not null)

--- a/src/Rask.Core/Components/Svg/SvgElement.cs
+++ b/src/Rask.Core/Components/Svg/SvgElement.cs
@@ -129,7 +129,7 @@ public abstract class SvgElement : Element
         }
 
         var click = (Delegate?)OnClick ?? OnClickAsync;
-        if (click is not null && LiveRenderContext.Current is { } ctx)
+        if (click is not null && LiveRenderContext.CurrentSync is { } ctx)
         {
             AppendAttr(sb, "data-rask-on-click", ctx.RegisterHandler(click));
         }

--- a/src/Rask.Core/Components/Svg/SvgScript.cs
+++ b/src/Rask.Core/Components/Svg/SvgScript.cs
@@ -15,7 +15,7 @@ public sealed class SvgScript : SvgElement
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (Type is not null)

--- a/src/Rask.Core/Components/Svg/TextPath.cs
+++ b/src/Rask.Core/Components/Svg/TextPath.cs
@@ -16,7 +16,7 @@ public sealed class TextPath : SvgElement
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (StartOffset is not null)

--- a/src/Rask.Core/Components/Svg/Use.cs
+++ b/src/Rask.Core/Components/Svg/Use.cs
@@ -17,7 +17,7 @@ public sealed class Use : SvgElement
         base.WriteAttributes(sb);
         if (Href is not null)
         {
-            AppendAttr(sb, "href", Href);
+            AppendUrlAttr(sb, "href", Href);
         }
 
         if (X is not null)

--- a/src/Rask.Core/Components/Textarea.cs
+++ b/src/Rask.Core/Components/Textarea.cs
@@ -225,7 +225,7 @@ public sealed class Textarea : Element
             AppendAttr(sb, "dirname", Dirname);
         }
 
-        if (LiveRenderContext.Current is { } ctx)
+        if (LiveRenderContext.CurrentSync is { } ctx)
         {
             var input = (Delegate?)OnInput ?? OnInputAsync;
             if (input is not null)

--- a/src/Rask.Core/Components/Track.cs
+++ b/src/Rask.Core/Components/Track.cs
@@ -23,7 +23,7 @@ public sealed class Track : Element
 
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendMediaUrlAttr(sb, "src", Src);
         }
 
         if (Srclang is not null)

--- a/src/Rask.Core/Components/Video.cs
+++ b/src/Rask.Core/Components/Video.cs
@@ -24,12 +24,12 @@ public sealed class Video : Element
         base.WriteAttributes(sb);
         if (Src is not null)
         {
-            AppendAttr(sb, "src", Src);
+            AppendMediaUrlAttr(sb, "src", Src);
         }
 
         if (Poster is not null)
         {
-            AppendAttr(sb, "poster", Poster);
+            AppendMediaUrlAttr(sb, "poster", Poster);
         }
 
         if (Width is not null)

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -65,7 +65,7 @@ public abstract class Element : Component
         // adopts it). Emitted in the data-* group below so FrameDiffer.ExtractRaskKey finds it
         // among the leading attribute frames, same as a Data["rask-key"] entry.
         var forwarded = KeyForwardScope.Consume();
-        var key = Key?.ToString() ?? forwarded;
+        var key = KeyString ?? forwarded;
 
         if (Data is not null)
         {
@@ -102,7 +102,7 @@ public abstract class Element : Component
             AppendAttr(sb, "draggable", "true");
         }
 
-        if (LiveRenderContext.Current is { } ctx)
+        if (LiveRenderContext.CurrentSync is { } ctx)
         {
             if (OnDragStart is not null)
             {

--- a/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
+++ b/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
@@ -39,6 +39,16 @@ internal sealed class HeadAssetRegistry
     // LATEST one wins — so a page's Title in Head supersedes the App's.
     private readonly HashSet<string> _seen = new(StringComparer.Ordinal);
 
+    // Reset for reuse across renders. The registry instance is hoisted onto the root's
+    // LiveState (so head emission doesn't allocate fresh lists/sets every frame) and cleared
+    // at the start of each render before the walk re-populates it.
+    public void Clear()
+    {
+        _orderedHtml.Clear();
+        _orderedKeys.Clear();
+        _seen.Clear();
+    }
+
     public void Add(Component head)
     {
         if (head is Fragment fragment && fragment.Children is { } children)
@@ -161,10 +171,18 @@ internal sealed class HeadAssetRegistry
     ///     </para>
     /// </summary>
     public string ApplyTo(string html, IServiceProvider? services = null)
+        => ApplyTo(html, html.IndexOf(Sentinel, StringComparison.Ordinal), services);
+
+    /// <inheritdoc cref="ApplyTo(string, IServiceProvider?)" />
+    /// <param name="sentinelIdx">
+    ///     Pre-computed index of <see cref="Sentinel" /> in <paramref name="html" /> (the caller
+    ///     already locates it to adjust diff-frame offsets), so this method skips a second
+    ///     whole-body <c>IndexOf</c> scan. Negative when the sentinel is absent.
+    /// </param>
+    public string ApplyTo(string html, int sentinelIdx, IServiceProvider? services = null)
     {
         _ = services; // see XML comment: parameter retained for ABI; no host strategy needed.
-        var idx = html.IndexOf(Sentinel, StringComparison.Ordinal);
-        if (idx < 0)
+        if (sentinelIdx < 0)
         {
             return html;
         }
@@ -172,49 +190,43 @@ internal sealed class HeadAssetRegistry
         // Per-component asset emission. Reads LiveRenderContext.Current.MountedTypes —
         // populated unconditionally during the render walk by every user component entry —
         // and emits one keyed <link>/<script> per mounted type that has a registered
-        // asset. Empty string when the current call is outside a live render (unit tests
-        // calling ApplyTo directly) or when no mounted component has an asset.
-        var perComponentSb = new StringBuilder();
+        // asset. Null when the current call is outside a live render (unit tests calling
+        // ApplyTo directly) or when no mounted component has an asset. Built through a pooled
+        // StringBuilder so the steady-state diff path stays allocation-light.
+        string? perComponentHtml = null;
         var liveCtx = LiveRenderContext.Current;
         if (liveCtx is not null && liveCtx.MountedTypes.Count > 0)
         {
+            var perComponentSb = RaskStringBuilderPool.Shared.Get();
             EmitMountedAssets(perComponentSb, liveCtx.MountedTypes);
-        }
+            if (perComponentSb.Length > 0)
+            {
+                perComponentHtml = perComponentSb.ToString();
+            }
 
-        var perComponentHtml = perComponentSb.Length > 0 ? perComponentSb.ToString() : null;
+            RaskStringBuilderPool.Shared.Return(perComponentSb);
+        }
 
         if (_orderedHtml.Count == 0 && perComponentHtml is null)
         {
-            return html.Remove(idx, Sentinel.Length);
+            return html.Remove(sentinelIdx, Sentinel.Length);
         }
 
-        // Pre-key each user-declared entry. Singleton entries (title, base) use the
-        // singleton key so the morph matches them across renders even when their
-        // content/attrs change; other entries get a content-derived hash so an
-        // unchanged asset (Bootstrap link, viewport meta, …) keeps the same key
-        // across renders and is moved (not destroyed) when its sibling count shifts.
-        var keyedAssets = new string[_orderedHtml.Count];
-        var totalLen = html.Length - Sentinel.Length;
+        var sb = RaskStringBuilderPool.Shared.Get();
+        sb.Append(html, 0, sentinelIdx);
+
+        // Key each user-declared entry. Singleton entries (title, base) use the singleton key
+        // so the morph matches them across renders even when their content/attrs change; other
+        // entries get a content-derived hash so an unchanged asset (Bootstrap link, viewport
+        // meta, …) keeps the same key across renders and is moved (not destroyed) when its
+        // sibling count shifts. Appended directly — no per-asset string.Insert allocation.
         for (var i = 0; i < _orderedHtml.Count; i++)
         {
             var raw = _orderedHtml[i];
             var morphKey = _orderedKeys[i].StartsWith("tag:", StringComparison.Ordinal)
                 ? _orderedKeys[i]
                 : "h-" + ContentHash(raw);
-            keyedAssets[i] = WithRaskKey(raw, morphKey);
-            totalLen += keyedAssets[i].Length;
-        }
-
-        if (perComponentHtml is not null)
-        {
-            totalLen += perComponentHtml.Length;
-        }
-
-        var sb = new StringBuilder(totalLen);
-        sb.Append(html, 0, idx);
-        foreach (var asset in keyedAssets)
-        {
-            sb.Append(asset);
+            AppendWithRaskKey(sb, raw, morphKey);
         }
 
         // Per-component tags emit AFTER user Head contributions so scoped CSS overrides
@@ -224,26 +236,24 @@ internal sealed class HeadAssetRegistry
             sb.Append(perComponentHtml);
         }
 
-        sb.Append(html, idx + Sentinel.Length, html.Length - idx - Sentinel.Length);
-        return sb.ToString();
+        sb.Append(html, sentinelIdx + Sentinel.Length, html.Length - sentinelIdx - Sentinel.Length);
+        var result = sb.ToString();
+        RaskStringBuilderPool.Shared.Return(sb);
+        return result;
     }
 
-    // Inserts data-rask-key="..." right after the opening tag name. The client
-    // morph promotes <head>'s children to its keyed-reconciliation branch as soon
-    // as one child carries data-rask-key, so emitting it on every head asset lets
-    // the morph match by identity instead of by position. If the caller already
-    // placed a data-rask-key on the tag (very rare for head children, but legal
-    // for explicit morph identity), leave it alone.
-    private static string WithRaskKey(string html, string key)
+    // Appends html with data-rask-key="..." spliced in right after the opening tag name. The
+    // client morph promotes <head>'s children to its keyed-reconciliation branch as soon as one
+    // child carries data-rask-key, so emitting it on every head asset lets the morph match by
+    // identity instead of by position. If the tag already carries a data-rask-key (very rare for
+    // head children, but legal for explicit morph identity) or is malformed, append verbatim.
+    private static void AppendWithRaskKey(StringBuilder sb, string html, string key)
     {
-        if (html.Length < 2 || html[0] != '<')
+        if (html.Length < 2 || html[0] != '<'
+            || html.IndexOf("data-rask-key=", StringComparison.Ordinal) >= 0)
         {
-            return html;
-        }
-
-        if (html.IndexOf("data-rask-key=", StringComparison.Ordinal) >= 0)
-        {
-            return html;
+            sb.Append(html);
+            return;
         }
 
         var i = 1;
@@ -255,7 +265,11 @@ internal sealed class HeadAssetRegistry
             i++;
         }
 
-        return html.Insert(i, $" data-rask-key=\"{HtmlAttrEscape(key)}\"");
+        sb.Append(html, 0, i);
+        sb.Append(" data-rask-key=\"");
+        sb.Append(HtmlAttrEscape(key));
+        sb.Append('"');
+        sb.Append(html, i, html.Length - i);
     }
 
     private static string HtmlAttrEscape(string s)

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -100,7 +100,7 @@ internal static class HtmlSerializer
             {
                 // A keyed Fragment forwards its Key onto the first element it renders (the
                 // first child's first element); Consume in WriteAttributes claims it once.
-                var fragKey = fragment.Key?.ToString();
+                var fragKey = fragment.KeyString;
                 if (fragKey is not null)
                 {
                     KeyForwardScope.Arm(fragKey);
@@ -144,7 +144,7 @@ internal static class HtmlSerializer
                 // the duration of the children walk, so any descendant's Render() (which runs
                 // inside this synchronous walk) resolves it via Context.Get<T>(). A keyed
                 // provider forwards its Key onto the first element its children render.
-                var ctxKey = context.Key?.ToString();
+                var ctxKey = context.KeyString;
                 if (ctxKey is not null)
                 {
                     KeyForwardScope.Arm(ctxKey);
@@ -182,7 +182,7 @@ internal static class HtmlSerializer
             }
 
             case { TagNameInternal: { } tagName } el:
-                var live = LiveRenderContext.Current;
+                var live = LiveRenderContext.CurrentSync;
                 var scopeId = live?.CurrentScopeId;
                 var isShell = _shellTags.Contains(tagName);
                 var elementStart = sb.Length;
@@ -268,7 +268,7 @@ internal static class HtmlSerializer
                 // component — including the walk of its rendered subtree. That way
                 // factories called from inside its Render AND handlers registered on
                 // elements deep in its rendered tree both attribute back to this component.
-                var liveCtx = LiveRenderContext.Current;
+                var liveCtx = LiveRenderContext.CurrentSync;
                 if (liveCtx is not null && component.Boundary is null)
                 {
                     // Stamp the nearest enclosing boundary on first traversal so async
@@ -299,7 +299,7 @@ internal static class HtmlSerializer
                     // body (the component's root element), which Consumes it in WriteAttributes.
                     // Only the first element claims it; Clear in finally stops it leaking to a
                     // following sibling when the body renders no element at all.
-                    var fwdKey = component.Key?.ToString();
+                    var fwdKey = component.KeyString;
                     if (fwdKey is not null)
                     {
                         KeyForwardScope.Arm(fwdKey);
@@ -324,7 +324,7 @@ internal static class HtmlSerializer
 
     private static void SerializeErrorBoundary(ErrorBoundary boundary, StringBuilder sb)
     {
-        var live = LiveRenderContext.Current;
+        var live = LiveRenderContext.CurrentSync;
         using (LiveRenderContext.PushScopeOrNone(live, boundary))
         using (LiveRenderContext.EnterParentScopeOrNone(live, boundary))
         using (LiveRenderContext.PushBoundaryOrNone(live, boundary))

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -10,6 +10,17 @@ namespace Rask.Core.Live;
 public sealed class LiveRenderContext : IDisposable
 {
     private static readonly AsyncLocal<LiveRenderContext?> _current = new();
+
+    // Thread-local fast mirror of _current, valid only during the synchronous render walk.
+    // AsyncLocal.Value reads walk the execution context and are markedly slower than a field
+    // read; the per-element attribute path reads "the current context" several times per
+    // element. Serialize() and WriteAttributes() run synchronously on one thread between this
+    // context's construction and disposal, so a ThreadStatic mirror is exact there. The
+    // AsyncLocal _current stays authoritative for async continuations (which may resume on a
+    // different thread and must still observe Current / IsActive) — those keep reading _current.
+    [ThreadStatic] private static LiveRenderContext? _syncCurrent;
+
+    private readonly LiveRenderContext? _previousSync;
     private readonly Stack<ErrorBoundary> _boundaryStack = new();
     private readonly Dictionary<ObjectKey, EditContext> _currentEditContexts;
     private readonly IRenderHandle? _handle;
@@ -32,20 +43,31 @@ public sealed class LiveRenderContext : IDisposable
         Component root,
         Dictionary<ObjectKey, EditContext> previousEditContexts,
         Dictionary<ObjectKey, EditContext> currentEditContexts,
-        IServiceProvider? services)
+        IServiceProvider? services,
+        HeadAssetRegistry headAssets,
+        HashSet<Type> mountedTypes)
     {
         _root = root;
         _previousEditContexts = previousEditContexts;
         _currentEditContexts = currentEditContexts;
         Services = services;
+        HeadAssets = headAssets;
+        MountedTypes = mountedTypes;
         _handle = root.RenderHandle;
         _previous = _current.Value;
+        _previousSync = _syncCurrent;
         _current.Value = this;
+        _syncCurrent = this;
     }
 
     internal bool IsActive { get; private set; } = true;
 
     public static LiveRenderContext? Current => _current.Value;
+
+    // Fast, synchronous-walk-only accessor for the hot attribute path. Equals Current on the
+    // render thread; null outside an active render (restored on Dispose). Do NOT use from async
+    // continuations — read Current there.
+    internal static LiveRenderContext? CurrentSync => _syncCurrent;
 
     internal RouteRenderState? Route { get; set; }
 
@@ -58,7 +80,7 @@ public sealed class LiveRenderContext : IDisposable
     ///     <see cref="Generated.RaskHeadAssets" /> placeholder is replaced with this
     ///     registry's content during <see cref="Component.RenderAsLiveRoot()" />.
     /// </summary>
-    internal HeadAssetRegistry HeadAssets { get; } = new();
+    internal HeadAssetRegistry HeadAssets { get; }
 
     /// <summary>
     ///     Every user-component type observed during this render walk. Populated
@@ -74,7 +96,7 @@ public sealed class LiveRenderContext : IDisposable
     ///         not <see cref="ScopedAssetRegistry.TryGetScopeId" /> finds a scope id.
     ///     </para>
     /// </summary>
-    public HashSet<Type> MountedTypes { get; } = new();
+    public HashSet<Type> MountedTypes { get; }
 
     internal ErrorBoundary? CurrentBoundary => _boundaryStack.Count > 0 ? _boundaryStack.Peek() : null;
 
@@ -84,6 +106,7 @@ public sealed class LiveRenderContext : IDisposable
     {
         IsActive = false;
         _current.Value = _previous;
+        _syncCurrent = _previousSync;
     }
 
     internal ContextScope PushScope(Component instance)
@@ -119,19 +142,25 @@ public sealed class LiveRenderContext : IDisposable
     }
 
     public static LiveRenderContext Begin(Component root) =>
-        new(root, new Dictionary<ObjectKey, EditContext>(), new Dictionary<ObjectKey, EditContext>(), null);
+        new(root, new Dictionary<ObjectKey, EditContext>(), new Dictionary<ObjectKey, EditContext>(), null,
+            new HeadAssetRegistry(), new HashSet<Type>());
 
     public static LiveRenderContext Begin(Component root, IServiceProvider? services) =>
-        new(root, new Dictionary<ObjectKey, EditContext>(), new Dictionary<ObjectKey, EditContext>(), services);
+        new(root, new Dictionary<ObjectKey, EditContext>(), new Dictionary<ObjectKey, EditContext>(), services,
+            new HeadAssetRegistry(), new HashSet<Type>());
 
     // RenderAsLiveRootCore swaps two dictionaries it owns and passes both in here, so neither
-    // the current nor the previous dict is allocated per render after warmup.
+    // the current nor the previous dict is allocated per render after warmup. It likewise
+    // supplies a reused HeadAssetRegistry + MountedTypes set (cleared per render) so head
+    // emission stops allocating ~5 collections every frame on the otherwise zero-alloc diff path.
     internal static LiveRenderContext Begin(
         Component root,
         Dictionary<ObjectKey, EditContext> previousEditContexts,
         Dictionary<ObjectKey, EditContext> currentEditContexts,
-        IServiceProvider? services) =>
-        new(root, previousEditContexts, currentEditContexts, services);
+        IServiceProvider? services,
+        HeadAssetRegistry headAssets,
+        HashSet<Type> mountedTypes) =>
+        new(root, previousEditContexts, currentEditContexts, services, headAssets, mountedTypes);
 
     public string RegisterHandler(Delegate handler) =>
         // Owner = the component currently rendering (top of parent stack). The root stores

--- a/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
+++ b/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -28,9 +29,14 @@ public static class ScopedAssetRegistry
 
     private static readonly object _lock = new();
 
-    private static readonly Dictionary<Type, string> _cssHashByType = new();
-    private static readonly Dictionary<Type, string> _jsHashByType = new();
-    private static readonly Dictionary<Type, string> _scopeIdByType = new();
+    // by-Type lookups are read once per user component per render (TryGetScopeId via
+    // LiveRenderContext.PushScope) and per mounted type during head emission — the hottest
+    // registry path. ConcurrentDictionary makes those reads lock-free so concurrent sessions
+    // never serialize on a shared lock. Writes (register/unregister) still run inside _lock so
+    // each stays atomic with the refcounted by-hash buckets below.
+    private static readonly ConcurrentDictionary<Type, string> _cssHashByType = new();
+    private static readonly ConcurrentDictionary<Type, string> _jsHashByType = new();
+    private static readonly ConcurrentDictionary<Type, string> _scopeIdByType = new();
 
     private static readonly Dictionary<string, AssetEntry> _cssByHash =
         new(StringComparer.Ordinal);
@@ -193,8 +199,8 @@ public static class ScopedAssetRegistry
                 return;
             }
 
-            _cssHashByType.Remove(componentType);
-            _scopeIdByType.Remove(componentType);
+            _cssHashByType.TryRemove(componentType, out _);
+            _scopeIdByType.TryRemove(componentType, out _);
             DecrementRefLocked(_cssByHash, hash);
             changed = true;
         }
@@ -216,7 +222,7 @@ public static class ScopedAssetRegistry
                 return;
             }
 
-            _jsHashByType.Remove(componentType);
+            _jsHashByType.TryRemove(componentType, out _);
             DecrementRefLocked(_jsByHash, hash);
             changed = true;
         }
@@ -308,13 +314,10 @@ public static class ScopedAssetRegistry
     public static bool TryGetCss(Type componentType, out string hash)
     {
         ArgumentNullException.ThrowIfNull(componentType);
-        lock (_lock)
+        if (_cssHashByType.TryGetValue(componentType, out var v))
         {
-            if (_cssHashByType.TryGetValue(componentType, out var v))
-            {
-                hash = v;
-                return true;
-            }
+            hash = v;
+            return true;
         }
 
         hash = string.Empty;
@@ -327,13 +330,10 @@ public static class ScopedAssetRegistry
     public static bool TryGetJs(Type componentType, out string hash)
     {
         ArgumentNullException.ThrowIfNull(componentType);
-        lock (_lock)
+        if (_jsHashByType.TryGetValue(componentType, out var v))
         {
-            if (_jsHashByType.TryGetValue(componentType, out var v))
-            {
-                hash = v;
-                return true;
-            }
+            hash = v;
+            return true;
         }
 
         hash = string.Empty;
@@ -348,13 +348,10 @@ public static class ScopedAssetRegistry
     public static bool TryGetScopeId(Type componentType, out string scopeId)
     {
         ArgumentNullException.ThrowIfNull(componentType);
-        lock (_lock)
+        if (_scopeIdByType.TryGetValue(componentType, out var v))
         {
-            if (_scopeIdByType.TryGetValue(componentType, out var v))
-            {
-                scopeId = v;
-                return true;
-            }
+            scopeId = v;
+            return true;
         }
 
         scopeId = string.Empty;

--- a/src/Rask.Core/UrlSanitizer.cs
+++ b/src/Rask.Core/UrlSanitizer.cs
@@ -8,9 +8,9 @@ namespace Rask.Core;
 /// </summary>
 public static class RaskUrl
 {
-    // A control-char sentinel that cannot occur in a real URL and is stripped before output:
-    // UrlSanitizer unwraps it; if it ever leaked unstripped it would be HTML-encoded harmlessly.
-    internal const string TrustedPrefix = "rask-trusted:";
+    // A sentinel prefix that the sanitizer recognizes and strips before output; a real URL would
+    // never start with it. If it ever leaked unstripped it would be HTML-encoded harmlessly.
+    internal const string TrustedPrefix = "rask-trusted:";
 
     /// <summary>
     ///     Marks <paramref name="url" /> as trusted so the next URL-attribute emit skips scheme
@@ -58,53 +58,56 @@ internal static class UrlSanitizer
             return url[RaskUrl.TrustedPrefix.Length..];
         }
 
-        // Normalize only the leading portion needed to identify the scheme + data media-type.
-        // 32 chars comfortably covers "data:image/svg+xml" and every blocked scheme.
-        var head = NormalizeHead(url, 32);
-
-        if (head.StartsWith("javascript:", StringComparison.Ordinal) ||
-            head.StartsWith("vbscript:", StringComparison.Ordinal))
+        // Allocation-free scheme check: the common safe URL (relative, http(s), mailto, #frag)
+        // fails the first prefix at its first char and returns the input unchanged — no string
+        // is materialized on the render hot path.
+        if (MatchesScheme(url, "javascript:") || MatchesScheme(url, "vbscript:"))
         {
             return Neutralized;
         }
 
-        if (head.StartsWith("data:", StringComparison.Ordinal))
+        if (MatchesScheme(url, "data:"))
         {
             var safe = allowMediaData &&
-                       (head.StartsWith("data:image/", StringComparison.Ordinal) ||
-                        head.StartsWith("data:video/", StringComparison.Ordinal) ||
-                        head.StartsWith("data:audio/", StringComparison.Ordinal));
+                       (MatchesScheme(url, "data:image/") ||
+                        MatchesScheme(url, "data:video/") ||
+                        MatchesScheme(url, "data:audio/"));
             return safe ? url : Neutralized;
         }
 
         return url;
     }
 
-    // Strip leading C0 controls + space, drop every embedded control char (the WHATWG parser
-    // removes tab/newline; we drop all <0x20 and 0x7F to also defeat NUL-stuffing), lowercase
-    // the rest. Returns at most maxLen chars — enough to match a scheme/media-type prefix.
-    private static string NormalizeHead(string url, int maxLen)
+    // True when url, after stripping leading C0 controls/space and dropping embedded control
+    // chars (tab/newline/CR/NUL/DEL — what the WHATWG URL parser ignores, plus NUL-stuffing),
+    // begins case-insensitively with prefix (which must be lowercase). Embedded spaces are NOT
+    // dropped — a space inside a scheme invalidates it, so "java script:" is not treated as
+    // javascript (matching browser behaviour). Allocates nothing.
+    private static bool MatchesScheme(string url, ReadOnlySpan<char> prefix)
     {
-        Span<char> buf = stackalloc char[maxLen];
-        var n = 0;
         var i = 0;
-
         while (i < url.Length && url[i] <= ' ')
         {
             i++;
         }
 
-        for (; i < url.Length && n < maxLen; i++)
+        var p = 0;
+        while (i < url.Length && p < prefix.Length)
         {
-            var c = url[i];
-            if (c <= ' ' || c == (char)0x7F) // NUL/control/space|| c == '')
+            var c = url[i++];
+            if (c < ' ' || c == (char)0x7F)
             {
-                continue;
+                continue; // drop embedded control / NUL / DEL (but keep space)
             }
 
-            buf[n++] = char.ToLowerInvariant(c);
+            if (char.ToLowerInvariant(c) != prefix[p])
+            {
+                return false;
+            }
+
+            p++;
         }
 
-        return new string(buf[..n]);
+        return p == prefix.Length;
     }
 }

--- a/src/Rask.Core/UrlSanitizer.cs
+++ b/src/Rask.Core/UrlSanitizer.cs
@@ -1,0 +1,110 @@
+namespace Rask.Core;
+
+/// <summary>
+///     Opt-out marker for the URL-attribute scheme sanitization Rask applies by default to
+///     <c>href</c>/<c>src</c>/<c>action</c>/<c>cite</c>/etc. Wrap a value you fully control in
+///     <see cref="Trusted" /> to emit it verbatim (it is still HTML-encoded). Use only for URLs
+///     that are not attacker-influenced — e.g. a hard-coded <c>javascript:void(0)</c> sentinel.
+/// </summary>
+public static class RaskUrl
+{
+    // A control-char sentinel that cannot occur in a real URL and is stripped before output:
+    // UrlSanitizer unwraps it; if it ever leaked unstripped it would be HTML-encoded harmlessly.
+    internal const string TrustedPrefix = "rask-trusted:";
+
+    /// <summary>
+    ///     Marks <paramref name="url" /> as trusted so the next URL-attribute emit skips scheme
+    ///     sanitization. The value is still HTML-encoded. Only use for non-attacker-controlled URLs.
+    /// </summary>
+    public static string Trusted(string url) => TrustedPrefix + (url ?? string.Empty);
+}
+
+/// <summary>
+///     Neutralizes dangerous URL schemes (<c>javascript:</c>, <c>vbscript:</c>, and — outside
+///     media attributes — <c>data:</c>) before they reach <c>href</c>/<c>src</c>/<c>action</c>/etc.
+///     Output encoding alone (<see cref="HtmlSerializer.AppendEncoded" />) does not stop these:
+///     <c>&lt;a href="javascript:..."&gt;</c> executes on click. Detection mirrors the WHATWG URL
+///     parser's leniencies (leading C0/space stripped, embedded tab/newline/control removed,
+///     scheme compared case-insensitively) so obfuscation like <c>java&#9;script:</c> is caught.
+/// </summary>
+internal static class UrlSanitizer
+{
+    // Replacement for a blocked URL. about:blank is inert in href/src and won't navigate.
+    private const string Neutralized = "about:blank";
+
+    /// <summary>
+    ///     Sanitizes a navigation/resource URL (<c>href</c>, <c>cite</c>, <c>action</c>,
+    ///     <c>iframe</c>/<c>script</c>/<c>object</c> sources). Blocks <c>javascript:</c>,
+    ///     <c>vbscript:</c>, and all <c>data:</c> URLs.
+    /// </summary>
+    public static string? Sanitize(string? url) => SanitizeCore(url, allowMediaData: false);
+
+    /// <summary>
+    ///     Sanitizes a media URL (<c>img</c>/<c>audio</c>/<c>video</c>/<c>source</c> <c>src</c>,
+    ///     <c>poster</c>). Blocks <c>javascript:</c>/<c>vbscript:</c> but allows
+    ///     <c>data:image/*</c>, <c>data:video/*</c>, and <c>data:audio/*</c>.
+    /// </summary>
+    public static string? SanitizeMedia(string? url) => SanitizeCore(url, allowMediaData: true);
+
+    private static string? SanitizeCore(string? url, bool allowMediaData)
+    {
+        if (url is null)
+        {
+            return null;
+        }
+
+        if (url.StartsWith(RaskUrl.TrustedPrefix, StringComparison.Ordinal))
+        {
+            return url[RaskUrl.TrustedPrefix.Length..];
+        }
+
+        // Normalize only the leading portion needed to identify the scheme + data media-type.
+        // 32 chars comfortably covers "data:image/svg+xml" and every blocked scheme.
+        var head = NormalizeHead(url, 32);
+
+        if (head.StartsWith("javascript:", StringComparison.Ordinal) ||
+            head.StartsWith("vbscript:", StringComparison.Ordinal))
+        {
+            return Neutralized;
+        }
+
+        if (head.StartsWith("data:", StringComparison.Ordinal))
+        {
+            var safe = allowMediaData &&
+                       (head.StartsWith("data:image/", StringComparison.Ordinal) ||
+                        head.StartsWith("data:video/", StringComparison.Ordinal) ||
+                        head.StartsWith("data:audio/", StringComparison.Ordinal));
+            return safe ? url : Neutralized;
+        }
+
+        return url;
+    }
+
+    // Strip leading C0 controls + space, drop every embedded control char (the WHATWG parser
+    // removes tab/newline; we drop all <0x20 and 0x7F to also defeat NUL-stuffing), lowercase
+    // the rest. Returns at most maxLen chars — enough to match a scheme/media-type prefix.
+    private static string NormalizeHead(string url, int maxLen)
+    {
+        Span<char> buf = stackalloc char[maxLen];
+        var n = 0;
+        var i = 0;
+
+        while (i < url.Length && url[i] <= ' ')
+        {
+            i++;
+        }
+
+        for (; i < url.Length && n < maxLen; i++)
+        {
+            var c = url[i];
+            if (c <= ' ' || c == (char)0x7F) // NUL/control/space|| c == '')
+            {
+                continue;
+            }
+
+            buf[n++] = char.ToLowerInvariant(c);
+        }
+
+        return new string(buf[..n]);
+    }
+}

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -135,6 +135,18 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     /// </summary>
     internal Task LastHandlerTask { get; set; } = Task.CompletedTask;
 
+    // Number of handler dispatches queued on the LastHandlerTask chain but not yet completed.
+    // Each queued dispatch retains a cloned JsonElement, so an unbounded chain (a flood of input
+    // arriving faster than handlers drain, or a single hung handler stalling the head) is a
+    // memory-exhaustion vector. The receive loop reads this to apply backpressure. Interlocked
+    // because the increment (receive loop) and decrement (dispatch continuation) can run on
+    // different ThreadPool threads.
+    private int _pendingHandlers;
+
+    internal int IncrementPendingHandlers() => Interlocked.Increment(ref _pendingHandlers);
+
+    internal void DecrementPendingHandlers() => Interlocked.Decrement(ref _pendingHandlers);
+
     public async ValueTask DisposeAsync()
     {
         await ComponentLifecycle.DisposeComponentTreeAsync(View).ConfigureAwait(false);

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -14,6 +14,11 @@ public sealed class LiveSessionStore : IAsyncDisposable
     private readonly ConcurrentDictionary<string, LiveSession> _sessions = new();
     private readonly CancellationToken _stopping;
 
+    // Atomic count of live + in-flight sessions, used by the hard capacity reservation in
+    // TryCreate. Incremented BEFORE the component tree is built and decremented on removal (or
+    // on a failed build), so a concurrent GET burst can never exceed MaxSessions.
+    private int _liveCount;
+
     public LiveSessionStore(IServiceScopeFactory scopeFactory, IHostApplicationLifetime? lifetime = null)
     {
         _scopeFactory = scopeFactory;
@@ -27,20 +32,19 @@ public sealed class LiveSessionStore : IAsyncDisposable
     public int Count => _sessions.Count;
 
     /// <summary>
-    ///     Soft cap on concurrent sessions (<c>0</c> = unlimited). Set from
-    ///     <see cref="Rask.Core.Live.RaskLiveOptions.MaxSessions" /> at registration. The
-    ///     capacity gate is intentionally check-then-create rather than a hard atomic
-    ///     reservation: a burst can admit a handful of sessions past the cap, which is fine
-    ///     for a DoS backstop and keeps the common (uncapped) <see cref="Create" /> path free
-    ///     of extra synchronisation. Tests set it directly on the resolved singleton.
+    ///     Hard cap on concurrent sessions (<c>0</c> = unlimited). Set from
+    ///     <see cref="Rask.Core.Live.RaskLiveOptions.MaxSessions" /> at registration. Enforced
+    ///     atomically by <see cref="TryCreate" /> (a reservation taken before the component tree
+    ///     is built), so a concurrent GET burst cannot exceed it. Tests set it directly on the
+    ///     resolved singleton.
     /// </summary>
     public int MaxSessions { get; set; }
 
     /// <summary>
-    ///     True when a new session would exceed <see cref="MaxSessions" />. The GET endpoint
-    ///     checks this before minting a session and returns 503 when it holds.
+    ///     True when a new session would exceed <see cref="MaxSessions" />. A fast advisory
+    ///     pre-check; the authoritative gate is <see cref="TryCreate" />'s atomic reservation.
     /// </summary>
-    public bool AtCapacity => MaxSessions > 0 && _sessions.Count >= MaxSessions;
+    public bool AtCapacity => MaxSessions > 0 && Volatile.Read(ref _liveCount) >= MaxSessions;
 
     public async ValueTask DisposeAsync()
     {
@@ -49,6 +53,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         {
             if (_sessions.TryRemove(key, out var session))
             {
+                Interlocked.Decrement(ref _liveCount);
                 await session.DisposeAsync().ConfigureAwait(false);
             }
         }
@@ -66,7 +71,51 @@ public sealed class LiveSessionStore : IAsyncDisposable
         }
     }
 
+    /// <summary>
+    ///     Creates a session unconditionally (no capacity check). Used internally and by tests.
+    ///     The GET endpoint uses <see cref="TryCreate" /> so the cap is enforced.
+    /// </summary>
     internal LiveSession Create(Func<IServiceProvider, Component> factory)
+    {
+        Interlocked.Increment(ref _liveCount);
+        try
+        {
+            return CreateCore(factory);
+        }
+        catch
+        {
+            Interlocked.Decrement(ref _liveCount);
+            throw;
+        }
+    }
+
+    /// <summary>
+    ///     Atomically reserves a capacity slot, then creates the session. Returns <c>null</c>
+    ///     (reserving nothing) when the session would exceed <see cref="MaxSessions" /> — the
+    ///     reservation is taken BEFORE the component tree is built, so a burst of concurrent GETs
+    ///     can never push past the cap (the old check-then-create gate could admit a handful).
+    /// </summary>
+    internal LiveSession? TryCreate(Func<IServiceProvider, Component> factory)
+    {
+        var reserved = Interlocked.Increment(ref _liveCount);
+        if (MaxSessions > 0 && reserved > MaxSessions)
+        {
+            Interlocked.Decrement(ref _liveCount);
+            return null;
+        }
+
+        try
+        {
+            return CreateCore(factory);
+        }
+        catch
+        {
+            Interlocked.Decrement(ref _liveCount);
+            throw;
+        }
+    }
+
+    private LiveSession CreateCore(Func<IServiceProvider, Component> factory)
     {
         var scope = _scopeFactory.CreateScope();
         // Cryptographically-random id: it is the bearer secret for the WS / upload / download
@@ -111,6 +160,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         CancelPendingRemoval(id);
         if (_sessions.TryRemove(id, out var session))
         {
+            Interlocked.Decrement(ref _liveCount);
             session.Dispose();
         }
     }
@@ -120,6 +170,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         CancelPendingRemoval(id);
         if (_sessions.TryRemove(id, out var session))
         {
+            Interlocked.Decrement(ref _liveCount);
             await session.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -50,6 +50,21 @@ public static class RaskEndpointExtensions
 
     internal static TimeSpan SessionGracePeriod = TimeSpan.FromSeconds(30);
 
+    // Grace for a session that was minted by the GET shell but has not yet received a WS
+    // `hello`. The runtime script connects within a second of page load, so a much shorter
+    // window than the 30s reconnect grace is enough — and it stops a flood of GETs that never
+    // open a socket (scanners, prefetchers, an unauthenticated DoS) from pinning a full DI
+    // scope + component tree for 30s each. A real `hello` cancels this removal (LiveSessionStore
+    // .Get) and any later disconnect re-arms the full SessionGracePeriod via DetachSocket.
+    internal static TimeSpan UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(10);
+
+    // Maximum handler dispatches that may be queued (awaiting their turn in WS-arrival order)
+    // before the receive loop trips the backpressure circuit-breaker and closes the socket.
+    // Each queued dispatch holds a cloned JsonElement; without a bound, a client sending faster
+    // than handlers drain — or a single hung handler stalling the chain head — would grow the
+    // queue (and retained memory) without limit. 512 is far above any legitimate burst. 0 = off.
+    internal static int MaxPendingHandlers = 512;
+
     private static readonly byte[] SessionUnknownPayload =
         Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "session", status = "unknown" }));
 
@@ -224,19 +239,12 @@ public static class RaskEndpointExtensions
                 }
             }
 
-            // Session-cap backstop (RaskLiveOptions.MaxSessions). Reject before minting a new
-            // session so untrusted GET traffic can't exhaust memory; checked after the auth
-            // guard above so challenge/forbid redirects (which create no session) still work.
-            if (store.AtCapacity)
-            {
-                httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
-                httpContext.Response.Headers.RetryAfter = "5";
-                await httpContext.Response.WriteAsync("Server is at session capacity; please retry shortly.")
-                    .ConfigureAwait(false);
-                return;
-            }
-
-            var session = store.Create(sp =>
+            // Session-cap backstop (RaskLiveOptions.MaxSessions). TryCreate reserves a slot
+            // atomically and returns null when over cap, rejecting BEFORE the component tree is
+            // built so untrusted GET traffic can't exhaust memory (and a concurrent burst can't
+            // race past the cap). Checked after the auth guard above so challenge/forbid
+            // redirects (which create no session) still work.
+            var session = store.TryCreate(sp =>
             {
                 // Wrap the App in an implicit RootErrorBoundary so an uncaught render /
                 // lifecycle / event-handler exception anywhere in the user's tree renders a
@@ -244,6 +252,14 @@ public static class RaskEndpointExtensions
                 var app = ActivatorUtilities.CreateInstance<TApp>(sp);
                 return new RootErrorBoundary(app);
             });
+            if (session is null)
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                httpContext.Response.Headers.RetryAfter = "5";
+                await httpContext.Response.WriteAsync("Server is at session capacity; please retry shortly.")
+                    .ConfigureAwait(false);
+                return;
+            }
             session.Services.GetRequiredService<SessionUserProvider>().Set(user);
             var routeState = session.Services.GetRequiredService<RouteState>();
             routeState.Path = path;
@@ -267,9 +283,11 @@ public static class RaskEndpointExtensions
             // Browsers / probes can hit the catch-all for resources that don't
             // need a live session (favicon.ico, robots.txt, scanner traffic) —
             // without this guard those sessions stay in the store forever.
-            // When a legitimate WS hello arrives within the grace window,
-            // LiveSessionStore.Get cancels the pending removal automatically.
-            store.ScheduleRemoval(session.Id, SessionGracePeriod);
+            // Uses the SHORT unconnected grace: the runtime connects within ~1s, so a session
+            // that never sends `hello` is almost certainly a probe / abandoned load and should
+            // not pin a DI scope + tree for the full 30s reconnect window. A real hello cancels
+            // this removal (LiveSessionStore.Get) and DetachSocket later re-arms the full grace.
+            store.ScheduleRemoval(session.Id, UnconnectedSessionGracePeriod);
         });
         return endpoints;
     }
@@ -660,6 +678,31 @@ public static class RaskEndpointExtensions
                 // buffer is disposed at the bottom of the iteration.
                 var capturedSession = session;
                 var capturedHandlerId = handlerId;
+
+                // Backpressure circuit-breaker: bound the number of dispatches queued on the
+                // chain. When handlers drain slower than the client sends (a flood) or the chain
+                // head is stuck (a hung handler), the queue — each entry holding a cloned
+                // JsonElement — would grow without limit. Trip before cloning so we don't even
+                // allocate the payload we'd have to drop; close the socket so the client
+                // reconnects (hello) against the intact session and resumes from current state.
+                var pending = capturedSession.IncrementPendingHandlers();
+                if (MaxPendingHandlers > 0 && pending > MaxPendingHandlers)
+                {
+                    capturedSession.DecrementPendingHandlers();
+                    using var capCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                    try
+                    {
+                        await ws.CloseAsync(
+                                WebSocketCloseStatus.PolicyViolation, "handler backlog", capCts.Token)
+                            .ConfigureAwait(false);
+                    }
+                    catch { }
+
+                    break;
+                }
+
+                // We clone the JSON element because the JsonDocument's backing buffer is disposed
+                // at the bottom of the iteration.
                 var capturedRoot = root.Clone();
                 capturedSession.LastHandlerTask = ChainHandlerDispatchAsync(
                     capturedSession.LastHandlerTask,
@@ -697,16 +740,25 @@ public static class RaskEndpointExtensions
     {
         try
         {
-            await previous.ConfigureAwait(false);
-        }
-        catch
-        {
-            // Previous handler's exceptions are already observed and logged inside
-            // DispatchHandlerAsync — swallow here so a faulted predecessor doesn't
-            // prevent this dispatch from running. The chain is for ordering only.
-        }
+            try
+            {
+                await previous.ConfigureAwait(false);
+            }
+            catch
+            {
+                // Previous handler's exceptions are already observed and logged inside
+                // DispatchHandlerAsync — swallow here so a faulted predecessor doesn't
+                // prevent this dispatch from running. The chain is for ordering only.
+            }
 
-        await DispatchHandlerAsync(session, handlerId, root, ct).ConfigureAwait(false);
+            await DispatchHandlerAsync(session, handlerId, root, ct).ConfigureAwait(false);
+        }
+        finally
+        {
+            // Pairs with the IncrementPendingHandlers in the receive loop when this dispatch was
+            // queued, so the backpressure counter tracks the live chain depth.
+            session.DecrementPendingHandlers();
+        }
     }
 
     private static async Task DispatchHandlerAsync(

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
@@ -79,6 +79,25 @@ public class HeadAssetRenderTests
         Assert.Contains(">User #42</title>", html);
     }
 
+    [Fact]
+    public void RepeatedRenders_ProduceIdenticalHead()
+    {
+        // The head-asset registry + mounted-type set are hoisted onto the root's LiveState and
+        // reused across renders (cleared each frame). Re-rendering the same root must yield the
+        // exact same head every time — a stale entry surviving Clear() (dup link, leftover
+        // title) would show up here. Also guards the singleton/dedup paths under reuse.
+        var view = new ShellWithTitle("App", new ContributesLink());
+
+        var first = view.RenderAsLiveRoot();
+        var second = view.RenderAsLiveRoot();
+        var third = view.RenderAsLiveRoot();
+
+        Assert.Equal(first, second);
+        Assert.Equal(second, third);
+        Assert.Equal(1, CountOccurrences(third, "<title "));
+        Assert.Equal(1, CountOccurrences(third, "/a.css"));
+    }
+
     // ----- helpers -----
 
     private static int CountOccurrences(string haystack, string needle)

--- a/tests/Rask.Core.Tests/Live/LiveSessionStoreTests.cs
+++ b/tests/Rask.Core.Tests/Live/LiveSessionStoreTests.cs
@@ -168,6 +168,66 @@ public class LiveSessionStoreTests
         Assert.True(disposed.Task.IsCompletedSuccessfully);
     }
 
+    [Fact]
+    public void TryCreate_Uncapped_AlwaysSucceeds()
+    {
+        var store = NewStore(); // MaxSessions defaults to 0 (unlimited)
+
+        for (var i = 0; i < 5; i++)
+        {
+            Assert.NotNull(store.TryCreate(_ => new StubComponent(Span())));
+        }
+
+        Assert.Equal(5, store.Count);
+    }
+
+    [Fact]
+    public void TryCreate_OverCap_ReturnsNullAndMintsNoSession()
+    {
+        var store = NewStore();
+        store.MaxSessions = 2;
+
+        Assert.NotNull(store.TryCreate(_ => new StubComponent(Span())));
+        Assert.NotNull(store.TryCreate(_ => new StubComponent(Span())));
+
+        // Third reservation exceeds the cap: rejected, and no session is built/stored.
+        Assert.Null(store.TryCreate(_ => new StubComponent(Span())));
+        Assert.Equal(2, store.Count);
+    }
+
+    [Fact]
+    public void TryCreate_AfterRemoval_FreesACapSlot()
+    {
+        var store = NewStore();
+        store.MaxSessions = 1;
+
+        var first = store.TryCreate(_ => new StubComponent(Span()));
+        Assert.NotNull(first);
+        Assert.Null(store.TryCreate(_ => new StubComponent(Span()))); // at cap
+
+        store.Remove(first!.Id); // releases the reservation
+
+        Assert.NotNull(store.TryCreate(_ => new StubComponent(Span())));
+        Assert.Equal(1, store.Count);
+    }
+
+    [Fact]
+    public async Task TryCreate_ConcurrentBurst_NeverExceedsCap()
+    {
+        var store = NewStore();
+        store.MaxSessions = 10;
+
+        // 100 concurrent reservations against a cap of 10 — the atomic reservation must admit
+        // exactly 10 and reject the rest, with no torn count from the race.
+        var tasks = Enumerable.Range(0, 100)
+            .Select(_ => Task.Run(() => store.TryCreate(_ => new StubComponent(Span())) is not null))
+            .ToArray();
+        var admitted = await Task.WhenAll(tasks);
+
+        Assert.Equal(10, admitted.Count(ok => ok));
+        Assert.Equal(10, store.Count);
+    }
+
     private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;

--- a/tests/Rask.Core.Tests/UrlSanitizerTests.cs
+++ b/tests/Rask.Core.Tests/UrlSanitizerTests.cs
@@ -1,0 +1,91 @@
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests;
+
+public class UrlSanitizerTests
+{
+    // --- dangerous schemes are neutralized on navigation/resource attributes ---
+
+    [Theory]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("JavaScript:alert(1)")]
+    [InlineData("  javascript:alert(1)")] // leading whitespace stripped before scheme
+    [InlineData("java\tscript:alert(1)")] // embedded tab removed before scheme
+    [InlineData("java\nscript:alert(1)")] // embedded newline removed before scheme
+    [InlineData("java\0script:alert(1)")] // embedded NUL removed before scheme
+    [InlineData("vbscript:msgbox(1)")]
+    [InlineData("data:text/html,<script>alert(1)</script>")]
+    public void Href_DangerousScheme_NeutralizedToAboutBlank(string url)
+    {
+        Assert.Equal("<a href=\"about:blank\"></a>", A(url).ToHtml());
+    }
+
+    [Theory]
+    [InlineData("/local/path", "/local/path")]
+    [InlineData("https://example.com/x?a=b", "https://example.com/x?a=b")]
+    [InlineData("http://example.com", "http://example.com")]
+    [InlineData("mailto:a@b.com", "mailto:a@b.com")]
+    [InlineData("tel:+123", "tel:&#x2B;123")] // '+' HTML-encoded by the attribute encoder
+    [InlineData("#frag", "#frag")]
+    [InlineData("?q=1", "?q=1")]
+    [InlineData("relative/path:withcolon", "relative/path:withcolon")] // not a scheme
+    public void Href_SafeUrl_PassesThrough(string url, string expected)
+    {
+        Assert.Equal($"<a href=\"{expected}\"></a>", A(url).ToHtml());
+    }
+
+    [Fact]
+    public void IframeSrc_JavascriptScheme_Neutralized() =>
+        Assert.Equal("<iframe src=\"about:blank\"></iframe>", Iframe("javascript:alert(1)").ToHtml());
+
+    [Fact]
+    public void IframeSrc_DataHtml_Neutralized() =>
+        Assert.Equal("<iframe src=\"about:blank\"></iframe>", Iframe("data:text/html,<x>").ToHtml());
+
+    // --- media attributes allow inline data: for image/video/audio only ---
+
+    [Fact]
+    public void ImgSrc_DataImage_PassesThrough() =>
+        Assert.Equal(
+            "<img src=\"data:image/png;base64,iVBOR\" />",
+            Img("data:image/png;base64,iVBOR").ToHtml());
+
+    [Fact]
+    public void ImgSrc_DataSvg_PassesThrough() =>
+        Assert.Equal(
+            "<img src=\"data:image/svg&#x2B;xml,abc\" />", // '+' HTML-encoded
+            Img("data:image/svg+xml,abc").ToHtml());
+
+    [Fact]
+    public void ImgSrc_DataHtml_Neutralized() =>
+        Assert.Equal("<img src=\"about:blank\" />", Img("data:text/html,<x>").ToHtml());
+
+    [Fact]
+    public void ImgSrc_Javascript_Neutralized() =>
+        Assert.Equal("<img src=\"about:blank\" />", Img("javascript:alert(1)").ToHtml());
+
+    // --- RaskUrl.Trusted opt-out round-trips verbatim (still HTML-encoded) ---
+
+    [Fact]
+    public void Href_Trusted_BypassesSanitization() =>
+        Assert.Equal(
+            "<a href=\"javascript:void(0)\"></a>",
+            A(RaskUrl.Trusted("javascript:void(0)")).ToHtml());
+
+    [Fact]
+    public void Href_Trusted_StillHtmlEncoded() =>
+        Assert.Equal(
+            "<a href=\"/x?a=1&amp;b=2\"></a>",
+            A(RaskUrl.Trusted("/x?a=1&b=2")).ToHtml());
+
+    // --- value still HTML-encoded after sanitization (no attribute breakout) ---
+
+    [Fact]
+    public void Href_QuoteInSafeUrl_Encoded() =>
+        Assert.Equal(
+            "<a href=\"/a&quot;b\"></a>",
+            A("/a\"b").ToHtml());
+
+    [Fact]
+    public void NullHref_OmitsAttribute() => Assert.Equal("<a></a>", A().ToHtml());
+}

--- a/tests/Rask.Server.Tests/Infrastructure/HangingApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/HangingApp.cs
@@ -1,0 +1,24 @@
+using Rask.Core;
+using Rask.Core.Components;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Infrastructure;
+
+// App whose click handler blocks on a test-controlled gate, stalling the handler-dispatch
+// chain head so queued dispatches pile up — used to exercise the backpressure circuit-breaker
+// (RaskEndpointExtensions.MaxPendingHandlers).
+public sealed class HangingApp : Component
+{
+    // Released by the test to let the hung handler complete. Static so the test can signal it
+    // without a handle to the DI-constructed instance; reset per test before the host starts.
+    public static TaskCompletionSource Gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    protected override RenderResult Render() =>
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["hang"]],
+            new Body()[
+                Button(OnClickAsync: async () => await Gate.Task)["hang"]]]
+    ];
+}

--- a/tests/Rask.Server.Tests/WebSockets/HandlerBackpressureTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerBackpressureTests.cs
@@ -1,0 +1,94 @@
+using System.Net.WebSockets;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// Backpressure circuit-breaker (RaskEndpointExtensions.MaxPendingHandlers): a hung handler
+// stalls the dispatch chain head, so queued dispatches — each retaining a cloned JsonElement —
+// accumulate. Once the queue exceeds the bound the receive loop must close the socket instead of
+// growing memory without limit.
+[Collection("SessionGracePeriod")]
+public class HandlerBackpressureTests
+{
+    [Fact]
+    public async Task QueueExceedsBound_WhileHandlerHung_ClosesSocket()
+    {
+        var prevMax = RaskEndpointExtensions.MaxPendingHandlers;
+        RaskEndpointExtensions.MaxPendingHandlers = 4;
+        HangingApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            using var host = RaskTestHost.Create<HangingApp>();
+            var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+            var sessionId = Markup.SessionId(initialHtml);
+            var handlerId = Markup.FirstHandlerId(initialHtml);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+            // First click hangs on the gate (chain head stalls); the rest queue behind it. Send
+            // well past the bound — once pending exceeds MaxPendingHandlers the server closes the
+            // socket, so later client sends may throw; that's expected.
+            for (var i = 0; i < 20; i++)
+            {
+                try
+                {
+                    await ws.SendJsonAsync(new { id = handlerId });
+                }
+                catch
+                {
+                    break; // socket closed mid-flood
+                }
+            }
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+            while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
+            {
+                // Draining receives lets the client observe the server's close frame.
+                if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
+                    && ws.State == WebSocketState.Open)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.NotEqual(WebSocketState.Open, ws.State);
+        }
+        finally
+        {
+            HangingApp.Gate.TrySetResult(); // unblock the hung handler so teardown is clean
+            RaskEndpointExtensions.MaxPendingHandlers = prevMax;
+        }
+    }
+
+    [Fact]
+    public async Task UnderBound_NormalTraffic_StaysOpen()
+    {
+        var prevMax = RaskEndpointExtensions.MaxPendingHandlers;
+        RaskEndpointExtensions.MaxPendingHandlers = 512;
+        try
+        {
+            using var host = RaskTestHost.Create<TestApp>();
+            var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+            var sessionId = Markup.SessionId(initialHtml);
+            var handlerId = Markup.FirstHandlerId(initialHtml);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+            // These drain quickly (no hung handler), so pending never approaches the bound.
+            for (var i = 0; i < 10; i++)
+            {
+                await ws.SendJsonAsync(new { id = handlerId });
+                _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            }
+
+            Assert.Equal(WebSocketState.Open, ws.State);
+        }
+        finally
+        {
+            RaskEndpointExtensions.MaxPendingHandlers = prevMax;
+        }
+    }
+}


### PR DESCRIPTION
Top-impact sweep across performance, memory, and security, scoped to fixes that run on every render/diff or close a real DoS/XSS gap. Full non-e2e suite green; `Rask.Example.Wasm` still trims warning-free.

## Security
- **URL-scheme sanitization by default** (was a live DOM-XSS hole). HTML-encoding alone leaves `<a href="javascript:…">` executable. New `UrlSanitizer` + `Component.AppendUrlAttr`/`AppendMediaUrlAttr` neutralize `javascript:`/`vbscript:`/untrusted `data:` to `about:blank` across every URL-bearing tag (`href`, `src`, `cite`, `formaction`, object `data`, `poster`, SVG `href`). Detection defeats leading-whitespace / embedded tab/newline/NUL obfuscation. Per-call opt-out via `RaskUrl.Trusted(...)` (still HTML-encoded). Media tags still allow inline `data:image|video|audio`.

## Performance
- **Lock-free scoped-asset reads** — the by-`Type` lookups hit per component per render move to `ConcurrentDictionary`, dropping the process-wide lock that serialized concurrent sessions.
- **`AsyncLocal` off the hot path** — `[ThreadStatic]` `CurrentSync` mirror for the synchronous render walk; per-element attribute reads use it (lifecycle reads stay on `AsyncLocal`). Cached `Component.Key` stringification (no per-render `ToString` alloc on keyed lists).
- **Head splice** — `ApplyTo` takes the pre-computed sentinel index (no second whole-body `IndexOf`), pools its `StringBuilder`s, appends keys instead of per-asset `string.Insert`.

## Memory
- **Hoisted render-context collections** — `HeadAssetRegistry` + `MountedTypes` live on the root `LiveState`, reused and cleared per render instead of allocating ~5 collections every frame.
- **Bounded session retention + hard cap (DoS)** — a GET-minted session that never sends `hello` is evicted on a short 10s grace (vs the 30s reconnect grace); `MaxSessions` is now an atomic `TryCreate` reservation taken before the tree is built, so a concurrent GET burst can't race past the cap.
- **Handler-chain backpressure (DoS)** — a per-session pending-dispatch counter (`MaxPendingHandlers`, default 512) closes the socket when the chain backs up behind a hung/flooding client, instead of retaining cloned `JsonElement`s without bound.

## Tests
- `UrlSanitizerTests` (26): dangerous/obfuscated schemes neutralized, safe URLs pass through, `data:image` allowed on media, `RaskUrl.Trusted` round-trips, still HTML-encoded.
- `LiveSessionStoreTests`: `TryCreate` hard cap incl. a 100-way concurrent burst against a cap of 10.
- `HandlerBackpressureTests`: hung-handler flood closes the socket; normal traffic stays open.
- `HeadAssetRenderTests`: repeated renders produce byte-identical head (guards the reused/cleared registry).

## Notes / deviations from plan
- A1 uses `ConcurrentDictionary` rather than a `FrozenDictionary` COW — same lock-free-read goal without an O(n²) startup rebuild.
- A3 implements the safe wins (sentinel-index reuse, pooled builders, append-based keying, B1 collection hoist) but **omits** the speculative content-hash memoization of the whole head block: head asset strings are re-rendered each frame regardless, so the memo's marginal benefit didn't justify the risk to the delicate head-morph reconciliation.
