### PR TITLE
fix(bootstrap): drop phantom Rask.Core package dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **`Rask.Bootstrap` no longer declares a phantom `Rask.Core` package dependency.** Its `Rask.Core`
+  `ProjectReference` was missing `PrivateAssets="all"`, so `dotnet pack` emitted a NuGet dependency on
+  `Rask.Core 1.0.0` — a package that does not exist (`Rask.Core` is `IsPackable=false`; its DLL ships
+  bundled inside the host packages `Rask.Server`/`Rask.Wasm`). An external consumer restoring
+  `Rask.Bootstrap` alongside a host package hit `NU1101: Unable to find package Rask.Core`. Adding
+  `PrivateAssets="all"` (as `Rask.Server`/`Rask.Wasm` already have) drops the phantom dependency;
+  `Rask.Core` continues to flow in bundled with the host package.
+
 ## [0.12.0] - 2026-07-03
 
 ### Added

--- a/src/Rask.Bootstrap/Rask.Bootstrap.csproj
+++ b/src/Rask.Bootstrap/Rask.Bootstrap.csproj
@@ -29,7 +29,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
     <ProjectReference Include="..\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>


### PR DESCRIPTION
## Summary
`Rask.Bootstrap`, `Rask.Wasm.Hosting`, `Rask.Validation.DataAnnotations` and `Rask.Validation.FluentValidation` packed a dependency on the non-existent `Rask.Core` package (their Core `ProjectReference` lacked `PrivateAssets="all"`). External consumers hit `NU1101: Unable to find package Rask.Core`. Fixed by adding `PrivateAssets="all"` (as `Rask.Server`/`Rask.Wasm` already do); `Rask.Core.dll` still ships bundled in the host packages.

## Testing
- Verified locally: `dotnet pack Rask.Bootstrap` now emits an empty dependency group (no `Rask.Core`).
- Unit + e2e: via CI.

## Benchmarks
n/a — packaging metadata only.

## CHANGELOG
- [Unreleased] Fixed entry added.