### PR TITLE
perf(core): defer the per-insert HTML slice in the diff codec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,15 @@ them until tagged releases begin.
   a11y-rich tree (`Aria` + `Role` + `TabIndex`) **808 KB → 677 KB** (−16%); small/medium trees −25–30%.
   No change to rendered output or the documented attribute order. New `AccessibilityAttributesBenchmarks`
   locks in the a11y path.
+- **Halve the diff-codec allocation when a keyed list grows.** `FrameDiffer` sliced each inserted
+  subtree's HTML out of the rendered document with a `Substring` while diffing — one short-lived string
+  per `InsertSubtree` op. Each op now carries the fragment's `[HtmlStart..HtmlEnd)` char range instead,
+  and `LivePayload.BuildPayloadUtf8Diff` slices it straight into the UTF-8 wire buffer at write time
+  (`Utf8JsonWriter.WriteStringValue(ReadOnlySpan<char>)`), so no intermediate string is materialised.
+  Directly-constructed ops still ship a verbatim `Value`, so the wire format is byte-identical. Measured
+  on the new `FrameDifferBenchmarks.InsertRows` (M-class, ShortRun): a 100-row list gaining 50 rows
+  dropped **11.32 KB → 5.11 KB** allocated (−55%), and a 1,000-row list gaining 500 rows
+  **113.27 KB → 50.81 KB** (−55%). Reorder/no-change/text paths are unchanged.
 
 ## [0.9.0] - 2026-06-16
 

--- a/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
@@ -28,6 +28,14 @@ public class FrameDifferBenchmarks
     private RenderFrame[] _afterText = null!;
 
     private RenderFrame[] _before = null!;
+
+    // Insert scenario: a sparse list (even keys only) grows into the full list, so every odd
+    // key is an InsertSubtree carrying its freshly-sliced HTML fragment. _fullHtml is the diff's
+    // newHtml source, so each insert op runs FrameDiffer.SliceHtml (one Substring per inserted row).
+    private RenderFrame[] _beforeSparse = null!;
+    private RenderFrame[] _afterFull = null!;
+    private string _fullHtml = "";
+
     [Params(100, 1000)] public int RowCount { get; set; }
 
     [GlobalSetup]
@@ -49,6 +57,16 @@ public class FrameDifferBenchmarks
         // Same key order, one kept row's inner text changed — exercises the keyed step-5
         // inner-diff recursion (the path that re-enters DiffSiblings under a keyed parent).
         _afterText = FramesOf(BuildKeyedList(order, RowCount / 2));
+
+        // Sparse → full: even keys present before, all keys after, so the odd keys insert.
+        var evenOrder = new int[(RowCount + 1) / 2];
+        for (var i = 0; i < evenOrder.Length; i++)
+        {
+            evenOrder[i] = i * 2;
+        }
+
+        _beforeSparse = FramesOf(BuildKeyedList(evenOrder, -1));
+        (_afterFull, _fullHtml) = FramesAndHtmlOf(BuildKeyedList(order, -1));
     }
 
     [Benchmark(Baseline = true)]
@@ -82,6 +100,16 @@ public class FrameDifferBenchmarks
     {
         _ops.Clear();
         FrameDiffer.Diff(_before, _afterText, _ops, _scratch, out _);
+        return _ops.Count;
+    }
+
+    [Benchmark]
+    public int InsertRows_ReusedScratch()
+    {
+        // Every odd key inserts, so this measures the per-InsertSubtree HTML SliceHtml cost
+        // (one Substring of _fullHtml per inserted row) on top of the keyed reconcile.
+        _ops.Clear();
+        FrameDiffer.Diff(_beforeSparse, _afterFull, _ops, _scratch, out _, _fullHtml);
         return _ops.Count;
     }
 

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -32,9 +32,10 @@ public enum EditOpKind : byte
     /// <summary>
     ///     Insert a new subtree at <see cref="EditOp.Path" /> (the index of the
     ///     slot among the parent's existing DOM children; ops further into the same
-    ///     parent reference subsequent indices). <see cref="EditOp.Value" /> carries the
-    ///     pre-serialized HTML fragment for the inserted subtree (set by the codec at
-    ///     wire-format time once HtmlSerializer captures per-frame byte offsets).
+    ///     parent reference subsequent indices). The inserted markup travels as the
+    ///     <see cref="EditOp.HtmlStart" />/<see cref="EditOp.HtmlEnd" /> char range into the render
+    ///     HTML (sliced into the wire payload at write time), or as a verbatim
+    ///     <see cref="EditOp.Value" /> string for directly-constructed ops.
     /// </summary>
     InsertSubtree = 4,
 
@@ -84,7 +85,7 @@ public enum EditOpKind : byte
 public readonly struct EditOp
 {
     public EditOp(EditOpKind kind, int[] path, string? name, string? value, int length = 0, bool trusted = false,
-        int[]? moves = null)
+        int[]? moves = null, int htmlStart = -1, int htmlEnd = -1)
     {
         Kind = kind;
         Path = path;
@@ -93,6 +94,8 @@ public readonly struct EditOp
         Length = length;
         Trusted = trusted;
         Moves = moves;
+        HtmlStart = htmlStart;
+        HtmlEnd = htmlEnd;
     }
 
     public EditOpKind Kind { get; }
@@ -108,6 +111,19 @@ public readonly struct EditOp
     public string? Name { get; }
     public string? Value { get; }
     public int Length { get; }
+
+    /// <summary>
+    ///     For <see cref="EditOpKind.InsertSubtree" />: the <c>[HtmlStart..HtmlEnd)</c> char range of
+    ///     the inserted subtree's markup within the render HTML, so the wire codec can slice the
+    ///     fragment straight into the UTF-8 payload at write time instead of materialising a
+    ///     per-insert <see cref="Value" /> string during the diff. <c>-1</c> (the default) means no
+    ///     deferred slice — the codec then ships <see cref="Value" /> verbatim (the path used by
+    ///     directly-constructed ops) or null. Ignored for every other op kind.
+    /// </summary>
+    public int HtmlStart { get; }
+
+    /// <summary>Companion to <see cref="HtmlStart" /> — the exclusive end of the fragment range.</summary>
+    public int HtmlEnd { get; }
 
     /// <summary>
     ///     For <see cref="EditOpKind.PermutationBatch" /> only: a flat
@@ -141,11 +157,12 @@ public static class FrameDiffer
     ///     producing edit ops into <paramref name="output" />. Returns the number of ops
     ///     written. When the streams are identical, returns 0 without touching the
     ///     output list. When <paramref name="newHtml" /> is supplied,
-    ///     <see cref="EditOpKind.InsertSubtree" /> ops carry the HTML fragment to ship
-    ///     to the client (sliced from <paramref name="newHtml" /> using each frame's
-    ///     <see cref="RenderFrame.HtmlStart" />/<see cref="RenderFrame.HtmlEnd" />);
-    ///     otherwise InsertSubtree ops have <c>Value == null</c> and the caller must
-    ///     route those payloads through the full-HTML fallback.
+    ///     <see cref="EditOpKind.InsertSubtree" /> ops carry the inserted fragment's
+    ///     <see cref="EditOp.HtmlStart" />/<see cref="EditOp.HtmlEnd" /> char range (from each frame's
+    ///     <see cref="RenderFrame.HtmlStart" />/<see cref="RenderFrame.HtmlEnd" />) so the wire codec
+    ///     slices it from the same HTML at write time — no per-insert string is allocated here.
+    ///     Without <paramref name="newHtml" /> those ops carry the <c>(-1, -1)</c> sentinel and the
+    ///     caller must route the payload through the full-HTML fallback.
     /// </summary>
     public static int Diff(
         ReadOnlySpan<RenderFrame> oldFrames,
@@ -255,9 +272,10 @@ public static class FrameDiffer
                 // without re-rendering.
                 output.Add(new EditOp(EditOpKind.RemoveSubtree, PathPlus(path, domSlot), null, null,
                     DomNodeCount(oldFrames, oi, oi + oldFrame.SubtreeLength)));
-                output.Add(new EditOp(EditOpKind.InsertSubtree, PathPlus(path, domSlot), null,
-                    SliceHtml(newHtml, newFrame.HtmlStart, newFrame.HtmlEnd),
-                    DomNodeCount(newFrames, ni, ni + newFrame.SubtreeLength)));
+                var (replStart, replEnd) = InsertHtmlRange(newHtml, newFrame);
+                output.Add(new EditOp(EditOpKind.InsertSubtree, PathPlus(path, domSlot), null, null,
+                    DomNodeCount(newFrames, ni, ni + newFrame.SubtreeLength),
+                    htmlStart: replStart, htmlEnd: replEnd));
                 oi += oldFrame.SubtreeLength;
                 ni += newFrame.SubtreeLength;
                 domSlot++;
@@ -341,22 +359,31 @@ public static class FrameDiffer
         while (ni < newEnd)
         {
             ref readonly var newFrame = ref newFrames[ni];
-            output.Add(new EditOp(EditOpKind.InsertSubtree, PathPlus(path, domSlot), null,
-                SliceHtml(newHtml, newFrame.HtmlStart, newFrame.HtmlEnd),
-                DomNodeCount(newFrames, ni, ni + newFrame.SubtreeLength)));
+            var (tailStart, tailEnd) = InsertHtmlRange(newHtml, newFrame);
+            output.Add(new EditOp(EditOpKind.InsertSubtree, PathPlus(path, domSlot), null, null,
+                DomNodeCount(newFrames, ni, ni + newFrame.SubtreeLength),
+                htmlStart: tailStart, htmlEnd: tailEnd));
             ni += newFrame.SubtreeLength;
             domSlot++;
         }
     }
 
-    private static string? SliceHtml(string? newHtml, int start, int end)
+    // Defer the inserted subtree's HTML slice to wire-format time: carry the fragment's char
+    // range so LivePayload can write it straight into the UTF-8 payload, instead of allocating a
+    // per-insert Value string here in the hot diff path. Returns the sentinel (-1, -1) — "no
+    // deferred slice" — when no render HTML was supplied (one-shot / test callers that inspect
+    // ops without a wire build) or the frame's offsets are degenerate, so the codec then ships a
+    // null fragment exactly as the old null-Value path did.
+    private static (int Start, int End) InsertHtmlRange(string? newHtml, in RenderFrame frame)
     {
+        var start = frame.HtmlStart;
+        var end = frame.HtmlEnd;
         if (newHtml is null || end <= start || (uint)end > (uint)newHtml.Length)
         {
-            return null;
+            return (-1, -1);
         }
 
-        return newHtml.Substring(start, end - start);
+        return (start, end);
     }
 
     private static void DiffAttributes(
@@ -642,14 +669,16 @@ public static class FrameDiffer
             }
 
             ref readonly var elem = ref newFrames[nc.FrameIndex];
-            var html = SliceHtml(newHtml, elem.HtmlStart, elem.HtmlEnd);
+            var (insStart, insEnd) = InsertHtmlRange(newHtml, elem);
             output.Add(new EditOp(
                 EditOpKind.InsertSubtree,
                 PathPlus(path, j),
                 null,
-                html,
+                null,
                 DomNodeCount(newFrames, nc.FrameIndex, nc.FrameIndex + elem.SubtreeLength),
-                true));
+                true,
+                htmlStart: insStart,
+                htmlEnd: insEnd));
             surviving.Insert(j, nc);
         }
 
@@ -789,13 +818,16 @@ public static class FrameDiffer
                     null,
                     DomNodeCount(oldFrames, oc.FrameIndex, oc.FrameIndex + oldElem.SubtreeLength),
                     true));
+                var (swapStart, swapEnd) = InsertHtmlRange(newHtml, newElem);
                 output.Add(new EditOp(
                     EditOpKind.InsertSubtree,
                     PathPlus(path, j),
                     null,
-                    SliceHtml(newHtml, newElem.HtmlStart, newElem.HtmlEnd),
+                    null,
                     DomNodeCount(newFrames, nc.FrameIndex, nc.FrameIndex + newElem.SubtreeLength),
-                    true));
+                    true,
+                    htmlStart: swapStart,
+                    htmlEnd: swapEnd));
                 continue;
             }
 

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -251,7 +251,8 @@ public static class LivePayload
         string? historyUrl = null,
         bool replace = false,
         IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
-        string? headHtml = null)
+        string? headHtml = null,
+        string? newHtml = null)
     {
         // Pass 1: build the attribute-name symbol table. Intern when the name appears
         // 3+ times — break-even with the table overhead lands around there for typical
@@ -356,13 +357,21 @@ public static class LivePayload
 
                     break;
                 case EditOpKind.InsertSubtree:
-                    if (op.Value is null)
+                    // Prefer a verbatim Value (directly-constructed ops); otherwise slice the
+                    // fragment straight out of the render HTML by the op's deferred char range
+                    // (the FrameDiffer hot path), encoding to UTF-8 with no intermediate string.
+                    if (op.Value is not null)
                     {
-                        writer.WriteNullValue();
+                        writer.WriteStringValue(op.Value);
+                    }
+                    else if (newHtml is not null && op.HtmlStart >= 0 && op.HtmlEnd > op.HtmlStart
+                             && op.HtmlEnd <= newHtml.Length)
+                    {
+                        writer.WriteStringValue(newHtml.AsSpan(op.HtmlStart, op.HtmlEnd - op.HtmlStart));
                     }
                     else
                     {
-                        writer.WriteStringValue(op.Value);
+                        writer.WriteNullValue();
                     }
 
                     writer.WriteNumberValue(op.Length);

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -134,7 +134,8 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
                 && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
             {
                 var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
-                LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes, headHtml);
+                LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes,
+                    headHtml, html);
 
                 // Ship the diff whenever it isn't larger than re-sending the body, or unconditionally
                 // under Forced. Only the pathological case (nearly every node changed on a tiny page,

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -207,11 +207,12 @@ public class FrameDifferTests
     }
 
     [Fact]
-    public void Diff_ChildAdded_WithNewHtml_InsertSubtreeCarriesFragment()
+    public void Diff_ChildAdded_WithNewHtml_InsertSubtreeCarriesFragmentRange()
     {
-        // When the caller passes newHtml, FrameDiffer attaches the HTML slice for the
-        // inserted subtree to op.Value. This is what makes the client-side InsertSubtree
-        // applicable without a follow-up full render: the op carries everything needed.
+        // When the caller passes newHtml, FrameDiffer records the inserted subtree's char range
+        // (HtmlStart/HtmlEnd) instead of allocating a Value string. The wire codec slices the
+        // fragment from the same HTML at write time — verified here by both the range and a full
+        // BuildPayloadUtf8Diff round-trip, which is what the client actually receives.
         var before = Frames(Ul()[Li()["a"], Li()["b"]]);
         var (afterFrames, afterHtml) = FramesAndHtml(Ul()[Li()["a"], Li()["b"], Li()["c"]]);
 
@@ -220,8 +221,10 @@ public class FrameDifferTests
 
         var insert = Assert.Single(ops);
         Assert.Equal(EditOpKind.InsertSubtree, insert.Kind);
-        Assert.NotNull(insert.Value);
-        Assert.Equal("<li>c</li>", insert.Value);
+        Assert.Null(insert.Value);
+        Assert.True(insert.HtmlStart >= 0 && insert.HtmlEnd > insert.HtmlStart);
+        Assert.Equal("<li>c</li>", afterHtml.Substring(insert.HtmlStart, insert.HtmlEnd - insert.HtmlStart));
+        Assert.Equal("<li>c</li>", WireInsertHtml(ops, afterHtml));
     }
 
     [Fact]
@@ -236,6 +239,27 @@ public class FrameDifferTests
         var insert = Assert.Single(ops);
         Assert.Equal(EditOpKind.InsertSubtree, insert.Kind);
         Assert.Null(insert.Value);
+        // No render HTML supplied → sentinel range, so the wire carries a null fragment and the
+        // caller routes the payload through the full-HTML fallback.
+        Assert.True(insert.HtmlStart < 0);
+    }
+
+    // Build the diff payload exactly as the live session does and pull the first InsertSubtree
+    // op's html field ([kind, path, html, domCount]) back out of the wire JSON.
+    private static string? WireInsertHtml(IReadOnlyList<EditOp> ops, string newHtml)
+    {
+        var buffer = new System.Buffers.ArrayBufferWriter<byte>();
+        LivePayload.BuildPayloadUtf8Diff(buffer, ops, newHtml: newHtml);
+        using var doc = System.Text.Json.JsonDocument.Parse(buffer.WrittenMemory);
+        foreach (var op in doc.RootElement.GetProperty("ops").EnumerateArray())
+        {
+            if (op[0].GetInt32() == (int)EditOpKind.InsertSubtree)
+            {
+                return op[2].ValueKind == System.Text.Json.JsonValueKind.Null ? null : op[2].GetString();
+            }
+        }
+
+        return null;
     }
 
     // ----- Keyed-list path -------------------------------------------------------------
@@ -333,8 +357,10 @@ public class FrameDifferTests
         var insert = Assert.Single(ops);
         Assert.Equal(EditOpKind.InsertSubtree, insert.Kind);
         Assert.True(insert.Trusted);
-        Assert.NotNull(insert.Value);
-        Assert.Contains("data-rask-key=\"3\"", insert.Value!);
+        // The fragment travels as a deferred char range, sliced into the wire payload at write
+        // time — assert via the actual BuildPayloadUtf8Diff output the client receives.
+        Assert.Null(insert.Value);
+        Assert.Contains("data-rask-key=\"3\"", WireInsertHtml(ops, afterHtml)!);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Verified-real performance item from the audit. `FrameDiffer` sliced each inserted subtree's markup out of the rendered document with a `Substring` **while diffing** — one short-lived string per `InsertSubtree` op. Each op now carries the fragment's `[HtmlStart..HtmlEnd)` char range instead, and `LivePayload.BuildPayloadUtf8Diff` slices it **straight into the UTF-8 wire buffer at write time** via `Utf8JsonWriter.WriteStringValue(ReadOnlySpan<char>)` — no intermediate string is materialised.

The change is **backward-compatible and byte-identical on the wire**: the writer prefers a verbatim `op.Value` (directly-constructed ops, e.g. tests) and only falls back to the deferred slice when `Value` is null. The wire shape stays `[k, path, html, domCount]`, so the unchanged Server + WASM JS clients decode it identically.

## Benchmark (gate)

New `FrameDifferBenchmarks.InsertRows` — a sparse (even-key) keyed list grows into the full list, so every odd key inserts and hits the slice path. ShortRun, M-class:

| Scenario | Before | After | Δ |
|---|--:|--:|--:|
| 100 rows, +50 inserts | 11.32 KB | **5.11 KB** | **−55%** |
| 1000 rows, +500 inserts | 113.27 KB | **50.81 KB** | **−55%** |

Reorder / no-change / text-update paths are unchanged (same `FrameDifferBenchmarks`).

## Testing

- `dotnet build Rask.slnx -warnaserror` — clean (Core + Server + WASM sample).
- **Core**: 1539 pass, including a rewritten `FrameDifferTests` that asserts the deferred range *and* round-trips the fragment through `BuildPayloadUtf8Diff` (the bytes the client actually receives).
- **Server**: 56 WS tests pass, including `KeyedInsertNavTests`, which slices a keyed insert fragment over a **live WebSocket** and asserts it is the complete, correctly-sliced element.
- **WASM**: 46 unit tests pass; JS clients untouched.

## Notes

Changes no sample and no user-facing behaviour — purely an internal allocation optimisation with byte-identical output. The keyed-list **E2E journey** (shared smoke test, both transports, "Keyed lists" step asserts survivor preservation + Atomic Move) is the final pre-merge gate and runs automatically in CI on this PR.