### PR TITLE
test(benchmarks): cover realistic partial-shuffle keyed-diff shapes

### DIFF
--- a/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
@@ -29,6 +29,16 @@ public class FrameDifferBenchmarks
     private string _afterReverseHtml = "";
     private RenderFrame[] _afterText = null!;
 
+    // Realistic partial-shuffle shapes the 2-swap / full-reverse pair didn't cover. TopNRerank
+    // reverses just the first 10 rows (a table sort that only reranks the head) — a localized
+    // permutation with a near-full LIS, so only ~10 rows are off-LIS and the move loop stays
+    // sub-quadratic. AppendWithDeletes drops every 10th row and appends the same number of new keys
+    // at the tail (a feed/log churn) — survivors keep order, so it's removes + inserts, not moves.
+    private RenderFrame[] _afterTopN = null!;
+    private string _afterTopNHtml = "";
+    private RenderFrame[] _afterAppendDel = null!;
+    private string _afterAppendDelHtml = "";
+
     private RenderFrame[] _before = null!;
 
     // Insert scenario: a sparse list (even keys only) grows into the full list, so every odd
@@ -77,6 +87,32 @@ public class FrameDifferBenchmarks
 
         _beforeSparse = FramesOf(BuildKeyedList(evenOrder, -1));
         (_afterFull, _fullHtml) = FramesAndHtmlOf(BuildKeyedList(order, -1));
+
+        // Top-N rerank: reverse only the first 10 rows; the rest keep their order.
+        var topN = (int[])order.Clone();
+        Array.Reverse(topN, 0, Math.Min(10, RowCount));
+        (_afterTopN, _afterTopNHtml) = FramesAndHtmlOf(BuildKeyedList(topN, -1));
+
+        // Append-with-deletes: drop every 10th key, append that many fresh keys at the tail.
+        var kept = new List<int>(RowCount);
+        var removed = 0;
+        for (var i = 0; i < RowCount; i++)
+        {
+            if (i % 10 == 9)
+            {
+                removed++;
+                continue;
+            }
+
+            kept.Add(order[i]);
+        }
+
+        for (var i = 0; i < removed; i++)
+        {
+            kept.Add(RowCount + i); // brand-new keys → InsertSubtree at the tail
+        }
+
+        (_afterAppendDel, _afterAppendDelHtml) = FramesAndHtmlOf(BuildKeyedList(kept.ToArray(), -1));
     }
 
     [Benchmark(Baseline = true)]
@@ -102,6 +138,26 @@ public class FrameDifferBenchmarks
         // O(n²) move loop (live.IndexOf + live.Insert per off-LIS row).
         _ops.Clear();
         FrameDiffer.Diff(_before, _afterReverse, _ops, _scratch, out _, _afterReverseHtml);
+        return _ops.Count;
+    }
+
+    [Benchmark]
+    public int TopNRerank_ReusedScratch()
+    {
+        // Localized permutation: only the first 10 rows move, so the LIS is ~n and the move loop
+        // touches a handful of rows — the realistic table-sort case that stays well sub-quadratic.
+        _ops.Clear();
+        FrameDiffer.Diff(_before, _afterTopN, _ops, _scratch, out _, _afterTopNHtml);
+        return _ops.Count;
+    }
+
+    [Benchmark]
+    public int AppendWithDeletes_ReusedScratch()
+    {
+        // Feed/log churn: every 10th row removed, the same count of new keys appended. Survivors keep
+        // order (no moves), so this measures keyed remove + tail-insert reconcile, not the move loop.
+        _ops.Clear();
+        FrameDiffer.Diff(_before, _afterAppendDel, _ops, _scratch, out _, _afterAppendDelHtml);
         return _ops.Count;
     }
 

--- a/docs/architecture/live-rendering.md
+++ b/docs/architecture/live-rendering.md
@@ -253,6 +253,20 @@ ComputeLisIndexSet(targets, n, lis);
 // already-final node at the next index — the standard correct minimal-move reconcile
 ```
 
+**Complexity.** The LIS itself is `O(n log n)`. The move loop then repositions each off-LIS node
+with a `live.IndexOf` + `live.Insert` on a `List<int>`, each `O(n)`, so the loop is
+`O((n − |LIS|) · n)`. The number of off-LIS nodes — not `n` — is what matters: a **full reverse**
+has `|LIS| = 1`, so all `n − 1` rows move and the loop degrades to `O(n²)` (this is the genuine
+worst case, and it's deliberately pinned by `FrameDifferBenchmarks.ReverseReorder_ReusedScratch`).
+**Realistic** edits keep a near-full LIS — a table sort that reranks only the head, a feed that
+drops a few rows and appends new ones — so only a handful of rows are off-LIS and the loop stays
+effectively linear (`TopNRerank_ReusedScratch` / `AppendWithDeletes_ReusedScratch` pin those shapes).
+The quadratic case is bounded (one `List<int>` per parent, `n` capped by the rendered list size) and
+hasn't warranted replacing the list with an `O(log n)` order-statistic structure; the benchmarks
+guard against a regression that would make it matter. At 1000 rows the full reverse runs ~1.9× a
+two-element swap, while the top-N rerank and append-with-deletes shapes run at ~1.0× — confirming the
+cost is the off-LIS move count, not the list size.
+
 ### `PermutationBatch` (op kind 7)
 
 Rather than emitting one `MoveSubtree` op per moved row — each re-emitting the full


### PR DESCRIPTION
## Summary

The `FrameDiffer` benchmark suite measured only the two extremes — a 2-element swap and a full reverse (the O(n²) move-loop worst case) — with nothing covering the realistic in-between shapes that dominate real apps. Adds two, closing the audit's "unmeasured realistic permutation shapes" gap:

- **`TopNRerank`** — reverses only the first 10 rows (a table sort that reranks the head): localized permutation, near-full LIS.
- **`AppendWithDeletes`** — drops every 10th row and appends the same count of fresh keys at the tail (feed/log churn): survivors keep order, so it's keyed remove + tail-insert, not moves.

## Evidence (RowCount = 1000, short job)

| Scenario | Ratio vs 2-swap baseline |
| --- | --- |
| `Reorder` (2-swap) | 1.00 |
| `ReverseReorder` (full reverse) | **1.91** |
| `TopNRerank` | **0.98** |
| `AppendWithDeletes` | **1.00** |

Confirms the move-loop cost tracks the **off-LIS move count, not the list size** — realistic shuffles are as cheap as a single swap; only the pathological full reverse hits the bounded quadratic case. Documented the complexity characteristic in `docs/architecture/live-rendering.md`.

## Testing

Benchmark-only change — **no runtime code touched**. Builds `-c Release` clean; new scenarios produced the table above; `dotnet format` clean. Independent of #125–#128; targets `main` directly.