### PR TITLE
feat(examples): fold the data-grid pages (phase 3, final cluster)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ them until tagged releases begin.
   optional package like the validation libraries.
 
 ### Changed
+- **Examples site — fold the data-grid pages (phase 3, final cluster).** The **Master-detail** page
+  (`/master-detail`) is removed; its grid becomes a new `MasterDetailDemo` embedded in **`docs/composition.md`**
+  under "Keyed lists" (registered `master-detail`) — it's a keyed-reconciliation showcase (expand inserts a
+  keyed detail `<tr>`; sibling open rows keep their own inner sort). `OrdersPageTests` → `MasterDetailDemoTests`.
+  The **Data table** (`/table`) teaches `[QueryParam]`-driven, shareable-URL state, which can't be a co-mounted
+  live guide demo, so it's shown **code-only in `docs/routing.md`** (registered `routing-querytable`) and its
+  `/table` route stays as a real, unlisted example the guide links to. Both are removed from the sidebar/home
+  nav. This completes the phase-3 example-folding; `TodosPage` remains a runnable capstone.
 - **Examples site — fold the Live ticker page into the Lifecycle guide (phase 3).** The standalone
   `/realtime/{Symbol}` page is removed; its reusable `LiveTicker` widget (poll loop in `OnMountAsync`, a symbol
   switch that fires `OnPropsChanged*`, `OnRendered` first-paint, `OnUnmount*`, `CancellationToken`, and a

--- a/docs/composition.md
+++ b/docs/composition.md
@@ -267,6 +267,13 @@ is the same reconciliation identity the diff uses everywhere — not a reactive 
 
 <!-- demo:keyed-lists-reorder -->
 
+A **master-detail** grid is the same identity trick at work: each order row carries a `Key`, and expanding
+one **inserts a keyed detail `<tr>`** right after it. The diff reconciles that as an in-place keyed insert
+(collapse → remove), so the other open rows keep their own independently-sorted inner grid across the change
+— no wholesale re-render of the table:
+
+<!-- demo:master-detail -->
+
 ---
 
 ## Flash messages

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -124,6 +124,13 @@ Other binding-related analyzers worth knowing:
 Route/query binding feeds the lifecycle: `OnPropsChanged*` fires on first render and whenever a bound param actually
 changes value. See [lifecycle.md](lifecycle.md).
 
+A worked example: the **data table** at [`/table`](/table) holds *all* of its UI state — the search filter,
+the sort column and direction, the current page and page size — in `[QueryParam]` properties, and writes each
+header click and pager button back through `Navigator.SetQuery`. Because the state lives in the URL, it's
+shareable and bookmarkable, and browser back/forward replay it for free. The source (the whole page, verbatim):
+
+<!-- demo:routing-querytable -->
+
 ## Nested routes — `[ParentRoute]` + `Outlet()`
 
 A page can declare a parent layout with `[ParentRoute(typeof(Parent))]`. The child's template is joined onto the

--- a/samples/Rask.Example.Shared/Features/Home/HomePage.cs
+++ b/samples/Rask.Example.Shared/Features/Home/HomePage.cs
@@ -22,8 +22,8 @@ public sealed class HomePage(Navigator nav) : Component
         ("Components", "bi-bell", "Toast", "Show, stack, dismiss & auto-hide — no JS.", "/guides/bootstrap"),
         ("Components", "bi-megaphone", "Flash messages", "Rails-style transient messages via IFlash.", "/guides/composition"),
         ("Components", "bi-mouse", "Events", "The full DOM event surface, typed.", "/guides/composition"),
-        ("Components", "bi-table", "Data table", "Sortable, paginated table.", "/table"),
-        ("Components", "bi-list-nested", "Master-detail", "Collapsible rows with a nested datagrid.", "/master-detail"),
+        ("Components", "bi-table", "Data table", "Sortable, paginated, URL-driven table.", "/guides/routing"),
+        ("Components", "bi-list-nested", "Master-detail", "Collapsible rows with a nested datagrid.", "/guides/composition"),
         ("Components", "bi-graph-up-arrow", "Live ticker", "Lifecycle hooks + a zero-JS SVG chart.", "/guides/lifecycle"),
         ("Components", "bi-person-lock", "User & auth", "Gate UI on the current user.", "/guides/authentication"),
 

--- a/samples/Rask.Example.Shared/Features/Orders/MasterDetailDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Orders/MasterDetailDemo.cs
@@ -1,20 +1,16 @@
 using System.Globalization;
-using Rask.Core.Routing;
 
 namespace Rask.Example.Shared.Features;
 
-// Master-detail datagrid. The sibling Data table page drives all of its state through the URL query
-// string; this page is the deliberate contrast — expand/collapse and both grids' sort live in plain
-// component fields. A click mutates a field and StateHasChanged() re-renders the page.
+// Master-detail datagrid, embedded in docs/composition.md's "Keyed lists" section (its standalone
+// /master-detail page folded in). Expand/collapse and both grids' sort live in plain component fields.
 //
-// Expanding a row inserts a second, keyed <tr> ("detail-{id}") right after the keyed main row
-// ("{id}"). Because every row carries a stable Key, the live diff treats expand as an in-place keyed
-// Insert and collapse as a keyed Remove — sibling expanded rows keep their own inner sort across the
-// reconcile. Each detail panel hosts its own plain <table> of line items with an independent sort, so
-// the page owns three pieces of state: the expanded set, the outer sort, and a per-order inner sort.
-[Route("master-detail")]
-[ParentRoute(typeof(ShowcaseLayout))]
-public sealed class OrdersPage : Component
+// Expanding a row inserts a second, keyed <tr> ("detail-{id}") right after the keyed main row ("{id}").
+// Because every row carries a stable Key, the live diff treats expand as an in-place keyed Insert and
+// collapse as a keyed Remove — sibling expanded rows keep their own inner sort across the reconcile. Each
+// detail panel hosts its own plain <table> of line items with an independent sort, so the demo owns three
+// pieces of state: the expanded set, the outer sort, and a per-order inner sort.
+public sealed class MasterDetailDemo : Component
 {
     private static readonly Order[] _orders = BuildOrders();
 
@@ -44,52 +40,22 @@ public sealed class OrdersPage : Component
     private readonly Dictionary<int, (string Col, bool Asc)> _itemSort = new();
     private (string Col, bool Asc) _orderSort = ("", true);
 
-    protected override Component? Head => Title()["Master-detail — Rask"];
-
     protected override Component? Render()
     {
         var orders = SortOrders(_orders, _orderSort);
 
-        return
-        [
-            PageHeader.Render(
-                "Master-detail",
-                "Collapsible rows with a nested datagrid. Click a row to reveal its line items in an inner, " +
-                "independently sortable table. Expand/collapse and both grids' sort are held in plain component " +
-                "fields — the deliberate contrast with the URL-driven Data table."),
-            BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
-                Div(Class: "table-responsive")[
-                    Table(Id: "md-orders", Class: "table table-hover align-middle mb-0")[
-                        Thead(Class: "table-light")[
-                            Tr()[_orderColumns.Select(c =>
-                                c.Sortable
-                                    ? SortHeader(c.Id, c.Header, _orderSort, ToggleOrderSort)
-                                    : Th(Scope: "col", Key: c.Id))]
-                        ],
-                        Tbody()[BuildOrderRows(orders)]
-                    ]
+        return BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
+            Div(Class: "table-responsive")[
+                Table(Id: "md-orders", Class: "table table-hover align-middle mb-0")[
+                    Thead(Class: "table-light")[
+                        Tr()[_orderColumns.Select(c =>
+                            c.Sortable
+                                ? SortHeader(c.Id, c.Header, _orderSort, ToggleOrderSort)
+                                : Th(Scope: "col", Key: c.Id))]
+                    ],
+                    Tbody()[BuildOrderRows(orders)]
                 ]
-            ],
-            P(Class: "small text-secondary mt-3 mb-0")[
-                "Expand state is a ",
-                Code()["HashSet<int>"],
-                " on the page; toggling it calls ",
-                Code()["StateHasChanged()"],
-                ". Each open row inserts a keyed ",
-                Code()["<tr>"],
-                " detail row, so the live diff reconciles it as an in-place insert/remove and the other open rows " +
-                "keep their own inner sort. The detail panel hosts a second plain ",
-                Code()["Table"],
-                " of line items with its own sort."
-            ],
-            CodeSample(
-                ["OrdersPage.cs"],
-                Title: "Source",
-                Notes:
-                "The whole page above, verbatim. Expand state is a HashSet<int>, the outer sort and each order's " +
-                "inner sort are plain fields — a click mutates one and StateHasChanged() re-renders. Open rows " +
-                "insert a keyed detail <tr>, so the live diff reconciles them as in-place insert/remove and sibling " +
-                "open rows keep their own inner sort.")
+            ]
         ];
     }
 

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -35,6 +35,17 @@ public static class DemoRegistry
             // Live: mutate the current URL's query through the scoped Navigator (its standalone example
             // page folded into docs/routing.md). Embed NavigatorDemo.cs as the teaching source.
             ["routing-navigator"] = () => CodeSample(["NavigatorDemo.cs"], Result: NavigatorQueryDemo()),
+            // Code-only: the Data table page is a full [QueryParam]-driven grid. It binds sort/filter/page/size
+            // from the URL, so it can't be a co-mounted live demo (a guide can't own query params) — the live
+            // page lives (unlisted) at /table; here we show its source as the query-param teaching example.
+            ["routing-querytable"] = () => CodeSample(
+                ["TablePage.cs"],
+                Title: "A [QueryParam]-driven data table",
+                Notes:
+                "Sort, filter, page and page-size are [QueryParam] properties bound from the URL; each header "
+                + "click and pager button writes them back via Navigator.SetQuery, so the page re-resolves "
+                + "against the new query and the state is shareable, bookmarkable, and replayed by browser "
+                + "back/forward. Visit /table to see it live."),
 
             // --- Forms guide: two-way binding ---
             ["binding-manual"] = () => CodeSample(
@@ -161,6 +172,7 @@ public static class DemoRegistry
             ["virtualize-items"] = () => CodeSample(["VirtualizeItemsDemo.cs"], Result: VirtualizeItemsDemo()),
             ["virtualize-provider"] = () => CodeSample(["VirtualizeProviderDemo.cs"], Result: VirtualizeProviderDemo()),
             ["keyed-lists-reorder"] = () => CodeSample(["KeyedListsReorderDemo.cs"], Result: KeyedListsReorderDemo()),
+            ["master-detail"] = () => CodeSample(["MasterDetailDemo.cs"], Result: MasterDetailDemo()),
             ["drag-drop-sortable"] = () => CodeSample(["DragDropSortableDemo.cs"], Result: DragDropSortableDemo()),
             ["drag-drop-kanban"] = () => CodeSample(["DragDropKanbanDemo.cs"], Result: DragDropKanbanDemo()),
             ["boom-handler"] = () => CodeSample(["BoomHandlerDemo.cs"], Result: BoomHandlerDemo()),

--- a/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
+++ b/samples/Rask.Example.Shared/Shared/ShowcaseLayout.cs
@@ -16,15 +16,15 @@ public sealed class ShowcaseLayout(RouteState route, IEnumerable<ShowcaseNavEntr
         // implicitly to the string Path slot, so a renamed/removed [Route] is a compile error here, not a
         // dead link. MatchPrefix stays a bare string (it is a URL prefix, not a whole route).
         (Features.Routes.HomePage(), "Welcome", "bi-house", "Start", null),
-        (Features.Routes.TablePage(), "Data table", "bi-table", "Components", null),
-        (Features.Routes.OrdersPage(), "Master-detail", "bi-list-nested", "Components", null),
         (Features.Routes.TodosPage(), "Todos", "bi-check2-square", "Apps", null)
         // Many example pages are now folded into their guides as inline live demos: HttpClient+DI /
         // upload / download → HTTP & files (docs/http-and-files.md); typed browser-API wrappers → Browser
         // APIs (docs/browser-apis.md); Events + Flash → Composition (docs/composition.md); Toast →
         // Bootstrap (docs/bootstrap.md); User & auth → Authentication (docs/authentication.md); User
         // components → Getting started (docs/getting-started.md); Live ticker → Lifecycle
-        // (docs/lifecycle.md). See DemoRegistry.
+        // (docs/lifecycle.md); Master-detail → Composition (docs/composition.md keyed lists). The Data
+        // table stays a working [QueryParam] example at /table (unlisted) — its source is shown in
+        // docs/routing.md's query-param section. See DemoRegistry.
     ];
 
     // Mobile drawer open state (ignored at ≥md, where the responsive offcanvas is static), the

--- a/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
@@ -59,7 +59,9 @@ public sealed class ShowcaseLayoutTests
         var open = Regex.Matches(html, "class=\"collapse show\"").Count;
         var closed = Regex.Matches(html, "class=\"collapse\"").Count;
         Assert.True(open >= 5, $"expected the guide groups expanded by default, only {open} open");
-        Assert.True(closed >= 2, $"expected the Examples groups collapsed, only {closed} closed");
+        // Most example pages are folded into guides now; the surviving Examples group(s) (e.g. Apps/Todos)
+        // stay collapsed. The guides-expanded assertion above is the primary contract.
+        Assert.True(closed >= 1, $"expected the Examples groups collapsed, only {closed} closed");
     }
 
     [Fact]
@@ -139,7 +141,7 @@ public sealed class ShowcaseLayoutTests
     [Fact]
     public void OnMount_SubscribesToRouteChanged_ActiveLinkRefreshesOnNav()
     {
-        // Behavioural test: navigate from "/" to "/table", then re-render App with the
+        // Behavioural test: navigate from "/" to "/todos", then re-render App with the
         // same RouteState. The layout's active-link computation must reflect the new
         // path — which requires its Render() to re-execute after the path change.
         var routeState = new RouteState { Path = "/" };
@@ -151,11 +153,11 @@ public sealed class ShowcaseLayoutTests
         Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-house",
             CollapseWhitespace(htmlAtRoot));
 
-        routeState.Path = "/table";
-        var htmlAtTable = app.RenderAsLiveRoot(services);
-        // After nav, the active link should be the Data-table one (bi-table icon).
-        Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-table",
-            CollapseWhitespace(htmlAtTable));
+        routeState.Path = "/todos";
+        var htmlAtTodos = app.RenderAsLiveRoot(services);
+        // After nav, the active link should be the Todos one (bi-check2-square icon).
+        Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-check2-square",
+            CollapseWhitespace(htmlAtTodos));
     }
 
     private static string CollapseWhitespace(string s) =>

--- a/tests/Rask.Example.Shared.Tests/Pages/MasterDetailDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/MasterDetailDemoTests.cs
@@ -1,12 +1,15 @@
-using Rask.Core.Routing;
+using Rask.Example.Shared.Features;
 using Rask.Example.Shared.Tests.Infrastructure;
 
 namespace Rask.Example.Shared.Tests.Pages;
 
-public sealed class OrdersPageTests
+// MasterDetailDemo (embedded in the Composition guide's "Keyed lists" section) is the former
+// /master-detail page with the page chrome stripped — the outer grid, keyed detail rows, and both
+// sorts are unchanged. Rendered directly here since its standalone page was folded into the guide.
+public sealed class MasterDetailDemoTests
 {
     [Fact]
-    public void Route_MasterDetail_RendersOuterGrid()
+    public void Render_RendersOuterGrid_WithKeyedRowsAndExpanders()
     {
         var html = Render();
 
@@ -30,6 +33,5 @@ public sealed class OrdersPageTests
     }
 
     private static string Render() =>
-        new Shared.App().RenderAsLiveRoot(
-            TestServices.Default(routeState: new RouteState { Path = "/master-detail" }));
+        new MasterDetailDemo().RenderAsLiveRoot(TestServices.Default());
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -54,7 +54,6 @@ public abstract partial class SharedSmokeTests
 
         await TestSidebarNavAsync();
         await WalkUserComponentsGuideAsync();
-        await WalkInteractiveComponentPagesAsync();
         await TestCompositionGuideAsync();
         await WalkLifecycleGuideAsync();
         await WalkRoutingGuideAsync();
@@ -111,7 +110,9 @@ public abstract partial class SharedSmokeTests
         var open = await Page.Locator(".side-nav .collapse.show").CountAsync();
         Assert.True(open >= 5, $"expected the guide groups expanded by default, got {open}");
         var groups = await Page.Locator(".side-nav .nav-group-toggle").CountAsync();
-        Assert.True(groups > 8, $"expected the nav split into many collapsible groups, got {groups}");
+        // The five guide groups (Overview + the four GuideCatalog categories) plus the surviving Examples
+        // groups (most example pages are now folded into guides). Keep this a "many groups" floor.
+        Assert.True(groups >= 6, $"expected the nav split into many collapsible groups, got {groups}");
 
         // Collapse/expand toggle: the guide category groups are open by default (guides-first), so
         // collapsing one hides its links and re-expanding reveals them. The "Core" guide group is stable
@@ -269,61 +270,6 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     }
 
-    private async Task WalkInteractiveComponentPagesAsync()
-    {
-        // Live ticker (lifecycle hooks + zero-JS SVG chart) moved to the Lifecycle guide
-        // (WalkLifecycleGuideAsync).
-
-        // Events (the full GlobalEventHandlers surface) moved to the Composition guide
-        // (TestCompositionGuideAsync). Virtualize and Keyed lists likewise.
-
-        // Data table: every interaction is a URL query-param mutation → rebind → re-render.
-        await SideAsync("Data table", "Data table");
-        await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(10,
-            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
-        await Page.Locator("th button:has-text('Name')").First.ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]sort=name"),
-            new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        await Page.Locator("input[type='search']").FillAsync("Linus");
-        await Page.WaitForTimeoutAsync(300);
-        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]filter=Linus"),
-            new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
-        var filtered = await Page.Locator("tbody tr").CountAsync();
-        Assert.True(filtered is > 0 and < 10, $"filter should reduce rows; got {filtered}");
-        await Page.Locator("input[type='search']").FillAsync("");
-        await Page.Locator("select.form-select-sm").SelectOptionAsync("25");
-        await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
-            new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
-        // Every showcase page shows its own source: the page-source CodeSample card is present.
-        await Expect(Page.Locator("main .sample-card").First).ToBeVisibleAsync(
-            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-
-        // Master-detail: expand state is local; toggling inserts a keyed detail <tr> hosting a nested,
-        // independently sortable plain <table>. Collapse removes it via the same keyed diff.
-        await SideAsync("Master-detail", "Master-detail");
-        await Expect(Page.Locator("#md-orders tbody tr.md-row")).ToHaveCountAsync(14,
-            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
-        await Page.Locator("[data-testid='expander-1']").ClickAsync();
-        await Expect(Page.Locator("[data-testid='inner-1']")).ToBeVisibleAsync(
-            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-        var innerRows = await Page.Locator("[data-testid='inner-1'] tbody tr").CountAsync();
-        Assert.True(innerRows > 0, $"expanded order should reveal line items; got {innerRows}");
-        // Sort the nested grid by Qty — the inner grid reacts on its own controlled state.
-        await Page.Locator("[data-testid='inner-1'] th button:has-text('Qty')").First.ClickAsync();
-        await Page.WaitForTimeoutAsync(200);
-        var firstQtyAfter = await Page.Locator("[data-testid='inner-1'] tbody tr").First
-            .Locator("td").Nth(2).InnerTextAsync();
-        Assert.False(string.IsNullOrWhiteSpace(firstQtyAfter), "inner grid should still render after sort");
-        // Collapse: the keyed detail row is removed.
-        await Page.Locator("[data-testid='expander-1']").ClickAsync();
-        await Expect(Page.Locator("[data-testid='inner-1']")).ToHaveCountAsync(0,
-            new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
-        // Page-source CodeSample card is present.
-        await Expect(Page.Locator("main .sample-card").First).ToBeVisibleAsync(
-            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-
-        // Drag & drop and Error boundary moved to the Composition guide (TestCompositionGuideAsync).
-    }
 
     // Composition guide: context, callbacks, virtualize, keyed lists, drag & drop, and error boundaries
     // — their standalone example pages folded into docs/composition.md as inline live demos. Open the
@@ -334,8 +280,8 @@ public abstract partial class SharedSmokeTests
         var contains = new LocatorAssertionsToContainTextOptions { Timeout = 10_000 };
 
         await SideAsync("Composition", "Composition", "main .markdown-body h1");
-        Assert.True(await Page.Locator(".guide-demo .sample-card").CountAsync() >= 12,
-            "expected the Composition guide to embed the demos (incl. the folded events + flash) as live demos");
+        Assert.True(await Page.Locator(".guide-demo .sample-card").CountAsync() >= 13,
+            "expected the Composition guide to embed the demos (incl. the folded events, flash + master-detail) as live demos");
         // Wait for a LATE demo's control (the error-boundary trigger, near the end) before driving any
         // interaction, so a fill/click never races the guide still hydrating on the slower transports.
         await Expect(Page.Locator("#boom-throw")).ToBeVisibleAsync(
@@ -408,6 +354,26 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("#kl-reverse").ClickAsync();
         await Expect(Page.Locator("#kl-list li").First.Locator("span.fw-semibold"))
             .ToContainTextAsync("Elderberry", contains);
+
+        // Master-detail (its /master-detail page folded into this section): expanding a row inserts a keyed
+        // detail <tr> hosting a nested, independently sortable table; collapse removes it via the keyed diff.
+        // The #md-orders / expander-{id} / inner-{id} ids are unique on the guide page.
+        await Expect(Page.Locator("#md-orders tbody tr.md-row")).ToHaveCountAsync(14,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        await Page.Locator("[data-testid='expander-1']").ClickAsync();
+        await Expect(Page.Locator("[data-testid='inner-1']")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        Assert.True(await Page.Locator("[data-testid='inner-1'] tbody tr").CountAsync() > 0,
+            "expanded order should reveal line items");
+        await Page.Locator("[data-testid='inner-1'] th button:has-text('Qty')").First.ClickAsync();
+        await Page.WaitForTimeoutAsync(200);
+        Assert.False(
+            string.IsNullOrWhiteSpace(await Page.Locator("[data-testid='inner-1'] tbody tr").First
+                .Locator("td").Nth(2).InnerTextAsync()),
+            "inner grid should still render after sort");
+        await Page.Locator("[data-testid='expander-1']").ClickAsync();
+        await Expect(Page.Locator("[data-testid='inner-1']")).ToHaveCountAsync(0,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
 
         // Drag & drop: native HTML5 drag events fire the C# handlers; the live diff morphs the DOM.
         await Expect(Page.Locator("#dd-fruit-list .dd-item")).ToHaveCountAsync(5,
@@ -1078,12 +1044,35 @@ public abstract partial class SharedSmokeTests
     private async Task RunUnusualActivityAsync(ShowcaseJourneyOptions opts)
     {
         // Back / forward: history navigation must preserve the SPA sentinel and resolve both ends.
-        await SideAsync("Data table", "Data table");
+        await SideAsync("Todos", "Todos");
         await Page.GoBackAsync();
         Assert.Equal("alive", await Page.EvaluateAsync<string?>("() => window.__raskSentinel"));
         await Page.GoForwardAsync();
-        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Data table",
+        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Todos",
             new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
+
+        // Data table: a [QueryParam]-driven grid — every interaction is a URL query mutation → rebind →
+        // re-render. Its /table route is unlisted (folded code-only into routing.md) but still a real page;
+        // exercise it here (post-sentinel) since reaching it is a hard nav. Sort → ?sort=name, filter →
+        // ?filter=…, page-size → 25 rows.
+        await Page.GotoAsync("/table");
+        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Data table",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
+        await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(10,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        await Page.Locator("th button:has-text('Name')").First.ClickAsync();
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]sort=name"),
+            new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
+        await Page.Locator("input[type='search']").FillAsync("Linus");
+        await Page.WaitForTimeoutAsync(300);
+        await Expect(Page).ToHaveURLAsync(new Regex(".*[\\?&]filter=Linus"),
+            new PageAssertionsToHaveURLOptions { Timeout = 5_000 });
+        var filteredRows = await Page.Locator("tbody tr").CountAsync();
+        Assert.True(filteredRows is > 0 and < 10, $"filter should reduce rows; got {filteredRows}");
+        await Page.Locator("input[type='search']").FillAsync("");
+        await Page.Locator("select.form-select-sm").SelectOptionAsync("25");
+        await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 5_000 });
 
         if (opts.DeepLink)
         {
@@ -1241,8 +1230,11 @@ public abstract partial class SharedSmokeTests
     {
         // --- a forward nav resets scroll to the top ---------------------------------------------
         // The data table at 25 rows is reliably taller than the viewport; scroll to the bottom and
-        // confirm the document actually moved before navigating away.
-        await SideAsync("Data table", "Data table");
+        // confirm the document actually moved before navigating away. (Its /table route is unlisted now —
+        // folded code-only into routing.md — so reach it directly.)
+        await Page.GotoAsync("/table");
+        await Expect(Page.Locator("main h1.h2")).ToHaveTextAsync("Data table",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
         await Page.Locator("select.form-select-sm").SelectOptionAsync("25");
         await Expect(Page.Locator("tbody tr")).ToHaveCountAsync(25,
             new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });


### PR DESCRIPTION
## Summary

The **final** phase-3 cluster of the guides-first migration. The two remaining standalone grid pages split by their teaching:

- **Master-detail** (`/master-detail`) is pure local state and teaches **keyed reconciliation** → folded into **`docs/composition.md`**'s "Keyed lists" section as a live `MasterDetailDemo` (expand inserts a keyed detail `<tr>`; sibling open rows keep their own inner sort).
- **Data table** (`/table`) teaches **`[QueryParam]`-driven, shareable-URL state** — which *can't* be a co-mounted live guide demo (a guide can't own query params), so it's shown **code-only in `docs/routing.md`**'s query-param section, and its `/table` route stays a real, **unlisted** example the guide links to (`TablePage.cs` unchanged).

This completes phase-3 example folding. `TodosPage` remains a runnable capstone; only the phase-4 docs sweep is left.

## What changed

- **New** `Features/Orders/MasterDetailDemo.cs` (OrdersPage with the page chrome stripped); **registered** `master-detail` (live) + `routing-querytable` (code-only, `TablePage.cs` source) in `DemoRegistry`; markers added to `composition.md` + `routing.md`.
- **Deleted** `OrdersPage.cs`; both pages removed from the sidebar/home nav (home cards repoint at the composition/routing guides).
- **Tests:** `OrdersPageTests` → `MasterDetailDemoTests` (render the demo directly); `ShowcaseLayoutTests` active-link retargeted `/table` → `/todos` and the group-count thresholds lowered (the Components sidebar group is now empty). `PageBaselineTests`' `TablePage` rows stay (route still resolves).
- **E2E:** master-detail assertions moved into `TestCompositionGuideAsync` (scoped to `#md-orders`); the `/table` query-param walk (sort → `?sort=name`, filter, page-size → 25) moved to `RunUnusualActivityAsync` — **post-sentinel**, because reaching the unlisted `/table` is a hard nav that would otherwise trip the SPA-sentinel invariant. Back/forward + scroll-reset tests repointed off `/table` (→ `/todos` / `GotoAsync("/table")`); the nav-groups floor lowered.

## Testing

- **Unit:** `Rask.Example.Shared.Tests` — 284 pass (incl. `DemoRegistry` integrity for both keys, `GuideEmbeddingTests` for `composition.md` + `routing.md`, `MasterDetailDemoTests`, the retargeted layout tests, and `PageBaselineTests` with `/table` still resolving).
- `dotnet build Rask.slnx` clean (0 warnings, warnings-as-errors); `dotnet format --verify-no-changes` clean.
- **E2E (local):** the `StandaloneWasm` journey passes (master-detail on the composition guide + the post-sentinel `/table` query-param walk). Full matrix on CI.
- No render/diff/dispatch hot-path changes → benchmarks N/A.

## Changelog

Added under `[Unreleased] → Changed`.
