### PR TITLE
feat(live): slow-connection affordances for both transports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ them until tagged releases begin.
   published as a single immutable snapshot swapped by reference so cross-thread reads are consistent.
   Runs in both the Server and WASM sample apps. `Sparkline` gains an optional `ValueFormat` so its
   axis labels can render as percentages (default unchanged).
+- **Slow-connection affordances on both transports.** WASM boot now renders a determinate
+  download-progress bar on the splash (driven by the runtime's `onDownloadResourceProgress`
+  resource count, not bytes — so Brotli/gzip-precompressed assets don't skew it), replacing the
+  indefinite spinner so a slow link shows movement instead of an apparent hang; it falls back to
+  the spinner when the total is unknown. Server mode adds a subtle top-of-viewport **pending-action
+  bar** that appears when a handler round-trip outlives a ~300ms latency threshold and clears when
+  the reply lands — so a high-latency user sees their click registered. It is backed by an opt-in
+  WebSocket ack: a client tags handler events with a monotonic `seq` and the server replies
+  `{type:"ack",seq}` once the dispatch completes, **even when the render dedupes and ships no
+  frame** (otherwise a no-op click would wedge the bar). Seq-less clients are unaffected — the prior
+  frame contract is byte-for-byte unchanged.
 
 ### Changed
 - **`Authorize`'s `Authorized` slot now receives the current user** — its type changed from `Child` to

--- a/NUGET.md
+++ b/NUGET.md
@@ -55,6 +55,7 @@ the page). It's a craft project built in the open, deep on Roslyn source generat
 - **Scoped CSS & JS** — sibling `Component.css`/`Component.js`, content-addressed and cached.
 - **Routing, lifecycle, forms, validation, auth** — batteries included, no JavaScript required.
 - **Tiny live updates** — a minimal edit-op diff ships instead of the whole page.
+- **Slow-link aware** — WASM boot shows download progress; a slow Server round-trip surfaces a pending bar.
 
 ## Links
 

--- a/README.md
+++ b/README.md
@@ -1306,6 +1306,11 @@ The other modes are `LiveDiffMode.DisabledFull` (always full HTML — bit-for-bi
 `LiveDiffMode.Forced` (always diff when one is computable; for tests/benchmarks). The codec is transparent to your
 components and is exercised end-to-end on both hosts by the Playwright E2E suite.
 
+**Slow links get honest feedback, automatically.** On WASM the boot splash shows a determinate download-progress bar
+instead of an indefinite spinner. On Server, a handler whose round-trip outlives ~300ms surfaces a subtle
+top-of-viewport pending bar that clears when the reply lands — so a high-latency click still feels responsive. Both stay
+invisible on a fast link; neither needs any code from you.
+
 </details>
 
 <details>

--- a/docs/architecture/live-rendering.md
+++ b/docs/architecture/live-rendering.md
@@ -355,6 +355,51 @@ across the awaited handler (`WasmLiveSession.cs`). The render walk is single-thr
 per session; `InHandlerScope` is a plain instance bool (deliberately *not* `AsyncLocal`)
 because the lock is owned by the session as a whole.
 
+## Slow-connection affordances
+
+Both transports give honest feedback on a slow link without changing the fast-path
+behaviour — each indicator stays invisible until a latency threshold is crossed.
+
+### WASM: boot progress
+
+The page shell (`src/Rask.Wasm/Browser/index.html`) carries a hidden
+`.rask-boot__progress` bar under the splash spinner. `main.js` wires the runtime's
+`onDownloadResourceProgress(resourcesLoaded, totalResources)` callback (via
+`dotnet.withModuleConfig(...)`) and reveals the bar with a determinate
+`loaded / total` percentage, so a slow link shows movement instead of an indefinite
+spinner. Progress is **resource-count, not bytes**: framework assets are commonly
+served Brotli/gzip precompressed, so a byte bar would have to reconcile encoded vs.
+decoded sizes — counts sidestep that. When the runtime reports no usable total the
+bar stays hidden and the spinner stands in. The App's first render morphs over the
+whole shell, so there's no teardown.
+
+### Server: the pending-action bar and the handler ack
+
+`rask.js` installs a managed (`data-rask-managed`) 2px top-of-viewport bar that
+appears when a handler round-trip outlives `PENDING_LATENCY_MS` (~300ms) and clears
+when the reply lands — distinct from, and one z-index below, the full reconnect
+overlay. It is driven by an **opt-in ack protocol**:
+
+- The client stamps a monotonic `seq` on handler events only (click/input/change/
+  submit/drag* — anything carrying an `id` that the server dispatches through its
+  handler chain; `jsResult`/`navigate`/`dotNetInvoke`/`hello` are excluded). It tracks
+  the highest outstanding seq, arms the latency timer, and a hard-timeout backstop.
+- After each handler dispatch completes, the server replies `{"type":"ack","seq":N}`
+  (`ChainHandlerDispatchAsync` → `SendHandlerAckAsync`, riding `SendOutOfBandAsync` so
+  it serialises on the render lock and lands *after* that handler's render frame and
+  *before* the next handler's). The ack fires **even when the render dedupes and ships
+  no frame** (`RenderAndSendAsync`'s HTML/byte dedup returns silently) — without it a
+  no-op click would wedge the bar.
+- The client clears the bar on the matching (or any later) ack, synchronously on
+  receipt (not inside the `_renderQueue`, so a CSS-gated deferred body swap can't keep
+  it up). Reconnect resets the outstanding/acked counters and the reconnect overlay
+  takes over.
+
+**Opt-in:** the server only acks when the inbound handler carried a `seq`, so a
+seq-less client gets byte-for-byte the prior frame contract (the render envelope is
+unchanged — the ack is a separate tiny frame, not a payload field). See
+`tests/Rask.Server.Tests/WebSockets/PendingAckTests.cs`.
+
 ## See also
 
 - [`../diagnostics.md`](../diagnostics.md) — **RASK022** (warning) flags a keyless list

--- a/samples/Rask.Example.Auth.WasmCookie/wwwroot/index.html
+++ b/samples/Rask.Example.Auth.WasmCookie/wwwroot/index.html
@@ -71,6 +71,38 @@
             animation: rask-spin 0.8s linear infinite;
         }
 
+        /* Determinate download progress, revealed by main.js once the boot config
+           reports a resource count. Stays hidden (spinner-only fallback) when the
+           total is unknown. */
+        .rask-boot__progress {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .rask-boot__bar {
+            width: 180px;
+            height: 4px;
+            border-radius: 999px;
+            background: rgba(124, 58, 237, 0.18);
+            overflow: hidden;
+        }
+
+        .rask-boot__fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: #7C3AED;
+            transition: width 0.2s ease;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            opacity: 0.72;
+            font-variant-numeric: tabular-nums;
+        }
+
         @keyframes rask-spin {
             to {
                 transform: rotate(360deg);
@@ -97,6 +129,12 @@
         <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
     </svg>
     <div class="rask-spin"></div>
+    <div class="rask-boot__progress" hidden>
+        <div class="rask-boot__bar">
+            <div class="rask-boot__fill"></div>
+        </div>
+        <div class="rask-boot__label">Loading…</div>
+    </div>
 </div>
 <script src="main.js" type="module"></script>
 </body>

--- a/samples/Rask.Example.Auth.WasmJwt/wwwroot/index.html
+++ b/samples/Rask.Example.Auth.WasmJwt/wwwroot/index.html
@@ -71,6 +71,38 @@
             animation: rask-spin 0.8s linear infinite;
         }
 
+        /* Determinate download progress, revealed by main.js once the boot config
+           reports a resource count. Stays hidden (spinner-only fallback) when the
+           total is unknown. */
+        .rask-boot__progress {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .rask-boot__bar {
+            width: 180px;
+            height: 4px;
+            border-radius: 999px;
+            background: rgba(124, 58, 237, 0.18);
+            overflow: hidden;
+        }
+
+        .rask-boot__fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: #7C3AED;
+            transition: width 0.2s ease;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            opacity: 0.72;
+            font-variant-numeric: tabular-nums;
+        }
+
         @keyframes rask-spin {
             to {
                 transform: rotate(360deg);
@@ -97,6 +129,12 @@
         <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
     </svg>
     <div class="rask-spin"></div>
+    <div class="rask-boot__progress" hidden>
+        <div class="rask-boot__bar">
+            <div class="rask-boot__fill"></div>
+        </div>
+        <div class="rask-boot__label">Loading…</div>
+    </div>
 </div>
 <script src="main.js" type="module"></script>
 </body>

--- a/samples/Rask.Example.Wasm/wwwroot/index.html
+++ b/samples/Rask.Example.Wasm/wwwroot/index.html
@@ -71,6 +71,38 @@
             animation: rask-spin 0.8s linear infinite;
         }
 
+        /* Determinate download progress, revealed by main.js once the boot config
+           reports a resource count. Stays hidden (spinner-only fallback) when the
+           total is unknown. */
+        .rask-boot__progress {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .rask-boot__bar {
+            width: 180px;
+            height: 4px;
+            border-radius: 999px;
+            background: rgba(124, 58, 237, 0.18);
+            overflow: hidden;
+        }
+
+        .rask-boot__fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: #7C3AED;
+            transition: width 0.2s ease;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            opacity: 0.72;
+            font-variant-numeric: tabular-nums;
+        }
+
         @keyframes rask-spin {
             to {
                 transform: rotate(360deg);
@@ -97,6 +129,12 @@
         <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
     </svg>
     <div class="rask-spin"></div>
+    <div class="rask-boot__progress" hidden>
+        <div class="rask-boot__bar">
+            <div class="rask-boot__fill"></div>
+        </div>
+        <div class="rask-boot__label">Loading…</div>
+    </div>
 </div>
 <script src="main.js" type="module"></script>
 </body>

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Globalization;
 using System.Net.WebSockets;
 using System.Security.Claims;
 using System.Text;
@@ -126,7 +127,8 @@ public static class RaskEndpointExtensions
 
         services.AddSingleton(sp => new LiveSessionStore(
             sp.GetRequiredService<IServiceScopeFactory>(),
-            sp.GetService<IHostApplicationLifetime>()) { MaxSessions = maxSessions });
+            sp.GetService<IHostApplicationLifetime>())
+        { MaxSessions = maxSessions });
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
@@ -759,12 +761,45 @@ public static class RaskEndpointExtensions
             }
 
             await DispatchHandlerAsync(session, handlerId, root, ct).ConfigureAwait(false);
+
+            // Acknowledge the handler so the client's slow-link pending indicator can
+            // resolve — crucially even when the render deduped and no frame was sent
+            // (RenderAndSendAsync's HTML/byte dedup returns silently). Opt-in: only a
+            // client that stamped a `seq` gets an ack, so seq-less clients keep the exact
+            // prior frame contract. The ack rides SendOutOfBandAsync, which serialises on
+            // the render lock, so it always lands after this handler's render frame and
+            // before the next handler's (the chain awaits this whole task in order).
+            if (root.TryGetProperty("seq", out var seqEl)
+                && seqEl.ValueKind == JsonValueKind.Number
+                && seqEl.TryGetInt64(out var seq))
+            {
+                await SendHandlerAckAsync(session, seq).ConfigureAwait(false);
+            }
         }
         finally
         {
             // Pairs with the IncrementPendingHandlers in the receive loop when this dispatch was
             // queued, so the backpressure counter tracks the live chain depth.
             session.DecrementPendingHandlers();
+        }
+    }
+
+    // Tiny out-of-band frame that closes the round-trip for a handler the client tagged
+    // with a `seq`. Lets the browser's pending-action bar (rask.js) clear without the
+    // server having to emit a render — the dedup path produces no frame, so the ack is
+    // the client's only signal that a no-op click was processed. Best-effort: a missed
+    // ack (socket closing, cancellation) is covered by the client's hard-timeout backstop.
+    private static async Task SendHandlerAckAsync(LiveSession session, long seq)
+    {
+        try
+        {
+            var payload = Encoding.UTF8.GetBytes(
+                "{\"type\":\"ack\",\"seq\":" + seq.ToString(CultureInfo.InvariantCulture) + "}");
+            await session.SendOutOfBandAsync(payload).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Swallow: the client re-syncs on the next ack or its hard-timeout backstop.
         }
     }
 

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -144,6 +144,13 @@
                 location.reload();
                 return;
             }
+            // Handler ack: resolve the slow-link pending bar. Handled synchronously here
+            // (not inside _renderQueue) so a CSS-gated deferred body swap can't keep the
+            // bar up after the round-trip has actually completed.
+            if (data.type === "ack") {
+                satisfySeq(data.seq);
+                return;
+            }
             // Diff-mode payload (kind:"diff"): apply ops directly against the live DOM.
             // Both render paths chain through _renderQueue so a diff that defers its body
             // for a scoped-CSS load (see applyDiffReply) can't be overtaken by the next
@@ -172,6 +179,7 @@
     function scheduleReconnect() {
         if (reconnectTimer !== null) return;
         open = false;
+        resetPending();
         showOverlay();
         var delays = [500, 1000, 2000, 4000, 5000];
         var delay = delays[Math.min(attempt, delays.length - 1)];
@@ -227,6 +235,109 @@
         overlay.removeAttribute("data-show");
         overlay.setAttribute("aria-hidden", "true");
         if ("inert" in document.body) document.body.inert = false;
+    }
+
+    // Slow-link pending-action indicator. A handler event (click/input/change/submit)
+    // is tagged with a monotonic seq; the server replies {type:"ack",seq} once it has
+    // processed the dispatch — crucially even when the render dedupes and ships no frame.
+    // If no ack lands within PENDING_LATENCY_MS we surface a thin top-of-viewport bar so
+    // a high-latency user sees that their action registered; it clears when the matching
+    // (or any later) ack arrives. A hard timeout backstops a genuinely lost frame. This
+    // is distinct from — and sits one z-index below — the full reconnect overlay above.
+    var PENDING_LATENCY_MS = 300;
+    var PENDING_HARD_TIMEOUT_MS = 10000;
+    var seqCounter = 0;
+    var outstandingSeq = 0;
+    var ackedSeq = 0;
+    var pendingTimer = null;
+    var pendingHardTimer = null;
+    var pendingVisible = false;
+    var pendingBar = installPendingBar();
+
+    function stampSeq(payload) {
+        // Only genuine handler events get a seq: they carry an `id` and dispatch through
+        // the server's handler chain, which acks the seq. jsResult also carries an id but
+        // is an interop reply (not a handler) — exclude it; navigate/dotNetInvoke/hello
+        // carry no id and so are excluded too.
+        if (!payload || payload.id == null || payload.type === "jsResult") return;
+        payload.seq = ++seqCounter;
+        outstandingSeq = payload.seq;
+        if (pendingTimer === null && !pendingVisible) {
+            pendingTimer = setTimeout(showPendingBar, PENDING_LATENCY_MS);
+        }
+        if (pendingHardTimer !== null) clearTimeout(pendingHardTimer);
+        pendingHardTimer = setTimeout(forcePendingTimeout, PENDING_HARD_TIMEOUT_MS);
+    }
+
+    function satisfySeq(s) {
+        if (typeof s !== "number") return;
+        if (s > ackedSeq) ackedSeq = s;
+        if (ackedSeq >= outstandingSeq) clearPending();
+    }
+
+    function clearPending() {
+        if (pendingTimer !== null) {
+            clearTimeout(pendingTimer);
+            pendingTimer = null;
+        }
+        if (pendingHardTimer !== null) {
+            clearTimeout(pendingHardTimer);
+            pendingHardTimer = null;
+        }
+        hidePendingBar();
+    }
+
+    function resetPending() {
+        // On disconnect the reconnect overlay takes over; drop the bar and treat every
+        // outstanding handler as settled so a pre-drop seq can't wedge the next session.
+        ackedSeq = outstandingSeq = seqCounter;
+        clearPending();
+    }
+
+    function forcePendingTimeout() {
+        // Backstop: no ack came back for an outstanding handler (lost frame or a hung
+        // handler). Settle and hide rather than leave the bar wedged.
+        ackedSeq = outstandingSeq = seqCounter;
+        clearPending();
+    }
+
+    function showPendingBar() {
+        pendingTimer = null;
+        pendingVisible = true;
+        if (pendingBar) pendingBar.setAttribute("data-show", "");
+    }
+
+    function hidePendingBar() {
+        pendingVisible = false;
+        if (pendingBar) pendingBar.removeAttribute("data-show");
+    }
+
+    function installPendingBar() {
+        // Managed siblings of the server-rendered tree (data-rask-managed), so the morph
+        // diff treats them as invisible and never trims them — same convention as the
+        // reconnect overlay.
+        var style = document.createElement("style");
+        style.setAttribute("data-rask-pending", "");
+        style.setAttribute("data-rask-managed", "");
+        style.textContent =
+            ".rask-pending{position:fixed;top:0;left:0;right:0;height:2px;" +
+            "z-index:2147483646;pointer-events:none;overflow:hidden;display:none;}" +
+            ".rask-pending[data-show]{display:block;}" +
+            ".rask-pending__bar{position:absolute;top:0;left:0;height:100%;width:40%;" +
+            "background:linear-gradient(90deg,rgba(124,58,237,0),#7C3AED,rgba(124,58,237,0));" +
+            "animation:rask-pending-slide 1s ease-in-out infinite;}" +
+            "@keyframes rask-pending-slide{0%{transform:translateX(-100%);}" +
+            "100%{transform:translateX(350%);}}";
+        document.head.appendChild(style);
+
+        var el = document.createElement("div");
+        el.className = "rask-pending";
+        el.setAttribute("data-rask-managed", "");
+        el.setAttribute("data-rask-pending", "");
+        el.setAttribute("aria-hidden", "true");
+        el.innerHTML = '<div class="rask-pending__bar"></div>';
+        document.documentElement.appendChild(el);
+        return el;
     }
 
     // scopedJsReady starts true: per-component scripts ship as
@@ -512,6 +623,7 @@
 
     function send(payload) {
         if (suppressEvents) return;
+        stampSeq(payload);
         var msg = JSON.stringify(payload);
         if (open && ws && ws.readyState === WebSocket.OPEN) ws.send(msg);
         else queue.push(msg);

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/index.html
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/index.html
@@ -71,6 +71,38 @@
             animation: rask-spin 0.8s linear infinite;
         }
 
+        /* Determinate download progress, revealed by main.js once the boot config
+           reports a resource count. Stays hidden (spinner-only fallback) when the
+           total is unknown. */
+        .rask-boot__progress {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .rask-boot__bar {
+            width: 180px;
+            height: 4px;
+            border-radius: 999px;
+            background: rgba(124, 58, 237, 0.18);
+            overflow: hidden;
+        }
+
+        .rask-boot__fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: #7C3AED;
+            transition: width 0.2s ease;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            opacity: 0.72;
+            font-variant-numeric: tabular-nums;
+        }
+
         @keyframes rask-spin {
             to {
                 transform: rotate(360deg);
@@ -97,6 +129,12 @@
         <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
     </svg>
     <div class="rask-spin"></div>
+    <div class="rask-boot__progress" hidden>
+        <div class="rask-boot__bar">
+            <div class="rask-boot__fill"></div>
+        </div>
+        <div class="rask-boot__label">Loading…</div>
+    </div>
 </div>
 <script src="main.js" type="module"></script>
 </body>

--- a/src/Rask.Templates/content/rask-wasm/wwwroot/index.html
+++ b/src/Rask.Templates/content/rask-wasm/wwwroot/index.html
@@ -71,6 +71,38 @@
             animation: rask-spin 0.8s linear infinite;
         }
 
+        /* Determinate download progress, revealed by main.js once the boot config
+           reports a resource count. Stays hidden (spinner-only fallback) when the
+           total is unknown. */
+        .rask-boot__progress {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .rask-boot__bar {
+            width: 180px;
+            height: 4px;
+            border-radius: 999px;
+            background: rgba(124, 58, 237, 0.18);
+            overflow: hidden;
+        }
+
+        .rask-boot__fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: #7C3AED;
+            transition: width 0.2s ease;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            opacity: 0.72;
+            font-variant-numeric: tabular-nums;
+        }
+
         @keyframes rask-spin {
             to {
                 transform: rotate(360deg);
@@ -97,6 +129,12 @@
         <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
     </svg>
     <div class="rask-spin"></div>
+    <div class="rask-boot__progress" hidden>
+        <div class="rask-boot__bar">
+            <div class="rask-boot__fill"></div>
+        </div>
+        <div class="rask-boot__label">Loading…</div>
+    </div>
 </div>
 <script src="main.js" type="module"></script>
 </body>

--- a/src/Rask.Wasm/Browser/index.html
+++ b/src/Rask.Wasm/Browser/index.html
@@ -71,6 +71,38 @@
             animation: rask-spin 0.8s linear infinite;
         }
 
+        /* Determinate download progress, revealed by main.js once the boot config
+           reports a resource count. Stays hidden (spinner-only fallback) when the
+           total is unknown. */
+        .rask-boot__progress {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .rask-boot__bar {
+            width: 180px;
+            height: 4px;
+            border-radius: 999px;
+            background: rgba(124, 58, 237, 0.18);
+            overflow: hidden;
+        }
+
+        .rask-boot__fill {
+            height: 100%;
+            width: 0;
+            border-radius: inherit;
+            background: #7C3AED;
+            transition: width 0.2s ease;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            opacity: 0.72;
+            font-variant-numeric: tabular-nums;
+        }
+
         @keyframes rask-spin {
             to {
                 transform: rotate(360deg);
@@ -97,6 +129,12 @@
         <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
     </svg>
     <div class="rask-spin"></div>
+    <div class="rask-boot__progress" hidden>
+        <div class="rask-boot__bar">
+            <div class="rask-boot__fill"></div>
+        </div>
+        <div class="rask-boot__label">Loading…</div>
+    </div>
 </div>
 <script src="main.js" type="module"></script>
 </body>

--- a/src/Rask.Wasm/Browser/main.js
+++ b/src/Rask.Wasm/Browser/main.js
@@ -4,8 +4,39 @@
 
 import {dotnet} from './_framework/dotnet.js';
 
+// Boot progress. On a slow link the runtime + assemblies are several MB, and the
+// bare splash spinner can't be told apart from a hang. The runtime's built-in
+// onDownloadResourceProgress callback reports how many boot resources have
+// finished out of the total, which we render as a determinate bar.
+//
+// Resource-COUNT progress (what the callback gives), not bytes: framework assets
+// are commonly served Brotli/gzip precompressed, so byte-based progress would
+// have to reconcile encoded vs. decoded sizes; counts sidestep that. The bar
+// stays hidden (spinner-only fallback) until the first progress tick arrives.
+const boot = document.querySelector(".rask-boot");
+const bootProgress = boot && boot.querySelector(".rask-boot__progress");
+const bootFill = boot && boot.querySelector(".rask-boot__fill");
+const bootLabel = boot && boot.querySelector(".rask-boot__label");
+
+function renderBootProgress(loaded, total) {
+    if (!bootProgress || !(total > 0)) return;
+    bootProgress.hidden = false;
+    const pct = Math.min(100, Math.round((loaded / total) * 100));
+    if (bootFill) bootFill.style.width = pct + "%";
+    if (bootLabel) bootLabel.textContent = "Loading… " + pct + "%";
+}
+
 const {getAssemblyExports, runMain} = await dotnet
     .withApplicationArgumentsFromQuery()
+    .withModuleConfig({
+        onDownloadResourceProgress: (resourcesLoaded, totalResources) => {
+            // Best-effort UI; never let a progress hiccup break boot.
+            try {
+                renderBootProgress(resourcesLoaded, totalResources);
+            } catch (e) {
+            }
+        }
+    })
     .create();
 
 // JSExport Dispatch lives in Rask.Wasm.dll, not the main assembly.

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -195,6 +195,17 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("#ticker-log")).ToContainTextAsync("OnPropsChanged: Symbol BTC → ETH",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
+        // Background service: an app-wide singleton's loop pushes updates to two decoupled
+        // subscribers. The tick badge must climb with NO user interaction — proof the
+        // background producer (not a click handler) is driving the render.
+        await SideAsync("Background service", "Background service");
+        await Expect(Page.Locator("#metrics-chart svg")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+        var firstTick = await ReadMetricsTickAsync();
+        await Expect(Page.Locator("#metrics-tick")).Not.ToContainTextAsync($"tick {firstTick}",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        Assert.True(await ReadMetricsTickAsync() > firstTick, "the background feed did not advance on its own");
+
         // Cancellation: unmount a probe mid-delay → its CancellationToken fires and it logs cancelled.
         await SideAsync("Cancellation", "Cancellation");
         await Page.Locator("#cancel-mount").ClickAsync();
@@ -560,6 +571,39 @@ public abstract partial class SharedSmokeTests
             await Page.GotoAsync("/http");
             await Expect(Page.Locator(".sample-result-body article.card")).ToBeVisibleAsync(
                 new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
+
+            if (opts.OfflineReconnect)
+            {
+                // Server only: on a high-latency link a handler round-trip should surface the
+                // slow-link pending bar (it appears past the ~300ms threshold) and then clear
+                // when the ack/render lands. 1.5s latency keeps the bar up long enough to assert
+                // without racing the reply.
+                await cdp.SendAsync("Network.emulateNetworkConditions", new Dictionary<string, object>
+                {
+                    ["offline"] = false,
+                    ["latency"] = 1500,
+                    ["downloadThroughput"] = 50 * 1024,
+                    ["uploadThroughput"] = 50 * 1024,
+                });
+                await Page.GotoAsync("/events");
+                var bump = Page.Locator(".sample-result-body button:has-text('Clicks:')").First;
+                await Expect(bump).ToBeVisibleAsync(
+                    new LocatorAssertionsToBeVisibleOptions { Timeout = 60_000 });
+                await bump.ClickAsync();
+                await Expect(Page.Locator(".rask-pending[data-show]")).ToBeVisibleAsync(
+                    new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+                await Expect(Page.Locator(".rask-pending[data-show]")).ToBeHiddenAsync(
+                    new LocatorAssertionsToBeHiddenOptions { Timeout = 15_000 });
+            }
+            else
+            {
+                // WASM only: the boot shell must carry the download-progress markup that main.js
+                // drives via onDownloadResourceProgress. A full throttled re-boot is impractical
+                // (multi-MB at 50 KB/s), so assert the shipped shell rather than the live fill.
+                var shell = await Page.APIRequest.GetAsync("/index.html");
+                Assert.Contains("rask-boot__progress", await shell.TextAsync());
+            }
+
             await cdp.SendAsync("Network.emulateNetworkConditions", new Dictionary<string, object>
             {
                 ["offline"] = false,

--- a/tests/Rask.Server.Tests/WebSockets/PendingAckTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/PendingAckTests.cs
@@ -1,0 +1,160 @@
+using System.Net.WebSockets;
+using System.Text.Json;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// The client's slow-link pending-action bar resolves on a server `{type:"ack",seq}` frame.
+// The ack is opt-in (only emitted when the inbound handler carried a `seq`) and must fire
+// even when the render dedupes and ships no frame — otherwise a no-op click would wedge the
+// bar until the client's hard-timeout backstop. These tests pin that protocol.
+public class PendingAckTests
+{
+    [Fact]
+    public async Task DedupedHandler_WithSeq_EmitsAckWithoutRenderFrame()
+    {
+        using var host = RaskTestHost.Create<NoOpApp>();
+        var (ws, handlerId) = await ConnectAsync(host);
+
+        // NoOpApp renders byte-identically, so the handler produces no frame — the ack is
+        // the only thing on the wire, and the client needs it to clear the pending bar.
+        await ws.SendJsonAsync(new { id = handlerId, seq = 1 });
+        var (renders, ackSeq) = await ReadUntilAckAsync(ws);
+
+        Assert.Empty(renders);
+        Assert.Equal(1, ackSeq);
+    }
+
+    [Fact]
+    public async Task StateChangingHandler_WithSeq_EmitsRenderThenAck()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var (ws, handlerId) = await ConnectAsync(host);
+
+        await ws.SendJsonAsync(new { id = handlerId, seq = 7 });
+        var (renders, ackSeq) = await ReadUntilAckAsync(ws);
+
+        // The render frame lands first (the chain acks only after the dispatch's render),
+        // then the ack closes the round-trip.
+        Assert.Single(renders);
+        Assert.Contains("count=1", renders[0]);
+        Assert.Equal(7, ackSeq);
+    }
+
+    [Fact]
+    public async Task Handler_WithoutSeq_EmitsNoAck()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var (ws, handlerId) = await ConnectAsync(host);
+
+        // Opt-in: a seq-less client gets the render frame and nothing else — the exact
+        // pre-feature contract, so existing dedup/ordering behaviour is untouched.
+        await ws.SendJsonAsync(new { id = handlerId });
+        var render = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(render);
+        Assert.Contains("count=1", render!);
+        Assert.False(IsAck(render!));
+
+        var trailing = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(400));
+        Assert.Null(trailing);
+    }
+
+    [Fact]
+    public async Task StaleHandlerId_WithSeq_StillAcks()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var (ws, _) = await ConnectAsync(host);
+
+        // Unknown handler id → TryInvokeHandlerAsync is false → no render runs, yet the
+        // dispatch still completes, so the ack must flow and unwedge the client.
+        await ws.SendJsonAsync(new { id = "does-not-exist", seq = 9 });
+        var (renders, ackSeq) = await ReadUntilAckAsync(ws);
+
+        Assert.Empty(renders);
+        Assert.Equal(9, ackSeq);
+    }
+
+    [Fact]
+    public async Task BurstOfHandlers_AcksInArrivalOrder()
+    {
+        using var host = RaskTestHost.Create<NoOpApp>();
+        var (ws, handlerId) = await ConnectAsync(host);
+
+        await ws.SendJsonAsync(new { id = handlerId, seq = 1 });
+        await ws.SendJsonAsync(new { id = handlerId, seq = 2 });
+        await ws.SendJsonAsync(new { id = handlerId, seq = 3 });
+
+        // The handler chain dispatches in WS-arrival order, so acks come back 1, 2, 3.
+        var seqs = new List<long>();
+        for (var i = 0; i < 3; i++)
+        {
+            var (renders, ackSeq) = await ReadUntilAckAsync(ws);
+            Assert.Empty(renders);
+            seqs.Add(ackSeq);
+        }
+
+        Assert.Equal(new long[] { 1, 2, 3 }, seqs);
+    }
+
+    [Fact]
+    public async Task Navigate_WithSeq_DoesNotAck()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var (ws, _) = await ConnectAsync(host);
+
+        // navigate is handled inline, never through the handler chain, so it carries no
+        // seq from the client and the server must not ack it even if a seq is present.
+        await ws.SendJsonAsync(new { type = "navigate", path = "/other", query = "", seq = 1 });
+
+        string? frame;
+        while ((frame = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500))) is not null)
+        {
+            Assert.False(IsAck(frame), "navigate must not produce an ack frame");
+        }
+    }
+
+    // Connects, sends hello, and drains any hello-time recovery frame so each test starts
+    // from a quiet socket. Returns the live socket and the page's first click-handler id.
+    private static async Task<(WebSocket ws, string handlerId)> ConnectAsync(RaskTestHost host)
+    {
+        var initial = await host.Http.GetAsync("/start");
+        var html = await initial.Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(html);
+        var handlerId = Markup.FirstHandlerId(html);
+
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(300));
+        return (ws, handlerId);
+    }
+
+    // Reads frames until an ack arrives, collecting any render frames seen first. An ack is
+    // expected within the timeout — a missing ack is a protocol failure, not a pass.
+    private static async Task<(List<string> renders, long ackSeq)> ReadUntilAckAsync(WebSocket ws)
+    {
+        var renders = new List<string>();
+        while (true)
+        {
+            var text = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            Assert.NotNull(text);
+            using var doc = JsonDocument.Parse(text!);
+            var root = doc.RootElement;
+            if (root.TryGetProperty("type", out var tp)
+                && tp.ValueKind == JsonValueKind.String
+                && tp.GetString() == "ack")
+            {
+                return (renders, root.GetProperty("seq").GetInt64());
+            }
+
+            renders.Add(text!);
+        }
+    }
+
+    private static bool IsAck(string frame)
+    {
+        using var doc = JsonDocument.Parse(frame);
+        return doc.RootElement.TryGetProperty("type", out var tp)
+               && tp.ValueKind == JsonValueKind.String
+               && tp.GetString() == "ack";
+    }
+}


### PR DESCRIPTION
## Summary

Gives users honest feedback on a slow link on both transports, with zero config and no change to fast-path behaviour — each indicator stays invisible until a latency threshold is crossed.

- **WASM boot progress.** The splash now shows a determinate download-progress bar instead of an indefinite spinner, driven by the runtime's built-in `onDownloadResourceProgress(loaded, total)` callback (wired via `dotnet.withModuleConfig`). Progress is **resource-count, not bytes** — framework assets are commonly Brotli/gzip precompressed, so a byte bar would have to reconcile encoded vs. decoded sizes and overshoot 100%. Falls back to the spinner when the total is unknown. (`src/Rask.Wasm/Browser/{index.html,main.js}` + the sample/template shells.)
- **Server pending-action bar.** A subtle 2px top-of-viewport bar appears when a handler round-trip outlives a ~300ms latency threshold and clears when the reply lands — distinct from, and one z-index below, the reconnect overlay. (`src/Rask.Server/Resources/rask.js`.)

### The ack protocol (opt-in)

The bar is backed by a tiny opt-in WebSocket ack:

- The client stamps a monotonic `seq` on **handler events only** (click/input/change/submit/drag* — anything with an `id` that the server dispatches through its handler chain; `jsResult`/`navigate`/`dotNetInvoke`/`hello` are excluded).
- After each handler dispatch completes, the server replies `{type:"ack",seq}` (`ChainHandlerDispatchAsync` → `SendHandlerAckAsync`, riding the existing `SendOutOfBandAsync` so it serialises on the render lock — landing after that handler's render frame and before the next handler's).
- Crucially the ack fires **even when the render dedupes and ships no frame** (`RenderAndSendAsync`'s HTML/byte dedup returns silently). Without it, a no-op click would wedge the bar.
- The client clears the bar on the matching (or any later) ack, synchronously on receipt; a hard timeout backstops a genuinely lost frame; reconnect resets the counters.

**Opt-in:** the server only acks when the inbound handler carried a `seq`, so seq-less clients get the **byte-for-byte unchanged** prior frame contract. The render envelope is untouched — the ack is a separate frame, not a payload field. (This is a simplification of the originally-planned per-render `seq` echo: same user-facing behaviour, but it keeps `LivePayload`/the render hot path completely unchanged.)

## Testing

- **Unit** — new `tests/Rask.Server.Tests/WebSockets/PendingAckTests.cs` (6 tests): dedup-handler acks without a render frame; state-changing handler emits render then ack; seq-less handler gets no ack (opt-in); stale handler id still acks; burst acks in arrival order; navigate-with-seq never acks. Full suite green (`Rask.Server.Tests` 170, `Rask.Core.Tests` 1485, etc.).
- **E2E** — extended the slow-3G journey (`SharedSmokeTests.Journey.cs`): under CDP throttling the Server pending bar shows then clears on a handler click, and the WASM boot-progress markup is asserted in the served shell. Compiles clean; the Playwright suite itself is run in CI (needs browsers + live hosts).
- **Build** — `dotnet format` clean; solution builds `-warnaserror` with 0 warnings.

## Benchmarks

`WsDispatchBenchmarks` — the per-event decode + JSON-parse hot path every handler event pays. Baseline `main` (330cff4) vs. this branch (7d723bd), Apple M4 Pro / .NET 10.0.5:

| Method | Allocated (main → branch) | Mean (main → branch) |
|---|---|---|
| `Bytes_SingleFragment` (common path) | 104 B → 104 B (**0%**) | 136.9 ns → 138.8 ns |
| `Bytes_FourFragments` | 216 B → 216 B (**0%**) | 159.3 ns → 159.2 ns |
| `LegacyString_SingleFragment` | 592 B → 592 B (**0%**) | 223.1 ns → 227.6 ns |
| `LegacyString_FourFragments` | 760 B → 760 B (**0%**) | 261.6 ns → 262.6 ns |

**No change to the dispatch hot path** — Allocated is byte-identical on every row; Mean moves under 2 ns, inside Error/StdDev. The seq-less common path is untouched: `TryGetProperty("seq")` is a non-allocating struct read, and the ack's `GetBytes`/`ToString` allocate only for opt-in seq-tagged clients (off the dedup-frame path, not modeled by this bench). No render-walk or payload-codec file changed (`LivePayload`, `HtmlSerializer`, `FrameDiffer`, the `LiveSession` render path all untouched).

## Changelog

`[Unreleased] → Added` entry covering both affordances.
