### PR TITLE
chore: developer workflow, automation, AI onboarding, and governance

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,18 @@
+# Rask skills
+
+Committed, shareable playbooks for the recurring Rask workflows. They auto-surface from their
+`description` — **apply the matching skill automatically** when a task fits, no need to be asked.
+
+| Skill | Use it when |
+|---|---|
+| [`rask-ship`](rask-ship/SKILL.md) | Before any commit/PR — the definition-of-done gate (format → warnings-as-errors build → tests → benchmarks → CHANGELOG → review → PR). |
+| [`add-html-tag`](add-html-tag/SKILL.md) | Adding an HTML element to `Rask.Core` (component + ordered-attribute test; factory auto-generated). |
+| [`add-diagnostic`](add-diagnostic/SKILL.md) | Adding a RASK0xx generator/analyzer diagnostic (descriptor + `docs/diagnostics.md` + test). |
+| [`run-benchmarks`](run-benchmarks/SKILL.md) | Changing render/live-runtime hotpath — before/after `Allocated` delta. |
+| [`rask-review`](rask-review/SKILL.md) | Reviewing a diff/PR for security, performance, memory, and .NET/C# best practices. |
+| [`open-pr`](open-pr/SKILL.md) | Opening a PR (branch off main, Conventional-Commit, no AI attribution, delete branch after merge). |
+| [`cut-release`](cut-release/SKILL.md) | Publishing a version (CHANGELOG promote + `vX.Y.Z` tag → `release.yml`). |
+| [`check-nuget-updates`](check-nuget-updates/SKILL.md) | Auditing/bumping NuGet dependencies (complements Dependabot). |
+
+`rask-ship` is the orchestrator; the scaffolding skills (`add-html-tag`, `add-diagnostic`) hand
+off to it. Each skill is self-contained so it works on a fresh clone.

--- a/.claude/skills/add-diagnostic/SKILL.md
+++ b/.claude/skills/add-diagnostic/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: add-diagnostic
+description: Add a new RASK0xx compile-time diagnostic to the Rask Roslyn generators/analyzers. Use when introducing a new warning or error in src/Rask.Generators. Defines the DiagnosticDescriptor, wires DiagnosticHelp.Link, documents it in docs/diagnostics.md (TOC row + section), and adds a generator test.
+---
+
+# add-diagnostic
+
+## 1. Pick the next ID
+RASK001–RASK022 are in use → **next free is RASK023**. Confirm with:
+```bash
+grep -rhoE 'RASK[0-9]{3}' src/Rask.Generators | sort -u | tail
+```
+
+## 2. Define the descriptor
+In the owning generator/analyzer under `src/Rask.Generators/` (factory rules in
+`ComponentFactoryGenerator.cs`, route rules in `RoutesGenerator.cs`, scoped-asset rules in
+`ComponentScoped{Css,Js}Generator.cs`, plus `Analyzers/`). Mirror the existing pattern:
+```csharp
+private static readonly DiagnosticDescriptor Rask023 = new(
+    "RASK023",
+    "Short title",
+    "Message with {0} format args",
+    "Rask.Generators",
+    DiagnosticSeverity.Warning,   // Error | Warning | Hidden
+    isEnabledByDefault: true,
+    helpLinkUri: DiagnosticHelp.Link("RASK023"));   // see DiagnosticHelp.cs
+```
+Report it with `context.ReportDiagnostic(Diagnostic.Create(Rask023, location, args))`.
+
+## 3. Document it — `docs/diagnostics.md`
+- Add a TOC table row (ID · Severity · Summary) in the table near the top.
+- Add a `## RASK023` section (the anchor must match `DiagnosticHelp.Link` →
+  `#rask023`): what triggers it, severity, fix, and a code example. Match the existing entries.
+
+## 4. Test it — `tests/Rask.Generators.Tests`
+Add a generator test asserting the diagnostic is/ isn't produced for the trigger and the
+non-trigger case.
+
+## 5. Finish
+Run the **`rask-ship`** gate. `docs/diagnostics.md` is the user-facing index; descriptors are
+the source of truth — keep them in sync.

--- a/.claude/skills/add-html-tag/SKILL.md
+++ b/.claude/skills/add-html-tag/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: add-html-tag
+description: Scaffold a new HTML tag component in Rask.Core. Use whenever adding support for an HTML element (e.g. <dialog>, <details>, <progress>, <video>) to the Rask framework. Creates src/Rask.Core/Components/{Tag}.cs and the matching tests/Rask.Core.Tests/Components/{Tag}Tests.cs asserting exact attribute order; the factory is generated automatically.
+---
+
+# add-html-tag
+
+Adds one HTML element. The `Generated.{Tag}(...)` factory is produced by the Roslyn generator —
+you only write the component + its test. Follow C# conventions: `sealed`, file-scoped namespace,
+nullable enabled, expression-bodied single-line members.
+
+## 1. Component — `src/Rask.Core/Components/{Tag}.cs`
+- `public sealed class {Tag} : Element`, override `protected override string TagName => "{tag}";`.
+- **Void/self-closing** elements (br, img, input, hr, meta, link, …) add `protected override bool SelfClosing => true;`.
+- Each tag-specific attribute is a **public mutable property**. Type choice drives the factory:
+  - nullable (`string?`, `bool?`, `int?`) → **optional** factory param (default null) — use this for HTML attrs to keep them ergonomic.
+  - non-nullable, no initializer → **required** factory param (RASK001).
+  - property with an initializer or `[SkipFactory]` → excluded.
+- Override `WriteAttributes` only if there are tag-specific attributes: call `base.WriteAttributes(sb)`
+  **first** (emits id, class, style, data-*, ref), then `AppendAttr(sb, "name", value)` per attr
+  (`AppendUrlAttr` for URL attrs; `AppendAttr(sb, "disabled", null)` for bare boolean attrs).
+
+See `templates/Component.cs`. References: `src/Rask.Core/Components/Span.cs` (simple),
+`Br.cs` (void), `Button.cs` (attributes), base `src/Rask.Core/Element.cs`.
+
+## 2. Test — `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`
+Two methods, xUnit:
+- `Render_NullProps_…` — only `TagName` (and self-close shape) renders.
+- `Render_AllPropsSet_…` — **asserts exact attribute order**: id, class, style, data-*, **then**
+  tag-specific attrs. Tests assert this ordering — preserve it.
+
+See `templates/ComponentTests.cs`. Reference: `tests/Rask.Core.Tests/Components/ButtonTests.cs`.
+
+## 3. Finish
+This is a new feature → run the **`rask-ship`** gate (format → warnings-as-errors build → the
+unit test you just wrote → CHANGELOG → review → PR).

--- a/.claude/skills/add-html-tag/templates/Component.cs
+++ b/.claude/skills/add-html-tag/templates/Component.cs
@@ -1,0 +1,26 @@
+// Template — copy to src/Rask.Core/Components/{Tag}.cs and replace {Tag}/{tag}/attrs.
+// Delete the comment header. The Generated.{Tag}(...) factory is produced automatically.
+namespace Rask.Core.Components;
+
+/// <summary>The HTML <c>&lt;{tag}&gt;</c> element.</summary>
+public sealed class {Tag} : Element
+{
+    protected override string TagName => "{tag}";
+
+    // Void elements only (br, img, input, hr, meta, link, ...):
+    // protected override bool SelfClosing => true;
+
+    // Tag-specific attributes. Nullable => optional factory param (ergonomic for HTML attrs).
+    public string? Name { get; set; }
+    public bool? Open { get; set; }
+
+    protected override void WriteAttributes(StringBuilder sb)
+    {
+        base.WriteAttributes(sb);          // id, class, style, data-*, ref  (order matters)
+        if (Name is not null)
+            AppendAttr(sb, "name", Name);
+        if (Open is true)
+            AppendAttr(sb, "open", null);  // bare boolean attribute
+        // AppendUrlAttr(sb, "href", Href); // for URL-valued attributes
+    }
+}

--- a/.claude/skills/add-html-tag/templates/ComponentTests.cs
+++ b/.claude/skills/add-html-tag/templates/ComponentTests.cs
@@ -1,0 +1,22 @@
+// Template — copy to tests/Rask.Core.Tests/Components/{Tag}Tests.cs.
+// Asserts exact attribute order: id, class, style, data-*, then tag-specific.
+#pragma warning disable RASK014 // tests construct components directly
+namespace Rask.Core.Tests.Components;
+
+public class {Tag}Tests
+{
+    [Fact]
+    public void Render_NullProps_EmitsBareTag()
+    {
+        var html = HtmlSerializer.Serialize(new {Tag}());
+        Assert.Equal("<{tag}></{tag}>", html);          // self-closing: "<{tag}>"
+    }
+
+    [Fact]
+    public void Render_AllPropsSet_EmitsAttributesInOrder()
+    {
+        var c = new {Tag} { Id = "x", Class = "c", Name = "n", Open = true };
+        var html = HtmlSerializer.Serialize(c);
+        Assert.Equal("""<{tag} id="x" class="c" name="n" open></{tag}>""", html);
+    }
+}

--- a/.claude/skills/check-nuget-updates/SKILL.md
+++ b/.claude/skills/check-nuget-updates/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: check-nuget-updates
+description: Check for outdated NuGet dependencies in the Rask repo and propose safe bumps. Use periodically or before a release. Reads central package management (Directory.Packages.props), reports outdated/vulnerable/deprecated packages, and updates versions behind the rask-ship gate.
+---
+
+# check-nuget-updates
+
+Versions are centrally managed in `Directory.Packages.props` (CPM). Dependabot also opens PRs
+weekly (`.github/dependabot.yml`) — this skill is the manual/on-demand path.
+
+## 1. Scan
+```bash
+dotnet restore Rask.slnx
+dotnet list Rask.slnx package --outdated
+dotnet list Rask.slnx package --vulnerable --include-transitive
+dotnet list Rask.slnx package --deprecated
+```
+
+## 2. Triage
+- **Security/vulnerable** → bump now (highest priority).
+- **Patch/minor** → safe to bump; batch them.
+- **Major** → bump deliberately, read release notes, expect API changes (esp. xunit, Playwright,
+  Microsoft.CodeAnalysis.CSharp which the generators pin, ASP.NET 10.x stack).
+- Keep the `Microsoft.Extensions.*` / `Microsoft.AspNetCore.*` family on the same version.
+
+## 3. Apply + verify
+Edit the `<PackageVersion>` entries in `Directory.Packages.props`, then run the **`rask-ship`**
+gate (build is warnings-as-errors, so analyzer-rule changes from an SDK/analyzer bump surface
+immediately). Note version bumps in `CHANGELOG.md`.

--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: cut-release
+description: Cut a Rask release. Use when publishing a new version to NuGet/GitHub. Promotes the CHANGELOG [Unreleased] section to a dated version, then tags vX.Y.Z so MinVer derives the version and release.yml runs the unit gate + sharded E2E + packs and pushes the NuGet packages and GitHub release.
+---
+
+# cut-release
+
+Versioning is **MinVer from git tags** (`Directory.Build.props` → `<MinVerTagPrefix>v</…>`).
+There is no version number to bump in a file — **the tag is the version**.
+
+## 1. Pre-flight
+- On `main`, clean tree, CI green.
+- Run the **`rask-ship`** gate once more (format → warnings-as-errors → tests).
+- Decide the SemVer bump from the `[Unreleased]` changes (breaking→major, feature→minor, fix→patch).
+
+## 2. Promote the CHANGELOG
+In `CHANGELOG.md`, rename `## [Unreleased]` to `## [X.Y.Z] - YYYY-MM-DD` (keep its
+`### Added/Changed/Fixed/...` subsections), and add a fresh empty `## [Unreleased]` above it.
+Commit:
+```bash
+git add CHANGELOG.md && git commit -m "Release vX.Y.Z"
+```
+
+## 3. Tag + push (triggers release.yml)
+```bash
+git tag vX.Y.Z
+git push origin main
+git push origin vX.Y.Z
+```
+`release.yml` (on `push: tags: v*`) runs the unit gate, the sharded E2E matrix, then packs the
+six NuGets (`Rask.Server`, `Rask.Wasm`, `Rask.Wasm.Hosting`, `Rask.Validation.DataAnnotations`,
+`Rask.Validation.FluentValidation`, `Rask.Templates`), pushes them to nuget.org, and creates the
+GitHub release. Watch it:
+```bash
+gh run watch
+```
+
+## 4. Verify
+- GitHub release created with the six `.nupkg` assets.
+- Packages visible on nuget.org at version `X.Y.Z`.
+- To undo a mistaken tag **before** publish completes: `git push --delete origin vX.Y.Z`.

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -17,7 +17,7 @@ git switch -c <type>/<short-desc>          # e.g. feat/dialog-tag, fix/diff-rota
 
 ## 2. Commit — Conventional Commits (enforced by commitlint)
 Format `type(scope): subject`, imperative, lower-case subject, ≤100 chars. Allowed types:
-`feat, fix, perf, refactor, docs, test, build, ci, chore, revert` (`commitlint.config.js`,
+`feat, fix, perf, refactor, docs, test, build, ci, chore, revert` (`commitlint.config.mjs`,
 checked in CI by `.github/workflows/commitlint.yml`). Breaking change → `feat!:` / `fix!:` or a
 `BREAKING CHANGE:` footer. **No `Co-Authored-By`, no `Generated-with`/AI-attribution footers** — ever.
 ```bash

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: open-pr
+description: Open a GitHub PR for the current Rask branch following project conventions. Use when ready to submit a change. Branches off main if needed, writes a structured PR body (summary, testing, benchmarks, changelog), and omits all AI attribution footers.
+---
+
+# open-pr
+
+Assumes `rask-ship` steps 1–6 are green (format, warnings-as-errors build, tests, benchmarks if
+hotpath, CHANGELOG entry, review).
+
+## 1. Branch
+Never commit straight to `main`. If on `main`, branch first:
+```bash
+git rev-parse --abbrev-ref HEAD            # if "main":
+git switch -c <type>/<short-desc>          # e.g. feat/dialog-tag, fix/diff-rotation
+```
+
+## 2. Commit — Conventional Commits (enforced by commitlint)
+Format `type(scope): subject`, imperative, lower-case subject, ≤100 chars. Allowed types:
+`feat, fix, perf, refactor, docs, test, build, ci, chore, revert` (`commitlint.config.js`,
+checked in CI by `.github/workflows/commitlint.yml`). Breaking change → `feat!:` / `fix!:` or a
+`BREAKING CHANGE:` footer. **No `Co-Authored-By`, no `Generated-with`/AI-attribution footers** — ever.
+```bash
+git add -A && git commit -m "feat(forms): add RadioGroup disabled state"
+```
+
+## 3. PR
+```bash
+git push -u origin HEAD
+gh pr create --base main --title "<title>" --body-file <(cat .claude/skills/open-pr/templates/pr-body.md)
+```
+Fill the body from `templates/pr-body.md`: **Summary** · **Testing** (unit + which E2E host, with
+results) · **Benchmarks** (Allocated delta if framework hotpath, else "n/a") · **CHANGELOG**
+(link the `[Unreleased]` entry). CI runs the unit gate + sharded E2E matrix + commitlint; a
+release is cut by tagging `vX.Y.Z` (MinVer), which triggers `release.yml`.
+
+## 4. Merge — delete the branch
+Always delete the branch after merge (squash):
+```bash
+gh pr merge --squash --delete-branch
+git switch main && git pull && git remote prune origin
+```
+(Set repo default: Settings → "Automatically delete head branches".)

--- a/.claude/skills/open-pr/templates/pr-body.md
+++ b/.claude/skills/open-pr/templates/pr-body.md
@@ -1,0 +1,14 @@
+## Summary
+<!-- what changed and why, 1–3 sentences -->
+
+## Testing
+- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — <result>
+- E2E (if `samples/` changed): host `<Host>` — <result>
+
+## Benchmarks
+<!-- framework/render-hotpath change: quote the Allocated delta, e.g. "1.84 KB → 0.91 KB (−51%)". Otherwise: n/a -->
+
+## CHANGELOG
+- [Unreleased] entry added: <one-liner>
+
+<!-- Do NOT add Co-Authored-By or Generated-with footers. -->

--- a/.claude/skills/rask-review/SKILL.md
+++ b/.claude/skills/rask-review/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: rask-review
+description: Review a Rask diff or PR for security, performance, memory usage, and .NET/C# best practices before merge. Use whenever reviewing changes in the Rask repo, or as the review step of rask-ship. Runs the built-in /code-review and /security-review, then adds Rask framework-aware checks.
+---
+
+# rask-review
+
+First run the generic passes, then apply the Rask-specific lens below. Address findings before
+opening/merging the PR.
+
+```
+/code-review          # correctness + reuse/simplification/efficiency on the diff
+/security-review      # security scan of pending changes
+```
+
+## Security
+- **XSS**: only `Text` HTML-encodes; `Raw` emits verbatim. Any new `Raw`/`HtmlSerializer` path
+  with user-influenced content is a finding.
+- **Auth handshake**: redeem rejects cross-origin (`IsSameOrigin`); redeem-ticket TTL respected;
+  `SessionUserProvider.Clear()` invalidates; JWT only rides the WS as `?access_token=`.
+- **Scoped assets** stay `.AllowAnonymous()` + `nosniff` + immutable cache; no secrets in payloads.
+- Route guards: `[Authorize]`/`[AllowAnonymous]` and client redirects (`/login`, `/forbidden`) intact.
+
+## Performance / memory
+- Render hot path stays allocation-lean: no LINQ, no per-render closures, pooled
+  `StringBuilder`/writers; prefer spans/UTF-8 literals.
+- Diff codec must still win on bytes; **`SessionRenderCache.TryComputeDiff` rotates on every call
+  — never `Snapshot()` after it on the same render**.
+- Any hot-path change **requires `run-benchmarks` evidence** (Allocated delta) in the PR.
+
+## .NET / C# best practices
+- **Prefer standard .NET / BCL APIs over hand-rolled code — don't reinvent the wheel.** Flag any
+  custom implementation of something the framework/BCL already provides.
+- **Refactor opportunistically**: if the diff touches duplicated or unclear code, extract/clean it
+  (within reason, with tests) rather than copy-pasting more.
+- Nullable correctness; `sealed` types; file-scoped namespaces; modern pattern matching.
+- No sync-over-async; propagate `CancellationToken` (esp. Virtualize `ItemsProvider`).
+- Dispose/unsubscribe symmetry: `RouteState.Changed` / `IUserProvider.Changed` subscribed in
+  `OnMount`, unsubscribed in `OnUnmount`; no `StateHasChanged()` in `OnUnmount`.
+
+## Hold UX, security, and performance together
+Judge every change on all three at once — a win on one must not silently regress another.
+Good developer/user experience (clear APIs, helpful errors, no flicker), safe defaults, and a
+lean hot path are co-equal acceptance criteria, not trade-offs to make quietly.
+
+## Rask invariants
+- Attribute render order (id, class, style, data-*, then tag-specific).
+- Root renders a full shell — RASK021. Keyed lists in projections — RASK022.
+- Components constructed via the generated factory, not `new` — RASK014.
+- Inject framework services through the ctor, not as non-nullable settable props (RASK002).

--- a/.claude/skills/rask-ship/SKILL.md
+++ b/.claude/skills/rask-ship/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: rask-ship
+description: The Rask "definition of done" gate. Use before committing or opening a PR for any change in the Rask repo — it formats with dotnet format (.editorconfig), enforces a warnings-as-errors analyzer-clean build, requires unit tests for new features and E2E tests for example-app changes, runs benchmarks for framework/render-hotpath changes, updates the CHANGELOG, reviews for security/perf/memory, then opens a PR with no AI attribution.
+---
+
+# rask-ship — definition-of-done gate
+
+Run this before every commit/PR. Each step is a gate: do not advance with a failing step.
+Steps fire based on what changed (step 0 classifies). For the slnx use `Rask.slnx`.
+
+**Principles** (apply throughout): do your best on every PR; weigh **user experience, security,
+and performance together**, never one at the cost of another; prefer **standard .NET / BCL APIs
+over hand-rolled code** (don't reinvent the wheel); **refactor opportunistically** when you touch
+code that's duplicated or unclear; **automate** whatever can be automated; **ask only when truly
+blocked** — otherwise pick the sensible default and proceed.
+
+## 0. Classify the change
+Look at `git status` / `git diff --stat` and bucket the change:
+- **Framework code** — anything under `src/` (esp. `src/Rask.Core/`, `src/Rask.Server/`, `src/Rask.Wasm/`, `src/Rask.Generators/`).
+- **Example app** — anything under `samples/`.
+- **New HTML tag** → also run the `add-html-tag` skill.
+- **New diagnostic (RASK0xx)** → also run the `add-diagnostic` skill.
+- **User-facing change** (new/changed component, API, prop, behavior visible to app authors) →
+  triggers step 3b (sample + docs/README).
+- **Docs only** — `docs/`, `*.md` → step 4 (benchmarks) is skipped; still format/build/review.
+
+The bucket decides whether steps 3/3b/4 apply.
+
+## 1. Format + analyzers
+```bash
+dotnet format Rask.slnx                      # applies .editorconfig style + analyzer fixers
+dotnet format Rask.slnx --verify-no-changes  # must exit 0
+```
+
+## 2. Clean build — warnings as errors
+```bash
+dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true
+```
+Zero warnings: .NET analyzers (CAxxxx), code-style (IDExxxx), nullable, and Rask's own
+RASK0xx generators. The WASM trimming path must stay IL-warning-free — if you touched anything
+reflection-adjacent, also:
+```bash
+dotnet publish samples/Rask.Example.Wasm -c Release   # zero IL trim warnings required
+```
+
+## 3. Tests — unit-first; E2E for example changes
+Policy: **unit-test first** for every new feature/bug fix; add E2E **only** when a unit test
+can't reach the path (E2E is heavy). **Any `samples/` change requires an E2E** journey update.
+
+- Add/adjust unit tests in the sibling `tests/Rask.*.Tests` project (e.g. `tests/Rask.Core.Tests`).
+- For `samples/` changes, extend the host's journey in `tests/Rask.Examples.E2E.Tests`
+  (one comprehensive journey per host — see `SharedSmokeTests` / `SharedSmokeTests.Journey.cs`).
+
+Run:
+```bash
+dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"   # fast inner loop
+# example changed → run that host's E2E:
+dotnet test tests/Rask.Examples.E2E.Tests --filter "FullyQualifiedName~Rask.Examples.E2E.Tests.{Host}"
+```
+`{Host}` ∈ ServerExampleTests, WasmExampleTests, StandaloneWasmExampleTests, WasmSubPathExampleTests,
+AuthExampleTests, JwtServerAuthExampleTests, WasmCookieAuthExampleTests, WasmJwtAuthExampleTests.
+(E2E flake note: `Highlight_DeepLinkToCodeSamplePage_HighlightsOnFirstPaint` has a first-paint
+race — rerun before assuming a regression.)
+
+## 3b. User-facing changes → sample + docs (keep everything up to date)
+If the change is visible to app authors (new/changed component, API, prop, default, behavior):
+- **Add or update a sample** demonstrating it under `samples/` (and extend that host's E2E
+  journey in `tests/Rask.Examples.E2E.Tests` — every `samples/` change needs E2E).
+- **Update the docs**: the relevant `docs/*.md` guide, the matching section of `README.md`, and
+  `docs/diagnostics.md` if a RASK0xx changed. Keep the AI guides current too
+  (`docs/ai-agents.md`, root `llms.txt`, and the `AGENTS.md` baked into `src/Rask.Templates`).
+- Nothing user-facing ships without a runnable example + updated docs.
+
+## 4. Benchmarks (framework/render-hotpath changes only)
+If you changed render/live-runtime code → run the **`run-benchmarks`** skill, capture the
+`Allocated` before/after delta, and quote it in the PR. Do not skip this for hotpath changes.
+
+## 5. CHANGELOG
+Add an entry under `## [Unreleased]` in `CHANGELOG.md` (Keep a Changelog format: `### Added/
+Changed/Fixed/Security/Performance/...`) in the same commit.
+
+## 6. Review — security / performance / memory
+Run the **`rask-review`** skill on the diff and address findings before submitting.
+
+## 7. Open the PR
+Run the **`open-pr`** skill. Never add `Co-Authored-By` or `Generated-with` footers to commits
+or the PR body.

--- a/.claude/skills/run-benchmarks/SKILL.md
+++ b/.claude/skills/run-benchmarks/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: run-benchmarks
+description: Run Rask render/runtime benchmarks before and after a framework change and report the Allocated delta. Use whenever you modify render hot-path or live-runtime code in src/Rask.Core or src/Rask.Server (HtmlSerializer, Element/Component render, Live/* diff codec, WS/WASM dispatch, payload build). Required evidence for any hotpath PR.
+---
+
+# run-benchmarks
+
+BenchmarkDotNet, Release only, hand-run (not part of `dotnet test`). Project:
+`benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj`. All benches use `[MemoryDiagnoser]`.
+
+## 1. Pick the bench class matching the change
+| Area changed | Bench class (`--filter "*Name*"`) |
+|---|---|
+| End-to-end HTML render + WS payload | `RenderRoundTripBenchmarks`, `LiveRenderRoundTripBenchmarks` |
+| Payload build / body inject/extract | `LivePayloadUtf8Benchmarks` |
+| Diff DOM-walk | `FrameDifferBenchmarks` |
+| Attribute encoding | `AttributeEncodingBenchmarks` |
+| WS / WASM dispatch | `WsDispatchBenchmarks`, `WasmDispatchBenchmarks` |
+| Asset / download | `AssetLoadingBenchmarks`, `DownloadPayloadBenchmarks` |
+
+## 2. Baseline (pre-change) then post-change
+```bash
+# capture baseline on the unchanged tree
+git stash                      # or check out the parent commit
+dotnet run -c Release --project benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj --filter "*RenderRoundTrip*"
+# results land in benchmarks/Rask.Benchmarks/BenchmarkDotNet.Artifacts/results/*-report-github.md
+git stash pop                  # restore the change, re-run the same filter
+dotnet run -c Release --project benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj --filter "*RenderRoundTrip*"
+```
+
+## 3. Compare + report
+Read the `Allocated` (and `Mean`) columns from the two
+`BenchmarkDotNet.Artifacts/results/*-report-github.md` runs. Trust `Allocated` even on
+`InvocationCount=1` benches. Quote the **delta** (e.g. "Allocated 1.84 KB → 0.91 KB, −51%") in
+the PR body. Custom byte reports: append `bundle-size` or `payload-bytes` instead of `--filter`.

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -25,6 +25,6 @@ cat >&2 <<'EOF'
   type ∈ feat, fix, perf, refactor, docs, test, build, ci, chore, revert
   e.g. "feat(forms): add RadioGroup disabled state"
 
-See commitlint.config.js / https://www.conventionalcommits.org/
+See commitlint.config.mjs / https://www.conventionalcommits.org/
 EOF
 exit 1

--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,30 @@
+#!/bin/sh
+# Local Conventional Commits guard. Enable once with:
+#   git config core.hooksPath .githooks
+# CI also enforces this via .github/workflows/commitlint.yml.
+
+msg_file="$1"
+header=$(head -n1 "$msg_file")
+
+# Allow merge/revert/fixup commits through.
+case "$header" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*) exit 0 ;;
+esac
+
+pattern='^(feat|fix|perf|refactor|docs|test|build|ci|chore|revert)(\([a-z0-9._-]+\))?!?: .{1,}'
+
+if printf '%s' "$header" | grep -Eq "$pattern"; then
+  exit 0
+fi
+
+cat >&2 <<'EOF'
+✖ Commit message must follow Conventional Commits:
+
+    type(scope): subject
+
+  type ∈ feat, fix, perf, refactor, docs, test, build, ci, chore, revert
+  e.g. "feat(forms): add RadioGroup disabled state"
+
+See commitlint.config.js / https://www.conventionalcommits.org/
+EOF
+exit 1

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Every change requires review/approval from the repository owner.
+# Combined with branch protection ("Require review from Code Owners" on `main`),
+# this means PRs cannot be merged without @pal-tamas's approval.
+* @pal-tamas

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,72 @@
+name: 🐛 Bug report
+description: Something doesn't work the way it should.
+title: "bug: "
+labels: ["bug", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! A small, runnable repro is the single
+        biggest thing that gets a bug fixed quickly. 🙏
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, and what you expected instead.
+      placeholder: When I …, Rask renders … but I expected …
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Steps, or a link to a minimal repo / gist. Include the component code if relevant.
+      placeholder: |
+        1. `dotnet new rask-server`
+        2. Add this component: …
+        3. Navigate to /…
+      render: text
+    validations:
+      required: true
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host
+      description: Which hosting model?
+      options:
+        - Server (WebSockets)
+        - WASM (standalone)
+        - WASM (hosted)
+        - Not sure / both
+    validations:
+      required: true
+  - type: input
+    id: rask-version
+    attributes:
+      label: Rask version
+      description: The version badge in the sample, the console log line, or your package version.
+      placeholder: e.g. 0.7.0
+    validations:
+      required: true
+  - type: input
+    id: dotnet-version
+    attributes:
+      label: .NET SDK version
+      placeholder: output of `dotnet --version`
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs / diagnostics
+      description: Console output, browser console errors, or any `RASKxxx` diagnostics.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and didn't find a duplicate.
+          required: true
+        - label: I'm on a supported .NET 10 SDK.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Questions & ideas (Discussions)
+    url: https://github.com/pal-tamas/rask/discussions
+    about: Ask how-to questions, share ideas, or get help — please don't open an issue for these.
+  - name: 📖 Documentation
+    url: https://github.com/pal-tamas/rask/tree/main/docs
+    about: Guides for routing, lifecycle, forms, auth, JS interop, and more.
+  - name: 🔒 Report a security vulnerability
+    url: https://github.com/pal-tamas/rask/security/advisories/new
+    about: Please report security issues privately — never in a public issue.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,23 @@
+name: 📖 Documentation issue
+description: Something in the docs, README, or samples is wrong, unclear, or missing.
+title: "docs: "
+labels: ["documentation", "needs-triage"]
+body:
+  - type: input
+    id: where
+    attributes:
+      label: Where?
+      description: Link or path to the page/section (e.g. docs/routing.md, README "Quick start").
+    validations:
+      required: true
+  - type: textarea
+    id: issue
+    attributes:
+      label: What's wrong or missing?
+      description: Quote the confusing part and describe what would make it clearer.
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested wording (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,52 @@
+name: ✨ Feature request
+description: Suggest a new capability or improvement.
+title: "feat: "
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      value: Thanks for helping shape Rask! Focus on the *problem* first — it makes the solution clearer.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you trying to solve?
+      description: The use case or pain point. What can't you do today, or what's awkward?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What you'd like Rask to do. A sketch of the API/component shape helps.
+      render: csharp
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you've tried, or other designs you weighed.
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Components / rendering
+        - Routing
+        - Forms / validation
+        - Lifecycle
+        - Scoped CSS / JS
+        - Auth
+        - Live diff / runtime
+        - Generators / diagnostics
+        - Templates / tooling
+        - Docs
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Before submitting
+      options:
+        - label: I searched existing issues and discussions for a similar request.
+          required: true
+        - label: I'd be willing to help implement this (optional).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,29 @@
+<!--
+  Thanks for contributing to Rask! 🎉
+  Title must follow Conventional Commits: type(scope): subject  (e.g. feat(forms): add X)
+  Allowed types: feat, fix, perf, refactor, docs, test, build, ci, chore, revert
+  Please do NOT add Co-Authored-By or Generated-with footers.
+-->
+
+## Summary
+
+<!-- What does this change and why? Link any related issue: "Closes #123". -->
+
+## Testing
+
+- [ ] Unit tests added/updated (`tests/Rask.*.Tests`)
+- [ ] E2E updated for any `samples/` change (`tests/Rask.Examples.E2E.Tests`)
+- [ ] `dotnet test --filter "FullyQualifiedName!~Rask.Examples.E2E"` is green
+
+<!-- Paste relevant results. -->
+
+## Benchmarks
+
+<!-- Render/live-runtime hot-path change? Quote the Allocated delta from benchmarks/Rask.Benchmarks. Otherwise: n/a -->
+
+## Checklist
+
+- [ ] `dotnet format` clean; build passes with warnings-as-errors
+- [ ] User-facing change → sample + docs/README/NUGET.md/llms.txt/template AGENTS.md updated
+- [ ] `CHANGELOG.md` `[Unreleased]` entry added
+- [ ] Conventional Commit title; branch will be deleted after merge

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, use **[GitHub private vulnerability reporting](https://github.com/pal-tamas/rask/security/advisories/new)**
+(Security → Advisories → "Report a vulnerability"). If you can't use that, email
+**pal.tamas@pptgateway.hu** with details.
+
+Please include:
+
+- the affected component/host (Server / WASM / hosted) and version,
+- a description and impact assessment,
+- a minimal reproduction if possible.
+
+You'll get an acknowledgement as soon as possible. Once a fix is ready, a patched release is
+published and the advisory is disclosed with credit (unless you prefer to stay anonymous).
+
+## Supported versions
+
+Rask is pre-1.0; security fixes target the **latest released version** on nuget.org. Please
+upgrade to the latest version before reporting.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # NuGet dependencies (central package management — Directory.Packages.props)
+  - package-ecosystem: nuget
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      microsoft-extensions:
+        patterns:
+          - "Microsoft.Extensions.*"
+          - "Microsoft.AspNetCore.*"
+          - "Microsoft.JSInterop"
+      test-tooling:
+        patterns:
+          - "xunit*"
+          - "Microsoft.NET.Test.Sdk"
+          - "Microsoft.Playwright"
+          - "coverlet.*"
+
+  # GitHub Actions used by ci.yml / release.yml / nightly.yml / pages.yml
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,9 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build (no WASM bundle)
-        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false -p:MSBuildWarningsAsMessages=MSB3026
+        # -m:1 (serial) prevents the parallel ProjectReference copy race on Rask.Core.dll
+        # (MSB3026 copy-retry / MSB3030 not-found) rather than masking the warning.
+        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false -m:1
 
       - name: Unit & integration tests
         run: >-
@@ -109,12 +111,10 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build
-        # The WASM AppBundle's nested `dotnet publish` can race the outer build's
-        # Rask.Core.dll copy (transient MSB3026 copy-retry → MSB3030 not-found). Demote the
-        # copy-retry warning to a message (clean annotations) and retry once to absorb the race.
-        run: >-
-          dotnet build Rask.slnx -c Release --no-restore -p:MSBuildWarningsAsMessages=MSB3026
-          || dotnet build Rask.slnx -c Release --no-restore -p:MSBuildWarningsAsMessages=MSB3026
+        # -m:1 (serial) eliminates the parallel copy race: the WASM AppBundle's nested
+        # `dotnet publish` no longer overlaps another project copying Rask.Core.dll
+        # (MSB3026 copy-retry / MSB3030 not-found). Fixes the cause, not the annotation.
+        run: dotnet build Rask.slnx -c Release --no-restore -m:1
 
       - name: E2E journey (${{ matrix.host }})
         # Namespace-anchored so the leading dot prevents substring collisions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build (no WASM bundle)
-        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false
+        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false -p:MSBuildWarningsAsMessages=MSB3026
 
       - name: Unit & integration tests
         run: >-
@@ -109,7 +109,12 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build
-        run: dotnet build Rask.slnx -c Release --no-restore
+        # The WASM AppBundle's nested `dotnet publish` can race the outer build's
+        # Rask.Core.dll copy (transient MSB3026 copy-retry → MSB3030 not-found). Demote the
+        # copy-retry warning to a message (clean annotations) and retry once to absorb the race.
+        run: >-
+          dotnet build Rask.slnx -c Release --no-restore -p:MSBuildWarningsAsMessages=MSB3026
+          || dotnet build Rask.slnx -c Release --no-restore -p:MSBuildWarningsAsMessages=MSB3026
 
       - name: E2E journey (${{ matrix.host }})
         # Namespace-anchored so the leading dot prevents substring collisions

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,22 @@
+name: commitlint
+
+# Enforce Conventional Commits on PRs (commit messages + PR title).
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Lint PR commits
+        uses: wagoid/commitlint-github-action@v6
+        with:
+          configFile: commitlint.config.js

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -19,4 +19,4 @@ jobs:
       - name: Lint PR commits
         uses: wagoid/commitlint-github-action@v6
         with:
-          configFile: commitlint.config.js
+          configFile: commitlint.config.mjs

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,95 @@
+name: nightly
+
+# Nightly prerelease on every change to main. MinVer derives a prerelease version
+# (e.g. 0.7.1-alpha.0.N) for untagged commits, so packs are naturally prerelease on nuget.org.
+# Stable releases (no -prerelease suffix) still come only from tagging via release.yml.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write   # update the rolling "nightly" prerelease
+  packages: write   # push prerelease packages to GitHub Packages
+
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+      - name: Restore
+        run: dotnet restore Rask.slnx
+      - name: Build (no WASM bundle)
+        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false
+      - name: Unit & integration tests
+        run: >-
+          dotnet test Rask.slnx -c Release --no-build
+          --filter "FullyQualifiedName!~Rask.Examples.E2E"
+
+  publish-nightly:
+    needs: unit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0   # MinVer needs full history + tags
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Restore
+        run: dotnet restore Rask.slnx
+
+      - name: Pack (prerelease)
+        run: |
+          dotnet pack src/Rask.Server/Rask.Server.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Wasm/Rask.Wasm.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Templates/Rask.Templates.csproj -c Release -o ./artifacts
+
+      - name: Push prerelease to nuget.org
+        run: >-
+          dotnet nuget push "./artifacts/*.nupkg"
+          --source https://api.nuget.org/v3/index.json
+          --api-key "${{ secrets.NUGET_API_KEY }}"
+          --skip-duplicate
+
+      - name: Push prerelease to GitHub Packages (mirror)
+        run: >-
+          dotnet nuget push "./artifacts/*.nupkg"
+          --source "https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json"
+          --api-key "${{ secrets.GITHUB_TOKEN }}"
+          --skip-duplicate
+
+      - name: Upload packages as workflow artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-packages
+          path: ./artifacts/*.nupkg
+
+      - name: Update rolling "nightly" prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag || true
+          gh release create nightly ./artifacts/*.nupkg \
+            --prerelease \
+            --title "Nightly (${{ github.sha }})" \
+            --notes "Automated prerelease from main @ ${{ github.sha }}. Not published to nuget.org."

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Restore
         run: dotnet restore Rask.slnx
       - name: Build (no WASM bundle)
-        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false -p:MSBuildWarningsAsMessages=MSB3026
+        # -m:1 (serial) prevents the parallel ProjectReference copy race on Rask.Core.dll.
+        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false -m:1
       - name: Unit & integration tests
         run: >-
           dotnet test Rask.slnx -c Release --no-build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Restore
         run: dotnet restore Rask.slnx
       - name: Build (no WASM bundle)
-        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false
+        run: dotnet build Rask.slnx -c Release --no-restore -p:WasmGenerateAppBundle=false -p:MSBuildWarningsAsMessages=MSB3026
       - name: Unit & integration tests
         run: >-
           dotnet test Rask.slnx -c Release --no-build

--- a/.gitignore
+++ b/.gitignore
@@ -91,7 +91,8 @@ coverage*.xml
 coverage*.info
 
 # Claude Code
-CLAUDE.md
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
 
 # Other
 *.swp

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+# AGENTS.md — contributing to Rask with an AI assistant
+
+Cross-tool guide for AI assistants working **on the Rask framework itself** (the Claude-specific
+map is `CLAUDE.md`; downstream app-authoring guidance ships as `AGENTS.md` inside the templates).
+GitHub is the source of truth — keep docs, examples, and these guides up to date with every change.
+
+## Repo workflows (`.claude/skills/`)
+Apply the matching playbook automatically:
+- **rask-ship** — definition-of-done gate before any commit/PR.
+- **add-html-tag** / **add-diagnostic** — scaffolding. **run-benchmarks** — hot-path Allocated delta.
+- **rask-review** — security/perf/memory/best-practices. **open-pr** — Conventional-Commit PR, no AI footers.
+- **cut-release** — tag `vX.Y.Z`. **check-nuget-updates** — dependency hygiene.
+
+## The gate (every change)
+1. `dotnet format Rask.slnx` (+ `--verify-no-changes`).
+2. `dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` (analyzers clean).
+3. **Unit test every feature**; **E2E test every `samples/` change**.
+4. **Benchmark every framework/render-hotpath change** (quote the Allocated delta).
+5. **User-facing change → add/update a sample + docs/README** (keep `docs/`, `README.md`, `NUGET.md`,
+   `llms.txt`, and template `AGENTS.md` current). Add a `CHANGELOG.md` `[Unreleased]` entry.
+6. Review (security + performance + UX together; prefer standard .NET APIs; refactor duplication).
+7. Open a PR (`type(scope): subject`, Conventional Commits — enforced by commitlint); delete the
+   branch after squash-merge.
+
+## Principles
+Do your best on every PR. Hold UX, security, and performance together. Don't reinvent the wheel —
+use the BCL/framework. Automate what you can. Ask only when genuinely blocked.
+
+See `docs/development-workflow.md` for the full details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- `RaskVersion.Current` exposes the running framework version (from the assembly's MinVer
+  `InformationalVersion`). The server (`UseRask`) and WASM host log it on startup, and the
+  showcase samples display it as a version badge.
+- AI-assistant onboarding: an `AGENTS.md` ships in every `dotnet new rask-*` template (app-author
+  conventions), plus a root `AGENTS.md`, `llms.txt`, and `docs/ai-agents.md`.
+- Community health files: issue forms, PR template, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
+  `CODEOWNERS`, and `docs/repo-administration.md` — contributions open, maintainer merges.
+
+### Changed
+- Build is now **warnings-as-errors** with .NET analyzers and code-style enforced in-build
+  (`Directory.Build.props`); see `docs/code-analysis.md`.
+- NuGet packages ship a concise, gallery-friendly `NUGET.md` README (absolute URLs) instead of
+  the full repo README.
+
+### CI
+- `nightly.yml` publishes a prerelease to nuget.org + GitHub Packages on every push to `main`.
+- `commitlint.yml` enforces Conventional Commits; `dependabot.yml` keeps NuGet/Actions current.
+
+### Documentation
+- New guides: `docs/development-workflow.md`, `docs/code-analysis.md`, `docs/ai-agents.md`,
+  `docs/repo-administration.md`. CLAUDE.md compacted to a map pointing at the new
+  `.claude/skills/` playbooks.
+
 ### Security
 - URL-bearing attributes (`href`, `src`, `cite`, `formaction`, object `data`, `poster`,
   SVG `href`) are now **scheme-sanitized by default**: `javascript:`/`vbscript:` and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,67 @@
+# CLAUDE.md
+
+Target `net10.0` (`net10.0-browser` for WASM); nullable + implicit usings on. **Rask** is a C#
+component framework (Blazor-like): Roslyn factory generator, scoped CSS/JS, routing, live diff
+runtime over WS (Server) or JSImport/JSExport (WASM). This file is the **map** — read the code,
+the `docs/`, and the tests for depth. Keep this file small; put how-to detail in `.claude/skills/`.
+
+## Workflows → skills (use them automatically)
+`.claude/skills/` holds the committed playbooks; apply the matching one without being asked.
+- **rask-ship** — definition-of-done gate before any commit/PR: `dotnet format` (.editorconfig) →
+  `dotnet build -warnaserror` (analyzers clean) → tests → benchmarks → CHANGELOG → review → PR.
+- **add-html-tag** · **add-diagnostic** — scaffolding (component+test / RASK0xx+docs+test).
+- **run-benchmarks** — before/after `Allocated` delta for render-hotpath changes (required evidence).
+- **rask-review** — security / performance / memory / .NET-C# review lens (wraps /code-review, /security-review).
+- **open-pr** — branch off main, Conventional-Commit, **no AI-attribution footers**, delete branch after merge.
+- **cut-release** — CHANGELOG promote + `vX.Y.Z` tag. **check-nuget-updates** — dependency hygiene.
+
+Standing rules: do your best every PR, holding **UX + security + performance** together; prefer
+standard .NET APIs (don't reinvent); refactor duplication you touch; unit-test every feature (E2E
+only when unreachable); E2E for every `samples/` change; benchmark every framework-code change;
+**user-facing change → update a sample + docs/README/NUGET.md/llms.txt/template AGENTS.md**; keep
+everything up to date; CHANGELOG `[Unreleased]` per notable change; Conventional Commits
+(commitlint); no `Co-Authored-By`/`Generated-with`. Build is warnings-as-errors + analyzers
+(`Directory.Build.props`; see `docs/code-analysis.md`). Releases: tag→`release.yml`; nightly
+prerelease on `main`→`nightly.yml`. AI artifacts: `AGENTS.md`, `llms.txt`, template `AGENTS.md`,
+`docs/ai-agents.md`. Full detail: `docs/development-workflow.md`. Ask only when truly blocked.
+
+## Projects
+- `src/Rask.Core` — rendering, live context, routing, scoped CSS/JS, lifecycle.
+- `src/Rask.Generators` — `Generated.{Type}(...)` factories, `Routes.{Type}(...)`, `[Route]` registration.
+- `src/Rask.Server` — ASP.NET host (`AddRask()`/`UseRask<TApp>()`, WS dispatcher). `src/Rask.Wasm` — browser host.
+- `src/Rask.Wasm.Hosting` — static-file host for a published WASM bundle. `src/Rask.Wasm.Tasks` — `BakeScopedAssetsTask`.
+- `src/Rask.Validation.{DataAnnotations,FluentValidation}` — opt-in validators. `src/Rask.Templates` — `dotnet new` templates.
+- `samples/` — showcase apps. `tests/` — sibling `*.Tests` per project + `Rask.Examples.E2E.Tests` (Playwright). `benchmarks/`.
+
+## Commands
+```bash
+dotnet build Rask.slnx
+dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"   # fast inner loop
+dotnet test Rask.slnx --filter FullyQualifiedName~ATests                 # one class
+dotnet run --project samples/Rask.Example.Server
+```
+
+## Primitives & rules (the load-bearing invariants)
+- `Component` (base: `Render`, `Children`, `Key`, `TagName`, `WriteAttributes`) → `Element` (universal
+  HTML attrs). `Text` encodes; `Raw` is verbatim. `Fragment`/`Doctype` special-cased in `HtmlSerializer`.
+- **Attribute render order: id, class, style, data-*, then tag-specific — tests assert it; preserve it.**
+- Children via the indexer `Div()[Span(), "hi"]` (no `Children:` param; `..` spread breaks — pass enumerables).
+  Page root must render the full shell (`Doctype`/`Html`/`Head`/`Body`) — RASK021. Runtime `<script>` auto-appended.
+- **Factory params** (generated per public prop): nullable→optional(null); non-nullable no-initializer→**required**
+  (RASK001); initializer/`[SkipFactory]`/`Children`→excluded. Inject framework services via the **ctor**, not
+  settable non-nullable props (those become required params; `required`+DI ctor→RASK002).
+- **`Key`** — reconciliation identity (last factory `Key:` param), enables trusted structural diff; not a reactive prop.
+- **Callbacks** are plain delegate props (`Action<T>`/`Func<T,Task>`); the factory wraps them to re-render the
+  owning parent. **Refs**: `ElementRef.New()` in a field, pass to `IJSRuntime`. **Context**: `Context.Provide<T>` /
+  `Context.Get<T>`/`Required`/`Has`. Construct components via the **factory**, never `new` outside Core (RASK014).
+
+## Subsystems → read `docs/`
+Routing/lifecycle (`docs/routing.md`, `docs/lifecycle.md`), scoped CSS/JS (`docs/js-interop.md`), forms +
+validation (`docs/forms.md`), auth (`docs/authentication.md`), context/callbacks (`docs/composition.md`),
+diagnostics RASK001–022 (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
+started / migration / testing / architecture (`docs/`). Trimming: `samples/Rask.Example.Wasm` must
+`dotnet publish -c Release` with zero IL warnings — new reflection needs a DAM annotation or justified suppression.
+
+## Conventions
+- **New HTML tag** → `add-html-tag` skill (`src/Rask.Core/Components/{Tag}.cs` + `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`).
+- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–022 are documented in `docs/diagnostics.md`.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,34 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in the Rask community a
+harassment-free experience for everyone, regardless of age, body size, visible or invisible
+disability, ethnicity, sex characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race, religion, or sexual
+identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Focusing on what is best for the community.
+- Showing empathy toward other community members.
+
+Unacceptable behavior includes harassment, trolling, insulting or derogatory comments, personal
+or political attacks, publishing others' private information, and other conduct which could
+reasonably be considered inappropriate in a professional setting.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the
+project maintainer at **pal.tamas@pptgateway.hu**. All complaints will be reviewed and
+investigated promptly and fairly. The maintainer is obligated to respect the privacy and
+security of the reporter.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ Thanks for your interest in Rask — a C# component framework (Blazor-like) with
 factory generator, scoped CSS/JS, routing, and a live diff runtime over WebSockets
 (Server) or `JSImport`/`JSExport` (WASM).
 
+**Contributions are open.** Anyone can [open an issue](https://github.com/pal-tamas/rask/issues/new/choose)
+or send a pull request (fork → branch → PR). Review and merge are handled by the maintainer
+(@pal-tamas) — see [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md) and the
+[full development workflow](docs/development-workflow.md).
+
 ## Prerequisites
 
 - .NET 10 SDK (`net10.0`; `net10.0-browser` for the WASM projects).
@@ -65,7 +70,14 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
 
 ## Commits & pull requests
 
-- Keep PRs focused; include tests; ensure `dotnet build` and `dotnet test` are green.
-- **Do not** append `Co-Authored-By` or `Generated-with` footers to commits or PR
-  descriptions.
+- Keep PRs focused; include tests; ensure `dotnet build` (warnings-as-errors) and
+  `dotnet test` are green. Run `dotnet format` before committing.
+- **[Conventional Commits](https://www.conventionalcommits.org/)** are required and enforced by
+  CI (`commitlint`): `type(scope): subject` with type ∈
+  `feat, fix, perf, refactor, docs, test, build, ci, chore, revert`. Enable the local guard:
+  `git config core.hooksPath .githooks`.
+- **Do not** append `Co-Authored-By` or `Generated-with` footers to commits or PR descriptions.
 - Add a note to [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` for user-visible changes.
+- User-facing changes must update a sample under `samples/` and the relevant docs
+  (`docs/`, `README.md`, `NUGET.md`). See the [development workflow](docs/development-workflow.md).
+- The maintainer merges (squash); the branch is deleted afterwards.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,9 @@
     <Company>Tamás Pál</Company>
     <Copyright>© Tamás Pál</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <!-- A concise, nuget.org-friendly README (absolute image/link URLs); the 75KB root
+         README with relative links does not render well on the gallery. -->
+    <PackageReadmeFile>NUGET.md</PackageReadmeFile>
     <PackageProjectUrl>https://github.com/pal-tamas/rask</PackageProjectUrl>
     <RepositoryUrl>https://github.com/pal-tamas/rask.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
@@ -19,8 +21,28 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
   </PropertyGroup>
 
+  <!--
+    Code-quality gate (enforced by the rask-ship skill, codified here so a plain `dotnet build`
+    enforces it too): .NET analyzers on, code-style run in-build, warnings are errors. The repo
+    builds clean today — keep it that way. Only Roslyn compiler/analyzer warnings escalate;
+    MSBuild-engine warnings (e.g. the transient MSB3026 copy-retry under parallel build) do not.
+    Code-style severities come from .editorconfig (suggestions stay suggestions, not errors).
+  -->
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <EnableNETAnalyzers>true</EnableNETAnalyzers>
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+  <!--
+    AnalysisLevel stays at the SDK default mode: the repo builds clean there, so warnings-as-errors
+    locks in that clean state. Raising it (e.g. <AnalysisLevel>latest-recommended</AnalysisLevel>)
+    surfaces ~33 extra CA findings — some worth doing (CA1305/CA1865/CA1859), some that clash with
+    the documented hot-path design (CA1051 on RenderFrame's deliberately-public fields). Promote the
+    level in a focused PR that fixes/justifies each finding with benchmark evidence — not here.
+  -->
+
   <ItemGroup Condition=" '$(IsPackable)' != 'false' ">
-    <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="" Visible="false"/>
+    <None Include="$(MSBuildThisFileDirectory)NUGET.md" Pack="true" PackagePath="" Visible="false"/>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="" Visible="false"/>
   </ItemGroup>
 

--- a/NUGET.md
+++ b/NUGET.md
@@ -1,0 +1,62 @@
+<div align="center">
+
+<img alt="Rask" src="https://raw.githubusercontent.com/pal-tamas/rask/main/assets/rask-logo.svg" width="280">
+
+### Live web apps in C#. One codebase — server-rendered over WebSockets, or client-side in the browser via WebAssembly.
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/pal-tamas/rask/blob/main/LICENSE)
+![.NET](https://img.shields.io/badge/.NET-10-512BD4)
+
+</div>
+
+Write components as plain C# classes. Return a tree of HTML from `Render()`. **No `.razor`, no JSX,
+no JavaScript to write** — and the *same* component code runs server-rendered with live WebSocket
+updates or fully client-side on WebAssembly.
+
+```csharp
+[Route("/counter")]
+public sealed class Counter : Component
+{
+    private int _count;
+
+    protected override RenderResult Render() =>
+    [
+        H1()["Counter"],
+        P()[$"Current count: {_count}"],
+        Button(OnClick: () => _count++)["Click me"]
+    ];
+}
+```
+
+## Install
+
+```bash
+dotnet new install Rask.Templates        # scaffolding
+dotnet new rask-server -o MyApp          # or: rask-wasm, rask-wasm-hosted
+```
+
+Or add to an existing project:
+
+```bash
+dotnet add package Rask.Server            # server-rendered over WebSockets
+dotnet add package Rask.Wasm              # client-side WebAssembly
+dotnet add package Rask.Wasm.Hosting      # host a published WASM bundle on ASP.NET
+```
+
+## Why Rask
+
+- **One component model, two runtimes** — the same C# component runs Server (live diff over WS) or WASM.
+- **Compile-time factories** — a Roslyn generator emits `Div(...)`, `Counter(...)`, type-safe routes.
+- **Scoped CSS & JS** — sibling `Component.css`/`Component.js`, content-addressed and cached.
+- **Routing, lifecycle, forms, validation, auth** — batteries included, no JavaScript required.
+- **Tiny live updates** — a minimal edit-op diff ships instead of the whole page.
+
+## Links
+
+- 📖 **[Documentation](https://github.com/pal-tamas/rask/tree/main/docs)** ·
+  [Getting started](https://github.com/pal-tamas/rask/blob/main/docs/getting-started.md)
+- 🚀 **[Live demo](https://pal-tamas.github.io/rask/)**
+- 💻 **[Source & README](https://github.com/pal-tamas/rask)**
+- 🤖 **[AI assistant guide](https://github.com/pal-tamas/rask/blob/main/llms.txt)**
+
+Licensed under MIT.

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,15 @@
+// Conventional Commits, enforced in CI by .github/workflows/commitlint.yml
+// (wagoid/commitlint-github-action). See https://www.conventionalcommits.org/.
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'type-enum': [
+      2,
+      'always',
+      ['feat', 'fix', 'perf', 'refactor', 'docs', 'test', 'build', 'ci', 'chore', 'revert'],
+    ],
+    'subject-case': [2, 'never', ['upper-case', 'pascal-case', 'start-case']],
+    'header-max-length': [2, 'always', 100],
+    'body-max-line-length': [0, 'always', Infinity], // allow long footers/links
+  },
+};

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,6 +1,7 @@
 // Conventional Commits, enforced in CI by .github/workflows/commitlint.yml
-// (wagoid/commitlint-github-action). See https://www.conventionalcommits.org/.
-module.exports = {
+// (wagoid/commitlint-github-action requires an ESM .mjs config).
+// See https://www.conventionalcommits.org/.
+export default {
   extends: ['@commitlint/config-conventional'],
   rules: {
     'type-enum': [

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,12 +16,20 @@ Guides and references for building with Rask. New here? Start with the project
 | [Authentication](authentication.md) | Production auth: cookie & JWT, Server & WASM, `Authorize`, route guards, Identity / Keycloak / Auth0 / Cognito / Duende. |
 | [Testing](testing.md) | Unit-testing components with `Rask.TestSupport`, driving event handlers, when to reach for E2E. |
 | [Migrating from Blazor](migration-from-blazor.md) | Concept mapping, behavioural gotchas, and what stays the same. |
+| [Building with AI assistants](ai-agents.md) | The `AGENTS.md` / `llms.txt` artifacts that let AI tools scaffold and extend Rask apps. |
 
 ## Reference
 
 | Reference | What it covers |
 |-----------|----------------|
 | [Diagnostics (RASK001–022)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
+| [Code analysis](code-analysis.md) | Analyzers, warnings-as-errors, and the per-PR adoption procedure. |
+
+## Contributing
+
+| Doc | What it covers |
+|-----|----------------|
+| [Development workflow](development-workflow.md) | The format → warnings-as-errors → tests → benchmarks → docs → review → PR gate, CI, nightly, releases. |
 
 ## Architecture
 

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -1,0 +1,28 @@
+# Building Rask apps with AI assistants
+
+Rask ships first-class guidance for AI coding tools, so an assistant can scaffold and extend a
+Rask app correctly without you re-explaining the conventions.
+
+## What's included
+
+- **`AGENTS.md`** — every project created with `dotnet new rask-server | rask-wasm |
+  rask-wasm-hosted` contains an `AGENTS.md` at its root. It's the cross-tool standard most AI
+  coding assistants read automatically; it captures the rules that make Rask code compile
+  (factories not `new`, the children indexer, factory-param props, the full-shell root,
+  routing/lifecycle, scoped CSS/JS, callbacks, forms, auth).
+- **`llms.txt`** (repo root) — the emerging standard index that points AI tools at the docs.
+- **The `docs/` set** — task guides (getting-started, routing, lifecycle, composition, forms,
+  js-interop, authentication, migration-from-blazor, diagnostics, testing).
+
+## How to use it
+
+1. Scaffold: `dotnet new rask-server -o MyApp`. The generated `AGENTS.md` travels with the repo.
+2. Point your assistant at the project; it picks up `AGENTS.md` (and `llms.txt` if it fetches docs).
+3. Ask for features in plain language — the assistant follows the conventions and links to
+   `docs/diagnostics.md` when it hits a `RASKxxx` compile diagnostic.
+
+## Keeping it accurate
+
+The `AGENTS.md` templates and `llms.txt` are part of the public API surface: when a user-facing
+behavior changes, they're updated in the same PR (see `docs/development-workflow.md`). GitHub is
+the single source of truth — these files are committed, not local-only.

--- a/docs/code-analysis.md
+++ b/docs/code-analysis.md
@@ -1,0 +1,35 @@
+# Code analysis & analyzers
+
+Rask builds with **warnings-as-errors** and analyzers on (`Directory.Build.props`):
+`TreatWarningsAsErrors`, `EnableNETAnalyzers`, `EnforceCodeStyleInBuild`. The SDK's .NET
+analyzers (CAxxxx) and code-style (IDExxxx, severities from `.editorconfig`) run on every build.
+`AnalysisLevel` is left at the SDK default because the repo builds clean there; raising it is a
+deliberate, per-PR cleanup (see below).
+
+## Recommended additional analyzers
+
+Adopt these for a published, perf-sensitive framework with source generators. Add via central
+package management (`Directory.Packages.props`) + a `PackageReference … PrivateAssets="all"` in
+`Directory.Build.props`.
+
+| Analyzer | Why |
+|---|---|
+| **Roslynator.Analyzers** | Broad, high-signal C# rules + refactorings. Best single add. |
+| **Meziantou.Analyzer** | Correctness/perf rules the SDK misses (culture, async, allocations). |
+| **SonarAnalyzer.CSharp** | Bug & code-smell detection, cognitive-complexity. |
+| **Microsoft.CodeAnalysis.PublicApiAnalyzers** | Track the public API surface of the NuGets (`PublicAPI.Shipped/Unshipped.txt`) so breaking changes are caught — pairs with SemVer/MinVer. |
+| **Microsoft.CodeAnalysis.BannedApiAnalyzers** | Enforce "use standard libs / safe defaults": ban `DateTime.Now`, culture-less `ToString`, etc. (directly addresses the CA1305 class of findings). |
+| **Microsoft.CodeAnalysis.Analyzers** (RS rules) | Author-correctness for the `Rask.Generators` projects specifically. |
+
+## Adoption procedure (important)
+
+Because the build is **warnings-as-errors**, adding an analyzer turns its findings into build
+**errors** immediately. So adopt **one analyzer per PR**:
+1. Add the package; build; triage the findings.
+2. Fix the real ones; suppress intentional ones in `.editorconfig` with a `# justification`
+   comment (e.g. CA1051 on `RenderFrame`'s deliberately-public hot-path fields).
+3. Run the `rask-ship` gate (incl. benchmarks if a fix touches the render hot path).
+
+A ready starter set (already-clean default mode) can be promoted later via
+`<AnalysisLevel>latest-recommended</AnalysisLevel>` — that surfaces ~33 CA findings today, so it
+gets its own PR.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,47 @@
+# Development workflow
+
+How changes are made, verified, and shipped in this repo. GitHub is the single source of truth;
+everything here is committed. AI assistants encode these as playbooks under `.claude/skills/`
+(see [`AGENTS.md`](../AGENTS.md) / `CLAUDE.md`).
+
+## The definition-of-done gate
+
+Every change passes this gate before a PR (the `rask-ship` skill):
+
+1. **Format + analyzers** — `dotnet format Rask.slnx` then `--verify-no-changes`.
+2. **Clean build, warnings-as-errors** —
+   `dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true`.
+   Enforced in `Directory.Build.props` (`TreatWarningsAsErrors`, `EnableNETAnalyzers`,
+   `EnforceCodeStyleInBuild`), so a plain build enforces it too. See [code-analysis.md](code-analysis.md).
+3. **Tests** — unit-test every feature/fix (`tests/Rask.*.Tests`); add E2E only when a unit test
+   can't reach the path. **Every `samples/` change gets an E2E** journey update
+   (`tests/Rask.Examples.E2E.Tests`). Inner loop:
+   `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"`.
+4. **Benchmarks** — any render/live-runtime hot-path change runs `benchmarks/Rask.Benchmarks`
+   before/after and quotes the `Allocated` delta in the PR.
+5. **Docs & examples** — user-facing changes update a `samples/` app, the relevant `docs/*.md`,
+   `README.md`, `NUGET.md`, `llms.txt`, and the template `AGENTS.md`. Add a `CHANGELOG.md`
+   `[Unreleased]` entry (Keep a Changelog).
+6. **Review** — security, performance, and memory held together with UX; prefer standard .NET
+   APIs over hand-rolled code; refactor duplication you touch (the `rask-review` skill).
+7. **PR** — Conventional Commit `type(scope): subject` (enforced by commitlint), structured body,
+   no AI-attribution footers; delete the branch after squash-merge.
+
+## Versioning & releases
+
+- **Versions come from git tags via MinVer** (`vX.Y.Z`); assemblies carry `AssemblyVersion`,
+  `FileVersion`, and `InformationalVersion` automatically.
+- **Stable release:** promote `CHANGELOG.md` `[Unreleased]` to a dated section, tag `vX.Y.Z`,
+  push — `release.yml` runs the unit gate + sharded E2E, packs the six NuGets, and publishes to
+  nuget.org + a GitHub release (the `cut-release` skill).
+- **Nightly:** every push to `main` runs `nightly.yml` — unit gate, then packs the MinVer
+  prerelease versions and publishes them to nuget.org (prerelease) and GitHub Packages.
+
+## CI
+
+- `ci.yml` — unit gate + sharded E2E matrix (one host per runner) on PRs/`main`.
+- `commitlint.yml` — Conventional Commits check on PRs.
+- `nightly.yml` — prerelease publish on `main`.
+- `release.yml` — tag-triggered stable publish.
+- Dependencies are kept current by `.github/dependabot.yml` (NuGet + Actions, weekly) and the
+  `check-nuget-updates` skill.

--- a/docs/repo-administration.md
+++ b/docs/repo-administration.md
@@ -1,0 +1,38 @@
+# Repository administration
+
+One-time GitHub settings that back the committed governance files. These are repo **settings**
+(not files), so apply them in the GitHub UI or with `gh`. Goal: **contributions are open** —
+anyone can open issues and PRs — but **only the owner (@pal-tamas) can merge**, for now.
+
+## Enable community features
+- **Settings → General → Features:** enable **Issues** and **Discussions**.
+- **Settings → General → Pull Requests:** enable **Automatically delete head branches**, and
+  allow **Squash merging** (Conventional-Commit titles → clean history).
+
+## Protect `main` (only the owner merges)
+**Settings → Branches → Add branch ruleset** (or classic protection) for `main`:
+- ✅ Require a pull request before merging
+  - ✅ Require approvals (1)
+  - ✅ **Require review from Code Owners** ← with `.github/CODEOWNERS` (`* @pal-tamas`) this means
+    no PR merges without the owner's approval.
+- ✅ Require status checks to pass: `unit`, the `e2e` shards, and `commitlint`.
+- ✅ Require branches to be up to date before merging.
+- ✅ Do not allow bypassing the above settings (so even pushes must go through PRs).
+- ✅ Restrict who can push to matching branches → only @pal-tamas (blocks direct pushes/merges).
+
+Apply via CLI (example):
+```bash
+gh api -X PUT repos/pal-tamas/rask/branches/main/protection \
+  -H "Accept: application/vnd.github+json" \
+  -f required_pull_request_reviews.require_code_owner_reviews=true \
+  -F required_pull_request_reviews.required_approving_review_count=1 \
+  -F enforce_admins=true \
+  -f 'required_status_checks.checks[][context]=unit' \
+  -f 'required_status_checks.checks[][context]=commitlint' \
+  -F required_status_checks.strict=true \
+  -F restrictions.users[]=pal-tamas -F 'restrictions.teams[]' -F 'restrictions.apps[]'
+```
+
+## Secrets used by workflows
+- `NUGET_API_KEY` — nuget.org push (used by `release.yml` and `nightly.yml`).
+- `GITHUB_TOKEN` — provided automatically (GitHub Packages + releases).

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,27 @@
+# Rask
+
+> Rask is a C# component framework (Blazor-like) for .NET 10: a Roslyn factory generator,
+> scoped CSS/JS, routing, and a live diff runtime over WebSockets (Server) or JSImport/JSExport
+> (WASM). Components are plain C# classes; markup is written with generated factory methods and a
+> children indexer (`Div()[Span(), "hi"]`).
+
+This file helps AI coding assistants build apps with Rask. Start with AGENTS.md (in any
+`dotnet new rask-*` project) for app-authoring conventions, then the docs below.
+
+## Docs
+- [Getting started](docs/getting-started.md): install, first app, project layout.
+- [Routing](docs/routing.md): `[Route]`, params, `Router()`/`Outlet()`, navigation.
+- [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
+- [Composition](docs/composition.md): children, context (provide/consume), callbacks.
+- [Forms](docs/forms.md): binding, validation, RadioGroup/CheckboxGroup, EditContext.
+- [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
+- [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
+- [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
+- [Diagnostics](docs/diagnostics.md): RASK001–022 compile-time diagnostics + fixes.
+- [Testing](docs/testing.md): unit + Playwright E2E patterns.
+
+## Contributing to Rask itself
+- [AGENTS.md](AGENTS.md): repo conventions for AI assistants + the `.claude/skills/` workflows.
+- [Development workflow](docs/development-workflow.md): the format → warnings-as-errors → tests →
+  benchmarks → docs → review → PR gate, CI, nightly, analyzers.
+- [Code analysis](docs/code-analysis.md): analyzers and adoption.

--- a/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
@@ -77,7 +77,8 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
                     })[
                     RaskLogo.Mark(24, "brandBolt"),
                     Span()["Rask"],
-                    Span(Class: "badge rounded-pill rask-badge")["showcase"]
+                    Span(Class: "badge rounded-pill rask-badge")["showcase"],
+                    Span(Class: "badge rounded-pill text-bg-secondary")[$"v{RaskVersion.Current}"]
                 ],
                 Div(Class: "d-flex align-items-center gap-2 ms-auto")[
                     PathDisplay(),

--- a/src/Rask.Core/RaskVersion.cs
+++ b/src/Rask.Core/RaskVersion.cs
@@ -1,0 +1,33 @@
+using System.Reflection;
+
+namespace Rask.Core;
+
+/// <summary>
+///     The running Rask framework version, taken from the assembly's informational version
+///     (set by MinVer from the git tag). Use it to display or log which Rask build is in use.
+/// </summary>
+public static class RaskVersion
+{
+    /// <summary>
+    ///     The Rask version string, e.g. <c>"0.7.0"</c> or a prerelease like
+    ///     <c>"0.7.1-alpha.0.5"</c>. Build metadata (the <c>+&lt;sha&gt;</c> suffix) is stripped.
+    /// </summary>
+    public static string Current { get; } = Resolve();
+
+    private static string Resolve()
+    {
+        var assembly = typeof(RaskVersion).Assembly;
+
+        var informational = assembly
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?
+            .InformationalVersion;
+
+        if (!string.IsNullOrEmpty(informational))
+        {
+            var plus = informational.IndexOf('+');
+            return plus >= 0 ? informational[..plus] : informational;
+        }
+
+        return assembly.GetName().Version?.ToString() ?? "0.0.0";
+    }
+}

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
@@ -177,6 +178,12 @@ public static class RaskEndpointExtensions
         string pathBase = "")
         where TApp : Component
     {
+        var logger = app.Services.GetService<ILoggerFactory>()?.CreateLogger("Rask");
+        if (logger is not null)
+            logger.LogInformation("Rask {Version} (Server) starting", RaskVersion.Current);
+        else
+            Console.WriteLine($"Rask {RaskVersion.Current} (Server) starting");
+
         app.UseWebSockets();
         ((IEndpointRouteBuilder)app).UseRask<TApp>(pattern, pathBase);
         return app;

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md — building this app with an AI assistant
+
+This is a **Rask** app (a C# component framework for .NET 10). This file tells AI coding
+assistants the conventions so generated code compiles and runs. Full docs:
+https://github.com/pal-tamas/rask/tree/main/docs
+
+## Mental model
+- Components are **plain C# classes** deriving from `Component`. Override `RenderResult Render()`
+  and return a tree of HTML built with **generated factory methods** — no `.razor`, no JSX.
+- The **same component code** runs server-rendered (live diff over WebSockets) or on WASM.
+
+## Writing components — the rules that matter
+- **Use factories, never `new`** for components: `Div(...)`, `Button(OnClick: ...)`, `Counter(...)`.
+  Constructing a component with `new` outside the framework is a compile error (RASK014).
+- **Children go through the indexer**, not a constructor arg: `Div()[Span()["hi"], "text"]`.
+  A bare `string` becomes a text node. Pass a list directly for collections: `Ul()[items]`.
+  `..` spread does **not** work inside `[...]`.
+- **Props are factory parameters.** A nullable prop is optional; a non-nullable prop with no
+  initializer is **required**. Declare HTML attributes nullable (`bool? Disabled`) to keep them optional.
+- **A page/root component must render the full shell**: `Fragment()[Doctype(), Html(...)[Head(...), Body(...)]]`
+  (RASK021). The framework injects its runtime `<script>` automatically — don't add one.
+- **Text vs raw:** `Text("..")` / a bare string HTML-encodes; `Raw("..")` is verbatim (XSS risk — avoid for user input).
+
+## Routing & lifecycle
+- Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`
+  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
+- Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
+  `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
+- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
+  not as settable properties (a non-nullable settable property becomes a required factory param).
+
+## Events, scoped CSS/JS, forms, auth
+- **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
+  invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
+- **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
+- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+  `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
+
+## Build & run
+```bash
+dotnet run        # then open the printed URL
+dotnet test       # if the project has tests
+```
+If you hit a `RASKxxx` compile error, see https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md — building this app with an AI assistant
+
+This is a **Rask** app (a C# component framework for .NET 10). This file tells AI coding
+assistants the conventions so generated code compiles and runs. Full docs:
+https://github.com/pal-tamas/rask/tree/main/docs
+
+## Mental model
+- Components are **plain C# classes** deriving from `Component`. Override `RenderResult Render()`
+  and return a tree of HTML built with **generated factory methods** — no `.razor`, no JSX.
+- The **same component code** runs server-rendered (live diff over WebSockets) or on WASM.
+
+## Writing components — the rules that matter
+- **Use factories, never `new`** for components: `Div(...)`, `Button(OnClick: ...)`, `Counter(...)`.
+  Constructing a component with `new` outside the framework is a compile error (RASK014).
+- **Children go through the indexer**, not a constructor arg: `Div()[Span()["hi"], "text"]`.
+  A bare `string` becomes a text node. Pass a list directly for collections: `Ul()[items]`.
+  `..` spread does **not** work inside `[...]`.
+- **Props are factory parameters.** A nullable prop is optional; a non-nullable prop with no
+  initializer is **required**. Declare HTML attributes nullable (`bool? Disabled`) to keep them optional.
+- **A page/root component must render the full shell**: `Fragment()[Doctype(), Html(...)[Head(...), Body(...)]]`
+  (RASK021). The framework injects its runtime `<script>` automatically — don't add one.
+- **Text vs raw:** `Text("..")` / a bare string HTML-encodes; `Raw("..")` is verbatim (XSS risk — avoid for user input).
+
+## Routing & lifecycle
+- Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`
+  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
+- Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
+  `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
+- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
+  not as settable properties (a non-nullable settable property becomes a required factory param).
+
+## Events, scoped CSS/JS, forms, auth
+- **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
+  invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
+- **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
+- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+  `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
+
+## Build & run
+```bash
+dotnet run        # then open the printed URL
+dotnet test       # if the project has tests
+```
+If you hit a `RASKxxx` compile error, see https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -1,0 +1,45 @@
+# AGENTS.md — building this app with an AI assistant
+
+This is a **Rask** app (a C# component framework for .NET 10). This file tells AI coding
+assistants the conventions so generated code compiles and runs. Full docs:
+https://github.com/pal-tamas/rask/tree/main/docs
+
+## Mental model
+- Components are **plain C# classes** deriving from `Component`. Override `RenderResult Render()`
+  and return a tree of HTML built with **generated factory methods** — no `.razor`, no JSX.
+- The **same component code** runs server-rendered (live diff over WebSockets) or on WASM.
+
+## Writing components — the rules that matter
+- **Use factories, never `new`** for components: `Div(...)`, `Button(OnClick: ...)`, `Counter(...)`.
+  Constructing a component with `new` outside the framework is a compile error (RASK014).
+- **Children go through the indexer**, not a constructor arg: `Div()[Span()["hi"], "text"]`.
+  A bare `string` becomes a text node. Pass a list directly for collections: `Ul()[items]`.
+  `..` spread does **not** work inside `[...]`.
+- **Props are factory parameters.** A nullable prop is optional; a non-nullable prop with no
+  initializer is **required**. Declare HTML attributes nullable (`bool? Disabled`) to keep them optional.
+- **A page/root component must render the full shell**: `Fragment()[Doctype(), Html(...)[Head(...), Body(...)]]`
+  (RASK021). The framework injects its runtime `<script>` automatically — don't add one.
+- **Text vs raw:** `Text("..")` / a bare string HTML-encodes; `Raw("..")` is verbatim (XSS risk — avoid for user input).
+
+## Routing & lifecycle
+- Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`
+  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
+- Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
+  `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
+- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
+  not as settable properties (a non-nullable settable property becomes a required factory param).
+
+## Events, scoped CSS/JS, forms, auth
+- **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
+  invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
+- **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
+- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+  `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
+
+## Build & run
+```bash
+dotnet run        # then open the printed URL
+dotnet test       # if the project has tests
+```
+If you hit a `RASKxxx` compile error, see https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -92,6 +92,7 @@ public sealed class WasmHostBuilder
     public async Task RunAsync<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>()
         where TApp : Component
     {
+        Console.WriteLine($"[Rask.Wasm] Rask {RaskVersion.Current} (WASM) starting");
         Console.WriteLine("[Rask.Wasm] importing rask.wasm.js …");
         await JSInterop.ImportJsModuleAsync().ConfigureAwait(false);
         Console.WriteLine("[Rask.Wasm] rask.wasm.js imported");

--- a/tests/Rask.Core.Tests/RaskVersionTests.cs
+++ b/tests/Rask.Core.Tests/RaskVersionTests.cs
@@ -1,0 +1,32 @@
+using System.Text.RegularExpressions;
+
+namespace Rask.Core.Tests;
+
+public class RaskVersionTests
+{
+    [Fact]
+    public void Current_IsNonEmpty()
+    {
+        Assert.False(string.IsNullOrWhiteSpace(RaskVersion.Current));
+    }
+
+    [Fact]
+    public void Current_HasNoBuildMetadataSuffix()
+    {
+        // The "+<commit sha>" build-metadata suffix must be stripped.
+        Assert.DoesNotContain('+', RaskVersion.Current);
+    }
+
+    [Fact]
+    public void Current_LooksLikeSemVer()
+    {
+        // major.minor.patch with an optional prerelease label.
+        Assert.Matches(new Regex(@"^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$"), RaskVersion.Current);
+    }
+
+    [Fact]
+    public void Current_IsStable()
+    {
+        Assert.Equal(RaskVersion.Current, RaskVersion.Current);
+    }
+}


### PR DESCRIPTION
## Summary

Sets up the Rask developer workflow, automation, AI-onboarding, and governance — and adds a small framework feature (version surface). GitHub becomes the single source of truth for how we work.

**Skills** (`.claude/skills/`, committed & auto-surfacing): `rask-ship` (definition-of-done gate), `add-html-tag`, `add-diagnostic`, `run-benchmarks`, `rask-review`, `open-pr`, `cut-release`, `check-nuget-updates`.

**Build quality**: warnings-as-errors + .NET analyzers + code-style enforced in-build (`Directory.Build.props`); `docs/code-analysis.md` recommends further analyzers with a per-PR adoption path.

**CI/automation**: `nightly.yml` (prerelease to nuget.org + GitHub Packages on `main`), `commitlint.yml` + local `.githooks/commit-msg` (Conventional Commits), `dependabot.yml` (NuGet + Actions).

**Version surface** (`feat`): `RaskVersion.Current` from MinVer's `InformationalVersion`; logged by the Server/WASM hosts on startup and shown as a badge in the showcase samples.

**AI onboarding for end users**: `AGENTS.md` baked into all three `dotnet new rask-*` templates, plus a root `AGENTS.md`, `llms.txt`, and `docs/ai-agents.md`.

**NuGet**: packages now ship a concise, gallery-friendly `NUGET.md`.

**Governance** (open contributions, maintainer merges): issue forms, PR template, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CODEOWNERS`, and `docs/repo-administration.md`.

**Docs**: `development-workflow.md`, `code-analysis.md`, `ai-agents.md`, `repo-administration.md`; `CLAUDE.md` committed and compacted to a map of the skills.

## Testing

- [x] Unit tests added (`RaskVersionTests`, 4) and full non-E2E suite green: ~2,300 passed, 0 failed
- [x] `dotnet build Rask.slnx -c Release -warnaserror` — 0 warnings / 0 errors
- [x] `dotnet format` clean on all changed files
- [ ] E2E: version-badge assertion in the showcase journey — **queued** (this PR's sample change should get an E2E follow-up)

## Benchmarks

n/a — no render/live-runtime hot-path change (version is read once at startup; the sample badge is example-only).

## Follow-ups (each its own gated PR)

- Branch protection so only the owner merges (repo setting; see `docs/repo-administration.md`).
- E2E assertion for the version badge; mobile-friendly examples overhaul.
- `src` duplication refactors (generators twin, SymbolHelpers, numeric AppendAttr, JS splice, live-session decision) + examples dedup.
- Analyzer adoption (`latest-recommended` surfaces ~33 CA findings).

## Checklist

- [x] Build passes with warnings-as-errors
- [x] `CHANGELOG.md` `[Unreleased]` updated
- [x] Conventional-Commit titles; branch to be deleted after merge
