### PR TITLE
refactor(generators): fan validator overloads from a single Bound core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **Generator-driven validator fan-out for bound form controls.** `[GenerateForwarderFactory]` gained a
+  `Validator` parameter: naming a `Delegate?` parameter makes the generator emit the none/sync/async
+  `Validate<T>`/`ValidateAsync<T>` overloads around a single hand-written core. `Input`/`Select`/`Textarea`
+  now declare one `Bound` core each instead of three near-identical overloads + a private `BoundCore` — the
+  generator emits the cast-free `Validate` overloads. The generated `Input(…)`/`Select(…)`/`Textarea(…)`
+  factory surface is unchanged (no consumer impact).
+
 ### Added
 - **`Callback` / `Callback<T>` / `CallbackAsync` / `CallbackAsync<T>` delegate types.** Named delegate
   types in `Rask.Core` are now the shape of every built-in component's event callbacks (the `X` / `XAsync`

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -51,22 +51,19 @@ public sealed class Input : Element
 
     public CallbackAsync<IReadOnlyList<RaskFileType>>? OnFilesAsync { get; set; }
 
-    // Expression-driven factory. The generator picks up [GenerateForwarderFactory] and emits
-    // `Components.Input<TProp>(Expression<Func<TProp>> Bind, …)` forwarding here, so callers
-    // write `Input(Bind: () => model.Name)` and get type-aware binding with auto-named field,
-    // per-type input type (checkbox/number/date/text), and per-type change handlers wired
-    // into the ambient EditContext.
+    // Expression-driven factory. The generator picks up [GenerateForwarderFactory(Validator=…)] and emits
+    // `Components.Input<TProp>(Expression<Func<TProp>> Bind, …)` forwarding here, so callers write
+    // `Input(Bind: () => model.Name)` and get type-aware binding with auto-named field, per-type input
+    // type (checkbox/number/date/text), and per-type change handlers wired into the ambient EditContext.
     //
-    // `Validate` ships as three overloads to dodge the delegate cast at the call site:
-    //   - no Validate parameter at all (omit to skip validation),
-    //   - typed sync   `Validate<TProp> Validate`,
-    //   - typed async  `ValidateAsync<TProp> Validate`.
-    // Both are the shared validator delegate types in Rask.Core.Forms.
-    // Overload resolution picks based on the lambda's arity; all three forward to the shared
-    // BoundCore which collapses to the single `Delegate?` the EditContext consumes.
-    [GenerateForwarderFactory]
+    // The `Validator = nameof(Validate)` arg makes the generator fan this single core into three emitted
+    // overloads — none / `Validate<TProp>` / `ValidateAsync<TProp>` — to dodge the delegate cast at the
+    // call site; overload resolution picks by the lambda's arity. The `Validate` parameter is the single
+    // `Delegate?` the EditContext consumes (null in the none overload).
+    [GenerateForwarderFactory(Validator = "Validate")]
     public static Input Bound<TProp>(
         Expression<Func<TProp>> Bind,
+        Delegate? Validate = null,
         Action<TProp>? AfterBind = null,
         Func<TProp, Task>? AfterBindAsync = null,
         string? Type = null,
@@ -89,98 +86,6 @@ public sealed class Input : Element
         string? Class = null,
         string? Style = null,
         IReadOnlyDictionary<string, string?>? Data = null)
-        => BoundCore(Bind, Type, Name, Placeholder, Required, Disabled, ReadOnly,
-            Min, Max, Step, Pattern, Size, MaxLength, MinLength,
-            Autocomplete, Autofocus, List, null,
-            AfterBind, AfterBindAsync, Id, Class, Style, Data);
-
-    [GenerateForwarderFactory]
-    public static Input Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        Validate<TProp> Validate,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Type = null,
-        string? Name = null,
-        string? Placeholder = null,
-        bool Required = false,
-        bool Disabled = false,
-        bool ReadOnly = false,
-        string? Min = null,
-        string? Max = null,
-        string? Step = null,
-        string? Pattern = null,
-        int? Size = null,
-        int? MaxLength = null,
-        int? MinLength = null,
-        string? Autocomplete = null,
-        bool Autofocus = false,
-        string? List = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null)
-        => BoundCore(Bind, Type, Name, Placeholder, Required, Disabled, ReadOnly,
-            Min, Max, Step, Pattern, Size, MaxLength, MinLength,
-            Autocomplete, Autofocus, List, Validate,
-            AfterBind, AfterBindAsync, Id, Class, Style, Data);
-
-    [GenerateForwarderFactory]
-    public static Input Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        ValidateAsync<TProp> Validate,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Type = null,
-        string? Name = null,
-        string? Placeholder = null,
-        bool Required = false,
-        bool Disabled = false,
-        bool ReadOnly = false,
-        string? Min = null,
-        string? Max = null,
-        string? Step = null,
-        string? Pattern = null,
-        int? Size = null,
-        int? MaxLength = null,
-        int? MinLength = null,
-        string? Autocomplete = null,
-        bool Autofocus = false,
-        string? List = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null)
-        => BoundCore(Bind, Type, Name, Placeholder, Required, Disabled, ReadOnly,
-            Min, Max, Step, Pattern, Size, MaxLength, MinLength,
-            Autocomplete, Autofocus, List, Validate,
-            AfterBind, AfterBindAsync, Id, Class, Style, Data);
-
-    private static Input BoundCore<TProp>(
-        Expression<Func<TProp>> Bind,
-        string? Type,
-        string? Name,
-        string? Placeholder,
-        bool Required,
-        bool Disabled,
-        bool ReadOnly,
-        string? Min,
-        string? Max,
-        string? Step,
-        string? Pattern,
-        int? Size,
-        int? MaxLength,
-        int? MinLength,
-        string? Autocomplete,
-        bool Autofocus,
-        string? List,
-        Delegate? validate,
-        Action<TProp>? afterBindSync,
-        Func<TProp, Task>? afterBindAsync,
-        string? Id,
-        string? Class,
-        string? Style,
-        IReadOnlyDictionary<string, string?>? Data)
     {
         var acc = ExpressionAccessor.Parse(Bind);
         var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
@@ -190,9 +95,9 @@ public sealed class Input : Element
 
         // Always call Register — null clears a stale delegate from a prior render so dropping
         // the parameter between frames doesn't leave the old rule running.
-        ctx?.RegisterFieldValidator(fid, validate, () => acc.Getter());
+        ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
 
-        var afterBind = BindingHelpers.BuildAfterBind(acc, afterBindSync, afterBindAsync);
+        var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
         var current = acc.Getter();
 
         if (resolvedType == "checkbox")

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -27,13 +27,13 @@ public sealed class Select : Element
 
     public CallbackAsync<string>? OnChangeAsync { get; set; }
 
-    // Expression-driven factory; pre-marks the matching <option> as selected so the
-    // initial render reflects the bound value without round-tripping through the browser.
-    // `Validate` ships as three overloads (none / `Validate<TProp>` / `ValidateAsync<TProp>`) to avoid a
-    // delegate cast at the call site — see Input.Bound for the dispatch rationale.
-    [GenerateForwarderFactory]
+    // Expression-driven factory; pre-marks the matching <option> as selected so the initial render
+    // reflects the bound value without round-tripping through the browser. The `Validator` arg fans this
+    // single core into none / `Validate<TProp>` / `ValidateAsync<TProp>` overloads — see Input.Bound.
+    [GenerateForwarderFactory(Validator = "Validate")]
     public static Select Bound<TProp>(
         Expression<Func<TProp>> Bind,
+        Delegate? Validate = null,
         Action<TProp>? AfterBind = null,
         Func<TProp, Task>? AfterBindAsync = null,
         string? Name = null,
@@ -47,72 +47,13 @@ public sealed class Select : Element
         string? Style = null,
         IReadOnlyDictionary<string, string?>? Data = null,
         params IEnumerable<Child> Children)
-        => BoundCore(Bind, Name, Required, Disabled, Size, Autofocus, Autocomplete,
-            null, AfterBind, AfterBindAsync, Id, Class, Style, Data, Children);
-
-    [GenerateForwarderFactory]
-    public static Select Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        Validate<TProp> Validate,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Name = null,
-        bool Required = false,
-        bool Disabled = false,
-        int? Size = null,
-        bool Autofocus = false,
-        string? Autocomplete = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null,
-        params IEnumerable<Child> Children)
-        => BoundCore(Bind, Name, Required, Disabled, Size, Autofocus, Autocomplete,
-            Validate, AfterBind, AfterBindAsync, Id, Class, Style, Data, Children);
-
-    [GenerateForwarderFactory]
-    public static Select Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        ValidateAsync<TProp> Validate,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Name = null,
-        bool Required = false,
-        bool Disabled = false,
-        int? Size = null,
-        bool Autofocus = false,
-        string? Autocomplete = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null,
-        params IEnumerable<Child> Children)
-        => BoundCore(Bind, Name, Required, Disabled, Size, Autofocus, Autocomplete,
-            Validate, AfterBind, AfterBindAsync, Id, Class, Style, Data, Children);
-
-    private static Select BoundCore<TProp>(
-        Expression<Func<TProp>> Bind,
-        string? Name,
-        bool Required,
-        bool Disabled,
-        int? Size,
-        bool Autofocus,
-        string? Autocomplete,
-        Delegate? validate,
-        Action<TProp>? afterBindSync,
-        Func<TProp, Task>? afterBindAsync,
-        string? Id,
-        string? Class,
-        string? Style,
-        IReadOnlyDictionary<string, string?>? Data,
-        IEnumerable<Child> Children)
     {
         var acc = ExpressionAccessor.Parse(Bind);
         var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
         var fid = acc.Field;
         var name = Name ?? acc.PropertyName;
-        ctx?.RegisterFieldValidator(fid, validate, () => acc.Getter());
-        var afterBind = BindingHelpers.BuildAfterBind(acc, afterBindSync, afterBindAsync);
+        ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+        var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
 
         var select = (Select)C.Select(
             name, Required: Required, Disabled: Disabled, Size: Size,

--- a/src/Rask.Core/Components/Textarea.cs
+++ b/src/Rask.Core/Components/Textarea.cs
@@ -31,13 +31,13 @@ public sealed class Textarea : Element
 
     public CallbackAsync<string>? OnChangeAsync { get; set; }
 
-    // Expression-driven factory; see Input.Bound for the broader pattern. Textarea always
-    // updates per-keystroke (OnInput) since textareas are inherently string-valued.
-    // `Validate` ships as three overloads (none / `Validate<TProp>` / `ValidateAsync<TProp>`) so callers
-    // can pass a bare lambda without a delegate cast.
-    [GenerateForwarderFactory]
+    // Expression-driven factory; see Input.Bound for the broader pattern. Textarea always updates
+    // per-keystroke (OnInput) since textareas are inherently string-valued. The `Validator` arg fans this
+    // single core into none / `Validate<TProp>` / `ValidateAsync<TProp>` overloads.
+    [GenerateForwarderFactory(Validator = "Validate")]
     public static Textarea Bound<TProp>(
         Expression<Func<TProp>> Bind,
+        Delegate? Validate = null,
         Action<TProp>? AfterBind = null,
         Func<TProp, Task>? AfterBindAsync = null,
         string? Name = null,
@@ -56,90 +56,13 @@ public sealed class Textarea : Element
         string? Class = null,
         string? Style = null,
         IReadOnlyDictionary<string, string?>? Data = null)
-        => BoundCore(Bind, Name, Rows, Cols, Placeholder, Required, Disabled, ReadOnly,
-            MaxLength, MinLength, Wrap, Autofocus, Autocomplete,
-            null, AfterBind, AfterBindAsync, Id, Class, Style, Data);
-
-    [GenerateForwarderFactory]
-    public static Textarea Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        Validate<TProp> Validate,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Name = null,
-        int? Rows = null,
-        int? Cols = null,
-        string? Placeholder = null,
-        bool Required = false,
-        bool Disabled = false,
-        bool ReadOnly = false,
-        int? MaxLength = null,
-        int? MinLength = null,
-        string? Wrap = null,
-        bool Autofocus = false,
-        string? Autocomplete = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null)
-        => BoundCore(Bind, Name, Rows, Cols, Placeholder, Required, Disabled, ReadOnly,
-            MaxLength, MinLength, Wrap, Autofocus, Autocomplete,
-            Validate, AfterBind, AfterBindAsync, Id, Class, Style, Data);
-
-    [GenerateForwarderFactory]
-    public static Textarea Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        ValidateAsync<TProp> Validate,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Name = null,
-        int? Rows = null,
-        int? Cols = null,
-        string? Placeholder = null,
-        bool Required = false,
-        bool Disabled = false,
-        bool ReadOnly = false,
-        int? MaxLength = null,
-        int? MinLength = null,
-        string? Wrap = null,
-        bool Autofocus = false,
-        string? Autocomplete = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null)
-        => BoundCore(Bind, Name, Rows, Cols, Placeholder, Required, Disabled, ReadOnly,
-            MaxLength, MinLength, Wrap, Autofocus, Autocomplete,
-            Validate, AfterBind, AfterBindAsync, Id, Class, Style, Data);
-
-    private static Textarea BoundCore<TProp>(
-        Expression<Func<TProp>> Bind,
-        string? Name,
-        int? Rows,
-        int? Cols,
-        string? Placeholder,
-        bool Required,
-        bool Disabled,
-        bool ReadOnly,
-        int? MaxLength,
-        int? MinLength,
-        string? Wrap,
-        bool Autofocus,
-        string? Autocomplete,
-        Delegate? validate,
-        Action<TProp>? afterBindSync,
-        Func<TProp, Task>? afterBindAsync,
-        string? Id,
-        string? Class,
-        string? Style,
-        IReadOnlyDictionary<string, string?>? Data)
     {
         var acc = ExpressionAccessor.Parse(Bind);
         var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
         var fid = acc.Field;
         var name = Name ?? acc.PropertyName;
-        ctx?.RegisterFieldValidator(fid, validate, () => acc.Getter());
-        var afterBind = BindingHelpers.BuildAfterBind(acc, afterBindSync, afterBindAsync);
+        ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+        var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
         var stringValue = BindingHelpers.FormatValue(acc.Getter());
 
         return (Textarea)C.Textarea(

--- a/src/Rask.Core/GenerateForwarderFactoryAttribute.cs
+++ b/src/Rask.Core/GenerateForwarderFactoryAttribute.cs
@@ -10,4 +10,10 @@ namespace Rask.Core;
 [AttributeUsage(AttributeTargets.Method)]
 public sealed class GenerateForwarderFactoryAttribute : Attribute
 {
+    // When set to the name of a `System.Delegate?` parameter on the source method, the generator fans the
+    // forwarder into three overloads (none / sync / async) instead of one verbatim forwarder — the
+    // validator parameter is omitted (forwarded as null), typed `Validate<T>`, or typed `ValidateAsync<T>`
+    // respectively, where T is the method's first type parameter. Lets a control declare a single `Bound`
+    // core and get the cast-free Validate overloads generated, instead of hand-writing all three.
+    public string? Validator { get; init; }
 }

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -168,11 +168,20 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             }
 
             var hasAttr = false;
+            string? validatorParam = null;
             foreach (var attr in method.GetAttributes())
             {
                 if (attr.AttributeClass?.ToDisplayString() == GenerateForwarderFactoryFullName)
                 {
                     hasAttr = true;
+                    foreach (var named in attr.NamedArguments)
+                    {
+                        if (named.Key == "Validator" && named.Value.Value is string v && v.Length > 0)
+                        {
+                            validatorParam = v;
+                        }
+                    }
+
                     break;
                 }
             }
@@ -181,6 +190,10 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             {
                 continue;
             }
+
+            // The validator fan-out types its sync/async overloads as Validate<T>/ValidateAsync<T> over the
+            // method's first type parameter (the bound property type), so it only applies to generic methods.
+            var validatorTypeArg = method.TypeParameters.Length > 0 ? method.TypeParameters[0].Name : string.Empty;
 
             var typeParams = method.TypeParameters.Length > 0
                 ? "<" + string.Join(", ", method.TypeParameters.Select(tp => tp.Name)) + ">"
@@ -206,7 +219,9 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                 method.Name,
                 typeParams,
                 constraints,
-                new EquatableArray<ForwarderParamInfo>(parameters)));
+                new EquatableArray<ForwarderParamInfo>(parameters),
+                validatorTypeArg.Length > 0 ? validatorParam : null,
+                validatorTypeArg));
         }
 
         return result;
@@ -936,35 +951,75 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
     private static void EmitForwarderFactory(StringBuilder sb, Candidate c, ForwarderInfo f, bool emitNavigation)
     {
+        // No validator configured → one verbatim forwarder (the original behavior).
+        if (f.ValidatorParam is null)
+        {
+            EmitForwarderOverload(sb, c, f, emitNavigation, ValidatorShape.None, fanOut: false);
+            return;
+        }
+
+        // Validator configured → fan into none/sync/async, exactly like the [FactoryGeneric] validator
+        // fan-out, but forwarding to the hand-written source method instead of building the component.
+        EmitForwarderOverload(sb, c, f, emitNavigation, ValidatorShape.None, fanOut: true);
+        EmitForwarderOverload(sb, c, f, emitNavigation, ValidatorShape.Sync, fanOut: true);
+        EmitForwarderOverload(sb, c, f, emitNavigation, ValidatorShape.Async, fanOut: true);
+    }
+
+    private static void EmitForwarderOverload(
+        StringBuilder sb, Candidate c, ForwarderInfo f, bool emitNavigation, ValidatorShape shape, bool fanOut)
+    {
         var visibility = c.IsPublic ? "public" : "internal";
 
         // Signature: `public static {Component} {ComponentName}<...>(<params>) <constraints>`
         EmitMethodHeader(sb, c, emitNavigation);
         sb.Append("    ").Append(visibility).Append(" static ").Append(c.FullyQualifiedName).Append(' ')
             .Append(c.TypeName).Append(f.TypeParameters).Append('(');
+        var first = true;
         for (var i = 0; i < f.Parameters.Count; i++)
         {
-            if (i > 0)
+            var p = f.Parameters[i];
+            var isValidator = fanOut && p.Name == f.ValidatorParam;
+
+            // The None overload drops the validator parameter entirely (it's forwarded as null below).
+            if (isValidator && shape == ValidatorShape.None)
+            {
+                continue;
+            }
+
+            if (!first)
             {
                 sb.Append(", ");
             }
 
-            var p = f.Parameters[i];
+            first = false;
             if (p.IsParams)
             {
                 sb.Append("params ");
             }
 
-            sb.Append(p.TypeFqn).Append(' ').Append(p.Name);
-            if (p.DefaultLiteral.Length > 0)
+            if (isValidator && shape == ValidatorShape.Sync)
             {
-                sb.Append(" = ").Append(p.DefaultLiteral);
+                sb.Append("global::Rask.Core.Forms.Validate<").Append(f.ValidatorTypeArg).Append("> ").Append(p.Name);
+            }
+            else if (isValidator && shape == ValidatorShape.Async)
+            {
+                sb.Append("global::Rask.Core.Forms.ValidateAsync<").Append(f.ValidatorTypeArg).Append("> ")
+                    .Append(p.Name);
+            }
+            else
+            {
+                sb.Append(p.TypeFqn).Append(' ').Append(p.Name);
+                if (p.DefaultLiteral.Length > 0)
+                {
+                    sb.Append(" = ").Append(p.DefaultLiteral);
+                }
             }
         }
 
         sb.Append(')').AppendLine(f.TypeParameterConstraints);
 
-        // Body: `=> global::{Component.FQN}.{MethodName}<...>(arg1, arg2, ...);`
+        // Body forwards to the source method. Non-fan-out keeps positional forwarding (verbatim shape);
+        // fan-out forwards by name so the omitted validator can be passed as null at its real position.
         sb.Append("        => ").Append(c.FullyQualifiedName).Append('.').Append(f.MethodName)
             .Append(f.TypeParameters).Append('(');
         for (var i = 0; i < f.Parameters.Count; i++)
@@ -974,7 +1029,19 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                 sb.Append(", ");
             }
 
-            sb.Append(f.Parameters[i].Name);
+            var p = f.Parameters[i];
+            if (!fanOut)
+            {
+                sb.Append(p.Name);
+            }
+            else if (p.Name == f.ValidatorParam && shape == ValidatorShape.None)
+            {
+                sb.Append(p.Name).Append(": null");
+            }
+            else
+            {
+                sb.Append(p.Name).Append(": ").Append(p.Name);
+            }
         }
 
         sb.AppendLine(");");
@@ -1366,7 +1433,9 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         string MethodName,
         string TypeParameters,
         string TypeParameterConstraints,
-        EquatableArray<ForwarderParamInfo> Parameters);
+        EquatableArray<ForwarderParamInfo> Parameters,
+        string? ValidatorParam,
+        string ValidatorTypeArg);
 
     private readonly record struct ForwarderParamInfo(
         string TypeFqn,

--- a/tests/Rask.Generators.Tests/ForwarderFactoryEmissionTests.cs
+++ b/tests/Rask.Generators.Tests/ForwarderFactoryEmissionTests.cs
@@ -101,4 +101,38 @@ public class ForwarderFactoryEmissionTests
         // Forwarders also carry the debugger-skip attribute (keeps stepping out of generated code).
         Assert.Contains("[global::System.Diagnostics.DebuggerStepThrough]", output);
     }
+
+    [Fact]
+    public void ValidatorForwarder_FansIntoNoneSyncAsyncOverloads()
+    {
+        var src = """
+                  using System;
+                  using System.Linq.Expressions;
+                  using Rask.Core;
+                  namespace Demo;
+                  public sealed class Widget : Component
+                  {
+                      [GenerateForwarderFactory(Validator = "Validate")]
+                      public static Widget Bound<TProp>(
+                          Expression<Func<TProp>> Bind, Delegate? Validate = null, string? Class = null)
+                          => new() { Class = Class };
+                      public override RenderResult Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.Run(src);
+        var output = run.GeneratedSource("Demo.Generated.g.cs");
+
+        // None overload: validator parameter omitted; forwarded as null (by name).
+        Assert.Contains(
+            "public static global::Demo.Widget Widget<TProp>(global::System.Linq.Expressions.Expression<global::System.Func<TProp>> Bind, string? Class = null)",
+            output);
+        Assert.Contains("=> global::Demo.Widget.Bound<TProp>(Bind: Bind, Validate: null, Class: Class);", output);
+
+        // Sync overload: typed Validate<TProp>, required (no default), right after Bind.
+        Assert.Contains("global::Rask.Core.Forms.Validate<TProp> Validate, string? Class = null)", output);
+        // Async overload: typed ValidateAsync<TProp>.
+        Assert.Contains("global::Rask.Core.Forms.ValidateAsync<TProp> Validate, string? Class = null)", output);
+        Assert.Contains("=> global::Demo.Widget.Bound<TProp>(Bind: Bind, Validate: Validate, Class: Class);", output);
+    }
 }


### PR DESCRIPTION
## Summary
Extends `[GenerateForwarderFactory]` with a `Validator` parameter: naming a `Delegate?` parameter makes the generator emit the none/sync/async `Validate<T>`/`ValidateAsync<T>` overloads around **one** hand-written core (forwarding by name; the omitted validator is passed `null`). `Input`/`Select`/`Textarea` now declare a single `Bound` core each instead of three near-identical `[GenerateForwarderFactory]` overloads + a private `BoundCore`.

The generated `Input(…)`/`Select(…)`/`Textarea(…)` factory surface is **unchanged** — no consumer impact. This is step 2 of the "make the generator smarter" effort (step 1 was the named callback delegates, #148).

Follow-ups (separate PRs): retire `MultiSelectBoundFactory` via generic-component generator support; remove `[SkipFactory]`.

## Testing
- `dotnet format --verify-no-changes`: clean. `dotnet build Rask.slnx -warnaserror`: clean (generator + analyzers).
- Unit: full fast suite green — `Rask.Generators.Tests` 160 (incl. new `ValidatorForwarder_FansIntoNoneSyncAsyncOverloads`; existing forwarder tests still assert positional forwarding for the non-fan-out path), Core 1539, samples, validation, etc.
- E2E (samples build on the generated factories): host **Server** — `ServerExampleTests.Journey` **passed**.

## Benchmarks
n/a — generator-only change; the emitted factory bodies are identical to the prior hand-written overloads.

## CHANGELOG
- [Unreleased] Changed: generator-driven validator fan-out; `Input`/`Select`/`Textarea` collapse to a single `Bound` core.