### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-16
+
 ### Added
 - **Eager prefetch of scoped CSS/JS eliminates navigation FOUC.** The page `<head>` now also
   emits a low-priority `<link rel="prefetch">` for *every* registered scoped asset — not just the


### PR DESCRIPTION
Promote the `[Unreleased]` CHANGELOG section to **v0.9.0** (dated 2026-06-16) and open a fresh `[Unreleased]`.

The `v0.9.0` tag is already pushed and `release.yml` is packing/publishing the six NuGet packages + GitHub release from it (MinVer derives the version from the tag). This PR lands the changelog promotion on `main` to match.

### v0.9.0 highlights
- **Added:** eager prefetch of scoped CSS/JS (`PreloadScopedAssets`, on by default).
- **Fixed:** scoped-asset FOUC on navigation/lazy mount — the runtime holds the body paint until the scoped stylesheet has *applied* (#83); code-sample `Raw`-tab swap no longer renders markup as literal text.
- **Changed:** showcase & auth samples reorganized into feature folders; samples show real verbatim source, one tab per file.