### PR TITLE
test(templates): guard the --pwa template symbol and scaffolding

### DIFF
--- a/tests/Rask.Generators.Tests/TemplateConfigTests.cs
+++ b/tests/Rask.Generators.Tests/TemplateConfigTests.cs
@@ -18,6 +18,13 @@ public class TemplateConfigTests
         ["rask-wasm-hosted", "Company.RaskWasmHosted"]
     ];
 
+    // The `--pwa` option only exists on the WASM templates (a Server app can't be an offline PWA).
+    public static IEnumerable<object[]> PwaTemplates =>
+    [
+        ["rask-wasm"],
+        ["rask-wasm-hosted"]
+    ];
+
     [Theory]
     [MemberData(nameof(Templates))]
     public void TemplateJson_IsValid_WithExpectedIdentity(string shortName, string sourceName)
@@ -82,6 +89,61 @@ public class TemplateConfigTests
             .GetFiles(dir, "Program.cs", SearchOption.AllDirectories)
             .Any(f => File.ReadAllText(f).Contains("#if (auth)", StringComparison.Ordinal));
         Assert.True(hasAuthConditional, $"{shortName}: no Program.cs with a //#if (auth) block");
+    }
+
+    [Theory]
+    [MemberData(nameof(PwaTemplates))]
+    public void PwaSymbol_IsBoolean_DefaultsFalse(string shortName)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(TemplatesRoot, shortName, ".template.config", "template.json")));
+
+        var pwa = doc.RootElement.GetProperty("symbols").GetProperty("pwa");
+        Assert.Equal("parameter", pwa.GetProperty("type").GetString());
+        Assert.Equal("bool", pwa.GetProperty("datatype").GetString());
+        Assert.Equal("false", pwa.GetProperty("defaultValue").GetString());
+    }
+
+    [Theory]
+    [MemberData(nameof(PwaTemplates))]
+    public void Sources_ExcludeIcon_WhenPwaOff(string shortName)
+    {
+        using var doc = JsonDocument.Parse(File.ReadAllText(
+            Path.Combine(TemplatesRoot, shortName, ".template.config", "template.json")));
+
+        var modifiers = doc.RootElement.GetProperty("sources")
+            .EnumerateArray()
+            .SelectMany(s => s.GetProperty("modifiers").EnumerateArray());
+
+        var pwaExclusion = modifiers.FirstOrDefault(m =>
+            m.TryGetProperty("condition", out var c) && c.GetString() == "(!pwa)");
+
+        Assert.True(pwaExclusion.ValueKind == JsonValueKind.Object,
+            "expected a (!pwa) source modifier");
+        var excludes = pwaExclusion.GetProperty("exclude").EnumerateArray().Select(e => e.GetString());
+        Assert.Contains(excludes, e => e!.Contains("icon.svg", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [MemberData(nameof(PwaTemplates))]
+    public void PwaScaffolding_Exists_AndProgramAndIndexHavePwaConditionals(string shortName)
+    {
+        var dir = Path.Combine(TemplatesRoot, shortName);
+
+        // The icon.svg excluded by (!pwa) must actually be present to ship.
+        Assert.NotEmpty(Directory.GetFiles(dir, "icon.svg", SearchOption.AllDirectories));
+
+        // Program.cs wires UseManifest behind //#if (pwa) blocks the engine strips when pwa is off.
+        var hasProgramConditional = Directory
+            .GetFiles(dir, "Program.cs", SearchOption.AllDirectories)
+            .Any(f => File.ReadAllText(f).Contains("#if (pwa)", StringComparison.Ordinal));
+        Assert.True(hasProgramConditional, $"{shortName}: no Program.cs with a //#if (pwa) block");
+
+        // index.html registers the service worker behind a <!--#if (pwa)--> block.
+        var hasIndexConditional = Directory
+            .GetFiles(dir, "index.html", SearchOption.AllDirectories)
+            .Any(f => File.ReadAllText(f).Contains("#if (pwa)", StringComparison.Ordinal));
+        Assert.True(hasIndexConditional, $"{shortName}: no index.html with a <!--#if (pwa)--> block");
     }
 
     // Walks up from the test assembly to the repo root (the directory holding Rask.slnx) so the


### PR DESCRIPTION
## Summary

The `--pwa` option on the WASM templates (`rask-wasm`, `rask-wasm-hosted`) had **no test guard**, unlike `--auth`. A renamed `pwa` symbol, a dropped `(!pwa)` icon exclusion, or a missing `//#if (pwa)` / `<!--#if (pwa)-->` block would only surface when a human ran `dotnet new` — silent scaffolding regressions. This closes the one gap exploration found in the otherwise-complete PWA infrastructure.

Adds three `[Theory]` cases over a new `PwaTemplates` member-data set (the two WASM templates only — a Server app can't be an offline PWA), mirroring the existing auth guards in `TemplateConfigTests`:

- `PwaSymbol_IsBoolean_DefaultsFalse` — `pwa` is a `bool` parameter defaulting `false`.
- `Sources_ExcludeIcon_WhenPwaOff` — a `(!pwa)` source modifier excludes `icon.svg`.
- `PwaScaffolding_Exists_AndProgramAndIndexHavePwaConditionals` — `icon.svg` ships, `Program.cs` carries a `//#if (pwa)` block, and `index.html` carries the SW-registration `<!--#if (pwa)-->` block.

## Testing

- `dotnet test tests/Rask.Generators.Tests --filter FullyQualifiedName~TemplateConfigTests` → **18 passed** (12 existing + 6 new).
- `dotnet format --verify-no-changes` clean; build is warnings-as-errors / analyzer-clean.

## Changelog

Pure internal test coverage (no user-facing change), so no CHANGELOG entry per Keep a Changelog conventions.