### PR TITLE
fix(live): scroll to top of the page on forward navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ them until tagged releases begin.
   external event subscriptions). The `Rask.Example.EfCore` sample's `DeleteAsync` drops the call.
 
 ### Fixed
+- **Navigation now scrolls to the top of the new page.** Forward client-side navigation (a `NavLink`
+  click or `Navigator.Navigate`) previously left the window at the previous page's scroll position, so
+  users could land mid-page on a new route. It now resets the scroll to the top on a history *push*,
+  matching a server-rendered page load. Back/Forward and in-place URL changes (`SetQuery`, auth
+  redirects — history *replace*) are left to the browser's native scroll restoration. When a
+  `NavLink`'s `Href` carries a `#fragment` that matches an element on the destination page, the runtime
+  scrolls to that element (and preserves the fragment in the address bar) instead of jumping to the
+  top. Fixed in the shared client runtime, so both the Server (WebSocket) and WASM transports get it.
 - **`Rask.Wasm.Hosting` now serves precompressed static assets with their real MIME type.** When a
   request for a `wwwroot` file (e.g. `global.css`) was satisfied from its publish-time `.br`/`.gz`
   sibling, `UseStaticFiles` keyed the content type off the `.br`/`.gz` extension and fell back to

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -217,6 +217,15 @@ nav.Navigate("/login", replace: true);   // redirect without a back-stack entry
 `Navigator` also exposes `Download(...)` for pushing files to the browser (same event-handler-only rule); that lives in
 the Files section of the README.
 
+### Scroll position on navigation
+
+Forward navigation — a `NavLink` click or `Navigate(...)` that **pushes** a history entry — scrolls the window back to
+the top of the new page, matching how a server-rendered page load behaves. `replace: true` navigations and the browser's
+Back/Forward buttons do **not** force a scroll reset: the browser's native scroll restoration owns those, so returning to
+a page restores where you were. If a `NavLink`'s `Href` includes a `#fragment` that matches an element on the destination
+page, the runtime scrolls to that element (and keeps the fragment in the address bar) instead of jumping to the top. This
+is handled entirely in the client runtime and applies to both transports.
+
 ## Reading the current URL — `RouteState`
 
 `RouteState` is the scoped, per-session source of truth for the current location. Inject it to read the live URL:

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -25,6 +25,11 @@
     // always commits before the following message's ops — paths in a later diff are
     // computed against the render this one produces, so they must not be applied first.
     var _renderQueue = Promise.resolve();
+    // The "#fragment" of an intercepted nav-link click. The fragment never leaves the
+    // browser (the navigate message carries only path+query, and the server's history
+    // url has no hash), so we stash it here on click and consume it when the matching
+    // push reply commits — scroll to that anchor, else to the top. Cleared on consume.
+    var _pendingScrollHash = "";
     // Hard cap on how long a navigation diff defers the body swap waiting for a newly
     // mounted page's scoped stylesheet to load. A warm content-addressed
     // /_rask/a/{hash}.css load resolves in a few ms; the cap only ever applies to a
@@ -466,6 +471,34 @@
         return pending.length ? Promise.all(pending) : null;
     }
 
+    // Reset scroll on forward navigation only (history.action "push" — a nav-link click
+    // or Navigator.Navigate). "replace" (Back/Forward popstate, SetQuery, auth redirect)
+    // is left to the browser's native scroll restoration. When the intercepted link
+    // carried a "#fragment" matching an element, scroll there instead of the top.
+    // Call this only after the new body has committed so the anchor target exists.
+    function applyNavScroll(history) {
+        if (!history || history.action === "replace") {
+            _pendingScrollHash = "";
+            return;
+        }
+        var hash = _pendingScrollHash;
+        _pendingScrollHash = "";
+        if (hash && hash.length > 1) {
+            var el = null;
+            try {
+                el = document.querySelector(hash) ||
+                    document.getElementById(decodeURIComponent(hash.slice(1)));
+            } catch (e) {
+                el = null;
+            }
+            if (el) {
+                el.scrollIntoView();
+                return;
+            }
+        }
+        window.scrollTo(0, 0);
+    }
+
     // Diff-mode render application (wire format matches LivePayload.BuildPayloadUtf8Diff).
     // The head rides the payload as a <head> fragment (user Head contributions are
     // collected + spliced server-side, so they're not in the frame stream). Morph the
@@ -483,9 +516,11 @@
                 if (data.history.action === "replace") {
                     history.replaceState({rask: true}, "", diffTarget);
                 } else {
+                    if (_pendingScrollHash) diffTarget += _pendingScrollHash;
                     history.pushState({rask: true}, "", diffTarget);
                 }
             }
+            applyNavScroll(data.history);
             // Re-scan so newly-added scoped <script>/<link> feed the Rask.* invoke gate.
             scanHeadAssets();
             // Fire-and-forget IJSRuntime invokes ride the diff payload too (e.g. a
@@ -527,9 +562,11 @@
             if (data.history.action === "replace") {
                 history.replaceState({rask: true}, "", fullTarget);
             } else {
+                if (_pendingScrollHash) fullTarget += _pendingScrollHash;
                 history.pushState({rask: true}, "", fullTarget);
             }
         }
+        applyNavScroll(data.history);
         if (Array.isArray(data.jsInvokes)) {
             for (var ji = 0; ji < data.jsInvokes.length; ji++) {
                 dispatchJsInvoke(data.jsInvokes[ji]);
@@ -676,6 +713,9 @@
         }
         if (url.origin !== location.origin) return;
         e.preventDefault();
+        // Stash the link's "#fragment" so applyNavScroll can scroll to the anchor once
+        // the new page commits (the fragment is not sent to the server).
+        _pendingScrollHash = url.hash || "";
         flushInputsNow();
         send({type: "navigate", path: stripBase(url.pathname), query: url.search});
     });

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -971,6 +971,10 @@ function applyFullReply(reply) {
             scanHeadAssets();
         }
         applyHistory(reply.history);
+        // Cross-route navigation in WASM commits via this full-HTML morph (not the
+        // diff path), so the scroll reset / fragment scroll must run here too — the
+        // new body has just committed, so the anchor target exists.
+        applyNavScroll(reply.history);
         // Scoped CSS/JS arrives in the morphed HTML as
         // <link href="/_rask/a/{hash}.css"> / <script src="/_rask/a/{hash}.js" defer>
         // tags — no payload-side cssText/jsText injection. Browser handles load
@@ -1025,6 +1029,9 @@ document.addEventListener("click", (e) => {
     }
     if (url.origin !== location.origin) return;
     e.preventDefault();
+    // Stash the link's "#fragment" so applyNavScroll can scroll to the anchor once
+    // the new page commits (the fragment is not sent to the server).
+    _pendingScrollHash = url.hash || "";
     flushInputsNow();
     send({type: "navigate", path: stripBase(url.pathname), query: url.search});
 });

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -28,6 +28,12 @@ window.__raskEl = window.__raskEl || {
 // computed against the render this one produces, so they must not be applied first.
 let _renderQueue = Promise.resolve();
 
+// The "#fragment" of an intercepted nav-link click. The fragment never leaves the
+// browser (the navigate message carries only path+query, and the history url has no
+// hash), so we stash it here on click and consume it when the matching push reply
+// commits — scroll to that anchor, else to the top. Cleared on consume.
+let _pendingScrollHash = "";
+
 // scopedJsReady starts true: per-component scripts ship as
 // <script src="/_rask/a/{hash}.js" defer> tags in the initial HTML's <head> (and
 // are morphed in/out as components mount/unmount). The browser's defer semantics
@@ -642,11 +648,41 @@ function morph(from, to) {
 
 function applyHistory(history) {
     if (!history || typeof history.url !== "string") return;
-    const target = prependBase(history.url);
-    if (history.action === "replace")
+    let target = prependBase(history.url);
+    if (history.action === "replace") {
         window.history.replaceState({rask: true}, "", target);
-    else
+    } else {
+        if (_pendingScrollHash) target += _pendingScrollHash;
         window.history.pushState({rask: true}, "", target);
+    }
+}
+
+// Reset scroll on forward navigation only (history.action "push" — a nav-link click
+// or Navigator.Navigate). "replace" (Back/Forward popstate, SetQuery, auth redirect)
+// is left to the browser's native scroll restoration. When the intercepted link
+// carried a "#fragment" matching an element, scroll there instead of the top.
+// Call this only after the new body has committed so the anchor target exists.
+function applyNavScroll(history) {
+    if (!history || history.action === "replace") {
+        _pendingScrollHash = "";
+        return;
+    }
+    const hash = _pendingScrollHash;
+    _pendingScrollHash = "";
+    if (hash && hash.length > 1) {
+        let el = null;
+        try {
+            el = document.querySelector(hash) ||
+                document.getElementById(decodeURIComponent(hash.slice(1)));
+        } catch (e) {
+            el = null;
+        }
+        if (el) {
+            el.scrollIntoView();
+            return;
+        }
+    }
+    window.scrollTo(0, 0);
 }
 
 // Comment nodes (nodeType 8) appear in document.childNodes for any HTML page
@@ -896,6 +932,7 @@ function applyDiffReply(reply) {
     const applyBody = () => {
         applyDiff(reply.ops, Array.isArray(reply.names) ? reply.names : null);
         applyHistory(reply.history);
+        applyNavScroll(reply.history);
         // A diff can insert Head-declared external <script>/<link> and scoped-JS tags
         // (keyed InsertSubtree). Track them so their load events feed the Rask.* invoke
         // gate, then drain anything now unblocked — the full-HTML morph path does the same.

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -28,6 +28,12 @@ window.__raskEl = window.__raskEl || {
 // computed against the render this one produces, so they must not be applied first.
 let _renderQueue = Promise.resolve();
 
+// The "#fragment" of an intercepted nav-link click. The fragment never leaves the
+// browser (the navigate message carries only path+query, and the history url has no
+// hash), so we stash it here on click and consume it when the matching push reply
+// commits — scroll to that anchor, else to the top. Cleared on consume.
+let _pendingScrollHash = "";
+
 // scopedJsReady starts true: per-component scripts ship as
 // <script src="/_rask/a/{hash}.js" defer> tags in the initial HTML's <head> (and
 // are morphed in/out as components mount/unmount). The browser's defer semantics
@@ -414,11 +420,41 @@ function inRoot(el) {
 
 function applyHistory(history) {
     if (!history || typeof history.url !== "string") return;
-    const target = prependBase(history.url);
-    if (history.action === "replace")
+    let target = prependBase(history.url);
+    if (history.action === "replace") {
         window.history.replaceState({rask: true}, "", target);
-    else
+    } else {
+        if (_pendingScrollHash) target += _pendingScrollHash;
         window.history.pushState({rask: true}, "", target);
+    }
+}
+
+// Reset scroll on forward navigation only (history.action "push" — a nav-link click
+// or Navigator.Navigate). "replace" (Back/Forward popstate, SetQuery, auth redirect)
+// is left to the browser's native scroll restoration. When the intercepted link
+// carried a "#fragment" matching an element, scroll there instead of the top.
+// Call this only after the new body has committed so the anchor target exists.
+function applyNavScroll(history) {
+    if (!history || history.action === "replace") {
+        _pendingScrollHash = "";
+        return;
+    }
+    const hash = _pendingScrollHash;
+    _pendingScrollHash = "";
+    if (hash && hash.length > 1) {
+        let el = null;
+        try {
+            el = document.querySelector(hash) ||
+                document.getElementById(decodeURIComponent(hash.slice(1)));
+        } catch (e) {
+            el = null;
+        }
+        if (el) {
+            el.scrollIntoView();
+            return;
+        }
+    }
+    window.scrollTo(0, 0);
 }
 
 // Comment nodes (nodeType 8) appear in document.childNodes for any HTML page
@@ -668,6 +704,7 @@ function applyDiffReply(reply) {
     const applyBody = () => {
         applyDiff(reply.ops, Array.isArray(reply.names) ? reply.names : null);
         applyHistory(reply.history);
+        applyNavScroll(reply.history);
         // A diff can insert Head-declared external <script>/<link> and scoped-JS tags
         // (keyed InsertSubtree). Track them so their load events feed the Rask.* invoke
         // gate, then drain anything now unblocked — the full-HTML morph path does the same.

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -743,6 +743,10 @@ function applyFullReply(reply) {
             scanHeadAssets();
         }
         applyHistory(reply.history);
+        // Cross-route navigation in WASM commits via this full-HTML morph (not the
+        // diff path), so the scroll reset / fragment scroll must run here too — the
+        // new body has just committed, so the anchor target exists.
+        applyNavScroll(reply.history);
         // Scoped CSS/JS arrives in the morphed HTML as
         // <link href="/_rask/a/{hash}.css"> / <script src="/_rask/a/{hash}.js" defer>
         // tags — no payload-side cssText/jsText injection. Browser handles load
@@ -797,6 +801,9 @@ document.addEventListener("click", (e) => {
     }
     if (url.origin !== location.origin) return;
     e.preventDefault();
+    // Stash the link's "#fragment" so applyNavScroll can scroll to the anchor once
+    // the new page commits (the fragment is not sent to the server).
+    _pendingScrollHash = url.hash || "";
     flushInputsNow();
     send({type: "navigate", path: stripBase(url.pathname), query: url.search});
 });

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -659,6 +659,60 @@ public abstract partial class SharedSmokeTests
         Assert.True(after > 0, $"no heap reading. baseline={baseline} after={after}");
         Assert.True(after < (baseline * 3) + 25_000_000 && after < 250_000_000,
             $"JS heap grew unexpectedly. baseline={baseline:N0} after={after:N0}.");
+
+        await AssertNavigationScrollAsync();
+    }
+
+    // Scroll behaviour on forward navigation. The runtime resets window scroll to the top on a
+    // "push" (a sidebar Navigator.Navigate or a data-rask-nav link click), and when the link
+    // carried a "#fragment" it scrolls to that element instead. Both transports share the JS
+    // runtime path (rask.js / rask.wasm.js applyNavScroll), so every host exercises it here.
+    private async Task AssertNavigationScrollAsync()
+    {
+        // --- a forward nav resets scroll to the top ---------------------------------------------
+        // The data table at 25 rows is reliably taller than the viewport; scroll to the bottom and
+        // confirm the document actually moved before navigating away.
+        await SideAsync("Data table", "Data table");
+        await Page.Locator("select.form-select-sm").SelectOptionAsync("25");
+        await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        await Page.EvaluateAsync("() => window.scrollTo(0, document.documentElement.scrollHeight)");
+        await Page.WaitForFunctionAsync("() => window.scrollY > 0",
+            null, new PageWaitForFunctionOptions { Timeout = 10_000 });
+
+        await SideAsync("Two-way binding", "Two-way binding");
+        // The new page must land at the top (the reset can lag a CSS-deferred body commit, so poll).
+        await Page.WaitForFunctionAsync("() => Math.round(window.scrollY) === 0",
+            null, new PageWaitForFunctionOptions { Timeout = 10_000 });
+
+        // --- a data-rask-nav link with a #fragment scrolls to that element ----------------------
+        // The showcase navigates via sidebar buttons, so inject a real NavLink-style anchor to drive
+        // the click-interceptor + fragment path. /validation is a long page and #v7-product sits well
+        // below the fold, so reaching it must move the scroll.
+        await SideAsync("Welcome", "The Rask framework", "h1.display-5");
+        await Page.EvaluateAsync(@"() => {
+            const a = document.createElement('a');
+            a.id = '__rask_anchor_probe';
+            a.setAttribute('data-rask-nav', '');
+            a.setAttribute('href', '/validation#v7-product');
+            a.textContent = 'probe';
+            document.querySelector('main').appendChild(a);
+        }");
+        await Page.Locator("#__rask_anchor_probe").ClickAsync();
+        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Validation",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
+        // The fragment is preserved in the pushed URL (it never reaches the server, so the client
+        // re-appends it) …
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/validation#v7-product$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 10_000 });
+        // … and the target is scrolled into view (top within the viewport) with the page actually
+        // moved to get there (proving it was below the fold, not a no-op).
+        await Page.WaitForFunctionAsync(@"() => {
+            const el = document.getElementById('v7-product');
+            if (!el) return false;
+            const r = el.getBoundingClientRect();
+            return window.scrollY > 0 && r.top >= -2 && r.top < window.innerHeight;
+        }", null, new PageWaitForFunctionOptions { Timeout = 10_000 });
     }
 
     // ---- low-level helpers (shared by the journey) ---------------------------------------------


### PR DESCRIPTION
## Summary
Forward client-side navigation (a `NavLink` click or `Navigator.Navigate`) previously left the window at the previous page's scroll position, so users could land mid-page on a new route. The shared client runtime now resets window scroll to the top on a history **push**; Back/Forward and in-place URL changes (`SetQuery`, auth redirects — history **replace**) keep the browser's native scroll restoration. When a `NavLink`'s `Href` carries a `#fragment` matching an element on the destination page, the runtime scrolls to that element and preserves the fragment in the address bar instead of jumping to the top. Implemented once in the shared runtime (`rask.js` / `rask.wasm.js` → `applyNavScroll`), so both the Server (WebSocket) and WASM transports get it.

## Testing
- Unit: n/a — the change is entirely client-runtime JS; no C# logic was touched, so it isn't reachable from the in-process unit suites.
- E2E (Playwright): added `AssertNavigationScrollAsync` to the shared showcase journey, so the **Server**, **Wasm.Host**, and **StandaloneWasm** matrices each exercise it. It (a) scrolls a tall page to the bottom, navigates forward via the sidebar, and asserts `window.scrollY === 0`; and (b) clicks an injected `data-rask-nav` link to `/validation#v7-product`, asserting the fragment lands in the URL and the target element is scrolled into view. Verified the new assertions pass against the **Server** host locally (isolated run); CI's sharded E2E matrix covers all three hosts.

## Benchmarks
n/a — client-side JS only; no render hot-path or live-payload codec change.

## CHANGELOG
- `[Unreleased] → Fixed`: "Navigation now scrolls to the top of the new page."
