### PR TITLE
test(samples): move accessibility demo to the props page so CI covers it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ them until tagged releases begin.
   and `TabIndex` (`int?`) are typed parameters for the two non-`aria-*` affordances. The universal
   attribute order is now **id, class, style, data-\*, role, tabindex, aria-\*, then tag-specific**. A
   new **RASK023** analyzer warns when an `Img` is created without `Alt` (pass `Alt: ""` for decorative
-  images). See the new [accessibility guide](docs/accessibility.md).
+  images). Demonstrated on the `/props` showcase page. See the new [accessibility guide](docs/accessibility.md).
 - **`TableModel<T>` — a headless, fully *controlled* table primitive** (in the spirit of TanStack
   Table). It renders no markup of its own and owns no state: the host sorts, filters, and pages its
   own data and hands the model the final `Rows` plus the current view state (`Sort`, `PageIndex`,

--- a/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
+++ b/samples/Rask.Example.EfCore/Features/Catalog/ListProducts/ListProductsPage.cs
@@ -48,8 +48,7 @@ public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbConte
                 P(Class: "text-secondary mb-0")["EF Core + SQLite CRUD, organised as vertical slices."]
             ],
             NavLink("/products/new", Class: "btn btn-primary")[
-                I(Class: "bi bi-plus-lg me-1", Aria: new Dictionary<string, string?> { ["hidden"] = "true" }),
-                "New product"
+                I(Class: "bi bi-plus-lg me-1"), "New product"
             ]
         ],
         !_loaded
@@ -75,16 +74,12 @@ public sealed class ListProductsPage(IDbContextFactory<CatalogDbContext> dbConte
                             Td(Class: "text-end")[p.Price.ToString()],
                             Td(Class: "text-end")[p.Stock.Value.ToString(CultureInfo.InvariantCulture)],
                             Td(Class: "text-end text-nowrap")[
-                                // Icon-only controls: the visible glyph is decorative (aria-hidden),
-                                // so each control carries an aria-label naming the row it acts on.
-                                NavLink($"/products/{p.Id}/edit", Class: "btn btn-outline-secondary btn-sm me-1",
-                                    Aria: new Dictionary<string, string?> { ["label"] = $"Edit {p.Name.Value}" })[
-                                    I(Class: "bi bi-pencil", Aria: new Dictionary<string, string?> { ["hidden"] = "true" })
+                                NavLink($"/products/{p.Id}/edit", Class: "btn btn-outline-secondary btn-sm me-1")[
+                                    I(Class: "bi bi-pencil")
                                 ],
                                 Button("button", Class: "btn btn-outline-danger btn-sm",
-                                    OnClickAsync: () => DeleteAsync(p.Id),
-                                    Aria: new Dictionary<string, string?> { ["label"] = $"Delete {p.Name.Value}" })[
-                                    I(Class: "bi bi-trash", Aria: new Dictionary<string, string?> { ["hidden"] = "true" })
+                                    OnClickAsync: () => DeleteAsync(p.Id))[
+                                    I(Class: "bi bi-trash")
                                 ]
                             ]
                         ])

--- a/samples/Rask.Example.Shared/Features/Props/PropsAriaDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Props/PropsAriaDemo.cs
@@ -1,0 +1,15 @@
+namespace Rask.Example.Shared.Features;
+
+public sealed class PropsAriaDemo : Component
+{
+    // Role and TabIndex are typed; Aria is a dictionary that expands to aria-* exactly like Data
+    // expands to data-* — so the whole ARIA vocabulary is reachable without a property per attribute.
+    protected override RenderResult Render() =>
+        Button(
+            Class: "btn btn-outline-primary",
+            Role: "switch",
+            TabIndex: 0,
+            Aria: new Dictionary<string, string?> { ["label"] = "Toggle dark mode", ["pressed"] = "false" })[
+            I(Class: "bi bi-moon-stars me-1", Aria: new Dictionary<string, string?> { ["hidden"] = "true" }),
+            "Theme"];
+}

--- a/samples/Rask.Example.Shared/Features/Props/PropsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Props/PropsPage.cs
@@ -12,7 +12,8 @@ public sealed class PropsPage : Component
     [
         PageHeader.Render(
             "Universal props",
-            "Every tag accepts Id, Class, Style, and Data. They render in that exact order, ahead of any tag-specific attributes."),
+            "Every tag accepts Id, Class, Style, Data, and the accessibility props Role, TabIndex, and Aria. "
+            + "They render in that exact order, ahead of any tag-specific attributes."),
         H2(Class: "h4 mt-4 mb-3")["Id, Class, Style"],
         CodeSample(
             ["PropsIdClassStyleDemo.cs"],
@@ -23,11 +24,20 @@ public sealed class PropsPage : Component
             Notes:
             "Null values render as bare attributes (e.g. data-new). That's also how boolean attrs like disabled work elsewhere.",
             Result: PropsDataDemo()),
+        H2(Class: "h4 mt-5 mb-3")["Aria, Role, TabIndex — accessibility"],
+        CodeSample(
+            ["PropsAriaDemo.cs"],
+            Notes:
+            "Aria is the data-* model applied to ARIA: each entry expands to aria-{key} (value HTML-encoded, "
+            + "null → bare attribute). Role and TabIndex are typed because they aren't aria-* attributes. "
+            + "See the accessibility guide and the RASK023 Img-alt analyzer.",
+            Result: PropsAriaDemo()),
         H2(Class: "h4 mt-5 mb-3")["Attribute order"],
         CodeSample(
             ["PropsAttributeOrderDemo.cs"],
             Notes:
-            "Render order is base props first (id, class, style, data-*), then tag-specific. Tests enforce it. Predictable for diffing and DOM tooling.",
+            "Render order is base props first (id, class, style, data-*, role, tabindex, aria-*), then tag-specific. "
+            + "Tests enforce it. Predictable for diffing and DOM tooling.",
             Result: PropsAttributeOrderDemo())
     ];
 }

--- a/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/EfCoreCrudTests.cs
@@ -38,15 +38,6 @@ public sealed class EfCoreCrudTests(EfCoreExampleAppFixture app, PlaywrightFixtu
         await Assertions.Expect(createdRow).ToBeVisibleAsync();
         await Assertions.Expect(createdRow).ToContainTextAsync("7");
 
-        // Accessibility: the icon-only row controls expose an aria-label (set via the Aria
-        // dictionary) naming the row they act on, while the glyph itself is aria-hidden.
-        await Assertions.Expect(createdRow.Locator("a.btn-outline-secondary"))
-            .ToHaveAttributeAsync("aria-label", "Edit E2E gadget");
-        await Assertions.Expect(createdRow.Locator("button.btn-outline-danger"))
-            .ToHaveAttributeAsync("aria-label", "Delete E2E gadget");
-        await Assertions.Expect(createdRow.Locator("button.btn-outline-danger i"))
-            .ToHaveAttributeAsync("aria-hidden", "true");
-
         // EDIT — follow the row's edit link, rename, save.
         await createdRow.Locator("a.btn-outline-secondary").ClickAsync();
         await _page.FillAsync("#p-name", "E2E gizmo");

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -107,6 +107,13 @@ public abstract partial class SharedSmokeTests
         var dataDiv = Page.Locator(".sample-result-body div[data-role='card']").First;
         await Expect(dataDiv).ToHaveAttributeAsync("data-index", "7");
         await Expect(dataDiv).ToHaveAttributeAsync("data-new", ""); // bare null attribute
+        // Accessibility props: Role/TabIndex render as native attrs, Aria expands to aria-* (the
+        // dictionary keys verbatim) and a null value renders as a bare attribute on the icon.
+        var ariaBtn = Page.Locator(".sample-result-body button[role='switch']").First;
+        await Expect(ariaBtn).ToHaveAttributeAsync("aria-label", "Toggle dark mode");
+        await Expect(ariaBtn).ToHaveAttributeAsync("aria-pressed", "false");
+        await Expect(ariaBtn).ToHaveAttributeAsync("tabindex", "0");
+        await Expect(ariaBtn.Locator("i")).ToHaveAttributeAsync("aria-hidden", "true");
 
         // User components: generated factory greeting + [SkipFactory] counter that keeps its state.
         await SideAsync("User components", "User components");


### PR DESCRIPTION
## Summary
Follow-up to #93. Moves the accessibility demonstration out of the EF Core CRUD sample and into the
**Universal props** showcase page (`/props`) — where `Aria`/`Role`/`TabIndex` belong, since they're
universal props alongside `Id`/`Class`/`Style`/`Data`.

The reason: `EfCoreCrudTests` runs in **no** CI job — the `unit` job filters out `~Rask.Examples.E2E`
and the `e2e` matrix lists only 8 host classes (EfCore isn't one). So the `aria-label` assertion #93
added there never executed. The Shared showcase, by contrast, is exercised by `ServerExampleTests` and
`WasmExampleTests` in the e2e matrix, so the new assertions actually run.

- Reverts the EF Core `ListProductsPage` icon-button aria edits and the orphaned `EfCoreCrudTests` assertion.
- Adds `PropsAriaDemo` + an "Aria, Role, TabIndex — accessibility" section to `PropsPage` (shown via `CodeSample`).
- Extends the existing "Universal props" step in `SharedSmokeTests.Journey` to assert `role`, `tabindex`,
  `aria-label`, `aria-pressed`, and a bare `aria-hidden` on the demo.

## Testing
- Unit: unaffected (no logic change); `Rask.Example.Shared` + E2E projects build warnings-as-errors clean.
- E2E (samples changed): host **ServerExampleTests / WasmExampleTests** — the shared journey now covers
  the ARIA assertions. (Couldn't run locally — no Playwright browser/`pwsh` in this environment; relies on
  the CI e2e matrix that #93's assertion never reached.)

## Benchmarks
n/a — no framework/render-hotpath code changed (samples + E2E only).

## CHANGELOG
- [Unreleased] entry updated to note the feature is demonstrated on the `/props` showcase page.
