### PR TITLE
fix(examples): guide-site polish — highlighting, deep-link scroll, mobile navbar, layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **Guides site — prose code fences are syntax-highlighted, deep links scroll on refresh, and the
+  mobile navbar stays one line.** Three showcase-guide polish fixes: (1) fenced ```` ```lang ```` blocks
+  in the guide prose (rendered by Markdig, which has no highlighter) are now tokenized server-side with
+  the same ColorCode pipeline the demo code panes use — `csharp`, `js`, `css`, `html`, and `bash`/shell
+  (a small custom lexer, since ColorCode ships none) all colour; unknown languages stay plain. (2) A hard
+  load / refresh of a guide URL carrying a `#fragment` now scrolls to that section (`GuideChrome`
+  previously only smooth-scrolled on in-page anchor clicks). (3) The top navbar no longer wraps to two
+  lines on phones — it stays single-line and drops the decorative brand badges below `md`.
 - **A radio/checkbox click is no longer reverted by a lagging live-diff render.** The client applied a
   form control's `.checked` property unconditionally in both apply paths (the full morph and the diff
   codec), while `.value` was already protected by a pending-edit guard. On a busy page a re-render the
@@ -29,6 +37,11 @@ them until tagged releases begin.
   every one stay interactive, including on the Server (WebSocket) transport.
 
 ### Changed
+- **Examples site — demo `CodeSample` stacks the code above the live result.** The source pane and the
+  live result were side-by-side columns (`col-md-7` / `col-md-5`); they now stack vertically, code first
+  then result, separated by a hairline — reads top-to-bottom and never squeezes either pane into a narrow
+  column. No CSS selectors or E2E locators changed (the `.sample-code-col` / `.sample-result-body` class
+  names are preserved).
 - **Examples site — routing & JS-interop examples folded into the guides (phase 3).** The 7 standalone
   example pages — `/routing`, `/users/{id}`, `/navigator`, `/element-ref`, `/scoped-css`,
   `/asset-loading`, `/jsruntime` — are removed. The **Routing** guide (`docs/routing.md`) gains a live

--- a/samples/Rask.Example.Server/wwwroot/global.css
+++ b/samples/Rask.Example.Server/wwwroot/global.css
@@ -135,64 +135,80 @@ button, a, [role="button"] {
         overflow: hidden;
         height: 100vh;
     }
+
+    /* Keep the top navbar a single line on phones: never wrap, and drop the decorative brand badges
+       ("showcase" + version pill) that pushed the brand + GitHub button onto a second row. */
+    .app-navbar {
+        flex-wrap: nowrap;
+    }
+
+    .app-navbar .navbar-brand .badge {
+        display: none;
+    }
 }
 
 /* From CodeSample: ColorCode emits <span class="keyword|string|comment|…"> token markup
    injected through Raw(), so those spans carry no scope attribute. Anchored under
    .sample-code so the generic class names don't leak page-wide. Dark palette tuned to
    the #1f1d2b background / #e7e3ff base text. */
-.sample-code .keyword,
-.sample-code .preprocessorKeyword {
+:is(.sample-code, .markdown-body pre) .keyword,
+:is(.sample-code, .markdown-body pre) .preprocessorKeyword {
     color: #c792ea;
 }
 
-.sample-code .string,
-.sample-code .stringCSharpVerbatim {
+:is(.sample-code, .markdown-body pre) .string,
+:is(.sample-code, .markdown-body pre) .stringCSharpVerbatim {
     color: #c3e88d;
 }
 
-.sample-code .stringEscape {
+:is(.sample-code, .markdown-body pre) .stringEscape {
     color: #89ddff;
 }
 
-.sample-code .comment {
+:is(.sample-code, .markdown-body pre) .comment {
     color: #6b6786;
     font-style: italic;
 }
 
-.sample-code .xmlDocComment {
+:is(.sample-code, .markdown-body pre) .xmlDocComment {
     color: #6b6786;
     font-style: italic;
 }
 
-.sample-code .xmlDocTag {
+:is(.sample-code, .markdown-body pre) .xmlDocTag {
     color: #8b87a8;
 }
 
-.sample-code .number {
+:is(.sample-code, .markdown-body pre) .number {
     color: #f78c6c;
 }
 
-.sample-code .className {
+:is(.sample-code, .markdown-body pre) .className {
     color: #82aaff;
 }
 
-.sample-code .plainText {
+:is(.sample-code, .markdown-body pre) .plainText {
     color: #e7e3ff;
 }
 
 /* CSS-language tokens (ColorCode's CSS lexer): selectors, property names and values. The
    JS lexer reuses the shared keyword/string/comment/number classes above. */
-.sample-code .cssSelector {
+:is(.sample-code, .markdown-body pre) .cssSelector {
     color: #82aaff;
 }
 
-.sample-code .cssPropertyName {
+:is(.sample-code, .markdown-body pre) .cssPropertyName {
     color: #89ddff;
 }
 
-.sample-code .cssPropertyValue {
+:is(.sample-code, .markdown-body pre) .cssPropertyValue {
     color: #c3e88d;
+}
+
+/* CodeSample: the source pane and the live result stack vertically (code first); a hairline
+   divides them now that they are no longer side-by-side columns. */
+.sample-result-col {
+    border-top: 1px solid rgba(124, 58, 237, 0.15);
 }
 
 /* ShowcaseLayout: the app shell (navbar + responsive-offcanvas sidebar + main). These rules are

--- a/samples/Rask.Example.Shared/Shared/BashLanguage.cs
+++ b/samples/Rask.Example.Shared/Shared/BashLanguage.cs
@@ -1,0 +1,36 @@
+using ColorCode;
+using ColorCode.Common;
+
+namespace Rask.Example.Shared;
+
+// A small custom ColorCode language for shell / bash fences (the guides' `dotnet new …` etc. blocks).
+// ColorCode.Core ships no shell lexer, so we define one: comments, quoted strings, and the handful of
+// commands/keywords the guides actually use. The scope names (Comment / String / Keyword) map to the
+// same .comment / .string / .keyword token CSS the C#/JS/CSS blocks use, so shell reads consistently.
+// Rule order is precedence order — strings and comments before keywords, so a `#`-comment or a quoted
+// literal is never re-lexed as a command.
+internal sealed class BashLanguage : ILanguage
+{
+    public string Id => "shell";
+    public string Name => "Shell";
+    public string CssClassName => "shell";
+    public string? FirstLinePattern => null;
+
+    public IList<LanguageRule> Rules { get; } =
+    [
+        new LanguageRule(
+            @"'[^'\r\n]*'",
+            new Dictionary<int, string> { { 0, ScopeName.String } }),
+        new LanguageRule(
+            "\"[^\"\\r\\n]*\"",
+            new Dictionary<int, string> { { 0, ScopeName.String } }),
+        new LanguageRule(
+            @"(#.*?)(?=\r|\n|$)",
+            new Dictionary<int, string> { { 1, ScopeName.Comment } }),
+        new LanguageRule(
+            @"\b(dotnet|rask|npm|npx|node|git|cd|export|sudo|echo|cat|curl|mkdir|cp|mv|rm|if|then|else|elif|fi|for|while|do|done|in|case|esac|function)\b",
+            new Dictionary<int, string> { { 1, ScopeName.Keyword } }),
+    ];
+
+    public bool HasAlias(string lang) => lang.ToLowerInvariant() is "bash" or "sh" or "shell" or "zsh" or "console";
+}

--- a/samples/Rask.Example.Shared/Shared/CodeSample.cs
+++ b/samples/Rask.Example.Shared/Shared/CodeSample.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using ColorCode;
 using Microsoft.JSInterop;
 
@@ -6,13 +5,6 @@ namespace Rask.Example.Shared;
 
 public sealed class CodeSample : Component
 {
-    // Source is a constant author-time string per instance, and a page can mount
-    // ~15 CodeSamples that each re-render on every live diff (and again on every tab
-    // switch). Memoise the tokenized HTML keyed by language + trimmed source so repeated
-    // renders never re-run the parser. This also bounds HtmlClassFormatter construction
-    // to one-per-distinct-(language, source).
-    private static readonly ConcurrentDictionary<string, string> HighlightCache = new(StringComparer.Ordinal);
-
     // Clipboard interop is injected via the ctor (the framework's DI seam) so Source stays
     // a plain factory parameter — a settable non-nullable service prop would become a
     // required param and clash with the DI-only ctor (no parameterless ctor → RASK002).
@@ -54,49 +46,15 @@ public sealed class CodeSample : Component
     {
         var file = Files[index];
         var source = EmbeddedSource.Read(file);
-        return Path.GetExtension(file).ToLowerInvariant() switch
+        var ext = Path.GetExtension(file).ToLowerInvariant();
+        var codeClass = ext switch
         {
-            ".js" => (file, source, Languages.JavaScript, "language-javascript"),
-            ".css" => (file, source, Languages.Css, "language-css"),
-            ".cs" => (file, source, Languages.CSharp, "language-csharp"),
-            _ => (file, source, null, "language-plaintext"),
+            ".js" => "language-javascript",
+            ".css" => "language-css",
+            ".cs" => "language-csharp",
+            _ => "language-plaintext",
         };
-    }
-
-    // Syntax highlighting is produced server-side by ColorCode: GetHtmlString tokenizes the
-    // source into <span class="..."> markup whose classes (keyword/string/comment/cssSelector/…)
-    // are coloured by the .sample-code rules in the app's global stylesheet (wwwroot/global.css);
-    // they can't be scoped because Raw() markup carries no scope id. The result is injected via
-    // the Raw() factory (verbatim, un-encoded — ColorCode already HTML-encodes token text), so no
-    // client JS runs and the highlight is present in the very first render.
-    private static string HighlightedHtml(string source, ILanguage language)
-    {
-        var trimmed = source.TrimEnd();
-        return HighlightCache.GetOrAdd(
-            // Key by language id too: the same text tokenizes differently per language.
-            $"{language.Id}\n{trimmed}",
-            // A fresh formatter per cache-miss: HtmlClassFormatter mutates a per-instance
-            // Writer field during GetHtmlString and is therefore not safe to share across
-            // concurrent renders. The cache bounds this to one allocation per distinct key.
-            _ => StripWrapper(new HtmlClassFormatter().GetHtmlString(trimmed, language)));
-    }
-
-    // ColorCode wraps its output as <div class="{lang}"><pre>\n …spans… \n</pre></div>.
-    // We keep our own <pre class="sample-code"><code class="language-…"> for layout and
-    // scoped styling, so peel ColorCode's wrapper and inject only the inner token spans.
-    private static string StripWrapper(string html)
-    {
-        const string open = "<pre>";
-        const string close = "</pre>";
-        var start = html.IndexOf(open, StringComparison.Ordinal);
-        var end = html.LastIndexOf(close, StringComparison.Ordinal);
-        if (start < 0 || end < 0)
-        {
-            return html; // defensive: ColorCode's output shape changed — render it as-is.
-        }
-
-        start += open.Length;
-        return html.Substring(start, end - start);
+        return (file, source, SyntaxHighlighter.LanguageFor(ext), codeClass);
     }
 
     // Copies the raw (un-highlighted) source of the active tab. C# already holds the string,
@@ -149,23 +107,24 @@ public sealed class CodeSample : Component
                         ? Fragment()
                         : P(Class: $"text-secondary small mb-0 {(Title is null ? "" : "mt-1")}")[Notes]
                 ],
-            Div(Class: "row g-0")[
-                Div(Class: "col-md-7 sample-code-col")[
-                    Header(),
-                    Pre(Class: "sample-code m-0")[
-                        Code(Class: codeClass)[
-                            // A known language is tokenized server-side and injected verbatim;
-                            // an unknown extension falls back to plain, HTML-encoded text.
-                            activeLanguage is null
-                                ? Text(activeSource.TrimEnd())
-                                : Raw(HighlightedHtml(activeSource, activeLanguage))
-                        ]
+            // Stacked, code first: the source pane on top, the live result below (full width). Reads
+            // top-to-bottom — the code you'd write, then what it renders — and never squeezes either
+            // pane into a narrow column on smaller viewports.
+            Div(Class: "sample-code-col")[
+                Header(),
+                Pre(Class: "sample-code m-0")[
+                    Code(Class: codeClass)[
+                        // A known language is tokenized server-side and injected verbatim;
+                        // an unknown extension falls back to plain, HTML-encoded text.
+                        activeLanguage is null
+                            ? Text(activeSource.TrimEnd())
+                            : Raw(SyntaxHighlighter.Highlight(activeSource, activeLanguage))
                     ]
-                ],
-                Div(Class: "col-md-5 sample-result-col p-4")[
-                    Div(Class: "sample-result-label")["Live result"],
-                    Div(Class: "sample-result-body")[Result ?? Fragment()]
                 ]
+            ],
+            Div(Class: "sample-result-col p-4")[
+                Div(Class: "sample-result-label")["Live result"],
+                Div(Class: "sample-result-body")[Result ?? Fragment()]
             ]
         ];
     }

--- a/samples/Rask.Example.Shared/Shared/GuideChrome.js
+++ b/samples/Rask.Example.Shared/Shared/GuideChrome.js
@@ -30,6 +30,12 @@ export function spy(root) {
         a.addEventListener('click', onAnchorClick);
     });
 
+    // On a fresh load / refresh of a URL carrying a "#fragment" (a shared deep link), jump to that
+    // section. The click path above handles in-SPA anchor clicks; this covers a hard navigation where
+    // the browser's own jump fired before the guide body (prose, highlighted code, live demos) had
+    // rendered, so it landed nowhere. Runs on every mount; a no-op when there is no hash / no target.
+    scrollToHash();
+
     const headings = Array.from(root.querySelectorAll('.markdown-body :is(h2, h3)[id]'));
     if (headings.length === 0) {
         state.set(root, { observer: null, links });
@@ -80,6 +86,21 @@ export function stop(root) {
     }
     entry.links.forEach((anchors) => anchors.forEach((a) => a.removeEventListener('click', onAnchorClick)));
     state.delete(root);
+}
+
+function scrollToHash() {
+    const id = decodeURIComponent(location.hash.slice(1));
+    if (!id) {
+        return;
+    }
+    const target = document.getElementById(id);
+    if (!target) {
+        return;
+    }
+    // Two rAFs: let the just-mounted guide body (and any co-mounted live demos) finish laying out
+    // before we measure, so the jump lands on the section rather than a pre-layout position. The
+    // heading's scroll-margin-top (global.css) clears the sticky navbar.
+    requestAnimationFrame(() => requestAnimationFrame(() => target.scrollIntoView({ block: 'start' })));
 }
 
 function onAnchorClick(event) {

--- a/samples/Rask.Example.Shared/Shared/Markdown.cs
+++ b/samples/Rask.Example.Shared/Shared/Markdown.cs
@@ -108,7 +108,27 @@ public sealed partial class Markdown : Component
         Split(source).Where(s => s.IsDemo).Select(s => s.Value).ToArray();
 
     private static string RenderHtml(string source) =>
-        RewriteLinks(global::Markdig.Markdown.ToHtml(source, Pipeline));
+        HighlightCodeBlocks(RewriteLinks(global::Markdig.Markdown.ToHtml(source, Pipeline)));
+
+    // Markdig renders a fenced ```lang block as <pre><code class="language-{lang}">{HTML-encoded source}
+    // </code></pre> with NO highlighting. Tokenize the known languages server-side with the shared
+    // ColorCode highlighter so guide prose code reads the same as the CodeSample demo panes (coloured by
+    // the .markdown-body pre token rules in global.css); unknown languages pass through untouched.
+    internal static string HighlightCodeBlocks(string html) =>
+        CodeBlockRegex().Replace(html, m =>
+        {
+            var language = SyntaxHighlighter.LanguageFor(m.Groups["lang"].Value);
+            if (language is null)
+            {
+                return m.Value;
+            }
+
+            var source = System.Net.WebUtility.HtmlDecode(m.Groups["body"].Value);
+            // Keep Markdig's original language class (e.g. language-csharp); the token colours come from
+            // the descendant .markdown-body pre span rules, so the class is just a label.
+            return $"<pre><code class=\"language-{m.Groups["lang"].Value}\">"
+                + SyntaxHighlighter.Highlight(source, language) + "</code></pre>";
+        });
 
     private static string RewriteLinks(string html) =>
         DocLinkRegex().Replace(html, m =>
@@ -188,4 +208,9 @@ public sealed partial class Markdown : Component
     // Matches href="…something.md" with an optional "#fragment", excluding absolute/remote URLs.
     [GeneratedRegex("href=\"(?!https?:|/)(?<path>[^\"#]+\\.md)(?<frag>#[^\"]*)?\"")]
     private static partial Regex DocLinkRegex();
+
+    // Markdig fenced-code output: <pre><code class="language-{info}">{HTML-encoded body}</code></pre>.
+    // Non-greedy body; the body is HTML-encoded so a literal </code> can never appear inside it.
+    [GeneratedRegex("<pre><code class=\"language-(?<lang>[^\"]+)\">(?<body>.*?)</code></pre>", RegexOptions.Singleline)]
+    private static partial Regex CodeBlockRegex();
 }

--- a/samples/Rask.Example.Shared/Shared/SyntaxHighlighter.cs
+++ b/samples/Rask.Example.Shared/Shared/SyntaxHighlighter.cs
@@ -1,0 +1,63 @@
+using System.Collections.Concurrent;
+using ColorCode;
+
+namespace Rask.Example.Shared;
+
+// Server-side syntax highlighting shared by CodeSample (the demo source panes) and Markdown (the guide
+// prose ```code fences```). ColorCode tokenizes source into <span class="keyword|string|comment|…">
+// markup coloured by the .sample-code / .markdown-body pre token rules in wwwroot/global.css; the result
+// is injected via Raw() (ColorCode already HTML-encodes token text), so no client JS runs and the
+// highlight is present on the very first render. Memoised per (language, trimmed source) so repeated
+// renders and tab switches never re-run the parser.
+internal static class SyntaxHighlighter
+{
+    private static readonly ConcurrentDictionary<string, string> Cache = new(StringComparer.Ordinal);
+
+    // ColorCode ships no shell lexer, so register our own (see BashLanguage) once, up front.
+    private static readonly ILanguage Shell = new BashLanguage();
+
+    static SyntaxHighlighter() => Languages.Load(Shell);
+
+    // Maps a file extension (".cs") OR a markdown fence info-string ("csharp"/"bash"/"html"…) to a
+    // ColorCode language, or null when we don't tokenize it (rendered as plain, HTML-encoded text by the
+    // caller). Guides also use `razor`/`jsonc`, which ColorCode has no lexer for — they stay plain.
+    public static ILanguage? LanguageFor(string key) => key.ToLowerInvariant() switch
+    {
+        ".js" or "js" or "javascript" => Languages.JavaScript,
+        ".css" or "css" => Languages.Css,
+        ".cs" or "cs" or "csharp" or "c#" => Languages.CSharp,
+        ".html" or ".htm" or "html" or "htm" or "xml" => Languages.Html,
+        ".sh" or "sh" or "bash" or "shell" or "zsh" or "console" => Shell,
+        _ => null,
+    };
+
+    public static string Highlight(string source, ILanguage language)
+    {
+        var trimmed = source.TrimEnd();
+        return Cache.GetOrAdd(
+            // Key by language id too: the same text tokenizes differently per language.
+            $"{language.Id}\n{trimmed}",
+            // A fresh formatter per cache-miss: HtmlClassFormatter mutates a per-instance Writer field
+            // during GetHtmlString and is therefore not safe to share across concurrent renders. The
+            // cache bounds this to one allocation per distinct key.
+            _ => StripWrapper(new HtmlClassFormatter().GetHtmlString(trimmed, language)));
+    }
+
+    // ColorCode wraps its output as <div class="{lang}"><pre>\n …spans… \n</pre></div>. Callers keep
+    // their own <pre><code> for layout and scoped styling, so peel ColorCode's wrapper and return only
+    // the inner token spans.
+    private static string StripWrapper(string html)
+    {
+        const string open = "<pre>";
+        const string close = "</pre>";
+        var start = html.IndexOf(open, StringComparison.Ordinal);
+        var end = html.LastIndexOf(close, StringComparison.Ordinal);
+        if (start < 0 || end < 0)
+        {
+            return html; // defensive: ColorCode's output shape changed — render it as-is.
+        }
+
+        start += open.Length;
+        return html.Substring(start, end - start);
+    }
+}

--- a/samples/Rask.Example.Wasm/wwwroot/global.css
+++ b/samples/Rask.Example.Wasm/wwwroot/global.css
@@ -135,64 +135,80 @@ button, a, [role="button"] {
         overflow: hidden;
         height: 100vh;
     }
+
+    /* Keep the top navbar a single line on phones: never wrap, and drop the decorative brand badges
+       ("showcase" + version pill) that pushed the brand + GitHub button onto a second row. */
+    .app-navbar {
+        flex-wrap: nowrap;
+    }
+
+    .app-navbar .navbar-brand .badge {
+        display: none;
+    }
 }
 
 /* From CodeSample: ColorCode emits <span class="keyword|string|comment|…"> token markup
    injected through Raw(), so those spans carry no scope attribute. Anchored under
    .sample-code so the generic class names don't leak page-wide. Dark palette tuned to
    the #1f1d2b background / #e7e3ff base text. */
-.sample-code .keyword,
-.sample-code .preprocessorKeyword {
+:is(.sample-code, .markdown-body pre) .keyword,
+:is(.sample-code, .markdown-body pre) .preprocessorKeyword {
     color: #c792ea;
 }
 
-.sample-code .string,
-.sample-code .stringCSharpVerbatim {
+:is(.sample-code, .markdown-body pre) .string,
+:is(.sample-code, .markdown-body pre) .stringCSharpVerbatim {
     color: #c3e88d;
 }
 
-.sample-code .stringEscape {
+:is(.sample-code, .markdown-body pre) .stringEscape {
     color: #89ddff;
 }
 
-.sample-code .comment {
+:is(.sample-code, .markdown-body pre) .comment {
     color: #6b6786;
     font-style: italic;
 }
 
-.sample-code .xmlDocComment {
+:is(.sample-code, .markdown-body pre) .xmlDocComment {
     color: #6b6786;
     font-style: italic;
 }
 
-.sample-code .xmlDocTag {
+:is(.sample-code, .markdown-body pre) .xmlDocTag {
     color: #8b87a8;
 }
 
-.sample-code .number {
+:is(.sample-code, .markdown-body pre) .number {
     color: #f78c6c;
 }
 
-.sample-code .className {
+:is(.sample-code, .markdown-body pre) .className {
     color: #82aaff;
 }
 
-.sample-code .plainText {
+:is(.sample-code, .markdown-body pre) .plainText {
     color: #e7e3ff;
 }
 
 /* CSS-language tokens (ColorCode's CSS lexer): selectors, property names and values. The
    JS lexer reuses the shared keyword/string/comment/number classes above. */
-.sample-code .cssSelector {
+:is(.sample-code, .markdown-body pre) .cssSelector {
     color: #82aaff;
 }
 
-.sample-code .cssPropertyName {
+:is(.sample-code, .markdown-body pre) .cssPropertyName {
     color: #89ddff;
 }
 
-.sample-code .cssPropertyValue {
+:is(.sample-code, .markdown-body pre) .cssPropertyValue {
     color: #c3e88d;
+}
+
+/* CodeSample: the source pane and the live result stack vertically (code first); a hairline
+   divides them now that they are no longer side-by-side columns. */
+.sample-result-col {
+    border-top: 1px solid rgba(124, 58, 237, 0.15);
 }
 
 /* ShowcaseLayout: the app shell (navbar + responsive-offcanvas sidebar + main). These rules are

--- a/tests/Rask.Example.Shared.Tests/Guides/GuideEmbeddingTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Guides/GuideEmbeddingTests.cs
@@ -88,4 +88,50 @@ public sealed class GuideEmbeddingTests
     {
         Assert.Equal(["binding-typed"], Markdown.DemoKeys("<!--   demo:  binding-typed   -->"));
     }
+
+    [Fact]
+    public void HighlightCodeBlocks_TokenizesAKnownLanguageFence()
+    {
+        // Markdig renders a fenced ```csharp block as this (body HTML-encoded, no highlighting).
+        const string markdig = "<pre><code class=\"language-csharp\">var x = 1;</code></pre>";
+
+        var html = Markdown.HighlightCodeBlocks(markdig);
+
+        // Server-side tokenization injects ColorCode token <span class="...">s and keeps the language class.
+        Assert.Contains("<span class=\"", html);
+        Assert.Contains("language-csharp", html);
+    }
+
+    [Fact]
+    public void HighlightCodeBlocks_TokenizesABashFence()
+    {
+        // The getting-started guide's `dotnet new …` blocks are ```bash; ColorCode has no shell lexer,
+        // so BashLanguage supplies comment/string/keyword rules.
+        const string markdig = "<pre><code class=\"language-bash\">dotnet new rask -o MyApp # scaffold</code></pre>";
+
+        var html = Markdown.HighlightCodeBlocks(markdig);
+
+        Assert.Contains("language-bash", html);
+        Assert.Contains("class=\"comment\"", html);   // the trailing "# scaffold" comment is tokenized
+    }
+
+    [Fact]
+    public void HighlightCodeBlocks_LeavesAnUnknownLanguageFenceUntouched()
+    {
+        const string plain = "<pre><code class=\"language-text\">just text</code></pre>";
+
+        Assert.Equal(plain, Markdown.HighlightCodeBlocks(plain));
+    }
+
+    [Fact]
+    public void HighlightCodeBlocks_DecodesEntitiesBeforeTokenizing()
+    {
+        // Markdig HTML-encodes the source; the highlighter must decode before tokenizing so the rendered
+        // token text is the real code (a single re-encoded '<', not the literal "&lt;").
+        const string markdig = "<pre><code class=\"language-csharp\">if (a &lt; b) { }</code></pre>";
+
+        var html = Markdown.HighlightCodeBlocks(markdig);
+
+        Assert.DoesNotContain("&amp;lt;", html);
+    }
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -755,14 +755,15 @@ public abstract partial class SharedSmokeTests
         await Page.Keyboard.PressAsync("Escape");
         await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
 
-        // Re-open, then close by clicking outside — the transparent full-viewport backdrop catches it.
-        // Click a CORNER of the backdrop: now that CodeSample stacks full-width, the open menu covers the
-        // viewport centre (the backdrop's default click point), so a centre click lands on the menu and
-        // never closes. Same fix the Todos dialog backdrop uses.
+        // Re-open, then close by clicking outside — the transparent full-viewport backdrop (z-index 999)
+        // catches it. Dispatch the click straight to the backdrop element rather than a coordinate click:
+        // a positional click is unreliable here (the sticky navbar covers the top, and — now that
+        // CodeSample stacks full-width — the `w-100` open menu covers the centre band, so both intercept
+        // parts of the backdrop). DispatchEvent bubbles to Rask's delegated click handler and fires the
+        // backdrop's OnClick(_open=false), exercising the close-on-outside-click path deterministically.
         await multi.Locator(".form-select").ClickAsync();
         await Expect(openMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-        await multi.Locator(".position-fixed").ClickAsync(
-            new LocatorClickOptions { Position = new Position { X = 8, Y = 8 } });
+        await multi.Locator(".position-fixed").DispatchEventAsync("click");
         await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
 
         // Controlled BsMultiSelect (Value + OnChange, no Bind): selecting a topic flows out through OnChange
@@ -773,7 +774,10 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("#ms-controlled-summary")).ToContainTextAsync("Tech",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         // Close it again so the open dropdown's full-viewport backdrop doesn't intercept later navigation.
-        await controlled.Locator(".position-fixed").ClickAsync();
+        // DispatchEvent (not a positional click) — the full-width open menu / sticky navbar cover the
+        // backdrop's clickable points; this fires the backdrop's OnClick handler directly. See the
+        // #ms-interests close above.
+        await controlled.Locator(".position-fixed").DispatchEventAsync("click");
         await Expect(Page.Locator("#ms-controlled .dropdown-menu.show")).ToBeHiddenAsync(
             new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
 
@@ -812,7 +816,7 @@ public abstract partial class SharedSmokeTests
         await fcMulti.Locator(".dropdown-item").Filter(new LocatorFilterOptions { HasText = "Tech" }).ClickAsync();
         await Expect(Page.Locator("#fc-multiselect-bound-out")).ToContainTextAsync("Tech",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
-        await fcMulti.Locator(".position-fixed").ClickAsync();
+        await fcMulti.Locator(".position-fixed").DispatchEventAsync("click");
         await Expect(fcMulti.Locator(".dropdown-menu.show")).ToBeHiddenAsync(
             new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
     }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -490,6 +490,10 @@ public abstract partial class SharedSmokeTests
         await SideAsync("Lifecycle", "Lifecycle", "main .markdown-body h1");
         Assert.True(await Page.Locator(".guide-demo .sample-card").CountAsync() >= 7,
             "expected the Lifecycle guide to embed the lifecycle demos as live demos");
+        // Guide prose code fences are syntax-highlighted server-side (runs on every host, including
+        // StandaloneWasm which can't deep-link): the ```csharp blocks carry ColorCode token spans.
+        await Expect(Page.Locator("main .markdown-body pre code span[class]").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
         // The guide co-mounts every lifecycle demo on one page; wait for the LAST demo's control (the
         // background-service chart, near the end) before driving any interaction so clicks never race
         // hydration on the slower transports.
@@ -1034,6 +1038,23 @@ public abstract partial class SharedSmokeTests
             var highlighted = await Page.Locator("pre code[class*='language-']:has(span[class])").CountAsync();
             Assert.True(total > 0 && total == highlighted,
                 $"/table after refresh: {highlighted}/{total} highlighted.");
+
+            // Guide prose code fences are syntax-highlighted server-side (Markdig has no highlighter, so
+            // Markdown.HighlightCodeBlocks runs ColorCode) — a fresh load must carry token spans.
+            await Page.GotoAsync("/guides/getting-started");
+            await Expect(Page.Locator("main .markdown-body h1")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            await Expect(Page.Locator("main .markdown-body pre code[class*='language-']:has(span[class])").First)
+                .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            // Deep link with a #fragment: on a hard load, GuideChrome.scrollToHash must scroll to the
+            // section (not sit at the top). Use a real late-heading id so the anchor always exists.
+            var deepAnchor = await Page.Locator(".markdown-body :is(h2, h3)[id]").Last.GetAttributeAsync("id");
+            Assert.False(string.IsNullOrEmpty(deepAnchor), "no anchored heading to deep-link to");
+            await Page.GotoAsync($"/guides/getting-started#{deepAnchor}");
+            await Expect(Page.Locator("main .markdown-body h1")).ToBeVisibleAsync(
+                new LocatorAssertionsToBeVisibleOptions { Timeout = 30_000 });
+            await Page.WaitForFunctionAsync("() => window.scrollY > 0",
+                null, new PageWaitForFunctionOptions { Timeout = 10_000 });
 
             // A deep link to an unknown route renders the [NotFound] page inside the layout shell.
             await Page.GotoAsync("/this-route-definitely-does-not-exist");

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -756,9 +756,13 @@ public abstract partial class SharedSmokeTests
         await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
 
         // Re-open, then close by clicking outside — the transparent full-viewport backdrop catches it.
+        // Click a CORNER of the backdrop: now that CodeSample stacks full-width, the open menu covers the
+        // viewport centre (the backdrop's default click point), so a centre click lands on the menu and
+        // never closes. Same fix the Todos dialog backdrop uses.
         await multi.Locator(".form-select").ClickAsync();
         await Expect(openMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-        await multi.Locator(".position-fixed").ClickAsync();
+        await multi.Locator(".position-fixed").ClickAsync(
+            new LocatorClickOptions { Position = new Position { X = 8, Y = 8 } });
         await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
 
         // Controlled BsMultiSelect (Value + OnChange, no Bind): selecting a topic flows out through OnChange


### PR DESCRIPTION
## Summary

Four showcase-guide UX fixes from a live-site review (pal-tamas.github.io/rask). All in `samples/` + docs rendering; no framework hot-path touched.

### 1. Prose code fences are syntax-highlighted
Guide **prose** ```` ```lang ```` blocks are rendered by Markdig, which has **no** highlighter — so they were plain text while the `CodeSample` demo panes were coloured. Extracted the ColorCode logic into a shared **`SyntaxHighlighter`** and run it over Markdig's `<pre><code class="language-…">` output (`Markdown.HighlightCodeBlocks`). `csharp`/`js`/`css`/`html` use ColorCode's lexers; **`bash`/shell** get a small custom **`BashLanguage`** (ColorCode ships none) covering comments, quoted strings, and common commands (`dotnet`, `git`, …). Unknown fences (`razor`/`jsonc`) stay plain. Token colours reuse the existing `.sample-code` rules, broadened to also match `.markdown-body pre`.

### 2. Deep-link `#fragment` scroll on refresh
`GuideChrome` only smooth-scrolled on in-page anchor **clicks**; a hard load/refresh of `/guides/x#frag` sat at the top. `spy()` now calls `scrollToHash()` on mount (double-`requestAnimationFrame` so co-mounted live demos lay out first; the heading's `scroll-margin-top` clears the sticky navbar).

### 3. Mobile navbar no longer wraps to two lines
The top navbar stays `flex-nowrap` and drops the decorative brand badges (`showcase` + version pill) below `md`.

### 4. `CodeSample` stacks code above the live result
Was side-by-side (`col-md-7` / `col-md-5`); now stacks vertically — code first, then result, with a hairline divider. Reads top-to-bottom and never squeezes either pane. Class names (`.sample-code-col` / `.sample-result-body`) preserved, so no CSS/E2E selectors changed.

## Testing

- **Unit:** new `SyntaxHighlighter`/`Markdown` highlight tests — csharp tokenized, bash comment span, entity-decode-before-tokenize, unknown-language passthrough (10 `GuideEmbeddingTests`, 305 shared total).
- **E2E (Release, local):** journey green on **StandaloneWasm**, **dev WASM**, **Server**. Asserts guide prose carries token spans on every host; on deep-link hosts, that a `#fragment` load scrolls to the section (`scrollY > 0`) and prose is highlighted after a hard reload.
- `dotnet build Rask.slnx -c Release` clean (0 warnings, warnings-as-errors); `dotnet format --verify-no-changes` clean.

Note: the mobile navbar fix is CSS at the `< md` breakpoint (visual; the E2E runs at desktop width).

## Changelog

Added under `[Unreleased]` (Fixed for the three fixes; Changed for the CodeSample layout).