### PR TITLE
docs(data-access): drop redundant StateHasChanged from delete example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ them until tagged releases begin.
   automatically. Sub-path deploys keep `/p:RaskPathBase=/<repo>` (now a post-publish `<base href>`
   rewrite; every other asset URL is document-relative).
 
+### Documentation
+- EF Core data-access guide: clarified that an awaited event handler re-renders automatically on
+  completion (like an async lifecycle hook), and removed the misleading explicit `StateHasChanged()`
+  from the delete example — it's only needed for out-of-band changes (timers, fire-and-forget,
+  external event subscriptions). The `Rask.Example.EfCore` sample's `DeleteAsync` drops the call.
+
 ### Fixed
 - GitHub Pages demo showed `v1.0.0` instead of the released version in the navbar badge. The
   `pages` workflow checked out a shallow clone, so MinVer couldn't read the git tags and the

--- a/docs/data-access.md
+++ b/docs/data-access.md
@@ -54,8 +54,9 @@ public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbConte
 }
 ```
 
-For an event-handler mutation (e.g. a delete button), do the work, reload, then call
-`StateHasChanged()` explicitly:
+For an event-handler mutation (e.g. a delete button), just do the work and reload — no
+`StateHasChanged()` needed. An awaited handler re-renders on completion exactly like the async
+lifecycle hook above, so the reloaded list paints automatically:
 
 ```csharp
 private async Task DeleteAsync(int id)
@@ -63,9 +64,13 @@ private async Task DeleteAsync(int id)
     await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
     await db.Products.Where(p => p.Id == id).ExecuteDeleteAsync(CancellationToken);
     await LoadAsync();
-    StateHasChanged();
 }
 ```
+
+You only call `StateHasChanged()` by hand for state that changes **outside** the handler-dispatch
+window — a timer tick, a fire-and-forget continuation, or an external event/observable
+subscription (e.g. `OnMount() => store.Changed += StateHasChanged`). See
+[lifecycle.md](lifecycle.md) for the auto-re-render rule.
 
 ## How the sample is organised
 

--- a/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
@@ -31,12 +31,13 @@ public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbConte
         _loaded = true;
     }
 
+    // No explicit StateHasChanged() needed: an awaited event handler re-renders on completion, so
+    // the reloaded list paints automatically (same as the async OnMountAsync above).
     private async Task DeleteAsync(int id)
     {
         await using var db = await dbContextFactory.CreateDbContextAsync(CancellationToken);
         await db.Products.Where(p => p.Id == id).ExecuteDeleteAsync(CancellationToken);
         await LoadAsync();
-        StateHasChanged();
     }
 
     protected override RenderResult Render() =>

--- a/tests/Rask.Core.Tests/Live/AsyncHandlerRenderingTests.cs
+++ b/tests/Rask.Core.Tests/Live/AsyncHandlerRenderingTests.cs
@@ -88,6 +88,40 @@ public class AsyncHandlerRenderingTests
     }
 
     [Fact]
+    public async Task AsyncHandler_StateMutatedAfterAwait_RepaintsWithoutStateHasChanged()
+    {
+        // The contract behind docs/data-access.md: an awaited DOM event handler needs no explicit
+        // StateHasChanged() — after the handler returns the framework re-marks the owner dirty, so the
+        // dispatcher's unconditional post-handler render repaints mutations made past the mid-await
+        // window. The render handle here consumes the dirty flag on every render exactly like the real
+        // RenderForLive does, so this proves the POST-await re-mark, not just the mark-before-run:
+        // without it, the final render below would be a stale cache hit (RenderCount unchanged).
+        var component = new CountingComponent();
+        var handle = new RecordingRenderHandle(() => component.LastRendered, onRender: () => component.RenderForLive());
+        component.RenderHandle = handle;
+
+        component.RenderForLive(); // first paint: populate the render cache and clear the dirty flag
+        var rendersAfterFirstPaint = component.RenderCount;
+
+        component.RegisterTestHandler("h0", new Func<Task>(async () =>
+        {
+            await Task.Yield(); // mid-await render fires here and consumes the dirty flag
+            component.State = "reloaded"; // the post-await mutation (e.g. _products = await Load())
+        }));
+
+        await component.TryInvokeHandlerAsync("h0", EmptyPayload);
+        var rendersAfterHandler = component.RenderCount;
+
+        // Simulate the dispatcher's post-handler render. A clean component would cache-hit here.
+        component.RenderForLive();
+
+        Assert.True(component.RenderCount > rendersAfterFirstPaint, "the handler should have driven renders");
+        Assert.True(component.RenderCount > rendersAfterHandler,
+            "dispatcher render must re-execute — the handler left the component dirty, no StateHasChanged() needed");
+        Assert.Equal("reloaded", component.LastRendered);
+    }
+
+    [Fact]
     public async Task AsyncHandler_NoRenderHandle_DoesNotThrow()
     {
         var component = new StubComponent(Span());
@@ -111,11 +145,31 @@ public class AsyncHandlerRenderingTests
         Assert.IsNotType<HandlerSyncContext>(SynchronizationContext.Current);
     }
 
+    private sealed class CountingComponent : Component
+    {
+        public int RenderCount { get; private set; }
+        public string State { get; set; } = "init";
+        public string LastRendered { get; private set; } = "";
+
+        protected override RenderResult Render()
+        {
+            RenderCount++;
+            LastRendered = State;
+            return Span()[State];
+        }
+    }
+
     private sealed class RecordingRenderHandle : IRenderHandle
     {
         private readonly Func<string> _snapshot;
+        private readonly Action? _onRender;
 
-        public RecordingRenderHandle(Func<string> snapshot) => _snapshot = snapshot;
+        public RecordingRenderHandle(Func<string> snapshot, Action? onRender = null)
+        {
+            _snapshot = snapshot;
+            _onRender = onRender;
+        }
+
         public List<string> Snapshots { get; } = new();
 
         public Task RequestRenderAsync() => Task.CompletedTask;
@@ -127,6 +181,7 @@ public class AsyncHandlerRenderingTests
                 Snapshots.Add(_snapshot());
             }
 
+            _onRender?.Invoke();
             return Task.CompletedTask;
         }
     }


### PR DESCRIPTION
## Summary
An awaited event handler in Rask re-renders automatically on completion — `Component.TryInvokeHandlerAsync` re-marks the owner dirty after the handler (`Component.cs:847`) and the WS dispatcher then renders unconditionally. So the explicit `StateHasChanged()` in the EF Core delete example was redundant and contradicted the lifecycle-hook guidance two paragraphs earlier. This removes it from `docs/data-access.md` + the `Rask.Example.EfCore` sample, states the real rule (manual `StateHasChanged()` only for out-of-band changes: timers, fire-and-forget, external event subscriptions), and adds a unit test locking the auto-repaint contract.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — pass (incl. new `AsyncHandler_StateMutatedAfterAwait_RepaintsWithoutStateHasChanged`; `AsyncHandlerRenderingTests` 7/7). Build `-warnaserror` clean, `dotnet format --verify-no-changes` clean.
- E2E (samples changed): host `EfCore` — `EfCoreCrudTests.Create_Edit_Delete_RoundTripsThroughSqlite` already asserts the deleted row disappears (the repaint this relies on); unchanged. Couldn't run locally (no `pwsh`/Playwright browser in the sandbox) — runs in CI.

## Benchmarks
n/a — docs/sample/test only, no render-hotpath code change.

## CHANGELOG
- [Unreleased] entry added: EF Core data-access guide clarifies awaited handlers auto-re-render; removed the misleading explicit `StateHasChanged()` from the delete example.
