### PR TITLE
ci: make dependabot emit conventional commit messages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    # Conventional Commits so the commitlint check passes (e.g. "build(deps): bump X").
+    commit-message:
+      prefix: build
+      include: scope
     groups:
       microsoft-extensions:
         patterns:
@@ -24,3 +28,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    # Conventional Commits so the commitlint check passes (e.g. "ci(deps): bump X").
+    commit-message:
+      prefix: ci
+      include: scope


### PR DESCRIPTION
Dependabot's default commit subject (`Bump X from A to B`) isn't a Conventional Commit, so the `commitlint` check fails on every bump PR (#44–#48: `type-empty`, `subject-empty`).

This adds `commit-message.prefix` to both ecosystems so future bump PRs read `build(deps): bump X` (NuGet) / `ci(deps): bump X` (Actions) and pass commitlint.

### Follow-up for the 5 open bump PRs
Their commits predate this config, so after merging this they need regenerating — comment `@dependabot recreate` on #44–#48 (I can do that once this lands).