### PR TITLE
fix(server): avoid ObjectDisposedException retiring pending session removals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- `LiveSessionStore` no longer throws `ObjectDisposedException` while retiring pending session
+  removals under contention. `ScheduleRemoval` disposed the prior `CancellationTokenSource` from
+  inside an `AddOrUpdate` factory — i.e. while it was still reachable through `_pendingRemovals` —
+  so a concurrent `CancelPendingRemoval` / `CancelAllPending` (e.g. two sockets detaching at host
+  shutdown) could `TryRemove` the same instance in that window and call `Cancel()` on an
+  already-disposed source. The install now swaps atomically (`TryUpdate`/`TryAdd`) and retires the
+  prior source only after the CAS has made it unreachable, so exactly one thread owns its disposal.
+  Fixes flaky `Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative`.
 - Showcase samples no longer 404 on `bootstrap.min.css.map`: the vendored `bootstrap.min.css`
   carried a `sourceMappingURL` comment pointing at a map file that isn't shipped, so browsers
   (and the GitHub Pages demo) logged a console 404. Dropped the dangling comment.

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -189,16 +189,29 @@ public sealed class LiveSessionStore : IAsyncDisposable
         }
 
         var cts = CancellationTokenSource.CreateLinkedTokenSource(_stopping);
-        var prior = _pendingRemovals.AddOrUpdate(id, cts, (_, existing) =>
+        // Install the new CTS, retiring any prior pending removal for this id. A CTS must
+        // never be cancelled/disposed while it is still reachable through _pendingRemovals:
+        // a concurrent CancelPendingRemoval / CancelAllPending could TryRemove the same
+        // instance and race us into a double-dispose (ObjectDisposedException out of Cancel).
+        // So swap atomically and retire the prior CTS only after our CAS has made it
+        // unreachable — never from inside an AddOrUpdate factory, whose side effects mutate a
+        // value other threads can still observe in the dictionary. The thread whose
+        // TryUpdate/TryRemove wins is the single owner responsible for disposing that value.
+        while (true)
         {
-            existing.Cancel();
-            existing.Dispose();
-            return cts;
-        });
-        if (!ReferenceEquals(prior, cts))
-        {
-            cts.Dispose();
-            return;
+            if (_pendingRemovals.TryGetValue(id, out var existing))
+            {
+                if (_pendingRemovals.TryUpdate(id, cts, existing))
+                {
+                    existing.Cancel();
+                    existing.Dispose();
+                    break;
+                }
+            }
+            else if (_pendingRemovals.TryAdd(id, cts))
+            {
+                break;
+            }
         }
 
         _ = Task.Run(async () =>


### PR DESCRIPTION
## Summary
`LiveSessionStore.ScheduleRemoval` disposed the prior pending-removal `CancellationTokenSource` from inside an `AddOrUpdate` factory — i.e. while it was still reachable through `_pendingRemovals`. A concurrent `CancelPendingRemoval` / `CancelAllPending` (e.g. two WebSockets detaching at host shutdown) could `TryRemove` that same instance in the window between `Dispose()` and the dictionary swap, then call `Cancel()` on an already-disposed source → `ObjectDisposedException`.

The install now swaps atomically via a `TryUpdate`/`TryAdd` CAS loop and retires the prior source only *after* the swap has made it unreachable, so exactly one thread owns each source's disposal. (Also removes the dead `ReferenceEquals(prior, cts)` guard — `AddOrUpdate` always returns the installed value.)

## Testing
- Unit: `Rask.Server.Tests` — **163/163 passed**. `Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative` (previously flaky on this race) passed **5/5** consecutive runs.
- `dotnet build -warnaserror` (Rask.Server) — clean; `dotnet format` on `LiveSessionStore.cs` — clean.
- E2E: n/a — no `samples/` change.

## Benchmarks
n/a — the change is in the session-removal scheduler, not the render/runtime hot path.

## CHANGELOG
- [Unreleased] → Fixed: `LiveSessionStore` no longer throws `ObjectDisposedException` while retiring pending session removals under contention.