### PR TITLE
feat(assets): eager-prefetch scoped CSS/JS to eliminate navigation FOUC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Eager prefetch of scoped CSS/JS eliminates navigation FOUC.** The page `<head>` now also
+  emits a low-priority `<link rel="prefetch">` for *every* registered scoped asset — not just the
+  components on the current route — so when a component first mounts later (client-side navigation,
+  a conditionally rendered section) its stylesheet/script is already in the browser cache: the body
+  swaps with no flash of unstyled content and the scoped-JS namespace is ready on first
+  interaction. `prefetch` (rather than `preload`) keeps these hints at the lowest priority and
+  avoids a *"resource preloaded but not used"* console warning for off-route assets. The markup is
+  render-independent and cached (rebuilt only when the asset set changes), so it costs a single
+  append per render. On by default; opt out with `AddRask(o => o.PreloadScopedAssets = false)` (or
+  the equivalent WASM host-builder option) to fetch each scoped asset only when its component first
+  mounts.
+
 ### Fixed
 - **Switching a syntax-highlighted code-sample tab no longer renders the new pane's markup as
   literal text.** A live re-render that replaced one `Raw` value with another (e.g. switching a

--- a/README.md
+++ b/README.md
@@ -213,7 +213,9 @@ public sealed class App : Component
 Both `<head>` and `<body>` are framework-managed. `<head>` collects every component's `Head`
 override during render, dedupes contributions, resolves singleton tags (`<title>`, `<base>` — last
 contributor wins), and splices the result plus the scoped-CSS link and scoped-JS bundle script in
-automatically — passing children to `Head()` is a `RASK019` compile error. `<body>` gets the live
+automatically — passing children to `Head()` is a `RASK019` compile error. It also prefetches every
+registered scoped asset up front (low-priority `<link rel="prefetch">`) so client-side navigation to
+a not-yet-mounted component is flash-free; opt out with `AddRask(o => o.PreloadScopedAssets = false)`. `<body>` gets the live
 runtime `<script>` injected as its last child automatically, so you no longer write
 `RaskRuntimeScript()`. The root must render the full shell (`Doctype`, `Html`, `Head`, `Body`); a
 missing element is flagged at compile time by **RASK021** and fails fast at runtime.

--- a/benchmarks/Rask.Benchmarks/AssetLoadingBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AssetLoadingBenchmarks.cs
@@ -199,6 +199,35 @@ public class AssetLoadingBenchmarks
     }
 
     // ──────────────────────────────────────────────────────────────────────
+    // EmitScopedPreloads: the eager-prefetch pass ApplyTo runs after
+    // EmitMountedAssets. The <link rel="prefetch"> block is render-independent
+    // and cached (rebuilt only when the registry mutates), so the steady-state
+    // per-render cost is a single Append of the cached string — no rebuild, no
+    // per-render registry snapshot. This warm-cache bench captures that cost.
+    // ──────────────────────────────────────────────────────────────────────
+    [Benchmark]
+    public int EmitScopedPreloads_Warm()
+    {
+        var sb = new StringBuilder(8192);
+        HeadAssetRegistry.EmitScopedPreloads(sb);
+        return sb.Length;
+    }
+
+    // Mirrors what ApplyTo emits per render with the feature on: mounted,
+    // render-blocking assets followed by the cached preload block. Compare its
+    // Allocated against EmitMountedAssets_200 — the delta is the feature's
+    // marginal per-render cost (a single cached-string append; the cache build
+    // is amortised to zero after the first render).
+    [Benchmark]
+    public int EmitMountedAssetsWithPreloads_200()
+    {
+        var sb = new StringBuilder(8192);
+        HeadAssetRegistry.EmitMountedAssets(sb, _mounted200);
+        HeadAssetRegistry.EmitScopedPreloads(sb);
+        return sb.Length;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────
     // Cold path: RegisterCss on a fresh type. Drives hot-reload latency —
     // generator-emitted RefreshAll calls this once per (component, CSS source).
     // Includes the SHA-256 hash + CssScoper.Rewrite cost.

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -144,6 +144,31 @@ is served at `/_rask/a/{hash}.{ext}` with `Cache-Control: immutable`, an `ETag`,
 `<script defer>` per mounted component type that has a registered asset. Static-file and
 WASM hosts get the same files baked to disk by the `BakeScopedAssetsTask` MSBuild task.
 
+### Eager prefetch
+
+By default the `<head>` *also* emits a low-priority `<link rel="prefetch">` for **every**
+registered scoped asset — not just the components on the current route. This warms the
+browser's HTTP cache up front, so when a component first mounts later (client-side
+navigation, a conditionally rendered section) its stylesheet/script is already loaded: the
+body swaps with **no flash of unstyled content** and the scoped-JS namespace is ready on
+first interaction. `prefetch` (rather than `preload`) is the future-navigation hint — it
+sits at the lowest priority so it never competes with the current route's critical
+resources, and it raises no *"resource preloaded but not used"* console warning for the
+off-route assets a visitor may never reach. The links are inert (`rel="prefetch"`, neither
+a render-blocking stylesheet nor an executable script), and the markup is cached so it
+costs a single append per render. Scoped CSS is selector-rewritten to `[data-r-xxxx]`, so
+prefetching an unmounted component's styles has no visual effect until its elements exist.
+
+Opt out — to fetch each scoped asset only when its component first mounts (smaller
+first-load payload, at the cost of a brief navigation FOUC the first time each new
+component type appears) — via `AddRask` / the WASM host builder:
+
+```csharp
+builder.Services.AddRask(o => o.PreloadScopedAssets = false); // Server
+// or
+WasmHostBuilder.CreateDefault(o => o.PreloadScopedAssets = false); // WASM
+```
+
 ---
 
 See also: [Composition](composition.md) for component-to-component communication, and the

--- a/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
+++ b/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
@@ -199,6 +199,10 @@ internal sealed class HeadAssetRegistry
         {
             var perComponentSb = RaskStringBuilderPool.Shared.Get();
             EmitMountedAssets(perComponentSb, liveCtx.MountedTypes);
+            // Eager prefetch of every registered scoped asset (not just the mounted ones) so a
+            // later mount finds its stylesheet/script already cached — no navigation FOUC.
+            // Appended after the mounted, render-blocking assets so those keep discovery priority.
+            EmitScopedPreloads(perComponentSb);
             if (perComponentSb.Length > 0)
             {
                 perComponentHtml = perComponentSb.ToString();
@@ -299,6 +303,10 @@ internal sealed class HeadAssetRegistry
     ///         iteration order), then JS. This matches the cascade contract — CSS is
     ///         render-blocking; JS uses <c>defer</c> and waits for parse.
     ///     </para>
+    ///     <para>
+    ///         Eager preload of <em>every</em> registered scoped asset (not just the mounted
+    ///         ones) is emitted separately by <see cref="EmitScopedPreloads" />.
+    ///     </para>
     /// </summary>
     internal static void EmitMountedAssets(StringBuilder sb, IEnumerable<Type> mountedTypes)
     {
@@ -360,6 +368,97 @@ internal sealed class HeadAssetRegistry
             sb.Append(hash);
             sb.Append("\"></script>");
         }
+    }
+
+    /// <summary>
+    ///     Appends a block of low-priority <c>&lt;link rel="prefetch"&gt;</c> hints for
+    ///     <em>every</em> registered scoped asset — not just the mounted ones — so a later mount
+    ///     (client-side navigation, a conditionally rendered section) finds its stylesheet/script
+    ///     already in the HTTP cache: the body swaps with no flash of unstyled content and the
+    ///     scoped-JS namespace is ready on first interaction. <c>prefetch</c> (rather than
+    ///     <c>preload</c>) is the future-navigation hint — it never competes with the current
+    ///     route's critical resources and raises no "resource preloaded but not used" console
+    ///     warning for assets the visitor never navigates to. No-op when
+    ///     <see cref="LiveOptions.PreloadScopedAssets" /> is <c>false</c>. The markup is
+    ///     render-independent and cached (rebuilt only when the asset set changes via hot
+    ///     reload), so the steady-state cost is a single <see cref="StringBuilder.Append(string)" />.
+    ///     Emitted after <see cref="EmitMountedAssets" />; the prefetch links are inert to the
+    ///     client invoke gate and FOUC guard (they are <c>rel="prefetch"</c>, neither a
+    ///     <c>&lt;script&gt;</c> nor a <c>rel="stylesheet"</c> link).
+    /// </summary>
+    internal static void EmitScopedPreloads(StringBuilder sb)
+    {
+        ArgumentNullException.ThrowIfNull(sb);
+        if (!LiveOptions.PreloadScopedAssets)
+        {
+            return;
+        }
+
+        sb.Append(GetScopedPreloadBlock());
+    }
+
+    // Cached <link rel="prefetch"> markup for every registered scoped asset. Built lazily and
+    // reused across renders; rebuilt only when the registry mutates (tracked by
+    // ScopedAssetRegistry.Version) or the URL prefix changes (PathBase). The record is published
+    // atomically (single volatile reference), so readers never see a torn field tuple.
+    private sealed record PreloadCacheEntry(string PathBase, long Version, string Block);
+
+    private static volatile PreloadCacheEntry? _preloadCache;
+
+    private static string GetScopedPreloadBlock()
+    {
+        var pathBase = LiveOptions.PathBase;
+        var version = ScopedAssetRegistry.Version;
+
+        var cache = _preloadCache;
+        if (cache is not null && cache.Version == version
+            && string.Equals(cache.PathBase, pathBase, StringComparison.Ordinal))
+        {
+            return cache.Block;
+        }
+
+        // Build lock-free (EnumerateAll takes the registry lock internally; we hold none). A
+        // benign race may build the string twice — both yield identical bytes. The entry is
+        // tagged with the version read BEFORE the build: if the registry mutated mid-build the
+        // tag is stale, and the next call simply rebuilds — never serves stale markup.
+        var block = BuildScopedPreloadBlock(pathBase);
+        _preloadCache = new PreloadCacheEntry(pathBase, version, block);
+        return block;
+    }
+
+    private static string BuildScopedPreloadBlock(string pathBase)
+    {
+        var sb = new StringBuilder();
+        foreach (var entry in ScopedAssetRegistry.EnumerateAll())
+        {
+            var isCss = entry.Kind == AssetKind.Css;
+
+            // rel="prefetch" (not "preload"): this block covers every registered asset, most of
+            // which are off-route and may not be used at all this session. "prefetch" is the
+            // future-navigation hint — lowest priority (never competes with the current route's
+            // critical resources) and, unlike "preload", it raises no "resource preloaded but not
+            // used within a few seconds" console warning for assets the visitor never navigates to.
+            // `as` is kept so the browser sets the right Accept header and cache partition. The
+            // current route's mounted assets already ship as a render-blocking <link>/<script>
+            // (EmitMountedAssets); a coincident low-priority prefetch for the same href coalesces.
+            //
+            // <link rel="prefetch" as="style|script" href="{PathBase}/_rask/a/{hash}.{ext}"
+            //       data-rask-key="rsk-prefetch-{css|js}-{hash}">
+            sb.Append("<link rel=\"prefetch\" as=\"");
+            sb.Append(isCss ? "style" : "script");
+            sb.Append("\" href=\"");
+            sb.Append(pathBase);
+            sb.Append("/_rask/a/");
+            sb.Append(entry.Hash);
+            sb.Append(isCss ? ".css" : ".js");
+            sb.Append("\" data-rask-key=\"");
+            sb.Append(FrameworkAssetKeyPrefix);
+            sb.Append(isCss ? "prefetch-css-" : "prefetch-js-");
+            sb.Append(entry.Hash);
+            sb.Append("\">");
+        }
+
+        return sb.ToString();
     }
 
     // FNV-1a 32-bit content hash. Stable for a given string within the process so

--- a/src/Rask.Core/Live/LiveOptions.cs
+++ b/src/Rask.Core/Live/LiveOptions.cs
@@ -85,6 +85,23 @@ public sealed class RaskLiveOptions
         get => _pathBase;
         set => _pathBase = RaskPath.Normalize(value);
     }
+
+    /// <summary>
+    ///     Whether the framework eagerly warms <em>every</em> registered scoped CSS and JS asset
+    ///     into the page <c>&lt;head&gt;</c> on first render via low-priority
+    ///     <c>&lt;link rel="prefetch"&gt;</c> hints — not just the assets of components mounted on
+    ///     the current route. <c>true</c> (default) warms the HTTP cache up front so a later mount
+    ///     (client-side navigation, a conditional section) finds its scoped stylesheet/script
+    ///     already loaded: the body swaps with no flash of unstyled content and no first-interaction
+    ///     wait for the scoped JS namespace. <c>prefetch</c> keeps these hints below the current
+    ///     route's critical resources and avoids a <c>"resource preloaded but not used"</c> console
+    ///     warning for off-route assets. Scoped CSS is selector-rewritten to <c>[data-r-xxxx]</c>,
+    ///     so prefetching an unmounted component's styles has no visual effect until its elements
+    ///     exist. Set <c>false</c> to fetch each scoped asset only when its component first mounts
+    ///     (smaller first-load payload, at the cost of a brief navigation FOUC the first time each
+    ///     new component type appears).
+    /// </summary>
+    public bool PreloadScopedAssets { get; set; } = true;
 }
 
 /// <summary>
@@ -109,6 +126,13 @@ public static class LiveOptions
         get => _pathBase;
         set => _pathBase = RaskPath.Normalize(value);
     }
+
+    /// <summary>
+    ///     Active eager-preload flag (see <see cref="RaskLiveOptions.PreloadScopedAssets" />).
+    ///     Read by <c>HeadAssetRegistry.EmitMountedAssets</c> on every render. Defaults to
+    ///     <c>true</c>.
+    /// </summary>
+    public static bool PreloadScopedAssets { get; set; } = true;
 }
 
 /// <summary>

--- a/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
+++ b/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
+using System.Threading;
 using Rask.Core.ScopedCss;
 
 namespace Rask.Core.ScopedAssets;
@@ -83,6 +84,19 @@ public static class ScopedAssetRegistry
 
     public static event Action<Type, AssetKind>? AssetChanged;
 
+    private static long _version;
+
+    /// <summary>
+    ///     Monotonic mutation counter — bumped under the registry lock on every change to the
+    ///     registered asset set (register, unregister, and the bulk <see cref="InvalidateAll" />
+    ///     / <see cref="InvalidateAllCss" /> / <see cref="InvalidateAllJs" /> paths). Consumers
+    ///     that cache derived output (the head <c>&lt;link rel="preload"&gt;</c> block) compare
+    ///     against this to detect staleness cheaply, without subscribing to
+    ///     <see cref="AssetChanged" /> — which intentionally does not fire on the bulk-clear
+    ///     paths, so it cannot be relied on to invalidate a whole-registry projection.
+    /// </summary>
+    internal static long Version => Interlocked.Read(ref _version);
+
     /// <summary>
     ///     Registers (or replaces) the scoped CSS source for a component type. Called by
     ///     generator-emitted module initializers and by the hot-reload handler. Whitespace-only
@@ -136,6 +150,7 @@ public static class ScopedAssetRegistry
             _cssHashByType[componentType] = hash;
             _scopeIdByType[componentType] = scopeId;
             IncrementOrInsertLocked(_cssByHash, hash, bytes);
+            Interlocked.Increment(ref _version);
             changed = true;
         }
 
@@ -186,6 +201,7 @@ public static class ScopedAssetRegistry
 
             _jsHashByType[componentType] = hash;
             IncrementOrInsertLocked(_jsByHash, hash, bytes);
+            Interlocked.Increment(ref _version);
             changed = true;
         }
 
@@ -209,6 +225,7 @@ public static class ScopedAssetRegistry
             _cssHashByType.TryRemove(componentType, out _);
             _scopeIdByType.TryRemove(componentType, out _);
             DecrementRefLocked(_cssByHash, hash);
+            Interlocked.Increment(ref _version);
             changed = true;
         }
 
@@ -231,6 +248,7 @@ public static class ScopedAssetRegistry
 
             _jsHashByType.TryRemove(componentType, out _);
             DecrementRefLocked(_jsByHash, hash);
+            Interlocked.Increment(ref _version);
             changed = true;
         }
 
@@ -256,6 +274,7 @@ public static class ScopedAssetRegistry
             _scopeIdByType.Clear();
             _cssByHash.Clear();
             _jsByHash.Clear();
+            Interlocked.Increment(ref _version);
         }
     }
 
@@ -272,6 +291,7 @@ public static class ScopedAssetRegistry
             _cssHashByType.Clear();
             _scopeIdByType.Clear();
             _cssByHash.Clear();
+            Interlocked.Increment(ref _version);
         }
     }
 
@@ -282,6 +302,7 @@ public static class ScopedAssetRegistry
         {
             _jsHashByType.Clear();
             _jsByHash.Clear();
+            Interlocked.Increment(ref _version);
         }
     }
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -120,6 +120,7 @@ public static class RaskEndpointExtensions
             // UseRask<TApp>(pathBase: ...) can still override this if the user
             // prefers to set the prefix at endpoint-registration time.
             LiveOptions.PathBase = liveOptions.PathBase;
+            LiveOptions.PreloadScopedAssets = liveOptions.PreloadScopedAssets;
             // Session cap is a per-store instance value (not a static) so concurrent
             // hosts/tests don't clobber each other through global state.
             maxSessions = liveOptions.MaxSessions;

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -67,6 +67,7 @@ public sealed class WasmHostBuilder
             var opts = new RaskLiveOptions();
             configureLive(opts);
             LiveOptions.DiffMode = opts.DiffMode;
+            LiveOptions.PreloadScopedAssets = opts.PreloadScopedAssets;
             // Only propagate a non-empty user-supplied PathBase; an explicit
             // override should win over the auto-detect that RunAsync performs
             // later. An empty value here means "I didn't set one — auto-detect

--- a/tests/Rask.Core.Tests/HeadAssets/ScopedPreloadEmissionTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/ScopedPreloadEmissionTests.cs
@@ -1,0 +1,231 @@
+using System.Text;
+using Rask.Core.HeadAssets;
+using Rask.Core.Live;
+using Rask.Core.ScopedAssets;
+using Rask.TestSupport;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.HeadAssets;
+
+/// <summary>
+///     Covers <see cref="HeadAssetRegistry.EmitScopedPreloads" /> — the eager prefetch pass that
+///     emits one low-priority <c>&lt;link rel="prefetch"&gt;</c> per <em>registered</em> scoped
+///     asset (not just the mounted ones), so a later mount finds its stylesheet/script already
+///     cached and swaps with no FOUC. Gated by <see cref="LiveOptions.PreloadScopedAssets" />
+///     (default on); the markup is cached and only rebuilt when the registry mutates
+///     (<see cref="ScopedAssetRegistry.Version" />) or the URL prefix changes.
+/// </summary>
+[Collection("ScopedAssets")]
+public sealed class ScopedPreloadEmissionTests : IDisposable
+{
+    private readonly bool _priorPreload;
+    private readonly string _priorPathBase;
+
+    public ScopedPreloadEmissionTests()
+    {
+        _priorPreload = LiveOptions.PreloadScopedAssets;
+        _priorPathBase = LiveOptions.PathBase;
+        ScopedAssetRegistry.InvalidateAll();
+        LiveOptions.PathBase = string.Empty;
+        LiveOptions.PreloadScopedAssets = true;
+    }
+
+    public void Dispose()
+    {
+        LiveOptions.PreloadScopedAssets = _priorPreload;
+        LiveOptions.PathBase = _priorPathBase;
+        ScopedAssetRegistry.InvalidateAll();
+    }
+
+    [Fact]
+    public void Disabled_EmitsNothing()
+    {
+        LiveOptions.PreloadScopedAssets = false;
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
+
+        var sb = new StringBuilder();
+        HeadAssetRegistry.EmitScopedPreloads(sb);
+
+        Assert.Equal(0, sb.Length);
+    }
+
+    [Fact]
+    public void Enabled_EmitsPrefetchLinkForCss()
+    {
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hash);
+
+        var html = Emit();
+
+        Assert.Contains(
+            $"<link rel=\"prefetch\" as=\"style\" href=\"/_rask/a/{hash}.css\" " +
+            $"data-rask-key=\"rsk-prefetch-css-{hash}\">",
+            html);
+        // Prefetch links must be inert to the cascade and the client invoke gate: never a
+        // render-blocking stylesheet, never a deferred script.
+        Assert.DoesNotContain("rel=\"stylesheet\"", html);
+        Assert.DoesNotContain("<script", html);
+    }
+
+    [Fact]
+    public void Enabled_EmitsPrefetchLinkForJs()
+    {
+        ScopedAssetRegistry.RegisterJs(typeof(JsOnly), "export function f() {}");
+        ScopedAssetRegistry.TryGetJs(typeof(JsOnly), out var hash);
+
+        var html = Emit();
+
+        Assert.Contains(
+            $"<link rel=\"prefetch\" as=\"script\" href=\"/_rask/a/{hash}.js\" " +
+            $"data-rask-key=\"rsk-prefetch-js-{hash}\">",
+            html);
+        Assert.DoesNotContain(" defer ", html);
+    }
+
+    [Fact]
+    public void Enabled_PrefetchesEveryRegisteredAsset_NotJustOne()
+    {
+        // The prefetch pass takes no mounted-types argument — it covers the whole registry, so a
+        // component that is registered but not on the current route is still warmed.
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".a { color: red; }");
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetB), ".b { color: blue; }");
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hashA);
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetB), out var hashB);
+
+        var html = Emit();
+
+        Assert.Contains($"rsk-prefetch-css-{hashA}", html);
+        Assert.Contains($"rsk-prefetch-css-{hashB}", html);
+        Assert.Equal(2, CountOccurrences(html, "rel=\"prefetch\""));
+    }
+
+    [Fact]
+    public void Enabled_EmitsCssPrefetchesBeforeJsPrefetches()
+    {
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
+        ScopedAssetRegistry.RegisterJs(typeof(JsOnly), "export function f() {}");
+
+        var html = Emit();
+
+        var stylePos = html.IndexOf("as=\"style\"", StringComparison.Ordinal);
+        var scriptPos = html.IndexOf("as=\"script\"", StringComparison.Ordinal);
+        Assert.True(stylePos >= 0 && scriptPos >= 0);
+        Assert.True(stylePos < scriptPos, "CSS prefetches should precede JS prefetches");
+    }
+
+    [Fact]
+    public void Enabled_HonoursPathBasePrefix()
+    {
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hash);
+
+        LiveOptions.PathBase = "/appA";
+        var html = Emit();
+
+        Assert.Contains($"href=\"/appA/_rask/a/{hash}.css\"", html);
+        Assert.DoesNotContain("//_rask/a/", html);
+        // The data-rask-key payload must not be re-prefixed.
+        Assert.Contains($"data-rask-key=\"rsk-prefetch-css-{hash}\"", html);
+    }
+
+    [Fact]
+    public void Cached_RepeatedEmitsAreByteIdentical()
+    {
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".x { color: red; }");
+
+        Assert.Equal(Emit(), Emit());
+    }
+
+    [Fact]
+    public void Cache_RebuildsAfterRegistryMutation()
+    {
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".a { color: red; }");
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var hashA);
+        var first = Emit();
+        Assert.Contains($"rsk-prefetch-css-{hashA}", first);
+        Assert.Equal(1, CountOccurrences(first, "rel=\"prefetch\""));
+
+        // Registering a second asset bumps ScopedAssetRegistry.Version → the cached block is
+        // recomputed and now covers both assets.
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetB), ".b { color: blue; }");
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetB), out var hashB);
+        var second = Emit();
+
+        Assert.Contains($"rsk-prefetch-css-{hashA}", second);
+        Assert.Contains($"rsk-prefetch-css-{hashB}", second);
+    }
+
+    [Fact]
+    public void ApplyTo_EmitsPrefetchForOffRouteAsset_AlongsideMountedStylesheet()
+    {
+        // End-to-end through the real head pipeline: CssOnly is mounted; WidgetA is registered
+        // but off-route. The mounted type gets a render-blocking stylesheet; both types get a
+        // low-priority prefetch so navigating to WidgetA later hits a warm cache (no FOUC).
+        ScopedAssetRegistry.RegisterCss(typeof(CssOnly), ".m { color: green; }");
+        ScopedAssetRegistry.RegisterCss(typeof(WidgetA), ".o { color: red; }");
+        ScopedAssetRegistry.TryGetCss(typeof(CssOnly), out var mountedHash);
+        ScopedAssetRegistry.TryGetCss(typeof(WidgetA), out var offRouteHash);
+
+        var view = new StubComponent(new CssOnly());
+        using var ctx = LiveRenderContext.Begin(view);
+        var serialized = new StringBuilder();
+        HtmlSerializer.Serialize(view, serialized);
+
+        var html = new HeadAssetRegistry().ApplyTo("<head><!--__rask_head_assets__--></head>");
+
+        Assert.Contains($"data-rask-key=\"rsk-css-{mountedHash}\"", html);
+        Assert.Contains($"rsk-prefetch-css-{mountedHash}", html);
+        Assert.Contains($"rsk-prefetch-css-{offRouteHash}", html);
+        // Cascade order: the render-blocking stylesheet precedes the low-priority prefetch block.
+        var sheetPos = html.IndexOf("rel=\"stylesheet\"", StringComparison.Ordinal);
+        var prefetchPos = html.IndexOf("rel=\"prefetch\"", StringComparison.Ordinal);
+        Assert.True(sheetPos >= 0 && prefetchPos >= 0 && sheetPos < prefetchPos);
+    }
+
+    [Fact]
+    public void NullArgument_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => HeadAssetRegistry.EmitScopedPreloads(null!));
+
+    private static string Emit()
+    {
+        var sb = new StringBuilder();
+        HeadAssetRegistry.EmitScopedPreloads(sb);
+        return sb.ToString();
+    }
+
+    private static int CountOccurrences(string haystack, string needle)
+    {
+        var count = 0;
+        var idx = 0;
+        while ((idx = haystack.IndexOf(needle, idx, StringComparison.Ordinal)) >= 0)
+        {
+            count++;
+            idx += needle.Length;
+        }
+
+        return count;
+    }
+
+    private sealed class WidgetA : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class WidgetB : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    private sealed class JsOnly : Component
+    {
+        protected override RenderResult Render() => this;
+    }
+
+    // Rendered (not just registered) by the ApplyTo integration test, so it must return a real
+    // element rather than `this`.
+    private sealed class CssOnly : Component
+    {
+        protected override RenderResult Render() => Div();
+    }
+}


### PR DESCRIPTION
Supersedes #80 and #81 (squashed into one PR).

## Summary

The page `<head>` now also emits a low-priority `<link rel="prefetch">` for **every** registered scoped asset — not just the components on the current route. When a component first mounts later (client-side navigation, a conditionally rendered section), its scoped stylesheet/script is already in the browser's HTTP cache, so:

- the body swaps with **no flash of unstyled content** (the client FOUC guard's `performance.getEntriesByName` check passes → no 500ms stall), and
- the scoped-JS `window.Rask[Type]` namespace is ready on first interaction (no cold namespace-poll latency).

`prefetch` (rather than `preload`) is the future-navigation hint: lowest priority so it never competes with the current route's critical resources, and no *"resource preloaded but not used"* console warning for off-route assets a visitor may never reach. Scoped CSS is selector-rewritten to `[data-r-xxxx]`, so prefetching an unmounted component's styles has no visual effect until its elements exist.

On by default; opt out with `AddRask(o => o.PreloadScopedAssets = false)` (or the WASM host-builder equivalent).

## How it works

- New `EmitScopedPreloads` pass runs in `HeadAssetRegistry.ApplyTo` after the existing mounted, render-blocking assets (so those keep discovery priority).
- The prefetch block is **render-independent and cached**, rebuilt only when the asset set changes — tracked by a new monotonic `ScopedAssetRegistry.Version` (bumped on every register/unregister/invalidate; `AssetChanged` intentionally does not fire on the bulk-clear paths, so a whole-registry projection can't rely on it).
- **No client change needed**: the prefetch links match neither the JS invoke gate (`tagName === "SCRIPT"`) nor the FOUC guard (`link[rel="stylesheet"]`) in `rask.js` / `rask.wasm.js`, so they stay inert. Verified in both runtimes; `as="style"/"script"` is kept for the correct Accept header / cache partition.

## Testing

- 10 unit tests in `ScopedPreloadEmissionTests` (emission shape, inert/non-blocking attrs, CSS-before-JS order, PathBase prefixing, cache reuse, cache rebuild on registry mutation, null-arg, and a real-pipeline `ApplyTo` integration test through `LiveRenderContext` + `HtmlSerializer`).
- Full unit suite green: Core 1492, plus Server / Wasm.Tasks / Example.Shared unaffected.
- Existing `EmitMountedAssets` tests unchanged (the pure mounted path was left untouched).

## Benchmarks

New `AssetLoadingBenchmarks` cases (`MemoryDiagnoser`) confirm the cached path adds no measurable per-render heap: `EmitScopedPreloads_Warm`'s allocation is essentially the benchmark's own `new StringBuilder(8192)` (≈16 KB); the cached-block lookup (an `Interlocked.Read` + reference compare) and single append add nothing beyond the emitted bytes. In production `ApplyTo` appends into the already-pooled head builder — no registry snapshot, no rebuild.

## Tradeoff (noted for the record)

`preload` is a slightly *stronger* no-FOUC guarantee (kept in the memory cache, immediately usable); `prefetch` is best-effort and may be evicted under memory pressure. For Rask's in-place morph navigation the future-navigation semantics + no console noise make `prefetch` the better default — happy to revisit if you'd prefer `preload`.

## Docs / changelog

`docs/js-interop.md`, `README.md`, and `CHANGELOG.md` (`[Unreleased]`) updated.

## Follow-ups (tracked, not in this PR)

- `103 Early Hints` for the current route's critical CSS (Server mode) — attacks the initial-paint round-trip prefetch can't.
- Inline critical scoped CSS for the initial route; pre-compress (Brotli) served assets.