### PR TITLE
fix(live): reparse changed Raw frames via morph instead of escaping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **Switching a syntax-highlighted code-sample tab no longer renders the new pane's markup as
+  literal text.** A live re-render that replaced one `Raw` value with another (e.g. switching a
+  `CodeSample` tab from highlighted C# to highlighted CSS) shipped an in-place `UpdateText` diff op,
+  which the client applied via `textContent` — escaping the token `<span>` markup into visible
+  `<span class="cssSelector">…` text and only touching the first of the `Raw`'s several DOM nodes.
+  A `Raw` value change is now treated as a structural replace that routes through the full-HTML
+  morph, so the browser reparses the new markup into real token spans. Unchanged `Raw` values still
+  diff to zero ops; `Text` nodes are unaffected.
+
 ### Changed
 - **Showcase & auth samples reorganized into feature folders.** `samples/Rask.Example.Shared`
   moved from flat `Pages/` + `Demos/` + `Layout/` to per-feature folders under `Features/` with

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -292,12 +292,21 @@ public static class FrameDiffer
                 }
 
                 case RenderFrameKind.Text:
-                case RenderFrameKind.Raw:
                     if (!string.Equals(oldFrame.Name, newFrame.Name, StringComparison.Ordinal))
                     {
                         output.Add(new EditOp(EditOpKind.UpdateText, PathPlus(path, domSlot), null, newFrame.Name));
                     }
 
+                    oi++;
+                    ni++;
+                    domSlot++;
+                    break;
+
+                case RenderFrameKind.Raw:
+                    // Only equal-valued Raw frames reach here — a changed Raw is a SiblingMatches
+                    // non-match (see SiblingMatches) and already shipped as Remove+Insert above, so
+                    // there is nothing to patch in place. Advance past the (single) Raw frame and
+                    // its DOM slot to keep the positional walk aligned.
                     oi++;
                     ni++;
                     domSlot++;
@@ -432,6 +441,14 @@ public static class FrameDiffer
         return a.Kind switch
         {
             RenderFrameKind.Element => string.Equals(a.Name, b.Name, StringComparison.Ordinal),
+            // A Raw frame's verbatim markup parses into a *variable-length* run of sibling DOM
+            // nodes with no boundary the client can address by path, so a changed Raw cannot be
+            // patched in place: UpdateText would both HTML-escape the markup (showing literal
+            // <span> tags) and only touch the run's first node. Treat differing Raw values as a
+            // non-match so the value change ships as an untrusted Remove+Insert, which routes to
+            // the full-HTML morph (LiveDiffGate.DiffOpsAreClientSupported) — the morph reparses
+            // the new markup correctly. Equal Raw values match and produce no op.
+            RenderFrameKind.Raw => string.Equals(a.Name, b.Name, StringComparison.Ordinal),
             _ => true
         };
     }

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -1263,14 +1263,12 @@
                 case 3: { // UpdateText [k, path, value]
                     var textNode = resolvePath(path);
                     if (textNode) {
-                        // Works for Text nodes (nodeType 3) and elements alike. We assign
-                        // .textContent (rather than .nodeValue) so the path resolving to
-                        // a Raw-rendered element still gets cleared and refilled — Raw
-                        // frames in the C# stream serialize verbatim markup into a
-                        // single string, which corresponds to a sequence of DOM nodes
-                        // the browser parsed. The current diff codec only emits
-                        // UpdateText when both sides are the SAME kind (Text vs Text or
-                        // Raw vs Raw), so textContent is the right knob.
+                        // UpdateText only ever targets a Text node now: the diff codec emits it
+                        // exclusively for changed Text frames (HTML-encoded content), so
+                        // .textContent is the correct knob. A changed Raw frame is NOT an
+                        // UpdateText — its verbatim markup parses into a variable run of DOM
+                        // nodes that textContent would escape and could not fully replace, so the
+                        // codec ships it as a Remove+Insert that routes to the full-HTML morph.
                         var txtVal = op[2];
                         textNode.textContent = txtVal == null ? "" : txtVal;
                     }

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -42,6 +42,45 @@ public class FrameDifferTests
     }
 
     [Fact]
+    public void Diff_RawValueUnchanged_ProducesZeroOps()
+    {
+        // An identical Raw value must produce no ops — the verbatim markup is the same
+        // string, so there is nothing to patch (and certainly no spurious UpdateText).
+        var before = Frames(Code()[Raw("<span class=\"keyword\">class</span> Foo")]);
+        var after = Frames(Code()[Raw("<span class=\"keyword\">class</span> Foo")]);
+
+        var ops = new List<EditOp>();
+        FrameDiffer.Diff(before, after, ops);
+
+        Assert.Empty(ops);
+    }
+
+    [Fact]
+    public void Diff_RawValueChanged_ProducesRemoveAndInsert_NotUpdateText()
+    {
+        // Regression: switching a syntax-highlight code tab swaps one Raw value
+        // (highlighted C#) for another (highlighted CSS). A Raw's markup parses into a
+        // variable run of sibling DOM nodes, so it must NOT ship as an in-place UpdateText
+        // (which sets textContent — escaping the markup into literal <span> text and only
+        // touching the first node). It must ship as a Remove + Insert that routes to the
+        // full-HTML morph so the browser reparses the new markup.
+        var before = Frames(Code()[Raw("<span class=\"keyword\">class</span> Foo")]);
+        var (after, afterHtml) = FramesAndHtml(Code()[Raw("<span class=\"cssSelector\">.box </span>{ }")]);
+
+        var ops = new List<EditOp>();
+        FrameDiffer.Diff(before, after, ops, afterHtml);
+
+        Assert.DoesNotContain(ops, o => o.Kind == EditOpKind.UpdateText);
+        Assert.Contains(ops, o => o.Kind == EditOpKind.RemoveSubtree);
+        Assert.Contains(ops, o => o.Kind == EditOpKind.InsertSubtree);
+
+        // The replace ops are untrusted positional structural ops, so the live session
+        // routes the whole render to the full-HTML morph rather than applying them directly
+        // — the morph reparses the new markup instead of escaping it.
+        Assert.False(LiveDiffGate.DiffOpsAreClientSupported(ops));
+    }
+
+    [Fact]
     public void Diff_AttributeValueChanged_ProducesSingleSetAttributeOp()
     {
         var before = Frames(Input("text", "f", "old", "edit"));

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -187,6 +187,14 @@ public abstract partial class SharedSmokeTests
         await codeCard.Locator(".sample-tab:has-text('ElementRefDemo.js')").ClickAsync();
         await Expect(codeCard.Locator(".sample-code"))
             .ToContainTextAsync("getBoundingClientRect", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        // Regression: switching tabs swaps the highlighted pane by replacing one Raw value
+        // (highlighted C#) with another (highlighted JS) over the live diff. The new markup must
+        // be reparsed into REAL token <span> elements — not escaped into literal "<span …>" text
+        // (which is what a textContent-based Raw update produced, ToContainText above can't catch
+        // it because the escaped text still "contains" the substring). Require a real token span
+        // element in the freshly-switched pane.
+        await Expect(codeCard.Locator(".sample-code code span[class]").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
         await codeCard.Locator(".sample-copy").ClickAsync();
         await Expect(codeCard.Locator(".sample-copy"))
             .ToContainTextAsync("Copied!", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });


### PR DESCRIPTION
## Summary
Switching a syntax-highlighted code-sample tab (e.g. the Scoped CSS page) rendered the new pane's token markup as **literal text** (`<span class="cssPropertyName">…` shown verbatim). The live-diff codec emitted an in-place `UpdateText` op for a changed `Raw` frame, which the client applies via `textContent` — escaping the markup and only touching the first of the `Raw`'s several parsed DOM nodes. A changed `Raw` is now a `SiblingMatches` non-match, so it ships as an untrusted `Remove`+`Insert` that routes through the existing full-HTML morph, which reparses the markup into real token spans. Fix lives in shared `FrameDiffer`/`LiveDiffGate`, so both the Server (WS) and WASM transports are covered. (The horizontal "clipping" in the bug report was a symptom of the over-long escaped lines, not a separate issue — `.sample-code` already has `overflow-x: auto`.)

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — green. Added 2 `FrameDiffer` tests (changed `Raw` → `Remove`+`Insert` and not client-supported; unchanged `Raw` → 0 ops).
- E2E: host **Server** (`ServerExampleTests.Journey`) — passed (35s). Strengthened the existing tab-switch assertion to require real token `span[class]` elements — the prior `textContent` check is exactly why this regression shipped unnoticed (escaped text still "contains" the substring).

## Benchmarks
`FrameDifferBenchmarks` Allocated before → after, byte-identical across all 8 cases (the new `Raw` arm isn't on the keyed/text hot path): e.g. Reorder@1000 `70.41 KB → 70.41 KB`, Text@100 `7.1 KB → 7.1 KB`, NoChange@1000 `70.34 KB → 70.34 KB`. No regression.

## CHANGELOG
- [Unreleased] entry added: changed `Raw` values now route through the morph instead of an escaping `UpdateText`, so tab-switched highlight markup renders as real spans.
