### PR TITLE
fix(generators): only raise RASK002 when no parameterless constructor exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ them until tagged releases begin.
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
 
 ### Changed
+- **RASK002 no longer fires when a parameterless constructor is available.** The "`required`
+  property is incompatible with a DI constructor" warning now only triggers when the component's
+  *only* constructor takes dependency-injected parameters (no parameterless ctor). With a
+  parameterless ctor present, the generated factory uses the object-initializer path — which *does*
+  honour `required` — so the previous warning was a false positive in that case. The diagnostic
+  message and `docs/diagnostics.md` now spell out the parameterless-ctor escape hatch, and the
+  `Sparkline`/`LiveTicker` samples mark their non-nullable factory parameters `required` (dropping a
+  `CS8618` suppression each) to demonstrate it.
 - **The `/drag-drop` showcase now splits its two demos into separate `CodeSample` cards.** The
   sortable list and the Kanban board were extracted from a single 178-line `DragDropDemo` into
   `DragDropSortableDemo` and `DragDropKanbanDemo` (each with its own scoped CSS), so the page shows

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -56,13 +56,16 @@ to stay ergonomic. See [factory generation rules](getting-started.md).
 ## RASK002
 **`required` property is incompatible with a DI constructor** · Warning
 
-A property is marked `required`, but the component has dependency-injected constructor parameters.
-The factory builds the component with `ActivatorUtilities.CreateInstance`, which can't satisfy a
-`required` member, so the requirement can't be honoured.
+A property is marked `required`, but the component's only constructor takes dependency-injected
+parameters. With no parameterless constructor available, the factory builds the component with
+`ActivatorUtilities.CreateInstance`, which can't satisfy a `required` member, so the requirement
+can't be honoured. (Adding a parameterless constructor lets the factory use the object-initializer
+path, which does honour `required` — so this warning does not fire in that case.)
 
-**Fix:** remove `required`, **or** move the value to a constructor parameter, **or** drop the DI
-constructor. Framework services (`RouteState`, `Navigator`, `HttpClient`, `IJSRuntime`) should come
-through the constructor, never as settable properties.
+**Fix:** remove `required`, **or** move the value to a constructor parameter, **or** add a
+parameterless constructor, **or** drop the DI constructor. Framework services (`RouteState`,
+`Navigator`, `HttpClient`, `IJSRuntime`) should come through the constructor, never as settable
+properties.
 
 ## RASK003
 **Malformed route template** · Error

--- a/samples/Rask.Example.Shared/Features/Components/ComponentsDiDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Components/ComponentsDiDemo.cs
@@ -6,7 +6,8 @@ namespace Rask.Example.Shared.Features;
 // Inject services like HttpClient/Navigator/RouteState through the primary
 // constructor — never as a public settable property. A non-nullable settable
 // property would become a *required* factory parameter the caller has to pass,
-// and required-on-a-property + a DI constructor is the RASK002 warning.
+// and the `required` keyword on a property + a DI-only constructor (no
+// parameterless ctor) is the RASK002 warning.
 public sealed class WeatherCard(HttpClient http) : Component
 {
     private Forecast? _forecast;
@@ -16,8 +17,9 @@ public sealed class WeatherCard(HttpClient http) : Component
     // from DI via ActivatorUtilities, invisible to the caller. City is a
     // non-nullable, no-initializer property, so the generator emits it as a
     // *required* factory parameter (RASK001) — note there's no `required`
-    // keyword: that keyword plus a DI constructor would be RASK002, since
-    // ActivatorUtilities can't satisfy `required` members. Rask assigns City
+    // keyword: that keyword plus a DI-only constructor (no parameterless ctor)
+    // would be RASK002, since ActivatorUtilities can't satisfy `required`
+    // members. Rask assigns City
     // after construction, which the CS8618 suppression acknowledges.
 #pragma warning disable CS8618
     public string City { get; set; }

--- a/samples/Rask.Example.Shared/Features/Components/ComponentsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Components/ComponentsPage.cs
@@ -46,9 +46,10 @@ public sealed class ComponentsPage : Component
                 Div()[
                     Strong()["Warning."],
                     " ", Code()["required"],
-                    " on a property combined with DI-injected constructor parameters: ",
+                    " on a property when the component's only constructor takes DI-injected parameters (no parameterless ctor): ",
                     Code()["ActivatorUtilities"],
-                    " cannot satisfy ", Code()["required"], " members. Drop one or the other."
+                    " cannot satisfy ", Code()["required"], " members. Add a parameterless ctor, or drop ",
+                    Code()["required"], " or the DI parameters."
                 ]
             ]
         ]

--- a/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
+++ b/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
@@ -59,11 +59,10 @@ public sealed class LiveTicker : Component
     private CancellationTokenSource? _wake;
 
     // Required factory parameter — properties with an initializer are excluded
-    // by the generator, but we want callers to pass Symbol explicitly. Same
-    // pattern as CodeSample.Source (CodeSample.cs:17).
-#pragma warning disable CS8618
-    public string Symbol { get; set; }
-#pragma warning restore CS8618
+    // by the generator, but we want callers to pass Symbol explicitly. LiveTicker
+    // has no DI constructor (unlike CodeSample), so we mark it `required` for
+    // language-level enforcement — no CS8618 suppression and no RASK002.
+    public required string Symbol { get; set; }
 
     // Nullable so the generator emits Interval as an optional factory parameter
     // (default null). Callers — production pages and unit tests alike — pass an

--- a/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
+++ b/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
@@ -127,7 +127,7 @@ public sealed class TodoFormDialog : Component
     // Focus interop injected via the ctor (the DI seam) so Model/OnCancel/OnSave stay plain factory
     // parameters. They are non-nullable + no initializer + no `required` keyword: the generator emits
     // them as required positional parameters, and Rask's post-render assignment satisfies them — so
-    // CS8618 here is intentional. `required` would clash with the DI ctor (RASK002). Mirrors CodeSample.
+    // CS8618 here is intentional. `required` would clash with the DI-only ctor (no parameterless ctor → RASK002). Mirrors CodeSample.
 #pragma warning disable CS8618
     private readonly IJSRuntime _js;
 

--- a/samples/Rask.Example.Shared/Shared/CodeSample.cs
+++ b/samples/Rask.Example.Shared/Shared/CodeSample.cs
@@ -15,7 +15,8 @@ public sealed class CodeSample : Component
 
     // Clipboard interop is injected via the ctor (the framework's DI seam) so Source stays
     // a plain factory parameter — a settable non-nullable service prop would become a
-    // required param and clash with DI (RASK002). Mirrors ElementRefDemo's IJSRuntime ctor.
+    // required param and clash with the DI-only ctor (no parameterless ctor → RASK002).
+    // Mirrors ElementRefDemo's IJSRuntime ctor.
     private readonly IJSRuntime _js;
 
     // A stable ref to the copy button so its scoped JS can flash "Copied!" on the element.

--- a/samples/Rask.Example.Shared/Shared/Sparkline.cs
+++ b/samples/Rask.Example.Shared/Shared/Sparkline.cs
@@ -24,10 +24,10 @@ public sealed class Sparkline : Component
     private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
 
     // The data series, in chronological order. Non-nullable reference + no initializer ⇒ the
-    // generator emits this as the first required positional factory parameter.
-#pragma warning disable CS8618
-    public IReadOnlyList<double> Values { get; set; }
-#pragma warning restore CS8618
+    // generator emits this as the first required positional factory parameter. Sparkline has no
+    // DI constructor, so we also mark it `required` for language-level enforcement (RASK001's
+    // suggestion) — no CS8618 suppression needed, and no RASK002 since there's a parameterless ctor.
+    public required IReadOnlyList<double> Values { get; set; }
 
     // Optional overrides; the defaults live at the read sites below so they stay out of the
     // generated factory (an initializer would exclude the property entirely).

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -34,7 +34,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask002 = new(
         "RASK002",
         "'required' property is incompatible with DI constructor",
-        "Property '{0}.{1}' is marked 'required', but '{0}' has dependency-injected constructor parameters; the generated factory cannot honor 'required' through ActivatorUtilities.CreateInstance. Remove 'required' or remove DI parameters.",
+        "Property '{0}.{1}' is marked 'required', but '{0}'s only constructor takes dependency-injected parameters; with no parameterless constructor the generated factory cannot honor 'required' through ActivatorUtilities.CreateInstance. Remove 'required', add a parameterless constructor, or remove the DI parameters.",
         "Rask.Generators",
         DiagnosticSeverity.Warning,
         true,
@@ -666,7 +666,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             foreach (var p in c.Properties)
             {
                 var location = MakeLocation(p);
-                if (p.UserMarkedRequired && c.HasDIConstructor)
+                if (p.UserMarkedRequired && c.HasDIConstructor && !c.HasParameterlessCtor)
                 {
                     spc.ReportDiagnostic(Diagnostic.Create(Rask002, location, c.FullyQualifiedName, p.Name));
                 }

--- a/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
@@ -315,6 +315,28 @@ public class ComponentFactoryGeneratorTests
     }
 
     [Fact]
+    public void UserMarkedRequiredWithDIAndParameterlessCtor_NoRask002()
+    {
+        // A parameterless ctor lets the factory use the object-initializer path, which
+        // honors `required` — so RASK002 must not fire even though a DI ctor also exists.
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public interface IClock { }
+                  public sealed class Widget : Component
+                  {
+                      public Widget() { }
+                      public Widget(IClock clock) { }
+                      public required string Name { get; set; }
+                      public override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.Run(src);
+        Assert.DoesNotContain(run.Diagnostics, d => d.Id == "RASK002");
+    }
+
+    [Fact]
     public void NonNullableNoDefault_RaisesRask001()
     {
         var src = """


### PR DESCRIPTION
## Summary
RASK002 ("`required` property is incompatible with a DI constructor") was firing on any component with a DI constructor, even when a parameterless constructor was also present. In that case the generated factory uses the object-initializer path, which *does* honour `required` — so the warning was a false positive. The diagnostic now fires only when the component's **only** constructor takes DI parameters (`HasDIConstructor && !HasParameterlessCtor`). Message + `docs/diagnostics.md` updated to spell out the parameterless-ctor escape hatch, and the `Sparkline`/`LiveTicker` samples now mark their non-nullable factory params `required` (dropping a `CS8618` suppression each) to demonstrate the supported pattern.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — all green (Generators 154 incl. new `UserMarkedRequiredWithDIAndParameterlessCtor_NoRask002`; Core 1536; Shared 254; Server 170; …).
- Build: `dotnet build Rask.slnx -warnaserror` — 0 warnings, 0 errors.
- E2E: not run locally — the sample edits are compile-time-only (added the `required` keyword + comment wording; generated factory call sites and runtime/render behaviour are unchanged). CI runs the sharded E2E matrix.

## Benchmarks
n/a — no render/runtime hot-path code touched (generator-side diagnostic condition only).

## CHANGELOG
- [Unreleased] entry added: RASK002 no longer fires when a parameterless constructor is available.
