### PR TITLE
fix(security): sanitize returnUrl on WASM sign-out to block open redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,12 @@ them until tagged releases begin.
   components whatever the host OS, strips control/NUL characters, caps the length at 255, and falls back
   to `file` for empty / path-dot inputs) as defence in depth. The returned `name` is still
   attacker-controlled and must be HTML-encoded by hosts before display — never bound into `Raw`.
+- **WASM sign-out now guards against open redirects.** `WasmAuthSignIn.SignOutAsync` SPA-navigated to
+  its `returnUrl` argument verbatim — commonly a `?returnUrl=` query value an attacker can shape — so a
+  crafted value (`//evil.com`, `https://evil.com`, a `\`-prefixed variant) could redirect the user
+  off-origin after logout. It now passes `returnUrl` through the shared `LocalUrl.Sanitize` rule (the
+  same open-redirect guard the server sign-in path already applies at dispatch), collapsing anything
+  non-local to `/` before navigating.
 
 ### Performance
 - **Lower render allocations for elements carrying `Data` / `Aria` / `TabIndex`.**

--- a/src/Rask.Wasm/Authentication/WasmAuthSignIn.cs
+++ b/src/Rask.Wasm/Authentication/WasmAuthSignIn.cs
@@ -24,6 +24,9 @@ public sealed class WasmAuthSignIn(HttpClient http, IUserProvider userProvider, 
     {
         await http.PostAsync(LogoutPath, null).ConfigureAwait(false);
         await userProvider.RefreshAsync().ConfigureAwait(false);
-        navigator.NavigateTo(returnUrl ?? "/");
+        // Open-redirect guard: returnUrl is whatever the caller passed (often a login/query value
+        // that can be attacker-influenced), and NavigateTo can leave the origin. Collapse anything
+        // non-local to "/" at this boundary — the same LocalUrl rule the server sign-in path applies.
+        navigator.NavigateTo(LocalUrl.Sanitize(returnUrl));
     }
 }

--- a/tests/Rask.Wasm.Tests/Authentication/WasmAuthSignInTests.cs
+++ b/tests/Rask.Wasm.Tests/Authentication/WasmAuthSignInTests.cs
@@ -1,0 +1,52 @@
+using System.Net;
+using System.Security.Claims;
+using Rask.Core.Authentication;
+using Rask.Core.Routing;
+using Rask.Wasm.Authentication;
+
+namespace Rask.Wasm.Tests.Authentication;
+
+// WASM sign-out SPA-navigates to returnUrl, which is whatever the caller passed (commonly a
+// ?returnUrl= query value an attacker can shape). NavigateTo can leave the origin, so the
+// implementation must collapse anything non-local to "/" via the shared LocalUrl rule — the same
+// open-redirect guard the server sign-in path applies — before navigating.
+public class WasmAuthSignInTests
+{
+    [Theory]
+    [InlineData("/dashboard", "/dashboard")]
+    [InlineData("/a/b?x=1", "/a/b?x=1")]
+    [InlineData(null, "/")]
+    [InlineData("//evil.com", "/")]       // protocol-relative
+    [InlineData("/\\evil.com", "/")]      // backslash → browser normalises to "//"
+    [InlineData("\\evil.com", "/")]
+    [InlineData("https://evil.com", "/")] // absolute URL
+    [InlineData("evil.com", "/")]         // not rooted
+    public async Task SignOut_SanitizesReturnUrl_BeforeNavigating(string? returnUrl, string expectedPath)
+    {
+        var state = new RouteState();
+        var nav = new Navigator(state);
+        var auth = new WasmAuthSignIn(StubHttp(), new StubUserProvider(), nav);
+
+        using (nav.EnterHandler())
+        {
+            await auth.SignOutAsync(returnUrl);
+        }
+
+        Assert.Equal(expectedPath, state.Path);
+    }
+
+    private static HttpClient StubHttp() =>
+        new(new OkHandler()) { BaseAddress = new Uri("http://localhost/") };
+
+    private sealed class OkHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+    }
+
+    private sealed class StubUserProvider : IUserProvider
+    {
+        public ClaimsPrincipal Current { get; } = new(new ClaimsIdentity());
+        public event Action? Changed { add { } remove { } }
+    }
+}


### PR DESCRIPTION
## Summary

SEC-C from the hardening pass — a **verified open-redirect gap** in the WASM auth path. `WasmAuthSignIn.SignOutAsync` SPA-navigated to its `returnUrl` argument **verbatim**:

```csharp
navigator.NavigateTo(returnUrl ?? "/");
```

`returnUrl` is whatever the caller passes — commonly a `?returnUrl=` query value an attacker can shape — and `NavigateTo` can leave the origin, so a crafted value (`//evil.com`, `https://evil.com`, `/\evil.com`, `\evil.com`) could redirect the user off-origin right after logout. The type's own XML-doc even claimed the logout flow used `LocalUrl`, but the implementation didn't.

The fix routes `returnUrl` through the shared `LocalUrl.Sanitize` rule — the same open-redirect guard the **server** sign-in path already applies at dispatch (`SanitizeReturnUrl`) — collapsing anything non-local to `/` before navigating.

## Scope of the audit

I mapped every `returnUrl` / `PendingAuth.ReturnUrl` consumer: the **server** dispatch path (`DispatchHandlerAsync`) sanitizes both sign-in and sign-out before the value reaches `AuthInstruction`/history, and `WasmLiveSession` only builds `?returnUrl=` from the server-controlled current path. The WASM sign-out was the one unsanitized boundary.

## Testing

- `dotnet build src/Rask.Wasm -warnaserror` clean.
- New `WasmAuthSignInTests` (theory): local paths (`/dashboard`, `/a/b?x=1`) pass through; every off-origin form — protocol-relative, backslash, absolute, non-rooted, `null` — collapses to `/`.
- Full `Rask.Wasm.Tests` suite: **54 pass**. Format clean.

## Changelog

Added under `[Unreleased] › Security`. No render/runtime hot-path touched — no benchmark.