### PR TITLE
docs(readme): add a first-person background story to "Why Rask"

### DIFF
--- a/NUGET.md
+++ b/NUGET.md
@@ -45,6 +45,11 @@ dotnet add package Rask.Wasm.Hosting      # host a published WASM bundle on ASP.
 
 ## Why Rask
 
+After 15+ years building full-stack .NET apps — WebForms, MVC, Angular and React over a C# API — I wanted the front end
+back in C# without `.razor` mixing markup and code. So Rask makes a component a plain C# class that returns a tree, runs
+the *same* code on Server or WASM, and treats the network as the bottleneck (a state change ships a minimal diff, not
+the page). It's a craft project built in the open, deep on Roslyn source generators and tree diffing.
+
 - **One component model, two runtimes** — the same C# component runs Server (live diff over WS) or WASM.
 - **Compile-time factories** — a Roslyn generator emits `Div(...)`, `Counter(...)`, type-safe routes.
 - **Scoped CSS & JS** — sibling `Component.css`/`Component.js`, content-addressed and cached.

--- a/README.md
+++ b/README.md
@@ -66,10 +66,25 @@ public sealed class Counter : Component
 
 ## ✨ Why Rask
 
-*Rask* is the Norwegian/Danish/Swedish word for **fast**. It's a component framework for .NET: you write components as
-plain C# classes, return a tree of HTML from `Render()`, and host the result one of three ways — server-rendered with
-live updates over a WebSocket, fully client-side in the browser via WebAssembly, or an ASP.NET app that serves a
-published WASM bundle. The **same component code runs under any host** — only the hosting glue changes.
+I've spent 15+ years building full-stack apps on .NET — WebForms, MVC, and a long stretch of SPA work in Angular and
+React over a C# API. That split is productive, but it never stopped being two worlds: two languages, two type systems,
+two build chains, and a serialization seam in the middle I maintained by hand. I wanted the front end back in C#.
+
+Blazor answers part of that, but `.razor` puts markup and code back in one file with its own templating dialect — the
+very thing I'd been trying to get away from. So I built Rask around a single conviction: a component is just a C# class
+that returns a tree. No `.razor`, no JSX, no template language — `Div(...)[Span(...), "hi"]` is plain, refactor-safe,
+IDE-native C#, and the *same* component runs server-rendered over a WebSocket or fully client-side on WebAssembly. One
+codebase; pick the host per project.
+
+The other thing I couldn't unsee from years of SPA work was how much we ship over the wire. So Rask treats the network
+as the real bottleneck: after first paint, a state change sends a minimal diff — a counter tick on a 50 KB page goes out
+as ~57 bytes, not 50 KB. And, honestly, Rask is also where I went deep on Roslyn source generators, rendering, and tree
+diffing — it's a craft project as much as a framework, built in the open.
+
+*Rask* is the Norwegian/Danish/Swedish word for **fast**. Concretely, it's a component framework for .NET: return a
+tree of HTML from `Render()` and host the result one of three ways — server-rendered with live updates over a
+WebSocket, fully client-side in the browser via WebAssembly, or an ASP.NET app that serves a published WASM bundle.
+Only the hosting glue changes.
 
 |     | Feature                            | What it means                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 |:---:|------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


### PR DESCRIPTION
## Summary

Leads the **✨ Why Rask** section of the README with a short first-person origin story, so readers learn *why* Rask exists before the feature table. The repo previously had strong technical positioning ("a different take on Blazor's problem space") but no narrative on the motivation behind it.

The story weaves four threads, grounded in 15+ years of full-stack .NET (WebForms, MVC, Angular, React):
- the pull to get the front end back in C# (one language, no serialization seam by hand);
- the `.razor` friction — markup + code in one file with a templating dialect — and Rask's answer (a component is just a C# class that returns a tree);
- one codebase running unchanged on Server (WS) or WASM;
- the network as the real bottleneck (minimal diff on the wire) and Rask as a craft project built in the open on Roslyn source generators + tree diffing.

## Changes

- `README.md` — three story paragraphs prepended to the Why Rask section; the etymology paragraph reworded to follow the story (drops the now-redundant "same component / any host" restatement). Heading text unchanged, so the `#-why-rask` TOC anchor still resolves.
- `NUGET.md` — a condensed one-paragraph version mirrored above the existing Why-Rask bullets, matching the package readme's tighter tone.

## Testing

Prose-only — no code, sample, or behavior change. Markdown renders cleanly (inline code `.razor`, `Div(...)[Span(...), "hi"]`; three paragraphs flow into the etymology line and feature table).

## Changelog

No entry — not a notable functional change.