### PR TITLE
feat(samples): add EF Core + SQLite CRUD sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
 
+# EF Core SQLite sample database (created at runtime by samples/Rask.Example.EfCore)
+raskExampleCatalog.db
+raskExampleCatalog.db-shm
+raskExampleCatalog.db-wal
+
 # Coverage
 *.coverage
 *.coveragexml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ them until tagged releases begin.
   `*_OutsideLiveContext_OmitsHandlerAttribute` tests.
 
 ### Added
+- New `samples/Rask.Example.EfCore` sample: an EF Core + SQLite CRUD app (Server host) showing data
+  persistence in Rask. It uses `IDbContextFactory` (right for long-lived live sessions), organises
+  code as vertical slices (List/Create/Edit), models the catalogue with a DDD aggregate + value
+  objects whose validation rules are reused by the inline form validators, and stores money as
+  integer minor units to sidestep SQLite's lack of a decimal type. Covered by unit + EF/SQLite
+  integration tests (`Rask.Example.EfCore.Tests`) and a Playwright CRUD smoke test, and documented in
+  `docs/data-access.md`.
 - `RaskVersion.Current` exposes the running framework version (from the assembly's MinVer
   `InformationalVersion`). The server (`UseRask`) and WASM host log it on startup, and the
   showcase samples display it as a version badge.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,10 +66,11 @@
       The validation packages inject their own global usings (Rask.Validation.* below). Downstream
       consumers only get them by referencing the validation NuGet package; in-repo we'd otherwise force
       every Rask.Example.* project to reference the validation libs just to satisfy the generated usings.
-      The auth samples (Rask.Example.Auth*) don't use validation, so skip those usings for them.
+      The auth samples (Rask.Example.Auth*) don't use validation, and the EF Core sample
+      (Rask.Example.EfCore) uses Rask.Core's inline Validate: lambdas only — so skip those usings for them.
     -->
     <_RaskExampleValidationUsings>$(_RaskInRepoImplicitUsings)</_RaskExampleValidationUsings>
-    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) ">false</_RaskExampleValidationUsings>
+    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) OR $(MSBuildProjectName.StartsWith('Rask.Example.EfCore')) ">false</_RaskExampleValidationUsings>
   </PropertyGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />

--- a/README.md
+++ b/README.md
@@ -361,6 +361,11 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
   page shows both imperative `IUserProvider.Current` and the declarative `Authorize` component). These are the canonical
   references cited throughout *Core concepts* below. For production auth flows see *
   *[docs/authentication.md](docs/authentication.md)**.
+- **`samples/Rask.Example.EfCore`** — data persistence with **EF Core + SQLite** (Server host): a
+  CRUD catalogue organised as vertical slices, with a DDD aggregate + value objects, `IDbContextFactory`,
+  and money stored as integer minor units (SQLite has no decimal type). Run it with
+  `dotnet run --project samples/Rask.Example.EfCore` and open `/products`. Guide:
+  **[docs/data-access.md](docs/data-access.md)**.
 - **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
   (`/login`, a protected `/members`, role-gated admin content, sign-out) backed by a browser E2E:
     - **`Rask.Example.Auth`** — cookie + Server (the redeem handshake).

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -10,6 +10,7 @@
         <Project Path="samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj"/>
         <Project Path="samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj"/>
         <Project Path="samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj"/>
+        <Project Path="samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj"/>
         <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj"/>
         <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj"/>
         <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj"/>
@@ -28,6 +29,7 @@
     </Folder>
     <Folder Name="/tests/">
         <Project Path="tests/Rask.Core.Tests/Rask.Core.Tests.csproj"/>
+        <Project Path="tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj"/>
         <Project Path="tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj"/>
         <Project Path="tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj"/>
         <Project Path="tests/Rask.Example.Wasm.Host.Tests/Rask.Example.Wasm.Host.Tests.csproj"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Guides and references for building with Rask. New here? Start with the project
 | [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), asset delivery. |
 | [Forms & validation](forms.md) | Two-way binding, `Form<T>`/`EditContext`, inline / DataAnnotations / FluentValidation / async validators, radio & checkbox groups. |
 | [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |
+| [Data access (EF Core)](data-access.md) | EF Core + SQLite in a Server app: `IDbContextFactory`, loading in the lifecycle, vertical slices, a DDD aggregate + value objects, and the SQLite decimal gotcha. |
 | [Authentication](authentication.md) | Production auth: cookie & JWT, Server & WASM, `Authorize`, route guards, Identity / Keycloak / Auth0 / Cognito / Duende. |
 | [Testing](testing.md) | Unit-testing components with `Rask.TestSupport`, driving event handlers, when to reach for E2E. |
 | [Migrating from Blazor](migration-from-blazor.md) | Concept mapping, behavioural gotchas, and what stays the same. |

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -1,0 +1,133 @@
+# Data access (EF Core + SQLite)
+
+Rask has no data layer of its own — you use whatever .NET gives you. This guide shows the
+idiomatic way to wire **EF Core + SQLite** into a Rask **Server** app: register the context, load
+data in the component lifecycle, and run forms against persisted state. The runnable reference is
+[`samples/Rask.Example.EfCore`](../samples/Rask.Example.EfCore).
+
+> WASM note: this is a Server-side pattern. EF Core's SQLite provider isn't a fit for the trimmed
+> browser runtime — keep data access behind the server (a Server host, or an API the WASM app calls).
+
+## Register the DbContext with a factory, not a scope
+
+A Rask Server session is **long-lived**: it lives for as long as the browser holds the WebSocket
+open. A `DbContext`, by contrast, is meant to be short-lived and is not thread-safe. So do **not**
+register a scoped `DbContext` and inject it into a component — it would outlive every unit of work
+and be shared across overlapping renders. Register an `IDbContextFactory<T>` instead and open a
+fresh context per operation:
+
+```csharp
+builder.Services.AddDbContextFactory<CatalogDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+```
+
+```csharp
+await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+var products = await db.Products.AsNoTracking().OrderBy(p => p.Id).ToListAsync(CancellationToken);
+```
+
+`AddDbContextFactory` registers the factory as a singleton; each `CreateDbContextAsync` hands back a
+brand-new context you dispose at the end of the unit of work. Always pass `Component.CancellationToken`
+to the async EF calls so navigating away mid-query cancels cleanly.
+
+## Load in the lifecycle, render the result
+
+Read data in an async lifecycle hook and store it in a field. The async-hook continuation
+re-renders automatically when the `await` completes — no explicit `StateHasChanged()` needed (see
+[lifecycle.md](lifecycle.md)). Use `OnMountAsync` for a one-time load, `OnPropsChangedAsync` to
+reload when a route/query param changes.
+
+```csharp
+public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbContextFactory) : Component
+{
+    private IReadOnlyList<Product> _products = [];
+    private bool _loaded;
+
+    protected override async Task OnMountAsync()
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        _products = await db.Products.AsNoTracking().OrderBy(p => p.Id).ToListAsync(CancellationToken);
+        _loaded = true;
+    }
+
+    // ... Render() shows a spinner until _loaded, then the rows.
+}
+```
+
+For an event-handler mutation (e.g. a delete button), do the work, reload, then call
+`StateHasChanged()` explicitly:
+
+```csharp
+private async Task DeleteAsync(int id)
+{
+    await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+    await db.Products.Where(p => p.Id == id).ExecuteDeleteAsync(CancellationToken);
+    await LoadAsync();
+    StateHasChanged();
+}
+```
+
+## How the sample is organised
+
+The sample uses **vertical slices**: code is grouped by use case (`ListProducts`, `CreateProduct`,
+`EditProduct`), each slice owning its page, its own form model, and its own EF Core access — no
+shared repository or service layer. The only shared things are the app shell, a form-error template,
+and the Catalog domain.
+
+The domain applies **DDD tactical patterns**: `Product` is an aggregate root with private setters
+that only changes through `Create` / `Update`, and `Money` / `ProductName` / `StockLevel` are value
+objects. Each value object **owns its validation rule** as a static `Validate` method shaped exactly
+like Rask's inline validator (`Func<T, IEnumerable<string>>`), so the form and the domain enforce the
+same rule from one source:
+
+```csharp
+// In the value object:
+public static IEnumerable<string> Validate(decimal amount) { /* the one rule */ }
+
+// In the form (reused as a method group — see forms.md §3 for inline validation):
+Input(() => _form.Price, Validate: Money.Validate, Id: "p-price", Class: "form-control")
+```
+
+The EF Core mapping lives in an `IEntityTypeConfiguration<Product>` (applied with
+`ApplyConfigurationsFromAssembly`), keeping the domain free of persistence attributes. Value objects
+map onto columns with value converters.
+
+## Does SQLite support `decimal`? (the money gotcha)
+
+No — SQLite has no native decimal type. EF Core maps a `decimal` to a **TEXT** column and falls back
+to **REAL** for `ORDER BY` and aggregates, which is lossy and sorts lexicographically. The sample
+sidesteps this by modelling `Money` as **integer minor units (cents)** and mapping it to an `INTEGER`
+column with a converter:
+
+```csharp
+entity.Property(p => p.Price)
+    .HasConversion(money => money.Cents, cents => Money.FromCents(cents));
+```
+
+Integer cents are exact, correctly sortable, and the conventional way to represent money anyway. The
+sample's integration tests assert the column is `INTEGER` and that values round-trip exactly.
+
+## Schema & seeding
+
+The sample calls `EnsureCreatedAsync()` on startup and seeds a few rows through the aggregate's
+`Create` factory (so even seed data honours the invariants). `EnsureCreated` is the simplest correct
+choice for a sample with no schema history — a real app with an evolving schema would use
+`Database.MigrateAsync()` with EF Core migrations instead.
+
+## Testing
+
+Data-access logic is testable without a browser:
+
+- **Unit-test** the value objects and aggregate (validation rules, invariants) directly.
+- **Integration-test** the EF mapping against a real SQLite file: create the context, save a
+  `Product`, reload it in a new context, and assert the round-trip (and the storage shape).
+
+See `tests/Rask.Example.EfCore.Tests`. The end-to-end CRUD flow over the live connection is covered
+by a Playwright smoke test in `tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs`.
+
+## Run it
+
+```bash
+dotnet run --project samples/Rask.Example.EfCore
+# then open the printed URL at /products
+```

--- a/llms.txt
+++ b/llms.txt
@@ -14,6 +14,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
 - [Composition](docs/composition.md): children, context (provide/consume), callbacks.
 - [Forms](docs/forms.md): binding, validation, RadioGroup/CheckboxGroup, EditContext.
+- [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.

--- a/samples/Rask.Example.EfCore/Features/Catalog/CreateProduct/CreateProductPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/CreateProduct/CreateProductPage.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+using Rask.Example.EfCore.Shared.Forms;
+
+namespace Rask.Example.EfCore.Features.Catalog.CreateProduct;
+
+// Vertical slice: add a product (a command). The slice owns its own form model and form markup;
+// the only things it shares are the domain (Product / value objects) and the FieldErrors template.
+// Inline field validators reuse the value objects' Validate methods, so the form and the domain
+// enforce the same rules from a single source.
+[Route("products/new")]
+public sealed class CreateProductPage(IDbContextFactory<CatalogDbContext> dbContextFactory, Navigator navigator)
+    : Component
+{
+    private readonly CreateProductForm _form = new();
+
+    protected override RenderResult Head => Title()["New product — Rask EF Core"];
+
+    private async Task SubmitAsync(CreateProductForm form)
+    {
+        // The form already passed the same rules the domain enforces; Create is the final guard.
+        var product = Product.Create(form.Name, form.Price, form.Stock);
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        db.Products.Add(product);
+        await db.SaveChangesAsync(CancellationToken);
+
+        navigator.Navigate("/products");
+    }
+
+    protected override RenderResult Render() =>
+        Div(Class: "card shadow-sm border-0 mx-auto", Style: "max-width: 32rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h4 mb-3")["New product"],
+                Form(_form, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
+                    Div()[
+                        Label("p-name", Class: "form-label small mb-1")["Name"],
+                        Input(() => _form.Name, Validate: ProductName.Validate,
+                            Id: "p-name", Class: "form-control"),
+                        ValidationMessage(() => _form.Name, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-price", Class: "form-label small mb-1")["Price"],
+                        Input(() => _form.Price, Validate: Money.Validate,
+                            Id: "p-price", Class: "form-control", Step: "0.01"),
+                        ValidationMessage(() => _form.Price, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-stock", Class: "form-label small mb-1")["Stock"],
+                        Input(() => _form.Stock, Validate: StockLevel.Validate,
+                            Id: "p-stock", Class: "form-control"),
+                        ValidationMessage(() => _form.Stock, FieldErrors.Template)
+                    ],
+                    Div(Class: "d-flex justify-content-end gap-2 pt-2")[
+                        NavLink("/products", Class: "btn btn-outline-secondary")["Cancel"],
+                        Button("submit", Class: "btn btn-primary")[
+                            I(Class: "bi bi-check2-circle me-1"), "Add product"
+                        ]
+                    ]
+                ]
+            ]
+        ];
+}
+
+// The slice's own input model: mutable primitives the inputs bind to. It maps onto the aggregate's
+// value objects at submit time.
+public sealed class CreateProductForm
+{
+    public string Name { get; set; } = "";
+    public decimal Price { get; set; } = 1m;
+    public int Stock { get; set; }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/EditProduct/EditProductPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/EditProduct/EditProductPage.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+using Rask.Example.EfCore.Shared.Forms;
+
+namespace Rask.Example.EfCore.Features.Catalog.EditProduct;
+
+// Vertical slice: edit a product (a command). Loads the current values into its own form, then on
+// submit loads the tracked aggregate and mutates it through Product.Update so the invariants and
+// the same value-object validation rules apply.
+[Route("products/{id:int}/edit")]
+public sealed class EditProductPage(IDbContextFactory<CatalogDbContext> dbContextFactory, Navigator navigator)
+    : Component
+{
+    private readonly EditProductForm _form = new();
+    private bool _loaded;
+    private bool _found;
+
+    [RouteParam] public int Id { get; set; }
+
+    protected override RenderResult Head => Title()["Edit product — Rask EF Core"];
+
+    // Fires on first render and whenever Id changes — load the row to edit into the form.
+    protected override async Task OnPropsChangedAsync()
+    {
+        _loaded = false;
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        var product = await db.Products
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == Id, CancellationToken);
+
+        _found = product is not null;
+        if (product is not null)
+        {
+            _form.Name = product.Name.Value;
+            _form.Price = product.Price.Amount;
+            _form.Stock = product.Stock.Value;
+        }
+
+        _loaded = true;
+    }
+
+    private async Task SubmitAsync(EditProductForm form)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        var product = await db.Products.FirstOrDefaultAsync(p => p.Id == Id, CancellationToken);
+        if (product is not null)
+        {
+            product.Update(form.Name, form.Price, form.Stock);
+            await db.SaveChangesAsync(CancellationToken);
+        }
+
+        navigator.Navigate("/products");
+    }
+
+    protected override RenderResult Render()
+    {
+        if (!_loaded)
+        {
+            return Div(Class: "text-secondary")[
+                Span(Class: "spinner-border spinner-border-sm me-2"), "Loading…"
+            ];
+        }
+
+        if (!_found)
+        {
+            return Div(Class: "alert alert-warning")[
+                "Product not found. ", NavLink("/products")["Back to the list"], "."
+            ];
+        }
+
+        return Div(Class: "card shadow-sm border-0 mx-auto", Style: "max-width: 32rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h4 mb-3")["Edit product"],
+                Form(_form, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
+                    Div()[
+                        Label("p-name", Class: "form-label small mb-1")["Name"],
+                        Input(() => _form.Name, Validate: ProductName.Validate,
+                            Id: "p-name", Class: "form-control"),
+                        ValidationMessage(() => _form.Name, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-price", Class: "form-label small mb-1")["Price"],
+                        Input(() => _form.Price, Validate: Money.Validate,
+                            Id: "p-price", Class: "form-control", Step: "0.01"),
+                        ValidationMessage(() => _form.Price, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-stock", Class: "form-label small mb-1")["Stock"],
+                        Input(() => _form.Stock, Validate: StockLevel.Validate,
+                            Id: "p-stock", Class: "form-control"),
+                        ValidationMessage(() => _form.Stock, FieldErrors.Template)
+                    ],
+                    Div(Class: "d-flex justify-content-end gap-2 pt-2")[
+                        NavLink("/products", Class: "btn btn-outline-secondary")["Cancel"],
+                        Button("submit", Class: "btn btn-primary")[
+                            I(Class: "bi bi-check2-circle me-1"), "Save changes"
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}
+
+public sealed class EditProductForm
+{
+    public string Name { get; set; } = "";
+    public decimal Price { get; set; } = 1m;
+    public int Stock { get; set; }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+
+namespace Rask.Example.EfCore.Features.Catalog.ListProducts;
+
+// Vertical slice: list the catalogue (a query) and delete a row (a command). It talks to EF Core
+// directly through the context factory — no repository abstraction — which is the vertical-slice
+// stance: each slice owns its own data access.
+[Route("/")]
+[Route("products")]
+public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbContextFactory) : Component
+{
+    private IReadOnlyList<Product> _products = [];
+    private bool _loaded;
+
+    protected override RenderResult Head => Title()["Products — Rask EF Core"];
+
+    // Runs on every mount — navigating back from the create/edit slices remounts this page, so the
+    // list always reflects the latest committed state.
+    protected override async Task OnMountAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        _products = await db.Products
+            .AsNoTracking()
+            .OrderBy(p => p.Id)
+            .ToListAsync(CancellationToken);
+        _loaded = true;
+    }
+
+    private async Task DeleteAsync(int id)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        await db.Products.Where(p => p.Id == id).ExecuteDeleteAsync(CancellationToken);
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    protected override RenderResult Render() =>
+    [
+        Div(Class: "d-flex justify-content-between align-items-center mb-3")[
+            Div()[
+                H1(Class: "h3 mb-1")["Products"],
+                P(Class: "text-secondary mb-0")["EF Core + SQLite CRUD, organised as vertical slices."]
+            ],
+            NavLink("/products/new", Class: "btn btn-primary")[
+                I(Class: "bi bi-plus-lg me-1"), "New product"
+            ]
+        ],
+        !_loaded
+            ? Div(Class: "text-secondary")[
+                Span(Class: "spinner-border spinner-border-sm me-2"), "Loading…"
+            ]
+            : _products.Count == 0
+                ? Div(Class: "alert alert-info")["No products yet — click \"New product\" to add one."]
+                : Table(Class: "table table-striped align-middle bg-white shadow-sm rounded overflow-hidden")[
+                    Thead()[
+                        Tr()[
+                            Th()["#"],
+                            Th()["Name"],
+                            Th(Class: "text-end")["Price"],
+                            Th(Class: "text-end")["Stock"],
+                            Th()[""]
+                        ]
+                    ],
+                    Tbody()[
+                        _products.Select(p => Tr(Key: p.Id)[
+                            Td(Class: "text-muted")[p.Id.ToString(CultureInfo.InvariantCulture)],
+                            Td(Class: "fw-semibold")[p.Name.Value],
+                            Td(Class: "text-end")[p.Price.ToString()],
+                            Td(Class: "text-end")[p.Stock.Value.ToString(CultureInfo.InvariantCulture)],
+                            Td(Class: "text-end text-nowrap")[
+                                NavLink($"/products/{p.Id}/edit", Class: "btn btn-outline-secondary btn-sm me-1")[
+                                    I(Class: "bi bi-pencil")
+                                ],
+                                Button("button", Class: "btn btn-outline-danger btn-sm",
+                                    OnClickAsync: () => DeleteAsync(p.Id))[
+                                    I(Class: "bi bi-trash")
+                                ]
+                            ]
+                        ])
+                    ]
+                ]
+    ];
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogDbContext.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// The Catalog bounded context's DbContext. Resolved through IDbContextFactory (see Program.cs),
+// so every slice gets a fresh short-lived instance per operation rather than a long-lived one
+// pinned to the WebSocket session.
+public sealed class CatalogDbContext(DbContextOptions<CatalogDbContext> options) : DbContext(options)
+{
+    public DbSet<Product> Products => Set<Product>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(CatalogDbContext).Assembly);
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogSeeder.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogSeeder.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Ensures the schema exists and seeds a few products on startup. Seeding goes through the
+// aggregate's Create factory (not raw column values), so even the seed data honours the invariants.
+// EnsureCreated (rather than migrations) is the simplest correct choice for a sample with no
+// schema history — a real app with an evolving schema would use db.Database.MigrateAsync().
+public static class CatalogSeeder
+{
+    public static async Task SeedAsync(IDbContextFactory<CatalogDbContext> dbContextFactory)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        await db.Database.EnsureCreatedAsync();
+
+        if (await db.Products.AnyAsync())
+        {
+            return;
+        }
+
+        db.Products.AddRange(
+            Product.Create("Mechanical keyboard", 89.00m, 12),
+            Product.Create("27\" 4K monitor", 329.00m, 5),
+            Product.Create("USB-C hub", 39.50m, 40));
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/Money.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/Money.cs
@@ -1,0 +1,50 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Value object for a price. The validation rule lives here and is reused verbatim by the inline
+// form validator (Input(..., Validate: Money.Validate)) and by FromDecimal — one source of truth.
+//
+// Money is stored as integer minor units (cents). SQLite has no native decimal type: EF Core
+// would map a decimal to a TEXT column and fall back to REAL for ORDER BY / aggregates, which is
+// lossy and sorts lexicographically. An INTEGER cents column is exact, correctly sortable, and is
+// the conventional way to model money — so the value object earns its keep.
+public readonly record struct Money
+{
+    public const decimal MaxAmount = 1_000_000m;
+
+    public long Cents { get; }
+
+    private Money(long cents) => Cents = cents;
+
+    public decimal Amount => Cents / 100m;
+
+    // The single rule, shaped as Func<decimal, IEnumerable<string>> so the form can pass it
+    // straight to Rask's inline Validate: parameter as a method group.
+    public static IEnumerable<string> Validate(decimal amount)
+    {
+        if (amount <= 0m)
+        {
+            yield return "Price must be greater than zero.";
+        }
+        else if (amount > MaxAmount)
+        {
+            yield return $"Price must be {MaxAmount:N0} or less.";
+        }
+    }
+
+    // Domain construction — enforces the same rule as a last line of defence.
+    public static Money FromDecimal(decimal amount)
+    {
+        var errors = Validate(amount).ToList();
+        if (errors.Count > 0)
+        {
+            throw new ArgumentException(string.Join(" ", errors), nameof(amount));
+        }
+
+        return new Money((long)decimal.Round(amount * 100m, MidpointRounding.ToEven));
+    }
+
+    // Rehydration from the persisted INTEGER column (already-valid data).
+    public static Money FromCents(long cents) => new(cents);
+
+    public override string ToString() => Amount.ToString("C");
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/Product.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/Product.cs
@@ -1,0 +1,38 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// The Catalog aggregate root. State is encapsulated behind private setters and only changes
+// through Create / Update, which compose the value objects — so an invalid Product can't exist.
+// Slices construct and mutate it through these methods (the ubiquitous language), never by
+// reaching in and setting properties.
+public sealed class Product
+{
+    // EF Core materialisation ctor — never used by application code.
+    private Product()
+    {
+    }
+
+    private Product(ProductName name, Money price, StockLevel stock)
+    {
+        Name = name;
+        Price = price;
+        Stock = stock;
+    }
+
+    public int Id { get; private set; }
+
+    public ProductName Name { get; private set; }
+
+    public Money Price { get; private set; }
+
+    public StockLevel Stock { get; private set; }
+
+    public static Product Create(string name, decimal price, int stock) =>
+        new(ProductName.From(name), Money.FromDecimal(price), StockLevel.From(stock));
+
+    public void Update(string name, decimal price, int stock)
+    {
+        Name = ProductName.From(name);
+        Price = Money.FromDecimal(price);
+        Stock = StockLevel.From(stock);
+    }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductConfiguration.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// EF Core entity configuration: maps the aggregate's value objects onto SQLite columns via value
+// converters. Keeping the mapping in an IEntityTypeConfiguration (applied with
+// ApplyConfigurationsFromAssembly) keeps the domain model free of persistence concerns.
+public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> entity)
+    {
+        entity.HasKey(p => p.Id);
+
+        entity.Property(p => p.Name)
+            .HasConversion(name => name.Value, value => ProductName.From(value))
+            .IsRequired()
+            .HasMaxLength(ProductName.MaxLength);
+
+        // Money <-> INTEGER minor units. No decimal column at all (SQLite has no decimal type).
+        entity.Property(p => p.Price)
+            .HasConversion(money => money.Cents, cents => Money.FromCents(cents));
+
+        entity.Property(p => p.Stock)
+            .HasConversion(stock => stock.Value, value => StockLevel.From(value));
+    }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductName.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductName.cs
@@ -1,0 +1,37 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Value object for a product's name. As with Money, the rule lives on the value object and is
+// reused by the inline form validator (Input(..., Validate: ProductName.Validate)) and by From.
+public readonly record struct ProductName
+{
+    public const int MaxLength = 120;
+
+    public string Value { get; }
+
+    private ProductName(string value) => Value = value;
+
+    public static IEnumerable<string> Validate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield return "Name is required.";
+        }
+        else if (value.Trim().Length > MaxLength)
+        {
+            yield return $"Name must be {MaxLength} characters or fewer.";
+        }
+    }
+
+    public static ProductName From(string value)
+    {
+        var errors = Validate(value).ToList();
+        if (errors.Count > 0)
+        {
+            throw new ArgumentException(string.Join(" ", errors), nameof(value));
+        }
+
+        return new ProductName(value.Trim());
+    }
+
+    public override string ToString() => Value;
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/StockLevel.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/StockLevel.cs
@@ -1,0 +1,31 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Value object for on-hand stock. Same pattern: the rule lives here and is reused by the inline
+// form validator (Input(..., Validate: StockLevel.Validate)) and by From.
+public readonly record struct StockLevel
+{
+    public int Value { get; }
+
+    private StockLevel(int value) => Value = value;
+
+    public static IEnumerable<string> Validate(int value)
+    {
+        if (value < 0)
+        {
+            yield return "Stock cannot be negative.";
+        }
+    }
+
+    public static StockLevel From(int value)
+    {
+        var errors = Validate(value).ToList();
+        if (errors.Count > 0)
+        {
+            throw new ArgumentException(string.Join(" ", errors), nameof(value));
+        }
+
+        return new StockLevel(value);
+    }
+
+    public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/samples/Rask.Example.EfCore/Program.cs
+++ b/samples/Rask.Example.EfCore/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Example.EfCore;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+using Rask.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRask();
+
+// IDbContextFactory rather than a scoped DbContext: a Rask Server live session is long-lived over
+// a WebSocket, so a session-scoped DbContext would outlive any unit of work (and a DbContext is
+// neither thread-safe nor meant to be long-lived). Each slice opens a short-lived context per
+// operation via the factory. RASK_DB_PATH lets the E2E fixture point at an isolated temp file.
+var dbPath = builder.Configuration["RASK_DB_PATH"] ?? "raskExampleCatalog.db";
+builder.Services.AddDbContextFactory<CatalogDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+
+var app = builder.Build();
+
+// Create the schema and seed sample data once at startup.
+await CatalogSeeder.SeedAsync(app.Services.GetRequiredService<IDbContextFactory<CatalogDbContext>>());
+
+// UseStaticFiles before UseRouting so static files win over Rask's catch-all route.
+app.UseStaticFiles();
+app.UseRouting();
+app.UseRask<App>();
+
+app.Run();

--- a/samples/Rask.Example.EfCore/README.md
+++ b/samples/Rask.Example.EfCore/README.md
@@ -1,0 +1,40 @@
+# Rask.Example.EfCore
+
+A Rask **Server** sample showing data persistence with **EF Core + SQLite** — a small product
+catalogue with full CRUD (list, create, edit, delete).
+
+```bash
+dotnet run --project samples/Rask.Example.EfCore
+# open the printed URL at /products
+```
+
+The full write-up is in [docs/data-access.md](../../docs/data-access.md). In short, it demonstrates:
+
+- **`IDbContextFactory<CatalogDbContext>`**, not a scoped `DbContext`. A Rask live session is
+  long-lived over a WebSocket, so each slice opens a short-lived context per operation
+  (`await using var db = await dbContextFactory.CreateDbContextAsync(ct)`).
+- **Vertical slice architecture** — code is grouped by use case under `Features/Catalog/`
+  (`ListProducts`, `CreateProduct`, `EditProduct`), each slice self-contained with its own form and
+  EF Core access. No repository/service layers. App-wide shared bits live in `Shared/`; the Catalog
+  domain shared across slices lives in `Features/Catalog/Shared/`.
+- **DDD tactical patterns** — `Product` is an aggregate root (private setters, `Create` / `Update`
+  only); `Money`, `ProductName`, and `StockLevel` are value objects. Each value object **owns its
+  validation rule**, reused verbatim by the inline form validators (`Validate: Money.Validate`) and
+  enforced again on construction.
+- **EF Core entity configuration** — mapping lives in `IEntityTypeConfiguration<Product>`
+  (`ApplyConfigurationsFromAssembly`), with value converters for the value objects.
+- **The SQLite decimal gotcha** — SQLite has no decimal type, so `Money` is stored as integer minor
+  units (cents) in an `INTEGER` column: exact, sortable, lossless.
+- **Built-in inline validation** — Rask.Core's `Validate:` lambdas, no validation package.
+
+## Database file
+
+The SQLite file (`raskExampleCatalog.db`, gitignored) is created and seeded on first run via
+`EnsureCreatedAsync()`. Set `RASK_DB_PATH` to point at a different file (the E2E test uses this to
+isolate each run). Delete the file to reset to the seed data.
+
+## Tests
+
+- `tests/Rask.Example.EfCore.Tests` — unit tests for the domain + EF/SQLite integration tests
+  (round-trip + proof that price is stored as `INTEGER`).
+- `tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs` — a Playwright CRUD smoke test.

--- a/samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj
+++ b/samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+  </ItemGroup>
+
+  <!-- The ASP.NET Web SDK requires a wwwroot to exist even when there are no static files. -->
+  <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="wwwroot"/>
+  </Target>
+
+</Project>

--- a/samples/Rask.Example.EfCore/Shared/App.cs
+++ b/samples/Rask.Example.EfCore/Shared/App.cs
@@ -1,0 +1,38 @@
+namespace Rask.Example.EfCore;
+
+// App shell: the framework-managed <head> (Bootstrap + icons via CDN), a navbar, and a Router
+// that renders the matched slice page. Only this component renders the Doctype/Html/Head/Body
+// shell — the slice pages return body fragments (RASK021).
+public sealed class App : Component
+{
+    protected override RenderResult Head =>
+    [
+        Title()["Rask — EF Core + SQLite"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
+
+    protected override RenderResult Render() =>
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container")[
+                        NavLink("/", Class: "navbar-brand fw-bold")[
+                            I(Class: "bi bi-database me-2"), "Rask · EF Core catalog"
+                        ],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container py-4")[Router()]
+            ]
+        ]
+    ];
+}

--- a/samples/Rask.Example.EfCore/Shared/Forms/FieldErrors.cs
+++ b/samples/Rask.Example.EfCore/Shared/Forms/FieldErrors.cs
@@ -1,0 +1,9 @@
+namespace Rask.Example.EfCore.Shared.Forms;
+
+// Shared ValidationMessage template — renders a field's inline messages under its input.
+// Used by every slice's form, so it lives in the app-wide Shared/ folder rather than a slice.
+public static class FieldErrors
+{
+    public static Component Template(IReadOnlyList<string> messages) =>
+        Fragment()[messages.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
+}

--- a/tests/Rask.Example.EfCore.Tests/CatalogDomainTests.cs
+++ b/tests/Rask.Example.EfCore.Tests/CatalogDomainTests.cs
@@ -1,0 +1,97 @@
+using Rask.Example.EfCore.Features.Catalog.Shared;
+
+namespace Rask.Example.EfCore.Tests;
+
+// The DDD core: the value objects own the validation rules (reused by the inline form validators)
+// and the aggregate enforces them on construction. These are pure unit tests — no browser, no DB.
+public sealed class CatalogDomainTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Money_Validate_RejectsNonPositive(decimal amount)
+    {
+        Assert.Contains("Price must be greater than zero.", Money.Validate(amount));
+    }
+
+    [Fact]
+    public void Money_Validate_RejectsAboveMax()
+    {
+        Assert.NotEmpty(Money.Validate(Money.MaxAmount + 1m));
+    }
+
+    [Fact]
+    public void Money_Validate_AcceptsValid() => Assert.Empty(Money.Validate(12.34m));
+
+    [Fact]
+    public void Money_StoresMinorUnits_AndRoundTrips()
+    {
+        var money = Money.FromDecimal(12.34m);
+        Assert.Equal(1234, money.Cents);
+        Assert.Equal(12.34m, money.Amount);
+        Assert.Equal(money, Money.FromCents(money.Cents));
+    }
+
+    [Fact]
+    public void Money_FromDecimal_RoundsToNearestCent()
+    {
+        Assert.Equal(1234, Money.FromDecimal(12.344m).Cents); // rounds down
+        Assert.Equal(1235, Money.FromDecimal(12.346m).Cents); // rounds up
+        Assert.Equal(1234, Money.FromDecimal(12.345m).Cents); // banker's rounding: .5 -> nearest even
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ProductName_Validate_RequiresText(string value)
+    {
+        Assert.Contains("Name is required.", ProductName.Validate(value));
+    }
+
+    [Fact]
+    public void ProductName_Validate_RejectsTooLong()
+    {
+        Assert.NotEmpty(ProductName.Validate(new string('x', ProductName.MaxLength + 1)));
+    }
+
+    [Fact]
+    public void ProductName_From_Trims() => Assert.Equal("Widget", ProductName.From("  Widget  ").Value);
+
+    [Fact]
+    public void StockLevel_Validate_RejectsNegative() =>
+        Assert.Contains("Stock cannot be negative.", StockLevel.Validate(-1));
+
+    [Fact]
+    public void StockLevel_Validate_AcceptsZeroAndPositive()
+    {
+        Assert.Empty(StockLevel.Validate(0));
+        Assert.Empty(StockLevel.Validate(40));
+    }
+
+    [Fact]
+    public void Product_Create_BuildsValidAggregate()
+    {
+        var product = Product.Create("Keyboard", 89.00m, 12);
+        Assert.Equal("Keyboard", product.Name.Value);
+        Assert.Equal(89.00m, product.Price.Amount);
+        Assert.Equal(12, product.Stock.Value);
+    }
+
+    [Fact]
+    public void Product_Create_RejectsInvalidInvariants()
+    {
+        Assert.Throws<ArgumentException>(() => Product.Create("", 10m, 1));
+        Assert.Throws<ArgumentException>(() => Product.Create("Ok", 0m, 1));
+        Assert.Throws<ArgumentException>(() => Product.Create("Ok", 10m, -1));
+    }
+
+    [Fact]
+    public void Product_Update_AppliesNewValues()
+    {
+        var product = Product.Create("Old", 10m, 1);
+        product.Update("New", 25.50m, 7);
+        Assert.Equal("New", product.Name.Value);
+        Assert.Equal(25.50m, product.Price.Amount);
+        Assert.Equal(7, product.Stock.Value);
+    }
+}

--- a/tests/Rask.Example.EfCore.Tests/CatalogPersistenceTests.cs
+++ b/tests/Rask.Example.EfCore.Tests/CatalogPersistenceTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+
+namespace Rask.Example.EfCore.Tests;
+
+// Integration tests against a real SQLite database file: they prove the entity configuration's
+// value-object converters persist and rehydrate correctly, and — answering "does SQLite support
+// decimal?" — that Money is stored as an exact INTEGER (minor units), never a lossy decimal/REAL.
+public sealed class CatalogPersistenceTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-efcore-test-{Guid.NewGuid():N}.db");
+
+    private CatalogDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        return new CatalogDbContext(options);
+    }
+
+    [Fact]
+    public async Task Product_RoundTripsThroughSqlite()
+    {
+        await using (var db = NewContext())
+        {
+            await db.Database.EnsureCreatedAsync();
+            db.Products.Add(Product.Create("Mechanical keyboard", 89.95m, 12));
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = NewContext())
+        {
+            var product = await db.Products.SingleAsync();
+            Assert.Equal("Mechanical keyboard", product.Name.Value);
+            Assert.Equal(89.95m, product.Price.Amount);
+            Assert.Equal(12, product.Stock.Value);
+        }
+    }
+
+    [Fact]
+    public async Task Price_IsStoredAsIntegerMinorUnits()
+    {
+        await using var db = NewContext();
+        await db.Database.EnsureCreatedAsync();
+        db.Products.Add(Product.Create("Hub", 39.50m, 1));
+        await db.SaveChangesAsync();
+
+        // The raw column holds cents as an integer — exact and sortable, with no decimal/REAL column.
+        // EF's scalar SqlQueryRaw<T> requires the single result column to be aliased "Value".
+        var cents = await db.Database.SqlQueryRaw<long>("SELECT Price AS Value FROM Products").SingleAsync();
+        Assert.Equal(3950, cents);
+
+        var columnType = await db.Database
+            .SqlQueryRaw<string>("SELECT type AS Value FROM pragma_table_info('Products') WHERE name = 'Price'")
+            .SingleAsync();
+        Assert.Equal("INTEGER", columnType);
+    }
+
+    [Fact]
+    public async Task Update_PersistsMutationThroughTrackedAggregate()
+    {
+        int id;
+        await using (var db = NewContext())
+        {
+            await db.Database.EnsureCreatedAsync();
+            var created = Product.Create("Old name", 10m, 1);
+            db.Products.Add(created);
+            await db.SaveChangesAsync();
+            id = created.Id;
+        }
+
+        await using (var db = NewContext())
+        {
+            var product = await db.Products.SingleAsync(p => p.Id == id);
+            product.Update("New name", 25.50m, 9);
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = NewContext())
+        {
+            var product = await db.Products.SingleAsync(p => p.Id == id);
+            Assert.Equal("New name", product.Name.Value);
+            Assert.Equal(25.50m, product.Price.Amount);
+            Assert.Equal(9, product.Stock.Value);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in new[] { _dbPath, $"{_dbPath}-shm", $"{_dbPath}-wal" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
+++ b/tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\Rask.Example.EfCore\Rask.Example.EfCore.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+
+namespace Rask.Examples.E2E.Tests;
+
+// End-to-end CRUD round-trip against the EF Core + SQLite sample: create, edit and delete a product
+// through the UI, asserting each step persisted (the list re-reads from SQLite on every navigation).
+[Collection(EfCoreExampleCollection.Name)]
+public sealed class EfCoreCrudTests(EfCoreExampleAppFixture app, PlaywrightFixture pw) : IAsyncLifetime
+{
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task Create_Edit_Delete_RoundTripsThroughSqlite()
+    {
+        await _page.GotoAsync("/products");
+
+        // Seeded data is present on first load.
+        await Assertions.Expect(_page.Locator("tr:has-text('Mechanical keyboard')")).ToBeVisibleAsync();
+
+        // CREATE
+        await _page.ClickAsync("a:has-text('New product')");
+        await _page.FillAsync("#p-name", "E2E gadget");
+        await _page.FillAsync("#p-price", "12.34");
+        await _page.FillAsync("#p-stock", "7");
+        await _page.ClickAsync("button[type=submit]");
+
+        var createdRow = _page.Locator("tr:has-text('E2E gadget')");
+        await Assertions.Expect(createdRow).ToBeVisibleAsync();
+        await Assertions.Expect(createdRow).ToContainTextAsync("7");
+
+        // EDIT — follow the row's edit link, rename, save.
+        await createdRow.Locator("a.btn-outline-secondary").ClickAsync();
+        await _page.FillAsync("#p-name", "E2E gizmo");
+        await _page.ClickAsync("button[type=submit]");
+
+        await Assertions.Expect(_page.Locator("tr:has-text('E2E gizmo')")).ToBeVisibleAsync();
+        await Assertions.Expect(_page.Locator("tr:has-text('E2E gadget')")).ToHaveCountAsync(0);
+
+        // DELETE
+        await _page.Locator("tr:has-text('E2E gizmo')").Locator("button.btn-outline-danger").ClickAsync();
+        await Assertions.Expect(_page.Locator("tr:has-text('E2E gizmo')")).ToHaveCountAsync(0);
+    }
+
+    [Fact]
+    public async Task Create_RejectsInvalidInput_WithInlineMessages()
+    {
+        await _page.GotoAsync("/products/new");
+
+        // Blank name + non-positive price violate the value-object rules reused by the inline validators.
+        await _page.FillAsync("#p-price", "0");
+        await _page.ClickAsync("button[type=submit]");
+
+        await Assertions.Expect(_page.Locator("text=Name is required.")).ToBeVisibleAsync();
+        await Assertions.Expect(_page.Locator("text=Price must be greater than zero.")).ToBeVisibleAsync();
+
+        // Still on the create page — the invalid submit did not navigate away.
+        await Assertions.Expect(_page.Locator("#p-name")).ToBeVisibleAsync();
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/EfCoreExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/EfCoreExampleAppFixture.cs
@@ -1,0 +1,16 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+public sealed class EfCoreExampleAppFixture : ExampleAppFixture
+{
+    // A unique SQLite file per run so the CRUD test starts from the known seed and never sees
+    // state left by a previous run. The sample reads RASK_DB_PATH from configuration.
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"rask-efcore-e2e-{Guid.NewGuid():N}.db");
+
+    protected override string ProjectRelativePath => "samples/Rask.Example.EfCore";
+
+    protected override int Port => 5110;
+
+    protected override IReadOnlyDictionary<string, string>? ExtraEnvironment =>
+        new Dictionary<string, string> { ["RASK_DB_PATH"] = _dbPath };
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -8,6 +8,13 @@ public sealed class ServerExampleCollection
 }
 
 [CollectionDefinition(Name)]
+public sealed class EfCoreExampleCollection
+    : ICollectionFixture<EfCoreExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "EfCoreExample";
+}
+
+[CollectionDefinition(Name)]
 public sealed class WasmExampleCollection
     : ICollectionFixture<WasmExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
 {

--- a/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+++ b/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
@@ -40,6 +40,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\samples\Rask.Example.Server\Rask.Example.Server.csproj"
                       ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\samples\Rask.Example.EfCore\Rask.Example.EfCore.csproj"
+                      ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Auth\Rask.Example.Auth.csproj"
                       ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Auth.Jwt\Rask.Example.Auth.Jwt.csproj"


### PR DESCRIPTION
## Summary

Adds `samples/Rask.Example.EfCore` — a Server-host sample showing **data persistence with EF Core + SQLite**: a product catalogue with full CRUD (list / create / edit / delete). Fills the common "how do I use a database with Rask?" gap.

Design (incorporating the requested constraints):

- **`IDbContextFactory<CatalogDbContext>`**, not a scoped `DbContext` — a Rask live session is long-lived over the WebSocket, so each slice opens a short-lived context per operation.
- **Vertical slice architecture** (not clean/layered): code grouped by use case under `Features/Catalog/` (`ListProducts`, `CreateProduct`, `EditProduct`), each slice owning its form + EF access. No repository/service layers. App-wide shared bits in `Shared/`; the Catalog domain shared across slices in `Features/Catalog/Shared/`.
- **DDD tactical patterns**: `Product` aggregate root (private setters; `Create`/`Update` only) with `Money`, `ProductName`, `StockLevel` value objects. Each value object **owns its validation rule**, reused verbatim by the inline form validators (`Validate: Money.Validate`) and enforced again on construction — a single source of truth.
- **Built-in inline validation** (`Validate:` lambdas in `Rask.Core`), not the DataAnnotations validator. The sample opts out of the validation global-usings injection in `Directory.Build.props`, like the auth samples.
- **EF Core entity configuration** in `IEntityTypeConfiguration<Product>` (`ApplyConfigurationsFromAssembly`) with value converters.
- **SQLite has no decimal type**, so `Money` is stored as integer minor units (cents) in an `INTEGER` column — exact, sortable, lossless.

## Testing

- `tests/Rask.Example.EfCore.Tests` — **18 passing**: domain unit tests (value-object rules, aggregate invariants) + EF/SQLite **integration tests** that round-trip a `Product` through a real SQLite file and assert the `Price` column is stored as `INTEGER` (proving the decimal workaround).
- `tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs` — Playwright CRUD smoke test (create → edit → delete) + an invalid-input test; runs in CI's sharded E2E job. (The Playwright browser driver is broken in my local sandbox — the existing `ServerExampleTests` fails identically — so I validated the running app manually over HTTP and covered the logic with the unit/integration suite.)
- Full non-E2E suite green; all changed projects build warnings-as-errors clean; `dotnet format` clean.
- No benchmarks: sample + tests + docs only, no render/runtime hot-path code.

## Docs / changelog

New `docs/data-access.md`; entries in `README.md`, `docs/README.md`, `llms.txt`, the sample `README.md`, and a `CHANGELOG.md` `[Unreleased]` line. `.gitignore` ignores the runtime DB file.

## Verify locally

```bash
dotnet run --project samples/Rask.Example.EfCore   # open /products
dotnet test tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
```