### PR TITLE
feat(samples): add floating select + textarea, derive labels from [Display]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
-- **Floating-label form input showcase (samples only).** A reusable `FloatingInput<TProp>` example
-  component (`samples/Rask.Example.Shared/Shared/FloatingInput.cs`) wraps Rask's `Input` + `Label` +
+- **Floating-label form controls showcase (samples only).** Reusable `FloatingInput<TProp>`,
+  `FloatingSelect<TProp>`, and `FloatingTextarea<TProp>` example components
+  (`samples/Rask.Example.Shared/Shared/`) wrap Rask's `Input`/`Select`/`Textarea` + `Label` +
   `ValidationMessage` in Bootstrap 5.3's `.form-floating` markup — one line per field, with the id
-  derived from the bound property and the input type inferred from `TProp`. It owns no validation
-  state and needs no extra CSS (errors show via Bootstrap's `.invalid-feedback .d-block`). Surfaced
-  on a new `/floating-labels` page under the Forms nav group.
+  derived from the bound property, the label read from its `[Display(Name)]` attribute, and the
+  input type inferred from `TProp`. They own no validation state and need no extra CSS (errors show
+  via Bootstrap's `.invalid-feedback .d-block`). Surfaced on a new `/floating-labels` page under the
+  Forms nav group.
 
 ### Security
 - **`CSS.escape` the ElementRef reviver selector (both runtimes).** The client reviver that

--- a/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsDemo.cs
@@ -15,13 +15,21 @@ public sealed class FloatingLabelsDemo : Component
             m => _submission = $"Created account for {m.FullName} <{m.Email}>",
             Class: "vstack gap-2")[
             DataAnnotationsValidator(),
-            // One line per field — FloatingInput wraps Input + Label + ValidationMessage in
-            // Bootstrap's .form-floating markup. The type is inferred from the property (FullName/
-            // Email are text, Age is number); validation flows from the [Required]/[Range]/etc.
-            // attributes on AccountModel through DataAnnotationsValidator().
-            FloatingInput(() => _model.FullName, "Full name"),
-            FloatingInput(() => _model.Email, "Email address"),
-            FloatingInput(() => _model.Age, "Age"),
+            // One line per field — the Floating* components wrap Input/Select/Textarea + Label +
+            // ValidationMessage in Bootstrap's .form-floating markup. The label is read from each
+            // property's [Display(Name)], the input type is inferred from the property's CLR type,
+            // and validation flows from the [Required]/[Range]/etc. attributes through
+            // DataAnnotationsValidator(). Every property is nullable — Rask clears to null.
+            FloatingInput(() => _model.FullName),
+            FloatingInput(() => _model.Email),
+            FloatingInput(() => _model.Age),
+            FloatingSelect(() => _model.Plan)[
+                Option("")["— choose —"],
+                Option("free")["Free"],
+                Option("pro")["Pro"],
+                Option("team")["Team"]
+            ],
+            FloatingTextarea(() => _model.Bio),
             Div(Class: "mt-1")[
                 Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-person-plus me-1"), "Create account"]
             ]
@@ -34,14 +42,25 @@ public sealed class FloatingLabelsDemo : Component
 
 public sealed class AccountModel
 {
+    [Display(Name = "Full name")]
     [Required(ErrorMessage = "Full name is required.")]
     [StringLength(60, MinimumLength = 2, ErrorMessage = "Full name must be 2–60 characters.")]
-    public string FullName { get; set; } = "";
+    public string? FullName { get; set; }
 
+    [Display(Name = "Email address")]
     [Required(ErrorMessage = "Email is required.")]
     [EmailAddress(ErrorMessage = "Enter a valid email address.")]
-    public string Email { get; set; } = "";
+    public string? Email { get; set; }
 
+    [Display(Name = "Age")]
     [Range(18, 120, ErrorMessage = "Age must be between 18 and 120.")]
-    public int Age { get; set; }
+    public int? Age { get; set; }
+
+    [Display(Name = "Plan")]
+    [Required(ErrorMessage = "Pick a plan.")]
+    public string? Plan { get; set; }
+
+    [Display(Name = "Short bio")]
+    [StringLength(200, ErrorMessage = "Bio must be 200 characters or fewer.")]
+    public string? Bio { get; set; }
 }

--- a/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsPage.cs
+++ b/samples/Rask.Example.Shared/Features/FloatingLabels/FloatingLabelsPage.cs
@@ -12,7 +12,7 @@ public sealed class FloatingLabelsPage : Component
     [
         PageHeader.Render(
             "Floating labels",
-            "FloatingInput is a reusable example component (not framework code) that wraps Rask's Input, Label, and ValidationMessage in Bootstrap 5.3's .form-floating markup. It owns no validation state and needs no extra CSS — DataAnnotationsValidator() drives the messages, shown via Bootstrap's own .invalid-feedback .d-block utilities. One line per field, with the input type inferred from the bound property."),
+            "FloatingInput, FloatingSelect, and FloatingTextarea are reusable example components (not framework code) that wrap Rask's Input/Select/Textarea + Label + ValidationMessage in Bootstrap 5.3's .form-floating markup. They own no validation state and need no extra CSS — DataAnnotationsValidator() drives the messages, shown via Bootstrap's own .invalid-feedback .d-block utilities. One line per field, with the input type inferred from the bound property."),
         H2(Class: "h4 mt-4 mb-3")["A floating-label form"],
         CodeSample(
             ["FloatingLabelsDemo.cs"],

--- a/samples/Rask.Example.Shared/Shared/FloatingField.cs
+++ b/samples/Rask.Example.Shared/Shared/FloatingField.cs
@@ -1,0 +1,25 @@
+using System.ComponentModel.DataAnnotations;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace Rask.Example.Shared;
+
+// Shared by FloatingInput / FloatingSelect / FloatingTextarea: resolves the bound property once into
+// the control id (ff-{Name}) and its label. The label is the property's [Display(Name)] when present,
+// otherwise the property name. Public System.Linq.Expressions/reflection only — no EditContext, no
+// internal Rask APIs.
+internal static class FloatingField
+{
+    public static (string Id, string Label) Resolve(LambdaExpression bind)
+    {
+        var body = bind.Body is UnaryExpression { NodeType: ExpressionType.Convert } u ? u.Operand : bind.Body;
+        if (body is not MemberExpression { Member: PropertyInfo prop })
+        {
+            throw new ArgumentException(
+                $"Bind must be a property access, e.g. () => model.Name. Got: {bind}", nameof(bind));
+        }
+
+        var label = prop.GetCustomAttribute<DisplayAttribute>()?.GetName() ?? prop.Name;
+        return ("ff-" + prop.Name, label);
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/FloatingInput.cs
+++ b/samples/Rask.Example.Shared/Shared/FloatingInput.cs
@@ -11,32 +11,23 @@ namespace Rask.Example.Shared;
 // FluentValidationValidator(…), or a per-field Validate:.
 //
 // Generic so the typed Bind expression can be handed straight to Input(Bind, …) in Render; TProp is
-// inferred from the lambda at the call site, e.g. FloatingInput(() => model.Name, "Name").
+// inferred from the lambda at the call site. The label comes from the bound property's
+// [Display(Name)] attribute (falling back to the property name), so a field is just:
+//   FloatingInput(() => model.Name)
 public sealed class FloatingInput<TProp> : Component
 {
     public required Expression<Func<TProp>> Bind { get; set; }
-    public required string LabelText { get; set; }
-
-    // Derived from the bound property name so <label for> matches <input id> without a manual id.
-    private string Id => "ff-" + FieldName(Bind);
 
     // Input infers its type from TProp (text/number/date/…). Bootstrap floating labels REQUIRE a
     // placeholder. ValidationMessage renders nothing until the field has messages; `d-block` forces
     // the feedback visible without an `.is-invalid` sibling toggle.
-    protected override RenderResult Render() =>
-        Div(Class: "form-floating mb-3")[
-            Input(Bind, Id: Id, Placeholder: LabelText, Class: "form-control"),
-            Label(Id)[LabelText],
+    protected override RenderResult Render()
+    {
+        var (id, label) = FloatingField.Resolve(Bind);
+        return Div(Class: "form-floating mb-3")[
+            Input(Bind, Id: id, Placeholder: label, Class: "form-control"),
+            Label(id)[label],
             ValidationMessage(Bind, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]])
         ];
-
-    // Public System.Linq.Expressions reflection only — no EditContext, no internal Rask APIs.
-    private static string FieldName(LambdaExpression expr)
-    {
-        var body = expr.Body is UnaryExpression { NodeType: ExpressionType.Convert } u ? u.Operand : expr.Body;
-        return body is MemberExpression m
-            ? m.Member.Name
-            : throw new ArgumentException(
-                $"FloatingInput.Bind must be a property access, e.g. () => model.Name. Got: {expr}", nameof(expr));
     }
 }

--- a/samples/Rask.Example.Shared/Shared/FloatingSelect.cs
+++ b/samples/Rask.Example.Shared/Shared/FloatingSelect.cs
@@ -1,0 +1,26 @@
+using System.Linq.Expressions;
+
+namespace Rask.Example.Shared;
+
+// Bootstrap 5.3 floating-label <select> — the sibling of FloatingInput for dropdowns
+// (https://getbootstrap.com/docs/5.3/forms/floating-labels/#selects). Same contract: no validation
+// state of its own, no extra CSS, label from the bound property's [Display(Name)]. The <option>s are
+// passed as children, so include an empty first option for the label to float over when nothing is
+// selected:
+//
+//   FloatingSelect(() => model.Plan)[Option("")["— choose —"], Option("pro")["Pro"]]
+public sealed class FloatingSelect<TProp> : Component
+{
+    public required Expression<Func<TProp>> Bind { get; set; }
+
+    protected override RenderResult Render()
+    {
+        var (id, label) = FloatingField.Resolve(Bind);
+        return Div(Class: "form-floating mb-3")[
+            // form-select (not form-control); the caller's <option>s flow in as Children.
+            Select(Bind, Id: id, Class: "form-select")[Children ?? Array.Empty<Child>()],
+            Label(id)[label],
+            ValidationMessage(Bind, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]])
+        ];
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/FloatingTextarea.cs
+++ b/samples/Rask.Example.Shared/Shared/FloatingTextarea.cs
@@ -1,0 +1,23 @@
+using System.Linq.Expressions;
+
+namespace Rask.Example.Shared;
+
+// Bootstrap 5.3 floating-label <textarea> — the sibling of FloatingInput for multi-line text
+// (https://getbootstrap.com/docs/5.3/forms/floating-labels/#textareas). Same contract: no validation
+// state of its own, no extra CSS, label from the bound property's [Display(Name)]. Floating-label
+// textareas need a placeholder and a fixed height for the label to sit correctly, so a default
+// height is applied.
+public sealed class FloatingTextarea<TProp> : Component
+{
+    public required Expression<Func<TProp>> Bind { get; set; }
+
+    protected override RenderResult Render()
+    {
+        var (id, label) = FloatingField.Resolve(Bind);
+        return Div(Class: "form-floating mb-3")[
+            Textarea(Bind, Id: id, Placeholder: label, Class: "form-control", Style: "height: 6rem"),
+            Label(id)[label],
+            ValidationMessage(Bind, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]])
+        ];
+    }
+}

--- a/tests/Rask.Example.Shared.Tests/Demos/FloatingLabelsDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/FloatingLabelsDemoTests.cs
@@ -12,16 +12,22 @@ public sealed class FloatingLabelsDemoTests
     {
         var html = new LiveHost(() => FloatingLabelsDemo(), TestServices.Default()).RenderAsLiveRoot();
 
-        // Bootstrap floating-label markup: a .form-floating wrapper around a .form-control input.
+        // Bootstrap floating-label markup across all three controls.
         Assert.Contains("form-floating", html);
-        Assert.Contains("form-control", html);
+        Assert.Contains("form-control", html);   // input + textarea
+        Assert.Contains("form-select", html);    // select
 
         // Ids are derived from the bound property name (ff-{Property}) and the label links to them.
-        foreach (var prop in new[] { "FullName", "Email", "Age" })
+        foreach (var prop in new[] { "FullName", "Email", "Age", "Plan", "Bio" })
         {
             Assert.Contains($"id=\"ff-{prop}\"", html);
             Assert.Contains($"for=\"ff-{prop}\"", html);
         }
+
+        // Labels come from the model's [Display(Name)] attributes, not the property names.
+        Assert.Contains(">Full name<", html);
+        Assert.Contains(">Email address<", html);
+        Assert.Contains(">Short bio<", html);
 
         Assert.Contains(">Create account<", html);
         // No messages until a failed submit.
@@ -29,18 +35,25 @@ public sealed class FloatingLabelsDemoTests
     }
 
     [Fact]
-    public void AccountModel_Empty_FailsRequiredAndAgeRange()
+    public void AccountModel_Empty_FailsRequiredFields()
     {
         var errors = Validate(new AccountModel());
         Assert.Contains(errors, e => e.MemberNames.Contains("FullName"));
         Assert.Contains(errors, e => e.MemberNames.Contains("Email"));
-        Assert.Contains(errors, e => e.MemberNames.Contains("Age"));
+        Assert.Contains(errors, e => e.MemberNames.Contains("Plan"));
     }
 
     [Fact]
     public void AccountModel_ValidValues_HasNoErrors()
     {
-        var model = new AccountModel { FullName = "Pat Lee", Email = "pat@example.com", Age = 30 };
+        var model = new AccountModel
+        {
+            FullName = "Pat Lee",
+            Email = "pat@example.com",
+            Age = 30,
+            Plan = "pro",
+            Bio = "Hello"
+        };
         Assert.Empty(Validate(model));
     }
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -460,9 +460,10 @@ public abstract partial class SharedSmokeTests
             .ToContainTextAsync("taken",
                 new LocatorAssertionsToContainTextOptions { Timeout = 10_000, IgnoreCase = true });
 
-        // Floating labels: the reusable FloatingInput wrapper. An empty submit surfaces the Bootstrap
-        // .invalid-feedback under a field (shown via .d-block, no is-invalid toggle); a valid submit
-        // reaches the success banner. (FloatingInput's structure/id derivation is unit-tested.)
+        // Floating labels: the reusable Floating* wrappers (input/select/textarea). An empty submit
+        // surfaces the Bootstrap .invalid-feedback under a field (shown via .d-block, no is-invalid
+        // toggle); a valid submit reaches the success banner. (Structure/id/label derivation is
+        // unit-tested.)
         await SideAsync("Floating labels", "Floating labels");
         var floatingForm = Page.Locator("form:has(#ff-FullName)");
         await floatingForm.Locator("button[type=submit]").ClickAsync();
@@ -471,6 +472,7 @@ public abstract partial class SharedSmokeTests
         await floatingForm.Locator("#ff-FullName").FillAsync("Ada Lovelace");
         await floatingForm.Locator("#ff-Email").FillAsync("ada@example.com");
         await floatingForm.Locator("#ff-Age").FillAsync("30");
+        await floatingForm.Locator("#ff-Plan").SelectOptionAsync("pro");
         await floatingForm.Locator("button[type=submit]").ClickAsync();
         await Expect(Page.Locator(".sample-result-body .alert-success")
                 .Filter(new LocatorFilterOptions { HasText = "Ada Lovelace" }))


### PR DESCRIPTION
## Summary
Follow-up to #138. Adds `FloatingSelect<TProp>` and `FloatingTextarea<TProp>` alongside `FloatingInput`, so all three Bootstrap floating-label controls exist as reusable **example** components. They share a small `FloatingField` helper that resolves the control id and reads the label from the bound property's `[Display(Name)]` attribute — so the `LabelText` param is gone and a field is just `FloatingInput(() => model.X)`. The `AccountModel` DTO properties are now nullable to exercise Rask's clear-to-null binding. The `/floating-labels` demo, unit tests, and shared-journey E2E all cover the three controls.

## Testing
- Unit: `Rask.Example.Shared.Tests` — **257/257 passed** (incl. updated `FloatingLabelsDemoTests`: `.form-floating`/`.form-control`/`.form-select` markup, derived `ff-{Prop}` ids for all five fields, `[Display]`-sourced label text, nullable-model validation). Full solution builds with `-warnaserror` (0 warnings); `dotnet format` clean; WASM `dotnet publish -c Release` is IL/trim-clean (the `[Display]` reflection is preserved by the same path as DataAnnotations validation).
- E2E (`samples/` changed): host **Server** — **passed** (`ServerExampleTests`, 38s). Empty submit surfaces `.invalid-feedback`; filling the inputs, selecting a plan, and submitting reaches the success banner.

## Benchmarks
n/a — example-only change, no render/runtime hot-path code touched.

## CHANGELOG
- [Unreleased] entry updated to cover all three floating-label controls + `[Display]`-sourced labels.
