### PR TITLE
feat(interop): typed browser-API foundation (Storage/Clipboard/Geolocation/Navigator)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Typed browser-API foundation** — strongly-typed, DI-injected C# wrappers over the Web APIs that
+  previously needed raw `IJSRuntime` string identifiers, identical on Server and WASM: `IBrowserStorage`
+  (`localStorage`/`sessionStorage`), `IClipboard`, `IGeolocation` (`GetCurrentPositionAsync` →
+  `GeolocationPosition`), and `INavigatorInfo` (`OnLine`/`Language`/`UserAgent`). Inject the interface
+  through a component constructor and await typed methods. Shared framework JS interop helpers
+  (`__raskEl`, `__raskApi`) are now a single source of truth in `Rask.Core/Resources/rask-api.js`,
+  spliced into both client runtimes at build time so the transports never drift. New `/browser`
+  showcase page. First step toward PWA support (WASM-only service-worker/cache/manifest APIs follow on
+  the same pattern).
+
 ### Fixed
 - **Live diff now updates adjacent text nodes correctly.** Two bare strings rendered side by side
   (e.g. `Button()[ "Toggle ?tab=", value ]`) were emitted as two render frames, but the browser

--- a/README.md
+++ b/README.md
@@ -1223,6 +1223,23 @@ On **WASM**, the standard Blazor-WASM trimming constraint applies: `T` in `Invok
 call site (via `[DynamicallyAccessedMembers]` or a `JsonSerializerContext`). JSON primitives (`bool`, `int`, `long`,
 `double`, `string`) are always safe. Server has no such constraint.
 
+**Typed browser APIs.** For common Web APIs you don't have to spell out raw identifiers — inject a typed wrapper
+through the constructor. Each is a thin layer over the same `IJSRuntime`, identical on Server and WASM:
+
+```csharp
+public sealed class Prefs(IBrowserStorage storage, IClipboard clipboard,
+                          IGeolocation geolocation, INavigatorInfo navigator) : Component
+{
+    async Task Save()    => await storage.Local.SetAsync("theme", "dark");   // localStorage / sessionStorage
+    async Task Copy()    => await clipboard.WriteTextAsync("hi");            // navigator.clipboard
+    async Task Where()   { var p = await geolocation.GetCurrentPositionAsync(); /* p.Latitude … */ }
+    async Task Online()  => _ = await navigator.OnLineAsync();               // navigator.onLine / language / userAgent
+}
+```
+
+Clipboard and geolocation are browser-gated (secure context + permission) — wrap those in `try/catch`. See
+[JS interop → Typed browser APIs](docs/js-interop.md#typed-browser-apis).
+
 </details>
 
 <details>

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -6,6 +6,7 @@ both transports — Server (WebSocket) and WASM (`JSImport`/`JSExport`).
 - [Scoped CSS](#scoped-css)
 - [Scoped JS](#scoped-js)
 - [Calling JS from C# (`IJSRuntime`)](#calling-js-from-c-ijsruntime)
+- [Typed browser APIs](#typed-browser-apis)
 - [Element refs](#element-refs)
 - [Delivery & caching](#delivery--caching)
 
@@ -95,6 +96,55 @@ public sealed class CodeSample : Component
 Nothing (no `el`) is passed automatically — pass what the function needs. For a return
 value use `InvokeAsync<T>`. On WASM a non-primitive `T` must be rooted for the trimmer
 (DAM annotation or a `JsonSerializerContext`).
+
+---
+
+## Typed browser APIs
+
+Rather than spelling out raw `IJSRuntime` identifiers (`"localStorage.getItem"`,
+`"navigator.clipboard.writeText"`) and getting the JSON shape right by hand, inject one of the
+built-in **typed wrappers** through a component constructor. Each is a thin, awaitable layer over
+the same unified `IJSRuntime`, so it behaves **identically on Server and WASM**. These are the
+Web APIs that work on both transports; WASM-only PWA APIs (service worker, cache, manifest) are a
+later step on the same pattern.
+
+| Service | Wraps | Key members |
+| --- | --- | --- |
+| `IBrowserStorage` | `localStorage` / `sessionStorage` | `.Local` / `.Session` → `GetAsync`, `SetAsync`, `RemoveAsync`, `ClearAsync`, `KeyAsync`, `LengthAsync` |
+| `IClipboard` | `navigator.clipboard` | `WriteTextAsync`, `ReadTextAsync` |
+| `IGeolocation` | `navigator.geolocation` | `GetCurrentPositionAsync(GeolocationOptions?)` → `GeolocationPosition` |
+| `INavigatorInfo` | `window.navigator` | `OnLineAsync`, `LanguageAsync`, `UserAgentAsync` |
+
+```csharp
+public sealed class ThemeToggle(IBrowserStorage storage, INavigatorInfo navigator) : Component
+{
+    private async Task Save() => await storage.Local.SetAsync("theme", "dark");
+
+    protected override async Task OnRenderedAsync(bool firstRender)
+    {
+        if (firstRender)
+        {
+            var theme = await storage.Local.GetAsync("theme");   // string?, null if absent
+            var online = await navigator.OnLineAsync();          // bool
+        }
+    }
+}
+```
+
+Call them from an **event handler or lifecycle hook** (not from `Render()`). Clipboard and
+geolocation are **browser-gated** — they need a secure context (HTTPS or localhost) and the user's
+permission; a denial or timeout surfaces as a `JSException` from the awaited task, so wrap those
+calls in `try/catch`.
+
+Under the hood: storage/clipboard methods are plain function calls; `navigator.onLine` and
+`localStorage.length` are *property* reads the client returns directly; and the callback-based
+`getCurrentPosition` is wrapped in a Promise by the framework helper `__raskApi.geolocation`. That
+helper (and `__raskEl`) lives in `src/Rask.Core/Resources/rask-api.js` and is spliced into both
+client runtimes at build time, so the two transports never drift. `GeolocationPosition` is rooted
+for the WASM trimmer by the framework, so it deserializes correctly in a `PublishTrimmed` app.
+
+Runnable demo: [`samples/Rask.Example.Shared/Features/Browser/BrowserApiDemo.cs`](../samples/Rask.Example.Shared/Features/Browser/BrowserApiDemo.cs)
+(the `/browser` page).
 
 ---
 

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Forms](docs/forms.md): binding, validation, EditContext, building form components — implement `IFormControl<T>` (Rask.Core.Forms) on a generic component and the generator synthesizes its controlled + bound factories, or use the public binding API directly (`ExpressionAccessor`/`BindingHelpers`/`RegisterFieldValidator`). RadioGroup/CheckboxGroup/MultiSelect are example controls in the samples, not framework primitives.
 - [Building form controls](docs/building-form-controls.md): end-to-end guide to authoring a custom control with `IFormControl<T>` — the interface, a complete worked example, the default-method helpers, and the bound-vs-controlled / Fragment-vs-Component trade-offs.
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
-- [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime.
+- [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime, typed browser APIs (IBrowserStorage/IClipboard/IGeolocation/INavigatorInfo).
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Observability](docs/observability.md): structured logging, the `Rask.Server` meter + activity source, `AddRaskLiveSessions()` health check.
 - [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.

--- a/samples/Rask.Example.Shared/Features/Browser/BrowserApiDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/BrowserApiDemo.cs
@@ -1,0 +1,198 @@
+using System.Globalization;
+using Rask.Core.Browser;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     Exercises the typed browser-API foundation — <see cref="IBrowserStorage" />,
+///     <see cref="IClipboard" />, <see cref="IGeolocation" />, <see cref="INavigatorInfo" /> — each
+///     injected through the ctor (the framework's DI seam) and identical on Server and WASM. Every call
+///     is wrapped in try/catch because these APIs are browser-gated (secure context, permissions).
+/// </summary>
+public sealed class BrowserApiDemo(
+    IBrowserStorage storage,
+    IClipboard clipboard,
+    IGeolocation geolocation,
+    INavigatorInfo navigator) : Component
+{
+    private const string StorageKey = "rask.browser.demo";
+
+    private string _storageInput = string.Empty;
+    private string? _storageRead;
+    private string _clipboardInput = "Copied from Rask!";
+    private string? _clipboardRead;
+    private string? _location;
+    private string? _navigator;
+    private string? _status;
+
+    protected override RenderResult Render() =>
+        Div(Class: "card shadow-sm border-0")[
+            Div(Class: "card-body d-flex flex-column gap-4")[
+                StorageSection(),
+                ClipboardSection(),
+                GeolocationSection(),
+                NavigatorSection(),
+                Div()[
+                    Span(Class: "text-secondary small text-uppercase")["Status"],
+                    Div()[Code(Class: "fs-6", Id: "browser-status")[_status ?? "(idle)"]]
+                ]
+            ]
+        ];
+
+    private Component StorageSection() =>
+        Div()[
+            H6(Class: "fw-bold")[I(Class: "bi bi-hdd me-2"), "localStorage"],
+            Div(Class: "input-group input-group-sm mb-2")[
+                Input(
+                    Id: "storage-input",
+                    Class: "form-control",
+                    Value: _storageInput,
+                    Placeholder: "Value to persist",
+                    OnInput: v => _storageInput = v),
+                Button(Class: "btn btn-primary", Id: "storage-set", OnClickAsync: StorageSet)["Set"],
+                Button(Class: "btn btn-outline-primary", Id: "storage-read", OnClickAsync: StorageRead)["Read"],
+                Button(Class: "btn btn-outline-danger", Id: "storage-remove", OnClickAsync: StorageRemove)["Remove"]
+            ],
+            Div(Class: "small text-secondary")[
+                "Last read: ", Code(Id: "storage-read-value")[_storageRead ?? "(null)"]
+            ]
+        ];
+
+    private Component ClipboardSection() =>
+        Div()[
+            H6(Class: "fw-bold")[I(Class: "bi bi-clipboard me-2"), "Clipboard"],
+            Div(Class: "input-group input-group-sm mb-2")[
+                Input(
+                    Id: "clipboard-input",
+                    Class: "form-control",
+                    Value: _clipboardInput,
+                    OnInput: v => _clipboardInput = v),
+                Button(Class: "btn btn-primary", Id: "clipboard-copy", OnClickAsync: ClipboardCopy)["Copy"],
+                Button(Class: "btn btn-outline-primary", Id: "clipboard-paste", OnClickAsync: ClipboardPaste)["Paste"]
+            ],
+            Div(Class: "small text-secondary")[
+                "Pasted: ", Code(Id: "clipboard-read-value")[_clipboardRead ?? "(nothing yet)"]
+            ]
+        ];
+
+    private Component GeolocationSection() =>
+        Div()[
+            H6(Class: "fw-bold")[I(Class: "bi bi-geo-alt me-2"), "Geolocation"],
+            Button(Class: "btn btn-outline-primary btn-sm mb-2", Id: "geo-get", OnClickAsync: GetLocation)[
+                "Get current position"],
+            Div(Class: "small text-secondary")[
+                Code(Id: "geo-value")[_location ?? "(not requested)"]
+            ]
+        ];
+
+    private Component NavigatorSection() =>
+        Div()[
+            H6(Class: "fw-bold")[I(Class: "bi bi-info-circle me-2"), "Navigator"],
+            Button(Class: "btn btn-outline-primary btn-sm mb-2", Id: "nav-read", OnClickAsync: ReadNavigator)[
+                "Read navigator info"],
+            Div(Class: "small text-secondary")[
+                Code(Id: "nav-value")[_navigator ?? "(not requested)"]
+            ]
+        ];
+
+    private async Task StorageSet()
+    {
+        try
+        {
+            await storage.Local.SetAsync(StorageKey, _storageInput);
+            _status = $"Stored: {_storageInput}";
+        }
+        catch (Exception ex)
+        {
+            _status = "Set failed: " + ex.Message;
+        }
+    }
+
+    private async Task StorageRead()
+    {
+        try
+        {
+            _storageRead = await storage.Local.GetAsync(StorageKey);
+            var count = await storage.Local.LengthAsync();
+            _status = $"Read (localStorage holds {count} key(s))";
+        }
+        catch (Exception ex)
+        {
+            _status = "Read failed: " + ex.Message;
+        }
+    }
+
+    private async Task StorageRemove()
+    {
+        try
+        {
+            await storage.Local.RemoveAsync(StorageKey);
+            _storageRead = null;
+            _status = "Removed";
+        }
+        catch (Exception ex)
+        {
+            _status = "Remove failed: " + ex.Message;
+        }
+    }
+
+    private async Task ClipboardCopy()
+    {
+        try
+        {
+            await clipboard.WriteTextAsync(_clipboardInput);
+            _status = "Copied to clipboard";
+        }
+        catch (Exception ex)
+        {
+            _status = "Copy failed: " + ex.Message;
+        }
+    }
+
+    private async Task ClipboardPaste()
+    {
+        try
+        {
+            _clipboardRead = await clipboard.ReadTextAsync();
+            _status = "Pasted from clipboard";
+        }
+        catch (Exception ex)
+        {
+            _status = "Paste failed: " + ex.Message;
+        }
+    }
+
+    private async Task GetLocation()
+    {
+        try
+        {
+            var pos = await geolocation.GetCurrentPositionAsync(
+                new GeolocationOptions { TimeoutMs = 10_000 });
+            // Coordinates format invariantly (decimal point) — independent of the server's locale.
+            _location = string.Create(
+                CultureInfo.InvariantCulture,
+                $"lat {pos.Latitude:F4}, lon {pos.Longitude:F4} (±{pos.Accuracy:F0} m)");
+            _status = "Position acquired";
+        }
+        catch (Exception ex)
+        {
+            _location = null;
+            _status = "Location failed: " + ex.Message;
+        }
+    }
+
+    private async Task ReadNavigator()
+    {
+        try
+        {
+            var online = await navigator.OnLineAsync();
+            var language = await navigator.LanguageAsync();
+            _navigator = $"online: {online}, language: {language}";
+            _status = "Navigator read";
+        }
+        catch (Exception ex)
+        {
+            _status = "Navigator read failed: " + ex.Message;
+        }
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Browser/BrowserApiPage.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/BrowserApiPage.cs
@@ -1,0 +1,46 @@
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     Hosts <see cref="BrowserApiDemo" />: the typed browser-API foundation (Storage, Clipboard,
+///     Geolocation, Navigator) injected as services and identical on Server and WASM. The first step
+///     toward PWA support — a discoverable, testable C# surface over the Web APIs that previously
+///     required raw <c>IJSRuntime</c> string identifiers.
+/// </summary>
+[Route("browser")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class BrowserApiPage : Component
+{
+    protected override RenderResult Head => Title()["Browser APIs — Rask"];
+
+    protected override RenderResult Render() =>
+    [
+        PageHeader.Render(
+            "Typed browser APIs",
+            "Strongly-typed C# wrappers over the Web APIs — injected as services, identical on Server and WASM."),
+        P(Class: "text-secondary")[
+            "Instead of raw ", Code()["IJSRuntime.InvokeAsync(\"localStorage.getItem\", …)"],
+            " calls, inject ", Code()["IBrowserStorage"], ", ", Code()["IClipboard"], ", ",
+            Code()["IGeolocation"], ", or ", Code()["INavigatorInfo"],
+            " through a component constructor and await typed methods. Clipboard and geolocation are ",
+            "browser-gated (secure context + permission), so each call is wrapped in try/catch."
+        ],
+        CodeSample(
+            ["BrowserApiDemo.cs"],
+            Notes:
+            "Each wrapper is a thin, awaitable layer over the unified IJSRuntime. Storage and clipboard " +
+            "methods are plain function calls; navigator.onLine/language are property reads the client " +
+            "returns directly; getCurrentPosition is callback-based, so it goes through the framework's " +
+            "__raskApi.geolocation helper (shared by both transports via rask-api.js).",
+            Result: BrowserApiDemo()),
+        Div(Class: "alert alert-info d-flex align-items-start")[
+            I(Class: "bi bi-info-circle-fill me-3 fs-4"),
+            Div()[
+                Strong()["First step toward PWAs:"],
+                " these are the Web APIs that work the same on both transports. WASM-only PWA APIs ",
+                "(service worker, cache, manifest, offline) build on the same wrapper pattern in a later step."
+            ]
+        ]
+    ];
+}

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.cs
@@ -53,7 +53,8 @@ public sealed class HomePage(Navigator nav) : Component
         ("Data & files", "bi-cloud-download", "File download", "One-shot secure downloads.", "/download"),
 
         ("Apps", "bi-check2-square", "Todos", "A small end-to-end app.", "/todos"),
-        ("Apps", "bi-braces", "IJSRuntime", "Dispatch to scoped JS modules.", "/jsruntime")
+        ("Apps", "bi-braces", "IJSRuntime", "Dispatch to scoped JS modules.", "/jsruntime"),
+        ("Apps", "bi-globe", "Browser APIs", "Typed Storage, Clipboard, Geolocation.", "/browser")
     ];
 
     protected override RenderResult Head => Title()["Welcome — Rask"];

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -48,7 +48,8 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route) : Component
         ("/upload", "File upload", "bi-upload", "Files", null),
         ("/download", "File download", "bi-cloud-download", "Files", null),
         ("/todos", "Todos", "bi-check2-square", "Apps", null),
-        ("/jsruntime", "IJSRuntime", "bi-braces", "Apps", null)
+        ("/jsruntime", "IJSRuntime", "bi-braces", "Apps", null),
+        ("/browser", "Browser APIs", "bi-globe", "Apps", null)
     ];
 
     private bool _drawerOpen;

--- a/src/Rask.Core/Browser/BrowserStorage.cs
+++ b/src/Rask.Core/Browser/BrowserStorage.cs
@@ -1,0 +1,56 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Default <see cref="IBrowserStorage" />, backed by the unified <see cref="IJSRuntime" />. Registered
+///     by both hosts alongside <c>Navigator</c>; you normally inject the interface, not this type.
+/// </summary>
+public sealed class BrowserStorage : IBrowserStorage
+{
+    /// <summary>Creates the two storage views over <paramref name="js" />.</summary>
+    public BrowserStorage(IJSRuntime js)
+    {
+        ArgumentNullException.ThrowIfNull(js);
+        Local = new WebStorage(js, "localStorage");
+        Session = new WebStorage(js, "sessionStorage");
+    }
+
+    /// <inheritdoc />
+    public IWebStorage Local { get; }
+
+    /// <inheritdoc />
+    public IWebStorage Session { get; }
+
+    // One storage area. The store name ("localStorage" / "sessionStorage") is the dotted-path root
+    // resolved on `window`, so the same code drives both areas — and both transports — unchanged.
+    private sealed class WebStorage(IJSRuntime js, string store) : IWebStorage
+    {
+        public ValueTask<string?> GetAsync(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            return js.InvokeAsync<string?>($"{store}.getItem", key);
+        }
+
+        public ValueTask SetAsync(string key, string value)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            ArgumentNullException.ThrowIfNull(value);
+            return js.InvokeVoidAsync($"{store}.setItem", key, value);
+        }
+
+        public ValueTask RemoveAsync(string key)
+        {
+            ArgumentNullException.ThrowIfNull(key);
+            return js.InvokeVoidAsync($"{store}.removeItem", key);
+        }
+
+        public ValueTask ClearAsync() => js.InvokeVoidAsync($"{store}.clear");
+
+        public ValueTask<string?> KeyAsync(int index) => js.InvokeAsync<string?>($"{store}.key", index);
+
+        // `length` is a property, not a method. The client resolves a dotted identifier and, when the
+        // last segment isn't a function, returns its value as-is — so a plain InvokeAsync reads it.
+        public ValueTask<int> LengthAsync() => js.InvokeAsync<int>($"{store}.length");
+    }
+}

--- a/src/Rask.Core/Browser/Clipboard.cs
+++ b/src/Rask.Core/Browser/Clipboard.cs
@@ -1,0 +1,20 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Default <see cref="IClipboard" />, backed by the unified <see cref="IJSRuntime" />.
+///     <c>writeText</c>/<c>readText</c> already return Promises, so no framework JS helper is needed.
+/// </summary>
+public sealed class Clipboard(IJSRuntime js) : IClipboard
+{
+    /// <inheritdoc />
+    public ValueTask WriteTextAsync(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return js.InvokeVoidAsync("navigator.clipboard.writeText", text);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<string> ReadTextAsync() => js.InvokeAsync<string>("navigator.clipboard.readText");
+}

--- a/src/Rask.Core/Browser/Geolocation.cs
+++ b/src/Rask.Core/Browser/Geolocation.cs
@@ -1,0 +1,24 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Default <see cref="IGeolocation" />, backed by the unified <see cref="IJSRuntime" />.
+///     <c>navigator.geolocation.getCurrentPosition</c> is callback-based, so the call goes through the
+///     framework's <c>__raskApi.geolocation</c> helper, which wraps it in a Promise.
+/// </summary>
+public sealed class Geolocation(IJSRuntime js) : IGeolocation
+{
+    /// <inheritdoc />
+    public ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null)
+    {
+        options ??= new GeolocationOptions();
+        // Args map to the helper's (enableHighAccuracy, timeoutMs, maximumAgeMs) signature; a null
+        // timeout becomes Infinity on the JS side.
+        return js.InvokeAsync<GeolocationPosition>(
+            "__raskApi.geolocation",
+            options.EnableHighAccuracy,
+            options.TimeoutMs,
+            options.MaximumAgeMs);
+    }
+}

--- a/src/Rask.Core/Browser/GeolocationOptions.cs
+++ b/src/Rask.Core/Browser/GeolocationOptions.cs
@@ -1,0 +1,26 @@
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Options for a Geolocation request
+///     (<see href="https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions" />).
+/// </summary>
+public sealed record GeolocationOptions
+{
+    /// <summary>
+    ///     Request the most accurate fix the device can provide (e.g. GPS). More accurate, but slower
+    ///     and more power-hungry. Defaults to <c>false</c>.
+    /// </summary>
+    public bool EnableHighAccuracy { get; init; }
+
+    /// <summary>
+    ///     Maximum time to wait for a fix, in milliseconds. <c>null</c> (the default) waits
+    ///     indefinitely; the awaited call faults with a timeout error once it elapses.
+    /// </summary>
+    public int? TimeoutMs { get; init; }
+
+    /// <summary>
+    ///     Maximum age, in milliseconds, of a cached fix the browser may return instead of fetching a
+    ///     fresh one. <c>0</c> (the default) always fetches a fresh position.
+    /// </summary>
+    public int MaximumAgeMs { get; init; }
+}

--- a/src/Rask.Core/Browser/GeolocationPosition.cs
+++ b/src/Rask.Core/Browser/GeolocationPosition.cs
@@ -1,0 +1,24 @@
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     A geographic position fix from the Geolocation API
+///     (<see href="https://developer.mozilla.org/en-US/docs/Web/API/GeolocationPosition" />). Distances
+///     are metres; angles are degrees. Fields the device cannot supply are <c>null</c>.
+/// </summary>
+/// <param name="Latitude">Latitude in decimal degrees.</param>
+/// <param name="Longitude">Longitude in decimal degrees.</param>
+/// <param name="Accuracy">Accuracy of the lat/long pair, in metres (always present).</param>
+/// <param name="Altitude">Altitude above the WGS84 ellipsoid in metres, or <c>null</c> if unavailable.</param>
+/// <param name="AltitudeAccuracy">Accuracy of <paramref name="Altitude" /> in metres, or <c>null</c>.</param>
+/// <param name="Heading">Direction of travel in degrees clockwise from true north, or <c>null</c>.</param>
+/// <param name="Speed">Ground speed in metres per second, or <c>null</c>.</param>
+/// <param name="TimestampMs">Fix time as Unix epoch milliseconds (<c>GeolocationPosition.timestamp</c>).</param>
+public sealed record GeolocationPosition(
+    double Latitude,
+    double Longitude,
+    double Accuracy,
+    double? Altitude,
+    double? AltitudeAccuracy,
+    double? Heading,
+    double? Speed,
+    double TimestampMs);

--- a/src/Rask.Core/Browser/IBrowserStorage.cs
+++ b/src/Rask.Core/Browser/IBrowserStorage.cs
@@ -1,0 +1,20 @@
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Typed access to the browser's two Web Storage areas. Inject it through a component constructor
+///     (<c>public MyPage(IBrowserStorage storage)</c>) and call from an event handler or lifecycle hook:
+///     <code>
+///     await storage.Local.SetAsync("theme", "dark");
+///     var theme = await storage.Local.GetAsync("theme");
+///     </code>
+///     Identical on Server and WASM — both resolve to the same <see cref="IWebStorage" /> surface over
+///     the unified <c>IJSRuntime</c>.
+/// </summary>
+public interface IBrowserStorage
+{
+    /// <summary>Persistent storage that survives across browser sessions (<c>window.localStorage</c>).</summary>
+    IWebStorage Local { get; }
+
+    /// <summary>Per-tab storage cleared when the page session ends (<c>window.sessionStorage</c>).</summary>
+    IWebStorage Session { get; }
+}

--- a/src/Rask.Core/Browser/IClipboard.cs
+++ b/src/Rask.Core/Browser/IClipboard.cs
@@ -1,0 +1,26 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Typed access to the system clipboard's text (the async Clipboard API,
+///     <see href="https://developer.mozilla.org/en-US/docs/Web/API/Clipboard" />). Inject it through a
+///     component constructor and call from an event handler:
+///     <code>
+///     await clipboard.WriteTextAsync(code);
+///     var pasted = await clipboard.ReadTextAsync();
+///     </code>
+/// </summary>
+/// <remarks>
+///     Clipboard access is gated by the browser: it requires a secure context (HTTPS or localhost) and,
+///     for reads, a user gesture and/or an explicit permission grant. A blocked call surfaces as a
+///     <see cref="JSException" /> from the awaited task — handle it rather than assuming success.
+/// </remarks>
+public interface IClipboard
+{
+    /// <summary>Writes <paramref name="text" /> to the clipboard (<c>navigator.clipboard.writeText</c>).</summary>
+    ValueTask WriteTextAsync(string text);
+
+    /// <summary>Reads the clipboard's current text (<c>navigator.clipboard.readText</c>).</summary>
+    ValueTask<string> ReadTextAsync();
+}

--- a/src/Rask.Core/Browser/IGeolocation.cs
+++ b/src/Rask.Core/Browser/IGeolocation.cs
@@ -1,0 +1,27 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Typed access to the device's current position (the Geolocation API,
+///     <see href="https://developer.mozilla.org/en-US/docs/Web/API/Geolocation" />). Inject it through a
+///     component constructor and call from an event handler:
+///     <code>
+///     var pos = await geolocation.GetCurrentPositionAsync();
+///     // pos.Latitude, pos.Longitude, pos.Accuracy ...
+///     </code>
+/// </summary>
+/// <remarks>
+///     Requires a secure context (HTTPS or localhost) and the user's permission. A denial, timeout, or
+///     unavailable sensor surfaces as a <see cref="JSException" /> from the awaited task — catch it.
+///     Continuous tracking (<c>watchPosition</c>) is not yet wrapped.
+/// </remarks>
+public interface IGeolocation
+{
+    /// <summary>
+    ///     Resolves the device's current position once (<c>navigator.geolocation.getCurrentPosition</c>),
+    ///     optionally tuned by <paramref name="options" />.
+    /// </summary>
+    /// <param name="options">Accuracy, timeout, and cache-age preferences; <c>null</c> uses defaults.</param>
+    ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null);
+}

--- a/src/Rask.Core/Browser/INavigatorInfo.cs
+++ b/src/Rask.Core/Browser/INavigatorInfo.cs
@@ -1,0 +1,44 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Read-only facts about the browser environment, from <c>window.navigator</c>
+///     (<see href="https://developer.mozilla.org/en-US/docs/Web/API/Navigator" />). Inject it through a
+///     component constructor and read from a lifecycle hook or event handler.
+/// </summary>
+/// <remarks>
+///     These are JavaScript <em>properties</em>, not methods; the client resolves the dotted identifier
+///     and returns the value directly when the last segment isn't a function, so no JS helper is needed.
+///     <see cref="OnLineAsync" /> is the seed for offline detection in a later PWA step.
+/// </remarks>
+public interface INavigatorInfo
+{
+    /// <summary>
+    ///     Whether the browser believes it currently has network connectivity (<c>navigator.onLine</c>).
+    ///     A <c>true</c> result only means "not definitely offline" — it is not a reachability guarantee.
+    /// </summary>
+    ValueTask<bool> OnLineAsync();
+
+    /// <summary>The user's preferred UI language, e.g. <c>"en-US"</c> (<c>navigator.language</c>).</summary>
+    ValueTask<string> LanguageAsync();
+
+    /// <summary>The browser's user-agent string (<c>navigator.userAgent</c>).</summary>
+    ValueTask<string> UserAgentAsync();
+}
+
+/// <summary>
+///     Default <see cref="INavigatorInfo" />, backed by the unified <see cref="IJSRuntime" />. Each
+///     property is read by its dotted identifier — the client returns the value when it isn't a function.
+/// </summary>
+public sealed class NavigatorInfo(IJSRuntime js) : INavigatorInfo
+{
+    /// <inheritdoc />
+    public ValueTask<bool> OnLineAsync() => js.InvokeAsync<bool>("navigator.onLine");
+
+    /// <inheritdoc />
+    public ValueTask<string> LanguageAsync() => js.InvokeAsync<string>("navigator.language");
+
+    /// <inheritdoc />
+    public ValueTask<string> UserAgentAsync() => js.InvokeAsync<string>("navigator.userAgent");
+}

--- a/src/Rask.Core/Browser/IWebStorage.cs
+++ b/src/Rask.Core/Browser/IWebStorage.cs
@@ -1,0 +1,41 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     A typed view over one Web Storage area — the browser's <c>localStorage</c> or
+///     <c>sessionStorage</c> (<see href="https://developer.mozilla.org/en-US/docs/Web/API/Storage" />).
+///     Reach it through <see cref="IBrowserStorage.Local" /> / <see cref="IBrowserStorage.Session" />,
+///     which inject the same way on Server (per-session WS-bound runtime) and WASM (in-process bridge).
+/// </summary>
+/// <remarks>
+///     Every member is a thin, awaitable wrapper over <see cref="IJSRuntime" />; each call round-trips
+///     to the browser, so prefer reading a value once into a field over calling these in a tight loop.
+///     Storage values are strings — serialize your own objects (e.g. with <c>System.Text.Json</c>).
+/// </remarks>
+public interface IWebStorage
+{
+    /// <summary>
+    ///     Reads the value stored under <paramref name="key" />, or <c>null</c> if the key is absent
+    ///     (<c>Storage.getItem</c>).
+    /// </summary>
+    ValueTask<string?> GetAsync(string key);
+
+    /// <summary>Writes <paramref name="value" /> under <paramref name="key" /> (<c>Storage.setItem</c>).</summary>
+    ValueTask SetAsync(string key, string value);
+
+    /// <summary>Removes <paramref name="key" /> if present (<c>Storage.removeItem</c>).</summary>
+    ValueTask RemoveAsync(string key);
+
+    /// <summary>Removes every key in this storage area (<c>Storage.clear</c>).</summary>
+    ValueTask ClearAsync();
+
+    /// <summary>
+    ///     Returns the key at <paramref name="index" /> in this storage area, or <c>null</c> if the
+    ///     index is out of range (<c>Storage.key</c>). Iteration order is implementation-defined.
+    /// </summary>
+    ValueTask<string?> KeyAsync(int index);
+
+    /// <summary>Returns the number of stored keys (<c>Storage.length</c>).</summary>
+    ValueTask<int> LengthAsync();
+}

--- a/src/Rask.Core/Browser/RaskBrowserJsonContext.cs
+++ b/src/Rask.Core/Browser/RaskBrowserJsonContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Source-generated JSON metadata for the framework's own browser-API types, so they deserialize
+///     from <see cref="Microsoft.JSInterop.IJSRuntime" /> results without reflection. The WASM runtime
+///     inserts <see cref="Default" /> ahead of its reflection fallback, keeping these types trim-safe in
+///     a <c>PublishTrimmed</c> app (where unrooted reflective members would otherwise be removed).
+///     Web defaults (camelCase, case-insensitive) match both the JS payload shape and the JSInterop
+///     serializer options.
+/// </summary>
+[JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+[JsonSerializable(typeof(GeolocationPosition))]
+internal sealed partial class RaskBrowserJsonContext : JsonSerializerContext;

--- a/src/Rask.Core/Resources/rask-api.js
+++ b/src/Rask.Core/Resources/rask-api.js
@@ -1,0 +1,49 @@
+// Shared framework Web-API / interop helpers, spliced into both client runtimes
+// (Server rask.js and WASM rask.wasm.js) by the RASK_API build marker. Single source of
+// truth so the two transports never drift. Each helper is assigned to a `window.__rask*`
+// namespace so a dotted IJSRuntime identifier (e.g. "__raskApi.geolocation") resolves to it.
+
+// Element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
+// The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
+window.__raskEl = window.__raskEl || {
+    focus: (el) => {
+        if (el) el.focus();
+    },
+    blur: (el) => {
+        if (el) el.blur();
+    },
+    scrollIntoView: (el, opts) => {
+        if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
+    }
+};
+
+// Web-API helpers for callback-shaped browser APIs that IJSRuntime can't await directly.
+// Property reads (navigator.onLine, localStorage.length) and Promise-returning methods
+// (clipboard.readText) need no helper — the invoke dispatcher returns the value / awaits the
+// Promise on its own. getCurrentPosition is callback-based, so wrap it in a Promise here.
+window.__raskApi = window.__raskApi || {
+    geolocation: (enableHighAccuracy, timeoutMs, maximumAgeMs) => new Promise((resolve, reject) => {
+        if (!navigator.geolocation) {
+            reject(new Error("Geolocation is not supported in this browser."));
+            return;
+        }
+        const opts = {enableHighAccuracy: !!enableHighAccuracy, maximumAge: maximumAgeMs || 0};
+        if (timeoutMs != null) opts.timeout = timeoutMs;
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                const c = pos.coords;
+                resolve({
+                    latitude: c.latitude,
+                    longitude: c.longitude,
+                    accuracy: c.accuracy,
+                    altitude: c.altitude,
+                    altitudeAccuracy: c.altitudeAccuracy,
+                    heading: c.heading,
+                    speed: c.speed,
+                    timestampMs: pos.timestamp
+                });
+            },
+            (err) => reject(new Error((err && err.message) || ("Geolocation error " + (err && err.code)))),
+            opts);
+    })
+};

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -32,11 +32,12 @@
   </ItemGroup>
 
   <!--
-    The embedded rask.js is generated at build time by splicing two shared
-    Rask.Core/Resources files into Resources/rask.js: rask-dom.js (the diff codec,
-    at @@RASK_DOM@@) and rask-morph.js (the full-HTML morph, at @@RASK_MORPH@@).
-    The generated artifact lives in $(IntermediateOutputPath) so the source file in
-    Resources/ stays free of duplicated client code and git status doesn't churn on build.
+    The embedded rask.js is generated at build time by splicing shared Rask.Core/Resources
+    files into Resources/rask.js: rask-dom.js (the diff codec, at @@RASK_DOM@@), rask-morph.js
+    (the full-HTML morph, at @@RASK_MORPH@@), and rask-api.js (framework interop helpers
+    __raskEl/__raskApi, at @@RASK_API@@). The generated artifact lives in
+    $(IntermediateOutputPath) so the source file in Resources/ stays free of duplicated client
+    code and git status doesn't churn on build.
   -->
   <ItemGroup>
     <EmbeddedResource Include="$(IntermediateOutputPath)rask.js" LogicalName="Rask.Server.Resources.rask.js"/>
@@ -45,13 +46,14 @@
   <Import Project="..\..\build\Rask.MinifyJs.targets"/>
 
   <Target Name="_RaskBuildClientJs" BeforeTargets="PrepareForBuild"
-          Inputs="Resources\rask.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js"
+          Inputs="Resources\rask.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js"
           Outputs="$(IntermediateOutputPath)rask.js">
     <PropertyGroup>
       <_RaskClientTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.js'))</_RaskClientTemplate>
       <_RaskDomBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-dom.js'))</_RaskDomBody>
       <_RaskMorphBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-morph.js'))</_RaskMorphBody>
-      <_RaskClientJs>$(_RaskClientTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)'))</_RaskClientJs>
+      <_RaskApiBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-api.js'))</_RaskApiBody>
+      <_RaskClientJs>$(_RaskClientTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)'))</_RaskClientJs>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath)"/>
     <WriteLinesToFile File="$(IntermediateOutputPath)rask.js" Lines="$(_RaskClientJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -21,6 +21,7 @@ using Microsoft.Net.Http.Headers;
 using Rask.Core;
 using Rask.Core.Authentication;
 using Rask.Core.Authorization;
+using Rask.Core.Browser;
 using Rask.Core.Components;
 using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
@@ -190,6 +191,10 @@ public static class RaskEndpointExtensions
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
+        services.AddScoped<IBrowserStorage, BrowserStorage>();
+        services.AddScoped<IClipboard, Clipboard>();
+        services.AddScoped<IGeolocation, Geolocation>();
+        services.AddScoped<INavigatorInfo, NavigatorInfo>();
         services.AddScoped<AuthSignIn>();
         services.AddScoped<IAuthSignIn>(sp => sp.GetRequiredService<AuthSignIn>());
         services.AddSingleton<IAuthTicketStore, AuthTicketStore>();

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -1,19 +1,9 @@
 (function () {
     "use strict";
 
-    // Built-in element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
-    // The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
-    window.__raskEl = window.__raskEl || {
-        focus: (el) => {
-            if (el) el.focus();
-        },
-        blur: (el) => {
-            if (el) el.blur();
-        },
-        scrollIntoView: (el, opts) => {
-            if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
-        }
-    };
+    // Shared framework interop helpers (__raskEl, __raskApi) spliced from
+    // Rask.Core/Resources/rask-api.js at build time — single source across both transports.
+    // @@RASK_API@@
 
     let root = document.querySelector("[data-rask-root]");
     if (!root) return;

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -33,7 +33,8 @@ https://github.com/pal-tamas/rask/tree/main/docs
   (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
-- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
+- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, the typed browser APIs
+  `IBrowserStorage`/`IClipboard`/`IGeolocation`/`INavigatorInfo`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
 - **Async cancellation:** pass `CancellationToken` into the cancellable work a handler or lifecycle hook
   starts, e.g. `await http.GetFromJsonAsync<T>(url, CancellationToken)`. It cancels on unmount, and —

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -29,7 +29,8 @@ https://github.com/pal-tamas/rask/tree/main/docs
   (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
-- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
+- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, the typed browser APIs
+  `IBrowserStorage`/`IClipboard`/`IGeolocation`/`INavigatorInfo`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
 
 ## Events, scoped CSS/JS, forms, auth

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -29,7 +29,8 @@ https://github.com/pal-tamas/rask/tree/main/docs
   (or `[QueryParam]`). Nested routes: `[ParentRoute(typeof(Parent))]` + `Outlet()`.
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
-- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, your own) through the constructor**,
+- **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, the typed browser APIs
+  `IBrowserStorage`/`IClipboard`/`IGeolocation`/`INavigatorInfo`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
 
 ## Events, scoped CSS/JS, forms, auth

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -6,7 +6,14 @@ let dotnetExports = null;
 let root = null;
 let basePath = null;
 
-// Built-in element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
+// Shared framework interop helpers (__raskEl, __raskApi) spliced from
+// Rask.Core/Resources/rask-api.js at build time — single source across both transports.
+// Shared framework Web-API / interop helpers, spliced into both client runtimes
+// (Server rask.js and WASM rask.wasm.js) by the RASK_API build marker. Single source of
+// truth so the two transports never drift. Each helper is assigned to a `window.__rask*`
+// namespace so a dotted IJSRuntime identifier (e.g. "__raskApi.geolocation") resolves to it.
+
+// Element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
 // The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
 window.__raskEl = window.__raskEl || {
     focus: (el) => {
@@ -19,6 +26,38 @@ window.__raskEl = window.__raskEl || {
         if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
     }
 };
+
+// Web-API helpers for callback-shaped browser APIs that IJSRuntime can't await directly.
+// Property reads (navigator.onLine, localStorage.length) and Promise-returning methods
+// (clipboard.readText) need no helper — the invoke dispatcher returns the value / awaits the
+// Promise on its own. getCurrentPosition is callback-based, so wrap it in a Promise here.
+window.__raskApi = window.__raskApi || {
+    geolocation: (enableHighAccuracy, timeoutMs, maximumAgeMs) => new Promise((resolve, reject) => {
+        if (!navigator.geolocation) {
+            reject(new Error("Geolocation is not supported in this browser."));
+            return;
+        }
+        const opts = {enableHighAccuracy: !!enableHighAccuracy, maximumAge: maximumAgeMs || 0};
+        if (timeoutMs != null) opts.timeout = timeoutMs;
+        navigator.geolocation.getCurrentPosition(
+            (pos) => {
+                const c = pos.coords;
+                resolve({
+                    latitude: c.latitude,
+                    longitude: c.longitude,
+                    accuracy: c.accuracy,
+                    altitude: c.altitude,
+                    altitudeAccuracy: c.altitudeAccuracy,
+                    heading: c.heading,
+                    speed: c.speed,
+                    timestampMs: pos.timestamp
+                });
+            },
+            (err) => reject(new Error((err && err.message) || ("Geolocation error " + (err && err.code)))),
+            opts);
+    })
+};
+
 
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /

--- a/src/Rask.Wasm/JSInterop/WasmJSRuntime.cs
+++ b/src/Rask.Wasm/JSInterop/WasmJSRuntime.cs
@@ -42,6 +42,11 @@ internal sealed class WasmJSRuntime : RaskJSRuntimeBase
         // chaining the reflection-based resolver here makes InvokeAsync<T> work for
         // any T the user (or framework) can keep rooted via DAM or a
         // JsonSerializerContext. Same model Blazor WASM ships with.
+        //
+        // Root the framework's own browser-API return types (e.g. GeolocationPosition from
+        // IGeolocation) with their source-generated, trim-safe metadata ahead of the reflection
+        // fallback — so they survive PublishTrimmed without the caller wiring up a context.
+        JsonSerializerOptions.TypeInfoResolverChain.Add(Rask.Core.Browser.RaskBrowserJsonContext.Default);
         JsonSerializerOptions.TypeInfoResolverChain.Add(new DefaultJsonTypeInfoResolver());
     }
 

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -53,9 +53,10 @@
     folders, matching the in-repo layout that Directory.Build.targets imports from.
 
     rask.wasm.js itself is generated at build time by _RaskSpliceClientJs (below), which
-    splices two shared Rask.Core/Resources files into the template Resources/rask.wasm.js:
-    rask-dom.js (the diff codec, at @@RASK_DOM@@) and rask-morph.js (the full-HTML morph,
-    at @@RASK_MORPH@@). The generated artifact lands directly in Browser/ so the existing
+    splices shared Rask.Core/Resources files into the template Resources/rask.wasm.js:
+    rask-dom.js (the diff codec, at @@RASK_DOM@@), rask-morph.js (the full-HTML morph,
+    at @@RASK_MORPH@@), and rask-api.js (framework interop helpers __raskEl/__raskApi, at
+    @@RASK_API@@). The generated artifact lands directly in Browser/ so the existing
     Browser/** Pack glob picks it up.
   -->
   <!--
@@ -85,13 +86,14 @@
     contributors look at). NuGet consumers see whichever version is packed (above).
   -->
   <Target Name="_RaskSpliceClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths;_RaskMinifyClientJs"
-          Inputs="Resources\rask.wasm.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js"
+          Inputs="Resources\rask.wasm.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js"
           Outputs="Browser\rask.wasm.js">
     <PropertyGroup>
       <_RaskWasmTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.wasm.js'))</_RaskWasmTemplate>
       <_RaskDomBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-dom.js'))</_RaskDomBody>
       <_RaskMorphBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-morph.js'))</_RaskMorphBody>
-      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)'))</_RaskWasmJs>
+      <_RaskApiBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-api.js'))</_RaskApiBody>
+      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)'))</_RaskWasmJs>
     </PropertyGroup>
     <WriteLinesToFile File="Browser\rask.wasm.js" Lines="$(_RaskWasmJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
   </Target>

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -6,19 +6,9 @@ let dotnetExports = null;
 let root = null;
 let basePath = null;
 
-// Built-in element-ref helpers, invoked from C# via ElementRef.FocusAsync/Blur/ScrollIntoView.
-// The JSON reviver resolves an ElementRef arg to the live DOM element, so each receives it.
-window.__raskEl = window.__raskEl || {
-    focus: (el) => {
-        if (el) el.focus();
-    },
-    blur: (el) => {
-        if (el) el.blur();
-    },
-    scrollIntoView: (el, opts) => {
-        if (el) el.scrollIntoView(opts || {behavior: "smooth", block: "nearest"});
-    }
-};
+// Shared framework interop helpers (__raskEl, __raskApi) spliced from
+// Rask.Core/Resources/rask-api.js at build time — single source across both transports.
+// @@RASK_API@@
 
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.JSInterop;
 using Rask.Core;
 using Rask.Core.Authentication;
+using Rask.Core.Browser;
 using Rask.Core.Diagnostics;
 using Rask.Core.Forms;
 using Rask.Core.Live;
@@ -29,6 +30,10 @@ public sealed class WasmHostBuilder
         Services.AddSingleton<IBrowserFileBackend, WasmFileBackend>();
         Services.AddSingleton<IDownloadSink, WasmDownloadSink>();
         Services.AddSingleton<Navigator>();
+        Services.AddSingleton<IBrowserStorage, BrowserStorage>();
+        Services.AddSingleton<IClipboard, Clipboard>();
+        Services.AddSingleton<IGeolocation, Geolocation>();
+        Services.AddSingleton<INavigatorInfo, NavigatorInfo>();
         Services.TryAddSingleton<IUserProvider, AnonymousUserProvider>();
         Services.TryAddSingleton<IAuthSignIn, WasmAuthSignIn>();
         Services.AddAuthorizationCore();

--- a/tests/Rask.Core.Tests/Interop/BrowserStorageTests.cs
+++ b/tests/Rask.Core.Tests/Interop/BrowserStorageTests.cs
@@ -1,0 +1,70 @@
+using Rask.Core.Browser;
+
+namespace Rask.Core.Tests.Interop;
+
+public class BrowserStorageTests
+{
+    [Fact]
+    public async Task Local_Set_SendsLocalStorageSetItem_WithKeyAndValue()
+    {
+        var js = new FakeJsRuntime();
+        var storage = new BrowserStorage(js);
+
+        await storage.Local.SetAsync("theme", "dark");
+
+        Assert.Equal(["theme", "dark"], js.ArgsFor("localStorage.setItem"));
+    }
+
+    [Fact]
+    public async Task Session_Set_TargetsSessionStorage_NotLocal()
+    {
+        var js = new FakeJsRuntime();
+        var storage = new BrowserStorage(js);
+
+        await storage.Session.SetAsync("k", "v");
+
+        Assert.Equal(1, js.CallCount("sessionStorage.setItem"));
+        Assert.Equal(0, js.CallCount("localStorage.setItem"));
+    }
+
+    [Fact]
+    public async Task Local_Get_SendsGetItem_AndReturnsCannedValue()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("localStorage.getItem", "dark");
+        var storage = new BrowserStorage(js);
+
+        var value = await storage.Local.GetAsync("theme");
+
+        Assert.Equal("dark", value);
+        Assert.Equal(["theme"], js.ArgsFor("localStorage.getItem"));
+    }
+
+    [Fact]
+    public async Task Remove_And_Clear_And_Key_And_Length_UseExpectedIdentifiers()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("localStorage.length", 3);
+        var storage = new BrowserStorage(js);
+
+        await storage.Local.RemoveAsync("k");
+        await storage.Local.ClearAsync();
+        await storage.Local.KeyAsync(2);
+        var length = await storage.Local.LengthAsync();
+
+        Assert.Equal(["k"], js.ArgsFor("localStorage.removeItem"));
+        Assert.Empty(js.ArgsFor("localStorage.clear")!);
+        Assert.Equal([2], js.ArgsFor("localStorage.key"));
+        Assert.Equal(3, length);
+    }
+
+    [Fact]
+    public async Task Null_Key_Or_Value_Throws()
+    {
+        var storage = new BrowserStorage(new FakeJsRuntime());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await storage.Local.GetAsync(null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await storage.Local.SetAsync("k", null!));
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await storage.Local.SetAsync(null!, "v"));
+    }
+}

--- a/tests/Rask.Core.Tests/Interop/ClipboardTests.cs
+++ b/tests/Rask.Core.Tests/Interop/ClipboardTests.cs
@@ -1,0 +1,38 @@
+using Rask.Core.Browser;
+
+namespace Rask.Core.Tests.Interop;
+
+public class ClipboardTests
+{
+    [Fact]
+    public async Task WriteText_SendsClipboardWriteText_WithText()
+    {
+        var js = new FakeJsRuntime();
+        var clipboard = new Clipboard(js);
+
+        await clipboard.WriteTextAsync("hello");
+
+        Assert.Equal(["hello"], js.ArgsFor("navigator.clipboard.writeText"));
+    }
+
+    [Fact]
+    public async Task ReadText_SendsClipboardReadText_AndReturnsValue()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("navigator.clipboard.readText", "pasted");
+        var clipboard = new Clipboard(js);
+
+        var text = await clipboard.ReadTextAsync();
+
+        Assert.Equal("pasted", text);
+        Assert.Equal(1, js.CallCount("navigator.clipboard.readText"));
+    }
+
+    [Fact]
+    public async Task WriteText_Null_Throws()
+    {
+        var clipboard = new Clipboard(new FakeJsRuntime());
+
+        await Assert.ThrowsAsync<ArgumentNullException>(async () => await clipboard.WriteTextAsync(null!));
+    }
+}

--- a/tests/Rask.Core.Tests/Interop/FakeJsRuntime.cs
+++ b/tests/Rask.Core.Tests/Interop/FakeJsRuntime.cs
@@ -1,0 +1,36 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Tests.Interop;
+
+// Records every IJSRuntime call (identifier + args) so the browser-API wrappers can be asserted
+// against the exact dotted identifier and argument list they ship — the contract the client-side
+// dispatcher and the framework JS helpers depend on. Returns canned values for read calls.
+internal sealed class FakeJsRuntime : IJSRuntime
+{
+    private readonly List<(string Identifier, object?[]? Args)> _calls = [];
+    private readonly Dictionary<string, object?> _responses = new();
+
+    public IReadOnlyList<(string Identifier, object?[]? Args)> Calls => _calls;
+
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        _calls.Add((identifier, args));
+        if (_responses.TryGetValue(identifier, out var canned) && canned is TValue typed)
+        {
+            return ValueTask.FromResult(typed);
+        }
+
+        return ValueTask.FromResult<TValue>(default!);
+    }
+
+    public ValueTask<TValue> InvokeAsync<TValue>(
+        string identifier, CancellationToken cancellationToken, object?[]? args) =>
+        InvokeAsync<TValue>(identifier, args);
+
+    public void SetResponse(string identifier, object? response) => _responses[identifier] = response;
+
+    public object?[]? ArgsFor(string identifier) =>
+        _calls.Single(c => c.Identifier == identifier).Args;
+
+    public int CallCount(string identifier) => _calls.Count(c => c.Identifier == identifier);
+}

--- a/tests/Rask.Core.Tests/Interop/GeolocationTests.cs
+++ b/tests/Rask.Core.Tests/Interop/GeolocationTests.cs
@@ -1,0 +1,95 @@
+using System.Text.Json;
+using Rask.Core.Browser;
+
+namespace Rask.Core.Tests.Interop;
+
+public class GeolocationTests
+{
+    [Fact]
+    public async Task GetCurrentPosition_Default_SendsHelper_WithDefaultOptions()
+    {
+        var js = new FakeJsRuntime();
+        var geo = new Geolocation(js);
+
+        await geo.GetCurrentPositionAsync();
+
+        // (enableHighAccuracy, timeoutMs, maximumAgeMs) — defaults: false, null (=> Infinity in JS), 0.
+        Assert.Equal([false, null, 0], js.ArgsFor("__raskApi.geolocation"));
+    }
+
+    [Fact]
+    public async Task GetCurrentPosition_PassesOptionsThrough()
+    {
+        var js = new FakeJsRuntime();
+        var geo = new Geolocation(js);
+
+        await geo.GetCurrentPositionAsync(new GeolocationOptions
+        {
+            EnableHighAccuracy = true,
+            TimeoutMs = 5000,
+            MaximumAgeMs = 1000
+        });
+
+        Assert.Equal([true, 5000, 1000], js.ArgsFor("__raskApi.geolocation"));
+    }
+
+    [Fact]
+    public async Task GetCurrentPosition_ReturnsCannedPosition()
+    {
+        var js = new FakeJsRuntime();
+        var expected = new GeolocationPosition(51.5, -0.12, 12.0, null, null, null, null, 1_700_000_000_000);
+        js.SetResponse("__raskApi.geolocation", expected);
+        var geo = new Geolocation(js);
+
+        var pos = await geo.GetCurrentPositionAsync();
+
+        Assert.Equal(expected, pos);
+    }
+
+    [Fact]
+    public void Position_DeserializesFrom_HelperCamelCaseJson()
+    {
+        // The contract between __raskApi.geolocation (rask-api.js) and the C# record: the helper
+        // emits camelCase coords; GeolocationPosition must map them under JSInterop's Web defaults.
+        const string json = """
+            {
+              "latitude": 51.5,
+              "longitude": -0.12,
+              "accuracy": 12.5,
+              "altitude": 30.0,
+              "altitudeAccuracy": 4.0,
+              "heading": 90.0,
+              "speed": 1.5,
+              "timestampMs": 1700000000000
+            }
+            """;
+
+        var pos = JsonSerializer.Deserialize<GeolocationPosition>(
+            json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(pos);
+        Assert.Equal(51.5, pos!.Latitude);
+        Assert.Equal(-0.12, pos.Longitude);
+        Assert.Equal(12.5, pos.Accuracy);
+        Assert.Equal(30.0, pos.Altitude);
+        Assert.Equal(4.0, pos.AltitudeAccuracy);
+        Assert.Equal(90.0, pos.Heading);
+        Assert.Equal(1.5, pos.Speed);
+        Assert.Equal(1_700_000_000_000, pos.TimestampMs);
+    }
+
+    [Fact]
+    public void Position_NullableFields_DeserializeToNull_WhenAbsent()
+    {
+        const string json = """
+            {"latitude":1.0,"longitude":2.0,"accuracy":3.0,"altitude":null,"altitudeAccuracy":null,"heading":null,"speed":null,"timestampMs":0}
+            """;
+
+        var pos = JsonSerializer.Deserialize<GeolocationPosition>(
+            json, new JsonSerializerOptions(JsonSerializerDefaults.Web));
+
+        Assert.NotNull(pos);
+        Assert.Null(pos!.Altitude);
+        Assert.Null(pos.Speed);
+    }
+}

--- a/tests/Rask.Core.Tests/Interop/NavigatorInfoTests.cs
+++ b/tests/Rask.Core.Tests/Interop/NavigatorInfoTests.cs
@@ -1,0 +1,40 @@
+using Rask.Core.Browser;
+
+namespace Rask.Core.Tests.Interop;
+
+public class NavigatorInfoTests
+{
+    [Fact]
+    public async Task OnLine_ReadsNavigatorOnLine_AsProperty()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("navigator.onLine", true);
+        var nav = new NavigatorInfo(js);
+
+        var online = await nav.OnLineAsync();
+
+        Assert.True(online);
+        // Property read: the identifier carries no args — the client returns the value directly.
+        Assert.Empty(js.ArgsFor("navigator.onLine")!);
+    }
+
+    [Fact]
+    public async Task Language_ReadsNavigatorLanguage()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("navigator.language", "en-US");
+        var nav = new NavigatorInfo(js);
+
+        Assert.Equal("en-US", await nav.LanguageAsync());
+    }
+
+    [Fact]
+    public async Task UserAgent_ReadsNavigatorUserAgent()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("navigator.userAgent", "Mozilla/5.0");
+        var nav = new NavigatorInfo(js);
+
+        Assert.Equal("Mozilla/5.0", await nav.UserAgentAsync());
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -745,6 +745,45 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("#demo-remove").ClickAsync();
         await Expect(Page.Locator("#demo-status")).ToContainTextAsync("Removed",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        await TestBrowserApisAsync();
+    }
+
+    // Typed browser-API foundation: Storage / Clipboard / Geolocation / Navigator wrappers, each over
+    // the unified IJSRuntime, identical on Server and WASM. Clipboard + geolocation are granted on the
+    // context (SharedSmokeTests.InitializeAsync), so every branch resolves rather than permission-faulting.
+    private async Task TestBrowserApisAsync()
+    {
+        await SideAsync("Browser APIs", "Typed browser APIs", "main h1.h2");
+        await Expect(Page.Locator("main .sample-card .sample-result-body #storage-input")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+
+        // localStorage round-trip via IBrowserStorage.
+        await Page.Locator("#storage-input").FillAsync("persist-me");
+        await Page.Locator("#storage-set").ClickAsync();
+        await Expect(Page.Locator("#browser-status")).ToContainTextAsync("Stored: persist-me",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await Page.Locator("#storage-read").ClickAsync();
+        await Expect(Page.Locator("#storage-read-value")).ToHaveTextAsync("persist-me",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
+
+        // Clipboard round-trip via IClipboard (copy then read back the same text).
+        await Page.Locator("#clipboard-copy").ClickAsync();
+        await Expect(Page.Locator("#browser-status")).ToContainTextAsync("Copied to clipboard",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await Page.Locator("#clipboard-paste").ClickAsync();
+        await Expect(Page.Locator("#clipboard-read-value")).ToContainTextAsync("Copied from Rask!",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // Geolocation via IGeolocation + the __raskApi.geolocation Promise helper (fixed context fix).
+        await Page.Locator("#geo-get").ClickAsync();
+        await Expect(Page.Locator("#geo-value")).ToContainTextAsync("lat 51.5",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // Navigator property reads via INavigatorInfo (returned directly by the invoke dispatcher).
+        await Page.Locator("#nav-read").ClickAsync();
+        await Expect(Page.Locator("#nav-value")).ToContainTextAsync("online:",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     }
 
     // In-session navigation to an unknown route (client pushState + popstate — the same signal

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
@@ -29,7 +29,14 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        _ctx = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = BaseUrl });
+        _ctx = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions
+        {
+            BaseURL = BaseUrl,
+            // Grant the browser-gated APIs the /browser showcase exercises so their journey step is
+            // deterministic in headless Chromium: clipboard read/write, plus a fixed geolocation fix.
+            Permissions = ["clipboard-read", "clipboard-write", "geolocation"],
+            Geolocation = new Geolocation { Latitude = 51.5074f, Longitude = -0.1278f, Accuracy = 50 }
+        });
         Page = await _ctx.NewPageAsync();
         // Capture the browser console + uncaught page errors so a failing test can surface
         // the real client-side cause (e.g. a scoped-JS "Could not find … on target" force-fault

--- a/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
+++ b/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
@@ -9,18 +9,21 @@ public sealed class ResourcesSpliceTests
         var templatePath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Resources", "rask.wasm.js");
         var domPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-dom.js");
         var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
+        var apiPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-api.js");
         var browserPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "rask.wasm.js");
 
         var template = File.ReadAllText(templatePath);
         var dom = File.ReadAllText(domPath);
         var morph = File.ReadAllText(morphPath);
+        var api = File.ReadAllText(apiPath);
         var committed = File.ReadAllText(browserPath);
 
-        // Mirror the two-marker splice order in _RaskSpliceClientJs (Rask.Wasm.csproj):
-        // the diff codec (rask-dom.js) first, then the full-HTML morph (rask-morph.js).
+        // Mirror the marker splice order in _RaskSpliceClientJs (Rask.Wasm.csproj): the diff codec
+        // (rask-dom.js), then the full-HTML morph (rask-morph.js), then the interop helpers (rask-api.js).
         var spliced = template
             .Replace("// @@RASK_DOM@@", dom)
-            .Replace("// @@RASK_MORPH@@", morph);
+            .Replace("// @@RASK_MORPH@@", morph)
+            .Replace("// @@RASK_API@@", api);
 
         Assert.True(
             spliced == committed,


### PR DESCRIPTION
## Summary

First step toward **PWA support**: strongly-typed, DI-injected C# wrappers over the Web APIs that previously required raw `IJSRuntime` string identifiers (e.g. `js.InvokeAsync("localStorage.getItem", …)`). This delivers the **shared** slice — the APIs that behave identically on **Server and WASM** because they're plain `IJSRuntime` calls. WASM-only PWA APIs (service worker, cache, manifest, offline) build on the same pattern in a later step.

### New API (`src/Rask.Core/Browser/`, namespace `Rask.Core.Browser`)
- **`IBrowserStorage`** — `.Local` / `.Session` (`localStorage` / `sessionStorage`): `Get/Set/Remove/Clear/Key/Length`.
- **`IClipboard`** — `WriteTextAsync` / `ReadTextAsync` (`navigator.clipboard`).
- **`IGeolocation`** — `GetCurrentPositionAsync(GeolocationOptions?)` → `GeolocationPosition`.
- **`INavigatorInfo`** — `OnLineAsync` / `LanguageAsync` / `UserAgentAsync`.

Each is a sealed class taking `IJSRuntime` via the ctor (mirrors `Navigator`), registered **AddScoped** (Server) / **AddSingleton** (WASM). Inject the interface through a component constructor and await typed methods from an event handler or lifecycle hook.

### Shared client JS extracted into Core
The framework JS interop helpers — the pre-existing `__raskEl` and the new `__raskApi.geolocation` — are now a **single source of truth** in `src/Rask.Core/Resources/rask-api.js`, spliced into both `rask.js` (Server) and `rask.wasm.js` (WASM) at a new `@@RASK_API@@` build marker (alongside `@@RASK_DOM@@`/`@@RASK_MORPH@@`). This removes the existing `__raskEl` duplication and keeps the two transports from drifting.

Only the **callback-based** `getCurrentPosition` needs a helper (Promise-wrapped): the invoke dispatcher already returns property values directly (`navigator.onLine`, `localStorage.length`) and auto-awaits Promises (`clipboard.readText`).

### WASM trimming
`GeolocationPosition` is rooted via a source-gen `RaskBrowserJsonContext` inserted ahead of the reflection fallback in `WasmJSRuntime`, so it deserializes correctly in a `PublishTrimmed` app.

### Sample + docs
- New `/browser` showcase page + `BrowserApiDemo` (with `CodeSample`), wired into the sidebar and home grid.
- `docs/js-interop.md` "Typed browser APIs" section; README, `llms.txt`, and the three template `AGENTS.md` updated; CHANGELOG `[Unreleased]`.

## Testing
- **Unit**: 17 new tests in `tests/Rask.Core.Tests/Interop/` asserting each wrapper sends the exact dotted identifier + args and deserializes returns (incl. the `GeolocationPosition` camelCase contract). Full suite green (Core 1565, Shared 281, Server 239, Wasm 54, Generators 170).
- **Splice**: `ResourcesSpliceTests` extended for the new `@@RASK_API@@` marker; committed `Browser/rask.wasm.js` regenerated and verified.
- **E2E**: new step in the shared journey (`TestBrowserApisAsync`) exercising storage + clipboard round-trips, geolocation, and navigator reads, with clipboard/geolocation permissions + a fixed position granted on the browser context. **Server-host journey passes.**
- `dotnet build -warnaserror` clean (0 warnings); `dotnet format` clean; `dotnet publish -c Release samples/Rask.Example.Wasm` is IL/trim-warning clean.

## Benchmarks
Not applicable — no render hot-path change. These are event-handler/lifecycle `IJSRuntime` calls; the client-JS helpers are served, not in the diff/morph path.