### PR TITLE
feat(examples): visual refresh — type system, ink surfaces, sharpened hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ them until tagged releases begin.
   `Match: "/realtime"`, `ActiveMatch: Prefix`).
 
 ### Changed
+- **Examples site — visual refresh.** A cohesive design pass over the showcase: a real type system
+  (Space Grotesk display, Inter body, JetBrains Mono for code and nav/section labels, loaded from the
+  font CDN), violet-tinted neutrals and a unified deep-ink code surface, a sharpened hero (mono eyebrow
+  + dot-grid texture), refined feature cards, an inset accent bar on the active nav item, and a pulsing
+  "Live result" marker on the code samples. Keeps the .NET-violet brand; motion respects
+  `prefers-reduced-motion`. No DOM/behaviour changes.
 - **Examples site (GitHub Pages) — redesigned, mobile-first navigation.** The left sidebar is now a
   fixed-width responsive offcanvas built from the `Bs*` navigation primitives: ~90 links are grouped
   into collapsible sections (only the active route's group is open by default), with a search filter at

--- a/samples/Rask.Example.Server/wwwroot/global.css
+++ b/samples/Rask.Example.Server/wwwroot/global.css
@@ -14,6 +14,22 @@
     --rask-accent-strong: #512BD4;
     --rask-accent-soft: #f1ebfd;
     --rask-gradient: linear-gradient(135deg, #7C3AED 0%, #512BD4 100%);
+
+    /* Violet-tinted neutrals — the whole surface leans into the brand hue instead of flat grey. */
+    --rask-ink: #14101f; /* deep violet-black: code panes, dark surfaces */
+    --rask-ink-2: #211b30; /* one step lifted from ink */
+    --rask-mist: #f7f5fc; /* page tint */
+    --rask-line: #e8e3f3; /* hairline */
+    --rask-body: #211c2b; /* body text */
+
+    /* Type system: Space Grotesk (display) / Inter (body) / JetBrains Mono (code). Routed through
+       Bootstrap's own font vars so every Bs component picks them up, plus --font-* for direct use. */
+    --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+    --font-body: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --bs-font-sans-serif: var(--font-body);
+    --bs-font-monospace: var(--font-mono);
+
     --nav-h: 56px;
 }
 
@@ -38,7 +54,23 @@
 }
 
 body {
-    font-feature-settings: "ss01", "cv11";
+    font-family: var(--font-body);
+    /* Inter stylistic sets: single-storey a (cv11), open digits — quiet, technical legibility. */
+    font-feature-settings: "cv11", "ss01";
+    color: var(--rask-body);
+    letter-spacing: -0.004em;
+}
+
+/* Headings carry the display face — tighter tracking, a touch more weight than Bootstrap's default. */
+h1, h2, h3, h4, h5, h6,
+.navbar-brand,
+.display-1, .display-2, .display-3, .display-4, .display-5, .display-6 {
+    font-family: var(--font-display);
+    letter-spacing: -0.022em;
+}
+
+.display-5 {
+    font-weight: 700;
 }
 
 a {
@@ -49,8 +81,8 @@ a:hover {
     color: var(--rask-accent-strong);
 }
 
-code, pre {
-    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+code, pre, .font-monospace {
+    font-family: var(--font-mono);
 }
 
 :not(pre) > code {
@@ -86,12 +118,17 @@ body {
     padding-right: env(safe-area-inset-right);
 }
 
+/* A faint violet wash on the page so the whole surface leans into the brand instead of flat grey. */
+body.bg-body-tertiary {
+    background-color: var(--rask-mist);
+}
+
 button, a, [role="button"] {
     touch-action: manipulation;
 }
 
 /* From ShowcaseLayout: lock body scroll while the mobile nav drawer (the responsive offcanvas) is
-   shown. :has() reaches up from the .show descendant; body is a shell tag so this rule belongs in the
+   shown — :has() reaches up from the .show descendant; body is a shell tag so this rule belongs in the
    global stylesheet (it could never be component-scoped). */
 @media (max-width: 767.98px) {
     body:has(.side-nav.show) {
@@ -233,14 +270,15 @@ button, a, [role="button"] {
 }
 
 .side-nav-section {
+    font-family: var(--font-mono);
     text-transform: uppercase;
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
     color: var(--rask-accent);
     padding: 0.75rem 0.5rem 0.25rem;
     margin-top: 0.5rem;
-    border-top: 1px solid var(--bs-border-color);
+    border-top: 1px solid var(--rask-line);
 }
 
 .side-nav-section:first-of-type {
@@ -257,10 +295,11 @@ button, a, [role="button"] {
     border: 0;
     background: transparent;
     color: var(--bs-secondary-color);
-    font-size: 0.72rem;
-    font-weight: 700;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.06em;
     padding: 0.5rem 0.5rem 0.35rem;
     border-radius: 0.4rem;
     text-align: left;
@@ -297,9 +336,9 @@ button, a, [role="button"] {
     min-height: 40px;
     padding: 0.45rem 0.6rem;
     border-radius: 0.5rem;
-    color: #333;
+    color: var(--rask-body);
     font-size: 0.9rem;
-    transition: background-color 120ms ease, color 120ms ease;
+    transition: background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
 }
 
 .side-nav-link:hover {
@@ -307,10 +346,12 @@ button, a, [role="button"] {
     color: var(--rask-accent-strong);
 }
 
+/* Active: the soft brand fill plus an inset accent bar on the leading edge. */
 .side-nav-link.active {
     background: var(--rask-accent-soft);
     color: var(--rask-accent);
     font-weight: 600;
+    box-shadow: inset 3px 0 0 var(--rask-accent);
 }
 
 .side-nav-link .bi {
@@ -414,14 +455,15 @@ button, a, [role="button"] {
 }
 
 .markdown-body pre {
-    background: #1f1d2b;
+    background: var(--rask-ink);
     color: #e7e3ff;
     padding: 1rem 1.2rem;
-    border-radius: 0.6rem;
+    border-radius: 0.7rem;
     overflow-x: auto;
     margin-bottom: 1.25rem;
     font-size: 0.85rem;
-    line-height: 1.55;
+    line-height: 1.6;
+    border: 1px solid rgba(124, 58, 237, 0.18);
 }
 
 .markdown-body pre code {

--- a/samples/Rask.Example.Shared/App.cs
+++ b/samples/Rask.Example.Shared/App.cs
@@ -19,6 +19,13 @@ public sealed class App : Component
         // Brand favicon (the purple bolt). Served from the app's own origin; PathBase keeps
         // it correct under a reverse-proxy prefix (Server) or sub-path deploy (WASM).
         Link(Rel: "icon", Type: "image/svg+xml", Href: LiveOptions.PathBase + "/img/rask-mark.svg"),
+        // The showcase type system: Space Grotesk (display), Inter (body), JetBrains Mono (code) — see
+        // the --font-* tokens in global.css. Preconnect to the font CDN so the swap lands fast.
+        Link(Rel: "preconnect", Href: "https://fonts.googleapis.com"),
+        Link(Rel: "preconnect", Href: "https://fonts.gstatic.com", CrossOrigin: "anonymous"),
+        Link(Rel: "stylesheet",
+            Href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700"
+                + "&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"),
         // Bootstrap 5.3 + Bootstrap Icons, delivered by the Rask.Bootstrap package as static web
         // assets under _content/Rask.Bootstrap (PathBase-aware). This dogfoods the package's own
         // BootstrapStyles() helper instead of vendoring the CSS per app.

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.cs
@@ -74,6 +74,7 @@ public sealed class HomePage(Navigator nav) : Component
         Div(Class: "p-4 p-md-5 mb-4 rounded-3 hero-card")[
             Div(Class: "container-fluid py-3")[
                 Div(Class: "hero-logo mb-4")[RaskLogo.Mark(76, "heroBolt")],
+                Div(Class: "hero-eyebrow")["C# UI framework"],
                 H1(Class: "display-5 fw-bold mb-3")[
                     "The Rask framework, ",
                     Span(Class: "hero-accent")["one page at a time."]

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.css
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.css
@@ -1,21 +1,36 @@
+/* The hero is the thesis: a deep violet field with a precise dot-grid (a nod to the framework's
+   grid-of-components rendering) and a single soft light source. */
 .hero-card {
     position: relative;
     overflow: hidden;
     background: var(--rask-gradient);
     border: 0;
+    border-radius: 1.4rem !important;
     color: #fff;
-    box-shadow: 0 18px 40px -18px rgba(81, 43, 212, 0.65);
+    box-shadow: 0 28px 70px -30px rgba(81, 43, 212, 0.7);
 }
 
-/* Soft radial glow in the top-right corner for depth. */
+/* Technical dot-grid, faded diagonally so it reads as texture, not pattern. */
+.hero-card::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background-image: radial-gradient(rgba(255, 255, 255, 0.13) 1px, transparent 1.4px);
+    background-size: 22px 22px;
+    -webkit-mask-image: linear-gradient(125deg, #000 0%, transparent 62%);
+    mask-image: linear-gradient(125deg, #000 0%, transparent 62%);
+    pointer-events: none;
+}
+
+/* Single soft light source, top-right. */
 .hero-card::after {
     content: "";
     position: absolute;
-    top: -40%;
-    right: -10%;
-    width: 60%;
-    height: 160%;
-    background: radial-gradient(circle, rgba(255, 255, 255, 0.18) 0%, rgba(255, 255, 255, 0) 70%);
+    top: -45%;
+    right: -8%;
+    width: 55%;
+    height: 170%;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0) 68%);
     pointer-events: none;
 }
 
@@ -24,55 +39,81 @@
     z-index: 1;
 }
 
+/* Eyebrow above the headline — names the category in the framework's own (monospace) register. */
+.hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 0.74rem;
+    font-weight: 500;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.72);
+    margin-bottom: 1.1rem;
+}
+
+.hero-eyebrow::before {
+    content: "";
+    width: 1.6rem;
+    height: 1px;
+    background: rgba(255, 255, 255, 0.5);
+}
+
 .hero-logo {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 5.5rem;
-    height: 5.5rem;
-    border-radius: 1.25rem;
-    background: #fff;
-    box-shadow: 0 10px 24px -10px rgba(0, 0, 0, 0.45);
+    width: 4.75rem;
+    height: 4.75rem;
+    border-radius: 1.1rem;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 14px 30px -12px rgba(0, 0, 0, 0.5);
 }
 
 .hero-accent {
-    color: #e9d5ff;
+    color: #d9c4ff;
 }
 
 .hero-lead {
-    color: rgba(255, 255, 255, 0.85);
+    color: rgba(255, 255, 255, 0.86);
+    line-height: 1.6;
 }
 
-/* Section dividers in the showcase index. A short accent rule sits to the left of the
-   uppercase label so the grouped grid reads as distinct bands. */
+/* Section dividers in the showcase index — a short accent rule before the uppercase label so the
+   grouped grid reads as labelled bands. */
 .feature-section {
-    letter-spacing: 0.06em;
+    letter-spacing: 0.1em;
     display: flex;
     align-items: center;
-    gap: 0.6rem;
+    gap: 0.65rem;
 }
 
 .feature-section::before {
     content: "";
-    width: 1.5rem;
+    width: 1.6rem;
     height: 2px;
     border-radius: 2px;
     background: var(--rask-accent);
 }
 
+/* Feature cards: a hairline that warms to the brand on hover, with a restrained lift. */
 .feature-card {
-    transition: transform 140ms ease, box-shadow 140ms ease;
+    border: 1px solid var(--rask-line) !important;
+    border-radius: 0.85rem !important;
+    transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
 }
 
 .feature-card:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 12px 24px -14px rgba(81, 43, 212, 0.55) !important;
+    transform: translateY(-3px);
+    border-color: rgba(124, 58, 237, 0.4) !important;
+    box-shadow: 0 16px 30px -18px rgba(81, 43, 212, 0.5) !important;
 }
 
 .feature-icon {
-    width: 2.4rem;
-    height: 2.4rem;
-    border-radius: 0.6rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 0.7rem;
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/samples/Rask.Example.Shared/Shared/CodeSample.cs
+++ b/samples/Rask.Example.Shared/Shared/CodeSample.cs
@@ -163,10 +163,7 @@ public sealed class CodeSample : Component
                     ]
                 ],
                 Div(Class: "col-md-5 sample-result-col p-4")[
-                    Div(Class: "sample-result-label")[
-                        BsIcon(Name: BsIconName.Eye, Class: "me-1"),
-                        "Live result"
-                    ],
+                    Div(Class: "sample-result-label")["Live result"],
                     Div(Class: "sample-result-body")[Result ?? Fragment()]
                 ]
             ]

--- a/samples/Rask.Example.Shared/Shared/CodeSample.css
+++ b/samples/Rask.Example.Shared/Shared/CodeSample.css
@@ -1,9 +1,10 @@
 .sample-card {
     overflow: hidden;
+    border-radius: 0.85rem !important;
 }
 
 .sample-code-col {
-    background: #1f1d2b;
+    background: var(--rask-ink);
     color: #e7e3ff;
     display: flex;
     flex-direction: column;
@@ -101,7 +102,7 @@
 .sample-code {
     padding: 1rem 1.2rem;
     font-size: 0.82rem;
-    line-height: 1.55;
+    line-height: 1.6;
     background: transparent;
     color: inherit;
     overflow-x: auto;
@@ -125,12 +126,40 @@
     flex-direction: column;
 }
 
+/* The "Live result" label reads as the output side of a C# → DOM pairing: the brand accent plus a
+   small pulsing dot, set in the mono face so it rhymes with the code header opposite it. */
 .sample-result-label {
-    font-size: 0.72rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
     text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--bs-secondary-color);
-    margin-bottom: 0.6rem;
+    letter-spacing: 0.12em;
+    color: var(--rask-accent);
+    margin-bottom: 0.75rem;
+}
+
+.sample-result-label::before {
+    content: "";
+    width: 0.45rem;
+    height: 0.45rem;
+    border-radius: 50%;
+    background: var(--rask-accent);
+    box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.5);
+    animation: sample-pulse 2.4s ease-out infinite;
+}
+
+@keyframes sample-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0.5); }
+    70% { box-shadow: 0 0 0 6px rgba(124, 58, 237, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(124, 58, 237, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .sample-result-label::before {
+        animation: none;
+    }
 }
 
 .sample-result-body {

--- a/samples/Rask.Example.Wasm/wwwroot/global.css
+++ b/samples/Rask.Example.Wasm/wwwroot/global.css
@@ -14,6 +14,22 @@
     --rask-accent-strong: #512BD4;
     --rask-accent-soft: #f1ebfd;
     --rask-gradient: linear-gradient(135deg, #7C3AED 0%, #512BD4 100%);
+
+    /* Violet-tinted neutrals — the whole surface leans into the brand hue instead of flat grey. */
+    --rask-ink: #14101f; /* deep violet-black: code panes, dark surfaces */
+    --rask-ink-2: #211b30; /* one step lifted from ink */
+    --rask-mist: #f7f5fc; /* page tint */
+    --rask-line: #e8e3f3; /* hairline */
+    --rask-body: #211c2b; /* body text */
+
+    /* Type system: Space Grotesk (display) / Inter (body) / JetBrains Mono (code). Routed through
+       Bootstrap's own font vars so every Bs component picks them up, plus --font-* for direct use. */
+    --font-display: "Space Grotesk", "Inter", system-ui, sans-serif;
+    --font-body: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+    --bs-font-sans-serif: var(--font-body);
+    --bs-font-monospace: var(--font-mono);
+
     --nav-h: 56px;
 }
 
@@ -38,7 +54,23 @@
 }
 
 body {
-    font-feature-settings: "ss01", "cv11";
+    font-family: var(--font-body);
+    /* Inter stylistic sets: single-storey a (cv11), open digits — quiet, technical legibility. */
+    font-feature-settings: "cv11", "ss01";
+    color: var(--rask-body);
+    letter-spacing: -0.004em;
+}
+
+/* Headings carry the display face — tighter tracking, a touch more weight than Bootstrap's default. */
+h1, h2, h3, h4, h5, h6,
+.navbar-brand,
+.display-1, .display-2, .display-3, .display-4, .display-5, .display-6 {
+    font-family: var(--font-display);
+    letter-spacing: -0.022em;
+}
+
+.display-5 {
+    font-weight: 700;
 }
 
 a {
@@ -49,8 +81,8 @@ a:hover {
     color: var(--rask-accent-strong);
 }
 
-code, pre {
-    font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+code, pre, .font-monospace {
+    font-family: var(--font-mono);
 }
 
 :not(pre) > code {
@@ -84,6 +116,11 @@ body {
     overscroll-behavior-y: none;
     padding-left: env(safe-area-inset-left);
     padding-right: env(safe-area-inset-right);
+}
+
+/* A faint violet wash on the page so the whole surface leans into the brand instead of flat grey. */
+body.bg-body-tertiary {
+    background-color: var(--rask-mist);
 }
 
 button, a, [role="button"] {
@@ -233,14 +270,15 @@ button, a, [role="button"] {
 }
 
 .side-nav-section {
+    font-family: var(--font-mono);
     text-transform: uppercase;
-    font-size: 0.7rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.14em;
     color: var(--rask-accent);
     padding: 0.75rem 0.5rem 0.25rem;
     margin-top: 0.5rem;
-    border-top: 1px solid var(--bs-border-color);
+    border-top: 1px solid var(--rask-line);
 }
 
 .side-nav-section:first-of-type {
@@ -257,10 +295,11 @@ button, a, [role="button"] {
     border: 0;
     background: transparent;
     color: var(--bs-secondary-color);
-    font-size: 0.72rem;
-    font-weight: 700;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 600;
     text-transform: uppercase;
-    letter-spacing: 0.04em;
+    letter-spacing: 0.06em;
     padding: 0.5rem 0.5rem 0.35rem;
     border-radius: 0.4rem;
     text-align: left;
@@ -297,9 +336,9 @@ button, a, [role="button"] {
     min-height: 40px;
     padding: 0.45rem 0.6rem;
     border-radius: 0.5rem;
-    color: #333;
+    color: var(--rask-body);
     font-size: 0.9rem;
-    transition: background-color 120ms ease, color 120ms ease;
+    transition: background-color 120ms ease, color 120ms ease, box-shadow 120ms ease;
 }
 
 .side-nav-link:hover {
@@ -307,10 +346,12 @@ button, a, [role="button"] {
     color: var(--rask-accent-strong);
 }
 
+/* Active: the soft brand fill plus an inset accent bar on the leading edge. */
 .side-nav-link.active {
     background: var(--rask-accent-soft);
     color: var(--rask-accent);
     font-weight: 600;
+    box-shadow: inset 3px 0 0 var(--rask-accent);
 }
 
 .side-nav-link .bi {
@@ -414,14 +455,15 @@ button, a, [role="button"] {
 }
 
 .markdown-body pre {
-    background: #1f1d2b;
+    background: var(--rask-ink);
     color: #e7e3ff;
     padding: 1rem 1.2rem;
-    border-radius: 0.6rem;
+    border-radius: 0.7rem;
     overflow-x: auto;
     margin-bottom: 1.25rem;
     font-size: 0.85rem;
-    line-height: 1.55;
+    line-height: 1.6;
+    border: 1px solid rgba(124, 58, 237, 0.18);
 }
 
 .markdown-body pre code {


### PR DESCRIPTION
Third and final PR of the examples-site improvement series (after #202 nav + #203 guides). Pure presentation — no framework behaviour changes.

## What changed
- **Type system** — Space Grotesk (display), Inter (body), JetBrains Mono (code), loaded via `App.cs` with preconnect. Routed through Bootstrap's `--bs-font-*` tokens so every component picks them up. Headings/brand/`.display-*` gain `letter-spacing:-0.022em`.
- **Ink surfaces** — new `--rask-ink`/`--rask-mist`/`--rask-line` tokens; dark code columns and markdown `<pre>` use `--rask-ink` with a violet hairline; body background is the soft `--rask-mist`.
- **Sharpened hero** — dot-grid `::before` via masked radial-gradient, mono uppercase eyebrow ("C# UI framework"), refined logo and feature cards (hairline + hover lift), accent rule on section headings.
- **Code samples** — "Live result" label restyled as a mono accent tag with a pulsing dot (`@keyframes sample-pulse`, honours `prefers-reduced-motion`).

## Ship gate
- `dotnet format` clean; `dotnet build -warnaserror` clean (analyzers).
- Full non-E2E unit suite green.
- WASM Release publish trim-clean — zero IL warnings.
- Server + StandaloneWasm E2E journeys pass.
- CHANGELOG `[Unreleased]` updated under Changed.