### PR TITLE
build(deps): suppress unactionable SQLitePCLRaw audit advisory GHSA-2m69-gcr7-jv3q

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,15 @@ them until tagged releases begin.
   call sites from `Virtualize<T>(…)` to `VirtualizeModel<T>(…)`; behaviour is unchanged. The
   `Rask.Core.Virtualization` support types keep their names.
 
+### Security
+- **Suppressed the unactionable `SQLitePCLRaw.lib.e_sqlite3` audit advisory (`GHSA-2m69-gcr7-jv3q`).**
+  The native SQLite package arrives transitively through the latest `Microsoft.EntityFrameworkCore.Sqlite`
+  (used only by the `Rask.Example.EfCore` sample); the whole SQLitePCLRaw family tops out at `2.1.11`
+  and the advisory reports no patched version, so the solution-wide NuGet audit (run as
+  warnings-as-errors) failed `restore` for every job. A scoped `NuGetAuditSuppress` for this single
+  advisory unblocks the build while leaving audit active for everything else; it is annotated to be
+  removed once a patched SQLitePCLRaw family ships.
+
 ## [0.9.0] - 2026-06-16
 
 ### Added

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,6 +41,18 @@
     level in a focused PR that fixes/justifies each finding with benchmark evidence — not here.
   -->
 
+  <!--
+    NuGet audit runs as part of the warnings-as-errors gate (NU1903 = known vulnerability). This one
+    advisory is unactionable: SQLitePCLRaw.lib.e_sqlite3 arrives transitively via the latest
+    Microsoft.EntityFrameworkCore.Sqlite (used only by the Rask.Example.EfCore *sample*), the whole
+    SQLitePCLRaw family tops out at 2.1.11, and the advisory reports no patched version
+    (patched: null). Suppress just this advisory — audit stays on for everything else — and remove
+    this entry once a patched SQLitePCLRaw family ships. https://github.com/advisories/GHSA-2m69-gcr7-jv3q
+  -->
+  <ItemGroup>
+    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(IsPackable)' != 'false' ">
     <None Include="$(MSBuildThisFileDirectory)NUGET.md" Pack="true" PackagePath="" Visible="false"/>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="" Visible="false"/>


### PR DESCRIPTION
## Summary
Solution-wide CI `restore` is failing on every PR with `NU1903` (NuGet audit runs as warnings-as-errors):

```
error NU1903: Package 'SQLitePCLRaw.lib.e_sqlite3' 2.1.11 has a known high severity
vulnerability (GHSA-2m69-gcr7-jv3q)
```

The package arrives **transitively** through the latest `Microsoft.EntityFrameworkCore.Sqlite 10.0.9` (already the newest), used only by the **`Rask.Example.EfCore` sample**. The advisory covers `SQLitePCLRaw.lib.e_sqlite3 <= 2.1.11` and reports **`patched: null`** — the whole SQLitePCLRaw family tops out at `2.1.11`, so there is no upgrade path right now.

This adds a **scoped `NuGetAuditSuppress`** for this single advisory in `Directory.Build.props`, annotated to be removed once a patched SQLitePCLRaw family ships. NuGet audit stays active for every other package/advisory.

## Testing
- `dotnet restore Rask.slnx` — clean (was failing `NU1903`).
- `dotnet build samples/Rask.Example.EfCore -warnaserror` — 0 warnings, 0 errors.
- `dotnet test tests/Rask.Example.EfCore.Tests` — **18/18 pass**.

## Benchmarks
n/a — build/dependency-audit config only; no code touched.

## CHANGELOG
- [Unreleased] → Security entry added: scoped suppression of `GHSA-2m69-gcr7-jv3q` with a TODO to remove when a patched SQLitePCLRaw ships.