### PR TITLE
feat(samples): show source via CodeSample on every showcase example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ them until tagged releases begin.
   plain component fields; each open row inserts a keyed detail `<tr>`, so the live diff reconciles
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
+### Changed
+- **Every showcase example page now shows its own source via `CodeSample`.** The five remaining
+  pages without a runnable-source panel were brought into the convention: `/asset-loading` (each
+  scoped-asset section is now a `CodeSample` with its component source + live result), `/jsruntime`
+  (the `sessionStorage` round-trip was extracted into a `JsRuntimeDemo` shown beside its source),
+  and `/master-detail`, `/table`, `/todos` (which append a `CodeSample` of the page's own source
+  beneath the live demo). The `[NotFound]` page and the routing-demo sub-page are intentionally
+  excluded.
+
 ### Fixed
 - **The `/virtualize` showcase table header no longer disappears while scrolling.** The off-screen
   rows were reserved by two spacer `<div>`s *outside* the table, so the table's own box was relaid

--- a/samples/Rask.Example.Shared/Features/AssetLoading/AssetLoadingPage.cs
+++ b/samples/Rask.Example.Shared/Features/AssetLoading/AssetLoadingPage.cs
@@ -28,21 +28,35 @@ public sealed class AssetLoadingPage : Component
                 Code()["Cache-Control: public, max-age=31536000, immutable"],
                 ". Open DevTools → Network and observe each section below."
             ],
-            Section("Basic scoped CSS",
-                "One component with a sibling .css file. Exactly one <link> request.",
-                BasicScopedCss()),
-            Section("JS-only component",
+            H2(Class: "h5 fw-semibold mb-2 mt-5")["Basic scoped CSS"],
+            CodeSample(
+                ["BasicScopedCss.cs", "BasicScopedCss.css"],
+                Notes:
+                "One component with a sibling .css file. Exactly one <link> request — the framework " +
+                "hashes the rewritten CSS and emits a single content-addressed tag into <head>.",
+                Result: BasicScopedCss()),
+            H2(Class: "h5 fw-semibold mb-2 mt-5")["JS-only component"],
+            CodeSample(
+                ["JsOnlyDemo.cs", "JsOnlyDemo.js"],
+                Notes:
                 "Sibling .js, no .css. Used to regress when the mounted-set only tracked CSS components. " +
                 "Click the button — it dispatches via IJSRuntime to the scoped JS module.",
-                JsOnlyDemo()),
-            Section("Two components, two URLs",
+                Result: JsOnlyDemo()),
+            H2(Class: "h5 fw-semibold mb-2 mt-5")["Two components, two URLs"],
+            CodeSample(
+                ["TwinA.cs", "TwinA.css"],
+                Notes:
                 "Different rewritten content → different content hash → two independent <link>s. " +
-                "Either component edited in isolation only re-fetches its own bytes.",
-                Div(Class: "d-flex gap-2 flex-wrap")[TwinA(), TwinB()]),
-            Section("Lazy mount / unmount",
+                "Either component edited in isolation only re-fetches its own bytes. TwinB is the same " +
+                "shape with its own .css, so it gets a distinct hash.",
+                Result: Div(Class: "d-flex gap-2 flex-wrap")[TwinA(), TwinB()]),
+            H2(Class: "h5 fw-semibold mb-2 mt-5")["Lazy mount / unmount"],
+            CodeSample(
+                ["LazyMount.cs", "LazyChild.cs", "LazyChild.css"],
+                Notes:
                 "Toggle the button. On mount, the framework adds the child's <link> via the head morph; " +
                 "on unmount, the tag is removed. The browser keeps the CSS bytes cached, so re-mounting is instant.",
-                LazyMount()),
+                Result: LazyMount()),
             Div(Class: "alert alert-info d-flex align-items-start mt-5")[
                 I(Class: "bi bi-info-circle-fill me-3 fs-4"),
                 Div()[
@@ -61,12 +75,5 @@ public sealed class AssetLoadingPage : Component
                     ]
                 ]
             ]
-        ];
-
-    private static Component Section(string title, string blurb, Component demo) =>
-        Div(Class: "mb-5")[
-            H2(Class: "h5 fw-semibold mb-2")[title],
-            P(Class: "text-secondary mb-3")[blurb],
-            Div(Class: "p-3 border rounded bg-body-tertiary")[demo]
         ];
 }

--- a/samples/Rask.Example.Shared/Features/JsRuntime/JsRuntimeDemo.cs
+++ b/samples/Rask.Example.Shared/Features/JsRuntime/JsRuntimeDemo.cs
@@ -1,0 +1,104 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     Round-trips <see cref="IJSRuntime" /> against <c>sessionStorage</c>. Works on both Server
+///     (per-session WS-bound <c>RaskJSRuntime</c>) and WASM (in-process bridge via <c>JSImport</c>) —
+///     the unified IJSRuntime surface keeps the component identical across hosts. IJSRuntime is
+///     injected through the ctor (the framework's DI seam), mirroring <c>ElementRefDemo</c>.
+/// </summary>
+public sealed class JsRuntimeDemo(IJSRuntime js) : Component
+{
+    private string _input = string.Empty;
+    private string? _lastRead;
+    private string? _status;
+
+    protected override async Task OnRenderedAsync(bool firstRender)
+    {
+        if (!firstRender)
+        {
+            return;
+        }
+
+        try
+        {
+            _lastRead = await js.InvokeAsync<string?>("sessionStorage.getItem", "rask.jsruntime.demo");
+            _status = _lastRead is null ? "(no value yet — try Set)" : $"Read on mount: {_lastRead}";
+        }
+        catch (Exception ex)
+        {
+            _status = "Read failed: " + ex.Message;
+        }
+    }
+
+    protected override RenderResult Render() =>
+        Div(Class: "card shadow-sm border-0")[
+            Div(Class: "card-body")[
+                Div(Class: "mb-3")[
+                    Label(Class: "form-label", For: "demo-input")["sessionStorage value"],
+                    Input(
+                        Id: "demo-input",
+                        Class: "form-control",
+                        Value: _input,
+                        OnInput: v => _input = v)
+                ],
+                Div(Class: "d-flex gap-2 flex-wrap mb-3")[
+                    Button(Class: "btn btn-primary btn-sm", Id: "demo-set", OnClickAsync: SetAsync)[
+                        I(Class: "bi bi-save me-1"), "Set"],
+                    Button(Class: "btn btn-outline-primary btn-sm", Id: "demo-read", OnClickAsync: ReadAsync)[
+                        I(Class: "bi bi-arrow-clockwise me-1"), "Read"],
+                    Button(Class: "btn btn-outline-danger btn-sm", Id: "demo-remove", OnClickAsync: RemoveAsync)[
+                        I(Class: "bi bi-trash me-1"), "Remove"]
+                ],
+                Div(Class: "mb-2")[
+                    Span(Class: "text-secondary small text-uppercase")["Last read"],
+                    Div()[Code(Class: "fs-6", Id: "demo-last-read")[_lastRead ?? "(null)"]]
+                ],
+                Div()[
+                    Span(Class: "text-secondary small text-uppercase")["Status"],
+                    Div()[Code(Class: "fs-6", Id: "demo-status")[_status ?? "(idle)"]]
+                ]
+            ]
+        ];
+
+    private async Task SetAsync()
+    {
+        try
+        {
+            await js.InvokeVoidAsync("sessionStorage.setItem", "rask.jsruntime.demo", _input);
+            _status = $"Set to: {_input}";
+        }
+        catch (Exception ex)
+        {
+            _status = "Set failed: " + ex.Message;
+        }
+    }
+
+    private async Task ReadAsync()
+    {
+        try
+        {
+            _lastRead = await js.InvokeAsync<string?>("sessionStorage.getItem", "rask.jsruntime.demo");
+            _status = _lastRead is null ? "Read: (null)" : $"Read: {_lastRead}";
+        }
+        catch (Exception ex)
+        {
+            _status = "Read failed: " + ex.Message;
+        }
+    }
+
+    private async Task RemoveAsync()
+    {
+        try
+        {
+            await js.InvokeVoidAsync("sessionStorage.removeItem", "rask.jsruntime.demo");
+            _lastRead = null;
+            _status = "Removed";
+        }
+        catch (Exception ex)
+        {
+            _status = "Remove failed: " + ex.Message;
+        }
+    }
+}

--- a/samples/Rask.Example.Shared/Features/JsRuntime/JsRuntimePage.cs
+++ b/samples/Rask.Example.Shared/Features/JsRuntime/JsRuntimePage.cs
@@ -1,41 +1,18 @@
-using Microsoft.JSInterop;
 using Rask.Core.Routing;
 
 namespace Rask.Example.Shared.Features;
 
 /// <summary>
-///     Round-trip <see cref="IJSRuntime" /> against <c>sessionStorage</c>. Works
-///     on both Server (per-session WS-bound <c>RaskJSRuntime</c>) and WASM (in-
-///     process bridge via <c>JSImport</c>) — the unified IJSRuntime surface
-///     keeps the component identical across hosts.
+///     Hosts <see cref="JsRuntimeDemo" />: a <c>sessionStorage</c> round-trip through the unified
+///     <c>IJSRuntime</c> surface, identical on Server (per-session WS-bound <c>RaskJSRuntime</c>) and
+///     WASM (in-process bridge via <c>JSImport</c>). The page shows the demo's real source beside the
+///     live result via <see cref="CodeSample" />.
 /// </summary>
 [Route("jsruntime")]
 [ParentRoute(typeof(ShowcaseLayout))]
-public sealed class JsRuntimePage(IJSRuntime js) : Component
+public sealed class JsRuntimePage : Component
 {
-    private string _input = string.Empty;
-    private string? _lastRead;
-    private string? _status;
-
     protected override RenderResult Head => Title()["IJSRuntime — Rask"];
-
-    protected override async Task OnRenderedAsync(bool firstRender)
-    {
-        if (!firstRender)
-        {
-            return;
-        }
-
-        try
-        {
-            _lastRead = await js.InvokeAsync<string?>("sessionStorage.getItem", "rask.jsruntime.demo");
-            _status = _lastRead is null ? "(no value yet — try Set)" : $"Read on mount: {_lastRead}";
-        }
-        catch (Exception ex)
-        {
-            _status = "Read failed: " + ex.Message;
-        }
-    }
 
     protected override RenderResult Render() =>
     [
@@ -48,34 +25,13 @@ public sealed class JsRuntimePage(IJSRuntime js) : Component
             ". Click ", Strong()["Read"], " to read it back. Refresh the page — ",
             Code()["OnRendered"], " reads the saved value automatically on the next mount."
         ],
-        Div(Class: "card shadow-sm border-0 mb-4")[
-            Div(Class: "card-body")[
-                Div(Class: "mb-3")[
-                    Label(Class: "form-label", For: "demo-input")["sessionStorage value"],
-                    Input(
-                        Id: "demo-input",
-                        Class: "form-control",
-                        Value: _input,
-                        OnInput: v => _input = v)
-                ],
-                Div(Class: "d-flex gap-2 flex-wrap mb-3")[
-                    Button(Class: "btn btn-primary btn-sm", Id: "demo-set", OnClickAsync: SetAsync)[
-                        I(Class: "bi bi-save me-1"), "Set"],
-                    Button(Class: "btn btn-outline-primary btn-sm", Id: "demo-read", OnClickAsync: ReadAsync)[
-                        I(Class: "bi bi-arrow-clockwise me-1"), "Read"],
-                    Button(Class: "btn btn-outline-danger btn-sm", Id: "demo-remove", OnClickAsync: RemoveAsync)[
-                        I(Class: "bi bi-trash me-1"), "Remove"]
-                ],
-                Div(Class: "mb-2")[
-                    Span(Class: "text-secondary small text-uppercase")["Last read"],
-                    Div()[Code(Class: "fs-6", Id: "demo-last-read")[_lastRead ?? "(null)"]]
-                ],
-                Div()[
-                    Span(Class: "text-secondary small text-uppercase")["Status"],
-                    Div()[Code(Class: "fs-6", Id: "demo-status")[_status ?? "(idle)"]]
-                ]
-            ]
-        ],
+        CodeSample(
+            ["JsRuntimeDemo.cs"],
+            Notes:
+            "Every call goes through the unified IJSRuntime: window APIs are resolved by their dotted " +
+            "identifier (e.g. sessionStorage.getItem), invoked, and the result is shipped back to the " +
+            "awaiting ValueTask<T>. OnRenderedAsync seeds the field from storage on first mount.",
+            Result: JsRuntimeDemo()),
         Div(Class: "alert alert-info d-flex align-items-start")[
             I(Class: "bi bi-info-circle-fill me-3 fs-4"),
             Div()[
@@ -87,44 +43,4 @@ public sealed class JsRuntimePage(IJSRuntime js) : Component
             ]
         ]
     ];
-
-    private async Task SetAsync()
-    {
-        try
-        {
-            await js.InvokeVoidAsync("sessionStorage.setItem", "rask.jsruntime.demo", _input);
-            _status = $"Set to: {_input}";
-        }
-        catch (Exception ex)
-        {
-            _status = "Set failed: " + ex.Message;
-        }
-    }
-
-    private async Task ReadAsync()
-    {
-        try
-        {
-            _lastRead = await js.InvokeAsync<string?>("sessionStorage.getItem", "rask.jsruntime.demo");
-            _status = _lastRead is null ? "Read: (null)" : $"Read: {_lastRead}";
-        }
-        catch (Exception ex)
-        {
-            _status = "Read failed: " + ex.Message;
-        }
-    }
-
-    private async Task RemoveAsync()
-    {
-        try
-        {
-            await js.InvokeVoidAsync("sessionStorage.removeItem", "rask.jsruntime.demo");
-            _lastRead = null;
-            _status = "Removed";
-        }
-        catch (Exception ex)
-        {
-            _status = "Remove failed: " + ex.Message;
-        }
-    }
 }

--- a/samples/Rask.Example.Shared/Features/Orders/OrdersPage.cs
+++ b/samples/Rask.Example.Shared/Features/Orders/OrdersPage.cs
@@ -87,7 +87,15 @@ public sealed class OrdersPage : Component
                 "open rows keep their own inner sort. The detail panel hosts a second controlled ",
                 Code()["TableModel<LineItem>"],
                 " — headless grids all the way down."
-            ]
+            ],
+            CodeSample(
+                ["OrdersPage.cs"],
+                Title: "Source",
+                Notes:
+                "The whole page above, verbatim. Expand state is a HashSet<int>, the outer sort and " +
+                "each order's inner sort are plain fields — a click mutates one and the auto-wrapped " +
+                "callback re-renders. Open rows insert a keyed detail <tr>, so the live diff reconciles " +
+                "them as in-place insert/remove and sibling open rows keep their own inner sort.")
         ];
     }
 

--- a/samples/Rask.Example.Shared/Features/Table/TablePage.cs
+++ b/samples/Rask.Example.Shared/Features/Table/TablePage.cs
@@ -215,7 +215,15 @@ public sealed class TablePage(Navigator nav) : Component
                 Code()["Navigator.SetQuery"],
                 ". The page is then re-resolved against the new query, so browser back / forward replay the state for " +
                 "free. Try sorting + paging, then copy the URL — it's shareable."
-            ]
+            ],
+            CodeSample(
+                ["TablePage.cs"],
+                Title: "Source",
+                Notes:
+                "The whole page above, verbatim. The [QueryParam] properties bind sort, filter, page and " +
+                "size from the URL; the host does the filtering, sorting and slicing, then hands the " +
+                "headless TableModel<Person> the visible page plus the current sort/page and writes its " +
+                "OnSort / OnPage intents back through Navigator.SetQuery.")
         ];
     }
 

--- a/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
+++ b/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
@@ -96,6 +96,16 @@ public sealed class TodosPage(Navigator nav, RouteState route) : Component
                         ]
                     ])
                 ],
+            CodeSample(
+                ["TodosPage.cs"],
+                Title: "Source",
+                Notes:
+                "The whole CRUD screen above, verbatim — page, dialog component, and model in one file. " +
+                "Three [Route] attributes drive the dialog: /todos lists, /todos/new opens add, " +
+                "/todos/{id:guid}/edit opens edit. OnPropsChanged seeds the form from the route so browser " +
+                "Back closes the dialog and deep links open it, without clobbering in-progress typing."),
+            // The open <dialog> is position:absolute (out of flow), so it must stay last in the DOM to
+            // paint above the source CodeSample — otherwise the sample would overlay its buttons.
             TodoFormDialog(
                 ShowDialog,
                 _form,

--- a/tests/Rask.Example.Server.Tests/Pages/JsRuntimePageTests.cs
+++ b/tests/Rask.Example.Server.Tests/Pages/JsRuntimePageTests.cs
@@ -5,9 +5,11 @@ using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Server.Tests.Pages;
 
-// Originally test for Server-only JsRuntimePage; the page has been unified into
-// Rask.Example.Shared.Pages so it now runs on Server + WASM. The unit tests
-// stay on the Server-Tests project since they don't depend on host transport.
+// The JsRuntime feature is split into a host page (JsRuntimePage: route + Head + CodeSample)
+// and the interactive demo (JsRuntimeDemo: the IJSRuntime sessionStorage round-trip). The page
+// is a parameterless host; the demo takes IJSRuntime through its ctor. Page-level tests target
+// JsRuntimePage; the behavioral tests target JsRuntimeDemo. Both run on Server + WASM, so the
+// unit tests stay on the Server-Tests project since they don't depend on host transport.
 
 public sealed class JsRuntimePageTests
 {
@@ -16,8 +18,7 @@ public sealed class JsRuntimePageTests
     {
         var head = typeof(JsRuntimePage).GetProperty("Head",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var js = new FakeJsRuntime();
-        var page = new JsRuntimePage(js);
+        var page = new JsRuntimePage();
         // Head now returns a RenderResult struct; unwrap to the contributed Component.
         var headComponent = ((RenderResult)head.GetValue(page)!).ToComponentOrNull();
         Assert.NotNull(headComponent);
@@ -29,12 +30,12 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         js.SetResponse("sessionStorage.getItem", "stored-value");
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokeOnRenderedAsync(page, true);
+        await InvokeOnRenderedAsync(demo, true);
 
-        Assert.Equal("stored-value", GetField<string?>(page, "_lastRead"));
-        Assert.Equal("Read on mount: stored-value", GetField<string?>(page, "_status"));
+        Assert.Equal("stored-value", GetField<string?>(demo, "_lastRead"));
+        Assert.Equal("Read on mount: stored-value", GetField<string?>(demo, "_status"));
     }
 
     [Fact]
@@ -42,25 +43,25 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         // No SetResponse → returns default (null for string?).
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokeOnRenderedAsync(page, true);
+        await InvokeOnRenderedAsync(demo, true);
 
-        Assert.Null(GetField<string?>(page, "_lastRead"));
-        Assert.Equal("(no value yet — try Set)", GetField<string?>(page, "_status"));
+        Assert.Null(GetField<string?>(demo, "_lastRead"));
+        Assert.Equal("(no value yet — try Set)", GetField<string?>(demo, "_status"));
     }
 
     [Fact]
     public async Task OnRenderedAsync_NonFirstRender_NoOp()
     {
         var js = new FakeJsRuntime();
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokeOnRenderedAsync(page, false);
+        await InvokeOnRenderedAsync(demo, false);
 
         // No call should have been made to sessionStorage.getItem.
         Assert.Equal(0, js.CallCount("sessionStorage.getItem"));
-        Assert.Null(GetField<string?>(page, "_status"));
+        Assert.Null(GetField<string?>(demo, "_status"));
     }
 
     [Fact]
@@ -68,11 +69,11 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         js.SetException("sessionStorage.getItem", new InvalidOperationException("boom"));
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokeOnRenderedAsync(page, true);
+        await InvokeOnRenderedAsync(demo, true);
 
-        var status = GetField<string?>(page, "_status");
+        var status = GetField<string?>(demo, "_status");
         Assert.NotNull(status);
         Assert.StartsWith("Read failed:", status);
         Assert.Contains("boom", status);
@@ -82,13 +83,13 @@ public sealed class JsRuntimePageTests
     public async Task SetAsync_InvokesSetItem_UpdatesStatus()
     {
         var js = new FakeJsRuntime();
-        var page = new JsRuntimePage(js);
-        SetField(page, "_input", "hello");
+        var demo = new JsRuntimeDemo(js);
+        SetField(demo, "_input", "hello");
 
-        await InvokePrivate(page, "SetAsync");
+        await InvokePrivate(demo, "SetAsync");
 
         Assert.Equal(1, js.CallCount("sessionStorage.setItem"));
-        Assert.Equal("Set to: hello", GetField<string?>(page, "_status"));
+        Assert.Equal("Set to: hello", GetField<string?>(demo, "_status"));
     }
 
     [Fact]
@@ -96,12 +97,12 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         js.SetException("sessionStorage.setItem", new InvalidOperationException("nope"));
-        var page = new JsRuntimePage(js);
-        SetField(page, "_input", "x");
+        var demo = new JsRuntimeDemo(js);
+        SetField(demo, "_input", "x");
 
-        await InvokePrivate(page, "SetAsync");
+        await InvokePrivate(demo, "SetAsync");
 
-        var status = GetField<string?>(page, "_status");
+        var status = GetField<string?>(demo, "_status");
         Assert.StartsWith("Set failed:", status);
     }
 
@@ -110,23 +111,23 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         js.SetResponse("sessionStorage.getItem", "read-back");
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokePrivate(page, "ReadAsync");
+        await InvokePrivate(demo, "ReadAsync");
 
-        Assert.Equal("read-back", GetField<string?>(page, "_lastRead"));
-        Assert.Equal("Read: read-back", GetField<string?>(page, "_status"));
+        Assert.Equal("read-back", GetField<string?>(demo, "_lastRead"));
+        Assert.Equal("Read: read-back", GetField<string?>(demo, "_status"));
     }
 
     [Fact]
     public async Task ReadAsync_NullStored_SetsStatusReadNull()
     {
         var js = new FakeJsRuntime();
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokePrivate(page, "ReadAsync");
+        await InvokePrivate(demo, "ReadAsync");
 
-        Assert.Equal("Read: (null)", GetField<string?>(page, "_status"));
+        Assert.Equal("Read: (null)", GetField<string?>(demo, "_status"));
     }
 
     [Fact]
@@ -134,11 +135,11 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         js.SetException("sessionStorage.getItem", new InvalidOperationException("boom"));
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokePrivate(page, "ReadAsync");
+        await InvokePrivate(demo, "ReadAsync");
 
-        var status = GetField<string?>(page, "_status");
+        var status = GetField<string?>(demo, "_status");
         Assert.StartsWith("Read failed:", status);
     }
 
@@ -146,14 +147,14 @@ public sealed class JsRuntimePageTests
     public async Task RemoveAsync_InvokesRemoveItem_ClearsLastRead()
     {
         var js = new FakeJsRuntime();
-        var page = new JsRuntimePage(js);
-        SetField(page, "_lastRead", "previous");
+        var demo = new JsRuntimeDemo(js);
+        SetField(demo, "_lastRead", "previous");
 
-        await InvokePrivate(page, "RemoveAsync");
+        await InvokePrivate(demo, "RemoveAsync");
 
         Assert.Equal(1, js.CallCount("sessionStorage.removeItem"));
-        Assert.Null(GetField<string?>(page, "_lastRead"));
-        Assert.Equal("Removed", GetField<string?>(page, "_status"));
+        Assert.Null(GetField<string?>(demo, "_lastRead"));
+        Assert.Equal("Removed", GetField<string?>(demo, "_status"));
     }
 
     [Fact]
@@ -161,11 +162,11 @@ public sealed class JsRuntimePageTests
     {
         var js = new FakeJsRuntime();
         js.SetException("sessionStorage.removeItem", new InvalidOperationException("nope"));
-        var page = new JsRuntimePage(js);
+        var demo = new JsRuntimeDemo(js);
 
-        await InvokePrivate(page, "RemoveAsync");
+        await InvokePrivate(demo, "RemoveAsync");
 
-        var status = GetField<string?>(page, "_status");
+        var status = GetField<string?>(demo, "_status");
         Assert.StartsWith("Remove failed:", status);
     }
 
@@ -178,32 +179,32 @@ public sealed class JsRuntimePageTests
         Assert.Equal("jsruntime", attr!.Template);
     }
 
-    private static async Task InvokeOnRenderedAsync(JsRuntimePage page, bool firstRender)
+    private static async Task InvokeOnRenderedAsync(JsRuntimeDemo demo, bool firstRender)
     {
-        var mi = typeof(JsRuntimePage).GetMethod("OnRenderedAsync",
+        var mi = typeof(JsRuntimeDemo).GetMethod("OnRenderedAsync",
             BindingFlags.Instance | BindingFlags.NonPublic)!;
-        await (Task)mi.Invoke(page, [firstRender])!;
+        await (Task)mi.Invoke(demo, [firstRender])!;
     }
 
-    private static async Task InvokePrivate(JsRuntimePage page, string name)
+    private static async Task InvokePrivate(JsRuntimeDemo demo, string name)
     {
-        var mi = typeof(JsRuntimePage).GetMethod(name,
+        var mi = typeof(JsRuntimeDemo).GetMethod(name,
             BindingFlags.Instance | BindingFlags.NonPublic)!;
-        await (Task)mi.Invoke(page, null)!;
+        await (Task)mi.Invoke(demo, null)!;
     }
 
-    private static T GetField<T>(JsRuntimePage page, string name)
+    private static T GetField<T>(JsRuntimeDemo demo, string name)
     {
-        var f = typeof(JsRuntimePage).GetField(name,
+        var f = typeof(JsRuntimeDemo).GetField(name,
             BindingFlags.Instance | BindingFlags.NonPublic)!;
-        var v = f.GetValue(page);
+        var v = f.GetValue(demo);
         return v is null ? default! : (T)v;
     }
 
-    private static void SetField(JsRuntimePage page, string name, object? value)
+    private static void SetField(JsRuntimeDemo demo, string name, object? value)
     {
-        var f = typeof(JsRuntimePage).GetField(name,
+        var f = typeof(JsRuntimeDemo).GetField(name,
             BindingFlags.Instance | BindingFlags.NonPublic)!;
-        f.SetValue(page, value);
+        f.SetValue(demo, value);
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -313,6 +313,9 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("select.form-select-sm").SelectOptionAsync("25");
         await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
             new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
+        // Every showcase page shows its own source: the page-source CodeSample card is present.
+        await Expect(Page.Locator("main .sample-card").First).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
         // Master-detail: expand state is local; toggling inserts a keyed detail <tr> hosting a nested,
         // independently sortable TableModel. Collapse removes it via the same keyed diff.
@@ -334,6 +337,9 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("[data-testid='expander-1']").ClickAsync();
         await Expect(Page.Locator("[data-testid='inner-1']")).ToHaveCountAsync(0,
             new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
+        // Page-source CodeSample card is present.
+        await Expect(Page.Locator("main .sample-card").First).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
         // Drag & drop: native HTML5 drag events fire the C# handlers; the live diff morphs the DOM.
         await SideAsync("Drag & drop", "Headless drag & drop");
@@ -514,6 +520,10 @@ public abstract partial class SharedSmokeTests
         Assert.True(await Page.Locator(cssLinkSel).CountAsync() >= 3, "expected >=3 per-component CSS links");
         Assert.True(await Page.Locator("head script[src^='/_rask/a/'][src$='.js']").CountAsync() >= 1,
             "expected >=1 JS-only script");
+        // Each section is now a CodeSample: source beside the live result. Assert all four cards mount
+        // (the scoped-asset live results above are the CodeSample Result panes).
+        Assert.True(await Page.Locator("main .sample-card").CountAsync() >= 4,
+            "expected >=4 CodeSample cards on the asset-loading page");
         var beforeLazy = await Page.Locator(cssLinkSel).CountAsync();
         // Warm-up toggle: LazyChild is never instantiated until shown, so its scoped stylesheet
         // (.lazy-child → #fff4d6) is not among the page-load prefetches. Mount it once and unmount
@@ -611,10 +621,16 @@ public abstract partial class SharedSmokeTests
         await Page.Locator(".list-group-item button:has(i.bi-trash)").First.ClickAsync();
         await Expect(Page.Locator(".list-group .list-group-item")).ToHaveCountAsync(rowsBefore - 1,
             new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
+        // Page-source CodeSample card is present.
+        await Expect(Page.Locator("main .sample-card").First).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
         // IJSRuntime: sessionStorage set/read/remove round-trip through the unified IJSRuntime.
+        // The interactive demo now lives in the CodeSample Result pane beside its own source.
         await ClearJsRuntimeStorageAsync();
         await SideAsync("IJSRuntime", "IJSRuntime", "main h1.h2");
+        await Expect(Page.Locator("main .sample-card .sample-result-body #demo-input")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
         await Page.Locator("#demo-input").FillAsync("hello-rask");
         await Page.Locator("#demo-set").ClickAsync();
         await Expect(Page.Locator("#demo-status")).ToContainTextAsync("Set to: hello-rask",


### PR DESCRIPTION
## Summary

Every Rask showcase page is supposed to display its own source beside a live result via the `CodeSample` component (verbatim embedded source, so the snippet never drifts from what runs). An audit found five feature pages without one — this brings them into the convention.

- **`/asset-loading`** — each scoped-asset section is now a `CodeSample` showing the component's source (with sibling `.css`/`.js` tabs) and the live component as the `Result`. The bespoke `Section()` helper is removed.
- **`/jsruntime`** — the `sessionStorage` round-trip is extracted into a new `JsRuntimeDemo` component (ctor-injected `IJSRuntime`, mirroring `ElementRefDemo`) shown beside its own source.
- **`/master-detail`, `/table`, `/todos`** — whole-page demos coupled to route/query state; each appends a `CodeSample` of the page's own embedded source beneath the live demo (no `Result`, matching the `LiveTicker`/`Routing` precedent). `/table` stays this way because its `[QueryParam]` binding is page-level and can't move to a child.

`/todos` renders the source `CodeSample` **before** the `TodoFormDialog`, because an open `<dialog>` is `position: absolute` (out of flow) and must stay last in the DOM to paint above the sample — otherwise the sample overlays its buttons.

The `[NotFound]` system page and the routing-demo sub-page (whose source is already shown inside `RoutingPage`) are intentionally excluded.

## Testing

- `dotnet format` clean; `dotnet build -warnaserror` clean on the affected managed projects (shared, server, E2E test project).
- Unit suite green (`--filter "FullyQualifiedName!~Rask.Examples.E2E"`): 2,000+ tests pass.
- E2E shared journey extended with `.sample-card` assertions on each affected page (and that the IJSRuntime demo now lives in the `.sample-result-body`). Ran green on all three showcase hosts: **Server**, **WASM**, and **Standalone WASM**.

> Note: the full-solution `dotnet build` hit a flaky emscripten native-relink error in the unrelated `Auth.WasmCookie` sample on this machine (`wasm_m2n_invoke.g.h` not found, 0 warnings). It is environment-toolchain, not this change — the showcase WASM sample built and the WASM E2E journeys pass.

## Benchmarks

Not applicable — samples-only change, no render/runtime hot-path code touched.

## Changelog

Added a `### Changed` entry under `[Unreleased]`.
