### PR TITLE
fix(live): match the diff frame model to the coalesced DOM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **Live diff now updates adjacent text nodes correctly.** Two bare strings rendered side by side
+  (e.g. `Button()[ "Toggle ?tab=", value ]`) were emitted as two render frames, but the browser
+  coalesces adjacent text into a single DOM node — so the diff's per-frame slot walk drifted past the
+  real child nodes and the `UpdateText` patch was silently dropped (the text never changed; surfaced on
+  the showcase "Switch user" toggle button after a `Navigator.SetQuery`). Adjacent text frames are now
+  coalesced at emission to match the DOM, including across transparent `Fragment`/`Context` boundaries.
+- **Empty text children no longer drift sibling positions.** An empty/`null` string child
+  (`Div()[Span(), "", Span()]`) produces no HTML and no DOM node, but still emitted a text frame — so
+  every following sibling's diff path was off by one. Empty text frames are now skipped.
+- **`Raw` adjacent to other siblings falls back to a full morph.** A `Raw`'s verbatim markup can parse
+  into zero, one, or many DOM nodes, so a sibling rendered after a non-sole-child `Raw` could be patched
+  at the wrong index by an ungated `UpdateText`/`SetAttribute`. When a changed sibling level mixes a
+  `Raw` with other nodes, the render now routes to the full-HTML morph (which reparses the markup
+  correctly) instead of shipping a mis-targeted positional op. A solitary `Raw` is unaffected.
+
 ### Changed
 - **`CheckboxGroup`/`RadioGroup` rewritten as Components** (the `MultiSelect<TItem>` template) instead of
   static `Fragment` factories. Each now supports **bound** (`() => model.X` with a per-field `Validate`

--- a/docs/architecture/live-rendering.md
+++ b/docs/architecture/live-rendering.md
@@ -119,6 +119,31 @@ surrounding level). The op kinds (`EditOpKind`):
 | `MoveSubtree`      | 6 | move an existing sibling node (detach at source, insert at dest) |
 | `PermutationBatch` | 7 | a batch of sibling moves under one keyed parent (see below) |
 
+### One frame per DOM node: text & `Raw`
+
+`Path` indexing only works if **every DOM-relevant frame maps to exactly one browser
+DOM node**. Two cases would otherwise break that 1:1 mapping, so the runtime normalizes
+them (`Live/RenderFrame.cs`, `FrameWriter.Text`):
+
+- **Adjacent text coalesces.** `Div()["a", value]` is two `Text` frames, but the browser
+  merges adjacent text into a *single* DOM node. The frame writer concatenates contiguous
+  text frames into one so the model matches — including text on either side of a
+  transparent `Fragment`/`Context`, which emits no markup of its own. (Contiguity is
+  detected by `HtmlEnd == htmlStart`: any tag or node between two texts advances the HTML,
+  so element-separated text stays distinct.)
+- **Empty text emits nothing.** An empty/`null` string child produces no HTML and no DOM
+  node, so no frame is emitted for it — otherwise every following sibling's path would
+  drift by one.
+
+`Raw` is the exception that *can't* be normalized: its verbatim markup parses into an
+unknown number of top-level nodes (zero, one, or many). A solitary `Raw` is safe (its
+nodes span the whole parent — nothing is indexed after it), but a `Raw` that shares a
+sibling level with other nodes makes every following position unreliable. When a changed
+sibling level mixes a `Raw` with other nodes, the diff sets a force-full-HTML flag
+(`DiffScratch.ForceFullHtml` → `SessionRenderCache.LastDiffForcedFullHtml`) and the render
+falls back to the morph, which reparses the markup correctly rather than shipping a
+mis-targeted positional op.
+
 ### When a diff ships vs full HTML
 
 `LiveDiffMode` (`Live/LiveOptions.cs`) is configured via

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -280,6 +280,14 @@ public static class FrameDiffer
 
         scratch.ReturnBundle(bundle);
 
+        // A Raw frame's verbatim markup parses into an unknown node count, so once a Raw shares a
+        // sibling level with anything else, every position after it is suspect. If this level (or
+        // its subtree) ends up emitting ANY op, the positional paths can't be trusted — flag the
+        // render for the full-HTML morph. Detected up front; committed below only if ops were
+        // actually produced, so an idle render of such a page still ships nothing.
+        var rawTaintedLevel = LevelHasRawWithSiblings(oldFrames, oldStart, oldEnd)
+                              || LevelHasRawWithSiblings(newFrames, newStart, newEnd);
+        var opCountAtEntry = output.Count;
 
         var oi = oldStart;
         var ni = newStart;
@@ -392,6 +400,37 @@ public static class FrameDiffer
             ni += newFrame.SubtreeLength;
             domSlot++;
         }
+
+        if (rawTaintedLevel && output.Count != opCountAtEntry)
+        {
+            scratch.ForceFullHtml = true;
+        }
+    }
+
+    // True when this sibling level contains a Raw frame alongside at least one other DOM-relevant
+    // sibling. A solitary Raw (the only child) is safe — its node(s) span the whole parent, so no
+    // sibling index follows it; only a Raw with neighbours can drift their positions.
+    private static bool LevelHasRawWithSiblings(ReadOnlySpan<RenderFrame> frames, int start, int end)
+    {
+        var hasRaw = false;
+        var domNodes = 0;
+        var i = start;
+        while (i < end)
+        {
+            var kind = frames[i].Kind;
+            if (kind != RenderFrameKind.Attribute)
+            {
+                domNodes++;
+                if (kind == RenderFrameKind.Raw)
+                {
+                    hasRaw = true;
+                }
+            }
+
+            i += frames[i].SubtreeLength;
+        }
+
+        return hasRaw && domNodes > 1;
     }
 
     // Defer the inserted subtree's HTML slice to wire-format time: carry the fragment's char
@@ -987,10 +1026,18 @@ public static class FrameDiffer
 
         internal bool UsedKeyedPath { get; set; }
 
+        // Set when the diff touched a sibling level that mixes a Raw frame with other DOM-relevant
+        // siblings. A Raw's verbatim markup parses into an unknown number of DOM nodes (0, 1, or
+        // many), so the positional domSlot of every sibling after it — and any descendant op routed
+        // through it — is unreliable. The session reads this to fall back to the full-HTML morph,
+        // which reparses the markup correctly, instead of shipping a mis-targeted positional patch.
+        internal bool ForceFullHtml { get; set; }
+
         internal void ResetForDiff()
         {
             Path.Clear();
             UsedKeyedPath = false;
+            ForceFullHtml = false;
         }
 
         internal KeyedBundle RentBundle() => _bundles.Count > 0 ? _bundles.Pop() : new KeyedBundle();

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -131,7 +131,8 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
             // the head fragment). Zero ops + no history + unchanged head means nothing to send.
             if (_renderCache.TryComputeDiff(_diffOps, commitCache, html)
                 && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
-                && LiveDiffGate.DiffOpsAreClientSupported(_diffOps))
+                && LiveDiffGate.DiffOpsAreClientSupported(_diffOps)
+                && !_renderCache.LastDiffForcedFullHtml)
             {
                 var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
                 LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes,

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -193,6 +193,32 @@ public sealed class FrameWriter
 
     public void Text(string? value, int htmlStart, int htmlEnd)
     {
+        // An empty text node emits no HTML and so produces NO DOM node — the browser never
+        // creates one. Emitting a frame for it would make the diff count a node that isn't there
+        // and drift every following sibling's domSlot path (same failure mode as adjacent text).
+        // htmlStart == htmlEnd means AppendEncoded wrote nothing — i.e. value was null or "".
+        if (htmlStart == htmlEnd)
+        {
+            return;
+        }
+
+        // The browser coalesces adjacent text into ONE DOM text node, so the frame model has to
+        // as well — otherwise the diff's per-frame domSlot walk drifts past the real childNodes
+        // and the UpdateText op targets a slot that doesn't exist (silently dropped → stale text).
+        // HtmlEnd == htmlStart means nothing was emitted between the two texts: a tag, element, or
+        // raw node would have advanced the StringBuilder, so contiguity is exactly DOM-adjacency.
+        // This catches Fragment/Context-boundary adjacency too (they emit no HTML of their own).
+        if (Count > 0)
+        {
+            ref var prev = ref _buffer[Count - 1];
+            if (prev.Kind == RenderFrameKind.Text && prev.HtmlEnd == htmlStart)
+            {
+                prev.Name = (prev.Name ?? string.Empty) + (value ?? string.Empty);
+                prev.HtmlEnd = htmlEnd;
+                return;
+            }
+        }
+
         var idx = Reserve();
         _buffer[idx] = new RenderFrame
         {

--- a/src/Rask.Core/Live/SessionRenderCache.cs
+++ b/src/Rask.Core/Live/SessionRenderCache.cs
@@ -133,6 +133,13 @@ public sealed class SessionRenderCache : IDisposable
     ///     corrupts the next diff: edits computed against an out-of-date snapshot
     ///     applied to a DOM the client has already moved past.
     /// </summary>
+    /// <summary>
+    ///     True when the last <see cref="TryComputeDiff" /> touched a sibling level that mixed a Raw
+    ///     frame with other siblings and emitted ops there — the positional paths are unreliable, so
+    ///     the session must ship full HTML (the morph reparses the Raw markup) rather than the diff.
+    /// </summary>
+    public bool LastDiffForcedFullHtml => _scratch?.ForceFullHtml ?? false;
+
     public void Snapshot() => RotateBuffers();
 
     /// <summary>

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -42,6 +42,95 @@ public class FrameDifferTests
     }
 
     [Fact]
+    public void Frames_AdjacentTextChildren_CoalesceIntoOneFrame()
+    {
+        // The browser merges adjacent text into ONE DOM node; the frame model must match or
+        // the diff's per-frame domSlot walk drifts past the real childNodes. Two string children
+        // with nothing between them must emit a single Text frame holding the concatenation.
+        var frames = Frames(Div()["Toggle ?tab=", "profile"]);
+
+        var text = Assert.Single(frames, f => f.Kind == RenderFrameKind.Text);
+        Assert.Equal("Toggle ?tab=profile", text.Name);
+    }
+
+    [Fact]
+    public void Diff_AdjacentTextChanged_ProducesSingleUpdateTextWithMergedValue()
+    {
+        // Regression (the "Switch user" toggle button): a label literal sits directly next to a
+        // dynamic value — `[<icon/>, "Toggle ?tab=", value]`. The browser coalesces the two texts
+        // into one node, so the changed value must ship as ONE UpdateText carrying the full merged
+        // string, targeting the single coalesced slot — not an op at a domSlot that doesn't exist.
+        var before = Frames(Div()[Span(), "Toggle ?tab=", "profile"]);
+        var after = Frames(Div()[Span(), "Toggle ?tab=", "activity"]);
+
+        var ops = new List<EditOp>();
+        FrameDiffer.Diff(before, after, ops);
+
+        var update = Assert.Single(ops);
+        Assert.Equal(EditOpKind.UpdateText, update.Kind);
+        Assert.Equal("Toggle ?tab=activity", update.Value);
+    }
+
+    [Fact]
+    public void Frames_AdjacentTextAcrossFragmentBoundary_Coalesces()
+    {
+        // A Fragment is transparent — it emits no HTML of its own — so text on either side of it
+        // is DOM-adjacent and coalesces. The contiguity (HtmlEnd == htmlStart) check catches this
+        // case that a children-list-level merge would miss.
+        var frames = Frames(Div()["a", Fragment()["b"]]);
+
+        var text = Assert.Single(frames, f => f.Kind == RenderFrameKind.Text);
+        Assert.Equal("ab", text.Name);
+    }
+
+    [Fact]
+    public void Frames_TextSeparatedByElement_StaysDistinct()
+    {
+        // An element between two texts breaks DOM adjacency (`<span></span>` advances the HTML), so
+        // the frames must stay separate — merging them would mis-map the diff onto the real DOM.
+        var frames = Frames(Div()["a", Span(), "b"]).Where(f => f.Kind == RenderFrameKind.Text).ToArray();
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal("a", frames[0].Name);
+        Assert.Equal("b", frames[1].Name);
+    }
+
+    [Fact]
+    public void Frames_TextAfterChildElement_NotMergedWithInnerText()
+    {
+        // The inner text "a" closes with `</span>` before the sibling text "b" starts, so they are
+        // not contiguous and must not merge — even though "a" is the most recently emitted frame.
+        var frames = Frames(Div()[Span()["a"], "b"]).Where(f => f.Kind == RenderFrameKind.Text).ToArray();
+
+        Assert.Equal(2, frames.Length);
+        Assert.Equal("a", frames[0].Name);
+        Assert.Equal("b", frames[1].Name);
+    }
+
+    [Fact]
+    public void Frames_EmptyTextBetweenElements_EmitsNoFrame()
+    {
+        // An empty string child produces no HTML and so no DOM node. If it emitted a Text frame,
+        // the diff would count a node the browser never created and every following sibling's
+        // domSlot would drift by one — the trailing Span here would be patched at the wrong index.
+        var (frames, html) = FramesAndHtml(Div()[Span(Id: "a"), "", Span(Id: "b")]);
+
+        Assert.DoesNotContain(frames, f => f.Kind == RenderFrameKind.Text);
+        Assert.Equal("<div><span id=\"a\"></span><span id=\"b\"></span></div>", html);
+    }
+
+    [Fact]
+    public void Frames_EmptyTextBetweenTexts_StillCoalescesNeighbours()
+    {
+        // An empty text in the middle of two real texts must drop out without breaking the
+        // coalescing of the survivors — the DOM has the single node "ab".
+        var frames = Frames(Div()["a", "", "b"]);
+
+        var text = Assert.Single(frames, f => f.Kind == RenderFrameKind.Text);
+        Assert.Equal("ab", text.Name);
+    }
+
+    [Fact]
     public void Diff_RawValueUnchanged_ProducesZeroOps()
     {
         // An identical Raw value must produce no ops — the verbatim markup is the same
@@ -78,6 +167,57 @@ public class FrameDifferTests
         // routes the whole render to the full-HTML morph rather than applying them directly
         // — the morph reparses the new markup instead of escaping it.
         Assert.False(LiveDiffGate.DiffOpsAreClientSupported(ops));
+    }
+
+    [Fact]
+    public void Diff_RawWithChangingSibling_ForcesFullHtmlMorph()
+    {
+        // A Raw's markup parses into an unknown number of DOM nodes, so a sibling after it can't be
+        // patched positionally (the domSlot index assumes Raw == 1 node). Changing such a sibling
+        // must route to the full-HTML morph — NOT ship a mis-targeted, ungated UpdateText.
+        var before = Frames(Div()[Raw("<a></a><b></b>"), Span()["x"]]);
+        var (after, afterHtml) = FramesAndHtml(Div()[Raw("<a></a><b></b>"), Span()["y"]]);
+
+        var ops = new List<EditOp>();
+        var scratch = new FrameDiffer.DiffScratch();
+        FrameDiffer.Diff(before, after, ops, scratch, out _, afterHtml);
+
+        Assert.True(scratch.ForceFullHtml);
+    }
+
+    [Fact]
+    public void Diff_RawWithSiblingsUnchanged_DoesNotForceFullHtml()
+    {
+        // The morph fallback only fires when something actually changed at the Raw-tainted level —
+        // an idle re-render of a page that happens to contain a Raw-with-siblings still ships nothing.
+        var before = Frames(Div()[Raw("<a></a><b></b>"), Span()["x"]]);
+        var (after, afterHtml) = FramesAndHtml(Div()[Raw("<a></a><b></b>"), Span()["x"]]);
+
+        var ops = new List<EditOp>();
+        var scratch = new FrameDiffer.DiffScratch();
+        FrameDiffer.Diff(before, after, ops, scratch, out _, afterHtml);
+
+        Assert.Empty(ops);
+        Assert.False(scratch.ForceFullHtml);
+    }
+
+    [Fact]
+    public void Diff_RawAsSoleChild_StaysOnDiffPath()
+    {
+        // A solitary Raw spans the whole parent — no sibling index follows it — so a sole-child Raw
+        // is safe and must not trip the morph fallback. (A CHANGED sole Raw still ships Remove+Insert
+        // via SiblingMatches, covered by Diff_RawValueChanged_*; here the surrounding text changes.)
+        var before = Frames(Div()[Code()[Raw("<i>x</i>")], Span()["a"]]);
+        var (after, afterHtml) = FramesAndHtml(Div()[Code()[Raw("<i>x</i>")], Span()["b"]]);
+
+        var ops = new List<EditOp>();
+        var scratch = new FrameDiffer.DiffScratch();
+        FrameDiffer.Diff(before, after, ops, scratch, out _, afterHtml);
+
+        var update = Assert.Single(ops);
+        Assert.Equal(EditOpKind.UpdateText, update.Kind);
+        Assert.Equal("b", update.Value);
+        Assert.False(scratch.ForceFullHtml);
     }
 
     [Fact]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -145,6 +145,20 @@ public abstract partial class SharedSmokeTests
         await Expect(Page).ToHaveTitleAsync("User #42 — Rask",
             new PageAssertionsToHaveTitleOptions { Timeout = 5_000 });
 
+        // Adjacent text nodes: the toggle renders a literal ("Toggle ?tab=") directly beside a dynamic
+        // value, which the browser coalesces into one text node. A diff-codec regression left the
+        // dynamic half stale after SetQuery (the bug that surfaced here). Assert the label actually
+        // flips on each click — exercises the coalesced-text UpdateText path on both transports.
+        var tabToggle = Page.Locator("button.btn-primary:has-text('Toggle ?tab=')");
+        await Expect(tabToggle).ToContainTextAsync("Toggle ?tab=profile",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await tabToggle.ClickAsync();
+        await Expect(tabToggle).ToContainTextAsync("Toggle ?tab=activity",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await tabToggle.ClickAsync();
+        await Expect(tabToggle).ToContainTextAsync("Toggle ?tab=profile",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
         // Navigator: SetQuery mutates the URL and the in-SPA head-diff updates <title> across a
         // route-param change.
         await SideAsync("Navigator", "Navigator");


### PR DESCRIPTION
## Summary

The live-diff codec assumes **one render frame == one browser DOM node**, indexing each `EditOp` by a child-slot path. Three cases broke that 1:1 mapping, so positional patches landed on the wrong node (or none):

1. **Adjacent text** — `Button()[ "Toggle ?tab=", value ]` emits two `Text` frames, but the browser coalesces adjacent text into one DOM node. The per-frame slot walk drifted and the `UpdateText` was silently dropped. This is the reported bug: the showcase **"Switch user"** toggle label never flipped after `Navigator.SetQuery` (hit in WASM; affects Server too).
2. **Empty text** — an empty/`null` string child (`Div()[Span(), "", Span()]`) produces no HTML and no DOM node, but still emitted a frame, drifting every following sibling by one.
3. **`Raw` with siblings** — a `Raw`'s verbatim markup parses into an unknown number of nodes, so a sibling after a non-sole-child `Raw` could be patched at the wrong index by an ungated `UpdateText`/`SetAttribute`.

## Fix

All at the frame-emission / diff boundary — HTML output is byte-identical:

- `FrameWriter.Text` coalesces contiguous text frames (contiguity = `HtmlEnd == htmlStart`, so element-separated text stays distinct; catches `Fragment`/`Context` boundaries) and skips empty-text frames.
- `FrameDiffer`/`DiffScratch` flag a render for the full-HTML morph when a *changed* sibling level mixes a `Raw` with other nodes (`SessionRenderCache.LastDiffForcedFullHtml`, gated in `LiveSessionBase.WritePayload`). A solitary `Raw` and idle renders are unaffected.

## Testing

- 7 new unit tests in `FrameDifferTests` (coalescing, empty-text skip, fragment-boundary merge, no-merge boundaries, Raw force-morph + no-spurious-morph). Core **1549** pass, Server **239** pass.
- E2E: added a toggle-flip assertion to the shared showcase journey — **Server (45s)** and **WASM (64s)** journeys pass.

## Benchmarks

`FrameDifferBenchmarks` + `HtmlSerializerBenchmarks`, ShortRun, before/after: **zero `Allocated` delta** on every render/diff hot path (e.g. `RenderTextHeavyTree` 73.9 KB, keyed `Reorder` 70.41 KB — byte-identical). Keyed diff paths bypass the new positional check; coalescing allocates only when an actual merge occurs.

## Changelog

`[Unreleased] → Fixed` entries added; architecture note in `docs/architecture/live-rendering.md`.