### PR TITLE
feat(core): per-outlet error boundary by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Per-outlet error boundary by default.** `Outlet()` now wraps the matched child page in an
+  `ErrorBoundary`, so a render-time fault in a nested page is contained to the outlet region — the
+  surrounding layout (nav/sidebar) stays live and the framework `DefaultErrorPage` renders in place,
+  instead of the fault bubbling to the `RootErrorBoundary` and replacing the whole page shell. The
+  boundary recovers automatically on navigation, so a crash on one page never sticks over the next.
+  Opt out per outlet with `Outlet(DisableErrorBoundary: true)`. For in-place retry, keep wrapping the
+  fallible part in an explicit `ErrorBoundary(...)` with a `recover` button. See the
+  [routing guide](docs/routing.md).
 - **Keyboard events on every element.** `Element` now exposes `OnKeyDown` and `OnKeyUp`, the
   focus-scoped counterpart to `OnClick`, wired by both client runtimes (Server WS + WASM) via
   `data-rask-on-keydown` / `data-rask-on-keyup`. A handler takes a parameterless delegate or a typed

--- a/README.md
+++ b/README.md
@@ -731,6 +731,10 @@ ErrorBoundary(
 Without a `Fallback`, the boundary renders a built-in default error page. The `recover` callback passed to the
 fallback is the only reset path.
 
+`Outlet()` wraps every matched page in one of these boundaries **by default**, so a nested page crash is contained
+to the outlet region (the layout stays live) and clears automatically on navigation. Opt out per outlet with
+`Outlet(DisableErrorBoundary: true)`.
+
 </details>
 
 <details>

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -155,6 +155,24 @@ every page declares `[ParentRoute(typeof(ShowcaseLayout))]` and the layout hosts
 `Outlet()` must be called inside a `Router()` render tree (it throws otherwise). A `[ParentRoute]` cycle raises
 [RASK007](diagnostics.md#rask007).
 
+### Per-outlet error boundary
+
+By default, `Outlet()` wraps the matched child page in an [`ErrorBoundary`](composition.md). If a nested page
+throws during render, the fault is **contained to the outlet region**: the surrounding layout (nav, sidebar) stays
+live and the framework `DefaultErrorPage` renders in the content area — instead of the fault bubbling up to the
+root boundary and replacing the whole page shell. The boundary recovers automatically on navigation, so a crash on
+one page never sticks over the next page rendered into the same outlet.
+
+```csharp
+Main()[Outlet()]                              // default: child faults are contained here
+Main()[Outlet(DisableErrorBoundary: true)]    // opt out: let faults bubble to an outer boundary
+```
+
+The default boundary is a *navigate-away* safety net — it has no in-place retry. When you want the user to retry
+without leaving the page, wrap the fallible part of the page in an explicit `ErrorBoundary(...)` with a `recover`
+callback (see [composition](composition.md)); that inner boundary catches first, so the outlet's boundary only
+sees faults the page didn't handle itself.
+
 ## Programmatic navigation — `Navigator`
 
 `Navigator` is the scoped service for imperative navigation and query mutation. Inject it through the **constructor**

--- a/samples/Rask.Example.Shared/Features/ErrorBoundary/OutletBoundaryPage.cs
+++ b/samples/Rask.Example.Shared/Features/ErrorBoundary/OutletBoundaryPage.cs
@@ -1,0 +1,38 @@
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+[Route("outlet-boundary")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class OutletBoundaryPage : Component
+{
+    // Flipped by the button; the next render throws so we can show that the failure is
+    // contained to the outlet region rather than taking down the whole shell.
+    private bool _crashed;
+
+    protected override RenderResult Head => Title()["Outlet boundary — Rask"];
+
+    protected override RenderResult Render()
+    {
+        if (_crashed)
+        {
+            throw new InvalidOperationException(
+                "This page threw during render — the outlet's default error boundary caught it.");
+        }
+
+        return
+        [
+            PageHeader.Render(
+                "Default outlet boundary",
+                "Every page rendered into an Outlet() is wrapped in an error boundary by default. When a page crashes, the failure is contained to the content region — the top nav and the sidebar stay live — instead of replacing the whole page shell. The boundary clears automatically when you navigate away, so a crash never sticks over the next page. Opt out per outlet with Outlet(DisableErrorBoundary: true)."),
+            CodeSample(
+                ["OutletBoundaryPage.cs"],
+                Notes:
+                "Click to make this page throw on its next render. Notice the sidebar and top nav remain usable — pick any other section to recover (navigating clears the boundary).",
+                Result: Button(
+                    Class: "btn btn-danger",
+                    Id: "outlet-crash-trigger",
+                    OnClick: () => _crashed = true)[I(Class: "bi bi-bug me-2"), "Crash this page"])
+        ];
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -35,6 +35,7 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
         ("/keyed-lists", "Keyed lists", "bi-key", "Components", null),
         ("/drag-drop", "Drag & drop", "bi-arrows-move", "Components", null),
         ("/boom", "Error boundary", "bi-shield-exclamation", "Components", null),
+        ("/outlet-boundary", "Outlet boundary", "bi-shield-shaded", "Components", null),
         ("/binding", "Two-way binding", "bi-arrow-left-right", "Forms", null),
         ("/validation", "Validation", "bi-shield-check", "Forms", null),
         ("/nested-forms", "Complex models", "bi-diagram-3", "Forms", null),

--- a/src/Rask.Core/Routing/Outlet.cs
+++ b/src/Rask.Core/Routing/Outlet.cs
@@ -1,5 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Components;
 using Rask.Core.Live;
+using F = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Routing;
 
@@ -8,6 +10,16 @@ public sealed class Outlet : Component
     // Cached at mount because LiveRenderContext.Current is null during disposal, so
     // OnUnmount can't re-resolve RouteState from the render scope.
     private RouteState? _route;
+
+    // The default per-outlet boundary. Reused positionally across renders, so once it trips
+    // it stays tripped until cleared — we Recover() it on every navigation so a crash on one
+    // page doesn't "stick" over the next (healthy) page rendered into this same outlet.
+    private ErrorBoundary? _boundary;
+
+    // Opt out of the default per-outlet error boundary. Nullable so the generated factory
+    // exposes it as the optional parameter `Outlet(bool? DisableErrorBoundary = null)`:
+    // null/false ⇒ boundary ON (the default), only true lets a child fault bubble outward.
+    public bool? DisableErrorBoundary { get; set; }
 
     protected override void OnMount()
     {
@@ -20,7 +32,7 @@ public sealed class Outlet : Component
             return;
         }
 
-        _route.Changed += StateHasChanged;
+        _route.Changed += OnRouteChanged;
     }
 
     protected override void OnUnmount()
@@ -30,7 +42,17 @@ public sealed class Outlet : Component
             return;
         }
 
-        _route.Changed -= StateHasChanged;
+        _route.Changed -= OnRouteChanged;
+    }
+
+    private void OnRouteChanged()
+    {
+        // Give the next route a clean attempt: clear any tripped state left by the previous
+        // page so the boundary doesn't keep rendering the old error over the new page. The
+        // default boundary is a navigate-away safety net — for in-place retry, wrap the part
+        // that can fail in an explicit ErrorBoundary with a Recover() button.
+        _boundary?.Recover();
+        StateHasChanged();
     }
 
     protected override RenderResult Render()
@@ -38,6 +60,23 @@ public sealed class Outlet : Component
         var ctx = LiveRenderContext.Current
                   ?? throw new InvalidOperationException(
                       "Outlet() must be called inside a Router render tree.");
-        return RouteChainRenderer.RenderChainEntry(ctx);
+
+        // Render the matched chain entry first so the route cursor advances identically
+        // whether or not we wrap it — preserving the empty-leaf and two-outlets-in-one-render
+        // semantics that RouteChainRenderer's cursor relies on.
+        var entry = RouteChainRenderer.RenderChainEntry(ctx);
+
+        if (DisableErrorBoundary == true)
+        {
+            return entry;
+        }
+
+        // By default, contain a child page's render fault to this outlet region: the
+        // surrounding layout (nav/sidebar) stays live and the framework DefaultErrorPage
+        // renders here, instead of the fault bubbling to the RootErrorBoundary and replacing
+        // the whole page shell. Opt out with Outlet(DisableErrorBoundary: true).
+        var boundary = F.ErrorBoundary();
+        _boundary = boundary;
+        return boundary[entry];
     }
 }

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -26,7 +26,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`
-  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
+  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`. `Outlet()` wraps the
+  matched page in an error boundary by default (a page crash stays contained to the outlet; the layout stays
+  live and it clears on navigation) — opt out with `Outlet(DisableErrorBoundary: true)`.
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -26,7 +26,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`
-  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
+  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`. `Outlet()` wraps the
+  matched page in an error boundary by default (a page crash stays contained to the outlet; the layout stays
+  live and it clears on navigation) — opt out with `Outlet(DisableErrorBoundary: true)`.
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -26,7 +26,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`
-  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
+  (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`. `Outlet()` wraps the
+  matched page in an error boundary by default (a page crash stays contained to the outlet; the layout stays
+  live and it clears on navigation) — opt out with `Outlet(DisableErrorBoundary: true)`.
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,

--- a/tests/Rask.Core.Tests/Routing/OutletTests.cs
+++ b/tests/Rask.Core.Tests/Routing/OutletTests.cs
@@ -67,10 +67,95 @@ public class OutletTests
         Assert.Equal("<div>first:<span>leaf</span>second:</div>", html);
     }
 
+    [Fact]
+    public void Outlet_ChildRenderThrows_ErrorContainedToOutlet_LayoutStaysLive()
+    {
+        // A child page faults during render. The default per-outlet boundary contains it to
+        // the outlet region: the layout shell (nav) stays live and the DefaultErrorPage
+        // renders in place, instead of the fault bubbling out and replacing everything.
+        var routes = new[]
+        {
+            Route<LayoutWithNav>("/app", new[] { Route<ThrowingLeaf>("boom") })
+        };
+        var (view, state, sp) = BuildView(routes);
+        state.Path = "/app/boom";
+
+        var html = view.RenderAsLiveRoot(sp);
+
+        Assert.Contains("nav:", html, StringComparison.Ordinal);
+        Assert.Contains("rask-error-boundary", html, StringComparison.Ordinal);
+        Assert.Contains("Something went wrong", html, StringComparison.Ordinal);
+        Assert.Contains("boom!", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Outlet_DisableErrorBoundaryTrue_ChildThrowPropagates()
+    {
+        // Opting out lets the fault bubble past the outlet (here, out of the render entirely
+        // since the test root has no RootErrorBoundary) — proving the boundary is off.
+        var routes = new[]
+        {
+            Route<LayoutNoBoundary>("/app", new[] { Route<ThrowingLeaf>("boom") })
+        };
+        var (view, state, sp) = BuildView(routes);
+        state.Path = "/app/boom";
+
+        var ex = Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot(sp));
+        Assert.Equal("boom!", ex.Message);
+    }
+
+    [Fact]
+    public void Outlet_BoundaryRecoversOnNavigation_AfterChildCrash()
+    {
+        // The boundary is reused positionally across renders. Without recover-on-nav it would
+        // stay tripped and keep showing the crash over the next (healthy) page. Navigating away
+        // must clear it.
+        var routes = new[]
+        {
+            Route<LayoutWithNav>("/app",
+                new[] { Route<ThrowingLeaf>("boom"), Route<HealthyLeaf>("ok") })
+        };
+        var (view, state, sp) = BuildView(routes);
+
+        state.Path = "/app/boom";
+        var crashed = view.RenderAsLiveRoot(sp);
+        Assert.Contains("rask-error-boundary", crashed, StringComparison.Ordinal);
+
+        state.Path = "/app/ok";
+        var recovered = view.RenderAsLiveRoot(sp);
+
+        Assert.DoesNotContain("rask-error-boundary", recovered, StringComparison.Ordinal);
+        Assert.Contains("ok!", recovered, StringComparison.Ordinal);
+    }
+
     [SkipFactory]
     public sealed class Layout : Component
     {
         protected override RenderResult Render() => Div()["layout:", Outlet()];
+    }
+
+    [SkipFactory]
+    public sealed class HealthyLeaf : Component
+    {
+        protected override RenderResult Render() => Span()["ok!"];
+    }
+
+    [SkipFactory]
+    public sealed class LayoutWithNav : Component
+    {
+        protected override RenderResult Render() => Div()["nav:", Outlet()];
+    }
+
+    [SkipFactory]
+    public sealed class LayoutNoBoundary : Component
+    {
+        protected override RenderResult Render() => Div()["nav:", Outlet(DisableErrorBoundary: true)];
+    }
+
+    [SkipFactory]
+    public sealed class ThrowingLeaf : Component
+    {
+        protected override RenderResult Render() => throw new InvalidOperationException("boom!");
     }
 
     [SkipFactory]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -378,6 +378,18 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("#boom-recover").First.ClickAsync();
         await Expect(Page.Locator("#boom-render-trigger")).ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+
+        // Default outlet boundary: a page that throws during render is contained to the outlet
+        // region — the DefaultErrorPage shows in <main> while the navbar/sidebar stay live — and
+        // the boundary clears automatically on navigation.
+        await SideAsync("Outlet boundary", "Default outlet boundary");
+        await Page.Locator("#outlet-crash-trigger").ClickAsync();
+        await Expect(Page.Locator("main:has-text(\"Something went wrong\")").First).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await Expect(Page.Locator(".navbar .navbar-brand")).ToContainTextAsync("Rask"); // shell survived
+        // Navigate away → the outlet boundary recovers and the crash content is gone.
+        await SideAsync("Error boundary", "Error boundary");
+        await AssertNoGlobalCrashAsync();
     }
 
     private async Task WalkAuthAndContextPagesAsync()


### PR DESCRIPTION
## Summary

`Outlet()` now wraps the matched child page in an `ErrorBoundary` **by default**, so a render-time fault in a nested page is contained to the outlet region — the surrounding layout (nav/sidebar) stays live and the framework `DefaultErrorPage` renders in place, instead of the fault bubbling to the `RootErrorBoundary` and replacing the whole page shell.

- The boundary is reused positionally across renders, so it would otherwise *stick* once tripped. It is now `Recover()`ed on `RouteState.Changed`, so a crash on one page never persists over the next page rendered into the same outlet.
- Opt out per outlet with `Outlet(DisableErrorBoundary: true)` (nullable `bool?` → optional generated factory param; existing `Outlet()` call sites are unchanged).
- The default boundary is a *navigate-away* safety net. For in-place retry, keep wrapping the fallible part in an explicit `ErrorBoundary(...)` with a `recover` button — the inner boundary catches first.
- `RenderChainEntry(ctx)` is still called unconditionally so the route cursor advances identically whether or not the boundary wraps — empty-leaf and two-outlets-in-one-render semantics are preserved.

## Testing

- **Unit:** Core (1532) + Server (170) + rest — all green. New `OutletTests`: error containment (layout survives), `DisableErrorBoundary: true` propagation, and navigation-recovery. Existing empty-leaf / two-outlet regression guards still pass.
- **E2E:** added an outlet-boundary step to the shared journey (crash → contained in `<main>`, navbar survives → navigate away → boundary recovered, no global crash). `ServerExampleTests.Journey` passes locally (36 s); the full host matrix runs in CI.
- **Build:** `dotnet build Rask.slnx` warnings-as-errors + analyzers — 0 warnings, 0 errors. `dotnet format --verify-no-changes` clean.

## Benchmarks

No existing benchmark constructs a `Router`/`Outlet`, and the shared render hot path (HtmlSerializer / Element / diff codec) is untouched. The change is a bounded O(1) per outlet — one positionally-reused `ErrorBoundary` plus one `Child[1]` — mirroring the app-wide `RootErrorBoundary` pattern, so existing benches show no signal. Happy to add a dedicated `OutletRenderBenchmarks` if hard numbers are wanted.

## Changelog

Added under `[Unreleased]`.

## Docs / samples

`docs/routing.md` (new "Per-outlet error boundary" section), `README.md`, all three template `AGENTS.md`, and a new `/outlet-boundary` showcase page (crash button; shell stays live) with a sidebar link.