### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/.claude/skills/cut-release/SKILL.md
+++ b/.claude/skills/cut-release/SKILL.md
@@ -45,8 +45,9 @@ git tag vX.Y.Z
 git push origin vX.Y.Z                          # push ONLY the tag — main is already up to date
 ```
 `release.yml` (on `push: tags: v*`) runs the unit gate, the sharded E2E matrix, then packs the
-six NuGets (`Rask.Server`, `Rask.Wasm`, `Rask.Wasm.Hosting`, `Rask.Validation.DataAnnotations`,
-`Rask.Validation.FluentValidation`, `Rask.Templates`), pushes them to nuget.org, and creates the
+eight NuGets (`Rask.Server`, `Rask.Wasm`, `Rask.Wasm.Hosting`, `Rask.Validation.DataAnnotations`,
+`Rask.Validation.FluentValidation`, `Rask.Templates`, `Rask.Bootstrap`, `Rask.WebPush`), pushes them
+to nuget.org, and creates the
 GitHub release. Watch it (`run watch` on the bare run id, not a job, exits on the run's conclusion):
 ```bash
 gh run list --workflow=release.yml -L 1     # grab the run id
@@ -54,7 +55,7 @@ gh run watch <run-id> --exit-status
 ```
 
 ## 5. Verify
-- GitHub release created with the six `.nupkg` assets (`gh release view vX.Y.Z`).
+- GitHub release created with the eight `.nupkg` assets (`gh release view vX.Y.Z`).
 - Packages visible on nuget.org at version `X.Y.Z`.
 - To undo a mistaken tag **before** publish completes: `git push --delete origin vX.Y.Z`. Once
   `release.yml` has pushed to nuget.org, the version is permanent (nuget rejects a re-push of the

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -171,6 +171,12 @@ jobs:
       - name: Pack Rask.Templates
         run: dotnet pack src/Rask.Templates/Rask.Templates.csproj -c Release --no-build -o ./artifacts
 
+      - name: Pack Rask.Bootstrap
+        run: dotnet pack src/Rask.Bootstrap/Rask.Bootstrap.csproj -c Release --no-build -o ./artifacts
+
+      - name: Pack Rask.WebPush
+        run: dotnet pack src/Rask.WebPush/Rask.WebPush.csproj -c Release --no-build -o ./artifacts
+
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-30
+
 ### Added
 - **Rask.Bootstrap — typed Bootstrap 5.3 component library (new optional package).** Discoverable C#
   factories that emit correct Bootstrap markup, with typed enums replacing stringly-typed variants
@@ -242,8 +244,6 @@ them until tagged releases begin.
   one `IUsbDevice` handle tore down a device a second handle still held (subsequent calls threw "device handle
   is closed or unknown"). The shared device is now ref-counted — it closes only once every handle to it has
   been disposed.
-
-## [0.11.0] - 2026-06-29
 
 ### Added
 - **[Browser APIs overview](docs/browser-apis.md)** — a new guide mapping the whole typed browser-API

--- a/src/Rask.Bootstrap/Rask.Bootstrap.csproj
+++ b/src/Rask.Bootstrap/Rask.Bootstrap.csproj
@@ -19,6 +19,13 @@
     <!-- This library is consumed from WASM (net10.0-browser) too, so it must stay free of any
          ASP.NET Core framework reference — the Razor SDK does not add one unless Razor components
          are used, and none are. -->
+
+    <!-- Provide build/Rask.Bootstrap.props ourselves instead of letting the Static Web Assets SDK
+         auto-generate it, so the same file can carry our global usings AND import the static-web-asset
+         wiring. The SDK still emits build/Microsoft.AspNetCore.StaticWebAssets*.props (which our file
+         imports) plus the buildMultiTargeting/buildTransitive shims that import our build/ file.
+         Without this, both files claim build/Rask.Bootstrap.props and pack fails with NU5118. -->
+    <StaticWebAssetsDisableProjectBuildPropsFileGeneration>true</StaticWebAssetsDisableProjectBuildPropsFileGeneration>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.Bootstrap/build/Rask.Bootstrap.props
+++ b/src/Rask.Bootstrap/build/Rask.Bootstrap.props
@@ -1,7 +1,20 @@
 <Project>
+
+  <!-- The Static Web Assets SDK normally auto-generates this build/$(PackageId).props to import the
+       static-web-asset wiring. We provide it ourselves (StaticWebAssetsDisableProjectBuildPropsFileGeneration
+       in the csproj) so we can ALSO contribute the global usings below — the SDK-documented extension
+       point. These imports must stay, or NuGet consumers won't get the bundled CSS/icons. They are
+       guarded by Exists() because Directory.Build.props imports THIS file in-repo (for the usings),
+       where the sibling SDK props live only in the packed layout, not on disk. -->
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssets.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssets.props')"/>
+  <Import Project="$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssetEndpoints.props"
+          Condition="Exists('$(MSBuildThisFileDirectory)Microsoft.AspNetCore.StaticWebAssetEndpoints.props')"/>
+
   <ItemGroup>
     <Using Include="Rask.Bootstrap"/>
     <!-- Auto-generated Bs* component factories live in Rask.Bootstrap.Generated. -->
     <Using Include="Rask.Bootstrap.Generated" Static="true"/>
   </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
Cuts **v0.11.0** and publishes the two new opt-in packages that had reached `main` but were never wired into the release pipeline:

- **`Rask.Bootstrap`** (typed Bootstrap 5.3 components, #184)
- **`Rask.WebPush`** (server-side Web Push sender, #199)

### Changes
- **`release.yml`** — add `Pack Rask.Bootstrap` and `Pack Rask.WebPush` steps. The publish job now packs **eight** NuGets; `dotnet nuget push`/`gh release create` already glob `./artifacts/*.nupkg`, so no other workflow edits are needed.
- **`CHANGELOG.md`** — promote `[Unreleased]` → `[0.11.0] - 2026-06-30`, collapsing a stale duplicate `[0.11.0]` header (never tagged) into the single dated section.
- **`cut-release` skill** — "six NuGets" → "eight NuGets".
- **`src/Rask.Bootstrap` packaging fix (release-blocker)** — `dotnet pack` failed with **NU5118** because both our hand-written `build/Rask.Bootstrap.props` and the Static Web Assets SDK's auto-generated file claimed `build/Rask.Bootstrap.props`. Per the SDK's documented extension point, we set `StaticWebAssetsDisableProjectBuildPropsFileGeneration` and import the static-web-asset props from our own file — which keeps the global usings so external consumers still get the `Bs*` factories in scope. CI never caught this because only `release.yml` runs `dotnet pack` (on tag).

### Testing
- `dotnet pack` of both new packages → valid `.nupkg`s (Bootstrap now succeeds; package contains `lib/net10.0/Rask.Bootstrap.dll`, the bundled `staticwebassets/` CSS/icons/fonts, and a `build/Rask.Bootstrap.props` carrying **both** the static-asset imports and the global usings).
- `Rask.Bootstrap.Tests` — 44/44 pass.
- Full warnings-as-errors build + unit gate + E2E matrix run here on CI.

### Release steps (after merge)
Tag the merged commit `v0.11.0` and push the tag to trigger `release.yml`.