### PR TITLE
docs: make getting-started beginner-friendly and surface prerequisites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **Beginner-friendly getting-started rewrite ([docs/getting-started.md](docs/getting-started.md)).**
+  Restructured for a developer new to Rask into a "run → understand → extend" path: promoted
+  prerequisites, a recommended default template, a *"what you should see"* checkpoint, a new tour of the
+  scaffolded files, and a troubleshooting section. Security/edge-case detail (string encoding, URL
+  sanitization, the `RenderResult` shapes) moved into clearly-labelled asides instead of interrupting
+  the main flow. Surfaced prerequisites up front in `README.md` and `NUGET.md`, and pointed the
+  `docs/README.md` index at the guide as the starting point.
+
 ### Added
 - **Best practices guide ([docs/best-practices.md](docs/best-practices.md)).** A new hub that
   consolidates the patterns and common pitfalls previously scattered across the subsystem docs and

--- a/NUGET.md
+++ b/NUGET.md
@@ -30,6 +30,9 @@ public sealed class Counter : Component
 
 ## Install
 
+> **Prerequisites:** the **.NET 10 SDK** (`dotnet --version` ≥ `10.0`); the `wasm-tools` workload
+> (`dotnet workload install wasm-tools`) for the WASM templates only.
+
 ```bash
 dotnet new install Rask.Templates        # scaffolding
 dotnet new rask-server -o MyApp          # or: rask-wasm, rask-wasm-hosted

--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ rest of this README walks through what they look like in practice.
 
 ## 📦 Install
 
+> **Prerequisites:** the **.NET 10 SDK** (`dotnet --version` ≥ `10.0`); the `wasm-tools` workload
+> (`dotnet workload install wasm-tools`) for the WASM templates only. New to Rask? The
+> [getting started](docs/getting-started.md) guide walks the whole path end to end.
+
 ### Scaffold a new project with `dotnet new` (recommended)
 
 The fastest way to start. `Rask.Templates` ships three project templates — one per host model — already wired up to the

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,14 @@
 # Rask documentation
 
-Guides and references for building with Rask. New here? Start with the project
-[README](../README.md) for the pitch and a quick demo, then come back for depth.
+Guides and references for building with Rask. **New to Rask?** Read
+[Getting started](getting-started.md) start to finish — it goes from zero to a running, routed,
+interactive app. Want the pitch and a quick demo first? See the project [README](../README.md).
 
 ## Guides
 
 | Guide | What it covers |
 |-------|----------------|
-| [Getting started](getting-started.md) | Install the templates, scaffold an app, write your first component, add interactivity and a route. |
+| [Getting started](getting-started.md) | Prerequisites, scaffold an app, a tour of the generated files, your first component, interactivity, routing, and troubleshooting. |
 | [Best practices](best-practices.md) | Production patterns and common pitfalls across component design, state, forms, data access, security, accessibility, performance and testing — each linking to the deep dive. |
 | [Routing](routing.md) | `[Route]`, route/query params, nested routes, type-safe `Routes.*` URLs, `Navigator`, `RouteState`. |
 | [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), `VirtualizeModel`, `TableModel`, drag-and-drop. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,66 +1,110 @@
 # Getting started with Rask
 
-This is a zero-to-running tutorial. By the end you'll have a Rask app on screen, a
-component of your own, an event handler that updates the UI, and a route.
+Rask lets you build web UIs as plain C# classes — no `.razor`, no JSX, no JavaScript to write. A
+component is a class that returns a tree of HTML from `Render()`, and the *same* component runs either
+server-rendered (live updates over a WebSocket) or fully client-side in the browser on WebAssembly.
 
-Rask requires the **.NET 10 SDK**. Check with `dotnet --version` (≥ `10.0`). WASM
-projects also need the WebAssembly tooling — install it once with
-`dotnet workload install wasm-tools`.
+This is a zero-to-running tutorial for someone new to Rask. By the end you'll have an app on screen,
+you'll understand the files the template gave you, and you'll have written your own component, an event
+handler that updates the UI, and a route. It assumes you're comfortable with C# — we explain the
+Rask-specific ideas, not the language.
 
-## 1. Install the templates and scaffold
+> **Coming from Blazor?** Skim [migrating from Blazor](migration-from-blazor.md) for the concept
+> mapping (`@page` → `[Route]`, `[Parameter]` → a property, `EventCallback` → a plain delegate). **Just
+> want to look first?** Click through the [live demo](https://pal-tamas.github.io/rask/) — a full
+> multi-page Rask app, no install needed.
 
-`Rask.Templates` ships three `dotnet new` templates, one per host model:
+## Before you start
+
+Rask requires the **.NET 10 SDK**. Confirm you have it:
 
 ```bash
-dotnet new install Rask.Templates
-
-dotnet new rask-server       -o MyApp    # ASP.NET live-server app (SSR over WebSockets)
-dotnet new rask-wasm         -o MyApp    # standalone browser-WASM SPA (static bundle)
-dotnet new rask-wasm-hosted  -o MyApp    # browser-WASM client + ASP.NET host project
+dotnet --version      # must be ≥ 10.0
 ```
 
-Which one to pick:
+If that prints an older version (or errors), install the .NET 10 SDK from
+[dotnet.microsoft.com](https://dotnet.microsoft.com/download) first.
 
-- **`rask-server`** — a single ASP.NET project. Components render on the server and
-  live updates ship over a WebSocket. Good default for apps that already have a
-  backend or want server-side secrets.
-- **`rask-wasm`** — a single `net10.0-browser` project that publishes to a static
-  `wwwroot/` you can host anywhere (GitHub Pages, S3, nginx). No server process for
-  the framework itself; bring your own API for whatever the client calls.
-- **`rask-wasm-hosted`** — two projects: the WASM client plus an ASP.NET host that
-  serves the published bundle and your own `/api/...` endpoints, pre-wired with the
-  cross-TFM `ProjectReference`.
+> **WASM only:** the two WebAssembly templates (`rask-wasm`, `rask-wasm-hosted`) also need the browser
+> WebAssembly tooling — install it once with `dotnet workload install wasm-tools`. If you're starting
+> with the server template (recommended below), you can skip this.
 
-All three accept a `--auth` switch that scaffolds a working login flow
-(`rask-server` / `rask-wasm-hosted` scaffold a **cookie** login; `rask-wasm`, having
-no host, scaffolds a **JWT** bearer login against an external API). See
-[authentication](authentication.md) for the full picture.
+## 1. Scaffold a project
 
-Each template emits a runnable solution with `App`, `HomePage`, `Counter`, and a
-`Weather` page that demonstrates async data through constructor DI.
+**Not sure which host to pick? Choose `rask-server`** — it's a single ASP.NET project that runs with no
+extra setup, and the components you write are identical across hosts, so nothing you learn here is
+wasted if you switch later.
+
+```bash
+dotnet new install Rask.Templates    # one-time: install the templates
+
+dotnet new rask-server -o MyApp      # create a server app in ./MyApp
+```
+
+`Rask.Templates` ships three templates, one per host model:
+
+| Template            | What you get                                                                                  |
+|---------------------|-----------------------------------------------------------------------------------------------|
+| `rask-server`       | One ASP.NET project. Components render on the server; live updates ship over a WebSocket. **Best default.** |
+| `rask-wasm`         | One `net10.0-browser` project that publishes to a static `wwwroot/` you can host anywhere (GitHub Pages, S3, nginx). Bring your own API. |
+| `rask-wasm-hosted`  | Two projects: the WASM client plus an ASP.NET host that serves the bundle and your own `/api/...` endpoints. |
+
+All three emit the same starter pages, so the rest of this guide applies whichever you chose. Each also
+accepts a `--auth` switch that scaffolds a working login flow — see [authentication](authentication.md)
+when you need it.
 
 ## 2. Run it
 
 ```bash
 cd MyApp
 dotnet run            # rask-server / rask-wasm
-# rask-wasm-hosted: run the host project
-dotnet run --project MyApp.Host
+# rask-wasm-hosted: run the host project — dotnet run --project MyApp.Host
 ```
 
-Open the URL printed in the console.
+Open the URL printed in the console. **You should see** a small nav bar (`Home | Counter | Weather`)
+above three working pages: a welcome card, a counter you can click, and a weather table that shows a
+*"Loading…"* placeholder for a moment before async data fills in.
 
-> The first build is also when the source generators run. The IDE may flag
-> `HomePage()`, `Counter()`, or `NavLink(...)` as undefined until then — they're
-> **generated** factories. Build once, then reload the solution so IntelliSense
-> picks them up.
+> **First build is slower, and the IDE may look broken — that's expected.** The first build is when
+> Rask's source generators run. Until then your IDE may flag `HomePage()`, `Counter()`, or
+> `NavLink(...)` as undefined — they're *generated* methods that don't exist until you build. Build
+> once, then reload the solution so IntelliSense picks them up. (More on this in
+> [Troubleshooting](#troubleshooting) below.)
 
-## 3. Your first component
+## 3. Tour of what the template generated
 
-Every component is a `sealed class : Component`. Override `Render()` and return a
-tree of HTML built from generated factories. Children attach through an **indexer**
-on every component — `Div()[ ... ]` — and strings, `Component`s, and value types
-all convert implicitly to a child node:
+Before writing code, here's what's in the project and why. This is the `rask-server` layout (the WASM
+templates differ only in `Program.cs`):
+
+- **`Program.cs`** — the host setup. `builder.Services.AddRask()` registers the framework, and
+  `app.UseRask<App>()` mounts your root component (`App`) as the whole site. Your own services go in
+  here too — the template registers `IWeatherForecastService` so the Weather page can inject it.
+
+- **`App.cs`** — the **root component**, and the one place that renders the full HTML page shell
+  (`Doctype` / `Html` / `Head` / `Body`). It holds the nav bar and drops a `Router()` where the current
+  page should appear. `<head>` is framework-managed — app-wide tags (title, charset, viewport) go
+  through its `Head` override, not by passing children to `Head()`. More on this in
+  [section 7](#7-the-page-shell-and-the-head-override).
+
+- **`HomePage.cs`** + **`HomePage.css`** — the `/` route. The sibling `.css` file is **auto-scoped** to
+  this component: drop a `{Component}.css` next to a `{Component}.cs` and its selectors only apply to
+  that component — no class-name discipline, no leaks. (Same idea for a sibling `{Component}.js`.)
+
+- **`Counter.cs`** — the `/counter` route: local state in a field, a click handler, automatic re-render.
+  You'll write something like it in [section 5](#5-add-interactivity).
+
+- **`Weather.cs`** (+ `WeatherForecast.cs`, `LocalWeatherForecastService.cs`) — the `/weather` route.
+  Shows the canonical async-data pattern: a service injected through the **constructor**, loaded in an
+  `OnMountAsync` lifecycle hook, with a loading placeholder until the data arrives.
+
+Open these side by side as you read the next sections — each one is a live example of a concept below.
+
+## 4. Your first component
+
+Every component is a `sealed class : Component`. Override `Render()` and return a tree of HTML built
+from generated factory methods (`Div()`, `H1()`, `P()`, …). Children attach through an **indexer** on
+every component — `Div()[ ... ]` — and strings, other components, and value types all convert to a
+child node automatically:
 
 ```csharp
 public sealed class Greeting : Component
@@ -74,47 +118,29 @@ public sealed class Greeting : Component
 }
 ```
 
-`Render()` returns `RenderResult`, which accepts three shapes:
+`Render()` returns `RenderResult`, which accepts three shapes — you'll mostly use the first two:
 
-- a single component — `Render() => Div()[...]`;
-- a **collection expression** for several top-level nodes with no wrapper —
-  `Render() => [H1()["Title"], P()["Body"]]` (sugar for `Fragment()[...]`);
+- a single node — `Render() => Div()[...]`;
+- a **collection expression** for several top-level nodes with no wrapper — `Render() => [H1()["Title"],
+  P()["Body"]]`;
 - `default` — render nothing.
 
-### Text vs. Raw
+> **Safe by default — good to know, not needed yet.** Two security defaults are worth knowing about but
+> won't get in your way:
+> - **Strings are HTML-encoded.** A plain string becomes a `Text` node, so `P()["<b>hi</b>"]` shows the
+>   angle brackets as text. When you genuinely need verbatim markup, use `Raw("<b>hi</b>")`.
+> - **URL attributes are scheme-sanitized.** `href`/`src`/etc. neutralize dangerous schemes
+>   (`javascript:` → `about:blank`) so a user-supplied URL can't run script on click. For a URL you
+>   fully control, opt out per-call with `RaskUrl.Trusted(...)`.
+>
+> See [best practices](best-practices.md) for the full security picture.
 
-A plain string becomes a `Text` node, which **HTML-encodes** its content (safe by
-default). When you genuinely need to emit verbatim markup, use `Raw`:
+## 5. Add interactivity
 
-```csharp
-P()["<b>encoded</b> — shows the angle brackets as text"],   // string → Text, encoded
-Div()[Raw("<b>bold</b>")]                                    // emitted verbatim
-```
-
-### URL attributes are scheme-sanitized
-
-URL-bearing attributes — `href` (`A`, `Area`, `Link`, `Base`, SVG), `src`
-(`Iframe`, `Script`, `Embed`, media), `cite`, `formaction`, object `data`, `poster` —
-are **sanitized by default**: HTML-encoding alone does not stop `<a href="javascript:…">`
-from executing on click. A dangerous scheme (`javascript:`, `vbscript:`, and `data:`
-outside media tags) is neutralized to `about:blank`; relative/`http(s)`/`mailto`/`tel`/
-fragment URLs pass through unchanged, and media tags (`img`/`audio`/`video`/`source`/
-`poster`) still allow inline `data:image/*`, `data:video/*`, `data:audio/*`.
-
-```csharp
-A(Href: userSuppliedUrl)["profile"]            // javascript:… → about:blank
-A(Href: RaskUrl.Trusted("javascript:void(0)"))["noop"]   // opt out for URLs you control
-```
-
-`RaskUrl.Trusted(...)` is the per-call escape hatch — the value is still HTML-encoded,
-just not scheme-checked. Use it only for non-attacker-controlled URLs.
-
-## 4. Add interactivity
-
-Keep local state in fields and wire event handlers as plain delegates. A click does
-a server round-trip (server host) or a local re-render (WASM host) — the same code.
-After the handler runs, **the component that owns the handler re-renders
-automatically**; you never call `StateHasChanged()` by hand for a local update.
+Keep local state in fields and wire event handlers as plain delegates. After the handler runs, **the
+component that owns it re-renders automatically** — you never call `StateHasChanged()` by hand for a
+local update. A click does a server round-trip (server host) or a local re-render (WASM host); the same
+code works for both.
 
 ```csharp
 [Route("/counter")]
@@ -131,10 +157,11 @@ public sealed class Counter : Component
 }
 ```
 
-Child → parent communication uses the same idea: a child declares a plain delegate
-property (`Action<int>?`, `Func<Task>?`, …), and the generated factory wraps it so
-invoking it re-renders the **parent** that owns the lambda. There is no
-`EventCallback` type. The child stays oblivious to the parent:
+### Going further: child → parent communication
+
+A child declares a plain delegate property (`Action<int>?`, `Func<Task>?`, …), and the generated factory
+wraps it so invoking it re-renders the **parent** that owns the lambda. There is no `EventCallback`
+type, and the child stays oblivious to the parent:
 
 ```csharp
 public sealed class RatingStars : Component
@@ -162,45 +189,45 @@ public sealed class RatingDemo : Component
 }
 ```
 
-## 5. Factory generation rules
+## 6. Why `HomePage()` already exists (factory generation)
 
-You never write a factory by hand. For each concrete `Component`, the generator
-emits a `{Type}(...)` factory and derives its parameters from your public settable
-properties:
+You never write a factory method by hand. For each concrete `Component`, the generator emits a
+`{Type}(...)` factory — that's why `HomePage()`, `Counter()`, and your own `Greeting()` are callable.
+Its parameters are derived from your public settable properties:
 
-| Property shape | In the factory |
-|----------------|----------------|
-| Non-nullable, **no initializer** | **required** parameter |
-| Nullable (`T?` / `Nullable<T>`), no initializer | optional, defaults to `null` |
-| Has an initializer (`= ...`) | **excluded** — your default wins |
-| `[SkipFactory]` (property or class) | **excluded** |
-| `Children` | always excluded (children attach via the indexer) |
+| Property shape                                    | In the factory                                  |
+|---------------------------------------------------|-------------------------------------------------|
+| Non-nullable, **no initializer**                  | **required** parameter                          |
+| Nullable (`T?` / `Nullable<T>`), no initializer   | optional, defaults to `null`                    |
+| Has an initializer (`= ...`)                      | **excluded** — your default wins                |
+| `[SkipFactory]` (property or class)               | **excluded**                                    |
+| `Children`                                        | always excluded (children attach via the indexer) |
 
 ```csharp
 public sealed class Card : Component
 {
-    public required string Title { get; set; }   // required factory param
-    public string? Subtitle { get; set; }         // optional, default null
+    public required string Title { get; set; }     // required factory param
+    public string? Subtitle { get; set; }          // optional, default null
     public int Elevation { get; set; } = 1;        // excluded — your default wins
     [SkipFactory] public int Internal { get; set; }// excluded explicitly
     // → generated: Card(string Title, string? Subtitle = null, ...)
 }
 ```
 
-**Inject framework services (`HttpClient`, `Navigator`, `RouteState`, `IJSRuntime`)
-through the constructor, not as properties** — a non-nullable settable property
-would become a required factory parameter:
+**Inject framework services (`HttpClient`, `Navigator`, `RouteState`, `IJSRuntime`) through the
+constructor, not as properties** — a non-nullable settable property would become a *required* factory
+parameter. The template's `Weather` page is the model to copy:
 
 ```csharp
 public sealed class Weather(IWeatherForecastService service) : Component { ... }
 ```
 
-## 6. The page-root shell and the `Head` override
+## 7. The page shell and the `Head` override
 
-Your root component (the `TApp` you pass to the host) must render the **full HTML
-shell** — `Doctype`, `Html`, `Head`, `Body`. Both `<head>` and `<body>` are
-framework-managed: the runtime `<script>` is auto-appended to `<body>`, and `<head>`
-is filled from every mounted component's `Head` override.
+Your root component (the `TApp` you pass to the host — `App` in the template) must render the **full
+HTML shell**: `Doctype`, `Html`, `Head`, `Body`. Both `<head>` and `<body>` are framework-managed — the
+runtime `<script>` is auto-appended to `<body>`, and `<head>` is filled from every mounted component's
+`Head` override.
 
 ```csharp
 public sealed class App : Component
@@ -225,24 +252,22 @@ public sealed class App : Component
 }
 ```
 
-Any component can contribute to `<head>` while it's in the tree by overriding
-`protected virtual RenderResult Head`. `<title>` and `<base>` are singleton tags —
-the last contributor wins, so a page's `Title` overrides the App fallback:
+Any component can contribute to `<head>` while it's in the tree by overriding `Head`. `<title>` and
+`<base>` are singleton tags — the last contributor wins, so a page's `Title` overrides the app fallback:
 
 ```csharp
 protected override RenderResult Head => Title()["Welcome — My Rask App"];
 ```
 
-Two compile-time guardrails to know about (full list in [diagnostics](diagnostics.md)):
+> **Guardrails:** two compile-time checks catch the common mistakes (full list in
+> [diagnostics](diagnostics.md)) — **RASK021** if the root doesn't render a complete shell, and
+> **RASK019** if you pass children to `Head()` instead of using the override.
 
-- **RASK021** — the root doesn't render a complete shell (`Doctype`/`Html`/`Head`/`Body`).
-- **RASK019** — you passed children to `Head()`. Use the `Head` override instead.
+## 8. Add a route
 
-## 7. Add a route
-
-Put `[Route("/path")]` on a component to register it as a page (`Rask.Core.Routing`
-is the one namespace you bring in explicitly). `[RouteParam]` and `[QueryParam]` bind
-URL pieces to properties, and every route gets a generated, type-safe URL builder:
+Put `[Route("/path")]` on a component to register it as a page (`Rask.Core.Routing` is the one namespace
+you bring in explicitly). `[RouteParam]` and `[QueryParam]` bind URL pieces to properties, and every
+route gets a generated, type-safe URL builder:
 
 ```csharp
 using Rask.Core.Routing;
@@ -261,17 +286,43 @@ public sealed class UserPage : Component
 NavLink(UserPage(id: 42))["View user"];
 ```
 
-The `Router()` in your shell matches the current path and renders the page. To
-navigate from an event handler, inject the `Navigator` service through the
-constructor and call `nav.NavigateTo(HomePage())`, `nav.SetQuery("tab", "settings")`,
-and so on. For nested layouts (`[ParentRoute]` + `Outlet()`), 404 pages
-(`[NotFound]`), and the full routing model, see [routing](routing.md).
+The `Router()` in your shell matches the current path and renders the page. To navigate from an event
+handler, inject the `Navigator` service through the constructor and call `nav.NavigateTo(HomePage())`,
+`nav.SetQuery("tab", "settings")`, and so on. For nested layouts (`[ParentRoute]` + `Outlet()`), 404
+pages (`[NotFound]`), and the full routing model, see [routing](routing.md).
+
+## Troubleshooting
+
+The snags you're most likely to hit on a fresh project (the README has a
+[fuller list](../README.md#-troubleshooting)):
+
+- **The IDE flags `HomePage()`, `Counter()`, or `NavLink(...)` as undefined.** These are
+  *source-generated* — the factory for every component, the URL builder for every `[Route]`. They don't
+  exist until the generator runs, which happens on build. Run `dotnet build` once, then reload the
+  solution / restart the language server.
+
+- **`net10.0` / `net10.0-browser` won't restore, or a WASM publish fails.** You're missing the .NET 10
+  SDK (`dotnet --version` must be ≥ `10.0`) or, for WASM, the workload — install it with
+  `dotnet workload install wasm-tools`.
+
+- **A scoped `.css` / `.js` file isn't taking effect.** The sibling file must sit in the **same folder**
+  as its component and share the **base name** (`Card.cs` ↔ `Card.css`). A mismatch is a build error
+  (`RASK015`–`RASK018`) — check the build output.
+
+- **Blank page or 404s on `/_rask/...` assets behind a reverse proxy or sub-path.** The app is running
+  under a URL prefix the framework doesn't know about — set `PathBase` (see the README's
+  *Sub-path hosting* section).
 
 ## Next steps
 
-- [routing](routing.md) — nested layouts, route/query params, `Navigator`.
-- [forms](forms.md) — `Form<T>`, `Input(Bind: ...)`, validation.
-- [lifecycle](lifecycle.md) — `OnMount*` / `OnPropsChanged*` / `OnRendered*`, async hooks.
-- [testing](testing.md) — unit-testing components and rendered HTML.
-- [diagnostics](diagnostics.md) — every RASK0xx analyzer ID and how to fix it.
-- [authentication](authentication.md) — cookie/JWT/OIDC on Server and WASM.
+You now have a running, routed, interactive app. Where to go for the next thing you need:
+
+- **Build a form** → [forms](forms.md) — `Form<T>`, `Input(Bind: ...)`, validation.
+- **Add more routes / layouts** → [routing](routing.md) — nested layouts, route/query params, `Navigator`.
+- **Load or save data** → [data access](data-access.md) — EF Core + SQLite in a Server app.
+- **Run code on mount / after render** → [lifecycle](lifecycle.md) — `OnMount*` / `OnRendered*`, async hooks.
+- **Share state without prop-drilling** → [composition](composition.md) — context, callbacks, `VirtualizeModel`.
+- **Add a login** → [authentication](authentication.md) — cookie/JWT/OIDC on Server and WASM.
+- **Test your components** → [testing](testing.md) — unit-testing components and rendered HTML.
+- **Write idiomatic Rask** → [best practices](best-practices.md) — patterns and pitfalls that keep an app correct, secure, and fast.
+- **Decode a build error** → [diagnostics](diagnostics.md) — every RASK0xx analyzer ID and its fix.


### PR DESCRIPTION
## Summary
Rewrites `docs/getting-started.md` for a developer new to Rask (but fluent in C#) into a *run → understand → extend* path: promoted prerequisites, a recommended default template (`rask-server`), a *"what you should see"* checkpoint, a **new tour of the scaffolded files**, and a **troubleshooting** section. Security/edge-case detail (string encoding, URL sanitization, the `RenderResult` shapes) moved into clearly-labelled asides instead of interrupting the main flow. Surfaces prerequisites up front in `README.md`/`NUGET.md` and points the `docs/README.md` index at the guide as the starting point.

> **Stacked on #135** (`docs/best-practices-guide`) because the new guide links to `docs/best-practices.md`, which lands in that PR. GitHub will auto-retarget this PR to `main` once #135 merges.

## Testing
- Unit: n/a — docs-only change, no code touched.
- E2E (if `samples/` changed): n/a — no `samples/` changes.
- Docs checks: all relative links resolve, in-page anchors match headings, code fences balanced; the file tour was written from the actual `src/Rask.Templates/content/rask-server/` sources.

## Benchmarks
n/a — no framework/render-hotpath code changed.

## CHANGELOG
- [Unreleased] entry added: beginner-friendly getting-started rewrite + prerequisites surfaced in README/NUGET and the docs index.
