### PR TITLE
test(forms): pin EditContext disposal during in-flight async validation

### DIFF
--- a/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
+++ b/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
@@ -76,6 +76,36 @@ public class EditContextDisposalTests
         Assert.True(ctx.IsDisposed);
     }
 
+    [Fact]
+    public async Task Dispose_WhileAsyncValidationInFlight_CompletesCleanly()
+    {
+        // Worst case: a form unmounts (Dispose) while an async field validator is still awaiting,
+        // then the validator resumes. The end-to-end handler serialization in the live transports
+        // normally prevents this overlap, but the EditContext itself must also be safe — Dispose
+        // disposes the per-field CTS, so the resuming validator must not trip an
+        // ObjectDisposedException (double CTS dispose) or fire a stale render after RequestRender
+        // was nulled.
+        var model = new Model { Name = "ada" };
+        var ctx = new EditContext(model);
+        var renderRequests = 0;
+        ctx.RequestRender = () => Interlocked.Increment(ref renderRequests);
+
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ctx.AddValidator(new GatedAsyncValidator(gate));
+
+        // Start validation; it parks inside the gated async validator's await.
+        var validation = ctx.ValidateFieldAsync(new FieldIdentifier(model, "Name"));
+        await Task.Yield();
+
+        ctx.Dispose();          // form unmounts mid-validation
+        gate.SetResult();       // validator resumes after disposal
+
+        var ex = await Record.ExceptionAsync(async () => await validation);
+        Assert.Null(ex);
+        Assert.True(ctx.IsDisposed);
+        Assert.Equal(0, renderRequests); // RequestRender was nulled on Dispose — no stale render
+    }
+
     private sealed class Model
     {
         public string Name { get; set; } = "";
@@ -87,5 +117,16 @@ public class EditContextDisposalTests
 
         public ValueTask ValidateFieldAsync(EditContext context, FieldIdentifier field,
             CancellationToken cancellationToken) => default;
+    }
+
+    // Async validator that parks on a test-controlled gate, so the test can dispose the EditContext
+    // while a field validation is mid-await and then release it.
+    private sealed class GatedAsyncValidator(TaskCompletionSource gate) : IAsyncFieldValidator
+    {
+        public ValueTask ValidateAsync(EditContext context, CancellationToken cancellationToken) => default;
+
+        public async ValueTask ValidateFieldAsync(EditContext context, FieldIdentifier field,
+            CancellationToken cancellationToken) =>
+            await gate.Task.ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary

Verify-then-build for **STAB-D**. The audit flagged that an in-flight async field validator could complete after its `EditContext` is disposed on form unmount, possibly throwing an unobserved `ObjectDisposedException` or firing a stale render. Investigation showed it's **already handled** on two levels, so this closes it with a regression test rather than a fix:

1. **Serialization.** The live transports hold their dispatch lock across the whole awaited handler (where validation runs), so a different handler/render can't unmount the form mid-validation.
2. **EditContext robustness.** Even under the worst-case overlap, `Dispose()` sets `IsDisposed`, nulls `RequestRender` (neutralizing any later render request), and per-field CTS disposal is idempotent — so a resuming validator can't throw or fire a stale render.

## Test added

`Dispose_WhileAsyncValidationInFlight_CompletesCleanly` — parks a gated async validator inside `ValidateFieldAsync`, calls `Dispose()` while it's awaiting, releases the gate, and asserts the validation completes with **no exception**, `IsDisposed`, and **zero render requests**. A `GatedAsyncValidator` fixture drives the timing.

The existing `EditContextDisposalTests` covered unmount→dispose, sticky-timer cancellation, and idempotent dispose, but not the mid-flight-validation case.

## Testing

`dotnet test --filter EditContextDisposal` — 5 pass (4 existing + new); format clean.

## Notes

**Test-only** — no production change, no benchmark, no behavioural CHANGELOG entry.