### PR TITLE
docs(ci): refresh nightly prerelease version example for v0.10.0

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,9 @@
 name: nightly
 
 # Nightly prerelease on every change to main. MinVer derives a prerelease version
-# (e.g. 0.7.1-alpha.0.N) for untagged commits, so packs are naturally prerelease on nuget.org.
-# Stable releases (no -prerelease suffix) still come only from tagging via release.yml.
+# (e.g. 0.10.1-alpha.0.N after the v0.10.0 tag) for untagged commits, so packs are naturally
+# prerelease on nuget.org. Stable releases (no -prerelease suffix) still come only from tagging
+# via release.yml.
 on:
   push:
     branches: [main]


### PR DESCRIPTION
The `nightly.yml` header comment showed a stale MinVer example (`0.7.1-alpha.0.N`). After the `v0.10.0` tag, MinVer derives the next untagged prerelease as `0.10.1-alpha.0.N`, so the example is updated to match. Comment-only change to the workflow.