### PR TITLE
test(live): cover keyed insert at head/middle/tail on nav; drop stale Key caveat

### DIFF
--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -58,8 +58,10 @@ public abstract class Component
     // ops (Insert/Remove/Move) instead of a positional full-HTML morph. `object?` so callers
     // pass a Guid/int/string directly; stringified on emit. Nullable + no initializer ⇒ the
     // factory generator exposes it as an optional `Key:` parameter on every factory.
-    // NOTE: keyed insert/append during a navigation currently renders the new row with wrong
-    // content (a known framework bug); delete/move/in-place keyed edits are correct.
+    // Keyed insert/append/delete/move/in-place edits are all correct, including when the
+    // structural change rides a navigation diff (the inserted row's HTML fragment is sliced from
+    // post-head-splice HTML via offsets that RenderAsLiveRootCore keeps in lockstep — see
+    // FrameWriter.AdjustOffsetsFrom and KeyedInsertNavTests).
     public object? Key { get; set; }
 
     private object? _cachedKeyValue;

--- a/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/KeyedNavApp.cs
@@ -7,12 +7,19 @@ using Rask.Core.Routing;
 namespace Rask.Server.Tests.Infrastructure;
 
 // Reproduces the keyed-insert-during-navigation scenario: a layout-style app subscribes to
-// RouteState.Changed and, when it navigates to "/add", appends an item to a keyed list — so
-// the keyed InsertSubtree rides the navigation diff (which on the server runs through the
-// coalescing send loop). The rows are keyed via data-rask-key.
+// RouteState.Changed and, when it navigates, inserts an item into a keyed list — so the keyed
+// InsertSubtree rides the navigation diff (which on the server runs through the coalescing send
+// loop). The rows are keyed via data-rask-key, and the list stays sorted so the navigation path
+// chooses where the new row lands:
+//   /add-head → 5  (before the [10,20,30] seed)
+//   /add-mid  → 15 (between 10 and 20)
+//   /add-tail → 40 (after 30)
+// Each scenario exercises the same HTML-slice path; the regression is that the inserted row's
+// fragment is sliced from post-head-splice HTML via frame offsets, which must be correct at any
+// position. (#7's NOTE claimed this was broken; #14/#37's AdjustOffsetsFrom fixed it.)
 public sealed class KeyedNavApp : Component
 {
-    private readonly List<int> _items = [1, 2];
+    private readonly List<int> _items = [10, 20, 30];
     private readonly RouteState _route;
 
     public KeyedNavApp(RouteState route) => _route = route;
@@ -22,9 +29,18 @@ public sealed class KeyedNavApp : Component
 
     private void OnRouteChanged()
     {
-        if (_route.Path == "/add" && !_items.Contains(3))
+        var insert = _route.Path switch
         {
-            _items.Add(3);
+            "/add-head" => 5,
+            "/add-mid" => 15,
+            "/add-tail" => 40,
+            _ => (int?)null
+        };
+
+        if (insert is { } value && !_items.Contains(value))
+        {
+            _items.Add(value);
+            _items.Sort();
         }
 
         StateHasChanged();

--- a/tests/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
@@ -15,8 +15,15 @@ public class KeyedInsertNavTests
 {
     public KeyedInsertNavTests() => LiveOptions.DiffMode = LiveDiffMode.Forced;
 
-    [Fact]
-    public async Task KeyedInsertDuringNavigation_ShipsCorrectRowHtml()
+    // The keyed list is seeded [10,20,30]; navigating inserts a row at the head, middle, or tail.
+    // Every position rides the same post-head-splice HTML-slice path, so all three must ship the
+    // complete, correctly-sliced <li> — the row-content regression had to be checked at each slot,
+    // not just the tail append the original test covered.
+    [Theory]
+    [InlineData("/add-head", 5)]
+    [InlineData("/add-mid", 15)]
+    [InlineData("/add-tail", 40)]
+    public async Task KeyedInsertDuringNavigation_ShipsCorrectRowHtml(string path, int key)
     {
         await using var fixture = await ConnectedSession.Connect<KeyedNavApp>();
 
@@ -24,15 +31,15 @@ public class KeyedInsertNavTests
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/list", query = "" });
         _ = await DrainAll(fixture.Ws);
 
-        // Navigate to /add: the RouteState.Changed handler appends keyed item 3 — the keyed
+        // Navigate: the RouteState.Changed handler inserts the keyed item — the keyed
         // InsertSubtree rides this navigation diff.
-        await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/add", query = "" });
+        await fixture.Ws.SendJsonAsync(new { type = "navigate", path, query = "" });
         var frames = await DrainAll(fixture.Ws);
 
         var insert = FindInsertSubtree(frames);
         Assert.NotNull(insert);
         // The fragment must be the complete, correctly-sliced <li> — not garbled bytes.
-        Assert.Equal("<li class=\"row\" data-rask-key=\"3\">item 3</li>", insert);
+        Assert.Equal($"<li class=\"row\" data-rask-key=\"{key}\">item {key}</li>", insert);
     }
 
     // Walk every shipped diff frame; return the HTML payload of the first InsertSubtree op


### PR DESCRIPTION
## Summary

The `Component.Key` doc carried a `NOTE` claiming *keyed insert/append during a navigation
renders the new row with wrong content (a known framework bug)*. That bug — a keyed
`InsertSubtree` fragment sliced from post-head-splice HTML using pre-splice frame offsets —
was **already fixed** by `FrameWriter.AdjustOffsetsFrom` in `RenderAsLiveRootCore`, which
shifts the offsets in lockstep with the head-asset sentinel splice. The fix lives in shared
Core code, so both the Server (WS) and WASM hosts are covered.

Git timeline confirms the caveat is stale: it was added in #7 (2026-06-02); the fix and its
regression test landed in #14/#37 (2026-06-03+). The comment was simply never removed.

This PR:
- Expands `KeyedInsertNavTests` from a single tail-append case into a theory covering
  **head / middle / tail** insertion during navigation — each rides the same HTML-slice path
  and must ship the complete, correctly-sliced `<li>`.
- Replaces the stale `NOTE` on `Component.Key` with an accurate pointer to the offset-adjustment
  mechanism and the test.

No framework behavior changes — the diff/render path is unchanged; this corrects documentation
and broadens regression coverage.

## Testing

- `dotnet build tests/Rask.Server.Tests -warnaserror` — clean (0 warnings).
- `dotnet format --verify-no-changes` on touched files — clean.
- `KeyedInsertNavTests` theory (head/middle/tail) — 3/3 pass.
- FrameDiffer / Reconciliation / KeyedMove / LivePayloadDiff / KeyTests suites — 61/61 pass.

## Benchmarks

None — no render/runtime hot-path code changed (doc + test only).

## Changelog

No entry — no user-observable behavior change in this PR (the underlying fix shipped in a prior release).
