### PR TITLE
feat(forms)!: MultiSelect bound/controlled modes + validation; move Checkbox/RadioGroup out of Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ them until tagged releases begin.
 ### Added
 - **Public binding API for custom form controls.** `ExpressionAccessor` (+ its `Accessor` record) and
   `BindingHelpers` (`ResolveBindingContext`, `FormatValue`) in `Rask.Core.Forms` are now public — the
-  same machinery `RadioGroup`/`CheckboxGroup` use, so consumers can build their own controls that bind
-  to a model property and drive the ambient `EditContext`. See `docs/forms.md` §9.
+  same machinery the sample `RadioGroup`/`CheckboxGroup`/`MultiSelect` use, so consumers can build their
+  own controls that bind to a model property and drive the ambient `EditContext`. `docs/forms.md` §9 is a
+  "building form components" guide. See also `EditContext.RegisterFieldValidator` for per-field rules.
 - **Multi-select showcase.** A reusable generic `MultiSelect<TItem>` example component
   (`samples/Rask.Example.Shared/Shared/MultiSelect.cs`) — a custom Bootstrap dropdown with removable
-  chips that binds to an `ICollection<TItem>` and validates like any bound field, with open/close
-  driven entirely by the server live diff (no client JS). Surfaced on a new `/multiselect` page under
-  the Forms nav group, alongside the built-in `CheckboxGroup`/`RadioGroup`.
+  chips, open/close + Esc / click-outside close driven entirely by the server live diff (no client JS).
+  Supports two shapes: **bound** (`() => model.Items` with `AfterBind`/`AfterBindAsync` post-bind hooks
+  and a per-field `Validate` rule, sync or async) and **controlled** (`Value` + `OnChange`/`OnChangeAsync`,
+  no `Bind`). Surfaced on the `/multiselect` page with both bound and controlled demos.
 - **Floating-label form controls showcase (samples only).** Reusable `FloatingInput<TProp>`,
   `FloatingSelect<TProp>`, and `FloatingTextarea<TProp>` example components
   (`samples/Rask.Example.Shared/Shared/`) wrap Rask's `Input`/`Select`/`Textarea` + `Label` +
@@ -25,6 +27,17 @@ them until tagged releases begin.
   input type inferred from `TProp`. They own no validation state and need no extra CSS (errors show
   via Bootstrap's `.invalid-feedback .d-block`). Surfaced on a new `/floating-labels` page under the
   Forms nav group.
+
+### Changed
+- **Moved `CheckboxGroup<TItem>` and `RadioGroup<TValue>` out of `Rask.Core` into the samples**
+  (`samples/Rask.Example.Shared/Shared/`), where they join `MultiSelect<TItem>` as copyable example
+  controls built on the public binding API — keeping `Rask.Core` minimal (the framework ships the
+  binding API, not a control library). They now render Bootstrap 5.3
+  [check markup](https://getbootstrap.com/docs/5.3/forms/checks-radios/) (`form-check` wrapper +
+  `form-check-input`/`form-check-label` with `id`/`for`); `ItemClass` now adds extra wrapper classes
+  (e.g. `form-check-inline`). **Breaking:** they are no longer part of `Rask.Core` — copy the sample
+  files into your project, or build equivalents on `ExpressionAccessor`/`BindingHelpers` (see
+  `docs/forms.md` §9).
 
 ### Removed
 - **Dropped the `TableModel<T>` headless-table primitive and the `Rask.Core.Tables` namespace**

--- a/README.md
+++ b/README.md
@@ -937,38 +937,46 @@ already applies to the root model (preserve its public properties via `[Dynamica
 `<TrimmerRootDescriptor>`) extends to every nested type. The full Forms/Complex-models showcase under `/nested-forms`
 demonstrates all four patterns side-by-side.
 
-#### Radio & checkbox groups
+#### Radio & checkbox groups (example components)
 
 `RadioGroup<TValue>` binds one value from a set of options; `CheckboxGroup<TItem>` binds an `ICollection<TItem>`,
-toggling each item in place. Both are transparent `Fragment`s built on the same `Input.Bound` machinery as the rest of
-the form, so changes flow through the `EditContext` (validation, touched-tracking) like any bound field:
+toggling each item in place. They are **example components that ship in the samples**
+(`samples/Rask.Example.Shared/Shared/`), not framework primitives — small, copyable controls built on the public
+binding API below. Both render a transparent `Fragment` with Bootstrap
+[check markup](https://getbootstrap.com/docs/5.3/forms/checks-radios/), so changes flow through the `EditContext`
+(validation, touched-tracking) like any bound field:
 
 ```csharp
 Form(_prefs)[
     RadioGroup(
         () => _prefs.Plan,                                  // single value
-        Options: new[] { Plan.Free, Plan.Pro, Plan.Team },
-        OptionLabel: p => Span()[p.ToString()]),
+        new[] { Plan.Free, Plan.Pro, Plan.Team },
+        ItemClass: "form-check-inline"),
 
     CheckboxGroup<string>(                                  // a collection — toggles in place
         () => _prefs.Interests,
-        Options: new[] { "Web", "Mobile", "AI", "Games" },
-        OptionLabel: t => Span()[t])
+        new[] { "Web", "Mobile", "AI", "Games" },
+        ItemClass: "form-check-inline")
 ]
 ```
 
 `CheckboxGroup` usually needs the explicit type argument (`CheckboxGroup<string>`) when the bound collection is a
-concrete `List<T>`. Membership is compared with `EqualityComparer<TItem>.Default`. Changing any option re-renders the
-component that declared the group, so a live summary updates immediately.
+concrete `List<T>`. Membership is compared with `EqualityComparer<TItem>.Default`. Because they return a `Fragment`
+(no component boundary), changing an option re-renders the component that declared the group, so a live summary updates
+immediately.
 
-#### Custom bound controls
+#### Building form components
 
-`RadioGroup`/`CheckboxGroup` are built on a small public API in `Rask.Core.Forms` you can reuse to write your own
-form-bound controls: `ExpressionAccessor.Parse(() => model.Prop)` yields a runtime accessor (target, getter, field),
-and `BindingHelpers.ResolveBindingContext(model)` resolves the surrounding `EditContext` so your handlers can call
-`NotifyFieldChanged` / `ValidateFieldAsync`. The showcase's `MultiSelect<TItem>` — a custom dropdown with removable
-chips bound to an `ICollection<TItem>`, open/close driven entirely by the live diff (no client JS) — is a worked
-example; see `docs/forms.md` §9 and the `/multiselect` page.
+Rask ships a small public binding API in `Rask.Core.Forms` rather than a large control library, so you write exactly
+the controls you need — `RadioGroup`/`CheckboxGroup` and the showcase `MultiSelect<TItem>` are built on it.
+`ExpressionAccessor.Parse(() => model.Prop)` yields a runtime accessor (target, getter, field);
+`BindingHelpers.ResolveBindingContext(model)` resolves the surrounding `EditContext` so your handlers can call
+`NotifyFieldChanged` / `ValidateFieldAsync`; `EditContext.RegisterFieldValidator` adds a per-field rule. A stateless
+control returns a `Fragment` (its handlers re-render the host for free, like a bound `Input`); a stateful one (an
+open/close dropdown) is a `Component` that keeps live feedback inside itself or exposes an auto-wrapped `OnChange`
+callback to refresh host-side UI. The showcase's `MultiSelect<TItem>` — a dropdown with removable chips, Esc /
+click-outside close (no client JS), bound and controlled modes, and a `Validate` rule — is the worked example; see
+`docs/forms.md` §9 and the `/multiselect` page.
 
 </details>
 

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -362,12 +362,13 @@ See `samples/Rask.Example.Shared/Features/NestedForms/NestedFormPage.cs` for all
 
 ---
 
-## 8. Radio & checkbox groups
+## 8. Radio & checkbox groups (example components)
 
 `RadioGroup<TValue>` binds one value from a set of options; `CheckboxGroup<TItem>` binds an
-`ICollection<TItem>`, toggling each item in place. Both are transparent `Fragment`s built on the same
-binding machinery, so changes flow through the `EditContext` (validation, touched-tracking) like any
-bound field.
+`ICollection<TItem>`, toggling each item in place. They are **example components that ship in the
+samples** (`samples/Rask.Example.Shared/Shared/`), not framework primitives — small, copyable controls
+built on the public binding API of §9. Both render a transparent `Fragment`, so changes flow through the
+`EditContext` (validation, touched-tracking) like any bound field.
 
 ```csharp
 public static Component RadioGroup<TValue>(
@@ -390,50 +391,60 @@ public static Component CheckboxGroup<TItem>(
 ```csharp
 Form(_prefs)[
     RadioGroup(() => _prefs.Plan,                       // single value
-        Options: new[] { Plan.Free, Plan.Pro, Plan.Team },
-        OptionLabel: p => Span()[p.ToString()]),
+        new[] { Plan.Free, Plan.Pro, Plan.Team },
+        ItemClass: "form-check-inline"),
 
     CheckboxGroup<string>(() => _prefs.Interests,       // a collection — toggles in place
-        Options: new[] { "Web", "Mobile", "AI", "Games" },
-        OptionLabel: t => Span()[t])
+        new[] { "Web", "Mobile", "AI", "Games" },
+        ItemClass: "form-check-inline")
 ]
 ```
 
 - The first positional argument is the `Bind` expression.
+- Each item renders Bootstrap 5.3
+  [check markup](https://getbootstrap.com/docs/5.3/forms/checks-radios/) — a
+  `<div class="form-check">` wrapping a `.form-check-input` and a `.form-check-label` tied together by
+  `id`/`for`. `ItemClass` adds extra classes to that wrapper (e.g. `"form-check-inline"`); `OptionLabel`
+  customizes the label content.
 - `RadioGroup` renders the option equal to the current value `checked`; the change handler sets the
-  bound property.
-- `CheckboxGroup` mutates the bound collection in place; membership is compared with
+  bound property. `CheckboxGroup` mutates the bound collection in place; membership is compared with
   `EqualityComparer<TItem>.Default`. You usually need the explicit type argument
   (`CheckboxGroup<string>`) when the bound collection is a concrete `List<T>`.
-- Each renders a transparent `Fragment` of `<label><input>…</label>` — control layout with
-  `OptionLabel` and `ItemClass`.
-- Changing an option re-renders the component that declared the group, so a live summary updates
-  immediately. Each change calls `NotifyFieldChanged` + `NotifyFieldTouched` + `ValidateFieldAsync`,
-  so DataAnnotations / FluentValidation rules on the bound property apply.
+- Because they return a `Fragment` (no component boundary of their own), changing an option re-renders
+  the component that declared the group — a live summary updates immediately. Each change calls
+  `NotifyFieldChanged` + `NotifyFieldTouched` + `ValidateFieldAsync`, so DataAnnotations /
+  FluentValidation rules on the bound property apply.
 
 See `samples/Rask.Example.Shared/Features/FormGroups/FormGroupsPage.cs`.
 
-## 9. Building a custom bound control (public binding API)
+## 9. Building form components (public binding API)
 
-`RadioGroup`/`CheckboxGroup` are built on a small public API in `Rask.Core.Forms` that you can use to
-write your own form-bound controls — anything that needs to read/write a model property and drive the
-ambient `EditContext`:
+Rask doesn't ship a large control library — instead it exposes a small public API in `Rask.Core.Forms`
+so you can write exactly the controls you need. `RadioGroup`/`CheckboxGroup` (§8) and the showcase
+`MultiSelect<TItem>` are built entirely on it. This section is the recipe.
+
+### The binding API
 
 - **`ExpressionAccessor.Parse(Expression)` → `Accessor`** — turns a `() => model.Prop` lambda into a
-  runtime accessor: `Target` (the owner instance), `Getter()`, `PropertyName`, `PropertyType`, and
-  `Field` (the `FieldIdentifier`). It accepts simple properties, nested chains, foreach-captured
-  locals, and indexer access on the inner expression (e.g. `() => model.Items[i].Name`).
-- **`BindingHelpers.ResolveBindingContext(object model)` → `EditContext?`** — resolves the
-  `EditContext` the surrounding `Form` will use (returns `null` outside a form/live render).
+  runtime accessor: `Target` (the owner instance), `Getter()`/`Setter(value)`, `PropertyName`,
+  `PropertyType`, and `Field` (the `FieldIdentifier`). Accepts simple properties, nested chains,
+  foreach-captured locals, and indexer access (e.g. `() => model.Items[i].Name`).
+- **`BindingHelpers.ResolveBindingContext(object model)` → `EditContext?`** — resolves the `EditContext`
+  the surrounding `Form` will use (returns `null` outside a form/live render).
 - **`BindingHelpers.FormatValue(object?)` → `string`** — the framework's value→string convention
   (invariant culture; the shapes `<input>` round-trips).
+- **`EditContext.RegisterFieldValidator(field, validate, valueGetter)`** — register a per-field
+  validator (a `Func<T, IEnumerable<string>>` or async
+  `Func<T, CancellationToken, ValueTask<IEnumerable<string>>>`). Always call it each render — passing
+  `null` clears a stale rule.
 
-A control reads the bound value during `Render`, and on each interaction mutates it, then calls
-`NotifyFieldChanged` / `NotifyFieldTouched` / `ValidateFieldAsync` on the resolved context:
+A bound control reads the value during `Render`, registers any validator, and on each interaction
+mutates the value then notifies/validates the field:
 
 ```csharp
 var acc = ExpressionAccessor.Parse(Bind);                 // Bind: Expression<Func<ICollection<T>>>
 var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
+ctx?.RegisterFieldValidator(acc.Field, Validate, () => acc.Getter());   // null clears a stale rule
 var selected = acc.Getter() as ICollection<T>;
 // …render options from `selected`…
 // in a click/change handler, after add/remove on the collection:
@@ -442,12 +453,38 @@ ctx?.NotifyFieldTouched(acc.Field);
 if (ctx is not null) await ctx.ValidateFieldAsync(acc.Field);
 ```
 
-If your control is a `Component` (so it can hold view state, like an open/closed dropdown), its own
-handlers re-render *it*, not the parent. Expose an `Action? OnChange` callback the consumer can pass
-(callbacks re-render the owning parent) so a live summary or sibling field updates as the selection
-changes.
+Surface field messages with `ValidationMessage(Bind, …)` (§2.Rendering messages) inside the control.
 
-The showcase's `MultiSelect<TItem>` (`samples/Rask.Example.Shared/Shared/MultiSelect.cs`) is a worked
-example: a custom Bootstrap dropdown with removable chips, bound to an `ICollection<TItem>`, open/close
-driven purely by the live diff (no client JS). See the `/multiselect` page, which also shows the
-built-in `CheckboxGroup`/`RadioGroup` alongside it.
+### Stateless (`Fragment`) vs stateful (`Component`) — and host re-render
+
+This is the one subtlety worth understanding:
+
+- A control with **no view state of its own** is best written as a static factory returning a
+  `Fragment` (like `CheckboxGroup`). Its `<input>` handlers are owned by the **host** component that
+  declared it (handler-owner resolution keeps the owner as the host when the handler isn't a
+  `Component`-targeted delegate), so a change re-renders the host for free — exactly like a bound
+  `Input`. Host-side derived UI (a live summary) just updates.
+- A control that **needs view state** (an open/closed dropdown) must be a `Component`. Now its own
+  handlers re-render *it*, not the host, so host-side derived UI would go stale. Two clean options:
+  - keep the live feedback **inside the control** (chips, an embedded `ValidationMessage`) — it refreshes
+    because the control re-renders itself; or
+  - expose an `Action<T>`/`Func<T,Task>` **callback** (`OnChange`) the consumer passes. Callback props on
+    a component are auto-wrapped (`AutoCallback`) so invoking them re-renders the component that owns the
+    handler — i.e. the host — so a host-side summary updates with no `StateHasChanged`.
+
+### Bound vs controlled
+
+Mirror `Input` and offer both shapes where it makes sense:
+
+- **Bound** — take a `Bind` expression and drive the `EditContext` (validation, touched-tracking). Add
+  `AfterBind`/`AfterBindAsync(value)` post-mutation hooks for consumer logic.
+- **Controlled** — take a `Value` + `OnChange`/`OnChangeAsync(newValue)` pair and let the parent own the
+  state (no `EditContext`, so no validation). Build a *new* collection rather than mutating `Value`.
+
+### Worked examples
+
+- `samples/Rask.Example.Shared/Shared/CheckboxGroup.cs` / `RadioGroup.cs` — minimal stateless
+  `Fragment` controls with per-field binding and validation.
+- `samples/Rask.Example.Shared/Shared/MultiSelect.cs` — a stateful `Component`: a Bootstrap dropdown
+  with removable chips, Esc / click-outside close (pure live-diff, no client JS), both bound (with a
+  `Validate` rule) and controlled (`Value` + auto-wrapped `OnChange`) modes. See the `/multiselect` page.

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Routing](docs/routing.md): `[Route]`, params, `Router()`/`Outlet()`, navigation.
 - [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
 - [Composition](docs/composition.md): children, context (provide/consume), callbacks, headless primitives (`VirtualizeModel<T>`), drag-and-drop.
-- [Forms](docs/forms.md): binding, validation, RadioGroup/CheckboxGroup, EditContext, public binding API (`ExpressionAccessor`/`BindingHelpers`) for custom bound controls.
+- [Forms](docs/forms.md): binding, validation, EditContext, building form components on the public binding API (`ExpressionAccessor`/`BindingHelpers`/`RegisterFieldValidator`) — RadioGroup/CheckboxGroup/MultiSelect are example controls in the samples, not framework primitives.
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.

--- a/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsDemo.cs
@@ -14,16 +14,14 @@ public sealed class FormGroupsDemo : Component
                 RadioGroup(
                     () => _prefs.Plan,
                     new[] { Plan.Free, Plan.Pro, Plan.Team },
-                    p => Span(Class: "ms-1 me-3")[p.ToString()],
-                    ItemClass: "form-check-label")
+                    ItemClass: "form-check-inline")
             ],
             Div(Class: "mb-3")[
                 Label(Class: "form-label fw-semibold d-block")["Interests"],
                 CheckboxGroup<string>(
                     () => _prefs.Interests,
                     new[] { "Web", "Mobile", "AI", "Games" },
-                    t => Span(Class: "ms-1 me-3")[t],
-                    ItemClass: "form-check-label")
+                    ItemClass: "form-check-inline")
             ],
             P(Class: "small text-secondary mb-0", Id: "groups-summary")[
                 $"Plan: {_prefs.Plan} · Interests: "

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectCheckboxDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectCheckboxDemo.cs
@@ -13,8 +13,7 @@ public sealed class MultiSelectCheckboxDemo : Component
                 CheckboxGroup<string>(
                     () => _prefs.Interests,
                     ["Web", "Mobile", "AI", "Games"],
-                    t => Span(Class: "ms-1 me-3")[t],
-                    ItemClass: "form-check-label")
+                    ItemClass: "form-check-inline")
             ],
             P(Class: "small text-secondary mb-0", Id: "ms-checkbox-summary")[
                 "Selected: " + (_prefs.Interests.Count == 0 ? "none" : string.Join(", ", _prefs.Interests))

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectControlledDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectControlledDemo.cs
@@ -1,0 +1,30 @@
+namespace Rask.Example.Shared.Features;
+
+// Controlled MultiSelect<TItem>: no Bind / EditContext. The parent owns the selection in its own field and
+// the control reports each change through OnChange (an OnChangeAsync variant also exists). Passing Value +
+// OnChange instead of Bind is the React-style controlled shape — useful when the selection is not a form
+// model property. The control still re-renders its host automatically, so the "Selected:" summary updates
+// without any StateHasChanged.
+public sealed class MultiSelectControlledDemo : Component
+{
+    private static readonly string[] AllTopics =
+        ["News", "Sports", "Tech", "Music", "Travel"];
+
+    private IReadOnlyCollection<string> _topics = [];
+
+    protected override RenderResult Render() =>
+        Div(Class: "vstack gap-3")[
+            Div()[
+                Label(Class: "form-label fw-semibold")["Topics"],
+                MultiSelect<string>(
+                    AllTopics,
+                    Value: _topics.ToList(),
+                    OnChange: next => _topics = next,
+                    Id: "ms-controlled",
+                    Placeholder: "Choose topics…")
+            ],
+            P(Class: "small text-secondary mb-0", Id: "ms-controlled-summary")[
+                "Selected: " + (_topics.Count == 0 ? "none" : string.Join(", ", _topics))
+            ]
+        ];
+}

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectDemo.cs
@@ -1,11 +1,10 @@
-using Rask.Core.Forms;
-
 namespace Rask.Example.Shared.Features;
 
-// The generic MultiSelect<TItem> bound to a model collection inside a Form: selecting/removing options
-// mutates model.Interests and a form-level Validate rule rejects fewer than two picks. OnChange =
-// StateHasChanged so the live summary re-renders as selections change. (A form-level inline validator
-// is used rather than a [MinLength] DataAnnotation so the WASM sample stays trim-clean.)
+// The generic MultiSelect<TItem> bound to a model collection inside a Form. A per-field Validate rule —
+// the same shape as Input's Validate — rejects fewer than two picks and surfaces its message inline through
+// the control's own ValidationMessage. Live feedback (the chips and the validation message) lives inside the
+// control, so it refreshes as you select without any StateHasChanged. (An inline Validate is used rather
+// than a [MinLength] DataAnnotation so the WASM sample stays trim-clean.)
 public sealed class MultiSelectDemo : Component
 {
     private static readonly string[] AllInterests =
@@ -14,37 +13,23 @@ public sealed class MultiSelectDemo : Component
     private readonly Prefs _prefs = new();
     private string? _submission;
 
-    private static Component SummaryAlert(IReadOnlyList<ValidationEntry> entries)
-    {
-        var formOnly = entries.Where(e => e.Field.Length == 0).ToList();
-        return formOnly.Count == 0
-            ? Fragment()
-            : Div(Class: "alert alert-danger small mb-0")[
-                Ul(Class: "mb-0 ps-3")[formOnly.Select((e, i) => Li(Key: i)[e.Message])]
-            ];
-    }
-
     protected override RenderResult Render() =>
     [
         Form(
             _prefs,
             OnValidSubmit: m => _submission = $"Saved {m.Interests.Count} interest(s)",
-            Class: "vstack gap-3",
-            Validate: m =>
-                m.Interests.Count >= 2 ? Array.Empty<string>() : new[] { "Pick at least two interests." })[
+            Class: "vstack gap-3")[
             Div()[
                 Label(Class: "form-label fw-semibold")["Interests"],
                 MultiSelect<string>(
                     () => _prefs.Interests,
                     AllInterests,
+                    Validate: interests => interests.Count >= 2
+                        ? Array.Empty<string>()
+                        : ["Pick at least two interests."],
                     Id: "ms-interests",
-                    Placeholder: "Pick a few…",
-                    OnChange: StateHasChanged)
+                    Placeholder: "Pick a few…")
             ],
-            P(Class: "small text-secondary mb-0", Id: "ms-summary")[
-                "Selected: " + (_prefs.Interests.Count == 0 ? "none" : string.Join(", ", _prefs.Interests))
-            ],
-            ValidationSummary(SummaryAlert),
             Div()[
                 Button("submit", Class: "btn btn-primary")[I(Class: "bi bi-check2-circle me-1"), "Save"]
             ]

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectPage.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectPage.cs
@@ -12,23 +12,30 @@ public sealed class MultiSelectPage : Component
     [
         PageHeader.Render(
             "Multi-select",
-            "Selecting many values into a form model. MultiSelect<T> is a reusable example component — a "
-            + "custom dropdown with removable chips — built on the public binding API (ExpressionAccessor + "
-            + "BindingHelpers), so it binds to an ICollection and drives validation. CheckboxGroup<T> and "
-            + "RadioGroup<T> are the built-in framework primitives for the same job."),
-        H2(Class: "h4 mt-4 mb-3")["MultiSelect<T> — dropdown + chips"],
+            "Selecting many values. MultiSelect<T> is a reusable example component — a custom dropdown with "
+            + "removable chips — built on the public binding API (ExpressionAccessor + BindingHelpers). It "
+            + "supports two shapes: bound (an ICollection model property, with validation) and controlled "
+            + "(Value + OnChange). CheckboxGroup<T> and RadioGroup<T> are smaller example components for the "
+            + "same job. See the \"building form components\" guide for how to write your own."),
+        H2(Class: "h4 mt-4 mb-3")["MultiSelect<T> — bound, dropdown + chips"],
         CodeSample(
             ["MultiSelectDemo.cs", "MultiSelect.cs"],
-            Notes: "Bound to a List<string> with a form-level \"pick at least two\" rule — open the dropdown, "
-                + "pick options (they appear as chips), and submit to see validation.",
+            Notes: "Bound to a List<string> with a per-field \"pick at least two\" Validate rule — open the "
+                + "dropdown, pick options (they appear as chips), Esc or click outside to close, and submit "
+                + "to see validation. The summary updates with no StateHasChanged.",
             Result: MultiSelectDemo()),
-        H2(Class: "h4 mt-5 mb-3")["CheckboxGroup<T> — built-in, many values"],
+        H2(Class: "h4 mt-5 mb-3")["MultiSelect<T> — controlled (Value + OnChange)"],
         CodeSample(
-            ["MultiSelectCheckboxDemo.cs"],
+            ["MultiSelectControlledDemo.cs"],
+            Notes: "No Bind: the parent owns the selection and MultiSelect reports changes through OnChange.",
+            Result: MultiSelectControlledDemo()),
+        H2(Class: "h4 mt-5 mb-3")["CheckboxGroup<T> — example, many values"],
+        CodeSample(
+            ["MultiSelectCheckboxDemo.cs", "CheckboxGroup.cs"],
             Result: MultiSelectCheckboxDemo()),
-        H2(Class: "h4 mt-5 mb-3")["RadioGroup<T> — built-in, single value"],
+        H2(Class: "h4 mt-5 mb-3")["RadioGroup<T> — example, single value"],
         CodeSample(
-            ["MultiSelectRadioDemo.cs"],
+            ["MultiSelectRadioDemo.cs", "RadioGroup.cs"],
             Result: MultiSelectRadioDemo())
     ];
 }

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectRadioDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectRadioDemo.cs
@@ -13,8 +13,7 @@ public sealed class MultiSelectRadioDemo : Component
                 RadioGroup(
                     () => _prefs.Plan,
                     [Tier.Free, Tier.Pro, Tier.Team],
-                    p => Span(Class: "ms-1 me-3")[p.ToString()],
-                    ItemClass: "form-check-label")
+                    ItemClass: "form-check-inline")
             ],
             P(Class: "small text-secondary mb-0", Id: "ms-radio-summary")[$"Plan: {_prefs.Plan}"]
         ];

--- a/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
@@ -1,11 +1,14 @@
 using System.Linq.Expressions;
 using Rask.Core.Forms;
 
-namespace Rask.Core.Components;
+namespace Rask.Example.Shared;
 
-// Hand-written generic factory: binds an ICollection<TItem> model property to a set of checkboxes,
-// one per option. Toggling an option adds/removes it from the bound collection (mutated in place)
-// and re-validates the field. Returns a transparent Fragment so the consumer owns layout.
+// Example generic form control: binds an ICollection<TItem> model property to a set of checkboxes, one per
+// option. Toggling an option adds/removes it from the bound collection (mutated in place) and re-validates
+// the field. Emits Bootstrap 5.3 check markup (https://getbootstrap.com/docs/5.3/forms/checks-radios/):
+// each item is a <div class="form-check"> wrapping a .form-check-input and a .form-check-label tied together
+// by id/for. ItemClass adds extra classes to that wrapper (e.g. "form-check-inline"). Returns a transparent
+// Fragment so the consumer owns the surrounding layout.
 public static partial class Generated
 {
     public static Component CheckboxGroup<TItem>(
@@ -25,22 +28,26 @@ public static partial class Generated
         var groupName = Name ?? acc.PropertyName;
         var selected = acc.Getter() as ICollection<TItem>;
         var comparer = EqualityComparer<TItem>.Default;
+        var wrapperClass = ItemClass is null ? "form-check" : $"form-check {ItemClass}";
 
         var children = new List<Child>();
         var index = 0;
         foreach (var option in Options)
         {
             var optionValue = option; // capture per iteration
+            var optionId = $"{groupName}-{index}";
             var isChecked = selected is not null && Contains(selected, optionValue, comparer);
-            var label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
+            Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
-            children.Add(Label(Class: ItemClass)[
+            children.Add(Div(Class: wrapperClass, Key: index)[
                 Input(
                     "checkbox",
                     groupName,
                     BindingHelpers.FormatValue(option),
                     Checked: isChecked,
                     Disabled: Disabled,
+                    Class: "form-check-input",
+                    Id: optionId,
                     // The checkbox change payload carries the new checked state as a bool string.
                     OnChangeAsync: async value =>
                     {
@@ -68,14 +75,13 @@ public static partial class Generated
                         {
                             await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
                         }
-                    },
-                    Key: index),
-                label
+                    }),
+                Label(Class: "form-check-label", For: optionId)[label]
             ]);
             index++;
         }
 
-        return new Fragment(children);
+        return Fragment()[children];
     }
 
     private static bool Contains<TItem>(ICollection<TItem> collection, TItem item, IEqualityComparer<TItem> comparer)

--- a/samples/Rask.Example.Shared/Shared/MultiSelect.cs
+++ b/samples/Rask.Example.Shared/Shared/MultiSelect.cs
@@ -1,44 +1,93 @@
 using System.Linq.Expressions;
 using Rask.Core.Forms;
+using Rask.Core.Live;
 
 namespace Rask.Example.Shared;
 
 // Generic multiselect: a custom Bootstrap dropdown of checkable options with the chosen items shown as
-// removable chips. Unlike the native <select multiple>, it binds to an ICollection<TItem> model property
-// and drives the ambient EditContext (validation) — the same contract as CheckboxGroup<TItem>. Open/close
-// is pure server live-diff state (no client JS; the showcase loads Bootstrap CSS only). It demonstrates
-// the public binding API: ExpressionAccessor.Parse + BindingHelpers.ResolveBindingContext are all a
-// custom form control needs to bind to a model and report changes/validation.
+// removable chips. Unlike the native <select multiple>, it binds to an ICollection<TItem> and drives the
+// ambient EditContext (validation) — the same contract as CheckboxGroup<TItem>. Open/close, the
+// click-outside backdrop and Esc-to-close are all pure server live-diff state (no client JS; the showcase
+// loads Bootstrap CSS only). It demonstrates the public binding API: ExpressionAccessor.Parse +
+// BindingHelpers.ResolveBindingContext are all a custom form control needs to bind to a model, register a
+// per-field validator and report changes.
 //
-//   MultiSelect<string>(() => model.Interests, new[] { "Web", "Mobile", "AI" })
+// Two usage shapes, mirroring Input:
+//   • Bound    — MultiSelect<string>(() => model.Interests, options, Validate: …, AfterBind: …)
+//                two-way binds the model collection, runs the per-field Validate rule and surfaces its
+//                message through the embedded ValidationMessage. AfterBind/AfterBindAsync are post-bind
+//                side-effect hooks (the bound value is passed in), exactly like Input's AfterBind.
+//   • Controlled — MultiSelect<string>(options, Value: selection, OnChange: next => …)
+//                the parent owns the selection; OnChange/OnChangeAsync deliver the new collection. No
+//                EditContext, so no Validate in this mode.
 //
-// The OnChange callback re-renders the consumer (a component can't re-render its own parent), so the
-// parent's summary/validation updates as selections change.
+// Live feedback in bound mode lives inside the control (the chips and the embedded ValidationMessage),
+// which refresh because MultiSelect re-renders itself. In controlled mode OnChange/OnChangeAsync are
+// auto-wrapped (AutoCallback) so invoking them re-renders the consumer that owns the handler — host-side
+// derived UI (a summary) updates for free, no StateHasChanged. AfterBind exists for consumer logic.
 public sealed class MultiSelect<TItem> : Component
 {
-    public required Expression<Func<ICollection<TItem>>> Bind { get; set; }
     public required IEnumerable<TItem> Options { get; set; }
+
+    // Controlled mode (no Bind): the parent owns the selection and is notified of every change.
+    public ICollection<TItem>? Value { get; set; }
+    public Action<IReadOnlyCollection<TItem>>? OnChange { get; set; }
+    public Func<IReadOnlyCollection<TItem>, Task>? OnChangeAsync { get; set; }
+
+    // Bound mode. Set through the Bind-first factory overloads (Generated.MultiSelect), kept off the
+    // generated controlled factory via [SkipFactory] so the two entry points stay distinct.
+    [SkipFactory] public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
+    [SkipFactory] public Action<ICollection<TItem>>? AfterBind { get; set; }
+    [SkipFactory] public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
+
+    // Per-field validator (bound mode only): a sync Func<ICollection<TItem>, IEnumerable<string>> or async
+    // Func<ICollection<TItem>, CancellationToken, ValueTask<IEnumerable<string>>>, registered with the
+    // EditContext just like Input's Validate. Collapsed to a single Delegate the context invokes.
+    [SkipFactory] public Delegate? Validate { get; set; }
+
     public Func<TItem, Child>? OptionLabel { get; set; }
-    public Action? OnChange { get; set; }
     public string? Id { get; set; }
     public string? Placeholder { get; set; }
     public bool? Disabled { get; set; }
 
-    // View state only — the selection itself lives in the bound model collection. Toggling re-renders
-    // this component through the live diff; no Bootstrap dropdown JS is involved.
+    // View state only — the selection itself lives in the bound model collection (bound mode) or the
+    // parent's Value (controlled mode). Toggling open/close re-renders this component through the live
+    // diff; no Bootstrap dropdown JS is involved.
     private bool _open;
 
     protected override RenderResult Render()
     {
-        ArgumentNullException.ThrowIfNull(Bind);
         ArgumentNullException.ThrowIfNull(Options);
 
-        var acc = ExpressionAccessor.Parse(Bind);
-        var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
-        var fid = acc.Field;
-        var selected = acc.Getter() as ICollection<TItem>;
+        var bound = Bind is not null;
+        if (bound == Value is not null)
+        {
+            throw new InvalidOperationException(
+                "MultiSelect requires exactly one of Bind (bound mode) or Value (controlled mode).");
+        }
+
         var comparer = EqualityComparer<TItem>.Default;
         var disabled = Disabled == true; // when disabled the whole control is inert: no wired handlers
+
+        // Resolve the binding once per render. In controlled mode there is no EditContext/field; the
+        // selection is read straight from Value and changes flow out through OnChange.
+        ExpressionAccessor.Accessor? acc = null;
+        EditContext? ctx = null;
+        var fid = default(FieldIdentifier);
+        ICollection<TItem>? selected;
+        if (bound)
+        {
+            acc = ExpressionAccessor.Parse(Bind!);
+            ctx = BindingHelpers.ResolveBindingContext(acc.Target);
+            fid = acc.Field;
+            // Always register — null clears a stale rule from a prior render, matching Input's BoundCore.
+            ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+            selected = acc.Getter() as ICollection<TItem>;
+        }
+        else
+        {
+            selected = Value;
+        }
 
         Child LabelOf(TItem item) =>
             OptionLabel is not null ? OptionLabel(item) : item?.ToString() ?? string.Empty;
@@ -70,7 +119,7 @@ public sealed class MultiSelect<TItem> : Component
         }
 
         // One row per option; a (display-only) checkbox shows membership and the row toggles it. The menu
-        // stays open across selections — only the box toggles _open.
+        // stays open across selections — only the box / backdrop / Esc toggle _open.
         var rows = new List<Child>();
         var idx = 0;
         foreach (var option in Options)
@@ -89,22 +138,70 @@ public sealed class MultiSelect<TItem> : Component
             idx++;
         }
 
-        return Div(Class: "dropdown", Id: Id)[
+        var children = new List<Child>
+        {
             // When disabled, the toggle drops its click handler and gains Bootstrap's .disabled look —
-            // mirroring the disabled option/chip buttons so the whole control is inert.
+            // mirroring the disabled option/chip buttons so the whole control is inert. TabIndex makes the
+            // box focusable so Esc (OnKeyDown) reaches it once the user has opened the menu.
             Div(
                 Class: disabled
                     ? "form-select h-auto d-flex flex-wrap align-items-center gap-1 disabled pe-none"
                     : "form-select h-auto d-flex flex-wrap align-items-center gap-1",
-                OnClick: disabled ? null : () => _open = !_open)[box],
-            Div(Class: _open ? "dropdown-menu show d-block w-100" : "dropdown-menu")[rows],
-            ValidationMessage(Bind, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]])
-        ];
+                TabIndex: disabled ? null : 0,
+                OnClick: disabled ? null : () => _open = !_open,
+                OnKeyDown: disabled ? null : OnBoxKeyDown)[box],
+            Div(Class: _open ? "dropdown-menu show d-block w-100" : "dropdown-menu")[rows]
+        };
+
+        // Click-outside: a transparent full-viewport backdrop sits behind the open menu but above the rest
+        // of the page; any click that misses the menu lands here and closes. Its z-index is below the
+        // Bootstrap dropdown-menu (1000) so option clicks reach the menu, not the backdrop.
+        if (_open && !disabled)
+        {
+            children.Add(Div(
+                Class: "position-fixed top-0 start-0 w-100 h-100",
+                Style: "z-index: 999;",
+                OnClick: () => _open = false));
+        }
+
+        if (bound)
+        {
+            children.Add(ValidationMessage(Bind!, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]]));
+        }
+
+        return Div(Class: "dropdown", Id: Id)[children];
     }
 
-    // Re-resolves the collection from the accessor (the model may have swapped it), adds/removes the item
-    // by comparer equality, then notifies + revalidates the field and pings the consumer to re-render.
+    private void OnBoxKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Escape")
+        {
+            _open = false;
+        }
+    }
+
+    // Adds/removes the item by comparer equality, then (bound) notifies + revalidates the field and runs
+    // AfterBind, or (controlled) emits a fresh collection through OnChange (auto-wrapped, so the consumer
+    // re-renders).
     private async Task ToggleAsync(
+        ExpressionAccessor.Accessor? acc,
+        EditContext? ctx,
+        FieldIdentifier fid,
+        TItem item,
+        IEqualityComparer<TItem> comparer,
+        bool add)
+    {
+        if (acc is not null)
+        {
+            await ToggleBoundAsync(acc, ctx, fid, item, comparer, add).ConfigureAwait(false);
+        }
+        else
+        {
+            await ToggleControlledAsync(item, comparer, add).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ToggleBoundAsync(
         ExpressionAccessor.Accessor acc,
         EditContext? ctx,
         FieldIdentifier fid,
@@ -112,6 +209,7 @@ public sealed class MultiSelect<TItem> : Component
         IEqualityComparer<TItem> comparer,
         bool add)
     {
+        // Re-resolve from the accessor (the model may have swapped the collection instance).
         if (acc.Getter() is not ICollection<TItem> collection)
         {
             return;
@@ -136,7 +234,34 @@ public sealed class MultiSelect<TItem> : Component
             await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
         }
 
-        OnChange?.Invoke();
+        AfterBind?.Invoke(collection);
+        if (AfterBindAsync is not null)
+        {
+            await AfterBindAsync(collection).ConfigureAwait(false);
+        }
+    }
+
+    private async Task ToggleControlledAsync(TItem item, IEqualityComparer<TItem> comparer, bool add)
+    {
+        // The parent owns Value; never mutate it in place. Build the next selection and hand it back.
+        var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
+        if (add)
+        {
+            if (!next.Contains(item, comparer))
+            {
+                next.Add(item);
+            }
+        }
+        else
+        {
+            Remove(next, item, comparer);
+        }
+
+        OnChange?.Invoke(next);
+        if (OnChangeAsync is not null)
+        {
+            await OnChangeAsync(next).ConfigureAwait(false);
+        }
     }
 
     // Membership uses Enumerable.Contains(comparer); removal finds the match first and removes it after

--- a/samples/Rask.Example.Shared/Shared/MultiSelectBoundFactory.cs
+++ b/samples/Rask.Example.Shared/Shared/MultiSelectBoundFactory.cs
@@ -1,0 +1,71 @@
+using System.Linq.Expressions;
+using Rask.Core;
+
+namespace Rask.Example.Shared;
+
+// Bind-first entry points for MultiSelect<TItem>, the bound-mode counterpart to the generated controlled
+// factory (which takes Options first). Mirrors Input.Bound: a [GenerateForwarderFactory] forwarder can't be
+// used here because the component is generic (a static forwarder method can't reuse the class type
+// parameter), so these are hand-written overloads on the same `Generated` partial. Each forwards the shared
+// presentation args to the controlled factory, then sets the [SkipFactory] bound-mode props on the returned
+// (context-managed) instance. Validate fans into three overloads — none / sync / async — so the call site
+// passes a typed lambda without a cast, exactly like Input's three Bound overloads.
+public static partial class Generated
+{
+    public static MultiSelect<TItem> MultiSelect<TItem>(
+        Expression<Func<ICollection<TItem>>> Bind,
+        IEnumerable<TItem> Options,
+        Func<TItem, Child>? OptionLabel = null,
+        Action<ICollection<TItem>>? AfterBind = null,
+        Func<ICollection<TItem>, Task>? AfterBindAsync = null,
+        string? Id = null,
+        string? Placeholder = null,
+        bool? Disabled = null)
+        => BindCore(Bind, Options, null, OptionLabel, AfterBind, AfterBindAsync, Id, Placeholder, Disabled);
+
+    public static MultiSelect<TItem> MultiSelect<TItem>(
+        Expression<Func<ICollection<TItem>>> Bind,
+        IEnumerable<TItem> Options,
+        Func<ICollection<TItem>, IEnumerable<string>> Validate,
+        Func<TItem, Child>? OptionLabel = null,
+        Action<ICollection<TItem>>? AfterBind = null,
+        Func<ICollection<TItem>, Task>? AfterBindAsync = null,
+        string? Id = null,
+        string? Placeholder = null,
+        bool? Disabled = null)
+        => BindCore(Bind, Options, Validate, OptionLabel, AfterBind, AfterBindAsync, Id, Placeholder, Disabled);
+
+    public static MultiSelect<TItem> MultiSelect<TItem>(
+        Expression<Func<ICollection<TItem>>> Bind,
+        IEnumerable<TItem> Options,
+        Func<ICollection<TItem>, CancellationToken, ValueTask<IEnumerable<string>>> Validate,
+        Func<TItem, Child>? OptionLabel = null,
+        Action<ICollection<TItem>>? AfterBind = null,
+        Func<ICollection<TItem>, Task>? AfterBindAsync = null,
+        string? Id = null,
+        string? Placeholder = null,
+        bool? Disabled = null)
+        => BindCore(Bind, Options, Validate, OptionLabel, AfterBind, AfterBindAsync, Id, Placeholder, Disabled);
+
+    private static MultiSelect<TItem> BindCore<TItem>(
+        Expression<Func<ICollection<TItem>>> bind,
+        IEnumerable<TItem> options,
+        Delegate? validate,
+        Func<TItem, Child>? optionLabel,
+        Action<ICollection<TItem>>? afterBind,
+        Func<ICollection<TItem>, Task>? afterBindAsync,
+        string? id,
+        string? placeholder,
+        bool? disabled)
+    {
+        // Build through the generated controlled factory so the instance is context-managed (RASK014),
+        // then layer on the [SkipFactory] bound-mode props. This runs every render (it is the call site),
+        // so the props are re-applied each frame just like generated factory params.
+        var c = MultiSelect<TItem>(options, OptionLabel: optionLabel, Id: id, Placeholder: placeholder, Disabled: disabled);
+        c.Bind = bind;
+        c.AfterBind = afterBind;
+        c.AfterBindAsync = afterBindAsync;
+        c.Validate = validate;
+        return c;
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/RadioGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/RadioGroup.cs
@@ -1,13 +1,15 @@
 using System.Linq.Expressions;
 using Rask.Core.Forms;
 
-namespace Rask.Core.Components;
+namespace Rask.Example.Shared;
 
-// Hand-written generic factory (same shape as VirtualizeModel<T> / Context.Provide<T>): binds a single
-// TValue model property to a set of mutually-exclusive radio inputs. Mirrors Input.Bound — parses
-// the expression, resolves the ambient EditContext, and wires each radio's change handler to set
-// the property and re-validate. Returns a transparent Fragment of <label><input radio>…</label>
-// so the consumer controls layout via Class/ItemClass.
+// Example generic form control (the single-value sibling of CheckboxGroup): binds a single TValue model
+// property to a set of mutually-exclusive radios. Parses the expression, resolves the ambient EditContext,
+// and wires each radio's change handler to set the property and re-validate. Emits Bootstrap 5.3 check
+// markup (https://getbootstrap.com/docs/5.3/forms/checks-radios/): each item is a <div class="form-check">
+// wrapping a .form-check-input radio and a .form-check-label tied together by id/for. ItemClass adds extra
+// classes to that wrapper (e.g. "form-check-inline"). Returns a transparent Fragment so the consumer owns
+// the surrounding layout.
 public static partial class Generated
 {
     public static Component RadioGroup<TValue>(
@@ -27,22 +29,26 @@ public static partial class Generated
         var groupName = Name ?? acc.PropertyName;
         var current = acc.Getter();
         var comparer = EqualityComparer<TValue>.Default;
+        var wrapperClass = ItemClass is null ? "form-check" : $"form-check {ItemClass}";
 
         var children = new List<Child>();
         var index = 0;
         foreach (var option in Options)
         {
             var optionValue = option; // capture per iteration for the handler closure
+            var optionId = $"{groupName}-{index}";
             var isChecked = current is TValue typed && comparer.Equals(option, typed);
-            var label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
+            Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
-            children.Add(Label(Class: ItemClass)[
+            children.Add(Div(Class: wrapperClass, Key: index)[
                 Input(
                     "radio",
                     groupName,
                     BindingHelpers.FormatValue(option),
                     Checked: isChecked,
                     Disabled: Disabled,
+                    Class: "form-check-input",
+                    Id: optionId,
                     OnChangeAsync: async _ =>
                     {
                         // A radio only fires change when it becomes selected → set the bound value.
@@ -53,13 +59,12 @@ public static partial class Generated
                         {
                             await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
                         }
-                    },
-                    Key: index),
-                label
+                    }),
+                Label(Class: "form-check-label", For: optionId)[label]
             ]);
             index++;
         }
 
-        return new Fragment(children);
+        return Fragment()[children];
     }
 }

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -43,7 +43,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
-- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices; build custom bound controls with the public `ExpressionAccessor`/`BindingHelpers` API in `Rask.Core.Forms`.
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls (radios/checkboxes/multi-select) with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
 - **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -36,7 +36,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
-- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices; build custom bound controls with the public `ExpressionAccessor`/`BindingHelpers` API in `Rask.Core.Forms`.
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls (radios/checkboxes/multi-select) with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
 - **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -36,7 +36,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
-- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; `RadioGroup`/`CheckboxGroup` for choices; build custom bound controls with the public `ExpressionAccessor`/`BindingHelpers` API in `Rask.Core.Forms`.
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls (radios/checkboxes/multi-select) with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
 - **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -6,18 +6,19 @@ using static Rask.Example.Shared.Generated;
 
 namespace Rask.Example.Shared.Tests.Demos;
 
-// The reusable MultiSelect<TItem> example component: a custom dropdown bound to an ICollection. These
-// tests drive the live handlers directly (open, select, deselect) and assert the bound collection +
-// rendered chips/checks. The full browser flow is covered in SharedSmokeTests (Multi-select branch).
+// The reusable MultiSelect<TItem> example component: a custom dropdown bound to an ICollection (bound mode)
+// or driven by Value + OnChange (controlled mode). These drive the live handlers directly (open, select,
+// deselect, Esc, click-outside) and assert the bound collection / emitted selection / rendered chips. The
+// full browser flow is covered in SharedSmokeTests (Multi-select branch).
 public sealed class MultiSelectTests
 {
     private static readonly string[] Options = ["a", "b", "c"];
 
-    private static (LiveHost Host, Bag Model) Mount(Action? onChange = null)
+    private static (LiveHost Host, Bag Model) MountBound()
     {
         var model = new Bag();
         var host = new LiveHost(
-            () => Form(model)[MultiSelect<string>(() => model.Tags, Options, OnChange: onChange)],
+            () => Form(model)[MultiSelect<string>(() => model.Tags, Options)],
             TestServices.Default());
         return (host, model);
     }
@@ -25,22 +26,60 @@ public sealed class MultiSelectTests
     [Fact]
     public void Render_Closed_ShowsPlaceholderAndAllOptions()
     {
-        var (host, _) = Mount();
+        var (host, _) = MountBound();
         var html = host.RenderAsLiveRoot();
 
-        Assert.Contains("Select&#x2026;", html);          // default placeholder, HTML-encoded ellipsis
-        Assert.DoesNotContain("dropdown-menu show", html); // closed by default
+        Assert.Contains("Select&#x2026;", html);           // default placeholder, HTML-encoded ellipsis
+        Assert.DoesNotContain("dropdown-menu show", html);  // closed by default
         Assert.Equal(3, CountOccurrences(html, "dropdown-item"));
-        Assert.DoesNotContain("badge", html);              // no chips when empty
+        Assert.DoesNotContain("badge", html);               // no chips when empty
     }
 
     [Fact]
-    public async Task Toggle_OpensMenu()
+    public async Task Toggle_OpensMenu_AndRendersBackdrop()
     {
-        var (host, _) = Mount();
+        var (host, _) = MountBound();
         var ids = ClickIds(host.RenderAsLiveRoot());
 
         await host.TryInvokeHandlerAsync(ids[0], Empty()); // box toggle is the first click handler
+
+        var html = host.RenderAsLiveRoot();
+        Assert.Contains("dropdown-menu show", html);
+        Assert.Contains("position-fixed", html);            // click-outside backdrop only when open
+    }
+
+    [Fact]
+    public async Task ClickOutside_ClosesMenu()
+    {
+        var (host, _) = MountBound();
+        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // open
+
+        var openIds = ClickIds(host.RenderAsLiveRoot()); // [box, opt-a, opt-b, opt-c, backdrop]
+        await host.TryInvokeHandlerAsync(openIds[^1], Empty()); // backdrop is the last click handler
+
+        Assert.DoesNotContain("dropdown-menu show", host.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public async Task Escape_ClosesMenu()
+    {
+        var (host, _) = MountBound();
+        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // open
+
+        var keyId = HandlerIds(host.RenderAsLiveRoot(), "data-rask-on-keydown")[0];
+        await host.TryInvokeHandlerAsync(keyId, Json("{\"key\":\"Escape\"}"));
+
+        Assert.DoesNotContain("dropdown-menu show", host.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public async Task Escape_OtherKey_DoesNotClose()
+    {
+        var (host, _) = MountBound();
+        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // open
+
+        var keyId = HandlerIds(host.RenderAsLiveRoot(), "data-rask-on-keydown")[0];
+        await host.TryInvokeHandlerAsync(keyId, Json("{\"key\":\"ArrowDown\"}"));
 
         Assert.Contains("dropdown-menu show", host.RenderAsLiveRoot());
     }
@@ -48,21 +87,21 @@ public sealed class MultiSelectTests
     [Fact]
     public async Task SelectOption_AddsToCollection_RendersChipAndCheck()
     {
-        var (host, model) = Mount();
+        var (host, model) = MountBound();
         var ids = ClickIds(host.RenderAsLiveRoot()); // [toggle, opt-a, opt-b, opt-c]
 
         await host.TryInvokeHandlerAsync(ids[2], Empty()); // select "b"
 
         Assert.Equal(["b"], model.Tags);
         var html = host.RenderAsLiveRoot();
-        Assert.Contains("badge", html);             // chip rendered for the selection
+        Assert.Contains("badge", html);                      // chip rendered for the selection
         Assert.Equal(1, CountOccurrences(html, " checked")); // exactly one option checked
     }
 
     [Fact]
     public async Task RemoveChip_RemovesFromCollection()
     {
-        var (host, model) = Mount();
+        var (host, model) = MountBound();
         model.Tags.Add("a");
         // Layout order: box toggle, then chip-remove buttons (inside the box), then option rows.
         var ids = ClickIds(host.RenderAsLiveRoot()); // [toggle, chip-remove-a, opt-a, opt-b, opt-c]
@@ -75,7 +114,7 @@ public sealed class MultiSelectTests
     [Fact]
     public async Task SelectingTwice_TogglesOff()
     {
-        var (host, model) = Mount();
+        var (host, model) = MountBound();
         var ids = ClickIds(host.RenderAsLiveRoot());
 
         await host.TryInvokeHandlerAsync(ids[1], Empty()); // select "a"
@@ -84,6 +123,110 @@ public sealed class MultiSelectTests
         var ids2 = ClickIds(host.RenderAsLiveRoot()); // now [toggle, chip-remove-a, opt-a, opt-b, opt-c]
         await host.TryInvokeHandlerAsync(ids2[2], Empty()); // click the "a" option row again
         Assert.Empty(model.Tags);
+    }
+
+    [Fact]
+    public async Task Validate_ShowsMessage_BelowMinimum_AndClearsWhenSatisfied()
+    {
+        var model = new Bag();
+        var host = new LiveHost(
+            () => Form(model)[
+                MultiSelect<string>(
+                    () => model.Tags,
+                    Options,
+                    Validate: tags => tags.Count >= 2 ? Array.Empty<string>() : ["Pick at least two."])],
+            TestServices.Default());
+
+        var ids = ClickIds(host.RenderAsLiveRoot());
+        await host.TryInvokeHandlerAsync(ids[1], Empty()); // select "a" (count 1 < 2)
+        Assert.Contains("Pick at least two.", host.RenderAsLiveRoot());
+
+        var ids2 = ClickIds(host.RenderAsLiveRoot());
+        await host.TryInvokeHandlerAsync(ids2[3], Empty()); // select "b" (count 2)
+        Assert.DoesNotContain("Pick at least two.", host.RenderAsLiveRoot());
+    }
+
+    [Fact]
+    public async Task AfterBind_FiresWithMutatedCollection()
+    {
+        var model = new Bag();
+        ICollection<string>? seen = null;
+        var host = new LiveHost(
+            () => Form(model)[MultiSelect<string>(() => model.Tags, Options, AfterBind: c => seen = c)],
+            TestServices.Default());
+
+        var ids = ClickIds(host.RenderAsLiveRoot());
+        await host.TryInvokeHandlerAsync(ids[2], Empty()); // select "b"
+
+        Assert.NotNull(seen);
+        Assert.Equal(["b"], seen!);
+        Assert.Same(model.Tags, seen); // bound mode mutates the model collection in place
+    }
+
+    [Fact]
+    public async Task AfterBindAsync_Fires()
+    {
+        var model = new Bag();
+        var fired = false;
+        var host = new LiveHost(
+            () => Form(model)[MultiSelect<string>(
+                () => model.Tags, Options, AfterBindAsync: _ =>
+                {
+                    fired = true;
+                    return Task.CompletedTask;
+                })],
+            TestServices.Default());
+
+        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[1], Empty());
+
+        Assert.True(fired);
+    }
+
+    [Fact]
+    public async Task Controlled_OnChange_EmitsNewSelection_WithoutMutatingValue()
+    {
+        var value = new List<string> { "a" };
+        IReadOnlyCollection<string>? emitted = null;
+        var host = new LiveHost(
+            () => MultiSelect<string>(Options, Value: value, OnChange: next => emitted = next),
+            TestServices.Default());
+
+        var ids = ClickIds(host.RenderAsLiveRoot()); // [box, chip-remove-a, opt-a, opt-b, opt-c]
+        await host.TryInvokeHandlerAsync(ids[3], Empty()); // select "b"
+
+        Assert.NotNull(emitted);
+        Assert.Equal(["a", "b"], emitted!);
+        Assert.Equal(["a"], value); // controlled mode never mutates the parent's Value in place
+    }
+
+    [Fact]
+    public async Task Controlled_OnChangeAsync_Fires()
+    {
+        var value = new List<string>();
+        IReadOnlyCollection<string>? emitted = null;
+        var host = new LiveHost(
+            () => MultiSelect<string>(Options, Value: value, OnChangeAsync: next =>
+            {
+                emitted = next;
+                return Task.CompletedTask;
+            }),
+            TestServices.Default());
+
+        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[1], Empty()); // select "a"
+
+        Assert.Equal(["a"], emitted!);
+    }
+
+    [Fact]
+    public void Controlled_NoValidationMessage_NoEditContext()
+    {
+        var host = new LiveHost(
+            () => MultiSelect<string>(Options, Value: new List<string>(), OnChange: _ => { }),
+            TestServices.Default());
+
+        var html = host.RenderAsLiveRoot();
+        Assert.Contains("dropdown-item", html);
+        Assert.DoesNotContain("invalid-feedback", html); // no bound field → no ValidationMessage
     }
 
     [Fact]
@@ -113,27 +256,29 @@ public sealed class MultiSelectTests
     }
 
     [Fact]
-    public async Task OnChange_FiresAfterSelection()
+    public void NeitherBindNorValue_Throws()
     {
-        var fired = 0;
-        var (host, _) = Mount(onChange: () => fired++);
-        var ids = ClickIds(host.RenderAsLiveRoot());
+        var host = new LiveHost(
+            () => MultiSelect<string>(Options),
+            TestServices.Default());
 
-        await host.TryInvokeHandlerAsync(ids[1], Empty());
-
-        Assert.Equal(1, fired);
+        Assert.Throws<InvalidOperationException>(() => host.RenderAsLiveRoot());
     }
 
-    private static JsonElement Empty()
+    private static JsonElement Empty() => Json("{}");
+
+    private static JsonElement Json(string json)
     {
-        using var doc = JsonDocument.Parse("{}");
+        using var doc = JsonDocument.Parse(json);
         return doc.RootElement.Clone();
     }
 
-    private static List<string> ClickIds(string html)
+    private static List<string> ClickIds(string html) => HandlerIds(html, "data-rask-on-click");
+
+    private static List<string> HandlerIds(string html, string attr)
     {
         var ids = new List<string>();
-        const string marker = "data-rask-on-click=\"";
+        var marker = attr + "=\"";
         var i = 0;
         while ((i = html.IndexOf(marker, i, StringComparison.Ordinal)) >= 0)
         {

--- a/tests/Rask.Example.Shared.Tests/RadioCheckboxGroupTests.cs
+++ b/tests/Rask.Example.Shared.Tests/RadioCheckboxGroupTests.cs
@@ -1,19 +1,24 @@
 using System.Text.Json;
+using Rask.Example.Shared;
+using Rask.Example.Shared.Tests.Infrastructure;
+using static Rask.Core.Components.Generated;
+using static Rask.Example.Shared.Generated;
 
-#pragma warning disable RASK014 // test uses the StubComponent test helper directly
+namespace Rask.Example.Shared.Tests.Demos;
 
-namespace Rask.Core.Tests.Forms;
-
+// RadioGroup<TValue> / CheckboxGroup<TItem> are example form controls (moved out of Rask.Core into the
+// samples). These drive the live change handlers directly and assert the bound model + rendered checks.
 public class RadioCheckboxGroupTests
 {
     [Fact]
     public void RadioGroup_RendersOnePerOption_CurrentChecked()
     {
         var m = new ColorModel { Choice = Color.Green };
-        var view = new StubComponent(() =>
-            Form(m)[RadioGroup(() => m.Choice, new[] { Color.Red, Color.Green, Color.Blue })]);
+        var host = new LiveHost(
+            () => Form(m)[RadioGroup(() => m.Choice, new[] { Color.Red, Color.Green, Color.Blue })],
+            TestServices.Default());
 
-        var html = view.RenderAsLiveRoot();
+        var html = host.RenderAsLiveRoot();
 
         Assert.Equal(3, CountOccurrences(html, "type=\"radio\""));
         Assert.Equal(3, CountOccurrences(html, "name=\"Choice\""));
@@ -29,22 +34,23 @@ public class RadioCheckboxGroupTests
     public async Task RadioGroup_Change_SetsBoundValue()
     {
         var m = new ColorModel { Choice = Color.Red };
-        var view = new StubComponent(() =>
-            Form(m)[RadioGroup(() => m.Choice, new[] { Color.Red, Color.Green, Color.Blue })]);
+        var host = new LiveHost(
+            () => Form(m)[RadioGroup(() => m.Choice, new[] { Color.Red, Color.Green, Color.Blue })],
+            TestServices.Default());
 
-        var html = view.RenderAsLiveRoot();
+        var html = host.RenderAsLiveRoot();
         var ids = AllChangeIds(html);
         Assert.Equal(3, ids.Count);
 
         // Fire the third radio (Blue). A radio change carries the checked state; the handler
         // ignores it and sets the bound value to its captured option.
         using var doc = JsonDocument.Parse("{\"value\":\"true\"}");
-        await view.TryInvokeHandlerAsync(ids[2], doc.RootElement);
+        await host.TryInvokeHandlerAsync(ids[2], doc.RootElement);
 
         Assert.Equal(Color.Blue, m.Choice);
 
         // Re-render: the checked radio moved to Blue.
-        var html2 = view.RenderAsLiveRoot();
+        var html2 = host.RenderAsLiveRoot();
         var blueIdx = html2.IndexOf("value=\"Blue\"", StringComparison.Ordinal);
         var checkedIdx = html2.IndexOf(" checked", StringComparison.Ordinal);
         Assert.Equal(1, CountOccurrences(html2, " checked"));
@@ -56,10 +62,11 @@ public class RadioCheckboxGroupTests
     {
         var m = new TagsModel();
         m.Tags.Add("b");
-        var view = new StubComponent(() =>
-            Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })]);
+        var host = new LiveHost(
+            () => Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })],
+            TestServices.Default());
 
-        var html = view.RenderAsLiveRoot();
+        var html = host.RenderAsLiveRoot();
 
         Assert.Equal(3, CountOccurrences(html, "type=\"checkbox\""));
         Assert.Equal(1, CountOccurrences(html, " checked")); // only "b"
@@ -73,14 +80,15 @@ public class RadioCheckboxGroupTests
     public async Task CheckboxGroup_Check_AddsToCollection()
     {
         var m = new TagsModel();
-        var view = new StubComponent(() =>
-            Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })]);
+        var host = new LiveHost(
+            () => Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })],
+            TestServices.Default());
 
-        var html = view.RenderAsLiveRoot();
+        var html = host.RenderAsLiveRoot();
         var ids = AllChangeIds(html);
 
         using var doc = JsonDocument.Parse("{\"value\":\"true\"}");
-        await view.TryInvokeHandlerAsync(ids[0], doc.RootElement); // check "a"
+        await host.TryInvokeHandlerAsync(ids[0], doc.RootElement); // check "a"
 
         Assert.Contains("a", m.Tags);
         Assert.Single(m.Tags);
@@ -92,14 +100,15 @@ public class RadioCheckboxGroupTests
         var m = new TagsModel();
         m.Tags.Add("a");
         m.Tags.Add("b");
-        var view = new StubComponent(() =>
-            Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })]);
+        var host = new LiveHost(
+            () => Form(m)[CheckboxGroup<string>(() => m.Tags, new[] { "a", "b", "c" })],
+            TestServices.Default());
 
-        var html = view.RenderAsLiveRoot();
+        var html = host.RenderAsLiveRoot();
         var ids = AllChangeIds(html);
 
         using var doc = JsonDocument.Parse("{\"value\":\"false\"}");
-        await view.TryInvokeHandlerAsync(ids[1], doc.RootElement); // uncheck "b"
+        await host.TryInvokeHandlerAsync(ids[1], doc.RootElement); // uncheck "b"
 
         Assert.DoesNotContain("b", m.Tags);
         Assert.Contains("a", m.Tags);

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -490,16 +490,39 @@ public abstract partial class SharedSmokeTests
         await Expect(groups).ToContainTextAsync("AI", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // Multi-select: the reusable MultiSelect<T> dropdown binds to an ICollection — open it (server
-        // live-diff, no Bootstrap JS), pick an option (it appears as a chip) and the bound-collection
-        // summary updates. (Component mechanics are unit-tested in Demos/MultiSelectTests.)
+        // live-diff, no Bootstrap JS), pick an option and it appears as a live chip (the control re-renders
+        // itself — no StateHasChanged). (Component mechanics are unit-tested in Demos/MultiSelectTests.)
         await SideAsync("Multi-select", "Multi-select");
         var multi = Page.Locator("#ms-interests");
         await multi.Locator(".form-select").ClickAsync(); // open the dropdown
         await multi.Locator(".dropdown-item").Filter(new LocatorFilterOptions { HasText = "AI" }).ClickAsync();
         await Expect(multi.Locator(".badge").Filter(new LocatorFilterOptions { HasText = "AI" }))
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-        await Expect(Page.Locator("#ms-summary")).ToContainTextAsync("AI",
+
+        // The menu stays open across selections; Escape closes it (the focusable box handles keydown — no JS).
+        var openMenu = Page.Locator("#ms-interests .dropdown-menu.show");
+        await Expect(openMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await multi.Locator(".form-select").FocusAsync();
+        await Page.Keyboard.PressAsync("Escape");
+        await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
+
+        // Re-open, then close by clicking outside — the transparent full-viewport backdrop catches it.
+        await multi.Locator(".form-select").ClickAsync();
+        await Expect(openMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await multi.Locator(".position-fixed").ClickAsync();
+        await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
+
+        // Controlled MultiSelect (Value + OnChange, no Bind): selecting a topic flows out through OnChange
+        // and the parent's summary updates — again with no StateHasChanged.
+        var controlled = Page.Locator("#ms-controlled");
+        await controlled.Locator(".form-select").ClickAsync();
+        await controlled.Locator(".dropdown-item").Filter(new LocatorFilterOptions { HasText = "Tech" }).ClickAsync();
+        await Expect(Page.Locator("#ms-controlled-summary")).ToContainTextAsync("Tech",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        // Close it again so the open dropdown's full-viewport backdrop doesn't intercept later navigation.
+        await controlled.Locator(".position-fixed").ClickAsync();
+        await Expect(Page.Locator("#ms-controlled .dropdown-menu.show")).ToBeHiddenAsync(
+            new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
     }
 
     private async Task WalkStylingDataAndAppPagesAsync()


### PR DESCRIPTION
## Summary
`MultiSelect<TItem>` now mirrors `Input`: a **bound** shape (`() => model.Items` with `AfterBind`/`AfterBindAsync` hooks and a per-field `Validate` rule, sync or async) and a **controlled** shape (`Value` + `OnChange`/`OnChangeAsync`, no `Bind`). The dropdown also closes on **Esc** and **click-outside** — still pure server live-diff, no client JS. `CheckboxGroup<TItem>` and `RadioGroup<TValue>` move out of `Rask.Core` into the samples as copyable example controls (now rendering Bootstrap 5.3 `form-check` markup), keeping Core to the binding API rather than a control library.

**Breaking:** `CheckboxGroup`/`RadioGroup` are no longer in `Rask.Core` — copy the sample files, or build equivalents on `ExpressionAccessor`/`BindingHelpers` (`docs/forms.md` §9). No `Rask.Core` source changed otherwise.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all green** (11 projects). New MultiSelect tests cover bound/controlled toggles, `Validate` (shows + clears), `AfterBind`/`AfterBindAsync`, `OnChange`/`OnChangeAsync`, Esc + click-outside close, and the mode guard; `RadioCheckboxGroupTests` moved to `Rask.Example.Shared.Tests` and rewritten on `LiveHost`.
- E2E (samples changed): host **Server** — `ServerExampleTests.Journey` **passed** (extended the Multi-select branch with Esc, click-outside, and the controlled demo).
- `dotnet format --verify-no-changes`: clean. `dotnet build -warnaserror`: clean. WASM `publish -c Release`: **0 IL/trim warnings**.

## Benchmarks
n/a — no `Rask.Core` render/runtime code changed (a Core host-re-render option was prototyped, measured a ~1% per-element allocation regression, and was dropped; controlled mode re-renders the host via the existing `AutoCallback` wrap instead).

## CHANGELOG
- [Unreleased] entries added: **Added** (MultiSelect bound/controlled modes, `AfterBind`, async hooks, `Validate`, Esc/click-outside close) and **Changed/Breaking** (CheckboxGroup/RadioGroup moved to samples, Bootstrap `form-check` markup).
