### PR TITLE
chore(release): v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-03
+
 ### Added
 - **Source-generated CQRS/mediator (`Rask.Cqrs`)** — a new opt-in, standalone package for structuring
   work as queries, commands and notifications. Define `IQuery<TResult>` / `ICommand` / `ICommand<TResult>`


### PR DESCRIPTION
## Summary
Promote CHANGELOG `[Unreleased]` → `[0.12.0]` and cut the v0.12.0 release. Highlights: the new source-generated `Rask.Cqrs` package, `BsDataGrid` (+ footer totals / master-detail), Bootstrap form-control submit-validation repaint fix, and generator/server fixes.

## Testing
- Unit + e2e: green on the merged feature work (PR #231).

## Benchmarks
n/a — release/CHANGELOG only.

## CHANGELOG
- [0.12.0] section dated; fresh empty [Unreleased] added above.