### PR TITLE
fix: stop LiveRenderContext.CurrentSync returning a disposed context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- `LiveRenderContext.CurrentSync` no longer returns a disposed context. The thread-static sync
+  mirror could linger on a pooled thread after an async render released it at an `await`; a later
+  synchronous render reusing that thread observed the stale context (wrong handler attribution).
+  Reading through the `IsActive` guard restores the documented "null outside an active render"
+  contract. Allocation-neutral (113.9 KB render unchanged). Fixes flaky
+  `*_OutsideLiveContext_OmitsHandlerAttribute` tests.
+
 ### Added
 - `RaskVersion.Current` exposes the running framework version (from the assembly's MinVer
   `InformationalVersion`). The server (`UseRask`) and WASM host log it on startup, and the

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -65,9 +65,22 @@ public sealed class LiveRenderContext : IDisposable
     public static LiveRenderContext? Current => _current.Value;
 
     // Fast, synchronous-walk-only accessor for the hot attribute path. Equals Current on the
-    // render thread; null outside an active render (restored on Dispose). Do NOT use from async
-    // continuations — read Current there.
-    internal static LiveRenderContext? CurrentSync => _syncCurrent;
+    // render thread; null outside an active render. Do NOT use from async continuations — read
+    // Current there.
+    //
+    // The IsActive guard enforces the "null outside an active render" contract even when the
+    // ThreadStatic was not restored on this thread: an async render sets _syncCurrent in its ctor,
+    // runs the synchronous walk, then awaits — releasing this pool thread with _syncCurrent still
+    // pointing at the context (Dispose runs on whatever thread the continuation resumes on). A
+    // later synchronous render reusing this thread would otherwise observe that stale context.
+    // Reading through IsActive makes a disposed context read as "no context", which is correct.
+    internal static LiveRenderContext? CurrentSync => _syncCurrent is { IsActive: true } ? _syncCurrent : null;
+
+    // Test-only: clears this thread's sync mirror. xUnit reuses pool threads across tests; an
+    // async render can release a thread at an await with _syncCurrent still set, so a later
+    // synchronous test on that thread would otherwise observe a leftover context. Tests call
+    // this before each test (see ResetLiveSyncContextAttribute). Not used by product code.
+    internal static void ResetSyncForTests() => _syncCurrent = null;
 
     internal RouteRenderState? Route { get; set; }
 

--- a/tests/Rask.Core.Tests/Live/LiveRenderContextSyncGuardTests.cs
+++ b/tests/Rask.Core.Tests/Live/LiveRenderContextSyncGuardTests.cs
@@ -1,0 +1,46 @@
+using System.Reflection;
+using Rask.Core.Live;
+
+#pragma warning disable RASK014 // test constructs a StubComponent directly
+
+namespace Rask.Core.Tests.Live;
+
+public class LiveRenderContextSyncGuardTests
+{
+    [Fact]
+    public void CurrentSync_WhenThreadHoldsDisposedContext_ReadsAsNull()
+    {
+        var services = RenderHarness.EmptyServices();
+
+        LiveRenderContext disposed;
+        using (var scope = RenderHarness.Render(new StubComponent(Span()), services))
+        {
+            disposed = scope.Context;
+            Assert.Same(disposed, LiveRenderContext.CurrentSync); // active mid-render
+        }
+
+        // Re-pollute this thread the way an async render that suspended at an await leaves it:
+        // _syncCurrent still points at a context that has already been disposed elsewhere.
+        SetSyncMirror(disposed);
+        try
+        {
+            Assert.False(disposed.IsActive);
+
+            // The guard makes the stale, disposed context read as "no active context".
+            Assert.Null(LiveRenderContext.CurrentSync);
+
+            // Observable effect: a handler emits no attribute outside an active live context,
+            // instead of attributing to a leftover context from an unrelated render.
+            Assert.Equal("<button></button>", Button(OnClick: () => { }).ToHtml());
+        }
+        finally
+        {
+            LiveRenderContext.ResetSyncForTests();
+        }
+    }
+
+    private static void SetSyncMirror(LiveRenderContext? ctx) =>
+        typeof(LiveRenderContext)
+            .GetField("_syncCurrent", BindingFlags.NonPublic | BindingFlags.Static)!
+            .SetValue(null, ctx);
+}

--- a/tests/Rask.Core.Tests/ResetLiveSyncContextAttribute.cs
+++ b/tests/Rask.Core.Tests/ResetLiveSyncContextAttribute.cs
@@ -1,0 +1,17 @@
+using System.Reflection;
+using Rask.Core.Live;
+using Xunit.Sdk;
+
+// Applies to every test in this assembly: guarantees a clean LiveRenderContext.CurrentSync
+// before each test body runs. The thread-static sync mirror can linger on a pooled thread after
+// an async render released it at an await (see LiveRenderContext.CurrentSync); xUnit then reuses
+// that thread for a synchronous test asserting "no live context". Resetting before every test
+// makes those assertions deterministic. Before() runs on the test's own thread, before the body.
+[assembly: Rask.Core.Tests.ResetLiveSyncContext]
+
+namespace Rask.Core.Tests;
+
+public sealed class ResetLiveSyncContextAttribute : BeforeAfterTestAttribute
+{
+    public override void Before(MethodInfo methodUnderTest) => LiveRenderContext.ResetSyncForTests();
+}


### PR DESCRIPTION
Addresses #43 (the `*_OutsideLiveContext_OmitsHandlerAttribute` flakes).

## Root cause

`LiveRenderContext._syncCurrent` is `[ThreadStatic]`, set in the ctor and cleared only on `Dispose`. An async render runs its synchronous walk, then `await`s — releasing the pool thread **with the mirror still set** (Dispose later runs on whatever thread the continuation resumes on). xUnit reuses that polluted thread for a synchronous test asserting "no live context", so `CurrentSync` returns a stale context and the element emits a handler attribute → assertion fails.

This is also a latent **production** hazard: a thread-pool thread released mid-async-render could leak a stale context into an unrelated synchronous render reusing it.

## Fix

- **Product:** guard `CurrentSync` with `IsActive` so a disposed/stale context reads as "no active context" — enforcing the accessor's already-documented "null outside an active render" contract. One branch, **allocation-neutral** (verified: `RenderOnce` 113.9 KB unchanged; timing within noise), no behavior change during a live render.
- **Tests:** a deterministic regression test (`LiveRenderContextSyncGuardTests`) that re-pollutes the thread with a disposed context and asserts `CurrentSync` is null + a handler renders no attribute; plus an assembly-level `ResetLiveSyncContextAttribute` that clears the mirror before each test for full isolation.

## Testing

- `dotnet test tests/Rask.Core.Tests` — **1483 passed**, incl. the new guard test and all 8 `*OutsideLiveContext*` tests.
- Build green under warnings-as-errors.

## Not included

The 4th test in #43, `Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative`, is a **separate** WS attach/detach timing flake (not `_syncCurrent`-related). Left for a focused follow-up rather than band-aided; #43 stays open for it.