### PR TITLE
refactor(core): fold EventCancellationToken into a context-aware CancellationToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
-- **Cooperative handler timeout (`RaskServerOptions.HandlerTimeout`).** A new
-  `Component.EventCancellationToken` exposes, inside an event handler, a token cancelled when the
-  component unmounts **or** when the host cancels the dispatch — the server's `HandlerTimeout` elapsing,
-  or the socket closing. Thread it into the cancellable async work a handler starts (`HttpClient`,
-  `Task.Delay`) and a slow handler unwinds cleanly instead of pinning the session's render pipeline;
-  the timeout is logged and counted on `rask.handlers.timedout`. It is cooperative — a handler that
-  ignores the token can't be force-aborted (a .NET reality; the backpressure and idle-socket caps remain
-  the backstop). Opt-in: `HandlerTimeout` defaults to `TimeSpan.Zero` (off), validated at startup like
-  the other server limits. See the [configuration](docs/configuration.md) and
+- **Cooperative handler timeout (`RaskServerOptions.HandlerTimeout`).** `Component.CancellationToken`
+  now does double duty: it still cancels on unmount, and *while an event handler is running* it **also**
+  cancels when the host cancels that dispatch — the server's new `HandlerTimeout` elapsing, or the socket
+  closing. Thread it into the cancellable async work a handler starts (`HttpClient`, `Task.Delay`) and a
+  slow handler unwinds cleanly instead of pinning the session's render pipeline; the timeout is logged
+  and counted on `rask.handlers.timedout`. Handlers that already pass `CancellationToken` to their async
+  calls gain this for free once an operator sets the timeout. It is cooperative — a handler that ignores
+  the token can't be force-aborted (a .NET reality; the backpressure and idle-socket caps remain the
+  backstop). Opt-in: `HandlerTimeout` defaults to `TimeSpan.Zero` (off), validated at startup like the
+  other server limits. See the [configuration](docs/configuration.md) and
   [composition](docs/composition.md) guides.
 - **Resource-exhaustion hardening for the server host (all opt-in, default off).** Three new bounds,
   configurable via `RaskServerOptions` / `RaskUploadOptions`: (1) **`IdleSocketTimeout`** closes a

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -110,20 +110,20 @@ focus — and the runtime never `preventDefault`s it, so handlers compose with n
 Todos sample uses it to close its dialog on Escape (it focuses the `<dialog>` on open via an
 `ElementRef`, since a diff-inserted element never fires the HTML `autofocus` attribute).
 
-**Cancelling async handler work.** Inside an event handler, `Component.EventCancellationToken` is a
-token cancelled when the component unmounts **or** when the host cancels the dispatch — the server's
-optional `RaskServerOptions.HandlerTimeout` elapsing, or the socket closing. Thread it into the
-cancellable async work a handler starts so a slow handler unwinds instead of pinning the session's
-render pipeline:
+**Cancelling async work.** `Component.CancellationToken` is cancelled when the component unmounts —
+and, *while an event handler is running*, **also** when the host cancels that dispatch (the server's
+optional `RaskServerOptions.HandlerTimeout` elapsing, or the socket closing). Thread it into the
+cancellable async work a handler or lifecycle hook starts, so the work aborts when the component goes
+away and a slow handler unwinds instead of pinning the session's render pipeline:
 
 ```csharp
 Button(OnClickAsync: async () =>
-    _rows = await _api.LoadAsync(EventCancellationToken))["Load"]
+    _rows = await _api.LoadAsync(CancellationToken))["Load"]
 ```
 
 It is cooperative: a handler that ignores the token (or runs unbounded synchronous work) can't be
-force-aborted — that's a .NET reality, not a Rask limitation. Outside a handler the property is just
-the component's lifetime `CancellationToken`.
+force-aborted — that's a .NET reality, not a Rask limitation. In a lifecycle hook (no handler
+dispatch) the token is simply the component's lifetime token.
 
 ---
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,13 +62,14 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `UnconnectedSessionGracePeriod` | `10 s` | How long a GET-minted session is retained before its first `hello` arrives. |
 | `IdleSocketTimeout` | `0` (off) | Close a connected socket that sends no inbound frame for this long (the session survives for reconnect). Reclaims silently-idle connections. |
 | `MaxPendingHandlerBytes` | `0` (off) | Aggregate-bytes companion to `MaxPendingHandlers` — bounds the queued cloned-payload *memory*, not just the queue length. |
-| `HandlerTimeout` | `0` (off) | Cancel a handler dispatch's `Component.EventCancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
+| `HandlerTimeout` | `0` (off) | Cancel a handler's `Component.CancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
 
-> **Using `HandlerTimeout`:** thread `EventCancellationToken` into the cancellable async work your event
-> handlers start, so the timeout (or socket close) can unwind them:
+> **Using `HandlerTimeout`:** thread `Component.CancellationToken` into the cancellable async work your
+> event handlers start, so the timeout (or socket close) can unwind them. Inside a handler that token
+> reflects the dispatch; in a lifecycle hook it's just the component's lifetime token.
 > ```csharp
 > Button(OnClickAsync: async () =>
->     _data = await http.GetFromJsonAsync<T>(url, EventCancellationToken))["Load"]
+>     _data = await http.GetFromJsonAsync<T>(url, CancellationToken))["Load"]
 > ```
 
 ### File uploads

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -286,33 +286,34 @@ public abstract class Component
     }
 
     /// <summary>
-    ///     A <see cref="System.Threading.CancellationToken" /> tied to this component's lifetime.
-    ///     Cancelled exactly once when the component is unmounted (navigation away, parent
-    ///     removed, or session teardown). Pass into <c>HttpClient</c> calls, <c>Task.Delay</c>,
-    ///     or any other cancellable async work started inside a lifecycle hook so it aborts
-    ///     cleanly when the component goes away.
+    ///     A <see cref="System.Threading.CancellationToken" /> for this component's cancellable async
+    ///     work. It is cancelled when the component is unmounted (navigation away, parent removed, or
+    ///     session teardown) — and, while an event handler is running, <em>also</em> when the host
+    ///     cancels that dispatch: a server-side <c>RaskServerOptions.HandlerTimeout</c> elapsing, or the
+    ///     WebSocket closing. Pass it into the <c>HttpClient</c> calls, <c>Task.Delay</c>s, and other
+    ///     cancellable work an <c>OnClick</c> / <c>OnSubmit</c> handler or a lifecycle hook starts, so the
+    ///     work aborts when the component goes away and a slow handler unwinds instead of pinning the
+    ///     session's render pipeline. In a lifecycle hook (no handler dispatch) it is just the lifetime
+    ///     token. Cancellation is cooperative — synchronous or token-ignoring handler code cannot be
+    ///     forcibly aborted; a handler must observe the token to be cancelled.
     /// </summary>
-    protected CancellationToken CancellationToken =>
-        LazyInitializer.EnsureInitialized(ref _lifetimeCts, () => new CancellationTokenSource()).Token;
-
-    /// <summary>
-    ///     The <see cref="System.Threading.CancellationToken" /> for the event handler currently
-    ///     running. It is cancelled when this component unmounts (like <see cref="CancellationToken" />)
-    ///     <em>and</em> when the dispatch is cancelled by the host — a server-side
-    ///     <c>RaskServerOptions.HandlerTimeout</c> elapsing, or the WebSocket closing. Pass it into the
-    ///     cancellable async work an <c>OnClick</c> / <c>OnSubmit</c> handler starts (an <c>HttpClient</c>
-    ///     call, a <c>Task.Delay</c>) so a stuck handler unwinds instead of pinning the session's render
-    ///     pipeline. Outside a handler it is the plain lifetime token. Forcibly aborting synchronous or
-    ///     token-ignoring handler code is not possible; a handler must observe this token to be cancelled.
-    /// </summary>
-    protected CancellationToken EventCancellationToken
+    protected CancellationToken CancellationToken
     {
         get
         {
+            // While an event handler runs, the dispatch scope holds a token already linked with this
+            // component's lifetime token (see TryInvokeHandlerAsync); outside one it is the raw lifetime
+            // token. The scope is only pushed when a handler timeout is configured, so the common path
+            // is the plain lifetime token below.
             var dispatch = DispatchEventTokenScope.Current;
-            return dispatch.CanBeCanceled ? dispatch : CancellationToken;
+            return dispatch.CanBeCanceled ? dispatch : LifetimeToken;
         }
     }
+
+    // The raw, stable lifetime token — cancelled once on unmount. Used internally to seed the linked
+    // per-dispatch token without re-entering the context-aware CancellationToken getter above.
+    private CancellationToken LifetimeToken =>
+        LazyInitializer.EnsureInitialized(ref _lifetimeCts, () => new CancellationTokenSource()).Token;
 
     internal IRenderHandle? RenderHandle { get; set; }
 
@@ -963,21 +964,20 @@ public abstract class Component
         var (owner, handler) = entry;
         using var __dispatchScope = DispatchServicesScope.Push(services);
 
-        // Expose a per-dispatch cancellation token to the handler via owner.EventCancellationToken.
-        // It cancels on the owner's unmount (lifetime token) AND on the host's dispatch token (a
-        // handler timeout / socket close). Only allocate the linked source when the host actually
-        // supplied a cancellable token (i.e. a timeout is configured); otherwise the lifetime token
-        // alone is the ambient, so the no-timeout path stays allocation-free.
+        // When the host supplied a cancellable dispatch token (a handler timeout is configured), make
+        // owner.CancellationToken observe it during this handler by publishing a token linked with the
+        // owner's lifetime token. With no timeout we push nothing — CancellationToken then resolves to
+        // the plain lifetime token — so the common path stays allocation-free.
         CancellationTokenSource? linkedCts = null;
-        var eventToken = owner.CancellationToken;
+        IDisposable? eventTokenScope = null;
         if (dispatchToken.CanBeCanceled)
         {
-            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(eventToken, dispatchToken);
-            eventToken = linkedCts.Token;
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(owner.LifetimeToken, dispatchToken);
+            eventTokenScope = DispatchEventTokenScope.Push(linkedCts.Token);
         }
 
-        using var __eventTokenScope = DispatchEventTokenScope.Push(eventToken);
         using var __linked = linkedCts;
+        using var __eventTokenScope = eventTokenScope;
 
         // Match Blazor: every event handler implicitly marks the registering component
         // dirty. Set BEFORE running so intermediate renders inside an async handler

--- a/src/Rask.Core/Live/DispatchEventTokenScope.cs
+++ b/src/Rask.Core/Live/DispatchEventTokenScope.cs
@@ -3,7 +3,7 @@ namespace Rask.Core.Live;
 /// <summary>
 ///     Ambient <see cref="CancellationToken" /> for the event-handler dispatch currently running on
 ///     this async flow. Pushed by <c>Component.TryInvokeHandlerAsync</c> around a handler invocation and
-///     read back through <c>Component.EventCancellationToken</c>, so a handler's async work can observe
+///     read back through <c>Component.CancellationToken</c>, so a handler's async work can observe
 ///     cancellation (a server-side handler timeout, or the socket closing) without the delegate having
 ///     to take a token parameter. Mirrors <see cref="Rask.Core.Forms.DispatchServicesScope" />; defaults
 ///     to <see cref="CancellationToken.None" /> outside a dispatch.

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -86,7 +86,7 @@ public static class RaskEndpointExtensions
     // reconnect under SessionGracePeriod). Seeded from RaskServerOptions.IdleSocketTimeout. Zero = off.
     internal static TimeSpan IdleSocketTimeout = TimeSpan.Zero;
 
-    // Cancel a handler dispatch's EventCancellationToken after this long, so a cooperative handler that
+    // Cancel a handler dispatch's CancellationToken after this long, so a cooperative handler that
     // observes it unwinds instead of pinning the render pipeline. Seeded from
     // RaskServerOptions.HandlerTimeout. Zero = off.
     internal static TimeSpan HandlerTimeout = TimeSpan.Zero;
@@ -1001,8 +1001,8 @@ public static class RaskEndpointExtensions
         metrics?.HandlerDispatched();
         var dispatchStart = Stopwatch.GetTimestamp();
 
-        // Handler timeout: cancel the dispatch's EventCancellationToken after HandlerTimeout (linked to
-        // the socket so a close cancels it too). A handler that threads EventCancellationToken into its
+        // Handler timeout: cancel the dispatch's CancellationToken after HandlerTimeout (linked to
+        // the socket so a close cancels it too). A handler that threads CancellationToken into its
         // async work unwinds cooperatively; one that ignores it can't be force-aborted (the timeout is
         // still logged + metered). Null when the timeout is disabled, so the default path allocates nothing.
         using var handlerCts = HandlerTimeout > TimeSpan.Zero
@@ -1078,7 +1078,7 @@ public static class RaskEndpointExtensions
             catch (OperationCanceledException)
                 when (handlerCts is not null && handlerCts.IsCancellationRequested && !ct.IsCancellationRequested)
             {
-                // The handler timed out and observed EventCancellationToken, unwinding cleanly. The
+                // The handler timed out and observed CancellationToken, unwinding cleanly. The
                 // session survives; record it rather than letting it look like a normal cancellation.
                 metrics?.HandlerTimedOut();
                 activity?.SetStatus(ActivityStatusCode.Error, "handler timed out");

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -76,7 +76,7 @@ public sealed class RaskServerOptions
 
     /// <summary>
     ///     How long a single event-handler dispatch may run before its cancellation token
-    ///     (<c>Component.EventCancellationToken</c>) is cancelled. A handler that threads that token
+    ///     (<c>Component.CancellationToken</c>) is cancelled. A handler that threads that token
     ///     into its async work (an <c>HttpClient</c> call, a <c>Task.Delay</c>) then unwinds cleanly
     ///     instead of pinning the session's render pipeline; the timeout is logged and metered. It is
     ///     cooperative — a handler that ignores the token cannot be force-aborted (the backpressure and

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -35,10 +35,9 @@ https://github.com/pal-tamas/rask/tree/main/docs
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
-- **Async handler cancellation:** pass `EventCancellationToken` (cancelled on unmount or the optional
-  `RaskServerOptions.HandlerTimeout`) into the cancellable work an `OnClickAsync`/`OnSubmitAsync` starts,
-  e.g. `await http.GetFromJsonAsync<T>(url, EventCancellationToken)`. Use `CancellationToken` (lifetime
-  only) inside lifecycle hooks.
+- **Async cancellation:** pass `CancellationToken` into the cancellable work a handler or lifecycle hook
+  starts, e.g. `await http.GetFromJsonAsync<T>(url, CancellationToken)`. It cancels on unmount, and —
+  inside an event handler — also on the optional `RaskServerOptions.HandlerTimeout` / socket close.
 
 ## Events, scoped CSS/JS, forms, auth
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,

--- a/tests/Rask.Core.Tests/Live/CancellationTokenScopeTests.cs
+++ b/tests/Rask.Core.Tests/Live/CancellationTokenScopeTests.cs
@@ -6,14 +6,19 @@ using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Tests.Live;
 
-public class EventCancellationTokenTests
+// Component.CancellationToken is the lifetime token by default, but reflects the per-dispatch token an
+// event handler runs under (so a handler timeout / socket close cancels the handler's async work).
+public class CancellationTokenScopeTests
 {
     [Fact]
-    public void OutsideAHandler_IsTheLifetimeToken()
+    public void OutsideAHandler_IsAStableLifetimeToken()
     {
         var c = new Probe();
-        Assert.Equal(c.Lifetime, c.Event);
-        Assert.False(c.Event.IsCancellationRequested);
+        var a = c.Token;
+        var b = c.Token;
+
+        Assert.Equal(a, b); // same lifetime token each read
+        Assert.False(a.IsCancellationRequested);
     }
 
     [Fact]
@@ -24,20 +29,18 @@ public class EventCancellationTokenTests
 
         using (DispatchEventTokenScope.Push(cts.Token))
         {
-            Assert.Equal(cts.Token, c.Event);
+            Assert.Equal(cts.Token, c.Token);
             cts.Cancel();
-            Assert.True(c.Event.IsCancellationRequested);
+            Assert.True(c.Token.IsCancellationRequested);
         }
 
         // Scope popped — back to the (un-cancelled) lifetime token.
-        Assert.Equal(c.Lifetime, c.Event);
-        Assert.False(c.Event.IsCancellationRequested);
+        Assert.False(c.Token.IsCancellationRequested);
     }
 
     private sealed class Probe : Component
     {
-        public CancellationToken Lifetime => CancellationToken;
-        public CancellationToken Event => EventCancellationToken;
+        public CancellationToken Token => CancellationToken;
         protected override RenderResult Render() => C.Span();
     }
 }

--- a/tests/Rask.Server.Tests/Infrastructure/CooperativeTimeoutApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/CooperativeTimeoutApp.cs
@@ -5,13 +5,13 @@ using Rask.Core.Components;
 
 namespace Rask.Server.Tests.Infrastructure;
 
-// App whose click handler awaits a long delay that observes EventCancellationToken — a *cooperative*
-// slow handler. With RaskServerOptions.HandlerTimeout set, the dispatch cancels the token and the delay
+// App whose click handler awaits a long delay that observes CancellationToken — a *cooperative* slow
+// handler. With RaskServerOptions.HandlerTimeout set, the dispatch cancels the token and the delay
 // throws, so the handler unwinds instead of pinning the session. Used to exercise the handler timeout.
 public sealed class CooperativeTimeoutApp : Component
 {
-    // Completed when the handler observes its EventCancellationToken being cancelled. Static so the test
-    // can await it without a handle to the DI-constructed instance; reset per test before the host starts.
+    // Completed when the handler observes its CancellationToken being cancelled. Static so the test can
+    // await it without a handle to the DI-constructed instance; reset per test before the host starts.
     public static TaskCompletionSource<bool> Cancelled = new(TaskCreationOptions.RunContinuationsAsynchronously);
 
     protected override RenderResult Render() =>
@@ -23,7 +23,7 @@ public sealed class CooperativeTimeoutApp : Component
                 {
                     try
                     {
-                        await Task.Delay(TimeSpan.FromSeconds(30), EventCancellationToken);
+                        await Task.Delay(TimeSpan.FromSeconds(30), CancellationToken);
                     }
                     catch (OperationCanceledException)
                     {

--- a/tests/Rask.Server.Tests/WebSockets/HandlerTimeoutTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerTimeoutTests.cs
@@ -4,7 +4,7 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-// RaskServerOptions.HandlerTimeout: a cooperative handler that threads EventCancellationToken into its
+// RaskServerOptions.HandlerTimeout: a cooperative handler that threads CancellationToken into its
 // async work is cancelled when the timeout elapses, so it unwinds instead of pinning the render lock.
 [Collection("SessionGracePeriod")]
 public class HandlerTimeoutTests
@@ -28,7 +28,7 @@ public class HandlerTimeoutTests
             await ws.SendJsonAsync(new { type = "hello", session = sessionId });
             _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
 
-            // Fire the slow handler. It awaits a 30 s delay observing EventCancellationToken, so without
+            // Fire the slow handler. It awaits a 30 s delay observing CancellationToken, so without
             // the timeout this would hang for 30 s; with it, the handler is cancelled within ~300 ms.
             await ws.SendJsonAsync(new { id = handlerId });
 


### PR DESCRIPTION
## Summary

Collapses the two component cancellation tokens into one, per review feedback that two was redundant surface.

`EventCancellationToken` is **removed**; `Component.CancellationToken` is now **context-aware**:
- outside a handler → the stable **lifetime** token (unchanged behaviour);
- while an event handler runs → the per-dispatch token, **linked with the lifetime token**, so a `HandlerTimeout` / socket close also cancels the handler's async work.

One token that "just does the right thing" in both lifecycle hooks and event handlers — and handlers that **already** pass `CancellationToken` to their async calls gain the timeout behaviour for free once an operator sets `HandlerTimeout`. The old `EventCancellationToken` was a strict superset that fell back to the lifetime token outside a handler anyway.

## Notes

- `TryInvokeHandlerAsync` pushes the dispatch scope (and allocates the linked source) **only when a timeout is configured**; with no timeout nothing is pushed and `CancellationToken` resolves to the plain lifetime token — the common path is unchanged and allocation-free. A private `LifetimeToken` seeds the link without re-entering the context-aware getter.
- **Not a breaking change:** `EventCancellationToken` was unreleased (added in #131 on this same `[Unreleased]` cycle).

## Testing

`CancellationTokenScopeTests` (lifetime fallback + dispatch reflection); the handler-timeout end-to-end test now drives the single `CancellationToken` and still passes (cooperative 30 s handler cancelled within a 300 ms timeout, metered, session survives). Full **Core (1554)** + **Server (239)** suites green; `dotnet format` clean; builds `-warnaserror`. Docs (configuration / composition / template `AGENTS` / CHANGELOG) reworded.