### PR TITLE
fix(live): harden session stability against malformed frames and double teardown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,23 @@ them until tagged releases begin.
   excluded.
 
 ### Fixed
+- **A single malformed WebSocket frame no longer tears down the live session.** The Server receive
+  loop parsed each inbound frame with an unguarded `JsonDocument.Parse`, and a valid-JSON-but-non-object
+  root (a bare array/number/string) reached `TryGetProperty`, which throws on non-objects — either way
+  the exception escaped the loop's `OperationCanceledException` / `WebSocketException` catches, detached
+  the socket and scheduled the session for removal. One buggy or adversarial frame could drop a whole
+  session. Such frames are now dropped (logged once) and the loop keeps serving; the existing 8 MB
+  inbound-frame cap still bounds memory.
+- **Component teardown is now strictly one-shot.** A tree mutation inside an `OnUnmount` hook (clearing
+  persisted children, re-parenting) could route a node through a second dispose pass, firing `OnUnmount`
+  and the user's `Dispose()` twice. `DisposeComponentTree`/`DisposeComponentTreeAsync` now guard on a
+  per-component flag so the unmount → cancel → dispose sequence runs exactly once. (The lifetime
+  `CancellationTokenSource` was already idempotent.)
+- **The deferred-session-removal task can no longer surface an unobserved `ObjectDisposedException`.**
+  A reconnect or a reschedule that disposed the pending-removal `CancellationTokenSource` while the
+  delayed task was about to read `cts.Token` produced an exception the `OperationCanceledException`
+  catch missed. The token is now captured before the task starts and `ObjectDisposedException` is
+  handled, so an obsolete removal exits cleanly without orphaning the session.
 - **WASM now runs `IJSRuntime` calls issued *during* a render after the DOM is patched, matching
   Server.** Interop from a lifecycle hook — e.g. `OnRenderedAsync` focusing a dialog as it opens —
   used to dispatch immediately on WASM, *before* that render's DOM patch, so a `focus()` could hit a

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -521,6 +521,24 @@ public abstract class Component
         }, this, TaskContinuationOptions.ExecuteSynchronously);
     }
 
+    // One-shot guard for the unmount → cancel → dispose teardown. A tree mutation inside an
+    // OnUnmount hook (e.g. clearing PersistedChildren, or re-parenting) can leave a node
+    // reachable from more than one dispose pass; without this guard that node would fire
+    // OnUnmount and the user's Dispose twice. Returns true exactly once. The lifetime CTS is
+    // already idempotent (DisposeLifetimeToken nulls it via Interlocked, Cancel swallows ODE);
+    // this protects the user-visible lifecycle hooks. Disposal runs under the session render
+    // lock, so a plain flag is sufficient — same threading contract as IsUnmounted.
+    internal bool TryBeginDispose()
+    {
+        if (Live.IsDisposed)
+        {
+            return false;
+        }
+
+        Live.IsDisposed = true;
+        return true;
+    }
+
     internal void CancelLifetimeToken()
     {
         var cts = Volatile.Read(ref _lifetimeCts);
@@ -1360,6 +1378,7 @@ public abstract class Component
         public Dictionary<string, (Component Owner, Delegate Handler)>? Handlers;
         public bool HasInitialized;
         public bool HasRenderedOnce;
+        public bool IsDisposed;
         public bool IsUnmounted;
         public int NextHandlerId;
         public Dictionary<Component, Component>? ParentMap;

--- a/src/Rask.Core/Live/ComponentLifecycle.cs
+++ b/src/Rask.Core/Live/ComponentLifecycle.cs
@@ -4,6 +4,13 @@ internal static class ComponentLifecycle
 {
     internal static void DisposeComponentTree(Component component)
     {
+        // Run the teardown at most once per component — a tree mutation inside an OnUnmount
+        // hook could otherwise route the same node through a second dispose pass.
+        if (!component.TryBeginDispose())
+        {
+            return;
+        }
+
         foreach (var child in component.PersistedChildren.Values)
         {
             DisposeComponentTree(child);
@@ -39,6 +46,13 @@ internal static class ComponentLifecycle
 
     internal static async Task DisposeComponentTreeAsync(Component component)
     {
+        // Run the teardown at most once per component — a tree mutation inside an OnUnmount
+        // hook could otherwise route the same node through a second dispose pass.
+        if (!component.TryBeginDispose())
+        {
+            return;
+        }
+
         foreach (var child in component.PersistedChildren.Values)
         {
             await DisposeComponentTreeAsync(child).ConfigureAwait(false);

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -214,14 +214,26 @@ public sealed class LiveSessionStore : IAsyncDisposable
             }
         }
 
+        // Capture the token here, on the calling thread, while this CTS is freshly created and
+        // provably not disposed. Reading cts.Token *inside* the task instead would race a
+        // concurrent CancelPendingRemoval / retire that disposes this CTS first — the getter
+        // then throws ObjectDisposedException, which the OperationCanceledException catch below
+        // would miss, surfacing as an unobserved task exception.
+        var token = cts.Token;
         _ = Task.Run(async () =>
         {
             try
             {
-                await Task.Delay(delay, cts.Token).ConfigureAwait(false);
+                await Task.Delay(delay, token).ConfigureAwait(false);
             }
             catch (OperationCanceledException)
             {
+                return;
+            }
+            catch (ObjectDisposedException)
+            {
+                // The CTS was retired (a newer ScheduleRemoval) or cancelled and disposed
+                // concurrently. Either way this removal is obsolete — the owning thread handles it.
                 return;
             }
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -513,6 +513,21 @@ public static class RaskEndpointExtensions
         }
     }
 
+    // Parse an inbound WS frame, returning null on malformed JSON instead of throwing.
+    // Keeps the receive loop alive across a single bad frame (see call site).
+    private static JsonDocument? SafeParse(ReadOnlyMemory<byte> payload)
+    {
+        try
+        {
+            return JsonDocument.Parse(payload);
+        }
+        catch (JsonException ex)
+        {
+            Console.Error.WriteLine($"Rask Live: dropped malformed WS frame ({ex.Message})");
+            return null;
+        }
+    }
+
     private static async Task RunSocketLoop(WebSocket ws, LiveSessionStore store, ClaimsPrincipal wsUser,
         CancellationToken ct, CancellationToken stopping)
     {
@@ -584,8 +599,26 @@ public static class RaskEndpointExtensions
                     continue;
                 }
 
-                using var doc = JsonDocument.Parse(payload);
+                // A malformed frame must not tear down the session. The receive loop's only
+                // catches are OperationCanceledException / WebSocketException, so an unguarded
+                // JsonException here would propagate to the finally and detach the socket —
+                // letting one bad (buggy or adversarial) frame drop the whole live session.
+                // Skip it and keep serving; the size cap above still bounds memory.
+                using var doc = SafeParse(payload);
+                if (doc is null)
+                {
+                    continue;
+                }
+
                 var root = doc.RootElement;
+
+                // A valid-JSON but non-object root (a bare array / number / string) would make the
+                // TryGetProperty calls below throw InvalidOperationException — another way one bad
+                // frame could tear the session down. Skip it like a malformed frame.
+                if (root.ValueKind != JsonValueKind.Object)
+                {
+                    continue;
+                }
                 var type = root.TryGetProperty("type", out var t) && t.ValueKind == JsonValueKind.String
                     ? t.GetString()
                     : null;

--- a/tests/Rask.Core.Tests/Lifecycle/UnmountTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/UnmountTests.cs
@@ -34,6 +34,59 @@ public class UnmountTests
     }
 
     [Fact]
+    public void DisposeComponentTree_CalledTwice_TearsDownOnlyOnce()
+    {
+        // A tree mutation inside an OnUnmount hook could route the same node through a second
+        // dispose pass. The one-shot guard (Component.TryBeginDispose) must keep OnUnmount and
+        // the user's Dispose firing exactly once even when DisposeComponentTree is re-entered.
+        var disposeCount = 0;
+        var c = new CountingDisposable(() => disposeCount++);
+        c.RaiseLifecycleBeforeRender(true);
+
+        ComponentLifecycle.DisposeComponentTree(c);
+        ComponentLifecycle.DisposeComponentTree(c);
+
+        Assert.Equal(1, c.UnmountCount);
+        Assert.Equal(1, disposeCount);
+    }
+
+    [Fact]
+    public async Task DisposeComponentTreeAsync_CalledTwice_TearsDownOnlyOnce()
+    {
+        var disposeCount = 0;
+        var c = new CountingDisposable(() => disposeCount++);
+        c.RaiseLifecycleBeforeRender(true);
+
+        await ComponentLifecycle.DisposeComponentTreeAsync(c);
+        await ComponentLifecycle.DisposeComponentTreeAsync(c);
+
+        Assert.Equal(1, c.UnmountCount);
+        Assert.Equal(1, disposeCount);
+    }
+
+    [Fact]
+    public void DisposeComponentTree_ChildClearedDuringParentUnmount_NotDisposedTwice()
+    {
+        // The parent's OnUnmount mutates its own persisted children (a realistic teardown
+        // pattern). The child was already disposed bottom-up before the parent's hook ran, so
+        // re-touching it must not re-run its OnUnmount / Dispose — the guard absorbs it.
+        var sp = RenderHarness.EmptyServices();
+        var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
+        var childDisposeCount = 0;
+        var child = new CountingDisposable(() => childDisposeCount++);
+        var host = new ClearChildrenOnUnmountHost(child);
+        var session = new LiveSession("test", host, scope);
+
+        host.IncludeChild = true;
+        session.View.RenderAsLiveRoot(scope.ServiceProvider);
+
+        session.Dispose();
+
+        Assert.Equal(1, child.UnmountCount);
+        Assert.Equal(1, childDisposeCount);
+    }
+
+    [Fact]
     public void OnUnmount_DoesNotFire_IfNeverMounted()
     {
         // A component created but never reaching RaiseLifecycleBeforeRender must not receive
@@ -243,6 +296,40 @@ public class UnmountTests
         ComponentLifecycle.DisposeComponentTree(c);
 
         Assert.Equal(new[] { "unmount", "cancel-callback" }, order);
+    }
+
+    private sealed class CountingDisposable : Component, IDisposable
+    {
+        private readonly Action _onDispose;
+        public int UnmountCount;
+        public CountingDisposable(Action onDispose) => _onDispose = onDispose;
+        public void Dispose() => _onDispose();
+        protected override void OnUnmount() => UnmountCount++;
+        protected override RenderResult Render() => Span();
+    }
+
+    // Re-disposes its already-disposed child from its own OnUnmount, mimicking a teardown that
+    // mutates the tree mid-unmount. The one-shot guard must absorb the second pass.
+    private sealed class ClearChildrenOnUnmountHost : Component
+    {
+        private readonly Component _child;
+        public bool IncludeChild;
+        public ClearChildrenOnUnmountHost(Component child) => _child = child;
+
+        protected override void OnUnmount() => ComponentLifecycle.DisposeComponentTree(_child);
+
+        protected override RenderResult Render()
+        {
+            if (!IncludeChild)
+            {
+                return Span();
+            }
+
+            var ctx = LiveRenderContext.Current!;
+            var c = ctx.GetOrCreate(_ => _child);
+            ctx.NotifyParameters(c, true);
+            return c;
+        }
     }
 
     private sealed class TokenObservingUnmount : Component

--- a/tests/Rask.Server.Tests/Live/LiveSessionStoreTests.cs
+++ b/tests/Rask.Server.Tests/Live/LiveSessionStoreTests.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Components;
+
+namespace Rask.Server.Tests.Live;
+
+// Direct tests for the schedule/cancel removal lifecycle. The CTS that backs a pending removal
+// must never be cancelled or disposed while still reachable, and the delayed removal task must
+// not orphan a session nor surface an unobserved ObjectDisposedException when a concurrent
+// reconnect (Get) or retire races it.
+public class LiveSessionStoreTests
+{
+    [Fact]
+    public async Task ScheduleRemoval_ThenGet_CancelsRemoval_SessionSurvives()
+    {
+        var store = NewStore();
+        var session = store.Create(_ => new BasicComponent());
+
+        store.ScheduleRemoval(session.Id, TimeSpan.FromMilliseconds(100));
+        // Reconnect within the grace window: Get must cancel the pending removal.
+        Assert.NotNull(store.Get(session.Id));
+
+        await Task.Delay(250);
+
+        Assert.Equal(1, store.Count);
+        Assert.NotNull(store.Get(session.Id));
+    }
+
+    [Fact]
+    public async Task ScheduleRemoval_NoReconnect_RemovesAfterDelay()
+    {
+        var store = NewStore();
+        var session = store.Create(_ => new BasicComponent());
+
+        store.ScheduleRemoval(session.Id, TimeSpan.FromMilliseconds(50));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (store.Count > 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public async Task ScheduleRemoval_RescheduledRepeatedly_DoesNotThrowOrOrphan()
+    {
+        // Each reschedule retires the prior CTS (cancel + dispose). Hammering it must not raise
+        // an ObjectDisposedException out of the delayed task nor leave the session orphaned.
+        var store = NewStore();
+        var session = store.Create(_ => new BasicComponent());
+
+        for (var i = 0; i < 50; i++)
+        {
+            store.ScheduleRemoval(session.Id, TimeSpan.FromMilliseconds(30));
+        }
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (store.Count > 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(20);
+        }
+
+        Assert.Equal(0, store.Count);
+    }
+
+    [Fact]
+    public async Task ConcurrentScheduleAndGet_StaysConsistent_NoCrash()
+    {
+        // Race a tight schedule/cancel loop against concurrent reconnects on many sessions. The
+        // store must never throw and _liveCount must stay in lockstep with the dictionary.
+        var store = NewStore();
+        var ids = Enumerable.Range(0, 40)
+            .Select(_ => store.Create(_ => new BasicComponent()).Id)
+            .ToArray();
+
+        var tasks = new List<Task>();
+        foreach (var id in ids)
+        {
+            tasks.Add(Task.Run(() =>
+            {
+                for (var i = 0; i < 20; i++)
+                {
+                    store.ScheduleRemoval(id, TimeSpan.FromMilliseconds(5));
+                    _ = store.Get(id); // reconnect cancels the pending removal
+                }
+            }));
+        }
+
+        await Task.WhenAll(tasks);
+
+        // Every session that was reconnected last should still be present; the count must match
+        // the number actually retained (no negative/leaked _liveCount, no orphan).
+        Assert.True(store.Count <= ids.Length);
+        await store.DisposeAsync();
+        Assert.Equal(0, store.Count);
+    }
+
+    private static LiveSessionStore NewStore()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        return new LiveSessionStore(sp.GetRequiredService<IServiceScopeFactory>());
+    }
+
+    private sealed class BasicComponent : Component
+    {
+        protected override RenderResult Render() => new Span();
+    }
+}

--- a/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
@@ -72,36 +72,36 @@ public class HandlerDispatchTests
     }
 
     [Fact]
-    public async Task MalformedJson_PayloadCausesSessionToBeRemoved()
+    public async Task MalformedJson_IsDropped_SessionSurvivesAndKeepsDispatching()
     {
-        var prev = RaskEndpointExtensions.SessionGracePeriod;
-        RaskEndpointExtensions.SessionGracePeriod = TimeSpan.FromMilliseconds(50);
-        try
-        {
-            using var host = RaskTestHost.Create<TestApp>();
-            var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+        // A single malformed frame must NOT tear down the live session. Previously the
+        // unguarded JsonDocument.Parse threw JsonException out of the receive loop, detaching
+        // the socket and scheduling the session for removal — one bad (buggy or adversarial)
+        // frame dropped the whole session. Now it is dropped and the loop keeps serving.
+        using var host = RaskTestHost.Create<TestApp>();
+        var initial = await host.Http.GetAsync("/start");
+        var initialHtml = await initial.Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(initialHtml);
+        var handlerId = Markup.FirstHandlerId(initialHtml);
 
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-            Assert.Equal(1, host.Store.Count);
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(1, host.Store.Count);
 
-            var bytes = Encoding.UTF8.GetBytes("{not-json");
-            await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+        var bytes = Encoding.UTF8.GetBytes("{not-json");
+        await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
 
-            // Socket loop tears down on JsonException; the session is then scheduled for removal.
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-            while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
-            {
-                await Task.Delay(20);
-            }
+        // No teardown: the socket stays open, the session is not removed, and a subsequent
+        // valid handler frame still dispatches and renders.
+        await ws.SendJsonAsync(new { id = handlerId });
+        var text = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
 
-            Assert.Equal(0, host.Store.Count);
-        }
-        finally
-        {
-            RaskEndpointExtensions.SessionGracePeriod = prev;
-        }
+        Assert.NotNull(text);
+        using var doc = JsonDocument.Parse(text!);
+        Assert.Contains("count=1", doc.RootElement.GetProperty("html").GetString()!);
+        Assert.Equal(WebSocketState.Open, ws.State);
+        Assert.Equal(1, host.Store.Count);
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/WebSockets/MalformedMessageTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/MalformedMessageTests.cs
@@ -1,0 +1,109 @@
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// A live session must survive any single bad inbound frame. The receive loop's only catches
+// are OperationCanceledException / WebSocketException, so before the guard an unguarded
+// JsonDocument.Parse (or a TryGetProperty against a non-object root) threw straight out of the
+// loop, detached the socket and scheduled the session for removal — one buggy or adversarial
+// frame dropped the whole session. These tests assert each bad frame is dropped and the loop
+// keeps dispatching.
+[Collection("SessionGracePeriod")]
+public class MalformedMessageTests
+{
+    // Assert against the full-HTML `html` field — force the legacy wire shape.
+    public MalformedMessageTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
+
+    public static TheoryData<string> BadFrames() =>
+    [
+        "{not-json",                        // not JSON at all
+        "{\"type\":",                       // truncated object
+        "[1,2,3]",                          // valid JSON, but an array root (TryGetProperty would throw)
+        "5",                                // valid JSON number root
+        "\"hello\"",                        // valid JSON string root
+        "true",                             // valid JSON bool root
+        "   ",                              // whitespace-only (parse throws)
+        "{\"type\":\"hello\",\"session\":"  // truncated mid-value
+    ];
+
+    [Theory]
+    [MemberData(nameof(BadFrames))]
+    public async Task BadFrame_IsDropped_SessionSurvivesAndKeepsDispatching(string badFrame)
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var initial = await host.Http.GetAsync("/start");
+        var initialHtml = await initial.Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(initialHtml);
+        var handlerId = Markup.FirstHandlerId(initialHtml);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.Equal(1, host.Store.Count);
+
+        await ws.SendAsync(Encoding.UTF8.GetBytes(badFrame), WebSocketMessageType.Text, true, CancellationToken.None);
+
+        // A valid handler frame after the bad one must still dispatch and render.
+        await ws.SendJsonAsync(new { id = handlerId });
+        var text = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(text);
+        using var doc = JsonDocument.Parse(text!);
+        Assert.Contains("count=1", doc.RootElement.GetProperty("html").GetString()!);
+        Assert.Equal(WebSocketState.Open, ws.State);
+        Assert.Equal(1, host.Store.Count);
+    }
+
+    [Theory]
+    [InlineData("type")] // type as a non-string is treated as absent
+    [InlineData("id")]   // handler id as a non-string is treated as absent
+    public async Task WrongFieldType_IsIgnored_NoTeardown(string field)
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        // Field present but the wrong JSON type (a number where a string is expected).
+        var json = $"{{\"{field}\":123}}";
+        await ws.SendAsync(Encoding.UTF8.GetBytes(json), WebSocketMessageType.Text, true, CancellationToken.None);
+
+        var text = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(400));
+        Assert.Null(text);
+        Assert.Equal(WebSocketState.Open, ws.State);
+        Assert.Equal(1, host.Store.Count);
+    }
+
+    [Fact]
+    public async Task ManyBadFramesInARow_DoNotDropTheSession()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var initial = await host.Http.GetAsync("/start");
+        var initialHtml = await initial.Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(initialHtml);
+        var handlerId = Markup.FirstHandlerId(initialHtml);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        for (var i = 0; i < 25; i++)
+        {
+            await ws.SendAsync(Encoding.UTF8.GetBytes("{garbage" + i), WebSocketMessageType.Text, true,
+                CancellationToken.None);
+        }
+
+        await ws.SendJsonAsync(new { id = handlerId });
+        var text = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(text);
+        Assert.Equal(WebSocketState.Open, ws.State);
+        Assert.Equal(1, host.Store.Count);
+    }
+}


### PR DESCRIPTION
## Summary

Phase 1 of the stability/security/performance hardening pass — **correctness-first**. A three-axis audit (stability, security, performance) found the framework's security to be genuinely solid, but surfaced a handful of real stability bugs in the live runtime. This PR fixes the confirmed ones and adds regression coverage. (Several other audit findings turned out to be already-correct code — see *Audit notes* — and were dropped rather than "fixed" into churn.)

### Fixes
1. **Malformed WS frame could drop a whole session.** The Server receive loop parsed each inbound frame with an unguarded `JsonDocument.Parse`, and a valid-JSON-but-non-object root (a bare array/number/string) reached `TryGetProperty`, which throws on non-objects. Either exception escaped the loop's only catches (`OperationCanceledException` / `WebSocketException`), detached the socket and scheduled the session for removal — so one buggy or adversarial frame killed the session. Now bad frames are dropped via `SafeParse` + a `ValueKind` guard (logged once) and the loop keeps serving. The 8 MB inbound-frame cap is unchanged.
2. **Component teardown is now strictly one-shot.** A tree mutation inside an `OnUnmount` hook (clearing persisted children, re-parenting) could route a node through a second dispose pass, firing `OnUnmount` and the user's `Dispose()` twice. `DisposeComponentTree`/`Async` now guard on a per-component flag. (The lifetime CTS was already idempotent.)
3. **Deferred session-removal no longer surfaces an unobserved `ObjectDisposedException`.** A reconnect/reschedule that disposed the pending-removal CTS while the delayed task was about to read `cts.Token` threw past the `OperationCanceledException` catch. The token is now captured before the task starts, and `ObjectDisposedException` is handled — an obsolete removal exits cleanly without orphaning the session.

## Testing
- New `MalformedMessageTests` (8 bad-frame shapes + wrong-field-types + flood) assert the socket survives and keeps dispatching.
- New `LiveSessionStoreTests` cover schedule/cancel/reconnect, reschedule storms, and concurrent schedule+get.
- New `UnmountTests` cases assert double-`DisposeComponentTree(Async)` and child-cleared-during-parent-unmount tear down exactly once.
- Updated the previously-misleading `MalformedJson_PayloadCausesSessionToBeRemoved` test (which asserted the old fragile behavior) to assert survival.
- Full fast suite green: Core 1539, Server 185. `dotnet format` clean, `dotnet build -warnaserror` clean (0 warnings).

## Benchmarks
Not a render-hotpath change, but the disposal path is exercised by the keyed-list round-trip bench. Before/after (stash baseline vs branch), `RenderKeyedList100_ShuffledEachIteration`: **137.05 KB → 137.05 KB allocated** — zero regression.

## Audit notes (verified already-correct, no change)
- Reconnect dedup-baseline reset already happens under `_renderLock` gated by `_forceResend` (`LiveSession`).
- JS-invokes queued after `Drain()` correctly stay pending for reconnect delivery rather than being failed on send error.

## Changelog
Added three entries under `[Unreleased] → Fixed`.