### PR TITLE
chore(release): v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-15
+
 ### Added
 - **Background-service showcase (`/background`).** A new example page demonstrating an app-wide
   background process driving the UI: a DI **singleton** `IMetricsFeed` runs its own loop and raises


### PR DESCRIPTION
## Summary
Promotes the CHANGELOG `[Unreleased]` section to **`[0.8.0] - 2026-06-15`** and adds a fresh empty `[Unreleased]` above it. No code changes — the version is derived by MinVer from the `v0.8.0` tag pushed after this merges.

This release bundles everything merged since v0.7.0, including PRs #69–#75. Highlights:
- **Added:** background-service showcase (`/background`), slow-connection affordances on both transports.
- **Changed:** `Authorize.Authorized` now receives the current user (**breaking**); WASM build migrated to `Microsoft.NET.Sdk.WebAssembly` (**breaking**); copy-paste + C#/JS/CSS tabs for showcase code samples.
- **Removed:** `:global(...)` scoped-CSS escape hatch (**breaking**).
- **Fixed:** scoped-JS `export async function`, scroll-to-top on forward navigation (both transports), showcase side-nav overflow, WASM-hosting precompressed MIME types, keyed-reorder focus/selection preservation.

Minor bump (0.7 → 0.8): a 0.x line where breaking changes are expected pre-1.0.

## Testing
- `dotnet build -c Release -warnaserror` — clean (0 warnings).
- Full unit + sharded E2E suite green on the merge-base (main `6866262`).

## Release steps after merge
1. Tag `v0.8.0` on the squashed merge commit and push it.
2. `release.yml` runs the unit gate + sharded E2E, packs the six NuGets, pushes to nuget.org, and creates the GitHub release.