### PR TITLE
feat(samples): add background-service showcase that updates the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Background-service showcase (`/background`).** A new example page demonstrating an app-wide
+  background process driving the UI: a DI **singleton** `IMetricsFeed` runs its own loop and raises
+  an event each tick, and two independent components (`MetricsGauge`, `MetricsChart`) subscribe via
+  `feed.Updated += StateHasChanged` in `OnMount` / `-=` in `OnUnmount`. Unlike the existing Live
+  ticker — whose poll loop lives inside one component — this producer is decoupled from the
+  component tree (it keeps ticking across navigations and, on the Server, across sessions). State is
+  published as a single immutable snapshot swapped by reference so cross-thread reads are consistent.
+  Runs in both the Server and WASM sample apps. `Sparkline` gains an optional `ValueFormat` so its
+  axis labels can render as percentages (default unchanged).
+
 ### Changed
 - **`Authorize`'s `Authorized` slot now receives the current user** — its type changed from `Child` to
   `Func<ClaimsPrincipal, Child>`, so authorized markup can greet the signed-in user

--- a/samples/Rask.Example.Shared/Demos/MetricsFeed.cs
+++ b/samples/Rask.Example.Shared/Demos/MetricsFeed.cs
@@ -1,0 +1,153 @@
+namespace Rask.Example.Shared.Demos;
+
+// An app-wide background process that pushes updates to the UI — the counterpart to
+// LiveTicker. Where LiveTicker runs a poll loop *inside* a single component (the loop
+// is born and dies with that component's lifecycle), MetricsFeed is a DI **singleton**
+// that runs its own loop independent of any component. One producer, many subscribers:
+// components opt in with `feed.Updated += StateHasChanged` in OnMount and opt out in
+// OnUnmount — the same shape the layout uses for RouteState.Changed (ShowcaseLayout.cs),
+// but driven by a background timer instead of navigation.
+//
+// Lifetime & sharing — registered AddSingleton (ExampleServiceCollectionExtensions.cs):
+//   * One instance per application. The loop keeps ticking across navigations and, on
+//     the Server transport, across every connected session — it is decoupled from the
+//     component tree, so the feed advances even while nobody is rendering it. (Contrast
+//     DemoUserProvider, which is deliberately *scoped*: a per-user principal must NOT be
+//     shared. A public synthetic metric stream is fine to share; auth state is not.)
+//   * Created lazily on first resolution (the first component that injects IMetricsFeed),
+//     then runs until the host disposes it on shutdown via IAsyncDisposable.
+//
+// Thread-safety — the load-bearing part:
+//   * Updated fires from a background thread (the loop continuation). Each subscriber's
+//     StateHasChanged() schedules a render under *its own* session render lock and is a
+//     no-op once the component has unmounted, so a tick racing an unsubscribe is benign
+//     (see Component.StateHasChanged).
+//   * State is published as a single **immutable** MetricsSnapshot swapped by reference.
+//     A reader on the render thread always sees a consistent (Current, Recent) pair from
+//     one atomic read — there is no torn read while the loop builds the next snapshot.
+//     This is the race LiveTicker can ignore only because its loop is component-local and
+//     strictly serialized; an app-wide singleton genuinely crosses threads, so the
+//     copy-on-write snapshot is what makes it correct.
+//
+// The feed is fully synthetic (a bounded random walk), so the demo is deterministic in
+// shape and offline-safe — swapping in a real source (a metrics endpoint, a message bus)
+// is a one-method change to Step, and the subscribe/snapshot/dispose story is unchanged.
+public interface IMetricsFeed
+{
+    // The latest consistent snapshot. Safe to read from any thread.
+    MetricsSnapshot State { get; }
+
+    // Raised after each tick, once State has been swapped to the new snapshot.
+    event Action? Updated;
+}
+
+public sealed class MetricsFeed : IMetricsFeed, IAsyncDisposable
+{
+    // ~1 min of history at the default cadence; bounded so a long-lived app doesn't grow
+    // the rolling buffer without limit (same discipline as LiveTicker.HistoryCapacity).
+    private const int HistoryCapacity = 60;
+    private const int IntervalMs = 1000;
+
+    private readonly CancellationTokenSource _cts = new();
+    private readonly int _intervalMs;
+    private readonly Task _loop;
+
+    private MetricsSnapshot _state;
+
+    public MetricsFeed() : this(IntervalMs)
+    {
+    }
+
+    // Internal ctor lets the unit tests run the loop fast without waiting out the
+    // production 1 s cadence.
+    internal MetricsFeed(int intervalMs)
+    {
+        _intervalMs = intervalMs;
+        _state = CreateInitialSnapshot(DateTimeOffset.UtcNow);
+        _loop = RunAsync(_cts.Token);
+    }
+
+    public MetricsSnapshot State => Volatile.Read(ref _state);
+
+    public event Action? Updated;
+
+    public async ValueTask DisposeAsync()
+    {
+        await _cts.CancelAsync().ConfigureAwait(false);
+        try
+        {
+            await _loop.ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected when the loop's in-flight Task.Delay is cancelled.
+        }
+
+        _cts.Dispose();
+    }
+
+    // First snapshot so the gauge shows numbers and the chart has a point before the
+    // first tick lands.
+    public static MetricsSnapshot CreateInitialSnapshot(DateTimeOffset now)
+    {
+        var sample = new MetricsSample(Tick: 0, CpuPercent: 50, ActiveJobs: 4, At: now);
+        return new MetricsSnapshot(sample, new[] { sample });
+    }
+
+    // Pure transition: previous snapshot + the tick's timestamp ⇒ next snapshot. Kept
+    // free of the loop/timer so it unit-tests deterministically. The randomness is the
+    // only non-deterministic part and only affects the *values*, not the invariants the
+    // tests assert (Tick increments, Recent stays capped, Current is the last point).
+    internal static MetricsSnapshot Step(MetricsSnapshot prev, DateTimeOffset now)
+    {
+        var c = prev.Current;
+        var cpu = Math.Clamp(c.CpuPercent + ((Random.Shared.NextDouble() - 0.5) * 12), 2, 99);
+        var jobs = Math.Clamp(c.ActiveJobs + Random.Shared.Next(-2, 3), 0, 24);
+        var next = new MetricsSample(c.Tick + 1, Math.Round(cpu, 1), jobs, now);
+        return new MetricsSnapshot(next, AppendCapped(prev.Recent, next, HistoryCapacity));
+    }
+
+    // Copy-on-write append: returns a fresh array (never mutates the previous one), so the
+    // snapshot a reader already holds is immutable and the swap below is a clean handover.
+    private static IReadOnlyList<MetricsSample> AppendCapped(
+        IReadOnlyList<MetricsSample> prev, MetricsSample next, int cap)
+    {
+        var start = prev.Count >= cap ? prev.Count - cap + 1 : 0;
+        var len = prev.Count - start + 1;
+        var arr = new MetricsSample[len];
+        for (var i = 0; i < len - 1; i++)
+        {
+            arr[i] = prev[start + i];
+        }
+
+        arr[len - 1] = next;
+        return arr;
+    }
+
+    private async Task RunAsync(CancellationToken ct)
+    {
+        try
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(_intervalMs, ct).ConfigureAwait(false);
+
+                // Build the next snapshot, then publish it as one atomic reference swap
+                // BEFORE notifying — so every subscriber that wakes reads the new state.
+                Volatile.Write(ref _state, Step(Volatile.Read(ref _state), DateTimeOffset.UtcNow));
+                Updated?.Invoke();
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Expected on dispose — the loop simply exits.
+        }
+    }
+}
+
+// One tick of the feed.
+public readonly record struct MetricsSample(int Tick, double CpuPercent, int ActiveJobs, DateTimeOffset At);
+
+// An immutable view of the feed: the latest sample plus the rolling history. Swapped as a
+// single reference each tick so readers never observe a half-updated state.
+public sealed record MetricsSnapshot(MetricsSample Current, IReadOnlyList<MetricsSample> Recent);

--- a/samples/Rask.Example.Shared/Demos/MetricsView.cs
+++ b/samples/Rask.Example.Shared/Demos/MetricsView.cs
@@ -1,0 +1,77 @@
+using System.Globalization;
+
+namespace Rask.Example.Shared.Demos;
+
+// Two independent subscribers to the same IMetricsFeed singleton, to make the
+// "one background producer, many decoupled consumers" story concrete: each component
+// subscribes to feed.Updated on mount, unsubscribes on unmount, and repaints itself
+// straight from the latest snapshot. Neither knows about the other — both are driven
+// by the background loop in MetricsFeed.
+//
+// The subscribe/unsubscribe pair mirrors ShowcaseLayout's route.Changed handling
+// (ShowcaseLayout.cs:57-59): += in OnMount, -= in OnUnmount so a navigated-away
+// component stops repainting and can be collected (no event-handler leak). Updated
+// fires from a background thread; StateHasChanged() is thread-safe and a no-op once
+// unmounted, so no extra marshalling is needed here (same as DisposalPage's timer probe).
+
+// Numeric readout of the latest tick. Ids are stable so the E2E journey can assert the
+// tick count advances without any user interaction.
+public sealed class MetricsGauge(IMetricsFeed feed) : Component
+{
+    private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+
+    protected override void OnMount() => feed.Updated += StateHasChanged;
+
+    protected override void OnUnmount() => feed.Updated -= StateHasChanged;
+
+    protected override RenderResult Render()
+    {
+        var s = feed.State.Current;
+        return Div(Class: "card shadow-sm border-0 h-100")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex align-items-baseline justify-content-between mb-3")[
+                    H3(Class: "h6 text-secondary text-uppercase small mb-0")["System metrics"],
+                    Span(Class: "badge rounded-pill text-bg-secondary", Id: "metrics-tick")[
+                        $"tick {s.Tick.ToString(Inv)}"]
+                ],
+                Div(Class: "row text-center g-3")[
+                    Stat("CPU", $"{s.CpuPercent.ToString("0.0", Inv)}%", "metrics-cpu"),
+                    Stat("Active jobs", s.ActiveJobs.ToString(Inv), "metrics-jobs")
+                ],
+                P(Class: "text-secondary small mb-0 mt-3")[
+                    "updated ", Code()[s.At.ToString("HH:mm:ss", Inv)], " · pushed by the background feed"
+                ]
+            ]
+        ];
+    }
+
+    private static Component Stat(string label, string value, string id) =>
+        Div(Class: "col-6")[
+            Div(Class: "fs-3 fw-bold", Id: id)[value],
+            Div(Class: "text-secondary small")[label]
+        ];
+}
+
+// SVG sparkline of the CPU history — a second, independent subscriber. Reuses the
+// stateless Sparkline demo (zero JS, server-rendered SVG); the feed's rolling buffer is
+// the data series. ValueFormat renders the axis labels as percentages instead of money.
+public sealed class MetricsChart(IMetricsFeed feed) : Component
+{
+    protected override void OnMount() => feed.Updated += StateHasChanged;
+
+    protected override void OnUnmount() => feed.Updated -= StateHasChanged;
+
+    protected override RenderResult Render() =>
+        Div(Class: "card shadow-sm border-0 h-100")[
+            Div(Class: "card-body")[
+                H3(Class: "h6 text-secondary text-uppercase small mb-3")["CPU %, last minute"],
+                Div(Class: "metrics-chart-container", Id: "metrics-chart",
+                    Style: "position: relative; height: 160px;")[
+                    Sparkline(
+                        feed.State.Recent.Select(p => p.CpuPercent).ToList(),
+                        ValueFormat: "0.0'%'",
+                        Class: "metrics-chart-svg")
+                ]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Shared/Demos/Sparkline.cs
+++ b/samples/Rask.Example.Shared/Demos/Sparkline.cs
@@ -38,8 +38,13 @@ public sealed class Sparkline : Component
     // Component, not an Element, so it doesn't inherit Element.Class).
     public string? Class { get; set; }
 
+    // Numeric format for the min/max/last axis labels (e.g. "0.0'%'" for percentages). The
+    // default reproduces the original money formatting, so existing callers are unaffected.
+    public string? ValueFormat { get; set; }
+
     private string StrokeColor => Stroke ?? "#0d6efd";
     private string AreaColor => AreaFill ?? "rgba(13, 110, 253, 0.15)";
+    private string LabelFormat => ValueFormat ?? "$#,##0.00";
 
     protected override RenderResult Render()
     {
@@ -120,13 +125,13 @@ public sealed class Sparkline : Component
 
         // Min / max value labels on the y-axis.
         children.Add(SvgText(Num(PadX + 2), Num(PadTop + 10), FontFamily: "sans-serif",
-            FontSize: "11", Fill: "#6c757d")[Money(max)]);
+            FontSize: "11", Fill: "#6c757d")[Label(max)]);
         children.Add(SvgText(Num(PadX + 2), Num(baseY - 3), FontFamily: "sans-serif",
-            FontSize: "11", Fill: "#6c757d")[Money(min)]);
+            FontSize: "11", Fill: "#6c757d")[Label(min)]);
 
         // Last-point marker carrying a native SVG <title> tooltip (no JS).
         children.Add(Circle(Num(lastX), Num(lastY), "3.5", Fill: StrokeColor)[
-            SvgTitle()[Money(values[n - 1])]
+            SvgTitle()[Label(values[n - 1])]
         ]);
 
         return Frame()[children];
@@ -138,5 +143,5 @@ public sealed class Sparkline : Component
 
     private static string Num(double v) => v.ToString("0.##", Inv);
 
-    private static string Money(double v) => "$" + v.ToString("N2", Inv);
+    private string Label(double v) => v.ToString(LabelFormat, Inv);
 }

--- a/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
+++ b/samples/Rask.Example.Shared/ExampleServiceCollectionExtensions.cs
@@ -22,6 +22,14 @@ public static class ExampleServiceCollectionExtensions
         services.AddSingleton(sp => new HttpClient { BaseAddress = httpBaseAddress(sp) });
         services.AddSingleton<IBannedWordService, BannedWordService>();
 
+        // App-wide background process for the /background showcase. Singleton — one producer
+        // for the whole app whose loop ticks independently of any component and is shared
+        // across sessions on the Server transport. That's safe here because it's a public
+        // synthetic metric stream; contrast DemoUserProvider below, which is deliberately
+        // *scoped* (a per-user principal must never be shared). The loop self-starts on first
+        // resolution and the host disposes it on shutdown (IAsyncDisposable).
+        services.AddSingleton<IMetricsFeed, MetricsFeed>();
+
         // Toggleable demo auth for the User-gating showcase (/user). Registered as the concrete
         // type (so the demo can sign in/out) and as IUserProvider (so injected consumers resolve it).
         // Defaults to anonymous, so other pages are unaffected. Scoped — NOT singleton — so each

--- a/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
@@ -26,6 +26,7 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
         ("/element-ref", "Element refs", "bi-bullseye", "Components", null),
         ("/user", "User & auth", "bi-person-lock", "Components", null),
         ("/realtime/BTC", "Live ticker", "bi-graph-up-arrow", "Components", "/realtime"),
+        ("/background", "Background service", "bi-broadcast", "Components", null),
         ("/cancellation", "Cancellation", "bi-x-circle", "Components", null),
         ("/disposal", "Disposal", "bi-trash", "Components", null),
         ("/events", "Events", "bi-mouse", "Components", null),

--- a/samples/Rask.Example.Shared/Pages/BackgroundServicePage.cs
+++ b/samples/Rask.Example.Shared/Pages/BackgroundServicePage.cs
@@ -1,0 +1,84 @@
+using Rask.Core.Routing;
+using Rask.Example.Shared.Demos;
+using Rask.Example.Shared.Layout;
+
+namespace Rask.Example.Shared.Pages;
+
+// Showcase for an app-wide background process driving the UI. The page itself is static —
+// all the live behaviour comes from MetricsGauge and MetricsChart, two independent
+// components that subscribe to the IMetricsFeed singleton (MetricsFeed.cs). The feed's
+// background loop ticks once a second whether or not this page is mounted, so navigating
+// away and back shows a higher tick count — proof the producer is decoupled from the UI.
+[Route("background")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class BackgroundServicePage : Component
+{
+    protected override RenderResult Head => Title()["Background service — Rask"];
+
+    protected override RenderResult Render() =>
+    [
+        PageHeader.Render(
+            "Background service",
+            "An app-wide background process pushing updates to the UI. A single IMetricsFeed singleton runs its own loop and raises an event each tick; the two widgets below each subscribe independently (feed.Updated += StateHasChanged) and repaint themselves. Unlike the Live ticker — whose poll loop lives inside one component — this producer is decoupled from the component tree: it keeps ticking across navigations (and, on the Server, across every session). Navigate away and back to see the tick count has advanced while nothing was rendering it."),
+        Div(Class: "row g-4")[
+            Div(Class: "col-lg-5")[
+                MetricsGauge()
+            ],
+            Div(Class: "col-lg-7")[
+                MetricsChart()
+            ]
+        ],
+        H2(Class: "h4 mt-5 mb-3")["The pattern"],
+        P(Class: "text-secondary")[
+            "The producer is a DI ", Code()["AddSingleton<IMetricsFeed, MetricsFeed>()"],
+            " — one instance for the whole app. Each consumer is a tiny component that subscribes on mount and ",
+            Strong()["unsubscribes on unmount"], " so it stops repainting (and can be collected) once it leaves the tree."
+        ],
+        CodeSample(
+            """
+            // The background producer — a singleton, not tied to any component.
+            public sealed class MetricsFeed : IMetricsFeed, IAsyncDisposable
+            {
+                private MetricsSnapshot _state;
+                public MetricsSnapshot State => Volatile.Read(ref _state);
+                public event Action? Updated;
+
+                public MetricsFeed() => _loop = RunAsync(_cts.Token);
+
+                private async Task RunAsync(CancellationToken ct)
+                {
+                    while (!ct.IsCancellationRequested)
+                    {
+                        await Task.Delay(1000, ct).ConfigureAwait(false);
+                        // Publish one immutable snapshot by reference, THEN notify.
+                        Volatile.Write(ref _state, Step(_state, DateTimeOffset.UtcNow));
+                        Updated?.Invoke();
+                    }
+                }
+
+                public async ValueTask DisposeAsync() { await _cts.CancelAsync(); /* … */ }
+            }
+
+            // A consumer — subscribes on mount, unsubscribes on unmount.
+            public sealed class MetricsGauge(IMetricsFeed feed) : Component
+            {
+                protected override void OnMount()   => feed.Updated += StateHasChanged;
+                protected override void OnUnmount() => feed.Updated -= StateHasChanged;
+                protected override RenderResult Render() =>
+                    Span()[$"CPU {feed.State.Current.CpuPercent}%"];
+            }
+            """,
+            Notes:
+            "The loop runs on a background thread, so StateHasChanged() crosses threads here — that's safe: it schedules a render under the subscriber's own session lock and is a no-op once the component unmounts (so a tick racing an unsubscribe is harmless). State is an immutable snapshot swapped by reference, so a render walking it on the UI thread never sees a half-built value. The feed is registered as a singleton (app-wide, shared) — deliberately unlike the scoped DemoUserProvider, because a metric stream is public but a user's principal must never be shared across sessions."),
+        Div(Class: "alert alert-info d-flex align-items-start mt-3")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["Decoupled lifetime."],
+                " The feed is created on first resolution and then runs for the app's lifetime, disposed by the host on shutdown (",
+                Code()["IAsyncDisposable"],
+                "). It advances independently of any page — swap the synthetic ",
+                Code()["Step"], " for a real metrics endpoint or message bus and nothing else changes."
+            ]
+        ]
+    ];
+}

--- a/tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj
+++ b/tests/Rask.Example.Server.Tests/Rask.Example.Server.Tests.csproj
@@ -50,6 +50,8 @@
              Link="Infrastructure\LiveHost.cs"/>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\TestServices.cs"
              Link="Infrastructure\TestServices.cs"/>
+    <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\FakeMetricsFeed.cs"
+             Link="Infrastructure\FakeMetricsFeed.cs"/>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\CapturingDownloadSink.cs"
              Link="Infrastructure\CapturingDownloadSink.cs"/>
     <Compile Include="..\Rask.Example.Shared.Tests\Infrastructure\TestNavigator.cs"

--- a/tests/Rask.Example.Shared.Tests/Demos/MetricsFeedTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MetricsFeedTests.cs
@@ -1,0 +1,98 @@
+using Rask.Example.Shared.Demos;
+using Rask.Example.Shared.Tests.Infrastructure;
+
+namespace Rask.Example.Shared.Tests.Demos;
+
+// The background producer behind the /background showcase. The pure Step transition is
+// tested deterministically (invariants only — Tick increments, history stays capped,
+// Current is the last point); the live loop is tested through the real MetricsFeed with
+// a fast interval, the same WaitFor approach LiveTickerTests uses.
+public sealed class MetricsFeedTests
+{
+    [Fact]
+    public void Step_IncrementsTick_AndAppendsCurrentAsLastPoint()
+    {
+        var initial = MetricsFeed.CreateInitialSnapshot(DateTimeOffset.UnixEpoch);
+
+        var next = MetricsFeed.Step(initial, DateTimeOffset.UnixEpoch.AddSeconds(1));
+
+        Assert.Equal(initial.Current.Tick + 1, next.Current.Tick);
+        Assert.Equal(next.Current, next.Recent[^1]);
+        Assert.Equal(2, next.Recent.Count);
+    }
+
+    [Fact]
+    public void Step_DoesNotMutatePreviousSnapshot()
+    {
+        var initial = MetricsFeed.CreateInitialSnapshot(DateTimeOffset.UnixEpoch);
+        var recentBefore = initial.Recent;
+
+        MetricsFeed.Step(initial, DateTimeOffset.UnixEpoch.AddSeconds(1));
+
+        // Copy-on-write: the snapshot a reader already holds is untouched by the next tick.
+        Assert.Same(recentBefore, initial.Recent);
+        Assert.Single(initial.Recent);
+    }
+
+    [Fact]
+    public void Step_HistoryStaysCappedAt60()
+    {
+        var snapshot = MetricsFeed.CreateInitialSnapshot(DateTimeOffset.UnixEpoch);
+
+        for (var i = 0; i < 200; i++)
+        {
+            snapshot = MetricsFeed.Step(snapshot, DateTimeOffset.UnixEpoch.AddSeconds(i + 1));
+            Assert.True(snapshot.Recent.Count <= 60);
+        }
+
+        Assert.Equal(60, snapshot.Recent.Count);
+        // Oldest rolled off: the buffer holds the 60 most-recent ticks, last one is Current.
+        Assert.Equal(snapshot.Current, snapshot.Recent[^1]);
+    }
+
+    [Fact]
+    public void Step_KeepsCpuWithinBounds()
+    {
+        var snapshot = MetricsFeed.CreateInitialSnapshot(DateTimeOffset.UnixEpoch);
+
+        for (var i = 0; i < 500; i++)
+        {
+            snapshot = MetricsFeed.Step(snapshot, DateTimeOffset.UnixEpoch.AddSeconds(i + 1));
+            Assert.InRange(snapshot.Current.CpuPercent, 2, 99);
+            Assert.InRange(snapshot.Current.ActiveJobs, 0, 24);
+        }
+    }
+
+    [Fact]
+    public async Task Loop_RaisesUpdated_AndAdvancesTick()
+    {
+        await using var feed = new MetricsFeed(intervalMs: 10);
+        var raised = 0;
+        feed.Updated += () => Interlocked.Increment(ref raised);
+
+        var startTick = feed.State.Current.Tick;
+        await WaitFor.True(
+            () => feed.State.Current.Tick > startTick && Volatile.Read(ref raised) > 0,
+            TimeSpan.FromSeconds(2),
+            "the background loop never ticked / raised Updated");
+
+        Assert.True(feed.State.Current.Tick > startTick);
+        Assert.True(Volatile.Read(ref raised) > 0);
+    }
+
+    [Fact]
+    public async Task DisposeAsync_StopsTheLoop()
+    {
+        var feed = new MetricsFeed(intervalMs: 10);
+        await WaitFor.True(
+            () => feed.State.Current.Tick > 0, TimeSpan.FromSeconds(2),
+            "the loop never started ticking");
+
+        await feed.DisposeAsync();
+        var tickAtDispose = feed.State.Current.Tick;
+
+        // Well over a few intervals — if the loop were still running the tick would climb.
+        await Task.Delay(80);
+        Assert.Equal(tickAtDispose, feed.State.Current.Tick);
+    }
+}

--- a/tests/Rask.Example.Shared.Tests/Demos/MetricsViewTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MetricsViewTests.cs
@@ -1,0 +1,83 @@
+using Rask.Example.Shared.Demos;
+using Rask.Example.Shared.Tests.Infrastructure;
+using static Rask.Example.Shared.Demos.Generated;
+
+namespace Rask.Example.Shared.Tests.Demos;
+
+// MetricsGauge / MetricsChart are driven through LiveHost so the real framework fires
+// their lifecycle hooks. A FakeMetricsFeed stands in for the producer so the test pushes
+// updates by hand (Publish) — fully deterministic, no background timer.
+public sealed class MetricsViewTests
+{
+    [Fact]
+    public void Gauge_RendersInitialSnapshot()
+    {
+        var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
+        var host = new LiveHost(() => MetricsGauge(), Services(feed));
+
+        var html = host.RenderAsLiveRoot();
+
+        Assert.Contains("tick 0", html);
+        Assert.Contains("50.0%", html);
+    }
+
+    [Fact]
+    public void Gauge_RepaintsWhenFeedPublishes()
+    {
+        var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
+        var host = new LiveHost(() => MetricsGauge(), Services(feed));
+        host.RenderAsLiveRoot();
+
+        feed.Publish(Snapshot(tick: 7, cpu: 73.5, jobs: 9));
+        var html = host.RenderAsLiveRoot();
+
+        Assert.Contains("tick 7", html);
+        Assert.Contains("73.5%", html);
+        Assert.Contains(">9<", html); // active jobs
+    }
+
+    [Fact]
+    public void Gauge_SubscribesOnMount_AndUnsubscribesOnUnmount()
+    {
+        var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
+        var host = new LiveHost(() => MetricsGauge(), Services(feed));
+
+        host.RenderAsLiveRoot();
+        Assert.Equal(1, feed.SubscriberCount);
+
+        host.Mounted = false;
+        host.RenderAsLiveRoot();
+        Assert.Equal(0, feed.SubscriberCount);
+
+        // A tick after unmount must not throw (no live handler) and produces no value change.
+        feed.Publish(Snapshot(tick: 99, cpu: 12, jobs: 1));
+        Assert.Equal(0, feed.SubscriberCount);
+    }
+
+    [Fact]
+    public void Chart_SubscribesAndRendersSvgFromHistory()
+    {
+        var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
+        var host = new LiveHost(() => MetricsChart(), Services(feed));
+
+        var html = host.RenderAsLiveRoot();
+        Assert.Equal(1, feed.SubscriberCount);
+        Assert.Contains("<svg", html);
+        // Percentage-formatted axis labels (ValueFormat "0.0'%'"), not the default money.
+        Assert.Contains("50.0%", html);
+        Assert.DoesNotContain("$", html);
+
+        host.Mounted = false;
+        host.RenderAsLiveRoot();
+        Assert.Equal(0, feed.SubscriberCount);
+    }
+
+    private static IServiceProvider Services(FakeMetricsFeed feed) =>
+        LiveHost.Services((typeof(IMetricsFeed), feed));
+
+    private static MetricsSnapshot Snapshot(int tick, double cpu, int jobs)
+    {
+        var sample = new MetricsSample(tick, cpu, jobs, DateTimeOffset.UnixEpoch.AddSeconds(tick));
+        return new MetricsSnapshot(sample, new[] { sample });
+    }
+}

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/FakeMetricsFeed.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/FakeMetricsFeed.cs
@@ -1,0 +1,27 @@
+using Rask.Example.Shared.Demos;
+
+namespace Rask.Example.Shared.Tests.Infrastructure;
+
+// Inert IMetricsFeed test double — no background loop, so it's deterministic and starts
+// no timers. State is settable and Publish() raises Updated, letting subscriber tests
+// drive the producer by hand. Used both as the default registration in TestServices
+// (page-baseline renders) and directly in MetricsViewTests.
+internal sealed class FakeMetricsFeed : IMetricsFeed
+{
+    public FakeMetricsFeed(MetricsSnapshot? initial = null) =>
+        State = initial ?? MetricsFeed.CreateInitialSnapshot(DateTimeOffset.UnixEpoch);
+
+    public MetricsSnapshot State { get; private set; }
+
+    public event Action? Updated;
+
+    // Swap the snapshot, then notify — mirrors MetricsFeed's publish-then-raise order.
+    public void Publish(MetricsSnapshot snapshot)
+    {
+        State = snapshot;
+        Updated?.Invoke();
+    }
+
+    // Number of currently attached handlers — lets a test assert unsubscribe happened.
+    public int SubscriberCount => Updated?.GetInvocationList().Length ?? 0;
+}

--- a/tests/Rask.Example.Shared.Tests/Infrastructure/TestServices.cs
+++ b/tests/Rask.Example.Shared.Tests/Infrastructure/TestServices.cs
@@ -28,6 +28,10 @@ internal static class TestServices
         sc.AddSingleton<IJSRuntime>(js ?? new FakeJsRuntime());
         sc.AddSingleton(downloadSink ?? new CapturingDownloadSink());
         sc.AddSingleton(bannedWords ?? new BannedWordService());
+        // Inert feed — no background loop — so the /background page baseline renders
+        // deterministically without starting timers. Behavioural coverage of the real
+        // MetricsFeed loop lives in MetricsFeedTests.
+        sc.AddSingleton<IMetricsFeed>(new FakeMetricsFeed());
 
         return sc.BuildServiceProvider();
     }

--- a/tests/Rask.Example.Shared.Tests/Pages/PageBaselineTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/PageBaselineTests.cs
@@ -11,6 +11,7 @@ public sealed class PageBaselineTests
 {
     [Theory]
     [InlineData(typeof(HomePage), "/", "Welcome")]
+    [InlineData(typeof(BackgroundServicePage), "/background", "Background service")]
     [InlineData(typeof(BindingPage), "/binding", "Two-way binding")]
     [InlineData(typeof(BoomPage), "/boom", "Error boundary")]
     [InlineData(typeof(CancellationPage), "/cancellation", "Cancellation")]
@@ -49,6 +50,7 @@ public sealed class PageBaselineTests
 
     [Theory]
     [InlineData(typeof(HomePage))]
+    [InlineData(typeof(BackgroundServicePage))]
     [InlineData(typeof(BindingPage))]
     [InlineData(typeof(BoomPage))]
     [InlineData(typeof(CancellationPage))]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -610,6 +610,10 @@ public abstract partial class SharedSmokeTests
     private static int ExtractRenderCount(string? text) =>
         int.Parse(Regex.Match(text ?? "0", @"\d+").Value);
 
+    // The #metrics-tick badge reads "tick N" — N is the background feed's tick count.
+    private async Task<int> ReadMetricsTickAsync() =>
+        ExtractRenderCount(await Page.Locator("#metrics-tick").TextContentAsync());
+
     private async Task HtmlDragDropAsync(string sourceSelector, string targetSelector)
     {
         var source = Page.Locator(sourceSelector);


### PR DESCRIPTION
## Summary
Adds a `/background` showcase demonstrating an app-wide background process driving the UI — the counterpart to the existing component-local Live ticker. A DI **singleton** `IMetricsFeed` runs its own loop and raises an event each tick; two independent components (`MetricsGauge`, `MetricsChart`) subscribe via `feed.Updated += StateHasChanged` in `OnMount` / `-=` in `OnUnmount`. The producer is decoupled from the component tree (it keeps ticking across navigations and, on the Server, across sessions), and publishes state as one immutable snapshot swapped by reference so cross-thread reads stay consistent. Runs in both the Server and WASM sample apps.

## Testing
- Unit: `Rask.Example.Shared.Tests` — 249 passed (incl. new `MetricsFeedTests`, `MetricsViewTests`, `/background` page baseline); `Rask.Example.Server.Tests` — 16 passed.
- E2E (`samples/` changed): host **Server** — `Journey_WalksEveryPageAndUnusualActivity` passed (39s). New step navigates to `/background`, asserts the chart SVG renders and the `#metrics-tick` count climbs with **no user interaction** (proving the background producer drives the render). The block lives in the shared journey, so the WASM hosts run it too.

## Benchmarks
n/a — samples + tests only; no `src/Rask.Core`/`Rask.Server` render hot-path code touched.

## CHANGELOG
- [Unreleased] entry added: Background-service showcase (`/background`); `Sparkline` gains optional `ValueFormat` for percentage axis labels (default unchanged).
