### PR TITLE
refactor!: remove Component.User; + EF Core sample + session-removal race fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,11 @@ ehthumbs.db
 Desktop.ini
 $RECYCLE.BIN/
 
+# EF Core SQLite sample database (created at runtime by samples/Rask.Example.EfCore)
+raskExampleCatalog.db
+raskExampleCatalog.db-shm
+raskExampleCatalog.db-wal
+
 # Coverage
 *.coverage
 *.coveragexml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,31 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **WASM build migrated to `Microsoft.NET.Sdk.WebAssembly`** so framework assets are
+  content-fingerprinted (`dotnet.<hash>.js`, `App.<hash>.wasm`) and `index.html` carries an
+  SDK-generated import map with integrity hashes. This fixes the GitHub Pages (and any static
+  host) failure where a redeploy paired a stale, browser-cached integrity manifest with freshly
+  served assemblies and tripped a subresource-integrity error on every `_framework/*.wasm` until
+  the cache expired — fingerprinted URLs change per release, so a stale asset can never collide
+  with a new manifest. **Breaking for downstream WASM consumers:** set
+  `<Project Sdk="Microsoft.NET.Sdk.WebAssembly">`, replace `<WasmGenerateAppBundle>true` with
+  `<RaskWasm>true</RaskWasm>` + `<OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>`,
+  and add a `wwwroot/index.html` shell (the `dotnet new rask-wasm*` templates already include
+  one). Published output moves from `bin/<cfg>/net10.0-browser/browser-wasm/AppBundle/` to
+  `bin/<cfg>/net10.0-browser/publish/wwwroot/`; `Rask.Wasm.Hosting`'s `UseRask()` follows it
+  automatically. Sub-path deploys keep `/p:RaskPathBase=/<repo>` (now a post-publish `<base href>`
+  rewrite; every other asset URL is document-relative).
+
 ### Fixed
+- `LiveSessionStore` no longer throws `ObjectDisposedException` while retiring pending session
+  removals under contention. `ScheduleRemoval` disposed the prior `CancellationTokenSource` from
+  inside an `AddOrUpdate` factory — i.e. while it was still reachable through `_pendingRemovals` —
+  so a concurrent `CancelPendingRemoval` / `CancelAllPending` (e.g. two sockets detaching at host
+  shutdown) could `TryRemove` the same instance in that window and call `Cancel()` on an
+  already-disposed source. The install now swaps atomically (`TryUpdate`/`TryAdd`) and retires the
+  prior source only after the CAS has made it unreachable, so exactly one thread owns its disposal.
+  Fixes flaky `Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative`.
 - Showcase samples no longer 404 on `bootstrap.min.css.map`: the vendored `bootstrap.min.css`
   carried a `sourceMappingURL` comment pointing at a map file that isn't shipped, so browsers
   (and the GitHub Pages demo) logged a console 404. Dropped the dangling comment.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ them until tagged releases begin.
 - Community health files: issue forms, PR template, `CODE_OF_CONDUCT.md`, `SECURITY.md`,
   `CODEOWNERS`, and `docs/repo-administration.md` — contributions open, maintainer merges.
 
+### Removed
+- **Breaking:** removed the `Component.User` convenience property. Components that need the current
+  principal now inject `IUserProvider` via the constructor and read `.Current` (a never-null
+  `ClaimsPrincipal`) — explicit, testable dependencies instead of a base-class service locator. The
+  built-in `Authorize` component, `[Authorize]` route gating, and the auth samples/templates are
+  unchanged in behaviour.
+
 ### Changed
 - Build is now **warnings-as-errors** with .NET analyzers and code-style enforced in-build
   (`Directory.Build.props`); see `docs/code-analysis.md`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ them until tagged releases begin.
   `*_OutsideLiveContext_OmitsHandlerAttribute` tests.
 
 ### Added
+- New `samples/Rask.Example.EfCore` sample: an EF Core + SQLite CRUD app (Server host) showing data
+  persistence in Rask. It uses `IDbContextFactory` (right for long-lived live sessions), organises
+  code as vertical slices (List/Create/Edit), models the catalogue with a DDD aggregate + value
+  objects whose validation rules are reused by the inline form validators, and stores money as
+  integer minor units to sidestep SQLite's lack of a decimal type. Covered by unit + EF/SQLite
+  integration tests (`Rask.Example.EfCore.Tests`) and a Playwright CRUD smoke test, and documented in
+  `docs/data-access.md`.
 - `RaskVersion.Current` exposes the running framework version (from the assembly's MinVer
   `InformationalVersion`). The server (`UseRask`) and WASM host log it on startup, and the
   showcase samples display it as a version badge.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -66,10 +66,11 @@
       The validation packages inject their own global usings (Rask.Validation.* below). Downstream
       consumers only get them by referencing the validation NuGet package; in-repo we'd otherwise force
       every Rask.Example.* project to reference the validation libs just to satisfy the generated usings.
-      The auth samples (Rask.Example.Auth*) don't use validation, so skip those usings for them.
+      The auth samples (Rask.Example.Auth*) don't use validation, and the EF Core sample
+      (Rask.Example.EfCore) uses Rask.Core's inline Validate: lambdas only — so skip those usings for them.
     -->
     <_RaskExampleValidationUsings>$(_RaskInRepoImplicitUsings)</_RaskExampleValidationUsings>
-    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) ">false</_RaskExampleValidationUsings>
+    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) OR $(MSBuildProjectName.StartsWith('Rask.Example.EfCore')) ">false</_RaskExampleValidationUsings>
   </PropertyGroup>
 
   <!--

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -14,6 +14,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />

--- a/README.md
+++ b/README.md
@@ -361,6 +361,11 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
   page shows both imperative `IUserProvider.Current` and the declarative `Authorize` component). These are the canonical
   references cited throughout *Core concepts* below. For production auth flows see *
   *[docs/authentication.md](docs/authentication.md)**.
+- **`samples/Rask.Example.EfCore`** — data persistence with **EF Core + SQLite** (Server host): a
+  CRUD catalogue organised as vertical slices, with a DDD aggregate + value objects, `IDbContextFactory`,
+  and money stored as integer minor units (SQLite has no decimal type). Run it with
+  `dotnet run --project samples/Rask.Example.EfCore` and open `/products`. Guide:
+  **[docs/data-access.md](docs/data-access.md)**.
 - **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
   (`/login`, a protected `/members`, role-gated admin content, sign-out) backed by a browser E2E:
     - **`Rask.Example.Auth`** — cookie + Server (the redeem handshake).

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ published WASM bundle. The **same component code runs under any host** — only 
 |  ✅  | **Forms with async validation**    | `Form<TModel>(model, OnValidSubmit: …)` routes submit through validators you opt into by dropping `DataAnnotationsValidator()` or `FluentValidationValidator(...)` inside the form. Implement `IAsyncFieldValidator` for ad-hoc server-side rules — the submit bridge awaits async checks before routing, and rapid keystrokes cancel any prior in-flight validation (latest-wins).                                                                                               |
 |  ⚡  | **Live diff codec**                | After first paint, a small state change ships a minimal edit-op payload instead of re-serializing the page — a counter tick on a 50 KB page goes from ~50 KB to ~57 bytes on the wire. On by default.                                                                                                                                                                                                                                                                             |
 | 🔑  | **Keyed lists**                    | Add a `Key:` to list items (Blazor `@key` parity) and inserts/removes/reorders reconcile by identity — shipping trusted structural diffs that preserve focus and input state on the survivors. A `RASK022` analyzer flags a list item that's missing a key.                                                                                                                                                                                                                       |
-| 🔐  | **Authentication, ASP.NET-native** | `Component.User` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
+| 🔐  | **Authentication, ASP.NET-native** | Inject `IUserProvider` and read `.Current` (a never-null `ClaimsPrincipal`) plus a headless `Authorize(Roles:, Policy:, Authorized:, NotAuthorized:, Authorizing:)` component for declarative gating, and `[Authorize]` on a page for route gating. No bespoke options — wire cookies/JWT/OIDC on ASP.NET's own `AddCookie`/`AddJwtBearer`/`AddAuthorization`. Runnable samples + `dotnet new --auth` cover cookie & JWT on both Server and WASM. See **[docs/authentication.md](docs/authentication.md)**. |
 
 ## ⚖️ Compared to Blazor
 
@@ -96,7 +96,7 @@ If you've worked in Blazor, here's how the day-to-day differs in Rask:
 | `RenderFragment` / `EventCallback`                | Children are `IEnumerable<Child>`; event handlers are plain delegates (`OnClick: () => _count++`). Child→parent callbacks are plain delegate props too (`Action<T>?` / `Func<T,Task>?`) — invoking one auto-re-renders the parent that owns it, no `EventCallback` wrapper. No specialised types, no `@bind-Value:event`. |
 | `.razor.css` association ceremony                 | Scoped CSS via a sibling `{Component}.css` (Blazor-parity descendant combinators) — auto-globbed at build time, hot-reloaded under `dotnet watch`. Same idea for JS: a sibling `{Component}.js` is bundled and dispatched by the framework.                                                                               |
 | Separate render modes to wire up                  | **Same component code on Server or WASM.** Pick the host package per project; you don't rewrite components when switching render mode. Server-only (multipart upload) and WASM-only (chunked file reads, inline downloads) behaviours live in the hosts, not in your tree.                                                |
-| `<AuthorizeView>` + `AuthenticationStateProvider` | `Component.User` everywhere (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface.                       |
+| `<AuthorizeView>` + `AuthenticationStateProvider` | Inject `IUserProvider` and read `.Current` (a never-null `ClaimsPrincipal`) and a headless `Authorize(...)` component with `Authorized`/`NotAuthorized`/`Authorizing` slots. Auth itself is configured on ASP.NET's **own** `AddCookie`/`AddJwtBearer`/`AddAuthorization` — Rask adds no parallel options surface.                       |
 
 Rask isn't a Blazor replacement so much as a different take on the same problem space. If those trade-offs appeal, the
 rest of this README walks through what they look like in practice.
@@ -358,7 +358,7 @@ Beyond the quick starts, the repo ships runnable showcase apps that exercise eve
 - **`samples/Rask.Example.Shared/Pages/`** — the feature-by-feature pages those hosts share: forms & validation,
   nested-form
   binding, routing, JS interop, virtualization (a 10K-row table), file upload/download, and **auth gating** (the `/user`
-  page shows both imperative `Component.User` and the declarative `Authorize` component). These are the canonical
+  page shows both imperative `IUserProvider.Current` and the declarative `Authorize` component). These are the canonical
   references cited throughout *Core concepts* below. For production auth flows see *
   *[docs/authentication.md](docs/authentication.md)**.
 - **Runnable auth samples — one per cell of the `{Cookie, JWT} × {Server, WASM}` matrix**, each a minimal app
@@ -605,12 +605,12 @@ built-in page if no app-defined one exists.
 </details>
 
 <details>
-<summary><b>🔐 Auth gating (built-in <code>User</code>)</b></summary>
+<summary><b>🔐 Auth gating (inject <code>IUserProvider</code>)</b></summary>
 <br>
 
-Every component exposes `Component.User` — a never-null `ClaimsPrincipal` resolved from the scoped `IUserProvider`
-(back it with a cookie/JWT on Server, or `/api/me` on WASM). Gate **imperatively** in `Render()` with plain C#, and
-subscribe to the provider's `Changed` event so a sign-in originating anywhere re-renders the gate:
+Inject `IUserProvider` via the constructor and read `.Current` — a never-null `ClaimsPrincipal` resolved from the
+scoped provider (back it with a cookie/JWT on Server, or `/api/me` on WASM). Gate **imperatively** in `Render()` with
+plain C#, and subscribe to the provider's `Changed` event so a sign-in originating anywhere re-renders the gate:
 
 ```csharp
 public sealed class AccountPanel : Component
@@ -622,10 +622,10 @@ public sealed class AccountPanel : Component
     protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
-        User.Identity?.IsAuthenticated == true
+        _auth.Current.Identity?.IsAuthenticated == true
             ? Fragment()[
-                P()["Signed in as ", Strong()[User.Identity!.Name ?? "?"]],
-                User.IsInRole("admin")                      // role-gated branch
+                P()["Signed in as ", Strong()[_auth.Current.Identity!.Name ?? "?"]],
+                _auth.Current.IsInRole("admin")             // role-gated branch
                     ? Div()["🔑 Admin-only panel"]
                     : (Child)Fragment()]
             : P()["You are signed out."];

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -10,6 +10,7 @@
         <Project Path="samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj"/>
         <Project Path="samples/Rask.Example.Auth.WasmJwt/Rask.Example.Auth.WasmJwt.csproj"/>
         <Project Path="samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj"/>
+        <Project Path="samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj"/>
         <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj"/>
         <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj"/>
         <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj"/>
@@ -28,6 +29,7 @@
     </Folder>
     <Folder Name="/tests/">
         <Project Path="tests/Rask.Core.Tests/Rask.Core.Tests.csproj"/>
+        <Project Path="tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj"/>
         <Project Path="tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj"/>
         <Project Path="tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj"/>
         <Project Path="tests/Rask.Example.Wasm.Host.Tests/Rask.Example.Wasm.Host.Tests.csproj"/>

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Guides and references for building with Rask. New here? Start with the project
 | [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), asset delivery. |
 | [Forms & validation](forms.md) | Two-way binding, `Form<T>`/`EditContext`, inline / DataAnnotations / FluentValidation / async validators, radio & checkbox groups. |
 | [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |
+| [Data access (EF Core)](data-access.md) | EF Core + SQLite in a Server app: `IDbContextFactory`, loading in the lifecycle, vertical slices, a DDD aggregate + value objects, and the SQLite decimal gotcha. |
 | [Authentication](authentication.md) | Production auth: cookie & JWT, Server & WASM, `Authorize`, route guards, Identity / Keycloak / Auth0 / Cognito / Duende. |
 | [Testing](testing.md) | Unit-testing components with `Rask.TestSupport`, driving event handlers, when to reach for E2E. |
 | [Migrating from Blazor](migration-from-blazor.md) | Concept mapping, behavioural gotchas, and what stays the same. |

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -26,7 +26,7 @@ Keycloak/OIDC, …). This guide shows the complete, copy-pasteable flow for each
 | Piece | What it is |
 |---|---|
 | `IUserProvider` | Scoped source of the current `ClaimsPrincipal` (`Current`), a `Changed` event, optional `EnsureLoadedAsync`/`RefreshAsync`, and `IsLoading`. Server: `SessionUserProvider` (seeded from `HttpContext.User`). WASM: you supply one (or the anonymous default). |
-| `Component.User` | The never-null `ClaimsPrincipal` resolved from `IUserProvider` in the active render scope. Gate in `Render()` on `User.Identity?.IsAuthenticated` / `User.IsInRole(...)`. |
+| Injecting `IUserProvider` | Inject it via the constructor and read `.Current` — the never-null `ClaimsPrincipal` for the active render scope. Gate in `Render()` on `provider.Current.Identity?.IsAuthenticated` / `provider.Current.IsInRole(...)`. |
 | `Authorize` component | Headless declarative gate with `Authorized` / `NotAuthorized` / `Authorizing` slots (see below). |
 | `IAuthSignIn` | Event-handler-only `SignInAsync(principal, returnUrl)` / `SignOutAsync(returnUrl)`. Server drives the cookie handshake; WASM signs out via `/auth/logout`. |
 | `[Authorize]` / `[AllowAnonymous]` | Route-level gating evaluated by `RouteAuthorizationGuard` → redirect to the auth scheme's `LoginPath` (401) or `AccessDeniedPath` (403). |
@@ -71,7 +71,7 @@ builder.Services.AddRask();              // no auth config here — it's all on 
 ## Declarative gating
 
 The headless `Authorize` component renders exactly one of three slots — no markup of its own — off
-`Component.User`:
+the current user (`IUserProvider`):
 
 ```csharp
 // Shorthand: children are the "authorized" branch.
@@ -91,8 +91,8 @@ Authorize(
 - **`Authorizing`** also covers the WASM bootstrap window: while a provider's `EnsureLoadedAsync`/`RefreshAsync`
   is in flight (`IUserProvider.IsLoading == true`), the slot bridges the anonymous→authenticated flash.
 
-Use `Authorize` for *content* gating; use `[Authorize]` on a page for *route* gating; use `Component.User`
-directly when you need imperative logic.
+Use `Authorize` for *content* gating; use `[Authorize]` on a page for *route* gating; inject `IUserProvider`
+and read `.Current` directly when you need imperative logic.
 
 ---
 
@@ -181,11 +181,11 @@ public sealed class SecurePage : Component
             Authorized:    SecureContent());     // child component → renders fresh when the gate opens
 }
 
-public sealed class SecureContent : Component
+public sealed class SecureContent(IUserProvider users) : Component
 {
     protected override RenderResult Render() =>
         Div()[
-            H1()[$"Hello, {User.Identity!.Name}"],
+            H1()[$"Hello, {users.Current.Identity!.Name}"],
             Authorize(Roles: ["admin"],
                 Authorized:    Div(Class: "alert alert-warning")["🔑 Admin tools"],
                 NotAuthorized: P()["You have standard access."])
@@ -195,8 +195,8 @@ public sealed class SecureContent : Component
 
 > **Reactivity.** Sign-in on the Server completes over a WS reconnect that re-seeds the principal and fires
 > `IUserProvider.Changed`. The `Authorize` component subscribes to that event and re-renders — but a page
-> that reads `User` *directly in its own `Render`* won't re-execute (it didn't subscribe), so a greeting
-> built there can go stale after a mid-session sign-in. Two fixes: put `User`-dependent markup inside a
+> that reads `users.Current` *directly in its own `Render`* won't re-execute (it didn't subscribe), so a greeting
+> built there can go stale after a mid-session sign-in. Two fixes: put principal-dependent markup inside a
 > **child component** in the `Authorized` slot (it first renders only once the gate opens, as above), or
 > subscribe the page itself: `OnMount() => users.Changed += StateHasChanged;`. The child-component form
 > needs no manual subscription.
@@ -683,7 +683,7 @@ host.Services.AddSingleton<LoginService>();
 await host.RunAsync<App>();
 ```
 
-`Component.User`, the `Authorize` component, and `[Authorize]` route gating all work against the decoded
+The injected `IUserProvider`, the `Authorize` component, and `[Authorize]` route gating all work against the decoded
 principal exactly as everywhere else — they just resolve from `JwtUserProvider` instead of a server-backed
 one. (Route-level `[Authorize]` redirects work client-side too, since the guard runs in the WASM session.)
 
@@ -799,7 +799,7 @@ public sealed class LoginPage(
 }
 ```
 
-Everything else (`Component.User`, `Authorize`, `[Authorize(Roles = "...")]`) works against the Identity
+Everything else (the injected `IUserProvider`, `Authorize`, `[Authorize(Roles = "...")]`) works against the Identity
 principal unchanged. Registration/2FA/lockout are standard Identity APIs called from your pages.
 
 ---

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -1,0 +1,133 @@
+# Data access (EF Core + SQLite)
+
+Rask has no data layer of its own — you use whatever .NET gives you. This guide shows the
+idiomatic way to wire **EF Core + SQLite** into a Rask **Server** app: register the context, load
+data in the component lifecycle, and run forms against persisted state. The runnable reference is
+[`samples/Rask.Example.EfCore`](../samples/Rask.Example.EfCore).
+
+> WASM note: this is a Server-side pattern. EF Core's SQLite provider isn't a fit for the trimmed
+> browser runtime — keep data access behind the server (a Server host, or an API the WASM app calls).
+
+## Register the DbContext with a factory, not a scope
+
+A Rask Server session is **long-lived**: it lives for as long as the browser holds the WebSocket
+open. A `DbContext`, by contrast, is meant to be short-lived and is not thread-safe. So do **not**
+register a scoped `DbContext` and inject it into a component — it would outlive every unit of work
+and be shared across overlapping renders. Register an `IDbContextFactory<T>` instead and open a
+fresh context per operation:
+
+```csharp
+builder.Services.AddDbContextFactory<CatalogDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+```
+
+```csharp
+await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+var products = await db.Products.AsNoTracking().OrderBy(p => p.Id).ToListAsync(CancellationToken);
+```
+
+`AddDbContextFactory` registers the factory as a singleton; each `CreateDbContextAsync` hands back a
+brand-new context you dispose at the end of the unit of work. Always pass `Component.CancellationToken`
+to the async EF calls so navigating away mid-query cancels cleanly.
+
+## Load in the lifecycle, render the result
+
+Read data in an async lifecycle hook and store it in a field. The async-hook continuation
+re-renders automatically when the `await` completes — no explicit `StateHasChanged()` needed (see
+[lifecycle.md](lifecycle.md)). Use `OnMountAsync` for a one-time load, `OnPropsChangedAsync` to
+reload when a route/query param changes.
+
+```csharp
+public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbContextFactory) : Component
+{
+    private IReadOnlyList<Product> _products = [];
+    private bool _loaded;
+
+    protected override async Task OnMountAsync()
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        _products = await db.Products.AsNoTracking().OrderBy(p => p.Id).ToListAsync(CancellationToken);
+        _loaded = true;
+    }
+
+    // ... Render() shows a spinner until _loaded, then the rows.
+}
+```
+
+For an event-handler mutation (e.g. a delete button), do the work, reload, then call
+`StateHasChanged()` explicitly:
+
+```csharp
+private async Task DeleteAsync(int id)
+{
+    await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+    await db.Products.Where(p => p.Id == id).ExecuteDeleteAsync(CancellationToken);
+    await LoadAsync();
+    StateHasChanged();
+}
+```
+
+## How the sample is organised
+
+The sample uses **vertical slices**: code is grouped by use case (`ListProducts`, `CreateProduct`,
+`EditProduct`), each slice owning its page, its own form model, and its own EF Core access — no
+shared repository or service layer. The only shared things are the app shell, a form-error template,
+and the Catalog domain.
+
+The domain applies **DDD tactical patterns**: `Product` is an aggregate root with private setters
+that only changes through `Create` / `Update`, and `Money` / `ProductName` / `StockLevel` are value
+objects. Each value object **owns its validation rule** as a static `Validate` method shaped exactly
+like Rask's inline validator (`Func<T, IEnumerable<string>>`), so the form and the domain enforce the
+same rule from one source:
+
+```csharp
+// In the value object:
+public static IEnumerable<string> Validate(decimal amount) { /* the one rule */ }
+
+// In the form (reused as a method group — see forms.md §3 for inline validation):
+Input(() => _form.Price, Validate: Money.Validate, Id: "p-price", Class: "form-control")
+```
+
+The EF Core mapping lives in an `IEntityTypeConfiguration<Product>` (applied with
+`ApplyConfigurationsFromAssembly`), keeping the domain free of persistence attributes. Value objects
+map onto columns with value converters.
+
+## Does SQLite support `decimal`? (the money gotcha)
+
+No — SQLite has no native decimal type. EF Core maps a `decimal` to a **TEXT** column and falls back
+to **REAL** for `ORDER BY` and aggregates, which is lossy and sorts lexicographically. The sample
+sidesteps this by modelling `Money` as **integer minor units (cents)** and mapping it to an `INTEGER`
+column with a converter:
+
+```csharp
+entity.Property(p => p.Price)
+    .HasConversion(money => money.Cents, cents => Money.FromCents(cents));
+```
+
+Integer cents are exact, correctly sortable, and the conventional way to represent money anyway. The
+sample's integration tests assert the column is `INTEGER` and that values round-trip exactly.
+
+## Schema & seeding
+
+The sample calls `EnsureCreatedAsync()` on startup and seeds a few rows through the aggregate's
+`Create` factory (so even seed data honours the invariants). `EnsureCreated` is the simplest correct
+choice for a sample with no schema history — a real app with an evolving schema would use
+`Database.MigrateAsync()` with EF Core migrations instead.
+
+## Testing
+
+Data-access logic is testable without a browser:
+
+- **Unit-test** the value objects and aggregate (validation rules, invariants) directly.
+- **Integration-test** the EF mapping against a real SQLite file: create the context, save a
+  `Product`, reload it in a new context, and assert the round-trip (and the storage shape).
+
+See `tests/Rask.Example.EfCore.Tests`. The end-to-end CRUD flow over the live connection is covered
+by a Playwright smoke test in `tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs`.
+
+## Run it
+
+```bash
+dotnet run --project samples/Rask.Example.EfCore
+# then open the printed URL at /products
+```

--- a/docs/migration-from-blazor.md
+++ b/docs/migration-from-blazor.md
@@ -27,7 +27,7 @@ New to Rask entirely? Start with [getting started](getting-started.md).
 | route/query binding | `[RouteParam]` / `[QueryParam]` on a property |
 | `<EditForm>` + `InputText`/`InputNumber` | `Form<TModel>(model, OnValidSubmit:)` + `Input(Bind: () => model.X)` |
 | `<DataAnnotationsValidator>` | drop `DataAnnotationsValidator()` inside the `Form<T>` |
-| `<AuthorizeView>` / `AuthenticationStateProvider` | `Component.User` + headless `Authorize(...)` component |
+| `<AuthorizeView>` / `AuthenticationStateProvider` | inject `IUserProvider` (read `.Current`) + headless `Authorize(...)` component |
 | `[Inject] T Svc { get; set; }` | constructor injection — `class Page(T svc) : Component` |
 | `Component.razor.css` | sibling `{Component}.css` next to `{Component}.cs` |
 | `IJSRuntime` | `IJSRuntime` (injected via the constructor) |

--- a/llms.txt
+++ b/llms.txt
@@ -14,6 +14,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
 - [Composition](docs/composition.md): children, context (provide/consume), callbacks.
 - [Forms](docs/forms.md): binding, validation, RadioGroup/CheckboxGroup, EditContext.
+- [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.

--- a/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
@@ -27,7 +27,7 @@ public sealed class MemberContent(ProtectedSessionStorage store, SessionUserProv
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {users.Current.Identity?.Name}"],
             P(Class: "text-secondary")["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
                 " — encrypted at rest, decrypted only server-side."],
             Authorize(

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmCookie.Pages;
@@ -22,11 +23,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(WasmLoginService login) : Component
+public sealed class MemberContent(WasmLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Auth.WasmJwt.Pages;
@@ -19,11 +20,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(JwtLoginService login) : Component
+public sealed class MemberContent(JwtLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 ["admin"],
                 Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],

--- a/samples/Rask.Example.Auth/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth/Pages/MembersPage.cs
@@ -8,7 +8,7 @@ namespace Rask.Example.Auth.Pages;
 // component gates the *content* — it subscribes to IUserProvider.Changed, so when the post-sign-in
 // reconnect re-seeds the principal it re-renders to the Authorized slot. The signed-in view lives in
 // its own component (MemberContent) so it first renders only once the gate opens, reading the
-// freshly-authenticated User — no manual Changed subscription needed on the page.
+// freshly-authenticated principal — no manual Changed subscription needed on the page.
 [Route("members")]
 [Authorize]
 public sealed class MembersPage : Component
@@ -26,12 +26,12 @@ public sealed class MembersPage : Component
 }
 
 // Rendered only by the Authorize component's Authorized slot, so its Render reads the current
-// (authenticated) User. Injects IAuthSignIn for sign-out.
-public sealed class MemberContent(IAuthSignIn auth) : Component
+// (authenticated) principal. Injects IUserProvider for the principal and IAuthSignIn for sign-out.
+public sealed class MemberContent(IUserProvider userProvider, IAuthSignIn auth) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {User.Identity?.Name}"],
+            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             P(Class: "text-secondary")["This page is gated by ", Code()["[Authorize]"],
                 " plus the Authorize component."],
             // Role gate: only an admin sees this.

--- a/samples/Rask.Example.EfCore/Features/Catalog/CreateProduct/CreateProductPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/CreateProduct/CreateProductPage.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+using Rask.Example.EfCore.Shared.Forms;
+
+namespace Rask.Example.EfCore.Features.Catalog.CreateProduct;
+
+// Vertical slice: add a product (a command). The slice owns its own form model and form markup;
+// the only things it shares are the domain (Product / value objects) and the FieldErrors template.
+// Inline field validators reuse the value objects' Validate methods, so the form and the domain
+// enforce the same rules from a single source.
+[Route("products/new")]
+public sealed class CreateProductPage(IDbContextFactory<CatalogDbContext> dbContextFactory, Navigator navigator)
+    : Component
+{
+    private readonly CreateProductForm _form = new();
+
+    protected override RenderResult Head => Title()["New product — Rask EF Core"];
+
+    private async Task SubmitAsync(CreateProductForm form)
+    {
+        // The form already passed the same rules the domain enforces; Create is the final guard.
+        var product = Product.Create(form.Name, form.Price, form.Stock);
+
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        db.Products.Add(product);
+        await db.SaveChangesAsync(CancellationToken);
+
+        navigator.Navigate("/products");
+    }
+
+    protected override RenderResult Render() =>
+        Div(Class: "card shadow-sm border-0 mx-auto", Style: "max-width: 32rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h4 mb-3")["New product"],
+                Form(_form, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
+                    Div()[
+                        Label("p-name", Class: "form-label small mb-1")["Name"],
+                        Input(() => _form.Name, Validate: ProductName.Validate,
+                            Id: "p-name", Class: "form-control"),
+                        ValidationMessage(() => _form.Name, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-price", Class: "form-label small mb-1")["Price"],
+                        Input(() => _form.Price, Validate: Money.Validate,
+                            Id: "p-price", Class: "form-control", Step: "0.01"),
+                        ValidationMessage(() => _form.Price, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-stock", Class: "form-label small mb-1")["Stock"],
+                        Input(() => _form.Stock, Validate: StockLevel.Validate,
+                            Id: "p-stock", Class: "form-control"),
+                        ValidationMessage(() => _form.Stock, FieldErrors.Template)
+                    ],
+                    Div(Class: "d-flex justify-content-end gap-2 pt-2")[
+                        NavLink("/products", Class: "btn btn-outline-secondary")["Cancel"],
+                        Button("submit", Class: "btn btn-primary")[
+                            I(Class: "bi bi-check2-circle me-1"), "Add product"
+                        ]
+                    ]
+                ]
+            ]
+        ];
+}
+
+// The slice's own input model: mutable primitives the inputs bind to. It maps onto the aggregate's
+// value objects at submit time.
+public sealed class CreateProductForm
+{
+    public string Name { get; set; } = "";
+    public decimal Price { get; set; } = 1m;
+    public int Stock { get; set; }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/EditProduct/EditProductPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/EditProduct/EditProductPage.cs
@@ -1,0 +1,111 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+using Rask.Example.EfCore.Shared.Forms;
+
+namespace Rask.Example.EfCore.Features.Catalog.EditProduct;
+
+// Vertical slice: edit a product (a command). Loads the current values into its own form, then on
+// submit loads the tracked aggregate and mutates it through Product.Update so the invariants and
+// the same value-object validation rules apply.
+[Route("products/{id:int}/edit")]
+public sealed class EditProductPage(IDbContextFactory<CatalogDbContext> dbContextFactory, Navigator navigator)
+    : Component
+{
+    private readonly EditProductForm _form = new();
+    private bool _loaded;
+    private bool _found;
+
+    [RouteParam] public int Id { get; set; }
+
+    protected override RenderResult Head => Title()["Edit product — Rask EF Core"];
+
+    // Fires on first render and whenever Id changes — load the row to edit into the form.
+    protected override async Task OnPropsChangedAsync()
+    {
+        _loaded = false;
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        var product = await db.Products
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.Id == Id, CancellationToken);
+
+        _found = product is not null;
+        if (product is not null)
+        {
+            _form.Name = product.Name.Value;
+            _form.Price = product.Price.Amount;
+            _form.Stock = product.Stock.Value;
+        }
+
+        _loaded = true;
+    }
+
+    private async Task SubmitAsync(EditProductForm form)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        var product = await db.Products.FirstOrDefaultAsync(p => p.Id == Id, CancellationToken);
+        if (product is not null)
+        {
+            product.Update(form.Name, form.Price, form.Stock);
+            await db.SaveChangesAsync(CancellationToken);
+        }
+
+        navigator.Navigate("/products");
+    }
+
+    protected override RenderResult Render()
+    {
+        if (!_loaded)
+        {
+            return Div(Class: "text-secondary")[
+                Span(Class: "spinner-border spinner-border-sm me-2"), "Loading…"
+            ];
+        }
+
+        if (!_found)
+        {
+            return Div(Class: "alert alert-warning")[
+                "Product not found. ", NavLink("/products")["Back to the list"], "."
+            ];
+        }
+
+        return Div(Class: "card shadow-sm border-0 mx-auto", Style: "max-width: 32rem")[
+            Div(Class: "card-body")[
+                H1(Class: "h4 mb-3")["Edit product"],
+                Form(_form, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
+                    Div()[
+                        Label("p-name", Class: "form-label small mb-1")["Name"],
+                        Input(() => _form.Name, Validate: ProductName.Validate,
+                            Id: "p-name", Class: "form-control"),
+                        ValidationMessage(() => _form.Name, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-price", Class: "form-label small mb-1")["Price"],
+                        Input(() => _form.Price, Validate: Money.Validate,
+                            Id: "p-price", Class: "form-control", Step: "0.01"),
+                        ValidationMessage(() => _form.Price, FieldErrors.Template)
+                    ],
+                    Div()[
+                        Label("p-stock", Class: "form-label small mb-1")["Stock"],
+                        Input(() => _form.Stock, Validate: StockLevel.Validate,
+                            Id: "p-stock", Class: "form-control"),
+                        ValidationMessage(() => _form.Stock, FieldErrors.Template)
+                    ],
+                    Div(Class: "d-flex justify-content-end gap-2 pt-2")[
+                        NavLink("/products", Class: "btn btn-outline-secondary")["Cancel"],
+                        Button("submit", Class: "btn btn-primary")[
+                            I(Class: "bi bi-check2-circle me-1"), "Save changes"
+                        ]
+                    ]
+                ]
+            ]
+        ];
+    }
+}
+
+public sealed class EditProductForm
+{
+    public string Name { get; set; } = "";
+    public decimal Price { get; set; } = 1m;
+    public int Stock { get; set; }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
@@ -1,0 +1,88 @@
+using System.Globalization;
+using Microsoft.EntityFrameworkCore;
+using Rask.Core.Routing;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+
+namespace Rask.Example.EfCore.Features.Catalog.ListProducts;
+
+// Vertical slice: list the catalogue (a query) and delete a row (a command). It talks to EF Core
+// directly through the context factory — no repository abstraction — which is the vertical-slice
+// stance: each slice owns its own data access.
+[Route("/")]
+[Route("products")]
+public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbContextFactory) : Component
+{
+    private IReadOnlyList<Product> _products = [];
+    private bool _loaded;
+
+    protected override RenderResult Head => Title()["Products — Rask EF Core"];
+
+    // Runs on every mount — navigating back from the create/edit slices remounts this page, so the
+    // list always reflects the latest committed state.
+    protected override async Task OnMountAsync() => await LoadAsync();
+
+    private async Task LoadAsync()
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        _products = await db.Products
+            .AsNoTracking()
+            .OrderBy(p => p.Id)
+            .ToListAsync(CancellationToken);
+        _loaded = true;
+    }
+
+    private async Task DeleteAsync(int id)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
+        await db.Products.Where(p => p.Id == id).ExecuteDeleteAsync(CancellationToken);
+        await LoadAsync();
+        StateHasChanged();
+    }
+
+    protected override RenderResult Render() =>
+    [
+        Div(Class: "d-flex justify-content-between align-items-center mb-3")[
+            Div()[
+                H1(Class: "h3 mb-1")["Products"],
+                P(Class: "text-secondary mb-0")["EF Core + SQLite CRUD, organised as vertical slices."]
+            ],
+            NavLink("/products/new", Class: "btn btn-primary")[
+                I(Class: "bi bi-plus-lg me-1"), "New product"
+            ]
+        ],
+        !_loaded
+            ? Div(Class: "text-secondary")[
+                Span(Class: "spinner-border spinner-border-sm me-2"), "Loading…"
+            ]
+            : _products.Count == 0
+                ? Div(Class: "alert alert-info")["No products yet — click \"New product\" to add one."]
+                : Table(Class: "table table-striped align-middle bg-white shadow-sm rounded overflow-hidden")[
+                    Thead()[
+                        Tr()[
+                            Th()["#"],
+                            Th()["Name"],
+                            Th(Class: "text-end")["Price"],
+                            Th(Class: "text-end")["Stock"],
+                            Th()[""]
+                        ]
+                    ],
+                    Tbody()[
+                        _products.Select(p => Tr(Key: p.Id)[
+                            Td(Class: "text-muted")[p.Id.ToString(CultureInfo.InvariantCulture)],
+                            Td(Class: "fw-semibold")[p.Name.Value],
+                            Td(Class: "text-end")[p.Price.ToString()],
+                            Td(Class: "text-end")[p.Stock.Value.ToString(CultureInfo.InvariantCulture)],
+                            Td(Class: "text-end text-nowrap")[
+                                NavLink($"/products/{p.Id}/edit", Class: "btn btn-outline-secondary btn-sm me-1")[
+                                    I(Class: "bi bi-pencil")
+                                ],
+                                Button("button", Class: "btn btn-outline-danger btn-sm",
+                                    OnClickAsync: () => DeleteAsync(p.Id))[
+                                    I(Class: "bi bi-trash")
+                                ]
+                            ]
+                        ])
+                    ]
+                ]
+    ];
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogDbContext.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogDbContext.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// The Catalog bounded context's DbContext. Resolved through IDbContextFactory (see Program.cs),
+// so every slice gets a fresh short-lived instance per operation rather than a long-lived one
+// pinned to the WebSocket session.
+public sealed class CatalogDbContext(DbContextOptions<CatalogDbContext> options) : DbContext(options)
+{
+    public DbSet<Product> Products => Set<Product>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+        modelBuilder.ApplyConfigurationsFromAssembly(typeof(CatalogDbContext).Assembly);
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogSeeder.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/CatalogSeeder.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Ensures the schema exists and seeds a few products on startup. Seeding goes through the
+// aggregate's Create factory (not raw column values), so even the seed data honours the invariants.
+// EnsureCreated (rather than migrations) is the simplest correct choice for a sample with no
+// schema history — a real app with an evolving schema would use db.Database.MigrateAsync().
+public static class CatalogSeeder
+{
+    public static async Task SeedAsync(IDbContextFactory<CatalogDbContext> dbContextFactory)
+    {
+        await using var db = await dbContextFactory.CreateDbContextAsync();
+        await db.Database.EnsureCreatedAsync();
+
+        if (await db.Products.AnyAsync())
+        {
+            return;
+        }
+
+        db.Products.AddRange(
+            Product.Create("Mechanical keyboard", 89.00m, 12),
+            Product.Create("27\" 4K monitor", 329.00m, 5),
+            Product.Create("USB-C hub", 39.50m, 40));
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/Money.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/Money.cs
@@ -1,0 +1,50 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Value object for a price. The validation rule lives here and is reused verbatim by the inline
+// form validator (Input(..., Validate: Money.Validate)) and by FromDecimal — one source of truth.
+//
+// Money is stored as integer minor units (cents). SQLite has no native decimal type: EF Core
+// would map a decimal to a TEXT column and fall back to REAL for ORDER BY / aggregates, which is
+// lossy and sorts lexicographically. An INTEGER cents column is exact, correctly sortable, and is
+// the conventional way to model money — so the value object earns its keep.
+public readonly record struct Money
+{
+    public const decimal MaxAmount = 1_000_000m;
+
+    public long Cents { get; }
+
+    private Money(long cents) => Cents = cents;
+
+    public decimal Amount => Cents / 100m;
+
+    // The single rule, shaped as Func<decimal, IEnumerable<string>> so the form can pass it
+    // straight to Rask's inline Validate: parameter as a method group.
+    public static IEnumerable<string> Validate(decimal amount)
+    {
+        if (amount <= 0m)
+        {
+            yield return "Price must be greater than zero.";
+        }
+        else if (amount > MaxAmount)
+        {
+            yield return $"Price must be {MaxAmount:N0} or less.";
+        }
+    }
+
+    // Domain construction — enforces the same rule as a last line of defence.
+    public static Money FromDecimal(decimal amount)
+    {
+        var errors = Validate(amount).ToList();
+        if (errors.Count > 0)
+        {
+            throw new ArgumentException(string.Join(" ", errors), nameof(amount));
+        }
+
+        return new Money((long)decimal.Round(amount * 100m, MidpointRounding.ToEven));
+    }
+
+    // Rehydration from the persisted INTEGER column (already-valid data).
+    public static Money FromCents(long cents) => new(cents);
+
+    public override string ToString() => Amount.ToString("C");
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/Product.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/Product.cs
@@ -1,0 +1,38 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// The Catalog aggregate root. State is encapsulated behind private setters and only changes
+// through Create / Update, which compose the value objects — so an invalid Product can't exist.
+// Slices construct and mutate it through these methods (the ubiquitous language), never by
+// reaching in and setting properties.
+public sealed class Product
+{
+    // EF Core materialisation ctor — never used by application code.
+    private Product()
+    {
+    }
+
+    private Product(ProductName name, Money price, StockLevel stock)
+    {
+        Name = name;
+        Price = price;
+        Stock = stock;
+    }
+
+    public int Id { get; private set; }
+
+    public ProductName Name { get; private set; }
+
+    public Money Price { get; private set; }
+
+    public StockLevel Stock { get; private set; }
+
+    public static Product Create(string name, decimal price, int stock) =>
+        new(ProductName.From(name), Money.FromDecimal(price), StockLevel.From(stock));
+
+    public void Update(string name, decimal price, int stock)
+    {
+        Name = ProductName.From(name);
+        Price = Money.FromDecimal(price);
+        Stock = StockLevel.From(stock);
+    }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductConfiguration.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductConfiguration.cs
@@ -1,0 +1,27 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// EF Core entity configuration: maps the aggregate's value objects onto SQLite columns via value
+// converters. Keeping the mapping in an IEntityTypeConfiguration (applied with
+// ApplyConfigurationsFromAssembly) keeps the domain model free of persistence concerns.
+public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>
+{
+    public void Configure(EntityTypeBuilder<Product> entity)
+    {
+        entity.HasKey(p => p.Id);
+
+        entity.Property(p => p.Name)
+            .HasConversion(name => name.Value, value => ProductName.From(value))
+            .IsRequired()
+            .HasMaxLength(ProductName.MaxLength);
+
+        // Money <-> INTEGER minor units. No decimal column at all (SQLite has no decimal type).
+        entity.Property(p => p.Price)
+            .HasConversion(money => money.Cents, cents => Money.FromCents(cents));
+
+        entity.Property(p => p.Stock)
+            .HasConversion(stock => stock.Value, value => StockLevel.From(value));
+    }
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductName.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/ProductName.cs
@@ -1,0 +1,37 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Value object for a product's name. As with Money, the rule lives on the value object and is
+// reused by the inline form validator (Input(..., Validate: ProductName.Validate)) and by From.
+public readonly record struct ProductName
+{
+    public const int MaxLength = 120;
+
+    public string Value { get; }
+
+    private ProductName(string value) => Value = value;
+
+    public static IEnumerable<string> Validate(string value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            yield return "Name is required.";
+        }
+        else if (value.Trim().Length > MaxLength)
+        {
+            yield return $"Name must be {MaxLength} characters or fewer.";
+        }
+    }
+
+    public static ProductName From(string value)
+    {
+        var errors = Validate(value).ToList();
+        if (errors.Count > 0)
+        {
+            throw new ArgumentException(string.Join(" ", errors), nameof(value));
+        }
+
+        return new ProductName(value.Trim());
+    }
+
+    public override string ToString() => Value;
+}

--- a/samples/Rask.Example.EfCore/Features/Catalog/Shared/StockLevel.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/Shared/StockLevel.cs
@@ -1,0 +1,31 @@
+namespace Rask.Example.EfCore.Features.Catalog.Shared;
+
+// Value object for on-hand stock. Same pattern: the rule lives here and is reused by the inline
+// form validator (Input(..., Validate: StockLevel.Validate)) and by From.
+public readonly record struct StockLevel
+{
+    public int Value { get; }
+
+    private StockLevel(int value) => Value = value;
+
+    public static IEnumerable<string> Validate(int value)
+    {
+        if (value < 0)
+        {
+            yield return "Stock cannot be negative.";
+        }
+    }
+
+    public static StockLevel From(int value)
+    {
+        var errors = Validate(value).ToList();
+        if (errors.Count > 0)
+        {
+            throw new ArgumentException(string.Join(" ", errors), nameof(value));
+        }
+
+        return new StockLevel(value);
+    }
+
+    public override string ToString() => Value.ToString(System.Globalization.CultureInfo.InvariantCulture);
+}

--- a/samples/Rask.Example.EfCore/Program.cs
+++ b/samples/Rask.Example.EfCore/Program.cs
@@ -1,0 +1,28 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Example.EfCore;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+using Rask.Server;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddRask();
+
+// IDbContextFactory rather than a scoped DbContext: a Rask Server live session is long-lived over
+// a WebSocket, so a session-scoped DbContext would outlive any unit of work (and a DbContext is
+// neither thread-safe nor meant to be long-lived). Each slice opens a short-lived context per
+// operation via the factory. RASK_DB_PATH lets the E2E fixture point at an isolated temp file.
+var dbPath = builder.Configuration["RASK_DB_PATH"] ?? "raskExampleCatalog.db";
+builder.Services.AddDbContextFactory<CatalogDbContext>(options =>
+    options.UseSqlite($"Data Source={dbPath}"));
+
+var app = builder.Build();
+
+// Create the schema and seed sample data once at startup.
+await CatalogSeeder.SeedAsync(app.Services.GetRequiredService<IDbContextFactory<CatalogDbContext>>());
+
+// UseStaticFiles before UseRouting so static files win over Rask's catch-all route.
+app.UseStaticFiles();
+app.UseRouting();
+app.UseRask<App>();
+
+app.Run();

--- a/samples/Rask.Example.EfCore/README.md
+++ b/samples/Rask.Example.EfCore/README.md
@@ -1,0 +1,40 @@
+# Rask.Example.EfCore
+
+A Rask **Server** sample showing data persistence with **EF Core + SQLite** — a small product
+catalogue with full CRUD (list, create, edit, delete).
+
+```bash
+dotnet run --project samples/Rask.Example.EfCore
+# open the printed URL at /products
+```
+
+The full write-up is in [docs/data-access.md](../../docs/data-access.md). In short, it demonstrates:
+
+- **`IDbContextFactory<CatalogDbContext>`**, not a scoped `DbContext`. A Rask live session is
+  long-lived over a WebSocket, so each slice opens a short-lived context per operation
+  (`await using var db = await dbContextFactory.CreateDbContextAsync(ct)`).
+- **Vertical slice architecture** — code is grouped by use case under `Features/Catalog/`
+  (`ListProducts`, `CreateProduct`, `EditProduct`), each slice self-contained with its own form and
+  EF Core access. No repository/service layers. App-wide shared bits live in `Shared/`; the Catalog
+  domain shared across slices lives in `Features/Catalog/Shared/`.
+- **DDD tactical patterns** — `Product` is an aggregate root (private setters, `Create` / `Update`
+  only); `Money`, `ProductName`, and `StockLevel` are value objects. Each value object **owns its
+  validation rule**, reused verbatim by the inline form validators (`Validate: Money.Validate`) and
+  enforced again on construction.
+- **EF Core entity configuration** — mapping lives in `IEntityTypeConfiguration<Product>`
+  (`ApplyConfigurationsFromAssembly`), with value converters for the value objects.
+- **The SQLite decimal gotcha** — SQLite has no decimal type, so `Money` is stored as integer minor
+  units (cents) in an `INTEGER` column: exact, sortable, lossless.
+- **Built-in inline validation** — Rask.Core's `Validate:` lambdas, no validation package.
+
+## Database file
+
+The SQLite file (`raskExampleCatalog.db`, gitignored) is created and seeded on first run via
+`EnsureCreatedAsync()`. Set `RASK_DB_PATH` to point at a different file (the E2E test uses this to
+isolate each run). Delete the file to reset to the seed data.
+
+## Tests
+
+- `tests/Rask.Example.EfCore.Tests` — unit tests for the domain + EF/SQLite integration tests
+  (round-trip + proof that price is stored as `INTEGER`).
+- `tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs` — a Playwright CRUD smoke test.

--- a/samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj
+++ b/samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+  </ItemGroup>
+
+  <!-- The ASP.NET Web SDK requires a wwwroot to exist even when there are no static files. -->
+  <Target Name="EnsureEmptyWwwroot" BeforeTargets="BeforeBuild">
+    <MakeDir Directories="wwwroot"/>
+  </Target>
+
+</Project>

--- a/samples/Rask.Example.EfCore/Shared/App.cs
+++ b/samples/Rask.Example.EfCore/Shared/App.cs
@@ -1,0 +1,38 @@
+namespace Rask.Example.EfCore;
+
+// App shell: the framework-managed <head> (Bootstrap + icons via CDN), a navbar, and a Router
+// that renders the matched slice page. Only this component renders the Doctype/Html/Head/Body
+// shell — the slice pages return body fragments (RASK021).
+public sealed class App : Component
+{
+    protected override RenderResult Head =>
+    [
+        Title()["Rask — EF Core + SQLite"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"),
+        Link(Rel: "stylesheet",
+            Href: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css")
+    ];
+
+    protected override RenderResult Render() =>
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body(Class: "bg-body-tertiary")[
+                Nav(Class: "navbar navbar-dark bg-dark border-bottom shadow-sm")[
+                    Div(Class: "container")[
+                        NavLink("/", Class: "navbar-brand fw-bold")[
+                            I(Class: "bi bi-database me-2"), "Rask · EF Core catalog"
+                        ],
+                        A("https://github.com/pal-tamas/rask", "_blank",
+                            Class: "btn btn-outline-light btn-sm")[I(Class: "bi bi-github me-1"), "GitHub"]
+                    ]
+                ],
+                Main(Class: "container py-4")[Router()]
+            ]
+        ]
+    ];
+}

--- a/samples/Rask.Example.EfCore/Shared/Forms/FieldErrors.cs
+++ b/samples/Rask.Example.EfCore/Shared/Forms/FieldErrors.cs
@@ -1,0 +1,9 @@
+namespace Rask.Example.EfCore.Shared.Forms;
+
+// Shared ValidationMessage template — renders a field's inline messages under its input.
+// Used by every slice's form, so it lives in the app-wide Shared/ folder rather than a slice.
+public static class FieldErrors
+{
+    public static Component Template(IReadOnlyList<string> messages) =>
+        Fragment()[messages.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
+}

--- a/samples/Rask.Example.Shared/Demos/DemoUserProvider.cs
+++ b/samples/Rask.Example.Shared/Demos/DemoUserProvider.cs
@@ -6,7 +6,7 @@ namespace Rask.Example.Shared.Demos;
 // A toggleable IUserProvider for the User-gating showcase. Real apps back IUserProvider with a
 // cookie/JWT (Server) or /api/me (WASM); this one just flips an in-memory principal so the demo
 // can show authenticated/role-gated rendering without real auth infrastructure. Registered as
-// both itself (so the demo can sign in/out) and IUserProvider (so Component.User resolves it).
+// both itself (so the demo can sign in/out) and IUserProvider (so injected consumers resolve it).
 public sealed class DemoUserProvider : IUserProvider
 {
     public ClaimsPrincipal Current { get; private set; } = new(new ClaimsIdentity());

--- a/samples/Rask.Example.Shared/Demos/UserGateDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/UserGateDemo.cs
@@ -1,8 +1,8 @@
 namespace Rask.Example.Shared.Demos;
 
-// Auth-gating with the built-in Component.User — no AuthorizeView component. The demo injects the
-// toggleable provider to sign in/out; Render() branches on User. It subscribes to the provider's
-// Changed event so a sign-in originating anywhere re-renders this component.
+// Auth-gating by injecting IUserProvider and reading .Current — no AuthorizeView component. The demo
+// injects the toggleable provider to sign in/out; Render() branches on _auth.Current. It subscribes
+// to the provider's Changed event so a sign-in originating anywhere re-renders this component.
 public sealed class UserGateDemo : Component
 {
     private readonly DemoUserProvider _auth;
@@ -15,11 +15,11 @@ public sealed class UserGateDemo : Component
 
     protected override RenderResult Render() =>
         Div(Id: "user-gate")[
-            User.Identity?.IsAuthenticated == true
+            _auth.Current.Identity?.IsAuthenticated == true
                 ? Fragment()[
-                    P()["Signed in as ", Strong()[User.Identity!.Name ?? "?"]],
+                    P()["Signed in as ", Strong()[_auth.Current.Identity!.Name ?? "?"]],
                     // Role-gated: only an admin sees this panel.
-                    User.IsInRole("admin")
+                    _auth.Current.IsInRole("admin")
                         ? Div(Class: "alert alert-warning py-2")["🔑 Admin-only panel"]
                         : (Child)Fragment(),
                     Button(Class: "btn btn-sm btn-outline-secondary", OnClick: _auth.SignOut)["Sign out"]]

--- a/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
+++ b/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
@@ -23,7 +23,7 @@ public static class ExampleServiceCollectionExtensions
         services.AddSingleton<IBannedWordService, BannedWordService>();
 
         // Toggleable demo auth for the User-gating showcase (/user). Registered as the concrete
-        // type (so the demo can sign in/out) and as IUserProvider (so Component.User resolves it).
+        // type (so the demo can sign in/out) and as IUserProvider (so injected consumers resolve it).
         // Defaults to anonymous, so other pages are unaffected. Scoped — NOT singleton — so each
         // live session gets its own principal (matching the framework's own SessionUserProvider,
         // RaskEndpointExtensions.AddScoped). A singleton would share one signed-in user across every

--- a/samples/Rask.Example.Shared/Pages/UserPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UserPage.cs
@@ -14,25 +14,28 @@ public sealed class UserPage : Component
     [
         PageHeader.Render(
             "User & auth gating",
-            "Gate content on the signed-in user — imperatively with the built-in Component.User (branch in Render() on User.Identity?.IsAuthenticated and User.IsInRole(...)), or declaratively with the headless Authorize component."),
-        H2(Class: "h4 mt-4 mb-3")["Conditional rendering on User"],
+            "Gate content on the signed-in user — imperatively by injecting IUserProvider and reading .Current (branch in Render() on _auth.Current.Identity?.IsAuthenticated and _auth.Current.IsInRole(...)), or declaratively with the headless Authorize component."),
+        H2(Class: "h4 mt-4 mb-3")["Conditional rendering on the current user"],
         CodeSample(
             """
-            // Component.User comes from the registered IUserProvider
-            protected override RenderResult Render() =>
-                User.Identity?.IsAuthenticated == true
-                    ? Fragment(
-                        P()[$"Signed in as {User.Identity!.Name}"],
-                        User.IsInRole("admin") ? AdminPanel() : Fragment(),
-                        Button(OnClick: _auth.SignOut)["Sign out"])
-                    : Button(OnClick: () => _auth.SignIn("alice", "user"))["Sign in"];
+            // Inject IUserProvider via the constructor and read .Current (a never-null ClaimsPrincipal)
+            public sealed class AccountPanel(IUserProvider auth) : Component
+            {
+                protected override RenderResult Render() =>
+                    auth.Current.Identity?.IsAuthenticated == true
+                        ? Fragment(
+                            P()[$"Signed in as {auth.Current.Identity!.Name}"],
+                            auth.Current.IsInRole("admin") ? AdminPanel() : Fragment(),
+                            Button(OnClick: auth.SignOut)["Sign out"])
+                        : Button(OnClick: () => auth.SignIn("alice", "user"))["Sign in"];
 
-            // re-render when auth changes (the provider raises Changed)
-            protected override void OnMount()   => _auth.Changed += StateHasChanged;
-            protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
+                // re-render when auth changes (the provider raises Changed)
+                protected override void OnMount()   => auth.Changed += StateHasChanged;
+                protected override void OnUnmount() => auth.Changed -= StateHasChanged;
+            }
             """,
             Notes:
-            "User resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on User subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
+            "The principal resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on the user subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
             Result: UserGateDemo()),
         H2(Class: "h4 mt-5 mb-3")["Declarative gating — the Authorize component"],
         CodeSample(
@@ -52,12 +55,12 @@ public sealed class UserPage : Component
             // until it lands (and while a WASM provider's principal is still loading).
             """,
             Notes:
-            "Authorize is the declarative counterpart to gating in Render() on User: it picks the Authorized, NotAuthorized, or Authorizing slot off the same Component.User. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
+            "Authorize is the declarative counterpart to gating in Render() on the current user: it picks the Authorized, NotAuthorized, or Authorizing slot off the same IUserProvider. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
             Result: AuthorizeDemo()),
         H2(Class: "h4 mt-5 mb-3")["Notes"],
         Ul(Class: "text-secondary")[
             Li()[
-                "Component.User never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so User.Identity?.IsAuthenticated is false."],
+                "IUserProvider.Current never returns null — with no provider (or signed out) it's an unauthenticated ClaimsPrincipal, so .Current.Identity?.IsAuthenticated is false."],
             Li()[
                 "Role checks use the standard ClaimsPrincipal.IsInRole. For route-level gating use [Authorize]/[AllowAnonymous] on the page (RouteAuthorizationGuard) instead of branching in Render()."]
         ]

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1,8 +1,5 @@
-using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
-using Microsoft.Extensions.DependencyInjection;
-using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Forms;
 using Rask.Core.HeadAssets;
@@ -213,14 +210,6 @@ public abstract class Component
             }
         }
     }
-
-    /// <summary>
-    ///     The current user, resolved from <see cref="IUserProvider" /> in the active render scope.
-    ///     Returns an unauthenticated <see cref="ClaimsPrincipal" /> when no provider is registered.
-    /// </summary>
-    protected ClaimsPrincipal User =>
-        LiveRenderContext.Current?.Services?.GetService<IUserProvider>()?.Current
-        ?? new ClaimsPrincipal(new ClaimsIdentity());
 
     /// <summary>
     ///     A <see cref="System.Threading.CancellationToken" /> tied to this component's lifetime.

--- a/src/Rask.Core/Components/Authorize.cs
+++ b/src/Rask.Core/Components/Authorize.cs
@@ -8,7 +8,7 @@ namespace Rask.Core.Components;
 
 /// <summary>
 ///     Declarative auth gating — the headless analogue of Blazor's <c>AuthorizeView</c>. Renders
-///     exactly one of three slots based on the current <see cref="Component.User" /> (and, optionally,
+///     exactly one of three slots based on the current <see cref="IUserProvider" /> (and, optionally,
 ///     a named authorization policy), with <b>no markup of its own</b> (transparent like
 ///     <see cref="Fragment" />):
 ///     <list type="bullet">
@@ -44,6 +44,12 @@ public sealed class Authorize : Component
     private int _policyGen;
     private IUserProvider? _provider;
     private IServiceProvider? _services;
+
+    // The current principal from the resolved provider; never null. _provider is wired in OnMount,
+    // which the lifecycle guarantees runs before OnPropsChangedAsync/Render, so this is safe at
+    // every read site.
+    private ClaimsPrincipal CurrentUser =>
+        _provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity());
 
     // Transparent — Authorize itself emits nothing, it only selects one slot. (Same as the base
     // default; stated explicitly to document the headless contract.)
@@ -97,7 +103,7 @@ public sealed class Authorize : Component
             return;
         }
 
-        await EvaluatePolicyAsync(User).ConfigureAwait(false);
+        await EvaluatePolicyAsync(CurrentUser).ConfigureAwait(false);
     }
 
     protected override RenderResult Render()
@@ -122,7 +128,7 @@ public sealed class Authorize : Component
 
     private bool IsAllowed()
     {
-        if (User.Identity?.IsAuthenticated != true)
+        if (CurrentUser.Identity?.IsAuthenticated != true)
         {
             return false;
         }
@@ -144,7 +150,7 @@ public sealed class Authorize : Component
     {
         foreach (var role in Roles!)
         {
-            if (!string.IsNullOrEmpty(role) && User.IsInRole(role))
+            if (!string.IsNullOrEmpty(role) && CurrentUser.IsInRole(role))
             {
                 return true;
             }
@@ -170,8 +176,7 @@ public sealed class Authorize : Component
     private async Task RefreshPolicyThenRenderAsync()
     {
         StateHasChanged(); // paint the Authorizing slot immediately
-        await EvaluatePolicyAsync(_provider?.Current ?? new ClaimsPrincipal(new ClaimsIdentity()))
-            .ConfigureAwait(false);
+        await EvaluatePolicyAsync(CurrentUser).ConfigureAwait(false);
         StateHasChanged(); // paint the resolved verdict
     }
 

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -189,16 +189,29 @@ public sealed class LiveSessionStore : IAsyncDisposable
         }
 
         var cts = CancellationTokenSource.CreateLinkedTokenSource(_stopping);
-        var prior = _pendingRemovals.AddOrUpdate(id, cts, (_, existing) =>
+        // Install the new CTS, retiring any prior pending removal for this id. A CTS must
+        // never be cancelled/disposed while it is still reachable through _pendingRemovals:
+        // a concurrent CancelPendingRemoval / CancelAllPending could TryRemove the same
+        // instance and race us into a double-dispose (ObjectDisposedException out of Cancel).
+        // So swap atomically and retire the prior CTS only after our CAS has made it
+        // unreachable — never from inside an AddOrUpdate factory, whose side effects mutate a
+        // value other threads can still observe in the dictionary. The thread whose
+        // TryUpdate/TryRemove wins is the single owner responsible for disposing that value.
+        while (true)
         {
-            existing.Cancel();
-            existing.Dispose();
-            return cts;
-        });
-        if (!ReferenceEquals(prior, cts))
-        {
-            cts.Dispose();
-            return;
+            if (_pendingRemovals.TryGetValue(id, out var existing))
+            {
+                if (_pendingRemovals.TryUpdate(id, cts, existing))
+                {
+                    existing.Cancel();
+                    existing.Dispose();
+                    break;
+                }
+            }
+            else if (_pendingRemovals.TryAdd(id, cts))
+            {
+                break;
+            }
         }
 
         _ = Task.Run(async () =>

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
@@ -7,7 +7,8 @@ namespace Company.RaskServer;
 
 // [Authorize] blocks anonymous deep-links (full GET → 302 to /login). The Authorize component gates the
 // content and re-renders when the post-sign-in reconnect re-seeds the principal; the signed-in view lives
-// in its own component so it reads the freshly-authenticated User — no manual Changed subscription.
+// in its own component that injects IUserProvider, so it reads the freshly-authenticated principal — no
+// manual Changed subscription.
 [Route("members")]
 [Authorize]
 public sealed class MembersPage : Component
@@ -20,11 +21,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(IAuthSignIn auth) : Component
+public sealed class MemberContent(IAuthSignIn auth, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1()[$"Welcome, {User.Identity?.Name}"],
+            H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
                 Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Routing;
 
@@ -19,11 +20,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(WasmLoginService login) : Component
+public sealed class MemberContent(WasmLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1()[$"Welcome, {User.Identity?.Name}"],
+            H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
                 Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate with `User` (a never-null `ClaimsPrincipal`) or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Authentication;
 using Rask.Core.Components;
 using Rask.Core.Routing;
 
@@ -16,11 +17,11 @@ public sealed class MembersPage : Component
         ];
 }
 
-public sealed class MemberContent(JwtLoginService login) : Component
+public sealed class MemberContent(JwtLoginService login, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1()[$"Welcome, {User.Identity?.Name}"],
+            H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
             Authorize(
                 Roles: ["admin"],
                 Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],

--- a/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
+++ b/tests/Rask.Core.Tests/Authentication/UserGatingTests.cs
@@ -6,7 +6,7 @@ using Rask.Core.Authentication;
 
 namespace Rask.Core.Tests.Authentication;
 
-// The built-in Component.User (resolved from IUserProvider in the active render scope) is the
+// Injecting IUserProvider and reading .Current (resolved from the active render scope) is the
 // imperative way to gate content (the declarative counterpart is the Authorize component — see
 // AuthorizeTests). These pin that gating in Render() reflects the provider's principal, incl. roles.
 public class UserGatingTests
@@ -48,10 +48,11 @@ public class UserGatingTests
 
     private static string Render(ClaimsPrincipal principal)
     {
+        var provider = new FixedUser(principal);
         var sp = new ServiceCollection()
-            .AddSingleton<IUserProvider>(new FixedUser(principal))
+            .AddSingleton<IUserProvider>(provider)
             .BuildServiceProvider();
-        return new StubComponent(() => new Gate()).RenderAsLiveRoot(sp);
+        return new StubComponent(() => new Gate(provider)).RenderAsLiveRoot(sp);
     }
 
     private static ClaimsPrincipal Principal(string name, params string[] roles)
@@ -65,8 +66,10 @@ public class UserGatingTests
         return new ClaimsPrincipal(new ClaimsIdentity(claims, "test"));
     }
 
-    private sealed class Gate : Component
+    private sealed class Gate(IUserProvider provider) : Component
     {
+        private ClaimsPrincipal User => provider.Current;
+
         protected override RenderResult Render() =>
             User.Identity?.IsAuthenticated == true
                 ? new Fragment(

--- a/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
@@ -9,7 +9,7 @@ using Rask.Core.Authentication;
 namespace Rask.Core.Tests.Components;
 
 // The headless Authorize component selects exactly one of three slots (Authorized / NotAuthorized /
-// Authorizing) off Component.User, plus optional role/policy gating. These pin that selection. The
+// Authorizing) off the current user (IUserProvider), plus optional role/policy gating. These pin that selection. The
 // gate is built INSIDE a render delegate so its generated factory runs under a live render context
 // (which fires OnMount/OnPropsChangedAsync) — building it eagerly would skip the lifecycle.
 public class AuthorizeTests

--- a/tests/Rask.Example.EfCore.Tests/CatalogDomainTests.cs
+++ b/tests/Rask.Example.EfCore.Tests/CatalogDomainTests.cs
@@ -1,0 +1,97 @@
+using Rask.Example.EfCore.Features.Catalog.Shared;
+
+namespace Rask.Example.EfCore.Tests;
+
+// The DDD core: the value objects own the validation rules (reused by the inline form validators)
+// and the aggregate enforces them on construction. These are pure unit tests — no browser, no DB.
+public sealed class CatalogDomainTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    public void Money_Validate_RejectsNonPositive(decimal amount)
+    {
+        Assert.Contains("Price must be greater than zero.", Money.Validate(amount));
+    }
+
+    [Fact]
+    public void Money_Validate_RejectsAboveMax()
+    {
+        Assert.NotEmpty(Money.Validate(Money.MaxAmount + 1m));
+    }
+
+    [Fact]
+    public void Money_Validate_AcceptsValid() => Assert.Empty(Money.Validate(12.34m));
+
+    [Fact]
+    public void Money_StoresMinorUnits_AndRoundTrips()
+    {
+        var money = Money.FromDecimal(12.34m);
+        Assert.Equal(1234, money.Cents);
+        Assert.Equal(12.34m, money.Amount);
+        Assert.Equal(money, Money.FromCents(money.Cents));
+    }
+
+    [Fact]
+    public void Money_FromDecimal_RoundsToNearestCent()
+    {
+        Assert.Equal(1234, Money.FromDecimal(12.344m).Cents); // rounds down
+        Assert.Equal(1235, Money.FromDecimal(12.346m).Cents); // rounds up
+        Assert.Equal(1234, Money.FromDecimal(12.345m).Cents); // banker's rounding: .5 -> nearest even
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ProductName_Validate_RequiresText(string value)
+    {
+        Assert.Contains("Name is required.", ProductName.Validate(value));
+    }
+
+    [Fact]
+    public void ProductName_Validate_RejectsTooLong()
+    {
+        Assert.NotEmpty(ProductName.Validate(new string('x', ProductName.MaxLength + 1)));
+    }
+
+    [Fact]
+    public void ProductName_From_Trims() => Assert.Equal("Widget", ProductName.From("  Widget  ").Value);
+
+    [Fact]
+    public void StockLevel_Validate_RejectsNegative() =>
+        Assert.Contains("Stock cannot be negative.", StockLevel.Validate(-1));
+
+    [Fact]
+    public void StockLevel_Validate_AcceptsZeroAndPositive()
+    {
+        Assert.Empty(StockLevel.Validate(0));
+        Assert.Empty(StockLevel.Validate(40));
+    }
+
+    [Fact]
+    public void Product_Create_BuildsValidAggregate()
+    {
+        var product = Product.Create("Keyboard", 89.00m, 12);
+        Assert.Equal("Keyboard", product.Name.Value);
+        Assert.Equal(89.00m, product.Price.Amount);
+        Assert.Equal(12, product.Stock.Value);
+    }
+
+    [Fact]
+    public void Product_Create_RejectsInvalidInvariants()
+    {
+        Assert.Throws<ArgumentException>(() => Product.Create("", 10m, 1));
+        Assert.Throws<ArgumentException>(() => Product.Create("Ok", 0m, 1));
+        Assert.Throws<ArgumentException>(() => Product.Create("Ok", 10m, -1));
+    }
+
+    [Fact]
+    public void Product_Update_AppliesNewValues()
+    {
+        var product = Product.Create("Old", 10m, 1);
+        product.Update("New", 25.50m, 7);
+        Assert.Equal("New", product.Name.Value);
+        Assert.Equal(25.50m, product.Price.Amount);
+        Assert.Equal(7, product.Stock.Value);
+    }
+}

--- a/tests/Rask.Example.EfCore.Tests/CatalogPersistenceTests.cs
+++ b/tests/Rask.Example.EfCore.Tests/CatalogPersistenceTests.cs
@@ -1,0 +1,98 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Example.EfCore.Features.Catalog.Shared;
+
+namespace Rask.Example.EfCore.Tests;
+
+// Integration tests against a real SQLite database file: they prove the entity configuration's
+// value-object converters persist and rehydrate correctly, and — answering "does SQLite support
+// decimal?" — that Money is stored as an exact INTEGER (minor units), never a lossy decimal/REAL.
+public sealed class CatalogPersistenceTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-efcore-test-{Guid.NewGuid():N}.db");
+
+    private CatalogDbContext NewContext()
+    {
+        var options = new DbContextOptionsBuilder<CatalogDbContext>()
+            .UseSqlite($"Data Source={_dbPath}")
+            .Options;
+        return new CatalogDbContext(options);
+    }
+
+    [Fact]
+    public async Task Product_RoundTripsThroughSqlite()
+    {
+        await using (var db = NewContext())
+        {
+            await db.Database.EnsureCreatedAsync();
+            db.Products.Add(Product.Create("Mechanical keyboard", 89.95m, 12));
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = NewContext())
+        {
+            var product = await db.Products.SingleAsync();
+            Assert.Equal("Mechanical keyboard", product.Name.Value);
+            Assert.Equal(89.95m, product.Price.Amount);
+            Assert.Equal(12, product.Stock.Value);
+        }
+    }
+
+    [Fact]
+    public async Task Price_IsStoredAsIntegerMinorUnits()
+    {
+        await using var db = NewContext();
+        await db.Database.EnsureCreatedAsync();
+        db.Products.Add(Product.Create("Hub", 39.50m, 1));
+        await db.SaveChangesAsync();
+
+        // The raw column holds cents as an integer — exact and sortable, with no decimal/REAL column.
+        // EF's scalar SqlQueryRaw<T> requires the single result column to be aliased "Value".
+        var cents = await db.Database.SqlQueryRaw<long>("SELECT Price AS Value FROM Products").SingleAsync();
+        Assert.Equal(3950, cents);
+
+        var columnType = await db.Database
+            .SqlQueryRaw<string>("SELECT type AS Value FROM pragma_table_info('Products') WHERE name = 'Price'")
+            .SingleAsync();
+        Assert.Equal("INTEGER", columnType);
+    }
+
+    [Fact]
+    public async Task Update_PersistsMutationThroughTrackedAggregate()
+    {
+        int id;
+        await using (var db = NewContext())
+        {
+            await db.Database.EnsureCreatedAsync();
+            var created = Product.Create("Old name", 10m, 1);
+            db.Products.Add(created);
+            await db.SaveChangesAsync();
+            id = created.Id;
+        }
+
+        await using (var db = NewContext())
+        {
+            var product = await db.Products.SingleAsync(p => p.Id == id);
+            product.Update("New name", 25.50m, 9);
+            await db.SaveChangesAsync();
+        }
+
+        await using (var db = NewContext())
+        {
+            var product = await db.Products.SingleAsync(p => p.Id == id);
+            Assert.Equal("New name", product.Name.Value);
+            Assert.Equal(25.50m, product.Price.Amount);
+            Assert.Equal(9, product.Stock.Value);
+        }
+    }
+
+    public void Dispose()
+    {
+        foreach (var path in new[] { _dbPath, $"{_dbPath}-shm", $"{_dbPath}-wal" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
+++ b/tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\samples\Rask.Example.EfCore\Rask.Example.EfCore.csproj"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
@@ -1,0 +1,69 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+
+namespace Rask.Examples.E2E.Tests;
+
+// End-to-end CRUD round-trip against the EF Core + SQLite sample: create, edit and delete a product
+// through the UI, asserting each step persisted (the list re-reads from SQLite on every navigation).
+[Collection(EfCoreExampleCollection.Name)]
+public sealed class EfCoreCrudTests(EfCoreExampleAppFixture app, PlaywrightFixture pw) : IAsyncLifetime
+{
+    private IBrowserContext _ctx = default!;
+    private IPage _page = default!;
+
+    public async Task InitializeAsync()
+    {
+        _ctx = await pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = app.BaseUrl });
+        _page = await _ctx.NewPageAsync();
+    }
+
+    public async Task DisposeAsync() => await _ctx.DisposeAsync();
+
+    [Fact]
+    public async Task Create_Edit_Delete_RoundTripsThroughSqlite()
+    {
+        await _page.GotoAsync("/products");
+
+        // Seeded data is present on first load.
+        await Assertions.Expect(_page.Locator("tr:has-text('Mechanical keyboard')")).ToBeVisibleAsync();
+
+        // CREATE
+        await _page.ClickAsync("a:has-text('New product')");
+        await _page.FillAsync("#p-name", "E2E gadget");
+        await _page.FillAsync("#p-price", "12.34");
+        await _page.FillAsync("#p-stock", "7");
+        await _page.ClickAsync("button[type=submit]");
+
+        var createdRow = _page.Locator("tr:has-text('E2E gadget')");
+        await Assertions.Expect(createdRow).ToBeVisibleAsync();
+        await Assertions.Expect(createdRow).ToContainTextAsync("7");
+
+        // EDIT — follow the row's edit link, rename, save.
+        await createdRow.Locator("a.btn-outline-secondary").ClickAsync();
+        await _page.FillAsync("#p-name", "E2E gizmo");
+        await _page.ClickAsync("button[type=submit]");
+
+        await Assertions.Expect(_page.Locator("tr:has-text('E2E gizmo')")).ToBeVisibleAsync();
+        await Assertions.Expect(_page.Locator("tr:has-text('E2E gadget')")).ToHaveCountAsync(0);
+
+        // DELETE
+        await _page.Locator("tr:has-text('E2E gizmo')").Locator("button.btn-outline-danger").ClickAsync();
+        await Assertions.Expect(_page.Locator("tr:has-text('E2E gizmo')")).ToHaveCountAsync(0);
+    }
+
+    [Fact]
+    public async Task Create_RejectsInvalidInput_WithInlineMessages()
+    {
+        await _page.GotoAsync("/products/new");
+
+        // Blank name + non-positive price violate the value-object rules reused by the inline validators.
+        await _page.FillAsync("#p-price", "0");
+        await _page.ClickAsync("button[type=submit]");
+
+        await Assertions.Expect(_page.Locator("text=Name is required.")).ToBeVisibleAsync();
+        await Assertions.Expect(_page.Locator("text=Price must be greater than zero.")).ToBeVisibleAsync();
+
+        // Still on the create page — the invalid submit did not navigate away.
+        await Assertions.Expect(_page.Locator("#p-name")).ToBeVisibleAsync();
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/EfCoreExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/EfCoreExampleAppFixture.cs
@@ -1,0 +1,16 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+public sealed class EfCoreExampleAppFixture : ExampleAppFixture
+{
+    // A unique SQLite file per run so the CRUD test starts from the known seed and never sees
+    // state left by a previous run. The sample reads RASK_DB_PATH from configuration.
+    private readonly string _dbPath =
+        Path.Combine(Path.GetTempPath(), $"rask-efcore-e2e-{Guid.NewGuid():N}.db");
+
+    protected override string ProjectRelativePath => "samples/Rask.Example.EfCore";
+
+    protected override int Port => 5110;
+
+    protected override IReadOnlyDictionary<string, string>? ExtraEnvironment =>
+        new Dictionary<string, string> { ["RASK_DB_PATH"] = _dbPath };
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -8,6 +8,13 @@ public sealed class ServerExampleCollection
 }
 
 [CollectionDefinition(Name)]
+public sealed class EfCoreExampleCollection
+    : ICollectionFixture<EfCoreExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "EfCoreExample";
+}
+
+[CollectionDefinition(Name)]
 public sealed class WasmExampleCollection
     : ICollectionFixture<WasmExampleAppFixture>, ICollectionFixture<PlaywrightFixture>
 {

--- a/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
+++ b/tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj
@@ -40,6 +40,8 @@
   <ItemGroup>
     <ProjectReference Include="..\..\samples\Rask.Example.Server\Rask.Example.Server.csproj"
                       ReferenceOutputAssembly="false"/>
+    <ProjectReference Include="..\..\samples\Rask.Example.EfCore\Rask.Example.EfCore.csproj"
+                      ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Auth\Rask.Example.Auth.csproj"
                       ReferenceOutputAssembly="false"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Auth.Jwt\Rask.Example.Auth.Jwt.csproj"

--- a/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/RouteGuardTestApp.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authorization;
 using Rask.Core;
+using Rask.Core.Authentication;
 using Rask.Core.Routing;
 
 #pragma warning disable RASK019 // test-infra app predates framework-managed <head>
@@ -29,10 +30,10 @@ public sealed class E2EPublicPage : Component
 
 [Route("/e2e/members")]
 [Authorize]
-public sealed class E2EMembersPage : Component
+public sealed class E2EMembersPage(IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
-        Div(Id: "members")["members-content for ", Span()[User.Identity?.Name ?? "?"]];
+        Div(Id: "members")["members-content for ", Span()[userProvider.Current.Identity?.Name ?? "?"]];
 }
 
 [Route("/e2e/admin")]

--- a/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
+++ b/tests/Rask.Server.Tests/Authentication/SignInTestApp.cs
@@ -8,14 +8,14 @@ using Rask.Core.Routing;
 
 namespace Rask.Server.Tests.Authentication;
 
-public sealed class SignInTestApp(AuthSignIn auth, RouteState routeState) : Component
+public sealed class SignInTestApp(AuthSignIn auth, RouteState routeState, IUserProvider userProvider) : Component
 {
     protected override RenderResult Render() =>
     [
         Doctype(),
         new Html()[new Head()[new Title()["auth-test"]],
             new Body()[new H1()[$"path={routeState.Path}"],
-                new P()[$"user={(User.Identity?.IsAuthenticated == true ? User.Identity.Name : "anon")}"],
+                new P()[$"user={(userProvider.Current.Identity?.IsAuthenticated == true ? userProvider.Current.Identity.Name : "anon")}"],
                 Button(OnClickAsync: SignInAsync)["sign-in"],
                 Button(OnClickAsync: SignOutAsync)["sign-out"]]]
     ];


### PR DESCRIPTION
## Summary
Branch bundles three changes destined for `main`:
- **`refactor!: remove Component.User`** (`9d2d781`) — drop the `Component.User` member; inject `IUserProvider` instead. **Breaking.**
- **`feat(samples): EF Core + SQLite CRUD sample`** (`0c616ae`).
- **`fix(server): avoid ObjectDisposedException retiring pending session removals`** (`0e11c04`) — `ScheduleRemoval` disposed the prior pending-removal `CancellationTokenSource` from inside an `AddOrUpdate` factory (while still reachable through `_pendingRemovals`), so a concurrent `CancelPendingRemoval`/`CancelAllPending` (two sockets detaching at shutdown) could `TryRemove` the same instance and `Cancel()` an already-disposed source. Now swaps atomically via `TryUpdate`/`TryAdd` and retires the prior source only after the CAS makes it unreachable, so exactly one thread owns its disposal.

## Testing
- Unit: `Rask.Server.Tests` — **163/163 passed**. `Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative` passed 5/5 consecutive runs (was flaky on the dispose race).
- `dotnet build -warnaserror` (Rask.Server) — clean; `dotnet format` on `LiveSessionStore.cs` — clean.
- E2E: `samples/` change is the EF Core sample (`feat` commit, pre-existing on branch); E2E matrix runs in CI.

## Benchmarks
n/a — the fix is in the session-removal scheduler, not the render/runtime hot path.

## CHANGELOG
- [Unreleased] → Fixed: `LiveSessionStore` no longer throws `ObjectDisposedException` while retiring pending session removals under contention.