### PR TITLE
feat(core): add headless TableModel<T>, rename Virtualize to VirtualizeModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`TableModel<T>` — a headless, fully *controlled* table primitive** (in the spirit of TanStack
+  Table). It renders no markup of its own and owns no state: the host sorts, filters, and pages its
+  own data and hands the model the final `Rows` plus the current view state (`Sort`, `PageIndex`,
+  `SelectedKeys`, …). The model projects sort-aware `Headers` and selection-aware `Rows` into the
+  `Render` delegate and raises `OnSort` / `OnPage` / `OnSelect` **intents**; the host applies them to
+  its own state and re-renders. Supporting types live in the new `Rask.Core.Tables` namespace
+  (`ColumnDef<T>`, `ColumnSort`, `SortDirection`, `HeaderCell`, `TableRow<T>`, `TableModelContext<T>`).
+  The `/table` showcase page now drives its sorting and paging through `TableModel<T>` from the URL
+  query string.
+
+### Changed
+- **Renamed the headless `Virtualize<T>` primitive to `VirtualizeModel<T>`** (component + factory) so
+  the headless "view-model" primitives read as one family with `TableModel<T>`. **Breaking:** update
+  call sites from `Virtualize<T>(…)` to `VirtualizeModel<T>(…)`; behaviour is unchanged. The
+  `Rask.Core.Virtualization` support types keep their names.
+
 ## [0.9.0] - 2026-06-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -998,11 +998,11 @@ an event handler. See `samples/Rask.Example.Shared/Features/Upload/UploadPage.cs
 <summary><b>📜 Virtualization</b></summary>
 <br>
 
-`Virtualize<T>` is a headless windowed-list primitive — it emits no DOM of its own and instead invokes the `Render`
+`VirtualizeModel<T>` is a headless windowed-list primitive — it emits no DOM of its own and instead invokes the `Render`
 delegate with the visible window of items plus the spacer offsets you wire into your own scroll container.
 
 ```csharp
-Virtualize<Row>(
+VirtualizeModel<Row>(
     Items: _rows,                                  // or ItemsProvider for async paging
     ItemSize: 32,                                  // pixel height of one row
     OverscanCount: 4,
@@ -1024,9 +1024,44 @@ Virtualize<Row>(
 ```
 
 Provide exactly one of `Items` (in-memory) or `ItemsProvider` (async paging:
-`Func<ItemsProviderRequest, ValueTask<ItemsProviderResult<T>>>`). With a provider, `Virtualize` caches loaded items by
-global index, requests missing windows in the background, and emits placeholder rows with `IsPlaceholder = true` until
-a fetch completes. See `samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs` for a 10K-row table demo.
+`Func<ItemsProviderRequest, ValueTask<ItemsProviderResult<T>>>`). With a provider, `VirtualizeModel` caches loaded items
+by global index, requests missing windows in the background, and emits placeholder rows with `IsPlaceholder = true`
+until a fetch completes. See `samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs` for a 10K-row table
+demo.
+
+</details>
+
+<details>
+<summary><b>🧮 Headless tables</b></summary>
+<br>
+
+`TableModel<T>` is a fully **controlled, headless** table primitive (à la TanStack Table). It owns no state and
+transforms no data — *you* sort, filter, and page your own data and pass it the final `Rows` plus the current view
+state (`Sort`, `PageIndex`, `SelectedKeys`). It projects sort-aware `Headers` and selection-aware `Rows` into the
+`Render` delegate and raises `OnSort` / `OnPage` / `OnSelect` **intents**; you apply them to your own state and
+re-render.
+
+```csharp
+TableModel<Person>(
+    Columns: columns,                  // ColumnDef<Person> { Id, Header, Sortable }
+    Rows: pageRows,                    // the final page YOU sorted + sliced
+    KeySelector: p => p.Id,
+    Sort: sort, PageIndex: page, PageCount: pages, SelectedKeys: selected,
+    MultiSort: true,
+    OnSort:   s => { sort = s; },       // YOU apply + re-render; new props flow back in
+    OnPage:   p => { page = p; },
+    OnSelect: k => { selected = k; },
+    Render: ctx => Table()[
+        Thead()[Tr()[ ctx.Headers.Select(h => Th(Key: h.ColumnId)[
+            Button(OnClick: h.ToggleSort)[h.Header]]) ]],
+        Tbody()[ ctx.Rows.Select(row => Tr(Key: row.Key)[
+            Td()[Input("checkbox", Checked: row.IsSelected, OnChange: _ => row.ToggleSelected())],
+            Td()[row.Value.Name] ]) ]
+    ])
+```
+
+`OnSort` / `OnPage` / `OnSelect` are auto-wrapped callbacks, so firing an intent re-renders the owning host. See
+`samples/Rask.Example.Shared/Features/Table/TablePage.cs` for a URL-driven, sortable + paged demo.
 
 </details>
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/VirtualizationScrollBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Benchmarks/VirtualizationScrollBenchmarks.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Components;
 using Rask.Benchmarks.VsBlazor.Components;
 using Rask.Benchmarks.VsBlazor.Infrastructure;
 using Rask.Core;
-using RaskVirtualize = Rask.Core.Components.Virtualize;
+using RaskVirtualize = Rask.Core.Components.VirtualizeModel;
 
 namespace Rask.Benchmarks.VsBlazor.Benchmarks;
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/VirtualizationScroll.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/VirtualizationScroll.cs
@@ -3,13 +3,13 @@ using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
 using Rask.Core;
 using C = Rask.Core.Components.Generated;
-using RaskVirtualize = Rask.Core.Components.Virtualize;
+using RaskVirtualize = Rask.Core.Components.VirtualizeModel;
 
 namespace Rask.Benchmarks.VsBlazor.Components;
 
 /// <summary>
 ///     1000-row list, item height 24px, viewport ~240px (10 rows visible). The Rask
-///     side wires <c>Rask.Core.Components.Virtualize&lt;int&gt;</c>; the Blazor side
+///     side wires <c>Rask.Core.Components.VirtualizeModel&lt;int&gt;</c>; the Blazor side
 ///     renders every row with an explicit <c>@for</c> loop. We deliberately do NOT
 ///     compare against Blazor's own <c>Microsoft.AspNetCore.Components.Web.Virtualization.Virtualize&lt;T&gt;</c>
 ///     because that component reads viewport size via JS interop — without a live
@@ -32,7 +32,7 @@ internal static class VirtualizationScroll
                                                            .GetField("_scrollTop",
                                                                BindingFlags.Instance | BindingFlags.NonPublic)
                                                        ?? throw new InvalidOperationException(
-                                                           "Rask.Core.Components.Virtualize._scrollTop field not found");
+                                                           "Rask.Core.Components.VirtualizeModel._scrollTop field not found");
 
     /// <summary>
     ///     Construct the Rask tree once. The returned root holds a reference to the
@@ -47,7 +47,7 @@ internal static class VirtualizationScroll
             items[i] = i;
         }
 
-        var virt = C.Virtualize(
+        var virt = C.VirtualizeModel(
             ctx =>
             {
                 var rows = new List<Child>(ctx.VisibleItems.Count);

--- a/benchmarks/Rask.Benchmarks/LiveRenderRoundTripBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/LiveRenderRoundTripBenchmarks.cs
@@ -19,7 +19,7 @@ namespace Rask.Benchmarks;
 [MemoryDiagnoser]
 public class LiveRenderRoundTripBenchmarks
 {
-    // 100-row list with data-rask-key emission per row. Mirrors the Virtualize / sortable
+    // 100-row list with data-rask-key emission per row. Mirrors the VirtualizeModel / sortable
     // table pattern: every render shuffles the row order so the keyed-morph branch (in
     // rask-morph.js) would do an O(k) reorder client-side instead of replacing every node.
     // The C# side measures the server-render allocation cost of producing the keyed HTML;

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ Guides and references for building with Rask. New here? Start with the project
 |-------|----------------|
 | [Getting started](getting-started.md) | Install the templates, scaffold an app, write your first component, add interactivity and a route. |
 | [Routing](routing.md) | `[Route]`, route/query params, nested routes, type-safe `Routes.*` URLs, `Navigator`, `RouteState`. |
-| [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), `Virtualize`, drag-and-drop. |
+| [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), `VirtualizeModel`, `TableModel`, drag-and-drop. |
 | [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), asset delivery. |
 | [Forms & validation](forms.md) | Two-way binding, `Form<T>`/`EditContext`, inline / DataAnnotations / FluentValidation / async validators, radio & checkbox groups. |
 | [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -6,7 +6,8 @@ sending events up, nesting children, and rendering windowed or reorderable lists
 - [Children & fragments](#children--fragments)
 - [Callbacks: child → parent](#callbacks-child--parent)
 - [Context: provide / consume](#context-provide--consume)
-- [Virtualize: windowed lists](#virtualize-windowed-lists)
+- [Virtualize: windowed lists](#virtualize--windowed-lists)
+- [TableModel: headless tables](#tablemodel--headless-tables)
 - [Drag and drop](#drag-and-drop)
 
 ---
@@ -134,13 +135,13 @@ Runnable demo: [`samples/Rask.Example.Shared/Features/Context/ContextThemeDemo.c
 
 ## Virtualize — windowed lists
 
-`Virtualize<T>` is **headless**: *you* render the scroll container and rows from a
+`VirtualizeModel<T>` is **headless**: *you* render the scroll container and rows from a
 `VirtualizationState ctx`, and it tells you which slice is visible. The first argument is
 the body builder; pass **exactly one** of `Items` (positional or named) or `ItemsProvider`,
 plus `ItemSize` (row height in px, required) and optional `OverscanCount`.
 
 ```csharp
-Virtualize<Row>(
+VirtualizeModel<Row>(
     ctx => Div(Style: "height:400px; overflow:auto;", OnScroll: ctx.OnScroll)[
         Div(Style: $"height:{ctx.OffsetBefore}px"),          // top spacer
         Table()[Tbody()[
@@ -172,6 +173,47 @@ Provider mode caches by index, marks rows `IsPlaceholder` while a page is in fli
 cancels + disposes superseded requests (and on unmount).
 
 Runnable demo: [`samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs`](../samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs).
+
+---
+
+## TableModel — headless tables
+
+`TableModel<T>` is a **fully controlled, headless** table primitive (à la TanStack Table). It owns
+**no state** and **transforms no data** — *you* sort, filter, and page your own data and pass it the
+final `Rows` plus the current view state. The model projects sort-aware headers and selection-aware
+rows into a `TableModelContext<T>` and raises **intent** events; you apply them to your own state and
+re-render, and the new props flow back down.
+
+```csharp
+TableModel<Person>(
+    ctx => Table()[
+        Thead()[Tr()[
+            // each HeaderCell carries the current sort Direction + a ToggleSort intent
+            ctx.Headers.Select(h => Th(Key: h.ColumnId)[
+                Button(OnClick: h.ToggleSort)[h.Header, h.Direction switch {
+                    SortDirection.Ascending => " ▲", SortDirection.Descending => " ▼", _ => "" }]])
+        ]],
+        Tbody()[
+            ctx.Rows.Select(row => Tr(Key: row.Key)[                 // already sorted + paged by you
+                Td()[Input("checkbox", Checked: row.IsSelected, OnChange: _ => row.ToggleSelected())],
+                Td()[row.Value.Name]])
+        ]
+    ],
+    Columns: columns,            // IReadOnlyList<ColumnDef<Person>> (Id / Header / Sortable)
+    Rows: pageRows,              // the final page YOU produced
+    KeySelector: p => p.Id,      // selection / row identity (defaults to the row reference)
+    Sort: sort,                  // current sort state (controlled in)
+    PageIndex: page, PageCount: pages, SelectedKeys: selected,
+    OnSort:   s => { sort = s; },        // YOU apply + re-render
+    OnPage:   p => { page = p; },
+    OnSelect: k => { selected = k; })
+```
+
+`OnSort` / `OnPage` / `OnSelect` are auto-wrapped callbacks, so invoking an intent re-renders the
+owning host. `MultiSort: true` makes `ToggleSort` additive (asc → desc → removed per column, others
+preserved). Runnable demo:
+[`samples/Rask.Example.Shared/Features/Table/TablePage.cs`](../samples/Rask.Example.Shared/Features/Table/TablePage.cs)
+drives it entirely from the URL query string.
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -213,7 +213,7 @@ up a real host and a browser — so reserve it for paths a unit test genuinely c
 - `rask.js` / `rask.wasm.js` client behaviour (DOM diff application, focus/IDL preservation on keyed
   reorders, scoped-asset delivery),
 - real auth handshakes (cookie redeem, WS reconnect after sign-in),
-- anything depending on real browser layout (e.g. `Virtualize` scroll windowing).
+- anything depending on real browser layout (e.g. `VirtualizeModel` scroll windowing).
 
 Everything else — rendering, attribute order, binding, validation, lifecycle ordering, event-handler
 dispatch — is faster and more reliable as a unit test.

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Getting started](docs/getting-started.md): install, first app, project layout.
 - [Routing](docs/routing.md): `[Route]`, params, `Router()`/`Outlet()`, navigation.
 - [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
-- [Composition](docs/composition.md): children, context (provide/consume), callbacks.
+- [Composition](docs/composition.md): children, context (provide/consume), callbacks, headless primitives (`VirtualizeModel<T>`, `TableModel<T>`), drag-and-drop.
 - [Forms](docs/forms.md): binding, validation, RadioGroup/CheckboxGroup, EditContext.
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.

--- a/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
+++ b/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
@@ -103,7 +103,7 @@ public sealed class LiveTicker : Component
                 // result, then the already-cancelled wake makes the inter-tick delay
                 // return immediately and the loop re-polls the new asset. Linked to ct
                 // so unmount tears the loop down. Exchange-before-Dispose mirrors
-                // Virtualize's superseded-CTS handling so a racing Cancel() is benign.
+                // VirtualizeModel's superseded-CTS handling so a racing Cancel() is benign.
                 var wake = CancellationTokenSource.CreateLinkedTokenSource(ct);
                 Interlocked.Exchange(ref _wake, wake)?.Dispose();
 

--- a/samples/Rask.Example.Shared/Features/Table/TablePage.cs
+++ b/samples/Rask.Example.Shared/Features/Table/TablePage.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Rask.Core.Routing;
+using Rask.Core.Tables;
 
 namespace Rask.Example.Shared.Features;
 
@@ -8,6 +9,19 @@ namespace Rask.Example.Shared.Features;
 public sealed class TablePage(Navigator nav) : Component
 {
     private static readonly Person[] _people = BuildPeople(120);
+
+    // Column metadata for the headless TableModel<T>. The model uses Id/Header/Sortable to project
+    // sort-aware header cells; this page renders each cell itself (badges, currency, dates), so no
+    // Value accessor is needed.
+    private static readonly IReadOnlyList<ColumnDef<Person>> _columns =
+    [
+        new() { Id = "id", Header = "#" },
+        new() { Id = "name", Header = "Name" },
+        new() { Id = "city", Header = "City" },
+        new() { Id = "department", Header = "Department" },
+        new() { Id = "salary", Header = "Salary" },
+        new() { Id = "joined", Header = "Joined" }
+    ];
 
     [QueryParam] public string? Filter { get; set; }
     [QueryParam("sort")] public string? SortKey { get; set; }
@@ -59,6 +73,7 @@ public sealed class TablePage(Navigator nav) : Component
         var sortKey = (SortKey ?? string.Empty).ToLowerInvariant();
         var filter = Filter?.Trim() ?? string.Empty;
 
+        // The host does the data work; TableModel never filters, sorts, or slices.
         IEnumerable<Person> view = _people;
         if (filter.Length > 0)
         {
@@ -88,170 +103,175 @@ public sealed class TablePage(Navigator nav) : Component
         var from = totalFiltered == 0 ? 0 : ((page - 1) * size) + 1;
         var to = totalFiltered == 0 ? 0 : from + visible.Length - 1;
 
+        // Current sort as the controlled-state prop the model echoes back through ctx.Headers.
+        IReadOnlyList<ColumnSort> sortState = sortKey.Length > 0
+            ? [new ColumnSort(sortKey, dirAsc ? SortDirection.Ascending : SortDirection.Descending)]
+            : [];
+
         return
         [
             PageHeader.Render(
                 "Data table",
-                "Sortable columns, paged rows, search and page-size selector — all driven from the URL query string. Bookmark or share any view."),
-            Div(Class: "card shadow-sm border-0")[
-                Div(Class: "card-header bg-white d-flex flex-wrap gap-2 align-items-center justify-content-between")[
-                    Div(Class: "input-group input-group-sm", Style: "max-width:320px;")[
-                        Span(Class: "input-group-text bg-white")[I(Class: "bi bi-search")],
-                        Input(
-                            "search",
-                            Class: "form-control",
-                            Placeholder: "Filter name, city, department…",
-                            Value: Filter ?? string.Empty,
-                            OnInput: v => nav.SetQuery(
-                                KeyValuePair.Create<string, string?>("filter", v ?? string.Empty),
-                                KeyValuePair.Create<string, string?>("page", "1")))
-                    ],
-                    Div(Class: "d-flex align-items-center gap-2")[
-                        Label(Class: "small text-secondary mb-0")["Rows per page"],
-                        Select(
-                            Class: "form-select form-select-sm",
-                            Style: "max-width:90px;",
-                            OnChange: v => nav.SetQuery(
-                                KeyValuePair.Create<string, string?>("size", v),
-                                KeyValuePair.Create<string, string?>("page", "1")))[
-                            Option("5", size == 5)["5"],
-                            Option("10", size == 10)["10"],
-                            Option("25", size == 25)["25"],
-                            Option("50", size == 50)["50"]
-                        ]
-                    ]
-                ],
-                Div(Class: "table-responsive")[
-                    Table(Class: "table table-hover table-striped align-middle mb-0")[
-                        Thead(Class: "table-light")[
-                            Tr()[
-                                SortHeader("id", "#", "width:80px;", sortKey, dirAsc),
-                                SortHeader("name", "Name", null, sortKey, dirAsc),
-                                SortHeader("city", "City", "width:160px;", sortKey, dirAsc),
-                                SortHeader("department", "Department", "width:160px;", sortKey, dirAsc),
-                                SortHeader("salary", "Salary", "width:140px; text-align:right;", sortKey, dirAsc, true),
-                                SortHeader("joined", "Joined", "width:140px;", sortKey, dirAsc)
-                            ]
+                "Sortable columns, paged rows, search and page-size selector — all driven from the URL query string. " +
+                "Sorting and paging flow through the headless TableModel<T> primitive; search and page size stay plain " +
+                "query-param controls."),
+            TableModel<Person>(
+                ctx => Div(Class: "card shadow-sm border-0")[
+                    Div(Class:
+                        "card-header bg-white d-flex flex-wrap gap-2 align-items-center justify-content-between")[
+                        Div(Class: "input-group input-group-sm", Style: "max-width:320px;")[
+                            Span(Class: "input-group-text bg-white")[I(Class: "bi bi-search")],
+                            Input(
+                                "search",
+                                Class: "form-control",
+                                Placeholder: "Filter name, city, department…",
+                                Value: Filter ?? string.Empty,
+                                OnInput: v => nav.SetQuery(
+                                    KeyValuePair.Create<string, string?>("filter", v ?? string.Empty),
+                                    KeyValuePair.Create<string, string?>("page", "1")))
                         ],
-                        Tbody()[
-                            totalFiltered == 0
-                                ? Tr()[
-                                    Td(6, Class: "text-center text-secondary py-4")[
-                                        I(Class: "bi bi-search me-2"),
-                                        "No people match your search."
+                        Div(Class: "d-flex align-items-center gap-2")[
+                            Label(Class: "small text-secondary mb-0")["Rows per page"],
+                            Select(
+                                Class: "form-select form-select-sm",
+                                Style: "max-width:90px;",
+                                OnChange: v => nav.SetQuery(
+                                    KeyValuePair.Create<string, string?>("size", v),
+                                    KeyValuePair.Create<string, string?>("page", "1")))[
+                                Option("5", size == 5)["5"],
+                                Option("10", size == 10)["10"],
+                                Option("25", size == 25)["25"],
+                                Option("50", size == 50)["50"]
+                            ]
+                        ]
+                    ],
+                    Div(Class: "table-responsive")[
+                        Table(Class: "table table-hover table-striped align-middle mb-0")[
+                            Thead(Class: "table-light")[
+                                Tr()[ctx.Headers.Select(SortHeader)]
+                            ],
+                            Tbody()[
+                                ctx.Rows.Count == 0
+                                    ? Tr()[
+                                        Td(6, Class: "text-center text-secondary py-4")[
+                                            I(Class: "bi bi-search me-2"),
+                                            "No people match your search."
+                                        ]
                                     ]
-                                ]
-                                : Fragment()[
-                                    visible.Select(p =>
-                                        Tr(Key: p.Id)[
-                                            Td(Class: "text-secondary")[p.Id],
-                                            Td(Class: "fw-semibold")[p.Name],
-                                            Td()[p.City],
-                                            Td()[
-                                                Span(Class: $"badge {DeptBadge(p.Department)}")[p.Department]
-                                            ],
-                                            Td(Style: "text-align:right; font-variant-numeric:tabular-nums;")[
-                                                "$" + p.Salary.ToString("N0", CultureInfo.InvariantCulture)
-                                            ],
-                                            Td(Class: "text-secondary small")[p.Joined.ToString("yyyy-MM-dd")]
-                                        ])
-                                ]
+                                    : Fragment()[
+                                        ctx.Rows.Select(row =>
+                                            Tr(Key: row.Key)[
+                                                Td(Class: "text-secondary")[row.Value.Id],
+                                                Td(Class: "fw-semibold")[row.Value.Name],
+                                                Td()[row.Value.City],
+                                                Td()[
+                                                    Span(Class: $"badge {DeptBadge(row.Value.Department)}")[
+                                                        row.Value.Department]
+                                                ],
+                                                Td(Style: "text-align:right; font-variant-numeric:tabular-nums;")[
+                                                    "$" + row.Value.Salary.ToString("N0", CultureInfo.InvariantCulture)
+                                                ],
+                                                Td(Class: "text-secondary small")[
+                                                    row.Value.Joined.ToString("yyyy-MM-dd")]
+                                            ])
+                                    ]
+                            ]
+                        ]
+                    ],
+                    Div(Class:
+                        "card-footer bg-white d-flex flex-wrap gap-2 align-items-center justify-content-between")[
+                        Small(Class: "text-secondary")[
+                            totalFiltered == 0
+                                ? "Showing 0 of 0"
+                                : $"Showing {from}–{to} of {totalFiltered}",
+                            filter.Length > 0
+                                ? Span(Class: "ms-1")[$"(filtered from {_people.Length} total)"]
+                                : Fragment()
+                        ],
+                        Nav()[
+                            Ul(Class: "pagination pagination-sm mb-0")[BuildPagination(page, totalPages, ctx.SetPage)]
                         ]
                     ]
                 ],
-                Div(Class: "card-footer bg-white d-flex flex-wrap gap-2 align-items-center justify-content-between")[
-                    Small(Class: "text-secondary")[
-                        totalFiltered == 0
-                            ? "Showing 0 of 0"
-                            : $"Showing {from}–{to} of {totalFiltered}",
-                        filter.Length > 0
-                            ? Span(Class: "ms-1")[$"(filtered from {_people.Length} total)"]
-                            : Fragment()
-                    ],
-                    Nav()[
-                        Ul(Class: "pagination pagination-sm mb-0")[BuildPagination(page, totalPages)]
-                    ]
-                ]
-            ],
+                Columns: _columns,
+                Rows: visible,
+                KeySelector: p => p.Id,
+                Sort: sortState,
+                PageIndex: page - 1,
+                PageCount: totalPages,
+                PageSize: size,
+                TotalRowCount: totalFiltered,
+                OnSort: OnSortChanged,
+                OnPage: OnPageChanged),
             P(Class: "small text-secondary mt-3 mb-0")[
-                "Every interaction writes to the URL via ",
+                "Sorting and paging go through ",
+                Code()["TableModel<Person>"],
+                " — a headless, controlled primitive. It owns no state: this page sorts and slices the data, hands it " +
+                "the page of rows plus the current sort/page, and reacts to its ",
+                Code()["OnSort"],
+                " / ",
+                Code()["OnPage"],
+                " intents by writing to the URL via ",
                 Code()["Navigator.SetQuery"],
-                ". The page is then re-resolved against the new query: ",
-                Code()["[QueryParam]"],
-                " properties are re-bound by ",
-                Code()["PageBinder"],
-                ", and browser back / forward replay the state for free. Try sorting + paging, then copy the URL — it's shareable. (Filter input pushes a history entry per keystroke; production code would debounce or use ",
-                Code()["Navigate(…, replace: true)"],
-                ".)"
+                ". The page is then re-resolved against the new query, so browser back / forward replay the state for " +
+                "free. Try sorting + paging, then copy the URL — it's shareable."
             ]
         ];
     }
 
-    private Component SortHeader(string key, string label, string? style, string sortKey, bool dirAsc,
-        bool rightAlign = false)
+    private void OnSortChanged(IReadOnlyList<ColumnSort> sort)
     {
-        var active = sortKey == key;
-        var activeAsc = active && dirAsc;
-        var activeDesc = active && !dirAsc;
+        var entry = sort.Count > 0 ? sort[0] : (ColumnSort?)null;
+        var nextSort = entry?.ColumnId ?? string.Empty;
+        var nextDir = entry is { Direction: SortDirection.Descending } ? "desc" : "asc";
+        nav.SetQuery(
+            KeyValuePair.Create<string, string?>("sort", nextSort),
+            KeyValuePair.Create<string, string?>("dir", nextDir),
+            KeyValuePair.Create<string, string?>("page", "1"));
+    }
 
-        string icon;
-        if (!active)
-        {
-            icon = "bi-chevron-expand text-secondary opacity-50";
-        }
-        else if (dirAsc)
-        {
-            icon = "bi-chevron-up";
-        }
-        else
-        {
-            icon = "bi-chevron-down";
-        }
+    private void OnPageChanged(int pageIndex) => nav.SetQuery("page", (pageIndex + 1).ToString());
 
-        string nextSort;
-        string nextDir;
-        if (activeDesc)
+    private static Component SortHeader(HeaderCell header)
+    {
+        var style = header.ColumnId switch
         {
-            nextSort = string.Empty;
-            nextDir = "asc";
-        }
-        else if (activeAsc)
+            "id" => "width:80px;",
+            "city" => "width:160px;",
+            "department" => "width:160px;",
+            "salary" => "width:140px; text-align:right;",
+            "joined" => "width:140px;",
+            _ => null
+        };
+
+        var icon = header.Direction switch
         {
-            nextSort = key;
-            nextDir = "desc";
-        }
-        else
-        {
-            nextSort = key;
-            nextDir = "asc";
-        }
+            SortDirection.Ascending => "bi-chevron-up",
+            SortDirection.Descending => "bi-chevron-down",
+            _ => "bi-chevron-expand text-secondary opacity-50"
+        };
 
         var btnClass =
             "btn btn-link p-0 text-decoration-none text-dark fw-semibold d-inline-flex align-items-center gap-1";
-        if (rightAlign)
+        if (header.ColumnId == "salary")
         {
             btnClass += " ms-auto";
         }
 
-        return Th(Style: style, Scope: "col")[
-            Button(
-                "button",
-                Class: btnClass,
-                OnClick: () => nav.SetQuery(
-                    KeyValuePair.Create<string, string?>("sort", nextSort),
-                    KeyValuePair.Create<string, string?>("dir", nextDir),
-                    KeyValuePair.Create<string, string?>("page", "1")))[
-                Span()[label],
+        return Th(Style: style, Scope: "col", Key: header.ColumnId)[
+            Button("button", Class: btnClass, OnClick: header.ToggleSort)[
+                Span()[header.Header],
                 I(Class: $"bi {icon} small")
             ]
         ];
     }
 
-    private List<Child> BuildPagination(int page, int totalPages)
+    private static List<Child> BuildPagination(int page, int totalPages, Action<int> setPage)
     {
         var items = new List<Child>
         {
-            PageItem("«", 1, page == 1, "First"), PageItem("‹", Math.Max(1, page - 1), page == 1, "Prev")
+            PageItem("«", 1, page == 1, "First", setPage),
+            PageItem("‹", Math.Max(1, page - 1), page == 1, "Prev", setPage)
         };
 
         var windowSize = 5;
@@ -261,7 +281,7 @@ public sealed class TablePage(Navigator nav) : Component
 
         if (start > 1)
         {
-            items.Add(NumberItem(1, page));
+            items.Add(NumberItem(1, page, setPage));
             if (start > 2)
             {
                 items.Add(Li(Class: "page-item disabled")[Span(Class: "page-link")["…"]]);
@@ -270,7 +290,7 @@ public sealed class TablePage(Navigator nav) : Component
 
         for (var i = start; i <= end; i++)
         {
-            items.Add(NumberItem(i, page));
+            items.Add(NumberItem(i, page, setPage));
         }
 
         if (end < totalPages)
@@ -280,36 +300,36 @@ public sealed class TablePage(Navigator nav) : Component
                 items.Add(Li(Class: "page-item disabled")[Span(Class: "page-link")["…"]]);
             }
 
-            items.Add(NumberItem(totalPages, page));
+            items.Add(NumberItem(totalPages, page, setPage));
         }
 
-        items.Add(PageItem("›", Math.Min(totalPages, page + 1), page == totalPages, "Next"));
-        items.Add(PageItem("»", totalPages, page == totalPages, "Last"));
+        items.Add(PageItem("›", Math.Min(totalPages, page + 1), page == totalPages, "Next", setPage));
+        items.Add(PageItem("»", totalPages, page == totalPages, "Last", setPage));
         return items;
     }
 
-    private Child PageItem(string glyph, int targetPage, bool disabled, string label)
+    private static Child PageItem(string glyph, int targetPage, bool disabled, string label, Action<int> setPage)
     {
         return Li(Class: disabled ? "page-item disabled" : "page-item")[
             Button(
                 "button",
                 Class: "page-link",
                 Disabled: disabled,
-                OnClick: () => nav.SetQuery("page", targetPage.ToString()))[
+                OnClick: () => setPage(targetPage - 1))[
                 Span(Class: "visually-hidden")[label],
                 Span()[glyph]
             ]
         ];
     }
 
-    private Child NumberItem(int n, int current)
+    private static Child NumberItem(int n, int current, Action<int> setPage)
     {
         var active = n == current;
         return Li(Class: active ? "page-item active" : "page-item")[
             Button(
                 "button",
                 Class: "page-link",
-                OnClick: () => nav.SetQuery("page", n.ToString()))[
+                OnClick: () => setPage(n - 1))[
                 n
             ]
         ];

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs
@@ -48,7 +48,7 @@ public sealed class VirtualizePage : Component
             ") keep the scrollbar consistent with the full row count while ",
             Code()["VisibleItems"], " only emits the rows currently on screen."
         ],
-        Virtualize<Row>(
+        VirtualizeModel<Row>(
             ctx => Div(
                 Class: "border rounded bg-white",
                 Style: "height:400px; overflow:auto;",
@@ -104,7 +104,7 @@ public sealed class VirtualizePage : Component
             "Honour ", Code()["req.CancellationToken"],
             " in your own providers so the cancellation actually propagates."
         ],
-        Virtualize(
+        VirtualizeModel(
             ctx => Div(
                 Class: "border rounded bg-white",
                 Style: "height:400px; overflow:auto;",

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -800,7 +800,7 @@ public abstract class Component
 
     // Overflow path for renders with > _smallHandlerIds.Length handlers in one root.
     // The prebake covers 1024 handlers per render — orders of magnitude past anything
-    // realistic. When a Virtualize / huge keyed list pushes past that, stackalloc + a
+    // realistic. When a VirtualizeModel / huge keyed list pushes past that, stackalloc + a
     // direct TryFormat skips the int.ToString allocation that `"h" + n` would force.
     private static string CreateLargeHandlerId(int n)
     {

--- a/src/Rask.Core/Components/DragDrop.cs
+++ b/src/Rask.Core/Components/DragDrop.cs
@@ -13,7 +13,7 @@ namespace Rask.Core.Components;
 // per column. See /drag-drop in the showcase for both patterns.
 //
 // Invoked through the generated factory `Components.DragDrop(...)`; the render delegate is the
-// `Body` parameter (named so to avoid colliding with Component.Render(), same as Virtualize).
+// `Body` parameter (named so to avoid colliding with Component.Render(), same as VirtualizeModel).
 public sealed class DragDrop : Component
 {
     // The render fragment. Called with a fresh DragDropContext every render; returns the user's
@@ -26,7 +26,7 @@ public sealed class DragDrop : Component
     public Func<DragDropMove, Task>? OnDropAsync { get; set; }
 
     // DragDrop reads mutable internal drag state (source / hover target) that the framework can't
-    // observe through props, so every render must re-execute — same reasoning as Virtualize.
+    // observe through props, so every render must re-execute — same reasoning as VirtualizeModel.
     protected override bool BypassRenderCache => true;
 
     internal string? SourceZoneInternal { get; private set; }

--- a/src/Rask.Core/Components/RadioGroup.cs
+++ b/src/Rask.Core/Components/RadioGroup.cs
@@ -3,7 +3,7 @@ using Rask.Core.Forms;
 
 namespace Rask.Core.Components;
 
-// Hand-written generic factory (same shape as Virtualize<T> / Context.Provide<T>): binds a single
+// Hand-written generic factory (same shape as VirtualizeModel<T> / Context.Provide<T>): binds a single
 // TValue model property to a set of mutually-exclusive radio inputs. Mirrors Input.Bound — parses
 // the expression, resolves the ambient EditContext, and wires each radio's change handler to set
 // the property and re-validate. Returns a transparent Fragment of <label><input radio>…</label>

--- a/src/Rask.Core/Components/TableModel.Generics.cs
+++ b/src/Rask.Core/Components/TableModel.Generics.cs
@@ -1,0 +1,87 @@
+using System.Diagnostics.CodeAnalysis;
+using Rask.Core.Live;
+using Rask.Core.Tables;
+
+namespace Rask.Core.Components;
+
+// Hand-written factory for the [SkipFactory] TableModel<T> component. Lives in the same
+// `partial class Generated` the generator emits the other Rask.Core.Components factories into, and
+// reproduces the generated factory shape (GetOrCreate via the live context + re-apply props +
+// NotifyParameters) so reconciliation and lifecycle behave identically to a generated component.
+//
+// The OnSort/OnPage/OnSelect (+ async) delegates are wrapped with AutoCallback.Wrap so that invoking
+// one — from a header click, pager button, or row checkbox — re-renders the host that supplied it.
+// That re-render is the whole controlled loop: the host mutates its own state in the callback, then
+// renders again with the new Sort/PageIndex/SelectedKeys props. The Render delegate
+// (Func<TableModelContext<T>, Component>) is deliberately NOT wrapped — only true event callbacks are.
+public static partial class Generated
+{
+    [UnconditionalSuppressMessage("Trimming", "IL2091",
+        Justification = "T flows only through generic instantiation and user-supplied delegates; " +
+                        "no reflection, no DynamicInvoke.")]
+    public static TableModel<T> TableModel<T>(
+        Func<TableModelContext<T>, Component> Render,
+        IReadOnlyList<ColumnDef<T>> Columns,
+        IReadOnlyList<T> Rows,
+        Func<T, object>? KeySelector = null,
+        IReadOnlyList<ColumnSort>? Sort = null,
+        int PageIndex = 0,
+        int PageCount = 1,
+        int PageSize = 0,
+        int TotalRowCount = 0,
+        IReadOnlyCollection<object>? SelectedKeys = null,
+        bool MultiSort = false,
+        Action<IReadOnlyList<ColumnSort>>? OnSort = null,
+        Func<IReadOnlyList<ColumnSort>, Task>? OnSortAsync = null,
+        Action<int>? OnPage = null,
+        Func<int, Task>? OnPageAsync = null,
+        Action<IReadOnlyCollection<object>>? OnSelect = null,
+        Func<IReadOnlyCollection<object>, Task>? OnSelectAsync = null,
+        object? Key = null)
+    {
+        ArgumentNullException.ThrowIfNull(Render);
+
+        var onSort = AutoCallback.Wrap(OnSort);
+        var onSortAsync = AutoCallback.Wrap(OnSortAsync);
+        var onPage = AutoCallback.Wrap(OnPage);
+        var onPageAsync = AutoCallback.Wrap(OnPageAsync);
+        var onSelect = AutoCallback.Wrap(OnSelect);
+        var onSelectAsync = AutoCallback.Wrap(OnSelectAsync);
+
+        TableModel<T> Apply(TableModel<T> c)
+        {
+            c.Body = Render;
+            c.Columns = Columns;
+            c.Rows = Rows;
+            c.KeySelector = KeySelector;
+            c.Sort = Sort;
+            c.PageIndex = PageIndex;
+            c.PageCount = PageCount;
+            c.PageSize = PageSize;
+            c.TotalRowCount = TotalRowCount;
+            c.SelectedKeys = SelectedKeys;
+            c.MultiSort = MultiSort;
+            c.OnSort = onSort;
+            c.OnSortAsync = onSortAsync;
+            c.OnPage = onPage;
+            c.OnPageAsync = onPageAsync;
+            c.OnSelect = onSelect;
+            c.OnSelectAsync = onSelectAsync;
+            c.Key = Key;
+            return c;
+        }
+
+        if (LiveRenderContext.Current is { } ctx)
+        {
+            var component = ctx.GetOrCreate<TableModel<T>>(static _ => new TableModel<T>());
+            Apply(component);
+            // Presentational: the projection is recomputed from whatever props the host passes this
+            // render, so always treat params as changed — the parent only re-invokes this factory when
+            // it re-renders, and a fresh projection per render is trivial.
+            ctx.NotifyParameters(component, true);
+            return component;
+        }
+
+        return Apply(new TableModel<T>());
+    }
+}

--- a/src/Rask.Core/Components/TableModel.cs
+++ b/src/Rask.Core/Components/TableModel.cs
@@ -1,0 +1,277 @@
+using Rask.Core.Tables;
+
+namespace Rask.Core.Components;
+
+// Headless, TanStack-Table-style table model. Fully *controlled* / presentational: it renders no DOM
+// of its own, holds no state, and transforms no data. The host sorts and slices its own data, passes
+// the final `Rows` plus the current view state (Sort / PageIndex / SelectedKeys / …) in as props, and
+// TableModel:
+//   • projects sort-aware HeaderCells and selection-aware TableRows into a TableModelContext<T>, and
+//   • exposes pure handler actions (ToggleSort, SetPage, ToggleRow, …) that only *propose* the next
+//     state by invoking the matching event (OnSort / OnPage / OnSelect) — they mutate nothing.
+// The host applies the proposal to its own state and re-renders, and the new props flow back down.
+//
+// Because all inputs are props, there is no hidden state for the framework to miss — so unlike
+// VirtualizeModel this needs no BypassRenderCache and no OnPropsChanged reset. The re-render after an event
+// is the standard callback path: the OnSort/OnPage/OnSelect delegates are wrapped by AutoCallback in
+// the factory, so invoking them re-renders the owning host (see TableModel.Generics.cs).
+//
+// Always invoked through the hand-written generic factory `Components.TableModel<T>(...)`
+// (see TableModel.Generics.cs); the class carries [SkipFactory] so the generator emits no competing
+// factory. The Render delegate is stored under `Body` to avoid colliding with Component.Render().
+[SkipFactory]
+public sealed class TableModel<T> : Component
+{
+    public IReadOnlyList<ColumnDef<T>>? Columns { get; set; }
+    public IReadOnlyList<T>? Rows { get; set; }
+
+    // The render fragment. Stored as "Body" rather than "Render" to avoid colliding with
+    // Component.Render(); the factory exposes it to callers as "Render".
+    public Func<TableModelContext<T>, Component>? Body { get; set; }
+
+    // Optional row identity. When null, the row reference itself is the key.
+    public Func<T, object>? KeySelector { get; set; }
+
+    // ----- controlled state in -----
+    public IReadOnlyList<ColumnSort>? Sort { get; set; }
+    public int PageIndex { get; set; }
+    public int PageCount { get; set; } = 1;
+    public int PageSize { get; set; }
+    public int TotalRowCount { get; set; }
+    public IReadOnlyCollection<object>? SelectedKeys { get; set; }
+    public bool MultiSort { get; set; }
+
+    // ----- events out (wrapped by AutoCallback in the factory) -----
+    public Action<IReadOnlyList<ColumnSort>>? OnSort { get; set; }
+    public Func<IReadOnlyList<ColumnSort>, Task>? OnSortAsync { get; set; }
+    public Action<int>? OnPage { get; set; }
+    public Func<int, Task>? OnPageAsync { get; set; }
+    public Action<IReadOnlyCollection<object>>? OnSelect { get; set; }
+    public Func<IReadOnlyCollection<object>, Task>? OnSelectAsync { get; set; }
+
+    protected override RenderResult Render()
+    {
+        if (Body is null)
+        {
+            throw new InvalidOperationException("TableModel: Render delegate is required.");
+        }
+
+        if (Columns is null || Columns.Count == 0)
+        {
+            throw new InvalidOperationException("TableModel: at least one ColumnDef is required.");
+        }
+
+        if (Rows is null)
+        {
+            throw new InvalidOperationException("TableModel: Rows is required.");
+        }
+
+        // Snapshot the controlled state for this render. The handler actions below close over these
+        // snapshots, so each render's handlers propose changes relative to the state that produced them
+        // — and the latest render's handlers are the ones the host's DOM wiring invokes.
+        var columns = Columns;
+        var rows = Rows;
+        var sort = Sort ?? Array.Empty<ColumnSort>();
+        var selected = SelectedKeys ?? Array.Empty<object>();
+        var selectedLookup = selected as HashSet<object> ?? new HashSet<object>(selected);
+
+        object KeyOf(T row) => KeySelector?.Invoke(row) ?? row!;
+
+        int SortIndexOf(string columnId)
+        {
+            for (var i = 0; i < sort.Count; i++)
+            {
+                if (sort[i].ColumnId == columnId)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
+        void RaiseSort(IReadOnlyList<ColumnSort> next)
+        {
+            if (OnSort is not null)
+            {
+                OnSort(next);
+            }
+            else if (OnSortAsync is not null)
+            {
+                _ = OnSortAsync(next);
+            }
+        }
+
+        void RaiseSelect(IReadOnlyCollection<object> next)
+        {
+            if (OnSelect is not null)
+            {
+                OnSelect(next);
+            }
+            else if (OnSelectAsync is not null)
+            {
+                _ = OnSelectAsync(next);
+            }
+        }
+
+        void RaisePage(int next)
+        {
+            if (OnPage is not null)
+            {
+                OnPage(next);
+            }
+            else if (OnPageAsync is not null)
+            {
+                _ = OnPageAsync(next);
+            }
+        }
+
+        void ToggleSort(string columnId)
+        {
+            ColumnDef<T>? col = null;
+            foreach (var c in columns)
+            {
+                if (c.Id == columnId)
+                {
+                    col = c;
+                    break;
+                }
+            }
+
+            if (col is null || !col.Sortable)
+            {
+                return;
+            }
+
+            var idx = SortIndexOf(columnId);
+            var current = idx >= 0 ? sort[idx].Direction : (SortDirection?)null;
+
+            if (!MultiSort)
+            {
+                IReadOnlyList<ColumnSort> next = current switch
+                {
+                    null => new[] { new ColumnSort(columnId, SortDirection.Ascending) },
+                    SortDirection.Ascending => new[] { new ColumnSort(columnId, SortDirection.Descending) },
+                    _ => Array.Empty<ColumnSort>()
+                };
+                RaiseSort(next);
+                return;
+            }
+
+            var list = new List<ColumnSort>(sort);
+            if (idx < 0)
+            {
+                list.Add(new ColumnSort(columnId, SortDirection.Ascending));
+            }
+            else if (sort[idx].Direction == SortDirection.Ascending)
+            {
+                list[idx] = new ColumnSort(columnId, SortDirection.Descending);
+            }
+            else
+            {
+                list.RemoveAt(idx);
+            }
+
+            RaiseSort(list);
+        }
+
+        void SetPage(int target)
+        {
+            var max = Math.Max(0, PageCount - 1);
+            var clamped = Math.Clamp(target, 0, max);
+            if (clamped != PageIndex)
+            {
+                RaisePage(clamped);
+            }
+        }
+
+        void ToggleRow(T row)
+        {
+            var key = KeyOf(row);
+            var next = new HashSet<object>(selected);
+            if (!next.Add(key))
+            {
+                next.Remove(key);
+            }
+
+            RaiseSelect(next);
+        }
+
+        void ToggleAll()
+        {
+            var keys = new List<object>(rows.Count);
+            foreach (var row in rows)
+            {
+                keys.Add(KeyOf(row));
+            }
+
+            var next = new HashSet<object>(selected);
+            var allSelected = keys.Count > 0 && keys.TrueForAll(next.Contains);
+            foreach (var key in keys)
+            {
+                if (allSelected)
+                {
+                    next.Remove(key);
+                }
+                else
+                {
+                    next.Add(key);
+                }
+            }
+
+            RaiseSelect(next);
+        }
+
+        var headers = new HeaderCell[columns.Count];
+        for (var i = 0; i < columns.Count; i++)
+        {
+            var col = columns[i];
+            var columnId = col.Id;
+            var sortIdx = col.Sortable ? SortIndexOf(columnId) : -1;
+            var direction = sortIdx >= 0 ? sort[sortIdx].Direction : (SortDirection?)null;
+            headers[i] = new HeaderCell(
+                columnId,
+                col.Header ?? columnId,
+                col.Sortable,
+                direction,
+                sortIdx,
+                () => ToggleSort(columnId));
+        }
+
+        var projectedRows = new TableRow<T>[rows.Count];
+        var allRowsSelected = rows.Count > 0;
+        for (var i = 0; i < rows.Count; i++)
+        {
+            var row = rows[i];
+            var key = KeyOf(row);
+            var isSelected = selectedLookup.Contains(key);
+            allRowsSelected &= isSelected;
+            projectedRows[i] = new TableRow<T>(row, key, i, isSelected, () => ToggleRow(row));
+        }
+
+        var context = new TableModelContext<T>
+        {
+            Headers = headers,
+            Rows = projectedRows,
+            Sort = sort,
+            ToggleSort = ToggleSort,
+            ClearSort = () => RaiseSort(Array.Empty<ColumnSort>()),
+            PageIndex = PageIndex,
+            PageCount = PageCount,
+            PageSize = PageSize,
+            TotalRowCount = TotalRowCount,
+            HasPrevPage = PageIndex > 0,
+            HasNextPage = PageIndex < PageCount - 1,
+            SetPage = SetPage,
+            NextPage = () => SetPage(PageIndex + 1),
+            PrevPage = () => SetPage(PageIndex - 1),
+            SelectedKeys = selected,
+            IsSelected = row => selectedLookup.Contains(KeyOf(row)),
+            ToggleRow = ToggleRow,
+            ToggleAll = ToggleAll,
+            AllSelected = allRowsSelected
+        };
+
+        return Body(context);
+    }
+}

--- a/src/Rask.Core/Components/VirtualizeModel.Generics.cs
+++ b/src/Rask.Core/Components/VirtualizeModel.Generics.cs
@@ -4,20 +4,20 @@ using Rask.Core.Virtualization;
 
 namespace Rask.Core.Components;
 
-// Hand-written generic factory for Virtualize. Lives in the same `partial class Generated`
+// Hand-written generic factory for VirtualizeModel. Lives in the same `partial class Generated`
 // that ComponentFactoryGenerator emits the non-generic factory into. Captures T in a closure
 // so the runtime side stays type-erased — no reflection, no DynamicInvoke, trim-safe.
 //
 // The typed call site:
-//   Virtualize<Person>(Items: people, ItemSize: 32, Render: ctx => Div(...)[..ctx.VisibleItems.Select(...)])
+//   VirtualizeModel<Person>(Items: people, ItemSize: 32, Render: ctx => Div(...)[..ctx.VisibleItems.Select(...)])
 // becomes a forward to the generated non-generic factory:
-//   Virtualize(Items: ..., ItemSize: 32, Body: state => Render(new VirtualizationContext<Person>(state)))
+//   VirtualizeModel(Items: ..., ItemSize: 32, Body: state => Render(new VirtualizationContext<Person>(state)))
 public static partial class Generated
 {
     // Wrapper-cache: dedup erased-provider closures per typed user delegate. Without this,
-    // every Virtualize<T> factory call would allocate a fresh `async req => …` wrapper, the
+    // every VirtualizeModel<T> factory call would allocate a fresh `async req => …` wrapper, the
     // generated non-generic factory's per-property reference compare would flag ItemsProvider
-    // as changed every render, and Virtualize.OnPropsChanged would treat that as a data-source
+    // as changed every render, and VirtualizeModel.OnPropsChanged would treat that as a data-source
     // swap and reset the cache. ConditionalWeakTable lets the wrapper live exactly as long as
     // the typed delegate the user supplied.
     private static readonly ConditionalWeakTable<Delegate, Delegate> _erasedProviderCache = new();
@@ -25,7 +25,7 @@ public static partial class Generated
     [UnconditionalSuppressMessage("Trimming", "IL2091",
         Justification = "T flows through here only via closures over user-supplied delegates. " +
                         "No reflection, no DynamicInvoke; the typed → erased projections are static casts.")]
-    public static Virtualize Virtualize<T>(
+    public static VirtualizeModel VirtualizeModel<T>(
         Func<VirtualizationContext<T>, Component> Render,
         IEnumerable<T>? Items = null,
         Func<ItemsProviderRequest, ValueTask<ItemsProviderResult<T>>>? ItemsProvider = null,
@@ -36,7 +36,7 @@ public static partial class Generated
         ArgumentNullException.ThrowIfNull(Render);
 
         // Wrap the typed render fragment into a closure over a VirtualizationState. Body
-        // changes per render are fine — Virtualize.OnPropsChanged doesn't reset state on
+        // changes per render are fine — VirtualizeModel.OnPropsChanged doesn't reset state on
         // Body swaps, only on Items/ItemsProvider swaps.
         Func<VirtualizationState, Component> body =
             state => Render(new VirtualizationContext<T>(state));
@@ -50,7 +50,7 @@ public static partial class Generated
                     (Func<ItemsProviderRequest, ValueTask<ItemsProviderResult<T>>>)typed));
         }
 
-        return Virtualize(
+        return VirtualizeModel(
             Body: body,
             Items: Items,
             ItemsProvider: erasedProvider,

--- a/src/Rask.Core/Components/VirtualizeModel.cs
+++ b/src/Rask.Core/Components/VirtualizeModel.cs
@@ -16,8 +16,8 @@ namespace Rask.Core.Components;
 // into place instead of replacing them — focus and scroll state survive the
 // re-render. See /virtualize in the showcase for the pattern.
 //
-// Always invoked through the hand-written generic factory `Components.Virtualize<T>(...)`
-// (see Virtualize.Generics.cs). The non-generic factory remains as the forwarding target.
+// Always invoked through the hand-written generic factory `Components.VirtualizeModel<T>(...)`
+// (see VirtualizeModel.Generics.cs). The non-generic factory remains as the forwarding target.
 //
 // Items vs ItemsProvider — exactly one must be set:
 //   • Items: IEnumerable in memory; window is sliced directly.
@@ -25,7 +25,7 @@ namespace Rask.Core.Components;
 //     async paging. Component caches loaded items by global index, requests missing windows
 //     in the background, and re-renders on completion. The first render before the count
 //     is known emits an all-placeholder window so the user can render a Loading view.
-public sealed class Virtualize : Component
+public sealed class VirtualizeModel : Component
 {
     private CancellationTokenSource? _activeFetch;
     private Dictionary<int, object?>? _cache;
@@ -40,7 +40,7 @@ public sealed class Virtualize : Component
     public IEnumerable? Items { get; set; }
 
     // Stored as a Delegate? so the non-generic factory's signature stays simple. The typed
-    // Virtualize<T>(...) factory wraps the user's
+    // VirtualizeModel<T>(...) factory wraps the user's
     //   Func<ItemsProviderRequest, ValueTask<ItemsProviderResult<T>>>
     // into the erased
     //   Func<ItemsProviderRequest, ValueTask<ItemsProviderResultErased>>
@@ -58,10 +58,10 @@ public sealed class Virtualize : Component
     // The render fragment. Called with the type-erased VirtualizationState every render;
     // returns the user's chosen root Component for the virtualized region. Stored under the
     // name "Body" rather than "Render" to avoid colliding with Component.Render(). The
-    // user-facing typed factory Virtualize<T>(...) exposes this parameter as "Render".
+    // user-facing typed factory VirtualizeModel<T>(...) exposes this parameter as "Render".
     public Func<VirtualizationState, Component>? Body { get; set; }
 
-    // Virtualize reads mutable internal state (scroll position, item cache, total count
+    // VirtualizeModel reads mutable internal state (scroll position, item cache, total count
     // from the async provider) that the framework can't observe through props alone, so
     // every render must re-execute. Without this, the cached Div from the last render
     // would be returned even after a scroll event changed _scrollTop. Same reasoning as
@@ -91,7 +91,7 @@ public sealed class Virtualize : Component
     {
         // Cancel any in-flight fetch when the component leaves the tree so the
         // provider's await unwinds promptly and the CTS doesn't leak through GC.
-        // Without this, a Virtualize whose ItemsProvider is mid-`await` keeps the
+        // Without this, a VirtualizeModel whose ItemsProvider is mid-`await` keeps the
         // CTS rooted via the captured request.CancellationToken and the
         // FetchAsync continuation still tries to update _cache + call
         // StateHasChanged after disposal — wasted work and a small unmanaged
@@ -118,18 +118,18 @@ public sealed class Virtualize : Component
     {
         if (Body is null)
         {
-            throw new InvalidOperationException("Virtualize: Render delegate is required.");
+            throw new InvalidOperationException("VirtualizeModel: Render delegate is required.");
         }
 
         if (Items is null == ItemsProvider is null)
         {
             throw new InvalidOperationException(
-                "Virtualize: provide exactly one of Items or ItemsProvider.");
+                "VirtualizeModel: provide exactly one of Items or ItemsProvider.");
         }
 
         if (ItemSize <= 0)
         {
-            throw new InvalidOperationException("Virtualize: ItemSize must be greater than zero.");
+            throw new InvalidOperationException("VirtualizeModel: ItemSize must be greater than zero.");
         }
 
         var itemSize = ItemSize;
@@ -332,7 +332,7 @@ public sealed class Virtualize : Component
     }
 
     [UnconditionalSuppressMessage("Trimming", "IL2026",
-        Justification = "ItemsProvider is set by Virtualize<T>(...) which wraps the typed provider " +
+        Justification = "ItemsProvider is set by VirtualizeModel<T>(...) which wraps the typed provider " +
                         "into the exact erased delegate shape we cast to here. No reflection.")]
     private async Task FetchAsync(int startIndex, int count)
     {
@@ -368,7 +368,7 @@ public sealed class Virtualize : Component
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Rask Virtualize: ItemsProvider threw: {ex}");
+            Console.Error.WriteLine($"Rask VirtualizeModel: ItemsProvider threw: {ex}");
             return;
         }
 
@@ -393,7 +393,7 @@ public sealed class Virtualize : Component
     }
 }
 
-// Type-erased ItemsProvider result. The typed Virtualize<T>(...) factory boxes the user's
+// Type-erased ItemsProvider result. The typed VirtualizeModel<T>(...) factory boxes the user's
 // IReadOnlyList<T> into IReadOnlyList<object?> before handing the closure off to the
 // non-generic component. Kept internal — users only see the typed ItemsProviderResult<T>.
 internal sealed record ItemsProviderResultErased(IReadOnlyList<object?> Items, int TotalItemCount);

--- a/src/Rask.Core/Tables/ColumnDef.cs
+++ b/src/Rask.Core/Tables/ColumnDef.cs
@@ -1,0 +1,24 @@
+namespace Rask.Core.Tables;
+
+// User-supplied definition of one table column. TableModel is fully presentational: it reads only
+// Id / Header / Sortable to build sort-aware header cells — it never sorts the data or reads cell
+// values itself. Value is an OPTIONAL convenience accessor for hosts that want to render cells from a
+// generic column loop (`ctx.Headers`/`Columns`) instead of hand-writing each <td>; the table never
+// invokes it.
+public sealed class ColumnDef<T>
+{
+    // Stable column identity — used as the header key and to match ColumnSort entries in the
+    // controlled sort state. Must be unique within a Columns list.
+    public required string Id { get; init; }
+
+    // Header label. Falls back to Id when null.
+    public string? Header { get; init; }
+
+    // Whether this column offers a sort affordance. When false, its HeaderCell.ToggleSort is a no-op
+    // and HeaderCell.Direction is always null.
+    public bool Sortable { get; init; } = true;
+
+    // Optional cell-value accessor. TableModel never calls it; it exists purely so a host iterating
+    // columns generically can pull a cell value without a per-column switch.
+    public Func<T, object?>? Value { get; init; }
+}

--- a/src/Rask.Core/Tables/ColumnSort.cs
+++ b/src/Rask.Core/Tables/ColumnSort.cs
@@ -1,0 +1,6 @@
+namespace Rask.Core.Tables;
+
+// One entry in the controlled sort state: a column and the direction it is sorted in. The host owns
+// the ordered list (first entry = primary key); TableModel only proposes the next list via OnSort and
+// never stores it.
+public readonly record struct ColumnSort(string ColumnId, SortDirection Direction);

--- a/src/Rask.Core/Tables/HeaderCell.cs
+++ b/src/Rask.Core/Tables/HeaderCell.cs
@@ -1,0 +1,16 @@
+namespace Rask.Core.Tables;
+
+// Projection of one ColumnDef for the current render: the header text plus this column's place in the
+// controlled sort state and a ToggleSort action that proposes the next sort (asc → desc → none) for it.
+//   • Direction     — the column's current sort direction, or null when it is not in the sort list.
+//   • SortPriority  — its index in the sort list (0 = primary), or -1 when not sorted (drives a
+//                     multi-sort UI's "1, 2, 3" badges).
+//   • ToggleSort    — proposes the next sort via OnSort; a no-op when the column is not Sortable or no
+//                     OnSort/OnSortAsync callback was supplied.
+public sealed record HeaderCell(
+    string ColumnId,
+    string Header,
+    bool Sortable,
+    SortDirection? Direction,
+    int SortPriority,
+    Action ToggleSort);

--- a/src/Rask.Core/Tables/SortDirection.cs
+++ b/src/Rask.Core/Tables/SortDirection.cs
@@ -1,0 +1,9 @@
+namespace Rask.Core.Tables;
+
+// Direction a column is sorted in. "Unsorted" is represented by the column's absence from the sort
+// list, not a third enum member — so the asc → desc → none cycle removes the entry on the third step.
+public enum SortDirection
+{
+    Ascending,
+    Descending
+}

--- a/src/Rask.Core/Tables/TableModelContext.cs
+++ b/src/Rask.Core/Tables/TableModelContext.cs
@@ -1,0 +1,53 @@
+namespace Rask.Core.Tables;
+
+// The typed view TableModel hands to its Render delegate. TableModel is fully controlled: every value
+// here is derived from the props the host passed (Rows + Sort/PageIndex/SelectedKeys, …), and every
+// action only *proposes* a change by invoking the matching event (OnSort / OnPage / OnSelect) — it
+// never mutates the table. The host applies the proposal to its own state and re-renders, and the new
+// props flow back down.
+public sealed class TableModelContext<T>
+{
+    // Headers in column-definition order.
+    public required IReadOnlyList<HeaderCell> Headers { get; init; }
+
+    // The rows the host supplied (already sorted + sliced by the host), each wrapped with its identity
+    // and selection flag.
+    public required IReadOnlyList<TableRow<T>> Rows { get; init; }
+
+    // ----- sorting (echoes the Sort prop) -----
+    public required IReadOnlyList<ColumnSort> Sort { get; init; }
+
+    // Propose the next sort for a column id: asc → desc → removed. Replaces the whole sort unless
+    // MultiSort is set, in which case it appends/updates/removes that column while preserving the rest.
+    public required Action<string> ToggleSort { get; init; }
+
+    // Propose an empty sort.
+    public required Action ClearSort { get; init; }
+
+    // ----- pagination (echoes the page props) -----
+    public required int PageIndex { get; init; }
+    public required int PageCount { get; init; }
+    public required int PageSize { get; init; }
+    public required int TotalRowCount { get; init; }
+    public required bool HasPrevPage { get; init; }
+    public required bool HasNextPage { get; init; }
+
+    // Propose a page index (clamped to [0, PageCount-1]); fires OnPage only when the clamped target
+    // differs from the current PageIndex.
+    public required Action<int> SetPage { get; init; }
+    public required Action NextPage { get; init; }
+    public required Action PrevPage { get; init; }
+
+    // ----- selection (over the current Rows window) -----
+    public required IReadOnlyCollection<object> SelectedKeys { get; init; }
+    public required Func<T, bool> IsSelected { get; init; }
+
+    // Propose toggling one row's key in/out of the selection set.
+    public required Action<T> ToggleRow { get; init; }
+
+    // Propose selecting every row in the current window, or clearing them when all are already
+    // selected. Operates only on the rows the host passed (the current page) — cross-page select-all
+    // is the host's concern.
+    public required Action ToggleAll { get; init; }
+    public required bool AllSelected { get; init; }
+}

--- a/src/Rask.Core/Tables/TableRow.cs
+++ b/src/Rask.Core/Tables/TableRow.cs
@@ -1,0 +1,13 @@
+namespace Rask.Core.Tables;
+
+// Wrapper for one row the host passed in `Rows`: the value plus its stable identity, its position on
+// the current page, the selection flag, and a ToggleSelected action that proposes the next selection
+// set via OnSelect (a no-op when no OnSelect/OnSelectAsync callback was supplied).
+//   • Key      — KeySelector(value) when supplied, else the row reference itself.
+//   • RowIndex — index within the current `Rows` window (the host-supplied page), 0-based.
+public sealed record TableRow<T>(
+    T Value,
+    object Key,
+    int RowIndex,
+    bool IsSelected,
+    Action ToggleSelected);

--- a/src/Rask.Core/Virtualization/VirtualizationContext.cs
+++ b/src/Rask.Core/Virtualization/VirtualizationContext.cs
@@ -3,7 +3,7 @@ using Rask.Core.Live;
 
 namespace Rask.Core.Virtualization;
 
-// Typed projection of the type-erased VirtualizationState. Built by the Virtualize<T>
+// Typed projection of the type-erased VirtualizationState. Built by the VirtualizeModel<T>
 // factory's closure before handing off to the user's render fragment. Lets users iterate
 // VisibleItems with strong typing and wire OnScroll into a scrollable element.
 public sealed class VirtualizationContext<T>

--- a/src/Rask.Core/Virtualization/VirtualizationState.cs
+++ b/src/Rask.Core/Virtualization/VirtualizationState.cs
@@ -2,12 +2,12 @@ using Rask.Core.Live;
 
 namespace Rask.Core.Virtualization;
 
-// Type-erased state the Virtualize component passes to a non-generic Render delegate.
-// The typed Virtualize<T> factory wraps the user's Func<VirtualizationContext<T>, Component>
+// Type-erased state the VirtualizeModel component passes to a non-generic Render delegate.
+// The typed VirtualizeModel<T> factory wraps the user's Func<VirtualizationContext<T>, Component>
 // in a closure that re-projects this payload into a typed VirtualizationContext<T> before
 // invoking the user code. Public so the Render property's signature stays accessible from
 // outside the assembly, but downstream callers should never assemble one of these by hand —
-// always go through Virtualize<T>(...).
+// always go through VirtualizeModel<T>(...).
 public sealed class VirtualizationState
 {
     public VirtualizationState(

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -404,7 +404,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     // An event-callback delegate prop whose invocation should re-render its owner: an
     // Action/Action<T>/Func<Task>/Func<T,Task> shape (void- or Task-returning, arity <= 1). The
     // return-type rule excludes template/data delegates — Func<…,Component>, Func<…,ValueTask<…>>
-    // (Virtualize.ItemsProvider), Func<…,Child> (ErrorBoundary.Fallback), Func<…,IEnumerable<…>>
+    // (VirtualizeModel.ItemsProvider), Func<…,Child> (ErrorBoundary.Fallback), Func<…,IEnumerable<…>>
     // (validators) — so only true parent→child callbacks are wrapped.
     private static bool IsAutoRerenderDelegate(ITypeSymbol type)
     {

--- a/tests/Rask.Core.Tests/Components/TableModelTests.cs
+++ b/tests/Rask.Core.Tests/Components/TableModelTests.cs
@@ -1,0 +1,473 @@
+using Rask.Core.Tables;
+
+#pragma warning disable RASK014 // test-defined StubComponent has no generated factory
+
+namespace Rask.Core.Tests.Components;
+
+public class TableModelTests
+{
+    private static readonly Person[] People =
+    [
+        new(1, "Ada", "London"),
+        new(2, "Linus", "Helsinki"),
+        new(3, "Grace", "New York")
+    ];
+
+    private static IReadOnlyList<ColumnDef<Person>> Columns() =>
+    [
+        new() { Id = "name", Header = "Name", Value = p => p.Name },
+        new() { Id = "city", Value = p => p.City }, // Header omitted → defaults to "city"
+        new() { Id = "id", Sortable = false, Value = p => p.Id }
+    ];
+
+    [Fact]
+    public void Render_HeadlessNoOwnDom_OnlyEmitsUserMarkup()
+    {
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx => Div()["x"],
+            Columns(),
+            People));
+
+        Assert.Equal("<div>x</div>", view.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public void Render_NullColumns_Throws()
+    {
+        var view = new StubComponent(() => TableModel<Person>(ctx => Div(), null!, People));
+        Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public void Render_EmptyColumns_Throws()
+    {
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx => Div(), Array.Empty<ColumnDef<Person>>(), People));
+        Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public void Render_NullRows_Throws()
+    {
+        var view = new StubComponent(() => TableModel<Person>(ctx => Div(), Columns(), null!));
+        Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public void Render_EmptyRows_IsValid()
+    {
+        TableModelContext<Person>? captured = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div()["empty"];
+            },
+            Columns(),
+            Array.Empty<Person>()));
+
+        Assert.Equal("<div>empty</div>", view.RenderAsLiveRoot());
+        Assert.Empty(captured!.Rows);
+        Assert.False(captured.AllSelected);
+    }
+
+    [Fact]
+    public void Headers_ReflectColumnDefs_InOrder_WithDefaultsAndSortState()
+    {
+        TableModelContext<Person>? captured = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            Sort: [new ColumnSort("name", SortDirection.Descending)]));
+
+        view.RenderAsLiveRoot();
+        var headers = captured!.Headers;
+
+        Assert.Equal(["name", "city", "id"], headers.Select(h => h.ColumnId));
+        Assert.Equal("Name", headers[0].Header);
+        Assert.Equal("city", headers[1].Header); // defaulted from Id
+        Assert.Equal(SortDirection.Descending, headers[0].Direction);
+        Assert.Equal(0, headers[0].SortPriority);
+        Assert.Null(headers[1].Direction);
+        Assert.Equal(-1, headers[1].SortPriority);
+        Assert.False(headers[2].Sortable);
+        Assert.Null(headers[2].Direction);
+    }
+
+    [Theory]
+    [InlineData(null, SortDirection.Ascending)] // unsorted → asc
+    [InlineData(SortDirection.Ascending, SortDirection.Descending)] // asc → desc
+    public void ToggleSort_Single_CyclesAscThenDesc(SortDirection? current, SortDirection expected)
+    {
+        var sort = current is { } c ? new[] { new ColumnSort("name", c) } : Array.Empty<ColumnSort>();
+        var (ctx, proposals) = RenderCapturingSort(sort, multiSort: false);
+
+        ctx.ToggleSort("name");
+
+        var proposed = Assert.Single(proposals);
+        var entry = Assert.Single(proposed);
+        Assert.Equal("name", entry.ColumnId);
+        Assert.Equal(expected, entry.Direction);
+        // Controlled: the table's own view still reflects the OLD Sort prop — no internal latch.
+        Assert.Equal(sort.Length, ctx.Sort.Count);
+    }
+
+    [Fact]
+    public void ToggleSort_Single_DescCyclesToNone()
+    {
+        var (ctx, proposals) = RenderCapturingSort(
+            [new ColumnSort("name", SortDirection.Descending)], multiSort: false);
+
+        ctx.ToggleSort("name");
+
+        Assert.Empty(Assert.Single(proposals));
+    }
+
+    [Fact]
+    public void ToggleSort_NonSortableColumn_DoesNothing()
+    {
+        var (ctx, proposals) = RenderCapturingSort(Array.Empty<ColumnSort>(), multiSort: false);
+        ctx.ToggleSort("id"); // id column is Sortable = false
+        Assert.Empty(proposals);
+    }
+
+    [Fact]
+    public void ToggleSort_Multi_AppendsUpdatesAndRemoves_PreservingOthers()
+    {
+        // append a second column
+        var (ctx1, p1) = RenderCapturingSort([new ColumnSort("name", SortDirection.Ascending)], multiSort: true);
+        ctx1.ToggleSort("city");
+        Assert.Equal(
+            [new ColumnSort("name", SortDirection.Ascending), new ColumnSort("city", SortDirection.Ascending)],
+            Assert.Single(p1));
+
+        // update asc → desc, preserving the other entry's order
+        var (ctx2, p2) = RenderCapturingSort(
+            [new ColumnSort("name", SortDirection.Ascending), new ColumnSort("city", SortDirection.Ascending)],
+            multiSort: true);
+        ctx2.ToggleSort("name");
+        Assert.Equal(
+            [new ColumnSort("name", SortDirection.Descending), new ColumnSort("city", SortDirection.Ascending)],
+            Assert.Single(p2));
+
+        // desc → removed, leaving the rest
+        var (ctx3, p3) = RenderCapturingSort(
+            [new ColumnSort("name", SortDirection.Descending), new ColumnSort("city", SortDirection.Ascending)],
+            multiSort: true);
+        ctx3.ToggleSort("name");
+        Assert.Equal([new ColumnSort("city", SortDirection.Ascending)], Assert.Single(p3));
+    }
+
+    [Fact]
+    public void Headers_SortPriority_ReflectsMultiColumnOrder()
+    {
+        TableModelContext<Person>? captured = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            Sort: [new ColumnSort("city", SortDirection.Ascending), new ColumnSort("name", SortDirection.Ascending)]));
+
+        view.RenderAsLiveRoot();
+        Assert.Equal(0, captured!.Headers.Single(h => h.ColumnId == "city").SortPriority);
+        Assert.Equal(1, captured.Headers.Single(h => h.ColumnId == "name").SortPriority);
+    }
+
+    [Fact]
+    public void ClearSort_ProposesEmptySort()
+    {
+        var (ctx, proposals) = RenderCapturingSort(
+            [new ColumnSort("name", SortDirection.Ascending)], multiSort: false);
+        ctx.ClearSort();
+        Assert.Empty(Assert.Single(proposals));
+    }
+
+    [Fact]
+    public void Rows_Projection_ExposesValueKeyIndexAndSelection()
+    {
+        TableModelContext<Person>? captured = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            KeySelector: p => p.Id,
+            SelectedKeys: [2]));
+
+        view.RenderAsLiveRoot();
+        var rows = captured!.Rows;
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal(0, rows[0].RowIndex);
+        Assert.Equal("Ada", rows[0].Value.Name);
+        Assert.Equal(1, rows[0].Key);
+        Assert.False(rows[0].IsSelected);
+        Assert.True(rows[1].IsSelected); // id 2
+        Assert.True(captured.IsSelected(People[1]));
+        Assert.False(captured.IsSelected(People[0]));
+    }
+
+    [Fact]
+    public void ToggleRow_ByKeySelector_AddsAndRemoves()
+    {
+        var (ctx, proposals) = RenderCapturingSelection([2], keyBySelector: true);
+
+        ctx.ToggleRow(People[0]); // id 1 not selected → add
+        var added = Assert.Single(proposals);
+        Assert.Contains((object)1, added);
+        Assert.Contains((object)2, added);
+
+        proposals.Clear();
+        ctx.ToggleRow(People[1]); // id 2 selected → remove
+        Assert.DoesNotContain((object)2, Assert.Single(proposals));
+    }
+
+    [Fact]
+    public void ToggleRow_ByReference_WhenNoKeySelector()
+    {
+        TableModelContext<Person>? captured = null;
+        var proposals = new List<IReadOnlyCollection<object>>();
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            SelectedKeys: [People[1]], // identity is the row reference
+            OnSelect: s => proposals.Add(s)));
+
+        view.RenderAsLiveRoot();
+        Assert.True(captured!.Rows[1].IsSelected);
+
+        captured.ToggleRow(People[1]); // remove the referenced row
+        Assert.DoesNotContain(People[1], Assert.Single(proposals));
+    }
+
+    [Fact]
+    public void ToggleAll_SelectsAllOrClears_AndAllSelectedFlag()
+    {
+        var (ctxNone, pNone) = RenderCapturingSelection([], keyBySelector: true);
+        Assert.False(ctxNone.AllSelected);
+        ctxNone.ToggleAll();
+        var all = Assert.Single(pNone);
+        Assert.Equal(new object[] { 1, 2, 3 }.OrderBy(x => x), all.OrderBy(x => x));
+
+        var (ctxAll, pAll) = RenderCapturingSelection([1, 2, 3], keyBySelector: true);
+        Assert.True(ctxAll.AllSelected);
+        ctxAll.ToggleAll();
+        Assert.Empty(Assert.Single(pAll));
+    }
+
+    [Fact]
+    public void Pagination_EchoesState_AndClampsAndFiresOnlyOnChange()
+    {
+        TableModelContext<Person>? captured = null;
+        var pages = new List<int>();
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            PageIndex: 1,
+            PageCount: 3,
+            PageSize: 10,
+            TotalRowCount: 25,
+            OnPage: p => pages.Add(p)));
+
+        view.RenderAsLiveRoot();
+        Assert.Equal(1, captured!.PageIndex);
+        Assert.Equal(3, captured.PageCount);
+        Assert.Equal(10, captured.PageSize);
+        Assert.Equal(25, captured.TotalRowCount);
+        Assert.True(captured.HasPrevPage);
+        Assert.True(captured.HasNextPage);
+
+        captured.NextPage();
+        Assert.Equal(2, pages[^1]);
+        captured.PrevPage();
+        Assert.Equal(0, pages[^1]);
+        captured.SetPage(99); // clamps to PageCount-1 = 2
+        Assert.Equal(2, pages[^1]);
+
+        var before = pages.Count;
+        captured.SetPage(1); // equals current PageIndex → no event
+        Assert.Equal(before, pages.Count);
+    }
+
+    [Fact]
+    public void ControlledLoop_HostAppliesSort_TableReflectsNewProp()
+    {
+        IReadOnlyList<ColumnSort> sort = Array.Empty<ColumnSort>();
+        TableModelContext<Person>? captured = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            Sort: sort,
+            OnSort: s => sort = s)); // host owns + applies the state
+
+        view.RenderAsLiveRoot();
+        Assert.Empty(captured!.Sort);
+
+        captured.ToggleSort("name");
+        Assert.Single(sort); // host applied the proposal
+
+        view.RenderAsLiveRoot(); // new Sort prop flows back in
+        Assert.Single(captured!.Sort);
+        Assert.Equal("name", captured.Sort[0].ColumnId);
+        Assert.Equal(SortDirection.Ascending, captured.Sort[0].Direction);
+    }
+
+    [Fact]
+    public void NullCallbacks_HandlersAreSafeNoOps()
+    {
+        TableModelContext<Person>? captured = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            PageCount: 3));
+
+        view.RenderAsLiveRoot();
+
+        // No OnSort/OnPage/OnSelect supplied — every action must no-op rather than throw.
+        captured!.ToggleSort("name");
+        captured.ClearSort();
+        captured.SetPage(2);
+        captured.NextPage();
+        captured.ToggleRow(People[0]);
+        captured.ToggleAll();
+    }
+
+    [Fact]
+    public void OnSortAsync_IsInvoked_WhenSyncCallbackAbsent()
+    {
+        TableModelContext<Person>? captured = null;
+        IReadOnlyList<ColumnSort>? proposed = null;
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            OnSortAsync: s =>
+            {
+                proposed = s;
+                return Task.CompletedTask;
+            }));
+
+        view.RenderAsLiveRoot();
+        captured!.ToggleSort("name");
+
+        Assert.NotNull(proposed);
+        Assert.Equal("name", proposed![0].ColumnId);
+    }
+
+    [Fact]
+    public void TwoTableModels_DifferentRowTypes_CoexistInSameTree()
+    {
+        TableModelContext<Person>? a = null;
+        TableModelContext<int>? b = null;
+        IReadOnlyList<ColumnDef<int>> intCols = [new() { Id = "v", Value = x => x }];
+
+        var view = new StubComponent(() => Div()[
+            TableModel<Person>(
+                ctx =>
+                {
+                    a = ctx;
+                    return Span()["p"];
+                },
+                Columns(),
+                People),
+            TableModel<int>(
+                ctx =>
+                {
+                    b = ctx;
+                    return Span()["i"];
+                },
+                intCols,
+                [10, 20])
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.NotNull(a);
+        Assert.NotNull(b);
+        Assert.Equal(3, a!.Rows.Count);
+        Assert.Equal(2, b!.Rows.Count);
+        Assert.Equal(20, b.Rows[1].Value);
+        Assert.Contains("<span>p</span>", html);
+        Assert.Contains("<span>i</span>", html);
+    }
+
+    private static (TableModelContext<Person> ctx, List<IReadOnlyList<ColumnSort>> proposals) RenderCapturingSort(
+        IReadOnlyList<ColumnSort> sort, bool multiSort)
+    {
+        TableModelContext<Person>? captured = null;
+        var proposals = new List<IReadOnlyList<ColumnSort>>();
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            Sort: sort,
+            MultiSort: multiSort,
+            OnSort: s => proposals.Add(s)));
+
+        view.RenderAsLiveRoot();
+        return (captured!, proposals);
+    }
+
+    private static (TableModelContext<Person> ctx, List<IReadOnlyCollection<object>> proposals) RenderCapturingSelection(
+        IReadOnlyCollection<object> selected, bool keyBySelector)
+    {
+        TableModelContext<Person>? captured = null;
+        var proposals = new List<IReadOnlyCollection<object>>();
+        var view = new StubComponent(() => TableModel<Person>(
+            ctx =>
+            {
+                captured = ctx;
+                return Div();
+            },
+            Columns(),
+            People,
+            KeySelector: keyBySelector ? p => p.Id : null,
+            SelectedKeys: selected,
+            OnSelect: s => proposals.Add(s)));
+
+        view.RenderAsLiveRoot();
+        return (captured!, proposals);
+    }
+
+    private sealed record Person(int Id, string Name, string City);
+}

--- a/tests/Rask.Core.Tests/Components/VirtualizeModelTests.cs
+++ b/tests/Rask.Core.Tests/Components/VirtualizeModelTests.cs
@@ -5,12 +5,12 @@ using Rask.Core.Virtualization;
 
 namespace Rask.Core.Tests.Components;
 
-public class VirtualizeTests
+public class VirtualizeModelTests
 {
     [Fact]
     public void Render_HeadlessNoOwnDom_OnlyEmitsUserMarkup()
     {
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx => Div()["x"],
             new List<int> { 1, 2, 3 },
             ItemSize: 20,
@@ -24,7 +24,7 @@ public class VirtualizeTests
     {
         VirtualizationContext<int>? captured = null;
         var items = Enumerable.Range(0, 100).ToList();
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx =>
             {
                 captured = ctx;
@@ -55,7 +55,7 @@ public class VirtualizeTests
     {
         VirtualizationContext<int>? captured = null;
         var items = Enumerable.Range(0, 100).ToList();
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx =>
             {
                 captured = ctx;
@@ -95,7 +95,7 @@ public class VirtualizeTests
         // flow where StateHasChanged would trigger the second render through the WS.
         var requests = new List<ItemsProviderRequest>();
         VirtualizationContext<string>? captured = null;
-        var view = new StubComponent(() => Virtualize<string>(
+        var view = new StubComponent(() => VirtualizeModel<string>(
             ctx =>
             {
                 captured = ctx;
@@ -134,7 +134,7 @@ public class VirtualizeTests
     [Fact]
     public void Render_NoItemsAndNoProvider_Throws()
     {
-        var view = new StubComponent(() => Virtualize<int>(
+        var view = new StubComponent(() => VirtualizeModel<int>(
             ctx => Div(),
             ItemSize: 20));
 
@@ -144,7 +144,7 @@ public class VirtualizeTests
     [Fact]
     public void Render_BothItemsAndProvider_Throws()
     {
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx => Div(),
             new List<int> { 1 },
             req => ValueTask.FromResult(new ItemsProviderResult<int>(Array.Empty<int>(), 0)),
@@ -156,7 +156,7 @@ public class VirtualizeTests
     [Fact]
     public void Render_ItemSizeZero_Throws()
     {
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx => Div(),
             new List<int> { 1 },
             ItemSize: 0));
@@ -169,7 +169,7 @@ public class VirtualizeTests
     {
         VirtualizationContext<int>? captured = null;
         var items = new List<int> { 1, 2, 3 };
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx =>
             {
                 captured = ctx;
@@ -189,12 +189,12 @@ public class VirtualizeTests
     [Fact]
     public void Render_UserSetsRaskKeyOnRow_AttributeFlowsToHtml()
     {
-        // Documents the recommended keying pattern for Virtualize rows: setting
+        // Documents the recommended keying pattern for VirtualizeModel rows: setting
         // Data["rask-key"] makes the client-side morph engage its keyed reconciliation
         // path so reordered / scrolled rows keep their DOM identity (focus, scroll
         // state) across re-renders.
         var items = Enumerable.Range(0, 50).ToList();
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx => Div()[
                 ctx.VisibleItems.Select(item =>
                     Div(Data: new Dictionary<string, string?> { ["rask-key"] = item.Index.ToString() })[
@@ -213,7 +213,7 @@ public class VirtualizeTests
     [Fact]
     public async Task ItemsProvider_Unmount_CancelsInFlightFetch()
     {
-        // Regression: Virtualize's in-flight ItemsProvider fetch must be
+        // Regression: VirtualizeModel's in-flight ItemsProvider fetch must be
         // cancelled when the component leaves the parent's tree. Pre-fix the
         // _activeFetch CTS was orphaned on unmount — the provider's await kept
         // running until it produced its own result, then tried to update _cache
@@ -233,7 +233,7 @@ public class VirtualizeTests
 
         var show = true;
         var view = new StubComponent(() => show
-            ? Virtualize<string>(
+            ? VirtualizeModel<string>(
                 ctx => Div(),
                 ItemsProvider: provider,
                 ItemSize: 20,
@@ -244,8 +244,8 @@ public class VirtualizeTests
         await providerStarted.Task;
         Assert.False(fetchObservedCt.IsCancellationRequested);
 
-        // Stop rendering Virtualize — the framework's diff fires OnUnmount on
-        // the Virtualize subtree, which should cancel the in-flight fetch.
+        // Stop rendering VirtualizeModel — the framework's diff fires OnUnmount on
+        // the VirtualizeModel subtree, which should cancel the in-flight fetch.
         show = false;
         view.RenderAsLiveRoot();
 
@@ -279,7 +279,7 @@ public class VirtualizeTests
 
         var show = true;
         var view = new StubComponent(() => show
-            ? Virtualize<string>(
+            ? VirtualizeModel<string>(
                 ctx => Div(),
                 ItemsProvider: provider,
                 ItemSize: 20,
@@ -304,7 +304,7 @@ public class VirtualizeTests
 
         Assert.True(completedAfterRelease, "provider should run to completion even after unmount");
         // The continuation ran to the guard and returned; re-rendering the host stays clean
-        // (no stale data leaked back through a disposed Virtualize).
+        // (no stale data leaked back through a disposed VirtualizeModel).
         var html = view.RenderAsLiveRoot();
         Assert.DoesNotContain("loaded", html);
     }
@@ -315,7 +315,7 @@ public class VirtualizeTests
         // FetchAsync wraps the provider call in try/catch(Exception): a throwing provider must be
         // logged and dropped, never surfaced out of render. The window stays empty (count unknown).
         VirtualizationContext<int>? captured = null;
-        var view = new StubComponent(() => Virtualize<int>(
+        var view = new StubComponent(() => VirtualizeModel<int>(
             ctx =>
             {
                 captured = ctx;
@@ -346,7 +346,7 @@ public class VirtualizeTests
         }
 
         VirtualizationContext<int>? captured = null;
-        var view = new StubComponent(() => Virtualize(
+        var view = new StubComponent(() => VirtualizeModel(
             ctx =>
             {
                 captured = ctx;


### PR DESCRIPTION
## Summary

- **`TableModel<T>` — a headless, fully *controlled* table primitive** (TanStack-Table-style). It renders no markup and owns no state: the host sorts/filters/pages its own data and passes the final `Rows` plus the current view state (`Sort`, `PageIndex`, `SelectedKeys`); the model projects sort-aware `Headers` and selection-aware `Rows` into the `Render` delegate and raises `OnSort` / `OnPage` / `OnSelect` **intents** the host applies to its own state. Implemented as a generic component (`[SkipFactory]` + a hand-written `TableModel<T>(Render: …)` factory that wraps the events via `AutoCallback.Wrap`, so firing an intent re-renders the owning host). New support types live in `Rask.Core.Tables` (`ColumnDef<T>`, `SortDirection`, `ColumnSort`, `HeaderCell`, `TableRow<T>`, `TableModelContext<T>`).
- **Refactored the existing `/table` showcase page** to drive its sorting + paging through `TableModel<T>` (kept the URL-query-string contract; search + page-size stay plain query-param controls). No new sample page.
- **Renamed the headless `Virtualize<T>` primitive to `VirtualizeModel<T>`** (component + factory + call sites) so the headless view-model primitives read as one family. Behaviour unchanged; the `Rask.Core.Virtualization` support types keep their names.

> **BREAKING:** `Virtualize<T>(...)` → `VirtualizeModel<T>(...)`.

## Testing

- `dotnet build` warnings-as-errors: clean across all projects.
- `dotnet test` (non-E2E): all pass — Core 1514, Example.Shared 252, Server 170, Generators 148, + the rest; 0 failures. Includes 22 new `TableModelTests` and the renamed `VirtualizeModelTests`.
- `dotnet publish -c Release samples/Rask.Example.Wasm`: **zero IL/trim warnings** (generic `TableModel<T>` + `IL2091`-only suppression is trim-safe).
- The existing `/table` E2E (sort by Name → `?sort=name`, page-size selector) covers the refactored page.

## Benchmarks

N/A — additive opt-in component plus a behaviour-identical rename; no measured render hot path (`HtmlSerializer`, `Element`/diff, dispatch) is touched, so there is no before/after `Allocated` delta to quote.

## Changelog

`[Unreleased]` updated with **Added** (`TableModel<T>`) and **Changed** (`Virtualize<T>` → `VirtualizeModel<T>`, with `BREAKING CHANGE`).