### PR TITLE
refactor(forms): share collection-toggle + field-commit helpers via BindingHelpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ them until tagged releases begin.
   same machinery the sample `RadioGroup`/`CheckboxGroup`/`MultiSelect` use, so consumers can build their
   own controls that bind to a model property and drive the ambient `EditContext`. `docs/forms.md` §9 is a
   "building form components" guide. See also `EditContext.RegisterFieldValidator` for per-field rules.
+- **`BindingHelpers.SetCollectionMembership<T>` and `NotifyAndValidateFieldAsync`.** Two more public
+  building blocks for custom bound controls: the first adds/removes an item in a bound `ICollection<T>`
+  by a comparer (returns whether it changed); the second commits a field change (marks it changed +
+  touched and re-validates, no-op without a context). The sample `MultiSelect`/`CheckboxGroup`/`RadioGroup`
+  now share these instead of each hand-rolling the add/remove + notify/validate logic.
 - **Multi-select showcase.** A reusable generic `MultiSelect<TItem>` example component
   (`samples/Rask.Example.Shared/Shared/MultiSelect.cs`) — a custom Bootstrap dropdown with removable
   chips, open/close + Esc / click-outside close driven entirely by the server live diff (no client JS).

--- a/README.md
+++ b/README.md
@@ -970,8 +970,10 @@ immediately.
 Rask ships a small public binding API in `Rask.Core.Forms` rather than a large control library, so you write exactly
 the controls you need — `RadioGroup`/`CheckboxGroup` and the showcase `MultiSelect<TItem>` are built on it.
 `ExpressionAccessor.Parse(() => model.Prop)` yields a runtime accessor (target, getter, field);
-`BindingHelpers.ResolveBindingContext(model)` resolves the surrounding `EditContext` so your handlers can call
-`NotifyFieldChanged` / `ValidateFieldAsync`; `EditContext.RegisterFieldValidator` adds a per-field rule. A stateless
+`BindingHelpers.ResolveBindingContext(model)` resolves the surrounding `EditContext`;
+`BindingHelpers.SetCollectionMembership(collection, item, include)` toggles a bound collection by comparer and
+`BindingHelpers.NotifyAndValidateFieldAsync(ctx, field)` commits a change (marks changed/touched + re-validates);
+`EditContext.RegisterFieldValidator` adds a per-field rule. A stateless
 control returns a `Fragment` (its handlers re-render the host for free, like a bound `Input`); a stateful one (an
 open/close dropdown) is a `Component` that keeps live feedback inside itself or exposes an auto-wrapped `OnChange`
 callback to refresh host-side UI. The showcase's `MultiSelect<TItem>` — a dropdown with removable chips, Esc /

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -437,9 +437,16 @@ so you can write exactly the controls you need. `RadioGroup`/`CheckboxGroup` (§
   validator (a `Func<T, IEnumerable<string>>` or async
   `Func<T, CancellationToken, ValueTask<IEnumerable<string>>>`). Always call it each render — passing
   `null` clears a stale rule.
+- **`BindingHelpers.SetCollectionMembership(collection, item, include, comparer?)`** — add (when absent)
+  or remove (the matched instance) an item in a bound `ICollection<T>` by a comparer
+  (default `EqualityComparer<T>.Default`); returns whether it changed. The membership edit a multi-select
+  / checkbox-group performs per toggle.
+- **`BindingHelpers.NotifyAndValidateFieldAsync(ctx, field)`** — commits a change: marks the field
+  changed + touched and re-validates it (no-op when `ctx` is `null`). The one call a custom control's
+  change handler needs.
 
 A bound control reads the value during `Render`, registers any validator, and on each interaction
-mutates the value then notifies/validates the field:
+mutates the value then commits the field:
 
 ```csharp
 var acc = ExpressionAccessor.Parse(Bind);                 // Bind: Expression<Func<ICollection<T>>>
@@ -447,10 +454,9 @@ var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
 ctx?.RegisterFieldValidator(acc.Field, Validate, () => acc.Getter());   // null clears a stale rule
 var selected = acc.Getter() as ICollection<T>;
 // …render options from `selected`…
-// in a click/change handler, after add/remove on the collection:
-ctx?.NotifyFieldChanged(acc.Field);
-ctx?.NotifyFieldTouched(acc.Field);
-if (ctx is not null) await ctx.ValidateFieldAsync(acc.Field);
+// in a click/change handler, after toggling the bound collection:
+BindingHelpers.SetCollectionMembership(selected!, item, include: nowChecked);
+await BindingHelpers.NotifyAndValidateFieldAsync(ctx, acc.Field);
 ```
 
 Surface field messages with `ValidationMessage(Bind, …)` (§2.Rendering messages) inside the control.

--- a/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
@@ -36,7 +36,7 @@ public static partial class Generated
         {
             var optionValue = option; // capture per iteration
             var optionId = $"{groupName}-{index}";
-            var isChecked = selected is not null && Contains(selected, optionValue, comparer);
+            var isChecked = selected is not null && selected.Contains(optionValue, comparer);
             Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
             children.Add(Div(Class: wrapperClass, Key: index)[
@@ -57,24 +57,8 @@ public static partial class Generated
                         }
 
                         var nowChecked = bool.TryParse(value, out var b) && b;
-                        if (nowChecked)
-                        {
-                            if (!Contains(collection, optionValue, comparer))
-                            {
-                                collection.Add(optionValue);
-                            }
-                        }
-                        else
-                        {
-                            Remove(collection, optionValue, comparer);
-                        }
-
-                        ctx?.NotifyFieldChanged(fid);
-                        ctx?.NotifyFieldTouched(fid);
-                        if (ctx is not null)
-                        {
-                            await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
-                        }
+                        BindingHelpers.SetCollectionMembership(collection, optionValue, nowChecked, comparer);
+                        await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
                     }),
                 Label(Class: "form-check-label", For: optionId)[label]
             ]);
@@ -82,40 +66,5 @@ public static partial class Generated
         }
 
         return Fragment()[children];
-    }
-
-    private static bool Contains<TItem>(ICollection<TItem> collection, TItem item, IEqualityComparer<TItem> comparer)
-    {
-        foreach (var existing in collection)
-        {
-            if (comparer.Equals(existing, item))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private static void Remove<TItem>(ICollection<TItem> collection, TItem item, IEqualityComparer<TItem> comparer)
-    {
-        // Remove by comparer equality (collection.Remove uses default equality, which for records
-        // is value equality but for reference items may differ from the supplied comparer).
-        TItem? match = default;
-        var found = false;
-        foreach (var existing in collection)
-        {
-            if (comparer.Equals(existing, item))
-            {
-                match = existing;
-                found = true;
-                break;
-            }
-        }
-
-        if (found)
-        {
-            collection.Remove(match!);
-        }
     }
 }

--- a/samples/Rask.Example.Shared/Shared/MultiSelect.cs
+++ b/samples/Rask.Example.Shared/Shared/MultiSelect.cs
@@ -215,24 +215,8 @@ public sealed class MultiSelect<TItem> : Component
             return;
         }
 
-        if (add)
-        {
-            if (!collection.Contains(item, comparer))
-            {
-                collection.Add(item);
-            }
-        }
-        else
-        {
-            Remove(collection, item, comparer);
-        }
-
-        ctx?.NotifyFieldChanged(fid);
-        ctx?.NotifyFieldTouched(fid);
-        if (ctx is not null)
-        {
-            await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
-        }
+        BindingHelpers.SetCollectionMembership(collection, item, add, comparer);
+        await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
 
         AfterBind?.Invoke(collection);
         if (AfterBindAsync is not null)
@@ -245,46 +229,12 @@ public sealed class MultiSelect<TItem> : Component
     {
         // The parent owns Value; never mutate it in place. Build the next selection and hand it back.
         var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
-        if (add)
-        {
-            if (!next.Contains(item, comparer))
-            {
-                next.Add(item);
-            }
-        }
-        else
-        {
-            Remove(next, item, comparer);
-        }
+        BindingHelpers.SetCollectionMembership(next, item, add, comparer);
 
         OnChange?.Invoke(next);
         if (OnChangeAsync is not null)
         {
             await OnChangeAsync(next).ConfigureAwait(false);
-        }
-    }
-
-    // Membership uses Enumerable.Contains(comparer); removal finds the match first and removes it after
-    // the loop (never mutating mid-enumeration), matching CheckboxGroup's vetted pattern. ICollection.Remove
-    // uses the collection's default equality, which can differ from the supplied comparer, so we remove the
-    // exact captured instance.
-    private static void Remove(ICollection<TItem> collection, TItem item, IEqualityComparer<TItem> comparer)
-    {
-        TItem? match = default;
-        var found = false;
-        foreach (var existing in collection)
-        {
-            if (comparer.Equals(existing, item))
-            {
-                match = existing;
-                found = true;
-                break;
-            }
-        }
-
-        if (found)
-        {
-            collection.Remove(match!);
         }
     }
 }

--- a/samples/Rask.Example.Shared/Shared/RadioGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/RadioGroup.cs
@@ -53,12 +53,7 @@ public static partial class Generated
                     {
                         // A radio only fires change when it becomes selected → set the bound value.
                         acc.Setter(optionValue);
-                        ctx?.NotifyFieldChanged(fid);
-                        ctx?.NotifyFieldTouched(fid);
-                        if (ctx is not null)
-                        {
-                            await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
-                        }
+                        await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
                     }),
                 Label(Class: "form-check-label", For: optionId)[label]
             ]);

--- a/src/Rask.Core/Forms/BindingHelpers.cs
+++ b/src/Rask.Core/Forms/BindingHelpers.cs
@@ -104,6 +104,66 @@ public static class BindingHelpers
         };
     }
 
+    // Adds or removes an item in a bound ICollection<T> by a supplied comparer — the membership edit a
+    // multi-select control performs on every toggle. When `include`, the item is added only if no element
+    // already compares equal; otherwise the first comparer-equal element is removed. Removal targets that
+    // exact matched instance because ICollection<T>.Remove uses the collection's own equality (value
+    // equality for records, reference equality for most classes), which can differ from `comparer`.
+    // Returns whether the collection changed. `comparer` defaults to EqualityComparer<T>.Default.
+    public static bool SetCollectionMembership<T>(
+        ICollection<T> collection, T item, bool include, IEqualityComparer<T>? comparer = null)
+    {
+        ArgumentNullException.ThrowIfNull(collection);
+        comparer ??= EqualityComparer<T>.Default;
+
+        T? match = default;
+        var present = false;
+        foreach (var existing in collection)
+        {
+            if (comparer.Equals(existing, item))
+            {
+                match = existing;
+                present = true;
+                break;
+            }
+        }
+
+        if (include)
+        {
+            if (present)
+            {
+                return false;
+            }
+
+            collection.Add(item);
+            return true;
+        }
+
+        if (!present)
+        {
+            return false;
+        }
+
+        collection.Remove(match!);
+        return true;
+    }
+
+    // Commits a field change to the EditContext from a custom control's change handler: marks the field
+    // changed and touched, then re-validates it. No-op when there is no ambient context (the control is
+    // rendered outside a Form / live render). Mirrors what the bound Input/Select/Textarea handlers do, so
+    // a hand-written control drives validation the same way. See docs/forms.md §9.
+    public static async Task NotifyAndValidateFieldAsync(EditContext? ctx, FieldIdentifier field)
+    {
+        if (ctx is null)
+        {
+            return;
+        }
+
+        ctx.NotifyFieldChanged(field);
+        ctx.NotifyFieldTouched(field);
+        await ctx.ValidateFieldAsync(field).ConfigureAwait(false);
+    }
+
     // Collapses the typed AfterBind / AfterBindAsync pair from a `Bound<TProp>` factory into a
     // single non-generic Func<Task>? closure. Returns null when neither is supplied so the
     // handler builders can stay on the cheap no-callback path. The closure reads the now-set

--- a/tests/Rask.Core.Tests/Forms/PublicBindingApiTests.cs
+++ b/tests/Rask.Core.Tests/Forms/PublicBindingApiTests.cs
@@ -59,9 +59,84 @@ public class PublicBindingApiTests
         // Outside a Form / live render, there's no EditContextScope or LiveRenderContext to resolve.
         Assert.Null(BindingHelpers.ResolveBindingContext(new Model()));
 
+    [Fact]
+    public void SetCollectionMembership_AddsWhenAbsent_AndIsIdempotent()
+    {
+        var list = new List<string>();
+
+        Assert.True(BindingHelpers.SetCollectionMembership(list, "a", include: true));
+        Assert.Equal(["a"], list);
+        // Already present → no change, returns false.
+        Assert.False(BindingHelpers.SetCollectionMembership(list, "a", include: true));
+        Assert.Equal(["a"], list);
+    }
+
+    [Fact]
+    public void SetCollectionMembership_RemovesWhenPresent_AndNoOpWhenAbsent()
+    {
+        var list = new List<string> { "a", "b" };
+
+        Assert.True(BindingHelpers.SetCollectionMembership(list, "a", include: false));
+        Assert.Equal(["b"], list);
+        // Already absent → no change, returns false.
+        Assert.False(BindingHelpers.SetCollectionMembership(list, "a", include: false));
+        Assert.Equal(["b"], list);
+    }
+
+    [Fact]
+    public void SetCollectionMembership_UsesComparer_ToRemoveMatchedInstance()
+    {
+        // Two distinct instances that compare equal under the supplied comparer but not by reference.
+        var first = new Box(1);
+        var list = new List<Box> { first };
+        var comparer = new BoxComparer();
+
+        // include=true with a comparer-equal item → treated as present, no duplicate added.
+        Assert.False(BindingHelpers.SetCollectionMembership(list, new Box(1), include: true, comparer));
+        Assert.Single(list);
+
+        // include=false removes the matched instance (the original `first`).
+        Assert.True(BindingHelpers.SetCollectionMembership(list, new Box(1), include: false, comparer));
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task NotifyAndValidateFieldAsync_NullContext_IsNoOp() =>
+        await BindingHelpers.NotifyAndValidateFieldAsync(null, new FieldIdentifier(new Model(), "Name"));
+
+    [Fact]
+    public async Task NotifyAndValidateFieldAsync_MarksChangedTouched_AndRunsValidator()
+    {
+        var m = new Model { Name = "" };
+        var ctx = new EditContext(m);
+        var fid = new FieldIdentifier(m, "Name");
+        ctx.RegisterFieldValidator(fid,
+            (Func<string, IEnumerable<string>>)(v => string.IsNullOrEmpty(v) ? ["required"] : []));
+
+        await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid);
+
+        Assert.True(ctx.IsModified(fid));
+        Assert.True(ctx.IsTouched(fid));
+        Assert.Contains("required", ctx.GetValidationMessages(fid));
+    }
+
     private sealed class Model
     {
         public string Name { get; set; } = "Ada";
         public List<string> Tags { get; } = [];
+    }
+
+    // A plain class (reference equality, no Equals override) so List<Box>.Remove uses the collection's
+    // own equality — which differs from BoxComparer. This proves SetCollectionMembership removes the
+    // matched instance, not the (reference-distinct) argument.
+    private sealed class Box(int id)
+    {
+        public int Id { get; } = id;
+    }
+
+    private sealed class BoxComparer : IEqualityComparer<Box>
+    {
+        public bool Equals(Box? x, Box? y) => x?.Id == y?.Id;
+        public int GetHashCode(Box obj) => obj.Id;
     }
 }


### PR DESCRIPTION
## Summary
Extracts the two pieces of binding logic the sample form controls each hand-rolled into the public `Rask.Core.Forms.BindingHelpers` API, so `MultiSelect`/`CheckboxGroup`/`RadioGroup` share them and consumers building their own bound controls get the same primitives:
- `SetCollectionMembership<T>(collection, item, include, comparer?)` — add (when absent) / remove (the matched instance) an item in a bound `ICollection<T>` by comparer; returns whether it changed.
- `NotifyAndValidateFieldAsync(ctx, field)` — commit a change: mark the field changed + touched and re-validate (no-op without a context).

The three sample controls drop their private `Contains`/`Remove` statics and the repeated notify/touch/validate blocks. **Behavior is unchanged** — pure refactor + additive public API.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all green**. Added `PublicBindingApiTests` for both helpers (add/remove/idempotent, comparer-removes-matched-instance, null-ctx no-op, marks changed/touched + runs the field validator); the existing `MultiSelectTests` (22) and `RadioCheckboxGroupTests` pass unchanged as the behavior regression net.
- E2E (samples changed): host **Server** — `ServerExampleTests.Journey` **passed**.
- `dotnet format --verify-no-changes`: clean. `dotnet build -warnaserror`: clean.

## Benchmarks
n/a — the helpers run on user-interaction change events, not the render/runtime hot path.

## CHANGELOG
- [Unreleased] **Added**: `BindingHelpers.SetCollectionMembership<T>` and `NotifyAndValidateFieldAsync`; the sample controls now share them.
