### PR TITLE
feat(examples): render the repo guides on-site (Guides section)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Examples site — on-site Guides (the repo's `docs/*.md` rendered in the showcase).** A new
+  **Guides** section renders the framework's narrative documentation in-app via a reusable `Markdown`
+  component (Markdig, with the rendered HTML cached). `/guides` lists the guides as grouped cards and
+  `/guides/{slug}` renders one; the guides' relative `*.md` cross-links are rewritten to SPA-routed
+  `/guides/{slug}` anchors, and links up to the repo root point at GitHub. High-traffic demo pages gain
+  a "See also" row linking to the matching guide. The guides are embedded from `docs/`, so they never
+  drift from the repo. (Markdig renders at build/runtime on the host; the WASM showcase still publishes
+  trim-clean.)
 - **Rask.Bootstrap navigation primitives — `BsNavbar`, `BsNav`, `BsNavItem`.** Typed navbar/nav
   containers; each `BsNavItem` with an `Href` renders a core `NavLink`, so links are SPA-routed
   (`data-rask-nav`) and light up their `.active` class by matching the current route — no client JS,

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,6 +9,7 @@
     <PackageVersion Include="ColorCode.HTML" Version="2.0.15" />
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
+    <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.9" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />

--- a/samples/Rask.Example.Server/wwwroot/global.css
+++ b/samples/Rask.Example.Server/wwwroot/global.css
@@ -363,3 +363,135 @@ button, a, [role="button"] {
         overscroll-behavior: contain;
     }
 }
+
+/* GuidePage: the Markdig-rendered guide HTML (docs/*.md) is injected verbatim via Raw(), so it carries
+   no scope id — these rules live here (global) and are anchored under .markdown-body so they never leak
+   into the rest of the app. Readable defaults; the broader visual pass refines them. */
+.markdown-body {
+    max-width: 52rem;
+    line-height: 1.7;
+    color: #24232b;
+}
+
+.markdown-body h1 {
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.markdown-body h2 {
+    font-weight: 700;
+    font-size: 1.5rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.markdown-body h3 {
+    font-weight: 600;
+    font-size: 1.2rem;
+    margin-top: 1.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.markdown-body p,
+.markdown-body ul,
+.markdown-body ol {
+    margin-bottom: 1rem;
+}
+
+.markdown-body li {
+    margin-bottom: 0.25rem;
+}
+
+.markdown-body a {
+    color: var(--rask-accent);
+    text-decoration: none;
+}
+
+.markdown-body a:hover {
+    text-decoration: underline;
+}
+
+.markdown-body pre {
+    background: #1f1d2b;
+    color: #e7e3ff;
+    padding: 1rem 1.2rem;
+    border-radius: 0.6rem;
+    overflow-x: auto;
+    margin-bottom: 1.25rem;
+    font-size: 0.85rem;
+    line-height: 1.55;
+}
+
+.markdown-body pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    font-size: inherit;
+}
+
+.markdown-body :not(pre) > code {
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.08rem 0.34rem;
+    border-radius: 4px;
+    font-size: 0.86em;
+}
+
+.markdown-body blockquote {
+    border-left: 4px solid var(--rask-accent);
+    background: var(--rask-accent-soft);
+    margin: 0 0 1.25rem;
+    padding: 0.6rem 1rem;
+    border-radius: 0 0.4rem 0.4rem 0;
+}
+
+.markdown-body blockquote > :last-child {
+    margin-bottom: 0;
+}
+
+.markdown-body table {
+    width: 100%;
+    margin-bottom: 1.25rem;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+}
+
+.markdown-body th,
+.markdown-body td {
+    border: 1px solid var(--bs-border-color);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+}
+
+.markdown-body th {
+    background: var(--bs-body-tertiary, #f6f4fb);
+    font-weight: 600;
+}
+
+.markdown-body img {
+    max-width: 100%;
+}
+
+.markdown-body hr {
+    margin: 2rem 0;
+    border: 0;
+    border-top: 1px solid var(--bs-border-color);
+}
+
+/* SeeAlso: small accent pills linking a demo page to its guide(s). A dedicated class (not Bootstrap's
+   .badge) so it never collides with demo markup that the page itself renders. */
+.see-also-link {
+    display: inline-block;
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.18rem 0.6rem;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.see-also-link:hover {
+    background: var(--rask-accent);
+    color: #fff;
+}

--- a/samples/Rask.Example.Shared/Features/Context/ContextPage.cs
+++ b/samples/Rask.Example.Shared/Features/Context/ContextPage.cs
@@ -29,6 +29,7 @@ public sealed class ContextPage : Component
                 "Reading is explicit (like React's useContext) rather than an attribute, so it composes anywhere a component renders — even outside a form or route."],
             Li()[
                 "Change detection rides the normal render walk: when the value changes the providing component re-renders, and consumers (which bypass the cache) re-read on the way down."]
-        ]
+        ],
+        SeeAlso.Guides(("composition", "Composition"))
     ];
 }

--- a/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
+++ b/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
@@ -1,0 +1,89 @@
+using System.Reflection;
+
+namespace Rask.Example.Shared.Features;
+
+// The curated set of repo guides surfaced on-site, in display order and grouped. Each entry's Slug is a
+// docs/{slug}.md file embedded into this assembly (see the EmbeddedResource glob in the csproj). Shared
+// by GuidesIndexPage (the cards) and the sidebar's Guides section so the two never drift.
+public sealed record GuideEntry(string Slug, string Title, string Blurb, string Icon, string Group);
+
+public static class GuideCatalog
+{
+    public static readonly GuideEntry[] All =
+    [
+        new("getting-started", "Getting started", "Scaffold a project and build your first component.",
+            "bi-rocket-takeoff", "Start here"),
+        new("best-practices", "Best practices", "Production patterns for state, forms, security, and perf.",
+            "bi-stars", "Start here"),
+        new("migration-from-blazor", "Migrating from Blazor", "Concept mapping and behavioural differences.",
+            "bi-arrow-left-right", "Start here"),
+
+        new("routing", "Routing", "Route attributes, params, nested layouts, type-safe URLs.",
+            "bi-signpost-2", "Core"),
+        new("composition", "Composition", "Children, fragments, callbacks, context, virtualize.",
+            "bi-diagram-3", "Core"),
+        new("lifecycle", "Lifecycle", "Mount, props-changed, rendered, unmount, cancellation.",
+            "bi-arrow-repeat", "Core"),
+        new("forms", "Forms & validation", "Two-way binding, Form<T>, inline/DataAnnotations/Fluent.",
+            "bi-input-cursor-text", "Core"),
+        new("js-interop", "JavaScript interop", "Scoped CSS/JS, element refs, IJSRuntime, typed APIs.",
+            "bi-braces", "Core"),
+        new("browser-apis", "Browser APIs", "The typed wrappers over the platform's browser APIs.",
+            "bi-globe", "Core"),
+
+        new("bootstrap", "Bootstrap", "The typed Rask.Bootstrap component library.",
+            "bi-bootstrap", "Integration"),
+        new("authentication", "Authentication", "Cookie/JWT/OIDC on Server and WASM, route guards.",
+            "bi-shield-lock", "Integration"),
+        new("data-access", "Data access", "EF Core + SQLite, vertical slices, DDD patterns.",
+            "bi-database", "Integration"),
+        new("accessibility", "Accessibility", "ARIA, focus management, the img-alt analyzer.",
+            "bi-universal-access", "Integration"),
+        new("pwa", "Mobile & PWA", "Service workers, Web Push, offline, installable apps.",
+            "bi-phone", "Integration"),
+        new("observability", "Observability", "Logging, tracing, diagnostics.",
+            "bi-activity", "Integration"),
+        new("configuration", "Configuration", "App configuration and settings.",
+            "bi-sliders", "Integration"),
+
+        new("testing", "Testing", "Unit testing with Rask.TestSupport, event handlers, E2E.",
+            "bi-clipboard-check", "Advanced"),
+        new("building-form-controls", "Building form controls", "Author your own IFormControl<T>.",
+            "bi-tools", "Advanced"),
+        new("code-analysis", "Code analysis", "The analyzers and warnings-as-errors adoption.",
+            "bi-search", "Advanced"),
+        new("diagnostics", "Diagnostics", "Every RASK0xx descriptor, its trigger, and the fix.",
+            "bi-exclamation-diamond", "Advanced")
+    ];
+
+    public static readonly string[] GroupOrder = ["Start here", "Core", "Integration", "Advanced"];
+
+    public static string TitleFor(string slug)
+    {
+        foreach (var g in All)
+        {
+            if (g.Slug == slug)
+            {
+                return g.Title;
+            }
+        }
+
+        return slug;
+    }
+
+    // Reads the verbatim markdown for a guide. The docs/{slug}.md files are embedded as raskdoc/{slug}.md
+    // (see the EmbeddedResource glob in Rask.Example.Shared.csproj). Returns null for an unknown slug, so
+    // GuidePage can render a not-found state instead of a blank page.
+    public static string? ReadMarkdown(string slug)
+    {
+        var asm = typeof(GuideCatalog).Assembly;
+        using var stream = asm.GetManifestResourceStream($"raskdoc/{slug}.md");
+        if (stream is null)
+        {
+            return null;
+        }
+
+        using var reader = new StreamReader(stream);
+        return reader.ReadToEnd();
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Guides/GuidePage.cs
+++ b/samples/Rask.Example.Shared/Features/Guides/GuidePage.cs
@@ -1,0 +1,37 @@
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+// Renders one guide: docs/{slug}.md, embedded and read by GuideCatalog, rendered by the Markdown
+// component. The slug comes straight from the route, so /guides/routing renders docs/routing.md.
+[Route("guides/{slug}")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class GuidePage : Component
+{
+    [RouteParam] public string Slug { get; set; } = string.Empty;
+
+    protected override RenderResult Head => Title()[$"{GuideCatalog.TitleFor(Slug)} — Guides — Rask"];
+
+    protected override RenderResult Render()
+    {
+        var backLink = NavLink(Href: Features.Routes.GuidesIndexPage(), ActiveClass: "",
+            Class: Bs.Join(Display.InlineFlex(), Flex.Align(BsAlign.Center), Margin.Bottom(3),
+                Txt.DecorationNone, "small"))[
+            BsIcon(Name: BsIconName.ArrowLeft, Class: "me-1"), "All guides"
+        ];
+
+        var source = GuideCatalog.ReadMarkdown(Slug);
+        return source is null
+            ?
+            [
+                backLink,
+                BsAlert(Color: BsColor.Warning)[$"No guide found for “{Slug}”."]
+            ]
+            :
+            [
+                backLink,
+                Markdown(source)
+            ];
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Guides/GuidesIndexPage.cs
+++ b/samples/Rask.Example.Shared/Features/Guides/GuidesIndexPage.cs
@@ -1,0 +1,52 @@
+using Rask.Core.Components;
+using Rask.Core.Routing;
+
+namespace Rask.Example.Shared.Features;
+
+// The Guides landing page: the repo's user guides (docs/*.md) rendered on-site, grouped as cards.
+// Each card links to /guides/{slug}, where GuidePage renders the markdown with Markdig.
+[Route("guides")]
+[ParentRoute(typeof(ShowcaseLayout))]
+public sealed class GuidesIndexPage : Component
+{
+    protected override RenderResult Head => Title()["Guides — Rask"];
+
+    protected override RenderResult Render() =>
+    [
+        PageHeader.Render(
+            "Guides",
+            "Narrative documentation for the framework — the same guides that ship in the repo's docs/ "
+            + "folder, rendered here. Every concept also has a runnable demo in the sidebar; the guides "
+            + "link out to them."),
+        Div()[BuildGroups()]
+    ];
+
+    private IEnumerable<Child> BuildGroups()
+    {
+        foreach (var group in GuideCatalog.GroupOrder)
+        {
+            var cards = GuideCatalog.All.Where(g => g.Group == group).ToArray();
+            if (cards.Length == 0)
+            {
+                continue;
+            }
+
+            yield return H2(Class: Bs.Join(Font.Bold, Txt.Uppercase, Txt.Color(BsColor.Secondary),
+                Margin.Top(4), Margin.Bottom(3), "h6", "feature-section"))[group];
+            yield return Div(Class: "row g-3")[cards.Select(c => (Child)Card(c))];
+        }
+    }
+
+    private static Component Card(GuideEntry g) =>
+        Div(Class: "col-md-6 col-lg-4", Key: g.Slug)[
+            NavLink(Href: Features.Routes.GuidePage(g.Slug), ActiveClass: "", Class: "text-decoration-none")[
+                BsCard(Class: Bs.Join(Sizing.H(100), Border.None, Shadow.Sm, "feature-card"))[
+                    BsCardBody(Class: "p-4")[
+                        Div(Class: "feature-icon mb-3")[I(Class: $"bi {g.Icon}")],
+                        H3(Class: Bs.Join(Font.Semibold, Margin.Bottom(2), "h6", "text-body"))[g.Title],
+                        P(Class: Bs.Join(Txt.Color(BsColor.Secondary), Margin.Bottom(0), "small"))[g.Blurb]
+                    ]
+                ]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.cs
@@ -86,6 +86,8 @@ public sealed class HomePage(Navigator nav) : Component
                 Div(Class: "d-flex flex-wrap gap-2")[
                     BsButton(Color: BsColor.Light, Size: BsSize.Lg, Class: "fw-semibold", OnClick: () => nav.NavigateTo("/tags"))[BsIcon(Name: BsIconName.ArrowRight, Class: "me-2"),
                         "Start with Tags"],
+                    BsButton(Size: BsSize.Lg, Class: "btn-outline-light", OnClick: () => nav.NavigateTo(Routes.GuidesIndexPage()))[
+                        BsIcon(Name: BsIconName.Book, Class: "me-2"), "Read the guides"],
                     A("https://github.com/pal-tamas/rask",
                         "_blank",
                         Class: "btn btn-outline-light btn-lg")[BsIcon(Name: BsIconName.Github, Class: "me-2"),

--- a/samples/Rask.Example.Shared/Features/Lifecycle/LifecyclePage.cs
+++ b/samples/Rask.Example.Shared/Features/Lifecycle/LifecyclePage.cs
@@ -61,7 +61,8 @@ public sealed class LifecyclePage : Component
                 Code()["Console.Error"],
                 " and does NOT trigger a re-render — so a component stuck on a loading placeholder is usually a hook that threw."
             ]
-        ]
+        ],
+        SeeAlso.Guides(("lifecycle", "Lifecycle"))
     ];
 
     private void MountCycle()

--- a/samples/Rask.Example.Shared/Features/Routing/RoutingPage.cs
+++ b/samples/Rask.Example.Shared/Features/Routing/RoutingPage.cs
@@ -53,6 +53,7 @@ public sealed class RoutingPage(Navigator nav) : Component
         CodeSample(
             ["PathDisplay.cs"],
             Notes:
-            "The handler is just StateHasChanged — the framework already knows how to coalesce the resulting render with whatever else the dispatcher is processing. Always pair the subscribe with the unsubscribe in OnUnmount; otherwise the RouteState keeps a strong reference to the (already-unmounted) component.")
+            "The handler is just StateHasChanged — the framework already knows how to coalesce the resulting render with whatever else the dispatcher is processing. Always pair the subscribe with the unsubscribe in OnUnmount; otherwise the RouteState keeps a strong reference to the (already-unmounted) component."),
+        SeeAlso.Guides(("routing", "Routing"))
     ];
 }

--- a/samples/Rask.Example.Shared/Features/Tags/TagsPage.cs
+++ b/samples/Rask.Example.Shared/Features/Tags/TagsPage.cs
@@ -35,6 +35,7 @@ public sealed class TagsPage : Component
             ["TagsVoidDemo.cs"],
             Notes:
             "Void elements (Br, Hr, Img, Meta, Link, Input, …) have SelfClosing => true and never accept children.",
-            Result: TagsVoidDemo())
+            Result: TagsVoidDemo()),
+        SeeAlso.Guides(("getting-started", "Getting started"), ("best-practices", "Best practices"))
     ];
 }

--- a/samples/Rask.Example.Shared/Features/Validation/ValidationPage.cs
+++ b/samples/Rask.Example.Shared/Features/Validation/ValidationPage.cs
@@ -90,6 +90,7 @@ public sealed class ValidationPage : Component
             ["CustomAttributeDemo.cs"],
             Notes:
             "Custom ValidationAttribute subclasses flow through DataAnnotationsValidator with no extra opt-in — System.ComponentModel.DataAnnotations.Validator walks every attribute on the property at validation time. ValidationContext is constructed with the render-scoped IServiceProvider, so attributes can resolve services via ctx.GetService<T>() the same way ASP.NET Core / Blazor's DataAnnotationsValidator do it. Try \"admin\" (NotBanned, DI-resolved), a weak password (StrongPassword.IsValid), or mismatched confirm (MatchesProperty reads ObjectInstance).",
-            Result: CustomAttributeDemo())
+            Result: CustomAttributeDemo()),
+        SeeAlso.Guides(("forms", "Forms & validation"))
     ];
 }

--- a/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
+++ b/samples/Rask.Example.Shared/Rask.Example.Shared.csproj
@@ -22,6 +22,17 @@
 
   <ItemGroup>
     <PackageReference Include="ColorCode.HTML"/>
+    <PackageReference Include="Markdig"/>
+  </ItemGroup>
+
+  <!-- Embed the repo's user-facing guides (docs/*.md) so the showcase can render them on-site as the
+       Guides section. GuideContent reads them as raskdoc/{leaf} and renders to HTML with Markdig at
+       render time (cached). The bare leaf is the slug, e.g. raskdoc/routing.md -> /guides/routing. -->
+  <ItemGroup>
+    <EmbeddedResource Include="..\..\docs\*.md">
+      <LogicalName>raskdoc/%(Filename)%(Extension)</LogicalName>
+      <Link>Docs/%(Filename)%(Extension)</Link>
+    </EmbeddedResource>
   </ItemGroup>
 
   <!-- Embed the feature/shared sources verbatim so CodeSample can show the *real* file text

--- a/samples/Rask.Example.Shared/Shared/Markdown.cs
+++ b/samples/Rask.Example.Shared/Shared/Markdown.cs
@@ -1,0 +1,55 @@
+using System.Collections.Concurrent;
+using System.Text.RegularExpressions;
+using Markdig;
+
+namespace Rask.Example.Shared;
+
+// A reusable Markdown renderer: pass it markdown Source and it renders to HTML with Markdig and injects
+// the result via Raw() inside a .markdown-body wrapper (styled globally in wwwroot/global.css — the Raw
+// HTML carries no scope id, so those prose rules can't be component-scoped). The rendered HTML is cached
+// per source, so Markdig parses once. This is the showcase's prose component; it also rewrites the docs'
+// relative cross-links so they work in the SPA: a link to another guide ("foo.md", optionally with a
+// "#frag" or "dir/" prefix) becomes a SPA-routed /guides/{leaf} anchor (data-rask-nav), and a link up to
+// the repo root (../README.md) points at GitHub.
+public sealed partial class Markdown : Component
+{
+    // AutoIdentifiers gives every heading a stable id (anchor links); the advanced extensions cover
+    // tables, fenced code, task lists, etc. — the Markdown the guides actually use. Thread-safe, reused.
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .UseAutoIdentifiers()
+        .Build();
+
+    private static readonly ConcurrentDictionary<string, string> HtmlCache = new(StringComparer.Ordinal);
+
+    // Non-nullable + no initializer ⇒ the factory generator emits Source as a required positional
+    // parameter (mirrors CodeSample.Files). Rask assigns it after construction, so CS8618 is expected.
+#pragma warning disable CS8618
+    public string Source { get; set; }
+#pragma warning restore CS8618
+
+    protected override RenderResult Render() =>
+        Div(Class: "markdown-body")[Raw(HtmlCache.GetOrAdd(Source, Render))];
+
+    private static string Render(string source) =>
+        RewriteLinks(global::Markdig.Markdown.ToHtml(source, Pipeline));
+
+    private static string RewriteLinks(string html) =>
+        DocLinkRegex().Replace(html, m =>
+        {
+            var path = m.Groups["path"].Value;
+            var fragment = m.Groups["frag"].Value;
+            if (path.Contains("../", StringComparison.Ordinal))
+            {
+                var leaf = path[(path.LastIndexOf('/') + 1)..];
+                return $"href=\"https://github.com/pal-tamas/rask/blob/main/{leaf}{fragment}\"";
+            }
+
+            var slug = path[(path.LastIndexOf('/') + 1)..^".md".Length];
+            return $"href=\"/guides/{slug}{fragment}\" data-rask-nav";
+        });
+
+    // Matches href="…something.md" with an optional "#fragment", excluding absolute/remote URLs.
+    [GeneratedRegex("href=\"(?!https?:|/)(?<path>[^\"#]+\\.md)(?<frag>#[^\"]*)?\"")]
+    private static partial Regex DocLinkRegex();
+}

--- a/samples/Rask.Example.Shared/Shared/SeeAlso.cs
+++ b/samples/Rask.Example.Shared/Shared/SeeAlso.cs
@@ -1,0 +1,23 @@
+namespace Rask.Example.Shared;
+
+// A "See also" row that cross-links a demo page to its narrative guide(s). The heavy conceptual prose
+// lives in the rendered docs/*.md guides; a demo page stays demo-first and just points at the matching
+// guide with this one-liner. Each link is a SPA-routed NavLink to /guides/{slug}.
+internal static class SeeAlso
+{
+    public static Component Guides(params (string Slug, string Title)[] guides)
+    {
+        var children = new List<Child>
+        {
+            Span(Class: Bs.Join(Txt.Color(BsColor.Secondary), Font.Semibold))[
+                BsIcon(Name: BsIconName.JournalText, Class: "me-1"), "See also"
+            ]
+        };
+        children.AddRange(guides.Select(g => (Child)Rask.Core.Components.Generated.NavLink(
+            Href: Features.Routes.GuidePage(g.Slug), ActiveClass: "",
+            Class: Bs.Join("see-also-link", Txt.DecorationNone), Key: g.Slug)[g.Title]));
+
+        return Div(Class: Bs.Join(Display.Flex(), Flex.Wrap(), Flex.Align(BsAlign.Center), Flex.Gap(2),
+            Margin.Top(5), Padding.Top(3), Border.Top, "small"))[children];
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -180,6 +180,17 @@ public sealed class ShowcaseLayout(RouteState route, IEnumerable<ShowcaseNavEntr
         yield return ("Framework",
             Links.Concat(extraNav.Select(e => (e.Path, e.Label, e.Icon, e.Group, e.MatchPrefix))));
         yield return ("Bootstrap", BootstrapLinks);
+        yield return ("Guides", GuidesNav());
+    }
+
+    // The Guides section mirrors the GuideCatalog (docs/*.md rendered on-site), led by the index.
+    private static IEnumerable<(string Path, string Label, string Icon, string Group, string? MatchPrefix)> GuidesNav()
+    {
+        yield return (Features.Routes.GuidesIndexPage(), "All guides", "bi-book", "Overview", null);
+        foreach (var g in Features.GuideCatalog.All)
+        {
+            yield return (Features.Routes.GuidePage(g.Slug), g.Title, g.Icon, g.Group, null);
+        }
     }
 
     private List<Child> BuildSections()

--- a/samples/Rask.Example.Wasm/wwwroot/global.css
+++ b/samples/Rask.Example.Wasm/wwwroot/global.css
@@ -363,3 +363,135 @@ button, a, [role="button"] {
         overscroll-behavior: contain;
     }
 }
+
+/* GuidePage: the Markdig-rendered guide HTML (docs/*.md) is injected verbatim via Raw(), so it carries
+   no scope id — these rules live here (global) and are anchored under .markdown-body so they never leak
+   into the rest of the app. Readable defaults; the broader visual pass refines them. */
+.markdown-body {
+    max-width: 52rem;
+    line-height: 1.7;
+    color: #24232b;
+}
+
+.markdown-body h1 {
+    font-weight: 700;
+    margin-bottom: 1rem;
+}
+
+.markdown-body h2 {
+    font-weight: 700;
+    font-size: 1.5rem;
+    margin-top: 2.5rem;
+    margin-bottom: 0.75rem;
+    padding-bottom: 0.3rem;
+    border-bottom: 1px solid var(--bs-border-color);
+}
+
+.markdown-body h3 {
+    font-weight: 600;
+    font-size: 1.2rem;
+    margin-top: 1.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.markdown-body p,
+.markdown-body ul,
+.markdown-body ol {
+    margin-bottom: 1rem;
+}
+
+.markdown-body li {
+    margin-bottom: 0.25rem;
+}
+
+.markdown-body a {
+    color: var(--rask-accent);
+    text-decoration: none;
+}
+
+.markdown-body a:hover {
+    text-decoration: underline;
+}
+
+.markdown-body pre {
+    background: #1f1d2b;
+    color: #e7e3ff;
+    padding: 1rem 1.2rem;
+    border-radius: 0.6rem;
+    overflow-x: auto;
+    margin-bottom: 1.25rem;
+    font-size: 0.85rem;
+    line-height: 1.55;
+}
+
+.markdown-body pre code {
+    background: transparent;
+    color: inherit;
+    padding: 0;
+    font-size: inherit;
+}
+
+.markdown-body :not(pre) > code {
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.08rem 0.34rem;
+    border-radius: 4px;
+    font-size: 0.86em;
+}
+
+.markdown-body blockquote {
+    border-left: 4px solid var(--rask-accent);
+    background: var(--rask-accent-soft);
+    margin: 0 0 1.25rem;
+    padding: 0.6rem 1rem;
+    border-radius: 0 0.4rem 0.4rem 0;
+}
+
+.markdown-body blockquote > :last-child {
+    margin-bottom: 0;
+}
+
+.markdown-body table {
+    width: 100%;
+    margin-bottom: 1.25rem;
+    border-collapse: collapse;
+    font-size: 0.92rem;
+}
+
+.markdown-body th,
+.markdown-body td {
+    border: 1px solid var(--bs-border-color);
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+}
+
+.markdown-body th {
+    background: var(--bs-body-tertiary, #f6f4fb);
+    font-weight: 600;
+}
+
+.markdown-body img {
+    max-width: 100%;
+}
+
+.markdown-body hr {
+    margin: 2rem 0;
+    border: 0;
+    border-top: 1px solid var(--bs-border-color);
+}
+
+/* SeeAlso: small accent pills linking a demo page to its guide(s). A dedicated class (not Bootstrap's
+   .badge) so it never collides with demo markup that the page itself renders. */
+.see-also-link {
+    display: inline-block;
+    background: var(--rask-accent-soft);
+    color: var(--rask-accent);
+    padding: 0.18rem 0.6rem;
+    border-radius: 999px;
+    font-weight: 600;
+}
+
+.see-also-link:hover {
+    background: var(--rask-accent);
+    color: #fff;
+}

--- a/tests/Rask.Example.Shared.Tests/Pages/GuidesTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/GuidesTests.cs
@@ -1,0 +1,98 @@
+using Rask.Example.Shared;
+using Rask.Example.Shared.Features;
+using static Rask.Example.Shared.Generated;
+
+#pragma warning disable RASK014 // tests construct page components directly to drive ToHtml()
+
+namespace Rask.Example.Shared.Tests.Pages;
+
+// The Guides section: the Markdown component (renders docs/*.md with Markdig + SPA link rewriting),
+// the GuideCatalog (embedded-doc lookup), and the index/detail pages.
+public sealed class GuidesTests
+{
+    [Fact]
+    public void Markdown_RendersHeadingsAndInlineMarkup()
+    {
+        var html = Markdown("# Title\n\nHello **world**.").ToHtml();
+        Assert.Contains("<div class=\"markdown-body\">", html);
+        Assert.Contains("Title", html);
+        Assert.Contains("<strong>world</strong>", html);
+    }
+
+    [Fact]
+    public void Markdown_RewritesInternalGuideLink_ToSpaRoute() =>
+        Assert.Contains("href=\"/guides/routing\" data-rask-nav", Markdown("[Routing](routing.md)").ToHtml());
+
+    [Fact]
+    public void Markdown_RewritesFragmentAndSubdirLinks()
+    {
+        Assert.Contains("href=\"/guides/forms#binding\" data-rask-nav", Markdown("[x](forms.md#binding)").ToHtml());
+        Assert.Contains("href=\"/guides/live-rendering\" data-rask-nav",
+            Markdown("[x](architecture/live-rendering.md)").ToHtml());
+    }
+
+    [Fact]
+    public void Markdown_RewritesRepoRootLink_ToGitHub() =>
+        Assert.Contains("href=\"https://github.com/pal-tamas/rask/blob/main/README.md\"",
+            Markdown("[readme](../README.md)").ToHtml());
+
+    [Fact]
+    public void Markdown_LeavesExternalAndAnchorLinksUntouched()
+    {
+        var html = Markdown("[g](https://example.com) and [a](#section)").ToHtml();
+        Assert.Contains("href=\"https://example.com\"", html);
+        Assert.DoesNotContain("/guides/", html);
+    }
+
+    [Fact]
+    public void GuideCatalog_ReadMarkdown_KnownSlug_ReturnsContent()
+    {
+        var md = GuideCatalog.ReadMarkdown("routing");
+        Assert.NotNull(md);
+        Assert.Contains("# Routing", md);
+    }
+
+    [Fact]
+    public void GuideCatalog_ReadMarkdown_UnknownSlug_ReturnsNull() =>
+        Assert.Null(GuideCatalog.ReadMarkdown("does-not-exist"));
+
+    [Fact]
+    public void GuideCatalog_EveryCuratedSlug_HasAnEmbeddedDoc()
+    {
+        // Guards against a typo'd slug in the catalog: every listed guide must resolve to an embedded
+        // docs/{slug}.md, or its sidebar/index entry would 404.
+        foreach (var g in GuideCatalog.All)
+        {
+            Assert.NotNull(GuideCatalog.ReadMarkdown(g.Slug));
+        }
+    }
+
+    [Fact]
+    public void GuidePage_KnownSlug_RendersMarkdownBody()
+    {
+        var html = new GuidePage { Slug = "routing" }.ToHtml();
+        Assert.Contains("markdown-body", html);
+        Assert.Contains("All guides", html); // the back link
+    }
+
+    [Fact]
+    public void GuidePage_UnknownSlug_RendersNotFound()
+    {
+        var html = new GuidePage { Slug = "nope" }.ToHtml();
+        Assert.Contains("No guide found", html);
+        Assert.DoesNotContain("markdown-body", html);
+    }
+
+    [Fact]
+    public void GuidesIndexPage_RendersEveryGroupAndGuide()
+    {
+        var html = new GuidesIndexPage().ToHtml();
+        foreach (var group in GuideCatalog.GroupOrder)
+        {
+            Assert.Contains($">{group}<", html);
+        }
+
+        Assert.Contains("Getting started", html);
+        Assert.Contains("href=\"/guides/routing\"", html);
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -59,6 +59,7 @@ public abstract partial class SharedSmokeTests
         await WalkFormsPagesAsync();
         await WalkStylingDataAndAppPagesAsync();
         await WalkBootstrapPagesAsync();
+        await TestGuidesAsync();
 
         await TestInSessionNotFoundAsync();
 
@@ -140,6 +141,21 @@ public abstract partial class SharedSmokeTests
     // Bootstrap section (Rask.Bootstrap). Proves the package's CSS is actually served from
     // _content/Rask.Bootstrap and that the interactive components run with ZERO bootstrap.js —
     // the modal opens and closes purely through Rask's live runtime.
+    // The Guides section: the repo's docs/*.md rendered on-site by the Markdown component. Verify the
+    // index lists guides, a guide renders to a .markdown-body, and cross-links are SPA-routed.
+    private async Task TestGuidesAsync()
+    {
+        await SideAsync("All guides", "Guides");
+        // A guide card links to /guides/{slug}; open the Routing guide.
+        await Page.Locator("main a[href$='/guides/routing']").First.ClickAsync();
+        await Expect(Page.Locator("main .markdown-body h1").First).ToContainTextAsync("Routing",
+            new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
+        // The markdown's relative .md cross-links are rewritten to SPA-routed /guides/* anchors.
+        Assert.True(await Page.Locator(".markdown-body a[data-rask-nav][href^='/guides/']").CountAsync() > 0,
+            "expected the rendered guide to carry SPA-routed cross-links");
+        await AssertNoGlobalCrashAsync();
+    }
+
     private async Task WalkBootstrapPagesAsync()
     {
         // Navbar & nav — the typed navigation primitives. The demo's nav links render as SPA-routed


### PR DESCRIPTION
## Summary
Surfaces the framework's narrative documentation (the repo's `docs/*.md`) **inside the showcase**, so the examples site has real, readable docs next to the runnable demos. (Follow-up to #202.)

- **`Markdown` component** (Shared) — renders markdown `Source` with Markdig (rendered HTML cached) into a `.markdown-body` wrapper, rewriting the docs' relative `*.md` cross-links to SPA-routed `/guides/{slug}` anchors (`data-rask-nav`) and repo-root links to GitHub.
- **`GuidesIndexPage` (`/guides`)** lists the guides as grouped cards; **`GuidePage` (`/guides/{slug}`)** renders one (with a not-found state). **`GuideCatalog`** holds the curated list + embedded-doc lookup. The `docs/*.md` files are embedded, so the on-site guides never drift from the repo.
- A **Guides** sidebar section and a **Read the guides** hero button; high-traffic demo pages (Tags/Routing/Validation/Lifecycle/Context) gain a **See also** link to the matching guide.

## Design decisions (asked & confirmed)
- **Markdown/code-sample CSS stays global** (co-located under `.markdown-body` / `.sample-code`) rather than scoped — `Raw()`-injected HTML carries no scope id, so true scoping would need a framework `::deep` change, which we opted out of for now.
- **`Markdown(Source)` owns rendering** (Markdig pipeline + caching); `GuidePage` just feeds it the embedded doc text.

## Testing
- `dotnet format` clean; WASM `-warnaserror` analyzer-clean; **Release WASM publish trim-clean (zero IL warnings)** with Markdig in the bundle.
- Unit: `Markdown` rendering + link rewriting, `GuideCatalog` (every curated slug resolves to an embedded doc), and the index/detail pages. Full non-E2E suite green.
- E2E: the shared journey gains a **Guides** step (index → open a guide → assert `.markdown-body` + SPA cross-links). **Server and StandaloneWasm journeys pass.**

## Changelog
`[Unreleased]` updated. New dependency: **Markdig 1.3.2** (central package), referenced only by the Shared sample.