### PR TITLE
fix(samples): scroll the showcase side nav within the viewport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ them until tagged releases begin.
   `bin/<cfg>/net10.0-browser/publish/wwwroot/`; `Rask.Wasm.Hosting`'s `UseRask()` follows it
   automatically. Sub-path deploys keep `/p:RaskPathBase=/<repo>` (now a post-publish `<base href>`
   rewrite; every other asset URL is document-relative).
+- **Showcase code samples are now copy-pasteable and multi-language.** Every `CodeSample` card in
+  the example apps gains a copy-to-clipboard button (scoped JS, with an `execCommand` fallback for
+  non-secure/headless contexts), and samples that have a JavaScript or CSS side render a **C# / JS /
+  CSS tab strip** — tab state is component state switched through the live diff, and each pane is
+  highlighted server-side by ColorCode. The Element-refs and Scoped-CSS pages now show the **real,
+  verbatim source** of their demo components (`ElementRefDemo.cs` + `.js`, `ScopedRed/Blue.cs` +
+  `.css`), embedded from the actual files via a new `EmbeddedSource` reader so the snippet always
+  compiles and matches the live result. Samples-only — no framework API change.
 
 ### Removed
 - **`:global(...)` scoped-CSS escape hatch removed.** A scoped `{Component}.css` no longer has a
@@ -71,6 +79,12 @@ them until tagged releases begin.
   external event subscriptions). The `Rask.Example.EfCore` sample's `DeleteAsync` drops the call.
 
 ### Fixed
+- **Showcase side navigation no longer overflows the page.** On desktop the long sidebar link list
+  was an unconstrained `position-sticky` block, so when it exceeded the viewport its bottom entries
+  fell below the fold and were only reachable by scrolling the whole page. The sidebar is now pinned
+  under the navbar, capped at the available viewport height, and scrolls on its own. The navbar
+  height — previously a `56px` literal duplicated across the sidebar `min-height`, the mobile-drawer
+  offset, and the sticky `top` — is centralised in a single `--nav-h` custom property (samples only).
 - **`Rask.Wasm.Hosting` now serves precompressed static assets with their real MIME type.** When a
   request for a `wwwroot` file (e.g. `global.css`) was satisfied from its publish-time `.br`/`.gz`
   sibling, `UseStaticFiles` keyed the content type off the `.br`/`.gz` extension and fell back to

--- a/samples/Rask.Example.Server/wwwroot/global.css
+++ b/samples/Rask.Example.Server/wwwroot/global.css
@@ -14,6 +14,7 @@
     --rask-accent-strong: #512BD4;
     --rask-accent-soft: #f1ebfd;
     --rask-gradient: linear-gradient(135deg, #7C3AED 0%, #512BD4 100%);
+    --nav-h: 56px;
 }
 
 .btn-primary {

--- a/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs
@@ -98,7 +98,7 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
                 Aside(Class: _drawerOpen
                     ? "col-12 col-md-4 col-lg-3 col-xl-2 bg-white border-end side-nav drawer-open"
                     : "col-12 col-md-4 col-lg-3 col-xl-2 bg-white border-end side-nav")[
-                    Div(Class: "position-sticky pt-3 pb-4 px-2", Style: "top: 56px;")[BuildGroups()]
+                    Div(Class: "position-sticky pt-3 pb-4 px-2", Style: "top: var(--nav-h);")[BuildGroups()]
                 ],
                 Main(Class: "col-12 col-md-8 col-lg-9 col-xl-10 py-4 px-md-5")[
                     Div(Class: "mx-auto", Style: "max-width: 1280px;")[Outlet()]

--- a/samples/Rask.Example.Shared/Layout/ShowcaseLayout.css
+++ b/samples/Rask.Example.Shared/Layout/ShowcaseLayout.css
@@ -1,5 +1,12 @@
 .side-nav {
-    min-height: calc(100vh - 56px);
+    min-height: calc(100vh - var(--nav-h));
+}
+
+/* Desktop: pin the link list under the navbar and let it scroll on its own so a
+   long list never stretches the page or hides its bottom entries below the fold. */
+.side-nav .position-sticky {
+    max-height: calc(100vh - var(--nav-h));
+    overflow-y: auto;
 }
 
 .nav-item-btn {
@@ -93,7 +100,7 @@ main {
         transform: translateX(-100%);
         transition: transform 220ms cubic-bezier(0.22, 1, 0.36, 1);
         will-change: transform;
-        padding-top: calc(56px + env(safe-area-inset-top));
+        padding-top: calc(var(--nav-h) + env(safe-area-inset-top));
         padding-bottom: env(safe-area-inset-bottom);
         padding-left: env(safe-area-inset-left);
         overflow-y: auto;
@@ -111,6 +118,8 @@ main {
     .side-nav .position-sticky {
         position: static !important;
         top: auto !important;
+        max-height: none;
+        overflow-y: visible;
     }
 
     .nav-backdrop {

--- a/samples/Rask.Example.Wasm/wwwroot/global.css
+++ b/samples/Rask.Example.Wasm/wwwroot/global.css
@@ -14,6 +14,7 @@
     --rask-accent-strong: #512BD4;
     --rask-accent-soft: #f1ebfd;
     --rask-gradient: linear-gradient(135deg, #7C3AED 0%, #512BD4 100%);
+    --nav-h: 56px;
 }
 
 .btn-primary {

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -435,6 +435,26 @@ public abstract partial class SharedSmokeTests
             null,
             new PageWaitForFunctionOptions { Timeout = 10_000 });
 
+        // The navbar height is centralised in a single --nav-h custom property (no hard-coded 56px),
+        // and on desktop the sidebar uses it to become an independent, viewport-bounded scroll region
+        // so its long link list scrolls inside itself rather than stretching the page — the
+        // "navbar too tall" fix. At the default 1280×720 viewport the 35-link list overflows the box.
+        Assert.Equal("56px", (await Page.EvaluateAsync<string>(
+            "() => getComputedStyle(document.documentElement).getPropertyValue('--nav-h').trim()")));
+        var navScroll = await Page.Locator("aside.side-nav .position-sticky").First.EvaluateAsync<string>(
+            @"el => {
+                const cs = getComputedStyle(el);
+                const navH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--nav-h'));
+                return JSON.stringify({
+                    overflowY: cs.overflowY,
+                    bounded: el.clientHeight <= window.innerHeight - navH + 1,
+                    scrollable: el.scrollHeight > el.clientHeight,
+                });
+            }");
+        Assert.Contains("\"overflowY\":\"auto\"", navScroll);
+        Assert.Contains("\"bounded\":true", navScroll);
+        Assert.Contains("\"scrollable\":true", navScroll);
+
         // Asset loading: per-component content-addressed <link>s, a JS-only <script>, and lazy
         // mount adding/removing a link via the keyed head-morph.
         await SideAsync("Asset loading", "Asset loading", "main h1.h3");


### PR DESCRIPTION
## Summary
The showcase **side navigation** (35+ links) read as "too tall": on desktop it was an unconstrained `position-sticky` block, so when the list exceeded the viewport its bottom entries fell below the fold and could only be reached by scrolling the whole page.

- The sidebar is now pinned under the navbar, capped at the available viewport height (`max-height: calc(100vh - var(--nav-h))`), and scrolls on its own. The mobile drawer keeps its single-panel scroll (the nested scroll region is reset inside the `max-width: 767.98px` query).
- The navbar height — previously a `56px` literal **duplicated** across the sidebar `min-height`, the mobile-drawer offset, and the sticky `top` inline style — is centralised in a single `--nav-h` custom property declared on `:root` in each showcase `global.css` (Server + Wasm). The `Auth*` samples use their own navbars and are untouched.

## Files
- `samples/Rask.Example.{Server,Wasm}/wwwroot/global.css` — `--nav-h: 56px` on `:root`.
- `samples/Rask.Example.Shared/Layout/ShowcaseLayout.css` — viewport-bounded scrollable sidebar; all `56px` → `var(--nav-h)`.
- `samples/Rask.Example.Shared/Layout/ShowcaseLayout.cs` — sticky `top: var(--nav-h)`.

## Testing
- `dotnet build -warnaserror` clean (shared sample + E2E project, 0 warnings).
- `dotnet test tests/Rask.Example.Shared.Tests` — 252 passed.
- E2E: extended every host's showcase journey (`SharedSmokeTests.Journey.cs`) to assert `--nav-h` resolves and the sidebar is a bounded, independently-scrollable region. (Full Playwright run deferred to CI.)
- No benchmarks: samples-only CSS, no render hot-path.

## Changelog
`[Unreleased] → Fixed` entry added.