### PR TITLE
fix(generators): keep RASK002 firing when the factory cannot satisfy a required property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,17 @@ them until tagged releases begin.
   excluded.
 
 ### Fixed
+- **RASK002 now catches the two cases where a parameterless ctor does *not* rescue a `required`
+  property.** The previous narrowing (only warn when no parameterless ctor exists) had two gaps.
+  First, a `required` property that *also* carries a member initializer is excluded from the factory
+  parameters, so the object-initializer path never assigns it — the consumer build failed with a
+  cryptic `CS9035` inside generated code and no diagnostic; RASK002 now fires for this combination.
+  Second, the diagnostic message, `docs/diagnostics.md`, and the `/components` showcase all
+  recommended "add a parameterless constructor" as a fix — but doing so while keeping the DI
+  constructor makes the factory build the component with `new C()` and silently skip the DI ctor,
+  leaving injected services `null` at render time (a runtime `NullReferenceException` in place of the
+  former compile-time nudge). The guidance now warns against that trap and points to dropping the DI
+  constructor or moving the value to a constructor parameter instead.
 - **WASM now runs `IJSRuntime` calls issued *during* a render after the DOM is patched, matching
   Server.** Interop from a lifecycle hook — e.g. `OnRenderedAsync` focusing a dialog as it opens —
   used to dispatch immediately on WASM, *before* that render's DOM patch, so a `focus()` could hit a

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -10,7 +10,7 @@ build once.
 | ID | Severity | Summary |
 |----|----------|---------|
 | [RASK001](#rask001) | Hidden | Property is treated as a required factory parameter |
-| [RASK002](#rask002) | Warning | `required` property is incompatible with a DI constructor |
+| [RASK002](#rask002) | Warning | `required` property cannot be honored by the generated factory |
 | [RASK003](#rask003) | Error | Malformed route template |
 | [RASK004](#rask004) | Error | Route segment has no matching property |
 | [RASK005](#rask005) | Error | Property type does not match the route constraint |
@@ -54,18 +54,25 @@ public sealed class Badge : Component
 to stay ergonomic. See [factory generation rules](getting-started.md).
 
 ## RASK002
-**`required` property is incompatible with a DI constructor** · Warning
+**`required` property cannot be honored by the generated factory** · Warning
 
-A property is marked `required`, but the component's only constructor takes dependency-injected
-parameters. With no parameterless constructor available, the factory builds the component with
-`ActivatorUtilities.CreateInstance`, which can't satisfy a `required` member, so the requirement
-can't be honoured. (Adding a parameterless constructor lets the factory use the object-initializer
-path, which does honour `required` — so this warning does not fire in that case.)
+A property is marked `required`, but the generated factory can't set it. This fires when the
+component has a dependency-injected constructor **and** either:
 
-**Fix:** remove `required`, **or** move the value to a constructor parameter, **or** add a
-parameterless constructor, **or** drop the DI constructor. Framework services (`RouteState`,
-`Navigator`, `HttpClient`, `IJSRuntime`) should come through the constructor, never as settable
-properties.
+- it has no parameterless constructor — the factory builds the component with
+  `ActivatorUtilities.CreateInstance`, which can't satisfy a `required` member; or
+- the `required` property carries a member initializer — that excludes it from the factory
+  parameters, so the generated object initializer never assigns it (the consumer build then fails
+  with `CS9035`).
+
+> **Adding a parameterless constructor is _not_ a safe fix while you keep the DI constructor.** The
+> factory prefers the parameterless ctor, so it builds the component with `new C()` and the DI
+> constructor never runs — your injected services stay `null` at render time. Only add a
+> parameterless constructor if you also remove the DI constructor.
+
+**Fix:** remove `required`, **or** move the value to a constructor parameter (with no member
+initializer on it), **or** drop the DI constructor. Framework services (`RouteState`, `Navigator`,
+`HttpClient`, `IJSRuntime`) should come through the constructor, never as settable properties.
 
 ## RASK003
 **Malformed route template** · Error

--- a/samples/Rask.Example.Shared/Features/Components/ComponentsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Components/ComponentsPage.cs
@@ -46,10 +46,10 @@ public sealed class ComponentsPage : Component
                 Div()[
                     Strong()["Warning."],
                     " ", Code()["required"],
-                    " on a property when the component's only constructor takes DI-injected parameters (no parameterless ctor): ",
+                    " on a property the generated factory can't set — when the component has a DI constructor and the property either has no parameterless ctor (",
                     Code()["ActivatorUtilities"],
-                    " cannot satisfy ", Code()["required"], " members. Add a parameterless ctor, or drop ",
-                    Code()["required"], " or the DI parameters."
+                    " can't satisfy ", Code()["required"], " members) or carries a member initializer (excluded from factory params). Drop ",
+                    Code()["required"], " or the DI ctor — note that adding a parameterless ctor makes the factory skip the DI ctor, leaving injected services null."
                 ]
             ]
         ]

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -33,8 +33,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
     private static readonly DiagnosticDescriptor Rask002 = new(
         "RASK002",
-        "'required' property is incompatible with DI constructor",
-        "Property '{0}.{1}' is marked 'required', but '{0}'s only constructor takes dependency-injected parameters; with no parameterless constructor the generated factory cannot honor 'required' through ActivatorUtilities.CreateInstance. Remove 'required', add a parameterless constructor, or remove the DI parameters.",
+        "'required' property cannot be honored by the generated factory",
+        "Property '{0}.{1}' is marked 'required', but the generated factory for '{0}' cannot set it: '{0}' has a dependency-injected constructor and the property is either excluded from the factory parameters (it has a member initializer) or only reachable via ActivatorUtilities.CreateInstance (no parameterless constructor). Adding a parameterless constructor does not help while the DI constructor remains — the factory then builds '{0}' with 'new {0}()' and the DI constructor never runs, leaving injected services null. Remove 'required', move the value to a constructor parameter (with no initializer), or drop the DI constructor.",
         "Rask.Generators",
         DiagnosticSeverity.Warning,
         true,
@@ -666,7 +666,11 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             foreach (var p in c.Properties)
             {
                 var location = MakeLocation(p);
-                if (p.UserMarkedRequired && c.HasDIConstructor && !c.HasParameterlessCtor)
+                // A parameterless ctor only rescues `required` props that are actually factory
+                // params. A `required` property carrying a member initializer is excluded from the
+                // factory params (IsParamProperty), so the generated object initializer never
+                // assigns it and the consumer build fails with CS9035 — keep warning in that case.
+                if (p.UserMarkedRequired && c.HasDIConstructor && (!c.HasParameterlessCtor || p.HasInitializer))
                 {
                     spc.ReportDiagnostic(Diagnostic.Create(Rask002, location, c.FullyQualifiedName, p.Name));
                 }

--- a/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
@@ -337,6 +337,29 @@ public class ComponentFactoryGeneratorTests
     }
 
     [Fact]
+    public void UserMarkedRequiredWithInitializerAndParameterlessCtor_RaisesRask002()
+    {
+        // A `required` property carrying a member initializer is excluded from the factory
+        // parameters, so the object-init path never assigns it — a parameterless ctor does not
+        // rescue it and the consumer build would fail with CS9035. RASK002 must still fire.
+        var src = """
+                  using Rask.Core;
+                  namespace Demo;
+                  public interface IClock { }
+                  public sealed class Widget : Component
+                  {
+                      public Widget() { }
+                      public Widget(IClock clock) { }
+                      public required string Name { get; set; } = "x";
+                      public override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.Run(src);
+        Assert.Contains(run.Diagnostics, d => d.Id == "RASK002");
+    }
+
+    [Fact]
     public void NonNullableNoDefault_RaisesRask001()
     {
         var src = """


### PR DESCRIPTION
## Summary
Fixes two regressions from the RASK002 narrowing in #104, surfaced by a code review:

1. **Compile-time break (no diagnostic).** A `required` property carrying a member initializer is excluded from the factory parameters, so the object-initializer path never assigns it and the consumer build fails with a cryptic `CS9035` inside generated code. RASK002 now also fires when a `required` property has an initializer, even if a parameterless ctor exists.
2. **Silent runtime NRE from misleading guidance.** The diagnostic message, `docs/diagnostics.md`, and the `/components` showcase all recommended *"add a parameterless constructor"* as a fix — but doing so while keeping the DI constructor makes the factory build via `new C()` and skip the DI ctor entirely, leaving injected services `null` at render time. The guidance now warns against that trap and points to dropping the DI constructor (or moving the value to a ctor parameter) instead.

No new analyzer was added for the "component has both ctors" case: `HasDIConstructor` treats any parameterized public ctor as DI (e.g. `Text`/`Raw`'s string-arg ctor), so it would mis-fire on legitimate components — wording fixes are the correct remedy.

## Testing
- Unit: `dotnet test tests/Rask.Generators.Tests` — **155/155 pass**, incl. new `UserMarkedRequiredWithInitializerAndParameterlessCtor_RaisesRask002`.
- `dotnet build -warnaserror` clean for `Rask.Generators` and `Rask.Example.Shared` (0 warnings).
- `dotnet format --verify-no-changes` clean.
- E2E (samples changed): the `/components` edit is showcase **prose only** (RASK002 explanation text), no behavioural change, so no E2E run was needed.

## Benchmarks
n/a — analyzer/diagnostic + docs only; no render/runtime hot-path code touched.

## CHANGELOG
- [Unreleased] → Fixed entry added: "RASK002 now catches the two cases where a parameterless ctor does *not* rescue a `required` property."