### PR TITLE
fix(interop): isolate device notification fan-out (HID/Bluetooth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,12 @@ them until tagged releases begin.
   Server and WASM. New `/browser/mutation` showcase page.
 
 ### Fixed
+- **Device notification fan-out hardening (`IHid` / `IBluetooth`)** — when several watchers subscribe to one
+  HID device / BLE characteristic, each pushed value/report is now delivered as its own `byte[]` copy (a
+  mutating callback can no longer corrupt another subscriber's bytes), and each callback is isolated so one
+  that throws no longer starves the rest of the fan-out. Documented that a Bluetooth device handle is shared
+  per physical device (`RequestDeviceAsync`/`GetDevicesAsync` return the same instance — dispose from a single
+  owner).
 - **Web Serial (`ISerial`) byte marshalling** — `WriteAsync` and the inbound read loop sent raw `byte[]`
   across the WASM JS bridge, which doesn't carry byte arrays (the base `JSRuntime`'s `ByteArrayJsonConverter`
   expects Blazor's byte-array side-channel that the bridge doesn't implement), so writes shipped no usable

--- a/src/Rask.Wasm/Browser/Bluetooth.cs
+++ b/src/Rask.Wasm/Browser/Bluetooth.cs
@@ -72,7 +72,12 @@ public interface IBluetooth
     /// </summary>
     ValueTask<IBluetoothDevice?> RequestDeviceAsync(BluetoothRequestOptions options);
 
-    /// <summary>Returns the devices the user has already granted access to (no prompt).</summary>
+    /// <summary>
+    ///     Returns the devices the user has already granted access to (no prompt). A given physical device maps
+    ///     to a single shared handle — <see cref="RequestDeviceAsync" /> and this method return the <em>same</em>
+    ///     <see cref="IBluetoothDevice" /> instance for it, so dispose it from a single owner (disposing one
+    ///     reference releases the device for all).
+    /// </summary>
     ValueTask<IReadOnlyList<IBluetoothDevice>> GetDevicesAsync();
 }
 
@@ -170,8 +175,9 @@ public static class BluetoothInterop
             }
 
             data ??= Convert.FromBase64String(base64);
-            // Isolate subscribers — one throwing callback must not starve the others on a shared notification.
-            try { await w.OnValue(data); }
+            // Each subscriber gets its own copy (a mutating callback must not corrupt the others' bytes), and
+            // one throwing callback must not starve the rest of the fan-out.
+            try { await w.OnValue((byte[])data.Clone()); }
             catch { /* a subscriber's own failure is its concern */ }
         }
     }

--- a/src/Rask.Wasm/Browser/Hid.cs
+++ b/src/Rask.Wasm/Browser/Hid.cs
@@ -133,7 +133,7 @@ public static class HidInterop
     [JSInvokable("RaskHidInputReport")]
     public static async Task Input(int deviceId, int reportId, string base64)
     {
-        HidInputReport? report = null;
+        byte[]? decoded = null;
         foreach (var w in Watchers.Values)
         {
             if (w.DeviceId != deviceId)
@@ -141,8 +141,12 @@ public static class HidInterop
                 continue;
             }
 
-            report ??= new HidInputReport(reportId, Convert.FromBase64String(base64));
-            await w.OnReport(report);
+            decoded ??= Convert.FromBase64String(base64);
+            // Each subscriber gets its own copy (a mutating callback must not corrupt the others' bytes), and
+            // one throwing callback must not starve the rest of the fan-out.
+            var report = new HidInputReport(reportId, (byte[])decoded.Clone());
+            try { await w.OnReport(report); }
+            catch { /* a subscriber's own failure is its concern */ }
         }
     }
 
@@ -155,7 +159,8 @@ public static class HidInterop
             // Remove on unplug (the device is gone) so the callback — and the component it captures — is released.
             if (entry.Value.DeviceId == deviceId && Watchers.TryRemove(entry.Key, out var w) && w.OnDisconnect is not null)
             {
-                await w.OnDisconnect();
+                try { await w.OnDisconnect(); }
+                catch { /* isolate subscribers */ }
             }
         }
     }

--- a/tests/Rask.Wasm.Tests/Browser/BluetoothTests.cs
+++ b/tests/Rask.Wasm.Tests/Browser/BluetoothTests.cs
@@ -215,6 +215,31 @@ public class BluetoothTests
     }
 
     [Fact]
+    public async Task NotificationFanout_GivesEachSubscriberOwnCopy_AndIsolatesExceptions()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskBluetooth.getCharacteristic", 8);
+        var device = await RequestDeviceAsync(js);
+        var ch = await device.GetCharacteristicAsync("svc", "chr");
+        byte[]? survivor = null;
+        // First subscriber mutates its copy and throws — must not corrupt or starve the second.
+        await ch.WatchAsync(v =>
+        {
+            v[0] = 0xFF;
+            throw new InvalidOperationException("boom");
+        });
+        await ch.WatchAsync(v =>
+        {
+            survivor = v;
+            return Task.CompletedTask;
+        });
+
+        await BluetoothInterop.Value(8, Convert.ToBase64String([1, 2, 3]));
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, survivor);
+    }
+
+    [Fact]
     public async Task NullArgs_Throw()
     {
         var js = new FakeJsRuntime();

--- a/tests/Rask.Wasm.Tests/Browser/HidTests.cs
+++ b/tests/Rask.Wasm.Tests/Browser/HidTests.cs
@@ -186,6 +186,30 @@ public class HidTests
     }
 
     [Fact]
+    public async Task InputFanout_GivesEachWatcherOwnCopy_AndIsolatesExceptions()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskHid.requestDevices", new[] { new HidDeviceHandshake(6, SampleInfo) });
+        var device = (await new Hid(js).RequestDevicesAsync())[0];
+        byte[]? survivor = null;
+        // First watcher mutates its copy and throws — must not corrupt or starve the second.
+        await device.WatchInputReportsAsync(r =>
+        {
+            r.Data[0] = 0xFF;
+            throw new InvalidOperationException("boom");
+        });
+        await device.WatchInputReportsAsync(r =>
+        {
+            survivor = r.Data;
+            return Task.CompletedTask;
+        });
+
+        await HidInterop.Input(6, 1, Convert.ToBase64String([1, 2, 3]));
+
+        Assert.Equal(new byte[] { 1, 2, 3 }, survivor); // own copy, untouched by the other's mutation/throw
+    }
+
+    [Fact]
     public async Task NullArgs_Throw()
     {
         var js = new FakeJsRuntime();


### PR DESCRIPTION
## Summary

Hardens the pushed-notification fan-out in **`IHid`** and **`IBluetooth`** — the residual findings from the Web Bluetooth review (#197), applied to both wrappers since they share the pattern.

When several watchers subscribe to one HID device or one BLE characteristic, the inbound value was decoded **once** and the same `byte[]` handed to every subscriber, and a callback that **threw** aborted the fan-out loop — silently starving later subscribers. Now:

- **Each subscriber gets its own `byte[]` copy** — a callback that mutates the buffer in place can no longer corrupt another subscriber's bytes.
- **Each callback is isolated in `try/catch`** — one that throws no longer starves the rest of the fan-out (HID's disconnect fan-out is isolated too; Bluetooth's value fan-out already had `try/catch` and now also copies).
- **Documented** that a Bluetooth device handle is shared per physical device — `RequestDeviceAsync`/`GetDevicesAsync` return the **same** `IBluetoothDevice` instance, so dispose it from a single owner.

## Changes
- `src/Rask.Wasm/Browser/Hid.cs` — `HidInterop.Input` copies per subscriber + per-callback `try/catch`; `Disconnected` per-callback `try/catch`.
- `src/Rask.Wasm/Browser/Bluetooth.cs` — `BluetoothInterop.Value` copies per subscriber; `GetDevicesAsync` doc notes the shared-handle / single-owner contract.
- `tests/Rask.Wasm.Tests/Browser/{HidTests,BluetoothTests}.cs` — each adds a fan-out isolation test (one subscriber mutates its copy **and** throws; the other still receives its own untouched bytes).
- `CHANGELOG.md` — Fixed entry.

## Not changed (deliberately)
- The legacy `writeValue()` without-response fallback and the O(N) watcher-dispatch scan flagged in review are left as-is: Chromium — the only BLE/HID target — exposes the explicit `writeValueWithResponse`/`writeValueWithoutResponse` methods (so the fallback is effectively dead there), and the active-watcher count is tiny.

## Testing
- `dotnet format` clean; `dotnet build -warnaserror` clean.
- Full Wasm suite **197** green (incl. the 2 new isolation tests); WASM `dotnet publish -c Release` emits **zero IL/trim warnings**.
- C#-only change (no JS), so the spliced client is unchanged.

## Benchmarks
N/A — interop callback path, not render/runtime hot-path.