### PR TITLE
feat(server): cooperative handler timeout via EventCancellationToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Cooperative handler timeout (`RaskServerOptions.HandlerTimeout`).** A new
+  `Component.EventCancellationToken` exposes, inside an event handler, a token cancelled when the
+  component unmounts **or** when the host cancels the dispatch — the server's `HandlerTimeout` elapsing,
+  or the socket closing. Thread it into the cancellable async work a handler starts (`HttpClient`,
+  `Task.Delay`) and a slow handler unwinds cleanly instead of pinning the session's render pipeline;
+  the timeout is logged and counted on `rask.handlers.timedout`. It is cooperative — a handler that
+  ignores the token can't be force-aborted (a .NET reality; the backpressure and idle-socket caps remain
+  the backstop). Opt-in: `HandlerTimeout` defaults to `TimeSpan.Zero` (off), validated at startup like
+  the other server limits. See the [configuration](docs/configuration.md) and
+  [composition](docs/composition.md) guides.
 - **Resource-exhaustion hardening for the server host (all opt-in, default off).** Three new bounds,
   configurable via `RaskServerOptions` / `RaskUploadOptions`: (1) **`IdleSocketTimeout`** closes a
   connected WebSocket that sends no inbound frame for the window — reclaiming silently-idle sockets

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -110,6 +110,21 @@ focus — and the runtime never `preventDefault`s it, so handlers compose with n
 Todos sample uses it to close its dialog on Escape (it focuses the `<dialog>` on open via an
 `ElementRef`, since a diff-inserted element never fires the HTML `autofocus` attribute).
 
+**Cancelling async handler work.** Inside an event handler, `Component.EventCancellationToken` is a
+token cancelled when the component unmounts **or** when the host cancels the dispatch — the server's
+optional `RaskServerOptions.HandlerTimeout` elapsing, or the socket closing. Thread it into the
+cancellable async work a handler starts so a slow handler unwinds instead of pinning the session's
+render pipeline:
+
+```csharp
+Button(OnClickAsync: async () =>
+    _rows = await _api.LoadAsync(EventCancellationToken))["Load"]
+```
+
+It is cooperative: a handler that ignores the token (or runs unbounded synchronous work) can't be
+force-aborted — that's a .NET reality, not a Rask limitation. Outside a handler the property is just
+the component's lifetime `CancellationToken`.
+
 ---
 
 ## Context: provide / consume

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,14 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `UnconnectedSessionGracePeriod` | `10 s` | How long a GET-minted session is retained before its first `hello` arrives. |
 | `IdleSocketTimeout` | `0` (off) | Close a connected socket that sends no inbound frame for this long (the session survives for reconnect). Reclaims silently-idle connections. |
 | `MaxPendingHandlerBytes` | `0` (off) | Aggregate-bytes companion to `MaxPendingHandlers` — bounds the queued cloned-payload *memory*, not just the queue length. |
+| `HandlerTimeout` | `0` (off) | Cancel a handler dispatch's `Component.EventCancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
+
+> **Using `HandlerTimeout`:** thread `EventCancellationToken` into the cancellable async work your event
+> handlers start, so the timeout (or socket close) can unwind them:
+> ```csharp
+> Button(OnClickAsync: async () =>
+>     _data = await http.GetFromJsonAsync<T>(url, EventCancellationToken))["Load"]
+> ```
 
 ### File uploads
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -57,6 +57,7 @@ All metrics publish on the meter named **`Rask.Server`** (`RaskTelemetry.MeterNa
 | `rask.sessions.active` | Gauge | | Live sessions currently held. |
 | `rask.handlers.dispatched` | Counter | | Client event handlers dispatched to user code. |
 | `rask.handlers.faulted` | Counter | | Handler dispatches that threw (isolated; session survives). |
+| `rask.handlers.timedout` | Counter | | Handler dispatches cancelled by `HandlerTimeout`. |
 | `rask.handler.duration` | Histogram (ms) | | Wall-clock duration of an event-handler dispatch. |
 | `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` | Inbound frames refused by a safety limit. |
 

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -295,6 +295,25 @@ public abstract class Component
     protected CancellationToken CancellationToken =>
         LazyInitializer.EnsureInitialized(ref _lifetimeCts, () => new CancellationTokenSource()).Token;
 
+    /// <summary>
+    ///     The <see cref="System.Threading.CancellationToken" /> for the event handler currently
+    ///     running. It is cancelled when this component unmounts (like <see cref="CancellationToken" />)
+    ///     <em>and</em> when the dispatch is cancelled by the host — a server-side
+    ///     <c>RaskServerOptions.HandlerTimeout</c> elapsing, or the WebSocket closing. Pass it into the
+    ///     cancellable async work an <c>OnClick</c> / <c>OnSubmit</c> handler starts (an <c>HttpClient</c>
+    ///     call, a <c>Task.Delay</c>) so a stuck handler unwinds instead of pinning the session's render
+    ///     pipeline. Outside a handler it is the plain lifetime token. Forcibly aborting synchronous or
+    ///     token-ignoring handler code is not possible; a handler must observe this token to be cancelled.
+    /// </summary>
+    protected CancellationToken EventCancellationToken
+    {
+        get
+        {
+            var dispatch = DispatchEventTokenScope.Current;
+            return dispatch.CanBeCanceled ? dispatch : CancellationToken;
+        }
+    }
+
     internal IRenderHandle? RenderHandle { get; set; }
 
     internal IReadOnlyDictionary<(Type, int), Component> PersistedChildren => _live?.Children ?? _emptyChildren;
@@ -933,7 +952,8 @@ public abstract class Component
     internal ValueTask<bool> TryInvokeHandlerAsync(string id, JsonElement payload)
         => TryInvokeHandlerAsync(id, payload, null);
 
-    internal async ValueTask<bool> TryInvokeHandlerAsync(string id, JsonElement payload, IServiceProvider? services)
+    internal async ValueTask<bool> TryInvokeHandlerAsync(
+        string id, JsonElement payload, IServiceProvider? services, CancellationToken dispatchToken = default)
     {
         if (Live.Handlers is null || !Live.Handlers.TryGetValue(id, out var entry))
         {
@@ -942,6 +962,23 @@ public abstract class Component
 
         var (owner, handler) = entry;
         using var __dispatchScope = DispatchServicesScope.Push(services);
+
+        // Expose a per-dispatch cancellation token to the handler via owner.EventCancellationToken.
+        // It cancels on the owner's unmount (lifetime token) AND on the host's dispatch token (a
+        // handler timeout / socket close). Only allocate the linked source when the host actually
+        // supplied a cancellable token (i.e. a timeout is configured); otherwise the lifetime token
+        // alone is the ambient, so the no-timeout path stays allocation-free.
+        CancellationTokenSource? linkedCts = null;
+        var eventToken = owner.CancellationToken;
+        if (dispatchToken.CanBeCanceled)
+        {
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(eventToken, dispatchToken);
+            eventToken = linkedCts.Token;
+        }
+
+        using var __eventTokenScope = DispatchEventTokenScope.Push(eventToken);
+        using var __linked = linkedCts;
+
         // Match Blazor: every event handler implicitly marks the registering component
         // dirty. Set BEFORE running so intermediate renders inside an async handler
         // (via InvokeWithRenderingAsync) already see the owner as dirty.

--- a/src/Rask.Core/Live/DispatchEventTokenScope.cs
+++ b/src/Rask.Core/Live/DispatchEventTokenScope.cs
@@ -1,0 +1,28 @@
+namespace Rask.Core.Live;
+
+/// <summary>
+///     Ambient <see cref="CancellationToken" /> for the event-handler dispatch currently running on
+///     this async flow. Pushed by <c>Component.TryInvokeHandlerAsync</c> around a handler invocation and
+///     read back through <c>Component.EventCancellationToken</c>, so a handler's async work can observe
+///     cancellation (a server-side handler timeout, or the socket closing) without the delegate having
+///     to take a token parameter. Mirrors <see cref="Rask.Core.Forms.DispatchServicesScope" />; defaults
+///     to <see cref="CancellationToken.None" /> outside a dispatch.
+/// </summary>
+internal static class DispatchEventTokenScope
+{
+    private static readonly AsyncLocal<CancellationToken> _current = new();
+
+    public static CancellationToken Current => _current.Value;
+
+    public static IDisposable Push(CancellationToken token)
+    {
+        var prev = _current.Value;
+        _current.Value = token;
+        return new Popper(prev);
+    }
+
+    private sealed class Popper(CancellationToken prev) : IDisposable
+    {
+        public void Dispose() => _current.Value = prev;
+    }
+}

--- a/src/Rask.Server/Diagnostics/RaskMetrics.cs
+++ b/src/Rask.Server/Diagnostics/RaskMetrics.cs
@@ -19,6 +19,7 @@ public sealed class RaskMetrics : IDisposable
     private readonly Counter<long> _framesRejected;
     private readonly Counter<long> _handlersDispatched;
     private readonly Counter<long> _handlersFaulted;
+    private readonly Counter<long> _handlersTimedOut;
     private readonly Histogram<double> _handlerDuration;
     private readonly Meter _meter;
     private readonly Counter<long> _sessionsCreated;
@@ -45,6 +46,8 @@ public sealed class RaskMetrics : IDisposable
             "rask.handlers.dispatched", "{handler}", "Client event handlers dispatched to user code.");
         _handlersFaulted = _meter.CreateCounter<long>(
             "rask.handlers.faulted", "{handler}", "Event-handler dispatches that threw (isolated, session survives).");
+        _handlersTimedOut = _meter.CreateCounter<long>(
+            "rask.handlers.timedout", "{handler}", "Event-handler dispatches cancelled by the HandlerTimeout.");
         _handlerDuration = _meter.CreateHistogram<double>(
             "rask.handler.duration", "ms", "Wall-clock duration of an event-handler dispatch.");
         _framesRejected = _meter.CreateCounter<long>(
@@ -71,6 +74,8 @@ public sealed class RaskMetrics : IDisposable
     public void HandlerDispatched() => _handlersDispatched.Add(1);
 
     public void HandlerFaulted() => _handlersFaulted.Add(1);
+
+    public void HandlerTimedOut() => _handlersTimedOut.Add(1);
 
     public void RecordHandlerDuration(double milliseconds) => _handlerDuration.Record(milliseconds);
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -86,6 +86,11 @@ public static class RaskEndpointExtensions
     // reconnect under SessionGracePeriod). Seeded from RaskServerOptions.IdleSocketTimeout. Zero = off.
     internal static TimeSpan IdleSocketTimeout = TimeSpan.Zero;
 
+    // Cancel a handler dispatch's EventCancellationToken after this long, so a cooperative handler that
+    // observes it unwinds instead of pinning the render pipeline. Seeded from
+    // RaskServerOptions.HandlerTimeout. Zero = off.
+    internal static TimeSpan HandlerTimeout = TimeSpan.Zero;
+
     // Aggregate-bytes companion to MaxPendingHandlers: bounds the queued cloned-payload memory, not just
     // the queue count. Seeded from RaskServerOptions.MaxPendingHandlerBytes. 0 = off.
     internal static long MaxPendingHandlerBytes;
@@ -171,6 +176,7 @@ public static class RaskEndpointExtensions
             SessionGracePeriod = serverOptions.SessionGracePeriod;
             UnconnectedSessionGracePeriod = serverOptions.UnconnectedSessionGracePeriod;
             IdleSocketTimeout = serverOptions.IdleSocketTimeout;
+            HandlerTimeout = serverOptions.HandlerTimeout;
             MaxPendingHandlerBytes = serverOptions.MaxPendingHandlerBytes;
         }
 
@@ -994,6 +1000,16 @@ public static class RaskEndpointExtensions
         activity?.SetTag("rask.handler.id", handlerId);
         metrics?.HandlerDispatched();
         var dispatchStart = Stopwatch.GetTimestamp();
+
+        // Handler timeout: cancel the dispatch's EventCancellationToken after HandlerTimeout (linked to
+        // the socket so a close cancels it too). A handler that threads EventCancellationToken into its
+        // async work unwinds cooperatively; one that ignores it can't be force-aborted (the timeout is
+        // still logged + metered). Null when the timeout is disabled, so the default path allocates nothing.
+        using var handlerCts = HandlerTimeout > TimeSpan.Zero
+            ? CancellationTokenSource.CreateLinkedTokenSource(ct)
+            : null;
+        handlerCts?.CancelAfter(HandlerTimeout);
+        var dispatchToken = handlerCts?.Token ?? default;
         try
         {
             var navigator = session.Services.GetRequiredService<Navigator>();
@@ -1014,7 +1030,8 @@ public static class RaskEndpointExtensions
                     {
                         await EnforceAuthAndRenderAsync(session, null, false).ConfigureAwait(false);
                     }
-                    else if (await session.View.TryInvokeHandlerAsync(handlerId, root, session.Services))
+                    else if (await session.View.TryInvokeHandlerAsync(
+                                 handlerId, root, session.Services, dispatchToken))
                     {
                         string? historyUrl = null;
                         var historyReplace = false;
@@ -1057,6 +1074,17 @@ public static class RaskEndpointExtensions
                         }
                     }
                 }
+            }
+            catch (OperationCanceledException)
+                when (handlerCts is not null && handlerCts.IsCancellationRequested && !ct.IsCancellationRequested)
+            {
+                // The handler timed out and observed EventCancellationToken, unwinding cleanly. The
+                // session survives; record it rather than letting it look like a normal cancellation.
+                metrics?.HandlerTimedOut();
+                activity?.SetStatus(ActivityStatusCode.Error, "handler timed out");
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Warning, "Rask.Live",
+                    $"Rask Live handler '{handlerId}' cancelled after HandlerTimeout ({HandlerTimeout})");
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -75,6 +75,17 @@ public sealed class RaskServerOptions
     public TimeSpan IdleSocketTimeout { get; set; } = TimeSpan.Zero;
 
     /// <summary>
+    ///     How long a single event-handler dispatch may run before its cancellation token
+    ///     (<c>Component.EventCancellationToken</c>) is cancelled. A handler that threads that token
+    ///     into its async work (an <c>HttpClient</c> call, a <c>Task.Delay</c>) then unwinds cleanly
+    ///     instead of pinning the session's render pipeline; the timeout is logged and metered. It is
+    ///     cooperative — a handler that ignores the token cannot be force-aborted (the backpressure and
+    ///     idle-socket caps remain the backstop for that). <see cref="TimeSpan.Zero" /> (default)
+    ///     disables the timeout.
+    /// </summary>
+    public TimeSpan HandlerTimeout { get; set; } = TimeSpan.Zero;
+
+    /// <summary>
     ///     Maximum aggregate bytes of inbound handler payloads queued (awaiting their turn in
     ///     WS-arrival order) before the server closes the socket with a backpressure policy violation.
     ///     Complements <see cref="MaxPendingHandlers" /> (which bounds the queue's <em>count</em>): a
@@ -133,6 +144,13 @@ public sealed class RaskServerOptions
             throw new ArgumentOutOfRangeException(
                 nameof(IdleSocketTimeout), IdleSocketTimeout,
                 "IdleSocketTimeout must be >= TimeSpan.Zero (Zero disables the timeout).");
+        }
+
+        if (HandlerTimeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(HandlerTimeout), HandlerTimeout,
+                "HandlerTimeout must be >= TimeSpan.Zero (Zero disables the timeout).");
         }
 
         if (MaxPendingHandlerBytes < 0)

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -35,6 +35,10 @@ https://github.com/pal-tamas/rask/tree/main/docs
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
+- **Async handler cancellation:** pass `EventCancellationToken` (cancelled on unmount or the optional
+  `RaskServerOptions.HandlerTimeout`) into the cancellable work an `OnClickAsync`/`OnSubmitAsync` starts,
+  e.g. `await http.GetFromJsonAsync<T>(url, EventCancellationToken)`. Use `CancellationToken` (lifetime
+  only) inside lifecycle hooks.
 
 ## Events, scoped CSS/JS, forms, auth
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,

--- a/tests/Rask.Core.Tests/Live/EventCancellationTokenTests.cs
+++ b/tests/Rask.Core.Tests/Live/EventCancellationTokenTests.cs
@@ -1,0 +1,43 @@
+using Rask.Core;
+using Rask.Core.Live;
+using C = Rask.Core.Components.Generated;
+
+#pragma warning disable RASK014 // test probe component has no generated factory
+
+namespace Rask.Core.Tests.Live;
+
+public class EventCancellationTokenTests
+{
+    [Fact]
+    public void OutsideAHandler_IsTheLifetimeToken()
+    {
+        var c = new Probe();
+        Assert.Equal(c.Lifetime, c.Event);
+        Assert.False(c.Event.IsCancellationRequested);
+    }
+
+    [Fact]
+    public void DuringADispatch_ReflectsThePushedDispatchToken()
+    {
+        var c = new Probe();
+        using var cts = new CancellationTokenSource();
+
+        using (DispatchEventTokenScope.Push(cts.Token))
+        {
+            Assert.Equal(cts.Token, c.Event);
+            cts.Cancel();
+            Assert.True(c.Event.IsCancellationRequested);
+        }
+
+        // Scope popped — back to the (un-cancelled) lifetime token.
+        Assert.Equal(c.Lifetime, c.Event);
+        Assert.False(c.Event.IsCancellationRequested);
+    }
+
+    private sealed class Probe : Component
+    {
+        public CancellationToken Lifetime => CancellationToken;
+        public CancellationToken Event => EventCancellationToken;
+        protected override RenderResult Render() => C.Span();
+    }
+}

--- a/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
@@ -29,7 +29,8 @@ public class ConfigurableLimitsTests
             RaskEndpointExtensions.SessionGracePeriod,
             RaskEndpointExtensions.UnconnectedSessionGracePeriod,
             RaskEndpointExtensions.IdleSocketTimeout,
-            RaskEndpointExtensions.MaxPendingHandlerBytes);
+            RaskEndpointExtensions.MaxPendingHandlerBytes,
+            RaskEndpointExtensions.HandlerTimeout);
         try
         {
             new ServiceCollection().AddRask(configureServer: o =>
@@ -41,6 +42,7 @@ public class ConfigurableLimitsTests
                 o.UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(2);
                 o.IdleSocketTimeout = TimeSpan.FromSeconds(90);
                 o.MaxPendingHandlerBytes = 4096;
+                o.HandlerTimeout = TimeSpan.FromSeconds(7);
             });
 
             Assert.Equal(1234, RaskEndpointExtensions.MaxInboundFrameBytes);
@@ -50,6 +52,7 @@ public class ConfigurableLimitsTests
             Assert.Equal(TimeSpan.FromSeconds(2), RaskEndpointExtensions.UnconnectedSessionGracePeriod);
             Assert.Equal(TimeSpan.FromSeconds(90), RaskEndpointExtensions.IdleSocketTimeout);
             Assert.Equal(4096, RaskEndpointExtensions.MaxPendingHandlerBytes);
+            Assert.Equal(TimeSpan.FromSeconds(7), RaskEndpointExtensions.HandlerTimeout);
         }
         finally
         {
@@ -59,8 +62,16 @@ public class ConfigurableLimitsTests
                 RaskEndpointExtensions.SessionGracePeriod,
                 RaskEndpointExtensions.UnconnectedSessionGracePeriod,
                 RaskEndpointExtensions.IdleSocketTimeout,
-                RaskEndpointExtensions.MaxPendingHandlerBytes) = saved;
+                RaskEndpointExtensions.MaxPendingHandlerBytes,
+                RaskEndpointExtensions.HandlerTimeout) = saved;
         }
+    }
+
+    [Fact]
+    public void AddRask_NegativeHandlerTimeout_ThrowsAtStartup()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            new ServiceCollection().AddRask(configureServer: o => o.HandlerTimeout = TimeSpan.FromSeconds(-1)));
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/Infrastructure/CooperativeTimeoutApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/CooperativeTimeoutApp.cs
@@ -1,0 +1,35 @@
+using Rask.Core;
+using Rask.Core.Components;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Infrastructure;
+
+// App whose click handler awaits a long delay that observes EventCancellationToken — a *cooperative*
+// slow handler. With RaskServerOptions.HandlerTimeout set, the dispatch cancels the token and the delay
+// throws, so the handler unwinds instead of pinning the session. Used to exercise the handler timeout.
+public sealed class CooperativeTimeoutApp : Component
+{
+    // Completed when the handler observes its EventCancellationToken being cancelled. Static so the test
+    // can await it without a handle to the DI-constructed instance; reset per test before the host starts.
+    public static TaskCompletionSource<bool> Cancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    protected override RenderResult Render() =>
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["timeout"]],
+            new Body()[
+                Button(OnClickAsync: async () =>
+                {
+                    try
+                    {
+                        await Task.Delay(TimeSpan.FromSeconds(30), EventCancellationToken);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        Cancelled.TrySetResult(true);
+                        throw; // let the dispatch see the cancellation (records the timeout)
+                    }
+                })["go"]]]
+    ];
+}

--- a/tests/Rask.Server.Tests/WebSockets/HandlerTimeoutTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerTimeoutTests.cs
@@ -1,0 +1,69 @@
+using System.Net.WebSockets;
+using Rask.Server.Tests.Diagnostics;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+// RaskServerOptions.HandlerTimeout: a cooperative handler that threads EventCancellationToken into its
+// async work is cancelled when the timeout elapses, so it unwinds instead of pinning the render lock.
+[Collection("SessionGracePeriod")]
+public class HandlerTimeoutTests
+{
+    [Fact]
+    public async Task CooperativeHandler_PastTimeout_IsCancelled_AndMetered_SessionSurvives()
+    {
+        var prev = RaskEndpointExtensions.HandlerTimeout;
+        RaskEndpointExtensions.HandlerTimeout = TimeSpan.FromMilliseconds(300);
+        CooperativeTimeoutApp.Cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            using var host = RaskTestHost.Create<CooperativeTimeoutApp>();
+            using var capture = MeterCapture.For(host.Store.Metrics!.Meter);
+
+            var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+            var sessionId = Markup.SessionId(html);
+            var handlerId = Markup.FirstHandlerId(html);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+            // Fire the slow handler. It awaits a 30 s delay observing EventCancellationToken, so without
+            // the timeout this would hang for 30 s; with it, the handler is cancelled within ~300 ms.
+            await ws.SendJsonAsync(new { id = handlerId });
+
+            // The handler observed cancellation well before its 30 s delay would elapse.
+            var observed = await Task.WhenAny(
+                CooperativeTimeoutApp.Cancelled.Task, Task.Delay(TimeSpan.FromSeconds(5)));
+            Assert.Same(CooperativeTimeoutApp.Cancelled.Task, observed);
+            Assert.True(await CooperativeTimeoutApp.Cancelled.Task);
+
+            // The timeout was metered, and the session/socket survived.
+            var metered = await WaitUntil(
+                () => capture.Counter("rask.handlers.timedout") >= 1, TimeSpan.FromSeconds(2));
+            Assert.True(metered, "expected rask.handlers.timedout to increment");
+            Assert.Equal(WebSocketState.Open, ws.State);
+        }
+        finally
+        {
+            RaskEndpointExtensions.HandlerTimeout = prev;
+            CooperativeTimeoutApp.Cancelled.TrySetResult(false);
+        }
+    }
+
+    private static async Task<bool> WaitUntil(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = Environment.TickCount64 + (long)timeout.TotalMilliseconds;
+        while (Environment.TickCount64 < deadline)
+        {
+            if (condition())
+            {
+                return true;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return condition();
+    }
+}


### PR DESCRIPTION
## Summary

Adds the per-handler execution timeout that was **deferred** from the resource-limits work (#128) — implemented the only way arbitrary user code can be bounded in .NET: **cooperatively**.

- **`Component.EventCancellationToken`** — inside an event handler, a token cancelled when the component unmounts (like the lifetime `CancellationToken`) **and** when the host cancels the dispatch: the server's new `RaskServerOptions.HandlerTimeout` elapsing, or the socket closing. Thread it into the cancellable async work a handler starts and a slow handler unwinds cleanly, releasing the render lock instead of pinning it:
  ```csharp
  Button(OnClickAsync: async () => _rows = await _api.LoadAsync(EventCancellationToken))["Load"]
  ```
- **`RaskServerOptions.HandlerTimeout`** — opt-in (`TimeSpan.Zero` default), validated at startup. On timeout the dispatch is logged + counted on `rask.handlers.timedout`.

It is genuinely cooperative: a handler that **ignores** the token (or runs unbounded synchronous work) can't be force-aborted — a .NET reality, not a Rask limitation. The backpressure + idle-socket caps remain the backstop for that case.

### How it's wired
- **Core:** `TryInvokeHandlerAsync` takes an optional dispatch token and publishes the per-dispatch token (linked with the owner's lifetime token — the linked source allocated *only* when a timeout is configured) via a new `DispatchEventTokenScope` ambient; `EventCancellationToken` reads it back. No allocation on the no-timeout path.
- **Server:** `DispatchHandlerAsync` builds a linked CTS with `CancelAfter(HandlerTimeout)`, passes its token down, and catches the resulting cancellation to log/meter it rather than treat it as a normal cancellation.

## Testing

- Core unit tests for `EventCancellationToken` (lifetime fallback + ambient dispatch token).
- End-to-end: a cooperative 30 s handler is cancelled within the 300 ms timeout, is metered (`rask.handlers.timedout`), and leaves the session/socket alive.
- Seeding + negative-value validation.
- Full Core (1554) + Server (239) suites green; `dotnet format` clean; builds `-warnaserror`.

## Docs

`docs/configuration.md`, `docs/composition.md`, `docs/observability.md`, the server template `AGENTS.md`, and CHANGELOG updated.