### PR TITLE
docs(security): document running Rask under a strict Content-Security-Policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -220,6 +220,13 @@ them until tagged releases begin.
   components whatever the host OS, strips control/NUL characters, caps the length at 255, and falls back
   to `file` for empty / path-dot inputs) as defence in depth. The returned `name` is still
   attacker-controlled and must be HTML-encoded by hosts before display — never bound into `Raw`.
+- **Content Security Policy guidance.** The [authentication guide](docs/authentication.md#content-security-policy)
+  now documents how to run Rask under a strict CSP. Rask's runtime is built for it — the runtime script
+  and scoped assets are external (`<script src>` / `<link>`, no inline JS), and events bind via
+  `data-rask-on-*` + `addEventListener` — so `script-src 'self'` suffices (add `'wasm-unsafe-eval'` on
+  the WASM host); only `style-src` needs `'unsafe-inline'` for the inline `style=""` the `Style:`
+  parameter emits, and the same-origin live WebSocket is covered by `connect-src 'self'`. Includes a
+  copy-paste middleware baseline and a new security-checklist item.
 
 ### Performance
 - **Lower render allocations for elements carrying `Data` / `Aria` / `TabIndex`.**

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1004,6 +1004,50 @@ app.UseRask<App>();
 
 ---
 
+## Content Security Policy
+
+Rask doesn't emit a `Content-Security-Policy` header — CSP is app- and deployment-specific, so the
+host owns it. Rask's runtime is built to work under a **strict** policy: the runtime script and every
+scoped asset are served as **external** `<script src>` / `<link rel="stylesheet">` (no inline
+`<script>` blocks), and DOM events bind through `data-rask-on-*` attributes + `addEventListener` (no
+inline `onclick=` handlers), so you don't need `script-src 'unsafe-inline'`.
+
+Two things do shape the policy:
+
+- **Inline style attributes.** The `Style:` parameter renders `style="…"` attributes, which CSP
+  governs via `style-src` — so a strict policy needs `style-src 'self' 'unsafe-inline'`. (`'unsafe-inline'`
+  for *style attributes* is far weaker than for scripts; if you avoid `Style:` entirely in favour of
+  scoped CSS classes you can drop it.)
+- **The WebSocket (Server host).** The live runtime opens a **same-origin** WebSocket to `/rask/ws`,
+  covered by `connect-src 'self'`.
+
+A working baseline, set as middleware **before** `UseRask<App>()`:
+
+```csharp
+app.Use(async (ctx, next) =>
+{
+    ctx.Response.Headers["Content-Security-Policy"] =
+        "default-src 'self'; " +
+        "script-src 'self'; " +          // runtime + scoped scripts are external; no inline JS
+        "style-src 'self' 'unsafe-inline'; " + // inline style="" from the Style: parameter
+        "img-src 'self' data:; " +
+        "connect-src 'self'; " +         // same-origin WebSocket (/rask/ws)
+        "base-uri 'self'; " +
+        "frame-ancestors 'none'";
+    await next();
+});
+```
+
+**WASM host:** the .NET WebAssembly runtime requires `'wasm-unsafe-eval'` in `script-src`, so use
+`script-src 'self' 'wasm-unsafe-eval'`. A standalone (static-file) WASM app sets the same policy via
+its host's header config (e.g. `staticwebapp.config.json`, an nginx `add_header`, or a CDN rule)
+rather than ASP.NET middleware.
+
+Tighten from there per app: add `upgrade-insecure-requests` on HTTPS, list any third-party CDN/API
+origins you actually use, and consider `report-uri`/`report-to` to catch violations before enforcing.
+
+---
+
 ## Security checklist
 
 - ☑ Serve auth over **HTTPS** only (`Cookie.SecurePolicy = Always` on `AddCookie`).
@@ -1013,6 +1057,7 @@ app.UseRask<App>();
 - ☑ Short JWT lifetime + app-driven silent refresh so sessions stay smooth without long-lived tokens.
 - ☑ Keep `UseAuthentication()` **before** `UseRask()`.
 - ☑ Validate redirect targets — Rask sanitizes the `returnUrl` to local same-origin paths (rejects `//`, `/\`, and backslash/control-char variants).
+- ☑ Set a **[Content-Security-Policy](#content-security-policy)** — Rask runs under a strict policy (`script-src 'self'`, plus `'wasm-unsafe-eval'` on WASM); only `style-src` needs `'unsafe-inline'` for `Style:` attributes.
 - ☑ Treat the **session id as a bearer secret** — HTTPS only, never logged or placed in URLs that leak via `Referer`.
 - ☑ Behind a reverse proxy, wire **ForwardedHeaders** so the host-only same-origin checks (redeem + WS) see the public host.
 - ☑ For untrusted-traffic hosts, set `RaskLiveOptions.MaxSessions` and a reverse-proxy rate limit to bound session creation.


### PR DESCRIPTION
## Summary

SEC-D from the hardening pass. Rask doesn't emit a `Content-Security-Policy` header (it's app/deployment-specific), but its runtime is **built to work under a strict policy** and that wasn't written down anywhere. This adds a **"Content Security Policy"** section to `docs/authentication.md` plus a security-checklist item.

The guidance is grounded in the actual runtime architecture (verified while writing it):
- Runtime script and scoped assets are **external** (`<script src="/rask/rask.js">`, `<script src="/_rask/a/{hash}.js">`, `<link rel="stylesheet">`) — no inline `<script>`, so **no `script-src 'unsafe-inline'`**.
- DOM events bind via `data-rask-on-*` attributes + `addEventListener` — no inline `onclick=`.
- The `Style:` parameter renders inline `style="…"` attributes → needs `style-src 'self' 'unsafe-inline'` (far weaker than for scripts; avoidable if you use scoped CSS classes instead).
- The Server live runtime opens a **same-origin** WebSocket to `/rask/ws` → covered by `connect-src 'self'`.
- The **WASM** host's .NET runtime needs `'wasm-unsafe-eval'` in `script-src`.

Includes a copy-paste middleware baseline (set before `UseRask<App>()`), WASM/static-host notes, and pointers to tighten further (`upgrade-insecure-requests`, `report-uri`).

## Testing

Docs-only — no code, build, or behaviour change. Anchors/links verified.

## Changelog

Added under `[Unreleased] › Security`.