### PR TITLE
refactor(samples): CheckboxGroup/RadioGroup as Components (bound + controlled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **`CheckboxGroup`/`RadioGroup` rewritten as Components** (the `MultiSelect<TItem>` template) instead of
+  static `Fragment` factories. Each now supports **bound** (`() => model.X` with a per-field `Validate`
+  rule + `AfterBind` hooks) and **controlled** (`Value` + `OnChange`/`OnChangeAsync`) modes, and their
+  factories are generator-emitted (Bind-first validator fan-out for bound mode). **Note:** as Components
+  they are their own re-render boundary, so host-side derived UI updates via the auto-wrapped controlled
+  `OnChange` (the showcase group demos moved to controlled mode) rather than the free host re-render the
+  old `Fragment` form gave.
 - **Generator-driven validator fan-out for bound form controls.** `[GenerateForwarderFactory]` gained a
   `Validator` parameter: naming a `Delegate?` parameter makes the generator emit the none/sync/async
   `Validate<T>`/`ValidateAsync<T>` overloads around a single hand-written core. `Input`/`Select`/`Textarea`

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -365,55 +365,41 @@ See `samples/Rask.Example.Shared/Features/NestedForms/NestedFormPage.cs` for all
 ## 8. Radio & checkbox groups (example components)
 
 `RadioGroup<TValue>` binds one value from a set of options; `CheckboxGroup<TItem>` binds an
-`ICollection<TItem>`, toggling each item in place. They are **example components that ship in the
-samples** (`samples/Rask.Example.Shared/Shared/`), not framework primitives — small, copyable controls
-built on the public binding API of §9. Both render a transparent `Fragment`, so changes flow through the
-`EditContext` (validation, touched-tracking) like any bound field.
+`ICollection<TItem>`. They are **example components that ship in the samples**
+(`samples/Rask.Example.Shared/Shared/`), not framework primitives — small, copyable controls built on the
+public binding API of §9, structured exactly like `MultiSelect<TItem>` with **bound** and **controlled**
+modes (so the generator emits their factories):
 
 ```csharp
-public static Component RadioGroup<TValue>(
-    Expression<Func<TValue>> Bind,
-    IEnumerable<TValue> Options,
-    Func<TValue, Child>? OptionLabel = null,
-    string? Name = null,
-    string? ItemClass = null,
-    bool Disabled = false)
-
-public static Component CheckboxGroup<TItem>(
-    Expression<Func<ICollection<TItem>>> Bind,
-    IEnumerable<TItem> Options,
-    Func<TItem, Child>? OptionLabel = null,
-    string? Name = null,
-    string? ItemClass = null,
-    bool Disabled = false)
-```
-
-```csharp
+// Bound — two-way binds the model, with an optional per-field Validate rule.
 Form(_prefs)[
     RadioGroup(() => _prefs.Plan,                       // single value
         new[] { Plan.Free, Plan.Pro, Plan.Team },
         ItemClass: "form-check-inline"),
 
-    CheckboxGroup<string>(() => _prefs.Interests,       // a collection — toggles in place
+    CheckboxGroup<string>(() => _prefs.Interests,       // a collection
         new[] { "Web", "Mobile", "AI", "Games" },
-        ItemClass: "form-check-inline")
+        Validate: tags => tags.Count >= 1 ? [] : ["Pick at least one."])
 ]
+
+// Controlled — the parent owns the value; OnChange (auto-wrapped) re-renders it.
+RadioGroup(plans, Value: _plan, OnChange: v => _plan = v)
+CheckboxGroup<string>(interests, Value: _interests, OnChange: next => _interests = next)
 ```
 
-- The first positional argument is the `Bind` expression.
+- Bound mode takes the `Bind` expression first; `Validate` fans into none/sync/async overloads like
+  `Input` (§9). `RadioGroup` renders the option equal to the current value `checked` and sets the bound
+  property on select; `CheckboxGroup` mutates the bound collection (membership by
+  `EqualityComparer<TItem>.Default`) — you usually need the explicit `CheckboxGroup<string>` when the
+  collection is a concrete `List<T>`. Each change calls `NotifyFieldChanged` + `NotifyFieldTouched` +
+  `ValidateFieldAsync`, so DataAnnotations / FluentValidation rules apply.
 - Each item renders Bootstrap 5.3
   [check markup](https://getbootstrap.com/docs/5.3/forms/checks-radios/) — a
   `<div class="form-check">` wrapping a `.form-check-input` and a `.form-check-label` tied together by
-  `id`/`for`. `ItemClass` adds extra classes to that wrapper (e.g. `"form-check-inline"`); `OptionLabel`
-  customizes the label content.
-- `RadioGroup` renders the option equal to the current value `checked`; the change handler sets the
-  bound property. `CheckboxGroup` mutates the bound collection in place; membership is compared with
-  `EqualityComparer<TItem>.Default`. You usually need the explicit type argument
-  (`CheckboxGroup<string>`) when the bound collection is a concrete `List<T>`.
-- Because they return a `Fragment` (no component boundary of their own), changing an option re-renders
-  the component that declared the group — a live summary updates immediately. Each change calls
-  `NotifyFieldChanged` + `NotifyFieldTouched` + `ValidateFieldAsync`, so DataAnnotations /
-  FluentValidation rules on the bound property apply.
+  `id`/`for`. `ItemClass` adds extra classes (e.g. `"form-check-inline"`); `OptionLabel` customizes the label.
+- They are **Components** (their own re-render boundary), so a toggle re-renders the control itself; for
+  host-side derived UI (a live summary) use **controlled** mode — the auto-wrapped `OnChange` re-renders
+  the host. (In bound mode, feedback lives inside the control via the embedded `ValidationMessage`.)
 
 See `samples/Rask.Example.Shared/Features/FormGroups/FormGroupsPage.cs`.
 
@@ -465,18 +451,19 @@ Surface field messages with `ValidationMessage(Bind, …)` (§2.Rendering messag
 
 This is the one subtlety worth understanding:
 
-- A control with **no view state of its own** is best written as a static factory returning a
-  `Fragment` (like `CheckboxGroup`). Its `<input>` handlers are owned by the **host** component that
-  declared it (handler-owner resolution keeps the owner as the host when the handler isn't a
-  `Component`-targeted delegate), so a change re-renders the host for free — exactly like a bound
-  `Input`. Host-side derived UI (a live summary) just updates.
-- A control that **needs view state** (an open/closed dropdown) must be a `Component`. Now its own
-  handlers re-render *it*, not the host, so host-side derived UI would go stale. Two clean options:
+- A control with **no view state of its own** *can* be a static factory returning a `Fragment`. Its
+  `<input>` handlers are owned by the **host** component that declared it (handler-owner resolution keeps
+  the owner as the host when the handler isn't a `Component`-targeted delegate), so a change re-renders
+  the host for free — exactly like a bound `Input`. Host-side derived UI (a live summary) just updates.
+- A control written as a **`Component`** (so the generator can emit its factory, or because it needs view
+  state like an open/closed dropdown) is its own re-render boundary: its handlers re-render *it*, not the
+  host, so host-side derived UI would go stale. Two clean options:
   - keep the live feedback **inside the control** (chips, an embedded `ValidationMessage`) — it refreshes
     because the control re-renders itself; or
-  - expose an `Action<T>`/`Func<T,Task>` **callback** (`OnChange`) the consumer passes. Callback props on
-    a component are auto-wrapped (`AutoCallback`) so invoking them re-renders the component that owns the
-    handler — i.e. the host — so a host-side summary updates with no `StateHasChanged`.
+  - expose an `OnChange` **callback** the consumer passes. Callback props on a component are auto-wrapped
+    (`AutoCallback`) so invoking them re-renders the component that owns the handler — i.e. the host — so a
+    host-side summary updates with no `StateHasChanged`. (The sample `CheckboxGroup`/`RadioGroup`/`MultiSelect`
+    are all Components and use exactly this for their controlled mode.)
 
 ### Bound vs controlled
 
@@ -489,8 +476,8 @@ Mirror `Input` and offer both shapes where it makes sense:
 
 ### Worked examples
 
-- `samples/Rask.Example.Shared/Shared/CheckboxGroup.cs` / `RadioGroup.cs` — minimal stateless
-  `Fragment` controls with per-field binding and validation.
+- `samples/Rask.Example.Shared/Shared/CheckboxGroup.cs` / `RadioGroup.cs` — Components with bound +
+  controlled modes and a per-field `Validate` rule, rendering Bootstrap `form-check` markup.
 - `samples/Rask.Example.Shared/Shared/MultiSelect.cs` — a stateful `Component`: a Bootstrap dropdown
   with removable chips, Esc / click-outside close (pure live-diff, no client JS), both bound (with a
   `Validate` rule) and controlled (`Value` + auto-wrapped `OnChange`) modes. See the `/multiselect` page.

--- a/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsDemo.cs
@@ -1,31 +1,37 @@
 namespace Rask.Example.Shared.Features;
 
-// RadioGroup (single value) + CheckboxGroup (collection) bound to a model, with a live readout.
-// Changing any option re-renders this demo (the change handlers' owner resolves to it), so the
-// summary line updates immediately.
+// RadioGroup (single value) + CheckboxGroup (collection) in controlled mode (Value + OnChange), with a live
+// readout. The controls are Components; their OnChange callbacks are auto-wrapped (AutoCallback), so
+// selecting an option re-renders this demo and the summary line updates immediately — no StateHasChanged.
 public sealed class FormGroupsDemo : Component
 {
-    private readonly Prefs _prefs = new();
+    private static readonly Plan[] AllPlans = [Plan.Free, Plan.Pro, Plan.Team];
+    private static readonly string[] AllInterests = ["Web", "Mobile", "AI", "Games"];
+
+    private Plan _plan = Plan.Free;
+    private IReadOnlyCollection<string> _interests = [];
 
     protected override RenderResult Render() =>
-        Form(_prefs)[
-            Div(Class: "mb-3")[
+        Div(Class: "vstack gap-3")[
+            Div()[
                 Label(Class: "form-label fw-semibold d-block")["Plan"],
                 RadioGroup(
-                    () => _prefs.Plan,
-                    new[] { Plan.Free, Plan.Pro, Plan.Team },
+                    AllPlans,
+                    Value: _plan,
+                    OnChange: v => _plan = v,
                     ItemClass: "form-check-inline")
             ],
-            Div(Class: "mb-3")[
+            Div()[
                 Label(Class: "form-label fw-semibold d-block")["Interests"],
                 CheckboxGroup<string>(
-                    () => _prefs.Interests,
-                    new[] { "Web", "Mobile", "AI", "Games" },
+                    AllInterests,
+                    Value: _interests.ToList(),
+                    OnChange: next => _interests = next,
                     ItemClass: "form-check-inline")
             ],
             P(Class: "small text-secondary mb-0", Id: "groups-summary")[
-                $"Plan: {_prefs.Plan} · Interests: "
-                + (_prefs.Interests.Count == 0 ? "none" : string.Join(", ", _prefs.Interests))
+                $"Plan: {_plan} · Interests: "
+                + (_interests.Count == 0 ? "none" : string.Join(", ", _interests))
             ]
         ];
 
@@ -34,11 +40,5 @@ public sealed class FormGroupsDemo : Component
         Free,
         Pro,
         Team
-    }
-
-    private sealed class Prefs
-    {
-        public Plan Plan { get; set; } = Plan.Free;
-        public List<string> Interests { get; } = new();
     }
 }

--- a/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsPage.cs
+++ b/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsPage.cs
@@ -12,21 +12,21 @@ public sealed class FormGroupsPage : Component
     [
         PageHeader.Render(
             "Radio & checkbox groups",
-            "Bind a set of radios to one value, or a set of checkboxes to a collection — one call each, wired into the same EditContext as Input(Bind: …)."),
+            "Pick one value from a set of radios, or many into a collection of checkboxes — example Components built on the public binding API, with the same bound and controlled shapes as MultiSelect<T>."),
         H2(Class: "h4 mt-4 mb-3")["RadioGroup + CheckboxGroup"],
         CodeSample(
-            ["FormGroupsDemo.cs"],
+            ["FormGroupsDemo.cs", "RadioGroup.cs", "CheckboxGroup.cs"],
             Notes:
-            "Both parse the bind expression, resolve the ambient EditContext, and wire each input's change handler to set the value (radios) or add/remove the item (checkboxes), then re-validate. They render a transparent Fragment of <label><input>…</label>, so you control layout with OptionLabel and ItemClass.",
+            "Shown in controlled mode (Value + OnChange): the parent owns the selection and OnChange (auto-wrapped) re-renders the demo, so the readout stays live. Each item is Bootstrap form-check markup; ItemClass adds wrapper classes like form-check-inline.",
             Result: FormGroupsDemo()),
         H2(Class: "h4 mt-5 mb-3")["Notes"],
         Ul(Class: "text-secondary")[
             Li()[
-                "RadioGroup binds a single TValue; the option equal to the current value renders checked. CheckboxGroup binds an ICollection<TItem>; the collection is mutated in place on toggle."],
+                "Two modes, like MultiSelect: bound — RadioGroup(() => model.Plan, …) / CheckboxGroup<T>(() => model.Tags, …) — two-way binds the model and runs a per-field Validate rule; controlled — Value + OnChange — the parent owns the value (used above)."],
             Li()[
-                "Changing an option re-renders the component that declared the group (the change handler's owner), so a summary like the one above updates immediately."],
+                "They're Components, so their own checks/radios update on toggle; host-side derived UI (the summary) updates via the auto-wrapped controlled OnChange."],
             Li()[
-                "Validation rides the same field: each change calls NotifyFieldChanged + ValidateFieldAsync, so DataAnnotations/FluentValidation rules on the bound property apply."]
+                "In bound mode, validation rides the field: each change calls NotifyFieldChanged + ValidateFieldAsync, so a Validate rule (or DataAnnotations/FluentValidation) on the bound property applies and surfaces via the embedded ValidationMessage."]
         ]
     ];
 }

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectCheckboxDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectCheckboxDemo.cs
@@ -1,27 +1,25 @@
 namespace Rask.Example.Shared.Features;
 
-// CheckboxGroup<TItem> — the framework primitive for selecting many values into an ICollection. Each
-// option is a checkbox; toggling adds/removes from the bound collection and re-validates the field.
+// CheckboxGroup<TItem> — selecting many values into a collection, here in controlled mode (Value + OnChange).
+// The parent owns the selection; OnChange (auto-wrapped) re-renders this demo so the summary stays live.
 public sealed class MultiSelectCheckboxDemo : Component
 {
-    private readonly Prefs _prefs = new();
+    private static readonly string[] AllInterests = ["Web", "Mobile", "AI", "Games"];
+
+    private IReadOnlyCollection<string> _interests = [];
 
     protected override RenderResult Render() =>
-        Form(_prefs)[
-            Div(Class: "mb-3")[
+        Div(Class: "vstack gap-3")[
+            Div()[
                 Label(Class: "form-label fw-semibold d-block")["Interests"],
                 CheckboxGroup<string>(
-                    () => _prefs.Interests,
-                    ["Web", "Mobile", "AI", "Games"],
+                    AllInterests,
+                    Value: _interests.ToList(),
+                    OnChange: next => _interests = next,
                     ItemClass: "form-check-inline")
             ],
             P(Class: "small text-secondary mb-0", Id: "ms-checkbox-summary")[
-                "Selected: " + (_prefs.Interests.Count == 0 ? "none" : string.Join(", ", _prefs.Interests))
+                "Selected: " + (_interests.Count == 0 ? "none" : string.Join(", ", _interests))
             ]
         ];
-
-    private sealed class Prefs
-    {
-        public List<string> Interests { get; } = [];
-    }
 }

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectRadioDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectRadioDemo.cs
@@ -1,21 +1,24 @@
 namespace Rask.Example.Shared.Features;
 
-// RadioGroup<TValue> — the single-value sibling of CheckboxGroup. Selecting an option writes the bound
-// scalar property (here an enum) and re-validates the field.
+// RadioGroup<TValue> — the single-value sibling of CheckboxGroup, here in controlled mode (Value + OnChange).
+// Selecting an option calls OnChange (auto-wrapped), which re-renders this demo so the readout stays live.
 public sealed class MultiSelectRadioDemo : Component
 {
-    private readonly Prefs _prefs = new();
+    private static readonly Tier[] AllTiers = [Tier.Free, Tier.Pro, Tier.Team];
+
+    private Tier _plan = Tier.Free;
 
     protected override RenderResult Render() =>
-        Form(_prefs)[
-            Div(Class: "mb-3")[
+        Div(Class: "vstack gap-3")[
+            Div()[
                 Label(Class: "form-label fw-semibold d-block")["Plan"],
                 RadioGroup(
-                    () => _prefs.Plan,
-                    [Tier.Free, Tier.Pro, Tier.Team],
+                    AllTiers,
+                    Value: _plan,
+                    OnChange: v => _plan = v,
                     ItemClass: "form-check-inline")
             ],
-            P(Class: "small text-secondary mb-0", Id: "ms-radio-summary")[$"Plan: {_prefs.Plan}"]
+            P(Class: "small text-secondary mb-0", Id: "ms-radio-summary")[$"Plan: {_plan}"]
         ];
 
     private enum Tier
@@ -23,10 +26,5 @@ public sealed class MultiSelectRadioDemo : Component
         Free,
         Pro,
         Team
-    }
-
-    private sealed class Prefs
-    {
-        public Tier Plan { get; set; } = Tier.Free;
     }
 }

--- a/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
@@ -3,38 +3,99 @@ using Rask.Core.Forms;
 
 namespace Rask.Example.Shared;
 
-// Example generic form control: binds an ICollection<TItem> model property to a set of checkboxes, one per
-// option. Toggling an option adds/removes it from the bound collection (mutated in place) and re-validates
-// the field. Emits Bootstrap 5.3 check markup (https://getbootstrap.com/docs/5.3/forms/checks-radios/):
-// each item is a <div class="form-check"> wrapping a .form-check-input and a .form-check-label tied together
-// by id/for. ItemClass adds extra classes to that wrapper (e.g. "form-check-inline"). Returns a transparent
-// Fragment so the consumer owns the surrounding layout.
-public static partial class Generated
+// Example generic form control: a set of Bootstrap 5.3 checkboxes
+// (https://getbootstrap.com/docs/5.3/forms/checks-radios/) selecting many values into an ICollection<TItem>.
+// Structured like MultiSelect<TItem> — a Component with two usage shapes:
+//   • Bound      — CheckboxGroup<string>(() => model.Tags, options, Validate: …) two-way binds the model
+//                  collection, runs the per-field Validate rule, and surfaces it via the embedded
+//                  ValidationMessage. AfterBind/AfterBindAsync are post-bind hooks (the bound value passed in).
+//   • Controlled — CheckboxGroup<string>(options, Value: selection, OnChange: next => …) the parent owns the
+//                  collection; OnChange/OnChangeAsync (auto-wrapped) deliver the new selection and re-render
+//                  the host. No EditContext, so no Validate in this mode.
+// Each item is a <div class="form-check"> wrapping a .form-check-input + .form-check-label tied by id/for;
+// ItemClass adds extra wrapper classes (e.g. "form-check-inline").
+public sealed class CheckboxGroup<TItem> : Component
 {
-    public static Component CheckboxGroup<TItem>(
+    public required IEnumerable<TItem> Options { get; set; }
+
+    // Controlled mode (no Bind).
+    public ICollection<TItem>? Value { get; set; }
+    public Action<IReadOnlyCollection<TItem>>? OnChange { get; set; }
+    public Func<IReadOnlyCollection<TItem>, Task>? OnChangeAsync { get; set; }
+
+    // Bound mode — set through the Bind-first factory overloads, kept off the controlled factory.
+    [SkipFactory] public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
+    [SkipFactory] public Action<ICollection<TItem>>? AfterBind { get; set; }
+    [SkipFactory] public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
+    [SkipFactory] public Delegate? Validate { get; set; }
+
+    public Func<TItem, Child>? OptionLabel { get; set; }
+    public string? Name { get; set; }
+    public string? ItemClass { get; set; }
+    public bool? Disabled { get; set; }
+
+    // Bound-mode entry — the generator fans this into none/sync/async Validate flavors (Validate over the
+    // ICollection<TItem> from the Bind expression), each forwarding here; builds via the controlled factory
+    // (RASK014) and layers on the [SkipFactory] bound-mode props.
+    [GenerateForwarderFactory(Validator = "Validate")]
+    public static CheckboxGroup<TItem> Bound(
         Expression<Func<ICollection<TItem>>> Bind,
         IEnumerable<TItem> Options,
+        Delegate? Validate = null,
+        Action<ICollection<TItem>>? AfterBind = null,
+        Func<ICollection<TItem>, Task>? AfterBindAsync = null,
         Func<TItem, Child>? OptionLabel = null,
         string? Name = null,
         string? ItemClass = null,
         bool Disabled = false)
     {
-        ArgumentNullException.ThrowIfNull(Bind);
+        var c = Generated.CheckboxGroup<TItem>(
+            Options, OptionLabel: OptionLabel, Name: Name, ItemClass: ItemClass, Disabled: Disabled);
+        c.Bind = Bind;
+        c.AfterBind = AfterBind;
+        c.AfterBindAsync = AfterBindAsync;
+        c.Validate = Validate;
+        return c;
+    }
+
+    protected override RenderResult Render()
+    {
         ArgumentNullException.ThrowIfNull(Options);
 
-        var acc = ExpressionAccessor.Parse(Bind);
-        var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
-        var fid = acc.Field;
-        var groupName = Name ?? acc.PropertyName;
-        var selected = acc.Getter() as ICollection<TItem>;
+        var bound = Bind is not null;
+        if (bound == Value is not null)
+        {
+            throw new InvalidOperationException(
+                "CheckboxGroup requires exactly one of Bind (bound mode) or Value (controlled mode).");
+        }
+
         var comparer = EqualityComparer<TItem>.Default;
+        ExpressionAccessor.Accessor? acc = null;
+        EditContext? ctx = null;
+        var fid = default(FieldIdentifier);
+        ICollection<TItem>? selected;
+        if (bound)
+        {
+            acc = ExpressionAccessor.Parse(Bind!);
+            ctx = BindingHelpers.ResolveBindingContext(acc.Target);
+            fid = acc.Field;
+            ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+            selected = acc.Getter() as ICollection<TItem>;
+        }
+        else
+        {
+            selected = Value;
+        }
+
+        var disabled = Disabled == true;
+        var groupName = Name ?? acc?.PropertyName ?? "checkbox-group";
         var wrapperClass = ItemClass is null ? "form-check" : $"form-check {ItemClass}";
 
         var children = new List<Child>();
         var index = 0;
         foreach (var option in Options)
         {
-            var optionValue = option; // capture per iteration
+            var optionValue = option;
             var optionId = $"{groupName}-{index}";
             var isChecked = selected is not null && selected.Contains(optionValue, comparer);
             Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
@@ -49,22 +110,54 @@ public static partial class Generated
                     Class: "form-check-input",
                     Id: optionId,
                     // The checkbox change payload carries the new checked state as a bool string.
-                    OnChangeAsync: async value =>
-                    {
-                        if (acc.Getter() is not ICollection<TItem> collection)
-                        {
-                            return;
-                        }
-
-                        var nowChecked = bool.TryParse(value, out var b) && b;
-                        BindingHelpers.SetCollectionMembership(collection, optionValue, nowChecked, comparer);
-                        await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
-                    }),
+                    OnChangeAsync: disabled
+                        ? null
+                        : value => ToggleAsync(acc, ctx, fid, optionValue, comparer, bool.TryParse(value, out var b) && b)),
                 Label(Class: "form-check-label", For: optionId)[label]
             ]);
             index++;
         }
 
+        if (bound)
+        {
+            children.Add(ValidationMessage(Bind!, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]]));
+        }
+
         return Fragment()[children];
+    }
+
+    private async Task ToggleAsync(
+        ExpressionAccessor.Accessor? acc,
+        EditContext? ctx,
+        FieldIdentifier fid,
+        TItem item,
+        IEqualityComparer<TItem> comparer,
+        bool include)
+    {
+        if (acc is not null)
+        {
+            if (acc.Getter() is not ICollection<TItem> collection)
+            {
+                return;
+            }
+
+            BindingHelpers.SetCollectionMembership(collection, item, include, comparer);
+            await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
+            AfterBind?.Invoke(collection);
+            if (AfterBindAsync is not null)
+            {
+                await AfterBindAsync(collection).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
+            BindingHelpers.SetCollectionMembership(next, item, include, comparer);
+            OnChange?.Invoke(next);
+            if (OnChangeAsync is not null)
+            {
+                await OnChangeAsync(next).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/samples/Rask.Example.Shared/Shared/RadioGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/RadioGroup.cs
@@ -3,41 +3,97 @@ using Rask.Core.Forms;
 
 namespace Rask.Example.Shared;
 
-// Example generic form control (the single-value sibling of CheckboxGroup): binds a single TValue model
-// property to a set of mutually-exclusive radios. Parses the expression, resolves the ambient EditContext,
-// and wires each radio's change handler to set the property and re-validate. Emits Bootstrap 5.3 check
-// markup (https://getbootstrap.com/docs/5.3/forms/checks-radios/): each item is a <div class="form-check">
-// wrapping a .form-check-input radio and a .form-check-label tied together by id/for. ItemClass adds extra
-// classes to that wrapper (e.g. "form-check-inline"). Returns a transparent Fragment so the consumer owns
-// the surrounding layout.
-public static partial class Generated
+// Example generic form control: the single-value sibling of CheckboxGroup — a set of mutually-exclusive
+// Bootstrap 5.3 radios (https://getbootstrap.com/docs/5.3/forms/checks-radios/) bound to one TValue.
+// Structured like MultiSelect/CheckboxGroup, with two shapes:
+//   • Bound      — RadioGroup(() => model.Plan, options, Validate: …) two-way binds the scalar and runs the
+//                  per-field Validate rule (surfaced via the embedded ValidationMessage).
+//   • Controlled — RadioGroup(options, Value: current, OnChange: v => …) the parent owns the value; OnChange/
+//                  OnChangeAsync (auto-wrapped) deliver the new value and re-render the host. No Validate.
+// Mode is chosen by whether Bind is set (a value type can't use a null Value as the signal). Each item is a
+// <div class="form-check"> with a .form-check-input radio + .form-check-label tied by id/for; ItemClass adds
+// extra wrapper classes (e.g. "form-check-inline").
+public sealed class RadioGroup<TValue> : Component
 {
-    public static Component RadioGroup<TValue>(
+    public required IEnumerable<TValue> Options { get; set; }
+
+    // Controlled mode (used when Bind is null): the parent owns the current value.
+    public TValue? Value { get; set; }
+    public Action<TValue>? OnChange { get; set; }
+    public Func<TValue, Task>? OnChangeAsync { get; set; }
+
+    // Bound mode — set through the Bind-first factory overloads, kept off the controlled factory.
+    [SkipFactory] public Expression<Func<TValue>>? Bind { get; set; }
+    [SkipFactory] public Action<TValue>? AfterBind { get; set; }
+    [SkipFactory] public Func<TValue, Task>? AfterBindAsync { get; set; }
+    [SkipFactory] public Delegate? Validate { get; set; }
+
+    public Func<TValue, Child>? OptionLabel { get; set; }
+    public string? Name { get; set; }
+    public string? ItemClass { get; set; }
+    public bool? Disabled { get; set; }
+
+    [GenerateForwarderFactory(Validator = "Validate")]
+    public static RadioGroup<TValue> Bound(
         Expression<Func<TValue>> Bind,
         IEnumerable<TValue> Options,
+        Delegate? Validate = null,
+        Action<TValue>? AfterBind = null,
+        Func<TValue, Task>? AfterBindAsync = null,
         Func<TValue, Child>? OptionLabel = null,
         string? Name = null,
         string? ItemClass = null,
         bool Disabled = false)
     {
-        ArgumentNullException.ThrowIfNull(Bind);
+        var c = Generated.RadioGroup<TValue>(
+            Options, OptionLabel: OptionLabel, Name: Name, ItemClass: ItemClass, Disabled: Disabled);
+        c.Bind = Bind;
+        c.AfterBind = AfterBind;
+        c.AfterBindAsync = AfterBindAsync;
+        c.Validate = Validate;
+        return c;
+    }
+
+    protected override RenderResult Render()
+    {
         ArgumentNullException.ThrowIfNull(Options);
 
-        var acc = ExpressionAccessor.Parse(Bind);
-        var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
-        var fid = acc.Field;
-        var groupName = Name ?? acc.PropertyName;
-        var current = acc.Getter();
+        var bound = Bind is not null;
+        if (!bound && OnChange is null && OnChangeAsync is null)
+        {
+            throw new InvalidOperationException(
+                "RadioGroup requires Bind (bound mode) or an OnChange/OnChangeAsync handler (controlled mode).");
+        }
+
         var comparer = EqualityComparer<TValue>.Default;
+        ExpressionAccessor.Accessor? acc = null;
+        EditContext? ctx = null;
+        var fid = default(FieldIdentifier);
+        TValue? current;
+        if (bound)
+        {
+            acc = ExpressionAccessor.Parse(Bind!);
+            ctx = BindingHelpers.ResolveBindingContext(acc.Target);
+            fid = acc.Field;
+            ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+            current = acc.Getter() is TValue typed ? typed : default;
+        }
+        else
+        {
+            current = Value;
+        }
+
+        var disabled = Disabled == true;
+        var groupName = Name ?? acc?.PropertyName ?? "radio-group";
         var wrapperClass = ItemClass is null ? "form-check" : $"form-check {ItemClass}";
 
         var children = new List<Child>();
         var index = 0;
         foreach (var option in Options)
         {
-            var optionValue = option; // capture per iteration for the handler closure
+            var optionValue = option;
             var optionId = $"{groupName}-{index}";
-            var isChecked = current is TValue typed && comparer.Equals(option, typed);
+            var isChecked = current is not null && comparer.Equals(optionValue, current);
             Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
             children.Add(Div(Class: wrapperClass, Key: index)[
@@ -49,17 +105,41 @@ public static partial class Generated
                     Disabled: Disabled,
                     Class: "form-check-input",
                     Id: optionId,
-                    OnChangeAsync: async _ =>
-                    {
-                        // A radio only fires change when it becomes selected → set the bound value.
-                        acc.Setter(optionValue);
-                        await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
-                    }),
+                    // A radio only fires change when it becomes selected → set the value.
+                    OnChangeAsync: disabled ? null : _ => SelectAsync(acc, ctx, fid, optionValue)),
                 Label(Class: "form-check-label", For: optionId)[label]
             ]);
             index++;
         }
 
+        if (bound)
+        {
+            children.Add(ValidationMessage(Bind!, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]]));
+        }
+
         return Fragment()[children];
+    }
+
+    private async Task SelectAsync(
+        ExpressionAccessor.Accessor? acc, EditContext? ctx, FieldIdentifier fid, TValue value)
+    {
+        if (acc is not null)
+        {
+            acc.Setter(value);
+            await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
+            AfterBind?.Invoke(value);
+            if (AfterBindAsync is not null)
+            {
+                await AfterBindAsync(value).ConfigureAwait(false);
+            }
+        }
+        else
+        {
+            OnChange?.Invoke(value);
+            if (OnChangeAsync is not null)
+            {
+                await OnChangeAsync(value).ConfigureAwait(false);
+            }
+        }
     }
 }

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -646,6 +646,12 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
 
                 var isAutoRerenderDelegate = !isElement && IsAutoRerenderDelegate(prop.Type);
 
+                // An unconstrained type-parameter prop (e.g. `TValue? Value`) can't default to `null` —
+                // there's no conversion from null to T — so its optional factory param must default to
+                // `default`. (A `class`/`notnull`-constrained T would accept null, but `default` is always
+                // valid, so key off the type-parameter kind rather than the constraint set.)
+                var isTypeParameter = prop.Type is ITypeParameterSymbol;
+
                 result.Add(new PropInfo(
                     prop.Name,
                     typeFqn,
@@ -656,7 +662,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                     filePath,
                     spanStart,
                     spanLength,
-                    isAutoRerenderDelegate));
+                    isAutoRerenderDelegate,
+                    isTypeParameter));
             }
         }
 
@@ -703,7 +710,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     {
         // Only optional params reach this; the optional set is exactly the nullable props (a
         // non-nullable prop with no initializer is a required factory param with no default).
-        return p.IsNullable ? "null" : "default";
+        // A type-parameter prop must use `default` — `null` has no conversion to an unconstrained T.
+        return p.IsNullable && !p.IsTypeParameter ? "null" : "default";
     }
 
     private static void Emit(SourceProductionContext spc, ImmutableArray<Candidate> candidates, bool emitNavigation)
@@ -1499,7 +1507,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         string DeclaringFilePath,
         int DeclaringSpanStart,
         int DeclaringSpanLength,
-        bool IsAutoRerenderDelegate)
+        bool IsAutoRerenderDelegate,
+        bool IsTypeParameter)
     {
         // The factory-parameter / property identifier, '@'-escaped when Name is a reserved keyword.
         public string Escaped => EscapeIdentifier(Name);

--- a/tests/Rask.Example.Shared.Tests/RadioCheckboxGroupTests.cs
+++ b/tests/Rask.Example.Shared.Tests/RadioCheckboxGroupTests.cs
@@ -114,6 +114,38 @@ public class RadioCheckboxGroupTests
         Assert.Contains("a", m.Tags);
     }
 
+    [Fact]
+    public async Task CheckboxGroup_Controlled_EmitsNewSelection_WithoutMutatingValue()
+    {
+        var value = new List<string> { "a" };
+        IReadOnlyCollection<string>? emitted = null;
+        var host = new LiveHost(
+            () => CheckboxGroup<string>(new[] { "a", "b", "c" }, Value: value, OnChange: next => emitted = next),
+            TestServices.Default());
+
+        var ids = AllChangeIds(host.RenderAsLiveRoot());
+        using var doc = JsonDocument.Parse("{\"value\":\"true\"}");
+        await host.TryInvokeHandlerAsync(ids[1], doc.RootElement); // check "b"
+
+        Assert.Equal(["a", "b"], emitted!);
+        Assert.Equal(["a"], value); // controlled mode never mutates the parent's Value
+    }
+
+    [Fact]
+    public async Task RadioGroup_Controlled_EmitsSelectedValue()
+    {
+        Color? picked = null;
+        var host = new LiveHost(
+            () => RadioGroup(new[] { Color.Red, Color.Green, Color.Blue }, Value: Color.Red, OnChange: v => picked = v),
+            TestServices.Default());
+
+        var ids = AllChangeIds(host.RenderAsLiveRoot());
+        using var doc = JsonDocument.Parse("{\"value\":\"true\"}");
+        await host.TryInvokeHandlerAsync(ids[2], doc.RootElement); // select Blue (third radio)
+
+        Assert.Equal(Color.Blue, picked);
+    }
+
     private static int CountOccurrences(string haystack, string needle)
     {
         var count = 0;


### PR DESCRIPTION
## Summary
Rewrites the sample `CheckboxGroup`/`RadioGroup` from static `Fragment` factories into `Component` classes following the `MultiSelect<TItem>` template:
- **bound** mode (`Bind` + per-field `Validate` + `AfterBind` hooks; the generator emits the Bind-first none/sync/async validator fan-out), and
- **controlled** mode (`Value` + `OnChange`/`OnChangeAsync`).

Bootstrap `form-check` markup is unchanged. As Components they're a re-render boundary, so the showcase group demos (`FormGroupsDemo`, `MultiSelectCheckbox/RadioDemo`) move to **controlled** mode — the auto-wrapped `OnChange` re-renders the host, keeping the live summary current.

Also fixes a generator gap: an unconstrained **type-parameter optional prop** (e.g. `RadioGroup`'s `TValue? Value`) now defaults to `default` rather than `null` in the emitted factory (`null` has no conversion to an unconstrained `T`).

Completes the form-control generator arc; the only roadmap item left is the `[SkipFactory]` removal.

## Testing
- `dotnet format --verify-no-changes`: clean. `dotnet build Rask.slnx -warnaserror`: clean (generator + analyzers).
- Unit: full fast suite green (13 projects) — `RadioCheckboxGroupTests` (5 bound + 2 new controlled), `Rask.Generators.Tests` 160, MultiSelect, Core, etc.
- E2E (samples changed): host **Server** — `ServerExampleTests.Journey` passed (`FormGroupsDemo` `#groups-summary` updates via controlled `OnChange`).

## Benchmarks
n/a — not a render/runtime hot-path change.

## CHANGELOG
- [Unreleased] Changed: `CheckboxGroup`/`RadioGroup` as Components (bound + controlled), generator-emitted; demos to controlled mode.