### PR TITLE
feat(wasm): PWA / mobile support — Web Push, offline service worker, manifest, --pwa templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **📱 PWA / mobile support (WASM)** — build installable, offline mobile apps in C#:
+  - **`IWebPush`** (`Rask.Wasm.Browser`): Web Push — `IsSupported`/`RequestPermission`/
+    `RegisterServiceWorker`/`Subscribe`/`GetSubscription`/`Unsubscribe`, returning a typed
+    `PushSubscription` to hand to your backend. (Server-side *sending* — VAPID/RFC 8291 — is out of scope.)
+  - **Default service worker `rask-sw.js`** shipped by `Rask.Wasm`: offline app-shell runtime cache
+    (navigations fall back to the cached shell) **plus** push display / notification-click handling.
+  - **`--pwa` option** on the `rask-wasm` and `rask-wasm-hosted` templates: scaffolds a web app
+    manifest + icon and registers the service worker, so `dotnet new rask-wasm --pwa` is installable
+    and offline out of the box.
+  - The **WASM showcase** (`samples/Rask.Example.Wasm`, deployed to GitHub Pages) is now an
+    installable, offline PWA.
+  - New [Mobile & PWA guide](docs/pwa.md).
 - **More typed browser APIs** (building on the typed browser-API foundation), all shared across Server
   and WASM and injected through the constructor: `ICookies` (`document.cookie` with typed
   `CookieOptions`), `IPermissions` (`QueryAsync` → `PermissionState`), `IVibration`

--- a/README.md
+++ b/README.md
@@ -44,10 +44,32 @@ public sealed class Counter : Component
 
 <sub>☝️ A complete, live, interactive component — routing, state, and event handling in a single C# class.</sub>
 
+---
+
+<div align="center">
+
+## 📱 Build mobile apps in C# — no Swift, Kotlin, React Native, or MAUI
+
+**The same component above ships as an installable, offline mobile app.** A Rask **WASM** app is a
+Progressive Web App: it **installs to the home screen**, **launches full-screen**, **works offline**,
+sends **push notifications**, and reaches the device — **vibration, share sheet, geolocation,
+clipboard** — through typed C#.
+
+```bash
+dotnet new rask-wasm --pwa     # → an installable, offline PWA, ready to deploy
+```
+
+**[📖 Build mobile apps with Rask →](docs/pwa.md)**  ·  **[Try the installable demo ↗](https://pal-tamas.github.io/rask/)**
+
+</div>
+
+---
+
 <details>
 <summary><b>Contents</b></summary>
 
 - [Why Rask](#-why-rask)
+- [📱 Build mobile apps in C#](#-build-mobile-apps-in-c--no-swift-kotlin-react-native-or-maui) — installable, offline PWAs
 - [Compared to Blazor](#-compared-to-blazor)
 - [Install](#-install)
 - [Quick Start — Server](#-quick-start--server)

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ interactive app. Want the pitch and a quick demo first? See the project [README]
 | [Best practices](best-practices.md) | Production patterns and common pitfalls across component design, state, forms, data access, security, accessibility, performance and testing — each linking to the deep dive. |
 | [Routing](routing.md) | `[Route]`, route/query params, nested routes, type-safe `Routes.*` URLs, `Navigator`, `RouteState`. |
 | [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), `VirtualizeModel`, drag-and-drop. |
-| [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), asset delivery. |
+| [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), typed browser APIs, asset delivery. |
+| [📱 Mobile & PWA](pwa.md) | Build installable, offline mobile apps in C# (WASM): web app manifest, service worker, Web Push (`IWebPush`), `dotnet new rask-wasm --pwa`. |
 | [Forms & validation](forms.md) | Two-way binding, `Form<T>`/`EditContext`, inline / DataAnnotations / FluentValidation / async validators, radio & checkbox groups. |
 | [Lifecycle](lifecycle.md) | `OnMount` / `OnPropsChanged` / `OnRendered` / `OnUnmount`, async-hook rules, cancellation, common gotchas. |
 | [Data access (EF Core)](data-access.md) | EF Core + SQLite in a Server app: `IDbContextFactory`, loading in the lifecycle, vertical slices, a DDD aggregate + value objects, and the SQLite decimal gotcha. |

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -1,0 +1,155 @@
+# 📱 Mobile apps with Rask — PWA, offline & push
+
+**Build installable, offline, native-feeling mobile apps in C# — no Swift, Kotlin, React Native, or
+MAUI.** A Rask **WASM** app is a Progressive Web App: it installs to the home screen, launches
+full-screen, works offline, sends push notifications, and reaches device capabilities (vibration,
+share sheet, geolocation, clipboard) through typed C# — the same component code you already write.
+
+> PWA features are **WASM-only**. Offline, install, and push run independently of any server, which
+> the Server/WebSocket transport can't provide. See
+> [When to use Server vs WASM](../README.md#-when-to-use-server-vs-wasm).
+
+- [Make your app a PWA](#make-your-app-a-pwa)
+- [Installable — the web app manifest](#installable--the-web-app-manifest)
+- [Offline — the service worker](#offline--the-service-worker)
+- [Push notifications (`IWebPush`)](#push-notifications-iwebpush)
+- [Device capabilities for mobile](#device-capabilities-for-mobile)
+- [Deploying (GitHub Pages & sub-paths)](#deploying-github-pages--sub-paths)
+
+---
+
+## Make your app a PWA
+
+Start a new app with the **`--pwa`** option and it's installable + offline out of the box:
+
+```bash
+dotnet new rask-wasm --pwa          # standalone browser-WASM PWA
+dotnet new rask-wasm-hosted --pwa   # WASM PWA + ASP.NET host
+```
+
+That scaffolds a web app manifest + icon and registers Rask's default service worker from
+`index.html`. To add it to an existing Rask WASM app, do the two steps below by hand
+(manifest + service-worker registration).
+
+---
+
+## Installable — the web app manifest
+
+A `wwwroot/manifest.webmanifest` plus a `<link rel="manifest">` makes the app installable (the
+browser's "Install app" / "Add to Home Screen"):
+
+```json
+{
+  "name": "My Rask App",
+  "short_name": "Rask App",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#faf9fe",
+  "theme_color": "#512BD4",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}
+```
+
+Relative `start_url`/`scope` (`"."`) keep it correct under a sub-path deploy (GitHub Pages). In
+`wwwroot/index.html`:
+
+```html
+<link href="manifest.webmanifest" rel="manifest"/>
+<meta content="#512BD4" name="theme-color"/>
+```
+
+---
+
+## Offline — the service worker
+
+Rask ships a default service worker, **`rask-sw.js`**, served at the app root. It does two jobs:
+
+1. **Offline app shell** — a network-first runtime cache (fresh when online, served from cache when
+   offline), with navigations falling back to the cached shell so deep links work offline.
+2. **Web Push** — shows the pushed notification and focuses/opens a window on click.
+
+Register it from `index.html` (the `--pwa` templates do this for you). It resolves relative to
+`<base href>`, so it works at the origin root and under a sub-path deploy:
+
+```html
+<script>
+  if ("serviceWorker" in navigator) {
+    window.addEventListener("load", function () {
+      var base = document.querySelector("base");
+      var scope = base ? new URL(base.href).pathname : "/";
+      navigator.serviceWorker.register(scope + "rask-sw.js").catch(function () {});
+    });
+  }
+</script>
+```
+
+Bring your own worker (custom caching/routing) by registering a different URL — e.g. via
+`IWebPush.RegisterServiceWorkerAsync("/my-sw.js")`.
+
+---
+
+## Push notifications (`IWebPush`)
+
+`IWebPush` (in `Rask.Wasm.Browser`, injected through the constructor) wraps the Web Push API. Drive
+it from an event handler:
+
+```csharp
+public sealed class PushButton(IWebPush push) : Component
+{
+    private async Task Enable()
+    {
+        if (!await push.IsSupportedAsync()) return;
+        if (await push.RequestPermissionAsync() != NotificationPermission.Granted) return;
+
+        await push.RegisterServiceWorkerAsync();              // default rask-sw.js
+        var sub = await push.SubscribeAsync(vapidPublicKey);  // your VAPID public key (base64url)
+
+        // POST `sub` (Endpoint, P256dh, Auth) to your backend, which signs (VAPID) and encrypts
+        // (RFC 8291) the push and delivers it to sub.Endpoint.
+    }
+}
+```
+
+**Sending** a push is a backend concern (the Web Push Protocol — VAPID signing + payload
+encryption), outside Rask: store the `PushSubscription` and send with any web-push library. The
+default `rask-sw.js` receives it and shows a notification from the JSON payload
+(`{ title, body, icon, tag, data: { url } }`).
+
+---
+
+## Device capabilities for mobile
+
+Typed wrappers for the browser APIs that make a web app feel native. The shared ones live in
+`Rask.Core.Browser` (work on both transports); `IShare` is WASM-only (it needs a live user gesture).
+
+| Capability | Service | Use |
+| --- | --- | --- |
+| **Share sheet** | `IShare` *(WASM)* | Hand a link/text to the OS share UI |
+| **Vibration** | `IVibration` | Haptic feedback (`VibrateAsync(200)`) |
+| **Geolocation** | `IGeolocation` | Current position |
+| **Clipboard** | `IClipboard` | Copy/paste |
+| **Storage / Cookies** | `IBrowserStorage` / `ICookies` | Persist state on-device |
+| **Permissions** | `IPermissions` | Check before prompting |
+| **Page visibility** | `IPageVisibility` | Pause work when backgrounded |
+| **Online status** | `INavigatorInfo` | `OnLineAsync()` for an offline indicator |
+
+See [JS interop → Typed browser APIs](js-interop.md#typed-browser-apis) for the full surface.
+
+---
+
+## Deploying (GitHub Pages & sub-paths)
+
+Publish with `RaskPathBase` so the `<base href>`, manifest, and service-worker scope resolve under
+the sub-path:
+
+```bash
+dotnet publish -c Release /p:RaskPathBase=/my-repo
+```
+
+The manifest's relative `start_url`/`scope` and the `<base href>`-relative SW registration handle the
+prefix automatically — the published app is installable and offline at `https://you.github.io/my-repo/`.
+The Rask showcase itself is a deployed WASM PWA — install it from
+[the live demo](https://pal-tamas.github.io/rask/).

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Building form controls](docs/building-form-controls.md): end-to-end guide to authoring a custom control with `IFormControl<T>` — the interface, a complete worked example, the default-method helpers, and the bound-vs-controlled / Fragment-vs-Component trade-offs.
 - [Data access](docs/data-access.md): EF Core + SQLite, IDbContextFactory, loading in the lifecycle, vertical slices, DDD value objects, SQLite decimal gotcha.
 - [JS interop](docs/js-interop.md): scoped CSS/JS, element refs, IJSRuntime, typed browser APIs — shared (both transports) in Rask.Core.Browser (IBrowserStorage/ICookies/IClipboard/IGeolocation/IPermissions/IVibration/IPageVisibility/INavigatorInfo); WASM-only in Rask.Wasm.Browser (IShare).
+- [Mobile & PWA](docs/pwa.md): build installable, offline mobile apps in C# (WASM-only). Web app manifest, default service worker (rask-sw.js — offline app-shell cache + Web Push), IWebPush (Rask.Wasm.Browser), `dotnet new rask-wasm --pwa`.
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Observability](docs/observability.md): structured logging, the `Rask.Server` meter + activity source, `AddRaskLiveSessions()` health check.
 - [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.

--- a/samples/Rask.Example.Wasm/wwwroot/icon.svg
+++ b/samples/Rask.Example.Wasm/wwwroot/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#512BD4"/>
+    </linearGradient>
+  </defs>
+  <!-- Maskable safe zone: keep the glyph within the central 80%. Full-bleed background. -->
+  <rect width="512" height="512" fill="#faf9fe"/>
+  <rect x="56" y="56" width="400" height="400" rx="88" fill="url(#g)"/>
+  <path d="M300 120 L196 248 L256 248 L240 392 L356 236 L292 236 Z" fill="#ffffff"/>
+</svg>

--- a/samples/Rask.Example.Wasm/wwwroot/index.html
+++ b/samples/Rask.Example.Wasm/wwwroot/index.html
@@ -41,6 +41,10 @@
          external file dependency; the App's <head> morphs in its own <link> on first paint. -->
     <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E" rel="icon"
           type="image/svg+xml"/>
+    <!-- PWA: installable manifest + theme color. Relative href resolves under any deploy sub-path
+         (e.g. GitHub Pages /Rask/) via <base href>. The service worker is registered below. -->
+    <link href="manifest.webmanifest" rel="manifest"/>
+    <meta content="#512BD4" name="theme-color"/>
     <style id="rask-scoped"></style>
     <style>
         .rask-boot {
@@ -137,5 +141,16 @@
     </div>
 </div>
 <script src="main.js" type="module"></script>
+<!-- PWA: register Rask's default service worker (offline app-shell cache + Web Push). It resolves
+     relative to <base href>, so it works at the origin root and under a sub-path deploy (GH Pages). -->
+<script>
+    if ("serviceWorker" in navigator) {
+        window.addEventListener("load", function () {
+            var base = document.querySelector("base");
+            var scope = base ? new URL(base.href).pathname : "/";
+            navigator.serviceWorker.register(scope + "rask-sw.js").catch(function () { });
+        });
+    }
+</script>
 </body>
 </html>

--- a/samples/Rask.Example.Wasm/wwwroot/manifest.webmanifest
+++ b/samples/Rask.Example.Wasm/wwwroot/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "Rask WASM Showcase",
+  "short_name": "Rask",
+  "description": "The Rask component framework showcase, running entirely in the browser as a WASM PWA.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#faf9fe",
+  "theme_color": "#512BD4",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/src/Rask.Templates/content/rask-wasm-hosted/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-wasm-hosted/.template.config/template.json
@@ -19,6 +19,12 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Scaffold a cookie-backed login: the host serves /api/login + /api/me + /auth/logout, the client hydrates the user and gates a protected /members page."
+    },
+    "pwa": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Make the client an installable, offline PWA: adds a web app manifest + icon and registers Rask's default service worker (offline app-shell cache + Web Push) from index.html."
     }
   },
   "sources": [
@@ -27,6 +33,10 @@
         {
           "condition": "(!auth)",
           "exclude": [ "**/Auth/**" ]
+        },
+        {
+          "condition": "(!pwa)",
+          "exclude": [ "**/wwwroot/manifest.webmanifest", "**/wwwroot/icon.svg" ]
         }
       ]
     }

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -30,7 +30,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, the typed browser APIs
-  `IBrowserStorage`/`ICookies`/`IClipboard`/`IGeolocation`/`IPermissions`/`IShare`/`IVibration`/`IPageVisibility`/`INavigatorInfo`, your own) through the constructor**,
+  `IBrowserStorage`/`ICookies`/`IClipboard`/`IGeolocation`/`IPermissions`/`IShare`/`IVibration`/`IPageVisibility`/`INavigatorInfo`/`IWebPush`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
 
 ## Events, scoped CSS/JS, forms, auth

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/icon.svg
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#512BD4"/>
+    </linearGradient>
+  </defs>
+  <!-- Maskable safe zone: keep the glyph within the central 80%. Full-bleed background. -->
+  <rect width="512" height="512" fill="#faf9fe"/>
+  <rect x="56" y="56" width="400" height="400" rx="88" fill="url(#g)"/>
+  <path d="M300 120 L196 248 L256 248 L240 392 L356 236 L292 236 Z" fill="#ffffff"/>
+</svg>

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/index.html
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/index.html
@@ -41,6 +41,11 @@
          external file dependency; the App's <head> morphs in its own <link> on first paint. -->
     <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E" rel="icon"
           type="image/svg+xml"/>
+    <!--#if (pwa)-->
+    <!-- PWA: installable manifest + theme color (relative href works under any deploy sub-path). -->
+    <link href="manifest.webmanifest" rel="manifest"/>
+    <meta content="#512BD4" name="theme-color"/>
+    <!--#endif-->
     <style id="rask-scoped"></style>
     <style>
         .rask-boot {
@@ -137,5 +142,18 @@
     </div>
 </div>
 <script src="main.js" type="module"></script>
+<!--#if (pwa)-->
+<!-- PWA: register Rask's default service worker (offline app-shell cache + Web Push). Resolves
+     relative to <base href>, so it works at the origin root and under a sub-path deploy. -->
+<script>
+    if ("serviceWorker" in navigator) {
+        window.addEventListener("load", function () {
+            var base = document.querySelector("base");
+            var scope = base ? new URL(base.href).pathname : "/";
+            navigator.serviceWorker.register(scope + "rask-sw.js").catch(function () { });
+        });
+    }
+</script>
+<!--#endif-->
 </body>
 </html>

--- a/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/manifest.webmanifest
+++ b/src/Rask.Templates/content/rask-wasm-hosted/Company.RaskWasmHosted.Wasm/wwwroot/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "Rask App",
+  "short_name": "Rask App",
+  "description": "A Rask browser-WASM app.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#faf9fe",
+  "theme_color": "#512BD4",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/src/Rask.Templates/content/rask-wasm/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-wasm/.template.config/template.json
@@ -19,6 +19,12 @@
       "datatype": "bool",
       "defaultValue": "false",
       "description": "Scaffold a JWT bearer login against an external API (token in localStorage, attached as Authorization: Bearer). Point BaseAddress at your auth API — a standalone SPA has no host of its own."
+    },
+    "pwa": {
+      "type": "parameter",
+      "datatype": "bool",
+      "defaultValue": "false",
+      "description": "Make the app an installable, offline PWA: adds a web app manifest + icon and registers Rask's default service worker (offline app-shell cache + Web Push) from index.html."
     }
   },
   "sources": [
@@ -27,6 +33,10 @@
         {
           "condition": "(!auth)",
           "exclude": [ "Auth/**" ]
+        },
+        {
+          "condition": "(!pwa)",
+          "exclude": [ "wwwroot/manifest.webmanifest", "wwwroot/icon.svg" ]
         }
       ]
     }

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -30,7 +30,7 @@ https://github.com/pal-tamas/rask/tree/main/docs
 - Lifecycle hooks: `OnMount`/`OnMountAsync` (once), `OnPropsChanged*` (on bound-prop/route change),
   `OnRendered(bool firstRender)`, `OnUnmount*`. Navigate only from event handlers via injected `Navigator`.
 - **Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, the typed browser APIs
-  `IBrowserStorage`/`ICookies`/`IClipboard`/`IGeolocation`/`IPermissions`/`IShare`/`IVibration`/`IPageVisibility`/`INavigatorInfo`, your own) through the constructor**,
+  `IBrowserStorage`/`ICookies`/`IClipboard`/`IGeolocation`/`IPermissions`/`IShare`/`IVibration`/`IPageVisibility`/`INavigatorInfo`/`IWebPush`, your own) through the constructor**,
   not as settable properties (a non-nullable settable property becomes a required factory param).
 
 ## Events, scoped CSS/JS, forms, auth

--- a/src/Rask.Templates/content/rask-wasm/wwwroot/icon.svg
+++ b/src/Rask.Templates/content/rask-wasm/wwwroot/icon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <defs>
+    <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#7C3AED"/>
+      <stop offset="1" stop-color="#512BD4"/>
+    </linearGradient>
+  </defs>
+  <!-- Maskable safe zone: keep the glyph within the central 80%. Full-bleed background. -->
+  <rect width="512" height="512" fill="#faf9fe"/>
+  <rect x="56" y="56" width="400" height="400" rx="88" fill="url(#g)"/>
+  <path d="M300 120 L196 248 L256 248 L240 392 L356 236 L292 236 Z" fill="#ffffff"/>
+</svg>

--- a/src/Rask.Templates/content/rask-wasm/wwwroot/index.html
+++ b/src/Rask.Templates/content/rask-wasm/wwwroot/index.html
@@ -41,6 +41,11 @@
          external file dependency; the App's <head> morphs in its own <link> on first paint. -->
     <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E" rel="icon"
           type="image/svg+xml"/>
+    <!--#if (pwa)-->
+    <!-- PWA: installable manifest + theme color (relative href works under any deploy sub-path). -->
+    <link href="manifest.webmanifest" rel="manifest"/>
+    <meta content="#512BD4" name="theme-color"/>
+    <!--#endif-->
     <style id="rask-scoped"></style>
     <style>
         .rask-boot {
@@ -137,5 +142,18 @@
     </div>
 </div>
 <script src="main.js" type="module"></script>
+<!--#if (pwa)-->
+<!-- PWA: register Rask's default service worker (offline app-shell cache + Web Push). Resolves
+     relative to <base href>, so it works at the origin root and under a sub-path deploy. -->
+<script>
+    if ("serviceWorker" in navigator) {
+        window.addEventListener("load", function () {
+            var base = document.querySelector("base");
+            var scope = base ? new URL(base.href).pathname : "/";
+            navigator.serviceWorker.register(scope + "rask-sw.js").catch(function () { });
+        });
+    }
+</script>
+<!--#endif-->
 </body>
 </html>

--- a/src/Rask.Templates/content/rask-wasm/wwwroot/manifest.webmanifest
+++ b/src/Rask.Templates/content/rask-wasm/wwwroot/manifest.webmanifest
@@ -1,0 +1,13 @@
+{
+  "name": "Rask App",
+  "short_name": "Rask App",
+  "description": "A Rask browser-WASM app.",
+  "start_url": ".",
+  "scope": ".",
+  "display": "standalone",
+  "background_color": "#faf9fe",
+  "theme_color": "#512BD4",
+  "icons": [
+    { "src": "icon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/src/Rask.Wasm/Browser/RaskWasmBrowserJsonContext.cs
+++ b/src/Rask.Wasm/Browser/RaskWasmBrowserJsonContext.cs
@@ -12,4 +12,5 @@ namespace Rask.Wasm.Browser;
 /// </summary>
 [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
 [JsonSerializable(typeof(ShareData))]
+[JsonSerializable(typeof(PushSubscription))]
 internal sealed partial class RaskWasmBrowserJsonContext : JsonSerializerContext;

--- a/src/Rask.Wasm/Browser/WebPush.cs
+++ b/src/Rask.Wasm/Browser/WebPush.cs
@@ -1,0 +1,116 @@
+using Microsoft.JSInterop;
+using Rask.Core.Live;
+
+namespace Rask.Wasm.Browser;
+
+/// <summary>The user's decision on a notification-permission prompt (<c>Notification.permission</c>).</summary>
+public enum NotificationPermission
+{
+    /// <summary>Not yet decided — the browser will prompt on the next request.</summary>
+    Default,
+
+    /// <summary>Granted; notifications (and push) are allowed.</summary>
+    Granted,
+
+    /// <summary>Denied; blocked until the user changes the site setting.</summary>
+    Denied
+}
+
+/// <summary>
+///     A push subscription handle (<see href="https://developer.mozilla.org/en-US/docs/Web/API/PushSubscription" />).
+///     Send these fields to your own backend, which signs (VAPID) and encrypts (RFC&#160;8291) push
+///     messages and POSTs them to <see cref="Endpoint" /> — that server side is outside Rask.
+/// </summary>
+/// <param name="Endpoint">The push service URL to deliver messages to.</param>
+/// <param name="P256dh">Base64url of the client's P-256 ECDH public key (for payload encryption).</param>
+/// <param name="Auth">Base64url of the client's auth secret (for payload encryption).</param>
+/// <param name="ExpirationTime">Epoch milliseconds when the subscription expires, or <c>null</c>.</param>
+public sealed record PushSubscription(string Endpoint, string P256dh, string Auth, double? ExpirationTime);
+
+/// <summary>
+///     Typed access to the Web Push API (<see href="https://developer.mozilla.org/en-US/docs/Web/API/Push_API" />).
+///     <b>WASM-only</b> and the first of Rask's PWA APIs: push relies on a Service Worker that runs
+///     independently of any page, which the Server/WebSocket model can't provide. Inject it through a
+///     component constructor and drive it from event handlers:
+///     <code>
+///     if (await push.IsSupportedAsync() &amp;&amp; await push.RequestPermissionAsync() == NotificationPermission.Granted)
+///     {
+///         await push.RegisterServiceWorkerAsync();
+///         var sub = await push.SubscribeAsync(vapidPublicKey);   // POST sub to your backend
+///     }
+///     </code>
+/// </summary>
+/// <remarks>
+///     Requires a secure context (HTTPS or localhost). Unsupported browsers / denied permission surface
+///     as a <see cref="JSException" /> from the awaited task — gate on <see cref="IsSupportedAsync" /> and
+///     wrap calls in try/catch. Rask ships a default service worker (<c>rask-sw.js</c>) that displays
+///     the pushed notification; pass your own URL to <see cref="RegisterServiceWorkerAsync" /> to override.
+/// </remarks>
+public interface IWebPush
+{
+    /// <summary>Whether this browser supports service workers, the Push API, and notifications.</summary>
+    ValueTask<bool> IsSupportedAsync();
+
+    /// <summary>Prompts for (or reports) notification permission (<c>Notification.requestPermission</c>).</summary>
+    ValueTask<NotificationPermission> RequestPermissionAsync();
+
+    /// <summary>
+    ///     Registers the service worker that receives pushes. <paramref name="swUrl" /> defaults to the
+    ///     framework's <c>{PathBase}/rask-sw.js</c>.
+    /// </summary>
+    ValueTask RegisterServiceWorkerAsync(string? swUrl = null);
+
+    /// <summary>
+    ///     Subscribes to push for this browser, returning the subscription to hand to your backend
+    ///     (<c>pushManager.subscribe</c>). <paramref name="vapidPublicKey" /> is your VAPID application
+    ///     server key (base64url). Register the service worker first.
+    /// </summary>
+    ValueTask<PushSubscription> SubscribeAsync(string vapidPublicKey);
+
+    /// <summary>Returns the current push subscription, or <c>null</c> if not subscribed.</summary>
+    ValueTask<PushSubscription?> GetSubscriptionAsync();
+
+    /// <summary>Unsubscribes from push; returns whether a subscription was removed.</summary>
+    ValueTask<bool> UnsubscribeAsync();
+}
+
+/// <summary>
+///     Default <see cref="IWebPush" />, backed by the unified <see cref="IJSRuntime" /> via the framework's
+///     <c>__raskPush.*</c> helpers (which wrap the service-worker registration, VAPID key decoding, and
+///     subscription serialization that <c>IJSRuntime</c> can't express directly).
+/// </summary>
+public sealed class WebPush(IJSRuntime js) : IWebPush
+{
+    /// <inheritdoc />
+    public ValueTask<bool> IsSupportedAsync() => js.InvokeAsync<bool>("__raskPush.isSupported");
+
+    /// <inheritdoc />
+    public async ValueTask<NotificationPermission> RequestPermissionAsync()
+    {
+        var result = await js.InvokeAsync<string?>("__raskPush.requestPermission");
+        return result switch
+        {
+            "granted" => NotificationPermission.Granted,
+            "denied" => NotificationPermission.Denied,
+            _ => NotificationPermission.Default
+        };
+    }
+
+    /// <inheritdoc />
+    public ValueTask RegisterServiceWorkerAsync(string? swUrl = null) =>
+        js.InvokeVoidAsync("__raskPush.register", swUrl ?? $"{LiveOptions.PathBase}/rask-sw.js");
+
+    /// <inheritdoc />
+    public ValueTask<PushSubscription> SubscribeAsync(string vapidPublicKey)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(vapidPublicKey);
+        return js.InvokeAsync<PushSubscription>("__raskPush.subscribe", vapidPublicKey);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<PushSubscription?> GetSubscriptionAsync() =>
+        js.InvokeAsync<PushSubscription?>("__raskPush.getSubscription");
+
+    /// <inheritdoc />
+    public ValueTask<bool> UnsubscribeAsync() => js.InvokeAsync<bool>("__raskPush.unsubscribe");
+}

--- a/src/Rask.Wasm/Browser/rask-sw.js
+++ b/src/Rask.Wasm/Browser/rask-sw.js
@@ -1,0 +1,78 @@
+// Rask default service worker — the one SW a Rask WASM PWA needs. It does two jobs:
+//   1. Offline app shell: a network-first runtime cache (fresh when online, cached when offline),
+//      with navigations falling back to the cached page shell so deep links work offline.
+//   2. Web Push: shows the pushed notification and focuses/opens a window on click (IWebPush).
+//
+// Registered by the page shell (see the WASM templates' / example's index.html) or by
+// IWebPush.RegisterServiceWorkerAsync(). Bring your own SW (pass a URL) to customize.
+
+const RASK_CACHE = "rask-cache-v1";
+
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+// Network-first with cache fallback. Only same-origin GETs are cached; cross-origin and
+// non-GET requests pass straight through.
+self.addEventListener("fetch", (event) => {
+    const req = event.request;
+    if (req.method !== "GET" || new URL(req.url).origin !== self.location.origin) {
+        return;
+    }
+    event.respondWith((async () => {
+        const cache = await caches.open(RASK_CACHE);
+        try {
+            const res = await fetch(req);
+            if (res && res.ok) {
+                cache.put(req, res.clone());
+            }
+            return res;
+        } catch (err) {
+            const cached = await cache.match(req);
+            if (cached) {
+                return cached;
+            }
+            // Offline navigation: fall back to the cached app shell so client-side routes render.
+            if (req.mode === "navigate") {
+                const shell = await cache.match("index.html") || await cache.match("./");
+                if (shell) {
+                    return shell;
+                }
+            }
+            throw err;
+        }
+    })());
+});
+
+// A push arrived: parse the (optional) JSON payload and show a notification.
+self.addEventListener("push", (event) => {
+    let data = {};
+    try {
+        data = event.data ? event.data.json() : {};
+    } catch (_) {
+        data = {body: event.data ? event.data.text() : ""};
+    }
+    const title = data.title || "Notification";
+    event.waitUntil(self.registration.showNotification(title, {
+        body: data.body,
+        icon: data.icon,
+        badge: data.badge,
+        tag: data.tag,
+        data: data.data || {}
+    }));
+});
+
+// Notification clicked: focus an existing window for the target URL, else open one.
+self.addEventListener("notificationclick", (event) => {
+    event.notification.close();
+    const url = (event.notification.data && event.notification.data.url) || "/";
+    event.waitUntil(
+        self.clients.matchAll({type: "window", includeUncontrolled: true}).then((clients) => {
+            for (let i = 0; i < clients.length; i++) {
+                if (clients[i].url === url && "focus" in clients[i]) {
+                    return clients[i].focus();
+                }
+            }
+            return self.clients.openWindow ? self.clients.openWindow(url) : undefined;
+        })
+    );
+});

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -100,6 +100,74 @@ window.__raskApi = window.__raskApi || {
 };
 
 
+// WASM-only helpers (__raskPush, …) spliced from Rask.Wasm/Resources/rask-wasm-api.js — never ship
+// in the Server client, since these back APIs that can't work over the WebSocket round-trip.
+// WASM-only framework Web-API helpers, spliced into rask.wasm.js ONLY (by the RASK_WASM_API marker).
+// These back APIs that can't work on the Server transport, so they must not ship in the Server
+// client (rask.js) — keeping the Core shared rask-api.js to genuinely-shared helpers only.
+
+// Web Push (driven by IWebPush in Rask.Wasm.Browser). Push needs a Service Worker registration plus
+// key (de)serialization that IJSRuntime can't express directly, so it all lives here.
+window.__raskPush = window.__raskPush || {
+    isSupported: () =>
+        ("serviceWorker" in navigator) && ("PushManager" in window) && ("Notification" in window),
+
+    requestPermission: () => Notification.requestPermission(),
+
+    register: (swUrl) => navigator.serviceWorker.register(swUrl).then(() => undefined),
+
+    subscribe: async (vapidPublicKey) => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: window.__raskPush._urlB64ToBytes(vapidPublicKey)
+        });
+        return window.__raskPush._serialize(sub);
+    },
+
+    getSubscription: async () => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        return sub ? window.__raskPush._serialize(sub) : null;
+    },
+
+    unsubscribe: async () => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        return sub ? await sub.unsubscribe() : false;
+    },
+
+    // Shape a live PushSubscription into the C# PushSubscription record (base64url key bytes).
+    _serialize: (sub) => ({
+        endpoint: sub.endpoint,
+        expirationTime: sub.expirationTime,
+        p256dh: window.__raskPush._b64url(sub.getKey("p256dh")),
+        auth: window.__raskPush._b64url(sub.getKey("auth"))
+    }),
+
+    // NB: no regex literals here — the MSBuild client-JS splice mangles backslashes, so base64url
+    // (de)coding uses split/join instead of regex replace patterns.
+    _b64url: (buf) => {
+        if (!buf) return "";
+        const bytes = new Uint8Array(buf);
+        let s = "";
+        for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+        let out = btoa(s).split("+").join("-").split("/").join("_");
+        while (out.length > 0 && out[out.length - 1] === "=") out = out.slice(0, -1);
+        return out;
+    },
+
+    _urlB64ToBytes: (base64) => {
+        const pad = "=".repeat((4 - base64.length % 4) % 4);
+        const norm = (base64 + pad).split("-").join("+").split("_").join("/");
+        const raw = atob(norm);
+        const out = new Uint8Array(raw.length);
+        for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+        return out;
+    }
+};
+
+
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
 // preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -69,6 +69,7 @@
   <ItemGroup>
     <None Include="Browser\main.js" Pack="true" PackagePath="Browser\"/>
     <None Include="Browser\index.html" Pack="true" PackagePath="Browser\"/>
+    <None Include="Browser\rask-sw.js" Pack="true" PackagePath="Browser\"/>
     <None Include="$(BaseIntermediateOutputPath)$(Configuration)\rask.wasm.js"
           Pack="true" PackagePath="Browser\rask.wasm.js"
           Condition=" '$(Configuration)' == 'Release' "/>
@@ -86,14 +87,15 @@
     contributors look at). NuGet consumers see whichever version is packed (above).
   -->
   <Target Name="_RaskSpliceClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths;_RaskMinifyClientJs"
-          Inputs="Resources\rask.wasm.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js"
+          Inputs="Resources\rask.wasm.js;Resources\rask-wasm-api.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js"
           Outputs="Browser\rask.wasm.js">
     <PropertyGroup>
       <_RaskWasmTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.wasm.js'))</_RaskWasmTemplate>
       <_RaskDomBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-dom.js'))</_RaskDomBody>
       <_RaskMorphBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-morph.js'))</_RaskMorphBody>
       <_RaskApiBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-api.js'))</_RaskApiBody>
-      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)'))</_RaskWasmJs>
+      <_RaskWasmApiBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask-wasm-api.js'))</_RaskWasmApiBody>
+      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)'))</_RaskWasmJs>
     </PropertyGroup>
     <WriteLinesToFile File="Browser\rask.wasm.js" Lines="$(_RaskWasmJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
   </Target>

--- a/src/Rask.Wasm/Resources/rask-wasm-api.js
+++ b/src/Rask.Wasm/Resources/rask-wasm-api.js
@@ -1,0 +1,64 @@
+// WASM-only framework Web-API helpers, spliced into rask.wasm.js ONLY (by the RASK_WASM_API marker).
+// These back APIs that can't work on the Server transport, so they must not ship in the Server
+// client (rask.js) — keeping the Core shared rask-api.js to genuinely-shared helpers only.
+
+// Web Push (driven by IWebPush in Rask.Wasm.Browser). Push needs a Service Worker registration plus
+// key (de)serialization that IJSRuntime can't express directly, so it all lives here.
+window.__raskPush = window.__raskPush || {
+    isSupported: () =>
+        ("serviceWorker" in navigator) && ("PushManager" in window) && ("Notification" in window),
+
+    requestPermission: () => Notification.requestPermission(),
+
+    register: (swUrl) => navigator.serviceWorker.register(swUrl).then(() => undefined),
+
+    subscribe: async (vapidPublicKey) => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.subscribe({
+            userVisibleOnly: true,
+            applicationServerKey: window.__raskPush._urlB64ToBytes(vapidPublicKey)
+        });
+        return window.__raskPush._serialize(sub);
+    },
+
+    getSubscription: async () => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        return sub ? window.__raskPush._serialize(sub) : null;
+    },
+
+    unsubscribe: async () => {
+        const reg = await navigator.serviceWorker.ready;
+        const sub = await reg.pushManager.getSubscription();
+        return sub ? await sub.unsubscribe() : false;
+    },
+
+    // Shape a live PushSubscription into the C# PushSubscription record (base64url key bytes).
+    _serialize: (sub) => ({
+        endpoint: sub.endpoint,
+        expirationTime: sub.expirationTime,
+        p256dh: window.__raskPush._b64url(sub.getKey("p256dh")),
+        auth: window.__raskPush._b64url(sub.getKey("auth"))
+    }),
+
+    // NB: no regex literals here — the MSBuild client-JS splice mangles backslashes, so base64url
+    // (de)coding uses split/join instead of regex replace patterns.
+    _b64url: (buf) => {
+        if (!buf) return "";
+        const bytes = new Uint8Array(buf);
+        let s = "";
+        for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+        let out = btoa(s).split("+").join("-").split("/").join("_");
+        while (out.length > 0 && out[out.length - 1] === "=") out = out.slice(0, -1);
+        return out;
+    },
+
+    _urlB64ToBytes: (base64) => {
+        const pad = "=".repeat((4 - base64.length % 4) % 4);
+        const norm = (base64 + pad).split("-").join("+").split("_").join("/");
+        const raw = atob(norm);
+        const out = new Uint8Array(raw.length);
+        for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+        return out;
+    }
+};

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -10,6 +10,10 @@ let basePath = null;
 // Rask.Core/Resources/rask-api.js at build time — single source across both transports.
 // @@RASK_API@@
 
+// WASM-only helpers (__raskPush, …) spliced from Rask.Wasm/Resources/rask-wasm-api.js — never ship
+// in the Server client, since these back APIs that can't work over the WebSocket round-trip.
+// @@RASK_WASM_API@@
+
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
 // preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -38,6 +38,7 @@ public sealed class WasmHostBuilder
         Services.AddSingleton<ICookies, Cookies>();
         Services.AddSingleton<IPermissions, Permissions>();
         Services.AddSingleton<IShare, Share>();
+        Services.AddSingleton<IWebPush, WebPush>();
         Services.AddSingleton<IVibration, Vibration>();
         Services.AddSingleton<IPageVisibility, PageVisibilityInfo>();
         Services.TryAddSingleton<IUserProvider, AnonymousUserProvider>();

--- a/src/Rask.Wasm/build/Rask.Wasm.targets
+++ b/src/Rask.Wasm/build/Rask.Wasm.targets
@@ -37,6 +37,8 @@
     <ItemGroup>
       <_RaskBootAsset Include="$(MSBuildThisFileDirectory)..\Browser\main.js"/>
       <_RaskBootAsset Include="$(MSBuildThisFileDirectory)..\Browser\rask.wasm.js"/>
+      <!-- Default PWA service worker (offline app-shell cache + Web Push), served at {root}/rask-sw.js. -->
+      <_RaskBootAsset Include="$(MSBuildThisFileDirectory)..\Browser\rask-sw.js"/>
     </ItemGroup>
     <DefineStaticWebAssets CandidateAssets="@(_RaskBootAsset)"
                            SourceType="Computed"

--- a/tests/Rask.Wasm.Tests/Browser/WebPushTests.cs
+++ b/tests/Rask.Wasm.Tests/Browser/WebPushTests.cs
@@ -1,0 +1,86 @@
+using Rask.Core.Live;
+using Rask.Wasm.Browser;
+
+namespace Rask.Wasm.Tests.Browser;
+
+public class WebPushTests
+{
+    [Fact]
+    public async Task IsSupported_CallsHelper()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskPush.isSupported", true);
+
+        Assert.True(await new WebPush(js).IsSupportedAsync());
+    }
+
+    [Theory]
+    [InlineData("granted", NotificationPermission.Granted)]
+    [InlineData("denied", NotificationPermission.Denied)]
+    [InlineData("default", NotificationPermission.Default)]
+    [InlineData(null, NotificationPermission.Default)]
+    public async Task RequestPermission_MapsResult(string? raw, NotificationPermission expected)
+    {
+        var js = new FakeJsRuntime();
+        if (raw is not null)
+        {
+            js.SetResponse("__raskPush.requestPermission", raw);
+        }
+
+        Assert.Equal(expected, await new WebPush(js).RequestPermissionAsync());
+    }
+
+    [Fact]
+    public async Task RegisterServiceWorker_DefaultsToFrameworkSw_UnderPathBase()
+    {
+        var js = new FakeJsRuntime();
+
+        await new WebPush(js).RegisterServiceWorkerAsync();
+
+        Assert.Equal([$"{LiveOptions.PathBase}/rask-sw.js"], js.ArgsFor("__raskPush.register"));
+    }
+
+    [Fact]
+    public async Task RegisterServiceWorker_UsesProvidedUrl()
+    {
+        var js = new FakeJsRuntime();
+
+        await new WebPush(js).RegisterServiceWorkerAsync("/custom-sw.js");
+
+        Assert.Equal(["/custom-sw.js"], js.ArgsFor("__raskPush.register"));
+    }
+
+    [Fact]
+    public async Task Subscribe_SendsVapidKey_AndReturnsSubscription()
+    {
+        var js = new FakeJsRuntime();
+        var expected = new PushSubscription("https://push.example/abc", "p256", "auth", null);
+        js.SetResponse("__raskPush.subscribe", expected);
+
+        var sub = await new WebPush(js).SubscribeAsync("VAPID_KEY");
+
+        Assert.Equal(expected, sub);
+        Assert.Equal(["VAPID_KEY"], js.ArgsFor("__raskPush.subscribe"));
+    }
+
+    [Fact]
+    public async Task Subscribe_EmptyKey_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(
+            async () => await new WebPush(new FakeJsRuntime()).SubscribeAsync(""));
+    }
+
+    [Fact]
+    public async Task GetSubscription_And_Unsubscribe_UseHelpers()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskPush.unsubscribe", true);
+        var push = new WebPush(js);
+
+        await push.GetSubscriptionAsync();
+        var removed = await push.UnsubscribeAsync();
+
+        Assert.Equal(1, js.CallCount("__raskPush.getSubscription"));
+        Assert.True(removed);
+    }
+}

--- a/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
+++ b/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
@@ -10,20 +10,24 @@ public sealed class ResourcesSpliceTests
         var domPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-dom.js");
         var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
         var apiPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-api.js");
+        var wasmApiPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Resources", "rask-wasm-api.js");
         var browserPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "rask.wasm.js");
 
         var template = File.ReadAllText(templatePath);
         var dom = File.ReadAllText(domPath);
         var morph = File.ReadAllText(morphPath);
         var api = File.ReadAllText(apiPath);
+        var wasmApi = File.ReadAllText(wasmApiPath);
         var committed = File.ReadAllText(browserPath);
 
         // Mirror the marker splice order in _RaskSpliceClientJs (Rask.Wasm.csproj): the diff codec
-        // (rask-dom.js), then the full-HTML morph (rask-morph.js), then the interop helpers (rask-api.js).
+        // (rask-dom.js), the full-HTML morph (rask-morph.js), the shared interop helpers (rask-api.js),
+        // then the WASM-only helpers (rask-wasm-api.js — spliced into the WASM client only).
         var spliced = template
             .Replace("// @@RASK_DOM@@", dom)
             .Replace("// @@RASK_MORPH@@", morph)
-            .Replace("// @@RASK_API@@", api);
+            .Replace("// @@RASK_API@@", api)
+            .Replace("// @@RASK_WASM_API@@", wasmApi);
 
         Assert.True(
             spliced == committed,


### PR DESCRIPTION
## Summary

**Build installable, offline mobile apps in C# — no Swift, Kotlin, React Native, or MAUI.** This starts Rask's PWA story (WASM-only — PWA features run independently of any server, which the Server/WebSocket transport can't provide). Follows the established convention: WASM-only APIs live in `Rask.Wasm.Browser`; Core's shared `rask-api.js` stays genuinely shared.

### Web Push — `IWebPush` (`Rask.Wasm.Browser`)
`IsSupportedAsync` · `RequestPermissionAsync` → `NotificationPermission` · `RegisterServiceWorkerAsync` · `SubscribeAsync(vapidKey)` → `PushSubscription` · `GetSubscriptionAsync` · `UnsubscribeAsync`. Registered by the WASM host only; `PushSubscription` rooted in `RaskWasmBrowserJsonContext` for the trimmer.

Client-only: **sending** a push (VAPID signing + RFC 8291 encryption) is a backend concern — store the `PushSubscription` and send with any web-push library. Out of scope here.

### Default service worker — `rask-sw.js`
Shipped by `Rask.Wasm`, served at the app root. Does both PWA jobs: **offline app-shell** (network-first runtime cache; navigations fall back to the cached shell) **+ Web Push** (notification display + click handling).

### Core/WASM client-JS split (addresses review feedback)
WASM-only helpers (`__raskPush`) now splice into `rask.wasm.js` **only**, via a new `@@RASK_WASM_API@@` marker + `Resources/rask-wasm-api.js` — they no longer ship in the Server client. (base64url uses `split/join`: the MSBuild splice mangles regex backslashes — noted in-code.)

### Templates — `--pwa`
`dotnet new rask-wasm --pwa` / `rask-wasm-hosted --pwa` scaffolds a web app manifest + icon and registers the service worker from `index.html`. Verified: with the flag → manifest/icon + index.html SW/manifest refs (conditionals processed cleanly); without → none.

### Example
`samples/Rask.Example.Wasm` (deployed to GitHub Pages) is now an installable, offline PWA (manifest + icon + SW registration; relative `start_url`/`scope` + `<base href>`-relative SW handle the `/rask/` sub-path).

### Docs
New **[Mobile & PWA guide](docs/pwa.md)** (mobile-first framing) + an eye-catching README **"📱 Build mobile apps in C#"** section; docs index, `llms.txt`, template `AGENTS.md`, and CHANGELOG updated.

## Testing
- **Unit:** `WebPushTests` + existing `ShareTests` in `tests/Rask.Wasm.Tests/Browser/` (Wasm suite 68 green; Core 1587 green). `ResourcesSpliceTests` extended for the `@@RASK_WASM_API@@` marker.
- **Templates:** installed locally and generated `rask-wasm --pwa` (and without) — content toggles correctly, no leftover conditional markers.
- **Publish:** `dotnet publish -c Release /p:RaskPathBase=/rask` is **IL/trim-warning clean** and ships `rask-sw.js` + `manifest.webmanifest` + `icon.svg`, with `<base href>` rewritten to `/rask/`.
- `dotnet build -warnaserror` clean (serial — WASM file-lock race); `dotnet format` clean.

**E2E caveat (honest):** real push and offline/install can't be reliably driven in Playwright; covered by unit tests + the verified publish + local template generation rather than faked E2E. The existing WASM-host journeys exercise the app still boots with the SW registered.

## Roadmap
Next PWA increments (same `Rask.Wasm.Browser` pattern): typed Web App Manifest API, richer offline (SDK `service-worker-assets.js` precache), Notifications, IndexedDB.