### PR TITLE
chore(release): v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-23
+
 ### Added
 - **Cooperative handler timeout (`RaskServerOptions.HandlerTimeout`).** `Component.CancellationToken`
   now does double duty: it still cancels on unmount, and *while an event handler is running* it **also**


### PR DESCRIPTION
Promotes the `[Unreleased]` changelog to **v0.10.0** (2026-06-23) and opens a fresh `[Unreleased]`.

This release lands the server-hardening initiative and follow-ups merged this cycle:

- **#125** Core diagnostics seam (`RaskDiagnostics`)
- **#130** OpenTelemetry-aligned observability (logging bridge, metrics, tracing, health checks)
- **#127** Configurable WS / session-grace limits (`RaskServerOptions`, validated at startup)
- **#128** Resource-exhaustion limits (idle-socket timeout, pending-handler byte cap, per-session upload quota)
- **#131 / #132** Cooperative handler timeout via a context-aware `Component.CancellationToken`
- **#129** Realistic partial-shuffle keyed-diff benchmarks

Minor bump (pre-1.0; additive features). Tag `v0.10.0` follows once this merges, triggering `release.yml` (unit gate → sharded E2E → pack + push the six NuGets + GitHub release).