### PR TITLE
refactor!: remove Component.User; inject IUserProvider instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ them until tagged releases begin.
 - Community health files: issue forms, PR template, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
   `CODEOWNERS`, and `docs/repo-administration.md` — contributions open, maintainer merges.
 
+### Removed
+- **Breaking:** removed the `Component.User` convenience property. Components that need the current
+  principal now inject `IUserProvider` via the constructor and read `.Current` (a never-null
+  `ClaimsPrincipal`) — explicit, testable dependencies instead of a base-class service locator. The
+  built-in `Authorize` component, `[Authorize]` route gating, and the auth samples/templates are
+  unchanged in behaviour.
+
 ### Changed
 - Build is now **warnings-as-errors** with .NET analyzers and code-style enforced in-build
   (`Directory.Build.props`); see `docs/code-analysis.md`.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ published WASM bundle. The **same component code runs under any host** — only 
 |  ✅  | **Forms with async validation**    | `Form<TModel>(model, OnValidSubmit: …)` routes submit through validators you opt into by dropping `DataAnnotationsValidator()` or `FluentValidationValidator(...)` inside the form. Implement `IAsyncFieldValidator` for ad-hoc server-side rules — the submit bridge awaits async checks before routing, and rapid keystrokes cancel any prior in-flight validation (latest-wins).                                                                                               |
 |  ⚡  | **Live diff codec**                | After first paint, a small state change ships a minimal edit-op payload instead of re-serializing the page — a counter tick on a 50 KB page goes from ~50 KB to ~57 bytes on the wire. On by default.                                                                                                                                                                                                                                                                             |
 | 🔑  | **Keyed lists**                    | Add a `Key:` to list items (Blazor `@key` parity) and inserts/removes/reorders reconcile by identity — shipping trusted structural diffs that preserve focus and input state on the survivors. A `RASK022` analyzer flags a list item that's missing a key.                                                                                                                                                                                                                       |
-| 🔐  | **Authentication, ASP.NET-native** | `Component.User` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
+| 🔐  | **Authentication, ASP.NET-native** | Inject `IUserProvider` and read `.Current` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
 
 ## ⚖️ Compared to Blazor
 
@@ -96,7 +96,7 @@ If you've worked in Blazor, here's how the day-to-day differs in Rask:
 | `RenderFragment` / `EventCallback`                | Children are `IEnumerable<Child>`; event handlers are plain delegates (`OnClick: () => _count++`). Child→parent callbacks are plain delegate props too (`Action<T>?` / `Func<T,Task>?`) — invoking one auto-re-renders the parent that owns it, no `EventCallback` wrapper. No specialised types, no `@bind-Value:event`. |
 | `.razor.css` association ceremony                 | Scoped CSS via a sibling `{Component}.css` (Blazor-parity descendant combinators) — auto-globbed at build time, hot-reloaded under `dotnet watch`. Same idea for JS: a sibling `{Component}.js` is bundled and dispatched by the framework.                                                                               |
 | Separate render modes to wire up                  | **Same component code on Server or WASM.** Pick the host package per project; you don't rewrite components when switching render mode. Server-only (multipart upload) and WASM-only (chunked file reads, inline downloads) behaviours live in the hosts, not in your tree.                                                |
-| `<AuthorizeView>` + `AuthenticationStateProvider` | `Component.User` everywhere (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface.                       |
+| `<AuthorizeView>` + `AuthenticationStateProvider` | Inject `IUserProvider` and read `.Current` (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface.                       |
 
 Rask isn't a Blazor replacement so much as a different take on the same problem space. If those trade-offs appeal, the
 rest of this README walks through what they look like in practice.
@@ -358,7 +358,7 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
 - **`samples/Rask.Example.Shared/Pages/`** — the feature-by-feature pages those hosts share: forms & validation,
   nested-form
   binding, routing, JS interop, virtualization (a 10K-row table), file upload/download, and **auth gating** (the `/user`
-  page shows both imperative `Component.User` and the declarative `Authorize` component). These are the canonical
+  page shows both imperative `IUserProvider.Current` and the declarative `Authorize` component). These are the canonical
   references cited throughout *Core concepts* below. For production auth flows see *
   *[docs/authentication.md](docs/authentication.md)**.
 - **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
@@ -605,12 +605,12 @@ built-in page if no app-defined one exists.
 </details>
 
 <details>
-<summary><b>🔐 Auth gating (built-in <code>User</code>)</b></summary>
+<summary><b>🔐 Auth gating (inject <code>IUserProvider</code>)</b></summary>
 <br>
 
-Every component exposes `Component.User` — a never-null `ClaimsPrincipal` resolved from the scoped `IUserProvider`
-(back it with a cookie/JWT on Server, or `/api/me` on WASM). Gate **imperatively** in `Render()` with plain C#, and
-subscribe to the provider's `Changed` event so a sign-in originating anywhere re-renders the gate:
+Inject `IUserProvider` via the constructor and read `.Current` — a never-null `ClaimsPrincipal` resolved from the
+scoped provider (back it with a cookie/JWT on Server, or `/api/me` on WASM). Gate **imperatively** in `Render()` with
+plain C#, and subscribe to the provider's `Changed` event so a sign-in originating anywhere re-renders the gate:
 
 ```csharp
 public sealed class AccountPanel : Component
@@ -622,10 +622,10 @@ public sealed class AccountPanel : Component
     protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        User.Identity?.IsAuthenticated == true
+        _auth.Current.Identity?.IsAuthenticated == true
             ? Fragment()[
-                P()["Signed in as ", Strong()[User.Identity!.Name ?? "?"]],
-                User.IsInRole("admin")                      // role-gated branch
+                P()["Signed in as ", Strong()[_auth.Current.Identity!.Name ?? "?"]],
+                _auth.Current.IsInRole("admin")             // role-gated branch
                     ? Div()["🔑 Admin-only panel"]
                     : (Child)Fragment()]
             : P()["You are signed out."];

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -26,7 +26,7 @@ Keycloak/OIDC, …). This guide shows the complete, copy-pasteable flow for each
 | Piece | What it is |
 |---|---|
 | `IUserProvider` | Scoped source of the current `ClaimsPrincipal` (`Current`), a `Changed` event, optional `EnsureLoadedAsync`/`RefreshAsync`, and `IsLoading`. Server: `SessionUserProvider` (seeded from `HttpContext.User`). WASM: you supply one (or the anonymous default). |
-| `Component.User` | The never-null `ClaimsPrincipal` resolved from `IUserProvider` in the active render scope. Gate in `Render()` on `User.Identity?.IsAuthenticated` / `User.IsInRole(...)`. |
+| Injecting `IUserProvider` | Inject it via the constructor and read `.Current` — the never-null `ClaimsPrincipal` for the active render scope. Gate in `Render()` on `provider.Current.Identity?.IsAuthenticated` / `provider.Current.IsInRole(...)`. |
 | `Authorize` component | Headless declarative gate with `Authorized` / `NotAuthorized` / `Authorizing` slots (see below). |
 | `IAuthSignIn` | Event-handler-only `SignInAsync(principal, returnUrl)` / `SignOutAsync(returnUrl)`. Server drives the cookie handshake; WASM signs out via `/auth/logout`. |
 | `[Authorize]` / `[AllowAnonymous]` | Route-level gating evaluated by `RouteAuthorizationGuard` → redirect to the auth scheme's `LoginPath` (401) or `AccessDeniedPath` (403). |
@@ -71,7 +71,7 @@ builder.Services.AddRask();              // no auth config here — it's all on 
 ## Declarative gating
 
 The headless `Authorize` component renders exactly one of three slots — no markup of its own — off
-`Component.User`:
+the current user (`IUserProvider`):
 
 ```csharp
 // Shorthand: children are the "authorized" branch.
@@ -91,8 +91,8 @@ Authorize(
 - **`Authorizing`** also covers the WASM bootstrap window: while a provider's `EnsureLoadedAsync`/`RefreshAsync`
   is in flight (`IUserProvider.IsLoading == true`), the slot bridges the anonymous→authenticated flash.
 
-Use `Authorize` for *content* gating; use `[Authorize]` on a page for *route* gating; use `Component.User`
-directly when you need imperative logic.
+Use `Authorize` for *content* gating; use `[Authorize]` on a page for *route* gating; inject `IUserProvider`
+and read `.Current` directly when you need imperative logic.
 
 ---
 
@@ -181,11 +181,11 @@ public sealed class SecurePage : Component
             Authorized:    SecureContent());     // child component → renders fresh when the gate opens
 }
 
-public sealed class SecureContent : Component
+public sealed class SecureContent(IUserProvider users) : Component
 {
     protected override RenderResult Render() =>
         Div()[
-            H1()[$"Hello, {User.Identity!.Name}"],
+            H1()[$"Hello, {users.Current.Identity!.Name}"],
             Authorize(Roles: ["admin"],
                 Authorized:    Div(Class: "alert alert-warning")["🔑 Admin tools"],
                 NotAuthorized: P()["You have standard access."])
@@ -195,8 +195,8 @@ public sealed class SecureContent : Component
 
 > **Reactivity.** Sign-in on the Server completes over a WS reconnect that re-seeds the principal and fires
 > `IUserProvider.Changed`. The `Authorize` component subscribes to that event and re-renders — but a page
-> that reads `User` *directly in its own `Render`* won't re-execute (it didn't subscribe), so a greeting
-> built there can go stale after a mid-session sign-in. Two fixes: put `User`-dependent markup inside a
+> that reads `users.Current` *directly in its own `Render`* won't re-execute (it didn't subscribe), so a greeting
+> built there can go stale after a mid-session sign-in. Two fixes: put principal-dependent markup inside a
 > **child component** in the `Authorized` slot (it first renders only once the gate opens, as above), or
 > subscribe the page itself: `OnMount() => users.Changed += StateHasChanged;`. The child-component form
 > needs no manual subscription.
@@ -683,7 +683,7 @@ host.Services.AddSingleton<LoginService>();
 await host.RunAsync<App>();
 ```
 
-`Component.User`, the `Authorize` component, and `[Authorize]` route gating all work against the decoded
+The injected `IUserProvider`, the `Authorize` component, and `[Authorize]` route gating all work against the decoded
 principal exactly as everywhere else — they just resolve from `JwtUserProvider` instead of a server-backed
 one. (Route-level `[Authorize]` redirects work client-side too, since the guard runs in the WASM session.)
 
@@ -799,7 +799,7 @@ public sealed class LoginPage(
 }
 ```
 
-Everything else (`Component.User`, `Authorize`, `[Authorize(Roles = "...")]`) works against the Identity
+Everything else (the injected `IUserProvider`, `Authorize`, `[Authorize(Roles = "...")]`) works against the Identity
 principal unchanged. Registration/2FA/lockout are standard Identity APIs called from your pages.
 
 ---

--- a/docs/migration-from-blazor.md
+++ b/docs/migration-from-blazor.md
@@ -27,7 +27,7 @@ New to Rask entirely? Start with [getting started](getting-started.md).
 | route/query binding | `[RouteParam]` / `[QueryParam]` on a property |
 | `<EditForm>` + `InputText`/`InputNumber` | `Form<TModel>(model, OnValidSubmit:)` + `Input(Bind: () => model.X)` |
 | `<DataAnnotationsValidator>` | drop `DataAnnotationsValidator()` inside the `Form<T>` |
-| `<AuthorizeView>` / `AuthenticationStateProvider` | `Component.User` + headless `Authorize(...)` component |
+| `<AuthorizeView>` / `AuthenticationStateProvider` | inject `IUserProvider` (read `.Current`) + headless `Authorize(...)` component |
 | `[Inject] T Svc { get; set; }` | constructor injection — `class Page(T svc) : Component` |
 | `Component.razor.css` | sibling `{Component}.css` next to `{Component}.cs` |
 | `IJSRuntime` | `IJSRuntime` (injected via the constructor) |

--- a/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
@@ -27,7 +27,7 @@ public sealed class MemberContent(ProtectedSessionStorage store, SessionUserProv
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {users.Current.Identity?.Name}"],
             P(Class: "text-secondary")["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
                 " — encrypted at rest, decrypted only server-side."],
             Authorize(

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmCookie.Pages;
@@ -22,11 +23,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(WasmLoginService login) : Component
+public sealed class MemberContent(WasmLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmJwt.Pages;
@@ -19,11 +20,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(JwtLoginService login) : Component
+public sealed class MemberContent(JwtLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],

--- a/samples/Rask.Example.Auth/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth/Pages/MembersPage.cs
@@ -8,7 +8,7 @@ namespace Rask.Example.Auth.Pages;
 // component gates the *content* — it subscribes to IUserProvider.Changed, so when the post-sign-in
 // reconnect re-seeds the principal it re-renders to the Authorized slot. The signed-in view lives in
 // its own component (MemberContent) so it first renders only once the gate opens, reading the
-// freshly-authenticated User — no manual Changed subscription needed on the page.
+// freshly-authenticated principal — no manual Changed subscription needed on the page.
 [Route("members")]
 [Authorize]
 public sealed class MembersPage : Component
@@ -26,12 +26,12 @@ public sealed class MembersPage : Component
 }
 
 // Rendered only by the Authorize component's Authorized slot, so its Render reads the current
-// (authenticated) User. Injects IAuthSignIn for sign-out.
-public sealed class MemberContent(IAuthSignIn auth) : Component
+// (authenticated) principal. Injects IUserProvider for the principal and IAuthSignIn for sign-out.
+public sealed class MemberContent(IUserProvider userProvider, IAuthSignIn auth) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             P(Class: "text-secondary")["This page is gated by ", Code()["[Authorize]"],
                 " plus the Authorize component."],
             // Role gate: only an admin sees this.

--- a/samples/Rask.Example.Shared/Demos/DemoUserProvider.cs
+++ b/samples/Rask.Example.Shared/Demos/DemoUserProvider.cs
@@ -6,7 +6,7 @@ namespace Rask.Example.Shared.Demos;
 // A toggleable IUserProvider for the User-gating showcase. Real apps back IUserProvider with a
 // cookie/JWT (Server) or /api/me (WASM); this one just flips an in-memory principal so the demo
 // can show authenticated/role-gated rendering without real auth infrastructure. Registered as
-// both itself (so the demo can sign in/out) and IUserProvider (so Component.User resolves it).
+// both itself (so the demo can sign in/out) and IUserProvider (so injected consumers resolve it).
 public sealed class DemoUserProvider : IUserProvider
 {
     public ClaimsPrincipal Current { get; private set; } = new(new ClaimsIdentity());

--- a/samples/Rask.Example.Shared/Demos/UserGateDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/UserGateDemo.cs
@@ -1,8 +1,8 @@
 namespace Rask.Example.Shared.Demos;
 
-// Auth-gating with the built-in Component.User — no AuthorizeView component. The demo injects the
-// toggleable provider to sign in/out; Render() branches on User. It subscribes to the provider's
-// Changed event so a sign-in originating anywhere re-renders this component.
+// Auth-gating by injecting IUserProvider and reading .Current — no AuthorizeView component. The demo
+// injects the toggleable provider to sign in/out; Render() branches on _auth.Current. It subscribes
+// to the provider's Changed event so a sign-in originating anywhere re-renders this component.
 public sealed class UserGateDemo : Component
 {
     private readonly DemoUserProvider _auth;
@@ -15,11 +15,11 @@ public sealed class UserGateDemo : Component
 
     protected override RenderResult Render() =>
         Div(Id: "user-gate")[
-            User.Identity?.IsAuthenticated == true
+            _auth.Current.Identity?.IsAuthenticated == true
                 ? Fragment()[
-                    P()["Signed in as ", Strong()[User.Identity!.Name ?? "?"]],
+                    P()["Signed in as ", Strong()[_auth.Current.Identity!.Name ?? "?"]],
                     // Role-gated: only an admin sees this panel.
-                    User.IsInRole("admin")
+                    _auth.Current.IsInRole("admin")
                         ? Div(Class: "alert alert-warning py-2")["🔑 Admin-only panel"]
                         : (Child)Fragment(),
                     Button(Class: "btn btn-sm btn-outline-secondary", OnClick: _auth.SignOut)["Sign out"]]

--- a/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
+++ b/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ExampleServiceCollectionExtensions
         services.AddSingleton<IBannedWordService, BannedWordService>();
 
         // Toggleable demo auth for the User-gating showcase (/user). Registered as the concrete
-        // type (so the demo can sign in/out) and as IUserProvider (so Component.User resolves it).
+        // type (so the demo can sign in/out) and as IUserProvider (so injected consumers resolve it).
         // Defaults to anonymous, so other pages are unaffected. Scoped — NOT singleton — so each
         // live session gets its own principal (matching the framework's own SessionUserProvider,
         // RaskEndpointExtensions.AddScoped). A singleton would share one signed-in user across every

--- a/samples/Rask.Example.Shared/Pages/UserPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UserPage.cs
@@ -14,25 +14,28 @@ public sealed class UserPage : Component
     [
         PageHeader.Render(
             "User & auth gating",
-            "Gate content on the signed-in user — imperatively with the built-in Component.User (branch in Render() on User.Identity?.IsAuthenticated and User.IsInRole(...)), or declaratively with the headless Authorize component."),
-        H2(Class: "h4 mt-4 mb-3")["Conditional rendering on User"],
+            "Gate content on the signed-in user — imperatively by injecting IUserProvider and reading .Current (branch in Render() on _auth.Current.Identity?.IsAuthenticated and _auth.Current.IsInRole(...)), or declaratively with the headless Authorize component."),
+        H2(Class: "h4 mt-4 mb-3")["Conditional rendering on the current user"],
         CodeSample(
             """
-            // Component.User comes from the registered IUserProvider
-            protected override RenderResult Render() =>
-                User.Identity?.IsAuthenticated == true
-                    ? Fragment(
-                        P()[$"Signed in as {User.Identity!.Name}"],
-                        User.IsInRole("admin") ? AdminPanel() : Fragment(),
-                        Button(OnClick: _auth.SignOut)["Sign out"])
-                    : Button(OnClick: () => _auth.SignIn("alice", "user"))["Sign in"];
+            // Inject IUserProvider via the constructor and read .Current (a never-null ClaimsPrincipal)
+            public sealed class AccountPanel(IUserProvider auth) : Component
+            {
+                protected override RenderResult Render() =>
+                    auth.Current.Identity?.IsAuthenticated == true
+                        ? Fragment(
+                            P()[$"Signed in as {auth.Current.Identity!.Name}"],
+                            auth.Current.IsInRole("admin") ? AdminPanel() : Fragment(),
+                            Button(OnClick: auth.SignOut)["Sign out"])
+                        : Button(OnClick: () => auth.SignIn("alice", "user"))["Sign in"];
 
-            // re-render when auth changes (the provider raises Changed)
-            protected override void OnMount()   => _auth.Changed += StateHasChanged;
-            protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
+                // re-render when auth changes (the provider raises Changed)
+                protected override void OnMount()   => auth.Changed += StateHasChanged;
+                protected override void OnUnmount() => auth.Changed -= StateHasChanged;
+            }
             """,
             Notes:
-            "User resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on User subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
+            "The principal resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on the user subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
             Result: UserGateDemo()),
         H2(Class: "h4 mt-5 mb-3")["Declarative gating — the Authorize component"],
         CodeSample(
@@ -52,12 +55,12 @@ public sealed class UserPage : Component
             // until it lands (and while a WASM provider's principal is still loading).
             """,
             Notes:
-            "Authorize is the declarative counterpart to gating in Render() on User: it picks the Authorized, NotAuthorized, or Authorizing slot off the same Component.User. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
+            "Authorize is the declarative counterpart to gating in Render() on the current user: it picks the Authorized, NotAuthorized, or Authorizing slot off the same IUserProvider. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
             Result: AuthorizeDemo()),
         H2(Class: "h4 mt-5 mb-3")["Notes"],
         Ul(Class: "text-secondary")[
             Li()[
-                "Component.User never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so User.Identity?.IsAuthenticated is false."],
+                "IUserProvider.Current never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so .Current.Identity?.IsAuthenticated is false."],
             Li()[
                 "Role checks use the standard ClaimsPrincipal.IsInRole. For route-level gating use [Authorize]/[AllowAnonymous] on the page (RouteAuthorizationGuard) instead of branching in Render()."]
         ]

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1,8 +1,5 @@
-using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Forms;
 using Rask.Core.HeadAssets;
@@ -213,14 +210,6 @@ public abstract class Component
             }
         }
     }
-
-    /// <summary>
-    ///     The current user, resolved from <see cref="IUserProvider" /> in the active render scope.
-    ///     Returns an unauthenticated <see cref="ClaimsPrincipal" /> when no provider is registered.
-    /// </summary>
-    protected ClaimsPrincipal User =>
-        LiveRenderContext.Current?.Services?.GetService<IUserProvider>()?.Current
-        ?? new ClaimsPrincipal(new ClaimsIdentity());
 
     /// <summary>
     ///     A <see cref="System.Threading.CancellationToken" /> tied to this component's lifetime.

--- a/src/Rask.Core/Components/Authorize.cs
+++ b/src/Rask.Core/Components/Authorize.cs
@@ -8,7 +8,7 @@ namespace Rask.Core.Components;
 
 /// <summary>
 ///     Declarative auth gating — the headless analogue of Blazor's <c>AuthorizeView</c>. Renders
-///     exactly one of three slots based on the current <see cref="Component.User" /> (and, optionally,
+///     exactly one of three slots based on the current <see cref="IUserProvider" /> (and, optionally,
 ///     a named authorization policy), with <b>no markup of its own</b> (transparent like
 ///     <see cref="Fragment" />):
 ///     <list type="bullet">
@@ -44,6 +44,12 @@ public sealed class Authorize : Component
     private int _policyGen;
     private IUserProvider? _provider;
     private IServiceProvider? _services;
+
+    // The current principal from the resolved provider; never null. _provider is wired in OnMount,
+    // which the lifecycle guarantees runs before OnPropsChangedAsync/Render, so this is safe at
+    // every read site.
+    private ClaimsPrincipal CurrentUser =>
+        _provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity());
 
     // Transparent — Authorize itself emits nothing, it only selects one slot. (Same as the base
     // default; stated explicitly to document the headless contract.)
@@ -97,7 +103,7 @@ public sealed class Authorize : Component
             return;
         }
 
-        await EvaluatePolicyAsync(User).ConfigureAwait(false);
+        await EvaluatePolicyAsync(CurrentUser).ConfigureAwait(false);
     }
 
     protected override RenderResult Render()
@@ -122,7 +128,7 @@ public sealed class Authorize : Component
 
     private bool IsAllowed()
     {
-        if (User.Identity?.IsAuthenticated != true)
+        if (CurrentUser.Identity?.IsAuthenticated != true)
         {
             return false;
         }
@@ -144,7 +150,7 @@ public sealed class Authorize : Component
     {
         foreach (var role in Roles!)
         {
-            if (!string.IsNullOrEmpty(role) && User.IsInRole(role))
+            if (!string.IsNullOrEmpty(role) && CurrentUser.IsInRole(role))
             {
                 return true;
             }
@@ -170,8 +176,7 @@ public sealed class Authorize : Component
     private async Task RefreshPolicyThenRenderAsync()
     {
         StateHasChanged(); // paint the Authorizing slot immediately
-        await EvaluatePolicyAsync(_provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity()))
-            .ConfigureAwait(false);
+        await EvaluatePolicyAsync(CurrentUser).ConfigureAwait(false);
         StateHasChanged(); // paint the resolved verdict
     }
 

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
@@ -7,7 +7,8 @@ namespace Company.RaskServer;
 
 // [Authorize] blocks anonymous deep-links (full GET → 302 to /login). The Authorize component gates the
 // content and re-renders when the post-sign-in reconnect re-seeds the principal; the signed-in view lives
-// in its own component so it reads the freshly-authenticated User — no manual Changed subscription.
+// in its own component that injects IUserProvider, so it reads the freshly-authenticated principal — no
+// manual Changed subscription.
 [Route("members")]
 [Authorize]
 public sealed class MembersPage : Component
@@ -20,11 +21,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(IAuthSignIn auth) : Component
+public sealed class MemberContent(IAuthSignIn auth, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1()[$"Welcome, {User.Identity?.Name}"],
+            H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
                 Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Routing;
 
@@ -19,11 +20,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(WasmLoginService login) : Component
+public sealed class MemberContent(WasmLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1()[$"Welcome, {User.Identity?.Name}"],
+            H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
                 Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Routing;
 
@@ -16,11 +17,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(JwtLoginService login) : Component
+public sealed class MemberContent(JwtLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1()[$"Welcome, {User.Identity?.Name}"],
+            H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
                 Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],

--- a/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
+++ b/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
@@ -6,7 +6,7 @@ using Rask.Core.Authentication;
 
 namespace Rask.Core.Tests.Authentication;
 
-// The built-in Component.User (resolved from IUserProvider in the active render scope) is the
+// Injecting IUserProvider and reading .Current (resolved from the active render scope) is the
 // imperative way to gate content (the declarative counterpart is the Authorize component — see
 // AuthorizeTests). These pin that gating in Render() reflects the provider's principal, incl. roles.
 public class UserGatingTests
@@ -48,10 +48,11 @@ public class UserGatingTests
 
     private static string Render(ClaimsPrincipal principal)
     {
+        var provider = new FixedUser(principal);
         var sp = new ServiceCollection()
-            .AddSingleton<IUserProvider>(new FixedUser(principal))
+            .AddSingleton<IUserProvider>(provider)
             .BuildServiceProvider();
-        return new StubComponent(() => new Gate()).RenderAsLiveRoot(sp);
+        return new StubComponent(() => new Gate(provider)).RenderAsLiveRoot(sp);
     }
 
     private static ClaimsPrincipal Principal(string name, params string[] roles)
@@ -65,8 +66,10 @@ public class UserGatingTests
         return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
     }
 
-    private sealed class Gate : Component
+    private sealed class Gate(IUserProvider provider) : Component
     {
+        private ClaimsPrincipal User => provider.Current;
+
         protected override RenderResult Render() =>
             User.Identity?.IsAuthenticated == true
                 ? new Fragment(

--- a/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
@@ -9,7 +9,7 @@ using Rask.Core.Authentication;
 namespace Rask.Core.Tests.Components;
 
 // The headless Authorize component selects exactly one of three slots (Authorized / NotAuthorized /
-// Authorizing) off Component.User, plus optional role/policy gating. These pin that selection. The
+// Authorizing) off the current user (IUserProvider), plus optional role/policy gating. These pin that selection. The
 // gate is built INSIDE a render delegate so its generated factory runs under a live render context
 // (which fires OnMount/OnPropsChangedAsync) — building it eagerly would skip the lifecycle.
 public class AuthorizeTests

--- a/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Rask.Core;
+using Rask.Core.Authentication;
 using Rask.Core.Routing;
 
 #pragma warning disable RASK019 // test-infra app predates framework-managed <head>
@@ -29,10 +30,10 @@ public sealed class E2EPublicPage : Component
 
 [Route("/e2e/members")]
 [Authorize]
-public sealed class E2EMembersPage : Component
+public sealed class E2EMembersPage(IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "members")["members-content for ", Span()[User.Identity?.Name ?? "?"]];
+        Div(Id: "members")["members-content for ", Span()[userProvider.Current.Identity?.Name ?? "?"]];
 }
 
 [Route("/e2e/admin")]

--- a/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
@@ -8,14 +8,14 @@ using Rask.Core.Routing;
 
 namespace Rask.Server.Tests.Authentication;
 
-public sealed class SignInTestApp(AuthSignIn auth, RouteState routeState) : Component
+public sealed class SignInTestApp(AuthSignIn auth, RouteState routeState, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
     [
         Doctype(),
         new Html()[new Head()[new Title()["auth-test"]],
             new Body()[new H1()[$"path={routeState.Path}"],
-                new P()[$"user={(User.Identity?.IsAuthenticated == true ? User.Identity.Name : "anon")}"],
+                new P()[$"user={(userProvider.Current.Identity?.IsAuthenticated == true ? userProvider.Current.Identity.Name : "anon")}"],
                 Button(OnClickAsync: SignInAsync)["sign-in"],
                 Button(OnClickAsync: SignOutAsync)["sign-out"]]]
     ];


### PR DESCRIPTION
## Summary
Removes the `protected Component.User` convenience property. It resolved the current `ClaimsPrincipal` through a service-locator lookup inside the base class, hiding a DI dependency and contradicting Rask's own "inject framework services via the ctor" rule. Components that need the principal now inject `IUserProvider` and read `.Current` (a never-null `ClaimsPrincipal`); `Authorize` becomes self-sufficient on the `_provider` field it already holds. Samples, `dotnet new` templates, tests, and docs are migrated to constructor injection.

**Breaking:** any subclass that read `Component.User` must switch to injecting `IUserProvider`. The `Authorize` component, `[Authorize]` route gating, and all auth flows are behaviourally unchanged.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all pass** (~2,400 tests, 1 pre-existing skip).
- Build: `dotnet build Rask.slnx -warnaserror` — **0 warnings, 0 errors** (incl. WASM trim-publish of the auth samples).
- E2E (`samples/` changed): user-gate demo DOM (`#user-gate`, sign-in/out) is unchanged, so the existing `Rask.Examples.E2E.Tests` auth coverage still applies — not re-run locally in this change.

## Benchmarks
n/a — off the render hot path (the `Authorize` change swaps a per-access `GetService<IUserProvider>()` lookup for a cached field read).

## CHANGELOG
- [Unreleased] entry added: removed `Component.User` (breaking) — inject `IUserProvider` via the constructor and read `.Current` instead.
