### PR TITLE
perf(core): cut render allocations for Data/Aria/TabIndex attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,19 @@ them until tagged releases begin.
   advisory unblocks the build while leaving audit active for everything else; it is annotated to be
   removed once a patched SQLitePCLRaw family ships.
 
+### Performance
+- **Lower render allocations for elements carrying `Data` / `Aria` / `TabIndex`.**
+  `Element.WriteAttributes` iterated the `Data` and `Aria` bags through the
+  `IReadOnlyDictionary<,>` interface, boxing an enumerator on every render of an attribute-bearing
+  element, and formatted `TabIndex` with `int.ToString()`, allocating a string per element. The bags
+  now take a `Dictionary<,>` struct-enumerator fast path (the common `new() { … }` literal), and
+  `TabIndex` formats straight into the pooled `StringBuilder` via a new integer `AppendAttr` overload
+  (zero allocation on the no-frame-sink path). Measured on the render benchmarks (M-class, ShortRun):
+  a 1,000-row data-rich tree dropped **661 KB → 552 KB** allocated (−16.5%), and a 1,000-row
+  a11y-rich tree (`Aria` + `Role` + `TabIndex`) **808 KB → 677 KB** (−16%); small/medium trees −25–30%.
+  No change to rendered output or the documented attribute order. New `AccessibilityAttributesBenchmarks`
+  locks in the a11y path.
+
 ## [0.9.0] - 2026-06-16
 
 ### Added

--- a/benchmarks/Rask.Benchmarks/AccessibilityAttributesBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/AccessibilityAttributesBenchmarks.cs
@@ -1,0 +1,53 @@
+using BenchmarkDotNet.Attributes;
+using Rask.Core;
+using C = Rask.Core.Components.Generated;
+
+namespace Rask.Benchmarks;
+
+// Renders trees where every leaf carries Aria (a dictionary bag), Role, and TabIndex. Isolates
+// the a11y attribute path in Element.WriteAttributes: foreach over the IReadOnlyDictionary
+// interface boxed an enumerator per Aria-bearing element, and TabIndex.ToString() allocated a
+// string per element, on every render. The Dictionary struct-enumerator fast path and the
+// integer AppendAttr overload remove both.
+[MemoryDiagnoser]
+public class AccessibilityAttributesBenchmarks
+{
+    private Component _large = null!;
+    private Component _medium = null!;
+    private Component _small = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _small = BuildTree(10);
+        _medium = BuildTree(100);
+        _large = BuildTree(1000);
+    }
+
+    [Benchmark]
+    public string RenderSmall() => _small.ToHtml();
+
+    [Benchmark]
+    public string RenderMedium() => _medium.ToHtml();
+
+    [Benchmark]
+    public string RenderLarge() => _large.ToHtml();
+
+    private static Component BuildTree(int rowCount)
+    {
+        var rows = new List<Child>(rowCount);
+        for (var i = 0; i < rowCount; i++)
+        {
+            var aria = new Dictionary<string, string?>
+            {
+                ["label"] = $"row {i}",
+                ["selected"] = "false"
+            };
+            rows.Add(C.Div(Class: "row", Role: "row", TabIndex: i, Aria: aria, Key: $"k{i}")[
+                C.Span(Role: "gridcell", Aria: new Dictionary<string, string?> { ["hidden"] = "false" })[$"Item {i}"]
+            ]);
+        }
+
+        return C.Div(Class: "container", Role: "grid", TabIndex: 0)[rows];
+    }
+}

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Rask.Core.Components;
@@ -362,6 +363,25 @@ public abstract class Component
             // Only allocate the concatenated name when a frame writer is active. The
             // common no-frames path stays zero-allocation.
             fw.Attribute(namePrefix + nameSuffix, value);
+        }
+    }
+
+    // Integer-valued attribute (e.g. tabindex). Formats the value straight into the builder via
+    // a stack buffer, so the no-frames render path allocates nothing — int.ToString() would
+    // allocate a string per element on every render. An int's text is always HTML-safe (digits
+    // plus an optional leading minus), so it skips the encode pass.
+    protected static void AppendAttr(StringBuilder sb, string name, int value)
+    {
+        sb.Append(' ').Append(name).Append("=\"");
+        Span<char> buffer = stackalloc char[12]; // int.MinValue is 11 chars; 12 always fits.
+        _ = value.TryFormat(buffer, out var written, provider: CultureInfo.InvariantCulture);
+        sb.Append(buffer[..written]);
+        sb.Append('"');
+
+        if (FrameSinkScope.Current is { } fw)
+        {
+            // Allocate the value string only when a frame writer is active.
+            fw.Attribute(name, value.ToString(CultureInfo.InvariantCulture));
         }
     }
 

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Text;
 using Rask.Core.Live;
 
@@ -256,17 +255,9 @@ public abstract class Element : Component
 
         if (Data is not null)
         {
-            foreach (var kv in Data)
-            {
-                // A literal Data["rask-key"] is superseded by an effective Key to avoid a
-                // duplicate attribute — Key is the canonical API; Data stays for back-compat.
-                if (key is not null && string.Equals(kv.Key, "rask-key", StringComparison.Ordinal))
-                {
-                    continue;
-                }
-
-                AppendAttr(sb, "data-", kv.Key, kv.Value);
-            }
+            // A literal Data["rask-key"] is superseded by an effective Key to avoid a duplicate
+            // attribute — Key is the canonical API; Data stays for back-compat.
+            AppendPrefixedAttrs(sb, "data-", Data, key is not null ? "rask-key" : null);
         }
 
         if (key is not null)
@@ -332,16 +323,43 @@ public abstract class Element : Component
             AppendAttr(sb, "role", Role);
         }
 
-        if (TabIndex is not null)
+        if (TabIndex is { } tabIndex)
         {
-            AppendAttr(sb, "tabindex", TabIndex.Value.ToString(CultureInfo.InvariantCulture));
+            AppendAttr(sb, "tabindex", tabIndex);
         }
 
         if (Aria is not null)
         {
-            foreach (var kv in Aria)
+            AppendPrefixedAttrs(sb, "aria-", Aria, skipKey: null);
+        }
+    }
+
+    // Emit each entry of a data-*/aria-* bag as "{prefix}{key}=\"{value}\"". Iterating a concrete
+    // Dictionary<,> uses its struct enumerator (no allocation); foreach over the
+    // IReadOnlyDictionary interface instead boxes an enumerator on every render of an element that
+    // carries a Data or Aria bag — the common literal (`new() { ... }`) is a Dictionary, so it
+    // takes the fast path. `skipKey`, when set, drops one entry (Data["rask-key"] superseded by Key).
+    private static void AppendPrefixedAttrs(StringBuilder sb, string prefix,
+        IReadOnlyDictionary<string, string?> map, string? skipKey)
+    {
+        if (map is Dictionary<string, string?> dict)
+        {
+            foreach (var kv in dict)
             {
-                AppendAttr(sb, "aria-", kv.Key, kv.Value);
+                if (skipKey is null || !string.Equals(kv.Key, skipKey, StringComparison.Ordinal))
+                {
+                    AppendAttr(sb, prefix, kv.Key, kv.Value);
+                }
+            }
+        }
+        else
+        {
+            foreach (var kv in map)
+            {
+                if (skipKey is null || !string.Equals(kv.Key, skipKey, StringComparison.Ordinal))
+                {
+                    AppendAttr(sb, prefix, kv.Key, kv.Value);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

Phase 2 of the stability/security/performance pass — the **performance** PR. A render-allocation audit found two avoidable per-element allocations in `Element.WriteAttributes`:

1. **`Data` / `Aria` bags iterated via the `IReadOnlyDictionary<,>` interface**, boxing an enumerator on every render of an attribute-bearing element.
2. **`TabIndex` formatted with `int.ToString()`**, allocating a string per element per render.

### Changes
- New private `Element.AppendPrefixedAttrs` helper iterates a concrete `Dictionary<,>` through its **struct enumerator** (no boxing) when that's the backing type — which it is for the common `new() { … }` literal — and falls back to the interface otherwise. Used for both `data-*` and `aria-*`.
- New `protected static AppendAttr(StringBuilder, string, int)` overload formats an integer straight into the pooled `StringBuilder` via a stack buffer + `TryFormat` — zero allocation on the no-frame-sink path. An int's text is always HTML-safe, so it skips the encode pass.
- **No change** to rendered output or the documented attribute order (id, class, style, data-\*, role, tabindex, aria-\*, then tag-specific).

## Benchmarks
M-class, BenchmarkDotNet ShortRun, `Allocated` (before = main, after = branch):

| Benchmark | Scenario | Before | After | Δ |
|-----------|----------|-------:|------:|--:|
| `DataAttributesBenchmarks` | RenderSmall (10) | 3.84 KB | 2.69 KB | −30% |
| | RenderMedium (100) | 37.23 KB | 26.24 KB | −30% |
| | RenderLarge (1000) | 661.22 KB | 551.79 KB | **−16.5%** |
| `AccessibilityAttributesBenchmarks` (new) | RenderSmall (10) | 4.43 KB | 3.34 KB | −25% |
| | RenderMedium (100) | 43.45 KB | 32.52 KB | −25% |
| | RenderLarge (1000) | 808.34 KB | 677.09 KB | **−16%** |

Adds `AccessibilityAttributesBenchmarks` to lock in the Aria/Role/TabIndex path against regression.

## Testing
- `dotnet format` clean · `dotnet build -warnaserror` clean (0 warnings) · full Core suite green (1536 passed), including the attribute-order and allocation-pin tests — no output or ordering regressions.

## Changelog
Added a `### Performance` entry under `[Unreleased]`.

## Notes
Independent of PR #108 (Phase 1, stability) — different files, no overlap.