### PR TITLE
docs(bootstrap): note Core is transitive-from-host, not re-packed

### DIFF
--- a/src/Rask.Bootstrap/Rask.Bootstrap.csproj
+++ b/src/Rask.Bootstrap/Rask.Bootstrap.csproj
@@ -29,6 +29,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- PrivateAssets="all" keeps the (unpublished) Rask.Core "package" out of the nuspec
+         dependency list. Unlike the host packages (Rask.Server/Rask.Wasm), we deliberately do
+         NOT re-pack Rask.Core.dll here: Rask.Bootstrap is always consumed alongside a host,
+         which already bundles Rask.Core.dll into lib/, so bundling it again would ship a
+         duplicate assembly. Rask.Core is only distributed via a host — Bootstrap has no
+         host-less consumption path by design. -->
     <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
     <ProjectReference Include="..\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"


### PR DESCRIPTION
## Summary
Follow-up to #233 (which added `PrivateAssets=\"all\"` to drop the phantom `Rask.Core` package dependency). A high-effort code review flagged that `Rask.Bootstrap` now uses the same `PrivateAssets=\"all\"` pattern as the host packages but — unlike `Rask.Server`/`Rask.Wasm` — neither declares a `Rask.Core` dependency nor re-packs `Rask.Core.dll`, making line 32 read like a truncated copy of the host pattern.

That omission is **intentional**, not a bug: `Rask.Core` is never published standalone, so `Rask.Bootstrap` is always consumed alongside a host package that already bundles `Rask.Core.dll` into `lib/`. Re-packing it here would ship a duplicate assembly and cause a resolution collision in the normal (host + Bootstrap) topology.

This PR makes that contract explicit with a comment mirroring the hosts', so the difference no longer looks accidental. No functional or packaging change.

## Testing
- `dotnet build src/Rask.Bootstrap/Rask.Bootstrap.csproj -warnaserror` → clean (0 warnings, 0 errors)

## Benchmarks
N/A — comment-only csproj change, no render/runtime code touched.

## Changelog
N/A — not user-facing (build-file comment only).