### PR TITLE
feat(forms)!: generic Input<T>/Select<T>/Textarea<T> implementing IFormControl<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,18 @@ them until tagged releases begin.
   `Expression<Func<T>>` Bind parameter, so the sample `MultiSelect<TItem>` declares one `Bound` core (its
   `Validate` over `ICollection<TItem>`) and the hand-written `MultiSelectBoundFactory` is removed.
 
+### Changed
+- **Built-in `Input`/`Select`/`Textarea` are now generic `Input<T>`/`Select<T>`/`Textarea<T>` implementing
+  `IFormControl<T>`.** Bound usage infers `T` from the expression (`Input(() => model.Age)` → `Input<int>` →
+  `<input type="number">` — the HTML input `type` derives from `T`: `bool`→checkbox, numeric→number,
+  `DateOnly`→date, etc.); binding is resolved at render time rather than in a `Bound` factory. **Breaking:**
+  plain (non-bound) usage now needs the explicit type argument — `Input<string>("text", …)`,
+  `Select<string>(…)`, `Textarea<string>(…)` — and bound `Select` takes its options via the `[...]` indexer
+  rather than a `Children:` argument. `IFormControl<T>` also gained default-method helpers that remove
+  per-control boilerplate (`Validator`, `RegisterValidator`, `InvokeAfterBindAsync`, `InvokeOnChangeAsync`,
+  `ControlledChangeHandler` — the string↔`T` bridge for controlled mode), adopted by the built-ins and the
+  sample `MultiSelect`/`CheckboxGroup`/`RadioGroup`.
+
 ### Added
 - **`IFormControl<T>` — a declarative contract for building custom form controls.** A generic component
   implementing `IFormControl<T>` (in `Rask.Core.Forms`) gets both of its factories synthesized by the

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/FormInputTyping.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/FormInputTyping.cs
@@ -21,11 +21,11 @@ internal static class FormInputTyping
     {
         return C.Form()[
             C.Label()["Field A"],
-            C.Input("text", "a", a),
+            C.Input<string>("text", "a", a),
             C.Label()["Field B"],
-            C.Input("text", "b", b),
+            C.Input<string>("text", "b", b),
             C.Label()["Field C"],
-            C.Input("text", "c", c),
+            C.Input<string>("text", "c", c),
             C.Button("submit")["Save"]
         ];
     }

--- a/benchmarks/Rask.Benchmarks/HtmlSerializerBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/HtmlSerializerBenchmarks.cs
@@ -78,7 +78,7 @@ public class HtmlSerializerBenchmarks
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", "_blank", "noopener", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32, "lazy"),
-                C.Input("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
+                C.Input<string>("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
             ]);
         }
 

--- a/benchmarks/Rask.Benchmarks/PayloadBytesPerUpdate.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesPerUpdate.cs
@@ -111,7 +111,7 @@ public class PayloadBytesPerUpdate
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),
-                C.Input("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
+                C.Input<string>("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
             ]);
         }
 
@@ -165,7 +165,7 @@ public class PayloadBytesPerUpdate
                 C.Span(Class: "label")[text],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),
-                C.Input("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
+                C.Input<string>("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
             ]);
         }
 

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -117,7 +117,7 @@ internal static class PayloadBytesReport
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),
-                C.Input("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
+                C.Input<string>("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
             ]);
         }
 
@@ -164,7 +164,7 @@ internal static class PayloadBytesReport
                 C.Span(Class: "label")[text],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
                 C.Img($"/img/{i}.png", $"item {i}", 32, 32),
-                C.Input("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
+                C.Input<string>("text", $"f{i}", $"v{i}", "edit", MaxLength: 64)
             ]);
         }
 

--- a/benchmarks/Rask.Benchmarks/RenderRoundTripBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/RenderRoundTripBenchmarks.cs
@@ -33,7 +33,7 @@ public class RenderRoundTripBenchmarks
             rows.Add(C.Div(Class: "row", Id: $"r{i}", Key: i)[
                 C.Span(Class: "label")[$"Item {i}"],
                 C.A($"/item/{i}", Class: "lnk")[$"open {i}"],
-                C.Input("text", $"f{i}", $"v{i}")
+                C.Input<string>("text", $"f{i}", $"v{i}")
             ]);
         }
 

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -488,9 +488,10 @@ All members are keyed on one value type `T`. In `Render`, collapse the typed val
 ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
 ```
 
-(Non-generic elements like the built-in `Input`/`Select`/`Textarea` can't carry a type-level `T`, so they
-keep their hand-written `Bound` + `[GenerateForwarderFactory]` instead — same validator fan-out, different
-type-system shape.)
+(The built-in `Input<T>`/`Select<T>`/`Textarea<T>` implement `IFormControl<T>` too: bound usage infers `T`
+from the expression (`Input(() => model.Age)` → `Input<int>`, type derived from `T`), while plain usage takes
+the explicit argument — `Input<string>("text", …)`. They resolve binding at render time via the same
+interface helpers (`RegisterValidator`/`ControlledChangeHandler`).)
 
 ### Stateless (`Fragment`) vs stateful (`Component`) — and host re-render
 

--- a/samples/Rask.Example.Shared/Features/Binding/BindingNullableDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Binding/BindingNullableDemo.cs
@@ -28,11 +28,9 @@ public sealed class BindingNullableDemo : Component
             Select(
                 () => _model.Favorite,
                 Id: "bind-null-color",
-                Class: "form-select",
-                Children: new Child[]
-                {
-                    Option("")["— none —"], Option("Red")["Red"], Option("Green")["Green"], Option("Blue")["Blue"]
-                })
+                Class: "form-select")[
+                Option("")["— none —"], Option("Red")["Red"], Option("Green")["Green"], Option("Blue")["Blue"]
+            ]
         ],
         Div(Class: "mb-3")[
             Label("bind-null-nick", Class: "form-label small")["Nickname (string?)"],

--- a/samples/Rask.Example.Shared/Features/ElementRef/ElementRefDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ElementRef/ElementRefDemo.cs
@@ -16,7 +16,7 @@ public sealed class ElementRefDemo : Component
 
     protected override RenderResult Render() =>
         Div()[
-            Input(
+            Input<string>(
                 "text",
                 Class: "form-control mb-2",
                 Placeholder: "Focus me from C#",

--- a/samples/Rask.Example.Shared/Features/Events/EventsFormDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Events/EventsFormDemo.cs
@@ -10,7 +10,7 @@ public sealed class EventsFormDemo : Component
     [
         Form(OnSubmit: OnSubmit, Class: "mb-2")[
             Div(Class: "input-group")[
-                Input(
+                Input<string>(
                     "text",
                     "name",
                     Class: "form-control",

--- a/samples/Rask.Example.Shared/Features/Events/EventsSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Events/EventsSelectDemo.cs
@@ -6,7 +6,7 @@ public sealed class EventsSelectDemo : Component
 
     protected override RenderResult Render() =>
     [
-        Select(
+        Select<string>(
             Class: "form-select mb-2",
             OnChange: v => _pick = v)[
             Option("rask", _pick == "rask")["Rask"],

--- a/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsPage.cs
+++ b/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsPage.cs
@@ -111,7 +111,7 @@ public sealed class KeyedListsPage : Component
     [
         Span(Class: "badge bg-secondary rounded-pill")[index + 1],
         Span(Class: "fw-semibold", Style: "min-width: 7rem;")[f.Name],
-        Input(
+        Input<string>(
             "text",
             Class: "form-control form-control-sm kl-note",
             Placeholder: "type here, then reorder…")

--- a/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsReorderDemo.cs
+++ b/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsReorderDemo.cs
@@ -19,7 +19,7 @@ public sealed class KeyedListsReorderDemo : Component
             Ul(Class: "list-group")[
                 _items.Select(f => Li(Key: f.Id, Class: "list-group-item")[
                     Span()[f.Name],
-                    Input("text") // unbound — its value lives only in the DOM
+                    Input<string>("text") // unbound — its value lives only in the DOM
                 ])
             ],
             Button(Class: "btn btn-sm btn-outline-primary mt-2", OnClick: Rotate)["Rotate"]

--- a/samples/Rask.Example.Shared/Features/Navigator/NavigatorDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Navigator/NavigatorDemo.cs
@@ -12,7 +12,7 @@ public sealed class NavigatorDemo(Navigator nav) : Component
                 OnClick: () => nav.NavigateTo("/dashboard"))["Open dashboard"],
 
             // Or update just the query, keeping the same path:
-            Select(
+            Select<string>(
                 OnChange: v => nav.SetQuery("sort", v))[
                 Option("asc")["Sort ascending"],
                 Option("desc")["Sort descending"]

--- a/samples/Rask.Example.Shared/Features/Table/TablePage.cs
+++ b/samples/Rask.Example.Shared/Features/Table/TablePage.cs
@@ -137,7 +137,7 @@ public sealed class TablePage(Navigator nav) : Component
                     ],
                     Div(Class: "d-flex align-items-center gap-2")[
                         Label(Class: "small text-secondary mb-0")["Rows per page"],
-                        Select(
+                        Select<string>(
                             Class: "form-select form-select-sm",
                             Style: "max-width:90px;",
                             OnChange: v => nav.SetQuery(

--- a/samples/Rask.Example.Shared/Features/Tags/TagsFormDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Tags/TagsFormDemo.cs
@@ -5,7 +5,7 @@ public sealed class TagsFormDemo : Component
     protected override RenderResult Render() => Form()[
         Div(Class: "mb-2")[
             Label("n", Class: "form-label small mb-1")["Name"],
-            Input("text", Id: "n", Class: "form-control form-control-sm", Placeholder: "Jane Doe")
+            Input<string>("text", Id: "n", Class: "form-control form-control-sm", Placeholder: "Jane Doe")
         ],
         Button("submit", Class: "btn btn-primary btn-sm")["Submit"]
     ];

--- a/samples/Rask.Example.Shared/Features/Upload/UploadDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Upload/UploadDemo.cs
@@ -30,7 +30,7 @@ public sealed class UploadDemo : Component
 
     protected override RenderResult Render() =>
         Div()[
-            Input(
+            Input<string>(
                 Id: "upload-input",
                 Type: "file",
                 Class: "form-control mb-3",

--- a/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/CheckboxGroup.cs
@@ -57,7 +57,7 @@ public sealed class CheckboxGroup<TItem> : Component, IFormControl<ICollection<T
             acc = ExpressionAccessor.Parse(Bind!);
             ctx = BindingHelpers.ResolveBindingContext(acc.Target);
             fid = acc.Field;
-            ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
+            ((IFormControl<ICollection<TItem>>)this).RegisterValidator(acc, ctx);
             selected = acc.Getter() as ICollection<TItem>;
         }
         else
@@ -79,7 +79,7 @@ public sealed class CheckboxGroup<TItem> : Component, IFormControl<ICollection<T
             Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
             children.Add(Div(Class: wrapperClass, Key: index)[
-                Input(
+                Input<string>(
                     "checkbox",
                     groupName,
                     BindingHelpers.FormatValue(option),
@@ -121,21 +121,13 @@ public sealed class CheckboxGroup<TItem> : Component, IFormControl<ICollection<T
 
             BindingHelpers.SetCollectionMembership(collection, item, include, comparer);
             await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
-            AfterBind?.Invoke(collection);
-            if (AfterBindAsync is not null)
-            {
-                await AfterBindAsync(collection).ConfigureAwait(false);
-            }
+            await ((IFormControl<ICollection<TItem>>)this).InvokeAfterBindAsync(collection).ConfigureAwait(false);
         }
         else
         {
             var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
             BindingHelpers.SetCollectionMembership(next, item, include, comparer);
-            OnChange?.Invoke(next);
-            if (OnChangeAsync is not null)
-            {
-                await OnChangeAsync(next).ConfigureAwait(false);
-            }
+            await ((IFormControl<ICollection<TItem>>)this).InvokeOnChangeAsync(next).ConfigureAwait(false);
         }
     }
 }

--- a/samples/Rask.Example.Shared/Shared/MultiSelect.cs
+++ b/samples/Rask.Example.Shared/Shared/MultiSelect.cs
@@ -80,9 +80,9 @@ public sealed class MultiSelect<TItem> : Component, IFormControl<ICollection<TIt
             acc = ExpressionAccessor.Parse(Bind!);
             ctx = BindingHelpers.ResolveBindingContext(acc.Target);
             fid = acc.Field;
-            // Always register — null clears a stale rule from a prior render, matching Input's BoundCore.
-            // Collapse the typed sync/async validators into the single Delegate the context dispatches.
-            ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
+            // Always register — null clears a stale rule from a prior render. The interface collapses the
+            // typed sync/async validators and wires the field getter.
+            ((IFormControl<ICollection<TItem>>)this).RegisterValidator(acc, ctx);
             selected = acc.Getter() as ICollection<TItem>;
         }
         else
@@ -133,7 +133,7 @@ public sealed class MultiSelect<TItem> : Component, IFormControl<ICollection<TIt
                 Disabled: Disabled,
                 OnClickAsync: disabled ? null : () => ToggleAsync(acc, ctx, fid, captured, comparer, add: !isChecked),
                 Key: idx)[
-                Input("checkbox", Class: "form-check-input m-0 pe-none", Checked: isChecked),
+                Input<string>("checkbox", Class: "form-check-input m-0 pe-none", Checked: isChecked),
                 LabelOf(captured)
             ]);
             idx++;
@@ -218,12 +218,7 @@ public sealed class MultiSelect<TItem> : Component, IFormControl<ICollection<TIt
 
         BindingHelpers.SetCollectionMembership(collection, item, add, comparer);
         await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
-
-        AfterBind?.Invoke(collection);
-        if (AfterBindAsync is not null)
-        {
-            await AfterBindAsync(collection).ConfigureAwait(false);
-        }
+        await ((IFormControl<ICollection<TItem>>)this).InvokeAfterBindAsync(collection).ConfigureAwait(false);
     }
 
     private async Task ToggleControlledAsync(TItem item, IEqualityComparer<TItem> comparer, bool add)
@@ -231,11 +226,6 @@ public sealed class MultiSelect<TItem> : Component, IFormControl<ICollection<TIt
         // The parent owns Value; never mutate it in place. Build the next selection and hand it back.
         var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
         BindingHelpers.SetCollectionMembership(next, item, add, comparer);
-
-        OnChange?.Invoke(next);
-        if (OnChangeAsync is not null)
-        {
-            await OnChangeAsync(next).ConfigureAwait(false);
-        }
+        await ((IFormControl<ICollection<TItem>>)this).InvokeOnChangeAsync(next).ConfigureAwait(false);
     }
 }

--- a/samples/Rask.Example.Shared/Shared/RadioGroup.cs
+++ b/samples/Rask.Example.Shared/Shared/RadioGroup.cs
@@ -55,7 +55,7 @@ public sealed class RadioGroup<TValue> : Component, IFormControl<TValue>
             acc = ExpressionAccessor.Parse(Bind!);
             ctx = BindingHelpers.ResolveBindingContext(acc.Target);
             fid = acc.Field;
-            ctx?.RegisterFieldValidator(fid, (Delegate?)Validate ?? ValidateAsync, () => acc.Getter());
+            ((IFormControl<TValue>)this).RegisterValidator(acc, ctx);
             current = acc.Getter() is TValue typed ? typed : default;
         }
         else
@@ -77,7 +77,7 @@ public sealed class RadioGroup<TValue> : Component, IFormControl<TValue>
             Child label = OptionLabel is not null ? OptionLabel(option) : option?.ToString() ?? string.Empty;
 
             children.Add(Div(Class: wrapperClass, Key: index)[
-                Input(
+                Input<string>(
                     "radio",
                     groupName,
                     BindingHelpers.FormatValue(option),
@@ -107,19 +107,11 @@ public sealed class RadioGroup<TValue> : Component, IFormControl<TValue>
         {
             acc.Setter(value);
             await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
-            AfterBind?.Invoke(value);
-            if (AfterBindAsync is not null)
-            {
-                await AfterBindAsync(value).ConfigureAwait(false);
-            }
+            await ((IFormControl<TValue>)this).InvokeAfterBindAsync(value).ConfigureAwait(false);
         }
         else
         {
-            OnChange?.Invoke(value);
-            if (OnChangeAsync is not null)
-            {
-                await OnChangeAsync(value).ConfigureAwait(false);
-            }
+            await ((IFormControl<TValue>)this).InvokeOnChangeAsync(value).ConfigureAwait(false);
         }
     }
 }

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -3,19 +3,33 @@ using System.Linq.Expressions;
 using System.Text;
 using Rask.Core.Forms;
 using Rask.Core.Live;
-using C = Rask.Core.Components.Generated;
 using RaskFileType = Rask.Core.Forms.RaskFile;
 
 namespace Rask.Core.Components;
 
-public sealed class Input : Element
+// Generic <input> form control implementing IFormControl<T>. The generator synthesizes a controlled/plain
+// factory (returning Input<string> — see the plain-factory note below) and a Bind-first bound factory
+// (validator fanned none/sync/async). Binding is resolved at render time (WriteAttributes): the HTML input
+// `type`, the value/checked state, and the change handlers are derived from the bound value type T and the
+// expression, rather than eagerly in a `Bound` factory.
+//
+// Type derivation from T: bool→checkbox, numeric→number, DateOnly→date, DateTime(Offset)→datetime-local,
+// TimeOnly/TimeSpan→time, everything else→text. In plain/controlled mode a string T keeps today's behavior
+// (no `type` attribute unless Type is set); bound mode and non-string T default the type from T.
+//
+// Plain usage stays string-shaped: `Input<string>("text", Value: …, OnInput: …)`. Bound usage infers T from
+// the expression: `Input(() => model.Age)` → Input<int> → <input type="number">.
+public sealed class Input<T> : Element, IFormControl<T>
 {
     protected override string TagName => "input";
     protected override bool SelfClosing => true;
 
     public string? Type { get; set; }
     public string? Name { get; set; }
-    public string? Value { get; set; }
+
+    // IFormControl<T> controlled value — kept at the legacy `Value` position so positional factory calls
+    // (Input<string>("text", "name", "value", …)) keep their argument order.
+    public T? Value { get; set; }
     public string? Placeholder { get; set; }
     public bool? Required { get; set; }
     public bool? Disabled { get; set; }
@@ -43,107 +57,85 @@ public sealed class Input : Element
     public string? Src { get; set; }
     public int? Width { get; set; }
     public int? Height { get; set; }
-    public Callback<string>? OnInput { get; set; }
-    public Callback<string>? OnChange { get; set; }
-    public CallbackAsync<string>? OnInputAsync { get; set; }
-    public CallbackAsync<string>? OnChangeAsync { get; set; }
-    public Callback<IReadOnlyList<RaskFileType>>? OnFiles { get; set; }
 
+    // DOM event handlers in the legacy declaration order so positional factory calls keep working.
+    // OnChange/OnChangeAsync are the IFormControl<T> controlled callbacks (typed T); OnInput/OnFiles are the
+    // string/file DOM handlers, not part of the interface.
+    public Callback<string>? OnInput { get; set; }
+    public Callback<T>? OnChange { get; set; }
+    public CallbackAsync<string>? OnInputAsync { get; set; }
+    public CallbackAsync<T>? OnChangeAsync { get; set; }
+    public Callback<IReadOnlyList<RaskFileType>>? OnFiles { get; set; }
     public CallbackAsync<IReadOnlyList<RaskFileType>>? OnFilesAsync { get; set; }
 
-    // Expression-driven factory. The generator picks up [GenerateForwarderFactory(Validator=…)] and emits
-    // `Components.Input<TProp>(Expression<Func<TProp>> Bind, …)` forwarding here, so callers write
-    // `Input(Bind: () => model.Name)` and get type-aware binding with auto-named field, per-type input
-    // type (checkbox/number/date/text), and per-type change handlers wired into the ambient EditContext.
-    //
-    // The `Validator = nameof(Validate)` arg makes the generator fan this single core into three emitted
-    // overloads — none / `Validate<TProp>` / `ValidateAsync<TProp>` — to dodge the delegate cast at the
-    // call site; overload resolution picks by the lambda's arity. The `Validate` parameter is the single
-    // `Delegate?` the EditContext consumes (null in the none overload).
-    [GenerateForwarderFactory(Validator = "Validate")]
-    public static Input Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        Delegate? Validate = null,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Type = null,
-        string? Name = null,
-        string? Placeholder = null,
-        bool Required = false,
-        bool Disabled = false,
-        bool ReadOnly = false,
-        string? Min = null,
-        string? Max = null,
-        string? Step = null,
-        string? Pattern = null,
-        int? Size = null,
-        int? MaxLength = null,
-        int? MinLength = null,
-        string? Autocomplete = null,
-        bool Autofocus = false,
-        string? List = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null)
-    {
-        var acc = ExpressionAccessor.Parse(Bind);
-        var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
-        var fid = acc.Field;
-        var resolvedType = Type ?? BindingHelpers.DefaultInputType(acc.PropertyType);
-        var name = Name ?? acc.PropertyName;
-
-        // Always call Register — null clears a stale delegate from a prior render so dropping
-        // the parameter between frames doesn't leave the old rule running.
-        ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
-
-        var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
-        var current = acc.Getter();
-
-        if (resolvedType == "checkbox")
-        {
-            var isChecked = current is bool b && b;
-            return C.Input(
-                "checkbox", name,
-                Checked: isChecked,
-                Required: Required, Disabled: Disabled, ReadOnly: ReadOnly,
-                Min: Min, Max: Max, Step: Step, Pattern: Pattern,
-                Size: Size, MaxLength: MaxLength, MinLength: MinLength,
-                Autocomplete: Autocomplete, Autofocus: Autofocus, List: List,
-                OnChangeAsync: BindingHelpers.BoolSetHandler(acc, ctx, fid, afterBind),
-                Id: Id, Class: Class, Style: Style, Data: Data);
-        }
-
-        var stringValue = BindingHelpers.FormatValue(current);
-        var isImmediate = BindingHelpers.IsImmediateUpdateType(acc.PropertyType);
-
-        return C.Input(
-            resolvedType, name, stringValue, Placeholder,
-            Required, Disabled, ReadOnly,
-            Min: Min, Max: Max, Step: Step, Pattern: Pattern,
-            Size: Size, MaxLength: MaxLength, MinLength: MinLength,
-            Autocomplete: Autocomplete, Autofocus: Autofocus, List: List,
-            OnInputAsync: isImmediate ? BindingHelpers.StringSetHandler(acc, ctx, fid, false, afterBind) : null,
-            OnChangeAsync: BindingHelpers.TouchAndValidateHandler(acc, ctx, fid, !isImmediate, afterBind),
-            Id: Id, Class: Class, Style: Style, Data: Data);
-    }
+    // IFormControl<T> — bound mode (excluded from the controlled factory by the generator).
+    public Expression<Func<T>>? Bind { get; set; }
+    public Validate<T>? Validate { get; set; }
+    public ValidateAsync<T>? ValidateAsync { get; set; }
+    public Action<T>? AfterBind { get; set; }
+    public Func<T, Task>? AfterBindAsync { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Type is not null)
+
+        // Resolve binding up front so the auto-derived name + value land in attribute order.
+        ExpressionAccessor.Accessor? acc = null;
+        EditContext? bindCtx = null;
+        var fid = default(FieldIdentifier);
+        object? boundValue = null;
+        if (Bind is not null)
         {
-            AppendAttr(sb, "type", Type);
+            acc = ExpressionAccessor.Parse(Bind);
+            bindCtx = BindingHelpers.ResolveBindingContext(acc.Target);
+            fid = acc.Field;
+            boundValue = acc.Getter();
         }
 
-        if (Name is not null)
+        // Type: bound mode (and non-string T) default from T; a plain string input keeps "no type unless set".
+        var resolvedType = Type;
+        if (resolvedType is null && (acc is not null || typeof(T) != typeof(string)))
         {
-            AppendAttr(sb, "name", Name);
+            resolvedType = BindingHelpers.DefaultInputType(typeof(T));
         }
 
-        if (Value is not null)
+        var isCheckbox = resolvedType == "checkbox";
+        var name = Name ?? acc?.PropertyName;
+
+        // Value / checked state. Bound mode derives one from the model (checkbox → checked, else → value);
+        // plain/controlled mode honors the explicit Value/Checked props independently, exactly as before.
+        string? valueString = null;
+        bool? checkedState = null;
+        if (acc is not null)
         {
-            AppendAttr(sb, "value", Value);
+            if (isCheckbox)
+            {
+                checkedState = boundValue is bool b && b;
+            }
+            else
+            {
+                valueString = BindingHelpers.FormatValue(boundValue);
+            }
+        }
+        else
+        {
+            checkedState = Checked;
+            valueString = Value is not null ? BindingHelpers.FormatValue(Value) : null;
+        }
+
+        if (resolvedType is not null)
+        {
+            AppendAttr(sb, "type", resolvedType);
+        }
+
+        if (name is not null)
+        {
+            AppendAttr(sb, "name", name);
+        }
+
+        if (valueString is not null)
+        {
+            AppendAttr(sb, "value", valueString);
         }
 
         if (Placeholder is not null)
@@ -166,7 +158,7 @@ public sealed class Input : Element
             AppendAttr(sb, "readonly", null);
         }
 
-        if (Checked is true)
+        if (checkedState is true)
         {
             AppendAttr(sb, "checked", null);
         }
@@ -281,25 +273,54 @@ public sealed class Input : Element
             AppendAttr(sb, "height", Height.Value.ToString(CultureInfo.InvariantCulture));
         }
 
-        if (LiveRenderContext.CurrentSync is { } ctx)
+        if (LiveRenderContext.CurrentSync is not { } ctx)
         {
+            return;
+        }
+
+        if (acc is not null)
+        {
+            // Bound: write the model on input (immediate for string) / change, validate.
+            var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
+            ((IFormControl<T>)this).RegisterValidator(acc, bindCtx);
+            if (isCheckbox)
+            {
+                AppendAttr(sb, "data-rask-on-change",
+                    ctx.RegisterHandler(BindingHelpers.BoolSetHandler(acc, bindCtx, fid, afterBind)));
+            }
+            else
+            {
+                var immediate = BindingHelpers.IsImmediateUpdateType(typeof(T));
+                if (immediate)
+                {
+                    AppendAttr(sb, "data-rask-on-input",
+                        ctx.RegisterHandler(BindingHelpers.StringSetHandler(acc, bindCtx, fid, false, afterBind)));
+                }
+
+                AppendAttr(sb, "data-rask-on-change",
+                    ctx.RegisterHandler(BindingHelpers.TouchAndValidateHandler(acc, bindCtx, fid, !immediate, afterBind)));
+            }
+        }
+        else
+        {
+            // Plain / controlled.
             var input = (Delegate?)OnInput ?? OnInputAsync;
             if (input is not null)
             {
                 AppendAttr(sb, "data-rask-on-input", ctx.RegisterHandler(input));
             }
 
-            var change = (Delegate?)OnChange ?? OnChangeAsync;
+            var change = ((IFormControl<T>)this).ControlledChangeHandler();
             if (change is not null)
             {
                 AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(change));
             }
+        }
 
-            var files = (Delegate?)OnFiles ?? OnFilesAsync;
-            if (files is not null)
-            {
-                AppendAttr(sb, "data-rask-on-files", ctx.RegisterHandler(files));
-            }
+        var files = (Delegate?)OnFiles ?? OnFilesAsync;
+        if (files is not null)
+        {
+            AppendAttr(sb, "data-rask-on-files", ctx.RegisterHandler(files));
         }
     }
 }

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -3,16 +3,20 @@ using System.Linq.Expressions;
 using System.Text;
 using Rask.Core.Forms;
 using Rask.Core.Live;
-using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Components;
 
-public sealed class Select : Element
+// Generic <select> form control implementing IFormControl<T>. The generator synthesizes a controlled/plain
+// factory and a Bind-first bound factory (validator fanned none/sync/async). Binding is resolved at render
+// time (WriteAttributes); the matching <option> is pre-marked selected just before the serializer reads
+// Children (EnterChildrenScope), so the initial render reflects the bound/controlled value without a
+// round-trip. Plain usage stays `Select<string>(Name: …)[Option(…)…]`; bound infers T from the expression.
+public sealed class Select<T> : Element, IFormControl<T>
 {
-    // Set by BoundCore; non-bound selects (plain Generated.Select) leave _bound false and
-    // skip the serialize-time marking entirely.
+    // Set in WriteAttributes (bound/controlled); a plain select leaves _bound false and skips marking.
     private bool _bound;
-    private string _boundValue = "";
+    private string _selectedValue = "";
+
     protected override string TagName => "select";
 
     public string? Name { get; set; }
@@ -23,59 +27,24 @@ public sealed class Select : Element
     public string? Form { get; set; }
     public bool? Autofocus { get; set; }
     public string? Autocomplete { get; set; }
-    public Callback<string>? OnChange { get; set; }
 
-    public CallbackAsync<string>? OnChangeAsync { get; set; }
+    // IFormControl<T> — controlled mode (OnChange/OnChangeAsync are the typed change callbacks).
+    public Callback<T>? OnChange { get; set; }
+    public CallbackAsync<T>? OnChangeAsync { get; set; }
+    public T? Value { get; set; }
 
-    // Expression-driven factory; pre-marks the matching <option> as selected so the initial render
-    // reflects the bound value without round-tripping through the browser. The `Validator` arg fans this
-    // single core into none / `Validate<TProp>` / `ValidateAsync<TProp>` overloads — see Input.Bound.
-    [GenerateForwarderFactory(Validator = "Validate")]
-    public static Select Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        Delegate? Validate = null,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Name = null,
-        bool Required = false,
-        bool Disabled = false,
-        int? Size = null,
-        bool Autofocus = false,
-        string? Autocomplete = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null,
-        params IEnumerable<Child> Children)
-    {
-        var acc = ExpressionAccessor.Parse(Bind);
-        var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
-        var fid = acc.Field;
-        var name = Name ?? acc.PropertyName;
-        ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
-        var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
-
-        var select = (Select)C.Select(
-            name, Required: Required, Disabled: Disabled, Size: Size,
-            Autofocus: Autofocus, Autocomplete: Autocomplete,
-            OnChangeAsync: BindingHelpers.TouchAndValidateHandler(acc, ctx, fid, true, afterBind),
-            Id: Id, Class: Class, Style: Style, Data: Data)[Children];
-
-        // Defer option pre-selection to serialize time. Options supplied via the [...] indexer
-        // (the idiomatic `Select(Bind: …)[Option(…)…]` form) replace Children *after* this
-        // factory returns, so marking them here would be discarded. EnterChildrenScope marks
-        // the matching <option> just before the serializer reads Children — covering both the
-        // indexer and the Children: argument forms.
-        select._bound = true;
-        select._boundValue = BindingHelpers.FormatValue(acc.Getter());
-        return select;
-    }
+    // IFormControl<T> — bound mode (excluded from the controlled factory by the generator).
+    public Expression<Func<T>>? Bind { get; set; }
+    public Validate<T>? Validate { get; set; }
+    public ValidateAsync<T>? ValidateAsync { get; set; }
+    public Action<T>? AfterBind { get; set; }
+    public Func<T, Task>? AfterBindAsync { get; set; }
 
     protected override IDisposable? EnterChildrenScope()
     {
         if (_bound && Children is not null)
         {
-            Children = MarkSelected(Children, _boundValue);
+            Children = MarkSelected(Children, _selectedValue);
         }
 
         return base.EnterChildrenScope();
@@ -150,9 +119,28 @@ public sealed class Select : Element
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Name is not null)
+
+        ExpressionAccessor.Accessor? acc = null;
+        EditContext? bindCtx = null;
+        var fid = default(FieldIdentifier);
+        if (Bind is not null)
         {
-            AppendAttr(sb, "name", Name);
+            acc = ExpressionAccessor.Parse(Bind);
+            bindCtx = BindingHelpers.ResolveBindingContext(acc.Target);
+            fid = acc.Field;
+            _bound = true;
+            _selectedValue = BindingHelpers.FormatValue(acc.Getter());
+        }
+        else if (Value is not null)
+        {
+            _bound = true;
+            _selectedValue = BindingHelpers.FormatValue(Value);
+        }
+
+        var name = Name ?? acc?.PropertyName;
+        if (name is not null)
+        {
+            AppendAttr(sb, "name", name);
         }
 
         if (Multiple is true)
@@ -190,10 +178,25 @@ public sealed class Select : Element
             AppendAttr(sb, "autocomplete", Autocomplete);
         }
 
-        var change = (Delegate?)OnChange ?? OnChangeAsync;
-        if (change is not null && LiveRenderContext.CurrentSync is { } ctx)
+        if (LiveRenderContext.CurrentSync is not { } ctx)
         {
-            AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(change));
+            return;
+        }
+
+        if (acc is not null)
+        {
+            var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
+            ((IFormControl<T>)this).RegisterValidator(acc, bindCtx);
+            AppendAttr(sb, "data-rask-on-change",
+                ctx.RegisterHandler(BindingHelpers.TouchAndValidateHandler(acc, bindCtx, fid, true, afterBind)));
+        }
+        else
+        {
+            var change = ((IFormControl<T>)this).ControlledChangeHandler();
+            if (change is not null)
+            {
+                AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(change));
+            }
         }
     }
 }

--- a/src/Rask.Core/Components/Textarea.cs
+++ b/src/Rask.Core/Components/Textarea.cs
@@ -3,11 +3,18 @@ using System.Linq.Expressions;
 using System.Text;
 using Rask.Core.Forms;
 using Rask.Core.Live;
-using C = Rask.Core.Components.Generated;
 
 namespace Rask.Core.Components;
 
-public sealed class Textarea : Element
+// Generic <textarea> form control implementing IFormControl<T>: the generator synthesizes a controlled
+// factory (Value/OnChange) and a Bind-first bound factory (validator fanned none/sync/async). The bound
+// value type T is usually string; non-string T round-trips through FormatValue (T→string) and the binding
+// parser (string→T). Binding is resolved at render time (WriteAttributes) rather than in a `Bound` factory:
+// the textarea's text content is the value, emitted as a child text node by RenderChildren.
+//
+// Plain usage stays `Textarea<string>(Name: …)[content]` — the value comes from Children; bound/controlled
+// usage derives it from Bind/Value.
+public sealed class Textarea<T> : Element, IFormControl<T>
 {
     protected override string TagName => "textarea";
 
@@ -25,62 +32,51 @@ public sealed class Textarea : Element
     public string? Autocomplete { get; set; }
     public string? Form { get; set; }
     public string? Dirname { get; set; }
+
+    // Per-keystroke DOM handler (a textarea is inherently string-valued); not part of IFormControl.
     public Callback<string>? OnInput { get; set; }
-    public Callback<string>? OnChange { get; set; }
     public CallbackAsync<string>? OnInputAsync { get; set; }
 
-    public CallbackAsync<string>? OnChangeAsync { get; set; }
+    // IFormControl<T> — bound mode.
+    public Expression<Func<T>>? Bind { get; set; }
+    public Validate<T>? Validate { get; set; }
+    public ValidateAsync<T>? ValidateAsync { get; set; }
+    public Action<T>? AfterBind { get; set; }
+    public Func<T, Task>? AfterBindAsync { get; set; }
 
-    // Expression-driven factory; see Input.Bound for the broader pattern. Textarea always updates
-    // per-keystroke (OnInput) since textareas are inherently string-valued. The `Validator` arg fans this
-    // single core into none / `Validate<TProp>` / `ValidateAsync<TProp>` overloads.
-    [GenerateForwarderFactory(Validator = "Validate")]
-    public static Textarea Bound<TProp>(
-        Expression<Func<TProp>> Bind,
-        Delegate? Validate = null,
-        Action<TProp>? AfterBind = null,
-        Func<TProp, Task>? AfterBindAsync = null,
-        string? Name = null,
-        int? Rows = null,
-        int? Cols = null,
-        string? Placeholder = null,
-        bool Required = false,
-        bool Disabled = false,
-        bool ReadOnly = false,
-        int? MaxLength = null,
-        int? MinLength = null,
-        string? Wrap = null,
-        bool Autofocus = false,
-        string? Autocomplete = null,
-        string? Id = null,
-        string? Class = null,
-        string? Style = null,
-        IReadOnlyDictionary<string, string?>? Data = null)
-    {
-        var acc = ExpressionAccessor.Parse(Bind);
-        var ctx = BindingHelpers.ResolveBindingContext(acc.Target);
-        var fid = acc.Field;
-        var name = Name ?? acc.PropertyName;
-        ctx?.RegisterFieldValidator(fid, Validate, () => acc.Getter());
-        var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
-        var stringValue = BindingHelpers.FormatValue(acc.Getter());
+    // IFormControl<T> — controlled mode.
+    public T? Value { get; set; }
+    public Callback<T>? OnChange { get; set; }
+    public CallbackAsync<T>? OnChangeAsync { get; set; }
 
-        return (Textarea)C.Textarea(
-            name, Rows, Cols, Placeholder,
-            Required, Disabled, ReadOnly,
-            MaxLength, MinLength, Wrap,
-            Autofocus, Autocomplete,
-            OnInputAsync: BindingHelpers.StringSetHandler(acc, ctx, fid, false, afterBind),
-            OnChangeAsync: BindingHelpers.TouchAndValidateHandler(acc, ctx, fid, false),
-            Id: Id, Class: Class, Style: Style, Data: Data)[stringValue];
-    }
+    // The rendered text content, resolved in WriteAttributes (bound/controlled) and emitted by
+    // RenderChildren. Null leaves the plain Children content (indexer) in place.
+    private string? _content;
 
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
-        if (Name is not null)
+
+        // Bound mode parses the expression up front so the auto-derived `name` lands in attribute order.
+        ExpressionAccessor.Accessor? acc = null;
+        EditContext? bindCtx = null;
+        var fid = default(FieldIdentifier);
+        if (Bind is not null)
         {
-            AppendAttr(sb, "name", Name);
+            acc = ExpressionAccessor.Parse(Bind);
+            bindCtx = BindingHelpers.ResolveBindingContext(acc.Target);
+            fid = acc.Field;
+            _content = BindingHelpers.FormatValue(acc.Getter());
+        }
+        else if (Value is not null)
+        {
+            _content = BindingHelpers.FormatValue(Value);
+        }
+
+        var name = Name ?? acc?.PropertyName;
+        if (name is not null)
+        {
+            AppendAttr(sb, "name", name);
         }
 
         if (Rows is not null)
@@ -148,19 +144,37 @@ public sealed class Textarea : Element
             AppendAttr(sb, "dirname", Dirname);
         }
 
-        if (LiveRenderContext.CurrentSync is { } ctx)
+        if (LiveRenderContext.CurrentSync is not { } ctx)
         {
-            var input = (Delegate?)OnInput ?? OnInputAsync;
-            if (input is not null)
-            {
-                AppendAttr(sb, "data-rask-on-input", ctx.RegisterHandler(input));
-            }
+            return;
+        }
 
-            var change = (Delegate?)OnChange ?? OnChangeAsync;
-            if (change is not null)
-            {
-                AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(change));
-            }
+        if (acc is not null)
+        {
+            // Bound: write the model on input, touch + revalidate on change.
+            var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
+            ((IFormControl<T>)this).RegisterValidator(acc, bindCtx);
+            AppendAttr(sb, "data-rask-on-input",
+                ctx.RegisterHandler(BindingHelpers.StringSetHandler(acc, bindCtx, fid, false, afterBind)));
+            AppendAttr(sb, "data-rask-on-change",
+                ctx.RegisterHandler(BindingHelpers.TouchAndValidateHandler(acc, bindCtx, fid, false)));
+            return;
+        }
+
+        // Plain / controlled.
+        var input = (Delegate?)OnInput ?? OnInputAsync;
+        if (input is not null)
+        {
+            AppendAttr(sb, "data-rask-on-input", ctx.RegisterHandler(input));
+        }
+
+        var change = ((IFormControl<T>)this).ControlledChangeHandler();
+        if (change is not null)
+        {
+            AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(change));
         }
     }
+
+    protected override IEnumerable<Child> RenderChildren() =>
+        _content is not null ? [_content] : base.RenderChildren();
 }

--- a/src/Rask.Core/Forms/BindingHelpers.cs
+++ b/src/Rask.Core/Forms/BindingHelpers.cs
@@ -358,6 +358,36 @@ public static class BindingHelpers
         return false;
     }
 
+    // Parses a DOM string value into the typed value of a controlled IFormControl<T> (the inverse of
+    // FormatValue). Identity for string; enums and IParsable<T> types round-trip via the same parser the
+    // bound setter uses. Takes a runtime Type so the caller's generic T carries no trimming annotation —
+    // the parse demands are covered by the same DynamicDependency that preserves the bound model's members,
+    // mirroring TrySetTyped's suppressions for the bound-setter path. Returns false when raw can't be parsed.
+    [UnconditionalSuppressMessage("Trimming", "IL2067",
+        Justification = "targetType is the declared value type of a typed form control; its enum/IParsable " +
+                        "parse demands are covered by the same DynamicDependency that preserves the model's " +
+                        "members, mirroring TrySetTyped.")]
+    [UnconditionalSuppressMessage("Trimming", "IL2070",
+        Justification = "Same rationale as IL2067 — targetType flows to RouteValueParser.TryParse, which " +
+                        "carries its own suppressions for the IParsable<T> probe.")]
+    public static bool TryParseValue(Type targetType, string raw, out object? value)
+    {
+        var effective = Nullable.GetUnderlyingType(targetType) ?? targetType;
+        if (effective.IsEnum)
+        {
+            if (Enum.TryParse(effective, raw, true, out var en))
+            {
+                value = en;
+                return true;
+            }
+
+            value = null;
+            return false;
+        }
+
+        return RouteValueParser.TryParse(targetType, raw, out value);
+    }
+
     private static bool IsNullableProperty(PropertyInfo prop, Type? underlying, Type type)
     {
         if (underlying is not null)

--- a/src/Rask.Core/Forms/FormControlInterfaces.cs
+++ b/src/Rask.Core/Forms/FormControlInterfaces.cs
@@ -31,4 +31,54 @@ public interface IFormControl<T>
     T? Value { get; set; }
     Callback<T>? OnChange { get; set; }
     CallbackAsync<T>? OnChangeAsync { get; set; }
+
+    // The single delegate the EditContext dispatches — sync or async, whichever the consumer set.
+    Delegate? Validator => (Delegate?)Validate ?? ValidateAsync;
+
+    // Registers the per-field validator for the bound field (no-op when context is null). Passing the
+    // collapsed Validator each render also clears a stale rule when the consumer drops it, so call it every
+    // render. Replaces the boilerplate `ctx?.RegisterFieldValidator(acc.Field, …, () => acc.Getter())` line.
+    void RegisterValidator(ExpressionAccessor.Accessor accessor, EditContext? context) =>
+        context?.RegisterFieldValidator(accessor.Field, Validator, () => accessor.Getter());
+
+    // Runs the post-bind hooks with the freshly-bound value.
+    async Task InvokeAfterBindAsync(T value)
+    {
+        AfterBind?.Invoke(value);
+        if (AfterBindAsync is not null)
+        {
+            await AfterBindAsync(value).ConfigureAwait(false);
+        }
+    }
+
+    // Notifies the controlled-mode consumer of a new value (sync + async).
+    async Task InvokeOnChangeAsync(T value)
+    {
+        OnChange?.Invoke(value);
+        if (OnChangeAsync is not null)
+        {
+            await OnChangeAsync(value).ConfigureAwait(false);
+        }
+    }
+
+    // Bridges a DOM string change to the typed OnChange/OnChangeAsync — parse the raw value to T (identity
+    // for string; enums / IParsable<T> round-trip via BindingHelpers.TryParseValue), then notify. Shared by
+    // every control's controlled mode; returns null when no controlled change handler is wired. Call it
+    // through the interface (`((IFormControl<T>)this).ControlledChangeHandler()`) and register the result as
+    // the element's `data-rask-on-change` handler.
+    Delegate? ControlledChangeHandler()
+    {
+        if (OnChange is null && OnChangeAsync is null)
+        {
+            return null;
+        }
+
+        return new CallbackAsync<string>(async raw =>
+        {
+            if (BindingHelpers.TryParseValue(typeof(T), raw, out var parsed) && parsed is T value)
+            {
+                await InvokeOnChangeAsync(value).ConfigureAwait(false);
+            }
+        });
+    }
 }

--- a/tests/Rask.Core.Tests/Components/InputTests.cs
+++ b/tests/Rask.Core.Tests/Components/InputTests.cs
@@ -6,14 +6,14 @@ public class InputTests
 {
     [Fact]
     public void Render_NullProps_ReturnsSelfClosingTag() =>
-        Assert.Equal("<input />", Input().ToHtml());
+        Assert.Equal("<input />", Input<string>().ToHtml());
 
     [Fact]
     public void Render_AllPropsSet_EmitsExpectedAttributes()
     {
         Assert.Equal(
             "<input id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" type=\"text\" name=\"n\" value=\"v\" placeholder=\"p\" required disabled readonly checked min=\"1\" max=\"10\" step=\"1\" pattern=\"[a-z]&#x2B;\" size=\"20\" maxlength=\"100\" minlength=\"1\" multiple accept=\".png\" alt=\"alt\" autocomplete=\"off\" autofocus form=\"f\" formaction=\"/a\" formenctype=\"multipart/form-data\" formmethod=\"post\" formnovalidate formtarget=\"_blank\" list=\"l\" src=\"/s\" width=\"80\" height=\"40\" />",
-            Input("text", "n", "v", "p", true, true, true, true, "1", "10", "1", "[a-z]+", 20, 100, 1, true, ".png",
+            Input<string>("text", "n", "v", "p", true, true, true, true, "1", "10", "1", "[a-z]+", 20, 100, 1, true, ".png",
                 "alt", "off", true, "f", "/a", "multipart/form-data", "post", true, "_blank", "l", "/s", 80, 40,
                 Id: "i", Class: "c", Style: "s", Data: new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
@@ -23,13 +23,13 @@ public class InputTests
     {
         Assert.Equal(
             "<input />",
-            Input(OnInput: _ => { }).ToHtml());
+            Input<string>(OnInput: _ => { }).ToHtml());
     }
 
     [Fact]
     public void Render_OnInputAndOnChangeInsideLiveContext_EmitSequentialIds()
     {
-        var view = new StubComponent(() => Input(OnInput: _ => { }, OnChange: _ => { }));
+        var view = new StubComponent(() => Input<string>(OnInput: _ => { }, OnChange: _ => { }));
         Assert.Equal(
             "<input data-rask-on-input=\"h0\" data-rask-on-change=\"h1\" />",
             view.RenderAsLiveRoot());
@@ -38,7 +38,7 @@ public class InputTests
     [Fact]
     public void Render_OnInputAsyncAndOnChangeAsyncInsideLiveContext_EmitSequentialIds()
     {
-        var view = new StubComponent(() => Input(OnInputAsync: async _ => { await Task.Yield(); },
+        var view = new StubComponent(() => Input<string>(OnInputAsync: async _ => { await Task.Yield(); },
             OnChangeAsync: async _ => { await Task.Yield(); }));
         Assert.Equal(
             "<input data-rask-on-input=\"h0\" data-rask-on-change=\"h1\" />",

--- a/tests/Rask.Core.Tests/Components/SelectTests.cs
+++ b/tests/Rask.Core.Tests/Components/SelectTests.cs
@@ -48,7 +48,7 @@ public class SelectTests
     {
         var model = new ColorPicker { Color = null };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Color, Children: new Child[] { Option(""), Option("red") })
+            Select(() => model.Color)[Option(""), Option("red")]
         ]);
 
         var html = view.RenderAsLiveRoot();
@@ -63,7 +63,7 @@ public class SelectTests
     {
         var model = new ColorPicker { Color = "red" };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Color, Children: new Child[] { Option(""), Option("red"), Option("blue") })
+            Select(() => model.Color)[Option(""), Option("red"), Option("blue")]
         ]);
 
         var html = view.RenderAsLiveRoot();
@@ -82,7 +82,7 @@ public class SelectTests
         // (see OnInput_NonNullableString_EmptyInput_SetsEmptyString in FormBindingTests).
         var model = new ColorPicker { Color = "red" };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Color, Children: new Child[] { Option(""), Option("red") })
+            Select(() => model.Color)[Option(""), Option("red")]
         ]);
         var html = view.RenderAsLiveRoot();
 
@@ -101,7 +101,7 @@ public class SelectTests
     {
         var model = new ChoiceModel { Choice = null };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Choice, Children: new Child[] { Option(""), Option("5"), Option("10") })
+            Select(() => model.Choice)[Option(""), Option("5"), Option("10")]
         ]);
         var html = view.RenderAsLiveRoot();
 
@@ -118,7 +118,7 @@ public class SelectTests
     {
         var model = new ChoiceModel { Choice = 5 };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Choice, Children: new Child[] { Option(""), Option("5") })
+            Select(() => model.Choice)[Option(""), Option("5")]
         ]);
         var html = view.RenderAsLiveRoot();
 
@@ -135,7 +135,7 @@ public class SelectTests
     {
         var model = new StatusModel { Status = null };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Status, Children: new Child[] { Option(""), Option("Active"), Option("Inactive") })
+            Select(() => model.Status)[Option(""), Option("Active"), Option("Inactive")]
         ]);
         var html = view.RenderAsLiveRoot();
 
@@ -152,7 +152,7 @@ public class SelectTests
     {
         var model = new StatusModel { Status = SelectStatus.Active };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Status, Children: new Child[] { Option(""), Option("Active") })
+            Select(() => model.Status)[Option(""), Option("Active")]
         ]);
         var html = view.RenderAsLiveRoot();
 
@@ -174,7 +174,7 @@ public class SelectTests
         // NOT match a null bound value.
         var model = new ColorPicker { Color = null };
         var view = new StubComponent(() => Form(model)[
-            Select(() => model.Color, Children: new Child[] { Option()["placeholder"], Option("red") })
+            Select(() => model.Color)[Option()["placeholder"], Option("red")]
         ]);
 
         var html = view.RenderAsLiveRoot();
@@ -184,31 +184,31 @@ public class SelectTests
 
     [Fact]
     public void Render_NullProps_ReturnsOpenAndCloseTags() =>
-        Assert.Equal("<select></select>", Select().ToHtml());
+        Assert.Equal("<select></select>", Select<string>().ToHtml());
 
     [Fact]
     public void Render_AllPropsSet_EmitsExpectedAttributes()
     {
         Assert.Equal(
             "<select id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" name=\"n\" multiple required disabled size=\"5\" form=\"f\" autofocus autocomplete=\"off\"></select>",
-            Select("n", true, true, true, 5, "f", true, "off", Id: "i", Class: "c", Style: "s",
+            Select<string>("n", true, true, true, 5, "f", true, "off", Id: "i", Class: "c", Style: "s",
                 Data: new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
 
     [Fact]
     public void Render_StringChild_EncodesText() =>
-        Assert.Equal("<select>&lt;x&gt;</select>", Select()["<x>"].ToHtml());
+        Assert.Equal("<select>&lt;x&gt;</select>", Select<string>()["<x>"].ToHtml());
 
     [Fact]
     public void Render_OnChangeOutsideLiveContext_OmitsHandlerAttribute() =>
         Assert.Equal(
             "<select></select>",
-            Select(OnChange: _ => { }).ToHtml());
+            Select<string>(OnChange: _ => { }).ToHtml());
 
     [Fact]
     public void Render_OnChangeInsideLiveContext_EmitsDataRaskOnChange()
     {
-        var view = new StubComponent(() => Select(OnChange: _ => { }));
+        var view = new StubComponent(() => Select<string>(OnChange: _ => { }));
         Assert.Equal(
             "<select data-rask-on-change=\"h0\"></select>",
             view.RenderAsLiveRoot());
@@ -217,7 +217,7 @@ public class SelectTests
     [Fact]
     public void Render_OnChangeAsyncInsideLiveContext_EmitsDataRaskOnChange()
     {
-        var view = new StubComponent(() => Select(OnChangeAsync: async _ => { await Task.Yield(); }));
+        var view = new StubComponent(() => Select<string>(OnChangeAsync: async _ => { await Task.Yield(); }));
         Assert.Equal(
             "<select data-rask-on-change=\"h0\"></select>",
             view.RenderAsLiveRoot());

--- a/tests/Rask.Core.Tests/Components/TextareaTests.cs
+++ b/tests/Rask.Core.Tests/Components/TextareaTests.cs
@@ -6,31 +6,31 @@ public class TextareaTests
 {
     [Fact]
     public void Render_NullProps_ReturnsOpenAndCloseTags() =>
-        Assert.Equal("<textarea></textarea>", Textarea().ToHtml());
+        Assert.Equal("<textarea></textarea>", Textarea<string>().ToHtml());
 
     [Fact]
     public void Render_AllPropsSet_EmitsExpectedAttributes()
     {
         Assert.Equal(
             "<textarea id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" name=\"n\" rows=\"4\" cols=\"80\" placeholder=\"p\" required disabled readonly maxlength=\"100\" minlength=\"1\" wrap=\"soft\" autofocus autocomplete=\"off\" form=\"f\" dirname=\"d\"></textarea>",
-            Textarea("n", 4, 80, "p", true, true, true, 100, 1, "soft", true, "off", "f", "d", Id: "i", Class: "c",
+            Textarea<string>("n", 4, 80, "p", true, true, true, 100, 1, "soft", true, "off", "f", "d", Id: "i", Class: "c",
                 Style: "s", Data: new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
 
     [Fact]
     public void Render_StringChild_EncodesText() =>
-        Assert.Equal("<textarea>&lt;x&gt;</textarea>", Textarea()["<x>"].ToHtml());
+        Assert.Equal("<textarea>&lt;x&gt;</textarea>", Textarea<string>()["<x>"].ToHtml());
 
     [Fact]
     public void Render_OnInputOutsideLiveContext_OmitsHandlerAttribute() =>
         Assert.Equal(
             "<textarea></textarea>",
-            Textarea(OnInput: _ => { }).ToHtml());
+            Textarea<string>(OnInput: _ => { }).ToHtml());
 
     [Fact]
     public void Render_OnInputAndOnChangeInsideLiveContext_EmitSequentialIds()
     {
-        var view = new StubComponent(() => Textarea(OnInput: _ => { }, OnChange: _ => { }));
+        var view = new StubComponent(() => Textarea<string>(OnInput: _ => { }, OnChange: _ => { }));
         Assert.Equal(
             "<textarea data-rask-on-input=\"h0\" data-rask-on-change=\"h1\"></textarea>",
             view.RenderAsLiveRoot());
@@ -39,7 +39,7 @@ public class TextareaTests
     [Fact]
     public void Render_OnInputAsyncAndOnChangeAsyncInsideLiveContext_EmitSequentialIds()
     {
-        var view = new StubComponent(() => Textarea(OnInputAsync: async _ => { await Task.Yield(); },
+        var view = new StubComponent(() => Textarea<string>(OnInputAsync: async _ => { await Task.Yield(); },
             OnChangeAsync: async _ => { await Task.Yield(); }));
         Assert.Equal(
             "<textarea data-rask-on-input=\"h0\" data-rask-on-change=\"h1\"></textarea>",

--- a/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
+++ b/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
@@ -19,7 +19,7 @@ public class RaskFileDispatchTests
         IReadOnlyList<RaskFile>? received = null;
         Callback<IReadOnlyList<RaskFile>> handler = files => received = files;
 
-        var view = new StubComponent(() => Input(OnFiles: handler));
+        var view = new StubComponent(() => Input<string>(OnFiles: handler));
         view.RenderAsLiveRoot();
 
         var payload = JsonDocument.Parse("""
@@ -54,7 +54,7 @@ public class RaskFileDispatchTests
             return Task.CompletedTask;
         };
 
-        var view = new StubComponent(() => Input(OnFilesAsync: handler));
+        var view = new StubComponent(() => Input<string>(OnFilesAsync: handler));
         view.RenderAsLiveRoot();
 
         var payload = JsonDocument.Parse("""
@@ -73,7 +73,7 @@ public class RaskFileDispatchTests
     public void Input_Emits_DataRaskOnFiles_Attribute_When_OnFiles_Set()
     {
         Callback<IReadOnlyList<RaskFile>> handler = _ => { };
-        var view = new StubComponent(() => Input("file", OnFiles: handler));
+        var view = new StubComponent(() => Input<string>("file", OnFiles: handler));
         var html = view.RenderAsLiveRoot();
         Assert.Contains("data-rask-on-files=", html);
         Assert.Contains("type=\"file\"", html);

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -83,8 +83,8 @@ public class FrameDifferTests
     [Fact]
     public void Diff_AttributeValueChanged_ProducesSingleSetAttributeOp()
     {
-        var before = Frames(Input("text", "f", "old", "edit"));
-        var after = Frames(Input("text", "f", "new", "edit"));
+        var before = Frames(Input<string>("text", "f", "old", "edit"));
+        var after = Frames(Input<string>("text", "f", "new", "edit"));
 
         var ops = new List<EditOp>();
         FrameDiffer.Diff(before, after, ops);
@@ -106,8 +106,8 @@ public class FrameDifferTests
         // checkbox losing its event handler (so it stopped responding after a click) and
         // gaining a spurious value="". Name-keyed diffing emits exactly one op for the
         // toggled attribute and leaves `list` (emitted AFTER `checked`) untouched.
-        var unchecked_ = Frames(Input("checkbox", "n", List: "dl"));
-        var checked_ = Frames(Input("checkbox", "n", Checked: true, List: "dl"));
+        var unchecked_ = Frames(Input<string>("checkbox", "n", List: "dl"));
+        var checked_ = Frames(Input<string>("checkbox", "n", Checked: true, List: "dl"));
 
         var on = new List<EditOp>();
         FrameDiffer.Diff(unchecked_, checked_, on);

--- a/tests/Rask.Core.Tests/Live/LiveViewTests.cs
+++ b/tests/Rask.Core.Tests/Live/LiveViewTests.cs
@@ -52,7 +52,7 @@ public class LiveViewTests
     public async Task TryInvokeHandlerAsync_StringActionHandler_ReceivesValueProperty()
     {
         var captured = string.Empty;
-        var view = new StubComponent(() => Input(OnInput: v => captured = v));
+        var view = new StubComponent(() => Input<string>(OnInput: v => captured = v));
         view.RenderAsLiveRoot();
 
         using var doc = JsonDocument.Parse("{\"id\":\"h0\",\"type\":\"input\",\"value\":\"hello\"}");
@@ -100,7 +100,7 @@ public class LiveViewTests
     public async Task TryInvokeHandlerAsync_FuncStringTaskHandler_ReceivesValue()
     {
         var captured = string.Empty;
-        var view = new StubComponent(() => Input(OnInputAsync: async v =>
+        var view = new StubComponent(() => Input<string>(OnInputAsync: async v =>
         {
             await Task.Yield();
             captured = v;


### PR DESCRIPTION
## Summary
PR2 of the form-control arc: the built-in `Input`/`Select`/`Textarea` become generic `Input<T>`/`Select<T>`/`Textarea<T>` and implement **`IFormControl<T>`**, so the framework's own controls declare binding/validation/controlled exactly like custom controls (PR1 #152).

- **Bound usage infers `T`** from the expression: `Input(() => model.Age)` → `Input<int>` → `<input type="number">`. The HTML input **`type` derives from `T`** (bool→checkbox, numeric→number, `DateOnly`→date, …), at compile time rather than via runtime `PropertyType` reflection.
- **Binding is resolved at render time** (`WriteAttributes`/`EnterChildrenScope`) instead of in a hand-written `Bound` factory.
- **`IFormControl<T>` gained default-method helpers** that remove per-control boilerplate — `Validator`, `RegisterValidator(acc, ctx)`, `InvokeAfterBindAsync`, `InvokeOnChangeAsync`, and `ControlledChangeHandler` (the string↔`T` bridge for controlled mode, via the new `BindingHelpers.TryParseValue`). The built-ins and the sample `MultiSelect`/`CheckboxGroup`/`RadioGroup` all adopt them.

### BREAKING
- Plain (non-bound) usage needs the explicit type argument: `Input<string>("text", …)`, `Select<string>(…)`, `Textarea<string>(…)`. Bound usage is unchanged (`T` inferred).
- Bound `Select` takes its options via the `[...]` indexer instead of a `Children:` argument.

## Testing
- `dotnet format --verify-no-changes`: clean. `dotnet build Rask.slnx -warnaserror`: clean, incl. the **WASM publish/trim** check (the controlled string↔`T` bridge is trimming-safe via a runtime-`Type` parse with localized suppression).
- Unit: full fast suite green (13 projects) — `Rask.Core.Tests` 1539 (Input/Select/Textarea/binding/differ behavior unchanged), generators 165, samples 281.
- E2E: host **Server** — `ServerExampleTests.Journey` passed.

## Benchmarks
Plain-input serialize hot path (`HtmlSerializerBenchmarks.RenderMedium`/`RenderLarge`, trees of N `Input<string>`), main vs branch — **Allocated byte-identical** (67.23 KB / 1377.03 KB), Mean within noise. The generic conversion adds no allocation to the per-element serialize path. (Bound-mode binding is render-deferred and runs per form field, not in a hot loop; no regression observed.)

## CHANGELOG
- [Unreleased] Changed: generic built-in form elements implementing `IFormControl<T>`; `IFormControl<T>` default-method helpers.