### PR TITLE
feat(forms): IFormControl<T> — generator-synthesized form-control factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ them until tagged releases begin.
   `Validate` over `ICollection<TItem>`) and the hand-written `MultiSelectBoundFactory` is removed.
 
 ### Added
+- **`IFormControl<T>` — a declarative contract for building custom form controls.** A generic component
+  implementing `IFormControl<T>` (in `Rask.Core.Forms`) gets both of its factories synthesized by the
+  generator: a **controlled** factory (`Value` + `OnChange`/`OnChangeAsync`) and a **bound** factory
+  (`() => model.Field`, Bind-first, with the per-field validator fanned into none/sync/async overloads).
+  The interface carries the typed `Bind`/`Validate`/`ValidateAsync`/`AfterBind`/`AfterBindAsync` (bound) and
+  `Value`/`OnChange`/`OnChangeAsync` (controlled) members over a single value type `T`; the generator
+  excludes the bound members from the controlled factory automatically (no `[SkipFactory]` needed). The
+  sample `MultiSelect<TItem>`/`CheckboxGroup<TItem>`/`RadioGroup<TValue>` now implement it and drop their
+  hand-written `Bound` methods. (Controlled `OnChange` for the collection controls now delivers
+  `ICollection<TItem>` rather than `IReadOnlyCollection<TItem>`, matching `Value`.)
 - **`Callback` / `Callback<T>` / `CallbackAsync` / `CallbackAsync<T>` delegate types.** Named delegate
   types in `Rask.Core` are now the shape of every built-in component's event callbacks (the `X` / `XAsync`
   pairs: `OnClick`/`OnClickAsync`, `OnInput`/`OnChange`/`…Async`, `OnKeyDown`/`OnKeyUp`, `OnDrag*`,

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -447,6 +447,51 @@ await BindingHelpers.NotifyAndValidateFieldAsync(ctx, acc.Field);
 
 Surface field messages with `ValidationMessage(Bind, …)` (§2.Rendering messages) inside the control.
 
+### The `IFormControl<T>` contract (generator-synthesized factories)
+
+For a **generic** component, the cleanest path is to implement `IFormControl<T>` (in `Rask.Core.Forms`) and
+let the generator synthesize **both** factories — you write no `Bound` method and no factory plumbing:
+
+```csharp
+public sealed class CheckboxGroup<TItem> : Component, IFormControl<ICollection<TItem>>
+{
+    public required IEnumerable<TItem> Options { get; set; }
+
+    // controlled
+    public ICollection<TItem>? Value { get; set; }
+    public Callback<ICollection<TItem>>? OnChange { get; set; }
+    public CallbackAsync<ICollection<TItem>>? OnChangeAsync { get; set; }
+
+    // bound
+    public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
+    public Validate<ICollection<TItem>>? Validate { get; set; }
+    public ValidateAsync<ICollection<TItem>>? ValidateAsync { get; set; }
+    public Action<ICollection<TItem>>? AfterBind { get; set; }
+    public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
+
+    public string? ItemClass { get; set; }   // shared/display — on both factories
+    protected override RenderResult Render() { /* … */ }
+}
+```
+
+The generator emits:
+- a **controlled** factory `CheckboxGroup<TItem>(Options, Value: …, OnChange: …, …)` — the bound members are
+  excluded automatically (no `[SkipFactory]`), and `OnChange`/`OnChangeAsync` are auto-wrapped so invoking
+  them re-renders the host;
+- a **bound** factory `CheckboxGroup<TItem>(() => model.Tags, Options, …)` — Bind-first, with the validator
+  fanned into none/sync/async overloads (`Validate:` accepts a sync `Validate<T>` or async `ValidateAsync<T>`).
+
+All members are keyed on one value type `T`. In `Render`, collapse the typed validators for the
+`EditContext`:
+
+```csharp
+ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
+```
+
+(Non-generic elements like the built-in `Input`/`Select`/`Textarea` can't carry a type-level `T`, so they
+keep their hand-written `Bound` + `[GenerateForwarderFactory]` instead — same validator fan-out, different
+type-system shape.)
+
 ### Stateless (`Fragment`) vs stateful (`Component`) — and host re-render
 
 This is the one subtlety worth understanding:

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Routing](docs/routing.md): `[Route]`, params, `Router()`/`Outlet()`, navigation.
 - [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
 - [Composition](docs/composition.md): children, context (provide/consume), callbacks, headless primitives (`VirtualizeModel<T>`), drag-and-drop.
-- [Forms](docs/forms.md): binding, validation, EditContext, building form components on the public binding API (`ExpressionAccessor`/`BindingHelpers`/`RegisterFieldValidator`) — RadioGroup/CheckboxGroup/MultiSelect are example controls in the samples, not framework primitives.
+- [Forms](docs/forms.md): binding, validation, EditContext, building form components — implement `IFormControl<T>` (Rask.Core.Forms) on a generic component and the generator synthesizes its controlled + bound factories, or use the public binding API directly (`ExpressionAccessor`/`BindingHelpers`/`RegisterFieldValidator`). RadioGroup/CheckboxGroup/MultiSelect are example controls in the samples, not framework primitives.
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.

--- a/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormGroups/FormGroupsDemo.cs
@@ -9,7 +9,7 @@ public sealed class FormGroupsDemo : Component
     private static readonly string[] AllInterests = ["Web", "Mobile", "AI", "Games"];
 
     private Plan _plan = Plan.Free;
-    private IReadOnlyCollection<string> _interests = [];
+    private ICollection<string> _interests = [];
 
     protected override RenderResult Render() =>
         Div(Class: "vstack gap-3")[

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectCheckboxDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectCheckboxDemo.cs
@@ -6,7 +6,7 @@ public sealed class MultiSelectCheckboxDemo : Component
 {
     private static readonly string[] AllInterests = ["Web", "Mobile", "AI", "Games"];
 
-    private IReadOnlyCollection<string> _interests = [];
+    private ICollection<string> _interests = [];
 
     protected override RenderResult Render() =>
         Div(Class: "vstack gap-3")[

--- a/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectControlledDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/MultiSelectControlledDemo.cs
@@ -10,7 +10,7 @@ public sealed class MultiSelectControlledDemo : Component
     private static readonly string[] AllTopics =
         ["News", "Sports", "Tech", "Music", "Travel"];
 
-    private IReadOnlyCollection<string> _topics = [];
+    private ICollection<string> _topics = [];
 
     protected override RenderResult Render() =>
         Div(Class: "vstack gap-3")[

--- a/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
@@ -14,49 +14,27 @@ namespace Rask.Example.Shared;
 //                  the host. No EditContext, so no Validate in this mode.
 // Each item is a <div class="form-check"> wrapping a .form-check-input + .form-check-label tied by id/for;
 // ItemClass adds extra wrapper classes (e.g. "form-check-inline").
-public sealed class CheckboxGroup<TItem> : Component
+public sealed class CheckboxGroup<TItem> : Component, IFormControl<ICollection<TItem>>
 {
     public required IEnumerable<TItem> Options { get; set; }
 
     // Controlled mode (no Bind).
     public ICollection<TItem>? Value { get; set; }
-    public Action<IReadOnlyCollection<TItem>>? OnChange { get; set; }
-    public Func<IReadOnlyCollection<TItem>, Task>? OnChangeAsync { get; set; }
+    public Callback<ICollection<TItem>>? OnChange { get; set; }
+    public CallbackAsync<ICollection<TItem>>? OnChangeAsync { get; set; }
 
-    // Bound mode — set through the Bind-first factory overloads, kept off the controlled factory.
-    [SkipFactory] public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
-    [SkipFactory] public Action<ICollection<TItem>>? AfterBind { get; set; }
-    [SkipFactory] public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
-    [SkipFactory] public Delegate? Validate { get; set; }
+    // Bound mode (IFormControl members) — the generator synthesizes the Bind-first factory (validator
+    // fanned into none/sync/async) and excludes these from the controlled factory.
+    public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
+    public Validate<ICollection<TItem>>? Validate { get; set; }
+    public ValidateAsync<ICollection<TItem>>? ValidateAsync { get; set; }
+    public Action<ICollection<TItem>>? AfterBind { get; set; }
+    public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
 
     public Func<TItem, Child>? OptionLabel { get; set; }
     public string? Name { get; set; }
     public string? ItemClass { get; set; }
     public bool? Disabled { get; set; }
-
-    // Bound-mode entry — the generator fans this into none/sync/async Validate flavors (Validate over the
-    // ICollection<TItem> from the Bind expression), each forwarding here; builds via the controlled factory
-    // (RASK014) and layers on the [SkipFactory] bound-mode props.
-    [GenerateForwarderFactory(Validator = "Validate")]
-    public static CheckboxGroup<TItem> Bound(
-        Expression<Func<ICollection<TItem>>> Bind,
-        IEnumerable<TItem> Options,
-        Delegate? Validate = null,
-        Action<ICollection<TItem>>? AfterBind = null,
-        Func<ICollection<TItem>, Task>? AfterBindAsync = null,
-        Func<TItem, Child>? OptionLabel = null,
-        string? Name = null,
-        string? ItemClass = null,
-        bool Disabled = false)
-    {
-        var c = Generated.CheckboxGroup<TItem>(
-            Options, OptionLabel: OptionLabel, Name: Name, ItemClass: ItemClass, Disabled: Disabled);
-        c.Bind = Bind;
-        c.AfterBind = AfterBind;
-        c.AfterBindAsync = AfterBindAsync;
-        c.Validate = Validate;
-        return c;
-    }
 
     protected override RenderResult Render()
     {
@@ -79,7 +57,7 @@ public sealed class CheckboxGroup<TItem> : Component
             acc = ExpressionAccessor.Parse(Bind!);
             ctx = BindingHelpers.ResolveBindingContext(acc.Target);
             fid = acc.Field;
-            ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+            ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
             selected = acc.Getter() as ICollection<TItem>;
         }
         else

--- a/samples/Rask.Example.Shared/Shared/MultiSelect.cs
+++ b/samples/Rask.Example.Shared/Shared/MultiSelect.cs
@@ -25,55 +25,30 @@ namespace Rask.Example.Shared;
 // which refresh because MultiSelect re-renders itself. In controlled mode OnChange/OnChangeAsync are
 // auto-wrapped (AutoCallback) so invoking them re-renders the consumer that owns the handler — host-side
 // derived UI (a summary) updates for free, no StateHasChanged. AfterBind exists for consumer logic.
-public sealed class MultiSelect<TItem> : Component
+// Implements IFormControl<ICollection<TItem>> so the factory generator synthesizes both the controlled
+// factory (Options, Value, OnChange, …) and the Bind-first bound factory (with the validator fanned into
+// none/sync/async). No hand-written Bound method, no [SkipFactory] — the generator excludes the bound-mode
+// members from the controlled factory by interface.
+public sealed class MultiSelect<TItem> : Component, IFormControl<ICollection<TItem>>
 {
     public required IEnumerable<TItem> Options { get; set; }
 
     // Controlled mode (no Bind): the parent owns the selection and is notified of every change.
     public ICollection<TItem>? Value { get; set; }
-    public Action<IReadOnlyCollection<TItem>>? OnChange { get; set; }
-    public Func<IReadOnlyCollection<TItem>, Task>? OnChangeAsync { get; set; }
+    public Callback<ICollection<TItem>>? OnChange { get; set; }
+    public CallbackAsync<ICollection<TItem>>? OnChangeAsync { get; set; }
 
-    // Bound mode. Set through the Bind-first factory overloads (Generated.MultiSelect), kept off the
-    // generated controlled factory via [SkipFactory] so the two entry points stay distinct.
-    [SkipFactory] public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
-    [SkipFactory] public Action<ICollection<TItem>>? AfterBind { get; set; }
-    [SkipFactory] public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
-
-    // Per-field validator (bound mode only): a sync Func<ICollection<TItem>, IEnumerable<string>> or async
-    // Func<ICollection<TItem>, CancellationToken, ValueTask<IEnumerable<string>>>, registered with the
-    // EditContext just like Input's Validate. Collapsed to a single Delegate the context invokes.
-    [SkipFactory] public Delegate? Validate { get; set; }
+    // Bound mode (IFormControl members): two-way binds the model collection and runs the per-field rule.
+    public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
+    public Validate<ICollection<TItem>>? Validate { get; set; }
+    public ValidateAsync<ICollection<TItem>>? ValidateAsync { get; set; }
+    public Action<ICollection<TItem>>? AfterBind { get; set; }
+    public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
 
     public Func<TItem, Child>? OptionLabel { get; set; }
     public string? Id { get; set; }
     public string? Placeholder { get; set; }
     public bool? Disabled { get; set; }
-
-    // Bound-mode entry. [GenerateForwarderFactory(Validator=…)] makes the generator emit the Bind-first
-    // Generated.MultiSelect<TItem>(…) factory in none/sync/async Validate flavors (Validate over the
-    // ICollection<TItem> from the Bind expression), each forwarding here. This builds the instance through
-    // the generated controlled factory (RASK014) and layers on the [SkipFactory] bound-mode props.
-    [GenerateForwarderFactory(Validator = "Validate")]
-    public static MultiSelect<TItem> Bound(
-        Expression<Func<ICollection<TItem>>> Bind,
-        IEnumerable<TItem> Options,
-        Delegate? Validate = null,
-        Action<ICollection<TItem>>? AfterBind = null,
-        Func<ICollection<TItem>, Task>? AfterBindAsync = null,
-        Func<TItem, Child>? OptionLabel = null,
-        string? Id = null,
-        string? Placeholder = null,
-        bool? Disabled = null)
-    {
-        var c = Generated.MultiSelect<TItem>(
-            Options, OptionLabel: OptionLabel, Id: Id, Placeholder: Placeholder, Disabled: Disabled);
-        c.Bind = Bind;
-        c.AfterBind = AfterBind;
-        c.AfterBindAsync = AfterBindAsync;
-        c.Validate = Validate;
-        return c;
-    }
 
     // View state only — the selection itself lives in the bound model collection (bound mode) or the
     // parent's Value (controlled mode). Toggling open/close re-renders this component through the live
@@ -106,7 +81,8 @@ public sealed class MultiSelect<TItem> : Component
             ctx = BindingHelpers.ResolveBindingContext(acc.Target);
             fid = acc.Field;
             // Always register — null clears a stale rule from a prior render, matching Input's BoundCore.
-            ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+            // Collapse the typed sync/async validators into the single Delegate the context dispatches.
+            ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
             selected = acc.Getter() as ICollection<TItem>;
         }
         else

--- a/samples/Rask.Example.Shared/Shared/RadioGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/RadioGroup.cs
@@ -13,46 +13,26 @@ namespace Rask.Example.Shared;
 // Mode is chosen by whether Bind is set (a value type can't use a null Value as the signal). Each item is a
 // <div class="form-check"> with a .form-check-input radio + .form-check-label tied by id/for; ItemClass adds
 // extra wrapper classes (e.g. "form-check-inline").
-public sealed class RadioGroup<TValue> : Component
+public sealed class RadioGroup<TValue> : Component, IFormControl<TValue>
 {
     public required IEnumerable<TValue> Options { get; set; }
 
     // Controlled mode (used when Bind is null): the parent owns the current value.
     public TValue? Value { get; set; }
-    public Action<TValue>? OnChange { get; set; }
-    public Func<TValue, Task>? OnChangeAsync { get; set; }
+    public Callback<TValue>? OnChange { get; set; }
+    public CallbackAsync<TValue>? OnChangeAsync { get; set; }
 
-    // Bound mode — set through the Bind-first factory overloads, kept off the controlled factory.
-    [SkipFactory] public Expression<Func<TValue>>? Bind { get; set; }
-    [SkipFactory] public Action<TValue>? AfterBind { get; set; }
-    [SkipFactory] public Func<TValue, Task>? AfterBindAsync { get; set; }
-    [SkipFactory] public Delegate? Validate { get; set; }
+    // Bound mode (IFormControl members) — symmetric single TValue throughout.
+    public Expression<Func<TValue>>? Bind { get; set; }
+    public Validate<TValue>? Validate { get; set; }
+    public ValidateAsync<TValue>? ValidateAsync { get; set; }
+    public Action<TValue>? AfterBind { get; set; }
+    public Func<TValue, Task>? AfterBindAsync { get; set; }
 
     public Func<TValue, Child>? OptionLabel { get; set; }
     public string? Name { get; set; }
     public string? ItemClass { get; set; }
     public bool? Disabled { get; set; }
-
-    [GenerateForwarderFactory(Validator = "Validate")]
-    public static RadioGroup<TValue> Bound(
-        Expression<Func<TValue>> Bind,
-        IEnumerable<TValue> Options,
-        Delegate? Validate = null,
-        Action<TValue>? AfterBind = null,
-        Func<TValue, Task>? AfterBindAsync = null,
-        Func<TValue, Child>? OptionLabel = null,
-        string? Name = null,
-        string? ItemClass = null,
-        bool Disabled = false)
-    {
-        var c = Generated.RadioGroup<TValue>(
-            Options, OptionLabel: OptionLabel, Name: Name, ItemClass: ItemClass, Disabled: Disabled);
-        c.Bind = Bind;
-        c.AfterBind = AfterBind;
-        c.AfterBindAsync = AfterBindAsync;
-        c.Validate = Validate;
-        return c;
-    }
 
     protected override RenderResult Render()
     {
@@ -75,7 +55,7 @@ public sealed class RadioGroup<TValue> : Component
             acc = ExpressionAccessor.Parse(Bind!);
             ctx = BindingHelpers.ResolveBindingContext(acc.Target);
             fid = acc.Field;
-            ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
+            ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
             current = acc.Getter() is TValue typed ? typed : default;
         }
         else

--- a/src/Rask.Core/Forms/FormControlInterfaces.cs
+++ b/src/Rask.Core/Forms/FormControlInterfaces.cs
@@ -1,0 +1,34 @@
+using System.Linq.Expressions;
+
+namespace Rask.Core.Forms;
+
+// The contract a custom form control implements so the factory generator can synthesize its
+// factories — both a bound factory (`Control(() => model.Field, …)`, two-way binding + per-field
+// validation, with the validator fanned into none/sync/async overloads) and a controlled factory
+// (`Control(…, Value: v, OnChange: …)`, parent-owned state). A control declares the value type T
+// once; the generator reads it off the interface and emits the typed surface.
+//
+// Members use fixed names (Bind/Validate/…/Value/OnChange/…) — the generator recognizes them by
+// name and excludes the bound-mode members from the controlled factory (so no [SkipFactory] is
+// needed). `Validate<T>`/`ValidateAsync<T>` (this namespace) and `Callback<T>`/`CallbackAsync<T>`
+// (Rask.Core) are the framework's named delegate types; the generator collapses the sync/async
+// validator pair into the none/sync/async factory fan-out, and auto-wraps OnChange/OnChangeAsync
+// (AutoCallback) so invoking them re-renders the consumer.
+//
+// The framework's own component-style controls (samples MultiSelect/CheckboxGroup/RadioGroup) are
+// the worked examples. In Render, collapse the typed validators for EditContext registration:
+//   ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
+public interface IFormControl<T>
+{
+    // Bound mode — two-way binds an lvalue of type T and drives the ambient EditContext.
+    Expression<Func<T>>? Bind { get; set; }
+    Validate<T>? Validate { get; set; }
+    ValidateAsync<T>? ValidateAsync { get; set; }
+    Action<T>? AfterBind { get; set; }
+    Func<T, Task>? AfterBindAsync { get; set; }
+
+    // Controlled mode — the parent owns Value and is notified of changes.
+    T? Value { get; set; }
+    Callback<T>? OnChange { get; set; }
+    CallbackAsync<T>? OnChangeAsync { get; set; }
+}

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -20,7 +20,14 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     private const string SkipFactoryFullName = "Rask.Core.SkipFactoryAttribute";
     private const string FactoryGenericFullName = "Rask.Core.FactoryGenericAttribute";
     private const string GenerateForwarderFactoryFullName = "Rask.Core.GenerateForwarderFactoryAttribute";
+    private const string FormControlOpenFullName = "Rask.Core.Forms.IFormControl<T>";
     private const string ContextFullName = "global::Rask.Core.Live.LiveRenderContext";
+
+    // The IFormControl<T> members that belong to BOUND mode: excluded from the synthesized controlled
+    // factory, and (for Bind/AfterBind/AfterBindAsync) emitted as params on the synthesized bound factory.
+    // Validate/ValidateAsync are not direct params — they drive the none/sync/async validator fan-out.
+    private static readonly string[] BoundInterfaceMembers =
+        { "Bind", "Validate", "ValidateAsync", "AfterBind", "AfterBindAsync" };
 
     private static readonly DiagnosticDescriptor Rask001 = new(
         "RASK001",
@@ -123,7 +130,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         var hasParameterlessCtor = HasPublicParameterlessConstructor(symbol);
         var hasDICtor = HasDIConstructor(symbol);
         var isPublic = IsExternallyVisible(symbol);
-        var properties = GetFactoryProperties(symbol);
+        var formControl = GetFormControlInfo(symbol);
+        var properties = GetFactoryProperties(symbol, formControl is not null);
         var typeParams = symbol.IsGenericType
             ? "<" + string.Join(", ", symbol.TypeParameters.Select(tp => tp.Name)) + ">"
             : string.Empty;
@@ -148,8 +156,28 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             hasDICtor,
             isPublic,
             genericFactory,
+            formControl,
             new EquatableArray<PropInfo>(properties),
             new EquatableArray<ForwarderInfo>(forwarders));
+    }
+
+    // Detects IFormControl<T> among the component's implemented interfaces and returns the bound value
+    // type T (fully qualified). Null when the component is not a form control.
+    private static FormControlInfo? GetFormControlInfo(INamedTypeSymbol symbol)
+    {
+        foreach (var i in symbol.AllInterfaces)
+        {
+            if (i.TypeArguments.Length == 1 &&
+                i.OriginalDefinition.ToDisplayString() == FormControlOpenFullName)
+            {
+                var valueType = i.TypeArguments[0].ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+                    .WithMiscellaneousOptions(SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier
+                                              | SymbolDisplayMiscellaneousOptions.UseSpecialTypes));
+                return new FormControlInfo(valueType);
+            }
+        }
+
+        return null;
     }
 
     private static List<ForwarderInfo> GetForwarderInfos(INamedTypeSymbol symbol)
@@ -542,7 +570,7 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         return false;
     }
 
-    private static List<PropInfo> GetFactoryProperties(INamedTypeSymbol symbol)
+    private static List<PropInfo> GetFactoryProperties(INamedTypeSymbol symbol, bool isFormControl)
     {
         var result = new List<PropInfo>();
         var seen = new HashSet<string>(StringComparer.Ordinal);
@@ -652,6 +680,11 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                 // valid, so key off the type-parameter kind rather than the constraint set.)
                 var isTypeParameter = prop.Type is ITypeParameterSymbol;
 
+                // A bound-mode IFormControl<T> member (Bind/Validate/ValidateAsync/AfterBind/AfterBindAsync):
+                // excluded from the controlled factory and instead emitted on the synthesized bound factory.
+                var isBoundInterfaceProp = isFormControl &&
+                    Array.IndexOf(BoundInterfaceMembers, prop.Name) >= 0;
+
                 result.Add(new PropInfo(
                     prop.Name,
                     typeFqn,
@@ -663,7 +696,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                     spanStart,
                     spanLength,
                     isAutoRerenderDelegate,
-                    isTypeParameter));
+                    isTypeParameter,
+                    isBoundInterfaceProp));
             }
         }
 
@@ -774,6 +808,12 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
                 EmitFactory(sb, c, emitNavigation);
                 sb.AppendLine();
 
+                if (c.FormControl is { } fc)
+                {
+                    EmitBoundFactory(sb, c, fc, emitNavigation);
+                    sb.AppendLine();
+                }
+
                 if (c.GenericFactory is { } gf)
                 {
                     EmitGenericFactoryOverload(sb, c, gf, emitNavigation);
@@ -842,7 +882,9 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
     private static void EmitFactory(StringBuilder sb, Candidate c, bool emitNavigation)
     {
         var visibility = c.IsPublic ? "public" : "internal";
-        var paramProps = c.Properties.Where(IsParamProperty).ToList();
+        // Bound-mode IFormControl members are excluded from the controlled factory — they appear on the
+        // synthesized bound factory (EmitBoundFactory) instead.
+        var paramProps = c.Properties.Where(p => IsParamProperty(p) && !p.IsBoundInterfaceProp).ToList();
         var requiredProps = paramProps.Where(IsRequiredFactoryParam).ToList();
         var optionalProps = paramProps.Where(p => !IsRequiredFactoryParam(p)).ToList();
 
@@ -989,6 +1031,169 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         }
 
         EmitSnapshotsAndAssignments(sb, paramProps, foldProps);
+        sb.Append("        if (").Append(ContextFullName).AppendLine(".Current is { } __ctx2)");
+        sb.AppendLine("            __ctx2.NotifyParameters(__c, __propsChanged);");
+        sb.AppendLine("        return __c;");
+        sb.AppendLine("    }");
+    }
+
+    // For an IFormControl<T> component, synthesizes the Bind-first bound factory in none/sync/async
+    // validator flavors. It builds the instance through the same GetOrCreate/NotifyParameters path as the
+    // controlled factory and sets the bound-mode members (Bind/Validate/ValidateAsync/AfterBind/
+    // AfterBindAsync); the controlled members (Value/OnChange/OnChangeAsync) are left at their defaults
+    // (= bound mode). This replaces the hand-written `[GenerateForwarderFactory(Validator="Validate")] Bound`.
+    private static void EmitBoundFactory(StringBuilder sb, Candidate c, FormControlInfo fc, bool emitNavigation)
+    {
+        EmitBoundOverload(sb, c, fc, emitNavigation, ValidatorShape.None);
+        sb.AppendLine();
+        EmitBoundOverload(sb, c, fc, emitNavigation, ValidatorShape.Sync);
+        sb.AppendLine();
+        EmitBoundOverload(sb, c, fc, emitNavigation, ValidatorShape.Async);
+    }
+
+    private static void EmitBoundOverload(
+        StringBuilder sb, Candidate c, FormControlInfo fc, bool emitNavigation, ValidatorShape shape)
+    {
+        var visibility = c.IsPublic ? "public" : "internal";
+        var canUseObjectInit = c.HasParameterlessCtor || !c.HasDIConstructor;
+
+        PropInfo Member(string name) => c.Properties.First(p => p.Name == name);
+        var bind = Member("Bind");
+        var afterBind = Member("AfterBind");
+        var afterBindAsync = Member("AfterBindAsync");
+
+        // Shared/display props: everything that's a factory param and not an IFormControl member.
+        var controlled = new[] { "Value", "OnChange", "OnChangeAsync" };
+        var shared = c.Properties
+            .Where(p => IsParamProperty(p) && !p.IsBoundInterfaceProp && Array.IndexOf(controlled, p.Name) < 0)
+            .ToList();
+        var sharedRequired = shared.Where(IsRequiredFactoryParam).ToList();
+        var sharedOptional = shared.Where(p => !IsRequiredFactoryParam(p)).ToList();
+
+        var validatorType = shape == ValidatorShape.Sync
+            ? "global::Rask.Core.Forms.Validate<" + fc.ValueTypeFqn + ">"
+            : "global::Rask.Core.Forms.ValidateAsync<" + fc.ValueTypeFqn + ">";
+
+        // Signature: Bind (required) → shared required (e.g. Options) → validator (sync/async, required) →
+        // AfterBind/AfterBindAsync (optional) → shared optional (display).
+        EmitMethodHeader(sb, c, emitNavigation);
+        sb.Append("    ").Append(visibility).Append(" static ").Append(c.FullyQualifiedName).Append(' ')
+            .Append(c.TypeName).Append(c.TypeParameters).Append('(');
+        sb.Append(StripNullable(bind.TypeFqn)).Append(" Bind");
+        foreach (var p in sharedRequired)
+        {
+            sb.Append(", ").Append(p.TypeFqn).Append(' ').Append(p.Escaped);
+        }
+
+        if (shape != ValidatorShape.None)
+        {
+            sb.Append(", ").Append(validatorType).Append(" Validate");
+        }
+
+        sb.Append(", ").Append(afterBind.TypeFqn).Append(' ').Append(afterBind.Escaped).Append(" = null");
+        sb.Append(", ").Append(afterBindAsync.TypeFqn).Append(' ').Append(afterBindAsync.Escaped).Append(" = null");
+        foreach (var p in sharedOptional)
+        {
+            sb.Append(", ").Append(p.TypeFqn).Append(' ').Append(p.Escaped).Append(" = ").Append(DefaultLiteralFor(p));
+        }
+
+        sb.Append(')').AppendLine(c.TypeParameterConstraints);
+        sb.AppendLine("    {");
+
+        // Bound-mode member assignments (raw — never auto-wrapped; AfterBind is a post-bind hook, not an
+        // event callback). The validator param (named Validate either way) sets Validate for the sync
+        // overload and ValidateAsync for the async overload.
+        var validateExpr = shape == ValidatorShape.Sync ? "Validate" : "null";
+        var validateAsyncExpr = shape == ValidatorShape.Async ? "Validate" : "null";
+        var assigns = new List<(string Esc, string Expr)>
+        {
+            ("Bind", "Bind"),
+            ("Validate", validateExpr),
+            ("ValidateAsync", validateAsyncExpr),
+            (afterBind.Escaped, afterBind.Escaped),
+            (afterBindAsync.Escaped, afterBindAsync.Escaped),
+        };
+        foreach (var p in shared)
+        {
+            assigns.Add((p.Escaped, p.Escaped));
+        }
+
+        // Fold (propsChanged): only the shared value props participate — the bound members are fresh
+        // expressions/delegates each render (folding them would force propsChanged: true every frame).
+        var foldProps = shared.Where(p => !IsKeyProp(p) && !p.IsAutoRerenderDelegate).ToList();
+
+        void EmitInit(string indent)
+        {
+            sb.AppendLine();
+            sb.Append(indent).AppendLine("{");
+            for (var i = 0; i < assigns.Count; i++)
+            {
+                sb.Append(indent).Append("    ").Append(assigns[i].Esc).Append(" = ").Append(assigns[i].Expr);
+                sb.AppendLine(i < assigns.Count - 1 ? "," : string.Empty);
+            }
+
+            sb.Append(indent).Append('}');
+        }
+
+        sb.Append("        ").Append(c.FullyQualifiedName).AppendLine(" __c;");
+        sb.Append("        if (").Append(ContextFullName).AppendLine(".Current is { } __ctx)");
+        if (canUseObjectInit)
+        {
+            sb.Append("            __c = __ctx.GetOrCreate<").Append(c.FullyQualifiedName).AppendLine(">(");
+            sb.Append("                __sp => new ").Append(c.FullyQualifiedName).Append("()");
+            EmitInit("                ");
+            sb.AppendLine(");");
+            sb.AppendLine("        else");
+            sb.Append("            __c = new ").Append(c.FullyQualifiedName).Append("()");
+            EmitInit("            ");
+            sb.AppendLine(";");
+        }
+        else
+        {
+            sb.Append("            __c = __ctx.GetOrCreate<").Append(c.FullyQualifiedName).AppendLine(">(");
+            sb.Append(
+                    "                static __sp => global::Microsoft.Extensions.DependencyInjection.ActivatorUtilities.CreateInstance<")
+                .Append(c.FullyQualifiedName).AppendLine(">(__sp));");
+            sb.AppendLine("        else");
+            sb.Append("            throw new global::System.InvalidOperationException(\"Component '")
+                .Append(c.FullyQualifiedName)
+                .AppendLine(
+                    "' has no parameterless constructor; it can only be instantiated inside a LiveRenderContext (e.g. via MapRask<TApp>).\");");
+        }
+
+        foreach (var p in foldProps)
+        {
+            sb.Append("        var __old_").Append(p.Name).Append(" = __c.").Append(p.Escaped).AppendLine(";");
+        }
+
+        foreach (var (esc, expr) in assigns)
+        {
+            sb.Append("        __c.").Append(esc).Append(" = ").Append(expr).AppendLine(";");
+        }
+
+        if (foldProps.Count == 0)
+        {
+            sb.AppendLine("        var __propsChanged = false;");
+        }
+        else if (foldProps.Count == 1)
+        {
+            var p = foldProps[0];
+            sb.Append("        var __propsChanged = !global::System.Collections.Generic.EqualityComparer<")
+                .Append(p.TypeFqn).Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Escaped)
+                .AppendLine(");");
+        }
+        else
+        {
+            sb.AppendLine("        var __propsChanged =");
+            for (var i = 0; i < foldProps.Count; i++)
+            {
+                var p = foldProps[i];
+                sb.Append("            !global::System.Collections.Generic.EqualityComparer<").Append(p.TypeFqn)
+                    .Append(">.Default.Equals(__old_").Append(p.Name).Append(", ").Append(p.Escaped).Append(')');
+                sb.AppendLine(i < foldProps.Count - 1 ? " ||" : ";");
+            }
+        }
+
         sb.Append("        if (").Append(ContextFullName).AppendLine(".Current is { } __ctx2)");
         sb.AppendLine("            __ctx2.NotifyParameters(__c, __propsChanged);");
         sb.AppendLine("        return __c;");
@@ -1473,8 +1678,14 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         bool HasDIConstructor,
         bool IsPublic,
         GenericFactoryConfig? GenericFactory,
+        FormControlInfo? FormControl,
         EquatableArray<PropInfo> Properties,
         EquatableArray<ForwarderInfo> Forwarders);
+
+    // Set when a component implements IFormControl<T> — drives the synthesized bound factory and the
+    // exclusion of the bound-mode interface members from the controlled factory. ValueTypeFqn is the T
+    // (the validator/after-bind fan key); the bound-member names are the fixed interface member names.
+    private readonly record struct FormControlInfo(string ValueTypeFqn);
 
     private readonly record struct GenericFactoryConfig(
         string TypeParameter,
@@ -1508,7 +1719,8 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         int DeclaringSpanStart,
         int DeclaringSpanLength,
         bool IsAutoRerenderDelegate,
-        bool IsTypeParameter)
+        bool IsTypeParameter,
+        bool IsBoundInterfaceProp)
     {
         // The factory-parameter / property identifier, '@'-escaped when Name is a reserved keyword.
         public string Escaped => EscapeIdentifier(Name);

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -43,7 +43,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
-- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls (radios/checkboxes/multi-select) with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls by implementing `IFormControl<T>` (the generator synthesizes the bound + controlled factories) or with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
 - **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -36,7 +36,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
-- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls (radios/checkboxes/multi-select) with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls by implementing `IFormControl<T>` (the generator synthesizes the bound + controlled factories) or with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
 - **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -36,7 +36,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - **Events / parent callbacks** are plain delegate props: child declares `Action<int>? OnRate`,
   invokes `OnRate?.Invoke(n)`; parent passes `OnRate: n => _x = n`. Invoking re-renders the parent.
 - **Scoped CSS/JS:** put `MyComponent.css` / `MyComponent.js` next to `MyComponent.cs`; auto-scoped.
-- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls (radios/checkboxes/multi-select) with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
+- **Forms:** two-way bind with `Input.Bound(() => model.Name)`; build choice controls by implementing `IFormControl<T>` (the generator synthesizes the bound + controlled factories) or with the public `ExpressionAccessor`/`BindingHelpers`/`EditContext.RegisterFieldValidator` API in `Rask.Core.Forms` (the Rask sample's `CheckboxGroup`/`RadioGroup`/`MultiSelect` are copyable examples).
 - **Auth:** gate by injecting `IUserProvider` and reading `.Current` (a never-null `ClaimsPrincipal`), or the `Authorize(...)` component (its `Authorized: user => …` slot is handed the principal; static content uses the `[ … ]` indexer);
   `[Authorize]`/`[AllowAnonymous]` on a page. Configure on ASP.NET's own `AddCookie`/`AddJwtBearer`.
 

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -186,7 +186,7 @@ public sealed class MultiSelectTests
     public async Task Controlled_OnChange_EmitsNewSelection_WithoutMutatingValue()
     {
         var value = new List<string> { "a" };
-        IReadOnlyCollection<string>? emitted = null;
+        ICollection<string>? emitted = null;
         var host = new LiveHost(
             () => MultiSelect<string>(Options, Value: value, OnChange: next => emitted = next),
             TestServices.Default());
@@ -203,7 +203,7 @@ public sealed class MultiSelectTests
     public async Task Controlled_OnChangeAsync_Fires()
     {
         var value = new List<string>();
-        IReadOnlyCollection<string>? emitted = null;
+        ICollection<string>? emitted = null;
         var host = new LiveHost(
             () => MultiSelect<string>(Options, Value: value, OnChangeAsync: next =>
             {

--- a/tests/Rask.Example.Shared.Tests/RadioCheckboxGroupTests.cs
+++ b/tests/Rask.Example.Shared.Tests/RadioCheckboxGroupTests.cs
@@ -118,7 +118,7 @@ public class RadioCheckboxGroupTests
     public async Task CheckboxGroup_Controlled_EmitsNewSelection_WithoutMutatingValue()
     {
         var value = new List<string> { "a" };
-        IReadOnlyCollection<string>? emitted = null;
+        ICollection<string>? emitted = null;
         var host = new LiveHost(
             () => CheckboxGroup<string>(new[] { "a", "b", "c" }, Value: value, OnChange: next => emitted = next),
             TestServices.Default());

--- a/tests/Rask.Generators.Tests/FormControlEmissionTests.cs
+++ b/tests/Rask.Generators.Tests/FormControlEmissionTests.cs
@@ -1,0 +1,108 @@
+namespace Rask.Generators.Tests;
+
+// A component implementing IFormControl<T> gets two generator-synthesized factories: a controlled factory
+// (Value/OnChange, excluding the bound members) and a Bind-first bound factory fanned into none/sync/async.
+public class FormControlEmissionTests
+{
+    private const string Widget = """
+                                  using System;
+                                  using System.Linq.Expressions;
+                                  using System.Threading.Tasks;
+                                  using Rask.Core;
+                                  using Rask.Core.Forms;
+                                  namespace Demo;
+                                  public sealed class Widget : Component, IFormControl<int>
+                                  {
+                                      public int? Value { get; set; }
+                                      public Callback<int>? OnChange { get; set; }
+                                      public CallbackAsync<int>? OnChangeAsync { get; set; }
+                                      public Expression<Func<int>>? Bind { get; set; }
+                                      public Validate<int>? Validate { get; set; }
+                                      public ValidateAsync<int>? ValidateAsync { get; set; }
+                                      public Action<int>? AfterBind { get; set; }
+                                      public Func<int, Task>? AfterBindAsync { get; set; }
+                                      public string? Label { get; set; }
+                                      public override RenderResult Render() => this;
+                                  }
+                                  """;
+
+    [Fact]
+    public void EmitsControlledFactory_WithoutBoundMembers()
+    {
+        var output = GeneratorDriverFixture.Run(Widget).GeneratedSource("Demo.Generated.g.cs");
+
+        // Controlled factory carries Value/OnChange…
+        Assert.Contains("global::Demo.Widget Widget(int? Value = null", output);
+        Assert.Contains("global::Rask.Core.Callback<int>? OnChange = null", output);
+        // …and never exposes the bound members as a controlled-factory parameter that defaults to null.
+        Assert.DoesNotContain("global::Rask.Core.Forms.Validate<int>? Validate = null", output);
+        Assert.DoesNotContain("Expression<global::System.Func<int>>? Bind = null", output);
+    }
+
+    [Fact]
+    public void EmitsBoundFactory_BindFirst()
+    {
+        var output = GeneratorDriverFixture.Run(Widget).GeneratedSource("Demo.Generated.g.cs");
+
+        Assert.Contains(
+            "global::Demo.Widget Widget(global::System.Linq.Expressions.Expression<global::System.Func<int>> Bind",
+            output);
+    }
+
+    [Fact]
+    public void BoundFactory_FansValidatorIntoNoneSyncAsync()
+    {
+        var output = GeneratorDriverFixture.Run(Widget).GeneratedSource("Demo.Generated.g.cs");
+
+        // Sync overload takes Validate<int>; async takes ValidateAsync<int> (param named Validate either way).
+        Assert.Contains("global::Rask.Core.Forms.Validate<int> Validate", output);
+        Assert.Contains("global::Rask.Core.Forms.ValidateAsync<int> Validate", output);
+        // None overload sets both validator props to null.
+        Assert.Contains("Validate = null", output);
+        Assert.Contains("ValidateAsync = null", output);
+    }
+
+    [Fact]
+    public void ControlledFactory_AutoWrapsOnChange()
+    {
+        var output = GeneratorDriverFixture.Run(Widget).GeneratedSource("Demo.Generated.g.cs");
+
+        Assert.Contains("global::Rask.Core.AutoCallback.Wrap(OnChange)", output);
+    }
+
+    [Fact]
+    public void GenericFormControl_CarriesTypeParam_AndValueTypedValidator()
+    {
+        var src = """
+                  using System;
+                  using System.Collections.Generic;
+                  using System.Linq.Expressions;
+                  using System.Threading.Tasks;
+                  using Rask.Core;
+                  using Rask.Core.Forms;
+                  namespace Demo;
+                  public sealed class Picker<TItem> : Component, IFormControl<ICollection<TItem>>
+                  {
+                      public ICollection<TItem>? Value { get; set; }
+                      public Callback<ICollection<TItem>>? OnChange { get; set; }
+                      public CallbackAsync<ICollection<TItem>>? OnChangeAsync { get; set; }
+                      public Expression<Func<ICollection<TItem>>>? Bind { get; set; }
+                      public Validate<ICollection<TItem>>? Validate { get; set; }
+                      public ValidateAsync<ICollection<TItem>>? ValidateAsync { get; set; }
+                      public Action<ICollection<TItem>>? AfterBind { get; set; }
+                      public Func<ICollection<TItem>, Task>? AfterBindAsync { get; set; }
+                      public override RenderResult Render() => this;
+                  }
+                  """;
+
+        var output = GeneratorDriverFixture.Run(src).GeneratedSource("Demo.Generated.g.cs");
+
+        // The bound factory carries the component's <TItem> and the validator closes over ICollection<TItem>.
+        Assert.Contains(
+            "global::Demo.Picker<TItem> Picker<TItem>(global::System.Linq.Expressions.Expression<global::System.Func<global::System.Collections.Generic.ICollection<TItem>>> Bind",
+            output);
+        Assert.Contains(
+            "global::Rask.Core.Forms.Validate<global::System.Collections.Generic.ICollection<TItem>> Validate",
+            output);
+    }
+}


### PR DESCRIPTION
## Summary
Introduces **`IFormControl<T>`** (`Rask.Core.Forms`) — a declarative contract for building custom form controls. A **generic** component that implements it gets both of its factories synthesized by the generator:
- a **controlled** factory (`Value` + `OnChange`/`OnChangeAsync`), and
- a **bound** factory (`() => model.Field`, Bind-first, with the per-field validator fanned into none/sync/async overloads).

The interface carries the typed bound members (`Bind`/`Validate`/`ValidateAsync`/`AfterBind`/`AfterBindAsync`) and controlled members (`Value`/`OnChange`/`OnChangeAsync`) over a single value type `T`. The generator excludes the bound members from the controlled factory **by interface** (no `[SkipFactory]`/initializer needed) and emits the Bind-first bound factory (new `EmitBoundFactory`), reusing the existing build/assign/`NotifyParameters` path.

The sample `MultiSelect<TItem>`/`CheckboxGroup<TItem>`/`RadioGroup<TValue>` now implement `IFormControl<T>` and **drop their hand-written `Bound` methods + `[GenerateForwarderFactory]` + `[SkipFactory]`**. This is PR1 of the form-control arc; built-in `Input`/`Select`/`Textarea` keep their hand-written `Bound` (they're non-generic — no type-level `T`), to be revisited in a later phase.

**Minor behavior:** controlled `OnChange` for the collection controls now delivers `ICollection<TItem>` (matching `Value`) instead of `IReadOnlyCollection<TItem>`.

## Testing
- `dotnet format --verify-no-changes`: clean. `dotnet build Rask.slnx -warnaserror`: clean (generator + analyzers).
- Unit: full fast suite green (13 projects) — new `FormControlEmissionTests` (5), `Rask.Generators.Tests` 165, and **unchanged** `MultiSelectTests`/`RadioCheckboxGroupTests` (24, bound + controlled + validate + AfterBind + Esc/backdrop) as the behavior-neutral gate proving the synthesized factories match the deleted `Bound`.
- E2E: host **Server** — `ServerExampleTests.Journey` **passed** (`/multiselect` + `/form-groups`).

## Benchmarks
n/a — generator-only; emitted bodies are equivalent to the hand-written `Bound`. (Built-in elements, the only hot-path risk, are untouched.)

## CHANGELOG
- [Unreleased] Added: `IFormControl<T>` + generator-synthesized form-control factories; sample controls migrated.