### PR TITLE
refactor(assets): use rel=prefetch for off-route scoped asset warming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,17 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
-- **Eager preload of scoped CSS/JS eliminates navigation FOUC.** The page `<head>` now also
-  emits a non-blocking `<link rel="preload" fetchpriority="low">` for *every* registered scoped
-  asset — not just the components on the current route — so when a component first mounts later
-  (client-side navigation, a conditionally rendered section) its stylesheet/script is already in
-  the browser cache: the body swaps with no flash of unstyled content and the scoped-JS namespace
-  is ready on first interaction. The preload markup is render-independent and cached (rebuilt only
-  when the asset set changes), so it costs a single append per render. On by default; opt out with
-  `AddRask(o => o.PreloadScopedAssets = false)` (or the equivalent WASM host-builder option) to
-  fetch each scoped asset only when its component first mounts.
+- **Eager prefetch of scoped CSS/JS eliminates navigation FOUC.** The page `<head>` now also
+  emits a low-priority `<link rel="prefetch">` for *every* registered scoped asset — not just the
+  components on the current route — so when a component first mounts later (client-side navigation,
+  a conditionally rendered section) its stylesheet/script is already in the browser cache: the body
+  swaps with no flash of unstyled content and the scoped-JS namespace is ready on first
+  interaction. `prefetch` (rather than `preload`) keeps these hints at the lowest priority and
+  avoids a *"resource preloaded but not used"* console warning for off-route assets. The markup is
+  render-independent and cached (rebuilt only when the asset set changes), so it costs a single
+  append per render. On by default; opt out with `AddRask(o => o.PreloadScopedAssets = false)` (or
+  the equivalent WASM host-builder option) to fetch each scoped asset only when its component first
+  mounts.
 
 ### Fixed
 - **Switching a syntax-highlighted code-sample tab no longer renders the new pane's markup as

--- a/README.md
+++ b/README.md
@@ -213,8 +213,8 @@ public sealed class App : Component
 Both `<head>` and `<body>` are framework-managed. `<head>` collects every component's `Head`
 override during render, dedupes contributions, resolves singleton tags (`<title>`, `<base>` — last
 contributor wins), and splices the result plus the scoped-CSS link and scoped-JS bundle script in
-automatically — passing children to `Head()` is a `RASK019` compile error. It also preloads every
-registered scoped asset up front (non-blocking `<link rel="preload">`) so client-side navigation to
+automatically — passing children to `Head()` is a `RASK019` compile error. It also prefetches every
+registered scoped asset up front (low-priority `<link rel="prefetch">`) so client-side navigation to
 a not-yet-mounted component is flash-free; opt out with `AddRask(o => o.PreloadScopedAssets = false)`. `<body>` gets the live
 runtime `<script>` injected as its last child automatically, so you no longer write
 `RaskRuntimeScript()`. The root must render the full shell (`Doctype`, `Html`, `Head`, `Body`); a

--- a/benchmarks/Rask.Benchmarks/AssetLoadingBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AssetLoadingBenchmarks.cs
@@ -199,8 +199,8 @@ public class AssetLoadingBenchmarks
     }
 
     // ──────────────────────────────────────────────────────────────────────
-    // EmitScopedPreloads: the eager-preload pass ApplyTo runs after
-    // EmitMountedAssets. The <link rel="preload"> block is render-independent
+    // EmitScopedPreloads: the eager-prefetch pass ApplyTo runs after
+    // EmitMountedAssets. The <link rel="prefetch"> block is render-independent
     // and cached (rebuilt only when the registry mutates), so the steady-state
     // per-render cost is a single Append of the cached string — no rebuild, no
     // per-render registry snapshot. This warm-cache bench captures that cost.

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -144,19 +144,20 @@ is served at `/_rask/a/{hash}.{ext}` with `Cache-Control: immutable`, an `ETag`,
 `<script defer>` per mounted component type that has a registered asset. Static-file and
 WASM hosts get the same files baked to disk by the `BakeScopedAssetsTask` MSBuild task.
 
-### Eager preload
+### Eager prefetch
 
-By default the `<head>` *also* emits a non-blocking
-`<link rel="preload" fetchpriority="low">` for **every** registered scoped asset — not
-just the components on the current route. This warms the browser's HTTP cache up front, so
-when a component first mounts later (client-side navigation, a conditionally rendered
-section) its stylesheet/script is already loaded: the body swaps with **no flash of
-unstyled content** and the scoped-JS namespace is ready on first interaction. The preload
-links are inert (`rel="preload"`, neither a render-blocking stylesheet nor an executable
-script), `fetchpriority="low"` so they never compete with first paint, and the markup is
-cached so it costs a single append per render. Scoped CSS is selector-rewritten to
-`[data-r-xxxx]`, so preloading an unmounted component's styles has no visual effect until
-its elements exist.
+By default the `<head>` *also* emits a low-priority `<link rel="prefetch">` for **every**
+registered scoped asset — not just the components on the current route. This warms the
+browser's HTTP cache up front, so when a component first mounts later (client-side
+navigation, a conditionally rendered section) its stylesheet/script is already loaded: the
+body swaps with **no flash of unstyled content** and the scoped-JS namespace is ready on
+first interaction. `prefetch` (rather than `preload`) is the future-navigation hint — it
+sits at the lowest priority so it never competes with the current route's critical
+resources, and it raises no *"resource preloaded but not used"* console warning for the
+off-route assets a visitor may never reach. The links are inert (`rel="prefetch"`, neither
+a render-blocking stylesheet nor an executable script), and the markup is cached so it
+costs a single append per render. Scoped CSS is selector-rewritten to `[data-r-xxxx]`, so
+prefetching an unmounted component's styles has no visual effect until its elements exist.
 
 Opt out — to fetch each scoped asset only when its component first mounts (smaller
 first-load payload, at the cost of a brief navigation FOUC the first time each new

--- a/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
+++ b/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
@@ -199,7 +199,7 @@ internal sealed class HeadAssetRegistry
         {
             var perComponentSb = RaskStringBuilderPool.Shared.Get();
             EmitMountedAssets(perComponentSb, liveCtx.MountedTypes);
-            // Eager preload of every registered scoped asset (not just the mounted ones) so a
+            // Eager prefetch of every registered scoped asset (not just the mounted ones) so a
             // later mount finds its stylesheet/script already cached — no navigation FOUC.
             // Appended after the mounted, render-blocking assets so those keep discovery priority.
             EmitScopedPreloads(perComponentSb);
@@ -371,18 +371,20 @@ internal sealed class HeadAssetRegistry
     }
 
     /// <summary>
-    ///     Appends a block of non-blocking <c>&lt;link rel="preload" fetchpriority="low"&gt;</c>
-    ///     hints for <em>every</em> registered scoped asset — not just the mounted ones — so a
-    ///     later mount (client-side navigation, a conditionally rendered section) finds its
-    ///     stylesheet/script already in the HTTP cache: the body swaps with no flash of unstyled
-    ///     content and the scoped-JS namespace is ready on first interaction. No-op when
+    ///     Appends a block of low-priority <c>&lt;link rel="prefetch"&gt;</c> hints for
+    ///     <em>every</em> registered scoped asset — not just the mounted ones — so a later mount
+    ///     (client-side navigation, a conditionally rendered section) finds its stylesheet/script
+    ///     already in the HTTP cache: the body swaps with no flash of unstyled content and the
+    ///     scoped-JS namespace is ready on first interaction. <c>prefetch</c> (rather than
+    ///     <c>preload</c>) is the future-navigation hint — it never competes with the current
+    ///     route's critical resources and raises no "resource preloaded but not used" console
+    ///     warning for assets the visitor never navigates to. No-op when
     ///     <see cref="LiveOptions.PreloadScopedAssets" /> is <c>false</c>. The markup is
     ///     render-independent and cached (rebuilt only when the asset set changes via hot
     ///     reload), so the steady-state cost is a single <see cref="StringBuilder.Append(string)" />.
-    ///     Emitted after <see cref="EmitMountedAssets" /> so the mounted route's render-blocking
-    ///     assets keep discovery priority; the preload links are inert to the client invoke gate
-    ///     and FOUC guard (they are <c>rel="preload"</c>, neither a <c>&lt;script&gt;</c> nor a
-    ///     <c>rel="stylesheet"</c> link).
+    ///     Emitted after <see cref="EmitMountedAssets" />; the prefetch links are inert to the
+    ///     client invoke gate and FOUC guard (they are <c>rel="prefetch"</c>, neither a
+    ///     <c>&lt;script&gt;</c> nor a <c>rel="stylesheet"</c> link).
     /// </summary>
     internal static void EmitScopedPreloads(StringBuilder sb)
     {
@@ -395,7 +397,7 @@ internal sealed class HeadAssetRegistry
         sb.Append(GetScopedPreloadBlock());
     }
 
-    // Cached <link rel="preload"> markup for every registered scoped asset. Built lazily and
+    // Cached <link rel="prefetch"> markup for every registered scoped asset. Built lazily and
     // reused across renders; rebuilt only when the registry mutates (tracked by
     // ScopedAssetRegistry.Version) or the URL prefix changes (PathBase). The record is published
     // atomically (single volatile reference), so readers never see a torn field tuple.
@@ -431,18 +433,27 @@ internal sealed class HeadAssetRegistry
         {
             var isCss = entry.Kind == AssetKind.Css;
 
-            // <link rel="preload" as="style|script" href="{PathBase}/_rask/a/{hash}.{ext}"
-            //       fetchpriority="low" data-rask-key="rsk-preload-{css|js}-{hash}">
-            sb.Append("<link rel=\"preload\" as=\"");
+            // rel="prefetch" (not "preload"): this block covers every registered asset, most of
+            // which are off-route and may not be used at all this session. "prefetch" is the
+            // future-navigation hint — lowest priority (never competes with the current route's
+            // critical resources) and, unlike "preload", it raises no "resource preloaded but not
+            // used within a few seconds" console warning for assets the visitor never navigates to.
+            // `as` is kept so the browser sets the right Accept header and cache partition. The
+            // current route's mounted assets already ship as a render-blocking <link>/<script>
+            // (EmitMountedAssets); a coincident low-priority prefetch for the same href coalesces.
+            //
+            // <link rel="prefetch" as="style|script" href="{PathBase}/_rask/a/{hash}.{ext}"
+            //       data-rask-key="rsk-prefetch-{css|js}-{hash}">
+            sb.Append("<link rel=\"prefetch\" as=\"");
             sb.Append(isCss ? "style" : "script");
             sb.Append("\" href=\"");
             sb.Append(pathBase);
             sb.Append("/_rask/a/");
             sb.Append(entry.Hash);
             sb.Append(isCss ? ".css" : ".js");
-            sb.Append("\" fetchpriority=\"low\" data-rask-key=\"");
+            sb.Append("\" data-rask-key=\"");
             sb.Append(FrameworkAssetKeyPrefix);
-            sb.Append(isCss ? "preload-css-" : "preload-js-");
+            sb.Append(isCss ? "prefetch-css-" : "prefetch-js-");
             sb.Append(entry.Hash);
             sb.Append("\">");
         }

--- a/src/Rask.Core/Live/LiveOptions.cs
+++ b/src/Rask.Core/Live/LiveOptions.cs
@@ -87,17 +87,19 @@ public sealed class RaskLiveOptions
     }
 
     /// <summary>
-    ///     Whether the framework eagerly preloads <em>every</em> registered scoped CSS and
-    ///     JS asset into the page <c>&lt;head&gt;</c> on first render via non-blocking
-    ///     <c>&lt;link rel="preload" fetchpriority="low"&gt;</c> hints — not just the assets of
-    ///     components mounted on the current route. <c>true</c> (default) warms the HTTP cache
-    ///     up front so a later mount (client-side navigation, a conditional section) finds its
-    ///     scoped stylesheet/script already loaded: the body swaps with no flash of unstyled
-    ///     content and no first-interaction wait for the scoped JS namespace. Scoped CSS is
-    ///     selector-rewritten to <c>[data-r-xxxx]</c>, so preloading an unmounted component's
-    ///     styles has no visual effect until its elements exist. Set <c>false</c> to fetch each
-    ///     scoped asset only when its component first mounts (smaller first-load payload, at the
-    ///     cost of a brief navigation FOUC the first time each new component type appears).
+    ///     Whether the framework eagerly warms <em>every</em> registered scoped CSS and JS asset
+    ///     into the page <c>&lt;head&gt;</c> on first render via low-priority
+    ///     <c>&lt;link rel="prefetch"&gt;</c> hints — not just the assets of components mounted on
+    ///     the current route. <c>true</c> (default) warms the HTTP cache up front so a later mount
+    ///     (client-side navigation, a conditional section) finds its scoped stylesheet/script
+    ///     already loaded: the body swaps with no flash of unstyled content and no first-interaction
+    ///     wait for the scoped JS namespace. <c>prefetch</c> keeps these hints below the current
+    ///     route's critical resources and avoids a <c>"resource preloaded but not used"</c> console
+    ///     warning for off-route assets. Scoped CSS is selector-rewritten to <c>[data-r-xxxx]</c>,
+    ///     so prefetching an unmounted component's styles has no visual effect until its elements
+    ///     exist. Set <c>false</c> to fetch each scoped asset only when its component first mounts
+    ///     (smaller first-load payload, at the cost of a brief navigation FOUC the first time each
+    ///     new component type appears).
     /// </summary>
     public bool PreloadScopedAssets { get; set; } = true;
 }

--- a/tests/Rask.Core.Tests/HeadAssets/ScopedPreloadEmissionTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/ScopedPreloadEmissionTests.cs
@@ -9,13 +9,12 @@ using Rask.TestSupport;
 namespace Rask.Core.Tests.HeadAssets;
 
 /// <summary>
-///     Covers <see cref="HeadAssetRegistry.EmitScopedPreloads" /> — the eager preload pass that
-///     emits one non-blocking <c>&lt;link rel="preload" fetchpriority="low"&gt;</c> per
-///     <em>registered</em> scoped asset (not just the mounted ones), so a later mount finds its
-///     stylesheet/script already cached and swaps with no FOUC. Gated by
-///     <see cref="LiveOptions.PreloadScopedAssets" /> (default on); the markup is cached and only
-///     rebuilt when the registry mutates (<see cref="ScopedAssetRegistry.Version" />) or the URL
-///     prefix changes.
+///     Covers <see cref="HeadAssetRegistry.EmitScopedPreloads" /> — the eager prefetch pass that
+///     emits one low-priority <c>&lt;link rel="prefetch"&gt;</c> per <em>registered</em> scoped
+///     asset (not just the mounted ones), so a later mount finds its stylesheet/script already
+///     cached and swaps with no FOUC. Gated by <see cref="LiveOptions.PreloadScopedAssets" />
+///     (default on); the markup is cached and only rebuilt when the registry mutates
+///     (<see cref="ScopedAssetRegistry.Version" />) or the URL prefix changes.
 /// </summary>
 [Collection("ScopedAssets")]
 public sealed class ScopedPreloadEmissionTests : IDisposable
@@ -52,7 +51,7 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
     }
 
     [Fact]
-    public void Enabled_EmitsNonBlockingPreloadLinkForCss()
+    public void Enabled_EmitsPrefetchLinkForCss()
     {
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
         ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hash);
@@ -60,17 +59,17 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         var html = Emit();
 
         Assert.Contains(
-            $"<link rel=\"preload\" as=\"style\" href=\"/_rask/a/{hash}.css\" fetchpriority=\"low\" " +
-            $"data-rask-key=\"rsk-preload-css-{hash}\">",
+            $"<link rel=\"prefetch\" as=\"style\" href=\"/_rask/a/{hash}.css\" " +
+            $"data-rask-key=\"rsk-prefetch-css-{hash}\">",
             html);
-        // Preload links must be inert to the cascade and the client invoke gate: never a
+        // Prefetch links must be inert to the cascade and the client invoke gate: never a
         // render-blocking stylesheet, never a deferred script.
         Assert.DoesNotContain("rel=\"stylesheet\"", html);
         Assert.DoesNotContain("<script", html);
     }
 
     [Fact]
-    public void Enabled_EmitsNonBlockingPreloadLinkForJs()
+    public void Enabled_EmitsPrefetchLinkForJs()
     {
         ScopedAssetRegistry.RegisterJs(typeof(JsOnly), "export function f() {}");
         ScopedAssetRegistry.TryGetJs(typeof(JsOnly), out var hash);
@@ -78,16 +77,16 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         var html = Emit();
 
         Assert.Contains(
-            $"<link rel=\"preload\" as=\"script\" href=\"/_rask/a/{hash}.js\" fetchpriority=\"low\" " +
-            $"data-rask-key=\"rsk-preload-js-{hash}\">",
+            $"<link rel=\"prefetch\" as=\"script\" href=\"/_rask/a/{hash}.js\" " +
+            $"data-rask-key=\"rsk-prefetch-js-{hash}\">",
             html);
         Assert.DoesNotContain(" defer ", html);
     }
 
     [Fact]
-    public void Enabled_PreloadsEveryRegisteredAsset_NotJustOne()
+    public void Enabled_PrefetchesEveryRegisteredAsset_NotJustOne()
     {
-        // The preload pass takes no mounted-types argument — it covers the whole registry, so a
+        // The prefetch pass takes no mounted-types argument — it covers the whole registry, so a
         // component that is registered but not on the current route is still warmed.
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".a { color: red; }");
         ScopedAssetRegistry.RegisterCss(typeof(WidgetB), ".b { color: blue; }");
@@ -96,13 +95,13 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
 
         var html = Emit();
 
-        Assert.Contains($"rsk-preload-css-{hashA}", html);
-        Assert.Contains($"rsk-preload-css-{hashB}", html);
-        Assert.Equal(2, CountOccurrences(html, "rel=\"preload\""));
+        Assert.Contains($"rsk-prefetch-css-{hashA}", html);
+        Assert.Contains($"rsk-prefetch-css-{hashB}", html);
+        Assert.Equal(2, CountOccurrences(html, "rel=\"prefetch\""));
     }
 
     [Fact]
-    public void Enabled_EmitsCssPreloadsBeforeJsPreloads()
+    public void Enabled_EmitsCssPrefetchesBeforeJsPrefetches()
     {
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
         ScopedAssetRegistry.RegisterJs(typeof(JsOnly), "export function f() {}");
@@ -112,7 +111,7 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         var stylePos = html.IndexOf("as=\"style\"", StringComparison.Ordinal);
         var scriptPos = html.IndexOf("as=\"script\"", StringComparison.Ordinal);
         Assert.True(stylePos >= 0 && scriptPos >= 0);
-        Assert.True(stylePos < scriptPos, "CSS preloads should precede JS preloads");
+        Assert.True(stylePos < scriptPos, "CSS prefetches should precede JS prefetches");
     }
 
     [Fact]
@@ -127,7 +126,7 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         Assert.Contains($"href=\"/appA/_rask/a/{hash}.css\"", html);
         Assert.DoesNotContain("//_rask/a/", html);
         // The data-rask-key payload must not be re-prefixed.
-        Assert.Contains($"data-rask-key=\"rsk-preload-css-{hash}\"", html);
+        Assert.Contains($"data-rask-key=\"rsk-prefetch-css-{hash}\"", html);
     }
 
     [Fact]
@@ -144,8 +143,8 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".a { color: red; }");
         ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hashA);
         var first = Emit();
-        Assert.Contains($"rsk-preload-css-{hashA}", first);
-        Assert.Equal(1, CountOccurrences(first, "rel=\"preload\""));
+        Assert.Contains($"rsk-prefetch-css-{hashA}", first);
+        Assert.Equal(1, CountOccurrences(first, "rel=\"prefetch\""));
 
         // Registering a second asset bumps ScopedAssetRegistry.Version → the cached block is
         // recomputed and now covers both assets.
@@ -153,16 +152,16 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         ScopedAssetRegistry.TryGetCss(typeof(WidgetB), out var hashB);
         var second = Emit();
 
-        Assert.Contains($"rsk-preload-css-{hashA}", second);
-        Assert.Contains($"rsk-preload-css-{hashB}", second);
+        Assert.Contains($"rsk-prefetch-css-{hashA}", second);
+        Assert.Contains($"rsk-prefetch-css-{hashB}", second);
     }
 
     [Fact]
-    public void ApplyTo_EmitsPreloadForOffRouteAsset_AlongsideMountedStylesheet()
+    public void ApplyTo_EmitsPrefetchForOffRouteAsset_AlongsideMountedStylesheet()
     {
         // End-to-end through the real head pipeline: CssOnly is mounted; WidgetA is registered
         // but off-route. The mounted type gets a render-blocking stylesheet; both types get a
-        // non-blocking preload so navigating to WidgetA later hits a warm cache (no FOUC).
+        // low-priority prefetch so navigating to WidgetA later hits a warm cache (no FOUC).
         ScopedAssetRegistry.RegisterCss(typeof(CssOnly), ".m { color: green; }");
         ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".o { color: red; }");
         ScopedAssetRegistry.TryGetCss(typeof(CssOnly), out var mountedHash);
@@ -176,12 +175,12 @@ public sealed class ScopedPreloadEmissionTests : IDisposable
         var html = new HeadAssetRegistry().ApplyTo("<head><!--__rask_head_assets__--></head>");
 
         Assert.Contains($"data-rask-key=\"rsk-css-{mountedHash}\"", html);
-        Assert.Contains($"rsk-preload-css-{mountedHash}", html);
-        Assert.Contains($"rsk-preload-css-{offRouteHash}", html);
-        // Cascade order: the render-blocking stylesheet precedes the non-blocking preload block.
+        Assert.Contains($"rsk-prefetch-css-{mountedHash}", html);
+        Assert.Contains($"rsk-prefetch-css-{offRouteHash}", html);
+        // Cascade order: the render-blocking stylesheet precedes the low-priority prefetch block.
         var sheetPos = html.IndexOf("rel=\"stylesheet\"", StringComparison.Ordinal);
-        var preloadPos = html.IndexOf("rel=\"preload\"", StringComparison.Ordinal);
-        Assert.True(sheetPos >= 0 && preloadPos >= 0 && sheetPos < preloadPos);
+        var prefetchPos = html.IndexOf("rel=\"prefetch\"", StringComparison.Ordinal);
+        Assert.True(sheetPos >= 0 && prefetchPos >= 0 && sheetPos < prefetchPos);
     }
 
     [Fact]


### PR DESCRIPTION
**Stacked on #80** — base is `feat/eager-preload-scoped-assets`, so this diff shows only the prefetch change. Retarget to `main` once #80 merges.

## Why

#80 emits `<link rel="preload" fetchpriority="low">` for *every* registered scoped asset. Most are off-route and may never be used this session, so:

- Chrome logs **"resource was preloaded but not used within a few seconds"** for each off-route asset, and
- `preload` competes at a higher base priority than these future-navigation hints deserve.

## What

Switch the cached block to **`<link rel="prefetch">`** (dropping the now-redundant `fetchpriority="low"` — prefetch is already the lowest-priority hint). `prefetch` is the textbook future-navigation hint:

- no "unused preload" console warning,
- never competes with the current route's critical resources,
- still lands the bytes in the HTTP cache so a later mount is flash-free.

`as="style"/"script"` is kept so the browser sets the right Accept header and cache partition. The current route's mounted assets still ship as render-blocking `<link>`/`<script>` via `EmitMountedAssets`; a coincident low-priority prefetch for the same href coalesces.

## No client change

The links remain inert to both client runtimes: `rel="prefetch"` matches neither the JS invoke gate (`tagName === "SCRIPT"`) nor the FOUC guard (`link[rel="stylesheet"]`). The FOUC guard's warm-cache check (`performance.getEntriesByName`) still sees the prefetched resource-timing entry, so the no-FOUC behavior holds.

## Tradeoff (noted for the record)

`preload` is a slightly *stronger* no-FOUC guarantee (kept in the memory cache, immediately usable); `prefetch` is best-effort and may be evicted under memory pressure or stored in a shorter-lived cache. For Rask's in-place morph navigation the future-navigation semantics + no console noise of `prefetch` are the better default, but the eviction nuance is real — happy to revisit if you'd rather keep `preload`.

## API

The public `PreloadScopedAssets` option keeps its name (it's the feature toggle); only the emitted hint and its `data-rask-key` (`rsk-prefetch-*`) change.

## Testing

- `ScopedPreloadEmissionTests` updated to assert `rel="prefetch"` / `rsk-prefetch-*` and renamed accordingly; all 10 pass.
- Full Core suite green (1492).
- Per-render cost is unchanged from #80 — still a single append of the cached block (the benchmark cases call the same `EmitScopedPreloads`).