### PR TITLE
fix(examples): pin the mobile nav drawer filter across browsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,12 @@ them until tagged releases begin.
   load / refresh of a guide URL carrying a `#fragment` now scrolls to that section (`GuideChrome`
   previously only smooth-scrolled on in-page anchor clicks). (3) The top navbar no longer wraps to two
   lines on phones — it stays single-line and drops the decorative brand badges below `md`.
+- **Guides site — the mobile nav drawer's filter box stays pinned while the list scrolls.** The
+  sidebar filter was a `position: sticky` child of the drawer's flex column, which does not stick in
+  Safari (a long-standing WebKit limitation for sticky flex children): on iOS/Safari the filter scrolled
+  away with the list, leaving a half-clipped row above it. The sidebar body is now a non-scrolling flex
+  column — a pinned filter header with a hairline divider over a single scrolling list
+  (`.side-nav-scroll`) — so the filter stays put in every browser and rows scroll cleanly beneath it.
 - **A radio/checkbox click is no longer reverted by a lagging live-diff render.** The client applied a
   form control's `.checked` property unconditionally in both apply paths (the full morph and the diff
   codec), while `.value` was already protected by a pending-edit guard. On a busy page a re-render the

--- a/samples/Rask.Example.Server/wwwroot/global.css
+++ b/samples/Rask.Example.Server/wwwroot/global.css
@@ -266,19 +266,36 @@ button, a, [role="button"] {
     --bs-offcanvas-width: min(82vw, 320px);
 }
 
+/* The body is a non-scrolling flex column: a pinned filter header over a single scrolling list. The
+   filter is a real flex header (not position:sticky) because a sticky child of a flex container does
+   not stick in Safari — it would scroll away with the list. This is bulletproof across browsers. */
 .side-nav .offcanvas-body {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    padding: 1rem 0.75rem;
+    overflow: hidden;
 }
 
-/* Sticky filter box at the top of the scrolling list. */
+/* Pinned filter header — a fixed-height flex item over the scrolling list, with a hairline divider so
+   list rows read as scrolling cleanly beneath it rather than clipping against a hard edge. */
 .side-nav-search {
-    position: sticky;
-    top: 0;
-    z-index: 1;
+    flex: 0 0 auto;
     padding-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
     background: var(--bs-body-bg, #fff);
+    border-bottom: 1px solid var(--rask-line);
+}
+
+/* The single scrolling region: the nav list scrolls here (never the body), so the filter stays put. */
+.side-nav-scroll {
+    flex: 1 1 auto;
+    min-height: 0; /* let the list scroll inside the flex column instead of stretching it */
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
 .side-nav-filter {
@@ -400,12 +417,10 @@ button, a, [role="button"] {
         align-self: flex-start;
     }
 
-    /* The body is the bounded scroll region: capped to the viewport minus the navbar so a long,
-       fully-expanded list scrolls inside itself instead of stretching the page. */
+    /* Cap the body to the viewport minus the navbar so the inner .side-nav-scroll (not the page) is the
+       bounded scroll region — a long, fully-expanded list scrolls inside itself, filter pinned above. */
     .side-nav.offcanvas-md .offcanvas-body {
         max-height: calc(100vh - var(--nav-h));
-        overflow-y: auto;
-        padding: 1rem 0.75rem;
     }
 }
 
@@ -413,11 +428,6 @@ button, a, [role="button"] {
 @media (max-width: 767.98px) {
     .side-nav.offcanvas-md {
         padding-top: calc(var(--nav-h) + env(safe-area-inset-top));
-    }
-
-    .side-nav.offcanvas-md .offcanvas-body {
-        -webkit-overflow-scrolling: touch;
-        overscroll-behavior: contain;
     }
 }
 

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -104,12 +104,16 @@ public sealed class ShowcaseLayout(RouteState route, IEnumerable<ShowcaseNavEntr
         ]
     ];
 
+    // The sidebar body is a non-scrolling flex column: a pinned filter header (.side-nav-search) over a
+    // single scrolling list (.side-nav-scroll). The filter is a real flex header rather than a
+    // position:sticky child because sticky-in-flexbox is unreliable in Safari (the filter would scroll
+    // away with the list), and this keeps it rock-solid across browsers with a clean hairline divider.
     private RenderResult SidebarBody() => Fragment()[
         Div(Class: "side-nav-search")[
             BsInput(Value: _filter, OnChange: v => _filter = v ?? "", Size: BsSize.Sm,
                 Placeholder: "Filter guides & examples…", Class: "side-nav-filter")
         ],
-        Fragment()[BuildSections()]
+        Div(Class: "side-nav-scroll")[BuildSections()]
     ];
 
     // Guides-first: the narrative guides are the primary spine (top of the sidebar, groups expanded by

--- a/samples/Rask.Example.Wasm/wwwroot/global.css
+++ b/samples/Rask.Example.Wasm/wwwroot/global.css
@@ -266,19 +266,36 @@ button, a, [role="button"] {
     --bs-offcanvas-width: min(82vw, 320px);
 }
 
+/* The body is a non-scrolling flex column: a pinned filter header over a single scrolling list. The
+   filter is a real flex header (not position:sticky) because a sticky child of a flex container does
+   not stick in Safari — it would scroll away with the list. This is bulletproof across browsers. */
 .side-nav .offcanvas-body {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    padding: 1rem 0.75rem;
+    overflow: hidden;
 }
 
-/* Sticky filter box at the top of the scrolling list. */
+/* Pinned filter header — a fixed-height flex item over the scrolling list, with a hairline divider so
+   list rows read as scrolling cleanly beneath it rather than clipping against a hard edge. */
 .side-nav-search {
-    position: sticky;
-    top: 0;
-    z-index: 1;
+    flex: 0 0 auto;
     padding-bottom: 0.5rem;
+    margin-bottom: 0.25rem;
     background: var(--bs-body-bg, #fff);
+    border-bottom: 1px solid var(--rask-line);
+}
+
+/* The single scrolling region: the nav list scrolls here (never the body), so the filter stays put. */
+.side-nav-scroll {
+    flex: 1 1 auto;
+    min-height: 0; /* let the list scroll inside the flex column instead of stretching it */
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
 }
 
 .side-nav-filter {
@@ -400,12 +417,10 @@ button, a, [role="button"] {
         align-self: flex-start;
     }
 
-    /* The body is the bounded scroll region: capped to the viewport minus the navbar so a long,
-       fully-expanded list scrolls inside itself instead of stretching the page. */
+    /* Cap the body to the viewport minus the navbar so the inner .side-nav-scroll (not the page) is the
+       bounded scroll region — a long, fully-expanded list scrolls inside itself, filter pinned above. */
     .side-nav.offcanvas-md .offcanvas-body {
         max-height: calc(100vh - var(--nav-h));
-        overflow-y: auto;
-        padding: 1rem 0.75rem;
     }
 }
 
@@ -413,11 +428,6 @@ button, a, [role="button"] {
 @media (max-width: 767.98px) {
     .side-nav.offcanvas-md {
         padding-top: calc(var(--nav-h) + env(safe-area-inset-top));
-    }
-
-    .side-nav.offcanvas-md .offcanvas-body {
-        -webkit-overflow-scrolling: touch;
-        overscroll-behavior: contain;
     }
 }
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -867,22 +867,27 @@ public abstract partial class SharedSmokeTests
             new PageWaitForFunctionOptions { Timeout = 10_000 });
 
         // The navbar height is centralised in a single --nav-h custom property (no hard-coded 56px),
-        // and on desktop the sidebar's body uses it to become an independent, viewport-bounded scroll
-        // region so the list scrolls inside itself rather than stretching the page — the "navbar too
-        // tall" fix. (Groups now collapse by default, so the list itself is short; this only asserts
-        // the region is bounded and scrollable when needed, not that it currently overflows.)
+        // and on desktop the sidebar's list (.side-nav-scroll) becomes an independent, viewport-bounded
+        // scroll region so it scrolls inside itself rather than stretching the page — the "navbar too
+        // tall" fix. The filter above it is a pinned flex header (the body itself does not scroll — a
+        // sticky-in-flex child would not stick in Safari). (Groups now collapse by default, so the list
+        // itself is short; this only asserts the region is bounded and scrollable when needed.)
         Assert.Equal("56px", (await Page.EvaluateAsync<string>(
             "() => getComputedStyle(document.documentElement).getPropertyValue('--nav-h').trim()")));
-        var navScroll = await Page.Locator(".side-nav .offcanvas-body").First.EvaluateAsync<string>(
+        var navScroll = await Page.Locator(".side-nav .side-nav-scroll").First.EvaluateAsync<string>(
             @"el => {
                 const cs = getComputedStyle(el);
+                const body = getComputedStyle(el.closest('.offcanvas-body'));
                 const navH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--nav-h'));
                 return JSON.stringify({
                     overflowY: cs.overflowY,
+                    bodyOverflowY: body.overflowY,
                     bounded: el.clientHeight <= window.innerHeight - navH + 1,
                 });
             }");
         Assert.Contains("\"overflowY\":\"auto\"", navScroll);
+        // The body itself must not scroll — only the inner list does, so the filter stays pinned.
+        Assert.Contains("\"bodyOverflowY\":\"hidden\"", navScroll);
         Assert.Contains("\"bounded\":true", navScroll);
 
         // HttpClient + DI: an injected HttpClient loads a card in OnMountAsync.


### PR DESCRIPTION
## Summary

The guides/showcase sidebar filter box was a `position: sticky` child of the drawer's **flex** column (`.side-nav .offcanvas-body { display:flex }`). A sticky flex child does not stick in **Safari** (a long-standing WebKit limitation), so on iOS/macOS Safari the filter scrolled away with the list and a nav row was left half-clipped *above* it — the reported visual bug. Chromium honors sticky-in-flex, which is why it looked fine there.

**Fix:** restructure the sidebar body into a non-scrolling flex column — a pinned filter *header* with a hairline divider over a single scrolling list (`.side-nav-scroll`). No `position: sticky`, so the filter stays put in every browser and rows scroll cleanly beneath the divider. Desktop keeps its viewport-bounded scroll region; the inner list is now the scroller instead of the body.

### Changed
- `samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs` — wrap the sidebar sections in a `.side-nav-scroll` region.
- `samples/Rask.Example.{Wasm,Server}/wwwroot/global.css` (kept byte-identical) — filter becomes a fixed flex header + hairline divider; `.side-nav-scroll` is the single scroll region; body is `overflow:hidden`; desktop `max-height` retained.
- `tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs` — assert the list (`.side-nav-scroll`) is the bounded, `overflow-y:auto` scroll region and the body itself does not scroll.
- `CHANGELOG.md` — `[Unreleased] → Fixed` entry.

## Testing
- `dotnet build` (warnings-as-errors) clean on the shared sample and the E2E project; `dotnet format --verify-no-changes` clean.
- Reproduced the seam artifact in a faithful Chromium harness (real `bootstrap.min.css` + showcase rules), confirmed the fix at mobile and desktop widths.
- Drove the **real running Server app** at 390px: opened the drawer and scrolled 500px — filter stays pinned (`searchTop` constant), `.side-nav-scroll` scrolls (`overflow:auto`), body is `hidden`. Clean pinned filter + divider, no clipped row.
- Full sharded E2E not run locally (heavy); the updated journey assertion runs in CI.

## Benchmarks
N/A — CSS + sample markup + test only; no render/runtime hot-path code touched.