### PR TITLE
fix(server): take render lock during session disposal to end teardown race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ them until tagged releases begin.
   already-disposed source. The install now swaps atomically (`TryUpdate`/`TryAdd`) and retires the
   prior source only after the CAS has made it unreachable, so exactly one thread owns its disposal.
   Fixes flaky `Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative`.
+- `LiveSession` disposal no longer throws `InvalidOperationException: Collection was modified`
+  while tearing down the component tree. `Dispose`/`DisposeAsync` walked the tree (enumerating
+  each component's persisted children) without holding `_renderLock`, so a render still draining on
+  a thread-pool thread at host shutdown could rebuild those same child dictionaries (the swap+clear
+  in `BuildRenderTree`) mid-enumeration. Teardown now takes `_renderLock` around the walk — the
+  same gate renders already use to keep concurrent tree mutations mutually exclusive — and a
+  `_disposed` guard stops a `StateHasChanged` from an unmount/dispose callback re-entering the
+  render path. Fixes flaky `HandlerOrderingTests.TwoHandlers_AcrossMultipleRounds_NeverReorder`.
 - Showcase samples no longer 404 on `bootstrap.min.css.map`: the vendored `bootstrap.min.css`
   carried a `sourceMappingURL` comment pointing at a map file that isn't shipped, so browsers
   (and the GitHub Pages demo) logged a console 404. Dropped the dangling comment.

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -87,6 +87,13 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     private WebSocket? _socket;
     private CancellationToken _socketCt;
 
+    // Set once disposal begins. Read by RequestRenderInternalAsync so a StateHasChanged fired
+    // from a component's Unmount/Dispose callback can't re-enter the render path and deadlock on
+    // the _renderLock that DisposeAsync/Dispose hold while tearing the tree down. Volatile because
+    // disposal (store/host thread) and the render request (async lifecycle continuation on a
+    // thread-pool worker) run on different threads. Mirrors the detached-socket early-return.
+    private volatile bool _disposed;
+
     // Two-buffer swap: `_writeBuffer` receives the next frame, `_lastSentBuffer` holds the
     // previous send (dedup compare target). After SendAsync the references swap so the just-
     // sent buffer becomes the dedup baseline without any byte[] copy. Both writers persist
@@ -149,7 +156,26 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
 
     public async ValueTask DisposeAsync()
     {
-        await ComponentLifecycle.DisposeComponentTreeAsync(View).ConfigureAwait(false);
+        _disposed = true;
+        // Serialise teardown against any in-flight render. RenderAndSendAsync mutates the
+        // component tree's child dictionaries under _renderLock (the swap+Clear in
+        // Component.BuildRenderTree, then GetOrCreateChild inserts), and
+        // DisposeComponentTreeAsync walks those same dictionaries. Without the lock a render
+        // draining on a thread-pool thread at host shutdown races the walk and throws
+        // "Collection was modified; enumeration operation may not execute" out of the dispose
+        // enumeration — the very class of concurrent-tree-mutation bug _renderLock exists to
+        // prevent (see its field comment). Hold it across the whole walk, then release before
+        // disposing the semaphore itself.
+        await _renderLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await ComponentLifecycle.DisposeComponentTreeAsync(View).ConfigureAwait(false);
+        }
+        finally
+        {
+            _renderLock.Release();
+        }
+
         ReleaseFileStores();
         Lock.Dispose();
         _renderLock.Dispose();
@@ -158,7 +184,19 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
 
     public void Dispose()
     {
-        ComponentLifecycle.DisposeComponentTree(View);
+        _disposed = true;
+        // See DisposeAsync: take the render lock so the synchronous tree walk can't race an
+        // in-flight render mutating the same child dictionaries.
+        _renderLock.Wait();
+        try
+        {
+            ComponentLifecycle.DisposeComponentTree(View);
+        }
+        finally
+        {
+            _renderLock.Release();
+        }
+
         ReleaseFileStores();
         Lock.Dispose();
         _renderLock.Dispose();
@@ -173,7 +211,10 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
 
     private async Task RequestRenderInternalAsync(bool publishOnly)
     {
-        if (_socket is null || _socket.State != WebSocketState.Open)
+        // _disposed short-circuits a StateHasChanged raised from an Unmount/Dispose callback during
+        // teardown: the tree walk runs under _renderLock, so re-entering RenderAndSendAsync (which
+        // also waits on _renderLock) would deadlock disposal against itself.
+        if (_disposed || _socket is null || _socket.State != WebSocketState.Open)
         {
             _renderRequestedWhileDetached = true;
             return;

--- a/tests/Rask.Server.Tests/Infrastructure/GatedRenderApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/GatedRenderApp.cs
@@ -1,0 +1,62 @@
+using Rask.Core;
+using Rask.Core.Components;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Infrastructure;
+
+/// <summary>
+///     Test app for the dispose/render teardown race. Clicking the button arms a one-shot gate;
+///     the resulting re-render enters <see cref="Render" />, signals <see cref="RenderEntered" />
+///     (so a test knows a render is now holding the session's <c>_renderLock</c> and is mid-walk),
+///     then blocks on <see cref="ReleaseRender" /> until the test releases it. That lets a test
+///     hold a render in flight deterministically and dispose the session underneath it.
+/// </summary>
+public sealed class GatedRenderApp : Component
+{
+    /// <summary>Completes when a gated render has entered <see cref="Render" />.</summary>
+    public static TaskCompletionSource RenderEntered { get; private set; } = NewLatch();
+
+    /// <summary>Released by the test to let the blocked render finish.</summary>
+    public static ManualResetEventSlim ReleaseRender { get; } = new(false);
+
+    private bool _gateNextRender;
+
+    /// <summary>Resets the static gate between tests (the statics are shared per app type).</summary>
+    public static void Reset()
+    {
+        RenderEntered = NewLatch();
+        ReleaseRender.Reset();
+    }
+
+    protected override RenderResult Render()
+    {
+        if (_gateNextRender)
+        {
+            // One-shot: only the click-triggered render gates, never the GET/hello renders.
+            _gateNextRender = false;
+            RenderEntered.TrySetResult();
+            ReleaseRender.Wait();
+        }
+
+        return
+        [
+            Doctype(),
+            new Html()[
+                new Head()[new Title()["gated"]],
+                new Body()[
+                    new P()["gated-render"],
+                    Button(OnClickAsync: GateAsync)["go"]
+                ]
+            ]
+        ];
+    }
+
+    private Task GateAsync()
+    {
+        _gateNextRender = true;
+        return Task.CompletedTask;
+    }
+
+    private static TaskCompletionSource NewLatch() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/tests/Rask.Server.Tests/WebSockets/SessionDisposeRaceTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/SessionDisposeRaceTests.cs
@@ -1,0 +1,63 @@
+using System.Text.RegularExpressions;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// Regression test for the teardown race between LiveSession disposal and an in-flight render.
+//
+// LiveSessionStore.DisposeAsync (host shutdown) walks each session's component tree via
+// ComponentLifecycle.DisposeComponentTreeAsync, which enumerates every component's
+// PersistedChildren. A render fired from an async lifecycle continuation rebuilds those same
+// child dictionaries under _renderLock (the swap+Clear in Component.BuildRenderTree). Disposal
+// did not take _renderLock, so a render still draining on a thread-pool thread at shutdown raced
+// the walk and intermittently threw "Collection was modified; enumeration operation may not
+// execute" (observed flaking HandlerOrderingTests.TwoHandlers_AcrossMultipleRounds_NeverReorder).
+//
+// The fix makes Dispose/DisposeAsync acquire _renderLock around the walk, so disposal and render
+// are mutually exclusive. This test gates a render in flight and asserts disposal blocks until the
+// render releases the lock — deterministic where a raw stress loop would only catch it sometimes.
+[Collection("SessionGracePeriod")]
+public class SessionDisposeRaceTests
+{
+    [Fact]
+    public async Task DisposeAsync_WhileRenderInFlight_WaitsForRenderLock_AndDoesNotThrow()
+    {
+        GatedRenderApp.Reset();
+
+        using var host = RaskTestHost.Create<GatedRenderApp>();
+        try
+        {
+            var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+            var sessionId = Markup.SessionId(html);
+            var handlerId = Regex.Match(html, "data-rask-on-click=\"(h\\d+)\"").Groups[1].Value;
+            Assert.NotEmpty(handlerId);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+            // Click the button: the resulting render enters Render() and parks there, holding the
+            // session's _renderLock mid-walk.
+            await ws.SendJsonAsync(new { id = handlerId });
+            await GatedRenderApp.RenderEntered.Task.WaitAsync(TimeSpan.FromSeconds(5));
+
+            // Tear the store down (host-shutdown path) while that render is still in flight.
+            var disposeTask = host.Store.DisposeAsync().AsTask();
+
+            // With the fix, disposal waits on _renderLock and cannot make progress while the render
+            // is gated. Pre-fix it ran straight into the racing tree walk.
+            var completedEarly = await Task.WhenAny(disposeTask, Task.Delay(TimeSpan.FromMilliseconds(500)))
+                                 == disposeTask;
+            Assert.False(completedEarly, "DisposeAsync must wait for the in-flight render to release the render lock");
+
+            // Release the render; disposal now completes cleanly with no collection-modified throw.
+            GatedRenderApp.ReleaseRender.Set();
+            await disposeTask.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            // Never leave the gate latched, or the host's own teardown would deadlock.
+            GatedRenderApp.ReleaseRender.Set();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`LiveSession.Dispose`/`DisposeAsync` tore down the component tree without holding `_renderLock`, so a render still draining on a thread-pool thread at host shutdown could rebuild the same child dictionaries (the swap+`Clear` in `Component.BuildRenderTree`, then `GetOrCreateChild` inserts) **while** `ComponentLifecycle.DisposeComponentTree[Async]` enumerated them. The result was an intermittent `InvalidOperationException: Collection was modified; enumeration operation may not execute` out of the dispose walk — the flaky failure seen on CI.

This is the exact class of concurrent tree-mutation bug `_renderLock` already exists to prevent (see its field comment in `LiveSession.cs`); disposal simply never took it.

## Fix
- `Dispose`/`DisposeAsync` now acquire `_renderLock` around the tree walk, making teardown and render mutually exclusive (in-flight render finishes first, then disposal proceeds on a quiescent tree).
- A new `_disposed` guard in `RequestRenderInternalAsync` makes a `StateHasChanged` raised from an unmount/dispose callback a no-op, so it can't re-enter the render path and deadlock against the lock disposal holds.

## Testing
- New `SessionDisposeRaceTests.DisposeAsync_WhileRenderInFlight_WaitsForRenderLock_AndDoesNotThrow`: parks a render in flight (holding `_renderLock` mid-walk via a gated app) and asserts disposal blocks until the render releases, then completes without throwing. **Deterministic** — verified it fails on the pre-fix code (`DisposeAsync must wait for the in-flight render to release the render lock`) and passes after.
- Full `Rask.Server.Tests` suite green (164/164), including the previously-flaky `HandlerOrderingTests.TwoHandlers_AcrossMultipleRounds_NeverReorder`.
- `dotnet build Rask.slnx -warnaserror` clean; `dotnet format` clean.

## Benchmarks
Not applicable: the change is on the session **teardown** path (one `SemaphoreSlim` acquire/release per disposal), not the render hot-path — no serialize/diff/dispatch/allocation change.

## Changelog
Added under `[Unreleased] › Fixed`.