### PR TITLE
feat(server): OpenTelemetry-aligned observability (logging, metrics, tracing, health)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ them until tagged releases begin.
   zero-cost when no listener is attached. (4) **Health checks:** `services.AddHealthChecks()`
   `.AddRaskLiveSessions()` reports live-session capacity — `Healthy` / `Degraded` (≥80% of
   `MaxSessions`) / `Unhealthy` (at the cap). All of it is on by default with no configuration; you opt
-  in only to *exporting* it. See the new [observability guide](docs/observability.md).
+  in only to *exporting* it. The render/diff/serialization hot path is untouched; the per-dispatch
+  instrumentation (a counter increment, a `Stopwatch` timing pair, a histogram record, and a tracing
+  `Activity` that is `null` when no tracer is attached) is allocation-free. See the new
+  [observability guide](docs/observability.md).
 - **Keyboard events on every element.** `Element` now exposes the `OnKeyDown` / `OnKeyDownAsync` and
   `OnKeyUp` / `OnKeyUpAsync` pairs, the focus-scoped counterpart to `OnClick`, wired by both client
   runtimes (Server WS + WASM) via `data-rask-on-keydown` / `data-rask-on-keyup`. A handler takes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Production observability for the server host (OpenTelemetry-aligned).** The Rask server is now
+  instrumented with standard .NET primitives — no extra packages, exportable to OpenTelemetry out of
+  the box. (1) **Structured logging:** `UseRask<TApp>()` bridges the framework's internal diagnostics
+  seam to your `ILogger` pipeline, so every framework fault (a lifecycle hook that threw with no
+  ancestor `ErrorBoundary`, a duplicate sibling `Key`, a malformed WS frame, a handler that threw) is
+  logged under a stable category (`Rask.Live`, `Rask.Diff`, `Rask.Lifecycle`, …) at the matching level
+  with the original exception — replacing the previous scattered `Console.Error` writes. (2)
+  **Metrics:** a `Meter` named `Rask.Server` (`RaskTelemetry.MeterName`) exposes session counters
+  (`rask.sessions.created` / `.rejected` / `.evicted`), an active-sessions gauge, handler counters
+  (`rask.handlers.dispatched` / `.faulted`) and duration histogram, and a `rask.ws.frames.rejected`
+  counter tagged by `reason` (`size` / `rate` / `backlog`) — the headline DoS-visibility signal. Read
+  with `dotnet-counters --counters Rask.Server` or `AddMeter(RaskTelemetry.MeterName)`. (3) **Tracing:**
+  an `ActivitySource` named `Rask.Server` spans each handler dispatch (`rask.handler.dispatch`),
+  zero-cost when no listener is attached. (4) **Health checks:** `services.AddHealthChecks()`
+  `.AddRaskLiveSessions()` reports live-session capacity — `Healthy` / `Degraded` (≥80% of
+  `MaxSessions`) / `Unhealthy` (at the cap). All of it is on by default with no configuration; you opt
+  in only to *exporting* it. See the new [observability guide](docs/observability.md).
 - **Keyboard events on every element.** `Element` now exposes the `OnKeyDown` / `OnKeyDownAsync` and
   `OnKeyUp` / `OnKeyUpAsync` pairs, the focus-scoped counterpart to `OnClick`, wired by both client
   runtimes (Server WS + WASM) via `data-rask-on-keydown` / `data-rask-on-keyup`. A handler takes

--- a/NUGET.md
+++ b/NUGET.md
@@ -61,6 +61,7 @@ the page). It's a craft project built in the open, deep on Roslyn source generat
 
 - 📖 **[Documentation](https://github.com/pal-tamas/rask/tree/main/docs)** ·
   [Getting started](https://github.com/pal-tamas/rask/blob/main/docs/getting-started.md) ·
+  [Observability](https://github.com/pal-tamas/rask/blob/main/docs/observability.md) ·
   [Accessibility](https://github.com/pal-tamas/rask/blob/main/docs/accessibility.md)
 - 🚀 **[Live demo](https://pal-tamas.github.io/rask/)**
 - 💻 **[Source & README](https://github.com/pal-tamas/rask)**

--- a/README.md
+++ b/README.md
@@ -411,7 +411,7 @@ see **[`docs/`](docs/)**:
 - **[Getting started](docs/getting-started.md)** — scaffold, first component, interactivity, routing.
 - **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Lifecycle](docs/lifecycle.md)** · *
   *[Authentication](docs/authentication.md)**
-- **[Accessibility](docs/accessibility.md)** · **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
+- **[Accessibility](docs/accessibility.md)** · **[Observability](docs/observability.md)** · **[Testing](docs/testing.md)** · **[Migrating from Blazor](docs/migration-from-blazor.md)**
 - **[Diagnostics (RASK001–024)](docs/diagnostics.md)** — every build error/warning and its fix.
 - **[Live rendering & the diff codec](docs/architecture/live-rendering.md)** — how the runtime works under the hood.
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,108 @@
+# Observability
+
+Rask's server host is instrumented for production operations with standard .NET primitives — no
+extra packages, OpenTelemetry-exportable out of the box. Four surfaces:
+
+1. **Structured logging** — framework faults flow into your `ILogger` pipeline.
+2. **Metrics** — a `Meter` named `Rask.Server` with session, handler, and frame counters/histograms.
+3. **Tracing** — an `ActivitySource` named `Rask.Server` spanning handler dispatch.
+4. **Health checks** — a live-session capacity check.
+
+Everything is on by default with zero configuration; you opt in to *exporting* it.
+
+## Structured logging
+
+`Rask.Core` and the WASM host take no dependency on `Microsoft.Extensions.Logging` — instead they
+report diagnostics through an internal seam (`RaskDiagnostics`). On the server, `UseRask<TApp>()`
+bridges that seam to your application's `ILogger` automatically. From then on every framework
+diagnostic — a lifecycle hook that threw with no ancestor `ErrorBoundary`, a component `Dispose`
+that faulted, a duplicate sibling `Key`, a malformed WebSocket frame, an event handler that threw —
+is logged through an `ILogger` named for the diagnostic's category, at the matching level, with the
+original exception attached:
+
+| Category | Emitted for |
+| --- | --- |
+| `Rask.Lifecycle` | Faulting lifecycle hooks / disposes with no ancestor `ErrorBoundary` |
+| `Rask.Diff` | Duplicate sibling `Key` (keyed reconciliation silently disabled) |
+| `Rask.Live` | Handler / navigate / JS-invoke faults, malformed frames, coalesce-budget drops |
+| `Rask.JsInvoke` | Failures surfacing a JS-invoke fault back to the caller |
+| `Rask.HotReload` | Dev-time asset/source-watch rerender failures |
+
+No wiring is needed — configure log levels for these categories like any other:
+
+```jsonc
+// appsettings.json
+{
+  "Logging": {
+    "LogLevel": {
+      "Rask.Live": "Warning",
+      "Rask.Diff": "Warning"
+    }
+  }
+}
+```
+
+When no `ILoggerFactory` is registered (e.g. a bare test host), the seam keeps its default behaviour
+and writes the same diagnostics to `stderr`.
+
+## Metrics
+
+All metrics publish on the meter named **`Rask.Server`** (`RaskTelemetry.MeterName`).
+
+| Instrument | Kind | Tags | Meaning |
+| --- | --- | --- | --- |
+| `rask.sessions.created` | Counter | | Live sessions created (component tree + DI scope). |
+| `rask.sessions.rejected` | Counter | | Creations refused because `MaxSessions` was reached. |
+| `rask.sessions.evicted` | Counter | | Sessions removed (disconnect grace elapsed / shutdown). |
+| `rask.sessions.active` | Gauge | | Live sessions currently held. |
+| `rask.handlers.dispatched` | Counter | | Client event handlers dispatched to user code. |
+| `rask.handlers.faulted` | Counter | | Handler dispatches that threw (isolated; session survives). |
+| `rask.handler.duration` | Histogram (ms) | | Wall-clock duration of an event-handler dispatch. |
+| `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` | Inbound frames refused by a safety limit. |
+
+The `rask.ws.frames.rejected` counter is the headline DoS-visibility signal: a spike on
+`reason=rate` or `reason=backlog` means a client is being throttled by the per-connection frame-rate
+cap or the pending-handler backpressure breaker.
+
+### Reading metrics locally
+
+```bash
+dotnet-counters monitor --counters Rask.Server --process-id <pid>
+```
+
+### Exporting via OpenTelemetry
+
+```csharp
+builder.Services.AddOpenTelemetry()
+    .WithMetrics(m => m.AddMeter(RaskTelemetry.MeterName))
+    .WithTracing(t => t.AddSource(RaskTelemetry.ActivitySourceName));
+```
+
+## Tracing
+
+Each event-handler dispatch starts an `Activity` named `rask.handler.dispatch` on the
+`Rask.Server` `ActivitySource`, tagged with `rask.handler.id` and marked `Error` (with the exception
+message) when the handler throws. With no listener registered the span is never materialised, so the
+instrumentation costs nothing. Subscribe with `.AddSource(RaskTelemetry.ActivitySourceName)` as
+above (or any `ActivityListener`).
+
+## Health checks
+
+`RaskLiveHealthCheck` reports live-session capacity. Register it on your health-checks pipeline:
+
+```csharp
+builder.Services.AddRask(o => o.MaxSessions = 1000);
+builder.Services.AddHealthChecks().AddRaskLiveSessions();
+// ...
+app.MapHealthChecks("/health");
+app.UseRask<App>();
+```
+
+| Status | Condition |
+| --- | --- |
+| `Healthy` | Below 80% of `MaxSessions` (or `MaxSessions == 0`, i.e. uncapped). |
+| `Degraded` | At or above 80% of `MaxSessions` — the host is filling up. |
+| `Unhealthy` | At `MaxSessions` — new sessions are being refused with `503`. |
+
+The active and maximum session counts are attached to the health-check result `data` for dashboards.
+Pair the capacity cap with a reverse-proxy rate limit for precise admission control.

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
+- [Observability](docs/observability.md): structured logging, the `Rask.Server` meter + activity source, `AddRaskLiveSessions()` health check.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
 - [Diagnostics](docs/diagnostics.md): RASK001–024 compile-time diagnostics + fixes.

--- a/samples/Rask.Example.Server/Program.cs
+++ b/samples/Rask.Example.Server/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting.Server.Features;
 using Rask.Core.Live;
 using Rask.Example.Shared;
 using Rask.Server;
+using Rask.Server.Diagnostics;
 
 // The framework default since AddRask gained an options shape is
 // LiveDiffMode.Auto, so `services.AddRask()` already ships the diff codec out of
@@ -18,6 +19,10 @@ if (Environment.GetEnvironmentVariable("RASK_DIFF_MODE") is { } diffModeName
 var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRask();
+// Live-session capacity health check (Healthy / Degraded ≥80% / Unhealthy at cap), surfaced at
+// /health below. Pairs with the OpenTelemetry-ready "Rask.Server" meter + activity source — see
+// docs/observability.md.
+builder.Services.AddHealthChecks().AddRaskLiveSessions();
 // The HTTP demo's HttpClient calls back into this server for its own static
 // data/posts-1.json. Resolve the bound origin lazily from IServerAddressesFeature
 // (populated once the server is listening); fall back to localhost for the
@@ -40,6 +45,10 @@ var app = builder.Build();
 // auto-insert and lets real files (wwwroot/lib, /img, /data) serve first.
 app.UseStaticFiles();
 app.UseRouting();
+
+// Live-session capacity probe (see docs/observability.md). Returns 200 Healthy / Degraded and
+// 503 Unhealthy once at the MaxSessions cap, so an orchestrator can shed load before refusals.
+app.MapHealthChecks("/health");
 
 // Test-only diagnostic endpoint: exposes the server's session count and GC heap
 // so E2E memory/session-lifecycle tests can assert bounded growth. Lives in the

--- a/src/Rask.Server/Diagnostics/RaskActivity.cs
+++ b/src/Rask.Server/Diagnostics/RaskActivity.cs
@@ -1,0 +1,15 @@
+using System.Diagnostics;
+
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     The Rask server's <see cref="ActivitySource" /> (named <see cref="RaskTelemetry.ActivitySourceName" />).
+///     A long-lived singleton, as the <c>ActivitySource</c> docs require. Subscribe from an
+///     OpenTelemetry tracer with <c>.AddSource(RaskTelemetry.ActivitySourceName)</c>. With no
+///     listener registered, <see cref="ActivitySource.StartActivity(string)" /> returns <c>null</c>
+///     and the instrumentation costs nothing.
+/// </summary>
+internal static class RaskActivity
+{
+    public static readonly ActivitySource Source = new(RaskTelemetry.ActivitySourceName);
+}

--- a/src/Rask.Server/Diagnostics/RaskHealthCheckExtensions.cs
+++ b/src/Rask.Server/Diagnostics/RaskHealthCheckExtensions.cs
@@ -1,0 +1,29 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     Registration helpers for the Rask live-session health check.
+/// </summary>
+public static class RaskHealthCheckExtensions
+{
+    /// <summary>
+    ///     Adds the <see cref="RaskLiveHealthCheck" /> (live-session capacity) to the health-checks
+    ///     pipeline. Requires <c>AddRask()</c> to have registered the <see cref="LiveSessionStore" />.
+    ///     Usage: <c>services.AddHealthChecks().AddRaskLiveSessions();</c>
+    /// </summary>
+    /// <param name="builder">The health-checks builder.</param>
+    /// <param name="name">The health-check registration name.</param>
+    /// <param name="failureStatus">
+    ///     The status reported when the check fails. Defaults to the check's own
+    ///     <see cref="HealthStatus.Unhealthy" /> result.
+    /// </param>
+    /// <param name="tags">Optional tags for filtering this check (e.g. <c>"ready"</c>, <c>"rask"</c>).</param>
+    public static IHealthChecksBuilder AddRaskLiveSessions(
+        this IHealthChecksBuilder builder,
+        string name = "rask_live_sessions",
+        HealthStatus? failureStatus = null,
+        IEnumerable<string>? tags = null) =>
+        builder.AddCheck<RaskLiveHealthCheck>(name, failureStatus, tags ?? []);
+}

--- a/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
+++ b/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
@@ -18,7 +18,10 @@ public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
     {
-        var active = store.Count;
+        // LiveCount (reservations + committed), not Count (committed only): admission refuses new
+        // sessions at LiveCount == MaxSessions, so the health status must track the same number or it
+        // would report Healthy while the host is already answering 503s during a concurrent GET burst.
+        var active = store.LiveCount;
         var max = store.MaxSessions;
         var data = new Dictionary<string, object>
         {

--- a/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
+++ b/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
@@ -1,0 +1,50 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     An ASP.NET health check reporting live-session capacity. <c>Healthy</c> while comfortably below
+///     the configured <see cref="LiveSessionStore.MaxSessions" /> cap, <c>Degraded</c> at or above 80%
+///     of it (the host is filling up), and <c>Unhealthy</c> once at the cap (new sessions are being
+///     refused with 503). When sessions are uncapped (<c>MaxSessions == 0</c>) it is always
+///     <c>Healthy</c> and simply reports the active count. The active/max counts are attached as
+///     health-check data for dashboards.
+/// </summary>
+public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
+{
+    internal const double DegradedRatio = 0.8;
+
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        var active = store.Count;
+        var max = store.MaxSessions;
+        var data = new Dictionary<string, object>
+        {
+            ["activeSessions"] = active,
+            ["maxSessions"] = max
+        };
+
+        if (max <= 0)
+        {
+            return Task.FromResult(HealthCheckResult.Healthy(
+                $"Rask live sessions: {active} active (uncapped).", data));
+        }
+
+        if (active >= max)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"Rask live sessions at capacity ({active}/{max}); new sessions are being refused.", null, data));
+        }
+
+        if (active >= max * DegradedRatio)
+        {
+            return Task.FromResult(HealthCheckResult.Degraded(
+                $"Rask live sessions near capacity ({active}/{max}).", null, data));
+        }
+
+        return Task.FromResult(HealthCheckResult.Healthy(
+            $"Rask live sessions: {active}/{max}.", data));
+    }
+}

--- a/src/Rask.Server/Diagnostics/RaskMetrics.cs
+++ b/src/Rask.Server/Diagnostics/RaskMetrics.cs
@@ -1,0 +1,84 @@
+using System.Diagnostics.Metrics;
+
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     The Rask server's OpenTelemetry-compatible metrics, published on the
+///     <see cref="RaskTelemetry.MeterName" /> meter. Registered as a singleton by
+///     <c>AddRask()</c> and threaded into the instrumentation points (session lifecycle in
+///     <see cref="LiveSessionStore" />, frame-rejection and handler dispatch in the WebSocket
+///     loop). Every instrument is allocation-light on the hot path: counters take a single
+///     <c>Add(1)</c>, the active-sessions reading is an observable gauge polled by the collector.
+///     <para>
+///         Subscribe with <c>dotnet-counters monitor --counters Rask.Server</c> or an OpenTelemetry
+///         <c>MeterProvider.AddMeter(RaskTelemetry.MeterName)</c>.
+///     </para>
+/// </summary>
+public sealed class RaskMetrics : IDisposable
+{
+    private readonly Counter<long> _framesRejected;
+    private readonly Counter<long> _handlersDispatched;
+    private readonly Counter<long> _handlersFaulted;
+    private readonly Histogram<double> _handlerDuration;
+    private readonly Meter _meter;
+    private readonly Counter<long> _sessionsCreated;
+    private readonly Counter<long> _sessionsEvicted;
+    private readonly Counter<long> _sessionsRejected;
+
+    /// <summary>
+    ///     Constructs the meter. Prefers the DI-supplied <see cref="IMeterFactory" /> (so the
+    ///     instruments participate in the host's metrics pipeline and test isolation); falls back to a
+    ///     standalone <see cref="Meter" /> when no factory is registered.
+    /// </summary>
+    public RaskMetrics(IMeterFactory? meterFactory = null)
+    {
+        _meter = meterFactory?.Create(RaskTelemetry.MeterName)
+                 ?? new Meter(RaskTelemetry.MeterName);
+
+        _sessionsCreated = _meter.CreateCounter<long>(
+            "rask.sessions.created", "{session}", "Live sessions created (component tree + DI scope).");
+        _sessionsRejected = _meter.CreateCounter<long>(
+            "rask.sessions.rejected", "{session}", "Session creations refused because MaxSessions was reached.");
+        _sessionsEvicted = _meter.CreateCounter<long>(
+            "rask.sessions.evicted", "{session}", "Live sessions removed (disconnect grace elapsed or shutdown).");
+        _handlersDispatched = _meter.CreateCounter<long>(
+            "rask.handlers.dispatched", "{handler}", "Client event handlers dispatched to user code.");
+        _handlersFaulted = _meter.CreateCounter<long>(
+            "rask.handlers.faulted", "{handler}", "Event-handler dispatches that threw (isolated, session survives).");
+        _handlerDuration = _meter.CreateHistogram<double>(
+            "rask.handler.duration", "ms", "Wall-clock duration of an event-handler dispatch.");
+        _framesRejected = _meter.CreateCounter<long>(
+            "rask.ws.frames.rejected", "{frame}", "Inbound WebSocket frames rejected by a safety limit.");
+    }
+
+    // Exposed for tests so a MeterListener can scope to this exact meter instance and ignore
+    // measurements from any other RaskMetrics constructed concurrently.
+    internal Meter Meter => _meter;
+
+    public void Dispose() => _meter.Dispose();
+
+    /// <summary>Registers the observable active-session gauge backed by <paramref name="readCount" />.</summary>
+    public void TrackActiveSessions(Func<int> readCount) =>
+        _meter.CreateObservableGauge(
+            "rask.sessions.active", readCount, "{session}", "Live sessions currently held by the store.");
+
+    public void SessionCreated() => _sessionsCreated.Add(1);
+
+    public void SessionRejected() => _sessionsRejected.Add(1);
+
+    public void SessionEvicted() => _sessionsEvicted.Add(1);
+
+    public void HandlerDispatched() => _handlersDispatched.Add(1);
+
+    public void HandlerFaulted() => _handlersFaulted.Add(1);
+
+    public void RecordHandlerDuration(double milliseconds) => _handlerDuration.Record(milliseconds);
+
+    /// <summary>
+    ///     Counts a rejected inbound frame, tagged with the limit that tripped:
+    ///     <c>size</c> (frame exceeded the byte cap), <c>rate</c> (frame-per-second flood), or
+    ///     <c>backlog</c> (pending-handler queue overflow).
+    /// </summary>
+    public void FrameRejected(string reason) =>
+        _framesRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+}

--- a/src/Rask.Server/Diagnostics/RaskServerDiagnostics.cs
+++ b/src/Rask.Server/Diagnostics/RaskServerDiagnostics.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using Microsoft.Extensions.Logging;
 using Rask.Core.Diagnostics;
 
@@ -13,10 +12,17 @@ namespace Rask.Server.Diagnostics;
 ///     <c>Rask.Live</c>), at the mapped <see cref="LogLevel" />, with the original exception attached.
 ///     Without this bridge the seam keeps its default behaviour (a plain <c>Console.Error</c> writer),
 ///     so logging is opt-in via the host but on by default for any Rask server app.
+///     <para>
+///         <see cref="RaskDiagnostics.Sink" /> is a process-global seam, so in a multi-host process
+///         (e.g. a test run that spins up several <c>WebApplication</c>s) the most recently installed
+///         factory wins for all hosts. That is benign — diagnostics are still logged — and
+///         <see cref="Emit" /> never lets a logging fault (including a factory disposed by an earlier
+///         host's teardown) escape back into the framework's own catch blocks.
+///     </para>
 /// </summary>
 internal static class RaskServerDiagnostics
 {
-    private static readonly ConcurrentDictionary<string, ILogger> Loggers = new(StringComparer.Ordinal);
+    private static readonly object Gate = new();
     private static ILoggerFactory? _factory;
 
     /// <summary>
@@ -31,24 +37,53 @@ internal static class RaskServerDiagnostics
             return;
         }
 
-        _factory = factory;
-        Loggers.Clear();
-        RaskDiagnostics.Sink = Forward;
+        lock (Gate)
+        {
+            // Publish the factory before the sink so a concurrent Forward always sees a non-null factory.
+            _factory = factory;
+            RaskDiagnostics.Sink = Forward;
+        }
     }
 
     private static void Forward(RaskDiagnosticEvent e)
     {
+        // Snapshot the settable factory so a concurrent Install/teardown can't null it out mid-call.
         var factory = _factory;
-        if (factory is null)
+        if (factory is not null)
         {
-            return;
+            Emit(factory, e);
         }
+    }
 
-        var logger = Loggers.GetOrAdd(e.Category, static (category, f) => f.CreateLogger(category), factory);
-
-        // The message is already a fully-formed human string; log it as a single structured field so the
-        // exception travels as a first-class argument rather than being concatenated into the text.
-        logger.Log(Map(e.Level), e.Exception, "{RaskMessage}", e.Message);
+    /// <summary>
+    ///     Log one event through <paramref name="factory" />. A diagnostic must never become a fault: a
+    ///     logging pipeline that throws — a factory disposed by an earlier host's teardown in a
+    ///     multi-host/test process, or a misbehaving <c>ILoggerProvider</c> — would otherwise escape
+    ///     <see cref="RaskDiagnostics.Report" /> into the framework catch blocks that previously only
+    ///     wrote to <c>stderr</c>, turning a swallowed warning into a torn-down session. Swallow and fall
+    ///     back to stderr. Exposed internally so the level/category mapping can be unit-tested without
+    ///     mutating the process-global sink. <c>ILoggerFactory.CreateLogger</c> caches loggers internally,
+    ///     so no per-category cache is kept here.
+    /// </summary>
+    internal static void Emit(ILoggerFactory factory, RaskDiagnosticEvent e)
+    {
+        try
+        {
+            // The message is already a fully-formed human string; log it as a single structured field so
+            // the exception travels as a first-class argument rather than being concatenated into the text.
+            factory.CreateLogger(e.Category).Log(Map(e.Level), e.Exception, "{RaskMessage}", e.Message);
+        }
+        catch
+        {
+            try
+            {
+                Console.Error.WriteLine(RaskDiagnostics.FormatDefault(e));
+            }
+            catch
+            {
+                // Nothing left to do — never rethrow out of a diagnostic.
+            }
+        }
     }
 
     private static LogLevel Map(RaskLogLevel level) => level switch

--- a/src/Rask.Server/Diagnostics/RaskServerDiagnostics.cs
+++ b/src/Rask.Server/Diagnostics/RaskServerDiagnostics.cs
@@ -1,0 +1,60 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Rask.Core.Diagnostics;
+
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     Bridges the framework's dependency-free <see cref="RaskDiagnostics" /> seam to the host's
+///     <c>ILogger</c> pipeline. Installed once by <c>UseRask&lt;TApp&gt;()</c>: from then on every
+///     framework diagnostic — a faulting lifecycle hook, a duplicate sibling key, a malformed WS
+///     frame, a handler that threw — is logged through an <c>ILogger</c> named for the event's
+///     <see cref="RaskDiagnosticEvent.Category" /> (e.g. <c>Rask.Lifecycle</c>, <c>Rask.Diff</c>,
+///     <c>Rask.Live</c>), at the mapped <see cref="LogLevel" />, with the original exception attached.
+///     Without this bridge the seam keeps its default behaviour (a plain <c>Console.Error</c> writer),
+///     so logging is opt-in via the host but on by default for any Rask server app.
+/// </summary>
+internal static class RaskServerDiagnostics
+{
+    private static readonly ConcurrentDictionary<string, ILogger> Loggers = new(StringComparer.Ordinal);
+    private static ILoggerFactory? _factory;
+
+    /// <summary>
+    ///     Routes <see cref="RaskDiagnostics.Sink" /> into <paramref name="factory" />. A no-op when no
+    ///     logger factory is available (the seam then keeps its stderr default). Idempotent: re-installing
+    ///     simply repoints at the latest factory.
+    /// </summary>
+    public static void Install(ILoggerFactory? factory)
+    {
+        if (factory is null)
+        {
+            return;
+        }
+
+        _factory = factory;
+        Loggers.Clear();
+        RaskDiagnostics.Sink = Forward;
+    }
+
+    private static void Forward(RaskDiagnosticEvent e)
+    {
+        var factory = _factory;
+        if (factory is null)
+        {
+            return;
+        }
+
+        var logger = Loggers.GetOrAdd(e.Category, static (category, f) => f.CreateLogger(category), factory);
+
+        // The message is already a fully-formed human string; log it as a single structured field so the
+        // exception travels as a first-class argument rather than being concatenated into the text.
+        logger.Log(Map(e.Level), e.Exception, "{RaskMessage}", e.Message);
+    }
+
+    private static LogLevel Map(RaskLogLevel level) => level switch
+    {
+        RaskLogLevel.Error => LogLevel.Error,
+        RaskLogLevel.Warning => LogLevel.Warning,
+        _ => LogLevel.Information
+    };
+}

--- a/src/Rask.Server/Diagnostics/RaskTelemetry.cs
+++ b/src/Rask.Server/Diagnostics/RaskTelemetry.cs
@@ -1,0 +1,16 @@
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     Well-known telemetry names for the Rask server host. Use these to subscribe from an
+///     OpenTelemetry pipeline (<c>builder.AddMeter(RaskTelemetry.MeterName)</c> /
+///     <c>.AddSource(RaskTelemetry.ActivitySourceName)</c>) or <c>dotnet-counters</c>
+///     (<c>--counters Rask.Server</c>).
+/// </summary>
+public static class RaskTelemetry
+{
+    /// <summary>The <see cref="System.Diagnostics.Metrics.Meter" /> name for all Rask server metrics.</summary>
+    public const string MeterName = "Rask.Server";
+
+    /// <summary>The <see cref="System.Diagnostics.ActivitySource" /> name for Rask server traces.</summary>
+    public const string ActivitySourceName = "Rask.Server";
+}

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.JSInterop.Infrastructure;
 using Rask.Core;
 using Rask.Core.Authentication;
+using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 using Rask.Core.Routing;
 using Rask.Server.Files;
@@ -473,7 +474,8 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         // warning gives the user a single grep target.
         if (_pendingRenderInScope)
         {
-            Console.Error.WriteLine(
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.Live",
                 $"[Rask.LiveSession] Coalesce-loop budget exhausted for session {Id}; " +
                 "a third in-dispatch render was queued and dropped. Inspect any handlers " +
                 "that re-trigger StateHasChanged in OnRenderedAsync / dispose callbacks " +
@@ -503,9 +505,10 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         }
         catch (Exception failEx)
         {
-            Console.Error.WriteLine(
+            RaskDiagnostics.Report(
+                RaskLogLevel.Error, "Rask.Live",
                 $"[Rask.LiveSession] Failed to fault {invokes.Length} pending JS invoke(s) for " +
-                $"session {Id} after a send error: {failEx}");
+                $"session {Id} after a send error", failEx);
         }
     }
 }

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Rask.Core;
+using Rask.Server.Diagnostics;
 using Rask.Server.Files;
 using Rask.Server.JSInterop;
 
@@ -9,6 +10,7 @@ namespace Rask.Server;
 
 public sealed class LiveSessionStore : IAsyncDisposable
 {
+    private readonly RaskMetrics? _metrics;
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _pendingRemovals = new();
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ConcurrentDictionary<string, LiveSession> _sessions = new();
@@ -19,17 +21,28 @@ public sealed class LiveSessionStore : IAsyncDisposable
     // on a failed build), so a concurrent GET burst can never exceed MaxSessions.
     private int _liveCount;
 
-    public LiveSessionStore(IServiceScopeFactory scopeFactory, IHostApplicationLifetime? lifetime = null)
+    public LiveSessionStore(
+        IServiceScopeFactory scopeFactory,
+        IHostApplicationLifetime? lifetime = null,
+        RaskMetrics? metrics = null)
     {
         _scopeFactory = scopeFactory;
+        _metrics = metrics;
         _stopping = lifetime?.ApplicationStopping ?? CancellationToken.None;
         if (lifetime is not null)
         {
             lifetime.ApplicationStopping.Register(CancelAllPending);
         }
+
+        // Active-session count is an observable gauge: the collector polls Count on scrape, so
+        // there's no per-create/per-remove bookkeeping beyond the counters below.
+        _metrics?.TrackActiveSessions(() => Count);
     }
 
     public int Count => _sessions.Count;
+
+    /// <summary>The metrics sink threaded into the WS loop for frame/handler instrumentation (may be null).</summary>
+    internal RaskMetrics? Metrics => _metrics;
 
     /// <summary>
     ///     Hard cap on concurrent sessions (<c>0</c> = unlimited). Set from
@@ -101,6 +114,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         if (MaxSessions > 0 && reserved > MaxSessions)
         {
             Interlocked.Decrement(ref _liveCount);
+            _metrics?.SessionRejected();
             return null;
         }
 
@@ -146,6 +160,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         }
 
         _sessions[session.Id] = session;
+        _metrics?.SessionCreated();
         return session;
     }
 
@@ -161,6 +176,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         if (_sessions.TryRemove(id, out var session))
         {
             Interlocked.Decrement(ref _liveCount);
+            _metrics?.SessionEvicted();
             session.Dispose();
         }
     }
@@ -171,6 +187,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
         if (_sessions.TryRemove(id, out var session))
         {
             Interlocked.Decrement(ref _liveCount);
+            _metrics?.SessionEvicted();
             await session.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -34,12 +34,21 @@ public sealed class LiveSessionStore : IAsyncDisposable
             lifetime.ApplicationStopping.Register(CancelAllPending);
         }
 
-        // Active-session count is an observable gauge: the collector polls Count on scrape, so
-        // there's no per-create/per-remove bookkeeping beyond the counters below.
-        _metrics?.TrackActiveSessions(() => Count);
+        // Active-session gauge: the collector polls on scrape. Reads LiveCount (reservations +
+        // committed) — the same number admission and the health check gate on — so the gauge, the
+        // capacity cap, and /health never disagree by the count of mid-build sessions.
+        _metrics?.TrackActiveSessions(() => LiveCount);
     }
 
     public int Count => _sessions.Count;
+
+    /// <summary>
+    ///     Reserved + in-flight + committed session count — the authoritative capacity number that
+    ///     <see cref="TryCreate" /> / <see cref="AtCapacity" /> gate on. Differs from
+    ///     <see cref="Count" /> (committed sessions only) during the window where a reserved session's
+    ///     component tree is still building.
+    /// </summary>
+    internal int LiveCount => Volatile.Read(ref _liveCount);
 
     /// <summary>The metrics sink threaded into the WS loop for frame/handler instrumentation (may be null).</summary>
     internal RaskMetrics? Metrics => _metrics;
@@ -64,12 +73,27 @@ public sealed class LiveSessionStore : IAsyncDisposable
         CancelAllPending();
         foreach (var key in _sessions.Keys.ToArray())
         {
-            if (_sessions.TryRemove(key, out var session))
+            if (Detach(key) is { } session)
             {
-                Interlocked.Decrement(ref _liveCount);
                 await session.DisposeAsync().ConfigureAwait(false);
             }
         }
+    }
+
+    // The single removal point all three paths (Remove / RemoveAsync / DisposeAsync) funnel through:
+    // atomically take the session out of the map, drop the live-count reservation, and record the
+    // eviction metric exactly once. Returns the detached session for the caller to dispose (sync or
+    // async), or null if another thread already removed it.
+    private LiveSession? Detach(string id)
+    {
+        if (_sessions.TryRemove(id, out var session))
+        {
+            Interlocked.Decrement(ref _liveCount);
+            _metrics?.SessionEvicted();
+            return session;
+        }
+
+        return null;
     }
 
     private void CancelAllPending()
@@ -173,21 +197,14 @@ public sealed class LiveSessionStore : IAsyncDisposable
     internal void Remove(string id)
     {
         CancelPendingRemoval(id);
-        if (_sessions.TryRemove(id, out var session))
-        {
-            Interlocked.Decrement(ref _liveCount);
-            _metrics?.SessionEvicted();
-            session.Dispose();
-        }
+        Detach(id)?.Dispose();
     }
 
     internal async Task RemoveAsync(string id)
     {
         CancelPendingRemoval(id);
-        if (_sessions.TryRemove(id, out var session))
+        if (Detach(id) is { } session)
         {
-            Interlocked.Decrement(ref _liveCount);
-            _metrics?.SessionEvicted();
             await session.DisposeAsync().ConfigureAwait(false);
         }
     }

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Globalization;
 using System.Net.WebSockets;
 using System.Security.Claims;
@@ -21,11 +22,13 @@ using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Core.Authorization;
 using Rask.Core.Components;
+using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
 using Rask.Core.Live;
 using Rask.Core.Routing;
 using Rask.Core.ScopedAssets;
 using Rask.Server.Authentication;
+using Rask.Server.Diagnostics;
 using Rask.Server.Files;
 using Rask.Server.JSInterop;
 using Components = Rask.Core.Components.Generated;
@@ -136,9 +139,12 @@ public static class RaskEndpointExtensions
             maxSessions = liveOptions.MaxSessions;
         }
 
+        // Metrics singleton (Meter "Rask.Server"). TryAdd so a host can pre-register its own.
+        services.TryAddSingleton<RaskMetrics>();
         services.AddSingleton(sp => new LiveSessionStore(
             sp.GetRequiredService<IServiceScopeFactory>(),
-            sp.GetService<IHostApplicationLifetime>())
+            sp.GetService<IHostApplicationLifetime>(),
+            sp.GetService<RaskMetrics>())
         { MaxSessions = maxSessions });
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
@@ -191,7 +197,12 @@ public static class RaskEndpointExtensions
         string pathBase = "")
         where TApp : Component
     {
-        var logger = app.Services.GetService<ILoggerFactory>()?.CreateLogger("Rask");
+        // Route every framework diagnostic (Rask.Core + this host) into the application's logging
+        // pipeline. No-ops when no ILoggerFactory is registered, leaving the stderr default in place.
+        var loggerFactory = app.Services.GetService<ILoggerFactory>();
+        RaskServerDiagnostics.Install(loggerFactory);
+
+        var logger = loggerFactory?.CreateLogger("Rask");
         if (logger is not null)
             logger.LogInformation("Rask {Version} (Server) starting", RaskVersion.Current);
         else
@@ -463,8 +474,9 @@ public static class RaskEndpointExtensions
                 }
                 catch (Exception ex)
                 {
-                    Console.Error.WriteLine(
-                        $"Rask: debounced asset-change rerender failed: {ex.Message}");
+                    RaskDiagnostics.Report(
+                        RaskLogLevel.Warning, "Rask.HotReload",
+                        "Rask: debounced asset-change rerender failed", ex);
                 }
             });
         };
@@ -507,7 +519,8 @@ public static class RaskEndpointExtensions
                     try { await sessionStore.RerenderAllAsync().ConfigureAwait(false); }
                     catch (Exception ex)
                     {
-                        Console.Error.WriteLine($"Rask: source-watch rerender failed: {ex.Message}");
+                        RaskDiagnostics.Report(
+                            RaskLogLevel.Warning, "Rask.HotReload", "Rask: source-watch rerender failed", ex);
                     }
                 });
             }
@@ -519,7 +532,8 @@ public static class RaskEndpointExtensions
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Rask: source watcher disabled ({ex.Message})");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.HotReload", "Rask: source watcher disabled", ex);
         }
     }
 
@@ -533,7 +547,8 @@ public static class RaskEndpointExtensions
         }
         catch (JsonException ex)
         {
-            Console.Error.WriteLine($"Rask Live: dropped malformed WS frame ({ex.Message})");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.Live", "Rask Live: dropped malformed WS frame", ex);
             return null;
         }
     }
@@ -546,6 +561,7 @@ public static class RaskEndpointExtensions
             try { ws.Abort(); }
             catch { }
         });
+        var metrics = store.Metrics;
         LiveSession? session = null;
         var buffer = new byte[16 * 1024];
         var message = new ArrayBufferWriter<byte>(16 * 1024);
@@ -598,6 +614,7 @@ public static class RaskEndpointExtensions
                         // whole — bounds per-socket memory against a fragmented-frame DoS.
                         if (message.WrittenCount > MaxInboundFrameBytes)
                         {
+                            metrics?.FrameRejected("size");
                             try { ws.Abort(); }
                             catch { }
 
@@ -624,6 +641,7 @@ public static class RaskEndpointExtensions
 
                     if (++framesInWindow > MaxInboundFramesPerSecond)
                     {
+                        metrics?.FrameRejected("rate");
                         using var rateCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
                         try
                         {
@@ -775,6 +793,7 @@ public static class RaskEndpointExtensions
                 if (MaxPendingHandlers > 0 && pending > MaxPendingHandlers)
                 {
                     capturedSession.DecrementPendingHandlers();
+                    metrics?.FrameRejected("backlog");
                     using var capCts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
                     try
                     {
@@ -795,6 +814,7 @@ public static class RaskEndpointExtensions
                     capturedSession,
                     capturedHandlerId,
                     capturedRoot,
+                    metrics,
                     ct);
             }
         }
@@ -822,6 +842,7 @@ public static class RaskEndpointExtensions
         LiveSession session,
         string handlerId,
         JsonElement root,
+        RaskMetrics? metrics,
         CancellationToken ct)
     {
         try
@@ -837,7 +858,7 @@ public static class RaskEndpointExtensions
                 // prevent this dispatch from running. The chain is for ordering only.
             }
 
-            await DispatchHandlerAsync(session, handlerId, root, ct).ConfigureAwait(false);
+            await DispatchHandlerAsync(session, handlerId, root, metrics, ct).ConfigureAwait(false);
 
             // Acknowledge the handler so the client's slow-link pending indicator can
             // resolve — crucially even when the render deduped and no frame was sent
@@ -884,6 +905,7 @@ public static class RaskEndpointExtensions
         LiveSession session,
         string handlerId,
         JsonElement root,
+        RaskMetrics? metrics,
         CancellationToken ct)
     {
         try
@@ -896,6 +918,10 @@ public static class RaskEndpointExtensions
         }
 
         session.InHandlerScope = true;
+        using var activity = RaskActivity.Source.StartActivity("rask.handler.dispatch");
+        activity?.SetTag("rask.handler.id", handlerId);
+        metrics?.HandlerDispatched();
+        var dispatchStart = Stopwatch.GetTimestamp();
         try
         {
             var navigator = session.Services.GetRequiredService<Navigator>();
@@ -962,13 +988,17 @@ public static class RaskEndpointExtensions
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                Console.Error.WriteLine($"Rask Live handler '{handlerId}' threw: {ex}");
+                metrics?.HandlerFaulted();
+                activity?.SetStatus(ActivityStatusCode.Error, ex.Message);
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error, "Rask.Live", $"Rask Live handler '{handlerId}' threw", ex);
             }
         }
         finally
         {
             session.InHandlerScope = false;
             session.Lock.Release();
+            metrics?.RecordHandlerDuration(Stopwatch.GetElapsedTime(dispatchStart).TotalMilliseconds);
         }
     }
 
@@ -1036,7 +1066,8 @@ public static class RaskEndpointExtensions
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Rask jsResult dispatch for taskId={taskId} threw: {ex}");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Error, "Rask.Live", $"Rask jsResult dispatch for taskId={taskId} threw", ex);
         }
     }
 
@@ -1083,7 +1114,9 @@ public static class RaskEndpointExtensions
         }
         catch (Exception ex)
         {
-            Console.Error.WriteLine($"Rask dotNetInvoke '{assemblyName}.{methodIdentifier}' threw: {ex}");
+            RaskDiagnostics.Report(
+                RaskLogLevel.Error, "Rask.Live",
+                $"Rask dotNetInvoke '{assemblyName}.{methodIdentifier}' threw", ex);
         }
     }
 
@@ -1122,7 +1155,8 @@ public static class RaskEndpointExtensions
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
-                Console.Error.WriteLine($"Rask Live navigate '{navPath}' threw: {ex}");
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error, "Rask.Live", $"Rask Live navigate '{navPath}' threw", ex);
             }
         }
         finally

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -23,6 +23,10 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Accessibility:** set ARIA via the `Aria` dictionary on any element — `Button(Aria: new() { ["label"] = "Close" })`
   renders `aria-label="Close"`. `Role:` / `TabIndex:` are typed params. `Img` needs `Alt:` (or `Alt: ""`
   for decorative images) or RASK023 warns. See `docs/accessibility.md`.
+- **Observability:** framework faults flow into your `ILogger` automatically; metrics publish on the
+  `Rask.Server` meter (`dotnet-counters --counters Rask.Server` or `AddMeter(...)`), traces on the
+  `Rask.Server` activity source. Add `services.AddHealthChecks().AddRaskLiveSessions()` for a
+  live-session capacity probe. See `docs/observability.md`.
 
 ## Routing & lifecycle
 - Route with an attribute: `[Route("/users/{id:int}")]` + `[RouteParam] public int Id { get; set; }`

--- a/tests/Rask.Example.Server.Tests/Hosting/ProgramTests.cs
+++ b/tests/Rask.Example.Server.Tests/Hosting/ProgramTests.cs
@@ -55,4 +55,15 @@ public sealed class ProgramTests
         // The framework's catch-all routes to the NotFound page; it returns 200 with HTML.
         Assert.Contains("Page not found", body);
     }
+
+    [Fact]
+    public async Task HealthEndpoint_ReportsHealthy_WhenBelowCapacity()
+    {
+        // Wired via services.AddHealthChecks().AddRaskLiveSessions() + app.MapHealthChecks("/health").
+        // With no sessions and the default uncapped store, the live-session check is Healthy.
+        using var host = ExampleServerTestHost.Create();
+        var response = await host.Http.GetAsync("/health");
+        response.EnsureSuccessStatusCode();
+        Assert.Equal("Healthy", await response.Content.ReadAsStringAsync());
+    }
 }

--- a/tests/Rask.Example.Server.Tests/Infrastructure/ExampleServerTestHost.cs
+++ b/tests/Rask.Example.Server.Tests/Infrastructure/ExampleServerTestHost.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Example.Shared;
 using Rask.Server;
+using Rask.Server.Diagnostics;
 
 namespace Rask.Example.Server.Tests.Infrastructure;
 
@@ -36,6 +37,7 @@ internal sealed class ExampleServerTestHost : IDisposable
         builder.WebHost.UseTestServer();
         builder.Services.AddRouting();
         builder.Services.AddRask();
+        builder.Services.AddHealthChecks().AddRaskLiveSessions();
         // Mirror Program.cs: resolve the origin from IServerAddressesFeature, falling
         // back to localhost for the in-memory TestServer (no real bound address).
         builder.Services.AddExampleServices(sp =>
@@ -47,6 +49,7 @@ internal sealed class ExampleServerTestHost : IDisposable
 
         var app = builder.Build();
         app.UseRouting();
+        app.MapHealthChecks("/health");
         app.UseWebSockets();
         app.UseRask<App>();
         app.StartAsync().GetAwaiter().GetResult();

--- a/tests/Rask.Server.Tests/Diagnostics/MeterCapture.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/MeterCapture.cs
@@ -1,0 +1,59 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+
+namespace Rask.Server.Tests.Diagnostics;
+
+// Captures measurements from a single Meter instance via a MeterListener, scoped by reference so
+// measurements from any other RaskMetrics constructed concurrently are ignored. Disposable — replaces
+// the per-test listener scaffolding that was copy-pasted (and, in one place, leaked) across the suite.
+internal sealed class MeterCapture : IDisposable
+{
+    private readonly ConcurrentBag<(string Name, KeyValuePair<string, object?>[] Tags)> _measurements = new();
+    private readonly ConcurrentDictionary<string, long> _counters = new();
+    private readonly ConcurrentDictionary<string, int> _gauges = new();
+    private readonly ConcurrentDictionary<string, int> _histogramSamples = new();
+    private readonly MeterListener _listener;
+
+    private MeterCapture(Meter meter)
+    {
+        _listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (ReferenceEquals(inst.Meter, meter))
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        _listener.SetMeasurementEventCallback<long>((inst, measurement, tags, _) =>
+        {
+            _counters.AddOrUpdate(inst.Name, measurement, (_, v) => v + measurement);
+            _measurements.Add((inst.Name, tags.ToArray()));
+        });
+        _listener.SetMeasurementEventCallback<int>((inst, measurement, _, _) => _gauges[inst.Name] = measurement);
+        _listener.SetMeasurementEventCallback<double>((inst, _, _, _) =>
+            _histogramSamples.AddOrUpdate(inst.Name, 1, (_, v) => v + 1));
+        _listener.Start();
+    }
+
+    public static MeterCapture For(Meter meter) => new(meter);
+
+    public void RecordObservable() => _listener.RecordObservableInstruments();
+
+    public long Counter(string name) => _counters.GetValueOrDefault(name);
+
+    public int Gauge(string name) => _gauges.GetValueOrDefault(name);
+
+    public int HistogramSampleCount(string name) => _histogramSamples.GetValueOrDefault(name);
+
+    public IEnumerable<string> TagValues(string instrument, string tagKey) =>
+        _measurements
+            .Where(m => m.Name == instrument)
+            .SelectMany(m => m.Tags)
+            .Where(t => t.Key == tagKey)
+            .Select(t => t.Value as string)
+            .Where(v => v is not null)!;
+
+    public void Dispose() => _listener.Dispose();
+}

--- a/tests/Rask.Server.Tests/Diagnostics/RaskLiveHealthCheckTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskLiveHealthCheckTests.cs
@@ -1,0 +1,79 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Server.Diagnostics;
+
+namespace Rask.Server.Tests.Diagnostics;
+
+public class RaskLiveHealthCheckTests
+{
+    [Fact]
+    public async Task Uncapped_IsAlwaysHealthy()
+    {
+        var store = NewStore();
+        store.MaxSessions = 0;
+        store.Create(_ => new BasicComponent());
+
+        Assert.Equal(HealthStatus.Healthy, await Status(store));
+    }
+
+    [Fact]
+    public async Task BelowEightyPercent_IsHealthy()
+    {
+        var store = NewStore();
+        store.MaxSessions = 5;
+        // 3/5 = 60% — comfortably below the degraded threshold.
+        for (var i = 0; i < 3; i++)
+        {
+            store.Create(_ => new BasicComponent());
+        }
+
+        Assert.Equal(HealthStatus.Healthy, await Status(store));
+    }
+
+    [Fact]
+    public async Task AtOrAboveEightyPercent_IsDegraded()
+    {
+        var store = NewStore();
+        store.MaxSessions = 5;
+        // 4/5 = 80% — at the degraded threshold.
+        for (var i = 0; i < 4; i++)
+        {
+            store.Create(_ => new BasicComponent());
+        }
+
+        Assert.Equal(HealthStatus.Degraded, await Status(store));
+    }
+
+    [Fact]
+    public async Task AtCapacity_IsUnhealthy()
+    {
+        var store = NewStore();
+        store.MaxSessions = 5;
+        for (var i = 0; i < 5; i++)
+        {
+            store.Create(_ => new BasicComponent());
+        }
+
+        Assert.Equal(HealthStatus.Unhealthy, await Status(store));
+    }
+
+    private static async Task<HealthStatus> Status(LiveSessionStore store)
+    {
+        var result = await new RaskLiveHealthCheck(store)
+            .CheckHealthAsync(new HealthCheckContext());
+        return result.Status;
+    }
+
+    private static LiveSessionStore NewStore()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        return new LiveSessionStore(sp.GetRequiredService<IServiceScopeFactory>());
+    }
+
+    private sealed class BasicComponent : Component
+    {
+        protected override RenderResult Render() => new Span();
+    }
+}

--- a/tests/Rask.Server.Tests/Diagnostics/RaskMetricsTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskMetricsTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Components;
@@ -13,7 +11,7 @@ public class RaskMetricsTests
     public void SessionLifecycle_EmitsCreatedRejectedEvictedCounters()
     {
         using var metrics = new RaskMetrics();
-        var counts = ListenCounters(metrics);
+        using var capture = MeterCapture.For(metrics.Meter);
 
         var store = NewStore(metrics);
         store.MaxSessions = 1;
@@ -24,86 +22,50 @@ public class RaskMetricsTests
         Assert.Null(s2);
         store.Remove(s1!.Id); // evicted
 
-        Assert.Equal(1, counts.GetValueOrDefault("rask.sessions.created"));
-        Assert.Equal(1, counts.GetValueOrDefault("rask.sessions.rejected"));
-        Assert.Equal(1, counts.GetValueOrDefault("rask.sessions.evicted"));
+        Assert.Equal(1, capture.Counter("rask.sessions.created"));
+        Assert.Equal(1, capture.Counter("rask.sessions.rejected"));
+        Assert.Equal(1, capture.Counter("rask.sessions.evicted"));
+    }
+
+    [Fact]
+    public async Task DisposeAsync_EvictsRemainingSessions_EmitsEvictedCounter()
+    {
+        using var metrics = new RaskMetrics();
+        using var capture = MeterCapture.For(metrics.Meter);
+
+        var store = NewStore(metrics);
+        store.Create(_ => new BasicComponent());
+        store.Create(_ => new BasicComponent());
+
+        await store.DisposeAsync(); // shutdown teardown must also count as eviction
+
+        Assert.Equal(2, capture.Counter("rask.sessions.created"));
+        Assert.Equal(2, capture.Counter("rask.sessions.evicted"));
     }
 
     [Fact]
     public void ActiveSessions_ObservableGauge_ReportsLiveCount()
     {
         using var metrics = new RaskMetrics();
-        var gauge = 0;
-        using var listener = new MeterListener
-        {
-            InstrumentPublished = (inst, l) =>
-            {
-                if (ReferenceEquals(inst.Meter, metrics.Meter) && inst.Name == "rask.sessions.active")
-                {
-                    l.EnableMeasurementEvents(inst);
-                }
-            }
-        };
-        listener.SetMeasurementEventCallback<int>((_, measurement, _, _) => gauge = measurement);
-        listener.Start();
+        using var capture = MeterCapture.For(metrics.Meter);
 
         var store = NewStore(metrics);
         store.Create(_ => new BasicComponent());
         store.Create(_ => new BasicComponent());
 
-        listener.RecordObservableInstruments();
-        Assert.Equal(2, gauge);
+        capture.RecordObservable();
+        Assert.Equal(2, capture.Gauge("rask.sessions.active"));
     }
 
     [Fact]
     public void FrameRejected_TagsTheReason()
     {
         using var metrics = new RaskMetrics();
-        var reasons = new ConcurrentBag<string?>();
-        using var listener = new MeterListener
-        {
-            InstrumentPublished = (inst, l) =>
-            {
-                if (ReferenceEquals(inst.Meter, metrics.Meter) && inst.Name == "rask.ws.frames.rejected")
-                {
-                    l.EnableMeasurementEvents(inst);
-                }
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
-        {
-            foreach (var tag in tags)
-            {
-                if (tag.Key == "reason")
-                {
-                    reasons.Add(tag.Value as string);
-                }
-            }
-        });
-        listener.Start();
+        using var capture = MeterCapture.For(metrics.Meter);
 
         metrics.FrameRejected("rate");
 
-        Assert.Contains("rate", reasons);
-    }
-
-    private static ConcurrentDictionary<string, long> ListenCounters(RaskMetrics metrics)
-    {
-        var counts = new ConcurrentDictionary<string, long>();
-        var listener = new MeterListener
-        {
-            InstrumentPublished = (inst, l) =>
-            {
-                if (ReferenceEquals(inst.Meter, metrics.Meter))
-                {
-                    l.EnableMeasurementEvents(inst);
-                }
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((inst, measurement, _, _) =>
-            counts.AddOrUpdate(inst.Name, measurement, (_, v) => v + measurement));
-        listener.Start();
-        return counts;
+        Assert.Contains("rate", capture.TagValues("rask.ws.frames.rejected", "reason"));
     }
 
     private static LiveSessionStore NewStore(RaskMetrics metrics)

--- a/tests/Rask.Server.Tests/Diagnostics/RaskMetricsTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskMetricsTests.cs
@@ -1,0 +1,119 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Server.Diagnostics;
+
+namespace Rask.Server.Tests.Diagnostics;
+
+public class RaskMetricsTests
+{
+    [Fact]
+    public void SessionLifecycle_EmitsCreatedRejectedEvictedCounters()
+    {
+        using var metrics = new RaskMetrics();
+        var counts = ListenCounters(metrics);
+
+        var store = NewStore(metrics);
+        store.MaxSessions = 1;
+
+        var s1 = store.TryCreate(_ => new BasicComponent());
+        Assert.NotNull(s1);
+        var s2 = store.TryCreate(_ => new BasicComponent()); // over cap → rejected
+        Assert.Null(s2);
+        store.Remove(s1!.Id); // evicted
+
+        Assert.Equal(1, counts.GetValueOrDefault("rask.sessions.created"));
+        Assert.Equal(1, counts.GetValueOrDefault("rask.sessions.rejected"));
+        Assert.Equal(1, counts.GetValueOrDefault("rask.sessions.evicted"));
+    }
+
+    [Fact]
+    public void ActiveSessions_ObservableGauge_ReportsLiveCount()
+    {
+        using var metrics = new RaskMetrics();
+        var gauge = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (ReferenceEquals(inst.Meter, metrics.Meter) && inst.Name == "rask.sessions.active")
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<int>((_, measurement, _, _) => gauge = measurement);
+        listener.Start();
+
+        var store = NewStore(metrics);
+        store.Create(_ => new BasicComponent());
+        store.Create(_ => new BasicComponent());
+
+        listener.RecordObservableInstruments();
+        Assert.Equal(2, gauge);
+    }
+
+    [Fact]
+    public void FrameRejected_TagsTheReason()
+    {
+        using var metrics = new RaskMetrics();
+        var reasons = new ConcurrentBag<string?>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (ReferenceEquals(inst.Meter, metrics.Meter) && inst.Name == "rask.ws.frames.rejected")
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+            {
+                if (tag.Key == "reason")
+                {
+                    reasons.Add(tag.Value as string);
+                }
+            }
+        });
+        listener.Start();
+
+        metrics.FrameRejected("rate");
+
+        Assert.Contains("rate", reasons);
+    }
+
+    private static ConcurrentDictionary<string, long> ListenCounters(RaskMetrics metrics)
+    {
+        var counts = new ConcurrentDictionary<string, long>();
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (ReferenceEquals(inst.Meter, metrics.Meter))
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((inst, measurement, _, _) =>
+            counts.AddOrUpdate(inst.Name, measurement, (_, v) => v + measurement));
+        listener.Start();
+        return counts;
+    }
+
+    private static LiveSessionStore NewStore(RaskMetrics metrics)
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        return new LiveSessionStore(sp.GetRequiredService<IServiceScopeFactory>(), null, metrics);
+    }
+
+    private sealed class BasicComponent : Component
+    {
+        protected override RenderResult Render() => new Span();
+    }
+}

--- a/tests/Rask.Server.Tests/Diagnostics/RaskServerDiagnosticsBridgeTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskServerDiagnosticsBridgeTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using Rask.Core.Diagnostics;
+using Rask.Server.Diagnostics;
+
+namespace Rask.Server.Tests.Diagnostics;
+
+public class RaskServerDiagnosticsBridgeTests
+{
+    [Fact]
+    public void Install_RoutesFrameworkDiagnostics_ToILogger()
+    {
+        var provider = new CapturingLoggerProvider();
+        using var factory = LoggerFactory.Create(b => b.AddProvider(provider));
+        var previousSink = RaskDiagnostics.Sink;
+        try
+        {
+            RaskServerDiagnostics.Install(factory);
+
+            var boom = new InvalidOperationException("boom");
+            RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Test.Bridge", "bridged fault", boom);
+
+            var entry = Assert.Single(provider.Entries, e => e.Category == "Rask.Test.Bridge");
+            Assert.Equal(LogLevel.Error, entry.Level);
+            Assert.Same(boom, entry.Exception);
+            Assert.Contains("bridged fault", entry.Message);
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previousSink;
+        }
+    }
+
+    [Fact]
+    public void Install_Null_LeavesSinkUnchanged()
+    {
+        var previousSink = RaskDiagnostics.Sink;
+        RaskServerDiagnostics.Install(null);
+        Assert.Same(previousSink, RaskDiagnostics.Sink);
+    }
+
+    private sealed record LogEntry(string Category, LogLevel Level, string Message, Exception? Exception);
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        public ConcurrentBag<LogEntry> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, Entries);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger(string category, ConcurrentBag<LogEntry> entries) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(
+                LogLevel logLevel,
+                EventId eventId,
+                TState state,
+                Exception? exception,
+                Func<TState, Exception?, string> formatter) =>
+                entries.Add(new LogEntry(category, logLevel, formatter(state, exception), exception));
+        }
+    }
+}

--- a/tests/Rask.Server.Tests/Diagnostics/RaskServerDiagnosticsBridgeTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RaskServerDiagnosticsBridgeTests.cs
@@ -5,38 +5,41 @@ using Rask.Server.Diagnostics;
 
 namespace Rask.Server.Tests.Diagnostics;
 
+// Exercises the bridge's per-event Emit directly rather than installing it as the process-global
+// RaskDiagnostics.Sink, so these tests never race host-based tests that drive the same global seam.
 public class RaskServerDiagnosticsBridgeTests
 {
-    [Fact]
-    public void Install_RoutesFrameworkDiagnostics_ToILogger()
+    // RaskLogLevel is internal, so it can't be a public test-method parameter — pass its numeric
+    // value and cast inside. LogLevel is public.
+    [Theory]
+    [InlineData((int)RaskLogLevel.Error, LogLevel.Error)]
+    [InlineData((int)RaskLogLevel.Warning, LogLevel.Warning)]
+    [InlineData((int)RaskLogLevel.Information, LogLevel.Information)]
+    public void Emit_RoutesToILogger_WithMappedLevelCategoryAndException(int raskLevel, LogLevel expected)
     {
         var provider = new CapturingLoggerProvider();
         using var factory = LoggerFactory.Create(b => b.AddProvider(provider));
-        var previousSink = RaskDiagnostics.Sink;
-        try
-        {
-            RaskServerDiagnostics.Install(factory);
 
-            var boom = new InvalidOperationException("boom");
-            RaskDiagnostics.Report(RaskLogLevel.Error, "Rask.Test.Bridge", "bridged fault", boom);
+        var boom = new InvalidOperationException("boom");
+        RaskServerDiagnostics.Emit(
+            factory, new RaskDiagnosticEvent((RaskLogLevel)raskLevel, "Rask.Test.Bridge", "bridged fault", boom));
 
-            var entry = Assert.Single(provider.Entries, e => e.Category == "Rask.Test.Bridge");
-            Assert.Equal(LogLevel.Error, entry.Level);
-            Assert.Same(boom, entry.Exception);
-            Assert.Contains("bridged fault", entry.Message);
-        }
-        finally
-        {
-            RaskDiagnostics.Sink = previousSink;
-        }
+        var entry = Assert.Single(provider.Entries, e => e.Category == "Rask.Test.Bridge");
+        Assert.Equal(expected, entry.Level);
+        Assert.Same(boom, entry.Exception);
+        Assert.Contains("bridged fault", entry.Message);
     }
 
     [Fact]
-    public void Install_Null_LeavesSinkUnchanged()
+    public void Emit_WhenLoggingThrows_Swallows_SoADiagnosticNeverBecomesAFault()
     {
-        var previousSink = RaskDiagnostics.Sink;
-        RaskServerDiagnostics.Install(null);
-        Assert.Same(previousSink, RaskDiagnostics.Sink);
+        // A disposed factory / misbehaving provider must not escape into the framework's catch blocks.
+        var ex = Record.Exception(() =>
+            RaskServerDiagnostics.Emit(
+                new ThrowingLoggerFactory(),
+                new RaskDiagnosticEvent(RaskLogLevel.Error, "Rask.Test", "ignored", null)));
+
+        Assert.Null(ex);
     }
 
     private sealed record LogEntry(string Category, LogLevel Level, string Message, Exception? Exception);
@@ -64,6 +67,19 @@ public class RaskServerDiagnosticsBridgeTests
                 Exception? exception,
                 Func<TState, Exception?, string> formatter) =>
                 entries.Add(new LogEntry(category, logLevel, formatter(state, exception), exception));
+        }
+    }
+
+    private sealed class ThrowingLoggerFactory : ILoggerFactory
+    {
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName) => throw new ObjectDisposedException("factory");
+
+        public void Dispose()
+        {
         }
     }
 }

--- a/tests/Rask.Server.Tests/Diagnostics/WsLoopMetricsTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/WsLoopMetricsTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Concurrent;
+using System.Diagnostics.Metrics;
+using System.Net.WebSockets;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Diagnostics;
+
+[Collection("SessionGracePeriod")]
+public class WsLoopMetricsTests
+{
+    [Fact]
+    public async Task HandlerDispatch_EmitsDispatchedCounter_AndDurationHistogram()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(initialHtml);
+        var handlerId = Markup.FirstHandlerId(initialHtml);
+
+        // Scope the listener to this host's metrics instance so parallel tests can't leak in.
+        var metrics = host.Store.Metrics!;
+        var counters = new ConcurrentDictionary<string, long>();
+        var durationSamples = 0;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (inst, l) =>
+            {
+                if (ReferenceEquals(inst.Meter, metrics.Meter))
+                {
+                    l.EnableMeasurementEvents(inst);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((inst, measurement, _, _) =>
+            counters.AddOrUpdate(inst.Name, measurement, (_, v) => v + measurement));
+        listener.SetMeasurementEventCallback<double>((inst, _, _, _) =>
+        {
+            if (inst.Name == "rask.handler.duration")
+            {
+                Interlocked.Increment(ref durationSamples);
+            }
+        });
+        listener.Start();
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(5));
+
+        // Awaiting the render reply guarantees the server-side dispatch (and its instrumentation)
+        // has completed before we assert.
+        await ws.SendJsonAsync(new { id = handlerId });
+        var reply = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(reply);
+
+        // The render frame is sent inside the dispatch's try; the duration histogram is recorded in
+        // its finally (so it includes the send). Receiving the reply therefore does not guarantee the
+        // finally has run yet — poll briefly rather than assume synchrony.
+        var ok = await WaitUntil(
+            () => counters.GetValueOrDefault("rask.handlers.dispatched") >= 1
+                  && Volatile.Read(ref durationSamples) >= 1,
+            TimeSpan.FromSeconds(2));
+
+        Assert.True(ok,
+            $"expected a dispatched counter and a duration sample; " +
+            $"dispatched={counters.GetValueOrDefault("rask.handlers.dispatched")}, durationSamples={durationSamples}");
+    }
+
+    private static async Task<bool> WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return condition();
+    }
+}

--- a/tests/Rask.Server.Tests/Diagnostics/WsLoopMetricsTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/WsLoopMetricsTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Concurrent;
-using System.Diagnostics.Metrics;
 using System.Net.WebSockets;
 using Rask.Server.Tests.Infrastructure;
 
@@ -16,30 +14,8 @@ public class WsLoopMetricsTests
         var sessionId = Markup.SessionId(initialHtml);
         var handlerId = Markup.FirstHandlerId(initialHtml);
 
-        // Scope the listener to this host's metrics instance so parallel tests can't leak in.
-        var metrics = host.Store.Metrics!;
-        var counters = new ConcurrentDictionary<string, long>();
-        var durationSamples = 0;
-        using var listener = new MeterListener
-        {
-            InstrumentPublished = (inst, l) =>
-            {
-                if (ReferenceEquals(inst.Meter, metrics.Meter))
-                {
-                    l.EnableMeasurementEvents(inst);
-                }
-            }
-        };
-        listener.SetMeasurementEventCallback<long>((inst, measurement, _, _) =>
-            counters.AddOrUpdate(inst.Name, measurement, (_, v) => v + measurement));
-        listener.SetMeasurementEventCallback<double>((inst, _, _, _) =>
-        {
-            if (inst.Name == "rask.handler.duration")
-            {
-                Interlocked.Increment(ref durationSamples);
-            }
-        });
-        listener.Start();
+        // Scope the capture to this host's metrics instance so parallel tests can't leak in.
+        using var capture = MeterCapture.For(host.Store.Metrics!.Meter);
 
         using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
         await ws.SendJsonAsync(new { type = "hello", session = sessionId });
@@ -55,13 +31,14 @@ public class WsLoopMetricsTests
         // its finally (so it includes the send). Receiving the reply therefore does not guarantee the
         // finally has run yet — poll briefly rather than assume synchrony.
         var ok = await WaitUntil(
-            () => counters.GetValueOrDefault("rask.handlers.dispatched") >= 1
-                  && Volatile.Read(ref durationSamples) >= 1,
+            () => capture.Counter("rask.handlers.dispatched") >= 1
+                  && capture.HistogramSampleCount("rask.handler.duration") >= 1,
             TimeSpan.FromSeconds(2));
 
         Assert.True(ok,
-            $"expected a dispatched counter and a duration sample; " +
-            $"dispatched={counters.GetValueOrDefault("rask.handlers.dispatched")}, durationSamples={durationSamples}");
+            "expected a dispatched counter and a duration sample; " +
+            $"dispatched={capture.Counter("rask.handlers.dispatched")}, " +
+            $"durationSamples={capture.HistogramSampleCount("rask.handler.duration")}");
     }
 
     private static async Task<bool> WaitUntil(Func<bool> condition, TimeSpan timeout)


### PR DESCRIPTION
> Replaces #126 (auto-closed when its stacked base branch was deleted on the #125 merge). Same content, rebased onto `main`.

## Summary

Makes the Rask server host production-observable with standard .NET primitives — **no new package dependencies**, OpenTelemetry-exportable out of the box. On by default with zero configuration; you opt in only to *exporting* it.

- **Structured logging** — `UseRask<TApp>()` bridges the framework `RaskDiagnostics` seam to the app's `ILogger`; every framework fault is logged under a stable category at the mapped level with the exception. Bridge swallows host-logging faults so a diagnostic can never become a framework fault.
- **Metrics** — a `Meter("Rask.Server")`: session counters + active gauge (reads the reservation count admission gates on), handler counters + duration histogram, `rask.ws.frames.rejected{reason}`.
- **Tracing** — an `ActivitySource("Rask.Server")` per handler dispatch, zero-cost when no listener.
- **Health checks** — `AddRaskLiveSessions()` → Healthy / Degraded (≥80%) / Unhealthy (at cap), tracking the same count as admission.

## Testing

Full Server + Example.Server suites green; `dotnet format` clean; `-warnaserror` clean. New `tests/Rask.Server.Tests/Diagnostics/*` (MeterListener-scoped metrics, health thresholds, the ILogger bridge incl. swallow-on-throw) + a sample `/health` test. Reviewed by the multi-agent workflow; all confirmed findings fixed (bridge exception-escape, health/admission count alignment, shutdown eviction, test isolation). New `docs/observability.md`; CHANGELOG/README/llms.txt/NUGET/template AGENTS updated.