### PR TITLE
refactor(core): route swallowed faults through an internal RaskDiagnostics seam

### DIFF
--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Rask.Core.Components;
+using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
 using Rask.Core.HeadAssets;
 using Rask.Core.Live;
@@ -630,7 +631,11 @@ public abstract class Component
     }
 
     internal static void LogUnmountError(Component comp, Exception ex) =>
-        Console.Error.WriteLine($"Rask unmount hook on {comp.GetType().Name} threw: {ex}");
+        RaskDiagnostics.Report(
+            RaskLogLevel.Error,
+            "Rask.Lifecycle",
+            $"Rask unmount hook on {comp.GetType().Name} threw",
+            ex);
 
     private void InvokeAsyncLifecycleWithRendering(Func<Task> invoke)
     {
@@ -694,8 +699,8 @@ public abstract class Component
             return;
         }
 
-        // Prefer the boundary: it'll re-render with the fallback. Fall back to Console.Error
-        // logging only when there is no ancestor boundary, so a faulting hook is never silent.
+        // Prefer the boundary: it'll re-render with the fallback. Fall back to a diagnostics
+        // report only when there is no ancestor boundary, so a faulting hook is never silent.
         var boundary = comp.Boundary;
         if (boundary is not null)
         {
@@ -703,7 +708,11 @@ public abstract class Component
             return;
         }
 
-        Console.Error.WriteLine($"Rask lifecycle hook on {comp.GetType().Name} faulted: {actual}");
+        RaskDiagnostics.Report(
+            RaskLogLevel.Error,
+            "Rask.Lifecycle",
+            $"Rask lifecycle hook on {comp.GetType().Name} faulted",
+            actual);
     }
 
     internal Component RenderForLive()

--- a/src/Rask.Core/Components/VirtualizeModel.cs
+++ b/src/Rask.Core/Components/VirtualizeModel.cs
@@ -1,5 +1,6 @@
 using System.Collections;
 using System.Diagnostics.CodeAnalysis;
+using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 using Rask.Core.Virtualization;
 
@@ -368,7 +369,11 @@ public sealed class VirtualizeModel : Component
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Rask VirtualizeModel: ItemsProvider threw: {ex}");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Error,
+                "Rask.Virtualize",
+                "Rask VirtualizeModel: ItemsProvider threw",
+                ex);
             return;
         }
 

--- a/src/Rask.Core/Diagnostics/RaskDiagnostics.cs
+++ b/src/Rask.Core/Diagnostics/RaskDiagnostics.cs
@@ -1,0 +1,142 @@
+namespace Rask.Core.Diagnostics;
+
+/// <summary>
+///     Severity of a <see cref="RaskDiagnosticEvent" />. Deliberately a small subset that maps
+///     cleanly onto <c>Microsoft.Extensions.Logging.LogLevel</c> when a host bridges the
+///     <see cref="RaskDiagnostics.Sink" /> to an <c>ILogger</c>:
+///     <see cref="Information" />→<c>Information</c>, <see cref="Warning" />→<c>Warning</c>,
+///     <see cref="Error" />→<c>Error</c>.
+/// </summary>
+internal enum RaskLogLevel
+{
+    Information,
+    Warning,
+    Error
+}
+
+/// <summary>
+///     A single framework diagnostic — a faulting lifecycle hook, a dispose that threw, a duplicate
+///     <c>data-rask-key</c>, a JS-invoke fault, and so on. Carries the human-readable
+///     <see cref="Message" /> and the <see cref="Exception" /> separately (rather than baking the
+///     exception into the message text) so a structured sink can log them as distinct fields.
+/// </summary>
+internal readonly struct RaskDiagnosticEvent(
+    RaskLogLevel level,
+    string category,
+    string message,
+    Exception? exception = null)
+{
+    /// <summary>Severity of the event.</summary>
+    public RaskLogLevel Level { get; } = level;
+
+    /// <summary>
+    ///     Stable subsystem category (e.g. <c>Rask.Lifecycle</c>, <c>Rask.Diff</c>,
+    ///     <c>Rask.JsInvoke</c>). Maps to the <c>ILogger</c> category on the host side.
+    /// </summary>
+    public string Category { get; } = category;
+
+    /// <summary>Human-readable message, <em>without</em> the exception text appended.</summary>
+    public string Message { get; } = message;
+
+    /// <summary>The associated exception, or <c>null</c> for a message-only diagnostic.</summary>
+    public Exception? Exception { get; } = exception;
+}
+
+/// <summary>
+///     The framework's dependency-free diagnostic seam. <c>Rask.Core</c> (and the WASM host) deliberately
+///     take no dependency on <c>Microsoft.Extensions.Logging</c>, yet still need to surface faults that
+///     would otherwise be swallowed — a lifecycle hook that threw with no ancestor
+///     <see cref="ErrorBoundary" />, a component <c>Dispose</c> that faulted, a duplicate sibling key, a
+///     JS-invoke fault. Those sites call <see cref="Report" /> / <see cref="ReportOnce" /> instead of
+///     writing to <see cref="Console.Error" /> directly.
+///     <para>
+///         The default <see cref="Sink" /> reproduces the historical <c>Console.Error</c> behaviour, so an
+///         unconfigured app is unchanged. A host (via the server/WASM hosting layer, which can see these
+///         internals) bridges <see cref="Sink" /> once at startup to route every framework diagnostic into
+///         its own <c>ILogger</c> / metrics pipeline; a test swaps in a capturing sink and restores the
+///         previous one afterwards. Kept <c>internal</c> for now: the public, documented host-facing knob
+///         is introduced by the server-side observability layer that consumes this seam.
+///     </para>
+/// </summary>
+internal static class RaskDiagnostics
+{
+    // Bounds ReportOnce's memory: a correct app never populates this, and a buggy one that churns
+    // unbounded distinct dedup keys stops being reported past the cap rather than growing without
+    // limit. The budget is shared across all ReportOnce call sites; today only the live diff's
+    // duplicate-key warning uses it, so the historical per-key 1024 cap is preserved exactly.
+    private const int ReportOnceCap = 1024;
+    private static readonly HashSet<string> ReportedOnce = new(StringComparer.Ordinal);
+
+    /// <summary>
+    ///     Where framework diagnostics go. Defaults to a <see cref="Console.Error" /> writer (matching the
+    ///     framework's prior <c>"…: {ex}"</c> stderr format). A host bridges this to structured logging; a
+    ///     test swaps in a capturing sink and restores the previous value. Set to <c>null</c> to silence
+    ///     framework diagnostics entirely. Read into a local before invocation, so reassigning it
+    ///     concurrently with a <see cref="Report" /> is safe.
+    /// </summary>
+    public static Action<RaskDiagnosticEvent>? Sink { get; set; } = WriteToStandardError;
+
+    /// <summary>
+    ///     Surface a framework diagnostic through the active <see cref="Sink" />. A no-op when the sink
+    ///     is <c>null</c>.
+    /// </summary>
+    public static void Report(RaskLogLevel level, string category, string message, Exception? exception = null)
+    {
+        // Snapshot the settable sink so a concurrent reassignment can't null it out mid-call.
+        var sink = Sink;
+        sink?.Invoke(new RaskDiagnosticEvent(level, category, message, exception));
+    }
+
+    /// <summary>
+    ///     Surface a diagnostic at most once per distinct <paramref name="dedupKey" />, bounded to
+    ///     <see cref="ReportOnceCap" /> distinct keys. <paramref name="messageFactory" /> is invoked only
+    ///     when the event is actually delivered, so a condition that recurs every render on an
+    ///     already-broken path (e.g. a duplicate key reappearing on each reconcile) pays nothing to build
+    ///     its message after the first report. The dedup key is recorded only once the event is delivered,
+    ///     so a diagnostic raised while the sink is momentarily <c>null</c> is not permanently suppressed.
+    ///     Callers should namespace <paramref name="dedupKey" /> (e.g. <c>"dupkey:" + key</c>) so unrelated
+    ///     call sites can't collide in the shared dedup set.
+    /// </summary>
+    public static void ReportOnce(
+        string dedupKey,
+        RaskLogLevel level,
+        string category,
+        Func<string> messageFactory,
+        Exception? exception = null)
+    {
+        // Nothing to deliver to, so don't burn the dedup key — a later, real sink should still see it.
+        var sink = Sink;
+        if (sink is null)
+        {
+            return;
+        }
+
+        lock (ReportedOnce)
+        {
+            if (ReportedOnce.Count >= ReportOnceCap || !ReportedOnce.Add(dedupKey))
+            {
+                return;
+            }
+        }
+
+        sink.Invoke(new RaskDiagnosticEvent(level, category, messageFactory(), exception));
+    }
+
+    private static void WriteToStandardError(RaskDiagnosticEvent e) =>
+        Console.Error.WriteLine(FormatDefault(e));
+
+    // The single-line stderr rendering used by the default sink. Extracted so it can be unit-tested
+    // without redirecting the process-global Console.Error stream.
+    internal static string FormatDefault(RaskDiagnosticEvent e) =>
+        e.Exception is null ? e.Message : $"{e.Message}: {e.Exception}";
+
+    // Test hook: clears the ReportOnce dedup set so a test can exercise the once-per-key behaviour
+    // deterministically regardless of what earlier tests reported.
+    internal static void ResetReportOnceForTests()
+    {
+        lock (ReportedOnce)
+        {
+            ReportedOnce.Clear();
+        }
+    }
+}

--- a/src/Rask.Core/Live/ComponentLifecycle.cs
+++ b/src/Rask.Core/Live/ComponentLifecycle.cs
@@ -1,3 +1,5 @@
+using Rask.Core.Diagnostics;
+
 namespace Rask.Core.Live;
 
 internal static class ComponentLifecycle
@@ -99,5 +101,9 @@ internal static class ComponentLifecycle
     }
 
     private static void LogDisposeError(Component component, Exception ex) =>
-        Console.Error.WriteLine($"Rask component dispose on {component.GetType().Name} threw: {ex}");
+        RaskDiagnostics.Report(
+            RaskLogLevel.Error,
+            "Rask.Lifecycle",
+            $"Rask component dispose on {component.GetType().Name} threw",
+            ex);
 }

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
+using Rask.Core.Diagnostics;
 
 namespace Rask.Core.Live;
 
@@ -152,40 +153,30 @@ public readonly struct EditOp
 /// </summary>
 public static class FrameDiffer
 {
-    // Bounds the warn-once memory: a correct app never populates this, and a buggy one that
-    // churns unbounded distinct duplicate keys stops being warned past the cap rather than
-    // growing without limit. Guarded by its own lock — the diff runs single-threaded per
-    // session but distinct sessions can diff concurrently.
-    private static readonly HashSet<string> WarnedDuplicateKeys = new(StringComparer.Ordinal);
-
     /// <summary>
     ///     Invoked with the offending <c>data-rask-key</c> value when the diff codec finds two
     ///     sibling elements sharing a key. A duplicate key defeats keyed reconciliation, so the
     ///     codec falls back to a positional walk that can graft a surviving node's DOM state
     ///     (focus, input value, scroll) onto the wrong sibling when the list reorders — a silent
-    ///     correctness bug. Defaults to a deduplicated <see cref="Console.Error" /> writer
-    ///     (<see cref="WarnDuplicateKeyOnce" />); set to <c>null</c> to silence, or replace to
-    ///     route into a logger or test sink. Only ever fires on the already-broken path, so it
-    ///     adds no cost to a correctly-keyed render.
+    ///     correctness bug. Defaults to a deduplicated writer (<see cref="WarnDuplicateKeyOnce" />)
+    ///     routed through the <see cref="RaskDiagnostics" /> seam; set to <c>null</c> to silence, or
+    ///     replace to route into a logger or test sink. Only ever fires on the already-broken path, so
+    ///     it adds no cost to a correctly-keyed render.
     /// </summary>
     internal static Action<string>? OnDuplicateKey = WarnDuplicateKeyOnce;
 
-    private static void WarnDuplicateKeyOnce(string key)
-    {
-        lock (WarnedDuplicateKeys)
-        {
-            if (WarnedDuplicateKeys.Count >= 1024 || !WarnedDuplicateKeys.Add(key))
-            {
-                return;
-            }
-        }
-
-        Console.Error.WriteLine(
-            $"Rask live diff: two sibling elements share data-rask-key=\"{key}\". Keys must be " +
-            "unique among siblings; the duplicate disables keyed reconciliation for that list and " +
-            "falls back to a positional diff, which can attach a node's state to the wrong sibling " +
-            "when the list reorders. Give each sibling a distinct Key.");
-    }
+    // Warn at most once per distinct key (bounded), routed through the shared diagnostics seam so a
+    // host can capture it. A correct app never reaches here; a buggy one that churns unbounded
+    // distinct duplicate keys stops being warned past the seam's cap rather than growing without limit.
+    private static void WarnDuplicateKeyOnce(string key) =>
+        RaskDiagnostics.ReportOnce(
+            "dupkey:" + key,
+            RaskLogLevel.Warning,
+            "Rask.Diff",
+            () => $"Rask live diff: two sibling elements share data-rask-key=\"{key}\". Keys must be " +
+                  "unique among siblings; the duplicate disables keyed reconciliation for that list and " +
+                  "falls back to a positional diff, which can attach a node's state to the wrong sibling " +
+                  "when the list reorders. Give each sibling a distinct Key.");
 
     /// <summary>
     ///     Walk <paramref name="oldFrames" /> and <paramref name="newFrames" /> together

--- a/src/Rask.Core/Live/LiveJsInvokeQueue.cs
+++ b/src/Rask.Core/Live/LiveJsInvokeQueue.cs
@@ -2,6 +2,7 @@ using System.Text;
 using System.Text.Json;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
+using Rask.Core.Diagnostics;
 
 namespace Rask.Core.Live;
 
@@ -82,8 +83,11 @@ internal sealed class LiveJsInvokeQueue
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine(
-                    $"Rask: failed to surface JS invoke fault for taskId={invoke.TaskId}: {ex}");
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error,
+                    "Rask.JsInvoke",
+                    $"Rask: failed to surface JS invoke fault for taskId={invoke.TaskId}",
+                    ex);
             }
         }
     }

--- a/src/Rask.Wasm/JSInterop.cs
+++ b/src/Rask.Wasm/JSInterop.cs
@@ -3,6 +3,7 @@ using System.Runtime.InteropServices.JavaScript;
 #endif
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop.Infrastructure;
+using Rask.Core.Diagnostics;
 using Rask.Core.Routing;
 using Rask.Wasm.Files;
 
@@ -66,7 +67,11 @@ internal static partial class JSInterop
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"[Rask.Wasm] EndInvokeJSResult dispatch failed: {ex}");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Error,
+                "Rask.Wasm",
+                "[Rask.Wasm] EndInvokeJSResult dispatch failed",
+                ex);
         }
     }
 
@@ -96,8 +101,11 @@ internal static partial class JSInterop
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine(
-                $"[Rask.Wasm] BeginDotNetInvoke '{assemblyName}.{methodIdentifier}' failed: {ex}");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Error,
+                "Rask.Wasm",
+                $"[Rask.Wasm] BeginDotNetInvoke '{assemblyName}.{methodIdentifier}' failed",
+                ex);
         }
     }
 

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.JSInterop;
 using Rask.Core;
 using Rask.Core.Authentication;
+using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
 using Rask.Core.Live;
 using Rask.Core.Routing;
@@ -130,7 +131,11 @@ public sealed class WasmHostBuilder
             try { await userProvider.EnsureLoadedAsync().ConfigureAwait(false); }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"[Rask.Wasm] IUserProvider.EnsureLoadedAsync failed: {ex.Message}");
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error,
+                    "Rask.Wasm",
+                    "[Rask.Wasm] IUserProvider.EnsureLoadedAsync failed",
+                    ex);
             }
         }
 

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Core.Authorization;
+using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 using Rask.Core.Routing;
 
@@ -242,7 +243,11 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Rask WASM handler '{handlerId}' threw: {ex}");
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error,
+                    "Rask.Wasm",
+                    $"Rask WASM handler '{handlerId}' threw",
+                    ex);
                 return Array.Empty<byte>();
             }
         }
@@ -292,7 +297,11 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
             }
             catch (Exception ex)
             {
-                Console.Error.WriteLine($"Rask WASM navigate '{navPath}' threw: {ex}");
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error,
+                    "Rask.Wasm",
+                    $"Rask WASM navigate '{navPath}' threw",
+                    ex);
                 return Array.Empty<byte>();
             }
         }
@@ -344,7 +353,9 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         // telemetry so dispatch-render-loop bugs are greppable on either runtime.
         if (_pendingRenderInScope)
         {
-            Console.Error.WriteLine(
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning,
+                "Rask.Wasm",
                 "[Rask.WasmLiveSession] Coalesce-loop budget exhausted; a third " +
                 "in-dispatch render was queued and dropped. Inspect any handlers " +
                 "that re-trigger StateHasChanged in OnRenderedAsync / dispose " +

--- a/tests/Rask.Core.Tests/Diagnostics/RaskDiagnosticsTests.cs
+++ b/tests/Rask.Core.Tests/Diagnostics/RaskDiagnosticsTests.cs
@@ -1,0 +1,153 @@
+using Rask.Core.Diagnostics;
+
+namespace Rask.Core.Tests.Diagnostics;
+
+// Joins the serialized ConsoleRedirect collection: these tests mutate the process-global
+// RaskDiagnostics.Sink (including setting it to null), and the lifecycle tests in that collection
+// capture Console.Error and assert that real faults reach the default (stderr) sink. Running in the
+// same non-parallel collection keeps the two from racing on that shared global state.
+[Collection("ConsoleRedirect")]
+public class RaskDiagnosticsTests
+{
+    [Fact]
+    public void Report_InvokesWiredSink_WithStructuredFields()
+    {
+        var captured = new List<RaskDiagnosticEvent>();
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.Sink = captured.Add;
+        try
+        {
+            var boom = new InvalidOperationException("boom");
+            RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Test", "something faulted", boom);
+
+            var e = Assert.Single(captured);
+            Assert.Equal(RaskLogLevel.Error, e.Level);
+            Assert.Equal("Rask.Test", e.Category);
+            Assert.Equal("something faulted", e.Message);
+            Assert.Same(boom, e.Exception);
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+        }
+    }
+
+    [Fact]
+    public void Report_NullSink_IsNoOp()
+    {
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.Sink = null;
+        try
+        {
+            // Must not throw when diagnostics are silenced.
+            RaskDiagnostics.Report(RaskLogLevel.Warning, "Rask.Test", "ignored");
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+        }
+    }
+
+    [Fact]
+    public void ReportOnce_SameKey_ReportsOnlyOnce_AndBuildsMessageOnce()
+    {
+        var captured = new List<RaskDiagnosticEvent>();
+        var builds = 0;
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.Sink = captured.Add;
+        RaskDiagnostics.ResetReportOnceForTests();
+        try
+        {
+            var key = "test:" + Guid.NewGuid();
+            string Factory()
+            {
+                builds++;
+                return "first";
+            }
+
+            RaskDiagnostics.ReportOnce(key, RaskLogLevel.Warning, "Rask.Test", Factory);
+            RaskDiagnostics.ReportOnce(key, RaskLogLevel.Warning, "Rask.Test", Factory);
+
+            var e = Assert.Single(captured);
+            Assert.Equal("first", e.Message);
+            // The message factory runs only for the delivered event, never on the deduped repeat.
+            Assert.Equal(1, builds);
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+    }
+
+    [Fact]
+    public void ReportOnce_DistinctKeys_EachReported()
+    {
+        var captured = new List<RaskDiagnosticEvent>();
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.Sink = captured.Add;
+        RaskDiagnostics.ResetReportOnceForTests();
+        try
+        {
+            var prefix = "test:" + Guid.NewGuid() + ":";
+            RaskDiagnostics.ReportOnce(prefix + "a", RaskLogLevel.Warning, "Rask.Test", () => "a");
+            RaskDiagnostics.ReportOnce(prefix + "b", RaskLogLevel.Warning, "Rask.Test", () => "b");
+
+            Assert.Equal(2, captured.Count);
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+    }
+
+    [Fact]
+    public void ReportOnce_NullSink_DoesNotBurnKey()
+    {
+        var captured = new List<RaskDiagnosticEvent>();
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.ResetReportOnceForTests();
+        try
+        {
+            var key = "test:" + Guid.NewGuid();
+
+            // First occurrence fires while the sink is null — nothing delivered, key not burned.
+            RaskDiagnostics.Sink = null;
+            RaskDiagnostics.ReportOnce(key, RaskLogLevel.Warning, "Rask.Test", () => "deferred");
+
+            // Once a real sink is active, the same key still surfaces.
+            RaskDiagnostics.Sink = captured.Add;
+            RaskDiagnostics.ReportOnce(key, RaskLogLevel.Warning, "Rask.Test", () => "deferred");
+
+            var e = Assert.Single(captured);
+            Assert.Equal("deferred", e.Message);
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+    }
+
+    [Fact]
+    public void FormatDefault_MessageOnly_RendersMessage()
+    {
+        var line = RaskDiagnostics.FormatDefault(
+            new RaskDiagnosticEvent(RaskLogLevel.Warning, "Rask.Test", "just a message"));
+
+        Assert.Equal("just a message", line);
+    }
+
+    [Fact]
+    public void FormatDefault_WithException_AppendsExceptionAfterColon()
+    {
+        var ex = new InvalidOperationException("boom");
+        var line = RaskDiagnostics.FormatDefault(
+            new RaskDiagnosticEvent(RaskLogLevel.Error, "Rask.Test", "handler threw", ex));
+
+        // Reproduces the framework's historical "<message>: <exception>" stderr format.
+        Assert.StartsWith("handler threw: ", line);
+        Assert.Contains("boom", line);
+    }
+}


### PR DESCRIPTION
## Summary

`Rask.Core` and the WASM host deliberately take no dependency on `Microsoft.Extensions.Logging`, yet several fault paths wrote directly to `Console.Error`, making framework diagnostics unroutable. This introduces an internal, dependency-free diagnostics **seam** (`Rask.Core.Diagnostics.RaskDiagnostics`) and routes every such site through it.

- **`RaskDiagnostics.Report(...)` / `ReportOnce(...)`** — a settable `Sink` (`Action<RaskDiagnosticEvent>`) defaulting to the historical `Console.Error` behaviour, so an unconfigured app is byte-for-byte unchanged. Each event carries a typed `RaskLogLevel`, a stable `Category` (`Rask.Lifecycle`, `Rask.Diff`, `Rask.JsInvoke`, `Rask.Wasm`, …), the message, and the `Exception` as **distinct fields** — so a host can bridge one delegate into structured logging.
- **`ReportOnce`** delivers at most once per (bounded) dedup key, builds its message **lazily** only when actually delivered, and does **not** burn the dedup key when no sink is wired — preserving the live diff's per-key duplicate-`Key` warn-once behaviour with zero per-render allocation on a persistently broken list.
- Routed all 7 `Rask.Core` + 6 `Rask.Wasm` `Console.Error` sites (lifecycle/dispose faults, duplicate-`Key`, JS-invoke faults, virtualization, WASM handler/navigate/interop) through the seam.

Kept **`internal`** for now: the documented, host-facing knob arrives with the upcoming server-side observability layer that consumes this seam (via `InternalsVisibleTo`).

## Testing

- New `tests/Rask.Core.Tests/Diagnostics/RaskDiagnosticsTests.cs` (7 tests): wired-sink structured fields, null-sink no-op, `ReportOnce` dedup + lazy-message + don't-burn-on-null-sink, default-format rendering. Joined the serialized `ConsoleRedirect` collection so it can't race the stderr-capturing lifecycle tests.
- Full unit suite green (~2,600 tests); `dotnet format` clean; solution builds `-warnaserror` (analyzers clean).
- Behaviour-preserving refactor on error/dispose/fault paths only — **not** the render hot path, so no benchmark applies.
- Passed a multi-agent code review; all findings addressed (test-isolation race, eager-message build, dedup-before-delivery, public-surface scope, stale doc).

## Changelog

Internal, behaviour-preserving refactor — no user-facing change, so no CHANGELOG entry (the headline observability entry lands with the server layer that builds on this).