### PR TITLE
ci(release): serialize solution build to avoid WASM copy race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build (no WASM bundle)
-        run: dotnet build Rask.slnx -c Release --no-restore -p:RaskWasm=false -p:WasmBuildNative=false
+        run: dotnet build Rask.slnx -c Release --no-restore -p:RaskWasm=false -p:WasmBuildNative=false -m:1
 
       - name: Unit & integration tests
         run: >-
@@ -101,7 +101,7 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build
-        run: dotnet build Rask.slnx -c Release --no-restore
+        run: dotnet build Rask.slnx -c Release --no-restore -m:1
 
       - name: E2E journey (${{ matrix.host }})
         # Namespace-anchored so the leading dot prevents substring collisions
@@ -151,7 +151,7 @@ jobs:
         run: dotnet restore Rask.slnx
 
       - name: Build
-        run: dotnet build Rask.slnx -c Release --no-restore
+        run: dotnet build Rask.slnx -c Release --no-restore -m:1
 
       - name: Pack Rask.Server
         run: dotnet pack src/Rask.Server/Rask.Server.csproj -c Release --no-build -o ./artifacts


### PR DESCRIPTION
## Summary
The `v0.11.0` release run failed twice on the same parallel-build race in `release.yml` — `MSB3026: Rask.Core.dll ... being used by another process` → `MSB3030: ... not found` — when multiple WASM hosts build the shared `Rask.Core`/`Rask.Wasm` projects concurrently. Because an e2e shard's build failed, the `publish` job was gated off, so **nothing was published** (the tag was deleted and will be re-cut).

`ci.yml` already passes `-m:1` on its build steps for exactly this reason, which is why PR CI is reliable. This brings `release.yml` in line.

## Changes
- Add `-m:1` (serial MSBuild) to all three `release.yml` build steps: `unit`, `e2e`, and `publish`.

## Testing
- No code change; mirrors the already-proven `ci.yml` configuration. The release pipeline itself re-runs on the re-pushed `v0.11.0` tag after merge.