### PR TITLE
fix(security): nosniff on file downloads, document Raw as the XSS sink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,6 +180,12 @@ them until tagged releases begin.
   warnings-as-errors) failed `restore` for every job. A scoped `NuGetAuditSuppress` for this single
   advisory unblocks the build while leaving audit active for everything else; it is annotated to be
   removed once a patched SQLitePCLRaw family ships.
+- **File downloads now send `X-Content-Type-Options: nosniff`.** The one-shot download endpoint serves
+  its content-type from whoever staged the entry — often echoed verbatim from a client upload — so a
+  mislabelled file could be MIME-sniffed by the browser. The response now sets `nosniff` alongside the
+  existing `Content-Disposition: attachment` and same-origin / same-session-owner guards, matching the
+  asset endpoints. The `Raw` component also gained an XML-doc XSS warning making explicit that it is the
+  framework's only un-encoded output path and must never carry untrusted input.
 
 ### Performance
 - **Lower render allocations for elements carrying `Data` / `Aria` / `TabIndex`.**

--- a/src/Rask.Core/Components/Raw.cs
+++ b/src/Rask.Core/Components/Raw.cs
@@ -1,9 +1,17 @@
 namespace Rask.Core.Components;
 
+/// <summary>
+///     Emits its <see cref="Value" /> verbatim, without HTML encoding. This is the framework's
+///     only un-encoded output path, so it is an XSS sink: only pass HTML you generate or fully
+///     trust. <b>Never</b> bind untrusted input (user text, request data, a download/upload file
+///     name) into <see cref="Value" /> — use <see cref="Text" /> (or any element child), which
+///     HTML-encodes, for anything a user can influence.
+/// </summary>
 public sealed class Raw : Component
 {
     public Raw() { }
     public Raw(string html) => Value = html;
 
+    /// <summary>The verbatim HTML to emit. Not encoded — see the type remarks on XSS.</summary>
     public string? Value { get; set; }
 }

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -1511,6 +1511,10 @@ public static class RaskEndpointExtensions
         {
             ctx.Response.ContentType = entry.ContentType;
             ctx.Response.Headers.CacheControl = "no-store";
+            // The content-type is supplied by whoever staged the download (often echoed from a
+            // client upload), so forbid MIME sniffing: paired with the attachment disposition below
+            // it keeps a mislabelled file from being sniffed into an inline-rendered HTML/script.
+            ctx.Response.Headers["X-Content-Type-Options"] = "nosniff";
             var disposition = $"attachment; filename=\"{Uri.EscapeDataString(entry.Filename)}\"";
             ctx.Response.Headers["Content-Disposition"] = disposition;
 

--- a/tests/Rask.Server.Tests/Endpoints/UploadDownloadEndpointTests.cs
+++ b/tests/Rask.Server.Tests/Endpoints/UploadDownloadEndpointTests.cs
@@ -63,6 +63,10 @@ public class UploadDownloadEndpointTests
         Assert.Equal(bytes, content);
         Assert.Equal("text/plain", first.Content.Headers.ContentType?.MediaType);
         Assert.Contains("attachment", first.Content.Headers.ContentDisposition?.ToString() ?? "");
+        // The staged content-type is attacker-influenceable (echoed from the upload), so the
+        // download must forbid MIME sniffing alongside forcing an attachment download.
+        Assert.True(first.Headers.TryGetValues("X-Content-Type-Options", out var nosniff));
+        Assert.Equal("nosniff", nosniff.Single());
 
         // One-shot: a second fetch returns 404.
         var second = await host.Http.GetAsync(url);


### PR DESCRIPTION
## Summary

Two small hardening items from the security pass, both verified against the code:

- **Download `nosniff`.** The one-shot download endpoint (`HandleDownloadAsync`) serves its content-type from whoever staged the entry — frequently echoed verbatim from a client upload — without `X-Content-Type-Options: nosniff`. A mislabelled file could therefore be MIME-sniffed by the browser. It now sets `nosniff` alongside the existing `Content-Disposition: attachment`, `Cache-Control: no-store`, and same-origin / same-session-owner guards, matching the asset endpoints (`RaskAssetEndpoint`, runtime-script endpoint).
- **`Raw` XSS doc.** `Raw` is the framework's only un-encoded output path. It now carries an XML-doc `<summary>` warning making explicit that it is an XSS sink and must never carry untrusted input (use `Text` / element children, which HTML-encode).

## Testing

- `dotnet build src/Rask.Server -warnaserror` — clean, 0 warnings.
- `dotnet test --filter UploadDownloadEndpointTests` — 6/6 pass, including a new assertion that the download response carries `X-Content-Type-Options: nosniff`.
- `dotnet format --verify-no-changes` on touched files — clean.

## Changelog

Added under `[Unreleased] › Security`.

## Notes

No render/runtime hot-path code touched, so no benchmark run required.