### PR TITLE
refactor(core): share the live-session render pipeline across both hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,14 @@ them until tagged releases begin.
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
 ### Changed
+- **The live-session render pipeline is now shared from `Rask.Core`.** A new `LiveSessionBase` owns
+  the render→diff-vs-full→payload build both hosts ran near-identically (`RenderTreeToHtml`,
+  `ConsumeDownload`, `WritePayload`) plus the common state (render cache, diff ops, write buffer,
+  dedup baseline, the IJSRuntime queue) and the `IRenderHandle`/`ILiveJsHost` plumbing. Server's
+  `LiveSession` and WASM's `WasmLiveSession` now extend it, keeping only what genuinely differs —
+  their transport (WebSocket push vs in-process `ApplyRender`), locking, reconnect/dispatch
+  lifecycle, and send-dedup strategy. Internal only — no API or behaviour change (both hosts'
+  full E2E journeys pass unchanged); ~340 lines of duplicate pipeline collapse into one base.
 - **The host JS-interop plumbing is now shared from `Rask.Core`.** The pending IJSRuntime-invoke
   queue (`LiveJsInvokeQueue`), the `BeginInvokeJS` deferral + `[JSInvokable]` result envelope
   (`RaskJSRuntimeBase`), and the after-`applyDiff` dispatch loop (`applyFrameInvokes`, in the shared

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -1,0 +1,167 @@
+using System.Buffers;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+
+namespace Rask.Core.Live;
+
+// The transport-independent half of a live session, shared by Rask.Server's LiveSession (WebSocket)
+// and Rask.Wasm's WasmLiveSession (in-process JSImport). It owns the render→payload pipeline both
+// hosts run identically: render the component tree (capturing the diff frame stream), then decide
+// diff-vs-full and write the frame into WriteBuffer. The hosts keep what genuinely differs — their
+// transport (WS push vs ApplyRender), their locking, reconnect/dispatch lifecycle, and the dedup
+// strategy around the send (Server double-buffers; WASM returns a byte[] each frame).
+internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
+{
+    // Pooled across the session lifetime; ResetWrittenCount between frames keeps the rented backing
+    // array hot. Non-readonly: Server swaps it with its previous-frame buffer for zero-copy dedup.
+    protected ArrayBufferWriter<byte> _writeBuffer = new(4096);
+
+    // Diff-codec state, lazily allocated only when LiveOptions.DiffMode opts in — the default
+    // (DisabledFull) path pays nothing for these.
+    protected List<EditOp>? _diffOps;
+    protected SessionRenderCache? _renderCache;
+
+    // Last rendered HTML, the dedup baseline that suppresses noop renders which would otherwise
+    // re-morph identical HTML and strip JS-applied DOM state (e.g. hljs's `.hljs` class).
+    protected string? _lastAppliedHtml;
+
+    // Set when an in-handler StateHasChanged lands mid-dispatch (InHandlerScope=true); the coalescing
+    // loop reads and clears it to rebuild the payload before releasing the dispatch lock.
+    protected bool _pendingRenderInScope;
+
+    protected LiveSessionBase(Component view, IServiceProvider services)
+    {
+        View = view;
+        Services = services;
+        view.RenderHandle = this;
+        // RootErrorBoundary wraps the user's App; forward the handle to the inner so its
+        // StateHasChanged() reaches the session even before the first GetOrCreate would attach it.
+        if (view is RootErrorBoundary root)
+        {
+            root.Inner.RenderHandle = this;
+        }
+    }
+
+    public Component View { get; }
+    public IServiceProvider Services { get; }
+
+    // Pending IJSRuntime calls, drained into each frame's jsInvokes and dispatched client-side after
+    // applyDiff (post-commit ordering). Shared queue type so both hosts order interop identically.
+    public LiveJsInvokeQueue JsInvokes { get; } = new();
+
+    // Plain instance bool, NOT AsyncLocal: the dispatch lock is owned by the session as a whole, not
+    // by any one async chain. AsyncLocal would flow into Timer/Task captures created during a render
+    // and later report InHandlerScope=true forever, stranding background StateHasChanged calls.
+    public bool InHandlerScope { get; set; }
+
+    public Task RequestRenderAsync() => RequestRenderInternalAsync(false);
+
+    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(true);
+
+    Task IRenderHandle.RenderInScopeAsync() => RenderInScopeCoreAsync();
+
+    protected abstract Task RequestRenderInternalAsync(bool publishOnly);
+
+    /// <summary>The framework's mid-await intermediate render (see Component.InvokeWithRenderingAsync).</summary>
+    protected abstract Task RenderInScopeCoreAsync();
+
+    /// <summary>
+    ///     Render the component tree to HTML, capturing the parallel <c>RenderFrame</c> stream when
+    ///     the diff codec is on (so <see cref="WritePayload" /> can emit a minimal edit-op payload).
+    ///     Default (DisabledFull) bypasses entirely — null frame sink, a single null check per
+    ///     HtmlSerializer branch.
+    /// </summary>
+    protected string RenderTreeToHtml(bool publishOnly, out FrameWriter? frameWriter)
+    {
+        frameWriter = null;
+        FrameSinkScope.Popper popper = default;
+        if (LiveOptions.DiffMode != LiveDiffMode.DisabledFull)
+        {
+            _renderCache ??= new SessionRenderCache();
+            frameWriter = _renderCache.PrepareCurrentBuffer();
+            popper = FrameSinkScope.Push(frameWriter);
+        }
+
+        try
+        {
+            return View.RenderAsLiveRoot(Services, publishOnly);
+        }
+        finally
+        {
+            if (frameWriter is not null)
+            {
+                popper.Dispose();
+            }
+        }
+    }
+
+    /// <summary>Consume a one-shot download side-effect produced during the render, if any.</summary>
+    protected PendingDownload? ConsumeDownload() =>
+        Services.GetService<IDownloadSink>() is { } sink && sink.TryConsume(out var pd) ? pd : null;
+
+    /// <summary>
+    ///     Decide diff-vs-full for the just-rendered <paramref name="html" /> and write the frame
+    ///     into <see cref="_writeBuffer" />. Identical on both hosts; the seams are parameters:
+    ///     <paramref name="auth" /> (Server only — gates the diff path and rides the full payload;
+    ///     WASM passes null), <paramref name="sessionId" /> (the data-rask-root value), and
+    ///     <paramref name="commitCache" /> (false during a coalescing loop, so intermediate rebuilds
+    ///     diff against the stable last-sent baseline and the caller Snapshots once after).
+    /// </summary>
+    protected void WritePayload(string html, FrameWriter? frameWriter, PendingDownload? download,
+        PendingJsInvoke[]? jsInvokes, string? historyUrl, bool replace, bool commitCache,
+        AuthInstruction? auth, string sessionId)
+    {
+        _writeBuffer.ResetWrittenCount();
+
+        // Out-of-band side effects (auth, download) and structural ops route to the full-HTML morph
+        // path; in-place state changes ship a diff. Head changes (per-route <title>, a scoped-asset
+        // <link>, a reactive title) ride the diff as an attached <head> fragment since the diff
+        // frame stream never carries <head>. Genuine body-restructuring page swaps fall back to full
+        // HTML via DiffOpsAreClientSupported. jsInvokes do NOT force full HTML — they ride the diff.
+        var usedDiff = false;
+        var diffPathEntered = false;
+        if (frameWriter is not null && _renderCache is not null && auth is null && download is null)
+        {
+            _diffOps ??= new List<EditOp>();
+            diffPathEntered = true;
+            var headChanged = _lastAppliedHtml is not null && !LiveDiffGate.HeadUnchanged(html, _lastAppliedHtml);
+            // Ship the diff when it carries DOM ops, OR when it carries none but a navigation or a
+            // head change must still flow (a query-only nav pushes the URL; a head-only change ships
+            // the head fragment). Zero ops + no history + unchanged head means nothing to send.
+            if (_renderCache.TryComputeDiff(_diffOps, commitCache, html)
+                && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
+                && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
+            {
+                var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
+                LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes, headHtml);
+
+                // Ship the diff whenever it isn't larger than re-sending the body, or unconditionally
+                // under Forced. Only the pathological case (nearly every node changed on a tiny page,
+                // so op-list framing exceeds the body) falls back to full HTML on size.
+                if (LiveOptions.DiffMode == LiveDiffMode.Forced || _writeBuffer.WrittenCount < html.Length)
+                {
+                    usedDiff = true;
+                }
+                else
+                {
+                    _writeBuffer.ResetWrittenCount();
+                }
+            }
+        }
+
+        if (!usedDiff)
+        {
+            LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, html, sessionId, historyUrl, replace,
+                auth, download, jsInvokes);
+            // Keep the cache in lockstep with the client even when shipping full HTML: promote
+            // current → previous so the NEXT diff's baseline matches what the client received. Skip
+            // when TryComputeDiff already rotated (diffPathEntered), or when the caller defers the
+            // commit to the coalescing loop (commitCache=false).
+            if (!diffPathEntered && commitCache)
+            {
+                _renderCache?.Snapshot();
+            }
+        }
+    }
+}

--- a/src/Rask.Core/Rask.Core.csproj
+++ b/src/Rask.Core/Rask.Core.csproj
@@ -23,7 +23,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Rask.Core.Tests"/>
     <InternalsVisibleTo Include="Rask.Server"/>
+    <InternalsVisibleTo Include="Rask.Server.Tests"/>
     <InternalsVisibleTo Include="Rask.Wasm"/>
+    <InternalsVisibleTo Include="Rask.Wasm.Tests"/>
     <InternalsVisibleTo Include="Rask.Validation.DataAnnotations.Tests"/>
     <InternalsVisibleTo Include="Rask.Validation.FluentValidation.Tests"/>
     <InternalsVisibleTo Include="Rask.Benchmarks"/>

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -13,13 +13,11 @@ using Rask.Server.JSInterop;
 
 namespace Rask.Server;
 
-internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle, ILiveJsHost
+// Render/diff/payload pipeline + the IJSRuntime queue live in LiveSessionBase (Core), shared with
+// the WASM host. LiveSession adds the WebSocket transport: the socket lifecycle, reconnect/force-
+// resend, the dispatch lock, out-of-band sends, and the zero-copy double-buffered send dedup.
+internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposable
 {
-    // IJSRuntime queue. Calls land here via RaskJSRuntimeBase.BeginInvokeJS and get drained into
-    // the next outbound payload by RenderAndSendAsync. The shared LiveJsInvokeQueue type (Core) is
-    // used by both hosts so interop is ordered identically (dispatched client-side after applyDiff).
-    public LiveJsInvokeQueue JsInvokes { get; } = new();
-
     // Serialises individual RenderAndSendAsync calls within one handler dispatch. The dispatcher's
     // outer Lock pins single-handler-at-a-time; this inner gate keeps the mid-await render (on the
     // handler thread) from racing the HandlerSyncContext.RunWithRendersAsync renders (fired on
@@ -28,8 +26,6 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // mutate the same Component state — _children, _stateDirty, _cachedRenderResult — and one
     // wins, dropping the other's payload, or both call _socket.SendAsync on the same WebSocket.
     private readonly SemaphoreSlim _renderLock = new(1, 1);
-
-    private List<EditOp>? _diffOps;
 
     // Set by AttachSocket on a reconnect to force the next render to bypass the HTML/buffer
     // dedup and re-emit even when the rendered bytes match the prior socket's last frame.
@@ -49,30 +45,10 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // reconnect always renders.
     private bool _hasAttachedBefore;
 
+    // Previous-frame buffer for the zero-copy send dedup: after SendAsync, _writeBuffer (base) and
+    // this swap, so the just-sent bytes become the dedup baseline without a copy. Server-specific —
+    // WASM ToArrays each frame for the JSImport boundary instead.
     private ArrayBufferWriter<byte>? _lastSentBuffer;
-
-    // Last rendered HTML (the `html` string the framework produced last time we
-    // sent a frame). Used to skip noop publish-renders that would otherwise
-    // re-morph identical HTML and clobber JS-applied DOM state (e.g. the
-    // `.hljs` class hljs added to <code> elements after the previous
-    // OnRenderedAsync invoke completed). Set after a successful send.
-    private string? _lastSentHtml;
-
-    // Set by RequestRenderInternalAsync when StateHasChanged fires while a handler
-    // dispatch is mid-flight (InHandlerScope=true). RenderAndSendCoalescingAsync
-    // reads and clears it to rebuild the payload before releasing the dispatch lock —
-    // captures state mutated by RouteState.Changed subscribers / dispose callbacks
-    // that fire after the first ToHtml walk but before the dispatch returns. Without
-    // this, every in-handler StateHasChanged emits a separate intermediate payload,
-    // double-morphing <head> on every nav and momentarily orphaning the scoped-css
-    // <link> (visible as a one-frame flash of the sidebar's .nav-item-btn styling).
-    // Mirrors WasmLiveSession._pendingRenderInScope (Rask.Wasm/WasmLiveSession.cs:41).
-    private bool _pendingRenderInScope;
-
-    // Diff-codec state. Populated only when LiveOptions.DiffMode != DisabledFull, so
-    // the default path pays nothing for these. Both fields are lazy because the
-    // common production path today still ships full HTML.
-    private SessionRenderCache? _renderCache;
 
     // Set true whenever a render request lands with no live socket — async lifecycle
     // continuations from OnMountAsync / OnRenderedAsync that resolve during the HTTP-GET-
@@ -93,43 +69,18 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     // thread-pool worker) run on different threads. Mirrors the detached-socket early-return.
     private volatile bool _disposed;
 
-    // Two-buffer swap: `_writeBuffer` receives the next frame, `_lastSentBuffer` holds the
-    // previous send (dedup compare target). After SendAsync the references swap so the just-
-    // sent buffer becomes the dedup baseline without any byte[] copy. Both writers persist
-    // across the session's lifetime; ResetWrittenCount keeps the underlying rented array hot.
-    private ArrayBufferWriter<byte> _writeBuffer = new(4096);
-
     public LiveSession(string id, Component view, IServiceScope scope)
+        : base(view, scope.ServiceProvider)
     {
         Id = id;
-        View = view;
         Scope = scope;
-        view.RenderHandle = this;
-        // RootErrorBoundary wraps the user's App; forward the handle to the inner so its
-        // StateHasChanged() still reaches the session even before the first GetOrCreate
-        // (which would otherwise be where the handle gets lazily attached).
-        if (view is RootErrorBoundary root)
-        {
-            root.Inner.RenderHandle = this;
-        }
     }
 
     public bool SuppressEventsUntilReconnect { get; set; }
 
     public string Id { get; }
-    public Component View { get; }
     public IServiceScope Scope { get; }
-    public IServiceProvider Services => Scope.ServiceProvider;
     public SemaphoreSlim Lock { get; } = new(1, 1);
-
-    // Plain instance bool, NOT AsyncLocal: the dispatch lock is owned by this session as a whole,
-    // not by any one async chain. AsyncLocal would flow into Timer/Task captures created during a
-    // dispatch — those captured ExecutionContexts would later report InHandlerScope=true forever,
-    // making background StateHasChanged calls (e.g. EditContext's sticky-dismissal Timer or a
-    // user component's Timer) hit the in-scope branch — which under the coalescing model just
-    // sets _pendingRenderInScope and returns, leaving the render to no one. WASM uses the same
-    // plain-bool approach for the same reason (Rask.Wasm/WasmLiveSession.cs:30-33).
-    public bool InHandlerScope { get; set; }
 
     /// <summary>
     ///     Tail of the WS-message handler chain. Each inbound handler dispatch awaits
@@ -202,13 +153,9 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
         Scope.Dispose();
     }
 
-    public Task RequestRenderAsync() => RequestRenderInternalAsync(false);
+    protected override Task RenderInScopeCoreAsync() => RenderAndSendAsync(null, false);
 
-    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(true);
-
-    Task IRenderHandle.RenderInScopeAsync() => RenderAndSendAsync(null, false);
-
-    private async Task RequestRenderInternalAsync(bool publishOnly)
+    protected override async Task RequestRenderInternalAsync(bool publishOnly)
     {
         // _disposed short-circuits a StateHasChanged raised from an Unmount/Dispose callback during
         // teardown: the tree walk runs under _renderLock, so re-entering RenderAndSendAsync (which
@@ -267,7 +214,7 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
     ///     identical-state renders the same way WASM's <c>InitialRenderAsync</c> does
     ///     via <c>_lastAppliedHtml</c>.
     /// </summary>
-    internal void SeedInitialHtml(string html) => _lastSentHtml = html;
+    internal void SeedInitialHtml(string html) => _lastAppliedHtml = html;
 
     /// <summary>
     ///     Render the initial root for the HTTP-GET response, seeding BOTH the dedup
@@ -415,159 +362,27 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
             {
                 _forceResend = false;
                 _lastSentBuffer = null;
-                _lastSentHtml = null;
+                _lastAppliedHtml = null;
             }
 
-            // Diff-codec path: capture the parallel RenderFrame[] stream during render so
-            // we can produce a minimal edit-op payload instead of re-shipping the whole
-            // body. Default (LiveDiffMode.DisabledFull) bypasses this entirely — the
-            // ambient FrameSinkScope is null on entry and HtmlSerializer's frame emit
-            // is a single null check per branch. Only the opted-in path pays for the
-            // FrameWriter, the diff walk, and the SessionRenderCache buffer rotation.
-            var diffMode = LiveOptions.DiffMode;
-            FrameWriter? frameWriter = null;
-            FrameSinkScope.Popper framePopper = default;
-            if (diffMode != LiveDiffMode.DisabledFull)
-            {
-                _renderCache ??= new SessionRenderCache();
-                frameWriter = _renderCache.PrepareCurrentBuffer();
-                framePopper = FrameSinkScope.Push(frameWriter);
-            }
-
-            string html;
-            try
-            {
-                html = View.RenderAsLiveRoot(Services, publishOnly);
-            }
-            finally
-            {
-                if (frameWriter is not null)
-                {
-                    framePopper.Dispose();
-                }
-            }
-
-            PendingDownload? download = null;
-            if (Services.GetService<IDownloadSink>() is { } sink && sink.TryConsume(out var pd))
-            {
-                download = pd;
-            }
-
-            // BuildPayloadUtf8WithRoot encodes the rendered HTML to UTF-8 once, splices
-            // data-rask-root onto <body>, and emits the WHOLE document (Doctype + Html +
-            // Head + Body). Sending the full document — same shape WASM uses — lets the
-            // client morph document.documentElement and pick up <head> changes
-            // (<title>, per-page Head asset contributions, scoped CSS/JS hash bumps)
-            // across in-app navigations. Body-only payloads froze <head> at whatever
-            // the initial HTTP GET produced, so a per-page Title declared via
-            // Component.Head never made it to the browser tab on SPA-style navigation.
-            // The added head bytes (~2-3 KB) compress away under permessage-deflate.
+            // Render + decide diff-vs-full + write the frame — shared with the WASM host (LiveSessionBase).
+            var html = RenderTreeToHtml(publishOnly, out var frameWriter);
+            var download = ConsumeDownload();
             var jsInvokes = JsInvokes.Drain();
 
-            // HTML-level dedup: when the rendered HTML matches the last sent (or the
-            // HTTP-GET-time seeded baseline) and there's nothing out-of-band to flow,
-            // the resulting payload would be byte-identical to what we sent last —
-            // skip without even building the payload. Originally a publish-only-render
-            // guard (preserves JS-applied DOM state like hljs's `.hljs` class across
-            // noop publish-renders); generalised so a fresh socket can also dedup
-            // against the GET-time HTML the browser already has, matching WASM's
-            // InitialRenderAsync dedup-baseline behaviour.
+            // HTML-level dedup: when the rendered HTML matches the last sent (or the GET-seeded
+            // baseline) and there's nothing out-of-band to flow, the payload would be byte-identical
+            // to the last send — skip before building. Preserves JS-applied DOM state (hljs's `.hljs`
+            // class) across noop publish-renders, and lets a fresh socket dedup against the GET HTML.
             if (jsInvokes is null
                 && historyUrl is null && auth is null && download is null
-                && _lastSentHtml is not null && string.Equals(html, _lastSentHtml, StringComparison.Ordinal))
+                && _lastAppliedHtml is not null && string.Equals(html, _lastAppliedHtml, StringComparison.Ordinal))
             {
                 return;
             }
 
-            _writeBuffer.ResetWrittenCount();
-
-            // Decide payload shape. Default (DisabledFull) and any case where we can't
-            // confidently ship a diff (first render, out-of-band side effects, ops we
-            // can't yet apply) routes to the full-HTML path. The diff path fires
-            // when LiveOptions.DiffMode is Auto/Forced AND we have a clean diff — under
-            // Auto we ship it whenever it's not larger than re-sending the body.
-            var usedDiff = false;
-            var diffPathEntered = false;
-            // Out-of-band side effects (auth, download) and structural ops
-            // (InsertSubtree/RemoveSubtree) still need the full-HTML payload. Why
-            // structural ops: e2e validation (83 of 430 tests failed when the structural
-            // gate was lifted) showed naive InsertSubtree/RemoveSubtree on top of the
-            // morph baseline produces DOM states the morph library wouldn't have —
-            // preserved focused inputs, event-listener identity on swapped elements,
-            // dialog open/close state. Until applyDiff reaches morph-quality book-keeping,
-            // full HTML wins for structural changes (the DiffOpsAreClientSupported gate
-            // below rejects untrusted positional structural ops independently of history).
-            //
-            // Head changes (a per-route <title>, a scoped-asset <link> for a newly-mounted
-            // page type, a reactive title) ride the diff too. The diff frame stream never
-            // carries <head> content — user Head contributions are collected and spliced
-            // post-render (HeadAssetRegistry), so a head change produces zero ops. When the
-            // head region changed vs the last sent document we attach the new <head> element
-            // (ExtractHead) to the diff payload; the client morphs it into document.head
-            // alongside applying the body ops. This covers navigation AND non-navigation
-            // reactive title updates — the latter previously shipped a body diff that froze
-            // the head. Genuine page swaps that restructure the body still fall back to full
-            // HTML via the DiffOpsAreClientSupported gate below (head fragment never sent).
-            //
-            // jsInvokes do NOT gate the diff: fire-and-forget IJSRuntime calls (e.g. a
-            // scoped-JS OnRenderedAsync hook firing on every render) ride the diff
-            // payload via BuildPayloadUtf8Diff, matching WASM — which dispatches such
-            // calls out-of-band and never forced full HTML. When we DO fall back to
-            // full HTML (first render, oversized diff, structural ops) the client morphs to
-            // match the server's frame snapshot, so the next render diffs cleanly against it.
-            if (frameWriter is not null && _renderCache is not null
-                                        && auth is null && download is null)
-            {
-                _diffOps ??= new List<EditOp>();
-                diffPathEntered = true;
-                var headChanged = _lastSentHtml is not null && !LiveDiffGate.HeadUnchanged(html, _lastSentHtml);
-                // Ship the diff when it carries DOM ops, OR when it carries no ops but a
-                // navigation or a head change needs to flow — a query-only nav (or any nav
-                // that doesn't alter the body) produces zero ops yet must still pushState the
-                // URL; a head-only change must still ship the head fragment. Zero ops + no
-                // history + unchanged head means nothing to send (the html-dedup above
-                // already returned for that case).
-                if (_renderCache.TryComputeDiff(_diffOps, html)
-                    && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
-                    && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
-                {
-                    var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
-                    LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes, headHtml);
-                    var diffBytes = _writeBuffer.WrittenCount;
-
-                    // Ship the diff whenever it isn't larger than re-sending the body, or
-                    // unconditionally under Forced. The only case we fall back to full
-                    // HTML on size is the pathological one where nearly every node changed
-                    // (typically a tiny page) and the op-list framing (paths + values +
-                    // JSON) exceeds the body itself — then the diff would cost more bytes
-                    // than the baseline. Every genuine in-place state change (counter,
-                    // text, attribute, keyed list edit) is far smaller than the body and
-                    // takes the diff path regardless of page size.
-                    if (diffMode == LiveDiffMode.Forced || diffBytes < html.Length)
-                    {
-                        usedDiff = true;
-                    }
-                    else
-                    {
-                        _writeBuffer.ResetWrittenCount();
-                    }
-                }
-            }
-
-            if (!usedDiff)
-            {
-                LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, html, Id, historyUrl, replace,
-                    auth, download, jsInvokes);
-                // Cache stays in lockstep with the client even when we ship full HTML —
-                // promote current → previous so the NEXT diff's baseline matches what
-                // the client most recently received. Only when we did NOT enter the
-                // diff branch: TryComputeDiff already rotates buffers internally, so a
-                // second Snapshot here would double-rotate and strand _previous=null.
-                if (!diffPathEntered)
-                {
-                    _renderCache?.Snapshot();
-                }
-            }
+            WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
+                commitCache: true, auth, Id);
 
             // Skip the frame when the payload is byte-identical to the previous one AND nothing
             // out-of-band (navigation, auth instruction) needs to flow. Catches handler invocations
@@ -600,7 +415,7 @@ internal sealed class LiveSession : IDisposable, IAsyncDisposable, IRenderHandle
             // Swap: the buffer we just sent becomes next frame's dedup baseline; the previous
             // baseline (or a fresh writer on first send) is reused as the next write target.
             (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>(4096));
-            _lastSentHtml = html;
+            _lastAppliedHtml = html;
         }
         finally
         {

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -10,7 +10,11 @@ using Rask.Core.Routing;
 
 namespace Rask.Wasm;
 
-internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
+// Render/diff/payload pipeline + the IJSRuntime queue live in LiveSessionBase (Core), shared with
+// the Server host. WasmLiveSession adds the in-process transport: the JSImport ApplyRender push,
+// the single dispatch lock, the route-auth guard, the navigate/dispatch handlers, and the byte[]-
+// per-frame model the JSExport boundary needs.
+internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
 {
     private readonly SemaphoreSlim _lock = new(1, 1);
 
@@ -21,64 +25,20 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
     // multi-session / re-init path.
     private readonly IUserProvider? _userProvider;
 
-    // Pooled across the session lifetime; ResetWrittenCount between frames keeps the rented
-    // backing array hot. Eliminates the per-render ArrayBufferWriter allocation that
-    // BuildPayloadUtf8WithRoot's byte[]-returning overload would otherwise make.
-    private readonly ArrayBufferWriter<byte> _writeBuffer = new(4096);
-
-    private List<EditOp>? _diffOps;
-
-    // Last rendered HTML string, used to suppress noop publish-renders that
-    // would otherwise re-morph identical HTML and strip JS-applied DOM state
-    // (e.g. the `.hljs` class hljs added in a prior frame's OnRenderedAsync).
-    // Set after a successful ApplyRender.
-    private string? _lastAppliedHtml;
+    // The last payload bytes ApplyRender pushed — WASM's dedup baseline (it ToArrays each frame for
+    // the JSExport boundary, where the Server double-buffers instead).
     private byte[]? _lastAppliedPayload;
-
-    // Set by RequestRenderAsync when called while InHandlerScope=true. The dispatch helpers
-    // (BuildPayloadCoalescingRerendersAsync) read and clear it to rebuild the payload before
-    // releasing the lock — catches state mutated by dispose callbacks that fire AFTER ToHtml
-    // serialised the first payload but BEFORE the dispatch returns.
-    private bool _pendingRenderInScope;
 
     // Set by BuildPayloadAsync when the frame it built carries queued IJSRuntime calls. The
     // publish-render noop guard must NOT drop such a frame even when the HTML is unchanged — the
     // invokes still need to reach the client (where they run after applyDiff).
     private bool _lastBuildHadJsInvokes;
 
-    // Plain instance bool, NOT AsyncLocal: the dispatch lock is owned by this session as a whole,
-    // not by any one async chain. AsyncLocal would flow into Timer/Task captures created during a
-    // render — those captured ExecutionContexts would later report InHandlerScope=true forever,
-    // making background StateHasChanged calls (e.g. from a Timer in a user component) silently no-op.
-    //
-    // Note: the historical _lastCssHashSent / _lastJsHashSent fields were removed when WASM
-    // moved off inline cssText/jsText payloads to the per-component asset endpoint.
-    // Scoped CSS/JS is now fetched by the browser via <link>/<script src> tags emitted into
-    // <head> by HeadAssetRegistry.EmitMountedAssets and served by Rask.Wasm.Hosting's
-    // /_rask/a/{hash}.{ext} endpoint with Cache-Control: immutable.
-
-    // Diff-codec state, lazily allocated only when LiveOptions.DiffMode opts in.
-    // Default path (DisabledFull) pays nothing for these.
-    private SessionRenderCache? _renderCache;
-
-    // Pending IJSRuntime calls, drained into each frame's jsInvokes and dispatched client-side after
-    // applyDiff (same post-commit ordering as the Server). Shared queue type across both hosts.
-    public LiveJsInvokeQueue JsInvokes { get; } = new();
-
     public WasmLiveSession(Component view, IServiceProvider services)
+        : base(view, services)
     {
-        View = view;
-        Services = services;
-        view.RenderHandle = this;
         // Bind this session to the runtime so its BeginInvokeJS queues onto JsInvokes.
         (services.GetService<WasmJSRuntime>())?.AttachHost(this);
-        // Forward the handle to the inner App when wrapped in a RootErrorBoundary so its
-        // StateHasChanged() reaches the session even before the first GetOrCreate would
-        // otherwise lazily attach it.
-        if (view is RootErrorBoundary root)
-        {
-            root.Inner.RenderHandle = this;
-        }
 
         if (services.GetService<IUserProvider>() is { } userProvider)
         {
@@ -86,11 +46,6 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
             userProvider.Changed += OnUserChanged;
         }
     }
-
-    public Component View { get; }
-    public IServiceProvider Services { get; }
-
-    public bool InHandlerScope { get; set; }
 
     public void Dispose()
     {
@@ -104,11 +59,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
         _lock.Dispose();
     }
 
-    public Task RequestRenderAsync() => RequestRenderInternalAsync(false);
-
-    public Task RequestPublishRenderAsync() => RequestRenderInternalAsync(true);
-
-    async Task IRenderHandle.RenderInScopeAsync()
+    protected override async Task RenderInScopeCoreAsync()
     {
         // Mirror Rask.Server LiveSession.RenderAndSendAsync: when the framework asks for a
         // mid-await render (Component.InvokeWithRenderingAsync), build and push an intermediate
@@ -142,7 +93,7 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
         }
     }
 
-    private async Task RequestRenderInternalAsync(bool publishOnly)
+    protected override async Task RequestRenderInternalAsync(bool publishOnly)
     {
         if (InHandlerScope)
         {
@@ -443,129 +394,23 @@ internal sealed class WasmLiveSession : IRenderHandle, IDisposable, ILiveJsHost
             }
         }
 
-        // Diff-codec path: capture the parallel RenderFrame[] stream during render so
-        // we can ship a minimal edit-op payload instead of the whole document. Default
-        // (LiveDiffMode.DisabledFull) bypasses entirely — null FrameSinkScope on entry,
-        // single null check per HtmlSerializer branch, zero overhead.
-        var diffMode = LiveOptions.DiffMode;
-        FrameWriter? frameWriter = null;
-        FrameSinkScope.Popper framePopper = default;
-        if (diffMode != LiveDiffMode.DisabledFull)
-        {
-            _renderCache ??= new SessionRenderCache();
-            frameWriter = _renderCache.PrepareCurrentBuffer();
-            framePopper = FrameSinkScope.Push(frameWriter);
-        }
-
-        // The App component owns the full page (Doctype + Html + Head + Body). Send the whole
-        // document so the JS runtime can morph <head> too — title, stylesheet <link>s, and the
-        // scoped-css <link> would otherwise stay frozen at whatever the static index.html shipped.
-        string html;
-        try
-        {
-            html = View.RenderAsLiveRoot(Services, publishOnly);
-        }
-        finally
-        {
-            if (frameWriter is not null)
-            {
-                framePopper.Dispose();
-            }
-        }
-
-        // CSS/JS no longer ship inline — scoped assets are content-addressed and fetched
-        // via /_rask/a/{hash}.{ext} from Rask.Wasm.Hosting. The diff-codec gate below
-        // tracks only side effects that still flow out of band (download payloads,
-        // navigation history) since the diff wire format doesn't carry them yet.
-        PendingDownload? download = null;
-        if (Services.GetService<IDownloadSink>() is { } sink && sink.TryConsume(out var pd))
-        {
-            download = pd;
-        }
+        // Render + decide diff-vs-full + write the frame — shared with the Server host
+        // (LiveSessionBase). WASM has no AuthInstruction in the diff codec (the route-auth guard
+        // above already redirected), so auth is null; the data-rask-root id is the constant "wasm".
+        var html = RenderTreeToHtml(publishOnly, out var frameWriter);
+        var download = ConsumeDownload();
 
         // Drain IJSRuntime calls queued during the render walk (e.g. an OnRenderedAsync focus). They
         // ride this frame's jsInvokes and the client runs them AFTER applyDiff, so they act on the
-        // committed DOM — the same post-commit ordering the Server has. _lastBuildHadJsInvokes lets
-        // the caller's noop guards know this frame must ship even if the HTML is unchanged.
+        // committed DOM. _lastBuildHadJsInvokes lets the caller's noop guard ship this frame even
+        // when the HTML is unchanged.
         var jsInvokes = JsInvokes.Drain();
         _lastBuildHadJsInvokes = jsInvokes is not null;
 
-        _writeBuffer.ResetWrittenCount();
+        WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
+            commitCache, auth: null, sessionId: "wasm");
 
-        // Decide payload shape. The diff path fires only when the flag is opted in,
-        // we have a prior render to diff against, the diff is supported client-side
-        // (no InsertSubtree/RemoveSubtree until HTML fragments wire in), and none of
-        // the out-of-band side effects (download, navigation history) need to flow —
-        // those aren't carried by the diff wire format yet.
-        var usedDiff = false;
-        // Conservative gate (mirrors server LiveSession): the diff path covers
-        // in-place state changes only. Side effects (download) and structural ops
-        // (InsertSubtree/RemoveSubtree) route to the full-HTML morph path — see the
-        // server-side DiffOpsAreClientSupported note for the rationale (e2e showed 83/430
-        // failures when structural ops bypass morph). Head changes (a per-route <title>, a
-        // scoped-asset <link> for a newly-mounted page, a reactive title) ride the diff too:
-        // the diff frame stream never carries <head> content (collected + spliced post-
-        // render), so a head change produces zero ops; when the head region changed vs the
-        // last applied document we attach the new <head> element (ExtractHead) and the client
-        // morphs it into document.head. Genuine page swaps that restructure the body still
-        // fall back to full HTML via DiffOpsAreClientSupported. `diffPathEntered` tracks
-        // whether we called TryComputeDiff (which internally rotates buffers regardless of
-        // return value) so the fallback Snapshot doesn't double-rotate and strand _previous.
-        var diffPathEntered = false;
-        if (frameWriter is not null && _renderCache is not null
-                                    && download is null)
-        {
-            _diffOps ??= new List<EditOp>();
-            diffPathEntered = true;
-            var headChanged = _lastAppliedHtml is not null && !LiveDiffGate.HeadUnchanged(html, _lastAppliedHtml);
-            // Ship the diff when it carries DOM ops, OR when it carries no ops but a
-            // navigation or a head change needs to flow — a query-only nav produces zero ops
-            // yet must still pushState the URL; a head-only change must still ship the head
-            // fragment. Zero ops + no history + unchanged head means nothing to send.
-            if (_renderCache.TryComputeDiff(_diffOps, commitCache, html)
-                && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
-                && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
-            {
-                var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
-                LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace,
-                    jsInvokes: jsInvokes, headHtml: headHtml);
-                var diffBytes = _writeBuffer.WrittenCount;
-
-                // Same rule as the server: ship the diff whenever it isn't larger than
-                // re-sending the body, or unconditionally under Forced. We only drop the
-                // diff bytes and fall through to full HTML in the pathological case where
-                // nearly every node changed (tiny page) and the op-list framing exceeds
-                // the body itself — then the diff would cost more bytes than the baseline.
-                if (diffMode == LiveDiffMode.Forced || diffBytes < html.Length)
-                {
-                    usedDiff = true;
-                }
-                else
-                {
-                    _writeBuffer.ResetWrittenCount();
-                }
-            }
-        }
-
-        if (!usedDiff)
-        {
-            // BuildPayloadUtf8WithRoot fuses InjectRootAttr + payload write on UTF-8 bytes,
-            // emitting the whole document (head + body) so the JS-side morph against
-            // document.documentElement can update head children. Writes into the pooled
-            // _writeBuffer so the per-render ArrayBufferWriter allocation is gone; the
-            // ToArray at the end is still needed today because the JS interop boundary
-            // marshals byte[] (PR6 will swap that for ReadOnlyMemory<byte>).
-            LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, html, "wasm", historyUrl, replace,
-                null, download, jsInvokes);
-            // Only Snapshot when TryComputeDiff was NOT called (it would have rotated) AND we
-            // own the commit (commitCache). When commitCache is false the coalescing loop
-            // commits once after it settles, so rotating here would strand the baseline.
-            if (!diffPathEntered && commitCache)
-            {
-                _renderCache?.Snapshot();
-            }
-        }
-
+        // ToArray for the JSExport byte[] boundary (PR6 will swap that for ReadOnlyMemory<byte>).
         return (_writeBuffer.WrittenSpan.ToArray(), html);
     }
 }


### PR DESCRIPTION
## Summary
The staged follow-up to #99: merge the common render pipeline of the two live sessions into one shared base in `Rask.Core`, so Server and WASM no longer carry near-identical copies of it.

A new **`LiveSessionBase`** owns the part both hosts ran the same way:
- the render → diff-vs-full → payload build (`RenderTreeToHtml`, `ConsumeDownload`, `WritePayload`);
- the shared render/diff state (render cache, diff ops, write buffer, `_lastAppliedHtml` dedup baseline) and the `LiveJsInvokeQueue`;
- the `IRenderHandle` / `ILiveJsHost` plumbing and the common ctor (RenderHandle wiring + `RootErrorBoundary` forwarding).

`LiveSession` (Server) and `WasmLiveSession` (WASM) now **extend** it and keep only what genuinely diverges — their **transport** (WebSocket push vs in-process `ApplyRender`), **locking**, **reconnect/dispatch lifecycle**, and **send-dedup strategy** (Server double-buffers; WASM `ToArray`s each frame for the `JSExport` boundary). The seams that differ per host are parameters of `WritePayload`: `auth` (Server-only — gates the diff and rides the full payload; WASM passes null), `sessionId` (`data-rask-root`), and `commitCache` (false during a coalescing loop).

**Internal only — no API or behaviour change.** Net: ~340 lines of duplicate pipeline collapse into a 167-line base (Server `LiveSession` 670→485, WASM `WasmLiveSession` 571→416).

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — all pass, incl. `Rask.Server.Tests` (170, the `LiveSession` direct + handler-scope tests) and `Rask.Wasm.Tests` (46). (`Rask.Server.Tests` / `Rask.Wasm.Tests` gain `[InternalsVisibleTo]` from Core to reach the now-inherited base members.)
- E2E: hosts **Server + Wasm + StandaloneWasm** — all pass (3/3, 54s); the full live runtime (render, diff, navigation, interop, auth, scoped JS, reconnect) is exercised unchanged on both transports.

## Benchmarks
Render round-trip (`LiveRenderRoundTripBenchmarks`), Allocated before → after — **zero delta** (pure method-extraction):
- RenderOnce 99.58 KB · RenderTenTimes 171.77 KB · RenderKeyedList100 129.09 KB · RenderDeep_50UserComponents 88.9 KB (all unchanged)

## CHANGELOG
- [Unreleased] **Changed**: the live-session render pipeline is now shared from `Rask.Core`.
