### PR TITLE
chore(release): v0.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-07-04
+
 ### Fixed
 - **`Rask.Bootstrap` no longer declares a phantom `Rask.Core` package dependency.** Its `Rask.Core`
   `ProjectReference` was missing `PrivateAssets="all"`, so `dotnet pack` emitted a NuGet dependency on


### PR DESCRIPTION
## Summary
Promote CHANGELOG `[Unreleased]` → `[0.12.1]` and cut the v0.12.1 patch: fixes the phantom `Rask.Core` package dependency in `Rask.Bootstrap` (blocked external consumers with `NU1101`).

## Testing
- Unit + e2e: green on #233.

## Benchmarks
n/a — packaging metadata only.

## CHANGELOG
- [0.12.1] section dated; fresh empty [Unreleased] above.