### PR TITLE
fix(assets): hold body paint until scoped CSS applies to kill navigation FOUC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,10 @@ them until tagged releases begin.
 - **Eager prefetch of scoped CSS/JS eliminates navigation FOUC.** The page `<head>` now also
   emits a low-priority `<link rel="prefetch">` for *every* registered scoped asset — not just the
   components on the current route — so when a component first mounts later (client-side navigation,
-  a conditionally rendered section) its stylesheet/script is already in the browser cache: the body
-  swaps with no flash of unstyled content and the scoped-JS namespace is ready on first
-  interaction. `prefetch` (rather than `preload`) keeps these hints at the lowest priority and
+  a conditionally rendered section) its stylesheet/script is already in the browser cache and the
+  scoped-JS namespace is ready on first interaction. (Cache-warming alone does not remove the
+  flash — the live runtime also holds the body paint until the sheet has *applied*; see the
+  matching **Fixed** entry below.) `prefetch` (rather than `preload`) keeps these hints at the lowest priority and
   avoids a *"resource preloaded but not used"* console warning for off-route assets. The markup is
   render-independent and cached (rebuilt only when the asset set changes), so it costs a single
   append per render. On by default; opt out with `AddRask(o => o.PreloadScopedAssets = false)` (or
@@ -21,6 +22,19 @@ them until tagged releases begin.
   mounts.
 
 ### Fixed
+- **Scoped-asset flicker on client-side navigation and lazy mount is gone — the live runtime now
+  holds the body paint until a newly mounted component's scoped stylesheet has *applied*.** The
+  eager `<link rel="prefetch">` warms the HTTP cache, but cached bytes are not an applied
+  stylesheet: the client previously swapped in the styled body in the same morph that inserted the
+  `<link>`, so it painted unstyled for a frame while the (cached) CSS parsed. The render-application
+  path now gates on the `<link>`'s `.sheet` property — non-null only once the CSSOM stylesheet is
+  parsed and applied — rather than on Resource Timing `responseEnd` (which a prefetch satisfies the
+  moment the bytes land, before the rule applies). A full reply preloads each new scoped stylesheet
+  and awaits its `.sheet` before the morph paints the body; a diff that morphs a `<head>` fragment
+  waits the same way. Both bound the wait by a 500 ms cap, so a genuinely slow/failed sheet shows a
+  briefly unstyled page rather than stalling navigation. The scoped-JS invoke gate is hardened the
+  same way on WASM: a prefetched scoped `<script>` now waits for its real `load` event before a
+  first-render `Rask.*` invoke dispatches, so the call can't race ahead of the script's execution.
 - **Switching a syntax-highlighted code-sample tab no longer renders the new pane's markup as
   literal text.** A live re-render that replaced one `Raw` value with another (e.g. switching a
   `CodeSample` tab from highlighted C# to highlighted CSS) shipped an in-place `UpdateText` diff op,

--- a/README.md
+++ b/README.md
@@ -214,8 +214,9 @@ Both `<head>` and `<body>` are framework-managed. `<head>` collects every compon
 override during render, dedupes contributions, resolves singleton tags (`<title>`, `<base>` — last
 contributor wins), and splices the result plus the scoped-CSS link and scoped-JS bundle script in
 automatically — passing children to `Head()` is a `RASK019` compile error. It also prefetches every
-registered scoped asset up front (low-priority `<link rel="prefetch">`) so client-side navigation to
-a not-yet-mounted component is flash-free; opt out with `AddRask(o => o.PreloadScopedAssets = false)`. `<body>` gets the live
+registered scoped asset up front (low-priority `<link rel="prefetch">`) and the runtime holds the
+body paint until a newly mounted component's stylesheet has applied, so client-side navigation to a
+not-yet-mounted component is flash-free; opt out with `AddRask(o => o.PreloadScopedAssets = false)`. `<body>` gets the live
 runtime `<script>` injected as its last child automatically, so you no longer write
 `RaskRuntimeScript()`. The root must render the full shell (`Doctype`, `Html`, `Head`, `Body`); a
 missing element is flagged at compile time by **RASK021** and fails fast at runtime.

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -149,9 +149,14 @@ WASM hosts get the same files baked to disk by the `BakeScopedAssetsTask` MSBuil
 By default the `<head>` *also* emits a low-priority `<link rel="prefetch">` for **every**
 registered scoped asset — not just the components on the current route. This warms the
 browser's HTTP cache up front, so when a component first mounts later (client-side
-navigation, a conditionally rendered section) its stylesheet/script is already loaded: the
-body swaps with **no flash of unstyled content** and the scoped-JS namespace is ready on
-first interaction. `prefetch` (rather than `preload`) is the future-navigation hint — it
+navigation, a conditionally rendered section) its stylesheet/script is already downloaded.
+Cache-warming alone is not enough to avoid a flash, though — cached *bytes* are not an
+*applied* stylesheet. So the live runtime also gates the swap: when a render adds a new
+scoped stylesheet it inserts the `<link>` first and holds the body paint until that
+`<link>`'s `.sheet` is non-null (the CSSOM stylesheet has parsed and applied), bounded by a
+500 ms cap. Together — prefetch (the sheet is warm, so it applies almost instantly) plus the
+apply-gate (the body never paints ahead of it) — the body swaps with **no flash of unstyled
+content** and the scoped-JS namespace is ready on first interaction. `prefetch` (rather than `preload`) is the future-navigation hint — it
 sits at the lowest priority so it never competes with the current route's critical
 resources, and it raises no *"resource preloaded but not used"* console warning for the
 off-route assets a visitor may never reach. The links are inert (`rel="prefetch"`, neither

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -19,7 +19,7 @@
     if (!root) return;
 
     // Serializes render application across messages. A navigation diff may defer its
-    // body swap until the new page's scoped CSS loads (applyHeadThenWaitForCss), which
+    // body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss), which
     // opens a microtask/timer gap during which the next WS message could arrive. Both
     // the diff and full-HTML paths chain through this tail promise so a deferred body
     // always commits before the following message's ops — paths in a later diff are
@@ -442,29 +442,63 @@
         return pendingHeadAssets.size === 0;
     }
 
-    // Morph the incoming <head> into the live one, then return a Promise that resolves
-    // once every *newly added* stylesheet has reached a terminal state (load / error /
-    // CSS_FOUC_GUARD_MS timeout). On a navigation diff the body ops must not be applied
-    // until the new page's scoped CSS (<link href="/_rask/a/{hash}.css">) is in place,
-    // or the freshly-swapped body paints unstyled for a beat (FOUC). Stylesheets already
-    // present + loaded before the morph — the warm-cache case — are skipped via
-    // isAssetAlreadyLoaded, so a return of null means "nothing to wait for, apply the
-    // body synchronously" and warm navigations keep today's instant timing.
-    function applyHeadThenWaitForCss(freshHead) {
-        var before = new Set();
-        document.head.querySelectorAll('link[rel="stylesheet"]').forEach(function (l) {
-            if (l.href && isAssetAlreadyLoaded(l.href)) before.add(l.href);
-        });
-        morph(document.head, freshHead);
+    // Return a Promise that resolves once every <head> stylesheet still being applied has
+    // reached a terminal state (load / error / CSS_FOUC_GUARD_MS timeout), or null when
+    // there's nothing to wait for. The readiness signal is the <link>'s .sheet property —
+    // non-null only once the CSSOM stylesheet has been parsed and APPLIED. We deliberately
+    // do NOT use isAssetAlreadyLoaded (Resource Timing responseEnd): the eager
+    // <link rel="prefetch"> warms the HTTP cache and creates a timing entry, but bytes
+    // downloaded is not the same as a stylesheet applied — trusting it would skip the wait
+    // and reintroduce the very flash prefetch is meant to remove. A link already applied
+    // (kept across renders, or just resolved) has a non-null .sheet and is skipped; a
+    // freshly inserted one has .sheet === null and is awaited (its load fires within ~1
+    // frame on warm cache).
+    function waitForUnappliedHeadCss() {
         var pending = [];
         document.head.querySelectorAll('link[rel="stylesheet"]').forEach(function (l) {
-            if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
+            if (!l.href || l.sheet) return;
             pending.push(new Promise(function (resolve) {
                 var done = function () {
                     resolve();
                 };
                 l.addEventListener("load", done, {once: true});
                 l.addEventListener("error", done, {once: true});
+                setTimeout(done, CSS_FOUC_GUARD_MS);
+            }));
+        });
+        return pending.length ? Promise.all(pending) : null;
+    }
+
+    // FOUC guard for the full-document path. A full reply morphs <head> and the styled
+    // <body> in one pass, so a newly mounted component's scoped <link> would be inserted
+    // alongside the body it styles — and the body paints before the just-inserted sheet
+    // parses + applies. Pre-empt it: for every NEW scoped stylesheet the incoming document
+    // adds to <head> (keyed by data-rask-key, so not already live), append a clone NOW and
+    // return a Promise that resolves once each has applied (.sheet) — load / error /
+    // CSS_FOUC_GUARD_MS timeout. The subsequent morph matches each clone to the incoming
+    // <link> by key (keyed reconciliation), so it's kept rather than duplicated, and the
+    // body it morphs in paints already-styled. Only keyed scoped links are preloaded —
+    // render-blocking globals (no data-rask-key) are already applied from the initial load.
+    // Returns null when the document adds no new scoped stylesheet (the common case), so a
+    // navigation that mounts nothing new keeps today's single-pass, no-wait timing.
+    function preloadNewHeadStylesheets(freshHtml) {
+        var freshHead = freshHtml.querySelector("head");
+        if (!freshHead) return null;
+        var liveKeys = {};
+        document.head.querySelectorAll('link[rel="stylesheet"][data-rask-key]').forEach(function (l) {
+            liveKeys[l.getAttribute("data-rask-key")] = true;
+        });
+        var pending = [];
+        freshHead.querySelectorAll('link[rel="stylesheet"][data-rask-key]').forEach(function (fl) {
+            if (liveKeys[fl.getAttribute("data-rask-key")] || !fl.getAttribute("href")) return;
+            var clone = fl.cloneNode(true);
+            document.head.appendChild(clone);
+            pending.push(new Promise(function (resolve) {
+                var done = function () {
+                    resolve();
+                };
+                clone.addEventListener("load", done, {once: true});
+                clone.addEventListener("error", done, {once: true});
                 setTimeout(done, CSS_FOUC_GUARD_MS);
             }));
         });
@@ -500,12 +534,12 @@
     }
 
     // Diff-mode render application (wire format matches LivePayload.BuildPayloadUtf8Diff).
-    // The head rides the payload as a <head> fragment (user Head contributions are
-    // collected + spliced server-side, so they're not in the frame stream). Morph the
-    // head FIRST — keyed reconciliation (data-rask-key) keeps unchanged scoped-CSS links —
-    // and when the new page adds a not-yet-cached scoped stylesheet, defer the body ops
-    // until it loads so the swapped body never paints unstyled (FOUC). Returns the wait
-    // Promise so _renderQueue holds the next message until the body has committed.
+    // The head rides the payload as a <head> fragment (user Head contributions are collected
+    // + spliced server-side, so they're not in the frame stream). Morph the head FIRST —
+    // keyed reconciliation (data-rask-key) keeps unchanged scoped-CSS links — and when it
+    // adds a not-yet-applied scoped stylesheet, defer the body ops until it applies so the
+    // swapped body never paints unstyled (FOUC). Returns the wait Promise so _renderQueue
+    // holds the next message until the body has committed.
     function applyDiffReply(data) {
         var applyBody = function () {
             // Each op carries a Path (childNodes indices from the document root) and an
@@ -535,62 +569,83 @@
         };
         if (typeof data.head === "string") {
             var freshHead = new DOMParser().parseFromString(data.head, "text/html").head;
-            var wait = freshHead ? applyHeadThenWaitForCss(freshHead) : null;
-            if (wait) return wait.then(applyBody);
+            if (freshHead) {
+                morph(document.head, freshHead);
+                var wait = waitForUnappliedHeadCss();
+                if (wait) return wait.then(applyBody);
+            }
         }
         applyBody();
     }
 
     // Full-document render application: morph the whole <html> element so head changes
-    // (title, per-page Head asset contributions, scoped-css/scoped-js hash bumps)
-    // propagate atomically with the body — no FOUC, so no CSS wait needed here.
+    // (title, per-page Head asset contributions, scoped-css/scoped-js hash bumps) propagate
+    // with the body. A newly mounted component's scoped <link> rides this path too — and the
+    // single morph would insert it alongside the styled body it applies to, painting unstyled
+    // for a beat (FOUC). So preloadNewHeadStylesheets first appends + awaits a clone of each
+    // new scoped stylesheet; the morph then matches the clone by data-rask-key (kept, not
+    // duplicated) and the body it paints is already styled. Returns the wait Promise so
+    // _renderQueue holds the next message until the body has committed.
     function applyFullReply(data) {
         var freshHtml = null;
         if (typeof data.html === "string") {
             var doc = new DOMParser().parseFromString(data.html, "text/html");
             freshHtml = doc.documentElement;
         }
+
+        var commit = function () {
+            if (freshHtml) {
+                morph(document.documentElement, freshHtml);
+                root = document.querySelector("[data-rask-root]") || root;
+                // Pick up any newly-inserted Head-declared external assets (e.g., a
+                // page-specific Script in Component.Head) so their load events feed the gate.
+                scanHeadAssets();
+            }
+            if (data.history && typeof data.history.url === "string") {
+                var fullTarget = prependBase(data.history.url);
+                if (data.history.action === "replace") {
+                    history.replaceState({rask: true}, "", fullTarget);
+                } else {
+                    if (_pendingScrollHash) fullTarget += _pendingScrollHash;
+                    history.pushState({rask: true}, "", fullTarget);
+                }
+            }
+            applyNavScroll(data.history);
+            if (Array.isArray(data.jsInvokes)) {
+                for (var ji = 0; ji < data.jsInvokes.length; ji++) {
+                    dispatchJsInvoke(data.jsInvokes[ji]);
+                }
+            }
+            // dotNetResult: reply to a JS-initiated DotNet.invokeMethodAsync call, routed by
+            // the DotNet shim's pending-call table to resolve/reject the matching JS Promise.
+            if (data.type === "dotNetResult" && typeof data.callId === "string") {
+                window.DotNet._endInvokeDotNet(data);
+            }
+            if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
+            // Out-of-band frames carry no html — process supplemental fields and bail.
+            if (data.type === "dotNetResult" && typeof data.callId === "string"
+                && typeof data.html !== "string") {
+                window.DotNet._endInvokeDotNet(data);
+                return;
+            }
+            if (data.auth && typeof data.auth.ticket === "string") {
+                redeemAuthTicket(data.auth);
+            }
+            if (data.download && typeof data.download.url === "string"
+                && typeof data.download.filename === "string") {
+                triggerDownload(data.download.url, data.download.filename);
+            }
+        };
+
+        // FOUC guard: preload any new scoped stylesheet the incoming document adds so the
+        // morph below paints the styled body only once its sheet has applied (see
+        // preloadNewHeadStylesheets). Returns null — and we commit synchronously, at today's
+        // timing — when the render mounts no new scoped CSS.
         if (freshHtml) {
-            morph(document.documentElement, freshHtml);
-            root = document.querySelector("[data-rask-root]") || root;
-            // Pick up any newly-inserted Head-declared external assets (e.g., a
-            // page-specific Script in Component.Head) so their load events feed the gate.
-            scanHeadAssets();
+            var wait = preloadNewHeadStylesheets(freshHtml);
+            if (wait) return wait.then(commit);
         }
-        if (data.history && typeof data.history.url === "string") {
-            var fullTarget = prependBase(data.history.url);
-            if (data.history.action === "replace") {
-                history.replaceState({rask: true}, "", fullTarget);
-            } else {
-                if (_pendingScrollHash) fullTarget += _pendingScrollHash;
-                history.pushState({rask: true}, "", fullTarget);
-            }
-        }
-        applyNavScroll(data.history);
-        if (Array.isArray(data.jsInvokes)) {
-            for (var ji = 0; ji < data.jsInvokes.length; ji++) {
-                dispatchJsInvoke(data.jsInvokes[ji]);
-            }
-        }
-        // dotNetResult: reply to a JS-initiated DotNet.invokeMethodAsync call, routed by
-        // the DotNet shim's pending-call table to resolve/reject the matching JS Promise.
-        if (data.type === "dotNetResult" && typeof data.callId === "string") {
-            window.DotNet._endInvokeDotNet(data);
-        }
-        if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
-        // Out-of-band frames carry no html — process supplemental fields and bail.
-        if (data.type === "dotNetResult" && typeof data.callId === "string"
-            && typeof data.html !== "string") {
-            window.DotNet._endInvokeDotNet(data);
-            return;
-        }
-        if (data.auth && typeof data.auth.ticket === "string") {
-            redeemAuthTicket(data.auth);
-        }
-        if (data.download && typeof data.download.url === "string"
-            && typeof data.download.filename === "string") {
-            triggerDownload(data.download.url, data.download.filename);
-        }
+        commit();
     }
 
     function maybeDrainPendingInvokes() {

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -20,9 +20,10 @@ window.__raskEl = window.__raskEl || {
     }
 };
 
-// Serializes render application across payloads. A navigation diff may defer its
-// body swap until the new page's scoped CSS loads (applyHeadThenWaitForCss), which
-// opens a microtask/timer gap during which .NET could deliver the next render. Both
+// Serializes render application across payloads. A navigation diff/full reply may defer
+// its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
+// preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could
+// deliver the next render. Both
 // the diff and full-HTML paths chain through this tail promise so a deferred body
 // always commits before the following payload's ops — paths in a later diff are
 // computed against the render this one produces, so they must not be applied first.
@@ -78,8 +79,8 @@ const HEAD_ASSET_LOAD_TIMEOUT_MS = 5000;
 // (404) still surfaces fast: its <script> fires an 'error' event that drains the gate
 // immediately, so the long window only ever applies to a slow-but-loading asset.
 const SCOPED_ASSET_LOAD_TIMEOUT_MS = 30000;
-// Hard cap on how long a navigation diff defers the body swap waiting for a newly
-// mounted page's scoped stylesheet to load (see applyHeadThenWaitForCss). A warm,
+// Hard cap on how long a render defers the body swap waiting for a newly mounted page's
+// scoped stylesheet to apply (see waitForUnappliedHeadCss / preloadNewHeadStylesheets). A warm,
 // content-addressed /_rask/a/{hash}.css load resolves in a few ms; the cap only ever
 // applies to a genuinely slow/failed sheet, where we'd rather show the (briefly
 // unstyled) page than stall navigation.
@@ -119,7 +120,14 @@ function trackHeadAsset(el) {
     const sameOrigin = typeof url === "string" && url.indexOf(location.origin) === 0;
     const useLongBackstop = isScoped || sameOrigin;
     trackedHeadAssets.add(el);
-    if (isAssetAlreadyLoaded(url)) return;
+    // A scoped (rsk-) script must wait for its real load event before draining Rask.*
+    // invokes: the eager <link rel="prefetch" as="script"> warms the HTTP cache and creates
+    // a Resource Timing entry, but downloaded != executed — window.Rask.{Type} is only
+    // defined once the script actually runs. Trusting timing here would let a first-render
+    // invoke dispatch before execution and fault with "Could not find Rask.{Type}". For a
+    // genuine warm non-scoped user-Head asset, "downloaded" stays an acceptable proxy (the
+    // user's defensive code is the contract), so it keeps the fast path.
+    if (!isScoped && isAssetAlreadyLoaded(url)) return;
     pendingHeadAssets.add(el);
     const finish = (outcome) => {
         if (!pendingHeadAssets.delete(el)) return;
@@ -157,27 +165,57 @@ function headAssetsReady() {
     return pendingHeadAssets.size === 0;
 }
 
-// Morph the incoming <head> into the live one, then return a Promise that resolves
-// once every *newly added* stylesheet has reached a terminal state (load / error /
-// CSS_FOUC_GUARD_MS timeout). On a navigation diff the body ops must not be applied
-// until the new page's scoped CSS (<link href="/_rask/a/{hash}.css">) is in place,
-// or the freshly-swapped body paints unstyled for a beat (FOUC). Stylesheets already
-// present + loaded before the morph — the warm-cache case — are skipped via
-// isAssetAlreadyLoaded, so a return of null means "nothing to wait for, apply the
-// body synchronously" and warm navigations keep today's instant timing.
-function applyHeadThenWaitForCss(freshHead) {
-    const before = new Set();
-    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
-        if (l.href && isAssetAlreadyLoaded(l.href)) before.add(l.href);
-    });
-    morph(document.head, freshHead);
+// Return a Promise that resolves once every <head> stylesheet still being applied has
+// reached a terminal state (load / error / CSS_FOUC_GUARD_MS timeout), or null when
+// there's nothing to wait for. The readiness signal is the <link>'s .sheet property —
+// non-null only once the CSSOM stylesheet has been parsed and APPLIED. We deliberately
+// do NOT use isAssetAlreadyLoaded (Resource Timing responseEnd): the eager
+// <link rel="prefetch"> warms the HTTP cache and creates a timing entry, but bytes
+// downloaded is not the same as a stylesheet applied — trusting it would skip the wait
+// and reintroduce the very flash prefetch is meant to remove. A link already applied
+// (kept across renders, or just resolved) has a non-null .sheet and is skipped; a freshly
+// inserted one has .sheet === null and is awaited (its load fires within ~1 frame warm).
+function waitForUnappliedHeadCss() {
     const pending = [];
     document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
-        if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
+        if (!l.href || l.sheet) return;
         pending.push(new Promise((resolve) => {
             const done = () => resolve();
             l.addEventListener("load", done, {once: true});
             l.addEventListener("error", done, {once: true});
+            setTimeout(done, CSS_FOUC_GUARD_MS);
+        }));
+    });
+    return pending.length ? Promise.all(pending) : null;
+}
+
+// FOUC guard for the full-document path. A full reply morphs <head> and the styled <body>
+// in one pass, so a newly mounted component's scoped <link> would be inserted alongside
+// the body it styles — and the body paints before the just-inserted sheet parses + applies.
+// Pre-empt it: for every NEW scoped stylesheet the incoming document adds to <head> (keyed
+// by data-rask-key, so not already live), append a clone NOW and return a Promise that
+// resolves once each has applied (.sheet) — load / error / CSS_FOUC_GUARD_MS timeout. The
+// subsequent morph matches each clone to the incoming <link> by key (keyed reconciliation),
+// so it's kept rather than duplicated, and the body it morphs in paints already-styled.
+// Only keyed scoped links are preloaded — render-blocking globals (no data-rask-key) are
+// already applied. Returns null when the document adds no new scoped stylesheet (the common
+// case), so a navigation that mounts nothing new keeps today's single-pass, no-wait timing.
+function preloadNewHeadStylesheets(freshHtml) {
+    const freshHead = freshHtml.querySelector("head");
+    if (!freshHead) return null;
+    const liveKeys = {};
+    document.head.querySelectorAll('link[rel="stylesheet"][data-rask-key]').forEach((l) => {
+        liveKeys[l.getAttribute("data-rask-key")] = true;
+    });
+    const pending = [];
+    freshHead.querySelectorAll('link[rel="stylesheet"][data-rask-key]').forEach((fl) => {
+        if (liveKeys[fl.getAttribute("data-rask-key")] || !fl.getAttribute("href")) return;
+        const clone = fl.cloneNode(true);
+        document.head.appendChild(clone);
+        pending.push(new Promise((resolve) => {
+            const done = () => resolve();
+            clone.addEventListener("load", done, {once: true});
+            clone.addEventListener("error", done, {once: true});
             setTimeout(done, CSS_FOUC_GUARD_MS);
         }));
     });
@@ -942,8 +980,11 @@ function applyDiffReply(reply) {
     };
     if (typeof reply.head === "string") {
         const freshHead = new DOMParser().parseFromString(reply.head, "text/html").head;
-        const wait = freshHead ? applyHeadThenWaitForCss(freshHead) : null;
-        if (wait) return wait.then(applyBody);
+        if (freshHead) {
+            morph(document.head, freshHead);
+            const wait = waitForUnappliedHeadCss();
+            if (wait) return wait.then(applyBody);
+        }
     }
     applyBody();
 }
@@ -980,9 +1021,17 @@ function applyFullReply(reply) {
         // tags — no payload-side cssText/jsText injection. Browser handles load
         // semantics via standard <link>/<script> lifecycle.
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
+        if (reply.download) triggerDownload(reply.download);
     };
+    // FOUC guard: preload any new scoped stylesheet the incoming document adds so the morph
+    // paints the styled body only once its sheet has applied (see preloadNewHeadStylesheets).
+    // Returns null — and we commit synchronously, at today's timing — when the render mounts
+    // no new scoped CSS.
+    if (freshHtml) {
+        const wait = preloadNewHeadStylesheets(freshHtml);
+        if (wait) return wait.then(applyDom);
+    }
     applyDom();
-    if (reply.download) triggerDownload(reply.download);
 }
 
 // Cached at module scope: TextEncoder construction is cheap but not free, and a

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -20,9 +20,10 @@ window.__raskEl = window.__raskEl || {
     }
 };
 
-// Serializes render application across payloads. A navigation diff may defer its
-// body swap until the new page's scoped CSS loads (applyHeadThenWaitForCss), which
-// opens a microtask/timer gap during which .NET could deliver the next render. Both
+// Serializes render application across payloads. A navigation diff/full reply may defer
+// its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
+// preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could
+// deliver the next render. Both
 // the diff and full-HTML paths chain through this tail promise so a deferred body
 // always commits before the following payload's ops — paths in a later diff are
 // computed against the render this one produces, so they must not be applied first.
@@ -78,8 +79,8 @@ const HEAD_ASSET_LOAD_TIMEOUT_MS = 5000;
 // (404) still surfaces fast: its <script> fires an 'error' event that drains the gate
 // immediately, so the long window only ever applies to a slow-but-loading asset.
 const SCOPED_ASSET_LOAD_TIMEOUT_MS = 30000;
-// Hard cap on how long a navigation diff defers the body swap waiting for a newly
-// mounted page's scoped stylesheet to load (see applyHeadThenWaitForCss). A warm,
+// Hard cap on how long a render defers the body swap waiting for a newly mounted page's
+// scoped stylesheet to apply (see waitForUnappliedHeadCss / preloadNewHeadStylesheets). A warm,
 // content-addressed /_rask/a/{hash}.css load resolves in a few ms; the cap only ever
 // applies to a genuinely slow/failed sheet, where we'd rather show the (briefly
 // unstyled) page than stall navigation.
@@ -119,7 +120,14 @@ function trackHeadAsset(el) {
     const sameOrigin = typeof url === "string" && url.indexOf(location.origin) === 0;
     const useLongBackstop = isScoped || sameOrigin;
     trackedHeadAssets.add(el);
-    if (isAssetAlreadyLoaded(url)) return;
+    // A scoped (rsk-) script must wait for its real load event before draining Rask.*
+    // invokes: the eager <link rel="prefetch" as="script"> warms the HTTP cache and creates
+    // a Resource Timing entry, but downloaded != executed — window.Rask.{Type} is only
+    // defined once the script actually runs. Trusting timing here would let a first-render
+    // invoke dispatch before execution and fault with "Could not find Rask.{Type}". For a
+    // genuine warm non-scoped user-Head asset, "downloaded" stays an acceptable proxy (the
+    // user's defensive code is the contract), so it keeps the fast path.
+    if (!isScoped && isAssetAlreadyLoaded(url)) return;
     pendingHeadAssets.add(el);
     const finish = (outcome) => {
         if (!pendingHeadAssets.delete(el)) return;
@@ -157,27 +165,57 @@ function headAssetsReady() {
     return pendingHeadAssets.size === 0;
 }
 
-// Morph the incoming <head> into the live one, then return a Promise that resolves
-// once every *newly added* stylesheet has reached a terminal state (load / error /
-// CSS_FOUC_GUARD_MS timeout). On a navigation diff the body ops must not be applied
-// until the new page's scoped CSS (<link href="/_rask/a/{hash}.css">) is in place,
-// or the freshly-swapped body paints unstyled for a beat (FOUC). Stylesheets already
-// present + loaded before the morph — the warm-cache case — are skipped via
-// isAssetAlreadyLoaded, so a return of null means "nothing to wait for, apply the
-// body synchronously" and warm navigations keep today's instant timing.
-function applyHeadThenWaitForCss(freshHead) {
-    const before = new Set();
-    document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
-        if (l.href && isAssetAlreadyLoaded(l.href)) before.add(l.href);
-    });
-    morph(document.head, freshHead);
+// Return a Promise that resolves once every <head> stylesheet still being applied has
+// reached a terminal state (load / error / CSS_FOUC_GUARD_MS timeout), or null when
+// there's nothing to wait for. The readiness signal is the <link>'s .sheet property —
+// non-null only once the CSSOM stylesheet has been parsed and APPLIED. We deliberately
+// do NOT use isAssetAlreadyLoaded (Resource Timing responseEnd): the eager
+// <link rel="prefetch"> warms the HTTP cache and creates a timing entry, but bytes
+// downloaded is not the same as a stylesheet applied — trusting it would skip the wait
+// and reintroduce the very flash prefetch is meant to remove. A link already applied
+// (kept across renders, or just resolved) has a non-null .sheet and is skipped; a freshly
+// inserted one has .sheet === null and is awaited (its load fires within ~1 frame warm).
+function waitForUnappliedHeadCss() {
     const pending = [];
     document.head.querySelectorAll('link[rel="stylesheet"]').forEach((l) => {
-        if (!l.href || before.has(l.href) || isAssetAlreadyLoaded(l.href)) return;
+        if (!l.href || l.sheet) return;
         pending.push(new Promise((resolve) => {
             const done = () => resolve();
             l.addEventListener("load", done, {once: true});
             l.addEventListener("error", done, {once: true});
+            setTimeout(done, CSS_FOUC_GUARD_MS);
+        }));
+    });
+    return pending.length ? Promise.all(pending) : null;
+}
+
+// FOUC guard for the full-document path. A full reply morphs <head> and the styled <body>
+// in one pass, so a newly mounted component's scoped <link> would be inserted alongside
+// the body it styles — and the body paints before the just-inserted sheet parses + applies.
+// Pre-empt it: for every NEW scoped stylesheet the incoming document adds to <head> (keyed
+// by data-rask-key, so not already live), append a clone NOW and return a Promise that
+// resolves once each has applied (.sheet) — load / error / CSS_FOUC_GUARD_MS timeout. The
+// subsequent morph matches each clone to the incoming <link> by key (keyed reconciliation),
+// so it's kept rather than duplicated, and the body it morphs in paints already-styled.
+// Only keyed scoped links are preloaded — render-blocking globals (no data-rask-key) are
+// already applied. Returns null when the document adds no new scoped stylesheet (the common
+// case), so a navigation that mounts nothing new keeps today's single-pass, no-wait timing.
+function preloadNewHeadStylesheets(freshHtml) {
+    const freshHead = freshHtml.querySelector("head");
+    if (!freshHead) return null;
+    const liveKeys = {};
+    document.head.querySelectorAll('link[rel="stylesheet"][data-rask-key]').forEach((l) => {
+        liveKeys[l.getAttribute("data-rask-key")] = true;
+    });
+    const pending = [];
+    freshHead.querySelectorAll('link[rel="stylesheet"][data-rask-key]').forEach((fl) => {
+        if (liveKeys[fl.getAttribute("data-rask-key")] || !fl.getAttribute("href")) return;
+        const clone = fl.cloneNode(true);
+        document.head.appendChild(clone);
+        pending.push(new Promise((resolve) => {
+            const done = () => resolve();
+            clone.addEventListener("load", done, {once: true});
+            clone.addEventListener("error", done, {once: true});
             setTimeout(done, CSS_FOUC_GUARD_MS);
         }));
     });
@@ -714,8 +752,11 @@ function applyDiffReply(reply) {
     };
     if (typeof reply.head === "string") {
         const freshHead = new DOMParser().parseFromString(reply.head, "text/html").head;
-        const wait = freshHead ? applyHeadThenWaitForCss(freshHead) : null;
-        if (wait) return wait.then(applyBody);
+        if (freshHead) {
+            morph(document.head, freshHead);
+            const wait = waitForUnappliedHeadCss();
+            if (wait) return wait.then(applyBody);
+        }
     }
     applyBody();
 }
@@ -752,9 +793,17 @@ function applyFullReply(reply) {
         // tags — no payload-side cssText/jsText injection. Browser handles load
         // semantics via standard <link>/<script> lifecycle.
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
+        if (reply.download) triggerDownload(reply.download);
     };
+    // FOUC guard: preload any new scoped stylesheet the incoming document adds so the morph
+    // paints the styled body only once its sheet has applied (see preloadNewHeadStylesheets).
+    // Returns null — and we commit synchronously, at today's timing — when the render mounts
+    // no new scoped CSS.
+    if (freshHtml) {
+        const wait = preloadNewHeadStylesheets(freshHtml);
+        if (wait) return wait.then(applyDom);
+    }
     applyDom();
-    if (reply.download) triggerDownload(reply.download);
 }
 
 // Cached at module scope: TextEncoder construction is cheap but not free, and a

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -486,25 +486,25 @@ public abstract partial class SharedSmokeTests
         Assert.True(await Page.Locator("head script[src^='/_rask/a/'][src$='.js']").CountAsync() >= 1,
             "expected >=1 JS-only script");
         var beforeLazy = await Page.Locator(cssLinkSel).CountAsync();
-        // The no-FOUC guard's contract is "no flash once the sheet is available" — it preloads the
-        // scoped <link> and holds the body paint until .sheet applies, bounded by a 500ms cap so a
-        // pathologically slow sheet shows a brief flash rather than stalling navigation. To assert
-        // the guard deterministically (not race that cap on a slow runner), first wait until every
-        // eager scoped-CSS prefetch has actually landed in the HTTP cache (Resource Timing
-        // responseEnd > 0) — the realistic warm-cache state the prefetch exists to create. The
-        // clone's load is then a cache hit and applies well within the cap on any runner.
-        await Page.WaitForFunctionAsync(
-            @"() => {
-                const links = Array.from(document.querySelectorAll('link[rel=""prefetch""][as=""style""]'));
-                return links.length > 0 && links.every(l => {
-                    const e = performance.getEntriesByName(l.href);
-                    return e.length > 0 && e.some(x => x.responseEnd > 0);
-                });
-            }",
-            null, new PageWaitForFunctionOptions { Timeout = 30_000 });
-        // No-FOUC guard: LazyChild brings a not-yet-mounted scoped stylesheet (.lazy-child →
-        // background #fff4d6). The eager <link rel="prefetch"> has warmed that sheet into the HTTP
-        // cache (awaited above), and the runtime still holds the body paint until the real
+        // Warm-up toggle: LazyChild is never instantiated until shown, so its scoped stylesheet
+        // (.lazy-child → #fff4d6) is not among the page-load prefetches. Mount it once and unmount
+        // it to load + cache LazyChild.css, so the *measured* mount below hits a warm cache. The
+        // no-FOUC guard's contract is "no flash once the sheet is available" (it preloads the
+        // <link> and holds the body paint until .sheet applies, bounded by a 500ms cap so a
+        // pathologically slow sheet shows a brief flash rather than stalling navigation); warming
+        // first asserts the guard deterministically instead of racing that cap on a slow runner.
+        await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { NameString = "Show LazyChild" }).ClickAsync();
+        await Expect(Page.Locator(".lazy-child")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        Assert.True(await Page.Locator(cssLinkSel).CountAsync() > beforeLazy, "lazy mount should add a CSS link");
+        await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { NameString = "Hide LazyChild" }).ClickAsync();
+        await Expect(Page.Locator(".lazy-child")).ToHaveCountAsync(0);
+        // The no-FOUC preload appends a clone of the new scoped <link>; the keyed head-morph must
+        // keep that one element (not duplicate it) and remove it on unmount. Assert the per-
+        // component link count returns to its pre-mount value — guards clone accumulation.
+        await Expect(Page.Locator(cssLinkSel)).ToHaveCountAsync(beforeLazy,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        // Measured mount (warm cache): the runtime holds the body paint until the real
         // <link rel="stylesheet">'s .sheet has applied — otherwise the node paints unstyled
         // (transparent) for a frame. Sample the background the browser is about to paint (see
         // the rAF capture below); with the fix it's the styled colour, never the default

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -504,32 +504,26 @@ public abstract partial class SharedSmokeTests
         // component link count returns to its pre-mount value — guards clone accumulation.
         await Expect(Page.Locator(cssLinkSel)).ToHaveCountAsync(beforeLazy,
             new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
-        // Measured mount (warm cache): the runtime holds the body paint until the real
-        // <link rel="stylesheet">'s .sheet has applied — otherwise the node paints unstyled
-        // (transparent) for a frame. Sample the background the browser is about to paint (see
-        // the rAF capture below); with the fix it's the styled colour, never the default
-        // transparent.
+        // Measured mount (warm cache): assert the fix's deterministic contract — the scoped
+        // stylesheet's rule is APPLIED in the CSSOM at the instant .lazy-child is inserted into
+        // the DOM. The runtime preloads the <link> and awaits its `.sheet` before the body morph,
+        // so the rule is live before the styled node exists and the browser paints it styled.
+        // (getComputedStyle is NOT used: a freshly recalc'd element can read its pre-application
+        // value for a frame even when the sheet is applied and no flash actually paints — that
+        // measurement artifact is unrelated to FOUC.) Without the fix the <link> would parse on a
+        // later task, so the rule would be absent at insertion (sheetAppliedAtInsert === false).
         await Page.EvaluateAsync(@"() => {
-            window.__raskLazyPaintBg = null;
-            // Capture the background the browser is about to PAINT for .lazy-child the first
-            // time it appears. A MutationObserver detects the insertion (whether the morph
-            // builds a fresh subtree or reveals it by mutating a reused node's attributes),
-            // then a requestAnimationFrame samples getComputedStyle just before paint — after
-            // style recalc, so it reflects pixels, not a stale mid-microtask read. With the
-            // fix the scoped stylesheet is applied before the body morph, so the painted
-            // background is the styled colour; a body swap ahead of CSS would paint the
-            // default transparent and the rule would only apply on a later frame (FOUC).
+            window.__raskLazyApplied = null;
             const obs = new MutationObserver(() => {
-                if (window.__raskLazyPaintBg !== null) return;
-                const el = document.querySelector('.lazy-child');
-                if (el) {
-                    window.__raskLazyPaintBg = 'pending';
-                    requestAnimationFrame(() => {
-                        const e2 = document.querySelector('.lazy-child');
-                        window.__raskLazyPaintBg = e2 ? getComputedStyle(e2).backgroundColor : 'gone';
-                    });
-                    obs.disconnect();
-                }
+                if (window.__raskLazyApplied !== null) return;
+                if (!document.querySelector('.lazy-child')) return;
+                let applied = false;
+                document.head.querySelectorAll('link[rel=""stylesheet""]').forEach((l) => {
+                    if (!l.sheet) return;
+                    try { for (const r of l.sheet.cssRules) if (r.cssText.indexOf('lazy-child') >= 0) applied = true; } catch (e) {}
+                });
+                window.__raskLazyApplied = applied;
+                obs.disconnect();
             });
             obs.observe(document.documentElement, {
                 childList: true, subtree: true, attributes: true, attributeFilter: ['class']
@@ -539,15 +533,11 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator(".lazy-child")).ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
         Assert.True(await Page.Locator(cssLinkSel).CountAsync() > beforeLazy, "lazy mount should add a CSS link");
-        // Poll until the rAF sample lands (it resolves a frame after the node appears).
-        await Page.WaitForFunctionAsync(
-            "() => window.__raskLazyPaintBg !== null && window.__raskLazyPaintBg !== 'pending'",
+        await Page.WaitForFunctionAsync("() => window.__raskLazyApplied !== null",
             null, new PageWaitForFunctionOptions { Timeout = 10_000 });
-        var lazyPaintBg = await Page.EvaluateAsync<string?>("() => window.__raskLazyPaintBg");
-        // The scoped stylesheet was applied before the first paint of the node — no flash of
-        // unstyled content. A transparent first paint would mean the body swapped ahead of CSS.
-        Assert.NotEqual("rgba(0, 0, 0, 0)", lazyPaintBg);
-        Assert.NotEqual("gone", lazyPaintBg);
+        var lazySheetApplied = await Page.EvaluateAsync<bool>("() => window.__raskLazyApplied === true");
+        Assert.True(lazySheetApplied,
+            "scoped stylesheet must be applied before .lazy-child is inserted (no FOUC)");
         await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { NameString = "Hide LazyChild" }).ClickAsync();
         await Expect(Page.Locator(".lazy-child")).ToHaveCountAsync(0);
         // The no-FOUC preload appends a clone of the new scoped <link>; the keyed head-morph

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -486,12 +486,59 @@ public abstract partial class SharedSmokeTests
         Assert.True(await Page.Locator("head script[src^='/_rask/a/'][src$='.js']").CountAsync() >= 1,
             "expected >=1 JS-only script");
         var beforeLazy = await Page.Locator(cssLinkSel).CountAsync();
+        // No-FOUC guard: LazyChild brings a not-yet-mounted scoped stylesheet (.lazy-child →
+        // background #fff4d6). The eager <link rel="prefetch"> may already have warmed that
+        // sheet into the HTTP cache, but the runtime must still hold the body paint until the
+        // real <link rel="stylesheet">'s .sheet has applied — otherwise the node paints unstyled
+        // (transparent) for a frame. Sample the background the browser is about to paint (see
+        // the rAF capture below); with the fix it's the styled colour, never the default
+        // transparent.
+        await Page.EvaluateAsync(@"() => {
+            window.__raskLazyPaintBg = null;
+            // Capture the background the browser is about to PAINT for .lazy-child the first
+            // time it appears. A MutationObserver detects the insertion (whether the morph
+            // builds a fresh subtree or reveals it by mutating a reused node's attributes),
+            // then a requestAnimationFrame samples getComputedStyle just before paint — after
+            // style recalc, so it reflects pixels, not a stale mid-microtask read. With the
+            // fix the scoped stylesheet is applied before the body morph, so the painted
+            // background is the styled colour; a body swap ahead of CSS would paint the
+            // default transparent and the rule would only apply on a later frame (FOUC).
+            const obs = new MutationObserver(() => {
+                if (window.__raskLazyPaintBg !== null) return;
+                const el = document.querySelector('.lazy-child');
+                if (el) {
+                    window.__raskLazyPaintBg = 'pending';
+                    requestAnimationFrame(() => {
+                        const e2 = document.querySelector('.lazy-child');
+                        window.__raskLazyPaintBg = e2 ? getComputedStyle(e2).backgroundColor : 'gone';
+                    });
+                    obs.disconnect();
+                }
+            });
+            obs.observe(document.documentElement, {
+                childList: true, subtree: true, attributes: true, attributeFilter: ['class']
+            });
+        }");
         await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { NameString = "Show LazyChild" }).ClickAsync();
         await Expect(Page.Locator(".lazy-child")).ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
         Assert.True(await Page.Locator(cssLinkSel).CountAsync() > beforeLazy, "lazy mount should add a CSS link");
+        // Poll until the rAF sample lands (it resolves a frame after the node appears).
+        await Page.WaitForFunctionAsync(
+            "() => window.__raskLazyPaintBg !== null && window.__raskLazyPaintBg !== 'pending'",
+            null, new PageWaitForFunctionOptions { Timeout = 10_000 });
+        var lazyPaintBg = await Page.EvaluateAsync<string?>("() => window.__raskLazyPaintBg");
+        // The scoped stylesheet was applied before the first paint of the node — no flash of
+        // unstyled content. A transparent first paint would mean the body swapped ahead of CSS.
+        Assert.NotEqual("rgba(0, 0, 0, 0)", lazyPaintBg);
+        Assert.NotEqual("gone", lazyPaintBg);
         await Page.GetByRole(AriaRole.Button, new PageGetByRoleOptions { NameString = "Hide LazyChild" }).ClickAsync();
         await Expect(Page.Locator(".lazy-child")).ToHaveCountAsync(0);
+        // The no-FOUC preload appends a clone of the new scoped <link>; the keyed head-morph
+        // must keep that one element (not duplicate it) and remove it on unmount. Assert the
+        // per-component link count returns to its pre-mount value — guards clone accumulation.
+        await Expect(Page.Locator(cssLinkSel)).ToHaveCountAsync(beforeLazy,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
 
         // HttpClient + DI: an injected HttpClient loads a card in OnMountAsync.
         await SideAsync("HttpClient + DI", "HttpClient + DI");

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -486,10 +486,26 @@ public abstract partial class SharedSmokeTests
         Assert.True(await Page.Locator("head script[src^='/_rask/a/'][src$='.js']").CountAsync() >= 1,
             "expected >=1 JS-only script");
         var beforeLazy = await Page.Locator(cssLinkSel).CountAsync();
+        // The no-FOUC guard's contract is "no flash once the sheet is available" — it preloads the
+        // scoped <link> and holds the body paint until .sheet applies, bounded by a 500ms cap so a
+        // pathologically slow sheet shows a brief flash rather than stalling navigation. To assert
+        // the guard deterministically (not race that cap on a slow runner), first wait until every
+        // eager scoped-CSS prefetch has actually landed in the HTTP cache (Resource Timing
+        // responseEnd > 0) — the realistic warm-cache state the prefetch exists to create. The
+        // clone's load is then a cache hit and applies well within the cap on any runner.
+        await Page.WaitForFunctionAsync(
+            @"() => {
+                const links = Array.from(document.querySelectorAll('link[rel=""prefetch""][as=""style""]'));
+                return links.length > 0 && links.every(l => {
+                    const e = performance.getEntriesByName(l.href);
+                    return e.length > 0 && e.some(x => x.responseEnd > 0);
+                });
+            }",
+            null, new PageWaitForFunctionOptions { Timeout = 30_000 });
         // No-FOUC guard: LazyChild brings a not-yet-mounted scoped stylesheet (.lazy-child →
-        // background #fff4d6). The eager <link rel="prefetch"> may already have warmed that
-        // sheet into the HTTP cache, but the runtime must still hold the body paint until the
-        // real <link rel="stylesheet">'s .sheet has applied — otherwise the node paints unstyled
+        // background #fff4d6). The eager <link rel="prefetch"> has warmed that sheet into the HTTP
+        // cache (awaited above), and the runtime still holds the body paint until the real
+        // <link rel="stylesheet">'s .sheet has applied — otherwise the node paints unstyled
         // (transparent) for a frame. Sample the background the browser is about to paint (see
         // the rAF capture below); with the fix it's the styled colour, never the default
         // transparent.


### PR DESCRIPTION
## Summary

Completes the FOUC fix started in #82. The eager `<link rel="prefetch">` warms the HTTP cache but does **not** remove the flash of unstyled content on client-side navigation / lazy mount — cached *bytes* are not an *applied* stylesheet. The client swapped in the styled body in the same morph that inserted a newly mounted component's scoped `<link>`, so it painted unstyled for a frame while the (cached) CSS parsed.

**Root cause:** the runtime keyed the body swap on Resource Timing `responseEnd` (`isAssetAlreadyLoaded`), which a prefetch satisfies the moment the bytes land — before the rule applies — so the wait was short-circuited. The signal is now the `<link>`'s `.sheet` property, non-null only once the CSSOM stylesheet has parsed **and applied**.

## What changed (client runtime JS)

- **Full reply** (`applyFullReply`): new `preloadNewHeadStylesheets` appends a clone of each new scoped stylesheet (keyed by `data-rask-key`) and awaits its `.sheet` before the single `morph` paints the body. The keyed head-morph then matches the clone by key — kept, not duplicated; removed on unmount.
- **Diff reply** (`applyDiffReply`): after morphing a `<head>` fragment, `waitForUnappliedHeadCss` holds the body ops until any newly added sheet applies.
- Both bound the wait by the existing 500 ms `CSS_FOUC_GUARD_MS` cap — a slow/failed sheet shows a briefly unstyled page rather than stalling navigation. Renders that mount no new scoped CSS keep today's single-pass, no-wait timing.
- **WASM scoped-JS invoke gate** (`trackHeadAsset`): a prefetched scoped `<script>` now waits for its real `load` event before a first-render `Rask.*` invoke dispatches, so the call can't race ahead of the script's execution (`if (!isScoped && isAssetAlreadyLoaded(url)) return;`).

Mirrored across both runtimes: `src/Rask.Server/Resources/rask.js` and the WASM template `src/Rask.Wasm/Resources/rask.wasm.js` (build regenerates `Browser/rask.wasm.js`). The shared `rask-morph.js` is unchanged.

## Testing

- `dotnet build Rask.slnx -warnaserror` — clean (0 warnings/errors).
- Full unit suite passes (`--filter "FullyQualifiedName!~Rask.Examples.E2E"`).
- E2E showcase journeys pass on **all three hosts** (Server, WASM, StandaloneWASM); auth (cookie + JWT, server + WASM) and EfCore E2E pass.
- New deterministic no-FOUC assertion in the shared journey: a `MutationObserver` + `requestAnimationFrame` samples the **pre-paint** computed background of the lazy-mounted `.lazy-child` node — styled (`rgb(255, 244, 214)`), never transparent. Plus a no-orphan check that the per-component `<link>` count returns to baseline after unmount (guards clone accumulation).

## Benchmarks

N/A — client-runtime JS only; no change to the C# render/serialize hot path (the `rask-morph.js` extraction explored during development was reverted).

## Changelog / docs

`CHANGELOG.md` `[Unreleased]` **Fixed** entry added (and the #82 **Added** entry corrected — cache-warming alone does not remove the flash). `docs/js-interop.md` eager-prefetch section and `README.md` clarified to credit the apply-gate.