### PR TITLE
fix(core): don't wipe an uncontrolled input's value on a full-document morph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,14 @@ them until tagged releases begin.
   expression returning a `Component`.
 
 ### Fixed
+- **An uncontrolled `<input>`'s value is no longer wiped by a full-document morph.** A full-HTML reply
+  (initial paint, scoped-CSS delivery, or a reconnect resync) reconciles the whole page through `morph()`,
+  which reset **every** input to the rendered `value` — treating a *missing* `value` attribute as `value=""`.
+  But an input with no rendered `value` is *uncontrolled* (the framework isn't managing it), so any full reply
+  that landed while the user had typed into one silently cleared their text (e.g. a form's `FormData` then read
+  blank). The morph now only syncs an input when the render actually provides a `value` (controlled/bound
+  inputs always render one, even `value=""`), leaving uncontrolled inputs' client-owned values alone. Guarded
+  by an E2E that types into an uncontrolled field, forces a reconnect resync, and asserts the value survives.
 - **WASM `WasmHostBuilder.BaseAddress` is now the app root, independent of the current route.** It read
   `document.baseURI`, which — once the SPA has navigated and the `<base>` element is no longer in the
   live DOM — reflects the *current route*. A singleton `HttpClient` whose `BaseAddress` is resolved

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -170,11 +170,17 @@ function morph(from, to) {
         if (!streaming || document.activeElement !== from) {
             let newVal = to.getAttribute("value");
             if (newVal === null && to.tagName === "TEXTAREA") newVal = to.textContent;
-            if (newVal === null) newVal = "";
-            // raskShouldSuppressValue runs first so it can clear a confirmed echo
-            // even when from.value already equals newVal; a still-pending user edit
-            // (incoming !== the value the user committed) is left untouched.
-            if (!raskShouldSuppressValue(from, newVal) && from.value !== newVal) from.value = newVal;
+            // No rendered `value` (an <input> with no `value` attribute) means the input is
+            // *uncontrolled* — the framework isn't managing its value, so a re-render (including a
+            // full-document morph on a full reply — scoped-CSS delivery, reconnect, …) must leave the
+            // user's typed DOM value alone rather than reset it to "". A controlled/bound input always
+            // renders a `value` attribute (even `value=""`), so it still syncs below.
+            // raskShouldSuppressValue runs first so it can clear a confirmed echo even when from.value
+            // already equals newVal; a still-pending user edit (incoming !== the committed value) is
+            // left untouched.
+            if (newVal !== null && !raskShouldSuppressValue(from, newVal) && from.value !== newVal) {
+                from.value = newVal;
+            }
             // raskShouldSuppressChecked runs first (like the value guard) so a confirmed echo can
             // clear the guard even when from.checked already matches — a lagging frame carrying the
             // pre-click checked is left to the browser's just-applied native state.

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2476,11 +2476,17 @@ function morph(from, to) {
         if (!streaming || document.activeElement !== from) {
             let newVal = to.getAttribute("value");
             if (newVal === null && to.tagName === "TEXTAREA") newVal = to.textContent;
-            if (newVal === null) newVal = "";
-            // raskShouldSuppressValue runs first so it can clear a confirmed echo
-            // even when from.value already equals newVal; a still-pending user edit
-            // (incoming !== the value the user committed) is left untouched.
-            if (!raskShouldSuppressValue(from, newVal) && from.value !== newVal) from.value = newVal;
+            // No rendered `value` (an <input> with no `value` attribute) means the input is
+            // *uncontrolled* — the framework isn't managing its value, so a re-render (including a
+            // full-document morph on a full reply — scoped-CSS delivery, reconnect, …) must leave the
+            // user's typed DOM value alone rather than reset it to "". A controlled/bound input always
+            // renders a `value` attribute (even `value=""`), so it still syncs below.
+            // raskShouldSuppressValue runs first so it can clear a confirmed echo even when from.value
+            // already equals newVal; a still-pending user edit (incoming !== the committed value) is
+            // left untouched.
+            if (newVal !== null && !raskShouldSuppressValue(from, newVal) && from.value !== newVal) {
+                from.value = newVal;
+            }
             // raskShouldSuppressChecked runs first (like the value guard) so a confirmed echo can
             // clear the guard even when from.checked already matches — a lagging frame carrying the
             // pre-click checked is left to the browser's just-applied native state.

--- a/tests/Rask.Example.Shared.Tests/Pages/EventsFormDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/EventsFormDemoTests.cs
@@ -4,9 +4,9 @@ using Rask.Example.Shared.Features;
 
 namespace Rask.Example.Shared.Tests.Pages;
 
-// EventsFormDemo (embedded in the Composition guide) collects a FormData on submit. The submit itself is
-// timing-fragile to drive through the co-mounted guide in E2E, so the OnSubmit → FormData behaviour is
-// asserted here at the unit level.
+// EventsFormDemo (embedded in the Composition guide) collects a FormData on submit. The end-to-end
+// fill → submit → echo path is exercised by the Composition guide walk; these unit tests pin the
+// OnSubmit → FormData mapping (named value vs blank) directly.
 public sealed class EventsFormDemoTests
 {
     [Fact]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -313,15 +313,14 @@ public abstract partial class SharedSmokeTests
         await eInput.Locator("input[type=text]").First.FillAsync("Hello Rask");
         await Expect(eInput).ToContainTextAsync("You typed: \"Hello Rask\"", contains);
 
-        // Form (onSubmit → FormData): assert the demo renders its named input + submit control. Driving the
-        // submit on the busy co-mounted guide is timing-fragile — the uncontrolled input's value can be
-        // reconciled away before the form's FormData is read at submit time (the readout lands "(blank)").
-        // The OnSubmit/FormData path is covered by EventsFormDemoTests; here we assert it mounts.
+        // Form (onSubmit → FormData): fill the named field and submit; OnSubmit reads it off a FormData and
+        // echoes it. This is reliable now that the morph no longer wipes an uncontrolled input's value on a
+        // full reply (it previously landed "(blank)" on the busy co-mounted guide — see the uncontrolled-input
+        // reconnect guard in RunUnusualActivityAsync). The readout wraps the value in <strong>.
         var eForm = Page.Locator(".guide-demo").Filter(new LocatorFilterOptions { HasText = "Last submitted:" });
-        await Expect(eForm.Locator("input[name=name]")).ToBeVisibleAsync(
-            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
-        await Expect(eForm.Locator("button[type=submit]")).ToBeVisibleAsync(
-            new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await eForm.Locator("input[name=name]").FillAsync("Ada");
+        await eForm.Locator("button[type=submit]").ClickAsync();
+        await Expect(eForm).ToContainTextAsync("Last submitted: Ada", contains);
 
         // Full surface demo: OnDoubleClick (MouseEventArgs) + OnFocus (parameterless) reach C# and re-render
         // — proving the universal event store dispatches over both transports, not just OnClick.
@@ -1195,11 +1194,21 @@ public abstract partial class SharedSmokeTests
             await clicks.ClickAsync();
             await Expect(clicks).ToContainTextAsync("Clicks: 2",
                 new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+            // An *uncontrolled* input's value is client-owned (the framework renders no `value` attribute
+            // for it). A reconnect forces a full-HTML resend that morphs the whole document — and that
+            // morph must NOT reset the uncontrolled input to "" (regression: it did, wiping any in-progress
+            // typed value on every full reply — scoped-CSS delivery, reconnect, …). The events-form demo's
+            // name field is uncontrolled; type into it, then reconnect and assert the value survived.
+            var uncontrolled = Page.Locator(".guide-demo")
+                .Filter(new LocatorFilterOptions { HasText = "Last submitted:" }).Locator("input[name=name]");
+            await uncontrolled.FillAsync("survive-the-reconnect");
             await Page.Context.SetOfflineAsync(true);
             await Page.Context.SetOfflineAsync(false);
             await clicks.ClickAsync();
             await Expect(clicks).ToContainTextAsync("Clicks: 3",
-                new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
+                new LocatorAssertionsToContainTextOptions { Timeout = 15_000 }); // server-held state survived
+            await Expect(uncontrolled).ToHaveValueAsync("survive-the-reconnect",
+                new LocatorAssertionsToHaveValueOptions { Timeout = 10_000 });   // client-owned value survived the resync morph
         }
 
         // Memory: a stress loop of in-SPA navigations must not balloon the JS heap.


### PR DESCRIPTION
## Summary

A latent framework bug (surfaced during the guides-first co-mount work): typing into an **uncontrolled `<input>`** and then hitting any **full-HTML reply** — initial paint, scoped-CSS delivery, or a **reconnect resync** — silently wiped the typed text.

**Root cause.** A full reply reconciles the whole page through `morph()` (`rask-morph.js`). It synced every input's `.value` to the rendered value, treating a *missing* `value` attribute as `value=""`:

```js
let newVal = to.getAttribute("value");
if (newVal === null) newVal = "";          // ← treats "uncontrolled" as "empty"
if (!raskShouldSuppressValue(from, newVal) && from.value !== newVal) from.value = newVal;
```

But an input with **no rendered `value`** is *uncontrolled* — the framework isn't managing it — so this reset the user's in-progress text to `""`. That's the intermittent co-mounted-guide events-form failure (its `FormData` read blank). A controlled/bound input always renders a `value` (even `value=""`), so it's unaffected.

**Fix.** The morph only syncs an input when the render actually provides a `value`; uncontrolled inputs' client-owned values are left alone. The diff codec (`rask-dom.js`) was already safe — it only syncs on an explicit value-attribute edit op.

## What changed

- **`src/Rask.Core/Resources/rask-morph.js`** — the one-line guard (skip the `.value` sync when the rendered node has no `value` attribute). Regenerated the spliced **`src/Rask.Wasm/Browser/rask.wasm.js`** (committed); the Server `rask.js` re-splices from `rask-morph.js` at build.
- **E2E regression guard** — a new deterministic check in the reconnect section: type into the events-form's uncontrolled field, force a WS reconnect resync (the exact full-morph trigger), assert the value survives. **Verified to fail without the fix and pass with it.**
- Restored the real events-form **fill → submit** assertion on the Composition guide walk (the earlier "render-only" workaround was added for *this* bug) and updated `EventsFormDemoTests`' note.

## Testing

- **Proof:** with the morph fix reverted, the Server journey fails at the uncontrolled-input assertion (bug reproduced); with the fix it passes.
- `dotnet build Rask.slnx` clean (warnings-as-errors); `dotnet format --verify-no-changes` clean; `Rask.Example.Shared.Tests` 284 pass.
- **E2E (local):** `StandaloneWasm` + `Server` journeys both pass (no regression to controlled inputs/forms). Full matrix on CI.
- Client-JS morph change, not a C# render/diff hot path → BenchmarkDotNet benchmarks N/A.

## Changelog

Added under `[Unreleased] → Fixed`.
