### PR TITLE
feat(interop): live geolocation tracking — IGeolocation.WatchAsync (shared)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Live geolocation tracking — `IGeolocation.WatchAsync` (`Rask.Core.Browser`)** — continuous position
+  updates (`navigator.geolocation.watchPosition`): `WatchAsync(Func<GeolocationPosition,Task> onPosition,
+  GeolocationOptions?)` returns an `IAsyncDisposable` and fires for the initial fix plus every update; the
+  browser **pushes** each fix to the C# handler via a static `[JSInvokable]`, so one implementation serves
+  **both** Server and WASM (rooted for the WASM trimmer). Pairs with the one-shot `GetCurrentPositionAsync`.
+  New `/browser/geolocation-watch` ("Live location") showcase page.
 - **Resize Observer (`IResizeObserver`, `Rask.Core.Browser`)** — be notified when an element's size changes,
   for container-responsive layouts or re-laying-out a canvas/chart (the sibling of `IIntersectionObserver`):
   `ObserveAsync(ElementRef element, Func<ResizeEntry,Task> onChange)` returns an `IAsyncDisposable` and fires

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -113,7 +113,7 @@ later step on the same pattern.
 | `IBrowserStorage` | `localStorage` / `sessionStorage` | `.Local` / `.Session` → `GetAsync`, `SetAsync`, `RemoveAsync`, `ClearAsync`, `KeyAsync`, `LengthAsync` |
 | `ICookies` | `document.cookie` | `GetAsync`, `SetAsync(name, value, CookieOptions?)`, `DeleteAsync`, `GetAllAsync` |
 | `IClipboard` | `navigator.clipboard` | `WriteTextAsync`, `ReadTextAsync` |
-| `IGeolocation` | `navigator.geolocation` | `GetCurrentPositionAsync(GeolocationOptions?)` → `GeolocationPosition` |
+| `IGeolocation` | `navigator.geolocation` | `GetCurrentPositionAsync(GeolocationOptions?)` → `GeolocationPosition`; `WatchAsync(Func<GeolocationPosition,Task>, …)` → `IAsyncDisposable` (live tracking) |
 | `IPermissions` | `navigator.permissions` | `QueryAsync(PermissionName)` → `PermissionState` |
 | `IVibration` | `navigator.vibrate` | `VibrateAsync(params int[])`, `CancelAsync` |
 | `IPageVisibility` | `document.visibilityState` | `GetStateAsync()` → `PageVisibility`, `IsHiddenAsync` |
@@ -172,10 +172,11 @@ transient activation has expired. The practical effect:
   visibility) is unaffected by activation and behaves identically on both transports.
 
 Most of these are one-shot request/response calls. **`IBroadcastChannel`**, **`IIntersectionObserver`**,
-and **`IResizeObserver`** are the exceptions — they're *subscriptions*: you open/observe (returning an
-`IAsyncDisposable`) and the browser **pushes** each change back to a C# handler (via a static
-`[JSInvokable]`, so one wiring works on both transports — the observers additionally hand the observed
-element across as an `ElementRef`). Open from a lifecycle hook and dispose on unmount; a handler
+**`IResizeObserver`**, and **`IGeolocation.WatchAsync`** are the exceptions — they're *subscriptions*: you
+open/observe/watch (returning an `IAsyncDisposable`) and the browser **pushes** each change back to a C#
+handler (via a static `[JSInvokable]`, so one wiring works on both transports — the observers additionally
+hand the observed element across as an `ElementRef`). Open from a lifecycle hook and dispose on unmount; a
+handler
 that updates state calls `StateHasChanged()` — the same pattern as subscribing to a background feed (it's a
 subscription, not a render/binding callback, so RASK026 doesn't apply).
 

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -129,7 +129,7 @@ they need a live user gesture or the installed-app instance the Server round-tri
 | --- | --- | --- |
 | **Share sheet** | `IShare` *(WASM)* | Hand a link/text to the OS share UI |
 | **Vibration** | `IVibration` | Haptic feedback (`VibrateAsync(200)`) |
-| **Geolocation** | `IGeolocation` | Current position |
+| **Geolocation** | `IGeolocation` | Current position (`GetCurrentPositionAsync`) + live tracking (`WatchAsync`) |
 | **Clipboard** | `IClipboard` | Copy/paste |
 | **Storage / Cookies** | `IBrowserStorage` / `ICookies` | Persist state on-device |
 | **Permissions** | `IPermissions` | Check before prompting |

--- a/samples/Rask.Example.Shared/Features/Browser/GeolocationWatchDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/GeolocationWatchDemo.cs
@@ -1,0 +1,74 @@
+using System.Globalization;
+using Rask.Core.Browser;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     <see cref="IGeolocation.WatchAsync" /> — live position tracking. Start watching and the browser
+///     pushes each fix to C#, which re-renders the readout (the handler calls <c>StateHasChanged()</c>,
+///     the sanctioned pushed-update pattern). Stop disposes the watch (<c>clearWatch</c>).
+/// </summary>
+public sealed class GeolocationWatchDemo(IGeolocation geolocation) : Component, IAsyncDisposable
+{
+    private static readonly CultureInfo Inv = CultureInfo.InvariantCulture;
+    private IAsyncDisposable? _watch;
+    private string? _location;
+    private int _fixes;
+    private string? _status;
+
+    protected override RenderResult Render() =>
+        Div(Class: "card shadow-sm border-0")[
+            Div(Class: "card-body")[
+                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                    _watch is null
+                        ? Button(Class: "btn btn-primary btn-sm", Id: "geowatch-start", OnClickAsync: Start)[
+                            "Start watching"]
+                        : Button(Class: "btn btn-outline-danger btn-sm", Id: "geowatch-stop", OnClickAsync: Stop)[
+                            "Stop"]
+                ],
+                Div(Class: "small text-secondary")[
+                    "Position: ", Code(Id: "geowatch-value")[_location ?? "(not watching)"],
+                    Span(Class: "ms-2", Id: "geowatch-fixes")[$"({_fixes} fix(es))"]
+                ],
+                Div(Class: "small text-secondary")["Status: ", Code(Id: "geowatch-status")[_status ?? "(idle)"]]
+            ]
+        ];
+
+    private async Task Start()
+    {
+        try
+        {
+            _watch = await geolocation.WatchAsync(pos =>
+            {
+                _fixes++;
+                _location = string.Create(Inv, $"lat {pos.Latitude:F4}, lon {pos.Longitude:F4} (±{pos.Accuracy:F0} m)");
+                StateHasChanged();
+                return Task.CompletedTask;
+            }, new GeolocationOptions { EnableHighAccuracy = true });
+            _status = "Watching — move the device to see updates";
+        }
+        catch (Exception ex)
+        {
+            _status = "Watch failed: " + ex.Message;
+        }
+    }
+
+    private async Task Stop()
+    {
+        if (_watch is not null)
+        {
+            await _watch.DisposeAsync();
+            _watch = null;
+        }
+
+        _status = "Stopped";
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_watch is not null)
+        {
+            await _watch.DisposeAsync();
+        }
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Browser/GeolocationWatchPage.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/GeolocationWatchPage.cs
@@ -1,0 +1,26 @@
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>Browser APIs section — <see cref="GeolocationWatchDemo" /> (<c>IGeolocation.WatchAsync</c>).</summary>
+[Route("browser/geolocation-watch")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class GeolocationWatchPage : Component
+{
+    protected override RenderResult Head => Title()["Live location — Browser APIs — Rask"];
+
+    protected override RenderResult Render() =>
+    [
+        PageHeader.Render(
+            "Live location",
+            "Track the device's position live via IGeolocation.WatchAsync (navigator.geolocation.watchPosition) "
+            + "— for maps or fitness. The browser pushes each fix to C#, which re-renders. Dispose to stop. "
+            + "Works on both transports; requires location permission."),
+        CodeSample(
+            ["GeolocationWatchDemo.cs"],
+            Notes: "WatchAsync(handler, options?) returns an IAsyncDisposable and fires for the initial fix "
+                + "plus each update; the handler is pushed from JS via a static [JSInvokable]. Pairs with the "
+                + "one-shot GetCurrentPositionAsync.",
+            Result: GeolocationWatchDemo())
+    ];
+}

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -78,7 +78,8 @@ public sealed class ShowcaseLayout(Navigator nav, RouteState route, IEnumerable<
         (Features.Routes.VisualViewportPage(), "Visual viewport", "bi-aspect-ratio-fill", "Browser APIs", null),
         (Features.Routes.BroadcastChannelPage(), "Broadcast channel", "bi-broadcast-pin", "Browser APIs", null),
         (Features.Routes.IntersectionObserverPage(), "Intersection observer", "bi-binoculars", "Browser APIs", null),
-        (Features.Routes.ResizeObserverPage(), "Resize observer", "bi-arrows-angle-expand", "Browser APIs", null)
+        (Features.Routes.ResizeObserverPage(), "Resize observer", "bi-arrows-angle-expand", "Browser APIs", null),
+        (Features.Routes.GeolocationWatchPage(), "Live location", "bi-geo", "Browser APIs", null)
     ];
 
     private bool _drawerOpen;

--- a/src/Rask.Core/Browser/Geolocation.cs
+++ b/src/Rask.Core/Browser/Geolocation.cs
@@ -1,11 +1,41 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.JSInterop;
 
 namespace Rask.Core.Browser;
 
 /// <summary>
+///     Infrastructure for <see cref="IGeolocation.WatchAsync" /> — routes a pushed <c>watchPosition</c> fix
+///     back to the right C# handler by watch id. <b>Not for application use;</b> invoked only by the
+///     framework's <c>__raskGeoWatch</c> JS helper via <c>window.DotNet.invokeMethodAsync</c>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class GeolocationWatchInterop
+{
+    private static int _nextId;
+    private static readonly ConcurrentDictionary<int, Func<GeolocationPosition, Task>> Handlers = new();
+
+    internal static int Register(Func<GeolocationPosition, Task> handler)
+    {
+        var id = Interlocked.Increment(ref _nextId);
+        Handlers[id] = handler;
+        return id;
+    }
+
+    internal static void Unregister(int id) => Handlers.TryRemove(id, out _);
+
+    /// <summary>Infrastructure. Invoked by the JS bridge for each position fix; do not call.</summary>
+    [JSInvokable("RaskGeolocationFix")]
+    public static Task Fix(int id, GeolocationPosition position) =>
+        Handlers.TryGetValue(id, out var handler) ? handler(position) : Task.CompletedTask;
+}
+
+/// <summary>
 ///     Default <see cref="IGeolocation" />, backed by the unified <see cref="IJSRuntime" />.
 ///     <c>navigator.geolocation.getCurrentPosition</c> is callback-based, so the call goes through the
-///     framework's <c>__raskApi.geolocation</c> helper, which wraps it in a Promise.
+///     framework's <c>__raskApi.geolocation</c> helper, which wraps it in a Promise; <c>watchPosition</c>
+///     pushes each fix through the <c>__raskGeoWatch</c> helper into <see cref="GeolocationWatchInterop" />.
 /// </summary>
 public sealed class Geolocation(IJSRuntime js) : IGeolocation
 {
@@ -20,5 +50,51 @@ public sealed class Geolocation(IJSRuntime js) : IGeolocation
             options.EnableHighAccuracy,
             options.TimeoutMs,
             options.MaximumAgeMs);
+    }
+
+    /// <inheritdoc />
+    // Root GeolocationWatchInterop's [JSInvokable] for the WASM trimmer — it's reached only via the JS
+    // DotNetDispatcher (reflection), so without this the Fix method could be trimmed away.
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(GeolocationWatchInterop))]
+    public async ValueTask<IAsyncDisposable> WatchAsync(
+        Func<GeolocationPosition, Task> onPosition, GeolocationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(onPosition);
+        options ??= new GeolocationOptions();
+
+        var id = GeolocationWatchInterop.Register(onPosition);
+        try
+        {
+            await js.InvokeVoidAsync(
+                "__raskGeoWatch.watch",
+                id,
+                options.EnableHighAccuracy,
+                options.TimeoutMs,
+                options.MaximumAgeMs);
+        }
+        catch
+        {
+            GeolocationWatchInterop.Unregister(id);
+            throw;
+        }
+
+        return new Watch(js, id);
+    }
+
+    private sealed class Watch(IJSRuntime js, int id) : IAsyncDisposable
+    {
+        private bool _disposed;
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            GeolocationWatchInterop.Unregister(id);
+            await js.InvokeVoidAsync("__raskGeoWatch.clear", id);
+        }
     }
 }

--- a/src/Rask.Core/Browser/IGeolocation.cs
+++ b/src/Rask.Core/Browser/IGeolocation.cs
@@ -14,7 +14,7 @@ namespace Rask.Core.Browser;
 /// <remarks>
 ///     Requires a secure context (HTTPS or localhost) and the user's permission. A denial, timeout, or
 ///     unavailable sensor surfaces as a <see cref="JSException" /> from the awaited task — catch it.
-///     Continuous tracking (<c>watchPosition</c>) is not yet wrapped.
+///     For continuous tracking use <see cref="WatchAsync" /> (<c>watchPosition</c>).
 /// </remarks>
 public interface IGeolocation
 {
@@ -24,4 +24,15 @@ public interface IGeolocation
     /// </summary>
     /// <param name="options">Accuracy, timeout, and cache-age preferences; <c>null</c> uses defaults.</param>
     ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null);
+
+    /// <summary>
+    ///     Starts tracking the device's position (<c>navigator.geolocation.watchPosition</c>), invoking
+    ///     <paramref name="onPosition" /> for the initial fix and every subsequent update. The browser
+    ///     <b>pushes</b> each fix to the handler, so a handler that updates state should call
+    ///     <c>StateHasChanged()</c> (a subscription, not a render/binding callback). Dispose the returned
+    ///     handle to stop watching (<c>clearWatch</c>).
+    /// </summary>
+    /// <param name="onPosition">Invoked for each position fix.</param>
+    /// <param name="options">Accuracy, timeout, and cache-age preferences; <c>null</c> uses defaults.</param>
+    ValueTask<IAsyncDisposable> WatchAsync(Func<GeolocationPosition, Task> onPosition, GeolocationOptions? options = null);
 }

--- a/src/Rask.Core/Resources/rask-api.js
+++ b/src/Rask.Core/Resources/rask-api.js
@@ -174,6 +174,50 @@ window.__raskApi = window.__raskApi || {
     }
 };
 
+// Geolocation watch (driven by IGeolocation.WatchAsync). navigator.geolocation.watchPosition pushes each
+// fix; forward it to C# via the shared window.DotNet.invokeMethodAsync shim (static [JSInvokable]
+// GeolocationWatchInterop.Fix in Rask.Core). The fix object matches the GeolocationPosition record (same
+// shape as __raskApi.geolocation). Errors are ignored so the watch keeps trying.
+window.__raskGeoWatch = window.__raskGeoWatch || (() => {
+    const watches = new Map();
+    return {
+        watch: (id, enableHighAccuracy, timeoutMs, maximumAgeMs) => {
+            if (!navigator.geolocation) {
+                return;
+            }
+            const opts = {enableHighAccuracy: !!enableHighAccuracy, maximumAge: maximumAgeMs || 0};
+            if (timeoutMs != null) {
+                opts.timeout = timeoutMs;
+            }
+            const watchId = navigator.geolocation.watchPosition(
+                (pos) => {
+                    const c = pos.coords;
+                    window.DotNet.invokeMethodAsync("Rask.Core", "RaskGeolocationFix", id, {
+                        latitude: c.latitude,
+                        longitude: c.longitude,
+                        accuracy: c.accuracy,
+                        altitude: c.altitude,
+                        altitudeAccuracy: c.altitudeAccuracy,
+                        heading: c.heading,
+                        speed: c.speed,
+                        timestampMs: pos.timestamp
+                    });
+                },
+                () => { /* error: keep watching, surface nothing */ },
+                opts);
+            watches.set(id, watchId);
+        },
+        clear: (id) => {
+            const watchId = watches.get(id);
+            if (watchId == null) {
+                return;
+            }
+            watches.delete(id);
+            navigator.geolocation.clearWatch(watchId);
+        }
+    };
+})();
+
 // Resize Observer (driven by IResizeObserver). Each observation is a live ResizeObserver held here under
 // the C#-minted id; each size change is pushed back to C# via the shared window.DotNet.invokeMethodAsync
 // shim (static [JSInvokable] ResizeInterop.Changed in Rask.Core). The element is resolved from an

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -184,6 +184,50 @@ window.__raskApi = window.__raskApi || {
     }
 };
 
+// Geolocation watch (driven by IGeolocation.WatchAsync). navigator.geolocation.watchPosition pushes each
+// fix; forward it to C# via the shared window.DotNet.invokeMethodAsync shim (static [JSInvokable]
+// GeolocationWatchInterop.Fix in Rask.Core). The fix object matches the GeolocationPosition record (same
+// shape as __raskApi.geolocation). Errors are ignored so the watch keeps trying.
+window.__raskGeoWatch = window.__raskGeoWatch || (() => {
+    const watches = new Map();
+    return {
+        watch: (id, enableHighAccuracy, timeoutMs, maximumAgeMs) => {
+            if (!navigator.geolocation) {
+                return;
+            }
+            const opts = {enableHighAccuracy: !!enableHighAccuracy, maximumAge: maximumAgeMs || 0};
+            if (timeoutMs != null) {
+                opts.timeout = timeoutMs;
+            }
+            const watchId = navigator.geolocation.watchPosition(
+                (pos) => {
+                    const c = pos.coords;
+                    window.DotNet.invokeMethodAsync("Rask.Core", "RaskGeolocationFix", id, {
+                        latitude: c.latitude,
+                        longitude: c.longitude,
+                        accuracy: c.accuracy,
+                        altitude: c.altitude,
+                        altitudeAccuracy: c.altitudeAccuracy,
+                        heading: c.heading,
+                        speed: c.speed,
+                        timestampMs: pos.timestamp
+                    });
+                },
+                () => { /* error: keep watching, surface nothing */ },
+                opts);
+            watches.set(id, watchId);
+        },
+        clear: (id) => {
+            const watchId = watches.get(id);
+            if (watchId == null) {
+                return;
+            }
+            watches.delete(id);
+            navigator.geolocation.clearWatch(watchId);
+        }
+    };
+})();
+
 // Resize Observer (driven by IResizeObserver). Each observation is a live ResizeObserver held here under
 // the C#-minted id; each size change is pushed back to C# via the shared window.DotNet.invokeMethodAsync
 // shim (static [JSInvokable] ResizeInterop.Changed in Rask.Core). The element is resolved from an

--- a/tests/Rask.Core.Tests/Interop/GeolocationWatchTests.cs
+++ b/tests/Rask.Core.Tests/Interop/GeolocationWatchTests.cs
@@ -1,0 +1,69 @@
+using Rask.Core.Browser;
+
+namespace Rask.Core.Tests.Interop;
+
+public class GeolocationWatchTests
+{
+    private static GeolocationPosition Pos(double lat, double lng) =>
+        new(lat, lng, 10, null, null, null, null, 0);
+
+    [Fact]
+    public async Task Watch_PassesOptions_ToHelper()
+    {
+        var js = new FakeJsRuntime();
+        var opts = new GeolocationOptions { EnableHighAccuracy = true, TimeoutMs = 5000, MaximumAgeMs = 1000 };
+
+        await new Geolocation(js).WatchAsync(_ => Task.CompletedTask, opts);
+
+        var args = js.ArgsFor("__raskGeoWatch.watch");
+        Assert.IsType<int>(args![0]);     // id
+        Assert.Equal(true, args[1]);      // enableHighAccuracy
+        Assert.Equal(5000, args[2]);      // timeoutMs
+        Assert.Equal(1000, args[3]);      // maximumAgeMs
+    }
+
+    [Fact]
+    public async Task Fix_RoutesPosition_ToTheRegisteredHandler()
+    {
+        var js = new FakeJsRuntime();
+        GeolocationPosition? got = null;
+        await new Geolocation(js).WatchAsync(p =>
+        {
+            got = p;
+            return Task.CompletedTask;
+        });
+        var id = (int)js.ArgsFor("__raskGeoWatch.watch")![0]!;
+
+        await GeolocationWatchInterop.Fix(id, Pos(51.5, -0.12));
+
+        Assert.NotNull(got);
+        Assert.Equal(51.5, got!.Latitude);
+        Assert.Equal(-0.12, got.Longitude);
+    }
+
+    [Fact]
+    public async Task Dispose_ClearsWatch_AndStopsRouting()
+    {
+        var js = new FakeJsRuntime();
+        var hits = 0;
+        var watch = await new Geolocation(js).WatchAsync(_ =>
+        {
+            hits++;
+            return Task.CompletedTask;
+        });
+        var id = (int)js.ArgsFor("__raskGeoWatch.watch")![0]!;
+
+        await watch.DisposeAsync();
+        await GeolocationWatchInterop.Fix(id, Pos(1, 1)); // unregistered → no-op
+
+        Assert.Equal([id], js.ArgsFor("__raskGeoWatch.clear"));
+        Assert.Equal(0, hits);
+    }
+
+    [Fact]
+    public async Task Watch_NullHandler_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await new Geolocation(new FakeJsRuntime()).WatchAsync(null!));
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -939,6 +939,12 @@ public abstract partial class SharedSmokeTests
         // box's current size, so the readout shows pixels (proves the round-trip) on every host.
         await SideAsync("Resize observer", "Resize observer");
         await Expect(Page.Locator("#resize-value")).ToContainTextAsync("px", contains);
+
+        // Live location — geolocation watch (push). The context grants permission + a fixed fix (51.5074),
+        // so starting the watch pushes that position via watchPosition → static [JSInvokable] → handler.
+        await SideAsync("Live location", "Live location");
+        await Page.Locator("#geowatch-start").ClickAsync();
+        await Expect(Page.Locator("#geowatch-value")).ToContainTextAsync("51.5", contains);
     }
 
     // In-session navigation to an unknown route (client pushState + popstate — the same signal


### PR DESCRIPTION
## Summary

Adds **`IGeolocation.WatchAsync`** — continuous position tracking (`navigator.geolocation.watchPosition`), for maps/navigation/fitness. Extends the existing `IGeolocation` (whose remarks already said "continuous tracking is not yet wrapped") and pairs with the one-shot `GetCurrentPositionAsync`. **Shared** — both transports.

```csharp
protected override async Task OnRenderedAsync(bool first)
{
    if (!first) return;
    _watch = await geolocation.WatchAsync(pos => { _here = pos; StateHasChanged(); return Task.CompletedTask; });
}
public async ValueTask DisposeAsync() { if (_watch is not null) await _watch.DisposeAsync(); }
```

- `WatchAsync(Func<GeolocationPosition,Task> onPosition, GeolocationOptions? options = null)` → `IAsyncDisposable`
- Fires for the initial fix and every subsequent update; dispose to `clearWatch`.

Reuses the push pattern from the recent observer PRs: each fix is **pushed** via a static `[JSInvokable]` (`GeolocationWatchInterop.Fix`, routed by id) over `window.DotNet.invokeMethodAsync` — one implementation for both transports, `[DynamicDependency]`-rooted for the WASM trimmer (verified — `RaskGeolocationFix` survives in the published webcil). Reuses the existing `GeolocationPosition` record (already in `RaskBrowserJsonContext`). A handler updating state calls the thread-safe `StateHasChanged()` (the sanctioned background-subscription pattern).

## Showcase
New `/browser/geolocation-watch` page — **"Live location"** in the sidebar (the label avoids the word "Geolocation" so it doesn't substring-collide with the existing "Geolocation" entry in the journey matcher). `GeolocationWatchDemo` + `GeolocationWatchPage` with `CodeSample`: Start/Stop tracking, with a live position readout + fix counter. Shared-journey step.

## Docs / AI artifacts
`docs/js-interop.md` (the `IGeolocation` row + the "these are subscriptions" note), `docs/pwa.md`, `CHANGELOG`. (`IGeolocation` was already in `llms.txt`/`AGENTS.md` — this adds a method, not a new service.)

## Testing
- **Unit**: `GeolocationWatchTests` (4 cases) via the Core `FakeJsRuntime` — watch passes the options; `Fix` routes the position to the right handler by id; dispose clears + stops routing; null-handler guard.
- **E2E**: the shared journey navigates to "Live location", starts the watch, and asserts the pushed fix (`51.5…`, the context's fixed geolocation) lands in the readout — i.e. the **watchPosition → `[JSInvokable]` → handler → `StateHasChanged` → re-render** round-trip, on **Server and WASM** (the context already grants geolocation for the existing one-shot demo).
- `dotnet format` clean · `Rask.slnx -warnaserror` clean · Core green (1669) · Wasm green (111) · `dotnet publish -c Release` **trim-clean** with the `[JSInvokable]` preserved.

## Benchmarks
Not applicable — no render-hotpath or live-runtime code changed.