### PR TITLE
ci: fetch full history in pages workflow so MinVer resolves the version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0 # MinVer needs full history + tags to resolve the version
 
       - uses: actions/setup-dotnet@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- GitHub Pages demo showed `v1.0.0` instead of the released version in the navbar badge. The
+  `pages` workflow checked out a shallow clone, so MinVer couldn't read the git tags and the
+  assembly kept the .NET default informational version. The workflow now fetches full history
+  (`fetch-depth: 0`), matching the CI/release/nightly workflows, so `RaskVersion.Current`
+  reflects the real tag.
 - Showcase samples no longer 404 on `bootstrap.min.css.map`: the vendored `bootstrap.min.css`
   carried a `sourceMappingURL` comment pointing at a map file that isn't shipped, so browsers
   (and the GitHub Pages demo) logged a console 404. Dropped the dangling comment.


### PR DESCRIPTION
## Summary

The deployed GitHub Pages showcase (`Rask.Example.Wasm`) always showed a **v1.0.0** version badge in the navbar, regardless of the latest release tag (currently `v0.7.0`).

**Root cause:** the `pages` workflow's `actions/checkout` step did a shallow clone (default depth, no tags). [MinVer](https://github.com/adamralph/minver) needs full git history + tags to derive the version, so it couldn't, and `Rask.Core` kept the .NET default `AssemblyInformationalVersion` of `1.0.0`. The navbar badge (`ShowcaseLayout.cs` → `RaskVersion.Current`, which reads that attribute) then rendered `v1.0.0`.

The `ci`, `release`, and `nightly` workflows already set `fetch-depth: 0`; `pages` was the only one missing it.

## Change

- `.github/workflows/pages.yml`: add `fetch-depth: 0` to the checkout step.

## Testing

- CI-config-only change — no framework/render code touched, so no benchmarks and no unit/E2E coverage applies (workflow YAML isn't exercised by the test suites).
- Verifiable after merge: the `pages` workflow runs on `main` and the deployed badge should reflect the real tag (e.g. `v0.7.0` / a MinVer height-bumped prerelease) instead of `v1.0.0`.

## Changelog

Added an `[Unreleased] → Fixed` entry.