### PR TITLE
test(live): pin keyed full-reverse worst case (benchmark + move-order replay)

### DIFF
--- a/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
@@ -25,6 +25,8 @@ public class FrameDifferBenchmarks
     private readonly FrameDiffer.DiffScratch _scratch = new();
     private RenderFrame[] _afterReorder = null!;
     private string _afterReorderHtml = "";
+    private RenderFrame[] _afterReverse = null!;
+    private string _afterReverseHtml = "";
     private RenderFrame[] _afterText = null!;
 
     private RenderFrame[] _before = null!;
@@ -54,6 +56,14 @@ public class FrameDifferBenchmarks
         (reordered[5], reordered[RowCount - 5]) = (reordered[RowCount - 5], reordered[5]);
         (_afterReorder, _afterReorderHtml) = FramesAndHtmlOf(BuildKeyedList(reordered, -1));
 
+        // Full reverse: the worst case for the keyed move loop. A reversed permutation has an LIS
+        // of length 1, so n-1 rows are off-LIS and each emits a move — the loop's per-move
+        // live.IndexOf + live.Insert (each O(n)) then makes the whole step O(n²). The two-swap
+        // Reorder above only ever moves a couple of rows, so it never surfaced this cost.
+        var reversed = (int[])order.Clone();
+        Array.Reverse(reversed);
+        (_afterReverse, _afterReverseHtml) = FramesAndHtmlOf(BuildKeyedList(reversed, -1));
+
         // Same key order, one kept row's inner text changed — exercises the keyed step-5
         // inner-diff recursion (the path that re-enters DiffSiblings under a keyed parent).
         _afterText = FramesOf(BuildKeyedList(order, RowCount / 2));
@@ -82,6 +92,16 @@ public class FrameDifferBenchmarks
     {
         _ops.Clear();
         FrameDiffer.Diff(_before, _afterReorder, _ops, new FrameDiffer.DiffScratch(), out _, _afterReorderHtml);
+        return _ops.Count;
+    }
+
+    [Benchmark]
+    public int ReverseReorder_ReusedScratch()
+    {
+        // Worst-case keyed reorder: ~n moves, so this is the benchmark that actually exercises the
+        // O(n²) move loop (live.IndexOf + live.Insert per off-LIS row).
+        _ops.Clear();
+        FrameDiffer.Diff(_before, _afterReverse, _ops, _scratch, out _, _afterReverseHtml);
         return _ops.Count;
     }
 

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -627,6 +627,52 @@ public class FrameDifferTests
         Assert.Equal(after, live.ToArray());
     }
 
+    [Theory]
+    [InlineData(50)]
+    [InlineData(500)]
+    [InlineData(1000)]
+    public void Diff_KeyedList_FullReverse_MoveOpsReproduceTargetOrder(int n)
+    {
+        // The worst case for the keyed move loop: a fully reversed list has an LIS of length 1, so
+        // n-1 rows are off-LIS and each emits a move. The RandomPermutation gate above (n ≤ 250)
+        // rarely lands on a clean reverse, and the FrameDiffer ReverseReorder benchmark measures
+        // this shape's *cost* — this test pins its *correctness*: replaying the single
+        // PermutationBatch's (dst,src) pairs against the before-order must reproduce the reverse.
+        // Covers large n so the move semantics stay correct if the O(n²) loop is ever reworked.
+        var before = new int[n];
+        for (var i = 0; i < n; i++)
+        {
+            before[i] = i;
+        }
+
+        var after = (int[])before.Clone();
+        Array.Reverse(after);
+
+        var beforeFrames = Frames(BuildKeyedRows(before));
+        var afterFrames = Frames(BuildKeyedRows(after));
+
+        var ops = new List<EditOp>();
+        FrameDiffer.Diff(beforeFrames, afterFrames, ops, out var usedKeyed);
+
+        Assert.True(usedKeyed);
+        var batch = Assert.Single(ops);
+        Assert.Equal(EditOpKind.PermutationBatch, batch.Kind);
+        Assert.True(batch.Trusted);
+
+        // Replay the (dst,src) pairs exactly as the DOM interpreter does: detach at src, insert at
+        // dst in the post-detach list.
+        var live = new List<int>(before);
+        var moves = batch.Moves!;
+        for (var m = 0; m + 1 < moves.Length; m += 2)
+        {
+            var moved = live[moves[m + 1]];
+            live.RemoveAt(moves[m + 1]);
+            live.Insert(moves[m], moved);
+        }
+
+        Assert.Equal(after, live.ToArray());
+    }
+
     [Fact]
     public void Diff_NestedKeyedList_OuterReorderAndInnerReorder_EmitsTrustedBatchesAtBothDepths()
     {


### PR DESCRIPTION
## Summary

A stability/perf audit measured the `FrameDiffer` keyed **move loop** to decide whether its
`O(n²)` shape (per-move `live.IndexOf` + `live.Insert`) was worth optimizing. The existing
`Reorder` benchmark only swaps two entries, so it never exercised the loop. This PR adds the
worst-case measurement and correctness coverage — and, on the evidence, **deliberately does not
rewrite the algorithm**.

### Benchmark: worst-case reorder
New `ReverseReorder_ReusedScratch` — a fully reversed list (LIS length 1 → `n-1` moves), the loop's
worst case. Measured on this machine (Apple M4 Pro, .NET 10):

| Scenario (1000 rows) | Mean | Allocated |
|---|---:|---:|
| `NoChange` (no moves) | 117.8 µs | 70.3 KB |
| `Reorder` (two-swap) | 128.2 µs | 70.4 KB |
| **`ReverseReorder` (~n moves)** | **250.3 µs** | 78.2 KB |

So the `O(n²)` loop adds ~**132 µs** only on a pathological full-reverse of a 1000-row keyed list,
and ~10 µs on a typical few-move reorder (dominated by the diff walk, not the loop). At 100 rows even
the full reverse is 13.8 µs.

### Why no rewrite
The wire protocol is numeric-index-based, so an `O(1)`/`O(n log n)` loop would need an order-statistics
structure (Fenwick/balanced tree) in code that grafts DOM state (focus, input value, scroll) onto rows
— a high-risk change for a sub-millisecond win on a rare extreme. The benchmark stays as a **regression
guard** on the move-loop cost instead.

### Correctness gate for the worst case
`Diff_KeyedList_FullReverse_MoveOpsReproduceTargetOrder` (n = 50/500/1000) replays the single
`PermutationBatch`'s `(dst,src)` pairs exactly as the client interpreter does (detach at `src`, insert
at `dst`) and asserts the reversed order is reproduced. The existing `RandomPermutation` gate stops at
n = 250 and rarely lands on a clean reverse, so this explicitly pins the worst-case move semantics —
guarding any future loop rewrite.

## Testing
- `FrameDifferTests` — **36 passing**, including the new full-reverse replay at n = 50/500/1000.
- `dotnet format --verify-no-changes` (touched files) — clean.
- `dotnet build benchmarks/Rask.Benchmarks -c Release -warnaserror` — clean.

## Benchmarks
The added `ReverseReorder` numbers above are the evidence; no framework code changed, so there is no
before/after delta to report — this PR *creates* the worst-case measurement.

## Changelog
No entry — benchmark + test only, no user-observable change.
