### PR TITLE
feat(core)!: give Authorize's Authorized slot the current principal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **`Authorize`'s `Authorized` slot now receives the current user** — its type changed from `Child` to
+  `Func<ClaimsPrincipal, Child>`, so authorized markup can greet the signed-in user
+  (`Authorized: user => H1()[$"Hi {user.Identity!.Name}"]`, the headless analogue of Blazor's
+  `AuthorizeView` `@context.User`) without injecting `IUserProvider` or subscribing to
+  `IUserProvider.Changed` — the delegate re-runs with the fresh principal whenever the gate
+  re-renders. **Breaking:** static authorized content moves to the children-indexer shorthand —
+  `Authorize(Authorized: Panel())` becomes `Authorize()[ Panel() ]`. `NotAuthorized`/`Authorizing`
+  are unchanged.
 - **WASM build migrated to `Microsoft.NET.Sdk.WebAssembly`** so framework assets are
   content-fingerprinted (`dotnet.<hash>.js`, `App.<hash>.wasm`) and `index.html` carries an
   SDK-generated import map with integrity hashes. This fixes the GitHub Pages (and any static

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -74,17 +74,22 @@ The headless `Authorize` component renders exactly one of three slots — no mar
 the current user (`IUserProvider`):
 
 ```csharp
-// Shorthand: children are the "authorized" branch.
+// Shorthand: children are the "authorized" branch (static content, no principal needed).
 Authorize(Roles: ["admin"])[ AdminPanel() ]
 
-// Full three-slot form.
+// Full three-slot form. `Authorized` is a delegate handed the current principal (Blazor's
+// @context.User), so a greeting reads the name with no injected IUserProvider and no subscription.
 Authorize(
     Roles: ["admin", "editor"],                       // ANY-of; omit for "any authenticated user"
-    Authorized:    Div(Class: "card")[ "Members-only content" ],
+    Authorized:    user => Div(Class: "card")[ $"Welcome, {user.Identity!.Name}" ],
     NotAuthorized: A(Href: "/login")[ "Please sign in" ],
     Authorizing:   Spinner())                     // shown while the principal/policy resolves
 ```
 
+- **`Authorized`** is `Func<ClaimsPrincipal, Child>` — it receives the signed-in principal and re-runs
+  whenever the gate re-renders (i.e. on `IUserProvider.Changed`), so user-dependent markup stays fresh
+  on its own. For static authorized content that ignores the user, use the children-indexer shorthand
+  `Authorize(...)[ content ]`.
 - **`Roles`** and the authenticated check are synchronous → no flicker.
 - **`Policy`** (e.g. `Authorize(Policy: "over-18")`) resolves via `IAuthorizationService` in the background;
   the `Authorizing` slot shows until it lands.
@@ -166,8 +171,9 @@ public sealed class LoginModel
 ```
 
 **A protected page** redirects to `/login?returnUrl=/secure` for anonymous users (handled by the route
-guard). Gate the *content* with the `Authorize` component and keep the user-dependent view in a child
-component in the `Authorized` slot — see the reactivity note below for why:
+guard). Gate the *content* with the `Authorize` component; the `Authorized` slot is a delegate handed
+the freshly-authenticated principal, so the greeting reads the name inline — no child component, no
+subscription:
 
 ```csharp
 [Route("secure")]
@@ -178,28 +184,23 @@ public sealed class SecurePage : Component
         Authorize(
             Authorizing:   P()["Signing you in…"],
             NotAuthorized: P()["Please sign in."],
-            Authorized:    SecureContent());     // child component → renders fresh when the gate opens
-}
-
-public sealed class SecureContent(IUserProvider users) : Component
-{
-    protected override RenderResult Render() =>
-        Div()[
-            H1()[$"Hello, {users.Current.Identity!.Name}"],
-            Authorize(Roles: ["admin"],
-                Authorized:    Div(Class: "alert alert-warning")["🔑 Admin tools"],
-                NotAuthorized: P()["You have standard access."])
-        ];
+            Authorized: user => Div()[      // ← receives the current principal, re-runs on sign-in/out
+                H1()[$"Hello, {user.Identity!.Name}"],
+                Authorize(Roles: ["admin"],
+                    NotAuthorized: P()["You have standard access."])[
+                    Div(Class: "alert alert-warning")["🔑 Admin tools"]]
+            ]);
 }
 ```
 
 > **Reactivity.** Sign-in on the Server completes over a WS reconnect that re-seeds the principal and fires
-> `IUserProvider.Changed`. The `Authorize` component subscribes to that event and re-renders — but a page
-> that reads `users.Current` *directly in its own `Render`* won't re-execute (it didn't subscribe), so a greeting
-> built there can go stale after a mid-session sign-in. Two fixes: put principal-dependent markup inside a
-> **child component** in the `Authorized` slot (it first renders only once the gate opens, as above), or
-> subscribe the page itself: `OnMount() => users.Changed += StateHasChanged;`. The child-component form
-> needs no manual subscription.
+> `IUserProvider.Changed`. The `Authorize` component subscribes to that event and re-renders, re-running its
+> `Authorized` delegate with the fresh principal — so reading `user.Identity!.Name` **inside the slot** always
+> reflects the current user with no extra work. By contrast, a page that reads `users.Current` *directly in its
+> own `Render`* won't re-execute (it didn't subscribe), so a greeting built there can go stale after a
+> mid-session sign-in. If you must read the principal outside the slot, either move that markup into a **child
+> component** placed in the `Authorized` slot (it first renders once the gate opens), or subscribe the page
+> itself: `OnMount() => users.Changed += StateHasChanged;`.
 
 **`Program.cs` — wire cookie auth *before* `UseRask`:**
 

--- a/docs/migration-from-blazor.md
+++ b/docs/migration-from-blazor.md
@@ -27,7 +27,8 @@ New to Rask entirely? Start with [getting started](getting-started.md).
 | route/query binding | `[RouteParam]` / `[QueryParam]` on a property |
 | `<EditForm>` + `InputText`/`InputNumber` | `Form<TModel>(model, OnValidSubmit:)` + `Input(Bind: () => model.X)` |
 | `<DataAnnotationsValidator>` | drop `DataAnnotationsValidator()` inside the `Form<T>` |
-| `<AuthorizeView>` / `AuthenticationStateProvider` | inject `IUserProvider` (read `.Current`) + headless `Authorize(...)` component |
+| `<AuthorizeView>` (+ `Context="user"` / `@context.User`) | headless `Authorize(...)` — its `Authorized: user => …` slot receives the `ClaimsPrincipal`, like `@context.User` |
+| `AuthenticationStateProvider` | inject `IUserProvider` and read `.Current` |
 | `[Inject] T Svc { get; set; }` | constructor injection — `class Page(T svc) : Component` |
 | `Component.razor.css` | sibling `{Component}.css` next to `{Component}.cs` |
 | `IJSRuntime` | `IJSRuntime` (injected via the constructor) |

--- a/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.Jwt/Pages/MembersPage.cs
@@ -16,8 +16,7 @@ public sealed class MembersPage : Component
             Div(Class: "card-body")[
                 Authorize(
                     NotAuthorized: P("members-anon", "mb-0")[
-                        "Please ", NavLink("/login")["sign in"], "."],
-                    Authorized: MemberContent())
+                        "Please ", NavLink("/login")["sign in"], "."])[MemberContent()]
             ]
         ];
 }
@@ -30,10 +29,8 @@ public sealed class MemberContent(ProtectedSessionStorage store, SessionUserProv
             H1("members-greeting", "h3 mb-3")[$"Welcome, {users.Current.Identity?.Name}"],
             P(Class: "text-secondary")["Signed in with a JWT held in ", Code()["ProtectedSessionStorage"],
                 " — encrypted at rest, decrypted only server-side."],
-            Authorize(
-                ["admin"],
-                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(["admin"])[
+                Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."]],
             Button(Id: "logout", OnClickAsync: SignOutAsync, Class: "btn btn-outline-primary")["Sign out"]
         ];
 

--- a/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmCookie/Pages/MembersPage.cs
@@ -17,8 +17,7 @@ public sealed class MembersPage : Component
                 Authorize(
                     Authorizing: P("members-authorizing", "text-secondary mb-0")["Loading…"],
                     NotAuthorized: P("members-anon", "mb-0")[
-                        "Please ", NavLink("/login")["sign in"], "."],
-                    Authorized: MemberContent())
+                        "Please ", NavLink("/login")["sign in"], "."])[MemberContent()]
             ]
         ];
 }
@@ -28,10 +27,8 @@ public sealed class MemberContent(WasmLoginService login, IUserProvider userProv
     protected override RenderResult Render() =>
         Fragment()[
             H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
-            Authorize(
-                ["admin"],
-                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(["admin"])[
+                Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."]],
             Button(Id: "logout", OnClickAsync: login.LogoutAsync, Class: "btn btn-outline-primary")["Sign out"]
         ];
 }

--- a/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth.WasmJwt/Pages/MembersPage.cs
@@ -14,8 +14,7 @@ public sealed class MembersPage : Component
                 Authorize(
                     Authorizing: P("members-authorizing", "text-secondary mb-0")["Loading…"],
                     NotAuthorized: P("members-anon", "mb-0")[
-                        "Please ", NavLink("/login")["sign in"], "."],
-                    Authorized: MemberContent())
+                        "Please ", NavLink("/login")["sign in"], "."])[MemberContent()]
             ]
         ];
 }
@@ -25,10 +24,8 @@ public sealed class MemberContent(JwtLoginService login, IUserProvider userProvi
     protected override RenderResult Render() =>
         Fragment()[
             H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
-            Authorize(
-                ["admin"],
-                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(["admin"])[
+                Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."]],
             Button(Id: "logout", OnClickAsync: login.LogoutAsync, Class: "btn btn-outline-primary")["Sign out"]
         ];
 }

--- a/samples/Rask.Example.Auth/Pages/MembersPage.cs
+++ b/samples/Rask.Example.Auth/Pages/MembersPage.cs
@@ -6,9 +6,9 @@ namespace Rask.Example.Auth.Pages;
 
 // [Authorize] blocks anonymous *deep-links* (full GET → 302 to /login). The headless Authorize
 // component gates the *content* — it subscribes to IUserProvider.Changed, so when the post-sign-in
-// reconnect re-seeds the principal it re-renders to the Authorized slot. The signed-in view lives in
-// its own component (MemberContent) so it first renders only once the gate opens, reading the
-// freshly-authenticated principal — no manual Changed subscription needed on the page.
+// reconnect re-seeds the principal it re-renders to the Authorized slot. That slot is a delegate
+// taking the freshly-authenticated principal, so the greeting reads the name directly — no injected
+// IUserProvider and no manual Changed subscription on the page.
 [Route("members")]
 [Authorize]
 public sealed class MembersPage : Component
@@ -20,25 +20,24 @@ public sealed class MembersPage : Component
                     Authorizing: P("members-authorizing", "text-secondary mb-0")["Signing you in…"],
                     NotAuthorized: P("members-anon", "mb-0")[
                         "Please ", NavLink("/login")["sign in"], "."],
-                    Authorized: MemberContent())
+                    Authorized: user => Fragment()[
+                        H1("members-greeting", "h3 mb-3")[$"Welcome, {user.Identity?.Name}"],
+                        MemberContent()])
             ]
         ];
 }
 
-// Rendered only by the Authorize component's Authorized slot, so its Render reads the current
-// (authenticated) principal. Injects IUserProvider for the principal and IAuthSignIn for sign-out.
-public sealed class MemberContent(IUserProvider userProvider, IAuthSignIn auth) : Component
+// The member actions, rendered only once the gate opens. The greeting now comes from the Authorized
+// delegate above, so this no longer needs IUserProvider — it injects IAuthSignIn purely for sign-out.
+public sealed class MemberContent(IAuthSignIn auth) : Component
 {
     protected override RenderResult Render() =>
         Fragment()[
-            H1("members-greeting", "h3 mb-3")[$"Welcome, {userProvider.Current.Identity?.Name}"],
             P(Class: "text-secondary")["This page is gated by ", Code()["[Authorize]"],
                 " plus the Authorize component."],
             // Role gate: only an admin sees this.
-            Authorize(
-                ["admin"],
-                Authorized: Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(["admin"])[
+                Div(Id: "admin-note", Class: "alert alert-warning py-2")["🔑 You have admin access."]],
             Button(Id: "logout", OnClickAsync: () => auth.SignOutAsync("/login"),
                 Class: "btn btn-outline-primary")["Sign out"]
         ];

--- a/samples/Rask.Example.Shared/Demos/AuthorizeDemo.cs
+++ b/samples/Rask.Example.Shared/Demos/AuthorizeDemo.cs
@@ -1,19 +1,16 @@
 namespace Rask.Example.Shared.Demos;
 
 // Declarative auth gating with the headless Authorize component (Authorized / NotAuthorized /
-// Authorizing slots). Driven by the same toggleable DemoUserProvider as UserGateDemo — the Authorize
-// component subscribes to IUserProvider.Changed itself, so signing in/out anywhere re-renders the gate.
-// Nesting an inner Authorize() in the outer's NotAuthorized slot yields three distinct states
-// (admin / signed-in / anonymous) with no imperative branching in Render().
+// Authorizing slots). Driven by the same toggleable DemoUserProvider as UserGateDemo — but unlike that
+// imperative demo this needs NO manual Changed subscription: the Authorize component subscribes to
+// IUserProvider.Changed itself, and its Authorized slot is a delegate handed the current principal, so
+// the greeting reads the name with zero plumbing. Nesting an inner Authorize() in the outer's
+// NotAuthorized slot yields three distinct states (admin / signed-in / anonymous).
 public sealed class AuthorizeDemo : Component
 {
     private readonly DemoUserProvider _auth;
 
     public AuthorizeDemo(DemoUserProvider auth) => _auth = auth;
-
-    protected override void OnMount() => _auth.Changed += StateHasChanged;
-
-    protected override void OnUnmount() => _auth.Changed -= StateHasChanged;
 
     protected override RenderResult Render() =>
         Div(Id: "authorize-demo")[
@@ -25,11 +22,14 @@ public sealed class AuthorizeDemo : Component
                 Button(Class: "btn btn-sm btn-outline-secondary", OnClick: _auth.SignOut)["Sign out"]
             ],
             // admin → admin slot; any other signed-in user → inner "authorized" slot; anonymous → inner fallback.
+            // The Authorized delegates greet the signed-in user by name straight off the principal.
             Authorize(
                 ["admin"],
-                Authorized: Div(Class: "alert alert-warning py-2 mb-0")["🔑 Admin-only content."],
+                Authorized: user => Div(Class: "alert alert-warning py-2 mb-0")[
+                    $"🔑 Admin-only content — welcome, {user.Identity!.Name}."],
                 NotAuthorized: Authorize(
-                    Authorized: Div(Class: "alert alert-success py-2 mb-0")["✅ Signed in — standard access."],
+                    Authorized: user => Div(Class: "alert alert-success py-2 mb-0")[
+                        $"✅ Signed in as {user.Identity!.Name} — standard access."],
                     NotAuthorized: Div(Class: "alert alert-secondary py-2 mb-0")["🔒 Sign in to see member content."]))
         ];
 }

--- a/samples/Rask.Example.Shared/Pages/UserPage.cs
+++ b/samples/Rask.Example.Shared/Pages/UserPage.cs
@@ -42,14 +42,16 @@ public sealed class UserPage : Component
             """
             // Headless: renders exactly one of three slots, no markup of its own.
             // The component subscribes to IUserProvider.Changed itself, so it reacts to sign-in/out.
+            // The Authorized slot is a delegate handed the current principal (Blazor's @context.User),
+            // so a greeting reads the name with no injected IUserProvider and no manual subscription.
             Authorize(
                 Roles: ["admin"],                                  // ANY-of; omit for "any authenticated user"
-                Authorized:    Div(Class: "alert alert-warning")["🔑 Admin-only content."],
+                Authorized:    user => Div(Class: "alert alert-warning")[$"🔑 Welcome admin, {user.Identity!.Name}."],
                 NotAuthorized: Authorize(                        // nest for an authenticated-but-not-admin branch
-                    Authorized:    Div(Class: "alert alert-success")["✅ Signed in — standard access."],
+                    Authorized:    user => Div(Class: "alert alert-success")[$"✅ Signed in as {user.Identity!.Name}."],
                     NotAuthorized: Div(Class: "alert alert-secondary")["🔒 Sign in to see member content."]));
 
-            // Shorthand — children are the Authorized branch:
+            // Static authorized content (no principal needed) uses the children indexer:
             //   Authorize(Roles: ["admin"])[ AdminPanel() ]
             // Policy gating resolves via IAuthorizationService; the optional Authorizing slot shows
             // until it lands (and while a WASM provider's principal is still loading).

--- a/src/Rask.Core/Components/Authorize.cs
+++ b/src/Rask.Core/Components/Authorize.cs
@@ -13,8 +13,11 @@ namespace Rask.Core.Components;
 ///     <see cref="Fragment" />):
 ///     <list type="bullet">
 ///         <item>
-///             <see cref="Authorized" /> — the user passes the gate. Falls back to the children
-///             indexer when the slot is null, so <c>Authorize(Roles: "admin")[ adminPanel ]</c> works.
+///             <see cref="Authorized" /> — the user passes the gate; the delegate receives the
+///             current <see cref="ClaimsPrincipal" /> (Blazor's <c>@context.User</c>), so a greeting
+///             can read <c>user.Identity!.Name</c> with no manual subscription. Falls back to the
+///             children indexer when null, so <c>Authorize(Roles: "admin")[ adminPanel ]</c> renders
+///             static content.
 ///         </item>
 ///         <item><see cref="NotAuthorized" /> — the user is denied (default: renders nothing).</item>
 ///         <item>
@@ -68,8 +71,14 @@ public sealed class Authorize : Component
     /// </summary>
     public string? Policy { get; set; }
 
-    /// <summary>Rendered when the gate passes. When null, the children indexer is used instead.</summary>
-    public Child? Authorized { get; set; }
+    /// <summary>
+    ///     Rendered when the gate passes; the delegate receives the current <see cref="ClaimsPrincipal" />
+    ///     so authorized markup can read the signed-in user (e.g. a name) with no manual
+    ///     <see cref="IUserProvider.Changed" /> subscription — it re-runs whenever the gate re-renders.
+    ///     When null, the children indexer supplies static authorized content instead:
+    ///     <c>Authorize(Roles: "admin")[ adminPanel ]</c>.
+    /// </summary>
+    public Func<ClaimsPrincipal, Child>? Authorized { get; set; }
 
     /// <summary>Rendered when the gate denies. Defaults to nothing.</summary>
     public Child? NotAuthorized { get; set; }
@@ -115,8 +124,11 @@ public sealed class Authorize : Component
 
         if (IsAllowed())
         {
-            return Authorized is { Component: { } authorized }
-                ? authorized
+            // The delegate runs fresh with the current principal on every re-render (the component
+            // re-renders on IUserProvider.Changed), so user-dependent markup stays in sync without a
+            // manual subscription. Null delegate → static authorized content via the children indexer.
+            return Authorized is { } authorized
+                ? authorized(CurrentUser).Component
                 : new Fragment { Children = Children ?? [] };
         }
 

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-server/Auth/MembersPage.cs
@@ -16,8 +16,7 @@ public sealed class MembersPage : Component
     protected override RenderResult Render() =>
         Div(Class: "welcome-card")[
             Authorize(
-                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."])[MemberContent()]
         ];
 }
 
@@ -26,10 +25,8 @@ public sealed class MemberContent(IAuthSignIn auth, IUserProvider userProvider) 
     protected override RenderResult Render() =>
         Fragment()[
             H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
-            Authorize(
-                Roles: ["admin"],
-                Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(Roles: ["admin"])[
+                Div(Style: "color:#7a5c00")["🔑 You have admin access."]],
             Button(OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"))["Sign out"]
         ];
 }

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/Auth/MembersPage.cs
@@ -15,8 +15,7 @@ public sealed class MembersPage : Component
     protected override RenderResult Render() =>
         Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
             Authorize(
-                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."])[MemberContent()]
         ];
 }
 
@@ -25,10 +24,8 @@ public sealed class MemberContent(WasmLoginService login, IUserProvider userProv
     protected override RenderResult Render() =>
         Fragment()[
             H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
-            Authorize(
-                Roles: ["admin"],
-                Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(Roles: ["admin"])[
+                Div(Style: "color:#7a5c00")["🔑 You have admin access."]],
             Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
         ];
 }

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -34,7 +34,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
 - **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices.
-- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component;
+- **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 
 ## Build & run

--- a/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/MembersPage.cs
@@ -12,8 +12,7 @@ public sealed class MembersPage : Component
     protected override RenderResult Render() =>
         Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
             Authorize(
-                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."],
-                Authorized: MemberContent())
+                NotAuthorized: P()["Please ", NavLink(Href: "/login")["sign in"], "."])[MemberContent()]
         ];
 }
 
@@ -22,10 +21,8 @@ public sealed class MemberContent(JwtLoginService login, IUserProvider userProvi
     protected override RenderResult Render() =>
         Fragment()[
             H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
-            Authorize(
-                Roles: ["admin"],
-                Authorized: Div(Style: "color:#7a5c00")["🔑 You have admin access."],
-                NotAuthorized: (Child)Fragment()),
+            Authorize(Roles: ["admin"])[
+                Div(Style: "color:#7a5c00")["🔑 You have admin access."]],
             Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
         ];
 }

--- a/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
+++ b/tests/Rask.Core.Tests/Components/AuthorizeTests.cs
@@ -17,7 +17,7 @@ public class AuthorizeTests
     [Fact]
     public void Anonymous_WithoutNotAuthorized_RendersNothing()
     {
-        var html = Render(Anonymous(), () => Authorize(Authorized: Span()["AUTHED"]));
+        var html = Render(Anonymous(), () => Authorize(Authorized: _ => Span()["AUTHED"]));
 
         Assert.DoesNotContain("AUTHED", html);
         Assert.DoesNotContain("DENIED", html);
@@ -27,7 +27,7 @@ public class AuthorizeTests
     public void Anonymous_RendersNotAuthorizedSlot()
     {
         var html = Render(Anonymous(),
-            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("DENIED", html);
         Assert.DoesNotContain("AUTHED", html);
@@ -37,7 +37,7 @@ public class AuthorizeTests
     public void Authenticated_RendersAuthorizedSlot()
     {
         var html = Render(User("alice"),
-            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("AUTHED", html);
         Assert.DoesNotContain("DENIED", html);
@@ -53,10 +53,33 @@ public class AuthorizeTests
     }
 
     [Fact]
+    public void AuthorizedDelegate_ReceivesCurrentPrincipal()
+    {
+        // The delegate form is handed the signed-in principal, so authorized markup can read the user
+        // (e.g. a greeting) without injecting IUserProvider or subscribing to Changed.
+        var html = Render(User("alice"),
+            () => Authorize(Authorized: user => Span()[$"Hi {user.Identity!.Name}"]));
+
+        Assert.Contains("Hi alice", html);
+    }
+
+    [Fact]
+    public void Anonymous_DoesNotInvokeAuthorizedDelegate()
+    {
+        // Denied gate must not run the authorized delegate (it would NRE on the anonymous identity).
+        var html = Render(Anonymous(),
+            () => Authorize(
+                Authorized: user => Span()[user.Identity!.Name!.ToUpperInvariant()],
+                NotAuthorized: Span()["DENIED"]));
+
+        Assert.Contains("DENIED", html);
+    }
+
+    [Fact]
     public void RoleMatch_RendersAuthorized()
     {
         var html = Render(User("root", "admin"),
-            () => Authorize(["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(["admin"], Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("AUTHED", html);
     }
@@ -65,7 +88,7 @@ public class AuthorizeTests
     public void RoleMiss_RendersNotAuthorized()
     {
         var html = Render(User("alice", "user"),
-            () => Authorize(["admin"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(["admin"], Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("DENIED", html);
         Assert.DoesNotContain("AUTHED", html);
@@ -75,7 +98,7 @@ public class AuthorizeTests
     public void AnyOfRoles_MatchesOnEither()
     {
         var html = Render(User("alice", "editor"),
-            () => Authorize(["admin", "editor"], Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
+            () => Authorize(["admin", "editor"], Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]));
 
         Assert.Contains("AUTHED", html);
     }
@@ -84,7 +107,7 @@ public class AuthorizeTests
     public void ProviderLoading_RendersAuthorizingSlot()
     {
         var html = Render(new LoadingUser(),
-            () => Authorize(Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"],
+            () => Authorize(Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"],
                 Authorizing: Span()["LOADING"]));
 
         Assert.Contains("LOADING", html);
@@ -96,7 +119,7 @@ public class AuthorizeTests
     public void PolicyAllow_RendersAuthorized()
     {
         var html = Render(User("root", "admin"),
-            () => Authorize(Policy: "admins-only", Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]),
+            () => Authorize(Policy: "admins-only", Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]),
             WithAdminsPolicy);
 
         Assert.Contains("AUTHED", html);
@@ -106,7 +129,7 @@ public class AuthorizeTests
     public void PolicyDeny_RendersNotAuthorized()
     {
         var html = Render(User("alice", "user"),
-            () => Authorize(Policy: "admins-only", Authorized: Span()["AUTHED"], NotAuthorized: Span()["DENIED"]),
+            () => Authorize(Policy: "admins-only", Authorized: _ => Span()["AUTHED"], NotAuthorized: Span()["DENIED"]),
             WithAdminsPolicy);
 
         Assert.Contains("DENIED", html);

--- a/tests/Rask.Example.Shared.Tests/Demos/AuthorizeDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/AuthorizeDemoTests.cs
@@ -29,6 +29,8 @@ public sealed class AuthorizeDemoTests
         var html = Render(provider);
 
         Assert.Contains("standard access", html);
+        // The Authorized slot greets the user by name straight off the principal — no subscription.
+        Assert.Contains("Signed in as alice", html);
         Assert.DoesNotContain("Admin-only", html);
     }
 
@@ -41,6 +43,7 @@ public sealed class AuthorizeDemoTests
         var html = Render(provider);
 
         Assert.Contains("Admin-only", html);
+        Assert.Contains("welcome, rootadmin", html);
         Assert.DoesNotContain("Sign in to see member content", html);
     }
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -320,6 +320,10 @@ public abstract partial class SharedSmokeTests
         await demo.Locator("button:has-text('Sign in as admin')").ClickAsync();
         await Expect(demo).ToContainTextAsync("Admin-only content",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        // The Authorized slot delegate re-runs with the fresh principal on Changed (no reload), so the
+        // greeting names the admin who just signed in.
+        await Expect(demo).ToContainTextAsync("welcome, rootadmin",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await demo.Locator("button:has-text('Sign out')").ClickAsync();
     }
 


### PR DESCRIPTION
## Summary

The `Authorize` component already self-subscribes to `IUserProvider.Changed`, but its slots were static `Child` with no access to the principal — so showing `"Signed in as {name}"` forced either a child component in the `Authorized` slot or a manual `auth.Changed += StateHasChanged` subscription on the page.

This makes the `Authorized` slot a **user-aware render delegate**: `Func<ClaimsPrincipal, Child>`. It receives the signed-in principal (the headless analogue of Blazor's `AuthorizeView` `@context.User`) and re-runs with the fresh principal whenever the gate re-renders, so user-dependent markup stays in sync with **no injected `IUserProvider` and no manual subscription**. It also restores ergonomics lost when `Component.User` was removed (#58).

```csharp
Authorize(Roles: ["admin"],
    Authorized: user => P()[$"Signed in as {user.Identity!.Name}"]);
```

Why a delegate-typed `Authorized` and not a second slot: C# doesn't apply user-defined conversions to lambdas, so one parameter can't accept both a lambda and static content. Static authorized content keeps its first-class home — the children-indexer shorthand `Authorize(...)[ content ]`. This is an idiomatic shape (`ErrorBoundary.Fallback` is `Func<Exception, Action, Child>`); the factory generator already excludes `Func<…,Child>` template delegates from callback-wrapping, so **no generator changes**.

### Breaking change

`Authorize.Authorized` is now `Func<ClaimsPrincipal, Child>`. Static authorized content migrates to the children indexer:

```diff
- Authorize(Authorized: Panel())
+ Authorize()[ Panel() ]
```

`NotAuthorized` / `Authorizing` are unchanged. All in-repo call sites (auth samples, `dotnet new` templates, showcase, docs) are migrated in this PR.

## Changes

- **Core:** `Authorize.Authorized` type change + one-line `Render()` branch (reuses the existing `CurrentUser`); XML docs updated.
- **Showcase:** `AuthorizeDemo` drops its redundant `auth.Changed` subscription and greets by name via the slot; the `Rask.Example.Auth` member page greets the member off the slot (its `MemberContent` no longer needs `IUserProvider`); `UserPage` code sample shows the delegate form.
- **Migration:** ~20 static `Authorized:` sites → children indexer across 3 `dotnet new` templates, 4 auth samples, tests, and docs.
- **Docs:** `authentication.md` (declarative-gating + reactivity sections now teach the delegate as the no-subscription default), `migration-from-blazor.md` (`@context.User` mapping), template `AGENTS.md` files.

## Testing

- `dotnet build -warnaserror` — clean (0 warnings/0 errors) on every touched project, incl. the generated `Authorize` factory and all `Authorized: user =>` call sites.
- `dotnet test` (non-E2E) — full suite green. Authorize unit tests **15/15** (added: delegate-receives-principal, denied-path-doesn't-invoke); `AuthorizeDemoTests` assert the name renders; E2E project compiles with a new "greeting names the admin after live sign-in" assertion (runs in CI's sharded E2E).
- `dotnet format --verify-no-changes` — clean on all touched files.

> Note: the WASM **Host** projects currently fail to build locally with `MSB4018: UpdateExternallyDefinedStaticWebAssets` (a StaticWebAssets SDK task) — pre-existing infra flakiness unrelated to this change; the WASM **app** projects build clean.

## Benchmarks

Not run: the suite has no `Authorize` coverage and the change is allocation-neutral by construction — the old code read a static `Child` on the same path the new code invokes a caller-supplied delegate on. If anything it allocates **less** for closed gates (authorized markup is built lazily at render, not eagerly at factory call).

## Changelog

`[Unreleased]` updated with the breaking change under **Changed**.