### PR TITLE
refactor(core): named Callback/CallbackAsync delegate types for event callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`Callback` / `Callback<T>` / `CallbackAsync` / `CallbackAsync<T>` delegate types.** Named delegate
+  types in `Rask.Core` are now the shape of every built-in component's event callbacks (the `X` / `XAsync`
+  pairs: `OnClick`/`OnClickAsync`, `OnInput`/`OnChange`/`…Async`, `OnKeyDown`/`OnKeyUp`, `OnDrag*`,
+  `OnScroll`, `OnSubmit`, `OnFiles`, and `Form`'s `OnValidSubmit`/`OnInvalidSubmit`), replacing the inline
+  `Action`/`Func<…,Task>` spellings — paired with the `Validate`/`ValidateAsync` convention. `AutoCallback`
+  and the live dispatcher (`Component.TryInvokeHandlerAsync`) carry typed overloads/cases for them, so the
+  re-render and DOM-dispatch hot paths stay reflection-free. **Standard `Action`/`Func` handlers remain
+  supported** for consumer code — these are additive. (`CallbackAsync`, not `AsyncCallback`, to avoid the
+  `System.AsyncCallback` clash.) **Minor breaking:** code passing a pre-typed `Action`/`Func` *variable* to
+  a built-in handler must switch the variable to the matching `Callback`/`CallbackAsync` type (inline
+  lambdas and method groups are unaffected).
 - **`Validate<T>` / `ValidateAsync<T>` delegate types.** Named, shared validator delegate types in
   `Rask.Core.Forms` replace the verbose inline `Func<T, IEnumerable<string>>` /
   `Func<T, CancellationToken, ValueTask<IEnumerable<string>>>` as the `Validate` parameter shape on every

--- a/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomHandlerDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomHandlerDemo.cs
@@ -19,7 +19,7 @@ public sealed class BoomHandlerDemo : Component
             ]
         ];
 
-    private static Child BoundaryFallback(Exception ex, Action recover) =>
+    private static Child BoundaryFallback(Exception ex, Callback recover) =>
         Div(Class: "alert alert-danger d-flex align-items-start", Id: "boom-fallback")[
             I(Class: "bi bi-exclamation-octagon-fill me-3 fs-4"),
             Div()[

--- a/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomNestedDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomNestedDemo.cs
@@ -24,7 +24,7 @@ public sealed class BoomNestedDemo : Component
             ]
         ];
 
-    private static Child InnerFallback(Exception ex, Action recover) =>
+    private static Child InnerFallback(Exception ex, Callback recover) =>
         Div(Class: "alert alert-warning d-flex align-items-start",
             Id: "boom-nested-inner-fallback")[
             I(Class: "bi bi-shield-exclamation me-3 fs-4"),

--- a/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomRenderDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ErrorBoundary/BoomRenderDemo.cs
@@ -48,7 +48,7 @@ public sealed class BoomRenderDemo : Component
             ]
         ];
 
-    private static Child BoundaryFallback(Exception ex, Action recover) =>
+    private static Child BoundaryFallback(Exception ex, Callback recover) =>
         Div(Class: "alert alert-danger d-flex align-items-start", Id: "boom-fallback")[
             I(Class: "bi bi-exclamation-octagon-fill me-3 fs-4"),
             Div()[

--- a/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
+++ b/samples/Rask.Example.Shared/Features/Todos/TodosPage.cs
@@ -136,8 +136,8 @@ public sealed class TodoFormDialog : Component
     public bool Open { get; set; }
     public TodoForm Model { get; set; }
     public bool IsAdding { get; set; }
-    public Action OnCancel { get; set; }
-    public Action<TodoForm> OnSave { get; set; }
+    public Callback OnCancel { get; set; }
+    public Callback<TodoForm> OnSave { get; set; }
 #pragma warning restore CS8618
 
     private static Component FieldError(IReadOnlyList<string> msgs) =>
@@ -171,7 +171,7 @@ public sealed class TodoFormDialog : Component
             // ::backdrop, so we render our own — clicking it cancels, like the nav drawer's backdrop.
             Open ? Div(Class: "todo-backdrop", OnClick: OnCancel) : Fragment(),
             // tabindex makes the <dialog> programmatically focusable; OnKeyDown gives it Escape-to-close.
-            Dialog(Open, Ref: _dialog, TabIndex: -1, OnKeyDown: new Action<KeyboardEventArgs>(OnKey))[
+            Dialog(Open, Ref: _dialog, TabIndex: -1, OnKeyDown: new Callback<KeyboardEventArgs>(OnKey))[
                 H5(Class: "mb-3")[IsAdding ? "Add todo" : "Edit todo"],
                 Form(Model, OnSave, Class: "vstack gap-3")[
                     DataAnnotationsValidator(),

--- a/src/Rask.Core/AutoCallback.cs
+++ b/src/Rask.Core/AutoCallback.cs
@@ -111,4 +111,88 @@ public static class AutoCallback
             r.StateHasChanged();
         };
     }
+
+    // Named-type overloads — the framework's own components declare callbacks as Callback/CallbackAsync
+    // (see Callbacks.cs). Same typed wrapper as above (no DynamicInvoke), so the re-render path stays
+    // allocation-equivalent. The Action/Func overloads remain for consumer code that uses standard delegates.
+
+    /// <summary>Wrap a no-arg sync <see cref="Callback" /> so it re-renders its owner after running.</summary>
+    public static Callback? Wrap(Callback? d)
+    {
+        if (d is null)
+        {
+            return null;
+        }
+
+        if (d.Target is not Component r)
+        {
+            return d;
+        }
+
+        return () =>
+        {
+            d();
+            r.StateHasChanged();
+        };
+    }
+
+    /// <summary>Wrap a one-arg sync <see cref="Callback{T}" /> so it re-renders its owner after running.</summary>
+    public static Callback<T>? Wrap<T>(Callback<T>? d)
+    {
+        if (d is null)
+        {
+            return null;
+        }
+
+        if (d.Target is not Component r)
+        {
+            return d;
+        }
+
+        return arg =>
+        {
+            d(arg);
+            r.StateHasChanged();
+        };
+    }
+
+    /// <summary>Wrap a no-arg <see cref="CallbackAsync" /> so it awaits, then re-renders its owner.</summary>
+    public static CallbackAsync? Wrap(CallbackAsync? d)
+    {
+        if (d is null)
+        {
+            return null;
+        }
+
+        if (d.Target is not Component r)
+        {
+            return d;
+        }
+
+        return async () =>
+        {
+            await d().ConfigureAwait(false);
+            r.StateHasChanged();
+        };
+    }
+
+    /// <summary>Wrap a one-arg <see cref="CallbackAsync{T}" /> so it awaits, then re-renders its owner.</summary>
+    public static CallbackAsync<T>? Wrap<T>(CallbackAsync<T>? d)
+    {
+        if (d is null)
+        {
+            return null;
+        }
+
+        if (d.Target is not Component r)
+        {
+            return d;
+        }
+
+        return async arg =>
+        {
+            await d(arg).ConfigureAwait(false);
+            r.StateHasChanged();
+        };
+    }
 }

--- a/src/Rask.Core/Callbacks.cs
+++ b/src/Rask.Core/Callbacks.cs
@@ -1,0 +1,27 @@
+namespace Rask.Core;
+
+// Named delegate types for the framework's event/callback props, paired sync (`X`) + async (`XAsync`) the
+// same way the validator types are (Rask.Core.Forms.Validate / ValidateAsync). They replace the inline
+// `Action`/`Func<…, Task>` spellings on the built-in components so the public surface reads as intentional
+// callback types rather than raw delegates, and so the factory generator's auto-rerender wrapping and the
+// live dispatcher can resolve them by name.
+//
+// Contravariant in T so a handler over a base type accepts a more-derived argument. Both
+// AutoCallback.Wrap and Component.TryInvokeHandlerAsync carry typed overloads/cases for these, so the
+// re-render and DOM-dispatch hot paths stay reflection-free. Standard Action/Func handlers remain
+// supported for consumer code — these are additive, not a replacement of the delegate model.
+//
+// Named CallbackAsync (not AsyncCallback) deliberately: System.AsyncCallback is a non-generic BCL delegate,
+// so an unqualified `AsyncCallback` would be ambiguous. `CallbackAsync` also mirrors the `XAsync` suffix.
+
+/// <summary>A parameterless synchronous event callback (the shape of <c>OnClick</c>, <c>OnDrop</c>, …).</summary>
+public delegate void Callback();
+
+/// <summary>A one-argument synchronous event callback (e.g. <c>OnInput</c>, <c>OnKeyDown</c>).</summary>
+public delegate void Callback<in T>(T arg);
+
+/// <summary>A parameterless asynchronous event callback — the async sibling of <see cref="Callback" />.</summary>
+public delegate Task CallbackAsync();
+
+/// <summary>A one-argument asynchronous event callback — the async sibling of <see cref="Callback{T}" />.</summary>
+public delegate Task CallbackAsync<in T>(T arg);

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1059,6 +1059,85 @@ public abstract class Component
                     owner.Live.StateDirty = true;
                     return true;
                 }
+                // Named callback delegate types (Callbacks.cs) — typed fast path mirroring the
+                // Action/Func cases above so the framework's own handlers don't fall to DynamicInvoke.
+                case Callback c:
+                    c();
+                    return true;
+                case Callback<MouseModifiers> c:
+                    c(ExtractModifiers(payload));
+                    return true;
+                case Callback<string> c:
+                    c(ExtractString(payload, "value"));
+                    return true;
+                case Callback<FormData> c:
+                    c(FormData.FromJson(payload));
+                    return true;
+                case Callback<ScrollEvent> c:
+                    c(ScrollEvent.FromJson(payload));
+                    return true;
+                case Callback<KeyboardEventArgs> c:
+                    c(KeyboardEventArgs.FromJson(payload));
+                    return true;
+                case Callback<IReadOnlyList<RaskFile>> c:
+                {
+                    var files = FileListReader.Read(payload);
+                    try { c(files); }
+                    finally { ReleaseFiles(files); }
+
+                    return true;
+                }
+                case CallbackAsync c:
+                    await InvokeWithRenderingAsync(() => c()).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                case CallbackAsync<MouseModifiers> c:
+                {
+                    var mods = ExtractModifiers(payload);
+                    await InvokeWithRenderingAsync(() => c(mods)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
+                case CallbackAsync<string> c:
+                {
+                    var value = ExtractString(payload, "value");
+                    await InvokeWithRenderingAsync(() => c(value)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
+                case CallbackAsync<FormData> c:
+                {
+                    var fd = FormData.FromJson(payload);
+                    await InvokeWithRenderingAsync(() => c(fd)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
+                case CallbackAsync<ScrollEvent> c:
+                {
+                    var sc = ScrollEvent.FromJson(payload);
+                    await InvokeWithRenderingAsync(() => c(sc)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
+                case CallbackAsync<KeyboardEventArgs> c:
+                {
+                    var ke = KeyboardEventArgs.FromJson(payload);
+                    await InvokeWithRenderingAsync(() => c(ke)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
+                case CallbackAsync<IReadOnlyList<RaskFile>> c:
+                {
+                    var files = FileListReader.Read(payload);
+                    try
+                    {
+                        await InvokeWithRenderingAsync(() => c(files)).ConfigureAwait(false);
+                    }
+                    finally { ReleaseFiles(files); }
+
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
                 default:
                 {
                     // Parameterless delegate shapes outside the fast-path list above can still arrive

--- a/src/Rask.Core/Components/A.cs
+++ b/src/Rask.Core/Components/A.cs
@@ -15,8 +15,8 @@ public sealed class A : Element
     public string? Type { get; set; }
     public string? ReferrerPolicy { get; set; }
     public string? Ping { get; set; }
-    public Action? OnClick { get; set; }
-    public Func<Task>? OnClickAsync { get; set; }
+    public Callback? OnClick { get; set; }
+    public CallbackAsync? OnClickAsync { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {

--- a/src/Rask.Core/Components/Button.cs
+++ b/src/Rask.Core/Components/Button.cs
@@ -11,8 +11,8 @@ public sealed class Button : Element
     public bool? Disabled { get; set; }
     public string? Name { get; set; }
     public string? Value { get; set; }
-    public Action? OnClick { get; set; }
-    public Func<Task>? OnClickAsync { get; set; }
+    public Callback? OnClick { get; set; }
+    public CallbackAsync? OnClickAsync { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {

--- a/src/Rask.Core/Components/Div.cs
+++ b/src/Rask.Core/Components/Div.cs
@@ -7,8 +7,8 @@ public sealed class Div : Element
 {
     protected override string TagName => "div";
 
-    public Action? OnClick { get; set; }
-    public Func<Task>? OnClickAsync { get; set; }
+    public Callback? OnClick { get; set; }
+    public CallbackAsync? OnClickAsync { get; set; }
 
     // Bound to the element's `scroll` event by the client runtime (data-rask-on-scroll). Ships a
     // sync `OnScroll` (Action<ScrollEvent>) and an async `OnScrollAsync` (Func<ScrollEvent, Task>)
@@ -18,32 +18,32 @@ public sealed class Div : Element
     // {scrollTop, clientHeight, scrollHeight} payload into a typed ScrollEvent before invoking.
     private Delegate? _onScroll;
 
-    public Action<ScrollEvent>? OnScroll
+    public Callback<ScrollEvent>? OnScroll
     {
-        get => _onScroll as Action<ScrollEvent>;
+        get => _onScroll as Callback<ScrollEvent>;
         set
         {
             if (value is not null)
             {
                 _onScroll = value;
             }
-            else if (_onScroll is Action<ScrollEvent>)
+            else if (_onScroll is Callback<ScrollEvent>)
             {
                 _onScroll = null;
             }
         }
     }
 
-    public Func<ScrollEvent, Task>? OnScrollAsync
+    public CallbackAsync<ScrollEvent>? OnScrollAsync
     {
-        get => _onScroll as Func<ScrollEvent, Task>;
+        get => _onScroll as CallbackAsync<ScrollEvent>;
         set
         {
             if (value is not null)
             {
                 _onScroll = value;
             }
-            else if (_onScroll is Func<ScrollEvent, Task>)
+            else if (_onScroll is CallbackAsync<ScrollEvent>)
             {
                 _onScroll = null;
             }

--- a/src/Rask.Core/Components/DragDrop.cs
+++ b/src/Rask.Core/Components/DragDrop.cs
@@ -22,8 +22,8 @@ public sealed class DragDrop : Component
     public Func<DragDropContext, Component>? Body { get; set; }
 
     // Fired once when an item is dropped onto a zone. Set exactly one of OnDrop / OnDropAsync.
-    public Action<DragDropMove>? OnDrop { get; set; }
-    public Func<DragDropMove, Task>? OnDropAsync { get; set; }
+    public Callback<DragDropMove>? OnDrop { get; set; }
+    public CallbackAsync<DragDropMove>? OnDropAsync { get; set; }
 
     // DragDrop reads mutable internal drag state (source / hover target) that the framework can't
     // observe through props, so every render must re-execute — same reasoning as VirtualizeModel.

--- a/src/Rask.Core/Components/ErrorBoundary.cs
+++ b/src/Rask.Core/Components/ErrorBoundary.cs
@@ -2,7 +2,7 @@ namespace Rask.Core.Components;
 
 public sealed class ErrorBoundary : Component
 {
-    public Func<Exception, Action, Child>? Fallback { get; set; }
+    public Func<Exception, Callback, Child>? Fallback { get; set; }
 
     internal Exception? Error { get; private set; }
 
@@ -15,7 +15,7 @@ public sealed class ErrorBoundary : Component
     // props in one call.
     internal void SetProps(
         IEnumerable<Child>? children,
-        Func<Exception, Action, Child>? fallback)
+        Func<Exception, Callback, Child>? fallback)
     {
         Children = children;
         Fallback = fallback;

--- a/src/Rask.Core/Components/Form.cs
+++ b/src/Rask.Core/Components/Form.cs
@@ -31,9 +31,9 @@ public sealed class Form : Element
     public string? Autocomplete { get; set; }
     public bool? Novalidate { get; set; }
     public string? Name { get; set; }
-    public Action<FormData>? OnSubmit { get; set; }
+    public Callback<FormData>? OnSubmit { get; set; }
 
-    public Func<FormData, Task>? OnSubmitAsync { get; set; }
+    public CallbackAsync<FormData>? OnSubmitAsync { get; set; }
 
     // Pre-registers the form's EditContext with LiveRenderContext (creating it if needed) and
     // walks the model graph so descendant sub-objects also resolve to the same context. Without

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -43,13 +43,13 @@ public sealed class Input : Element
     public string? Src { get; set; }
     public int? Width { get; set; }
     public int? Height { get; set; }
-    public Action<string>? OnInput { get; set; }
-    public Action<string>? OnChange { get; set; }
-    public Func<string, Task>? OnInputAsync { get; set; }
-    public Func<string, Task>? OnChangeAsync { get; set; }
-    public Action<IReadOnlyList<RaskFileType>>? OnFiles { get; set; }
+    public Callback<string>? OnInput { get; set; }
+    public Callback<string>? OnChange { get; set; }
+    public CallbackAsync<string>? OnInputAsync { get; set; }
+    public CallbackAsync<string>? OnChangeAsync { get; set; }
+    public Callback<IReadOnlyList<RaskFileType>>? OnFiles { get; set; }
 
-    public Func<IReadOnlyList<RaskFileType>, Task>? OnFilesAsync { get; set; }
+    public CallbackAsync<IReadOnlyList<RaskFileType>>? OnFilesAsync { get; set; }
 
     // Expression-driven factory. The generator picks up [GenerateForwarderFactory] and emits
     // `Components.Input<TProp>(Expression<Func<TProp>> Bind, …)` forwarding here, so callers

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -23,9 +23,9 @@ public sealed class Select : Element
     public string? Form { get; set; }
     public bool? Autofocus { get; set; }
     public string? Autocomplete { get; set; }
-    public Action<string>? OnChange { get; set; }
+    public Callback<string>? OnChange { get; set; }
 
-    public Func<string, Task>? OnChangeAsync { get; set; }
+    public CallbackAsync<string>? OnChangeAsync { get; set; }
 
     // Expression-driven factory; pre-marks the matching <option> as selected so the
     // initial render reflects the bound value without round-tripping through the browser.

--- a/src/Rask.Core/Components/Svg/SvgElement.cs
+++ b/src/Rask.Core/Components/Svg/SvgElement.cs
@@ -36,8 +36,8 @@ public abstract class SvgElement : Element
     public string? Visibility { get; set; }
     public string? PointerEvents { get; set; }
 
-    public Action? OnClick { get; set; }
-    public Func<Task>? OnClickAsync { get; set; }
+    public Callback? OnClick { get; set; }
+    public CallbackAsync? OnClickAsync { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {

--- a/src/Rask.Core/Components/Textarea.cs
+++ b/src/Rask.Core/Components/Textarea.cs
@@ -25,11 +25,11 @@ public sealed class Textarea : Element
     public string? Autocomplete { get; set; }
     public string? Form { get; set; }
     public string? Dirname { get; set; }
-    public Action<string>? OnInput { get; set; }
-    public Action<string>? OnChange { get; set; }
-    public Func<string, Task>? OnInputAsync { get; set; }
+    public Callback<string>? OnInput { get; set; }
+    public Callback<string>? OnChange { get; set; }
+    public CallbackAsync<string>? OnInputAsync { get; set; }
 
-    public Func<string, Task>? OnChangeAsync { get; set; }
+    public CallbackAsync<string>? OnChangeAsync { get; set; }
 
     // Expression-driven factory; see Input.Bound for the broader pattern. Textarea always
     // updates per-keystroke (OnInput) since textareas are inherently string-valued.

--- a/src/Rask.Core/Components/VirtualizeModel.cs
+++ b/src/Rask.Core/Components/VirtualizeModel.cs
@@ -33,7 +33,7 @@ public sealed class VirtualizeModel : Component
     private int _clientHeight;
     private IEnumerable? _lastItems;
     private Delegate? _lastProvider;
-    private Action<ScrollEvent>? _onScrollDelegate;
+    private Callback<ScrollEvent>? _onScrollDelegate;
     private int _scrollTop;
     private int _totalCount;
     private bool _totalCountKnown;

--- a/src/Rask.Core/DragAndDrop/DragDropContext.cs
+++ b/src/Rask.Core/DragAndDrop/DragDropContext.cs
@@ -32,7 +32,7 @@ public sealed class DragDropContext
     public string? TargetZone => _owner.TargetZoneInternal;
     public int TargetIndex => _owner.TargetIndexInternal;
 
-    public Action DragEnd => _owner.EndDrag;
+    public Callback DragEnd => _owner.EndDrag;
 
     // Convenience for the common "highlight the slot under the cursor" case.
     public bool IsDropTarget(string zone, int index) =>
@@ -44,13 +44,13 @@ public sealed class DragDropContext
         string.Equals(_owner.SourceZoneInternal, zone, StringComparison.Ordinal)
         && _owner.SourceIndexInternal == index;
 
-    public Action DragStart(string zone, int index) => () => _owner.BeginDrag(zone, index);
+    public Callback DragStart(string zone, int index) => () => _owner.BeginDrag(zone, index);
 
-    public Action DragOver(string zone, int index) => () => _owner.HoverTarget(zone, index);
+    public Callback DragOver(string zone, int index) => () => _owner.HoverTarget(zone, index);
 
     // Always async: wire to Element.OnDropAsync. CommitDropAsync routes to whichever drop handler
     // (sync OnDrop or async OnDropAsync) the DragDrop primitive holds, so a sync consumer still
     // works — the context can't know the consumer's choice at the call site, so it always returns
     // a Func<Task> and the (rare) sync commit completes synchronously inside it.
-    public Func<Task> Drop(string zone, int index) => () => _owner.CommitDropAsync(zone, index);
+    public CallbackAsync Drop(string zone, int index) => () => _owner.CommitDropAsync(zone, index);
 }

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -76,121 +76,121 @@ public abstract class Element : Component
     private Delegate? _onDrop;
     private Delegate? _onDragEnd;
 
-    public Action? OnDragStart
+    public Callback? OnDragStart
     {
-        get => _onDragStart as Action;
+        get => _onDragStart as Callback;
         set => SetSync(ref _onDragStart, value);
     }
 
-    public Func<Task>? OnDragStartAsync
+    public CallbackAsync? OnDragStartAsync
     {
-        get => _onDragStart as Func<Task>;
+        get => _onDragStart as CallbackAsync;
         set => SetAsync(ref _onDragStart, value);
     }
 
-    public Action? OnDragOver
+    public Callback? OnDragOver
     {
-        get => _onDragOver as Action;
+        get => _onDragOver as Callback;
         set => SetSync(ref _onDragOver, value);
     }
 
-    public Func<Task>? OnDragOverAsync
+    public CallbackAsync? OnDragOverAsync
     {
-        get => _onDragOver as Func<Task>;
+        get => _onDragOver as CallbackAsync;
         set => SetAsync(ref _onDragOver, value);
     }
 
-    public Action? OnDrop
+    public Callback? OnDrop
     {
-        get => _onDrop as Action;
+        get => _onDrop as Callback;
         set => SetSync(ref _onDrop, value);
     }
 
-    public Func<Task>? OnDropAsync
+    public CallbackAsync? OnDropAsync
     {
-        get => _onDrop as Func<Task>;
+        get => _onDrop as CallbackAsync;
         set => SetAsync(ref _onDrop, value);
     }
 
-    public Action? OnDragEnd
+    public Callback? OnDragEnd
     {
-        get => _onDragEnd as Action;
+        get => _onDragEnd as Callback;
         set => SetSync(ref _onDragEnd, value);
     }
 
-    public Func<Task>? OnDragEndAsync
+    public CallbackAsync? OnDragEndAsync
     {
-        get => _onDragEnd as Func<Task>;
+        get => _onDragEnd as CallbackAsync;
         set => SetAsync(ref _onDragEnd, value);
     }
 
     // Keyboard events, available on every element (a key event needs the element — or a descendant
     // — focused, the same focus-scoped model as click). Bound by the client runtime via
     // data-rask-on-keydown / data-rask-on-keyup. Each ships a sync `OnXxx`
-    // (Action<KeyboardEventArgs>) and an async `OnXxxAsync` (Func<KeyboardEventArgs, Task>) sibling
+    // (Callback<KeyboardEventArgs>) and an async `OnXxxAsync` (CallbackAsync<KeyboardEventArgs>) sibling
     // coalesced over a single LiveState slot by delegate type (like the drag pairs above); the
     // dispatcher unpacks the {key, code, modifiers, repeat} payload into a KeyboardEventArgs. The
     // client never preventDefaults a key event, so handlers compose with normal typing. Storage is
     // hoisted into the lazy LiveState (like Ref/Role/Aria) so an element with no key handler keeps
     // `_live` null and pays no per-instance footprint — see OnKeyDownInternal/OnKeyUpInternal.
-    public Action<KeyboardEventArgs>? OnKeyDown
+    public Callback<KeyboardEventArgs>? OnKeyDown
     {
-        get => OnKeyDownInternal as Action<KeyboardEventArgs>;
+        get => OnKeyDownInternal as Callback<KeyboardEventArgs>;
         set
         {
             if (value is not null)
             {
                 OnKeyDownInternal = value;
             }
-            else if (OnKeyDownInternal is Action<KeyboardEventArgs>)
+            else if (OnKeyDownInternal is Callback<KeyboardEventArgs>)
             {
                 OnKeyDownInternal = null;
             }
         }
     }
 
-    public Func<KeyboardEventArgs, Task>? OnKeyDownAsync
+    public CallbackAsync<KeyboardEventArgs>? OnKeyDownAsync
     {
-        get => OnKeyDownInternal as Func<KeyboardEventArgs, Task>;
+        get => OnKeyDownInternal as CallbackAsync<KeyboardEventArgs>;
         set
         {
             if (value is not null)
             {
                 OnKeyDownInternal = value;
             }
-            else if (OnKeyDownInternal is Func<KeyboardEventArgs, Task>)
+            else if (OnKeyDownInternal is CallbackAsync<KeyboardEventArgs>)
             {
                 OnKeyDownInternal = null;
             }
         }
     }
 
-    public Action<KeyboardEventArgs>? OnKeyUp
+    public Callback<KeyboardEventArgs>? OnKeyUp
     {
-        get => OnKeyUpInternal as Action<KeyboardEventArgs>;
+        get => OnKeyUpInternal as Callback<KeyboardEventArgs>;
         set
         {
             if (value is not null)
             {
                 OnKeyUpInternal = value;
             }
-            else if (OnKeyUpInternal is Action<KeyboardEventArgs>)
+            else if (OnKeyUpInternal is Callback<KeyboardEventArgs>)
             {
                 OnKeyUpInternal = null;
             }
         }
     }
 
-    public Func<KeyboardEventArgs, Task>? OnKeyUpAsync
+    public CallbackAsync<KeyboardEventArgs>? OnKeyUpAsync
     {
-        get => OnKeyUpInternal as Func<KeyboardEventArgs, Task>;
+        get => OnKeyUpInternal as CallbackAsync<KeyboardEventArgs>;
         set
         {
             if (value is not null)
             {
                 OnKeyUpInternal = value;
             }
-            else if (OnKeyUpInternal is Func<KeyboardEventArgs, Task>)
+            else if (OnKeyUpInternal is CallbackAsync<KeyboardEventArgs>)
             {
                 OnKeyUpInternal = null;
             }
@@ -200,25 +200,25 @@ public abstract class Element : Component
     // Shared coalescing helpers for the drag handler pairs: a non-null value always wins; a null
     // only clears the slot when it currently holds the same kind (sync Action vs async Func<Task>),
     // so re-applying the unset sibling never wipes the handler the caller set.
-    private static void SetSync(ref Delegate? slot, Action? value)
+    private static void SetSync(ref Delegate? slot, Callback? value)
     {
         if (value is not null)
         {
             slot = value;
         }
-        else if (slot is Action)
+        else if (slot is Callback)
         {
             slot = null;
         }
     }
 
-    private static void SetAsync(ref Delegate? slot, Func<Task>? value)
+    private static void SetAsync(ref Delegate? slot, CallbackAsync? value)
     {
         if (value is not null)
         {
             slot = value;
         }
-        else if (slot is Func<Task>)
+        else if (slot is CallbackAsync)
         {
             slot = null;
         }

--- a/src/Rask.Core/Forms/BindingHelpers.cs
+++ b/src/Rask.Core/Forms/BindingHelpers.cs
@@ -194,7 +194,7 @@ public static class BindingHelpers
     // `AfterBindAsync` factory parameters on Input/Select/Textarea). It only fires when a parse
     // actually mutated the model, so the user never sees a stale value; we run it after
     // NotifyFieldChanged so validators that observe IsModified see the new state.
-    public static Func<string, Task> StringSetHandler(
+    public static CallbackAsync<string> StringSetHandler(
         ExpressionAccessor.Accessor acc, EditContext? ctx, FieldIdentifier fid, bool validateOnSet,
         Func<Task>? afterBind = null) =>
         async raw =>
@@ -226,7 +226,7 @@ public static class BindingHelpers
             }
         };
 
-    public static Func<string, Task> TouchAndValidateHandler(
+    public static CallbackAsync<string> TouchAndValidateHandler(
         ExpressionAccessor.Accessor acc, EditContext? ctx, FieldIdentifier fid, bool setOnChange,
         Func<Task>? afterBind = null) =>
         async raw =>
@@ -270,7 +270,7 @@ public static class BindingHelpers
     // inverting, which surfaced as the checkbox "sticking" after a few clicks once those
     // clicks started shipping diffs (which don't re-base an unchanged checked attribute)
     // instead of full HTML (whose morph re-based it every time).
-    public static Func<string, Task> BoolSetHandler(
+    public static CallbackAsync<string> BoolSetHandler(
         ExpressionAccessor.Accessor acc, EditContext? ctx, FieldIdentifier fid,
         Func<Task>? afterBind = null) =>
         async value =>

--- a/src/Rask.Core/Virtualization/VirtualizationContext.cs
+++ b/src/Rask.Core/Virtualization/VirtualizationContext.cs
@@ -34,5 +34,5 @@ public sealed class VirtualizationContext<T>
     public int ItemSize => State.ItemSize;
     public int OffsetBefore => State.OffsetBefore;
     public int OffsetAfter => State.OffsetAfter;
-    public Action<ScrollEvent> OnScroll => State.OnScroll;
+    public Callback<ScrollEvent> OnScroll => State.OnScroll;
 }

--- a/src/Rask.Core/Virtualization/VirtualizationState.cs
+++ b/src/Rask.Core/Virtualization/VirtualizationState.cs
@@ -19,7 +19,7 @@ public sealed class VirtualizationState
         int itemSize,
         int offsetBefore,
         int offsetAfter,
-        Action<ScrollEvent> onScroll)
+        Callback<ScrollEvent> onScroll)
     {
         VisibleValues = visibleValues;
         VisibleIndices = visibleIndices;
@@ -40,5 +40,5 @@ public sealed class VirtualizationState
     public int ItemSize { get; }
     public int OffsetBefore { get; }
     public int OffsetAfter { get; }
-    public Action<ScrollEvent> OnScroll { get; }
+    public Callback<ScrollEvent> OnScroll { get; }
 }

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -1102,7 +1102,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             }
 
             first = false;
-            sb.Append("global::System.Action<").Append(gf.TypeParameter).Append(">? ").Append(dp).Append(" = null");
+            sb.Append("global::Rask.Core.Callback<").Append(gf.TypeParameter).Append(">? ").Append(dp).Append(" = null");
         }
 
         foreach (var dp in typedDelegates)
@@ -1113,8 +1113,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             }
 
             first = false;
-            sb.Append("global::System.Func<").Append(gf.TypeParameter)
-                .Append(", global::System.Threading.Tasks.Task>? ").Append(dp).Append("Async = null");
+            sb.Append("global::Rask.Core.CallbackAsync<").Append(gf.TypeParameter)
+                .Append(">? ").Append(dp).Append("Async = null");
         }
 
         // Remaining props in declaration order, skipping the Model and typed-delegate names

--- a/tests/Rask.Core.Tests/Callbacks/AutoCallbackTests.cs
+++ b/tests/Rask.Core.Tests/Callbacks/AutoCallbackTests.cs
@@ -64,7 +64,7 @@ public class AutoCallbackTests
     public void Wrap_NullDelegate_ReturnsNull()
     {
         Assert.Null(AutoCallback.Wrap((Action?)null));
-        Assert.Null(AutoCallback.Wrap(null));
+        Assert.Null(AutoCallback.Wrap((Func<Task>?)null));
         Assert.Null(AutoCallback.Wrap((Action<int>?)null));
         Assert.Null(AutoCallback.Wrap((Func<int, Task>?)null));
     }
@@ -158,17 +158,17 @@ public class AutoCallbackTests
             switch (_mode)
             {
                 case Mode.Sync:
-                    OnAdd = AutoCallback.Wrap<int>(n => Count += n);
+                    OnAdd = AutoCallback.Wrap((Action<int>)(n => Count += n));
                     break;
                 case Mode.Async:
-                    OnAddAsync = AutoCallback.Wrap<int>(async n =>
+                    OnAddAsync = AutoCallback.Wrap((Func<int, Task>)(async n =>
                     {
                         await Task.Yield();
                         Count += n;
-                    });
+                    }));
                     break;
                 case Mode.StringArg:
-                    OnText = AutoCallback.Wrap<string>(s => Text = s);
+                    OnText = AutoCallback.Wrap((Action<string>)(s => Text = s));
                     break;
             }
 
@@ -215,7 +215,7 @@ public class AutoCallbackTests
 
         public ValueTask Fire(int n)
         {
-            var cb = AutoCallback.Wrap<int>(v => Seen = v);
+            var cb = AutoCallback.Wrap((Action<int>)(v => Seen = v));
             cb!(n);
             return default;
         }

--- a/tests/Rask.Core.Tests/Components/ElementDragTests.cs
+++ b/tests/Rask.Core.Tests/Components/ElementDragTests.cs
@@ -21,7 +21,7 @@ public class ElementDragTests
         // static draggable attribute survives.
         Assert.Equal(
             "<div draggable=\"true\"></div>",
-            Div(Draggable: true, OnDragStart: new Action(() => { }), OnDrop: new Action(() => { })).ToHtml());
+            Div(Draggable: true, OnDragStart: new Callback(() => { }), OnDrop: new Callback(() => { })).ToHtml());
 
     [Fact]
     public void DragHandlers_InsideLiveContext_EmitDataAttributesInRegistrationOrder()
@@ -30,10 +30,10 @@ public class ElementDragTests
             Id: "d",
             Class: "x",
             Draggable: true,
-            OnDragStart: new Action(() => { }),
-            OnDragOver: new Action(() => { }),
-            OnDrop: new Action(() => { }),
-            OnDragEnd: new Action(() => { })));
+            OnDragStart: new Callback(() => { }),
+            OnDragOver: new Callback(() => { }),
+            OnDrop: new Callback(() => { }),
+            OnDragEnd: new Callback(() => { })));
 
         // Universal attrs first (id, class), then draggable, then the drag handler hooks in
         // dragstart → dragover → drop → dragend order (matching RegisterHandler id assignment).
@@ -47,7 +47,7 @@ public class ElementDragTests
     [Fact]
     public void DragHandlers_OnlyNonNullEmitted()
     {
-        var view = new StubComponent(() => Div(OnDrop: new Action(() => { })));
+        var view = new StubComponent(() => Div(OnDrop: new Callback(() => { })));
         Assert.Equal("<div data-rask-on-drop=\"h0\"></div>", view.RenderAsLiveRoot());
     }
 

--- a/tests/Rask.Core.Tests/Components/ElementKeyboardTests.cs
+++ b/tests/Rask.Core.Tests/Components/ElementKeyboardTests.cs
@@ -17,13 +17,13 @@ public class ElementKeyboardTests
         Assert.Equal(
             "<div></div>",
             Div(
-                OnKeyDown: new Action<KeyboardEventArgs>(_ => { }),
-                OnKeyUp: new Action<KeyboardEventArgs>(_ => { })).ToHtml());
+                OnKeyDown: new Callback<KeyboardEventArgs>(_ => { }),
+                OnKeyUp: new Callback<KeyboardEventArgs>(_ => { })).ToHtml());
 
     [Fact]
     public void KeyHandlers_OnlyNonNullEmitted()
     {
-        var view = new StubComponent(() => Div(OnKeyDown: new Action<KeyboardEventArgs>(_ => { })));
+        var view = new StubComponent(() => Div(OnKeyDown: new Callback<KeyboardEventArgs>(_ => { })));
         Assert.Equal("<div data-rask-on-keydown=\"h0\"></div>", view.RenderAsLiveRoot());
     }
 
@@ -32,8 +32,8 @@ public class ElementKeyboardTests
     {
         // Setting only the async variant still registers the handler and emits the attribute.
         var view = new StubComponent(() => Div(
-            OnKeyDownAsync: new Func<KeyboardEventArgs, Task>(_ => Task.CompletedTask),
-            OnKeyUpAsync: new Func<KeyboardEventArgs, Task>(_ => Task.CompletedTask)));
+            OnKeyDownAsync: new CallbackAsync<KeyboardEventArgs>(_ => Task.CompletedTask),
+            OnKeyUpAsync: new CallbackAsync<KeyboardEventArgs>(_ => Task.CompletedTask)));
         Assert.Equal(
             "<div data-rask-on-keydown=\"h0\" data-rask-on-keyup=\"h1\"></div>",
             view.RenderAsLiveRoot());
@@ -46,9 +46,9 @@ public class ElementKeyboardTests
             Id: "d",
             Class: "x",
             Draggable: true,
-            OnDragStart: new Action(() => { }),
-            OnKeyDown: new Action<KeyboardEventArgs>(_ => { }),
-            OnKeyUp: new Action<KeyboardEventArgs>(_ => { }),
+            OnDragStart: new Callback(() => { }),
+            OnKeyDown: new Callback<KeyboardEventArgs>(_ => { }),
+            OnKeyUp: new Callback<KeyboardEventArgs>(_ => { }),
             Role: "dialog",
             TabIndex: -1));
 
@@ -79,7 +79,7 @@ public class ElementKeyboardTests
     public async Task KeyDown_TypedHandler_ReceivesParsedKeyCodeModifiersAndRepeat()
     {
         KeyboardEventArgs? seen = null;
-        var view = new StubComponent(() => Div(OnKeyDown: new Action<KeyboardEventArgs>(e => seen = e)));
+        var view = new StubComponent(() => Div(OnKeyDown: new Callback<KeyboardEventArgs>(e => seen = e)));
         var id = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-keydown")!;
 
         using var payload = JsonDocument.Parse(
@@ -100,7 +100,7 @@ public class ElementKeyboardTests
     public async Task KeyUp_AsyncTypedHandler_IsAwaited()
     {
         string? seenKey = null;
-        var view = new StubComponent(() => Div(OnKeyUpAsync: new Func<KeyboardEventArgs, Task>(e =>
+        var view = new StubComponent(() => Div(OnKeyUpAsync: new CallbackAsync<KeyboardEventArgs>(e =>
         {
             seenKey = e.Key;
             return Task.CompletedTask;
@@ -117,7 +117,7 @@ public class ElementKeyboardTests
     public async Task KeyDown_AsyncTypedHandler_IsAwaited()
     {
         KeyboardEventArgs? seen = null;
-        var view = new StubComponent(() => Div(OnKeyDownAsync: new Func<KeyboardEventArgs, Task>(e =>
+        var view = new StubComponent(() => Div(OnKeyDownAsync: new CallbackAsync<KeyboardEventArgs>(e =>
         {
             seen = e;
             return Task.CompletedTask;
@@ -135,7 +135,7 @@ public class ElementKeyboardTests
     public async Task KeyDown_MissingPayloadFields_DefaultToEmptyAndFalse()
     {
         KeyboardEventArgs? seen = null;
-        var view = new StubComponent(() => Div(OnKeyDown: new Action<KeyboardEventArgs>(e => seen = e)));
+        var view = new StubComponent(() => Div(OnKeyDown: new Callback<KeyboardEventArgs>(e => seen = e)));
         var id = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-keydown")!;
 
         using var payload = JsonDocument.Parse("{}");

--- a/tests/Rask.Core.Tests/Components/FormTests.cs
+++ b/tests/Rask.Core.Tests/Components/FormTests.cs
@@ -61,8 +61,8 @@ public class FormTests
 
         var view = new StubComponent(() => Form(
             p,
-            (Action<Person>)(_ => validCalled++),
-            (Action<Person>)(_ => invalidCalled++),
+            (Callback<Person>)(_ => validCalled++),
+            (Callback<Person>)(_ => invalidCalled++),
             Context: ctx)[Input(() => p.Name), Input(() => p.Age)]);
         var html = view.RenderAsLiveRoot();
 

--- a/tests/Rask.Core.Tests/Forms/FormBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/FormBindingTests.cs
@@ -133,7 +133,7 @@ public class FormBindingTests
 
         var view = new StubComponent(() => Form(
             p,
-            (Action<Person>)(m => captured = m))[Input(() => p.Name), Input(() => p.Age)]);
+            (Callback<Person>)(m => captured = m))[Input(() => p.Name), Input(() => p.Age)]);
         var html = view.RenderAsLiveRoot();
 
         var submitId = Markup.Attr(html, "data-rask-on-submit");

--- a/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
+++ b/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
@@ -17,7 +17,7 @@ public class RaskFileDispatchTests
             .BuildServiceProvider();
 
         IReadOnlyList<RaskFile>? received = null;
-        Action<IReadOnlyList<RaskFile>> handler = files => received = files;
+        Callback<IReadOnlyList<RaskFile>> handler = files => received = files;
 
         var view = new StubComponent(() => Input(OnFiles: handler));
         view.RenderAsLiveRoot();
@@ -48,7 +48,7 @@ public class RaskFileDispatchTests
             .BuildServiceProvider();
 
         var seen = 0;
-        Func<IReadOnlyList<RaskFile>, Task> handler = files =>
+        CallbackAsync<IReadOnlyList<RaskFile>> handler = files =>
         {
             seen = files.Count;
             return Task.CompletedTask;
@@ -72,7 +72,7 @@ public class RaskFileDispatchTests
     [Fact]
     public void Input_Emits_DataRaskOnFiles_Attribute_When_OnFiles_Set()
     {
-        Action<IReadOnlyList<RaskFile>> handler = _ => { };
+        Callback<IReadOnlyList<RaskFile>> handler = _ => { };
         var view = new StubComponent(() => Input("file", OnFiles: handler));
         var html = view.RenderAsLiveRoot();
         Assert.Contains("data-rask-on-files=", html);

--- a/tests/Rask.Generators.Tests/FactoryAttributeTests.cs
+++ b/tests/Rask.Generators.Tests/FactoryAttributeTests.cs
@@ -51,12 +51,12 @@ public class FactoryAttributeTests
         Assert.Contains("object? Model = null", output);
         Assert.Contains("global::System.Delegate? OnValidSubmit = null", output);
 
-        // Generic overload: TModel Model + narrowed Action<TModel>?/Func<TModel,Task>? pair.
+        // Generic overload: TModel Model + narrowed Callback<TModel>?/CallbackAsync<TModel>? pair.
         Assert.Contains("public static global::Demo.FormLike FormLike<TModel>(", output);
         Assert.Contains("TModel Model", output);
-        Assert.Contains("global::System.Action<TModel>? OnValidSubmit = null", output);
+        Assert.Contains("global::Rask.Core.Callback<TModel>? OnValidSubmit = null", output);
         Assert.Contains(
-            "global::System.Func<TModel, global::System.Threading.Tasks.Task>? OnValidSubmitAsync = null",
+            "global::Rask.Core.CallbackAsync<TModel>? OnValidSubmitAsync = null",
             output);
         Assert.Contains("where TModel : class", output);
 

--- a/tests/Rask.Validation.DataAnnotations.Tests/DataAnnotationsValidatorTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/DataAnnotationsValidatorTests.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
+using Rask.Core;
 using Rask.Core.Forms;
 
 #pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory
@@ -23,7 +24,7 @@ public class DataAnnotationsValidatorTests
         Person? captured = null;
         var view = new StubComponent(() => Form<Person>(
             p,
-            (Action<Person>)(m => captured = m))[
+            (Callback<Person>)(m => captured = m))[
             DataAnnotationsValidator(),
             Input(() => p.Name),
             Input(() => p.Age)


### PR DESCRIPTION
## Summary
Introduces named delegate types `Callback` / `Callback<T>` / `CallbackAsync` / `CallbackAsync<T>` in `Rask.Core` and makes them the type of every built-in component's event callbacks — the `X`/`XAsync` pairs (`OnClick`/`OnClickAsync`, `OnInput`/`OnChange`/`…Async`, `OnKeyDown`/`OnKeyUp`, `OnDrag*`, `OnScroll`, `OnSubmit`, `OnFiles`, and `Form`'s `OnValidSubmit`/`OnInvalidSubmit`) — replacing the inline `Action`/`Func<…,Task>` spellings, pairing with the existing `Validate`/`ValidateAsync` convention.

`AutoCallback.Wrap` gains typed overloads and `Component.TryInvokeHandlerAsync` gains typed `case`s for the named types, so the re-render and DOM-dispatch hot paths stay **reflection-free**. The generator's `[FactoryGeneric]` delegate-collapse emits the named types (Form). Framework callback *producers* (`DragDropContext`, `ErrorBoundary`'s `reset`, `VirtualizationState`/`Context` scroll) and `BindingHelpers`' handler builders now return the named types. **Standard `Action`/`Func` handlers remain supported** for consumer code (the named overloads/cases are additive). `CallbackAsync` (not `AsyncCallback`) avoids the `System.AsyncCallback` clash.

This is step 1 of the larger "generator-driven form controls" effort; follow-ups: generator-driven validator/callback fan-out (drop hand-written `Bound` overloads + `MultiSelectBoundFactory`), promote `CheckboxGroup`/`RadioGroup` to Components, remove `[SkipFactory]`.

**Minor breaking:** passing a pre-typed `Action`/`Func` *variable* to a built-in handler must switch the variable to the matching `Callback`/`CallbackAsync` type; inline lambdas and method groups are unaffected.

## Testing
- `dotnet format --verify-no-changes`: clean. `dotnet build Rask.slnx -warnaserror`: clean (generator + analyzers).
- Unit: full fast suite green — incl. `AutoCallbackTests` (overloads), `Rask.Generators.Tests` (Form emission updated to the named types), and the migrated Element/Form/DragDrop/RaskFile/DataAnnotations suites.
- E2E (samples changed): host **Server** — `ServerExampleTests.Journey` **passed**.

## Benchmarks
Render hot path (`LiveRenderRoundTrip`, before on `main` vs after) — **Allocated identical, zero delta**:

| Bench | Before | After |
|---|---|---|
| RenderOnce | 105.36 KB | 105.36 KB |
| RenderTenTimes | 175.67 KB | 175.67 KB |
| RenderKeyedList100 | 133.92 KB | 133.92 KB |
| RenderDeep_50UserComponents | 91.88 KB | 91.88 KB |

The typed overloads/cases keep `AutoCallback.Wrap` and the dispatcher reflection-free, so allocations are unchanged. (`WsDispatch` payload encoding untouched.)

## CHANGELOG
- [Unreleased] Added: the four `Callback`/`CallbackAsync` delegate types; minor-breaking note on the handler param types.