### PR TITLE
feat(samples): add reusable Bootstrap floating-label input + showcase page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Floating-label form input showcase (samples only).** A reusable `FloatingInput<TProp>` example
+  component (`samples/Rask.Example.Shared/Shared/FloatingInput.cs`) wraps Rask's `Input` + `Label` +
+  `ValidationMessage` in Bootstrap 5.3's `.form-floating` markup — one line per field, with the id
+  derived from the bound property and the input type inferred from `TProp`. It owns no validation
+  state and needs no extra CSS (errors show via Bootstrap's `.invalid-feedback .d-block`). Surfaced
+  on a new `/floating-labels` page under the Forms nav group.
+
 ### Security
 - **`CSS.escape` the ElementRef reviver selector (both runtimes).** The client reviver that
   resolves an `{"__raskRef__":"id"}` placeholder to a live DOM element now escapes the id via

--- a/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsDemo.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using Rask.Example.Shared;
+
+namespace Rask.Example.Shared.Features;
+
+public sealed class FloatingLabelsDemo : Component
+{
+    private readonly AccountModel _model = new();
+    private string? _submission;
+
+    protected override RenderResult Render() =>
+    [
+        Form<AccountModel>(
+            _model,
+            m => _submission = $"Created account for {m.FullName} <{m.Email}>",
+            Class: "vstack gap-2")[
+            DataAnnotationsValidator(),
+            // One line per field — FloatingInput wraps Input + Label + ValidationMessage in
+            // Bootstrap's .form-floating markup. The type is inferred from the property (FullName/
+            // Email are text, Age is number); validation flows from the [Required]/[Range]/etc.
+            // attributes on AccountModel through DataAnnotationsValidator().
+            FloatingInput(() => _model.FullName, "Full name"),
+            FloatingInput(() => _model.Email, "Email address"),
+            FloatingInput(() => _model.Age, "Age"),
+            Div(Class: "mt-1")[
+                Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-person-plus me-1"), "Create account"]
+            ]
+        ],
+        _submission is null
+            ? Fragment()
+            : Div(Class: "alert alert-success small mt-3 mb-0")[I(Class: "bi bi-check-circle me-2"), _submission]
+    ];
+}
+
+public sealed class AccountModel
+{
+    [Required(ErrorMessage = "Full name is required.")]
+    [StringLength(60, MinimumLength = 2, ErrorMessage = "Full name must be 2–60 characters.")]
+    public string FullName { get; set; } = "";
+
+    [Required(ErrorMessage = "Email is required.")]
+    [EmailAddress(ErrorMessage = "Enter a valid email address.")]
+    public string Email { get; set; } = "";
+
+    [Range(18, 120, ErrorMessage = "Age must be between 18 and 120.")]
+    public int Age { get; set; }
+}

--- a/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsPage.cs
+++ b/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsPage.cs
@@ -1,0 +1,23 @@
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+[Route("floating-labels")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class FloatingLabelsPage : Component
+{
+    protected override RenderResult Head => Title()["Floating labels — Rask"];
+
+    protected override RenderResult Render() =>
+    [
+        PageHeader.Render(
+            "Floating labels",
+            "FloatingInput is a reusable example component (not framework code) that wraps Rask's Input, Label, and ValidationMessage in Bootstrap 5.3's .form-floating markup. It owns no validation state and needs no extra CSS — DataAnnotationsValidator() drives the messages, shown via Bootstrap's own .invalid-feedback .d-block utilities. One line per field, with the input type inferred from the bound property."),
+        H2(Class: "h4 mt-4 mb-3")["A floating-label form"],
+        CodeSample(
+            ["FloatingLabelsDemo.cs"],
+            Notes:
+            "Each field is a single FloatingInput(() => model.X, \"Label\") call. The id linking <label> to <input> is derived from the property name, and validation messages render only when the field is invalid — submit empty to see the feedback appear under each field.",
+            Result: FloatingLabelsDemo())
+    ];
+}

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.cs
@@ -40,6 +40,7 @@ public sealed class HomePage(Navigator nav) : Component
 
         ("Forms", "bi-arrow-left-right", "Two-way binding", "() => model.X bindings.", "/binding"),
         ("Forms", "bi-shield-check", "Validation", "Inline, DataAnnotations, FluentValidation.", "/validation"),
+        ("Forms", "bi-input-cursor-text", "Floating labels", "Bootstrap floating labels + validation.", "/floating-labels"),
         ("Forms", "bi-diagram-3", "Complex models", "Nested objects and collections.", "/nested-forms"),
         ("Forms", "bi-ui-radios", "Radio & checkbox", "RadioGroup and CheckboxGroup.", "/form-groups"),
 

--- a/samples/Rask.Example.Shared/Shared/FloatingInput.cs
+++ b/samples/Rask.Example.Shared/Shared/FloatingInput.cs
@@ -1,0 +1,42 @@
+using System.Linq.Expressions;
+
+namespace Rask.Example.Shared;
+
+// A reusable Bootstrap 5.3 floating-label text input, built only from Rask's public form
+// primitives — Input + Label + ValidationMessage wrapped in Bootstrap's `.form-floating` markup
+// (https://getbootstrap.com/docs/5.3/forms/floating-labels/). It owns no validation state and needs
+// no extra CSS: the framework's ValidationMessage reads the EditContext, and the error text uses
+// Bootstrap's own `.invalid-feedback .d-block` utilities so it shows without an `.is-invalid` toggle.
+// Pairs with any validator dropped into the surrounding Form — DataAnnotationsValidator(),
+// FluentValidationValidator(…), or a per-field Validate:.
+//
+// Generic so the typed Bind expression can be handed straight to Input(Bind, …) in Render; TProp is
+// inferred from the lambda at the call site, e.g. FloatingInput(() => model.Name, "Name").
+public sealed class FloatingInput<TProp> : Component
+{
+    public required Expression<Func<TProp>> Bind { get; set; }
+    public required string LabelText { get; set; }
+
+    // Derived from the bound property name so <label for> matches <input id> without a manual id.
+    private string Id => "ff-" + FieldName(Bind);
+
+    // Input infers its type from TProp (text/number/date/…). Bootstrap floating labels REQUIRE a
+    // placeholder. ValidationMessage renders nothing until the field has messages; `d-block` forces
+    // the feedback visible without an `.is-invalid` sibling toggle.
+    protected override RenderResult Render() =>
+        Div(Class: "form-floating mb-3")[
+            Input(Bind, Id: Id, Placeholder: LabelText, Class: "form-control"),
+            Label(Id)[LabelText],
+            ValidationMessage(Bind, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]])
+        ];
+
+    // Public System.Linq.Expressions reflection only — no EditContext, no internal Rask APIs.
+    private static string FieldName(LambdaExpression expr)
+    {
+        var body = expr.Body is UnaryExpression { NodeType: ExpressionType.Convert } u ? u.Operand : expr.Body;
+        return body is MemberExpression m
+            ? m.Member.Name
+            : throw new ArgumentException(
+                $"FloatingInput.Bind must be a property access, e.g. () => model.Name. Got: {expr}", nameof(expr));
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -37,6 +37,7 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
         ("/boom", "Error boundary", "bi-shield-exclamation", "Components", null),
         ("/binding", "Two-way binding", "bi-arrow-left-right", "Forms", null),
         ("/validation", "Validation", "bi-shield-check", "Forms", null),
+        ("/floating-labels", "Floating labels", "bi-input-cursor-text", "Forms", null),
         ("/nested-forms", "Complex models", "bi-diagram-3", "Forms", null),
         ("/form-groups", "Radio & checkbox", "bi-ui-radios", "Forms", null),
         ("/svg", "SVG", "bi-vector-pen", "DSL", null),

--- a/tests/Rask.Example.Shared.Tests/Demos/FloatingLabelsDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/FloatingLabelsDemoTests.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+using Rask.Example.Shared.Features;
+using Rask.Example.Shared.Tests.Infrastructure;
+using static Rask.Example.Shared.Features.Generated;
+
+namespace Rask.Example.Shared.Tests.Demos;
+
+public sealed class FloatingLabelsDemoTests
+{
+    [Fact]
+    public void FloatingLabelsDemo_Render_EmitsFloatingFieldsAndLinkedLabels()
+    {
+        var html = new LiveHost(() => FloatingLabelsDemo(), TestServices.Default()).RenderAsLiveRoot();
+
+        // Bootstrap floating-label markup: a .form-floating wrapper around a .form-control input.
+        Assert.Contains("form-floating", html);
+        Assert.Contains("form-control", html);
+
+        // Ids are derived from the bound property name (ff-{Property}) and the label links to them.
+        foreach (var prop in new[] { "FullName", "Email", "Age" })
+        {
+            Assert.Contains($"id=\"ff-{prop}\"", html);
+            Assert.Contains($"for=\"ff-{prop}\"", html);
+        }
+
+        Assert.Contains(">Create account<", html);
+        // No messages until a failed submit.
+        Assert.DoesNotContain("invalid-feedback", html);
+    }
+
+    [Fact]
+    public void AccountModel_Empty_FailsRequiredAndAgeRange()
+    {
+        var errors = Validate(new AccountModel());
+        Assert.Contains(errors, e => e.MemberNames.Contains("FullName"));
+        Assert.Contains(errors, e => e.MemberNames.Contains("Email"));
+        Assert.Contains(errors, e => e.MemberNames.Contains("Age"));
+    }
+
+    [Fact]
+    public void AccountModel_ValidValues_HasNoErrors()
+    {
+        var model = new AccountModel { FullName = "Pat Lee", Email = "pat@example.com", Age = 30 };
+        Assert.Empty(Validate(model));
+    }
+
+    private static List<ValidationResult> Validate(object instance)
+    {
+        var ctx = new ValidationContext(instance);
+        var results = new List<ValidationResult>();
+        Validator.TryValidateObject(instance, ctx, results, true);
+        return results;
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -460,6 +460,22 @@ public abstract partial class SharedSmokeTests
             .ToContainTextAsync("taken",
                 new LocatorAssertionsToContainTextOptions { Timeout = 10_000, IgnoreCase = true });
 
+        // Floating labels: the reusable FloatingInput wrapper. An empty submit surfaces the Bootstrap
+        // .invalid-feedback under a field (shown via .d-block, no is-invalid toggle); a valid submit
+        // reaches the success banner. (FloatingInput's structure/id derivation is unit-tested.)
+        await SideAsync("Floating labels", "Floating labels");
+        var floatingForm = Page.Locator("form:has(#ff-FullName)");
+        await floatingForm.Locator("button[type=submit]").ClickAsync();
+        await Expect(floatingForm.Locator(".invalid-feedback").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await floatingForm.Locator("#ff-FullName").FillAsync("Ada Lovelace");
+        await floatingForm.Locator("#ff-Email").FillAsync("ada@example.com");
+        await floatingForm.Locator("#ff-Age").FillAsync("30");
+        await floatingForm.Locator("button[type=submit]").ClickAsync();
+        await Expect(Page.Locator(".sample-result-body .alert-success")
+                .Filter(new LocatorFilterOptions { HasText = "Ada Lovelace" }))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+
         // Complex models (nested forms): render smoke (nested binding/validation is unit-tested).
         await SideAsync("Complex models", "Complex models");
 


### PR DESCRIPTION
## Summary
Adds `FloatingInput<TProp>`, a reusable **example** component (no shipped-package change) that wraps Rask's `Input` + `Label` + `ValidationMessage` in Bootstrap 5.3's `.form-floating` markup. Call it with one line per field — `FloatingInput(() => model.X, "Label")` — and the input type is inferred from `TProp` while the `<label for>`↔`<input id>` link is derived from the bound property. It owns no validation state and needs no extra CSS: errors render through `ValidationMessage` using Bootstrap's `.invalid-feedback .d-block` utilities, so it pairs with any validator dropped into the surrounding `Form`. Surfaced on a new `/floating-labels` page under the Forms nav group (with `CodeSample`-embedded source) and a Home feature card.

## Testing
- Unit: `Rask.Example.Shared.Tests` — **257/257 passed** (incl. new `FloatingLabelsDemoTests`: `.form-floating` structure, derived `ff-{Prop}` ids, label/input linkage, model validation). Full solution builds with `-warnaserror` (0 warnings); `dotnet format` clean; WASM `dotnet publish -c Release` is IL/trim-clean.
- E2E (`samples/` changed): host **Server** — **passed** (`ServerExampleTests.Journey_WalksEveryPageAndUnusualActivity`, 38s). New `/floating-labels` branch: empty submit surfaces `.invalid-feedback`; a valid submit reaches the success banner.

## Benchmarks
n/a — example-only change, no render/runtime hot-path code touched.

## CHANGELOG
- [Unreleased] entry added: Floating-label form input showcase (samples only).
