### PR TITLE
refactor(samples): one tab per file labelled by filename in code samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ them until tagged releases begin.
   literal, so the shown code is the actual compiled class and can never drift from the live result.
   Inline demos were promoted to dedicated, self-contained component classes co-located with their
   feature. A build-time check now fails if two embedded source files share a leaf name.
+- **Showcase code samples now show one tab per source file, labelled with its file name.**
+  `CodeSample` takes an ordered list of embedded file names and renders a tab per file (the
+  highlight language is inferred from the extension), replacing the previous generic `C#` / `JS` /
+  `CSS` strip that concatenated sibling files of the same language into a single pane. Multi-file
+  demos (e.g. Scoped CSS, Context, Background service) now expose each file on its own tab.
 
 ## [0.8.0] - 2026-06-15
 

--- a/samples/Rask.Example.Shared/Features/BackgroundService/BackgroundServicePage.cs
+++ b/samples/Rask.Example.Shared/Features/BackgroundService/BackgroundServicePage.cs
@@ -33,7 +33,7 @@ public sealed class BackgroundServicePage : Component
             Strong()["unsubscribes on unmount"], " so it stops repainting (and can be collected) once it leaves the tree."
         ],
         CodeSample(
-            EmbeddedSource.Read("MetricsFeed.cs", "MetricsGauge.cs", "MetricsChart.cs"),
+            ["MetricsFeed.cs", "MetricsGauge.cs", "MetricsChart.cs"],
             Notes:
             "The loop runs on a background thread, so StateHasChanged() crosses threads here — that's safe: it schedules a render under the subscriber's own session lock and is a no-op once the component unmounts (so a tick racing an unsubscribe is harmless). State is an immutable snapshot swapped by reference, so a render walking it on the UI thread never sees a half-built value. The feed is registered as a singleton (app-wide, shared) — deliberately unlike the scoped DemoUserProvider, because a metric stream is public but a user's principal must never be shared across sessions."),
         Div(Class: "alert alert-info d-flex align-items-start mt-3")[

--- a/samples/Rask.Example.Shared/Features/Binding/BindingPage.cs
+++ b/samples/Rask.Example.Shared/Features/Binding/BindingPage.cs
@@ -15,49 +15,49 @@ public sealed class BindingPage : Component
             "Inputs can be wired with plain Value + OnInput, or with a strongly-typed Bind expression that resolves the input name, type, and update timing for you."),
         H2(Class: "h4 mt-4 mb-3")["Manual — Value + OnInput"],
         CodeSample(
-            EmbeddedSource.Read("BindingManualDemo.cs"),
+            ["BindingManualDemo.cs"],
             Notes:
             "The low-level path: wire Value and the event handler yourself. Works for any input type, but you parse and re-render manually.",
             Result: BindingManualDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — Input<TProp>(Bind: ...)"],
         CodeSample(
-            EmbeddedSource.Read("BindingTypedDemo.cs"),
+            ["BindingTypedDemo.cs"],
             Notes:
             "Bind reads the expression — the property name becomes the input name, the property type picks the input type, and string fields update on every keystroke. One call replaces Value + OnInput + parsing.",
             Result: BindingTypedDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — across primitive types"],
         CodeSample(
-            EmbeddedSource.Read("BindingMultiDemo.cs"),
+            ["BindingMultiDemo.cs"],
             Notes:
             "The same Bind helper picks the right input type from the property's CLR type and wires immediate (string) or change-deferred (everything else) update timing automatically.",
             Result: BindingMultiDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — nullable properties"],
         CodeSample(
-            EmbeddedSource.Read("BindingNullableDemo.cs"),
+            ["BindingNullableDemo.cs"],
             Notes:
             "BindingHelpers.TrySetTyped routes empty input to null when the property is nullable — either Nullable<T> for value types or NRT-annotated for reference types (detected via NullabilityInfoContext). Non-nullable string still becomes \"\" when emptied; non-nullable value types clear to default(T) — see the next section.",
             Result: BindingNullableDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — clearing a non-nullable value-type input"],
         CodeSample(
-            EmbeddedSource.Read("BindingClearDefaultDemo.cs"),
+            ["BindingClearDefaultDemo.cs"],
             Notes:
             "Clearing a number/date/enum input on a non-nullable value type now snaps the model to default(T) instead of silently reverting. The nullable companion still routes empty → null, so the two paths stay distinguishable.",
             Result: BindingClearDefaultDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — Textarea<TProp>(Bind: ...)"],
         CodeSample(
-            EmbeddedSource.Read("BindingTextareaDemo.cs"),
+            ["BindingTextareaDemo.cs"],
             Notes:
             "Textareas always stream — Textarea.Bound wires OnInputAsync for every keystroke so the echo updates without blur or submit, no matter how long the text is.",
             Result: BindingTextareaDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — AfterBind (sync)"],
         CodeSample(
-            EmbeddedSource.Read("BindingAfterBindDemo.cs"),
+            ["BindingAfterBindDemo.cs"],
             Notes:
             "AfterBind fires after TrySetTyped has written the new value to the model and before validators run. The dependent dropdown rebinds in the same render — no extra round-trip.",
             Result: BindingAfterBindDemo()),
         H2(Class: "h4 mt-5 mb-3")["Typed — AfterBindAsync (async)"],
         CodeSample(
-            EmbeddedSource.Read("BindingAfterBindAsyncDemo.cs"),
+            ["BindingAfterBindAsyncDemo.cs"],
             Notes:
             "Rask re-renders at every await suspension inside an async handler, so setting _loading before the await surfaces the \"loading…\" UI on its own — no manual StateHasChanged() is required. AfterBindAsync is still awaited before the post-handler render, so validators see the new dependent state. Note the empty-value placeholder option: it matches the initial model so the dropdown doesn't falsely show the first track, and so picking any track (including the first) fires a real change.",
             Result: BindingAfterBindAsyncDemo())

--- a/samples/Rask.Example.Shared/Features/Callback/CallbackPage.cs
+++ b/samples/Rask.Example.Shared/Features/Callback/CallbackPage.cs
@@ -15,7 +15,7 @@ public sealed class CallbackPage : Component
             "Child→parent events are plain delegate props — no special type. Invoking one re-renders the parent that owns it, automatically."),
         H2(Class: "h4 mt-4 mb-3")["Child emits, parent re-renders"],
         CodeSample(
-            EmbeddedSource.Read("RatingStars.cs", "CallbackRatingDemo.cs"),
+            ["RatingStars.cs", "CallbackRatingDemo.cs"],
             Notes:
             "The star button's handler belongs to RatingStars, so the DOM dispatch only dirties the child — and the child invokes OnRate off that path. The parent still re-renders because the framework wraps the delegate to re-render its owner (the parent, captured from the lambda's `this`). RatingStars never knows the parent exists, and the parent never wires StateHasChanged by hand.",
             Result: CallbackRatingDemo()),

--- a/samples/Rask.Example.Shared/Features/Cancellation/CancellationPage.cs
+++ b/samples/Rask.Example.Shared/Features/Cancellation/CancellationPage.cs
@@ -52,7 +52,7 @@ public sealed class CancellationPage : Component
         ],
         H2(Class: "h4 mt-4 mb-3")["Source"],
         CodeSample(
-            EmbeddedSource.Read("CancellationProbe.cs"),
+            ["CancellationProbe.cs"],
             Notes:
             "Component.CancellationToken is allocated lazily — components that don't read it never pay the CTS cost. The framework cancels the token before disposing the subtree, so awaits unwind via OperationCanceledException before Dispose runs."),
         Div(Class: "alert alert-info d-flex align-items-start mt-3")[

--- a/samples/Rask.Example.Shared/Features/Components/ComponentsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Components/ComponentsPage.cs
@@ -15,18 +15,18 @@ public sealed class ComponentsPage : Component
             "Subclass Component, override Render. The Rask source generator emits a Namespace.Generated.TypeName(...) factory for every concrete user component, with parameters derived from your public settable properties."),
         H2(Class: "h4 mt-4 mb-3")["A component and its generated factory"],
         CodeSample(
-            EmbeddedSource.Read("ComponentsGreetingDemo.cs"),
+            ["ComponentsGreetingDemo.cs"],
             Notes:
             "Non-nullable property without an initializer → required factory parameter. Nullable property → optional with default null. Property with an initializer → excluded from the factory.",
             Result: ComponentsGreetingDemo()),
         H2(Class: "h4 mt-5 mb-3")["DI via constructor"],
         CodeSample(
-            EmbeddedSource.Read("ComponentsDiDemo.cs"),
+            ["ComponentsDiDemo.cs"],
             Notes:
             "ActivatorUtilities.CreateInstance constructs the component each time; constructor parameters resolve from DI, properties are then re-applied so cached private state survives across renders while props stay fresh."),
         H2(Class: "h4 mt-5 mb-3")["[SkipFactory] hides a property"],
         CodeSample(
-            EmbeddedSource.Read("ComponentsSkipFactoryDemo.cs"),
+            ["ComponentsSkipFactoryDemo.cs"],
             Notes:
             "[SkipFactory] keeps a property settable in code while removing it from the generated factory signature. The counter below started at 7 — click it and the state persists across re-renders.",
             Result: ComponentsSkipFactoryDemo()),

--- a/samples/Rask.Example.Shared/Features/Context/ContextPage.cs
+++ b/samples/Rask.Example.Shared/Features/Context/ContextPage.cs
@@ -15,7 +15,7 @@ public sealed class ContextPage : Component
             "Supply a value to a whole subtree and read it deep down — no prop drilling. Rask's analogue of React Context / Blazor CascadingValue, with the provider and readers on one Context type."),
         H2(Class: "h4 mt-4 mb-3")["Provide once, consume anywhere below"],
         CodeSample(
-            EmbeddedSource.Read("ContextThemeDemo.cs", "ThemeCard.cs", "ThemeBadge.cs"),
+            ["ContextThemeDemo.cs", "ThemeCard.cs", "ThemeBadge.cs"],
             Notes:
             "The badge sits inside ThemeCard, which receives no theme parameter and is render-cached after first paint. Reading the value with Context.Required opts the badge out of the render cache, so each toggle re-renders only the badge — straight through the cached intermediate, with nothing threaded between them.",
             Result: ContextThemeDemo()),

--- a/samples/Rask.Example.Shared/Features/Disposal/DisposalPage.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/DisposalPage.cs
@@ -49,7 +49,7 @@ public sealed class DisposalPage : Component
             ]
         ],
         CodeSample(
-            EmbeddedSource.Read("DisposableTimerProbe.cs"),
+            ["DisposableTimerProbe.cs"],
             Notes:
             "Dispose runs once when the component leaves the render tree — either because its parent stopped including it, the route changed, or the live session is being torn down. The framework walks children depth-first, so nested IDisposables dispose bottom-up."),
         H2(Class: "h4 mt-5 mb-3")["IAsyncDisposable"],
@@ -118,7 +118,7 @@ public sealed class DisposalPage : Component
             ]
         ],
         CodeSample(
-            EmbeddedSource.Read("UnmountTimerProbe.cs"),
+            ["UnmountTimerProbe.cs"],
             Notes:
             "No IDisposable on the component. The timer is owned by a render hook, so its cleanup belongs in OnUnmount — symmetric with OnMount. The lifetime CancellationToken is still live here, so you could also pass it to any pending awaits if you wanted to fan out cancellation.")
     ];

--- a/samples/Rask.Example.Shared/Features/Download/DownloadPage.cs
+++ b/samples/Rask.Example.Shared/Features/Download/DownloadPage.cs
@@ -15,7 +15,7 @@ public sealed class DownloadPage : Component
             "Navigator.Download stages bytes (or a stream) on the active session. On the server they're served from /_rask/download/{sid}/{token}; on WASM they're handed to JS as a base64 payload. The component code is the same."),
         H2(Class: "h4 mt-4 mb-3")["Generated report"],
         CodeSample(
-            EmbeddedSource.Read("DownloadDemo.cs"),
+            ["DownloadDemo.cs"],
             Notes:
             "Navigator.Download must be called from an event handler — outside that scope it throws, because there's no live render round-trip to attach the download to. The handler can do other state changes too (here, bump a counter); both ship in the same render.",
             Result: DownloadDemo())

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropPage.cs
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropPage.cs
@@ -15,8 +15,7 @@ public sealed class DragDropPage : Component
             "DragDrop is a headless primitive: it owns no DOM and tracks only the in-flight drag, handing your Body delegate a DragDropContext. You draw the items and drop zones, wire the context's DragStart/DragOver/Drop/DragEnd onto them, and move your own data when OnDrop reports where the drag landed. Zones are arbitrary string keys — one zone is a sortable list, several are a Kanban board."),
 
         CodeSample(
-            EmbeddedSource.Read("DragDropDemo.cs"),
-            Css: EmbeddedSource.Read("DragDropDemo.css"),
+            ["DragDropDemo.cs", "DragDropDemo.css"],
             Result: DragDropDemo(),
             Notes:
             "Drag handlers are parameterless (like OnClick) — the dragged item's identity rides the handler closure, not the event payload, so no custom wire type is needed. DragDropMove.ApplyTo handles the direction-aware insert math (down-after, up-before) for both same-list and cross-list moves. Items carry a stable Key: so reorders ship trusted keyed structural diff ops that preserve survivors' DOM state.")

--- a/samples/Rask.Example.Shared/Features/ElementRef/ElementRefPage.cs
+++ b/samples/Rask.Example.Shared/Features/ElementRef/ElementRefPage.cs
@@ -15,10 +15,9 @@ public sealed class ElementRefPage : Component
             "Hand a rendered DOM element to JavaScript — for third-party widgets (charts, datepickers, editors) that need the raw node, or for focus and measurement. Rask's analogue of Blazor's ElementReference."),
         H2(Class: "h4 mt-4 mb-3")["Attach a ref, pass it to JS"],
         CodeSample(
-            // The real component source and its sibling scoped JS, embedded verbatim — the
-            // C#/JS tabs show exactly what produces the live result on the right.
-            EmbeddedSource.Read("ElementRefDemo.cs"),
-            Js: EmbeddedSource.Read("ElementRefDemo.js"),
+            // The real component source and its sibling scoped JS, embedded verbatim — one tab
+            // per file shows exactly what produces the live result on the right.
+            ["ElementRefDemo.cs", "ElementRefDemo.js"],
             Notes:
             "An ElementRef stamps data-rask-ref on the element. When you pass it to IJSRuntime, the client's JSON reviver swaps it for document.querySelector('[data-rask-ref=…]'), so your JS function receives the live element — no marker-class convention needed. FocusAsync/BlurAsync/ScrollIntoViewAsync are built in.",
             Result: ElementRefDemo()),

--- a/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomPage.cs
+++ b/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomPage.cs
@@ -15,17 +15,17 @@ public sealed class BoomPage : Component
             "ErrorBoundary catches exceptions thrown by descendants — render-time, sync lifecycle, async lifecycle, and event handlers — and renders a fallback in their place. The fallback receives a Recover() callback so the boundary can be reset from a button click."),
         H2(Class: "h4 mt-4 mb-3")["Handler throw — boundary catches and renders fallback"],
         CodeSample(
-            EmbeddedSource.Read("BoomHandlerDemo.cs"),
+            ["BoomHandlerDemo.cs"],
             Result: BoomHandlerDemo()),
         H2(Class: "h4 mt-5 mb-3")["Render-time throw"],
         CodeSample(
-            EmbeddedSource.Read("BoomRenderDemo.cs"),
+            ["BoomRenderDemo.cs"],
             Notes:
             "The same boundary catches synchronous exceptions thrown inside a descendant's Render(). Click below to flip a flag; the next render of the child throws and the fallback replaces it.",
             Result: BoomRenderDemo()),
         H2(Class: "h4 mt-5 mb-3")["Nested boundaries — inner catches first"],
         CodeSample(
-            EmbeddedSource.Read("BoomNestedDemo.cs"),
+            ["BoomNestedDemo.cs"],
             Notes:
             "The inner boundary catches first — the outer healthy region (and its sibling paragraph) stays mounted. If the inner fallback itself throws, the outer boundary catches the escalation.",
             Result: BoomNestedDemo())

--- a/samples/Rask.Example.Shared/Features/Events/EventsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Events/EventsPage.cs
@@ -16,19 +16,19 @@ public sealed class EventsPage : Component
             "Event handlers are plain delegates on the factory call site — OnClick, OnInput, OnChange, OnSubmit. Each handler triggers a re-render after it runs."),
         H2(Class: "h4 mt-4 mb-3")["Click"],
         CodeSample(
-            EmbeddedSource.Read("EventsClickDemo.cs"),
+            ["EventsClickDemo.cs"],
             Result: EventsClickDemo()),
         H2(Class: "h4 mt-5 mb-3")["Input — onInput"],
         CodeSample(
-            EmbeddedSource.Read("EventsInputDemo.cs"),
+            ["EventsInputDemo.cs"],
             Result: EventsInputDemo()),
         H2(Class: "h4 mt-5 mb-3")["Select — onChange"],
         CodeSample(
-            EmbeddedSource.Read("EventsSelectDemo.cs"),
+            ["EventsSelectDemo.cs"],
             Result: EventsSelectDemo()),
         H2(Class: "h4 mt-5 mb-3")["Form — onSubmit"],
         CodeSample(
-            EmbeddedSource.Read("EventsFormDemo.cs"),
+            ["EventsFormDemo.cs"],
             Notes: "OnSubmit receives a FormData object collected from all named form fields.",
             Result: EventsFormDemo())
     ];

--- a/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsPage.cs
+++ b/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsPage.cs
@@ -15,7 +15,7 @@ public sealed class FormGroupsPage : Component
             "Bind a set of radios to one value, or a set of checkboxes to a collection — one call each, wired into the same EditContext as Input(Bind: …)."),
         H2(Class: "h4 mt-4 mb-3")["RadioGroup + CheckboxGroup"],
         CodeSample(
-            EmbeddedSource.Read("FormGroupsDemo.cs"),
+            ["FormGroupsDemo.cs"],
             Notes:
             "Both parse the bind expression, resolve the ambient EditContext, and wire each input's change handler to set the value (radios) or add/remove the item (checkboxes), then re-validate. They render a transparent Fragment of <label><input>…</label>, so you control layout with OptionLabel and ItemClass.",
             Result: FormGroupsDemo()),

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.cs
@@ -83,7 +83,7 @@ public sealed class HomePage(Navigator nav) : Component
             ]
         ],
         CodeSample(
-            EmbeddedSource.Read("HomeWelcomeDemo.cs"),
+            ["HomeWelcomeDemo.cs"],
             "The minimal page",
             Notes:
             "Generator-emitted factories build a tree. Strings convert implicitly to Child. Component.ToHtml() produces the final HTML.",

--- a/samples/Rask.Example.Shared/Features/Http/HttpPage.cs
+++ b/samples/Rask.Example.Shared/Features/Http/HttpPage.cs
@@ -15,13 +15,13 @@ public sealed class HttpPage : Component
             "HttpClient is registered as a service in Program.cs and injected into pages through their primary constructor. This demo fetches data/posts-1.json — a static JSON file the app serves from its own origin, so the showcase stays self-contained and offline-safe."),
         H2(Class: "h4 mt-4 mb-3")["Register"],
         CodeSample(
-            EmbeddedSource.Read("HttpRegisterDemo.cs"),
+            ["HttpRegisterDemo.cs"],
             Notes:
             "Relative URLs require BaseAddress. WasmHostBuilder.BaseAddress is the page origin (and carries any sub-path) — read it lazily inside the factory so it fires after the JS module imports.",
             Result: HttpRegisterDemo()),
         H2(Class: "h4 mt-5 mb-3")["Inject and fetch"],
         CodeSample(
-            EmbeddedSource.Read("HttpFetchDemo.cs"),
+            ["HttpFetchDemo.cs"],
             Notes:
             "OnMountAsync runs once on first render. The framework's async lifecycle handler triggers a re-render when the awaited task completes. Component.CancellationToken cancels on unmount — navigate away mid-fetch and the in-flight request aborts.",
             Result: HttpFetchDemo()),

--- a/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsPage.cs
+++ b/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsPage.cs
@@ -72,7 +72,7 @@ public sealed class KeyedListsPage : Component
         ],
 
         CodeSample(
-            EmbeddedSource.Read("KeyedListsReorderDemo.cs"),
+            ["KeyedListsReorderDemo.cs"],
             Notes:
             "Key is an identity, not a reactive prop: a Key change mounts a fresh instance and never fires OnPropsChanged. On an element Key emits data-rask-key; on a transparent component or Fragment it auto-forwards onto the first rendered element. RASK022 warns when a projected/looped list item is missing a Key."),
 

--- a/samples/Rask.Example.Shared/Features/Lifecycle/LifecyclePage.cs
+++ b/samples/Rask.Example.Shared/Features/Lifecycle/LifecyclePage.cs
@@ -58,7 +58,7 @@ public sealed class LifecyclePage : Component
         ],
         H2(Class: "h4 mt-5 mb-3")["Source"],
         CodeSample(
-            EmbeddedSource.Read("LifecycleProbe.cs"),
+            ["LifecycleProbe.cs"],
             Notes:
             "OnMount* fires once on first creation; OnPropsChanged* on first render and whenever a bound prop or route/query param actually changes — a bare event-handler re-render (like the Trigger button above) does NOT refire it; OnRendered* after every render commits; OnUnmount* once on disposal (children before parents). StateHasChanged() inside OnUnmount* is a no-op — the component is already leaving the tree."),
         Div(Class: "alert alert-danger d-flex align-items-start mt-3")[

--- a/samples/Rask.Example.Shared/Features/LiveTicker/LiveTickerPage.cs
+++ b/samples/Rask.Example.Shared/Features/LiveTicker/LiveTickerPage.cs
@@ -60,7 +60,7 @@ public sealed class LiveTickerPage(Navigator nav) : Component
             " (the log lives on the page, so unmount entries survive)."
         ],
         CodeSample(
-            EmbeddedSource.Read("LiveTicker.cs"),
+            ["LiveTicker.cs"],
             Notes:
             "OnMountAsync runs a long-lived poll loop. Every await uses ConfigureAwait(false) so the loop doesn't auto-render on each yield; instead it calls StateHasChanged() once per real data change — one render per tick. The inter-tick delay is interruptible: a Symbol switch cancels _wake so the new asset polls immediately. CancellationToken cancels on unmount, breaking the loop. There is no OnRenderedAsync: the chart is a server-rendered SVG (the Sparkline component) emitted straight from Render(), so the framework ships the updated <svg> over the same transport as the rest of the page — zero JavaScript."),
         Div(Class: "alert alert-info d-flex align-items-start mt-3")[

--- a/samples/Rask.Example.Shared/Features/Navigator/NavigatorPage.cs
+++ b/samples/Rask.Example.Shared/Features/Navigator/NavigatorPage.cs
@@ -67,7 +67,7 @@ public sealed class NavigatorPage(Navigator nav, RouteState route) : Component
             ]
         ],
         CodeSample(
-            EmbeddedSource.Read("NavigatorDemo.cs"))
+            ["NavigatorDemo.cs"])
     ];
 
     private static string BuildQuery(RouteState route)

--- a/samples/Rask.Example.Shared/Features/NestedForms/NestedFormPage.cs
+++ b/samples/Rask.Example.Shared/Features/NestedForms/NestedFormPage.cs
@@ -15,25 +15,25 @@ public sealed class NestedFormPage : Component
             "Forms aren't always flat. Drop a single DataAnnotationsValidator() or FluentValidationValidator(...) at the top of the Form and the same Input(Bind: ...) syntax binds through sub-objects, lists, and dictionaries. The reference-based FieldIdentifier means each sub-instance owns its own validation state, so add/remove/reorder works without re-keying."),
         H2(Class: "h4 mt-4 mb-3")["Sub-object — () => model.Address.Street"],
         CodeSample(
-            EmbeddedSource.Read("NestedSubObjectDemo.cs"),
+            ["NestedSubObjectDemo.cs"],
             Notes:
             "The graph walker in DataAnnotationsValidator visits the Address sub-object automatically, so [Required] / [RegularExpression] on its properties fire just like the root model's. ValidationMessage(() => _model.Address.Street, ...) reads the message off the Address instance — not off the root — so reassigning _model.Address = new(...) between renders rewires the bindings without leftover errors.",
             Result: NestedSubObjectDemo()),
         H2(Class: "h4 mt-5 mb-3")["Collection — foreach + per-item capture"],
         CodeSample(
-            EmbeddedSource.Read("NestedListForeachDemo.cs"),
+            ["NestedListForeachDemo.cs"],
             Notes:
             "Each foreach iteration closes over a different `item` reference, so the resulting lambdas point at distinct instances — each row owns its own validation state. When the user removes a row, that item's FieldIdentifier entries simply stop being read; no key juggling. When they add a row, the new item starts with empty state.",
             Result: NestedListForeachDemo()),
         H2(Class: "h4 mt-5 mb-3")["Collection — indexer with the for-loop closure workaround"],
         CodeSample(
-            EmbeddedSource.Read("NestedListIndexerDemo.cs"),
+            ["NestedListIndexerDemo.cs"],
             Notes:
             "Indexer binding compiles to a MethodCallExpression on get_Item (List<T>) or BinaryExpression(ArrayIndex) (T[]). The parser invokes it each render, so reassigning _model.Skus[i] (record replacement, reorder) is picked up next frame without any rebind boilerplate. The catch is the C# `for` closure trap — copy the index into a per-iteration local. `foreach` doesn't have this problem.",
             Result: NestedListIndexerDemo()),
         H2(Class: "h4 mt-5 mb-3")["FluentValidation — SetValidator and RuleForEach"],
         CodeSample(
-            EmbeddedSource.Read("NestedFluentValidationDemo.cs"),
+            ["NestedFluentValidationDemo.cs"],
             Notes:
             "FluentValidation already walks nested rules via .SetValidator(...) and RuleForEach(...). Rask's job is just to route the dotted PropertyName (\"Address.Street\", \"Lines[0].Description\") back to the runtime sub-instance so the message lands where ValidationMessage(For: () => _model.Address.Street, ...) is reading. Per-keystroke validation on a root-model field uses MemberNameValidatorSelector (fast path); on a nested field it runs the full validator and filters by resolved owner.",
             Result: NestedFluentValidationDemo())

--- a/samples/Rask.Example.Shared/Features/Primitives/PrimitivesPage.cs
+++ b/samples/Rask.Example.Shared/Features/Primitives/PrimitivesPage.cs
@@ -15,13 +15,13 @@ public sealed class PrimitivesPage : Component
             "Four primitives sit beneath every Rask page: Text, Raw, Fragment, and Doctype. Everything else is built out of them."),
         H2(Class: "h4 mt-4 mb-3")["Text — auto-escaped strings"],
         CodeSample(
-            EmbeddedSource.Read("PrimitivesTextDemo.cs"),
+            ["PrimitivesTextDemo.cs"],
             Notes:
             "Text HTML-encodes its value. The < and & above render as literal characters, not parsed as markup.",
             Result: PrimitivesTextDemo()),
         H2(Class: "h4 mt-5 mb-3")["Raw — verbatim HTML"],
         CodeSample(
-            EmbeddedSource.Read("PrimitivesRawDemo.cs"),
+            ["PrimitivesRawDemo.cs"],
             Notes:
             "Raw is the escape hatch. Use when you control the source (markdown output, sanitized snippets); never on user input.",
             Result: PrimitivesRawDemo()),
@@ -36,19 +36,19 @@ public sealed class PrimitivesPage : Component
         ],
         H2(Class: "h4 mt-5 mb-3")["Fragment — siblings without a wrapper"],
         CodeSample(
-            EmbeddedSource.Read("PrimitivesFragmentDemo.cs"),
+            ["PrimitivesFragmentDemo.cs"],
             Notes:
             "Fragment renders its children with no surrounding tag — handy for siblings at the root, especially Fragment(Doctype(), Html(...)) as the page entry.",
             Result: PrimitivesFragmentDemo()),
         H2(Class: "h4 mt-5 mb-3")["Doctype"],
         CodeSample(
-            EmbeddedSource.Read("PrimitivesDoctypeDemo.cs"),
+            ["PrimitivesDoctypeDemo.cs"],
             Notes:
             "Doctype() emits exactly <!DOCTYPE html>. Special-cased — no attributes, no children, no wrapping tag.",
             Result: PrimitivesDoctypeDemo()),
         H2(Class: "h4 mt-5 mb-3")["Children from strings"],
         CodeSample(
-            EmbeddedSource.Read("PrimitivesChildrenDemo.cs"),
+            ["PrimitivesChildrenDemo.cs"],
             Result: PrimitivesChildrenDemo())
     ];
 }

--- a/samples/Rask.Example.Shared/Features/Props/PropsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Props/PropsPage.cs
@@ -15,17 +15,17 @@ public sealed class PropsPage : Component
             "Every tag accepts Id, Class, Style, and Data. They render in that exact order, ahead of any tag-specific attributes."),
         H2(Class: "h4 mt-4 mb-3")["Id, Class, Style"],
         CodeSample(
-            EmbeddedSource.Read("PropsIdClassStyleDemo.cs"),
+            ["PropsIdClassStyleDemo.cs"],
             Result: PropsIdClassStyleDemo()),
         H2(Class: "h4 mt-5 mb-3")["Data — dictionary expands as data-*"],
         CodeSample(
-            EmbeddedSource.Read("PropsDataDemo.cs"),
+            ["PropsDataDemo.cs"],
             Notes:
             "Null values render as bare attributes (e.g. data-new). That's also how boolean attrs like disabled work elsewhere.",
             Result: PropsDataDemo()),
         H2(Class: "h4 mt-5 mb-3")["Attribute order"],
         CodeSample(
-            EmbeddedSource.Read("PropsAttributeOrderDemo.cs"),
+            ["PropsAttributeOrderDemo.cs"],
             Notes:
             "Render order is base props first (id, class, style, data-*), then tag-specific. Tests enforce it. Predictable for diffing and DOM tooling.",
             Result: PropsAttributeOrderDemo())

--- a/samples/Rask.Example.Shared/Features/Routing/RoutingPage.cs
+++ b/samples/Rask.Example.Shared/Features/Routing/RoutingPage.cs
@@ -15,12 +15,12 @@ public sealed class RoutingPage(Navigator nav) : Component
             "Annotate a component with [Route(\"/path\")]. A module initializer registers it; Router() in your App tree matches the current URL and renders the page."),
         H2(Class: "h4 mt-4 mb-3")["A page is a routed component"],
         CodeSample(
-            EmbeddedSource.Read("RoutingAboutPage.cs"),
+            ["RoutingAboutPage.cs"],
             Notes:
             "Routes use Blazor-style {param} placeholders. Optional, catch-all (**rest), and type-constrained variants are all supported."),
         H2(Class: "h4 mt-5 mb-3")["Nested layouts with [ParentRoute] + Outlet"],
         CodeSample(
-            EmbeddedSource.Read("RoutingLayoutDemo.cs"),
+            ["RoutingLayoutDemo.cs"],
             Notes:
             "Child templates are joined to the parent's. An empty child template (\"\") means \"default child for this layout\". This very showcase is built that way — every page declares [ParentRoute(typeof(ShowcaseLayout))]."),
         H2(Class: "h4 mt-5 mb-3")["Try the live param demo"],
@@ -57,7 +57,7 @@ public sealed class RoutingPage(Navigator nav) : Component
             " (sidebars, breadcrumbs, the path display in the showcase header) that need to refresh on every nav, including browser back/forward."
         ],
         CodeSample(
-            EmbeddedSource.Read("PathDisplay.cs"),
+            ["PathDisplay.cs"],
             Notes:
             "The handler is just StateHasChanged — the framework already knows how to coalesce the resulting render with whatever else the dispatcher is processing. Always pair the subscribe with the unsubscribe in OnUnmount; otherwise the RouteState keeps a strong reference to the (already-unmounted) component.")
     ];

--- a/samples/Rask.Example.Shared/Features/ScopedCss/ScopedCssPage.cs
+++ b/samples/Rask.Example.Shared/Features/ScopedCss/ScopedCssPage.cs
@@ -15,11 +15,10 @@ public sealed class ScopedCssPage : Component
             "Drop a sibling {Component}.css file next to {Component}.cs and Rask pairs them at compile time. The framework hashes the type's full name into a stable scope id and rewrites every selector to apply only inside that component — no class-name discipline, no BEM, no leaks."),
         H2(Class: "h4 mt-4 mb-3")["Two components, same selector, no conflict"],
         CodeSample(
-            // The two real components and their sibling stylesheets, embedded verbatim. Both
-            // declare the same .box / .dot selectors; the CSS tab shows the unmodified source
-            // that Rask rewrites per-scope to produce the isolated red/blue results.
-            EmbeddedSource.Read("ScopedRed.cs", "ScopedBlue.cs"),
-            Css: EmbeddedSource.Read("ScopedRed.css", "ScopedBlue.css"),
+            // The two real components and their sibling stylesheets, embedded verbatim — one tab
+            // per file. Both components declare the same .box / .dot selectors; the .css tabs show
+            // the unmodified source that Rask rewrites per-scope into the isolated red/blue results.
+            ["ScopedRed.cs", "ScopedBlue.cs", "ScopedRed.css", "ScopedBlue.css"],
             Notes:
             "Both classes use the same .box selector. The framework stamps every rendered body element with data-{scopeId}, then rewrites .box to .box[data-{scopeId}] — same source CSS, isolated outputs.",
             Result: Div(Class: "d-flex flex-column gap-2")[

--- a/samples/Rask.Example.Shared/Features/Svg/SvgPage.cs
+++ b/samples/Rask.Example.Shared/Features/Svg/SvgPage.cs
@@ -28,28 +28,28 @@ public sealed class SvgPage : Component
 
         H2(Class: "h4 mt-4 mb-3")["Shapes inside an <svg>"],
         CodeSample(
-            EmbeddedSource.Read("SvgShapesDemo.cs"),
+            ["SvgShapesDemo.cs"],
             Notes:
             "Presentation attributes (Fill, Stroke, StrokeWidth, StrokeLinecap, …) live on the shared SvgElement base, so every shape exposes them as optional factory parameters.",
             Result: SvgShapesDemo()),
 
         H2(Class: "h4 mt-5 mb-3")["Gradients via <defs> and <linearGradient>"],
         CodeSample(
-            EmbeddedSource.Read("SvgGradientDemo.cs"),
+            ["SvgGradientDemo.cs"],
             Notes:
             "The Rask brand mark itself is built this way — see Demos/RaskLogo.cs. A nested SvgTitle gives the graphic its accessible name.",
             Result: SvgGradientDemo()),
 
         H2(Class: "h4 mt-5 mb-3")["Clickable shapes — OnClick on any element"],
         CodeSample(
-            EmbeddedSource.Read("SvgClickableDemo.cs"),
+            ["SvgClickableDemo.cs"],
             Notes:
             $"Click a swatch — the selection re-renders live over the same transport as the rest of the page. Selected: {Swatches[_selected].Name}.",
             Result: SvgClickableDemo()),
 
         H2(Class: "h4 mt-5 mb-3")["Text with <text> and <tspan>"],
         CodeSample(
-            EmbeddedSource.Read("SvgTextDemo.cs"),
+            ["SvgTextDemo.cs"],
             Notes:
             "SvgText is the <text> tag (renamed to avoid colliding with the Text primitive); Tspan styles a run inside it.",
             Result: SvgTextDemo())

--- a/samples/Rask.Example.Shared/Features/Tags/TagsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Tags/TagsPage.cs
@@ -16,23 +16,23 @@ public sealed class TagsPage : Component
             "Tag-specific attributes come first; the universal Id/Class/Style/Data trail at the end."),
         H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-fonts text-accent me-2"), "Text & semantic"],
         CodeSample(
-            EmbeddedSource.Read("TagsTextDemo.cs"),
+            ["TagsTextDemo.cs"],
             Result: TagsTextDemo()),
         H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-input-cursor-text text-accent me-2"), "Forms"],
         CodeSample(
-            EmbeddedSource.Read("TagsFormDemo.cs"),
+            ["TagsFormDemo.cs"],
             Result: TagsFormDemo()),
         H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-table text-accent me-2"), "Tables"],
         CodeSample(
-            EmbeddedSource.Read("TagsTableDemo.cs"),
+            ["TagsTableDemo.cs"],
             Result: TagsTableDemo()),
         H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-image text-accent me-2"), "Media"],
         CodeSample(
-            EmbeddedSource.Read("TagsMediaDemo.cs"),
+            ["TagsMediaDemo.cs"],
             Result: TagsMediaDemo()),
         H2(Class: "h4 mt-5 mb-3")[I(Class: "bi bi-dash-circle text-accent me-2"), "Void elements"],
         CodeSample(
-            EmbeddedSource.Read("TagsVoidDemo.cs"),
+            ["TagsVoidDemo.cs"],
             Notes:
             "Void elements (Br, Hr, Img, Meta, Link, Input, …) have SelfClosing => true and never accept children.",
             Result: TagsVoidDemo())

--- a/samples/Rask.Example.Shared/Features/Upload/UploadPage.cs
+++ b/samples/Rask.Example.Shared/Features/Upload/UploadPage.cs
@@ -15,7 +15,7 @@ public sealed class UploadPage : Component
             "Input(Type: \"file\", OnFiles: …) wires a file picker to a typed handler. RaskFile carries the metadata; OpenReadStream gives you a Stream for the bytes — over multipart POST on the server, via JS chunked reads on WASM."),
         H2(Class: "h4 mt-4 mb-3")["Pick a file"],
         CodeSample(
-            EmbeddedSource.Read("UploadDemo.cs"),
+            ["UploadDemo.cs"],
             Notes:
             "The handler runs once per change event. RaskFile is only valid while the handler is on the stack — read whatever you need (bytes, metadata) before returning. The same component code runs unchanged on both hosts.",
             Result: UploadDemo())

--- a/samples/Rask.Example.Shared/Features/Users/UserDetailPage.cs
+++ b/samples/Rask.Example.Shared/Features/Users/UserDetailPage.cs
@@ -32,7 +32,7 @@ public sealed class UserDetailPage(Navigator nav) : Component
             ]
         ],
         CodeSample(
-            EmbeddedSource.Read("UserDetailPage.cs"),
+            ["UserDetailPage.cs"],
             Notes:
             "Route templates use {name} for segments. Add a type constraint with {name:int}, optional with {name?}, or a catch-all with {**rest}. [RouteParam] without an argument matches by property name; pass a string to alias."),
         H2(Class: "h4 mt-5 mb-3")["Switch user"],

--- a/samples/Rask.Example.Shared/Features/Users/UserPage.cs
+++ b/samples/Rask.Example.Shared/Features/Users/UserPage.cs
@@ -15,13 +15,13 @@ public sealed class UserPage : Component
             "Gate content on the signed-in user — imperatively by injecting IUserProvider and reading .Current (branch in Render() on _auth.Current.Identity?.IsAuthenticated and _auth.Current.IsInRole(...)), or declaratively with the headless Authorize component."),
         H2(Class: "h4 mt-4 mb-3")["Conditional rendering on the current user"],
         CodeSample(
-            EmbeddedSource.Read("UserGateDemo.cs"),
+            ["UserGateDemo.cs"],
             Notes:
             "The principal resolves from the IUserProvider in scope (real apps back it with a cookie/JWT on Server or /api/me on WASM). A component that gates on the user subscribes to the provider's Changed event — the same pattern sidebars use for RouteState — so it re-renders when the principal changes.",
             Result: UserGateDemo()),
         H2(Class: "h4 mt-5 mb-3")["Declarative gating — the Authorize component"],
         CodeSample(
-            EmbeddedSource.Read("AuthorizeDemo.cs"),
+            ["AuthorizeDemo.cs"],
             Notes:
             "Authorize is the declarative counterpart to gating in Render() on the current user: it picks the Authorized, NotAuthorized, or Authorizing slot off the same IUserProvider. Roles and the authenticated check are synchronous (no flicker); Policy resolves in the background. For whole-page gating use [Authorize] on the page instead. See docs/authentication.md for production flows (cookie/JWT, Identity, Keycloak, Auth0, Cognito, Duende).",
             Result: AuthorizeDemo()),

--- a/samples/Rask.Example.Shared/Features/Validation/ValidationPage.cs
+++ b/samples/Rask.Example.Shared/Features/Validation/ValidationPage.cs
@@ -15,79 +15,79 @@ public sealed class ValidationPage : Component
             "Validators are opt-in components placed inside the Form. Drop DataAnnotationsValidator() in if your model uses [Required]/[Range]/etc., or FluentValidationValidator(...) if you wired up FluentValidation. Or skip both and pass Validate: directly on Form (cross-field rule) or on Input/Select/Textarea (per-field rule) — the callback is just a Func that returns IEnumerable<string>, sync or async."),
         H2(Class: "h4 mt-4 mb-3")["Per-field — DataAnnotations + ValidationMessage"],
         CodeSample(
-            EmbeddedSource.Read("ValidationFieldsDemo.cs"),
+            ["ValidationFieldsDemo.cs"],
             Notes:
             "DataAnnotationsValidator() is a real component — drop it in to opt into [Required]/[EmailAddress]/[Range]/[StringLength]. ValidationMessage's Template runs only when the field has at least one message — the empty state stays out of the DOM.",
             Result: ValidationFieldsDemo()),
         H2(Class: "h4 mt-5 mb-3")["Top-of-form — ValidationSummary"],
         CodeSample(
-            EmbeddedSource.Read("ValidationSummaryDemo.cs"),
+            ["ValidationSummaryDemo.cs"],
             Notes:
             "ValidationSummary's Template receives every current ValidationEntry (Field + Message). The component itself emits nothing — wrapper, list shape, and field formatting are entirely yours.",
             Result: ValidationSummaryDemo()),
         H2(Class: "h4 mt-5 mb-3")["Inline — Validate: on field & form"],
         CodeSample(
-            EmbeddedSource.Read("InlineValidateDemo.cs"),
+            ["InlineValidateDemo.cs"],
             Notes:
             "No DataAnnotations on the model — every rule lives at the call site. Validate: on Input runs per-keystroke (after the field is touched) and produces field-scoped messages. Validate: on Form runs at submit and produces summary-scoped messages. Both delegates accept either a Func<T, IEnumerable<string>> (sync) or Func<T, CancellationToken, ValueTask<IEnumerable<string>>> (async).",
             Result: InlineValidateDemo()),
         H2(Class: "h4 mt-5 mb-3")["Nested test"],
         CodeSample(
-            EmbeddedSource.Read("NestedAsyncWithLiveTotalsDemo.cs"),
+            ["NestedAsyncWithLiveTotalsDemo.cs"],
             Notes:
             "Combines async validation on a nested field with live derived UI. The Validate: lambda on Input(() => _model.Address.PostalCode, …) routes through the form's EditContext, same as a root field — latest-wins cancellation supersedes the prior in-flight check, ValidatingIndicator surfaces while the await is pending, and OperationCanceledException is swallowed without producing a generic message. Live calcs work because every event handler re-renders the owning component: string fields (DiscountCode) update on every keystroke via OnInput, numeric fields (Quantity / UnitPrice) update on blur via OnChange — both flow through the same dispatcher path. Submit only fires OnValidSubmit when every per-field rule passes; an undeliverable ZIP keeps the form pending until corrected.",
             Result: NestedAsyncWithLiveTotalsDemo()),
         H2(Class: "h4 mt-5 mb-3")["Inline async — Validate: as Func<T, CT, ValueTask<IEnumerable<string>>>"],
         CodeSample(
-            EmbeddedSource.Read("InlineAsyncValidateDemo.cs"),
+            ["InlineAsyncValidateDemo.cs"],
             Notes:
             "Same call-site shape as the sync Validate above — overload resolution picks the async variant from the lambda's two-parameter arity (or method-group conversion against a `(T, CancellationToken) -> ValueTask<IEnumerable<string>>` method). The ValidatingIndicator surfaces while the 250ms delay runs; rapid typing supersedes the prior in-flight check (latest-wins) and OperationCanceledException is swallowed without producing a generic message.",
             Result: InlineAsyncValidateDemo()),
         H2(Class: "h4 mt-5 mb-3")["Async — IAsyncFieldValidator / FluentValidation"],
         CodeSample(
-            EmbeddedSource.Read("AsyncValidationDemo.cs"),
+            ["AsyncValidationDemo.cs"],
             Notes:
             "Try \"admin\" or \"taken\" — the ValidatingIndicator shows while the 400ms check runs, then a message appears. Per-keystroke calls cancel any prior in-flight check (latest-wins). Submit awaits all validators before routing to OnValidSubmit vs OnInvalidSubmit. The literal \"explode\" forces the demo validator to throw mid-await so you can see the generic \"Validation could not be completed.\" fallback that the framework surfaces when a validator faults. The indicator stays visible for ~200 ms after the check completes — EditContext.ValidatingStickyMs (default 200) smooths over sub-second validators that would otherwise flash on/off; set it to 0 on a manually-built EditContext to opt out.",
             Result: AsyncValidationDemo()),
         H2(Class: "h4 mt-5 mb-3")["Cross-field — Form-level Validate feeding ValidationSummary"],
         CodeSample(
-            EmbeddedSource.Read("CrossFieldSummaryDemo.cs"),
+            ["CrossFieldSummaryDemo.cs"],
             Notes:
             "Form-level Validate runs at submit time and adds its messages to FieldIdentifier(model, \"\") — they surface in ValidationSummary alongside any field-level messages but never tag a specific input.",
             Result: CrossFieldSummaryDemo()),
         H2(Class: "h4 mt-5 mb-3")["IValidatableObject — model-level Validate(ctx) alongside attributes"],
         CodeSample(
-            EmbeddedSource.Read("ValidatableObjectDemo.cs"),
+            ["ValidatableObjectDemo.cs"],
             Notes:
             "ASP.NET Core MVC accumulates attribute errors and IValidatableObject errors into the same ModelState — the BCL's own Validator.TryValidateObject silences IValidatableObject as soon as any attribute fails. DataAnnotationsValidator calls the interface directly so both layers always surface together. ValidationResult.MemberNames routes the message: an empty collection lands on FieldIdentifier(model, \"\") (ValidationSummary), a populated one tags a specific field (ValidationMessage). Submit empty to see Name's [Required] and the model's two Validate() results land in the same render.",
             Result: ValidatableObjectDemo()),
         H2(Class: "h4 mt-5 mb-3")["Programmatic — EditContext.Validate() and IsValidating"],
         CodeSample(
-            EmbeddedSource.Read("ProgrammaticValidateDemo.cs"),
+            ["ProgrammaticValidateDemo.cs"],
             Notes:
             "Hold your own EditContext and pass it via Context: on Form to drive validation from anywhere. Calling ctx.ValidateAsync() outside the submit path raises messages without routing through OnValidSubmit/OnInvalidSubmit. ctx.IsValidatingAny flips while async validators run — bind it to a button's Disabled to block submit during in-flight checks.",
             Result: ProgrammaticValidateDemo()),
         H2(Class: "h4 mt-5 mb-3")["FluentValidation — AbstractValidator<TModel>"],
         CodeSample(
-            EmbeddedSource.Read("FluentValidationDemo.cs"),
+            ["FluentValidationDemo.cs"],
             Notes:
             "FluentValidationValidator wraps any IValidator into an IAsyncFieldValidator. Per-keystroke runs use MemberNameValidatorSelector to scope FV to a single property; submit runs every rule on the model.",
             Result: FluentValidationDemo()),
         H2(Class: "h4 mt-5 mb-3")["First-error-wins — inline gates DataAnnotations"],
         CodeSample(
-            EmbeddedSource.Read("FirstErrorWinsDemo.cs"),
+            ["FirstErrorWinsDemo.cs"],
             Notes:
             "The chain runs inline → form-level inline → sync IFieldValidator → async IAsyncFieldValidator. EditContext gates each later stage per-field: once any rule has flagged a field, the later rules on the SAME field stay quiet. Type nothing — only \"Code is required.\" shows. Type \"abc\" — the inline rule passes and DataAnnotations' \"Use the ABC-123 format.\" takes over. Type \"ABC-123\" — both pass and the form submits.",
             Result: FirstErrorWinsDemo()),
         H2(Class: "h4 mt-5 mb-3")["FluentValidation async — MustAsync inside the RuleFor chain"],
         CodeSample(
-            EmbeddedSource.Read("FluentValidationAsyncDemo.cs"),
+            ["FluentValidationAsyncDemo.cs"],
             Notes:
             "FluentValidation's own Cascade(CascadeMode.Stop) mirrors Rask's first-error-wins: NotEmpty must pass before Matches, which must pass before the MustAsync API check fires. Type \"TKT-001\" to see the indicator while the await is in flight, then the \"already reserved\" message land. Type a value not in the reserved set (e.g. \"TKT-999\") to submit successfully. FluentValidationValidator is registered as an IAsyncFieldValidator — async rules and sync rules share the one wrapper.",
             Result: FluentValidationAsyncDemo()),
         H2(Class: "h4 mt-5 mb-3")["Custom ValidationAttribute — IsValid, GetValidationResult, and DI"],
         CodeSample(
-            EmbeddedSource.Read("CustomAttributeDemo.cs"),
+            ["CustomAttributeDemo.cs"],
             Notes:
             "Custom ValidationAttribute subclasses flow through DataAnnotationsValidator with no extra opt-in — System.ComponentModel.DataAnnotations.Validator walks every attribute on the property at validation time. ValidationContext is constructed with the render-scoped IServiceProvider, so attributes can resolve services via ctx.GetService<T>() the same way ASP.NET Core / Blazor's DataAnnotationsValidator do it. Try \"admin\" (NotBanned, DI-resolved), a weak password (StrongPassword.IsValid), or mismatched confirm (MatchesProperty reads ObjectInstance).",
             Result: CustomAttributeDemo())

--- a/samples/Rask.Example.Shared/Shared/CodeSample.cs
+++ b/samples/Rask.Example.Shared/Shared/CodeSample.cs
@@ -22,63 +22,44 @@ public sealed class CodeSample : Component
     private readonly ElementRef _copyButton = ElementRef.New();
 
     // Non-nullable + no initializer + no `required` keyword: the factory generator emits
-    // Source as the first required positional parameter (no default), preserving the
+    // Files as the first required positional parameter (no default), preserving the
     // existing call-site shapes. The CS8618 warnings (here and on the ctor) are intentional —
-    // Rask's post-render property assignment satisfies Source at runtime. `required` is
-    // deliberately omitted to keep `CodeSample(Source: ...)` a plain positional/named argument.
+    // Rask's post-render property assignment satisfies Files at runtime. `required` is
+    // deliberately omitted to keep `CodeSample(Files: ...)` a plain positional/named argument.
 #pragma warning disable CS8618
     public CodeSample(IJSRuntime js) => _js = js;
 
     public string? Title { get; set; }
 
-    public string Source { get; set; }
+    // The demo source files to show, in tab order, as bare embedded-resource leaf names
+    // (e.g. ["ElementRefDemo.cs", "ElementRefDemo.js"]). Each file gets its own tab labelled
+    // with the file name; the syntax-highlight language is inferred from the extension. The
+    // first file is the active tab. The verbatim text is read on demand via EmbeddedSource so
+    // the snippet always compiles and never drifts from what actually runs.
+    public IReadOnlyList<string> Files { get; set; }
 #pragma warning restore CS8618
-
-    // Optional sibling-language sources. When either is set the header shows a C#/JS/CSS
-    // tab strip; otherwise the card keeps its single "C#" label. Both are nullable, so the
-    // generator emits them as optional named factory parameters (default null).
-    public string? Js { get; set; }
-    public string? Css { get; set; }
 
     public Component? Result { get; set; }
     public string? Notes { get; set; }
 
-    // Which language pane is visible. A plain component field (not a reactive prop): the tab
-    // buttons set it and re-render through Rask's live diff — the framework way, no client JS.
-    private enum Lang { Cs, Js, Css }
+    // Index of the visible tab into Files. A plain component field (not a reactive prop): the
+    // tab buttons set it and re-render through Rask's live diff — the framework way, no client JS.
+    private int _active;
 
-    private Lang _active = Lang.Cs;
-
-    // The (raw source, ColorCode language, <code> class) triple for a pane.
-    private (string Source, ILanguage Language, string CodeClass) Pane(Lang lang) => lang switch
+    // The (file name, raw source, ColorCode language, <code> class) tuple for a tab. The
+    // highlight language is inferred from the file extension; an unknown extension falls back
+    // to plain (un-tokenized) text rendered through the Text-encoding code path.
+    private (string File, string Source, ILanguage? Language, string CodeClass) Pane(int index)
     {
-        Lang.Js => (Js!, Languages.JavaScript, "language-javascript"),
-        Lang.Css => (Css!, Languages.Css, "language-css"),
-        _ => (Source, Languages.CSharp, "language-csharp"),
-    };
-
-    private static string Label(Lang lang) => lang switch
-    {
-        Lang.Js => "JS",
-        Lang.Css => "CSS",
-        _ => "C#",
-    };
-
-    // C# is always first; JS/CSS only appear when their source was supplied.
-    private List<Lang> PresentLanguages()
-    {
-        var langs = new List<Lang> { Lang.Cs };
-        if (Js is not null)
+        var file = Files[index];
+        var source = EmbeddedSource.Read(file);
+        return Path.GetExtension(file).ToLowerInvariant() switch
         {
-            langs.Add(Lang.Js);
-        }
-
-        if (Css is not null)
-        {
-            langs.Add(Lang.Css);
-        }
-
-        return langs;
+            ".js" => (file, source, Languages.JavaScript, "language-javascript"),
+            ".css" => (file, source, Languages.Css, "language-css"),
+            ".cs" => (file, source, Languages.CSharp, "language-csharp"),
+            _ => (file, source, null, "language-plaintext"),
+        };
     }
 
     // Syntax highlighting is produced server-side by ColorCode: GetHtmlString tokenizes the
@@ -121,28 +102,27 @@ public sealed class CodeSample : Component
     // so JS needs no DOM read; the button ref lets the scoped JS flash a "Copied!" affordance.
     private async Task CopyAsync()
     {
-        var (source, _, _) = Pane(_active);
+        var (_, source, _, _) = Pane(_active);
         await _js.InvokeVoidAsync("Rask.CodeSample.copy", source, _copyButton);
     }
 
     private Child Header()
     {
-        var present = PresentLanguages();
-        Child languages = present.Count == 1
-            ? Span(Class: "sample-code-label ms-2")["C#"]
+        Child files = Files.Count == 1
+            ? Span(Class: "sample-code-label ms-2")[Files[0]]
             : Span(Class: "sample-tabs ms-2")[
-                present.Select(lang => Button(
+                Files.Select((file, index) => Button(
                     Type: "button",
-                    Class: $"sample-tab{(lang == _active ? " active" : "")}",
-                    Key: Label(lang),
-                    OnClick: () => _active = lang)[Label(lang)])
+                    Class: $"sample-tab{(index == _active ? " active" : "")}",
+                    Key: file,
+                    OnClick: () => _active = index)[file])
             ];
 
         return Div(Class: "sample-code-header")[
             Span(Class: "sample-dot dot-r"),
             Span(Class: "sample-dot dot-y"),
             Span(Class: "sample-dot dot-g"),
-            languages,
+            files,
             Button(
                 Type: "button",
                 Class: "sample-copy",
@@ -158,7 +138,7 @@ public sealed class CodeSample : Component
 
     protected override RenderResult Render()
     {
-        var (activeSource, activeLanguage, codeClass) = Pane(_active);
+        var (_, activeSource, activeLanguage, codeClass) = Pane(_active);
         return Div(Class: "card shadow-sm border-0 mb-4 sample-card")[
             Title is null && Notes is null
                 ? Fragment()
@@ -172,7 +152,13 @@ public sealed class CodeSample : Component
                 Div(Class: "col-md-7 sample-code-col")[
                     Header(),
                     Pre(Class: "sample-code m-0")[
-                        Code(Class: codeClass)[Raw(HighlightedHtml(activeSource, activeLanguage))]
+                        Code(Class: codeClass)[
+                            // A known language is tokenized server-side and injected verbatim;
+                            // an unknown extension falls back to plain, HTML-encoded text.
+                            activeLanguage is null
+                                ? Text(activeSource.TrimEnd())
+                                : Raw(HighlightedHtml(activeSource, activeLanguage))
+                        ]
                     ]
                 ],
                 Div(Class: "col-md-5 sample-result-col p-4")[

--- a/samples/Rask.Example.Shared/Shared/CodeSample.css
+++ b/samples/Rask.Example.Shared/Shared/CodeSample.css
@@ -38,16 +38,17 @@
 }
 
 .sample-code-label {
+    font-family: var(--bs-font-monospace);
     font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
     color: rgba(255, 255, 255, 0.45);
 }
 
-/* Language tabs (C# / JS / CSS) — only rendered when a sample carries more than one
-   language. The active tab is driven by component state through Rask's live diff. */
+/* One tab per source file, labelled with the file name — only rendered when a sample carries
+   more than one file. The active tab is driven by component state through Rask's live diff.
+   The strip wraps so demos that span several files don't overflow the header. */
 .sample-tabs {
     display: inline-flex;
+    flex-wrap: wrap;
     gap: 0.25rem;
 }
 
@@ -55,9 +56,8 @@
     border: 0;
     background: transparent;
     color: rgba(255, 255, 255, 0.5);
+    font-family: var(--bs-font-monospace);
     font-size: 0.72rem;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
     padding: 0.15rem 0.55rem;
     border-radius: 0.35rem;
     cursor: pointer;

--- a/samples/Rask.Example.Shared/Shared/EmbeddedSource.cs
+++ b/samples/Rask.Example.Shared/Shared/EmbeddedSource.cs
@@ -15,20 +15,9 @@ public static class EmbeddedSource
     // memoise per file name (mirrors CodeSample's HighlightCache rationale).
     private static readonly ConcurrentDictionary<string, string> Cache = new(StringComparer.Ordinal);
 
-    // Reads one or more embedded files and joins them with a blank line, so a single tab
-    // can show a pair of sibling files (e.g. ScopedRed.cs + ScopedBlue.cs). File names are
-    // the bare leaf names, e.g. "ElementRefDemo.cs".
-    public static string Read(params string[] fileNames)
-    {
-        if (fileNames.Length == 1)
-        {
-            return ReadOne(fileNames[0]);
-        }
-
-        return string.Join("\n\n", fileNames.Select(ReadOne));
-    }
-
-    private static string ReadOne(string fileName) =>
+    // Reads one embedded file's verbatim text. The file name is the bare leaf name, e.g.
+    // "ElementRefDemo.cs" (CodeSample shows one file per tab, so there is no joining).
+    public static string Read(string fileName) =>
         Cache.GetOrAdd(fileName, static name =>
         {
             using var stream = Asm.GetManifestResourceStream($"raksrc/{name}")

--- a/tests/Rask.Example.Shared.Tests/Demos/CodeSampleTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/CodeSampleTests.cs
@@ -14,7 +14,7 @@ public sealed class CodeSampleTests
         var js = new FakeJsRuntime();
         var host = new LiveHost(
             () => CodeSample(
-                "var x = 1;",
+                ["ElementRefDemo.cs"],
                 "Sample title",
                 Notes: "A note",
                 Result: Div()["the result"]),
@@ -24,9 +24,8 @@ public sealed class CodeSampleTests
 
         Assert.Contains("Sample title", html);
         Assert.Contains("A note", html);
-        // The C# source is tokenized server-side by ColorCode, so `var` is wrapped in a
-        // <span class="keyword"> rather than appearing as the literal contiguous string.
-        Assert.Contains(">var</span>", html);
+        // The C# source is tokenized server-side by ColorCode, so keywords (class/public/…) are
+        // wrapped in <span class="keyword"> rather than appearing as literal contiguous text.
         Assert.Contains("class=\"keyword\"", html);
         Assert.Contains("the result", html);
         Assert.Contains("sample-card", html);
@@ -37,27 +36,29 @@ public sealed class CodeSampleTests
     {
         var js = new FakeJsRuntime();
         var host = new LiveHost(
-            () => CodeSample("code"),
+            () => CodeSample(["ElementRefDemo.js"]),
             TestServices.Default(js: js));
 
         var html = host.RenderAsLiveRoot();
 
         // Header card-header is only emitted when at least one of Title/Notes is set.
         Assert.DoesNotContain("card-header", html);
-        Assert.Contains("code", html);
+        // The real embedded JS source is shown.
+        Assert.Contains("getBoundingClientRect", html);
     }
 
     [Fact]
-    public void Render_SingleLanguage_KeepsCSharpLabel_NoTabStrip_HasCopyButton()
+    public void Render_SingleFile_ShowsFilenameLabel_NoTabStrip_HasCopyButton()
     {
         var host = new LiveHost(
-            () => CodeSample("var x = 1;"),
+            () => CodeSample(["ElementRefDemo.cs"]),
             TestServices.Default(js: new FakeJsRuntime()));
 
         var html = host.RenderAsLiveRoot();
 
-        // A C#-only sample keeps the plain label and shows no tab strip (back-compat).
+        // A single-file sample shows the file name as a plain label, no clickable tab strip.
         Assert.Contains("sample-code-label", html);
+        Assert.Contains("ElementRefDemo.cs", html);
         Assert.DoesNotContain("sample-tabs", html);
         // The copy button is present on every card.
         Assert.Contains("sample-copy", html);
@@ -65,40 +66,30 @@ public sealed class CodeSampleTests
     }
 
     [Fact]
-    public void Render_MultiLanguage_ShowsTabsWithCSharpActive_AndOnlyActivePane()
+    public void Render_MultiFile_ShowsFilenameTabs_FirstActive_OnlyActivePane()
     {
         var host = new LiveHost(
-            () => CodeSample(
-                "var x = 1;",
-                Js: "export function f() { return 1; }",
-                Css: ".a { color: red; }"),
+            () => CodeSample(["ElementRefDemo.cs", "ElementRefDemo.js"]),
             TestServices.Default(js: new FakeJsRuntime()));
 
         var html = host.RenderAsLiveRoot();
 
-        // A tab strip with one button per supplied language, C# active by default.
+        // A tab strip with one button per file, labelled by file name, first file active.
         Assert.Contains("sample-tabs", html);
         Assert.Contains("sample-tab active", html);
-        Assert.Contains(">C#</button>", html);
-        Assert.Contains(">JS</button>", html);
-        Assert.Contains(">CSS</button>", html);
-        // Only the active (C#) pane is rendered — the JS/CSS panes appear after a tab switch.
+        Assert.Contains(">ElementRefDemo.cs</button>", html);
+        Assert.Contains(">ElementRefDemo.js</button>", html);
+        // Only the active (first, C#) pane is rendered — the JS pane appears after a tab switch.
         Assert.Contains("language-csharp", html);
         Assert.DoesNotContain("language-javascript", html);
-        Assert.DoesNotContain("language-css", html);
     }
 
     [Fact]
-    public void EmbeddedSource_ReadsRealFileText_AndJoinsMultiple()
+    public void EmbeddedSource_ReadsRealFileText()
     {
         // The real scoped JS the ElementRef sample shows must be readable from the manifest.
         var js = EmbeddedSource.Read("ElementRefDemo.js");
         Assert.Contains("getBoundingClientRect", js);
-
-        // Multiple files join into one pane (the scoped-CSS sample shows both stylesheets).
-        var css = EmbeddedSource.Read("ScopedRed.css", "ScopedBlue.css");
-        Assert.Contains("#d23030", css); // red dot
-        Assert.Contains("#0066B3", css); // blue dot
     }
 
     [Fact]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -178,12 +178,13 @@ public abstract partial class SharedSmokeTests
             await Page.EvaluateAsync<bool>("() => typeof window.Rask === 'object' && window.Rask !== null"),
             "scoped JS namespace window.Rask is missing — component JS did not load");
 
-        // Code sample tabs + copy: the Element refs sample shows the real component (C# tab) and
-        // its sibling scoped JS (JS tab). Switching tabs is a Rask state round-trip that swaps the
-        // highlighted pane; clicking copy runs the scoped Rask.CodeSample.copy, which flashes
-        // "Copied!" (resilient to headless clipboard restrictions via its execCommand fallback).
+        // Code sample tabs + copy: the Element refs sample shows the real component
+        // (ElementRefDemo.cs tab) and its sibling scoped JS (ElementRefDemo.js tab). Switching
+        // tabs is a Rask state round-trip that swaps the highlighted pane; clicking copy runs the
+        // scoped Rask.CodeSample.copy, which flashes "Copied!" (resilient to headless clipboard
+        // restrictions via its execCommand fallback).
         var codeCard = Page.Locator("main .sample-code-col").First;
-        await codeCard.Locator(".sample-tab:has-text('JS')").ClickAsync();
+        await codeCard.Locator(".sample-tab:has-text('ElementRefDemo.js')").ClickAsync();
         await Expect(codeCard.Locator(".sample-code"))
             .ToContainTextAsync("getBoundingClientRect", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await codeCard.Locator(".sample-copy").ClickAsync();


### PR DESCRIPTION
## Summary
Showcase code samples now render **one tab per source file, labelled with its file name**. `CodeSample` previously grouped panes by language (`C#`/`JS`/`CSS`) and concatenated sibling files of the same language into a single pane — so multi-file demos (Scoped CSS, Context, Background service) hid which file you were looking at, and the JS/CSS panes lumped files together. It now takes an ordered list of embedded file names, reads each individually, infers the highlight language from the extension, and gives every file its own filename-labelled tab.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — `Rask.Example.Shared.Tests` 252 passed (incl. 6 reworked `CodeSampleTests`); full serial `dotnet build Rask.slnx -warnaserror` clean (0 warnings, 0 errors).
- E2E (`samples/` changed): host Server — not run locally (heavy); the `SharedSmokeTests.Journey` tab-click selector was updated to `ElementRefDemo.js` and compiles. CI sharded E2E matrix will exercise it.

## Benchmarks
n/a — sample-app code only, no framework render/runtime hotpath change.

## CHANGELOG
- [Unreleased] entry added: showcase code samples show one tab per source file labelled with its file name.
