### PR TITLE
ci: relax commitlint footer line length to match body

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -11,6 +11,8 @@ export default {
     ],
     'subject-case': [2, 'never', ['upper-case', 'pascal-case', 'start-case']],
     'header-max-length': [2, 'always', 100],
-    'body-max-line-length': [0, 'always', Infinity], // allow long footers/links
+    // Allow long body/footer lines (URLs, issue refs, wrapped prose) — only the header is bounded.
+    'body-max-line-length': [0, 'always', Infinity],
+    'footer-max-line-length': [0, 'always', Infinity],
   },
 };


### PR DESCRIPTION
`@commitlint/config-conventional` caps footer lines at 100 chars, so a commit with long links or wrapped prose in its body fails the `commitlint` check (hit on #53). Body length was already disabled; this disables `footer-max-line-length` too so only the header is bounded.