### PR TITLE
feat(samples): copy-paste and C#/JS/CSS tabs for showcase code samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,14 @@ them until tagged releases begin.
   `bin/<cfg>/net10.0-browser/publish/wwwroot/`; `Rask.Wasm.Hosting`'s `UseRask()` follows it
   automatically. Sub-path deploys keep `/p:RaskPathBase=/<repo>` (now a post-publish `<base href>`
   rewrite; every other asset URL is document-relative).
+- **Showcase code samples are now copy-pasteable and multi-language.** Every `CodeSample` card in
+  the example apps gains a copy-to-clipboard button (scoped JS, with an `execCommand` fallback for
+  non-secure/headless contexts), and samples that have a JavaScript or CSS side render a **C# / JS /
+  CSS tab strip** — tab state is component state switched through the live diff, and each pane is
+  highlighted server-side by ColorCode. The Element-refs and Scoped-CSS pages now show the **real,
+  verbatim source** of their demo components (`ElementRefDemo.cs` + `.js`, `ScopedRed/Blue.cs` +
+  `.css`), embedded from the actual files via a new `EmbeddedSource` reader so the snippet always
+  compiles and matches the live result. Samples-only — no framework API change.
 
 ### Removed
 - **`:global(...)` scoped-CSS escape hatch removed.** A scoped `{Component}.css` no longer has a
@@ -71,6 +79,14 @@ them until tagged releases begin.
   external event subscriptions). The `Rask.Example.EfCore` sample's `DeleteAsync` drops the call.
 
 ### Fixed
+- **Scoped JS now supports `export async function`.** The module wrapper that exposes a sibling
+  `{Component}.js` on `window.Rask["{Type}"]` only recognised `export function` / `export const`,
+  so an `export async function name(...)` kept its `export` keyword inside the (non-module) IIFE —
+  a `SyntaxError` that silently prevented the *entire* file from loading, leaving `Rask.{Type}`
+  undefined and every invoke into it failing with "Could not find … on target". The export-strip
+  and export-collection now accept the optional `async` modifier (sync and async exports may be
+  mixed in one file). Affects both the Server runtime and the WASM publish bake (both go through
+  the same `ScopedAssetRegistry` wrapping).
 - **`Rask.Wasm.Hosting` now serves precompressed static assets with their real MIME type.** When a
   request for a `wwwroot` file (e.g. `global.css`) was satisfied from its publish-time `.br`/`.gz`
   sibling, `UseStaticFiles` keyed the content type off the `.br`/`.gz` extension and fell back to

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -55,12 +55,17 @@ component CSS.
 ## Scoped JS
 
 A sibling `{Component}.js` is wrapped onto `window.Rask["{TypeName}"]`, with every
-`export function NAME` becoming a method:
+`export function NAME` (or `export async function NAME`) becoming a method:
 
 ```js
 // ElementRefDemo.js
 export function width(el) {
     return el ? el.getBoundingClientRect().width : 0;
+}
+
+// async exports work too — e.g. CodeSample.js
+export async function copy(text) {
+    await navigator.clipboard.writeText(text);
 }
 ```
 

--- a/samples/Rask.Example.Server/wwwroot/global.css
+++ b/samples/Rask.Example.Server/wwwroot/global.css
@@ -142,3 +142,17 @@ button, a, [role="button"] {
 .sample-code .plainText {
     color: #e7e3ff;
 }
+
+/* CSS-language tokens (ColorCode's CSS lexer): selectors, property names and values. The
+   JS lexer reuses the shared keyword/string/comment/number classes above. */
+.sample-code .cssSelector {
+    color: #82aaff;
+}
+
+.sample-code .cssPropertyName {
+    color: #89ddff;
+}
+
+.sample-code .cssPropertyValue {
+    color: #c3e88d;
+}

--- a/samples/Rask.Example.Shared/Demos/CodeSample.cs
+++ b/samples/Rask.Example.Shared/Demos/CodeSample.cs
@@ -1,46 +1,106 @@
 using System.Collections.Concurrent;
 using ColorCode;
+using Microsoft.JSInterop;
 
 namespace Rask.Example.Shared.Demos;
 
 public sealed class CodeSample : Component
 {
     // Source is a constant author-time string per instance, and a page can mount
-    // ~15 CodeSamples that each re-render on every live diff. Memoise the tokenized
-    // HTML keyed by the trimmed source so repeated renders never re-run the parser.
-    // This also bounds HtmlClassFormatter construction to one-per-distinct-source.
+    // ~15 CodeSamples that each re-render on every live diff (and again on every tab
+    // switch). Memoise the tokenized HTML keyed by language + trimmed source so repeated
+    // renders never re-run the parser. This also bounds HtmlClassFormatter construction
+    // to one-per-distinct-(language, source).
     private static readonly ConcurrentDictionary<string, string> HighlightCache = new(StringComparer.Ordinal);
 
-    public string? Title { get; set; }
+    // Clipboard interop is injected via the ctor (the framework's DI seam) so Source stays
+    // a plain factory parameter — a settable non-nullable service prop would become a
+    // required param and clash with DI (RASK002). Mirrors ElementRefDemo's IJSRuntime ctor.
+    private readonly IJSRuntime _js;
+
+    // A stable ref to the copy button so its scoped JS can flash "Copied!" on the element.
+    private readonly ElementRef _copyButton = ElementRef.New();
 
     // Non-nullable + no initializer + no `required` keyword: the factory generator emits
     // Source as the first required positional parameter (no default), preserving the
-    // existing 74 call-site shapes. The CS8618 warning is intentional — Rask's
-    // post-render property assignment satisfies it at runtime. `required` is deliberately
-    // omitted to keep `CodeSample(Source: ...)` as a plain positional/named argument.
+    // existing call-site shapes. The CS8618 warnings (here and on the ctor) are intentional —
+    // Rask's post-render property assignment satisfies Source at runtime. `required` is
+    // deliberately omitted to keep `CodeSample(Source: ...)` a plain positional/named argument.
 #pragma warning disable CS8618
+    public CodeSample(IJSRuntime js) => _js = js;
+
+    public string? Title { get; set; }
+
     public string Source { get; set; }
 #pragma warning restore CS8618
+
+    // Optional sibling-language sources. When either is set the header shows a C#/JS/CSS
+    // tab strip; otherwise the card keeps its single "C#" label. Both are nullable, so the
+    // generator emits them as optional named factory parameters (default null).
+    public string? Js { get; set; }
+    public string? Css { get; set; }
 
     public Component? Result { get; set; }
     public string? Notes { get; set; }
 
-    // Syntax highlighting is produced server-side by ColorCode: GetHtmlString tokenizes
-    // the C# source into <span class="..."> markup whose classes (keyword/string/comment/…)
+    // Which language pane is visible. A plain component field (not a reactive prop): the tab
+    // buttons set it and re-render through Rask's live diff — the framework way, no client JS.
+    private enum Lang { Cs, Js, Css }
+
+    private Lang _active = Lang.Cs;
+
+    // The (raw source, ColorCode language, <code> class) triple for a pane.
+    private (string Source, ILanguage Language, string CodeClass) Pane(Lang lang) => lang switch
+    {
+        Lang.Js => (Js!, Languages.JavaScript, "language-javascript"),
+        Lang.Css => (Css!, Languages.Css, "language-css"),
+        _ => (Source, Languages.CSharp, "language-csharp"),
+    };
+
+    private static string Label(Lang lang) => lang switch
+    {
+        Lang.Js => "JS",
+        Lang.Css => "CSS",
+        _ => "C#",
+    };
+
+    // C# is always first; JS/CSS only appear when their source was supplied.
+    private List<Lang> PresentLanguages()
+    {
+        var langs = new List<Lang> { Lang.Cs };
+        if (Js is not null)
+        {
+            langs.Add(Lang.Js);
+        }
+
+        if (Css is not null)
+        {
+            langs.Add(Lang.Css);
+        }
+
+        return langs;
+    }
+
+    // Syntax highlighting is produced server-side by ColorCode: GetHtmlString tokenizes the
+    // source into <span class="..."> markup whose classes (keyword/string/comment/cssSelector/…)
     // are coloured by the .sample-code rules in the app's global stylesheet (wwwroot/global.css);
-    // they can't be scoped because Raw() markup carries no scope id. The result is injected via the
-    // Raw() factory (verbatim, un-encoded — ColorCode already HTML-encodes token text), so
-    // no client JS runs and the highlight is present in the very first render.
-    private string HighlightedHtml() =>
-        HighlightCache.GetOrAdd(
-            Source.TrimEnd(),
+    // they can't be scoped because Raw() markup carries no scope id. The result is injected via
+    // the Raw() factory (verbatim, un-encoded — ColorCode already HTML-encodes token text), so no
+    // client JS runs and the highlight is present in the very first render.
+    private static string HighlightedHtml(string source, ILanguage language)
+    {
+        var trimmed = source.TrimEnd();
+        return HighlightCache.GetOrAdd(
+            // Key by language id too: the same text tokenizes differently per language.
+            $"{language.Id}\n{trimmed}",
             // A fresh formatter per cache-miss: HtmlClassFormatter mutates a per-instance
             // Writer field during GetHtmlString and is therefore not safe to share across
-            // concurrent renders. The cache bounds this to one allocation per distinct source.
-            static src => StripWrapper(new HtmlClassFormatter().GetHtmlString(src, Languages.CSharp)));
+            // concurrent renders. The cache bounds this to one allocation per distinct key.
+            _ => StripWrapper(new HtmlClassFormatter().GetHtmlString(trimmed, language)));
+    }
 
-    // ColorCode wraps its output as <div class="csharp"><pre>\n …spans… \n</pre></div>.
-    // We keep our own <pre class="sample-code"><code class="language-csharp"> for layout and
+    // ColorCode wraps its output as <div class="{lang}"><pre>\n …spans… \n</pre></div>.
+    // We keep our own <pre class="sample-code"><code class="language-…"> for layout and
     // scoped styling, so peel ColorCode's wrapper and inject only the inner token spans.
     private static string StripWrapper(string html)
     {
@@ -57,8 +117,49 @@ public sealed class CodeSample : Component
         return html.Substring(start, end - start);
     }
 
-    protected override RenderResult Render() =>
-        Div(Class: "card shadow-sm border-0 mb-4 sample-card")[
+    // Copies the raw (un-highlighted) source of the active tab. C# already holds the string,
+    // so JS needs no DOM read; the button ref lets the scoped JS flash a "Copied!" affordance.
+    private async Task CopyAsync()
+    {
+        var (source, _, _) = Pane(_active);
+        await _js.InvokeVoidAsync("Rask.CodeSample.copy", source, _copyButton);
+    }
+
+    private Child Header()
+    {
+        var present = PresentLanguages();
+        Child languages = present.Count == 1
+            ? Span(Class: "sample-code-label ms-2")["C#"]
+            : Span(Class: "sample-tabs ms-2")[
+                present.Select(lang => Button(
+                    Type: "button",
+                    Class: $"sample-tab{(lang == _active ? " active" : "")}",
+                    Key: Label(lang),
+                    OnClick: () => _active = lang)[Label(lang)])
+            ];
+
+        return Div(Class: "sample-code-header")[
+            Span(Class: "sample-dot dot-r"),
+            Span(Class: "sample-dot dot-y"),
+            Span(Class: "sample-dot dot-g"),
+            languages,
+            Button(
+                Type: "button",
+                Class: "sample-copy",
+                Ref: _copyButton,
+                OnClickAsync: CopyAsync)[
+                    I(Class: "bi bi-clipboard me-1"),
+                    // A real text node (not a CSS pseudo-element) so the button has an
+                    // accessible name; the scoped JS swaps it to "Copied!" on click.
+                    Span(Class: "sample-copy-text")["Copy"]
+            ]
+        ];
+    }
+
+    protected override RenderResult Render()
+    {
+        var (activeSource, activeLanguage, codeClass) = Pane(_active);
+        return Div(Class: "card shadow-sm border-0 mb-4 sample-card")[
             Title is null && Notes is null
                 ? Fragment()
                 : Div(Class: "card-header bg-white border-bottom")[
@@ -69,14 +170,9 @@ public sealed class CodeSample : Component
                 ],
             Div(Class: "row g-0")[
                 Div(Class: "col-md-7 sample-code-col")[
-                    Div(Class: "sample-code-header")[
-                        Span(Class: "sample-dot dot-r"),
-                        Span(Class: "sample-dot dot-y"),
-                        Span(Class: "sample-dot dot-g"),
-                        Span(Class: "sample-code-label ms-2")["C#"]
-                    ],
+                    Header(),
                     Pre(Class: "sample-code m-0")[
-                        Code(Class: "language-csharp")[Raw(HighlightedHtml())]
+                        Code(Class: codeClass)[Raw(HighlightedHtml(activeSource, activeLanguage))]
                     ]
                 ],
                 Div(Class: "col-md-5 sample-result-col p-4")[
@@ -88,4 +184,5 @@ public sealed class CodeSample : Component
                 ]
             ]
         ];
+    }
 }

--- a/samples/Rask.Example.Shared/Demos/CodeSample.css
+++ b/samples/Rask.Example.Shared/Demos/CodeSample.css
@@ -44,6 +44,60 @@
     color: rgba(255, 255, 255, 0.45);
 }
 
+/* Language tabs (C# / JS / CSS) — only rendered when a sample carries more than one
+   language. The active tab is driven by component state through Rask's live diff. */
+.sample-tabs {
+    display: inline-flex;
+    gap: 0.25rem;
+}
+
+.sample-tab {
+    border: 0;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.15rem 0.55rem;
+    border-radius: 0.35rem;
+    cursor: pointer;
+    transition: color 0.12s ease, background 0.12s ease;
+}
+
+.sample-tab:hover {
+    color: rgba(255, 255, 255, 0.85);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.sample-tab.active {
+    color: #fff;
+    background: rgba(255, 255, 255, 0.12);
+}
+
+/* Copy-to-clipboard button, pushed to the right edge of the header. */
+.sample-copy {
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    border: 0;
+    background: transparent;
+    color: rgba(255, 255, 255, 0.5);
+    font-size: 0.72rem;
+    padding: 0.15rem 0.55rem;
+    border-radius: 0.35rem;
+    cursor: pointer;
+    transition: color 0.12s ease, background 0.12s ease;
+}
+
+.sample-copy:hover {
+    color: rgba(255, 255, 255, 0.9);
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.sample-copy.copied {
+    color: #28c840;
+}
+
 .sample-code {
     padding: 1rem 1.2rem;
     font-size: 0.82rem;

--- a/samples/Rask.Example.Shared/Demos/CodeSample.js
+++ b/samples/Rask.Example.Shared/Demos/CodeSample.js
@@ -1,0 +1,43 @@
+// Scoped JS for CodeSample, exposed as Rask.CodeSample.copy. The C# side passes the raw
+// (un-highlighted) source of the active tab plus an ElementRef to the copy button; the
+// runtime reviver resolves the ref to the live element before this runs.
+export async function copy(text, btn) {
+    try {
+        await navigator.clipboard.writeText(text);
+    } catch {
+        // Clipboard can reject (permissions, insecure context). Fall back to a hidden
+        // textarea + execCommand so the button still works on http/older browsers.
+        const ta = document.createElement('textarea');
+        ta.value = text;
+        ta.style.position = 'fixed';
+        ta.style.opacity = '0';
+        document.body.appendChild(ta);
+        ta.select();
+        try {
+            document.execCommand('copy');
+        } catch {
+            // Nothing else to try — swallow so the "Copied!" flash still fires.
+        }
+        ta.remove();
+    }
+
+    if (!btn) {
+        return;
+    }
+
+    // Flash "Copied!" for a moment, then restore — transient UI state lives on the client
+    // so it never costs a server round-trip or a re-render.
+    const label = btn.querySelector('.sample-copy-text');
+    const previous = label ? label.textContent : null;
+    btn.classList.add('copied');
+    if (label) {
+        label.textContent = 'Copied!';
+    }
+
+    setTimeout(() => {
+        btn.classList.remove('copied');
+        if (label && previous !== null) {
+            label.textContent = previous;
+        }
+    }, 1500);
+}

--- a/samples/Rask.Example.Shared/Demos/EmbeddedSource.cs
+++ b/samples/Rask.Example.Shared/Demos/EmbeddedSource.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace Rask.Example.Shared.Demos;
+
+// Reads the verbatim text of a demo source file that the build embeds as a manifest
+// resource (see the EmbeddedResource glob in Rask.Example.Shared.csproj, logical name
+// "raksrc/{file}"). CodeSample uses this to show the *real* source beside the live
+// Result, so the snippet always compiles and never drifts from what actually runs.
+public static class EmbeddedSource
+{
+    private static readonly Assembly Asm = typeof(EmbeddedSource).Assembly;
+
+    // Reading a manifest stream allocates; the set of demo files is small and fixed, so
+    // memoise per file name (mirrors CodeSample's HighlightCache rationale).
+    private static readonly ConcurrentDictionary<string, string> Cache = new(StringComparer.Ordinal);
+
+    // Reads one or more embedded files and joins them with a blank line, so a single tab
+    // can show a pair of sibling files (e.g. ScopedRed.cs + ScopedBlue.cs). File names are
+    // the bare leaf names, e.g. "ElementRefDemo.cs".
+    public static string Read(params string[] fileNames)
+    {
+        if (fileNames.Length == 1)
+        {
+            return ReadOne(fileNames[0]);
+        }
+
+        return string.Join("\n\n", fileNames.Select(ReadOne));
+    }
+
+    private static string ReadOne(string fileName) =>
+        Cache.GetOrAdd(fileName, static name =>
+        {
+            using var stream = Asm.GetManifestResourceStream($"raksrc/{name}")
+                ?? throw new InvalidOperationException(
+                    $"Embedded source 'raksrc/{name}' was not found. Ensure {name} lives under " +
+                    "samples/Rask.Example.Shared/Demos and matches the EmbeddedResource glob.");
+            using var reader = new StreamReader(stream);
+            return reader.ReadToEnd().TrimEnd();
+        });
+}

--- a/samples/Rask.Example.Shared/Pages/ElementRefPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ElementRefPage.cs
@@ -17,19 +17,10 @@ public sealed class ElementRefPage : Component
             "Hand a rendered DOM element to JavaScript — for third-party widgets (charts, datepickers, editors) that need the raw node, or for focus and measurement. Rask's analogue of Blazor's ElementReference."),
         H2(Class: "h4 mt-4 mb-3")["Attach a ref, pass it to JS"],
         CodeSample(
-            """
-            private readonly ElementRef _input = ElementRef.New();
-            private readonly ElementRef _box   = ElementRef.New();
-
-            Input(Ref: _input)                     // stamps data-rask-ref="…"
-            Div(Ref: _box)[ "…" ]
-
-            // built-in helper — resolves the ref to the element, then focuses it
-            await _input.FocusAsync(js);
-
-            // hand the element to your own scoped JS (it receives the DOM node)
-            var w = await js.InvokeAsync<double>("Rask.ElementRefDemo.width", _box);
-            """,
+            // The real component source and its sibling scoped JS, embedded verbatim — the
+            // C#/JS tabs show exactly what produces the live result on the right.
+            EmbeddedSource.Read("ElementRefDemo.cs"),
+            Js: EmbeddedSource.Read("ElementRefDemo.js"),
             Notes:
             "An ElementRef stamps data-rask-ref on the element. When you pass it to IJSRuntime, the client's JSON reviver swaps it for document.querySelector('[data-rask-ref=…]'), so your JS function receives the live element — no marker-class convention needed. FocusAsync/BlurAsync/ScrollIntoViewAsync are built in.",
             Result: ElementRefDemo()),

--- a/samples/Rask.Example.Shared/Pages/ScopedCssPage.cs
+++ b/samples/Rask.Example.Shared/Pages/ScopedCssPage.cs
@@ -17,26 +17,11 @@ public sealed class ScopedCssPage : Component
             "Drop a sibling {Component}.css file next to {Component}.cs and Rask pairs them at compile time. The framework hashes the type's full name into a stable scope id and rewrites every selector to apply only inside that component — no class-name discipline, no BEM, no leaks."),
         H2(Class: "h4 mt-4 mb-3")["Two components, same selector, no conflict"],
         CodeSample(
-            """""
-            // ScopedRed.cs
-            public sealed class ScopedRed : Component
-            {
-                protected override RenderResult Render() =>
-                    Div(Class: "box")[Span(Class: "dot"), "I think .box should be red."];
-            }
-
-            /* ScopedRed.css (sibling file) */
-            .box { background: #fdecec; color: #8a1f1f; ... }
-            .dot { width: 0.6rem; height: 0.6rem; background: #d23030; border-radius: 50%; }
-
-
-            // ScopedBlue.cs — same .box selector, different sibling .css
-            public sealed class ScopedBlue : Component
-            {
-                protected override RenderResult Render() =>
-                    Div(Class: "box")[Span(Class: "dot"), "I think .box should be blue."];
-            }
-            """"",
+            // The two real components and their sibling stylesheets, embedded verbatim. Both
+            // declare the same .box / .dot selectors; the CSS tab shows the unmodified source
+            // that Rask rewrites per-scope to produce the isolated red/blue results.
+            EmbeddedSource.Read("ScopedRed.cs", "ScopedBlue.cs"),
+            Css: EmbeddedSource.Read("ScopedRed.css", "ScopedBlue.css"),
             Notes:
             "Both classes use the same .box selector. The framework stamps every rendered body element with data-{scopeId}, then rewrites .box to .box[data-{scopeId}] — same source CSS, isolated outputs.",
             Result: Div(Class: "d-flex flex-column gap-2")[

--- a/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
+++ b/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
@@ -23,4 +23,14 @@
     <PackageReference Include="ColorCode.HTML"/>
   </ItemGroup>
 
+  <!-- Embed the demo sources verbatim so CodeSample can show the *real* file text beside
+       the live Result (EmbeddedSource reads them as raksrc/{file}). A .cs stays compiled
+       too — this only adds its text as a manifest resource; the .js/.css remain scoped
+       assets. Guarantees the shown snippet always compiles and matches what runs. -->
+  <ItemGroup>
+    <EmbeddedResource Include="Demos/**/*.cs;Demos/**/*.js;Demos/**/*.css">
+      <LogicalName>raksrc/%(Filename)%(Extension)</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
+
 </Project>

--- a/samples/Rask.Example.Wasm/wwwroot/global.css
+++ b/samples/Rask.Example.Wasm/wwwroot/global.css
@@ -142,3 +142,17 @@ button, a, [role="button"] {
 .sample-code .plainText {
     color: #e7e3ff;
 }
+
+/* CSS-language tokens (ColorCode's CSS lexer): selectors, property names and values. The
+   JS lexer reuses the shared keyword/string/comment/number classes above. */
+.sample-code .cssSelector {
+    color: #82aaff;
+}
+
+.sample-code .cssPropertyName {
+    color: #89ddff;
+}
+
+.sample-code .cssPropertyValue {
+    color: #c3e88d;
+}

--- a/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
+++ b/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
@@ -44,12 +44,19 @@ public static class ScopedAssetRegistry
     private static readonly Dictionary<string, AssetEntry> _jsByHash =
         new(StringComparer.Ordinal);
 
+    // Strips the leading `export ` (and an optional `default `) from a declaration so the
+    // module body can run inside the IIFE. The lookahead lists `async function` alongside
+    // the bare forms — without it an `export async function` keeps its `export` keyword and
+    // throws a SyntaxError inside the (non-module) wrapper.
     private static readonly Regex _exportStrip =
-        new(@"(^|\n)\s*export\s+(default\s+)?(?=(function|const|let|var)\b)",
+        new(@"(^|\n)\s*export\s+(default\s+)?(?=(async\s+function|function|const|let|var)\b)",
             RegexOptions.Compiled);
 
+    // Collects the names of exported function declarations (sync or async) so they can be
+    // re-exposed on the returned object. The `async` modifier is optional and non-capturing,
+    // so the name stays in group 2.
     private static readonly Regex _exportedFunctionNames =
-        new(@"(^|\n)\s*export\s+(?:default\s+)?function\s+(\w+)\s*\(",
+        new(@"(^|\n)\s*export\s+(?:default\s+)?(?:async\s+)?function\s+(\w+)\s*\(",
             RegexOptions.Compiled);
 
     internal static int CssEntryCount

--- a/tests/Rask.Core.Tests/ScopedAssets/ScopedAssetRegistryTests.cs
+++ b/tests/Rask.Core.Tests/ScopedAssets/ScopedAssetRegistryTests.cs
@@ -63,6 +63,30 @@ public class ScopedAssetRegistryTests
     }
 
     [Fact]
+    public void RegisterJs_AsyncFunctionExport_StripsExportAndExposesIt()
+    {
+        // An `export async function` must have its `export` stripped (the wrapper IIFE is
+        // not an ES module, so a leftover `export` is a SyntaxError) and still be re-exposed
+        // on window.Rask. A mixed sync export verifies both forms collect together.
+        ScopedAssetRegistry.RegisterJs(
+            typeof(WidgetA),
+            "export async function copy(t) { await navigator.clipboard.writeText(t); }\n" +
+            "export function size() { return 1; }");
+
+        Assert.True(ScopedAssetRegistry.TryGetJs(typeof(WidgetA), out var hash));
+        var bytes = ScopedAssetRegistry.GetByHash(hash, AssetKind.Js);
+        Assert.NotNull(bytes);
+        var content = Encoding.UTF8.GetString(bytes.Value.Utf8.Span);
+
+        // The `export` keyword is gone; the bare `async function` declaration remains.
+        Assert.DoesNotContain("export ", content);
+        Assert.Contains("async function copy(", content);
+        // Both functions are re-exposed on the returned namespace object.
+        Assert.Contains("copy: typeof copy === 'function'", content);
+        Assert.Contains("size: typeof size === 'function'", content);
+    }
+
+    [Fact]
     public void RegisterBoth_TypeHasIndependentCssAndJsHashes()
     {
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");

--- a/tests/Rask.Example.Shared.Tests/Demos/CodeSampleTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/CodeSampleTests.cs
@@ -1,3 +1,4 @@
+using Rask.Example.Shared.Demos;
 using Rask.Example.Shared.Tests.Infrastructure;
 using static Rask.Example.Shared.Demos.Generated;
 
@@ -42,6 +43,60 @@ public sealed class CodeSampleTests
         // Header card-header is only emitted when at least one of Title/Notes is set.
         Assert.DoesNotContain("card-header", html);
         Assert.Contains("code", html);
+    }
+
+    [Fact]
+    public void Render_SingleLanguage_KeepsCSharpLabel_NoTabStrip_HasCopyButton()
+    {
+        var host = new LiveHost(
+            () => CodeSample("var x = 1;"),
+            TestServices.Default(js: new FakeJsRuntime()));
+
+        var html = host.RenderAsLiveRoot();
+
+        // A C#-only sample keeps the plain label and shows no tab strip (back-compat).
+        Assert.Contains("sample-code-label", html);
+        Assert.DoesNotContain("sample-tabs", html);
+        // The copy button is present on every card.
+        Assert.Contains("sample-copy", html);
+        Assert.Contains(">Copy</span>", html);
+    }
+
+    [Fact]
+    public void Render_MultiLanguage_ShowsTabsWithCSharpActive_AndOnlyActivePane()
+    {
+        var host = new LiveHost(
+            () => CodeSample(
+                "var x = 1;",
+                Js: "export function f() { return 1; }",
+                Css: ".a { color: red; }"),
+            TestServices.Default(js: new FakeJsRuntime()));
+
+        var html = host.RenderAsLiveRoot();
+
+        // A tab strip with one button per supplied language, C# active by default.
+        Assert.Contains("sample-tabs", html);
+        Assert.Contains("sample-tab active", html);
+        Assert.Contains(">C#</button>", html);
+        Assert.Contains(">JS</button>", html);
+        Assert.Contains(">CSS</button>", html);
+        // Only the active (C#) pane is rendered — the JS/CSS panes appear after a tab switch.
+        Assert.Contains("language-csharp", html);
+        Assert.DoesNotContain("language-javascript", html);
+        Assert.DoesNotContain("language-css", html);
+    }
+
+    [Fact]
+    public void EmbeddedSource_ReadsRealFileText_AndJoinsMultiple()
+    {
+        // The real scoped JS the ElementRef sample shows must be readable from the manifest.
+        var js = EmbeddedSource.Read("ElementRefDemo.js");
+        Assert.Contains("getBoundingClientRect", js);
+
+        // Multiple files join into one pane (the scoped-CSS sample shows both stylesheets).
+        var css = EmbeddedSource.Read("ScopedRed.css", "ScopedBlue.css");
+        Assert.Contains("#d23030", css); // red dot
+        Assert.Contains("#0066B3", css); // blue dot
     }
 
     [Fact]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -178,6 +178,18 @@ public abstract partial class SharedSmokeTests
             await Page.EvaluateAsync<bool>("() => typeof window.Rask === 'object' && window.Rask !== null"),
             "scoped JS namespace window.Rask is missing — component JS did not load");
 
+        // Code sample tabs + copy: the Element refs sample shows the real component (C# tab) and
+        // its sibling scoped JS (JS tab). Switching tabs is a Rask state round-trip that swaps the
+        // highlighted pane; clicking copy runs the scoped Rask.CodeSample.copy, which flashes
+        // "Copied!" (resilient to headless clipboard restrictions via its execCommand fallback).
+        var codeCard = Page.Locator("main .sample-code-col").First;
+        await codeCard.Locator(".sample-tab:has-text('JS')").ClickAsync();
+        await Expect(codeCard.Locator(".sample-code"))
+            .ToContainTextAsync("getBoundingClientRect", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await codeCard.Locator(".sample-copy").ClickAsync();
+        await Expect(codeCard.Locator(".sample-copy"))
+            .ToContainTextAsync("Copied!", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
         // Live ticker: lifecycle hooks drive a zero-JS server-rendered SVG; switching symbol fires
         // OnPropsChanged without remounting.
         await SideAsync("Live ticker", "BTC live ticker");


### PR DESCRIPTION
## Summary
Every `CodeSample` card in the showcase apps gains a copy-to-clipboard button and, when a sample has a JS or CSS side, a **C# / JS / CSS tab strip** (active tab is component state switched through the live diff; each pane highlighted server-side by ColorCode). The Element-refs and Scoped-CSS pages now show the **real, verbatim source** of their demo components, embedded from the actual files via a new `EmbeddedSource` reader so snippets always compile and match the live result. This surfaced — and fixes — a framework bug: the scoped-JS module wrapper (`ScopedAssetRegistry`) didn't recognise `export async function`, leaving the `export` keyword inside the non-module IIFE (a SyntaxError that silently broke the whole file); the export-strip/name regexes now accept the optional `async` modifier (Server runtime + WASM bake both use this path).

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — green (Core incl. new `ScopedAssetRegistry` async-export test 58/58; Shared `CodeSample` 6/6 covering tab rendering, single-language back-compat, and `EmbeddedSource`).
- E2E (`samples/` changed): host **Server** (`ServerExampleTests.Journey_WalksEveryPageAndUnusualActivity`) — passing; the Element-refs step switches the JS tab (asserts the pane swaps to the scoped JS) and clicks copy (asserts the "Copied!" flash). This is the run that originally caught the async-export bug.
- `dotnet format` clean; warnings-as-errors build clean; `Rask.Example.Wasm` `publish -c Release` has 0 IL-trim warnings and bakes the scoped `CodeSample.js`.

## Benchmarks
n/a — `CodeSample` lives in `samples/`; the framework change is in `ScopedAssetRegistry.WrapModule`, which runs once at JS registration / build-time bake, not on the render hot path.

## CHANGELOG
- [Unreleased] entries added: **Changed** — "Showcase code samples are now copy-pasteable and multi-language"; **Fixed** — "Scoped JS now supports `export async function`".
