### PR TITLE
refactor(samples): split drag & drop into sortable and kanban demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ them until tagged releases begin.
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
 ### Changed
+- **The `/drag-drop` showcase now splits its two demos into separate `CodeSample` cards.** The
+  sortable list and the Kanban board were extracted from a single 178-line `DragDropDemo` into
+  `DragDropSortableDemo` and `DragDropKanbanDemo` (each with its own scoped CSS), so the page shows
+  one focused source panel per use case — matching the multi-demo layout already used by
+  `/virtualize` and `/binding`. Same route, same behaviour.
 - **The live-session render pipeline is now shared from `Rask.Core`.** A new `LiveSessionBase` owns
   the render→diff-vs-full→payload build both hosts ran near-identically (`RenderTreeToHtml`,
   `ConsumeDownload`, `WritePayload`) plus the common state (render cache, diff ops, write buffer,

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropKanbanDemo.cs
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropKanbanDemo.cs
@@ -2,9 +2,9 @@ using Rask.Core.DragAndDrop;
 
 namespace Rask.Example.Shared.Features;
 
-public sealed class DragDropDemo : Component
+// Multi-column board. One drop zone per column; drag cards across columns or reorder within one.
+public sealed class DragDropKanbanDemo : Component
 {
-    // Demo B — Kanban board. One drop zone per column.
     private static readonly string[] _columns = ["todo", "doing", "done"];
 
     private static readonly Dictionary<string, string> _columnLabels = new()
@@ -22,82 +22,7 @@ public sealed class DragDropDemo : Component
         ["done"] = [new Card(5, "Read the codebase")]
     };
 
-    // Demo A — single-list reorder. One drop zone ("list").
-    private readonly List<string> _fruits =
-    [
-        "Apple", "Banana", "Cherry", "Date", "Elderberry"
-    ];
-
-    protected override RenderResult Render() =>
-    [
-        SortableDemo(),
-        KanbanDemo()
-    ];
-
-    // ----- Demo A: sortable list ---------------------------------------------
-
-    private Component SortableDemo() =>
-        Div(Class: "card shadow-sm border-0 mb-4")[
-            Div(Class: "card-body")[
-                H5(Class: "fw-semibold mb-1")["Sortable list"],
-                P(Class: "text-secondary small")["Drag a fruit and drop it onto another to reorder. One drop zone."],
-                DragDrop(
-                    SortableBody,
-                    ReorderFruit)
-            ]
-        ];
-
-    private Component SortableBody(DragDropContext ctx)
-    {
-        var rows = new List<Child>(_fruits.Count);
-        for (var i = 0; i < _fruits.Count; i++)
-        {
-            var fruit = _fruits[i];
-            var index = i;
-            var cls = "list-group-item d-flex align-items-center gap-2 dd-item";
-            if (ctx.IsSource("list", index))
-            {
-                cls += " dd-dragging";
-            }
-
-            if (ctx.IsDropTarget("list", index))
-            {
-                cls += " dd-drop-target";
-            }
-
-            rows.Add(Li(
-                Key: fruit,
-                Class: cls,
-                Draggable: true,
-                OnDragStart: ctx.DragStart("list", index),
-                OnDragOver: ctx.DragOver("list", index),
-                OnDrop: ctx.Drop("list", index),
-                OnDragEnd: ctx.DragEnd,
-                Data: new Dictionary<string, string?> { ["testid"] = $"fruit-{index}" })[
-                I(Class: "bi bi-grip-vertical text-secondary"),
-                Span(Class: "fw-semibold")[fruit]
-            ]);
-        }
-
-        return Ul(Class: "list-group dd-list", Id: "dd-fruit-list")[rows];
-    }
-
-    // Direction-aware: dragging down lands after the target, dragging up lands before it.
-    private void ReorderFruit(DragDropMove move) => move.ApplyTo(_fruits);
-
-    // ----- Demo B: Kanban board ----------------------------------------------
-
-    private Component KanbanDemo() =>
-        Div(Class: "card shadow-sm border-0 mb-4")[
-            Div(Class: "card-body")[
-                H5(Class: "fw-semibold mb-1")["Kanban board"],
-                P(Class: "text-secondary small")[
-                    "Drag cards between columns, or reorder within one. Each column is a drop zone."],
-                DragDrop(
-                    KanbanBody,
-                    MoveCard)
-            ]
-        ];
+    protected override RenderResult Render() => DragDrop(KanbanBody, MoveCard);
 
     private Component KanbanBody(DragDropContext ctx)
     {

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropKanbanDemo.css
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropKanbanDemo.css
@@ -1,12 +1,3 @@
-.dd-item {
-    cursor: grab;
-    user-select: none;
-}
-
-.dd-item:active {
-    cursor: grabbing;
-}
-
 .dd-dragging {
     opacity: 0.4;
 }

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropPage.cs
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropPage.cs
@@ -14,10 +14,18 @@ public sealed class DragDropPage : Component
             "Headless drag & drop",
             "DragDrop is a headless primitive: it owns no DOM and tracks only the in-flight drag, handing your Body delegate a DragDropContext. You draw the items and drop zones, wire the context's DragStart/DragOver/Drop/DragEnd onto them, and move your own data when OnDrop reports where the drag landed. Zones are arbitrary string keys — one zone is a sortable list, several are a Kanban board."),
 
+        H2(Class: "h4 mt-4 mb-3")["Sortable list"],
         CodeSample(
-            ["DragDropDemo.cs", "DragDropDemo.css"],
-            Result: DragDropDemo(),
+            ["DragDropSortableDemo.cs", "DragDropSortableDemo.css"],
+            Result: DragDropSortableDemo(),
             Notes:
-            "Drag handlers are parameterless (like OnClick) — the dragged item's identity rides the handler closure, not the event payload, so no custom wire type is needed. DragDropMove.ApplyTo handles the direction-aware insert math (down-after, up-before) for both same-list and cross-list moves. Items carry a stable Key: so reorders ship trusted keyed structural diff ops that preserve survivors' DOM state.")
+            "Drag a fruit and drop it onto another to reorder — one drop zone. Drag handlers are parameterless (like OnClick): the dragged item's identity rides the handler closure, not the event payload, so no custom wire type is needed. DragDropMove.ApplyTo handles the direction-aware insert math (down-after, up-before). Items carry a stable Key: so reorders ship trusted keyed structural diff ops that preserve survivors' DOM state."),
+
+        H2(Class: "h4 mt-5 mb-3")["Kanban board"],
+        CodeSample(
+            ["DragDropKanbanDemo.cs", "DragDropKanbanDemo.css"],
+            Result: DragDropKanbanDemo(),
+            Notes:
+            "The same primitive with one zone per column — drag cards between columns or reorder within one. A single OnDrop moves the card across lists via ApplyTo(from, to). Each column body is its own drop-at-end zone, so a card can land in empty space, at a column's tail, or into an empty column.")
     ];
 }

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropSortableDemo.cs
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropSortableDemo.cs
@@ -1,0 +1,52 @@
+using Rask.Core.DragAndDrop;
+
+namespace Rask.Example.Shared.Features;
+
+// Single-list reorder. One drop zone ("list"); drop a fruit onto another to reorder.
+public sealed class DragDropSortableDemo : Component
+{
+    private readonly List<string> _fruits =
+    [
+        "Apple", "Banana", "Cherry", "Date", "Elderberry"
+    ];
+
+    protected override RenderResult Render() => DragDrop(SortableBody, ReorderFruit);
+
+    private Component SortableBody(DragDropContext ctx)
+    {
+        var rows = new List<Child>(_fruits.Count);
+        for (var i = 0; i < _fruits.Count; i++)
+        {
+            var fruit = _fruits[i];
+            var index = i;
+            var cls = "list-group-item d-flex align-items-center gap-2 dd-item";
+            if (ctx.IsSource("list", index))
+            {
+                cls += " dd-dragging";
+            }
+
+            if (ctx.IsDropTarget("list", index))
+            {
+                cls += " dd-drop-target";
+            }
+
+            rows.Add(Li(
+                Key: fruit,
+                Class: cls,
+                Draggable: true,
+                OnDragStart: ctx.DragStart("list", index),
+                OnDragOver: ctx.DragOver("list", index),
+                OnDrop: ctx.Drop("list", index),
+                OnDragEnd: ctx.DragEnd,
+                Data: new Dictionary<string, string?> { ["testid"] = $"fruit-{index}" })[
+                I(Class: "bi bi-grip-vertical text-secondary"),
+                Span(Class: "fw-semibold")[fruit]
+            ]);
+        }
+
+        return Ul(Class: "list-group dd-list", Id: "dd-fruit-list")[rows];
+    }
+
+    // Direction-aware: dragging down lands after the target, dragging up lands before it.
+    private void ReorderFruit(DragDropMove move) => move.ApplyTo(_fruits);
+}

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropSortableDemo.css
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropSortableDemo.css
@@ -1,0 +1,18 @@
+.dd-item {
+    cursor: grab;
+    user-select: none;
+}
+
+.dd-item:active {
+    cursor: grabbing;
+}
+
+.dd-dragging {
+    opacity: 0.4;
+}
+
+.dd-drop-target {
+    outline: 2px dashed var(--rask-accent, #6610f2);
+    outline-offset: -2px;
+    background-color: var(--rask-accent-soft, #f1ebfd);
+}


### PR DESCRIPTION
## Summary

The `/drag-drop` showcase hosted **both** demos — the single-list **Sortable list** and the multi-column **Kanban board** — inside one 178-line `DragDropDemo` rendered through a single `CodeSample`, so the page showed one large code listing covering two unrelated use cases.

This splits the combined demo into two focused files, each rendered as its own `CodeSample` card under an `H2` header — matching the multi-demo layout already used by `/virtualize` and `/binding`.

- **New:** `DragDropSortableDemo.cs` + `DragDropSortableDemo.css`, `DragDropKanbanDemo.cs` + `DragDropKanbanDemo.css`
- **Removed:** the combined `DragDropDemo.cs` / `DragDropDemo.css`
- **Updated:** `DragDropPage.cs` — one `CodeSample` → two cards, each showing its own `.cs` + `.css`

The route (`/drag-drop`), page header, sidebar/home entries, and all `data-testid`s are unchanged, so it's a pure presentational refactor of the sample. `CodeSample` auto-discovers the new files via the existing `Features/**/*.cs|.css` embed glob (no manifest edit); the shared `.dd-dragging` / `.dd-drop-target` rules are duplicated into both scoped stylesheets since scoped CSS is per-component.

## Testing

- `dotnet format --verify-no-changes` — clean
- `dotnet build Rask.slnx -warnaserror` — 0 warnings/errors (factories generated; unique-leaf-filename check passes)
- `dotnet test` fast unit gate — 2197 passed, 0 failed
- Server showcase E2E journey — passed; the `/drag-drop` drag assertions (fruit reorder + card-2 → done column) still hold. The change lives in `Rask.Example.Shared`, which the WASM host consumes identically.

## Benchmarks

Not applicable — samples-only change, no render/runtime hot-path code touched.

## Changelog

Added under `[Unreleased] → Changed`.