### PR TITLE
feat(server): resource-exhaustion limits (idle-socket, pending-byte cap, upload quota)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Resource-exhaustion hardening for the server host (all opt-in, default off).** Three new bounds,
+  configurable via `RaskServerOptions` / `RaskUploadOptions`: (1) **`IdleSocketTimeout`** closes a
+  connected WebSocket that sends no inbound frame for the window — reclaiming silently-idle sockets
+  that would otherwise hold a receive loop open indefinitely; the session survives for reconnect under
+  the grace period. (2) **`MaxPendingHandlerBytes`** bounds the *aggregate bytes* of queued handler
+  payloads (the memory companion to `MaxPendingHandlers`, which bounds only the queue length), so a
+  client can't fill the count-bounded queue with large frames and pin gigabytes of cloned payloads;
+  tracked on the live session and tripped before cloning. (3) **`RaskUploadOptions.MaxBytesPerSession`**
+  caps the cumulative staged-upload bytes a single session may hold at once — an authenticated client
+  can no longer accumulate unbounded temp-file storage across requests (a request over the quota is
+  rejected with `413`; staged bytes are freed when the session ends). Each new limit is validated at
+  startup and defaults to off, so upgrading is a no-op. See the [configuration guide](docs/configuration.md).
 - **The WebSocket and session-lifecycle safety limits are now configurable** through a new
   server-host-only options object, `RaskServerOptions`, set via a second `AddRask` callback
   (`configureServer`): the inbound frame-size cap (`MaxInboundFrameBytes`), the handler-backpressure

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -60,6 +60,8 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `MaxInboundFramesPerSecond` | `1000` | Per-connection inbound message rate cap over a sliding 1 s window — bounds a small-frame CPU DoS. `0` disables. |
 | `SessionGracePeriod` | `30 s` | How long a session is retained after its socket disconnects, for reconnect. |
 | `UnconnectedSessionGracePeriod` | `10 s` | How long a GET-minted session is retained before its first `hello` arrives. |
+| `IdleSocketTimeout` | `0` (off) | Close a connected socket that sends no inbound frame for this long (the session survives for reconnect). Reclaims silently-idle connections. |
+| `MaxPendingHandlerBytes` | `0` (off) | Aggregate-bytes companion to `MaxPendingHandlers` — bounds the queued cloned-payload *memory*, not just the queue length. |
 
 ### File uploads
 
@@ -69,6 +71,7 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | --- | --- | --- |
 | `MaxFileSize` | `50 MB` | Maximum size of a single uploaded file. |
 | `MaxFilesPerRequest` | `16` | Maximum files in one multipart upload request. |
+| `MaxBytesPerSession` | `0` (off) | Maximum cumulative staged-upload bytes one session may hold at once; a request over the quota is rejected with `413`. Released when the session ends. |
 
 ```csharp
 builder.Services.Configure<RaskUploadOptions>(o => o.MaxFileSize = 10 * 1024 * 1024);

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Observability](docs/observability.md): structured logging, the `Rask.Server` meter + activity source, `AddRaskLiveSessions()` health check.
-- [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace limits), appsettings binding, upload limits.
+- [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
 - [Diagnostics](docs/diagnostics.md): RASK001–024 compile-time diagnostics + fixes.

--- a/src/Rask.Server/Diagnostics/RaskMetrics.cs
+++ b/src/Rask.Server/Diagnostics/RaskMetrics.cs
@@ -75,9 +75,9 @@ public sealed class RaskMetrics : IDisposable
     public void RecordHandlerDuration(double milliseconds) => _handlerDuration.Record(milliseconds);
 
     /// <summary>
-    ///     Counts a rejected inbound frame, tagged with the limit that tripped:
-    ///     <c>size</c> (frame exceeded the byte cap), <c>rate</c> (frame-per-second flood), or
-    ///     <c>backlog</c> (pending-handler queue overflow).
+    ///     Counts an inbound frame/socket the receive loop refused, tagged with the limit that tripped:
+    ///     <c>size</c> (frame exceeded the byte cap), <c>rate</c> (frame-per-second flood),
+    ///     <c>backlog</c> (pending-handler queue overflow), or <c>idle</c> (idle-socket timeout).
     /// </summary>
     public void FrameRejected(string reason) =>
         _framesRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));

--- a/src/Rask.Server/Files/RaskUploadOptions.cs
+++ b/src/Rask.Server/Files/RaskUploadOptions.cs
@@ -5,4 +5,13 @@ public sealed class RaskUploadOptions
     public long MaxFileSize { get; set; } = 50 * 1024 * 1024;
 
     public int MaxFilesPerRequest { get; set; } = 16;
+
+    /// <summary>
+    ///     Maximum cumulative bytes a single session may hold in staged uploads at once. Without it an
+    ///     authenticated client can stage <see cref="MaxFileSize" /> × <see cref="MaxFilesPerRequest" />
+    ///     bytes per request repeatedly and accumulate unbounded temp-file storage across requests; this
+    ///     caps the running total (a request that would exceed it is rejected with <c>413</c>). Staged
+    ///     bytes are released when the session ends. <c>0</c> (default) or negative disables the quota.
+    /// </summary>
+    public long MaxBytesPerSession { get; set; }
 }

--- a/src/Rask.Server/Files/SessionUploadStore.cs
+++ b/src/Rask.Server/Files/SessionUploadStore.cs
@@ -6,6 +6,9 @@ internal sealed class SessionUploadStore : IDisposable
 {
     private readonly ConcurrentDictionary<string, Entry> _entries = new();
 
+    // Running total of staged bytes per session, for the optional per-session upload quota.
+    private readonly ConcurrentDictionary<string, long> _sessionBytes = new();
+
     public void Dispose()
     {
         foreach (var key in _entries.Keys.ToArray())
@@ -15,7 +18,18 @@ internal sealed class SessionUploadStore : IDisposable
                 TryDelete(entry.Path);
             }
         }
+
+        _sessionBytes.Clear();
     }
+
+    /// <summary>
+    ///     True when staging <paramref name="incomingBytes" /> more bytes for <paramref name="sessionId" />
+    ///     would push its cumulative staged total over <paramref name="maxBytesPerSession" /> (a
+    ///     non-positive quota is always allowed). The upload endpoint calls this before staging and
+    ///     answers <c>413</c> when it returns true.
+    /// </summary>
+    public bool WouldExceedQuota(string sessionId, long incomingBytes, long maxBytesPerSession) =>
+        maxBytesPerSession > 0 && _sessionBytes.GetValueOrDefault(sessionId) + incomingBytes > maxBytesPerSession;
 
     public async Task<Entry> StageAsync(string sessionId, string name, string contentType, long size,
         DateTimeOffset lastModified, Func<string, Task> writeToPath)
@@ -24,9 +38,10 @@ internal sealed class SessionUploadStore : IDisposable
         var path = Path.Combine(Path.GetTempPath(), $"rask-upload-{token}.bin");
         await writeToPath(path).ConfigureAwait(false);
         var info = new FileInfo(path);
-        var entry = new Entry(sessionId, token, path, name, info.Exists ? info.Length : size, contentType,
-            lastModified);
+        var actualSize = info.Exists ? info.Length : size;
+        var entry = new Entry(sessionId, token, path, name, actualSize, contentType, lastModified);
         _entries[Key(sessionId, token)] = entry;
+        _sessionBytes.AddOrUpdate(sessionId, actualSize, (_, current) => current + actualSize);
         return entry;
     }
 
@@ -37,12 +52,14 @@ internal sealed class SessionUploadStore : IDisposable
     {
         if (_entries.TryRemove(Key(sessionId, token), out var entry))
         {
+            _sessionBytes.AddOrUpdate(sessionId, 0, (_, current) => current - entry.Size);
             TryDelete(entry.Path);
         }
     }
 
     public void ReleaseSession(string sessionId)
     {
+        _sessionBytes.TryRemove(sessionId, out _);
         foreach (var key in _entries.Keys.ToArray())
         {
             if (!key.StartsWith(sessionId + ":", StringComparison.Ordinal))

--- a/src/Rask.Server/Files/SessionUploadStore.cs
+++ b/src/Rask.Server/Files/SessionUploadStore.cs
@@ -6,8 +6,11 @@ internal sealed class SessionUploadStore : IDisposable
 {
     private readonly ConcurrentDictionary<string, Entry> _entries = new();
 
-    // Running total of staged bytes per session, for the optional per-session upload quota.
-    private readonly ConcurrentDictionary<string, long> _sessionBytes = new();
+    // Running total of staged bytes per session, for the optional per-session upload quota. Guarded by
+    // its own lock so the quota check + reserve in StageAsync is atomic (concurrent same-session uploads
+    // can't both pass a stale check and overshoot) and a release can't resurrect a removed session key.
+    private readonly object _quotaLock = new();
+    private readonly Dictionary<string, long> _sessionBytes = new(StringComparer.Ordinal);
 
     public void Dispose()
     {
@@ -19,29 +22,47 @@ internal sealed class SessionUploadStore : IDisposable
             }
         }
 
-        _sessionBytes.Clear();
+        lock (_quotaLock)
+        {
+            _sessionBytes.Clear();
+        }
     }
 
     /// <summary>
-    ///     True when staging <paramref name="incomingBytes" /> more bytes for <paramref name="sessionId" />
-    ///     would push its cumulative staged total over <paramref name="maxBytesPerSession" /> (a
-    ///     non-positive quota is always allowed). The upload endpoint calls this before staging and
-    ///     answers <c>413</c> when it returns true.
+    ///     Stages an uploaded file. When <paramref name="maxBytesPerSession" /> is positive and staging
+    ///     this file would push the session's cumulative staged bytes over the quota, the just-written
+    ///     temp file is deleted and <c>null</c> is returned (the caller answers <c>413</c>). The check
+    ///     and the reserve are a single atomic step, so concurrent same-session uploads can't both pass a
+    ///     stale check and overshoot the cap. Bytes are accounted by the actual written size, matching
+    ///     what <see cref="Release" /> later frees.
     /// </summary>
-    public bool WouldExceedQuota(string sessionId, long incomingBytes, long maxBytesPerSession) =>
-        maxBytesPerSession > 0 && _sessionBytes.GetValueOrDefault(sessionId) + incomingBytes > maxBytesPerSession;
-
-    public async Task<Entry> StageAsync(string sessionId, string name, string contentType, long size,
-        DateTimeOffset lastModified, Func<string, Task> writeToPath)
+    public async Task<Entry?> StageAsync(string sessionId, string name, string contentType, long size,
+        DateTimeOffset lastModified, Func<string, Task> writeToPath, long maxBytesPerSession = 0)
     {
         var token = Guid.NewGuid().ToString("N");
         var path = Path.Combine(Path.GetTempPath(), $"rask-upload-{token}.bin");
         await writeToPath(path).ConfigureAwait(false);
         var info = new FileInfo(path);
         var actualSize = info.Exists ? info.Length : size;
+
+        if (maxBytesPerSession > 0)
+        {
+            lock (_quotaLock)
+            {
+                var current = _sessionBytes.GetValueOrDefault(sessionId);
+                if (current + actualSize > maxBytesPerSession)
+                {
+                    // Over quota — drop the temp file and signal rejection without recording anything.
+                    TryDelete(path);
+                    return null;
+                }
+
+                _sessionBytes[sessionId] = current + actualSize;
+            }
+        }
+
         var entry = new Entry(sessionId, token, path, name, actualSize, contentType, lastModified);
         _entries[Key(sessionId, token)] = entry;
-        _sessionBytes.AddOrUpdate(sessionId, actualSize, (_, current) => current + actualSize);
         return entry;
     }
 
@@ -52,14 +73,18 @@ internal sealed class SessionUploadStore : IDisposable
     {
         if (_entries.TryRemove(Key(sessionId, token), out var entry))
         {
-            _sessionBytes.AddOrUpdate(sessionId, 0, (_, current) => current - entry.Size);
+            ReleaseQuota(sessionId, entry.Size);
             TryDelete(entry.Path);
         }
     }
 
     public void ReleaseSession(string sessionId)
     {
-        _sessionBytes.TryRemove(sessionId, out _);
+        lock (_quotaLock)
+        {
+            _sessionBytes.Remove(sessionId);
+        }
+
         foreach (var key in _entries.Keys.ToArray())
         {
             if (!key.StartsWith(sessionId + ":", StringComparison.Ordinal))
@@ -70,6 +95,30 @@ internal sealed class SessionUploadStore : IDisposable
             if (_entries.TryRemove(key, out var entry))
             {
                 TryDelete(entry.Path);
+            }
+        }
+    }
+
+    // Decrement a session's staged-byte total, removing the key at zero. Only ever updates an existing
+    // key — never inserts — so a Release racing just after ReleaseSession cleared the session can't
+    // resurrect a phantom entry for the now-dead session.
+    private void ReleaseQuota(string sessionId, long bytes)
+    {
+        lock (_quotaLock)
+        {
+            if (!_sessionBytes.TryGetValue(sessionId, out var current))
+            {
+                return;
+            }
+
+            var next = current - bytes;
+            if (next <= 0)
+            {
+                _sessionBytes.Remove(sessionId);
+            }
+            else
+            {
+                _sessionBytes[sessionId] = next;
             }
         }
     }

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -116,6 +116,14 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
 
     internal void DecrementPendingHandlers() => Interlocked.Decrement(ref _pendingHandlers);
 
+    // Aggregate bytes of the cloned payloads currently queued — the memory companion to the count
+    // above, so the receive loop can bound the queue's footprint, not just its length.
+    private long _pendingHandlerBytes;
+
+    internal long AddPendingHandlerBytes(long bytes) => Interlocked.Add(ref _pendingHandlerBytes, bytes);
+
+    internal void SubtractPendingHandlerBytes(long bytes) => Interlocked.Add(ref _pendingHandlerBytes, -bytes);
+
     public async ValueTask DisposeAsync()
     {
         _disposed = true;

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -82,6 +82,14 @@ public static class RaskEndpointExtensions
     // tune ingress with a reverse-proxy rate limiter. 0 = off.
     internal static int MaxInboundFramesPerSecond = 1000;
 
+    // Close a connected socket that sends no inbound frame for this long (the session survives for
+    // reconnect under SessionGracePeriod). Seeded from RaskServerOptions.IdleSocketTimeout. Zero = off.
+    internal static TimeSpan IdleSocketTimeout = TimeSpan.Zero;
+
+    // Aggregate-bytes companion to MaxPendingHandlers: bounds the queued cloned-payload memory, not just
+    // the queue count. Seeded from RaskServerOptions.MaxPendingHandlerBytes. 0 = off.
+    internal static long MaxPendingHandlerBytes;
+
     private static readonly byte[] SessionUnknownPayload =
         Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "session", status = "unknown" }));
 
@@ -162,6 +170,8 @@ public static class RaskEndpointExtensions
             MaxInboundFramesPerSecond = serverOptions.MaxInboundFramesPerSecond;
             SessionGracePeriod = serverOptions.SessionGracePeriod;
             UnconnectedSessionGracePeriod = serverOptions.UnconnectedSessionGracePeriod;
+            IdleSocketTimeout = serverOptions.IdleSocketTimeout;
+            MaxPendingHandlerBytes = serverOptions.MaxPendingHandlerBytes;
         }
 
         // Metrics singleton (Meter "Rask.Server"). TryAdd so a host can pre-register its own.
@@ -602,7 +612,37 @@ public static class RaskEndpointExtensions
                 WebSocketReceiveResult result;
                 ReadOnlyMemory<byte> payload;
 
-                result = await ws.ReceiveAsync(buffer, ct);
+                // Idle-socket timeout: if enabled, bound how long we wait for the *next* message to
+                // start. A fired timer (and not a shutdown) means the client went silent — close the
+                // socket; the session survives for reconnect under the grace period.
+                if (IdleSocketTimeout > TimeSpan.Zero)
+                {
+                    using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                    idleCts.CancelAfter(IdleSocketTimeout);
+                    try
+                    {
+                        result = await ws.ReceiveAsync(buffer, idleCts.Token);
+                    }
+                    catch (OperationCanceledException)
+                        when (idleCts.IsCancellationRequested && !ct.IsCancellationRequested)
+                    {
+                        using var idleClose = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+                        try
+                        {
+                            await ws.CloseAsync(
+                                    WebSocketCloseStatus.PolicyViolation, "idle timeout", idleClose.Token)
+                                .ConfigureAwait(false);
+                        }
+                        catch { }
+
+                        break;
+                    }
+                }
+                else
+                {
+                    result = await ws.ReceiveAsync(buffer, ct);
+                }
+
                 if (result.MessageType == WebSocketMessageType.Close)
                 {
                     return;
@@ -808,16 +848,21 @@ public static class RaskEndpointExtensions
                 var capturedSession = session;
                 var capturedHandlerId = handlerId;
 
-                // Backpressure circuit-breaker: bound the number of dispatches queued on the
-                // chain. When handlers drain slower than the client sends (a flood) or the chain
-                // head is stuck (a hung handler), the queue — each entry holding a cloned
-                // JsonElement — would grow without limit. Trip before cloning so we don't even
-                // allocate the payload we'd have to drop; close the socket so the client
-                // reconnects (hello) against the intact session and resumes from current state.
+                // Backpressure circuit-breaker: bound both the number of dispatches queued on the
+                // chain (MaxPendingHandlers) and their aggregate cloned-payload bytes
+                // (MaxPendingHandlerBytes). When handlers drain slower than the client sends (a flood)
+                // or the chain head is stuck (a hung handler), the queue — each entry holding a cloned
+                // JsonElement — would grow without limit. Trip before cloning so we don't even allocate
+                // the payload we'd have to drop; close the socket so the client reconnects (hello)
+                // against the intact session and resumes from current state.
+                var payloadBytes = (long)payload.Length;
                 var pending = capturedSession.IncrementPendingHandlers();
-                if (MaxPendingHandlers > 0 && pending > MaxPendingHandlers)
+                var pendingBytes = capturedSession.AddPendingHandlerBytes(payloadBytes);
+                if ((MaxPendingHandlers > 0 && pending > MaxPendingHandlers)
+                    || (MaxPendingHandlerBytes > 0 && pendingBytes > MaxPendingHandlerBytes))
                 {
                     capturedSession.DecrementPendingHandlers();
+                    capturedSession.SubtractPendingHandlerBytes(payloadBytes);
                     metrics?.FrameRejected("backlog");
                     using var capCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
                     try
@@ -839,6 +884,7 @@ public static class RaskEndpointExtensions
                     capturedSession,
                     capturedHandlerId,
                     capturedRoot,
+                    payloadBytes,
                     metrics,
                     ct);
             }
@@ -867,6 +913,7 @@ public static class RaskEndpointExtensions
         LiveSession session,
         string handlerId,
         JsonElement root,
+        long payloadBytes,
         RaskMetrics? metrics,
         CancellationToken ct)
     {
@@ -901,9 +948,10 @@ public static class RaskEndpointExtensions
         }
         finally
         {
-            // Pairs with the IncrementPendingHandlers in the receive loop when this dispatch was
-            // queued, so the backpressure counter tracks the live chain depth.
+            // Pairs with the Increment/AddPendingHandlerBytes in the receive loop when this dispatch
+            // was queued, so the backpressure count and byte total track the live chain depth.
             session.DecrementPendingHandlers();
+            session.SubtractPendingHandlerBytes(payloadBytes);
         }
     }
 
@@ -1558,7 +1606,9 @@ public static class RaskEndpointExtensions
         var staged = new List<SessionUploadStore.Entry>(form.Files.Count);
         foreach (var file in form.Files)
         {
-            if (file.Length > options.MaxFileSize)
+            // Per-file size cap, and the cumulative per-session upload quota.
+            if (file.Length > options.MaxFileSize
+                || uploads.WouldExceedQuota(sessionId, file.Length, options.MaxBytesPerSession))
             {
                 foreach (var prior in staged)
                 {

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -605,6 +605,14 @@ public static class RaskEndpointExtensions
         var rateWindowStartTick = Environment.TickCount64;
         var framesInWindow = 0;
 
+        // One connection-scoped CTS for the idle-socket timeout (null when disabled). Armed across the
+        // whole inbound message — first frame and every continuation fragment — and disarmed while the
+        // message is dispatched, so a mid-fragment stall is reclaimed too and we don't allocate a CTS
+        // per message. CancelAfter just reschedules the one internal timer.
+        using var idleCts = IdleSocketTimeout > TimeSpan.Zero
+            ? CancellationTokenSource.CreateLinkedTokenSource(ct)
+            : null;
+
         try
         {
             while (ws.State == WebSocketState.Open && !ct.IsCancellationRequested)
@@ -612,82 +620,74 @@ public static class RaskEndpointExtensions
                 WebSocketReceiveResult result;
                 ReadOnlyMemory<byte> payload;
 
-                // Idle-socket timeout: if enabled, bound how long we wait for the *next* message to
-                // start. A fired timer (and not a shutdown) means the client went silent — close the
-                // socket; the session survives for reconnect under the grace period.
-                if (IdleSocketTimeout > TimeSpan.Zero)
+                // Arm the idle timer for this whole message-receive cycle; the finally disarms it
+                // before dispatch so a slow handler doesn't trip it. A fired timer (not a shutdown)
+                // means the client went silent mid-stream — close the socket (the session survives for
+                // reconnect under the grace period).
+                idleCts?.CancelAfter(IdleSocketTimeout);
+                var receiveToken = idleCts?.Token ?? ct;
+                try
                 {
-                    using var idleCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-                    idleCts.CancelAfter(IdleSocketTimeout);
-                    try
+                    result = await ws.ReceiveAsync(buffer, receiveToken);
+                    if (result.MessageType == WebSocketMessageType.Close)
                     {
-                        result = await ws.ReceiveAsync(buffer, idleCts.Token);
-                    }
-                    catch (OperationCanceledException)
-                        when (idleCts.IsCancellationRequested && !ct.IsCancellationRequested)
-                    {
-                        using var idleClose = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                        try
-                        {
-                            await ws.CloseAsync(
-                                    WebSocketCloseStatus.PolicyViolation, "idle timeout", idleClose.Token)
-                                .ConfigureAwait(false);
-                        }
-                        catch { }
-
-                        break;
-                    }
-                }
-                else
-                {
-                    result = await ws.ReceiveAsync(buffer, ct);
-                }
-
-                if (result.MessageType == WebSocketMessageType.Close)
-                {
-                    return;
-                }
-
-                if (result.EndOfMessage)
-                {
-                    // Hot path: single-fragment message. Parse JSON directly from the
-                    // receive buffer slice — no UTF-8 string decode, no accumulator copy.
-                    payload = buffer.AsMemory(0, result.Count);
-                }
-                else
-                {
-                    message.ResetWrittenCount();
-                    if (result.Count > 0)
-                    {
-                        message.Write(buffer.AsSpan(0, result.Count));
+                        return;
                     }
 
-                    do
+                    if (result.EndOfMessage)
                     {
-                        result = await ws.ReceiveAsync(buffer, ct);
-                        if (result.MessageType == WebSocketMessageType.Close)
-                        {
-                            return;
-                        }
-
+                        // Hot path: single-fragment message. Parse JSON directly from the
+                        // receive buffer slice — no UTF-8 string decode, no accumulator copy.
+                        payload = buffer.AsMemory(0, result.Count);
+                    }
+                    else
+                    {
+                        message.ResetWrittenCount();
                         if (result.Count > 0)
                         {
                             message.Write(buffer.AsSpan(0, result.Count));
                         }
 
-                        // Abort a socket that streams a frame past the cap rather than buffering it
-                        // whole — bounds per-socket memory against a fragmented-frame DoS.
-                        if (message.WrittenCount > MaxInboundFrameBytes)
+                        do
                         {
-                            metrics?.FrameRejected("size");
-                            try { ws.Abort(); }
-                            catch { }
+                            // Same idle token covers continuation fragments, so a client that stalls
+                            // mid-message is reclaimed too.
+                            result = await ws.ReceiveAsync(buffer, receiveToken);
+                            if (result.MessageType == WebSocketMessageType.Close)
+                            {
+                                return;
+                            }
 
-                            return;
-                        }
-                    } while (!result.EndOfMessage);
+                            if (result.Count > 0)
+                            {
+                                message.Write(buffer.AsSpan(0, result.Count));
+                            }
 
-                    payload = message.WrittenMemory;
+                            // Abort a socket that streams a frame past the cap rather than buffering it
+                            // whole — bounds per-socket memory against a fragmented-frame DoS.
+                            if (message.WrittenCount > MaxInboundFrameBytes)
+                            {
+                                metrics?.FrameRejected("size");
+                                try { ws.Abort(); }
+                                catch { }
+
+                                return;
+                            }
+                        } while (!result.EndOfMessage);
+
+                        payload = message.WrittenMemory;
+                    }
+                }
+                catch (OperationCanceledException)
+                    when (idleCts is not null && idleCts.IsCancellationRequested && !ct.IsCancellationRequested)
+                {
+                    metrics?.FrameRejected("idle");
+                    await ClosePolicyViolationAsync(ws, "idle timeout").ConfigureAwait(false);
+                    break;
+                }
+                finally
+                {
+                    idleCts?.CancelAfter(Timeout.InfiniteTimeSpan);
                 }
 
                 // Inbound frame-rate cap: count every completed receive over a sliding one-second
@@ -707,15 +707,7 @@ public static class RaskEndpointExtensions
                     if (++framesInWindow > MaxInboundFramesPerSecond)
                     {
                         metrics?.FrameRejected("rate");
-                        using var rateCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                        try
-                        {
-                            await ws.CloseAsync(
-                                    WebSocketCloseStatus.PolicyViolation, "frame rate", rateCts.Token)
-                                .ConfigureAwait(false);
-                        }
-                        catch { }
-
+                        await ClosePolicyViolationAsync(ws, "frame rate").ConfigureAwait(false);
                         break;
                     }
                 }
@@ -864,15 +856,7 @@ public static class RaskEndpointExtensions
                     capturedSession.DecrementPendingHandlers();
                     capturedSession.SubtractPendingHandlerBytes(payloadBytes);
                     metrics?.FrameRejected("backlog");
-                    using var capCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
-                    try
-                    {
-                        await ws.CloseAsync(
-                                WebSocketCloseStatus.PolicyViolation, "handler backlog", capCts.Token)
-                            .ConfigureAwait(false);
-                    }
-                    catch { }
-
+                    await ClosePolicyViolationAsync(ws, "handler backlog").ConfigureAwait(false);
                     break;
                 }
 
@@ -905,6 +889,21 @@ public static class RaskEndpointExtensions
                 try { await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", closeCts.Token); }
                 catch { }
             }
+        }
+    }
+
+    // Best-effort PolicyViolation close shared by the rate / backlog / idle breakers: the client
+    // reconnects (hello) against the intact session. A 2 s deadline bounds a wedged close handshake.
+    private static async Task ClosePolicyViolationAsync(WebSocket ws, string reason)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        try
+        {
+            await ws.CloseAsync(WebSocketCloseStatus.PolicyViolation, reason, cts.Token).ConfigureAwait(false);
+        }
+        catch
+        {
+            // Socket already faulted / closing — nothing to do.
         }
     }
 
@@ -1560,6 +1559,14 @@ public static class RaskEndpointExtensions
         return reader.ReadToEnd();
     }
 
+    private static void RollbackStaged(SessionUploadStore uploads, List<SessionUploadStore.Entry> staged)
+    {
+        foreach (var prior in staged)
+        {
+            uploads.Release(prior.SessionId, prior.Token);
+        }
+    }
+
     private static async Task HandleUploadAsync(
         HttpContext ctx,
         string sessionId,
@@ -1606,15 +1613,9 @@ public static class RaskEndpointExtensions
         var staged = new List<SessionUploadStore.Entry>(form.Files.Count);
         foreach (var file in form.Files)
         {
-            // Per-file size cap, and the cumulative per-session upload quota.
-            if (file.Length > options.MaxFileSize
-                || uploads.WouldExceedQuota(sessionId, file.Length, options.MaxBytesPerSession))
+            if (file.Length > options.MaxFileSize)
             {
-                foreach (var prior in staged)
-                {
-                    uploads.Release(prior.SessionId, prior.Token);
-                }
-
+                RollbackStaged(uploads, staged);
                 ctx.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
                 return;
             }
@@ -1625,6 +1626,8 @@ public static class RaskEndpointExtensions
                 lastModified = lm;
             }
 
+            // StageAsync atomically enforces the cumulative per-session quota: a null return means this
+            // file would push the session over MaxBytesPerSession (the temp file is already cleaned up).
             var entry = await uploads.StageAsync(
                 sessionId,
                 SanitizeUploadFileName(file.FileName),
@@ -1636,7 +1639,16 @@ public static class RaskEndpointExtensions
                     await using var output = File.Create(path);
                     await using var input = file.OpenReadStream();
                     await input.CopyToAsync(output, ctx.RequestAborted).ConfigureAwait(false);
-                });
+                },
+                options.MaxBytesPerSession);
+
+            if (entry is null)
+            {
+                RollbackStaged(uploads, staged);
+                ctx.Response.StatusCode = StatusCodes.Status413PayloadTooLarge;
+                return;
+            }
+
             staged.Add(entry);
         }
 

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -79,7 +79,9 @@ public sealed class RaskServerOptions
     ///     WS-arrival order) before the server closes the socket with a backpressure policy violation.
     ///     Complements <see cref="MaxPendingHandlers" /> (which bounds the queue's <em>count</em>): a
     ///     client could fill the count-bounded queue with large frames and pin many megabytes of cloned
-    ///     payloads, so this bounds the queue's <em>memory</em>. <c>0</c> (default) disables the cap.
+    ///     payloads, so this bounds the queue's <em>memory</em>. Measured by inbound wire bytes — a close
+    ///     proxy for the cloned <c>JsonElement</c> footprint, sized to bound the same order of magnitude
+    ///     rather than the exact managed size. <c>0</c> (default) disables the cap.
     /// </summary>
     public long MaxPendingHandlerBytes { get; set; }
 

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -66,6 +66,24 @@ public sealed class RaskServerOptions
     public TimeSpan UnconnectedSessionGracePeriod { get; set; } = TimeSpan.FromSeconds(10);
 
     /// <summary>
+    ///     If a connected WebSocket sends no inbound frame for this long, the server closes it. The
+    ///     session itself survives under <see cref="SessionGracePeriod" /> for reconnect, so this only
+    ///     reclaims the idle socket (and its receive loop), not the component tree. Bounds a silently
+    ///     connected client that would otherwise hold a socket open indefinitely.
+    ///     <see cref="TimeSpan.Zero" /> (default) disables the timeout, preserving prior behaviour.
+    /// </summary>
+    public TimeSpan IdleSocketTimeout { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
+    ///     Maximum aggregate bytes of inbound handler payloads queued (awaiting their turn in
+    ///     WS-arrival order) before the server closes the socket with a backpressure policy violation.
+    ///     Complements <see cref="MaxPendingHandlers" /> (which bounds the queue's <em>count</em>): a
+    ///     client could fill the count-bounded queue with large frames and pin many megabytes of cloned
+    ///     payloads, so this bounds the queue's <em>memory</em>. <c>0</c> (default) disables the cap.
+    /// </summary>
+    public long MaxPendingHandlerBytes { get; set; }
+
+    /// <summary>
     ///     Throws <see cref="ArgumentOutOfRangeException" /> if any value is out of range. Called by
     ///     <c>AddRask</c> after the caller's <c>configureServer</c> runs, so a bad value (a negative
     ///     grace period that would crash <c>Task.Delay</c> and leak the session, a non-positive
@@ -106,6 +124,20 @@ public sealed class RaskServerOptions
             throw new ArgumentOutOfRangeException(
                 nameof(UnconnectedSessionGracePeriod), UnconnectedSessionGracePeriod,
                 "UnconnectedSessionGracePeriod must be positive.");
+        }
+
+        if (IdleSocketTimeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(IdleSocketTimeout), IdleSocketTimeout,
+                "IdleSocketTimeout must be >= TimeSpan.Zero (Zero disables the timeout).");
+        }
+
+        if (MaxPendingHandlerBytes < 0)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxPendingHandlerBytes), MaxPendingHandlerBytes,
+                "MaxPendingHandlerBytes must be >= 0 (0 disables the cap).");
         }
     }
 }

--- a/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
@@ -27,7 +27,9 @@ public class ConfigurableLimitsTests
             RaskEndpointExtensions.MaxPendingHandlers,
             RaskEndpointExtensions.MaxInboundFramesPerSecond,
             RaskEndpointExtensions.SessionGracePeriod,
-            RaskEndpointExtensions.UnconnectedSessionGracePeriod);
+            RaskEndpointExtensions.UnconnectedSessionGracePeriod,
+            RaskEndpointExtensions.IdleSocketTimeout,
+            RaskEndpointExtensions.MaxPendingHandlerBytes);
         try
         {
             new ServiceCollection().AddRask(configureServer: o =>
@@ -37,6 +39,8 @@ public class ConfigurableLimitsTests
                 o.MaxInboundFramesPerSecond = 42;
                 o.SessionGracePeriod = TimeSpan.FromSeconds(5);
                 o.UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(2);
+                o.IdleSocketTimeout = TimeSpan.FromSeconds(90);
+                o.MaxPendingHandlerBytes = 4096;
             });
 
             Assert.Equal(1234, RaskEndpointExtensions.MaxInboundFrameBytes);
@@ -44,6 +48,8 @@ public class ConfigurableLimitsTests
             Assert.Equal(42, RaskEndpointExtensions.MaxInboundFramesPerSecond);
             Assert.Equal(TimeSpan.FromSeconds(5), RaskEndpointExtensions.SessionGracePeriod);
             Assert.Equal(TimeSpan.FromSeconds(2), RaskEndpointExtensions.UnconnectedSessionGracePeriod);
+            Assert.Equal(TimeSpan.FromSeconds(90), RaskEndpointExtensions.IdleSocketTimeout);
+            Assert.Equal(4096, RaskEndpointExtensions.MaxPendingHandlerBytes);
         }
         finally
         {
@@ -51,8 +57,24 @@ public class ConfigurableLimitsTests
                 RaskEndpointExtensions.MaxPendingHandlers,
                 RaskEndpointExtensions.MaxInboundFramesPerSecond,
                 RaskEndpointExtensions.SessionGracePeriod,
-                RaskEndpointExtensions.UnconnectedSessionGracePeriod) = saved;
+                RaskEndpointExtensions.UnconnectedSessionGracePeriod,
+                RaskEndpointExtensions.IdleSocketTimeout,
+                RaskEndpointExtensions.MaxPendingHandlerBytes) = saved;
         }
+    }
+
+    [Fact]
+    public void AddRask_NegativeIdleSocketTimeout_ThrowsAtStartup()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ServiceCollection().AddRask(configureServer: o => o.IdleSocketTimeout = TimeSpan.FromSeconds(-1)));
+    }
+
+    [Fact]
+    public void AddRask_NegativePendingHandlerBytes_ThrowsAtStartup()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ServiceCollection().AddRask(configureServer: o => o.MaxPendingHandlerBytes = -1));
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
+++ b/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
@@ -53,4 +53,46 @@ public class SessionUploadStoreTests
         Assert.Equal(42, entry.Size);
         store.Release("session-1", entry.Token);
     }
+
+    [Fact]
+    public async Task WouldExceedQuota_TracksCumulativeStagedBytesPerSession()
+    {
+        using var store = new SessionUploadStore();
+        const long quota = 100;
+
+        // Nothing staged yet — a 60-byte file fits.
+        Assert.False(store.WouldExceedQuota("s1", 60, quota));
+        var a = await store.StageAsync("s1", "a.bin", "application/octet-stream", 60, DateTimeOffset.UnixEpoch,
+            path => File.WriteAllBytesAsync(path, new byte[60]));
+
+        // 60 staged; another 60 would total 120 > 100 → rejected. A 40-byte one (→100) still fits.
+        Assert.True(store.WouldExceedQuota("s1", 60, quota));
+        Assert.False(store.WouldExceedQuota("s1", 40, quota));
+
+        // The quota is per-session: a different session has its own budget.
+        Assert.False(store.WouldExceedQuota("s2", 90, quota));
+
+        // Releasing frees the bytes back to the session's budget.
+        store.Release("s1", a.Token);
+        Assert.False(store.WouldExceedQuota("s1", 90, quota));
+    }
+
+    [Fact]
+    public async Task ReleaseSession_ResetsTheQuotaTotal()
+    {
+        using var store = new SessionUploadStore();
+        await store.StageAsync("s1", "a.bin", "application/octet-stream", 80, DateTimeOffset.UnixEpoch,
+            path => File.WriteAllBytesAsync(path, new byte[80]));
+        Assert.True(store.WouldExceedQuota("s1", 80, 100));
+
+        store.ReleaseSession("s1");
+        Assert.False(store.WouldExceedQuota("s1", 80, 100));
+    }
+
+    [Fact]
+    public void WouldExceedQuota_NonPositiveQuota_IsAlwaysAllowed()
+    {
+        using var store = new SessionUploadStore();
+        Assert.False(store.WouldExceedQuota("s1", long.MaxValue, 0));
+    }
 }

--- a/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
+++ b/tests/Rask.Server.Tests/Files/SessionUploadStoreTests.cs
@@ -30,8 +30,9 @@ public class SessionUploadStoreTests
 
         gate.SetResult();
         var entry = await stageTask;
+        Assert.NotNull(entry);
 
-        Assert.Equal("data.bin", entry.Name);
+        Assert.Equal("data.bin", entry!.Name);
         Assert.Equal(writeBytes.Length, entry.Size);
         var staged = await File.ReadAllBytesAsync(entry.Path);
         Assert.Equal(writeBytes, staged);
@@ -50,49 +51,60 @@ public class SessionUploadStoreTests
             "session-1", "empty.bin", "text/plain", 42, DateTimeOffset.UnixEpoch,
             _ => Task.CompletedTask);
 
-        Assert.Equal(42, entry.Size);
+        Assert.NotNull(entry);
+        Assert.Equal(42, entry!.Size);
         store.Release("session-1", entry.Token);
     }
 
     [Fact]
-    public async Task WouldExceedQuota_TracksCumulativeStagedBytesPerSession()
+    public async Task Quota_RejectsTheFileThatWouldExceedTheCumulativeCap()
     {
         using var store = new SessionUploadStore();
         const long quota = 100;
 
-        // Nothing staged yet — a 60-byte file fits.
-        Assert.False(store.WouldExceedQuota("s1", 60, quota));
-        var a = await store.StageAsync("s1", "a.bin", "application/octet-stream", 60, DateTimeOffset.UnixEpoch,
-            path => File.WriteAllBytesAsync(path, new byte[60]));
+        // 60 staged (under quota → non-null).
+        var a = await Stage(store, "s1", 60, quota);
+        Assert.NotNull(a);
 
-        // 60 staged; another 60 would total 120 > 100 → rejected. A 40-byte one (→100) still fits.
-        Assert.True(store.WouldExceedQuota("s1", 60, quota));
-        Assert.False(store.WouldExceedQuota("s1", 40, quota));
+        // Another 60 would total 120 > 100 → rejected (null), nothing recorded.
+        Assert.Null(await Stage(store, "s1", 60, quota));
 
-        // The quota is per-session: a different session has its own budget.
-        Assert.False(store.WouldExceedQuota("s2", 90, quota));
+        // A 40-byte one (→ exactly 100) still fits.
+        var b = await Stage(store, "s1", 40, quota);
+        Assert.NotNull(b);
 
-        // Releasing frees the bytes back to the session's budget.
-        store.Release("s1", a.Token);
-        Assert.False(store.WouldExceedQuota("s1", 90, quota));
+        // Per-session budget: a different session has its own.
+        Assert.NotNull(await Stage(store, "s2", 90, quota));
+
+        // Releasing frees bytes back: s1 is full (100 = 60 + 40); release the 60, leaving 40, so a
+        // 60-byte file now fits again (40 + 60 = 100) — but a 70 would not.
+        store.Release("s1", a!.Token);
+        Assert.Null(await Stage(store, "s1", 70, quota));
+        Assert.NotNull(await Stage(store, "s1", 60, quota));
     }
 
     [Fact]
     public async Task ReleaseSession_ResetsTheQuotaTotal()
     {
         using var store = new SessionUploadStore();
-        await store.StageAsync("s1", "a.bin", "application/octet-stream", 80, DateTimeOffset.UnixEpoch,
-            path => File.WriteAllBytesAsync(path, new byte[80]));
-        Assert.True(store.WouldExceedQuota("s1", 80, 100));
+        Assert.NotNull(await Stage(store, "s1", 80, 100));
+        Assert.Null(await Stage(store, "s1", 80, 100)); // 160 > 100
 
         store.ReleaseSession("s1");
-        Assert.False(store.WouldExceedQuota("s1", 80, 100));
+        Assert.NotNull(await Stage(store, "s1", 80, 100)); // budget reset
     }
 
     [Fact]
-    public void WouldExceedQuota_NonPositiveQuota_IsAlwaysAllowed()
+    public async Task Quota_NonPositive_NeverRejects()
     {
         using var store = new SessionUploadStore();
-        Assert.False(store.WouldExceedQuota("s1", long.MaxValue, 0));
+        Assert.NotNull(await Stage(store, "s1", 10 * 1024 * 1024, 0));
+        Assert.NotNull(await Stage(store, "s1", 10 * 1024 * 1024, 0));
     }
+
+    private static Task<SessionUploadStore.Entry?> Stage(
+        SessionUploadStore store, string sessionId, int size, long quota) =>
+        store.StageAsync(
+            sessionId, $"f{size}.bin", "application/octet-stream", size, DateTimeOffset.UnixEpoch,
+            path => File.WriteAllBytesAsync(path, new byte[size]), quota);
 }

--- a/tests/Rask.Server.Tests/Security/ResourceLimitTests.cs
+++ b/tests/Rask.Server.Tests/Security/ResourceLimitTests.cs
@@ -1,0 +1,122 @@
+using System.Net.WebSockets;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Security;
+
+// Phase-4 resource-exhaustion limits: an idle connected socket is reclaimed, and the pending-handler
+// queue is bounded by aggregate bytes (not just count). Both close the socket; the session survives.
+[Collection("SessionGracePeriod")]
+public class ResourceLimitTests
+{
+    [Fact]
+    public async Task IdleSocket_NoInboundFrames_IsClosedAfterTheTimeout()
+    {
+        var prev = RaskEndpointExtensions.IdleSocketTimeout;
+        RaskEndpointExtensions.IdleSocketTimeout = TimeSpan.FromMilliseconds(300);
+        try
+        {
+            using var host = RaskTestHost.Create<TestApp>();
+            var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+            // Send nothing further — the server must close the idle socket within the timeout window.
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+            while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
+            {
+                if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
+                    && ws.State == WebSocketState.Open)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.NotEqual(WebSocketState.Open, ws.State);
+        }
+        finally
+        {
+            RaskEndpointExtensions.IdleSocketTimeout = prev;
+        }
+    }
+
+    [Fact]
+    public async Task ActiveSocket_UnderIdleTimeout_StaysOpen()
+    {
+        var prev = RaskEndpointExtensions.IdleSocketTimeout;
+        // Comfortably larger than the inter-send gap below, so only genuine inactivity trips it.
+        RaskEndpointExtensions.IdleSocketTimeout = TimeSpan.FromSeconds(5);
+        try
+        {
+            using var host = RaskTestHost.Create<TestApp>();
+            var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+            var sessionId = Markup.SessionId(html);
+            var handlerId = Markup.FirstHandlerId(html);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500));
+
+            // Keep sending well within the 5 s window — the socket must stay open across a span
+            // (~3 s) that would have tripped a naive total-lifetime timeout.
+            for (var i = 0; i < 4; i++)
+            {
+                await Task.Delay(800);
+                await ws.SendJsonAsync(new { id = handlerId });
+                _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            }
+
+            Assert.Equal(WebSocketState.Open, ws.State);
+        }
+        finally
+        {
+            RaskEndpointExtensions.IdleSocketTimeout = prev;
+        }
+    }
+
+    [Fact]
+    public async Task PendingHandlerBytes_ExceedsCap_ClosesSocket()
+    {
+        var prevBytes = RaskEndpointExtensions.MaxPendingHandlerBytes;
+        var prevCount = RaskEndpointExtensions.MaxPendingHandlers;
+        // 1 byte: the first handler frame's payload exceeds it, so the byte cap trips immediately
+        // (the count cap is left generous so this isolates the byte path).
+        RaskEndpointExtensions.MaxPendingHandlerBytes = 1;
+        RaskEndpointExtensions.MaxPendingHandlers = 10_000;
+        try
+        {
+            using var host = RaskTestHost.Create<TestApp>();
+            var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+            var sessionId = Markup.SessionId(html);
+            var handlerId = Markup.FirstHandlerId(html);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+            for (var i = 0; i < 20; i++)
+            {
+                try { await ws.SendJsonAsync(new { id = handlerId }); }
+                catch { break; }
+            }
+
+            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+            while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
+            {
+                if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
+                    && ws.State == WebSocketState.Open)
+                {
+                    await Task.Delay(20);
+                }
+            }
+
+            Assert.NotEqual(WebSocketState.Open, ws.State);
+        }
+        finally
+        {
+            RaskEndpointExtensions.MaxPendingHandlerBytes = prevBytes;
+            RaskEndpointExtensions.MaxPendingHandlers = prevCount;
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #127** (`feat/configurable-limits`). Base retargets to `main` as #125→#126→#127 merge.

## Summary

Three new server-host resource bounds, all **opt-in and default-off** (upgrading is a no-op):

- **`RaskServerOptions.IdleSocketTimeout`** — closes a connected WebSocket that sends no inbound frame for the window, reclaiming a silently-idle socket + its receive loop. The session survives for reconnect under the grace period. Wired into the receive loop via a per-message linked CTS, only when enabled.
- **`RaskServerOptions.MaxPendingHandlerBytes`** — bounds the *aggregate bytes* of queued handler payloads (the memory companion to `MaxPendingHandlers`, which bounds only the queue length), so a client can't fill the count-bounded queue with large frames and pin gigabytes of cloned payloads. Tracked on `LiveSession` (`Interlocked`), tripped before cloning.
- **`RaskUploadOptions.MaxBytesPerSession`** — caps cumulative staged-upload bytes per session; the endpoint pre-checks via `SessionUploadStore.WouldExceedQuota` and answers `413`. Bytes are freed on `Release`/`ReleaseSession`, so an authenticated client can't accumulate unbounded temp-file storage.

**Deliberately not added: a per-handler execution timeout.** Handler delegates take no `CancellationToken` and can't be force-cancelled; abandoning the await would let the handler keep mutating component state outside the render lock (a data race). The existing backpressure cap already closes the socket when a stuck handler backs up the queue.

All three are **validated at startup** (`RaskServerOptions.Validate`). The render hot path is untouched; the only always-on addition is one non-allocating `Interlocked.Add` per dispatch (the idle-timeout CTS is allocated only when the timeout is enabled).

## Testing

- Upload-quota unit tests (cumulative tracking, per-session isolation, release/reset, off-when-non-positive).
- Integration: idle socket is closed after the timeout; an active socket stays open across a span that would trip a naive lifetime timeout; the byte cap closes the socket.
- Seeding + negative-value validation tests.
- Full Server suite green (229→237); `dotnet format` clean; builds `-warnaserror`.

## Docs

`docs/configuration.md` (new limits in the server + upload tables) and CHANGELOG updated.