### PR TITLE
build(samples): disable static web assets on WASM hosts to fix clean-build race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ them until tagged releases begin.
   The `/table` showcase page now drives its sorting and paging through `TableModel<T>` from the URL
   query string.
 
+### Fixed
+- **Clean parallel builds of WASM-hosted apps no longer race the static-web-assets pipeline.** A full
+  rebuild (`dotnet build --no-incremental`, or Rider's *Rebuild Solution*) could fail with `MSB4018`
+  from `UpdateExternallyDefinedStaticWebAssets` — the ASP.NET host project resolved the WASM
+  project's fingerprinted `dotnet.native.*` assets before that project had emitted them. A Rask WASM
+  host serves the published bundle from the publish directory at runtime (`app.UseRask()`) and owns no
+  static web assets of its own, so the hosts (and the `rask-wasm-hosted` template) now set
+  `StaticWebAssetsEnabled=false`, which skips the racy cross-project resolution while preserving build
+  ordering. Downstream hosts that serve only a Rask WASM bundle should do the same.
+
 ### Changed
 - **Renamed the headless `Virtualize<T>` primitive to `VirtualizeModel<T>`** (component + factory) so
   the headless "view-model" primitives read as one family with `TableModel<T>`. **Breaking:** update

--- a/samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj
@@ -5,6 +5,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Rask.Example.Auth.WasmCookie.Host</RootNamespace>
+    <!--
+      No static web assets of its own: Rask.Wasm.Hosting serves the published WASM bundle at runtime
+      (app.UseRask()), not via the SDK's static-web-assets manifest. Disabling the SWA pipeline skips
+      the cross-project ResolveReferencedProjectsStaticWebAssets step, which otherwise races on a clean
+      parallel build (MSB4018 resolving the WASM project's fingerprinted dotnet.native.* assets before
+      they exist). BuildReference stays true, so build ordering is preserved.
+    -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj
@@ -5,6 +5,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Rask.Example.Auth.WasmJwt.Host</RootNamespace>
+    <!--
+      No static web assets of its own: Rask.Wasm.Hosting serves the published WASM bundle at runtime
+      (app.UseRask()), not via the SDK's static-web-assets manifest. Disabling the SWA pipeline skips
+      the cross-project ResolveReferencedProjectsStaticWebAssets step, which otherwise races on a clean
+      parallel build (MSB4018 resolving the WASM project's fingerprinted dotnet.native.* assets before
+      they exist). BuildReference stays true, so build ordering is preserved.
+    -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj
+++ b/samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj
@@ -5,6 +5,15 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Rask.Example.Wasm.Host</RootNamespace>
+    <!--
+      This host owns no static web assets: Rask.Wasm.Hosting serves the published WASM bundle from
+      the publish directory at runtime (app.UseRask()), not via the SDK's static-web-assets manifest.
+      Disabling the SWA pipeline skips the cross-project ResolveReferencedProjectsStaticWebAssets step,
+      which otherwise races on a clean parallel build — the host resolves the WASM project's
+      fingerprinted dotnet.native.* assets before that project has emitted them (MSB4018 from
+      UpdateExternallyDefinedStaticWebAssets). BuildReference stays true, so build ordering is preserved.
+    -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Company.RaskWasmHosted.Host.csproj
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Host/Company.RaskWasmHosted.Host.csproj
@@ -4,6 +4,15 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <!--
+      This host serves the published WASM bundle from the publish directory at runtime
+      (app.UseRask()), not via the SDK's static-web-assets manifest, so it owns no static web
+      assets. Disabling the SWA pipeline skips the cross-project static-web-asset resolution that
+      otherwise races on a clean parallel build, when the host tries to resolve the WASM project's
+      fingerprinted dotnet.native.* assets before that project has emitted them (MSB4018). Build
+      ordering is unaffected. Remove this if you add static web assets (e.g. an RCL) to the host.
+    -->
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.Templates/content/rask-wasm-hosted/README.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/README.md
@@ -7,7 +7,10 @@ projects in one solution:
 - `Company.RaskWasmHosted.Host` (`net10.0`) — serves the published WASM client and any
   server APIs. It references the Wasm project across target frameworks
   (`SkipGetTargetFrameworkProperties`) and uses a generic `UseRask<TApp>()` so the client
-  assembly's `[ModuleInitializer]` (route registration) loads.
+  assembly's `[ModuleInitializer]` (route registration) loads. Because it serves the published
+  bundle from disk at runtime (not via the static-web-assets manifest) it sets
+  `StaticWebAssetsEnabled=false`, which also keeps clean parallel builds from racing the
+  cross-project static-web-assets resolution. Remove that if you add static web assets to the host.
 
 ## Run
 

--- a/src/Rask.Wasm.Hosting/build/Rask.Wasm.Hosting.targets
+++ b/src/Rask.Wasm.Hosting/build/Rask.Wasm.Hosting.targets
@@ -13,6 +13,16 @@
                           ReferenceOutputAssembly="false"
                           SkipGetTargetFrameworkProperties="true"/>
 
+    A host that serves only the WASM bundle (the common case) should also set
+    <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>. The host serves the
+    published bundle from the publish directory at runtime (app.UseRask()), not
+    via the SDK's static-web-assets manifest, so it owns no static web assets.
+    Disabling the pipeline avoids a clean-parallel-build race where the host
+    resolves the WASM project's fingerprinted dotnet.native.* assets before that
+    project has emitted them (MSB4018 from UpdateExternallyDefinedStaticWebAssets).
+    Build ordering is unaffected. Omit it only if the host adds its own static web
+    assets (e.g. references a Razor Class Library).
+
     This file then, at build time:
       1. Finds the WASM ProjectReference by reading RaskWasm out of each
          referenced csproj via XmlPeek.


### PR DESCRIPTION
## Summary
Clean parallel builds of the WASM-hosted samples (`dotnet build --no-incremental`, Rider *Rebuild Solution*) failed with `MSB4018` from `UpdateExternallyDefinedStaticWebAssets`: the ASP.NET host resolved the WASM project's fingerprinted `dotnet.native.*` assets before that project had emitted them. A Rask WASM host serves the published bundle from disk at runtime (`app.UseRask()`) and owns no static web assets of its own, so the three sample hosts and the `rask-wasm-hosted` template now set `StaticWebAssetsEnabled=false`. This skips the racy cross-project static-web-assets resolution while keeping `BuildReference=true`, so build ordering (WASM builds before the host publishes it) is preserved. Documented the recommendation in `Rask.Wasm.Hosting.targets` and the template README.

## Testing
- Repro confirmed fixed: `dotnet build Rask.slnx --no-incremental` after `rm -rf` of the WASM sample/host `obj`+`bin` — **Build succeeded, 0 warnings, 0 errors** (previously `MSB4018`).
- Release gate: `dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — clean.
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — all green (one Core flake passed on rerun; no Core code touched).
- E2E: hosts `WasmExampleTests`, `WasmCookieAuthExampleTests`, `WasmJwtAuthExampleTests` — **4/4 passed**. Manual smoke of `Rask.Example.Wasm.Host` confirmed index, `main.js`, fingerprinted runtime JS, and native wasm all serve `200`.

## Benchmarks
n/a — build-configuration change only; no render/runtime hot-path code touched.

## CHANGELOG
- [Unreleased] entry added: Clean parallel builds of WASM-hosted apps no longer race the static-web-assets pipeline.
