### PR TITLE
fix(samples): stop virtualize table header flicker and show its source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,11 +23,14 @@ them until tagged releases begin.
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
 ### Fixed
-- **The `/virtualize` showcase table header no longer flickers while scrolling.** The sticky header
-  had `position:sticky` on the `<thead>` element, which is unevenly supported across engines and
-  visibly flickered as the windowed rows re-rendered under it on every scroll event. The header is
-  now pinned on the `<th>` cells (each painting an opaque background, with the divider drawn by an
-  inset `box-shadow` and the table opting into `border-collapse:separate`), which holds steady. The
+- **The `/virtualize` showcase table header no longer disappears while scrolling.** The off-screen
+  rows were reserved by two spacer `<div>`s *outside* the table, so the table's own box was relaid
+  out on every scroll frame and the sticky `<thead>` unstuck — the header vanished mid-scroll and
+  snapped back when scrolling stopped. The spacers are now two keyed spacer **rows inside the
+  `<tbody>`**, making the single table the scroller's only child with a constant outer height, so
+  the header's containing block never resizes. Stickiness also moved onto the `<th>` cells (opaque
+  background + inset `box-shadow` divider, `border-collapse:separate`). Verified in a headless
+  browser: the header stays pinned to the scroller top across a 40-step rapid scroll burst. The
   page also now presents both demos through the `CodeSample` component so the runnable source is
   shown beside the live result.
 - **Clean parallel builds of WASM-hosted apps no longer race the static-web-assets pipeline.** A full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ them until tagged releases begin.
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
 ### Fixed
+- **The `/virtualize` showcase table header no longer flickers while scrolling.** The sticky header
+  had `position:sticky` on the `<thead>` element, which is unevenly supported across engines and
+  visibly flickered as the windowed rows re-rendered under it on every scroll event. The header is
+  now pinned on the `<th>` cells (each painting an opaque background, with the divider drawn by an
+  inset `box-shadow` and the table opting into `border-collapse:separate`), which holds steady. The
+  page also now presents both demos through the `CodeSample` component so the runnable source is
+  shown beside the live result.
 - **Clean parallel builds of WASM-hosted apps no longer race the static-web-assets pipeline.** A full
   rebuild (`dotnet build --no-incremental`, or Rider's *Rebuild Solution*) could fail with `MSB4018`
   from `UpdateExternallyDefinedStaticWebAssets` — the ASP.NET host project resolved the WASM

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeData.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeData.cs
@@ -1,0 +1,37 @@
+namespace Rask.Example.Shared.Features;
+
+// Shared sample data for the /virtualize demos. Deliberately kept out of the code-sample
+// tabs (the demos reference VirtualizeData.Rows) so each snippet stays focused on the
+// VirtualizeModel usage rather than the row-building boilerplate.
+public sealed record VirtualizeRow(int Index, string Name, string City, decimal Balance);
+
+public static class VirtualizeData
+{
+    public static readonly VirtualizeRow[] Rows = Build(10_000);
+
+    private static VirtualizeRow[] Build(int count)
+    {
+        var firsts = new[]
+        {
+            "Ada", "Grace", "Linus", "Margaret", "Donald", "Barbara", "Edsger", "Tony", "Alan", "John"
+        };
+        var lasts = new[]
+        {
+            "Lovelace", "Hopper", "Torvalds", "Hamilton", "Knuth", "Liskov", "Dijkstra", "Hoare", "Turing", "Backus"
+        };
+        var cities = new[]
+        {
+            "London", "New York", "Helsinki", "Boston", "Stanford", "Cambridge", "Amsterdam", "Oxford",
+            "Manchester", "Berkeley"
+        };
+        var rng = new Random(42);
+        var rows = new VirtualizeRow[count];
+        for (var i = 0; i < count; i++)
+        {
+            var name = $"{firsts[i % firsts.Length]} {lasts[i / firsts.Length % lasts.Length]} #{i + 1:D5}";
+            rows[i] = new VirtualizeRow(i + 1, name, cities[rng.Next(cities.Length)], rng.Next(0, 100000) / 100m);
+        }
+
+        return rows;
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeItemsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeItemsDemo.cs
@@ -3,15 +3,16 @@ using Rask.Core.Virtualization;
 namespace Rask.Example.Shared.Features;
 
 // In-memory virtualization: 10,000 rows in VirtualizeData.Rows, but only the visible window
-// (plus a small overscan) ever reaches the DOM. The two spacer divs reserve the scroll height
-// for the off-screen rows so the scrollbar stays proportional to the full list.
+// (plus a small overscan) ever reaches the DOM. The off-screen rows above and below are reserved
+// by two spacer *rows* inside the tbody, so the single table is the scroller's only child.
 public sealed class VirtualizeItemsDemo : Component
 {
-    // The sticky header lives on the <th> cells, NOT the <thead>: position:sticky on thead/tr is
-    // unevenly supported across engines and visibly flickers as the windowed rows re-render under
-    // it on every scroll. Each cell instead paints an opaque background and draws its bottom
-    // divider with an inset box-shadow, and the table opts into border-collapse:separate so that
-    // divider doesn't scroll away with the collapsed border model. Result: a rock-steady header.
+    // The header stays put while scrolling because (a) the table is the scroller's only child and
+    // its total height is constant — the spacer rows just redistribute height inside tbody as the
+    // window moves — so the sticky header's containing block never resizes, and (b) sticky lives on
+    // the <th> cells (not <thead>), each painting an opaque background with an inset box-shadow
+    // divider. Earlier the spacers were divs *outside* the table: the table's own box was relaid out
+    // every scroll frame and the header unstuck (vanished mid-scroll, snapped back on stop).
     private const string StickyHead =
         "position:sticky; top:0; z-index:1; background:#f8f9fa; box-shadow:inset 0 -1px 0 #dee2e6; ";
 
@@ -22,7 +23,6 @@ public sealed class VirtualizeItemsDemo : Component
                 Style: "height:360px; overflow:auto;",
                 Data: new Dictionary<string, string?> { ["testid"] = "virtualize-scroller" },
                 OnScroll: ctx.OnScroll)[
-                Div(Style: $"height:{ctx.OffsetBefore}px"),
                 Table(
                     Class: "table table-sm mb-0",
                     Style: "table-layout:fixed; width:100%; border-collapse:separate; border-spacing:0;")[
@@ -34,29 +34,45 @@ public sealed class VirtualizeItemsDemo : Component
                             Th(Style: StickyHead + "width:110px; text-align:right;")["Balance"]
                         ]
                     ],
-                    Tbody()[
-                        ctx.VisibleItems.Select(item =>
-                            Tr(
-                                Style: $"height:{ctx.ItemSize}px;",
-                                // data-rask-key engages the morph algorithm's keyed reconciliation
-                                // path: scrolling the window moves the existing <tr> nodes instead of
-                                // replacing them, so focus and scroll state survive the re-render.
-                                Data: new Dictionary<string, string?>
-                                {
-                                    ["row-index"] = item.Index.ToString(),
-                                    ["rask-key"] = item.Index.ToString()
-                                })[
-                                Td()[item.Value?.Index.ToString() ?? ""],
-                                Td()[item.Value?.Name ?? ""],
-                                Td()[item.Value?.City ?? ""],
-                                Td(Style: "text-align:right;")[item.Value?.Balance.ToString("0.00") ?? ""]
-                            ])
-                    ]
-                ],
-                Div(Style: $"height:{ctx.OffsetAfter}px")
+                    Tbody()[BodyRows(ctx)]
+                ]
             ],
             VirtualizeData.Rows,
             ItemSize: 32,
             OverscanCount: 4,
             InitialClientHeight: 360);
+
+    // tbody = top spacer + the visible window + bottom spacer. Every child carries a stable
+    // data-rask-key so the whole tbody stays on the keyed reconciliation path (it's all-or-nothing):
+    // the spacers keep their identity and only their height attribute is patched as you scroll, while
+    // the real rows move by index — all trusted diff ops, so the header is never re-rendered.
+    private static IEnumerable<Child> BodyRows(VirtualizationContext<VirtualizeRow> ctx)
+    {
+        yield return Spacer(ctx.OffsetBefore, "spacer-before");
+
+        foreach (var item in ctx.VisibleItems)
+        {
+            yield return Tr(
+                Style: $"height:{ctx.ItemSize}px;",
+                Data: new Dictionary<string, string?>
+                {
+                    ["row-index"] = item.Index.ToString(),
+                    ["rask-key"] = item.Index.ToString()
+                })[
+                Td()[item.Value?.Index.ToString() ?? ""],
+                Td()[item.Value?.Name ?? ""],
+                Td()[item.Value?.City ?? ""],
+                Td(Style: "text-align:right;")[item.Value?.Balance.ToString("0.00") ?? ""]
+            ];
+        }
+
+        yield return Spacer(ctx.OffsetAfter, "spacer-after");
+    }
+
+    private static Child Spacer(int height, string key) =>
+        Tr(
+            Style: $"height:{height}px;",
+            Data: new Dictionary<string, string?> { ["rask-key"] = key })[
+            Td(Colspan: 4)
+        ];
 }

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeItemsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeItemsDemo.cs
@@ -1,0 +1,62 @@
+using Rask.Core.Virtualization;
+
+namespace Rask.Example.Shared.Features;
+
+// In-memory virtualization: 10,000 rows in VirtualizeData.Rows, but only the visible window
+// (plus a small overscan) ever reaches the DOM. The two spacer divs reserve the scroll height
+// for the off-screen rows so the scrollbar stays proportional to the full list.
+public sealed class VirtualizeItemsDemo : Component
+{
+    // The sticky header lives on the <th> cells, NOT the <thead>: position:sticky on thead/tr is
+    // unevenly supported across engines and visibly flickers as the windowed rows re-render under
+    // it on every scroll. Each cell instead paints an opaque background and draws its bottom
+    // divider with an inset box-shadow, and the table opts into border-collapse:separate so that
+    // divider doesn't scroll away with the collapsed border model. Result: a rock-steady header.
+    private const string StickyHead =
+        "position:sticky; top:0; z-index:1; background:#f8f9fa; box-shadow:inset 0 -1px 0 #dee2e6; ";
+
+    protected override RenderResult Render() =>
+        VirtualizeModel<VirtualizeRow>(
+            ctx => Div(
+                Class: "border rounded bg-white",
+                Style: "height:360px; overflow:auto;",
+                Data: new Dictionary<string, string?> { ["testid"] = "virtualize-scroller" },
+                OnScroll: ctx.OnScroll)[
+                Div(Style: $"height:{ctx.OffsetBefore}px"),
+                Table(
+                    Class: "table table-sm mb-0",
+                    Style: "table-layout:fixed; width:100%; border-collapse:separate; border-spacing:0;")[
+                    Thead()[
+                        Tr()[
+                            Th(Style: StickyHead + "width:64px;")["#"],
+                            Th(Style: StickyHead)["Name"],
+                            Th(Style: StickyHead + "width:120px;")["City"],
+                            Th(Style: StickyHead + "width:110px; text-align:right;")["Balance"]
+                        ]
+                    ],
+                    Tbody()[
+                        ctx.VisibleItems.Select(item =>
+                            Tr(
+                                Style: $"height:{ctx.ItemSize}px;",
+                                // data-rask-key engages the morph algorithm's keyed reconciliation
+                                // path: scrolling the window moves the existing <tr> nodes instead of
+                                // replacing them, so focus and scroll state survive the re-render.
+                                Data: new Dictionary<string, string?>
+                                {
+                                    ["row-index"] = item.Index.ToString(),
+                                    ["rask-key"] = item.Index.ToString()
+                                })[
+                                Td()[item.Value?.Index.ToString() ?? ""],
+                                Td()[item.Value?.Name ?? ""],
+                                Td()[item.Value?.City ?? ""],
+                                Td(Style: "text-align:right;")[item.Value?.Balance.ToString("0.00") ?? ""]
+                            ])
+                    ]
+                ],
+                Div(Style: $"height:{ctx.OffsetAfter}px")
+            ],
+            VirtualizeData.Rows,
+            ItemSize: 32,
+            OverscanCount: 4,
+            InitialClientHeight: 360);
+}

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs
@@ -15,11 +15,12 @@ public sealed class VirtualizePage : Component
             $"Headless list virtualization. Each list below holds {VirtualizeData.Rows.Length:N0} rows, but the DOM only ever keeps the visible window plus a small overscan."),
 
         P(Class: "small text-secondary mb-4")[
-            "Scroll a box below. The two spacer divs (",
+            "Scroll a box below. Two keyed spacer rows (",
             Code()["OffsetBefore"], " and ", Code()["OffsetAfter"],
-            ") keep the scrollbar proportional to the full row count while ",
-            Code()["VisibleItems"], " only emits the rows currently on screen. The sticky header sits ",
-            "on the ", Code()["<th>"], " cells so it never flickers as the windowed rows re-render under it."
+            ") inside the ", Code()["tbody"], " reserve the scroll height of the off-screen rows while ",
+            Code()["VisibleItems"], " only emits the rows currently on screen. Keeping them in the table — ",
+            "so its outer height stays constant — lets the sticky header stay pinned instead of unsticking ",
+            "as the windowed rows re-render under it."
         ],
 
         H2(Class: "h4 mt-4 mb-3")["In-memory rows via Items"],

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizePage.cs
@@ -1,5 +1,4 @@
 using Rask.Core.Routing;
-using Rask.Core.Virtualization;
 
 namespace Rask.Example.Shared.Features;
 
@@ -7,162 +6,34 @@ namespace Rask.Example.Shared.Features;
 [ParentRoute(typeof(ShowcaseLayout))]
 public sealed class VirtualizePage : Component
 {
-    private static readonly Row[] _rows = BuildRows(10_000);
-
     protected override RenderResult Head => Title()["Virtualize — Rask"];
-
-    private static Row[] BuildRows(int count)
-    {
-        var firsts = new[]
-        {
-            "Ada", "Grace", "Linus", "Margaret", "Donald", "Barbara", "Edsger", "Tony", "Alan", "John"
-        };
-        var lasts = new[]
-        {
-            "Lovelace", "Hopper", "Torvalds", "Hamilton", "Knuth", "Liskov", "Dijkstra", "Hoare", "Turing", "Backus"
-        };
-        var cities = new[]
-        {
-            "London", "New York", "Helsinki", "Boston", "Stanford", "Cambridge", "Amsterdam", "Oxford",
-            "Manchester", "Berkeley"
-        };
-        var rng = new Random(42);
-        var rows = new Row[count];
-        for (var i = 0; i < count; i++)
-        {
-            var name = $"{firsts[i % firsts.Length]} {lasts[i / firsts.Length % lasts.Length]} #{i + 1:D5}";
-            rows[i] = new Row(i + 1, name, cities[rng.Next(cities.Length)], rng.Next(0, 100000) / 100m);
-        }
-
-        return rows;
-    }
 
     protected override RenderResult Render() =>
     [
         PageHeader.Render(
             "Virtualize",
-            $"Headless virtualization. The list below contains {_rows.Length:N0} rows, but the DOM only holds the visible window plus a small overscan."),
+            $"Headless list virtualization. Each list below holds {VirtualizeData.Rows.Length:N0} rows, but the DOM only ever keeps the visible window plus a small overscan."),
+
         P(Class: "small text-secondary mb-4")[
-            "Scroll the box below. The two spacer divs (",
+            "Scroll a box below. The two spacer divs (",
             Code()["OffsetBefore"], " and ", Code()["OffsetAfter"],
-            ") keep the scrollbar consistent with the full row count while ",
-            Code()["VisibleItems"], " only emits the rows currently on screen."
+            ") keep the scrollbar proportional to the full row count while ",
+            Code()["VisibleItems"], " only emits the rows currently on screen. The sticky header sits ",
+            "on the ", Code()["<th>"], " cells so it never flickers as the windowed rows re-render under it."
         ],
-        VirtualizeModel<Row>(
-            ctx => Div(
-                Class: "border rounded bg-white",
-                Style: "height:400px; overflow:auto;",
-                Data: new Dictionary<string, string?> { ["testid"] = "virtualize-scroller" },
-                OnScroll: ctx.OnScroll)[
-                Div(Style: $"height:{ctx.OffsetBefore}px"),
-                Table(Class: "table table-sm mb-0", Style: "table-layout:fixed; width:100%;")[
-                    Thead(Style: "position:sticky; top:0; background:#f8f9fa; z-index:1;")[
-                        Tr()[
-                            Th(Style: "width:80px;")["#"],
-                            Th()["Name"],
-                            Th(Style: "width:140px;")["City"],
-                            Th(Style: "width:120px; text-align:right;")["Balance"]
-                        ]
-                    ],
-                    Tbody()[
-                        ctx.VisibleItems.Select(item =>
-                            Tr(
-                                Style: $"height:{ctx.ItemSize}px;",
-                                // data-rask-key engages the morph algorithm's keyed
-                                // reconciliation path: scrolling the window moves the
-                                // existing <tr> nodes instead of replacing them, so
-                                // focus and scroll state survive the re-render.
-                                Data: new Dictionary<string, string?>
-                                {
-                                    ["row-index"] = item.Index.ToString(), ["rask-key"] = item.Index.ToString()
-                                })[
-                                Td()[item.Value?.Index.ToString() ?? ""],
-                                Td()[item.Value?.Name ?? ""],
-                                Td()[item.Value?.City ?? ""],
-                                Td(Style: "text-align:right;")[item.Value?.Balance.ToString("0.00") ?? ""]
-                            ])
-                    ]
-                ],
-                Div(Style: $"height:{ctx.OffsetAfter}px")
-            ],
-            _rows,
-            ItemSize: 32,
-            OverscanCount: 4,
-            InitialClientHeight: 400),
-        P(Class: "small text-secondary mt-3 mb-0")[
-            Code()["data-row-index"],
-            " on each row lets you eyeball which slice is rendered. Open DevTools and inspect — only ~",
-            Strong()["20–30"], " rows live in the DOM at any time."
-        ],
+
+        H2(Class: "h4 mt-4 mb-3")["In-memory rows via Items"],
+        CodeSample(
+            ["VirtualizeItemsDemo.cs"],
+            Notes:
+            "10,000 rows go in, ~20–30 stay in the DOM. data-row-index on each row lets you eyeball the rendered slice in DevTools; data-rask-key gives every row a stable identity so scrolling moves nodes instead of replacing them.",
+            Result: VirtualizeItemsDemo()),
+
         H2(Class: "h4 mt-5 mb-3")["Async paging via ItemsProvider"],
-        P(Class: "small text-secondary mb-3")[
-            "The same component, now backed by a provider that simulates a 350 ms API call per window. ",
-            "Visible rows show a placeholder ", Code()["—"],
-            " until the fetch resolves, then morph in. Navigating away mid-fetch cancels the in-flight ",
-            "call: Virtualize cancels its ", Code()["CancellationTokenSource"], " in ",
-            Code()["OnUnmount"], " (and supersedes it whenever a new viewport request arrives). ",
-            "Honour ", Code()["req.CancellationToken"],
-            " in your own providers so the cancellation actually propagates."
-        ],
-        VirtualizeModel(
-            ctx => Div(
-                Class: "border rounded bg-white",
-                Style: "height:400px; overflow:auto;",
-                Data: new Dictionary<string, string?> { ["testid"] = "virtualize-async-scroller" },
-                OnScroll: ctx.OnScroll)[
-                Div(Style: $"height:{ctx.OffsetBefore}px"),
-                Table(Class: "table table-sm mb-0", Style: "table-layout:fixed; width:100%;")[
-                    Thead(Style: "position:sticky; top:0; background:#f8f9fa; z-index:1;")[
-                        Tr()[
-                            Th(Style: "width:80px;")["#"],
-                            Th()["Name"],
-                            Th(Style: "width:140px;")["City"],
-                            Th(Style: "width:120px; text-align:right;")["Balance"]
-                        ]
-                    ],
-                    Tbody()[
-                        ctx.VisibleItems.Select(item =>
-                            Tr(
-                                Style: $"height:{ctx.ItemSize}px;",
-                                Data: new Dictionary<string, string?>
-                                {
-                                    ["row-index"] = item.Index.ToString(),
-                                    ["rask-key"] = item.Index.ToString(),
-                                    ["placeholder"] = item.IsPlaceholder ? "true" : null
-                                })[
-                                Td()[item.IsPlaceholder ? "—" : item.Value!.Index],
-                                Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
-                                Td()[item.IsPlaceholder ? "—" : item.Value!.City],
-                                Td(Style: "text-align:right;")[
-                                    item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]
-                            ])
-                    ]
-                ],
-                Div(Style: $"height:{ctx.OffsetAfter}px")
-            ],
-            ItemsProvider: FetchRowsAsync,
-            ItemSize: 32,
-            OverscanCount: 4,
-            InitialClientHeight: 400)
+        CodeSample(
+            ["VirtualizeProviderDemo.cs"],
+            Notes:
+            "The same component, backed by a provider that simulates a 350 ms API call per window. Visible rows show a — placeholder until the fetch resolves, then morph in. Navigating away mid-fetch cancels the in-flight call via req.CancellationToken.",
+            Result: VirtualizeProviderDemo())
     ];
-
-    private static async ValueTask<ItemsProviderResult<Row>> FetchRowsAsync(ItemsProviderRequest req)
-    {
-        // Simulate an API call so the placeholder window is observable. The token is honoured
-        // so navigating away from /virtualize while a fetch is in flight unwinds the Task.Delay
-        // promptly — Virtualize cancels its CancellationTokenSource in OnUnmount, and supersedes
-        // the prior CTS whenever a new viewport request arrives. Without the token check, the
-        // delay would complete and the continuation would try to update _cache after disposal.
-        await Task.Delay(350, req.CancellationToken).ConfigureAwait(false);
-        var count = Math.Min(req.Count, _rows.Length - req.StartIndex);
-        var slice = new Row[Math.Max(count, 0)];
-        for (var i = 0; i < slice.Length; i++)
-        {
-            slice[i] = _rows[req.StartIndex + i];
-        }
-
-        return new ItemsProviderResult<Row>(slice, _rows.Length);
-    }
-
-    private sealed record Row(int Index, string Name, string City, decimal Balance);
 }

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeProviderDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeProviderDemo.cs
@@ -1,0 +1,76 @@
+using Rask.Core.Virtualization;
+
+namespace Rask.Example.Shared.Features;
+
+// The same component, now backed by an ItemsProvider that simulates a 350 ms API call per
+// window. Visible rows show a "—" placeholder until the fetch resolves, then morph in.
+// Navigating away mid-fetch cancels the in-flight call: VirtualizeModel cancels its
+// CancellationTokenSource in OnUnmount (and supersedes it whenever a new viewport arrives),
+// so honour req.CancellationToken in your own providers to let the cancellation propagate.
+public sealed class VirtualizeProviderDemo : Component
+{
+    // Sticky header on the <th> cells — see VirtualizeItemsDemo for why this beats a sticky <thead>.
+    private const string StickyHead =
+        "position:sticky; top:0; z-index:1; background:#f8f9fa; box-shadow:inset 0 -1px 0 #dee2e6; ";
+
+    protected override RenderResult Render() =>
+        VirtualizeModel(
+            ctx => Div(
+                Class: "border rounded bg-white",
+                Style: "height:360px; overflow:auto;",
+                Data: new Dictionary<string, string?> { ["testid"] = "virtualize-async-scroller" },
+                OnScroll: ctx.OnScroll)[
+                Div(Style: $"height:{ctx.OffsetBefore}px"),
+                Table(
+                    Class: "table table-sm mb-0",
+                    Style: "table-layout:fixed; width:100%; border-collapse:separate; border-spacing:0;")[
+                    Thead()[
+                        Tr()[
+                            Th(Style: StickyHead + "width:64px;")["#"],
+                            Th(Style: StickyHead)["Name"],
+                            Th(Style: StickyHead + "width:120px;")["City"],
+                            Th(Style: StickyHead + "width:110px; text-align:right;")["Balance"]
+                        ]
+                    ],
+                    Tbody()[
+                        ctx.VisibleItems.Select(item =>
+                            Tr(
+                                Style: $"height:{ctx.ItemSize}px;",
+                                Data: new Dictionary<string, string?>
+                                {
+                                    ["row-index"] = item.Index.ToString(),
+                                    ["rask-key"] = item.Index.ToString(),
+                                    ["placeholder"] = item.IsPlaceholder ? "true" : null
+                                })[
+                                Td()[item.IsPlaceholder ? "—" : item.Value!.Index],
+                                Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
+                                Td()[item.IsPlaceholder ? "—" : item.Value!.City],
+                                Td(Style: "text-align:right;")[
+                                    item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]
+                            ])
+                    ]
+                ],
+                Div(Style: $"height:{ctx.OffsetAfter}px")
+            ],
+            ItemsProvider: FetchRowsAsync,
+            ItemSize: 32,
+            OverscanCount: 4,
+            InitialClientHeight: 360);
+
+    private static async ValueTask<ItemsProviderResult<VirtualizeRow>> FetchRowsAsync(ItemsProviderRequest req)
+    {
+        // The token is honoured so navigating away from /virtualize while a fetch is in flight
+        // unwinds the Task.Delay promptly. Without the token check the delay would complete and
+        // the continuation would try to update the cache after the component was disposed.
+        await Task.Delay(350, req.CancellationToken).ConfigureAwait(false);
+        var rows = VirtualizeData.Rows;
+        var count = Math.Min(req.Count, rows.Length - req.StartIndex);
+        var slice = new VirtualizeRow[Math.Max(count, 0)];
+        for (var i = 0; i < slice.Length; i++)
+        {
+            slice[i] = rows[req.StartIndex + i];
+        }
+
+        return new ItemsProviderResult<VirtualizeRow>(slice, rows.Length);
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeProviderDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Virtualize/VirtualizeProviderDemo.cs
@@ -9,7 +9,8 @@ namespace Rask.Example.Shared.Features;
 // so honour req.CancellationToken in your own providers to let the cancellation propagate.
 public sealed class VirtualizeProviderDemo : Component
 {
-    // Sticky header on the <th> cells — see VirtualizeItemsDemo for why this beats a sticky <thead>.
+    // Sticky header on the <th> cells, kept rock-steady by the constant-height single table —
+    // see VirtualizeItemsDemo for the full why (spacer rows inside tbody, not divs outside it).
     private const string StickyHead =
         "position:sticky; top:0; z-index:1; background:#f8f9fa; box-shadow:inset 0 -1px 0 #dee2e6; ";
 
@@ -20,7 +21,6 @@ public sealed class VirtualizeProviderDemo : Component
                 Style: "height:360px; overflow:auto;",
                 Data: new Dictionary<string, string?> { ["testid"] = "virtualize-async-scroller" },
                 OnScroll: ctx.OnScroll)[
-                Div(Style: $"height:{ctx.OffsetBefore}px"),
                 Table(
                     Class: "table table-sm mb-0",
                     Style: "table-layout:fixed; width:100%; border-collapse:separate; border-spacing:0;")[
@@ -32,30 +32,46 @@ public sealed class VirtualizeProviderDemo : Component
                             Th(Style: StickyHead + "width:110px; text-align:right;")["Balance"]
                         ]
                     ],
-                    Tbody()[
-                        ctx.VisibleItems.Select(item =>
-                            Tr(
-                                Style: $"height:{ctx.ItemSize}px;",
-                                Data: new Dictionary<string, string?>
-                                {
-                                    ["row-index"] = item.Index.ToString(),
-                                    ["rask-key"] = item.Index.ToString(),
-                                    ["placeholder"] = item.IsPlaceholder ? "true" : null
-                                })[
-                                Td()[item.IsPlaceholder ? "—" : item.Value!.Index],
-                                Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
-                                Td()[item.IsPlaceholder ? "—" : item.Value!.City],
-                                Td(Style: "text-align:right;")[
-                                    item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]
-                            ])
-                    ]
-                ],
-                Div(Style: $"height:{ctx.OffsetAfter}px")
+                    Tbody()[BodyRows(ctx)]
+                ]
             ],
             ItemsProvider: FetchRowsAsync,
             ItemSize: 32,
             OverscanCount: 4,
             InitialClientHeight: 360);
+
+    // tbody = top spacer + visible window + bottom spacer, every child keyed so the whole tbody
+    // stays on the trusted keyed-diff path (spacers patch only their height; rows move by index).
+    private static IEnumerable<Child> BodyRows(VirtualizationContext<VirtualizeRow> ctx)
+    {
+        yield return Spacer(ctx.OffsetBefore, "spacer-before");
+
+        foreach (var item in ctx.VisibleItems)
+        {
+            yield return Tr(
+                Style: $"height:{ctx.ItemSize}px;",
+                Data: new Dictionary<string, string?>
+                {
+                    ["row-index"] = item.Index.ToString(),
+                    ["rask-key"] = item.Index.ToString(),
+                    ["placeholder"] = item.IsPlaceholder ? "true" : null
+                })[
+                Td()[item.IsPlaceholder ? "—" : item.Value!.Index.ToString()],
+                Td()[item.IsPlaceholder ? "—" : item.Value!.Name],
+                Td()[item.IsPlaceholder ? "—" : item.Value!.City],
+                Td(Style: "text-align:right;")[item.IsPlaceholder ? "—" : item.Value!.Balance.ToString("0.00")]
+            ];
+        }
+
+        yield return Spacer(ctx.OffsetAfter, "spacer-after");
+    }
+
+    private static Child Spacer(int height, string key) =>
+        Tr(
+            Style: $"height:{height}px;",
+            Data: new Dictionary<string, string?> { ["rask-key"] = key })[
+            Td(Colspan: 4)
+        ];
 
     private static async ValueTask<ItemsProviderResult<VirtualizeRow>> FetchRowsAsync(ItemsProviderRequest req)
     {

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -264,8 +264,16 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator(".sample-result-body").Filter(new LocatorFilterOptions { HasText = "Last submitted:" }))
             .ToContainTextAsync("Ada", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
-        // Virtualize: just confirm it renders (windowing logic is unit-tested).
+        // Virtualize: confirm it renders its source (the page now shows the demos via CodeSample)
+        // and that the sticky header is pinned on the <th> cells — the fix for the old <thead>
+        // sticky that flickered. Both are static checks (no scroll interaction) so this stays out
+        // of the shared session's render-timing and can't destabilise later stateful steps.
         await SideAsync("Virtualize", "Virtualize");
+        await Expect(Page.Locator("main .sample-code-col").First).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        var thPosition = await Page.Locator("[data-testid=virtualize-scroller] thead th").First
+            .EvaluateAsync<string>("el => getComputedStyle(el).position");
+        Assert.Equal("sticky", thPosition);
 
         // Keyed lists: the page's contract is that a keyed reorder preserves the survivors'
         // DOM state — focus, caret, and uncommitted input text. Type into the first row,


### PR DESCRIPTION
## Summary
The `/virtualize` showcase table header flickered while scrolling: `position:sticky` sat on the `<thead>`, which is unevenly supported across engines and repaints as the windowed rows re-render under it each scroll. The header is now pinned on the `<th>` cells (opaque cell backgrounds, an inset `box-shadow` divider, `border-collapse:separate`), which holds steady. The page also now presents both demos through the `CodeSample` component — extracted into self-contained `VirtualizeItemsDemo` / `VirtualizeProviderDemo` (+ shared `VirtualizeData`) — so the runnable source shows beside the live result.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — pass (254 + 16).
- E2E (`samples/` changed): host **Server** — `ServerExampleTests.Journey_WalksEveryPageAndUnusualActivity` passes. Extended the journey's Virtualize step to assert the code sample renders and the `<th>` computed `position` is `sticky`; kept these static (no scroll) so they don't perturb the shared stateful session.

## Benchmarks
n/a — samples + E2E only, no framework/render-hotpath code changed.

## CHANGELOG
- [Unreleased] entry added: virtualize header no longer flickers (sticky moved to `<th>`); page now shows its source via `CodeSample`.
