### PR TITLE
feat(server): configurable WS + session-grace limits via RaskServerOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,10 @@ them until tagged releases begin.
   These are server-only (the WASM runtime has no socket server), so they live in `Rask.Server` rather
   than the shared `RaskLiveOptions`. They were previously hardcoded; **all defaults are unchanged**, so
   upgrading is a no-op until you set one. Bind from configuration with
-  `AddRask(configureServer: o => builder.Configuration.GetSection("Rask").Bind(o))`. See the new
-  [configuration guide](docs/configuration.md).
+  `AddRask(configureServer: o => builder.Configuration.GetSection("Rask").Bind(o))`; `AddRask`
+  validates the values and throws `ArgumentOutOfRangeException` at startup on an out-of-range one (a
+  negative grace period, a non-positive frame-size cap), so a misconfiguration fails the boot rather
+  than misbehaving at runtime. See the new [configuration guide](docs/configuration.md).
 - **Production observability for the server host (OpenTelemetry-aligned).** The Rask server is now
   instrumented with standard .NET primitives — no extra packages, exportable to OpenTelemetry out of
   the box. (1) **Structured logging:** `UseRask<TApp>()` bridges the framework's internal diagnostics

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The WebSocket and session-lifecycle safety limits are now configurable** through a new
+  server-host-only options object, `RaskServerOptions`, set via a second `AddRask` callback
+  (`configureServer`): the inbound frame-size cap (`MaxInboundFrameBytes`), the handler-backpressure
+  cap (`MaxPendingHandlers`), the per-connection inbound rate cap (`MaxInboundFramesPerSecond`), and the
+  reconnect / unconnected session grace periods (`SessionGracePeriod` / `UnconnectedSessionGracePeriod`).
+  These are server-only (the WASM runtime has no socket server), so they live in `Rask.Server` rather
+  than the shared `RaskLiveOptions`. They were previously hardcoded; **all defaults are unchanged**, so
+  upgrading is a no-op until you set one. Bind from configuration with
+  `AddRask(configureServer: o => builder.Configuration.GetSection("Rask").Bind(o))`. See the new
+  [configuration guide](docs/configuration.md).
 - **Production observability for the server host (OpenTelemetry-aligned).** The Rask server is now
   instrumented with standard .NET primitives — no extra packages, exportable to OpenTelemetry out of
   the box. (1) **Structured logging:** `UseRask<TApp>()` bridges the framework's internal diagnostics

--- a/NUGET.md
+++ b/NUGET.md
@@ -61,6 +61,7 @@ the page). It's a craft project built in the open, deep on Roslyn source generat
 
 - 📖 **[Documentation](https://github.com/pal-tamas/rask/tree/main/docs)** ·
   [Getting started](https://github.com/pal-tamas/rask/blob/main/docs/getting-started.md) ·
+  [Configuration](https://github.com/pal-tamas/rask/blob/main/docs/configuration.md) ·
   [Observability](https://github.com/pal-tamas/rask/blob/main/docs/observability.md) ·
   [Accessibility](https://github.com/pal-tamas/rask/blob/main/docs/accessibility.md)
 - 🚀 **[Live demo](https://pal-tamas.github.io/rask/)**

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ see **[`docs/`](docs/)**:
 - **[Getting started](docs/getting-started.md)** — scaffold, first component, interactivity, routing.
 - **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · *
   *[Authentication](docs/authentication.md)**
-- **[Accessibility](docs/accessibility.md)** · **[Observability](docs/observability.md)** · **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
+- **[Accessibility](docs/accessibility.md)** · **[Observability](docs/observability.md)** · **[Configuration](docs/configuration.md)** · **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
 - **[Diagnostics (RASK001–024)](docs/diagnostics.md)** — every build error/warning and its fix.
 - **[Live rendering & the diff codec](docs/architecture/live-rendering.md)** — how the runtime works under the hood.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,79 @@
+# Configuration
+
+`AddRask` takes two optional callbacks: `configure` for **shared** runtime options
+(`RaskLiveOptions`, used by both the Server and WASM runtimes) and `configureServer` for the
+**server-host-only** limits (`RaskServerOptions` — the WebSocket caps and session grace periods that
+only the ASP.NET host has):
+
+```csharp
+builder.Services.AddRask(
+    live   => live.MaxSessions = 1000,
+    server => { server.MaxInboundFramesPerSecond = 500; server.SessionGracePeriod = TimeSpan.FromSeconds(20); });
+```
+
+Every option has a production-safe default, so `AddRask()` with no callback is fully functional. The
+defaults are unchanged from previous releases — these knobs only *expose* limits that were previously
+hardcoded, so upgrading changes nothing until you set one.
+
+## Binding from appsettings.json
+
+Both options objects are plain POCOs — bind them from configuration inside the callback:
+
+```csharp
+builder.Services.AddRask(
+    configureServer: o => builder.Configuration.GetSection("Rask").Bind(o));
+```
+
+```jsonc
+// appsettings.json
+{
+  "Rask": {
+    "MaxInboundFramesPerSecond": 500,
+    "SessionGracePeriod": "00:00:20"
+  }
+}
+```
+
+## Shared options — `RaskLiveOptions` (`configure`)
+
+Applied to both the Server and WASM runtimes.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `DiffMode` | `Auto` | Wire payload shape — `Auto` ships a diff when smaller, `DisabledFull` always full HTML, `Forced` always a diff. |
+| `PathBase` | `""` | URL prefix so two Rask apps share one origin (e.g. `/appA`). |
+| `PreloadScopedAssets` | `true` | Warm every scoped CSS/JS asset into `<head>` up front (vs. on first mount). |
+| `MaxSessions` | `0` (uncapped) | Hard cap on concurrent live sessions; a GET past the cap gets `503` + `Retry-After`. Pairs with the [health check](observability.md#health-checks). |
+
+## Server-host-only options — `RaskServerOptions` (`configureServer`)
+
+WebSocket safety caps and session grace periods — only the ASP.NET host has these.
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `MaxInboundFrameBytes` | `8 MB` | Cap on a single reassembled inbound WebSocket frame — bounds a fragmented-frame memory DoS. |
+| `MaxPendingHandlers` | `512` | Max queued handler dispatches before the socket is closed (backpressure). `0` disables. |
+| `MaxInboundFramesPerSecond` | `1000` | Per-connection inbound message rate cap over a sliding 1 s window — bounds a small-frame CPU DoS. `0` disables. |
+| `SessionGracePeriod` | `30 s` | How long a session is retained after its socket disconnects, for reconnect. |
+| `UnconnectedSessionGracePeriod` | `10 s` | How long a GET-minted session is retained before its first `hello` arrives. |
+
+### File uploads
+
+`RaskUploadOptions` (registered separately) caps uploads:
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `MaxFileSize` | `50 MB` | Maximum size of a single uploaded file. |
+| `MaxFilesPerRequest` | `16` | Maximum files in one multipart upload request. |
+
+```csharp
+builder.Services.Configure<RaskUploadOptions>(o => o.MaxFileSize = 10 * 1024 * 1024);
+```
+
+## A note on limits and reverse proxies
+
+The frame-size / frame-rate / pending-handler caps are coarse per-connection backstops, not a
+substitute for edge protection. For precise admission control and rate limiting, pair them with a
+reverse proxy (nginx, Envoy, a cloud load balancer) and the `MaxSessions` cap + the
+[live-session health check](observability.md#health-checks) so an orchestrator can shed load before
+the host starts refusing sessions.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -29,10 +29,14 @@ builder.Services.AddRask(
 {
   "Rask": {
     "MaxInboundFramesPerSecond": 500,
-    "SessionGracePeriod": "00:00:20"
+    "SessionGracePeriod": "00:00:20"   // TimeSpan: "hh:mm:ss" (or "d.hh:mm:ss")
   }
 }
 ```
+
+`TimeSpan` values bind from the standard `"[d.]hh:mm:ss"` format. `AddRask` validates the bound values
+and throws `ArgumentOutOfRangeException` at startup on an out-of-range one (a negative grace period, a
+non-positive `MaxInboundFrameBytes`), so a typo fails the boot rather than misbehaving at runtime.
 
 ## Shared options — `RaskLiveOptions` (`configure`)
 

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Observability](docs/observability.md): structured logging, the `Rask.Server` meter + activity source, `AddRaskLiveSessions()` health check.
+- [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace limits), appsettings binding, upload limits.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
 - [Diagnostics](docs/diagnostics.md): RASK001–024 compile-time diagnostics + fixes.

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -47,7 +47,8 @@ public static class RaskEndpointExtensions
     // dispatch / jsResult / navigate / dotNetInvoke args) are small, and file uploads use the HTTP
     // endpoint — never the socket — so this is generous headroom. It bounds a per-socket memory DoS
     // where a client streams an unbounded fragmented frame the server would otherwise buffer whole
-    // before JsonDocument.Parse. Mutable static so a test can lower it; not a public knob.
+    // before JsonDocument.Parse. Seeded from RaskServerOptions.MaxInboundFrameBytes by AddRask; the
+    // static is the DI-free hot-path source of truth (tests also set it directly).
     internal static int MaxInboundFrameBytes = 8 * 1024 * 1024;
 
     private static FileSystemWatcher? _sourceWatcher;
@@ -77,7 +78,8 @@ public static class RaskEndpointExtensions
     // a flood of them is a CPU DoS those caps miss. Counted over a sliding one-second window. A
     // realistic interaction peak (rapid typing with per-keystroke handlers, a 60 Hz scroll handler)
     // is well under 100/s, so 1000 is far above any legitimate burst. Mutable static so a test can
-    // lower it; not a public knob — operators tune ingress with a reverse-proxy rate limiter. 0 = off.
+    // lower it. Seeded from RaskServerOptions.MaxInboundFramesPerSecond by AddRask; operators can also
+    // tune ingress with a reverse-proxy rate limiter. 0 = off.
     internal static int MaxInboundFramesPerSecond = 1000;
 
     private static readonly byte[] SessionUnknownPayload =
@@ -105,12 +107,20 @@ public static class RaskEndpointExtensions
     /// </summary>
     /// <param name="services">The service collection to add Rask services to.</param>
     /// <param name="configure">
-    ///     Optional per-app live-runtime options (diff mode, path base, session cap). When omitted,
-    ///     framework defaults apply (<see cref="Rask.Core.Live.LiveDiffMode.Auto" />, no path base, uncapped).
+    ///     Optional per-app live-runtime options shared by the Server and WASM runtimes (diff mode,
+    ///     path base, session cap, scoped-asset preload). When omitted, framework defaults apply
+    ///     (<see cref="Rask.Core.Live.LiveDiffMode.Auto" />, no path base, uncapped).
+    /// </param>
+    /// <param name="configureServer">
+    ///     Optional server-host-only limits (<see cref="RaskServerOptions" />): the WebSocket
+    ///     frame-size / frame-rate / pending-handler caps and the session grace periods. When omitted,
+    ///     the framework's prior hardcoded defaults apply. Bind from configuration with
+    ///     <c>AddRask(configureServer: o =&gt; config.GetSection("Rask").Bind(o))</c>.
     /// </param>
     /// <returns>The same <paramref name="services" /> instance, for chaining.</returns>
     public static IServiceCollection AddRask(this IServiceCollection services,
-        Action<RaskLiveOptions>? configure = null)
+        Action<RaskLiveOptions>? configure = null,
+        Action<RaskServerOptions>? configureServer = null)
     {
         // Per-app live runtime options. The framework default for DiffMode is
         // LiveDiffMode.Auto (set on the static LiveOptions.DiffMode at class init),
@@ -137,6 +147,20 @@ public static class RaskEndpointExtensions
             // Session cap is a per-store instance value (not a static) so concurrent
             // hosts/tests don't clobber each other through global state.
             maxSessions = liveOptions.MaxSessions;
+        }
+
+        // Seed the server-only WS / grace-period safety limits from RaskServerOptions. Defaults match
+        // the statics, so an absent callback is a no-op. The statics are the DI-free hot-path source of
+        // truth read by the WS receive loop; tests also set them directly.
+        if (configureServer is not null)
+        {
+            var serverOptions = new RaskServerOptions();
+            configureServer(serverOptions);
+            MaxInboundFrameBytes = serverOptions.MaxInboundFrameBytes;
+            MaxPendingHandlers = serverOptions.MaxPendingHandlers;
+            MaxInboundFramesPerSecond = serverOptions.MaxInboundFramesPerSecond;
+            SessionGracePeriod = serverOptions.SessionGracePeriod;
+            UnconnectedSessionGracePeriod = serverOptions.UnconnectedSessionGracePeriod;
         }
 
         // Metrics singleton (Meter "Rask.Server"). TryAdd so a host can pre-register its own.

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -156,6 +156,7 @@ public static class RaskEndpointExtensions
         {
             var serverOptions = new RaskServerOptions();
             configureServer(serverOptions);
+            serverOptions.Validate();
             MaxInboundFrameBytes = serverOptions.MaxInboundFrameBytes;
             MaxPendingHandlers = serverOptions.MaxPendingHandlers;
             MaxInboundFramesPerSecond = serverOptions.MaxInboundFramesPerSecond;

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -12,7 +12,15 @@ namespace Rask.Server;
 ///     Bind from configuration with
 ///     <c>AddRask(configureServer: o =&gt; builder.Configuration.GetSection("Rask").Bind(o))</c>.
 ///     Every default matches the framework's prior hardcoded value, so leaving this unconfigured
-///     changes nothing.
+///     changes nothing. <c>AddRask</c> validates the values and throws
+///     <see cref="ArgumentOutOfRangeException" /> on an out-of-range one (a negative grace period, a
+///     non-positive frame-size cap), so a misconfiguration fails fast at startup rather than at runtime.
+///     <para>
+///         These are applied to process-global state read by the WebSocket receive loop, so in a
+///         multi-host process the last <c>configureServer</c> wins for every host (the framework's
+///         original constants were likewise process-wide). Per-app limits would need a per-connection
+///         options lookup; configure one set of limits per process.
+///     </para>
 /// </summary>
 public sealed class RaskServerOptions
 {
@@ -20,7 +28,8 @@ public sealed class RaskServerOptions
     ///     Hard cap (bytes) on a single reassembled inbound WebSocket frame. Client→server messages
     ///     are small (event dispatch / jsResult / navigate) and file uploads use the HTTP endpoint, so
     ///     the 8&nbsp;MB default is generous headroom; it bounds a per-socket memory DoS where a client
-    ///     streams an unbounded fragmented frame.
+    ///     streams an unbounded fragmented frame. Must be positive — a frame-size cap is mandatory, so
+    ///     unlike the other caps there is no <c>0 = off</c>.
     /// </summary>
     public int MaxInboundFrameBytes { get; set; } = 8 * 1024 * 1024;
 
@@ -55,4 +64,48 @@ public sealed class RaskServerOptions
     ///     10&nbsp;seconds.
     /// </summary>
     public TimeSpan UnconnectedSessionGracePeriod { get; set; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    ///     Throws <see cref="ArgumentOutOfRangeException" /> if any value is out of range. Called by
+    ///     <c>AddRask</c> after the caller's <c>configureServer</c> runs, so a bad value (a negative
+    ///     grace period that would crash <c>Task.Delay</c> and leak the session, a non-positive
+    ///     frame-size cap that would abort every socket) surfaces at startup instead of at runtime.
+    /// </summary>
+    internal void Validate()
+    {
+        if (MaxInboundFrameBytes <= 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxInboundFrameBytes), MaxInboundFrameBytes,
+                "MaxInboundFrameBytes must be positive — a frame-size cap is mandatory.");
+        }
+
+        if (MaxPendingHandlers < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxPendingHandlers), MaxPendingHandlers,
+                "MaxPendingHandlers must be >= 0 (0 disables the cap).");
+        }
+
+        if (MaxInboundFramesPerSecond < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxInboundFramesPerSecond), MaxInboundFramesPerSecond,
+                "MaxInboundFramesPerSecond must be >= 0 (0 disables the cap).");
+        }
+
+        if (SessionGracePeriod <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SessionGracePeriod), SessionGracePeriod,
+                "SessionGracePeriod must be positive.");
+        }
+
+        if (UnconnectedSessionGracePeriod <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(UnconnectedSessionGracePeriod), UnconnectedSessionGracePeriod,
+                "UnconnectedSessionGracePeriod must be positive.");
+        }
+    }
 }

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -1,0 +1,58 @@
+namespace Rask.Server;
+
+/// <summary>
+///     Server-host-only runtime limits — the WebSocket safety caps and session grace periods that
+///     only the ASP.NET host has (the WASM runtime has no socket server). Configured through the
+///     second callback of <c>AddRask</c>:
+///     <code>
+///     services.AddRask(
+///         live   =&gt; live.DiffMode = LiveDiffMode.Auto,
+///         server =&gt; server.MaxInboundFramesPerSecond = 500);
+///     </code>
+///     Bind from configuration with
+///     <c>AddRask(configureServer: o =&gt; builder.Configuration.GetSection("Rask").Bind(o))</c>.
+///     Every default matches the framework's prior hardcoded value, so leaving this unconfigured
+///     changes nothing.
+/// </summary>
+public sealed class RaskServerOptions
+{
+    /// <summary>
+    ///     Hard cap (bytes) on a single reassembled inbound WebSocket frame. Client→server messages
+    ///     are small (event dispatch / jsResult / navigate) and file uploads use the HTTP endpoint, so
+    ///     the 8&nbsp;MB default is generous headroom; it bounds a per-socket memory DoS where a client
+    ///     streams an unbounded fragmented frame.
+    /// </summary>
+    public int MaxInboundFrameBytes { get; set; } = 8 * 1024 * 1024;
+
+    /// <summary>
+    ///     Maximum handler dispatches that may be queued (awaiting their turn in WS-arrival order)
+    ///     before the server closes the socket with a backpressure policy violation. Each queued
+    ///     dispatch holds a cloned payload, so an unbounded queue is a memory DoS. <c>0</c> disables
+    ///     the cap. Default 512 — far above any legitimate burst.
+    /// </summary>
+    public int MaxPendingHandlers { get; set; } = 512;
+
+    /// <summary>
+    ///     Maximum inbound WebSocket messages per second on a single connection before the server
+    ///     closes the socket, counted over a sliding one-second window. Bounds a small-frame CPU DoS
+    ///     the size and backpressure caps miss. <c>0</c> disables the cap. Default 1000 — well above a
+    ///     realistic interaction peak; tune ingress with a reverse-proxy rate limiter too.
+    /// </summary>
+    public int MaxInboundFramesPerSecond { get; set; } = 1000;
+
+    /// <summary>
+    ///     How long a session is retained after its WebSocket disconnects, so a reconnecting client
+    ///     resumes against the same component tree. Longer survives flakier networks at the cost of
+    ///     holding a DI scope + tree per disconnected client. Default 30&nbsp;seconds.
+    /// </summary>
+    public TimeSpan SessionGracePeriod { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    ///     How long a session minted by the GET shell is retained before its first WebSocket
+    ///     <c>hello</c> arrives. The runtime connects within a second of page load, so a much shorter
+    ///     window than <see cref="SessionGracePeriod" /> suffices — and it stops a flood of GETs that
+    ///     never open a socket (scanners, prefetchers) from pinning a scope + tree. Default
+    ///     10&nbsp;seconds.
+    /// </summary>
+    public TimeSpan UnconnectedSessionGracePeriod { get; set; } = TimeSpan.FromSeconds(10);
+}

--- a/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
@@ -56,11 +56,52 @@ public class ConfigurableLimitsTests
     }
 
     [Fact]
-    public void AddRask_NoConfigureServer_LeavesStaticLimitsAtTheirCurrentValue()
+    public void AddRask_NoConfigureServer_DoesNotResetStaticLimits()
     {
-        var before = RaskEndpointExtensions.MaxInboundFramesPerSecond;
-        new ServiceCollection().AddRask();
-        Assert.Equal(before, RaskEndpointExtensions.MaxInboundFramesPerSecond);
+        var saved = RaskEndpointExtensions.MaxInboundFramesPerSecond;
+        try
+        {
+            // Set a sentinel, then a bare AddRask() must leave it untouched (it would catch a
+            // regression that reset the statics to defaults on the no-callback path).
+            RaskEndpointExtensions.MaxInboundFramesPerSecond = 777;
+            new ServiceCollection().AddRask();
+            Assert.Equal(777, RaskEndpointExtensions.MaxInboundFramesPerSecond);
+        }
+        finally
+        {
+            RaskEndpointExtensions.MaxInboundFramesPerSecond = saved;
+        }
+    }
+
+    [Fact]
+    public void AddRask_NegativeGracePeriod_ThrowsAtStartup()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ServiceCollection().AddRask(configureServer: o => o.SessionGracePeriod = TimeSpan.FromSeconds(-1)));
+    }
+
+    [Fact]
+    public void AddRask_ZeroFrameByteCap_ThrowsAtStartup()
+    {
+        // 0 would abort every non-empty frame; a frame-size cap is mandatory, so it must be rejected.
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ServiceCollection().AddRask(configureServer: o => o.MaxInboundFrameBytes = 0));
+    }
+
+    [Fact]
+    public void AddRask_NegativeFrameRateCap_ThrowsAtStartup()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ServiceCollection().AddRask(configureServer: o => o.MaxInboundFramesPerSecond = -1));
+    }
+
+    [Fact]
+    public void Validate_AllowsZeroForTheCountBasedCaps()
+    {
+        // 0 is the documented "disable this cap" value for the two count caps — Validate must accept it.
+        // Tested directly (not via AddRask) so it doesn't seed the process-global statics.
+        var o = new RaskServerOptions { MaxPendingHandlers = 0, MaxInboundFramesPerSecond = 0 };
+        Assert.Null(Record.Exception(o.Validate));
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
@@ -1,0 +1,86 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rask.Server.Tests.Configuration;
+
+// Serialized with the other tests that read/write the process-global WS/grace-period statics.
+[Collection("SessionGracePeriod")]
+public class ConfigurableLimitsTests
+{
+    [Fact]
+    public void RaskServerOptions_Defaults_MatchTheShippedStaticLimits()
+    {
+        var o = new RaskServerOptions();
+
+        Assert.Equal(8 * 1024 * 1024, o.MaxInboundFrameBytes);
+        Assert.Equal(512, o.MaxPendingHandlers);
+        Assert.Equal(1000, o.MaxInboundFramesPerSecond);
+        Assert.Equal(TimeSpan.FromSeconds(30), o.SessionGracePeriod);
+        Assert.Equal(TimeSpan.FromSeconds(10), o.UnconnectedSessionGracePeriod);
+    }
+
+    [Fact]
+    public void AddRask_ConfigureServer_SeedsTheServerStaticLimits()
+    {
+        var saved = (
+            RaskEndpointExtensions.MaxInboundFrameBytes,
+            RaskEndpointExtensions.MaxPendingHandlers,
+            RaskEndpointExtensions.MaxInboundFramesPerSecond,
+            RaskEndpointExtensions.SessionGracePeriod,
+            RaskEndpointExtensions.UnconnectedSessionGracePeriod);
+        try
+        {
+            new ServiceCollection().AddRask(configureServer: o =>
+            {
+                o.MaxInboundFrameBytes = 1234;
+                o.MaxPendingHandlers = 7;
+                o.MaxInboundFramesPerSecond = 42;
+                o.SessionGracePeriod = TimeSpan.FromSeconds(5);
+                o.UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(2);
+            });
+
+            Assert.Equal(1234, RaskEndpointExtensions.MaxInboundFrameBytes);
+            Assert.Equal(7, RaskEndpointExtensions.MaxPendingHandlers);
+            Assert.Equal(42, RaskEndpointExtensions.MaxInboundFramesPerSecond);
+            Assert.Equal(TimeSpan.FromSeconds(5), RaskEndpointExtensions.SessionGracePeriod);
+            Assert.Equal(TimeSpan.FromSeconds(2), RaskEndpointExtensions.UnconnectedSessionGracePeriod);
+        }
+        finally
+        {
+            (RaskEndpointExtensions.MaxInboundFrameBytes,
+                RaskEndpointExtensions.MaxPendingHandlers,
+                RaskEndpointExtensions.MaxInboundFramesPerSecond,
+                RaskEndpointExtensions.SessionGracePeriod,
+                RaskEndpointExtensions.UnconnectedSessionGracePeriod) = saved;
+        }
+    }
+
+    [Fact]
+    public void AddRask_NoConfigureServer_LeavesStaticLimitsAtTheirCurrentValue()
+    {
+        var before = RaskEndpointExtensions.MaxInboundFramesPerSecond;
+        new ServiceCollection().AddRask();
+        Assert.Equal(before, RaskEndpointExtensions.MaxInboundFramesPerSecond);
+    }
+
+    [Fact]
+    public void AppSettings_BindIntoServerOptions_RoundTrips()
+    {
+        // The documented operator pattern: AddRask(configureServer: o => config.GetSection("Rask").Bind(o)).
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Rask:MaxInboundFramesPerSecond"] = "250",
+                ["Rask:MaxPendingHandlers"] = "64",
+                ["Rask:SessionGracePeriod"] = "00:00:15"
+            })
+            .Build();
+
+        var o = new RaskServerOptions();
+        config.GetSection("Rask").Bind(o);
+
+        Assert.Equal(250, o.MaxInboundFramesPerSecond);
+        Assert.Equal(64, o.MaxPendingHandlers);
+        Assert.Equal(TimeSpan.FromSeconds(15), o.SessionGracePeriod);
+    }
+}


### PR DESCRIPTION
> **Stacked on #126** (`feat/server-observability`). Base retargets to `main` as #125 → #126 merge.

## Summary

The five WebSocket / session-lifecycle safety limits were hardcoded `internal static` fields with no operator knob. They're now configured through a new **`RaskServerOptions`**, set via a second `AddRask` callback (`configureServer`):

```csharp
builder.Services.AddRask(
    live   => live.MaxSessions = 1000,
    server => server.MaxInboundFramesPerSecond = 500);
```

| Option | Default |
| --- | --- |
| `MaxInboundFrameBytes` | 8 MB |
| `MaxPendingHandlers` | 512 |
| `MaxInboundFramesPerSecond` | 1000 |
| `SessionGracePeriod` | 30 s |
| `UnconnectedSessionGracePeriod` | 10 s |

These are **server-host-only** concerns (the WASM runtime has no socket server), so `RaskServerOptions` lives in `Rask.Server`, **not** the shared `Rask.Core` `RaskLiveOptions`. `AddRask` keeps applying the shared `configure` (`RaskLiveOptions`) and now also seeds the server statics from `configureServer`; the statics stay the DI-free hot-path source of truth the WS receive loop reads. **Every default matches the prior hardcoded value**, so upgrading is a no-op until a limit is set.

Bind from configuration: `AddRask(configureServer: o => builder.Configuration.GetSection("Rask").Bind(o))`.

## Testing

`tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs` (4): `RaskServerOptions` defaults match the shipped limits; `configureServer` seeds the statics; no callback leaves them untouched; appsettings `Bind` round-trips (incl. `TimeSpan`). Full Core + Server suites green; `dotnet format` clean; solution builds `-warnaserror`.

## Docs

New `docs/configuration.md` (shared `RaskLiveOptions` vs server-only `RaskServerOptions`, appsettings binding, reverse-proxy note); CHANGELOG, README, llms.txt, NUGET.md indexes updated.