### PR TITLE
docs: reconcile the doc index — guides-first wrap-up (phase 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,13 @@ them until tagged releases begin.
   optional package like the validation libraries.
 
 ### Changed
+- **Docs — guides-first migration wrap-up (phase 4).** With every foldable example page now living inside a
+  `docs/*.md` guide as an inline live demo, the doc index is reconciled: `llms.txt` gains the missing
+  **Elements & the DSL** entry (all 24 guides indexed), the README documentation table adds **HTTP & files**
+  and **CQRS**, and `docs/ai-agents.md`'s guide list is refreshed to a representative-not-exhaustive form so it
+  stops going stale. Verified no doc/artifact references a deleted example route, and `GuideCatalog` ↔ `docs/`
+  ↔ `llms.txt` ↔ README all line up. Only `TodosPage` and the unlisted `[QueryParam]` `/table` example remain
+  standalone. This closes the guides-first epic.
 - **Examples site — fold the data-grid pages (phase 3, final cluster).** The **Master-detail** page
   (`/master-detail`) is removed; its grid becomes a new `MasterDetailDemo` embedded in **`docs/composition.md`**
   under "Keyed lists" (registered `master-detail`) — it's a keyed-reconciliation showcase (expand inserts a

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Everything lives in **[`docs/`](docs/)** — start here, then dive into the topi
 | **[Elements & the DSL](docs/elements.md)** | Primitives, tag factories, universal props, and typed SVG — the render surface. |
 | **[Composition](docs/composition.md)** · **[Lifecycle](docs/lifecycle.md)** | Context, callbacks, children; mount/update/dispose. |
 | **[Routing](docs/routing.md)** · **[Forms & validation](docs/forms.md)** · **[Building form controls](docs/building-form-controls.md)** | URLs, route params, the form pipeline, custom `IFormControl<T>` inputs. |
-| **[Authentication](docs/authentication.md)** · **[Data access](docs/data-access.md)** | Cookie/JWT on Server & WASM; EF Core + SQLite. |
+| **[Authentication](docs/authentication.md)** · **[Data access](docs/data-access.md)** · **[HTTP & files](docs/http-and-files.md)** · **[CQRS](docs/cqrs.md)** | Cookie/JWT on Server & WASM; EF Core + SQLite; a DI'd `HttpClient` + file upload/download; source-generated CQRS. |
 | **[Bootstrap](docs/bootstrap.md)** | Typed Bootstrap 5.3 components, zero-JS interactivity, typed utility classes. |
 | **[Browser APIs](docs/browser-apis.md)** · **[PWA](docs/pwa.md)** | 43 typed Web-API wrappers; installable, offline apps. |
 | **[JS interop](docs/js-interop.md)** · **[Accessibility](docs/accessibility.md)** · **[Testing](docs/testing.md)** | Scoped JS + element refs; a11y; unit + E2E. |

--- a/docs/ai-agents.md
+++ b/docs/ai-agents.md
@@ -11,10 +11,12 @@ Rask app correctly without you re-explaining the conventions.
   (factories not `new`, the children indexer, factory-param props, the full-shell root,
   routing/lifecycle, scoped CSS/JS, callbacks, forms, auth).
 - **`llms.txt`** (repo root) — the emerging standard index that points AI tools at the docs.
-- **The `docs/` set** — task guides (getting-started, routing, lifecycle, composition, forms,
-  js-interop, authentication, migration-from-blazor, diagnostics, testing) plus the optional
-  `Rask.Bootstrap` reference (`docs/bootstrap.md`: typed Bootstrap 5.3 components, zero-JS
-  interactivity, typed utility classes).
+- **The `docs/` set** — a task guide for each subsystem (getting-started, elements & the DSL, routing,
+  lifecycle, composition, forms, js-interop, browser APIs, authentication, data access, HTTP & files,
+  PWA, CQRS, diagnostics, testing, … — the full curated list is in the on-site guides index) plus the
+  optional `Rask.Bootstrap` reference (`docs/bootstrap.md`: typed Bootstrap 5.3 components, zero-JS
+  interactivity, typed utility classes). Each guide embeds its examples as live demos, so the source
+  a user reads on GitHub and the running showcase stay in lockstep.
 
 ## How to use it
 

--- a/llms.txt
+++ b/llms.txt
@@ -11,6 +11,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 ## Docs
 - [Getting started](docs/getting-started.md): install, first app, project layout.
 - [Best practices](docs/best-practices.md): production patterns + common pitfalls across components, state, forms, data, security, accessibility, performance, testing (each links the deep dive).
+- [Elements & the DSL](docs/elements.md): the render surface — the primitives (`Text` HTML-encodes, `Raw` is verbatim, `Doctype`) and the `[...]` collection expression for sibling fragments; a generator-emitted factory for every HTML and SVG element; the universal props (`Id`/`Class`/`Style`/`Data`/`Role`/`TabIndex`/`Aria`, fixed attribute render order) on every tag; typed SVG components (no `Raw()`); and the full HTML-element catalog by category.
 - [Routing](docs/routing.md): `[Route]`, params, `Router()`/`Outlet()`, navigation.
 - [Lifecycle](docs/lifecycle.md): OnMount/OnPropsChanged/OnRendered/OnUnmount, async hooks.
 - [Composition](docs/composition.md): children, context (provide/consume), callbacks, flash messages (Rails-style `IFlash` — scoped-per-session, consumed-once transient messages that survive a client-side navigation; drained by a headless `FlashOutlet`, or `Rask.Bootstrap`'s ready-made `BsFlash`), the full DOM `GlobalEventHandlers` event surface on every element (mouse/pointer/touch/wheel/focus/keyboard/clipboard/drag as typed `OnX`+`OnXAsync` pairs; Audio/Video add the `HTMLMediaElement` events), headless primitives (`VirtualizeModel<T>`), drag-and-drop.


### PR DESCRIPTION
## Summary

The closing **phase-4** pass of the guides-first migration. With every foldable example page now living inside a `docs/*.md` guide as an inline live demo (11 phase-3 clusters merged), this reconciles the doc index so nothing points at the old examples-first structure and every guide is discoverable.

The incremental clusters kept the docs largely current — the audit found **no stale example-route references** and **`GuideCatalog` (23) == docs top-level user guides (23)**. Three real gaps remained:

- **`llms.txt`** was missing the **Elements & the DSL** guide (added in #222) — now all 24 guide docs are indexed.
- **The README documentation table** omitted **HTTP & files** (inconsistent next to Data access) and **CQRS** (a shipped, NuGet-badged package) — both added.
- **`docs/ai-agents.md`**'s guide enumeration was stale — refreshed to a representative-not-exhaustive form so it stops going stale on each new guide.

The template `AGENTS.md` set and root `AGENTS.md` were already current (no changes). Only `TodosPage` and the unlisted `[QueryParam]` `/table` example remain standalone by design. **This closes the guides-first epic.**

## Testing

- Docs-only change. `GuideEmbeddingTests` green (every `docs/*.md` in `GuideCatalog` embeds; every `<!-- demo:key -->` resolves).
- `dotnet format --verify-no-changes` clean.
- Grep proof: no `docs/`/README/`llms.txt`/`AGENTS.md` reference to a deleted example route (`/events` `/toast` `/flash` `/user` `/components` `/realtime` `/master-detail`); every `docs/<slug>.md` user guide appears in `llms.txt`; `GuideCatalog` ↔ `docs/` ↔ `llms.txt` ↔ README all line up.
- No render/dispatch hot-path → benchmarks N/A.

## Changelog

Added under `[Unreleased] → Changed`.
