### PR TITLE
fix(samples): center the todos dialog over a backdrop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,12 @@ them until tagged releases begin.
   excluded.
 
 ### Fixed
+- **The `/todos` showcase dialog now opens centered over a dim backdrop.** A declaratively-open
+  `<dialog open>` is non-modal, so the browser left it `position:absolute` at its in-flow spot (low
+  on the page, partly off-screen) with no `::backdrop`. The `TodoFormDialog` scoped CSS now pins the
+  open dialog to the viewport centre (`position:fixed; inset:0; margin:auto`) above a clickable
+  `.todo-backdrop` overlay — clicking the backdrop cancels, mirroring the nav-drawer pattern. No JS;
+  the URL-driven open/close (New todo, Cancel, browser Back, deep links) is unchanged.
 - **Server mode now executes scripts inserted through a keyed diff.** A scoped
   `<script src="/_rask/a/{hash}.js">` (or a user `Head` `<script>`) delivered via a keyed
   `InsertSubtree` diff was parsed by the Server client but never ran — `innerHTML`-parsed scripts

--- a/samples/Rask.Example.Shared/Features/Todos/TodoFormDialog.css
+++ b/samples/Rask.Example.Shared/Features/Todos/TodoFormDialog.css
@@ -1,9 +1,26 @@
-dialog {
-    margin: 2rem auto;
+/* Center the open dialog in the viewport. A declaratively-open <dialog open> is non-modal,
+   so the browser leaves it position:absolute at its in-flow spot (low on the page) with no
+   ::backdrop. position:fixed + inset:0 + auto margins re-centres it on both axes; the dim
+   .todo-backdrop below supplies the missing overlay. */
+dialog[open] {
+    position: fixed;
+    inset: 0;
+    margin: auto;
+    z-index: 1055;
     border: 1px solid var(--bs-border-color);
     border-radius: .5rem;
     padding: 1.25rem;
     min-width: 320px;
     max-width: 480px;
     box-shadow: 0 .5rem 1rem rgba(0, 0, 0, .15);
+}
+
+.todo-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 1050;
+    background: rgba(0, 0, 0, .4);
+    backdrop-filter: blur(2px);
+    -webkit-backdrop-filter: blur(2px);
+    cursor: pointer;
 }

--- a/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
+++ b/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
@@ -101,8 +101,9 @@ public sealed class TodosPage(Navigator nav, RouteState route) : Component
                 "Three [Route] attributes drive the dialog: /todos lists, /todos/new opens add, " +
                 "/todos/{id:guid}/edit opens edit. OnPropsChanged seeds the form from the route so browser " +
                 "Back closes the dialog and deep links open it, without clobbering in-progress typing."),
-            // The open <dialog> is position:absolute (out of flow), so it must stay last in the DOM to
-            // paint above the source CodeSample — otherwise the sample would overlay its buttons.
+            // The open <dialog> is a viewport-centered overlay (position:fixed + high z-index, with a
+            // dim backdrop) — see TodoFormDialog.css. Kept last in the DOM as a tidy belt-and-braces
+            // so source order matches paint order even before the z-index applies.
             TodoFormDialog(
                 ShowDialog,
                 _form,
@@ -124,20 +125,25 @@ public sealed class TodoFormDialog : Component
         Fragment()[msgs.Select((m, i) => Div(Key: i, Class: "text-danger small mt-1")[m])];
 
     protected override RenderResult Render() =>
-        Dialog(Open)[
-            H5(Class: "mb-3")[IsAdding ? "Add todo" : "Edit todo"],
-            Form(Model, OnSave, Class: "vstack gap-3")[
-                DataAnnotationsValidator(),
-                Div()[
-                    Label("todo-title", Class: "form-label small mb-1")["Title"],
-                    Input(() => Model.Title, Id: "todo-title", Class: "form-control"),
-                    ValidationMessage(() => Model.Title, FieldError)
-                ],
-                Div(Class: "d-flex justify-content-end gap-2")[
-                    Button("button", Class: "btn btn-outline-secondary", OnClick: OnCancel)["Cancel"],
-                    Button("submit", Class: "btn btn-primary")[
-                        I(Class: "bi bi-check2-circle me-1"),
-                        IsAdding ? "Add" : "Save"
+        Fragment()[
+            // Dim, clickable backdrop behind the centered dialog. A non-modal <dialog open> gets no
+            // ::backdrop, so we render our own — clicking it cancels, like the nav drawer's backdrop.
+            Open ? Div(Class: "todo-backdrop", OnClick: OnCancel) : Fragment(),
+            Dialog(Open)[
+                H5(Class: "mb-3")[IsAdding ? "Add todo" : "Edit todo"],
+                Form(Model, OnSave, Class: "vstack gap-3")[
+                    DataAnnotationsValidator(),
+                    Div()[
+                        Label("todo-title", Class: "form-label small mb-1")["Title"],
+                        Input(() => Model.Title, Id: "todo-title", Class: "form-control"),
+                        ValidationMessage(() => Model.Title, FieldError)
+                    ],
+                    Div(Class: "d-flex justify-content-end gap-2")[
+                        Button("button", Class: "btn btn-outline-secondary", OnClick: OnCancel)["Cancel"],
+                        Button("submit", Class: "btn btn-primary")[
+                            I(Class: "bi bi-check2-circle me-1"),
+                            IsAdding ? "Add" : "Save"
+                        ]
                     ]
                 ]
             ]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -608,6 +608,20 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("button:has-text('New todo')").ClickAsync();
         await Expect(Page).ToHaveURLAsync(new Regex(".*/todos/new$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
+        // Dialog opens centered over a dim backdrop; clicking the backdrop cancels (back to /todos).
+        await Expect(Page.Locator("dialog[open]")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
+        await Expect(Page.Locator(".todo-backdrop")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
+        // Click a corner — the backdrop's centre is covered by the centered dialog.
+        await Page.Locator(".todo-backdrop").ClickAsync(
+            new LocatorClickOptions { Position = new Position { X = 8, Y = 8 } });
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
+        // Reopen for the rest of the flow.
+        await Page.Locator("button:has-text('New todo')").ClickAsync();
+        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos/new$"),
+            new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
         // Empty submit → [Required].
         await Page.Locator("button:has-text('Add')").ClickAsync();
         await Expect(Page.Locator(".text-danger.small")).ToContainTextAsync("Title is required",


### PR DESCRIPTION
## Summary
The `/todos` "Add todo" / "Edit todo" dialog opened low on the page and partly off-screen with no
backdrop: a declaratively-open `<dialog open>` is non-modal, so the browser left it
`position:absolute` at its in-flow spot and rendered no `::backdrop`. The `TodoFormDialog` scoped
CSS now pins the open dialog to the viewport centre (`position:fixed; inset:0; margin:auto`) above a
clickable `.todo-backdrop` overlay; clicking the backdrop cancels (back to `/todos`), mirroring the
existing nav-drawer backdrop pattern. No JS — the URL-driven open/close (New todo, Cancel, browser
Back, deep links) is unchanged.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — all pass (incl. `Rask.Example.Shared.Tests`, 254 passed)
- E2E (`samples/` changed): host **Server** (`ServerExampleTests` shared journey) — passed (1 test, 37s); new assertions cover dialog-open-over-backdrop, backdrop-click-dismiss, and reopen

## Benchmarks
n/a — samples-only CSS/markup, not a render hot-path change.

## CHANGELOG
- [Unreleased] entry added: "The `/todos` showcase dialog now opens centered over a dim backdrop."
