### PR TITLE
ci: gate nightly prerelease on the full test suite

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,8 +38,74 @@ jobs:
           dotnet test Rask.slnx -c Release --no-build
           --filter "FullyQualifiedName!~Rask.Examples.E2E"
 
+  # Browser journeys — one comprehensive journey per hosting project, sharded one host
+  # per runner (mirrors ci.yml). Nightly must not publish unless every journey is green.
+  e2e:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        host:
+          - ServerExampleTests
+          - WasmExampleTests
+          - StandaloneWasmExampleTests
+          - WasmSubPathExampleTests
+          - AuthExampleTests
+          - JwtServerAuthExampleTests
+          - WasmCookieAuthExampleTests
+          - WasmJwtAuthExampleTests
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Build.targets') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj') }}
+          restore-keys: playwright-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore Rask.slnx
+
+      - name: Build
+        # -m:1 (serial) eliminates the parallel copy race on Rask.Core.dll (matches ci.yml).
+        run: dotnet build Rask.slnx -c Release --no-restore -m:1
+
+      - name: E2E journey (${{ matrix.host }})
+        run: >-
+          dotnet test tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+          -c Release --no-build
+          --filter "FullyQualifiedName~Rask.Examples.E2E.Tests.${{ matrix.host }}"
+          --logger "trx;LogFileName=${{ matrix.host }}.trx"
+          --logger "console;verbosity=normal"
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v5
+        with:
+          name: nightly-e2e-test-results-${{ matrix.host }}
+          path: |
+            **/TestResults/**
+            **/bin/**/test-artifacts/**
+
   publish-nightly:
-    needs: unit
+    needs: [unit, e2e]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,9 @@ them until tagged releases begin.
   the full repo README.
 
 ### CI
-- `nightly.yml` publishes a prerelease to nuget.org + GitHub Packages on every push to `main`.
+- `nightly.yml` publishes a prerelease to nuget.org + GitHub Packages on every push to `main`,
+  now gated on the **full** test suite — the prerelease only publishes after both the `unit` job
+  and the complete sharded `e2e` matrix pass (previously `unit` only).
 - `commitlint.yml` enforces Conventional Commits; `dependabot.yml` keeps NuGet/Actions current.
 
 ### Documentation


### PR DESCRIPTION
## Summary
The nightly prerelease (`nightly.yml`) previously published after only the `unit` job ran. This adds the sharded `e2e` matrix (mirroring `ci.yml`) and makes `publish-nightly` depend on **both** `unit` and `e2e` — so a nightly build is only created when the entire test suite is green.

## Changes
- `nightly.yml`: new `e2e` job (8-host matrix), `publish-nightly: needs: [unit, e2e]`.
- `CHANGELOG.md`: note under `### CI`.

## Testing
CI (`unit` + `e2e`) runs on this PR and is the gate.

## Changelog
Updated `[Unreleased]` → `### CI`.