### PR TITLE
fix(core): preserve focus and selection across keyed reorders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,17 @@ them until tagged releases begin.
   external event subscriptions). The `Rask.Example.EfCore` sample's `DeleteAsync` drops the call.
 
 ### Fixed
+- **Keyed reorders now preserve the survivors' focus, text selection, and caret position**, not
+  just their uncommitted input *value*. Applying a trusted structural diff (`MoveSubtree` /
+  `PermutationBatch`) — and the keyed branch of the untrusted morph — relocated each surviving
+  node with `removeChild` + `insertBefore`. Detaching a node blurs any focused descendant, so the
+  typed text travelled with its row (the same DOM node is reused) but focus, selection, and caret
+  silently did not — contradicting the "survivors keep their DOM state" contract the Keyed lists
+  demo advertises. The runtime now relocates with the Atomic Move API (`Node.moveBefore`,
+  Chromium 133+), which moves a node without disconnecting it, and falls back to `insertBefore`
+  where it is unavailable. Affects `Rask.Server` (`rask.js`), `Rask.Wasm` (`rask.wasm.js`), and
+  the shared morph runtime (`rask-morph.js`); covered by the Keyed lists step of every host's E2E
+  journey, which now reverses a list with a focused, mid-string caret and asserts it survives.
 - GitHub Pages demo showed `v1.0.0` instead of the released version in the navbar badge. The
   `pages` workflow checked out a shallow clone, so MinVer couldn't read the git tags and the
   assembly kept the .NET default informational version. The workflow now fetches full history

--- a/docs/architecture/live-rendering.md
+++ b/docs/architecture/live-rendering.md
@@ -205,8 +205,13 @@ the path coordinates line up with the server's DOM-relevant frame counting.
 Give list items a stable `Key:` (Blazor `@key` parity — last optional factory param)
 and the diff reconciles them by *identity* instead of position. This unlocks
 **trusted** Insert/Remove/Move ops that preserve focus, selection, scroll, IDL
-property state, and event listeners on surviving nodes (moving a node via
-`insertBefore` doesn't materialise a new element).
+property state, and event listeners on surviving nodes. The client relocates a moved
+node with the Atomic Move API (`Node.moveBefore`, Chromium 133+), which repositions it
+**without disconnecting it from the document** — the distinction matters: `removeChild`
++ `insertBefore`, or even a bare `insertBefore` of a connected node, briefly detaches it
+and so *blurs* a focused descendant and drops its selection/caret (the element survives,
+but its interaction state does not). Where `moveBefore` is unavailable the runtime falls
+back to `insertBefore`, preserving the node and its value but not its focus.
 
 `EditOp.Trusted` marks an op produced by `FrameDiffer`'s keyed-matching branch. The
 gate `LiveDiffGate.DiffOpsAreClientSupported` (`Live/LiveDiffGate.cs`) routes any

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -44,6 +44,22 @@ function _raskInsertBefore(parent, dst, anchor) {
     parent.insertBefore(dst, anchor);
 }
 
+// Relocate an already-attached child before `anchor`. Prefer the Atomic Move API
+// (moveBefore, Chromium 133+): it moves the node WITHOUT disconnecting it, so a
+// focused descendant keeps focus, selection, and caret across a keyed reorder. A
+// plain insertBefore of a connected node still disconnects it briefly and blurs it.
+function _raskMoveBefore(parent, node, anchor) {
+    if (parent.moveBefore) {
+        try {
+            parent.moveBefore(node, anchor);
+            return;
+        } catch (e) {
+            // Not connected / cross-document — fall through to insertBefore.
+        }
+    }
+    parent.insertBefore(node, anchor);
+}
+
 function _raskAppendChild(parent, dst) {
     parent.appendChild(dst);
 }
@@ -184,7 +200,7 @@ function morph(from, to) {
                 _raskInsertBefore(from, reviveScript(dst), anchor);
                 _raskRemoveChild(from, src);
             } else {
-                if (src !== anchor) from.insertBefore(src, anchor);
+                if (src !== anchor) _raskMoveBefore(from, src, anchor);
                 else anchor = anchor.nextSibling;
                 morph(src, dst);
             }

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -997,6 +997,41 @@
         return null;
     }
 
+    // Like relevantChild but counts as if `skip` were already gone — the post-detach
+    // coordinate the keyed differ uses for move targets. Lets us resolve the anchor
+    // WITHOUT detaching the moving node, so the move can run as a single relocation.
+    function relevantChildSkipping(parent, index, skip) {
+        if (!parent || !parent.childNodes) return null;
+        var seen = 0;
+        for (var i = 0; i < parent.childNodes.length; i++) {
+            var n = parent.childNodes[i];
+            if (n === skip) continue;
+            if (_relevantNodeTypes[n.nodeType]) {
+                if (seen === index) return n;
+                seen++;
+            }
+        }
+        return null;
+    }
+
+    // Relocate `node` before `ref` under `parent`. Prefer the Atomic Move API
+    // (moveBefore, Chromium 133+): it moves the node WITHOUT disconnecting it, so a
+    // focused descendant keeps its focus, selection, and caret across a keyed reorder.
+    // removeChild+insertBefore — and even a bare insertBefore — disconnect the node
+    // and blur it, which silently broke the "survivors keep their DOM state" contract.
+    // Fall back to insertBefore where moveBefore is unavailable or rejects the move.
+    function moveChildBefore(parent, node, ref) {
+        if (parent.moveBefore) {
+            try {
+                parent.moveBefore(node, ref);
+                return;
+            } catch (e) {
+                // Not connected / cross-document — fall through to insertBefore.
+            }
+        }
+        parent.insertBefore(node, ref);
+    }
+
     function resolvePath(path) {
         var node = document;
         for (var i = 0; i < path.length; i++) {
@@ -1124,10 +1159,10 @@
                 }
                 case 6: { // MoveSubtree [k, path, sourceSlot]
                     // Path encodes parent + destination slot; op[2] is the source slot.
-                    // Detach the source node FIRST, then resolve the destination refNode
-                    // in the post-detach sibling list — that matches how the server's
-                    // keyed differ computes target indices (against the live DOM right
-                    // before the move runs, with the moved node removed).
+                    // The destination slot is in the server's post-detach coordinate
+                    // (the live DOM with the moved node removed), so resolve the anchor
+                    // by SKIPPING the moving node rather than detaching it — then relocate
+                    // with moveChildBefore so a focused descendant keeps focus/selection.
                     var mvParentPath = path.slice(0, path.length - 1);
                     var mvDst = path[path.length - 1];
                     var mvParent = resolvePath(mvParentPath);
@@ -1136,16 +1171,16 @@
                     var mvSrc = mvSrcRaw == null ? 0 : mvSrcRaw;
                     var mvNode = relevantChild(mvParent, mvSrc);
                     if (!mvNode) break;
-                    mvParent.removeChild(mvNode);
-                    var mvRef = relevantChild(mvParent, mvDst);
-                    mvParent.insertBefore(mvNode, mvRef);
+                    var mvRef = relevantChildSkipping(mvParent, mvDst, mvNode);
+                    moveChildBefore(mvParent, mvNode, mvRef);
                     break;
                 }
                 case 7: { // PermutationBatch [k, parentPath, moves] — moves = [dst0,src0,dst1,src1,…]
                     // path IS the parent (no trailing slot to split off). Replay each (dst,src)
-                    // pair in array order with the same detach-source-first semantics as a single
-                    // MoveSubtree: the server computed every pair against the live DOM as mutated
-                    // by the preceding pairs, so order is load-bearing — never reorder.
+                    // pair in array order: the server computed every pair against the live DOM
+                    // as mutated by the preceding pairs, so order is load-bearing — never reorder.
+                    // Each dst is a post-detach slot, so resolve the anchor by skipping the moving
+                    // node and relocate with moveChildBefore (preserves focus across the reorder).
                     var pbParent = resolvePath(path);
                     if (!pbParent) break;
                     var pbMoves = op[2] || [];
@@ -1154,9 +1189,8 @@
                         var pbSrc = pbMoves[m + 1];
                         var pbNode = relevantChild(pbParent, pbSrc);
                         if (!pbNode) continue;
-                        pbParent.removeChild(pbNode);
-                        var pbRef = relevantChild(pbParent, pbDst);
-                        pbParent.insertBefore(pbNode, pbRef);
+                        var pbRef = relevantChildSkipping(pbParent, pbDst, pbNode);
+                        moveChildBefore(pbParent, pbNode, pbRef);
                     }
                     break;
                 }

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -456,6 +456,22 @@ function _raskInsertBefore(parent, dst, anchor) {
     parent.insertBefore(dst, anchor);
 }
 
+// Relocate an already-attached child before `anchor`. Prefer the Atomic Move API
+// (moveBefore, Chromium 133+): it moves the node WITHOUT disconnecting it, so a
+// focused descendant keeps focus, selection, and caret across a keyed reorder. A
+// plain insertBefore of a connected node still disconnects it briefly and blurs it.
+function _raskMoveBefore(parent, node, anchor) {
+    if (parent.moveBefore) {
+        try {
+            parent.moveBefore(node, anchor);
+            return;
+        } catch (e) {
+            // Not connected / cross-document — fall through to insertBefore.
+        }
+    }
+    parent.insertBefore(node, anchor);
+}
+
 function _raskAppendChild(parent, dst) {
     parent.appendChild(dst);
 }
@@ -596,7 +612,7 @@ function morph(from, to) {
                 _raskInsertBefore(from, reviveScript(dst), anchor);
                 _raskRemoveChild(from, src);
             } else {
-                if (src !== anchor) from.insertBefore(src, anchor);
+                if (src !== anchor) _raskMoveBefore(from, src, anchor);
                 else anchor = anchor.nextSibling;
                 morph(src, dst);
             }
@@ -652,6 +668,41 @@ function relevantChild(parent, index) {
         }
     }
     return null;
+}
+
+// Like relevantChild but counts as if `skip` were already gone — the post-detach
+// coordinate the keyed differ uses for move targets. Lets us resolve the anchor
+// WITHOUT detaching the moving node, so the move can run as a single relocation.
+function relevantChildSkipping(parent, index, skip) {
+    if (!parent || !parent.childNodes) return null;
+    let seen = 0;
+    for (let i = 0; i < parent.childNodes.length; i++) {
+        const n = parent.childNodes[i];
+        if (n === skip) continue;
+        if (_RELEVANT_NODE_TYPES.has(n.nodeType)) {
+            if (seen === index) return n;
+            seen++;
+        }
+    }
+    return null;
+}
+
+// Relocate `node` before `ref` under `parent`. Prefer the Atomic Move API
+// (moveBefore, Chromium 133+): it moves the node WITHOUT disconnecting it, so a
+// focused descendant keeps its focus, selection, and caret across a keyed reorder.
+// removeChild+insertBefore — and even a bare insertBefore — disconnect the node
+// and blur it, which silently broke the "survivors keep their DOM state" contract.
+// Fall back to insertBefore where moveBefore is unavailable or rejects the move.
+function moveChildBefore(parent, node, ref) {
+    if (parent.moveBefore) {
+        try {
+            parent.moveBefore(node, ref);
+            return;
+        } catch {
+            // Not connected / cross-document — fall through to insertBefore.
+        }
+    }
+    parent.insertBefore(node, ref);
 }
 
 function resolvePath(path) {
@@ -780,9 +831,10 @@ function applyDiff(ops, names) {
             }
             case 6: { // MoveSubtree [k, path, sourceSlot]
                 // Path encodes parent + destination slot; op[2] is the source slot.
-                // Detach the source FIRST, then resolve the destination refNode against
-                // the post-detach sibling list — same coordinate model the server's
-                // keyed differ uses when computing move targets.
+                // The destination slot is in the server's post-detach coordinate (the live
+                // DOM with the moved node removed), so resolve the anchor by SKIPPING the
+                // moving node rather than detaching it — then relocate with moveChildBefore
+                // so a focused descendant keeps focus/selection across the reorder.
                 const mvParentPath = path.slice(0, path.length - 1);
                 const mvDst = path[path.length - 1];
                 const mvParent = resolvePath(mvParentPath);
@@ -791,16 +843,16 @@ function applyDiff(ops, names) {
                 const mvSrc = mvSrcRaw == null ? 0 : mvSrcRaw;
                 const mvNode = relevantChild(mvParent, mvSrc);
                 if (!mvNode) break;
-                mvParent.removeChild(mvNode);
-                const mvRef = relevantChild(mvParent, mvDst);
-                mvParent.insertBefore(mvNode, mvRef);
+                const mvRef = relevantChildSkipping(mvParent, mvDst, mvNode);
+                moveChildBefore(mvParent, mvNode, mvRef);
                 break;
             }
             case 7: { // PermutationBatch [k, parentPath, moves] — moves = [dst0,src0,dst1,src1,…]
                 // path IS the parent (no trailing slot to split off). Replay each (dst,src)
-                // pair in array order with the same detach-source-first semantics as a single
-                // MoveSubtree: the server computed every pair against the live DOM as mutated
-                // by the preceding pairs, so order is load-bearing — never reorder.
+                // pair in array order: the server computed every pair against the live DOM
+                // as mutated by the preceding pairs, so order is load-bearing — never reorder.
+                // Each dst is a post-detach slot, so resolve the anchor by skipping the moving
+                // node and relocate with moveChildBefore (preserves focus across the reorder).
                 const pbParent = resolvePath(path);
                 if (!pbParent) break;
                 const pbMoves = op[2] || [];
@@ -809,9 +861,8 @@ function applyDiff(ops, names) {
                     const pbSrc = pbMoves[m + 1];
                     const pbNode = relevantChild(pbParent, pbSrc);
                     if (!pbNode) continue;
-                    pbParent.removeChild(pbNode);
-                    const pbRef = relevantChild(pbParent, pbDst);
-                    pbParent.insertBefore(pbNode, pbRef);
+                    const pbRef = relevantChildSkipping(pbParent, pbDst, pbNode);
+                    moveChildBefore(pbParent, pbNode, pbRef);
                 }
                 break;
             }

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -442,6 +442,41 @@ function relevantChild(parent, index) {
     return null;
 }
 
+// Like relevantChild but counts as if `skip` were already gone — the post-detach
+// coordinate the keyed differ uses for move targets. Lets us resolve the anchor
+// WITHOUT detaching the moving node, so the move can run as a single relocation.
+function relevantChildSkipping(parent, index, skip) {
+    if (!parent || !parent.childNodes) return null;
+    let seen = 0;
+    for (let i = 0; i < parent.childNodes.length; i++) {
+        const n = parent.childNodes[i];
+        if (n === skip) continue;
+        if (_RELEVANT_NODE_TYPES.has(n.nodeType)) {
+            if (seen === index) return n;
+            seen++;
+        }
+    }
+    return null;
+}
+
+// Relocate `node` before `ref` under `parent`. Prefer the Atomic Move API
+// (moveBefore, Chromium 133+): it moves the node WITHOUT disconnecting it, so a
+// focused descendant keeps its focus, selection, and caret across a keyed reorder.
+// removeChild+insertBefore — and even a bare insertBefore — disconnect the node
+// and blur it, which silently broke the "survivors keep their DOM state" contract.
+// Fall back to insertBefore where moveBefore is unavailable or rejects the move.
+function moveChildBefore(parent, node, ref) {
+    if (parent.moveBefore) {
+        try {
+            parent.moveBefore(node, ref);
+            return;
+        } catch {
+            // Not connected / cross-document — fall through to insertBefore.
+        }
+    }
+    parent.insertBefore(node, ref);
+}
+
 function resolvePath(path) {
     let node = document;
     for (let i = 0; i < path.length; i++) {
@@ -568,9 +603,10 @@ function applyDiff(ops, names) {
             }
             case 6: { // MoveSubtree [k, path, sourceSlot]
                 // Path encodes parent + destination slot; op[2] is the source slot.
-                // Detach the source FIRST, then resolve the destination refNode against
-                // the post-detach sibling list — same coordinate model the server's
-                // keyed differ uses when computing move targets.
+                // The destination slot is in the server's post-detach coordinate (the live
+                // DOM with the moved node removed), so resolve the anchor by SKIPPING the
+                // moving node rather than detaching it — then relocate with moveChildBefore
+                // so a focused descendant keeps focus/selection across the reorder.
                 const mvParentPath = path.slice(0, path.length - 1);
                 const mvDst = path[path.length - 1];
                 const mvParent = resolvePath(mvParentPath);
@@ -579,16 +615,16 @@ function applyDiff(ops, names) {
                 const mvSrc = mvSrcRaw == null ? 0 : mvSrcRaw;
                 const mvNode = relevantChild(mvParent, mvSrc);
                 if (!mvNode) break;
-                mvParent.removeChild(mvNode);
-                const mvRef = relevantChild(mvParent, mvDst);
-                mvParent.insertBefore(mvNode, mvRef);
+                const mvRef = relevantChildSkipping(mvParent, mvDst, mvNode);
+                moveChildBefore(mvParent, mvNode, mvRef);
                 break;
             }
             case 7: { // PermutationBatch [k, parentPath, moves] — moves = [dst0,src0,dst1,src1,…]
                 // path IS the parent (no trailing slot to split off). Replay each (dst,src)
-                // pair in array order with the same detach-source-first semantics as a single
-                // MoveSubtree: the server computed every pair against the live DOM as mutated
-                // by the preceding pairs, so order is load-bearing — never reorder.
+                // pair in array order: the server computed every pair against the live DOM
+                // as mutated by the preceding pairs, so order is load-bearing — never reorder.
+                // Each dst is a post-detach slot, so resolve the anchor by skipping the moving
+                // node and relocate with moveChildBefore (preserves focus across the reorder).
                 const pbParent = resolvePath(path);
                 if (!pbParent) break;
                 const pbMoves = op[2] || [];
@@ -597,9 +633,8 @@ function applyDiff(ops, names) {
                     const pbSrc = pbMoves[m + 1];
                     const pbNode = relevantChild(pbParent, pbSrc);
                     if (!pbNode) continue;
-                    pbParent.removeChild(pbNode);
-                    const pbRef = relevantChild(pbParent, pbDst);
-                    pbParent.insertBefore(pbNode, pbRef);
+                    const pbRef = relevantChildSkipping(pbParent, pbDst, pbNode);
+                    moveChildBefore(pbParent, pbNode, pbRef);
                 }
                 break;
             }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -232,9 +232,29 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator(".sample-result-body").Filter(new LocatorFilterOptions { HasText = "Last submitted:" }))
             .ToContainTextAsync("Ada", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
-        // Virtualize + Keyed lists: just confirm they render (windowing / keyed-diff logic is unit-tested).
+        // Virtualize: just confirm it renders (windowing logic is unit-tested).
         await SideAsync("Virtualize", "Virtualize");
+
+        // Keyed lists: the page's contract is that a keyed reorder preserves the survivors'
+        // DOM state — focus, caret, and uncommitted input text. Type into the first row,
+        // place a caret mid-string, then reverse. We dispatch the reverse via a synthetic
+        // (non-focus-stealing) click so the assertion isolates the reorder's effect on focus
+        // from the focus the pointer would otherwise hand to the button itself. A keyed move
+        // must relocate the live <li> node (Atomic Move), not detach + re-insert it.
         await SideAsync("Keyed lists", "Keyed lists");
+        await Page.Locator("#kl-list li:nth-child(1) input.kl-note").ClickAsync();
+        await Page.Locator("#kl-list li:nth-child(1) input.kl-note").FillAsync("travels");
+        await Page.EvaluateAsync("() => document.activeElement.setSelectionRange(3, 3)");
+        await Page.EvaluateAsync(
+            "() => document.getElementById('kl-reverse').dispatchEvent(new MouseEvent('click', { bubbles: true }))");
+        var keyedState = await Page.EvaluateAsync<string>(@"() => {
+            const a = document.activeElement;
+            if (!a || !a.classList || !a.classList.contains('kl-note')) return 'focus-lost';
+            const li = a.closest('li');
+            const name = li ? li.querySelector('span.fw-semibold').textContent.trim() : '?';
+            return `${name}|${a.value}|${a.selectionStart}`;
+        }");
+        Assert.Equal("Apple|travels|3", keyedState);
 
         // Data table: every interaction is a URL query-param mutation → rebind → re-render.
         await SideAsync("Data table", "Data table");
@@ -598,7 +618,9 @@ public abstract partial class SharedSmokeTests
         var dataTransfer = await Page.EvaluateHandleAsync("() => new DataTransfer()");
         var init = new Dictionary<string, object>
         {
-            ["dataTransfer"] = dataTransfer, ["bubbles"] = true, ["cancelable"] = true,
+            ["dataTransfer"] = dataTransfer,
+            ["bubbles"] = true,
+            ["cancelable"] = true,
         };
         await source.DispatchEventAsync("dragstart", init);
         await target.DispatchEventAsync("dragover", init);


### PR DESCRIPTION
## Summary
Keyed reorders relocated each surviving node with `removeChild` + `insertBefore`. Detaching a node blurs any focused descendant, so the typed text travelled with its row (the same DOM node is reused) but **focus, text selection, and caret silently did not** — contradicting the "survivors keep their DOM state" contract the Keyed lists demo advertises. The runtime now relocates with the Atomic Move API (`Node.moveBefore`, Chromium 133+), which moves a node without disconnecting it, with an `insertBefore` fallback where unavailable. The destination anchor is resolved in post-detach coordinates by *skipping* the moving node in the child count rather than actually detaching it, so the server's move-target indices stay correct.

Touches the trusted structural-op appliers (`rask.js`, `rask.wasm.js` + the regenerated source-tracked `Browser/rask.wasm.js`) and the keyed branch of the morph runtime (`rask-morph.js`).

### Verified
| | value travels | focus + caret survive |
|---|---|---|
| Before (`removeChild`+`insertBefore`) | ✅ | ❌ `activeElement` falls back to body |
| After (`moveBefore`) | ✅ | ✅ focus + caret position both intact |

(Confirmed by forcing the `insertBefore` fallback with `delete Element.prototype.moveBefore` — focus is lost; with `moveBefore` present it is preserved.)

> Note: the demo's own Rotate/Reverse buttons steal focus when clicked, so through the UI you only ever observe value-travel. Focus/selection preservation matters for reorders not driven by a focus-stealing click (drag handles, server-pushed updates, programmatic reorders) and for caret/selection within an already-focused survivor — which is why the regression test triggers the reverse with a synthetic, non-focus-stealing click.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all green** (2,200+ tests across all suites).
- E2E: the Keyed lists step of the shared journey now reverses a list with a focused, mid-string caret and asserts `Apple|travels|3` survives. Passing on **all three hosts** — Server, Wasm.Host, StandaloneWasm.
- Framework libs build clean under `-warnaserror`; `dotnet format` clean.

## Benchmarks
n/a — client-side DOM-call swap only (`moveBefore` vs `removeChild`+`insertBefore`); no C# render-hotpath change, op count and wire bytes unchanged.

## CHANGELOG
- [Unreleased] → Fixed entry added: keyed reorders now preserve survivors' focus, selection, and caret (Atomic Move API), not just input value.