### PR TITLE
fix(live): guard .checked so a lagging re-render can't revert a clicked radio/checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **A radio/checkbox click is no longer reverted by a lagging live-diff render.** The client applied a
+  form control's `.checked` property unconditionally in both apply paths (the full morph and the diff
+  codec), while `.value` was already protected by a pending-edit guard. On a busy page a re-render the
+  runtime computed *before* the click reached it could land afterwards and flip the just-clicked
+  radio/checkbox back — most visibly on the slower standalone WASM bundle, where clicking a radio in
+  the Forms guide's group demo reverted to unchecked. `.checked` now uses the same guard: the change
+  dispatch records the pre-click state (the `checked` attribute a native click leaves untouched — for a
+  radio, the whole same-name group), and a lagging frame carrying that stale state is suppressed until
+  an authoritative frame (the echo of the new state, or a server correction) arrives and releases it.
 - **Live components embedded in a lazy child sequence are now reconciled (state persists).** A
   component built inside a *lazy* `IEnumerable<Child>` (a `yield`/LINQ pipeline passed to an element's
   `[...]` children indexer) was evaluated during serialization — after the owning component's

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -121,6 +121,7 @@ function syncFormProperty(el, name, value, isPresent) {
         if (raskShouldSuppressValue(el, value)) return;
         el.value = value;
     } else if (name === "checked" && tag === "INPUT") {
+        if (raskShouldSuppressChecked(el, !!isPresent)) return;
         el.checked = !!isPresent;
     } else if (name === "selected" && tag === "OPTION") {
         el.selected = !!isPresent;

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -114,6 +114,31 @@ function raskShouldSuppressValue(el, incoming) {
     return false;
 }
 
+// The `.checked` analogue of the value guard above. A native radio/checkbox click flips the
+// `.checked` PROPERTY but leaves the `checked` ATTRIBUTE untouched, so the change dispatch records
+// the pre-click attribute state (raskNotePendingChecked) — exactly as the value guard records the
+// pre-edit `value` attribute. A lagging frame the server computed BEFORE the click reached it still
+// carries that stale checked, so it's suppressed until an authoritative frame (the echo of the new
+// state OR a server correction) arrives with a different value and releases the guard. For a radio
+// the dispatch records the whole same-name group, so a stale frame can't re-check the previously
+// selected radio (which would natively uncheck the new one). Kept a hoisted `function` so the
+// spliced rask-dom.js can call it regardless of splice ordering — same rationale as the value guard.
+function _raskPendingChecked() {
+    return window.__raskPendingChecked || (window.__raskPendingChecked = new WeakMap());
+}
+
+function raskNotePendingChecked(el, supersededChecked) {
+    if (el) _raskPendingChecked().set(el, !!supersededChecked);
+}
+
+function raskShouldSuppressChecked(el, incoming) {
+    const map = _raskPendingChecked();
+    if (!el || !map.has(el)) return false;
+    if (map.get(el) === !!incoming) return true;   // lagging frame carrying the stale checked
+    map.delete(el);                                 // authoritative response — release the guard
+    return false;
+}
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -150,8 +175,11 @@ function morph(from, to) {
             // even when from.value already equals newVal; a still-pending user edit
             // (incoming !== the value the user committed) is left untouched.
             if (!raskShouldSuppressValue(from, newVal) && from.value !== newVal) from.value = newVal;
+            // raskShouldSuppressChecked runs first (like the value guard) so a confirmed echo can
+            // clear the guard even when from.checked already matches — a lagging frame carrying the
+            // pre-click checked is left to the browser's just-applied native state.
             const checked = to.hasAttribute("checked");
-            if (from.checked !== checked) from.checked = checked;
+            if (!raskShouldSuppressChecked(from, checked) && from.checked !== checked) from.checked = checked;
         }
     }
     // Skip JS-owned elements (marked data-rask-managed) — they're not part of

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -855,6 +855,19 @@
                 const sv = t.getAttribute("value");
                 raskNotePendingValue(t, sv === null ? "" : sv);
             }
+            // Same guard for the `.checked` property: record the PRE-CLICK checked (the `checked`
+            // attribute, which a native click leaves untouched) so a lagging re-render can't revert
+            // the just-committed selection before the server echoes it — see raskShouldSuppressChecked.
+            // For a radio, note the whole same-name group: a stale frame that re-checks the previously
+            // selected radio would natively uncheck the new one, so the siblings need the guard too.
+            if (t.tagName === "INPUT" && (t.type === "checkbox" || t.type === "radio")) {
+                if (t.type === "radio" && t.name) {
+                    root.querySelectorAll('input[type=radio][name="' + CSS.escape(t.name) + '"]')
+                        .forEach((r) => raskNotePendingChecked(r, r.hasAttribute("checked")));
+                } else {
+                    raskNotePendingChecked(t, t.hasAttribute("checked"));
+                }
+            }
             send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
         }
     });

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2413,6 +2413,31 @@ function raskShouldSuppressValue(el, incoming) {
     return false;
 }
 
+// The `.checked` analogue of the value guard above. A native radio/checkbox click flips the
+// `.checked` PROPERTY but leaves the `checked` ATTRIBUTE untouched, so the change dispatch records
+// the pre-click attribute state (raskNotePendingChecked) — exactly as the value guard records the
+// pre-edit `value` attribute. A lagging frame the server computed BEFORE the click reached it still
+// carries that stale checked, so it's suppressed until an authoritative frame (the echo of the new
+// state OR a server correction) arrives with a different value and releases the guard. For a radio
+// the dispatch records the whole same-name group, so a stale frame can't re-check the previously
+// selected radio (which would natively uncheck the new one). Kept a hoisted `function` so the
+// spliced rask-dom.js can call it regardless of splice ordering — same rationale as the value guard.
+function _raskPendingChecked() {
+    return window.__raskPendingChecked || (window.__raskPendingChecked = new WeakMap());
+}
+
+function raskNotePendingChecked(el, supersededChecked) {
+    if (el) _raskPendingChecked().set(el, !!supersededChecked);
+}
+
+function raskShouldSuppressChecked(el, incoming) {
+    const map = _raskPendingChecked();
+    if (!el || !map.has(el)) return false;
+    if (map.get(el) === !!incoming) return true;   // lagging frame carrying the stale checked
+    map.delete(el);                                 // authoritative response — release the guard
+    return false;
+}
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -2449,8 +2474,11 @@ function morph(from, to) {
             // even when from.value already equals newVal; a still-pending user edit
             // (incoming !== the value the user committed) is left untouched.
             if (!raskShouldSuppressValue(from, newVal) && from.value !== newVal) from.value = newVal;
+            // raskShouldSuppressChecked runs first (like the value guard) so a confirmed echo can
+            // clear the guard even when from.checked already matches — a lagging frame carrying the
+            // pre-click checked is left to the browser's just-applied native state.
             const checked = to.hasAttribute("checked");
-            if (from.checked !== checked) from.checked = checked;
+            if (!raskShouldSuppressChecked(from, checked) && from.checked !== checked) from.checked = checked;
         }
     }
     // Skip JS-owned elements (marked data-rask-managed) — they're not part of
@@ -2702,6 +2730,7 @@ function syncFormProperty(el, name, value, isPresent) {
         if (raskShouldSuppressValue(el, value)) return;
         el.value = value;
     } else if (name === "checked" && tag === "INPUT") {
+        if (raskShouldSuppressChecked(el, !!isPresent)) return;
         el.checked = !!isPresent;
     } else if (name === "selected" && tag === "OPTION") {
         el.selected = !!isPresent;
@@ -3112,6 +3141,19 @@ document.addEventListener("change", (e) => {
         if (!(t.tagName === "INPUT" && t.type === "checkbox")) {
             const sv = t.getAttribute("value");
             raskNotePendingValue(t, sv === null ? "" : sv);
+        }
+        // Same guard for the `.checked` property: record the PRE-CLICK checked (the `checked`
+        // attribute, which a native click leaves untouched) so a lagging re-render can't revert
+        // the just-committed selection before the authoritative frame lands — see
+        // raskShouldSuppressChecked. For a radio, note the whole same-name group: a stale frame that
+        // re-checks the previously selected radio would natively uncheck the new one.
+        if (t.tagName === "INPUT" && (t.type === "checkbox" || t.type === "radio")) {
+            if (t.type === "radio" && t.name) {
+                root.querySelectorAll('input[type=radio][name="' + CSS.escape(t.name) + '"]')
+                    .forEach((r) => raskNotePendingChecked(r, r.hasAttribute("checked")));
+            } else {
+                raskNotePendingChecked(t, t.hasAttribute("checked"));
+            }
         }
         send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
     }

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -747,6 +747,19 @@ document.addEventListener("change", (e) => {
             const sv = t.getAttribute("value");
             raskNotePendingValue(t, sv === null ? "" : sv);
         }
+        // Same guard for the `.checked` property: record the PRE-CLICK checked (the `checked`
+        // attribute, which a native click leaves untouched) so a lagging re-render can't revert
+        // the just-committed selection before the authoritative frame lands — see
+        // raskShouldSuppressChecked. For a radio, note the whole same-name group: a stale frame that
+        // re-checks the previously selected radio would natively uncheck the new one.
+        if (t.tagName === "INPUT" && (t.type === "checkbox" || t.type === "radio")) {
+            if (t.type === "radio" && t.name) {
+                root.querySelectorAll('input[type=radio][name="' + CSS.escape(t.name) + '"]')
+                    .forEach((r) => raskNotePendingChecked(r, r.hasAttribute("checked")));
+            } else {
+                raskNotePendingChecked(t, t.hasAttribute("checked"));
+            }
+        }
         send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
     }
 });

--- a/tests/Rask.Core.Tests/Live/MorphCheckedGuardFixture.mjs
+++ b/tests/Rask.Core.Tests/Live/MorphCheckedGuardFixture.mjs
@@ -1,0 +1,135 @@
+// Node-driven fixture for the shared client's `.checked` echo guard
+// (raskNotePendingChecked / raskShouldSuppressChecked in rask-morph.js, consumed
+// by both the full morph (rask-morph.js) and the diff codec (rask-dom.js's
+// syncFormProperty), which in turn feed rask.js and rask.wasm.js).
+//
+// Reproduces the radio/checkbox desync that turned the Forms guide's radio-group
+// step red on the standalone WASM host: a user clicks a radio (browser flips the
+// `.checked` PROPERTY natively, leaving the `checked` ATTRIBUTE untouched), and a
+// re-render the server computed BEFORE that click reached it lands afterwards.
+// Pre-fix, both apply paths set `.checked` unconditionally, reverting the click —
+// Playwright then reports "Clicking the checkbox did not change its state". The
+// guard records the pre-click attribute state on the change dispatch and suppresses
+// a frame that still carries it, until an authoritative frame (the echo of the new
+// state) arrives with a different value and releases the guard.
+//
+// The C# test (MorphCheckedGuardTests) runs this in a node subprocess and asserts
+// the single JSON line on stdout. Exits non-zero on an internal stub failure.
+import {readFileSync} from "node:fs";
+
+const morphPath = process.argv[2];
+const domPath = process.argv[3];
+if (!morphPath || !domPath) {
+    console.error("usage: node MorphCheckedGuardFixture.mjs <rask-morph.js path> <rask-dom.js path>");
+    process.exit(2);
+}
+
+// ----- Minimal element stub -----
+// Models a real input AFTER a native click: the `checked` attribute (the last
+// server-rendered default) and the live `.checked` property are independent —
+// clicking flips the property but never the attribute.
+function makeInput(attrs, checked) {
+    const a = new Map(Object.entries(attrs || {}));
+    return {
+        nodeType: 1,
+        nodeName: "INPUT",
+        tagName: "INPUT",
+        parentNode: null,
+        firstChild: null,
+        nextSibling: null,
+        textContent: "",
+        value: a.has("value") ? a.get("value") : "",
+        checked: !!checked,
+        hasAttribute: (n) => a.has(n),
+        getAttribute: (n) => (a.has(n) ? a.get(n) : null),
+        setAttribute: (n, v) => a.set(n, String(v)),
+        removeAttribute: (n) => a.delete(n),
+        get attributes() {
+            return [...a.entries()].map(([name, value]) => ({name, value}));
+        }
+    };
+}
+
+// A spectator element owns focus so the morph value/checked path runs (the
+// realistic post-click state — focus is on the just-clicked control's group,
+// never mid-typing here).
+const elsewhere = {nodeType: 1, nodeName: "BODY", tagName: "BODY"};
+globalThis.window = globalThis;
+globalThis.document = {
+    activeElement: elsewhere,
+    createElement: () => makeInput({})
+};
+
+// ----- Load the shared snippets (plain function declarations, not modules) -----
+// Concat both: rask-dom.js's syncFormProperty calls raskShouldSuppressChecked,
+// which lives in rask-morph.js — the runtime splices them into one scope.
+const src = readFileSync(morphPath, "utf8") + "\n" + readFileSync(domPath, "utf8");
+const factory = new Function(
+    src + "\n;return { morph, syncFormProperty, raskNotePendingChecked, raskShouldSuppressChecked };");
+const {morph, syncFormProperty, raskNotePendingChecked} = factory();
+
+// Radio option markup: value + name + data-rask-on-change, `checked` present only
+// on the currently selected option (mirrors Input.WriteAttributes / BsRadioGroup).
+const radio = (value, checked) =>
+    makeInput({"data-rask-on-change": "hR", "name": "plan", "value": value, ...(checked ? {"checked": ""} : {})},
+        checked);
+
+// ---- Scenario 1: diff codec (syncFormProperty) — a stale checked op is suppressed ----
+// User clicks "Pro"; the browser sets pro.checked=true (attribute still absent).
+// The dispatch notes the pre-click group state (from the `checked` attribute).
+const proLive = radio("Pro", false);
+proLive.checked = true;                              // native click flipped the property
+raskNotePendingChecked(proLive, proLive.hasAttribute("checked")); // superseded = false
+// A lagging RemoveAttribute-checked op (server's pre-click view) must NOT unset it.
+syncFormProperty(proLive, "checked", "", false);
+const s1AfterStale = proLive.checked;                // expect true — suppressed
+// The authoritative echo (SetAttribute checked) applies and releases the guard.
+syncFormProperty(proLive, "checked", "", true);
+const s1AfterEcho = proLive.checked;                 // expect true — applied
+
+// ---- Scenario 2: full morph, radio group — group guard blocks the whole revert ----
+// Initial DOM: Free selected. User clicks Pro → pro.checked=true, free.checked=false
+// natively; both `checked` attributes still reflect the server (free has it, pro doesn't).
+const freeFrom = radio("Free", false); // free: attr present below; property now false
+freeFrom.setAttribute("checked", "");  // server-rendered default still marks Free
+freeFrom.checked = false;              // native exclusivity unchecked it
+const proFrom = radio("Pro", false);
+proFrom.checked = true;                // native click checked it (no attribute)
+// Dispatch notes the whole group's pre-click state from the attributes.
+raskNotePendingChecked(freeFrom, freeFrom.hasAttribute("checked")); // superseded = true
+raskNotePendingChecked(proFrom, proFrom.hasAttribute("checked"));   // superseded = false
+// A stale morph frame (server computed with Free still selected) must neither
+// re-check Free nor uncheck Pro.
+morph(freeFrom, radio("Free", true));  // to: Free checked  → suppressed (== superseded true)
+morph(proFrom, radio("Pro", false));   // to: Pro unchecked → suppressed (== superseded false)
+const s2FreeAfterStale = freeFrom.checked; // expect false
+const s2ProAfterStale = proFrom.checked;   // expect true
+// The echo (Pro selected) applies and releases both guards.
+morph(freeFrom, radio("Free", false)); // to: Free unchecked → applies (!= superseded)
+morph(proFrom, radio("Pro", true));    // to: Pro checked    → applies (!= superseded)
+const s2FreeAfterEcho = freeFrom.checked; // expect false
+const s2ProAfterEcho = proFrom.checked;   // expect true
+// After release, a later server-driven change wins (guard didn't pin the value).
+morph(proFrom, radio("Pro", false));   // programmatic deselect
+const s2ProAfterLater = proFrom.checked;  // expect false
+
+// ---- Scenario 3: full morph, lone checkbox — stale revert suppressed, echo applies ----
+const cbFrom = makeInput({"data-rask-on-change": "hC"}, false);
+cbFrom.checked = true;                                // user checked it (no attribute yet)
+raskNotePendingChecked(cbFrom, cbFrom.hasAttribute("checked")); // superseded = false
+morph(cbFrom, makeInput({"data-rask-on-change": "hC"}, false)); // stale: unchecked → suppressed
+const s3AfterStale = cbFrom.checked;                  // expect true
+morph(cbFrom, makeInput({"data-rask-on-change": "hC", "checked": ""}, true)); // echo → applies
+const s3AfterEcho = cbFrom.checked;                   // expect true
+
+process.stdout.write(JSON.stringify({
+    s1AfterStale,       // true  — stale diff op suppressed
+    s1AfterEcho,        // true  — echo applied
+    s2FreeAfterStale,   // false — stale frame didn't re-check the old radio
+    s2ProAfterStale,    // true  — stale frame didn't revert the clicked radio
+    s2FreeAfterEcho,    // false — echo applied
+    s2ProAfterEcho,     // true  — echo applied, guard released
+    s2ProAfterLater,    // false — later server change wins (not pinned)
+    s3AfterStale,       // true  — checkbox stale revert suppressed
+    s3AfterEcho         // true  — checkbox echo applied
+}) + "\n");

--- a/tests/Rask.Core.Tests/Live/MorphCheckedGuardTests.cs
+++ b/tests/Rask.Core.Tests/Live/MorphCheckedGuardTests.cs
@@ -1,0 +1,129 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Rask.Core.Tests.Live;
+
+// Regression guard for the radio/checkbox `.checked` desync (E2E:
+// StandaloneWasmExampleTests.Journey_WalksEveryPageAndUnusualActivity, the Forms
+// guide's radio-group step).
+//
+// Symptom: after the user clicked a radio, a re-render the server computed BEFORE
+// the change reached it landed afterwards; both client apply paths (the full morph
+// in rask-morph.js and the diff codec's syncFormProperty in rask-dom.js) set
+// `.checked` unconditionally, reverting the click. Playwright then reported
+// "Clicking the checkbox did not change its state". The `.value` property already
+// had a pending-edit guard; `.checked` did not.
+//
+// Fix: raskNotePendingChecked records the pre-click checked (the `checked`
+// attribute a native click leaves untouched) on dispatch — for a radio, the whole
+// same-name group; raskShouldSuppressChecked suppresses any frame that still
+// carries that stale state until an authoritative frame differs, then releases so
+// server-driven changes win again.
+//
+// This exercises the production rask-morph.js + rask-dom.js in a Node subprocess
+// with a stub DOM. Pairs with the WASM/Server E2E journeys.
+public sealed class MorphCheckedGuardTests
+{
+    [Fact]
+    public void Checked_StaleRender_DoesNotClobberJustClickedRadioOrCheckbox_ThenReleases()
+    {
+        var node = ResolveNode();
+        if (node is null)
+        {
+            // No node on PATH — the JS-driven reproduction can't run. Don't
+            // hard-fail; the E2E journeys cover the user-observable side.
+            return;
+        }
+
+        var repoRoot = LocateRepoRoot();
+        var fixtureScript = Path.Combine(repoRoot, "tests", "Rask.Core.Tests", "Live", "MorphCheckedGuardFixture.mjs");
+        var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
+        var domPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-dom.js");
+        Assert.True(File.Exists(fixtureScript), $"Fixture script missing: {fixtureScript}");
+        Assert.True(File.Exists(morphPath), $"Morph source missing: {morphPath}");
+        Assert.True(File.Exists(domPath), $"Dom source missing: {domPath}");
+
+        var psi = new ProcessStartInfo(node, $"\"{fixtureScript}\" \"{morphPath}\" \"{domPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        Assert.True(proc.ExitCode == 0,
+            $"Fixture exited with code {proc.ExitCode}. stderr:\n{stderr}\nstdout:\n{stdout}");
+
+        var jsonLine = stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(s => s.StartsWith("{") && s.EndsWith("}"));
+        Assert.False(jsonLine is null,
+            $"Fixture didn't emit a JSON line. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(jsonLine!);
+        var root = doc.RootElement;
+
+        bool Get(string name) => root.GetProperty(name).GetBoolean();
+
+        // Diff codec: the lagging RemoveAttribute-checked op must NOT unset the radio
+        // the user just clicked; the SetAttribute echo then applies.
+        Assert.True(Get("s1AfterStale"), "stale diff op reverted the clicked radio");
+        Assert.True(Get("s1AfterEcho"), "echo diff op didn't apply");
+
+        // Full morph, radio group: a stale frame must neither re-check the previously
+        // selected radio (which would natively uncheck the new one) nor unset the new one.
+        Assert.False(Get("s2FreeAfterStale"), "stale frame re-checked the old radio");
+        Assert.True(Get("s2ProAfterStale"), "stale frame reverted the clicked radio");
+        // The echo applies and releases both guards.
+        Assert.False(Get("s2FreeAfterEcho"), "echo didn't unset the old radio");
+        Assert.True(Get("s2ProAfterEcho"), "echo didn't apply to the clicked radio");
+        // The guard released — a later server-driven change is not pinned.
+        Assert.False(Get("s2ProAfterLater"), "guard pinned the value after the echo");
+
+        // Full morph, lone checkbox: stale revert suppressed, echo applies.
+        Assert.True(Get("s3AfterStale"), "stale frame reverted the checkbox");
+        Assert.True(Get("s3AfterEcho"), "checkbox echo didn't apply");
+    }
+
+    private static string? ResolveNode()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "node.exe", "node.cmd" } : new[] { "node" };
+        foreach (var dir in path.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in exeNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the red `main` CI: the `e2e (StandaloneWasmExampleTests)` journey failed at the Forms guide's radio-group step with Playwright's `Clicking the checkbox did not change its state` — i.e. a re-render was reverting the just-clicked radio.

Both client apply paths — the full morph (`rask-morph.js`) and the diff codec's `syncFormProperty` (`rask-dom.js`) — set a form control's `.checked` **unconditionally**, while `.value` was already protected by a pending-edit guard (`raskShouldSuppressValue`). On a busy page (the ~38-demo Forms guide) a re-render the runtime computed *before* the click reached it could land afterwards and flip `.checked` back. The slower standalone WASM bundle hit this window deterministically; the dev host didn't. The existing code even asserted "Checkboxes self-correct via the checked path" — that assumption was the bug.

## Fix

Give `.checked` the same guard `.value` has:
- `raskNotePendingChecked` / `raskShouldSuppressChecked` in `rask-morph.js` (WeakMap mirror of the value guard), consulted in `syncFormProperty` (`rask-dom.js`) and the morph checked-set.
- The `change` handlers (`rask.js`, `rask.wasm.js`) record the **pre-click** state — the `checked` attribute, which a native click leaves untouched. For a radio, the whole same-name group is noted, so a stale frame can't re-check the previously selected radio (which would natively uncheck the new one).
- A lagging frame carrying that stale state is suppressed until an authoritative frame (the echo of the new state, or a server correction) arrives with a different value and releases the guard — same suppress-if-stale semantics as the value guard, so server corrections still win.

Regenerates the spliced `src/Rask.Wasm/Browser/rask.wasm.js`.

## Testing

- **Unit:** new `MorphCheckedGuardTests` + `MorphCheckedGuardFixture.mjs` (Node-driven stub over the production `rask-morph.js` + `rask-dom.js`) — diff path, radio-group morph, lone checkbox, and guard release. Passes alongside the existing `MorphValueGuardTests`.
- **E2E (Release, local):** the previously-failing `StandaloneWasmExampleTests.Journey_WalksEveryPageAndUnusualActivity` now passes; `WasmExampleTests` (10/10) and `ServerExampleTests` (journey + PWA) confirm no regression on the faster hosts.
- `dotnet build Rask.slnx -c Release` clean (0 warnings, warnings-as-errors); `dotnet format --verify-no-changes` clean.

## Benchmarks

N/A — the change is client-side JS delivered as a resource; no C# render/runtime hot-path (HtmlSerializer / Element·Component render / Live diff codec / dispatch / payload build) is touched, and the added work runs only on user `change` events.

## Changelog

Added under `[Unreleased] → Fixed`.