### PR TITLE
feat(core): warn when the live diff finds duplicate sibling Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,13 @@ them until tagged releases begin.
   panel hosts a second, independently sortable `TableModel<T>`. Expand and both grids' sort are held in
   plain component fields; each open row inserts a keyed detail `<tr>`, so the live diff reconciles
   expand/collapse as an in-place keyed insert/remove and sibling open rows keep their own inner sort.
+- **Duplicate-`Key` warning in the live diff.** Two sibling elements sharing the same `Key:`
+  (`data-rask-key`) silently disabled keyed reconciliation and fell back to a positional diff, which
+  can graft a row's DOM state (focus, input value, scroll position) onto the wrong sibling when the
+  list reorders — a hard-to-spot correctness bug. The diff codec now emits a one-time warning naming
+  the offending key to standard error when it detects a duplicate (deduplicated, capped, and only ever
+  reached on the already-broken path, so a correctly-keyed render pays nothing). See the
+  [composition guide](docs/composition.md).
 
 ### Changed
 - **`Navigator.Navigate(...)` renamed to `Navigator.NavigateTo(...)`.** All three overloads

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -24,6 +24,13 @@ Div(Class: "card")[
 ]
 ```
 
+> **Keys must be unique among siblings.** `Key:` is the reconciliation identity the live diff
+> uses to move a row instead of rebuilding it. If two siblings share a key, keyed
+> reconciliation can't tell them apart, so the diff falls back to a positional walk that may
+> attach a row's DOM state (focus, input value, scroll) to the wrong sibling on reorder. The
+> diff codec writes a one-time `data-rask-key="…"` warning to standard error when it detects a
+> duplicate — treat it as a bug to fix, not noise.
+
 `Fragment()` renders its children with **no wrapping element** — use it for a list of
 siblings, or as the conditional "render nothing" branch:
 

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -136,6 +136,41 @@ public readonly struct EditOp
 /// </summary>
 public static class FrameDiffer
 {
+    // Bounds the warn-once memory: a correct app never populates this, and a buggy one that
+    // churns unbounded distinct duplicate keys stops being warned past the cap rather than
+    // growing without limit. Guarded by its own lock — the diff runs single-threaded per
+    // session but distinct sessions can diff concurrently.
+    private static readonly HashSet<string> WarnedDuplicateKeys = new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Invoked with the offending <c>data-rask-key</c> value when the diff codec finds two
+    ///     sibling elements sharing a key. A duplicate key defeats keyed reconciliation, so the
+    ///     codec falls back to a positional walk that can graft a surviving node's DOM state
+    ///     (focus, input value, scroll) onto the wrong sibling when the list reorders — a silent
+    ///     correctness bug. Defaults to a deduplicated <see cref="Console.Error" /> writer
+    ///     (<see cref="WarnDuplicateKeyOnce" />); set to <c>null</c> to silence, or replace to
+    ///     route into a logger or test sink. Only ever fires on the already-broken path, so it
+    ///     adds no cost to a correctly-keyed render.
+    /// </summary>
+    internal static Action<string>? OnDuplicateKey = WarnDuplicateKeyOnce;
+
+    private static void WarnDuplicateKeyOnce(string key)
+    {
+        lock (WarnedDuplicateKeys)
+        {
+            if (WarnedDuplicateKeys.Count >= 1024 || !WarnedDuplicateKeys.Add(key))
+            {
+                return;
+            }
+        }
+
+        Console.Error.WriteLine(
+            $"Rask live diff: two sibling elements share data-rask-key=\"{key}\". Keys must be " +
+            "unique among siblings; the duplicate disables keyed reconciliation for that list and " +
+            "falls back to a positional diff, which can attach a node's state to the wrong sibling " +
+            "when the list reorders. Give each sibling a distinct Key.");
+    }
+
     /// <summary>
     ///     Walk <paramref name="oldFrames" /> and <paramref name="newFrames" /> together
     ///     producing edit ops into <paramref name="output" />. Returns the number of ops
@@ -537,8 +572,12 @@ public static class FrameDiffer
 
             if (!seen.Add(key))
             {
-                // Duplicate keys in the same sibling list — diagnostic-worthy but we
-                // fall back to positional rather than guessing which one to match.
+                // Duplicate keys in the same sibling list. We can't trust the keyed match
+                // (which survivor does the key name?), so we fall back to positional — but
+                // a positional walk can attach a surviving node's state to the wrong sibling
+                // on reorder, so surface the bug rather than failing silently. The hook only
+                // ever fires on this genuinely-broken path, so it costs correct apps nothing.
+                OnDuplicateKey?.Invoke(key);
                 return false;
             }
 

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -435,6 +435,60 @@ public class FrameDifferTests
     }
 
     [Fact]
+    public void Diff_KeyedList_DuplicateKeys_WarnsWithTheOffendingKey()
+    {
+        var before = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "row-7" })["a"],
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "row-7" })["b"]
+        ]);
+        var after = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "row-7" })["a!"],
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "row-7" })["b"]
+        ]);
+
+        var warned = new List<string>();
+        var previous = FrameDiffer.OnDuplicateKey;
+        FrameDiffer.OnDuplicateKey = warned.Add;
+        try
+        {
+            FrameDiffer.Diff(before, after, new List<EditOp>(), out var usedKeyed);
+            Assert.False(usedKeyed);
+            Assert.Contains("row-7", warned);
+        }
+        finally
+        {
+            FrameDiffer.OnDuplicateKey = previous;
+        }
+    }
+
+    [Fact]
+    public void Diff_KeyedList_UniqueKeys_DoesNotWarn()
+    {
+        var before = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["1"],
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "b" })["2"]
+        ]);
+        var after = Frames(Ul()[
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "a" })["1!"],
+            Li(Data: new Dictionary<string, string?> { ["rask-key"] = "b" })["2"]
+        ]);
+
+        var warned = new List<string>();
+        var previous = FrameDiffer.OnDuplicateKey;
+        FrameDiffer.OnDuplicateKey = warned.Add;
+        try
+        {
+            FrameDiffer.Diff(before, after, new List<EditOp>(), out var usedKeyed);
+            Assert.True(usedKeyed);
+            Assert.Empty(warned);
+        }
+        finally
+        {
+            FrameDiffer.OnDuplicateKey = previous;
+        }
+    }
+
+    [Fact]
     public void Diff_KeyedList_SameKeyDifferentTag_EmitsTrustedRemoveAndInsert()
     {
         // Same data-rask-key but the element kind changed (Li → Span). The keyed branch


### PR DESCRIPTION
## Summary

Verified-real correctness footgun from the stability pass. Two sibling elements sharing the same `Key:` (`data-rask-key`) silently disabled keyed reconciliation: `FrameDiffer.TryCollectKeyedChildren` returned `false` on the `!seen.Add(key)` branch (its own comment called it "diagnostic-worthy") and the codec fell back to a **positional** diff. On reorder, a positional walk can attach a surviving node's DOM state — focus, input value, scroll position — to the *wrong* sibling. React warns on exactly this; Rask now does too.

`FrameDiffer` gained an `OnDuplicateKey` hook invoked with the offending key at the detection point. The default sink writes a **one-time, deduplicated, capped** warning to standard error (matching the existing `Console.Error` diagnostics in `ComponentLifecycle` / `LiveJsInvokeQueue`). The hook only ever fires on the already-broken path, so a correctly-keyed render is byte-for-byte unchanged.

## Testing

- `dotnet build src/Rask.Core -warnaserror` — clean.
- `dotnet test tests/Rask.Core.Tests` — **1541 pass**, including two new `FrameDifferTests`: the warning fires with the offending key on a duplicate-key list, and stays silent on a uniquely-keyed one (each saves/restores the hook so it's order-independent).
- **Benchmark (gate):** `FrameDifferBenchmarks --job short`. The keyed-reorder hot path is unchanged — `Reorder_ReusedScratch` 7.13 KB (100 rows) / 70.41 KB (1000 rows), identical profile — because the new call sits on a branch correctly-keyed lists never reach.

## Changelog

Added under `[Unreleased] › Added`. Documented in `docs/composition.md` (keys-must-be-unique note).

## Notes

Scoped deliberately to the **duplicate-key** case, which is an unambiguous bug. The *missing*-key-in-a-loop case (a build-time RASK025 analyzer) was considered and deferred: many loops legitimately render unkeyed, so a compile-time warning there would be too noisy to be useful.