### PR TITLE
feat(core): add Aria/Role/TabIndex to every element + RASK023 Img-alt analyzer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Accessibility primitives on every element.** A new `Aria` parameter — a `string → string?`
+  dictionary modelled on the existing `Data` (`data-*`) bag — renders each entry as
+  `aria-{key}="{value}"`, so the full WAI-ARIA vocabulary is reachable without a typed property per
+  attribute (`Button(Aria: new() { ["label"] = "Close" })` → `aria-label="Close"`). `Role` (`string?`)
+  and `TabIndex` (`int?`) are typed parameters for the two non-`aria-*` affordances. The universal
+  attribute order is now **id, class, style, data-\*, role, tabindex, aria-\*, then tag-specific**. A
+  new **RASK023** analyzer warns when an `Img` is created without `Alt` (pass `Alt: ""` for decorative
+  images). See the new [accessibility guide](docs/accessibility.md).
 - **`TableModel<T>` — a headless, fully *controlled* table primitive** (in the spirit of TanStack
   Table). It renders no markup of its own and owns no state: the host sorts, filters, and pages its
   own data and hands the model the final `Rows` plus the current view state (`Sort`, `PageIndex`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,7 +44,7 @@ dotnet run --project samples/Rask.Example.Server
 ## Primitives & rules (the load-bearing invariants)
 - `Component` (base: `Render`, `Children`, `Key`, `TagName`, `WriteAttributes`) → `Element` (universal
   HTML attrs). `Text` encodes; `Raw` is verbatim. `Fragment`/`Doctype` special-cased in `HtmlSerializer`.
-- **Attribute render order: id, class, style, data-*, then tag-specific — tests assert it; preserve it.**
+- **Attribute render order: id, class, style, data-*, role, tabindex, aria-*, then tag-specific — tests assert it; preserve it.**
 - Children via the indexer `Div()[Span(), "hi"]` (no `Children:` param; `..` spread breaks — pass enumerables).
   Page root must render the full shell (`Doctype`/`Html`/`Head`/`Body`) — RASK021. Runtime `<script>` auto-appended.
 - **Factory params** (generated per public prop): nullable→optional(null); non-nullable no-initializer→**required**

--- a/NUGET.md
+++ b/NUGET.md
@@ -60,7 +60,8 @@ the page). It's a craft project built in the open, deep on Roslyn source generat
 ## Links
 
 - 📖 **[Documentation](https://github.com/pal-tamas/rask/tree/main/docs)** ·
-  [Getting started](https://github.com/pal-tamas/rask/blob/main/docs/getting-started.md)
+  [Getting started](https://github.com/pal-tamas/rask/blob/main/docs/getting-started.md) ·
+  [Accessibility](https://github.com/pal-tamas/rask/blob/main/docs/accessibility.md)
 - 🚀 **[Live demo](https://pal-tamas.github.io/rask/)**
 - 💻 **[Source & README](https://github.com/pal-tamas/rask)**
 - 🤖 **[AI assistant guide](https://github.com/pal-tamas/rask/blob/main/llms.txt)**

--- a/README.md
+++ b/README.md
@@ -411,8 +411,8 @@ see **[`docs/`](docs/)**:
 - **[Getting started](docs/getting-started.md)** — scaffold, first component, interactivity, routing.
 - **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · *
   *[Authentication](docs/authentication.md)**
-- **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
-- **[Diagnostics (RASK001–022)](docs/diagnostics.md)** — every build error/warning and its fix.
+- **[Accessibility](docs/accessibility.md)** · **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
+- **[Diagnostics (RASK001–023)](docs/diagnostics.md)** — every build error/warning and its fix.
 - **[Live rendering & the diff codec](docs/architecture/live-rendering.md)** — how the runtime works under the hood.
 
 ## 🧩 Core concepts

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Guides and references for building with Rask. New here? Start with the project
 | [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |
 | [Data access (EF Core)](data-access.md) | EF Core + SQLite in a Server app: `IDbContextFactory`, loading in the lifecycle, vertical slices, a DDD aggregate + value objects, and the SQLite decimal gotcha. |
 | [Authentication](authentication.md) | Production auth: cookie & JWT, Server & WASM, `Authorize`, route guards, Identity / Keycloak / Auth0 / Cognito / Duende. |
+| [Accessibility](accessibility.md) | Setting ARIA attributes, `Role`/`TabIndex`, and focus on any element; the `Img` alt-text analyzer (RASK023). |
 | [Testing](testing.md) | Unit-testing components with `Rask.TestSupport`, driving event handlers, when to reach for E2E. |
 | [Migrating from Blazor](migration-from-blazor.md) | Concept mapping, behavioural gotchas, and what stays the same. |
 | [Building with AI assistants](ai-agents.md) | The `AGENTS.md` / `llms.txt` artifacts that let AI tools scaffold and extend Rask apps. |
@@ -23,7 +24,7 @@ Guides and references for building with Rask. New here? Start with the project
 
 | Reference | What it covers |
 |-----------|----------------|
-| [Diagnostics (RASK001–022)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
+| [Diagnostics (RASK001–023)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
 | [Code analysis](code-analysis.md) | Analyzers, warnings-as-errors, and the per-PR adoption procedure. |
 
 ## Contributing

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -1,0 +1,84 @@
+# Accessibility: ARIA, roles & focus
+
+How to make Rask components accessible — setting ARIA attributes, roles, and keyboard focus on any
+element, plus the analyzer that catches missing image alt text.
+
+- [The `Aria` dictionary](#the-aria-dictionary)
+- [`Role` and `TabIndex`](#role-and-tabindex)
+- [Attribute order](#attribute-order)
+- [Images and alt text (RASK023)](#images-and-alt-text-rask023)
+- [What's not covered yet](#whats-not-covered-yet)
+
+---
+
+## The `Aria` dictionary
+
+Every element exposes an `Aria` parameter — a `string → string?` dictionary modelled exactly on the
+[`Data` (data-*) bag](js-interop.md). Each entry renders as `aria-{key}="{value}"`: the key is used
+verbatim (so you write `"label"`, not `"aria-label"`) and the value is HTML-encoded. A `null` value
+emits a bare attribute.
+
+```csharp
+Button(Aria: new() { ["label"] = "Close", ["expanded"] = "false" })["✕"]
+// <button aria-label="Close" aria-expanded="false">✕</button>
+
+I(Class: "bi bi-trash", Aria: new() { ["hidden"] = "true" })
+// <i class="bi bi-trash" aria-hidden="true"></i>  — decorative icon, skipped by screen readers
+```
+
+Because it's a dictionary, the full [WAI-ARIA](https://www.w3.org/TR/wai-aria-1.2/) vocabulary is
+reachable without a typed property per attribute — `aria-live`, `aria-labelledby`, `aria-describedby`,
+`aria-current`, `aria-modal`, and the rest are all just keys.
+
+A common live-region pattern:
+
+```csharp
+Div(Role: "status", Aria: new() { ["live"] = "polite" })[_statusMessage]
+```
+
+## `Role` and `TabIndex`
+
+`role` and `tabindex` are not `aria-*` attributes, so they have their own typed parameters on every
+element:
+
+```csharp
+Div(Role: "dialog", TabIndex: -1, Aria: new() { ["modal"] = "true", ["labelledby"] = "title" })[
+    H2(Id: "title")["Edit product"],
+    // ...
+]
+```
+
+`Role` is a `string?`; `TabIndex` is an `int?` (`0` to make a non-interactive element focusable, `-1`
+to take it out of the tab order but keep it programmatically focusable).
+
+## Attribute order
+
+Accessibility attributes render in the universal attribute block, after `data-*` and before any
+tag-specific attributes. The full documented order is:
+
+```
+id, class, style, data-*, role, tabindex, aria-*, then tag-specific
+```
+
+Tests assert this order; it is stable across releases.
+
+## Images and alt text (RASK023)
+
+`Img` requires an `Alt` for accessibility. The [RASK023](diagnostics.md#rask023) analyzer warns when
+an `Img(...)` factory call omits it:
+
+```csharp
+Img(Src: "/logo.png", Alt: "Rask logo")   // informative image
+Img(Src: "/divider.png", Alt: "")          // decorative: empty alt hides it from assistive tech
+```
+
+Pass `Alt: ""` for purely decorative images so screen readers skip them; pass a meaningful string
+for everything else.
+
+## What's not covered yet
+
+This is the framework primitive layer. Higher-level affordances — a focus-trapping modal dialog
+primitive, skip links, ARIA `tablist`/`tab` widgets, and automated axe-core scans in the sample E2E
+suite — are tracked as follow-up work. Today you build those from the `Aria`/`Role`/`TabIndex`
+primitives above plus standard semantic HTML (`Nav`, `Main`, `Aside`, `Label(For:)`,
+`Th(Scope:)`, …).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,4 +1,4 @@
-# Rask diagnostics (RASK001–RASK022)
+# Rask diagnostics (RASK001–RASK023)
 
 Every Rask diagnostic, what triggers it, and how to fix it. Errors block the build; warnings don't
 but flag a real problem; one is hidden (informational, surfaced only as an IDE suggestion).
@@ -31,6 +31,7 @@ build once.
 | [RASK020](#rask020) | Warning | Scoped-JS simple-name collision |
 | [RASK021](#rask021) | Warning | Root component must render a complete page shell |
 | [RASK022](#rask022) | Warning | List item is missing a `Key` |
+| [RASK023](#rask023) | Warning | `Img` is missing `Alt` text |
 
 ---
 
@@ -235,3 +236,18 @@ input state and emits untrusted structural diffs on insert/remove/move.
 **Fix:** pass a stable `Key:` (an entity id, not the loop index). See
 [keyed lists](getting-started.md) and the [live-rendering architecture](architecture/live-rendering.md)
 for why identity beats position.
+
+## RASK023
+**`Img` is missing `Alt` text** · Warning
+
+An `Img(...)` factory call supplies no `Alt`. Without a text alternative, screen readers fall back to
+announcing the file name (or nothing), failing [WCAG 1.1.1](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content).
+
+```csharp
+// ✗ Img(Src: "/logo.png")
+// ✓ Img(Src: "/logo.png", Alt: "Rask logo")
+// ✓ Img(Src: "/divider.png", Alt: "")   // decorative: empty alt hides it from assistive tech
+```
+
+**Fix:** pass a meaningful `Alt:`, or the empty string `Alt: ""` for a purely decorative image so
+assistive technology skips it. See [accessibility](accessibility.md).

--- a/llms.txt
+++ b/llms.txt
@@ -17,8 +17,9 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
+- [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
-- [Diagnostics](docs/diagnostics.md): RASK001–022 compile-time diagnostics + fixes.
+- [Diagnostics](docs/diagnostics.md): RASK001–023 compile-time diagnostics + fixes.
 - [Testing](docs/testing.md): unit + Playwright E2E patterns.
 
 ## Contributing to Rask itself

--- a/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
@@ -48,7 +48,8 @@ public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbConte
                 P(Class: "text-secondary mb-0")["EF Core + SQLite CRUD, organised as vertical slices."]
             ],
             NavLink("/products/new", Class: "btn btn-primary")[
-                I(Class: "bi bi-plus-lg me-1"), "New product"
+                I(Class: "bi bi-plus-lg me-1", Aria: new Dictionary<string, string?> { ["hidden"] = "true" }),
+                "New product"
             ]
         ],
         !_loaded
@@ -74,12 +75,16 @@ public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbConte
                             Td(Class: "text-end")[p.Price.ToString()],
                             Td(Class: "text-end")[p.Stock.Value.ToString(CultureInfo.InvariantCulture)],
                             Td(Class: "text-end text-nowrap")[
-                                NavLink($"/products/{p.Id}/edit", Class: "btn btn-outline-secondary btn-sm me-1")[
-                                    I(Class: "bi bi-pencil")
+                                // Icon-only controls: the visible glyph is decorative (aria-hidden),
+                                // so each control carries an aria-label naming the row it acts on.
+                                NavLink($"/products/{p.Id}/edit", Class: "btn btn-outline-secondary btn-sm me-1",
+                                    Aria: new Dictionary<string, string?> { ["label"] = $"Edit {p.Name.Value}" })[
+                                    I(Class: "bi bi-pencil", Aria: new Dictionary<string, string?> { ["hidden"] = "true" })
                                 ],
                                 Button("button", Class: "btn btn-outline-danger btn-sm",
-                                    OnClickAsync: () => DeleteAsync(p.Id))[
-                                    I(Class: "bi bi-trash")
+                                    OnClickAsync: () => DeleteAsync(p.Id),
+                                    Aria: new Dictionary<string, string?> { ["label"] = $"Delete {p.Name.Value}" })[
+                                    I(Class: "bi bi-trash", Aria: new Dictionary<string, string?> { ["hidden"] = "true" })
                                 ]
                             ]
                         ])

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -211,6 +211,46 @@ public abstract class Component
         }
     }
 
+    // Backing store for Element.Role/TabIndex/Aria, hoisted into the lazy LiveState for the same
+    // reason as Ref: accessibility attributes are opt-in and rare, so a plain element keeps `_live`
+    // null and adds zero footprint. The setters only force a LiveState allocation when an actual
+    // value is assigned; setting null on an element that never used the feature is a no-op.
+    internal string? RoleInternal
+    {
+        get => _live?.Role;
+        set
+        {
+            if (value is not null || _live is not null)
+            {
+                Live.Role = value;
+            }
+        }
+    }
+
+    internal int? TabIndexInternal
+    {
+        get => _live?.TabIndex;
+        set
+        {
+            if (value is not null || _live is not null)
+            {
+                Live.TabIndex = value;
+            }
+        }
+    }
+
+    internal IReadOnlyDictionary<string, string?>? AriaInternal
+    {
+        get => _live?.Aria;
+        set
+        {
+            if (value is not null || _live is not null)
+            {
+                Live.Aria = value;
+            }
+        }
+    }
+
     /// <summary>
     ///     A <see cref="System.Threading.CancellationToken" /> tied to this component's lifetime.
     ///     Cancelled exactly once when the component is unmounted (navigation away, parent
@@ -1272,6 +1312,9 @@ public abstract class Component
         public Dictionary<(Type, int), Component>? Children;
         public Dictionary<LiveRenderContext.ObjectKey, EditContext>? EditContextsPool;
         public ElementRef? ElementRef;
+        public string? Role;
+        public int? TabIndex;
+        public IReadOnlyDictionary<string, string?>? Aria;
         public HeadAssetRegistry? HeadAssets;
         public HashSet<Type>? MountedTypes;
         public Dictionary<string, (Component Owner, Delegate Handler)>? Handlers;

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using Rask.Core.Live;
 
@@ -13,6 +14,32 @@ public abstract class Element : Component
     public string? Class { get; set; }
     public string? Style { get; set; }
     public IReadOnlyDictionary<string, string?>? Data { get; set; }
+
+    // Accessibility, available on every element. `Aria` is the data-* model applied to ARIA: each
+    // entry emits aria-{key}="{value}" (key verbatim, value HTML-encoded) — so `Aria: new() {
+    // ["label"] = "Close" }` renders aria-label="Close", and the full ARIA vocabulary is reachable
+    // without a typed property per attribute. `Role` and `TabIndex` are plain attributes (not aria-*,
+    // so not expressible through the dictionary) but are core a11y affordances for custom widgets and
+    // keyboard focus. All three are nullable → optional factory parameters, like the other HTML attrs.
+    // Like Ref, their storage is hoisted into the lazy LiveState (a11y attrs are opt-in and rare), so
+    // an element that sets none keeps `_live` null and pays no per-instance footprint for the feature.
+    public string? Role
+    {
+        get => RoleInternal;
+        set => RoleInternal = value;
+    }
+
+    public int? TabIndex
+    {
+        get => TabIndexInternal;
+        set => TabIndexInternal = value;
+    }
+
+    public IReadOnlyDictionary<string, string?>? Aria
+    {
+        get => AriaInternal;
+        set => AriaInternal = value;
+    }
 
     // A stable DOM handle for JS interop. When set, emits data-rask-ref="{id}" in the data-* group;
     // the client reviver resolves an ElementRef arg to this element via [data-rask-ref="..."].
@@ -122,6 +149,27 @@ public abstract class Element : Component
             if (OnDragEnd is not null)
             {
                 AppendAttr(sb, "data-rask-on-dragend", ctx.RegisterHandler(OnDragEnd));
+            }
+        }
+
+        // Accessibility group, last in the universal block so it lands after data-* yet before any
+        // subclass tag-specific attrs (those run after base.WriteAttributes). Documented order:
+        // id, class, style, data-*, role, tabindex, aria-*, then tag-specific.
+        if (Role is not null)
+        {
+            AppendAttr(sb, "role", Role);
+        }
+
+        if (TabIndex is not null)
+        {
+            AppendAttr(sb, "tabindex", TabIndex.Value.ToString(CultureInfo.InvariantCulture));
+        }
+
+        if (Aria is not null)
+        {
+            foreach (var kv in Aria)
+            {
+                AppendAttr(sb, "aria-", kv.Key, kv.Value);
             }
         }
     }

--- a/src/Rask.Generators/Analyzers/ImgMissingAltAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/ImgMissingAltAnalyzer.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Analyzers;
+
+// RASK023 — warn when an Img factory call omits Alt. Every informative image needs a text
+// alternative (WCAG 1.1.1): without `alt`, screen readers fall back to announcing the file name or
+// nothing at all. The fix is to pass a meaningful `Alt:`; for a purely decorative image, pass the
+// empty string (`Alt: ""`) so assistive tech skips it. The warning fires only when no Alt argument
+// is supplied at all — `Alt: ""` counts as supplied and stays quiet. Suppressible like any analyzer.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class ImgMissingAltAnalyzer : DiagnosticAnalyzer
+{
+    private const string ImgFullName = "Rask.Core.Components.Img";
+    private const string RaskCoreAssembly = "Rask.Core";
+    private const string GeneratedClassName = "Generated";
+    private const string AltParameter = "Alt";
+
+    private static readonly DiagnosticDescriptor Rask023 = new(
+        "RASK023",
+        "Img is missing Alt text",
+        "Img is created without Alt — set Alt: to a text alternative, or Alt: \"\" for a decorative "
+        + "image, so screen readers don't announce the file name (WCAG 1.1.1)",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        true,
+        "Every informative image needs a text alternative. Pass a meaningful Alt:, or the empty "
+        + "string (Alt: \"\") for a purely decorative image so assistive technology skips it.",
+        DiagnosticHelp.Link("RASK023"));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rask023);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(static start =>
+        {
+            if (string.Equals(start.Compilation.AssemblyName, RaskCoreAssembly, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var img = start.Compilation.GetTypeByMetadataName(ImgFullName);
+            if (img is null)
+            {
+                return;
+            }
+
+            start.RegisterSyntaxNodeAction(
+                ctx => Analyze(ctx, img),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol img)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+
+        // Is this the generated Img factory? A static `Generated.Img(...)` returning Rask.Core.Components.Img.
+        if (context.SemanticModel.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method
+            || !method.IsStatic
+            || !string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
+            || !string.Equals(method.Name, "Img", StringComparison.Ordinal)
+            || !SymbolEqualityComparer.Default.Equals(method.ReturnType, img))
+        {
+            return;
+        }
+
+        if (!SuppliesAlt(invocation, method))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(Rask023, NameLocation(invocation)));
+        }
+    }
+
+    // Alt may be passed by name (Alt: "...") or positionally. Positional arguments fill parameters
+    // left-to-right and (per C# rules) precede any named argument, so Alt is supplied positionally
+    // when its parameter index is within the leading positional-argument count.
+    private static bool SuppliesAlt(InvocationExpressionSyntax invocation, IMethodSymbol method)
+    {
+        var altIndex = -1;
+        for (var i = 0; i < method.Parameters.Length; i++)
+        {
+            if (string.Equals(method.Parameters[i].Name, AltParameter, StringComparison.Ordinal))
+            {
+                altIndex = i;
+                break;
+            }
+        }
+
+        if (altIndex < 0)
+        {
+            return true; // No Alt parameter (shouldn't happen) — don't flag.
+        }
+
+        var positionalCount = 0;
+        var sawNamed = false;
+        foreach (var arg in invocation.ArgumentList.Arguments)
+        {
+            if (arg.NameColon is { } name)
+            {
+                sawNamed = true;
+                if (string.Equals(name.Name.Identifier.ValueText, AltParameter, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+            else if (!sawNamed)
+            {
+                positionalCount++;
+            }
+        }
+
+        return altIndex < positionalCount;
+    }
+
+    private static Location NameLocation(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.GetLocation(),
+        _ => inv.Expression.GetLocation()
+    };
+}

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -20,6 +20,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **A page/root component must render the full shell**: `Fragment()[Doctype(), Html(...)[Head(...), Body(...)]]`
   (RASK021). The framework injects its runtime `<script>` automatically — don't add one.
 - **Text vs raw:** `Text("..")` / a bare string HTML-encodes; `Raw("..")` is verbatim (XSS risk — avoid for user input).
+- **Accessibility:** set ARIA via the `Aria` dictionary on any element — `Button(Aria: new() { ["label"] = "Close" })`
+  renders `aria-label="Close"`. `Role:` / `TabIndex:` are typed params. `Img` needs `Alt:` (or `Alt: ""`
+  for decorative images) or RASK023 warns. See `docs/accessibility.md`.
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -20,6 +20,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **A page/root component must render the full shell**: `Fragment()[Doctype(), Html(...)[Head(...), Body(...)]]`
   (RASK021). The framework injects its runtime `<script>` automatically — don't add one.
 - **Text vs raw:** `Text("..")` / a bare string HTML-encodes; `Raw("..")` is verbatim (XSS risk — avoid for user input).
+- **Accessibility:** set ARIA via the `Aria` dictionary on any element — `Button(Aria: new() { ["label"] = "Close" })`
+  renders `aria-label="Close"`. `Role:` / `TabIndex:` are typed params. `Img` needs `Alt:` (or `Alt: ""`
+  for decorative images) or RASK023 warns. See `docs/accessibility.md`.
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -20,6 +20,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **A page/root component must render the full shell**: `Fragment()[Doctype(), Html(...)[Head(...), Body(...)]]`
   (RASK021). The framework injects its runtime `<script>` automatically — don't add one.
 - **Text vs raw:** `Text("..")` / a bare string HTML-encodes; `Raw("..")` is verbatim (XSS risk — avoid for user input).
+- **Accessibility:** set ARIA via the `Aria` dictionary on any element — `Button(Aria: new() { ["label"] = "Close" })`
+  renders `aria-label="Close"`. `Role:` / `TabIndex:` are typed params. `Img` needs `Alt:` (or `Alt: ""`
+  for decorative images) or RASK023 warns. See `docs/accessibility.md`.
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`

--- a/tests/Rask.Core.Tests/Components/ButtonTests.cs
+++ b/tests/Rask.Core.Tests/Components/ButtonTests.cs
@@ -50,6 +50,16 @@ public class ButtonTests
     }
 
     [Fact]
+    public void Render_AccessibilityProps_PrecedeTagSpecificAttributes()
+    {
+        Assert.Equal(
+            "<button data-test-id=\"x\" role=\"button\" tabindex=\"0\" aria-pressed=\"true\" type=\"submit\" disabled></button>",
+            Button("submit", true, Data: new Dictionary<string, string?> { ["test-id"] = "x" },
+                Role: "button", TabIndex: 0,
+                Aria: new Dictionary<string, string?> { ["pressed"] = "true" }).ToHtml());
+    }
+
+    [Fact]
     public void Render_StringChild_EncodesText()
     {
         Assert.Equal(

--- a/tests/Rask.Core.Tests/Components/DivTests.cs
+++ b/tests/Rask.Core.Tests/Components/DivTests.cs
@@ -15,4 +15,45 @@ public class DivTests
 
     [Fact]
     public void Render_StringChild_EncodesText() => Assert.Equal("<div>&lt;x&gt;</div>", Div()["<x>"].ToHtml());
+
+    [Fact]
+    public void Render_NoAccessibilityProps_EmitsNoAriaRoleOrTabindex() =>
+        Assert.Equal("<div></div>", Div().ToHtml());
+
+    [Fact]
+    public void Render_Aria_EmitsAriaPrefixedAttributes() =>
+        Assert.Equal(
+            "<div aria-label=\"Close\" aria-expanded=\"true\"></div>",
+            Div(Aria: new Dictionary<string, string?> { ["label"] = "Close", ["expanded"] = "true" }).ToHtml());
+
+    [Fact]
+    public void Render_AriaNullValue_EmitsBareAttribute() =>
+        Assert.Equal(
+            "<div aria-hidden></div>",
+            Div(Aria: new Dictionary<string, string?> { ["hidden"] = null }).ToHtml());
+
+    [Fact]
+    public void Render_AriaValue_IsHtmlEncoded() =>
+        Assert.Equal(
+            "<div aria-label=\"a &amp; b\"></div>",
+            Div(Aria: new Dictionary<string, string?> { ["label"] = "a & b" }).ToHtml());
+
+    [Fact]
+    public void Render_RoleAndTabIndex_EmitNativeAttributes() =>
+        Assert.Equal(
+            "<div role=\"dialog\" tabindex=\"-1\"></div>",
+            Div(Role: "dialog", TabIndex: -1).ToHtml());
+
+    [Fact]
+    public void Render_AccessibilityProps_FollowDataInDocumentedOrder() =>
+        Assert.Equal(
+            "<div id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" role=\"dialog\" tabindex=\"0\" aria-label=\"L\"></div>",
+            Div(
+                Id: "i",
+                Class: "c",
+                Style: "s",
+                Data: new Dictionary<string, string?> { ["k"] = "v" },
+                Role: "dialog",
+                TabIndex: 0,
+                Aria: new Dictionary<string, string?> { ["label"] = "L" }).ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/ImgTests.cs
+++ b/tests/Rask.Core.Tests/Components/ImgTests.cs
@@ -1,3 +1,5 @@
+#pragma warning disable RASK023 // null-props test deliberately omits Alt to assert bare rendering
+
 namespace Rask.Core.Tests.Components;
 
 public class ImgTests

--- a/tests/Rask.Core.Tests/Performance/CounterAllocationPinTests.cs
+++ b/tests/Rask.Core.Tests/Performance/CounterAllocationPinTests.cs
@@ -30,9 +30,12 @@ public class CounterAllocationPinTests
         // at ~1.15 KB on 2026-05-27 after the LiveState hoist + the lazy-alloc series, drifting
         // to ~1.39 KB by 2026-06-08. The universal `Ref:` element-ref parameter (a nullable
         // ElementRef reference — class, not struct, precisely so it stays a cheap reference-type
-        // optional param) adds ~24 B, to ~1.42 KB. Pin at <= 1.5 KB to catch regression while
-        // leaving slack for runtime jitter.
-        Assert.InRange(perIterationBytes, 0, 1500);
+        // optional param) adds ~24 B, to ~1.42 KB (~1496 B). The universal accessibility params
+        // (`Role`/`TabIndex`/`Aria`) add ~72 B more, to ~1568 B: their storage is hoisted into the
+        // lazy LiveState (like Ref) so an a11y-free element grows no Element instance, but these
+        // elements allocate a LiveState during render regardless, so the three extra LiveState
+        // fields ride along. Pin at <= 1.65 KB to catch regression while leaving slack for jitter.
+        Assert.InRange(perIterationBytes, 0, 1650);
     }
 
     [Fact(Skip = "diagnostic — run manually to gather allocation deltas")]

--- a/tests/Rask.Core.Tests/UrlSanitizerTests.cs
+++ b/tests/Rask.Core.Tests/UrlSanitizerTests.cs
@@ -1,4 +1,5 @@
 #pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+#pragma warning disable RASK023 // these tests exercise src/URL sanitization, not alt text
 
 namespace Rask.Core.Tests;
 

--- a/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
@@ -38,6 +38,15 @@ public sealed class EfCoreCrudTests(EfCoreExampleAppFixture app, PlaywrightFixtu
         await Assertions.Expect(createdRow).ToBeVisibleAsync();
         await Assertions.Expect(createdRow).ToContainTextAsync("7");
 
+        // Accessibility: the icon-only row controls expose an aria-label (set via the Aria
+        // dictionary) naming the row they act on, while the glyph itself is aria-hidden.
+        await Assertions.Expect(createdRow.Locator("a.btn-outline-secondary"))
+            .ToHaveAttributeAsync("aria-label", "Edit E2E gadget");
+        await Assertions.Expect(createdRow.Locator("button.btn-outline-danger"))
+            .ToHaveAttributeAsync("aria-label", "Delete E2E gadget");
+        await Assertions.Expect(createdRow.Locator("button.btn-outline-danger i"))
+            .ToHaveAttributeAsync("aria-hidden", "true");
+
         // EDIT — follow the row's edit link, rename, save.
         await createdRow.Locator("a.btn-outline-secondary").ClickAsync();
         await _page.FillAsync("#p-name", "E2E gizmo");

--- a/tests/Rask.Generators.Tests/ImgMissingAltAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/ImgMissingAltAnalyzerTests.cs
@@ -1,0 +1,65 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+
+namespace Rask.Generators.Tests;
+
+public class ImgMissingAltAnalyzerTests
+{
+    // Wraps a Render() body in a component. Real Rask.Core factories (Generated.Img/...) are
+    // referenced via BuildReferences(), so the analyzer resolves the genuine Img factory symbol.
+    private static string App(string body) => $$"""
+                                                using System.Collections.Generic;
+                                                using Rask.Core;
+                                                using static Rask.Core.Components.Generated;
+                                                namespace Demo;
+                                                public sealed class App : Component
+                                                {
+                                                    protected override RenderResult Render()
+                                                    {
+                                                        {{body}}
+                                                    }
+                                                }
+                                                """;
+
+    [Fact]
+    public async Task Img_NoAlt_ReportsRask023()
+    {
+        var d = Assert.Single(await Diagnostics(App("return Img(Src: \"/a.png\");")));
+        Assert.Equal("RASK023", d.Id);
+        Assert.Contains("Alt", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task Img_NoArguments_ReportsRask023() =>
+        Assert.Equal("RASK023", Assert.Single(await Diagnostics(App("return Img();"))).Id);
+
+    [Fact]
+    public async Task Img_AltByName_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Img(Src: \"/a.png\", Alt: \"A logo\");")));
+
+    [Fact]
+    public async Task Img_EmptyAltForDecorative_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Img(Src: \"/a.png\", Alt: \"\");")));
+
+    [Fact]
+    public async Task Img_AltPositionally_NoDiagnostic() =>
+        // Factory order is Src, Alt, ... so the second positional argument is Alt.
+        Assert.Empty(await Diagnostics(App("return Img(\"/a.png\", \"A logo\");")));
+
+    private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new ImgMissingAltAnalyzer());
+        var all = await compilation.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+        return all.Where(d => d.Id == "RASK023").ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Summary
Adds the first accessibility primitives to the framework. Every element gains an `Aria`
dictionary (the `data-*` model applied to ARIA — `Aria: new() { ["label"] = "Close" }` →
`aria-label="Close"`, so the full WAI-ARIA vocabulary is reachable without a typed property
per attribute) plus typed `Role` and `TabIndex` for the two non-`aria-*` affordances. Their
storage is hoisted into the lazy `LiveState` (like `Ref`) so an a11y-free element keeps zero
per-instance footprint. A new **RASK023** analyzer warns when an `Img` is created without `Alt`
(`Alt: ""` for decorative images). New attribute order: id, class, style, data-\*, role,
tabindex, aria-\*, then tag-specific.

User-facing surface updated: new `docs/accessibility.md`, plus `docs/diagnostics.md`,
README/NUGET/llms.txt, the three template `AGENTS.md`, and `CLAUDE.md`. The EfCore sample's
icon-only edit/delete buttons now carry `aria-label`s with `aria-hidden` glyphs.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — pass
  (Core 1521, Generators 153 incl. 5 new RASK023 tests, Server 170, DataAnnotations 31,
  FluentValidation 13). New `Aria`/`Role`/`TabIndex` ordering tests in `DivTests`/`ButtonTests`.
- E2E (samples changed): host EfCore — added an `aria-label` assertion to `EfCoreCrudTests`.
  Could not run locally (no Playwright browser/`pwsh` in this environment); compiles and uses
  standard `ToHaveAttributeAsync`. Relies on the CI E2E matrix.

## Benchmarks
`RenderRoundTrip / RenderAndBuildPayload`: **35.31 KB → 35.31 KB** (flat), 9.171 → 9.178 µs
(noise). Deterministic allocation pin (Counter inner, no a11y): **1496 B → 1568 B / iter
(+72 B)** from the three hoisted `LiveState` fields riding along on elements that already
allocate a `LiveState` during render; the hoist halved what direct `Element` fields cost
(1640 B). Pin ceiling bumped 1500 → 1650 with a documented-delta comment matching the `Ref`
precedent.

## CHANGELOG
- [Unreleased] entry added: accessibility primitives on every element (`Aria` dictionary,
  `Role`/`TabIndex`) + RASK023 `Img`-without-`Alt` analyzer.
