### PR TITLE
feat(security): RASK024 auth-ordering analyzer, dependency-scan CI, auth hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,42 @@ jobs:
       - name: Restore
         run: dotnet restore Rask.slnx
 
+      # Dependency hygiene. NuGetAudit already fails restore on vulnerable packages (honouring the
+      # scoped NuGetAuditSuppress entries), so this is defence-in-depth that also covers transitive
+      # vulnerabilities and DEPRECATED packages — which audit does not flag. `dotnet list package`
+      # exits 0 even on findings, so we parse its output. The accepted-and-suppressed SQLitePCLRaw
+      # advisory (GHSA-2m69-gcr7-jv3q, no patched version) is excluded so it doesn't re-fail here;
+      # remove that filter once a patched SQLitePCLRaw family ships.
+      - name: Vulnerable & deprecated package scan
+        run: |
+          set -euo pipefail
+          echo "== Vulnerable (incl. transitive) =="
+          dotnet list Rask.slnx package --vulnerable --include-transitive > vuln.log 2>&1 || true
+          cat vuln.log
+          unexpected="$(grep -E '^\s*>' vuln.log | grep -v 'GHSA-2m69-gcr7-jv3q' || true)"
+          if [ -n "$unexpected" ]; then
+            echo "::error::Unexpected vulnerable package(s) found:"
+            echo "$unexpected"
+            exit 1
+          fi
+          echo "== Deprecated =="
+          dotnet list Rask.slnx package --deprecated > deprecated.log 2>&1 || true
+          cat deprecated.log
+          # Package rows start with '>'. "Legacy" means superseded-but-functional (e.g. xunit v2 ->
+          # v3, a large separate migration); treat those as informational. Fail only on harder
+          # deprecation reasons (Critical Bugs / Other) that warrant action now.
+          deprecated_rows="$(grep -E '^\s*>' deprecated.log || true)"
+          if [ -n "$deprecated_rows" ]; then
+            actionable="$(printf '%s\n' "$deprecated_rows" | grep -v -i 'Legacy' || true)"
+            if [ -n "$actionable" ]; then
+              echo "::error::Actionable deprecated package(s) found:"
+              echo "$actionable"
+              exit 1
+            fi
+            echo "::warning::Legacy (superseded) packages present — informational only:"
+            printf '%s\n' "$deprecated_rows"
+          fi
+
       - name: Build (no WASM bundle)
         # -m:1 (serial) prevents the parallel ProjectReference copy race on Rask.Core.dll
         # (MSB3026 copy-retry / MSB3030 not-found) rather than masking the warning.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,25 @@ them until tagged releases begin.
   warnings-as-errors) failed `restore` for every job. A scoped `NuGetAuditSuppress` for this single
   advisory unblocks the build while leaving audit active for everything else; it is annotated to be
   removed once a patched SQLitePCLRaw family ships.
+- **New `RASK024` analyzer — `UseAuthentication()` must precede `UseRask()`.** A compile-time warning
+  when `app.UseRask<App>()` is wired before `app.UseAuthentication()`. Rask seeds the live session from
+  `HttpContext.User` during the initial GET render and the WebSocket upgrade; if authentication runs
+  after `UseRask`, the principal is empty at that point and every `[Authorize]` page challenges — a
+  silent, easy-to-miss misconfiguration the docs previously only warned about in prose. Fires only when
+  both calls are present and `UseAuthentication` is positioned after `UseRask`; an app with no
+  authentication middleware is left alone. Documented in [diagnostics](docs/diagnostics.md#rask024).
+- **CI now scans for vulnerable and deprecated dependencies.** The `unit` job runs
+  `dotnet list package --vulnerable --include-transitive` and `--deprecated` and fails on findings —
+  defence-in-depth beyond restore-time `NuGetAudit` (which doesn't cover transitive or deprecated
+  packages). The accepted-and-suppressed SQLitePCLRaw advisory is excluded, and "Legacy" (superseded
+  but functional) deprecations are reported as informational rather than failing the build.
+- **The scaffolded WASM JWT token store now warns when it holds a plaintext token.** The
+  `dotnet new rask-wasm --auth` `TokenStore` keeps the bearer JWT in `localStorage` (a development
+  floor — readable by any script via XSS); it now logs a one-time `console.warn` steering to an
+  HttpOnly cookie or `ProtectedTokenStore` so a scaffold shipped to production unchanged surfaces the
+  risk. New [reverse-proxy `ForwardedHeaders` guidance](docs/authentication.md) documents that the
+  host-only anti-CSWSH / redeem-CSRF checks need forwarded headers behind a TLS-terminating proxy, or
+  legitimate same-origin WebSocket handshakes are rejected with `403`.
 
 ## [0.9.0] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -412,7 +412,7 @@ see **[`docs/`](docs/)**:
 - **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · *
   *[Authentication](docs/authentication.md)**
 - **[Accessibility](docs/accessibility.md)** · **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
-- **[Diagnostics (RASK001–023)](docs/diagnostics.md)** — every build error/warning and its fix.
+- **[Diagnostics (RASK001–024)](docs/diagnostics.md)** — every build error/warning and its fix.
 - **[Live rendering & the diff codec](docs/architecture/live-rendering.md)** — how the runtime works under the hood.
 
 ## 🧩 Core concepts

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,7 +24,7 @@ Guides and references for building with Rask. New here? Start with the project
 
 | Reference | What it covers |
 |-----------|----------------|
-| [Diagnostics (RASK001–023)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
+| [Diagnostics (RASK001–024)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
 | [Code analysis](code-analysis.md) | Analyzers, warnings-as-errors, and the per-PR adoption procedure. |
 
 ## Contributing

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -963,6 +963,47 @@ Define an IdentityResource/`role` claim and add it to the client's allowed scope
 
 ---
 
+## Behind a reverse proxy (ForwardedHeaders)
+
+Rask's anti-CSWSH and redeem-CSRF defenses are a **host-only same-origin check**: the `/rask/ws`
+handshake and `/_rask/auth/redeem` compare the request's host to the `Origin` header's host and reject a
+mismatch with `403`. Behind a TLS-terminating proxy (nginx, Caddy, a cloud load balancer, Azure App
+Service, …) the app receives the request on an internal address, so `HttpContext.Request.Host` is the
+**internal** host (e.g. `localhost:8080`) while the browser's `Origin` carries the **public** host
+(`app.example.com`). Those don't match, and **every legitimate same-origin WebSocket handshake and
+redeem POST is rejected** — auth appears to silently break in production but works locally.
+
+Restore the public host by enabling forwarded headers **before** `UseAuthentication()`/`UseRask()`, so
+the rest of the pipeline (including Rask's origin checks) sees the real host and scheme:
+
+```csharp
+using Microsoft.AspNetCore.HttpOverrides;
+
+builder.Services.Configure<ForwardedHeadersOptions>(o =>
+{
+    o.ForwardedHeaders = ForwardedHeaders.XForwardedFor
+                       | ForwardedHeaders.XForwardedProto
+                       | ForwardedHeaders.XForwardedHost;   // <- the host the origin check needs
+    // Trust only your proxy. The defaults clear KnownNetworks/KnownProxies, which drops forwarded
+    // headers entirely unless you add the proxy here (or trust a known network range).
+    o.KnownProxies.Add(System.Net.IPAddress.Parse("10.0.0.1"));
+});
+
+var app = builder.Build();
+
+app.UseForwardedHeaders();   // FIRST — before auth/Rask, so Host/Scheme are corrected upstream
+app.UseAuthentication();
+app.UseAuthorization();
+app.UseRask<App>();
+```
+
+> **Make sure the proxy actually sends `X-Forwarded-Host`** (and `X-Forwarded-Proto`). Some proxies
+> forward `For`/`Proto` but not `Host` by default. Only trust these headers from a proxy you control —
+> an attacker who can reach the app directly could otherwise spoof the host. If you can't use
+> `ForwardedHeaders`, host Rask on the same origin the browser sees so the internal host already matches.
+
+---
+
 ## Security checklist
 
 - ☑ Serve auth over **HTTPS** only (`Cookie.SecurePolicy = Always` on `AddCookie`).

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,4 +1,4 @@
-# Rask diagnostics (RASK001–RASK023)
+# Rask diagnostics (RASK001–RASK024)
 
 Every Rask diagnostic, what triggers it, and how to fix it. Errors block the build; warnings don't
 but flag a real problem; one is hidden (informational, surfaced only as an IDE suggestion).
@@ -32,6 +32,7 @@ build once.
 | [RASK021](#rask021) | Warning | Root component must render a complete page shell |
 | [RASK022](#rask022) | Warning | List item is missing a `Key` |
 | [RASK023](#rask023) | Warning | `Img` is missing `Alt` text |
+| [RASK024](#rask024) | Warning | `UseAuthentication()` must precede `UseRask()` |
 
 ---
 
@@ -254,3 +255,23 @@ announcing the file name (or nothing), failing [WCAG 1.1.1](https://www.w3.org/W
 
 **Fix:** pass a meaningful `Alt:`, or the empty string `Alt: ""` for a purely decorative image so
 assistive technology skips it. See [accessibility](accessibility.md).
+
+## RASK024
+**`UseAuthentication()` must precede `UseRask()`** · Warning
+
+`app.UseRask<App>()` is wired before `app.UseAuthentication()`. Rask seeds the live session from
+`HttpContext.User` during the initial GET render and the WebSocket upgrade — if the authentication
+middleware runs *after* `UseRask`, the principal is empty at that point and every `[Authorize]` page
+challenges.
+
+```csharp
+// ✗ app.UseRask<App>();
+//   app.UseAuthentication();
+// ✓ app.UseAuthentication();   // populates HttpContext.User on GET + WS upgrade
+//   app.UseAuthorization();
+//   app.UseRask<App>();
+```
+
+**Fix:** call `app.UseAuthentication()` (and `app.UseAuthorization()`) before `app.UseRask()`. The
+warning fires only when both calls are present and `UseAuthentication` is positioned after `UseRask`;
+an app with no authentication middleware is left alone. See [authentication](authentication.md).

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
-- [Diagnostics](docs/diagnostics.md): RASK001–023 compile-time diagnostics + fixes.
+- [Diagnostics](docs/diagnostics.md): RASK001–024 compile-time diagnostics + fixes.
 - [Testing](docs/testing.md): unit + Playwright E2E patterns.
 
 ## Contributing to Rask itself

--- a/src/Rask.Generators/Analyzers/AuthBeforeRaskAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/AuthBeforeRaskAnalyzer.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Analyzers;
+
+// RASK024 — warn when app.UseRask<App>() is wired before app.UseAuthentication(). Rask seeds the
+// live session from HttpContext.User during the initial GET render and the WebSocket upgrade; if the
+// authentication middleware runs after UseRask, the principal is empty at that point and every
+// [Authorize] page challenges. The fix is to call UseAuthentication() (and UseAuthorization()) before
+// UseRask(). Fires only when both calls are present and the earliest UseAuthentication is positioned
+// after UseRask in source — an app with no UseAuthentication at all is left alone. Suppressible.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class AuthBeforeRaskAnalyzer : DiagnosticAnalyzer
+{
+    private const string RaskServerAssembly = "Rask.Server";
+    private const string UseRaskMethod = "UseRask";
+    private const string UseAuthenticationMethod = "UseAuthentication";
+    private const string AspNetBuilderNamespace = "Microsoft.AspNetCore.Builder";
+
+    private static readonly DiagnosticDescriptor Rask024 = new(
+        "RASK024",
+        "UseAuthentication must precede UseRask",
+        "UseAuthentication() is called after UseRask<{0}>() — move it before UseRask so HttpContext.User is "
+        + "populated on the GET render and the WebSocket upgrade; otherwise every [Authorize] page challenges",
+        "Usage",
+        DiagnosticSeverity.Warning,
+        true,
+        "Rask seeds the live session from HttpContext.User during the initial GET and the WS upgrade. If the "
+        + "authentication middleware runs after UseRask, the principal is empty at that point and authorized "
+        + "routes reject the user. Call app.UseAuthentication() (and UseAuthorization()) before app.UseRask().",
+        DiagnosticHelp.Link("RASK024"));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rask024);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+
+        // A per-tree pass: the ordering check needs to see every UseRask / UseAuthentication call in
+        // the file at once (Program.cs is one tree), which RegisterSyntaxNodeAction can't do statelessly.
+        context.RegisterSemanticModelAction(Analyze);
+    }
+
+    private static void Analyze(SemanticModelAnalysisContext context)
+    {
+        var model = context.SemanticModel;
+        var root = model.SyntaxTree.GetRoot(context.CancellationToken);
+
+        var authPositions = new List<int>();
+        var raskCalls = new List<(InvocationExpressionSyntax Inv, string AppType)>();
+
+        foreach (var node in root.DescendantNodes())
+        {
+            if (node is not InvocationExpressionSyntax inv)
+            {
+                continue;
+            }
+
+            var name = MethodName(inv);
+            if (!string.Equals(name, UseRaskMethod, StringComparison.Ordinal)
+                && !string.Equals(name, UseAuthenticationMethod, StringComparison.Ordinal))
+            {
+                continue; // Cheap syntactic filter before the semantic lookup.
+            }
+
+            if (model.GetSymbolInfo(inv, context.CancellationToken).Symbol is not IMethodSymbol method)
+            {
+                continue;
+            }
+
+            if (string.Equals(method.Name, UseAuthenticationMethod, StringComparison.Ordinal)
+                && string.Equals(method.ContainingNamespace?.ToDisplayString(), AspNetBuilderNamespace,
+                    StringComparison.Ordinal))
+            {
+                authPositions.Add(inv.SpanStart);
+            }
+            else if (string.Equals(method.Name, UseRaskMethod, StringComparison.Ordinal)
+                     && string.Equals(method.ContainingAssembly?.Name, RaskServerAssembly, StringComparison.Ordinal))
+            {
+                var appType = method.TypeArguments.Length == 1 ? method.TypeArguments[0].Name : "TApp";
+                raskCalls.Add((inv, appType));
+            }
+        }
+
+        if (raskCalls.Count == 0 || authPositions.Count == 0)
+        {
+            return;
+        }
+
+        foreach (var (inv, appType) in raskCalls)
+        {
+            // Safe when any UseAuthentication call precedes this UseRask in source order. Only flag when
+            // every UseAuthentication is positioned after it (the documented misordering footgun).
+            if (authPositions.All(p => p > inv.SpanStart))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Rask024, NameLocation(inv), appType));
+            }
+        }
+    }
+
+    private static string? MethodName(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.Identifier.ValueText,
+        SimpleNameSyntax s => s.Identifier.ValueText,
+        _ => null
+    };
+
+    private static Location NameLocation(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.GetLocation(),
+        _ => inv.Expression.GetLocation()
+    };
+}

--- a/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
+++ b/src/Rask.Templates/content/rask-wasm/Auth/Auth.cs
@@ -30,23 +30,52 @@ public sealed class LoginModel
 public partial class AuthJson : JsonSerializerContext;
 
 // Bearer JWT in localStorage (survives refresh) + an in-memory copy the handler reads synchronously.
-// Note: a token in JS storage is readable by any script (XSS). Prefer an HttpOnly cookie where you can.
+// SECURITY: a token in localStorage is plaintext and readable by ANY script on the page (XSS), so this
+// scaffolded store is a development-grade floor. Before production, prefer an HttpOnly cookie (the token
+// never reaches JS) or encrypt at rest with ProtectedTokenStore — see docs/authentication.md. The
+// WarnOnce below logs a one-time reminder to the browser console while this plaintext store is in use.
 public sealed class TokenStore(IJSRuntime js)
 {
+    private bool _warned;
+
     public string? Token { get; private set; }
 
-    public async Task InitAsync() => Token = await js.InvokeAsync<string?>("localStorage.getItem", "rask.jwt");
+    public async Task InitAsync()
+    {
+        Token = await js.InvokeAsync<string?>("localStorage.getItem", "rask.jwt");
+        if (Token is not null)
+        {
+            await WarnOnceAsync();
+        }
+    }
 
     public async Task SetAsync(string token)
     {
         Token = token;
         await js.InvokeVoidAsync("localStorage.setItem", "rask.jwt", token);
+        await WarnOnceAsync();
     }
 
     public async Task ClearAsync()
     {
         Token = null;
         await js.InvokeVoidAsync("localStorage.removeItem", "rask.jwt");
+    }
+
+    // One-time console warning so a scaffold shipped to production unchanged surfaces the risk.
+    // Delete this (and harden the store) once you've moved to an HttpOnly cookie or ProtectedTokenStore.
+    private async Task WarnOnceAsync()
+    {
+        if (_warned)
+        {
+            return;
+        }
+
+        _warned = true;
+        await js.InvokeVoidAsync("console.warn",
+            "Rask: the bearer token is stored in plaintext localStorage and is readable by any script "
+            + "(XSS risk). This is a development floor — for production use an HttpOnly cookie or encrypt "
+            + "the token at rest (ProtectedTokenStore). See docs/authentication.md.");
     }
 }
 

--- a/tests/Rask.Generators.Tests/AuthBeforeRaskAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/AuthBeforeRaskAnalyzerTests.cs
@@ -1,0 +1,72 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+
+namespace Rask.Generators.Tests;
+
+public class AuthBeforeRaskAnalyzerTests
+{
+    // A minimal Program.cs-style top-level program. The real Rask.Server UseRask and ASP.NET Core
+    // UseAuthentication symbols are referenced via BuildReferences(), so the analyzer resolves the
+    // genuine method symbols (assembly / namespace checks).
+    private static string Program(string body) => $$"""
+                                                   using Microsoft.AspNetCore.Builder;
+                                                   using Rask.Core;
+                                                   using Rask.Server;
+
+                                                   public sealed class App : Component
+                                                   {
+                                                       protected override RenderResult Render() => new Doctype();
+                                                   }
+
+                                                   public static class Program
+                                                   {
+                                                       public static void Main()
+                                                       {
+                                                           var builder = WebApplication.CreateBuilder();
+                                                           var app = builder.Build();
+                                                           {{body}}
+                                                       }
+                                                   }
+                                                   """;
+
+    [Fact]
+    public async Task UseRaskBeforeUseAuthentication_ReportsRask024()
+    {
+        var d = Assert.Single(await Diagnostics(Program(
+            "app.UseRask<App>(); app.UseAuthentication();")));
+        Assert.Equal("RASK024", d.Id);
+        Assert.Contains("UseAuthentication", d.GetMessage());
+        Assert.Contains("App", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task UseAuthenticationBeforeUseRask_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(Program(
+            "app.UseAuthentication(); app.UseAuthorization(); app.UseRask<App>();")));
+
+    [Fact]
+    public async Task NoUseAuthentication_NoDiagnostic() =>
+        // An app that doesn't use authentication middleware is left alone.
+        Assert.Empty(await Diagnostics(Program("app.UseRask<App>();")));
+
+    [Fact]
+    public async Task NoUseRask_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(Program("app.UseAuthentication();")));
+
+    private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestProgram",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.ConsoleApplication,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new AuthBeforeRaskAnalyzer());
+        var all = await compilation.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+        return all.Where(d => d.Id == "RASK024").ToImmutableArray();
+    }
+}

--- a/tests/Rask.Generators.Tests/GeneratorDriverFixture.cs
+++ b/tests/Rask.Generators.Tests/GeneratorDriverFixture.cs
@@ -83,6 +83,12 @@ internal static class GeneratorDriverFixture
         // Pull Rask.Core in directly (TestAssembly compilation needs to know about Rask.Core.Component).
         var raskCore = Assembly.Load("Rask.Core");
         refs.Add(MetadataReference.CreateFromFile(raskCore.Location));
+
+        // Rask.Server too, so analyzer tests can resolve the real UseRask symbol (the ASP.NET Core
+        // shared framework rides along in the trusted-platform-assemblies set above via the project's
+        // transitive framework reference, giving UseAuthentication / WebApplication as well).
+        var raskServer = Assembly.Load("Rask.Server");
+        refs.Add(MetadataReference.CreateFromFile(raskServer.Location));
         return refs.ToImmutableArray();
     }
 

--- a/tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj
+++ b/tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj
@@ -24,6 +24,9 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <!-- Rask.Server (and, transitively, the ASP.NET Core shared framework) so AuthBeforeRaskAnalyzer
+         tests can resolve the real UseRask / UseAuthentication symbols in their test compilations. -->
+    <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary

Phase 3 of the stability/security/performance pass — **security hardening + CI guardrails**. The audit found **no vulnerabilities** (CSWSH origin checks, output/URL encoding, single-use session-bound auth tickets, same-origin/same-session file IO, payload caps + backpressure all hold). This PR is misconfiguration-prevention and drift-detection — **no behaviour change to existing secure paths**.

### Changes
1. **RASK024 analyzer — `UseAuthentication()` must precede `UseRask()`.** Compile-time warning when `app.UseRask<App>()` is wired before `app.UseAuthentication()`. Rask seeds the live session from `HttpContext.User` during the GET render and the WS upgrade, so the wrong order silently makes every `[Authorize]` page challenge — previously only a prose warning in the docs. Fires only when both calls are present and `UseAuthentication` is positioned after `UseRask`; an app with no auth middleware is untouched. (`RASK023` was already taken by the Img-alt analyzer, hence `024`.)
2. **CI dependency-hygiene scan.** The `unit` job runs `dotnet list package --vulnerable --include-transitive` and `--deprecated`, failing on findings — defence-in-depth beyond restore-time `NuGetAudit` (which covers neither transitive nor deprecated packages). The accepted-and-suppressed SQLitePCLRaw advisory is excluded; "Legacy" (superseded-but-functional, e.g. xunit v2) deprecations are reported as informational rather than failing. Logic validated locally against the current restore graph.
3. **WASM scaffold token-store warning.** The `dotnet new rask-wasm --auth` plaintext-`localStorage` `TokenStore` now logs a one-time `console.warn` steering to an HttpOnly cookie / `ProtectedTokenStore`, so a scaffold shipped to production unchanged surfaces the XSS-readability risk.
4. **Reverse-proxy docs.** New `docs/authentication.md` section: the host-only anti-CSWSH / redeem-CSRF checks compare request host to `Origin` host, so behind a TLS-terminating proxy you must wire `ForwardedHeaders` (incl. `X-Forwarded-Host`) before auth/Rask — otherwise legitimate same-origin WebSocket handshakes are rejected with `403`. Includes the concrete `UseForwardedHeaders` wiring and a known-proxy caveat.

## Testing
- 4 new `AuthBeforeRaskAnalyzerTests` (positive misordering + 3 negatives) — the positive case resolves the **real** `Rask.Server.UseRask` / ASP.NET `UseAuthentication` symbols (added `Rask.Server` to the Generators.Tests reference set).
- `dotnet format` clean · `dotnet build Rask.slnx -warnaserror` clean (0 warnings) **with the analyzer active across all samples** — confirms no sample trips RASK024.
- Full unit suite green (Core 1536, Server 170, Generators 158, all others), E2E unchanged.

## Docs / artifacts
`docs/diagnostics.md` (RASK024 TOC row + section, title range → RASK001–024), `docs/authentication.md`, CHANGELOG `### Security`, and diagnostic-range bumps in `llms.txt` / `README.md` / `docs/README.md`.

## Notes
Independent of #108 (stability) and #109 (performance) — no file overlap.