### PR TITLE
fix(wasm): run render-time IJSRuntime calls after the DOM patch; share interop in Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,13 @@ them until tagged releases begin.
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
 ### Changed
+- **The host JS-interop plumbing is now shared from `Rask.Core`.** The pending IJSRuntime-invoke
+  queue (`LiveJsInvokeQueue`), the `BeginInvokeJS` deferral + `[JSInvokable]` result envelope
+  (`RaskJSRuntimeBase`), and the after-`applyDiff` dispatch loop (`applyFrameInvokes`, in the shared
+  `rask-dom.js`) were duplicated between Server (`RaskJSRuntime` / `LiveSession` / `rask.js`) and WASM
+  (`WasmJSRuntime` / `WasmLiveSession` / `rask.wasm.js`); both hosts now compose the Core pieces
+  through a shared `ILiveJsHost` seam. Internal only — no API change beyond the WASM ordering fix
+  noted below.
 - **The live-diff codec is now a single shared client source.** `applyDiff` and its helpers
   (`resolvePath`, `relevantChild`/`relevantChildSkipping`, `moveChildBefore`, `syncFormProperty`)
   were duplicated between the Server (`rask.js`) and WASM (`rask.wasm.js`) clients; they now live
@@ -56,6 +63,15 @@ them until tagged releases begin.
   excluded.
 
 ### Fixed
+- **WASM now runs `IJSRuntime` calls issued *during* a render after the DOM is patched, matching
+  Server.** Interop from a lifecycle hook — e.g. `OnRenderedAsync` focusing a dialog as it opens —
+  used to dispatch immediately on WASM, *before* that render's DOM patch, so a `focus()` could hit a
+  still-`display:none` element (a `<dialog>` whose `open` attribute the diff hadn't added yet) and
+  silently no-op. Such mid-render calls now ride the render frame's `jsInvokes` and the client
+  dispatches them after `applyDiff`, against the committed DOM — the post-commit ordering the Server
+  already had. Interop from event handlers is unchanged (WASM still dispatches it immediately, the
+  path awaited handler interop relies on). The `/todos` dialog now auto-focuses on open on every
+  host, so Escape-to-close works without a prior click.
 - **The `/todos` showcase dialog now opens centered over a dim backdrop.** A declaratively-open
   `<dialog open>` is non-modal, so the browser left it `position:absolute` at its in-flow spot (low
   on the page, partly off-screen) with no `::backdrop`. The `TodoFormDialog` scoped CSS now pins the

--- a/src/Rask.Core/Live/LiveJsInvokeQueue.cs
+++ b/src/Rask.Core/Live/LiveJsInvokeQueue.cs
@@ -1,0 +1,99 @@
+using System.Text;
+using System.Text.Json;
+using Microsoft.JSInterop;
+using Microsoft.JSInterop.Infrastructure;
+
+namespace Rask.Core.Live;
+
+// The per-session queue of pending IJSRuntime.InvokeAsync calls, shared by both hosts. A call lands
+// here via RaskJSRuntimeBase.BeginInvokeJS during a render (or an event handler); the session's
+// payload builder drains it into the outbound frame's `jsInvokes`, and the client dispatches each
+// AFTER it applies the render's DOM patch. That post-commit ordering is the whole point: interop
+// issued from a lifecycle hook (e.g. OnRenderedAsync focusing a dialog as it opens) must run against
+// the committed DOM, not the pre-patch one. Server always worked this way; routing WASM through the
+// same queue gives it the same ordering instead of dispatching immediately (pre-patch).
+internal sealed class LiveJsInvokeQueue
+{
+    private readonly List<PendingJsInvoke> _pending = new();
+
+    public void Enqueue(PendingJsInvoke invoke)
+    {
+        lock (_pending)
+        {
+            _pending.Add(invoke);
+        }
+    }
+
+    public bool HasPending
+    {
+        get
+        {
+            lock (_pending)
+            {
+                return _pending.Count > 0;
+            }
+        }
+    }
+
+    /// <summary>Snapshot and clear the queue, or null when empty.</summary>
+    public PendingJsInvoke[]? Drain()
+    {
+        lock (_pending)
+        {
+            if (_pending.Count == 0)
+            {
+                return null;
+            }
+
+            var invokes = _pending.ToArray();
+            _pending.Clear();
+            return invokes;
+        }
+    }
+
+    /// <summary>
+    ///     Complete the awaiting <see cref="ValueTask{T}" />s with a failure when the frame carrying
+    ///     these invokes never reached the client (e.g. the WebSocket send threw). Without this the
+    ///     caller's <c>await js.InvokeAsync(...)</c> would hang forever.
+    /// </summary>
+    public static void Fail(JSRuntime runtime, PendingJsInvoke[] invokes, string message)
+    {
+        if (string.IsNullOrEmpty(message))
+        {
+            message = "Rask: render frame carrying the JS invoke was never delivered";
+        }
+
+        foreach (var invoke in invokes)
+        {
+            try
+            {
+                using var stream = new MemoryStream(128);
+                using (var writer = new Utf8JsonWriter(stream))
+                {
+                    // Canonical EndInvokeJS triple: [taskId, success=false, error].
+                    writer.WriteStartArray();
+                    writer.WriteNumberValue(invoke.TaskId);
+                    writer.WriteBooleanValue(false);
+                    writer.WriteStringValue(message);
+                    writer.WriteEndArray();
+                }
+
+                DotNetDispatcher.EndInvokeJS(runtime, Encoding.UTF8.GetString(stream.ToArray()));
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"Rask: failed to surface JS invoke fault for taskId={invoke.TaskId}: {ex}");
+            }
+        }
+    }
+}
+
+// Implemented by both LiveSession (Server) and WasmLiveSession (WASM) so RaskJSRuntimeBase can queue
+// a call and request a render without knowing the transport.
+internal interface ILiveJsHost
+{
+    LiveJsInvokeQueue JsInvokes { get; }
+
+    Task RequestRenderAsync();
+}

--- a/src/Rask.Core/Live/RaskJSRuntimeBase.cs
+++ b/src/Rask.Core/Live/RaskJSRuntimeBase.cs
@@ -1,0 +1,98 @@
+using System.Text.Json;
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Live;
+
+// Shared base for both hosts' IJSRuntime implementations (Rask.Server's RaskJSRuntime,
+// Rask.Wasm's WasmJSRuntime). The base owns the transport-independent contract: every
+// InvokeAsync/InvokeVoidAsync lands in BeginInvokeJS, which queues the call onto the current
+// session and asks for a render so the next outbound frame ships it to the client (where it runs
+// AFTER applyDiff). Subclasses supply the host seam — which session is current and how a
+// [JSInvokable] result is shipped back — plus any host-specific serializer setup.
+internal abstract class RaskJSRuntimeBase : JSRuntime
+{
+    /// <summary>
+    ///     The session this call belongs to. Throws when used outside a Rask session scope (e.g.
+    ///     from a unit test or an app-level singleton rather than a component lifecycle hook).
+    /// </summary>
+    protected abstract ILiveJsHost CurrentHost { get; }
+
+    protected override void BeginInvokeJS(
+        long taskId,
+        string identifier,
+        string? argsJson,
+        JSCallResultType resultType,
+        long targetInstanceId)
+    {
+        var invoke = new PendingJsInvoke(taskId, identifier, argsJson, (int)resultType, targetInstanceId);
+
+        // Mid-render (e.g. an OnRenderedAsync hook focusing a dialog as it opens): queue onto the
+        // current frame so the client runs it AFTER applyDiff — i.e. against the committed DOM. This
+        // is the shared, transport-independent half, and the reason WASM focus now lands like Server.
+        // Don't request another render: the in-flight frame's builder drains the queue after the
+        // walk, and re-rendering here would re-fire lifecycle hooks → an unbounded loop. IsActive
+        // (not just Current) matters — an async continuation that captured a ctx via AsyncLocal still
+        // observes Current after the walk disposed; only the live walk's drain picks up our invoke.
+        if (LiveRenderContext.Current is { IsActive: true })
+        {
+            CurrentHost.JsInvokes.Enqueue(invoke);
+            return;
+        }
+
+        // Outside a render (an event handler awaiting js.InvokeAsync): the hosts diverge. Server
+        // queues it and requests a render — its mid-await render pump flushes the frame so the
+        // awaiting ValueTask completes. WASM dispatches it immediately through the JSImport bridge,
+        // the same path it has always used for handler interop (the DOM is already committed from
+        // the prior frame, and an immediate round-trip is what unblocks the awaiting handler).
+        DispatchOutsideRender(invoke);
+    }
+
+    /// <summary>Handle a call issued outside a render walk — see <see cref="BeginInvokeJS" />.</summary>
+    protected abstract void DispatchOutsideRender(PendingJsInvoke invoke);
+
+    /// <summary>
+    ///     Build the <c>{ callId, success, result?, error? }</c> envelope a <c>[JSInvokable]</c>
+    ///     result is shipped back in. Shared by both hosts; only the transport (WS out-of-band send
+    ///     vs the WASM <c>endDotNetInvoke</c> JSImport) differs, so subclasses call this from
+    ///     <see cref="JSRuntime.EndInvokeDotNet" /> and forward the bytes their own way.
+    ///     <paramref name="type" /> tags the envelope for hosts that multiplex many message kinds
+    ///     over one channel (Server's WS sends <c>type:"dotNetResult"</c>); WASM passes null because
+    ///     its dedicated <c>endDotNetInvoke</c> JSImport needs no discriminator.
+    /// </summary>
+    protected static byte[] BuildDotNetResultJson(
+        string? callId, bool success, string? resultJson, string? error, string? type = null)
+    {
+        using var stream = new MemoryStream(128);
+        using (var writer = new Utf8JsonWriter(stream))
+        {
+            writer.WriteStartObject();
+            if (type is not null)
+            {
+                writer.WriteString("type", type);
+            }
+
+            if (callId is not null)
+            {
+                writer.WriteString("callId", callId);
+            }
+
+            writer.WriteBoolean("success", success);
+            if (resultJson is not null)
+            {
+                writer.WritePropertyName("result");
+                // Pre-serialised JSON — write as a raw value so we don't double-encode.
+                using var doc = JsonDocument.Parse(resultJson);
+                doc.RootElement.WriteTo(writer);
+            }
+
+            if (error is not null)
+            {
+                writer.WriteString("error", error);
+            }
+
+            writer.WriteEndObject();
+        }
+
+        return stream.ToArray();
+    }
+}

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -270,3 +270,18 @@ function applyDiff(ops, names) {
         }
     }
 }
+
+// ----- Frame jsInvokes dispatch ------------------------------------------
+// The IJSRuntime calls a render frame carried (reply.jsInvokes) run HERE — after applyDiff/morph
+// has patched the DOM — so each acts on the committed DOM (e.g. focus a <dialog> that just gained
+// its `open` attribute). Both clients call this right after applying the body; only the per-invoke
+// executor differs per host (Server posts the result over the WS; WASM returns it through the
+// endInvokeJSResult JSExport), so the caller passes dispatchOne. Shared so the loop isn't copied.
+function applyFrameInvokes(reply, dispatchOne) {
+    var invokes = reply && reply.jsInvokes;
+    if (!invokes || typeof invokes.length !== "number") return;
+    for (var i = 0; i < invokes.length; i++) {
+        var inv = invokes[i];
+        if (inv && typeof inv.identifier === "string") dispatchOne(inv);
+    }
+}

--- a/src/Rask.Server/JSInterop/RaskJSRuntime.cs
+++ b/src/Rask.Server/JSInterop/RaskJSRuntime.cs
@@ -33,55 +33,30 @@ namespace Rask.Server.JSInterop;
 [UnconditionalSuppressMessage("Trimming", "IL2026",
     Justification = "Server-side only; Rask.Server is not trim-published. " +
                     "Users of generic InvokeAsync<T> rooted via DAM on IJSRuntime.")]
-internal sealed class RaskJSRuntime : JSRuntime
+internal sealed class RaskJSRuntime : RaskJSRuntimeBase
 {
     private readonly LiveSessionAccessor _accessor;
 
     public RaskJSRuntime(LiveSessionAccessor accessor) => _accessor = accessor;
 
-    private LiveSession CurrentSession =>
+    // The shared base owns BeginInvokeJS (queue onto the session + request a render so the next
+    // outbound frame's jsInvokes carries the call). This class only supplies the host seam: which
+    // session is current, and how a [JSInvokable] result rides the WebSocket back.
+    protected override ILiveJsHost CurrentHost =>
         _accessor.Session ?? throw new InvalidOperationException(
             "IJSRuntime can only be used within a Rask session scope. " +
             "Inject it through a Component ctor (DI) and call it from a lifecycle hook " +
             "(OnMountAsync, OnRenderedAsync) or event handler — not from a unit test or " +
             "app-level singleton.");
 
-    /// <summary>
-    ///     Called by the base <see cref="JSRuntime" /> for every <c>InvokeAsync&lt;T&gt;</c>
-    ///     and <c>InvokeVoidAsync</c>. Queues the call onto the current session's pending
-    ///     list and triggers a render — the next outbound frame's <c>jsInvokes</c> array
-    ///     carries the payload to the client, which resolves the dotted identifier on
-    ///     <c>window</c>, invokes it, and ships the result back as a <c>jsResult</c>
-    ///     message. The base class completes the awaiting <see cref="ValueTask{T}" /> when
-    ///     <see cref="JSRuntime.EndInvokeJS(string)" /> fires from
-    ///     <c>RaskEndpointExtensions.HandleJsResult</c>.
-    /// </summary>
-    protected override void BeginInvokeJS(
-        long taskId,
-        string identifier,
-        string? argsJson,
-        JSCallResultType resultType,
-        long targetInstanceId)
+    // Server is frame-based even outside a render: queue the call and request a render so the next
+    // outbound WS frame ships it; the mid-await render pump flushes that frame while a handler
+    // awaits, so the awaiting ValueTask completes when the client's jsResult comes back.
+    protected override void DispatchOutsideRender(PendingJsInvoke invoke)
     {
-        var session = CurrentSession;
-        var invoke = new PendingJsInvoke(taskId, identifier, argsJson, (int)resultType, targetInstanceId);
-        session.EnqueueJsInvoke(invoke);
-        // Skip RequestRenderAsync when we're already mid-render: the current frame's
-        // payload builder drains _pendingJsInvokes after the walk, so the invoke ships
-        // on this frame anyway. Requesting another render here would re-fire every
-        // lifecycle hook (most notably OnRenderedAsync), which would call into us
-        // again → infinite render loop. Check IsActive rather than just Current — an
-        // async continuation that captured a ctx via AsyncLocal still observes Current
-        // after the walk disposed; only the live walk's drain will pick up our invoke.
-        if (LiveRenderContext.Current is { IsActive: true })
-        {
-            return;
-        }
-
-        // Fire and forget: the ValueTask returned to the caller (via the base class's
-        // TCS) completes when the client's jsResult message comes back, regardless of
-        // how the render cycle interleaves.
-        _ = session.RequestRenderAsync();
+        var host = CurrentHost;
+        host.JsInvokes.Enqueue(invoke);
+        _ = host.RequestRenderAsync();
     }
 
     /// <summary>
@@ -94,49 +69,18 @@ internal sealed class RaskJSRuntime : JSRuntime
         DotNetInvocationInfo invocationInfo,
         in DotNetInvocationResult invocationResult)
     {
-        var session = CurrentSession;
+        var session = (LiveSession)CurrentHost;
         // invocationResult.ResultJson is already serialised against this runtime's
         // JsonSerializerOptions (including IJSObjectReference handle ids); we just package
         // it into a WS message and let the client-side DotNet shim parse it.
-        var payload = BuildDotNetResultPayload(
+        var payload = BuildDotNetResultJson(
             invocationInfo.CallId,
             invocationResult.Success,
             invocationResult.Success ? invocationResult.ResultJson : null,
             invocationResult.Success
                 ? null
-                : invocationResult.Exception?.Message ?? "DotNet invocation failed");
+                : invocationResult.Exception?.Message ?? "DotNet invocation failed",
+            type: "dotNetResult");
         _ = session.SendOutOfBandAsync(payload);
-    }
-
-    private static byte[] BuildDotNetResultPayload(string? callId, bool success, string? resultJson, string? error)
-    {
-        using var stream = new MemoryStream(128);
-        using (var writer = new Utf8JsonWriter(stream))
-        {
-            writer.WriteStartObject();
-            writer.WriteString("type", "dotNetResult");
-            if (callId is not null)
-            {
-                writer.WriteString("callId", callId);
-            }
-
-            writer.WriteBoolean("success", success);
-            if (resultJson is not null)
-            {
-                writer.WritePropertyName("result");
-                // Pre-serialised JSON — write as a raw value so we don't double-encode.
-                using var doc = JsonDocument.Parse(resultJson);
-                doc.RootElement.WriteTo(writer);
-            }
-
-            if (error is not null)
-            {
-                writer.WriteString("error", error);
-            }
-
-            writer.WriteEndObject();
-        }
-
-        return stream.ToArray();
     }
 }

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -13,13 +13,12 @@ using Rask.Server.JSInterop;
 
 namespace Rask.Server;
 
-internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
+internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle, ILiveJsHost
 {
-    // IJSRuntime queue. Calls land here via RaskJSRuntime.BeginInvokeJS and get drained
-    // into the next outbound payload by RenderAndSendAsync. A plain List under lock —
-    // contention is bounded by the session's outer Lock semaphore (one handler at a time),
-    // so writes only race with the drain at flush time.
-    private readonly List<PendingJsInvoke> _pendingJsInvokes = new();
+    // IJSRuntime queue. Calls land here via RaskJSRuntimeBase.BeginInvokeJS and get drained into
+    // the next outbound payload by RenderAndSendAsync. The shared LiveJsInvokeQueue type (Core) is
+    // used by both hosts so interop is ordered identically (dispatched client-side after applyDiff).
+    public LiveJsInvokeQueue JsInvokes { get; } = new();
 
     // Serialises individual RenderAndSendAsync calls within one handler dispatch. The dispatcher's
     // outer Lock pins single-handler-at-a-time; this inner gate keeps the mid-await render (on the
@@ -342,11 +341,7 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
         // the GET render walk (the invoke sits in _pendingJsInvokes until the next outbound
         // frame). When neither is true, the browser's GET HTML still matches and there's
         // nothing for the WS to ship — skip the redundant render.
-        bool jsPending;
-        lock (_pendingJsInvokes)
-        {
-            jsPending = _pendingJsInvokes.Count > 0;
-        }
+        var jsPending = JsInvokes.HasPending;
 
         if (!_renderRequestedWhileDetached && !jsPending)
         {
@@ -370,19 +365,6 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     {
         _socket = null;
         _socketCt = default;
-    }
-
-    /// <summary>
-    ///     Queue a global-JS interop call (from <see cref="JSInterop.RaskJSRuntime" />) to be
-    ///     emitted on the next outbound frame. Thread-safe — calls can arrive from awaited
-    ///     continuations on thread-pool workers.
-    /// </summary>
-    internal void EnqueueJsInvoke(PendingJsInvoke invoke)
-    {
-        lock (_pendingJsInvokes)
-        {
-            _pendingJsInvokes.Add(invoke);
-        }
     }
 
     /// <summary>
@@ -480,15 +462,7 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
             // the initial HTTP GET produced, so a per-page Title declared via
             // Component.Head never made it to the browser tab on SPA-style navigation.
             // The added head bytes (~2-3 KB) compress away under permessage-deflate.
-            PendingJsInvoke[]? jsInvokes = null;
-            lock (_pendingJsInvokes)
-            {
-                if (_pendingJsInvokes.Count > 0)
-                {
-                    jsInvokes = _pendingJsInvokes.ToArray();
-                    _pendingJsInvokes.Clear();
-                }
-            }
+            var jsInvokes = JsInvokes.Drain();
 
             // HTML-level dedup: when the rendered HTML matches the last sent (or the
             // HTTP-GET-time seeded baseline) and there's nothing out-of-band to flow,
@@ -685,39 +659,12 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // log and move on; the original send exception is the meaningful one for the caller.
     private void FailPendingJsInvokes(PendingJsInvoke[] invokes, Exception cause)
     {
-        var runtime = Services.GetService<RaskJSRuntime>();
-        if (runtime is null)
+        if (Services.GetService<RaskJSRuntime>() is { } runtime)
         {
-            return;
-        }
-
-        var message = cause.Message;
-        if (string.IsNullOrEmpty(message))
-        {
-            message = "Rask: WebSocket send failed before JS invoke could be dispatched";
-        }
-
-        foreach (var invoke in invokes)
-        {
-            try
-            {
-                using var stream = new MemoryStream(128);
-                using (var w = new Utf8JsonWriter(stream))
-                {
-                    w.WriteStartArray();
-                    w.WriteNumberValue(invoke.TaskId);
-                    w.WriteBooleanValue(false);
-                    w.WriteStringValue(message);
-                    w.WriteEndArray();
-                }
-
-                DotNetDispatcher.EndInvokeJS(runtime, Encoding.UTF8.GetString(stream.ToArray()));
-            }
-            catch (Exception ex)
-            {
-                Console.Error.WriteLine(
-                    $"Rask: failed to surface JS invoke fault for taskId={invoke.TaskId}: {ex}");
-            }
+            LiveJsInvokeQueue.Fail(runtime, invokes,
+                string.IsNullOrEmpty(cause.Message)
+                    ? "Rask: WebSocket send failed before JS invoke could be dispatched"
+                    : cause.Message);
         }
     }
 }

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -558,13 +558,9 @@
             // Re-scan so newly-added scoped <script>/<link> feed the Rask.* invoke gate.
             scanHeadAssets();
             // Fire-and-forget IJSRuntime invokes ride the diff payload too (e.g. a
-            // scoped-JS OnRenderedAsync hook); drain them via the same dispatchJsInvoke
-            // path the full-HTML branch uses so the per-namespace deferral keeps working.
-            if (Array.isArray(data.jsInvokes)) {
-                for (var ji = 0; ji < data.jsInvokes.length; ji++) {
-                    dispatchJsInvoke(data.jsInvokes[ji]);
-                }
-            }
+            // scoped-JS OnRenderedAsync hook); dispatch them via the shared loop so the
+            // per-namespace deferral inside dispatchJsInvoke keeps working.
+            applyFrameInvokes(data, dispatchJsInvoke);
             if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
         };
         if (typeof data.head === "string") {
@@ -611,11 +607,7 @@
                 }
             }
             applyNavScroll(data.history);
-            if (Array.isArray(data.jsInvokes)) {
-                for (var ji = 0; ji < data.jsInvokes.length; ji++) {
-                    dispatchJsInvoke(data.jsInvokes[ji]);
-                }
-            }
+            applyFrameInvokes(data, dispatchJsInvoke);
             // dotNetResult: reply to a JS-initiated DotNet.invokeMethodAsync call, routed by
             // the DotNet shim's pending-call table to resolve/reject the matching JS Promise.
             if (data.type === "dotNetResult" && typeof data.callId === "string") {

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -996,6 +996,21 @@ function applyDiff(ops, names) {
     }
 }
 
+// ----- Frame jsInvokes dispatch ------------------------------------------
+// The IJSRuntime calls a render frame carried (reply.jsInvokes) run HERE — after applyDiff/morph
+// has patched the DOM — so each acts on the committed DOM (e.g. focus a <dialog> that just gained
+// its `open` attribute). Both clients call this right after applying the body; only the per-invoke
+// executor differs per host (Server posts the result over the WS; WASM returns it through the
+// endInvokeJSResult JSExport), so the caller passes dispatchOne. Shared so the loop isn't copied.
+function applyFrameInvokes(reply, dispatchOne) {
+    var invokes = reply && reply.jsInvokes;
+    if (!invokes || typeof invokes.length !== "number") return;
+    for (var i = 0; i < invokes.length; i++) {
+        var inv = invokes[i];
+        if (inv && typeof inv.identifier === "string") dispatchOne(inv);
+    }
+}
+
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
@@ -1007,6 +1022,19 @@ function handle(reply) {
         return;
     }
     _renderQueue = _renderQueue.then(() => applyFullReply(reply), () => applyFullReply(reply));
+}
+
+// Per-invoke executor for the shared applyFrameInvokes loop (rask-dom.js). A frame's jsInvokes run
+// AFTER applyDiff/morph patched the DOM — so a queued OnRenderedAsync focus acts on the committed
+// DOM (e.g. a <dialog> that just gained its `open` attribute), the same post-commit ordering the
+// Server has. beginInvokeJS runs the call and returns its result via the endInvokeJSResult JSExport.
+function dispatchWasmInvoke(inv) {
+    beginInvokeJS(
+        String(inv.id),
+        inv.identifier,
+        typeof inv.argsJson === "string" ? inv.argsJson : null,
+        typeof inv.resultType === "number" ? inv.resultType : 0,
+        typeof inv.targetInstanceId === "number" ? String(inv.targetInstanceId) : "0");
 }
 
 function applyDiffReply(reply) {
@@ -1025,6 +1053,7 @@ function applyDiffReply(reply) {
         // gate, then drain anything now unblocked — the full-HTML morph path does the same.
         scanHeadAssets();
         maybeDrainPendingInvokes();
+        applyFrameInvokes(reply, dispatchWasmInvoke);
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
     };
     if (typeof reply.head === "string") {
@@ -1069,6 +1098,7 @@ function applyFullReply(reply) {
         // <link href="/_rask/a/{hash}.css"> / <script src="/_rask/a/{hash}.js" defer>
         // tags — no payload-side cssText/jsText injection. Browser handles load
         // semantics via standard <link>/<script> lifecycle.
+        applyFrameInvokes(reply, dispatchWasmInvoke);
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
         if (reply.download) triggerDownload(reply.download);
     };

--- a/src/Rask.Wasm/JSInterop/WasmJSRuntime.cs
+++ b/src/Rask.Wasm/JSInterop/WasmJSRuntime.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text;
-using System.Text.Json;
 using System.Text.Json.Serialization.Metadata;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
+using Rask.Core.Live;
 
 namespace Rask.Wasm;
 
@@ -25,8 +25,12 @@ namespace Rask.Wasm;
 [UnconditionalSuppressMessage("Trimming", "IL2026",
     Justification = "Forwards TValue's trim annotations from IJSRuntime.InvokeAsync<TValue>. " +
                     "Users must keep their TValue types rooted on WASM.")]
-internal sealed class WasmJSRuntime : JSRuntime
+internal sealed class WasmJSRuntime : RaskJSRuntimeBase
 {
+    // Set once the session exists (it's built after this DI singleton — see WasmLiveSession ctor).
+    // BeginInvokeJS (in the base) queues onto it; WasmLiveSession drains the queue into each frame.
+    private ILiveJsHost? _host;
+
     public WasmJSRuntime()
     {
         // The base JSRuntime's JsonSerializerOptions ships with no TypeInfoResolver,
@@ -41,31 +45,36 @@ internal sealed class WasmJSRuntime : JSRuntime
         JsonSerializerOptions.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver());
     }
 
-    protected override void BeginInvokeJS(
-        long taskId,
-        string identifier,
-        string? argsJson,
-        JSCallResultType resultType,
-        long targetInstanceId)
-    {
-        // Pass through to the JS-side dispatcher. taskId / targetInstanceId travel as
-        // strings to avoid BigInt marshalling on the JS boundary — they're rebuilt as
-        // numbers inside the dispatcher (safe for the values we mint).
+    /// <summary>Bind the session this runtime queues calls onto (called from the session ctor).</summary>
+    public void AttachHost(ILiveJsHost host) => _host = host;
+
+    // The shared base queues calls made DURING a render (e.g. an OnRenderedAsync focus) onto this
+    // host so they ship in the frame and run after applyDiff — the post-commit ordering that makes
+    // WASM focus land like Server. Calls OUTSIDE a render go through DispatchOutsideRender below.
+    protected override ILiveJsHost CurrentHost =>
+        _host ?? throw new InvalidOperationException(
+            "IJSRuntime can only be used within a Rask session scope. " +
+            "Inject it through a Component ctor (DI) and call it from a lifecycle hook " +
+            "(OnMountAsync, OnRenderedAsync) or event handler.");
+
+    // Outside a render (a handler awaiting js.InvokeAsync), dispatch immediately through the JSImport
+    // bridge — WASM's long-standing handler-interop path. The result returns via the EndInvokeJSResult
+    // JSExport, completing the awaiting ValueTask without needing a render frame to flush it. taskId /
+    // targetInstanceId travel as strings to dodge BigInt marshalling; the dispatcher rebuilds them.
+    protected override void DispatchOutsideRender(PendingJsInvoke invoke) =>
         JSInterop.BeginInvokeJSImport(
-            taskId.ToString(),
-            identifier,
-            argsJson,
-            (int)resultType,
-            targetInstanceId.ToString());
-    }
+            invoke.TaskId.ToString(),
+            invoke.Identifier,
+            invoke.ArgsJson,
+            invoke.ResultType,
+            invoke.TargetInstanceId.ToString());
 
     protected override void EndInvokeDotNet(
         DotNetInvocationInfo invocationInfo,
         in DotNetInvocationResult invocationResult)
     {
-        // Ship a [JSInvokable] call's result back to the JS-side `DotNet` shim. Mirrors
-        // RaskJSRuntime's wire shape (`type: "dotNetResult"`), encoded as JSON so the
-        // single JSImport signature stays type-stable.
+        // Ship a [JSInvokable] call's result back to the JS-side `DotNet` shim via the dedicated
+        // endDotNetInvoke JSImport — no `type` discriminator needed (unlike the Server's multiplexed WS).
         var payload = BuildDotNetResultJson(
             invocationInfo.CallId,
             invocationResult.Success,
@@ -73,36 +82,6 @@ internal sealed class WasmJSRuntime : JSRuntime
             invocationResult.Success
                 ? null
                 : invocationResult.Exception?.Message ?? "DotNet invocation failed");
-        JSInterop.EndDotNetInvokeImport(payload);
-    }
-
-    private static string BuildDotNetResultJson(string? callId, bool success, string? resultJson, string? error)
-    {
-        using var stream = new MemoryStream(128);
-        using (var writer = new Utf8JsonWriter(stream))
-        {
-            writer.WriteStartObject();
-            if (callId is not null)
-            {
-                writer.WriteString("callId", callId);
-            }
-
-            writer.WriteBoolean("success", success);
-            if (resultJson is not null)
-            {
-                writer.WritePropertyName("result");
-                using var doc = JsonDocument.Parse(resultJson);
-                doc.RootElement.WriteTo(writer);
-            }
-
-            if (error is not null)
-            {
-                writer.WriteString("error", error);
-            }
-
-            writer.WriteEndObject();
-        }
-
-        return Encoding.UTF8.GetString(stream.ToArray());
+        JSInterop.EndDotNetInvokeImport(Encoding.UTF8.GetString(payload));
     }
 }

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -509,6 +509,19 @@ function handle(reply) {
     _renderQueue = _renderQueue.then(() => applyFullReply(reply), () => applyFullReply(reply));
 }
 
+// Per-invoke executor for the shared applyFrameInvokes loop (rask-dom.js). A frame's jsInvokes run
+// AFTER applyDiff/morph patched the DOM — so a queued OnRenderedAsync focus acts on the committed
+// DOM (e.g. a <dialog> that just gained its `open` attribute), the same post-commit ordering the
+// Server has. beginInvokeJS runs the call and returns its result via the endInvokeJSResult JSExport.
+function dispatchWasmInvoke(inv) {
+    beginInvokeJS(
+        String(inv.id),
+        inv.identifier,
+        typeof inv.argsJson === "string" ? inv.argsJson : null,
+        typeof inv.resultType === "number" ? inv.resultType : 0,
+        typeof inv.targetInstanceId === "number" ? String(inv.targetInstanceId) : "0");
+}
+
 function applyDiffReply(reply) {
     // The head isn't in the diff frame stream (user Head contributions are collected +
     // spliced render-side), so a head change rides the payload as a <head> fragment.
@@ -525,6 +538,7 @@ function applyDiffReply(reply) {
         // gate, then drain anything now unblocked — the full-HTML morph path does the same.
         scanHeadAssets();
         maybeDrainPendingInvokes();
+        applyFrameInvokes(reply, dispatchWasmInvoke);
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
     };
     if (typeof reply.head === "string") {
@@ -569,6 +583,7 @@ function applyFullReply(reply) {
         // <link href="/_rask/a/{hash}.css"> / <script src="/_rask/a/{hash}.js" defer>
         // tags — no payload-side cssText/jsText injection. Browser handles load
         // semantics via standard <link>/<script> lifecycle.
+        applyFrameInvokes(reply, dispatchWasmInvoke);
         if (typeof window.raskAfterMorph === "function") window.raskAfterMorph();
         if (reply.download) triggerDownload(reply.download);
     };

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -10,7 +10,7 @@ using Rask.Core.Routing;
 
 namespace Rask.Wasm;
 
-internal sealed class WasmLiveSession : IRenderHandle, IDisposable
+internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
 {
     private readonly SemaphoreSlim _lock = new(1, 1);
 
@@ -41,6 +41,11 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
     // serialised the first payload but BEFORE the dispatch returns.
     private bool _pendingRenderInScope;
 
+    // Set by BuildPayloadAsync when the frame it built carries queued IJSRuntime calls. The
+    // publish-render noop guard must NOT drop such a frame even when the HTML is unchanged — the
+    // invokes still need to reach the client (where they run after applyDiff).
+    private bool _lastBuildHadJsInvokes;
+
     // Plain instance bool, NOT AsyncLocal: the dispatch lock is owned by this session as a whole,
     // not by any one async chain. AsyncLocal would flow into Timer/Task captures created during a
     // render — those captured ExecutionContexts would later report InHandlerScope=true forever,
@@ -56,11 +61,17 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
     // Default path (DisabledFull) pays nothing for these.
     private SessionRenderCache? _renderCache;
 
+    // Pending IJSRuntime calls, drained into each frame's jsInvokes and dispatched client-side after
+    // applyDiff (same post-commit ordering as the Server). Shared queue type across both hosts.
+    public LiveJsInvokeQueue JsInvokes { get; } = new();
+
     public WasmLiveSession(Component view, IServiceProvider services)
     {
         View = view;
         Services = services;
         view.RenderHandle = this;
+        // Bind this session to the runtime so its BeginInvokeJS queues onto JsInvokes.
+        (services.GetService<WasmJSRuntime>())?.AttachHost(this);
         // Forward the handle to the inner App when wrapped in a RootErrorBoundary so its
         // StateHasChanged() reaches the session even before the first GetOrCreate would
         // otherwise lazily attach it.
@@ -157,6 +168,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
             // and now — most visibly the `.hljs` class hljs added during the
             // previous frame's dispatch. Skip such frames entirely.
             if (publishOnly
+                && !_lastBuildHadJsInvokes
                 && _lastAppliedHtml is not null
                 && string.Equals(html, _lastAppliedHtml, StringComparison.Ordinal))
             {
@@ -471,6 +483,13 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
             download = pd;
         }
 
+        // Drain IJSRuntime calls queued during the render walk (e.g. an OnRenderedAsync focus). They
+        // ride this frame's jsInvokes and the client runs them AFTER applyDiff, so they act on the
+        // committed DOM — the same post-commit ordering the Server has. _lastBuildHadJsInvokes lets
+        // the caller's noop guards know this frame must ship even if the HTML is unchanged.
+        var jsInvokes = JsInvokes.Drain();
+        _lastBuildHadJsInvokes = jsInvokes is not null;
+
         _writeBuffer.ResetWrittenCount();
 
         // Decide payload shape. The diff path fires only when the flag is opted in,
@@ -508,7 +527,8 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
                 && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
             {
                 var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
-                LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, headHtml: headHtml);
+                LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace,
+                    jsInvokes: jsInvokes, headHtml: headHtml);
                 var diffBytes = _writeBuffer.WrittenCount;
 
                 // Same rule as the server: ship the diff whenever it isn't larger than
@@ -536,7 +556,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable
             // ToArray at the end is still needed today because the JS interop boundary
             // marshals byte[] (PR6 will swap that for ReadOnlyMemory<byte>).
             LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, html, "wasm", historyUrl, replace,
-                null, download);
+                null, download, jsInvokes);
             // Only Snapshot when TryComputeDiff was NOT called (it would have rotated) AND we
             // own the commit (commitCache). When commitCache is false the coalescing loop
             // commits once after it settles, so rotating here would strand the baseline.

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -613,11 +613,13 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
         await Expect(Page.Locator(".todo-backdrop")).ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 5_000 });
-        // Escape closes the dialog: OnKeyDown on the <dialog> routes Escape to cancel. Focus the
-        // title field first (a real interaction) so the keydown has a target inside the dialog —
-        // this exercises the framework keyboard primitive without depending on the sample's
-        // focus-on-open timing, which is instant on Server but races the runtime boot on WASM.
-        await Page.Locator("#todo-title").ClickAsync();
+        // The dialog auto-focuses on open (OnRenderedAsync → ElementRef.FocusAsync), so the
+        // keyboard primitive works with no prior click. This is deterministic on both hosts: the
+        // focus helper retries on the next frame, so a focus issued during a render (before the
+        // DOM patch on WASM) still lands once the <dialog> gains its `open` attribute.
+        await Expect(Page.Locator("dialog[open]")).ToBeFocusedAsync(
+            new LocatorAssertionsToBeFocusedOptions { Timeout = 5_000 });
+        // Escape closes the focused dialog: OnKeyDown on the <dialog> routes Escape to cancel.
         await Page.Keyboard.PressAsync("Escape");
         await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"),
             new PageAssertionsToHaveURLOptions { Timeout = 5_000 });

--- a/tests/Rask.Wasm.Tests/JSInterop/WasmJSRuntimeTests.cs
+++ b/tests/Rask.Wasm.Tests/JSInterop/WasmJSRuntimeTests.cs
@@ -3,13 +3,13 @@ using Microsoft.JSInterop;
 
 namespace Rask.Wasm.Tests.JsInteropRuntime;
 
-// Exercises the WASM IJSRuntime round-trip via the non-browser test seam in
-// Rask.Wasm.JSInterop: BeginInvokeJS calls are recorded as LastBeginInvokeJsCall,
-// and EndInvokeJSResult routes a synthesized [taskId, success, result|error]
-// triple back through DotNetDispatcher.EndInvokeJS — the same code path the
-// real JSExport calls in a browser. Tests in this class share the JSInterop
-// static singleton (_runtime), so the class runs sequentially under xunit's
-// default per-class collection.
+// Exercises the WASM IJSRuntime round-trip via the non-browser test seam. A call made OUTSIDE a
+// render (this test's scenario) dispatches immediately through the JSImport bridge — recorded as
+// LastBeginInvokeJsCall — and EndInvokeJSResult routes a synthesized [taskId, success, result|error]
+// triple back through DotNetDispatcher.EndInvokeJS, the same path the real JSExport calls in a
+// browser. (Calls made DURING a render queue onto the session frame instead — see the shared
+// RaskJSRuntimeBase; that post-commit path is covered end-to-end by the WASM E2E journey.) Tests
+// share the JSInterop static singleton (_runtime), so the class runs sequentially.
 public sealed class WasmJSRuntimeTests
 {
     [Fact]


### PR DESCRIPTION
## Summary
Fixes the WASM root cause behind the dialog auto-focus race, and deduplicates the host JS-interop plumbing into `Rask.Core`.

**The fix.** WASM dispatched every `IJSRuntime` call immediately, so interop issued *during* a render — e.g. `OnRenderedAsync` focusing a `<dialog>` as it opens — ran **before** that render's DOM patch, and `focus()` hit a still-`display:none` element and silently no-op'd. Such **mid-render** calls now ride the render frame's `jsInvokes` and the client runs them **after `applyDiff`**, against the committed DOM — the post-commit ordering the Server already had. Interop from **event handlers** still dispatches immediately on WASM (the path awaited handler interop, e.g. `CodeSample`'s clipboard copy, relies on — deferring it deadlocked the awaiting handler).

The split is by `LiveRenderContext.IsActive`: mid-render → queue onto the frame (shared by both hosts); outside a render → host's existing path (Server queues + its mid-await pump flushes; WASM dispatches immediately).

**The dedup (per request).** The previously-duplicated interop logic now lives once in Core, composed by both hosts through a shared `ILiveJsHost` seam:
- `LiveJsInvokeQueue` — the pending-invoke queue (enqueue/drain/fail).
- `RaskJSRuntimeBase` — `BeginInvokeJS` deferral + the `[JSInvokable]` result envelope.
- `applyFrameInvokes` — the after-`applyDiff` dispatch loop, in the shared `rask-dom.js` (spliced into both clients), replacing the copy in `rask.js` and `rask.wasm.js`.

> A deeper follow-up (merging the full `LiveSession`/`WasmLiveSession` render/diff/payload pipeline into a shared Core base) is intentionally **staged** — the two hosts have genuinely divergent I/O models (WS push vs in-process request/response), so it warrants its own verified PR.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — all pass (Server 170, WASM 46, Core 1529, …).
- E2E (`samples/` touched): hosts **Server + Wasm + StandaloneWasm** — all pass (3/3, 54s). The Todos step now asserts the dialog **auto-focuses on open** (`ToBeFocused`) then **Escape closes** it, with no prior click — on every host. (An earlier full-defer attempt regressed `CodeSample` copy on WASM; the hybrid above fixes it, confirmed by this run.)

## Benchmarks
Dispatch hot-path (`WsDispatchBenchmarks`), Allocated before → after — **zero delta**:
- SingleFragment 592 B → 592 B · 104 B → 104 B
- FourFragments 760 B → 760 B · 216 B → 216 B

## CHANGELOG
- [Unreleased] **Fixed**: WASM runs render-time `IJSRuntime` calls after the DOM patch.
- [Unreleased] **Changed**: host JS-interop plumbing shared from `Rask.Core`.
