### PR TITLE
feat(nuget): per-package tags + standalone READMEs (Cqrs/WebPush/Validation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ them until tagged releases begin.
   (`rask-icon.png`) and a human-readable `<Title>`. `CS1591` (missing doc on a public member) is
   suppressed so partial doc coverage ships as-is without forcing a full-coverage sweep.
 
+### Changed
+- **Per-package NuGet identity for the standalone packages.** `Rask.Cqrs`, `Rask.WebPush` and both
+  `Rask.Validation.*` packages now carry their own `PackageTags` instead of inheriting the framework
+  default (`web component framework wasm net10`), which mis-signalled scope and hurt search — e.g.
+  `Rask.Cqrs` (a reflection-free mediator) and `Rask.WebPush` (a transport-neutral server sender) are
+  no longer tagged `wasm`/`component`. `Rask.Cqrs` and `Rask.WebPush` also ship a **package-specific
+  `NUGET.md`** (install + quickstart for that package) rather than the shared framework overview a
+  consumer landed on before.
+
 ### Fixed
 - **Corrected pre-existing malformed XML doc comments** exposed once `GenerateDocumentationFile` turned
   on doc validation — a dangling `<summary>` on `Component.ToHtml`, `paramref`s to non-existent

--- a/src/Rask.Cqrs/NUGET.md
+++ b/src/Rask.Cqrs/NUGET.md
@@ -1,0 +1,55 @@
+# Rask.Cqrs
+
+**Source-generated, reflection-free CQRS / mediator for .NET.** Structure your app as queries,
+commands and notifications, and dispatch them through a single injectable interface — with every
+handler wired at **compile time**, so there is no runtime reflection and no assembly scanning. It
+publishes clean under the WASM/AOT trimmer.
+
+Standalone: the only dependency is `Microsoft.Extensions.DependencyInjection.Abstractions`. You do
+**not** need the rest of Rask to use it.
+
+## Install
+
+```bash
+dotnet add package Rask.Cqrs
+```
+
+## Use
+
+Define messages and their handlers:
+
+```csharp
+public sealed record GetUser(int Id) : IQuery<User>;
+
+public sealed class GetUserHandler(AppDb db) : IQueryHandler<GetUser, User>
+{
+    public Task<User> HandleAsync(GetUser q, CancellationToken ct) => db.Users.FindAsync(q.Id, ct);
+}
+```
+
+Register once, then dispatch — the response type is inferred:
+
+```csharp
+builder.Services.AddRaskCqrs();
+
+// ...
+var user = await dispatcher.DispatchAsync(new GetUser(42));   // returns User
+```
+
+`ICommand` / `ICommand<TResult>` dispatch the same way; `INotification` fans out to every handler
+via `PublishAsync`.
+
+## Pipeline behaviors
+
+Cross-cutting concerns (logging, validation, transactions, caching) are decorators — implement
+`IPipelineBehavior<TRequest, TResult>` and register it. Behaviors run in registration order, the
+first-registered wrapping outermost.
+
+## Notes
+
+- **Reflection-free / trim-safe** — a Roslyn generator emits the handler registry via a
+  `[ModuleInitializer]`; nothing is discovered at runtime.
+- **Host-agnostic** — the same `AddRaskCqrs()` works on a Rask Server or WASM host, or any plain
+  .NET app.
+
+Full documentation: <https://github.com/pal-tamas/rask/blob/main/docs/cqrs.md>

--- a/src/Rask.Cqrs/Rask.Cqrs.csproj
+++ b/src/Rask.Cqrs/Rask.Cqrs.csproj
@@ -9,7 +9,17 @@
     <PackageId>Rask.Cqrs</PackageId>
     <Title>Rask.Cqrs — Source-Generated CQRS/Mediator</Title>
     <Description>Source-generated, reflection-free CQRS/mediator for .NET. Define `IQuery&lt;T&gt;`, `ICommand`, `ICommand&lt;T&gt;` and `INotification` messages with their handlers, then dispatch through `IDispatcher` with the response type inferred — no runtime reflection and no assembly scanning, so it publishes clean under the WASM/AOT trimmer. Pipeline behaviors provide the decorator hook for cross-cutting logging/validation/transactions. Standalone: depends only on Microsoft.Extensions.DependencyInjection.Abstractions.</Description>
+    <!-- Override the framework default tags (web/component/wasm) — Rask.Cqrs is a standalone,
+         host-agnostic mediator with no web/UI coupling. -->
+    <PackageTags>cqrs mediator dispatcher source-generator reflection-free aot trimming dotnet net10</PackageTags>
   </PropertyGroup>
+
+  <!-- Ship a package-specific README (this project's NUGET.md) instead of the shared framework
+       overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
+  <ItemGroup>
+    <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
+    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>

--- a/src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj
+++ b/src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj
@@ -9,6 +9,8 @@
     <PackageId>Rask.Validation.DataAnnotations</PackageId>
     <Title>Rask — DataAnnotations Validation</Title>
     <Description>Rask validator that runs System.ComponentModel.DataAnnotations over the form model. Drop `DataAnnotationsValidator()` inside a `Form&lt;T&gt;` to wire attribute-based validation (`[Required]`, `[Range]`, `IValidatableObject`, …) into Rask's EditContext. No external dependencies beyond Rask.Core.</Description>
+    <!-- Override the framework default tags (web/component/wasm) — this is a forms-validation adapter. -->
+    <PackageTags>validation dataannotations forms model-validation rask dotnet net10</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj
+++ b/src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj
@@ -9,6 +9,8 @@
     <PackageId>Rask.Validation.FluentValidation</PackageId>
     <Title>Rask — FluentValidation Validation</Title>
     <Description>Rask validator that delegates to a `FluentValidation.IValidator`. Drop `FluentValidationValidator(new MyValidator())` inside a `Form&lt;T&gt;` to wire FluentValidation rules into Rask's EditContext, including async per-field validation. Depends on FluentValidation 12.x.</Description>
+    <!-- Override the framework default tags (web/component/wasm) — this is a forms-validation adapter. -->
+    <PackageTags>validation fluentvalidation forms model-validation rask dotnet net10</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.WebPush/NUGET.md
+++ b/src/Rask.WebPush/NUGET.md
@@ -1,0 +1,47 @@
+# Rask.WebPush
+
+**Server-side Web Push sender.** Signs [VAPID](https://www.rfc-editor.org/rfc/rfc8292) and encrypts
+([RFC 8291](https://www.rfc-editor.org/rfc/rfc8291), `aes128gcm`) push messages, then POSTs them to
+a browser `PushSubscription` endpoint. It is the **send half** that pairs with `Rask.Wasm`'s
+`IWebPush` client — but it is **transport-neutral**: usable from a Rask Server app or any ASP.NET
+backend behind a WASM PWA.
+
+No external dependencies beyond `Microsoft.Extensions.*` — all crypto is in-box
+`System.Security.Cryptography`.
+
+## Install
+
+```bash
+dotnet add package Rask.WebPush
+```
+
+## Use
+
+```csharp
+builder.Services.AddRaskWebPush(o =>
+{
+    o.VapidKeys = VapidKeys.Generate();          // generate once, then load from config/secrets
+    o.Subject   = "mailto:admin@example.com";    // a contact the push service can reach
+});
+
+// ... inject IWebPushSender, then given a PushSubscription the browser sent you:
+var result = await sender.SendAsync(
+    subscription,
+    new WebPushMessage { Title = "Hello", Body = "from the server" },
+    ct);
+
+// Inspect the result to prune dead subscriptions:
+if (result.ShouldDelete) await store.RemoveAsync(subscription);
+```
+
+## Notes
+
+- **Standards-based** — VAPID (RFC 8292) auth + RFC 8291 `aes128gcm` payload encryption; interops
+  with any standard browser Push service (FCM, Mozilla, WNS).
+- **Zero external deps** — ECDH, HKDF and AES-GCM come from `System.Security.Cryptography`.
+- Generate a VAPID key pair once with `VapidKeys.Generate()` and keep the private key server-side;
+  hand the public key to the browser subscription.
+- `SendAsync` returns a `WebPushResult` whose `ShouldDelete` / `ShouldRetry` flags map the push
+  service's response to the action to take on the subscription.
+
+Full documentation: <https://github.com/pal-tamas/rask/blob/main/docs/pwa.md>

--- a/src/Rask.WebPush/Rask.WebPush.csproj
+++ b/src/Rask.WebPush/Rask.WebPush.csproj
@@ -9,7 +9,17 @@
     <PackageId>Rask.WebPush</PackageId>
     <Title>Rask.WebPush — Web Push (VAPID) Sender</Title>
     <Description>Server-side Web Push sender for Rask. Signs VAPID (RFC&#160;8292) and encrypts (RFC&#160;8291 aes128gcm) push messages, then POSTs them to a browser PushSubscription endpoint — the send half that pairs with Rask.Wasm's IWebPush client. Transport-neutral: usable from a Rask.Server app or any ASP.NET backend behind a WASM PWA. No external dependencies beyond Microsoft.Extensions.* — all crypto is in-box System.Security.Cryptography.</Description>
+    <!-- Override the framework default tags (web/component/wasm) — Rask.WebPush is a transport-neutral
+         server-side sender, not a web-UI component library. -->
+    <PackageTags>web-push push-notifications vapid rfc8291 rfc8292 aes128gcm notifications dotnet net10</PackageTags>
   </PropertyGroup>
+
+  <!-- Ship a package-specific README (this project's NUGET.md) instead of the shared framework
+       overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
+  <ItemGroup>
+    <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
+    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>


### PR DESCRIPTION
## Summary
Tier-1 follow-up to #236. Gives the standalone packages their own NuGet identity instead of inheriting the framework defaults, so nuget.org search and the gallery landing page match what each package actually is.

- **Per-package `PackageTags`** for the four off-profile packages — `Rask.Cqrs`, `Rask.WebPush`, `Rask.Validation.DataAnnotations`, `Rask.Validation.FluentValidation` — dropping the inherited `web`/`component`/`wasm`/`framework` tags that mis-signalled scope (e.g. `Rask.Cqrs` is a host-agnostic mediator; `Rask.WebPush` a transport-neutral server sender — neither is web-UI).
- **Package-specific `NUGET.md`** for `Rask.Cqrs` and `Rask.WebPush` (install + a verified quickstart) instead of the shared framework-overview README a consumer landed on before. Implemented per-project (`None Remove` the inherited root README + `None Update` the local one); `PackageReadmeFile` stays inherited — no change to `Directory.Build.props`.

The README code samples were checked against the actual API (`AddRaskCqrs` / `IQueryHandler` / `DispatchAsync`; `AddRaskWebPush` / `IWebPushSender.SendAsync` / `WebPushOptions.VapidKeys` / `WebPushMessage`) and the doc links point to existing pages (`docs/cqrs.md`, `docs/pwa.md`).

## Testing
- `dotnet build Rask.slnx` — **0 warnings, 0 errors** (rebased on merged #236)
- **Package inspection** — packed all four; confirmed corrected `<tags>` in each nuspec, and for `Rask.Cqrs`/`Rask.WebPush` **exactly one** `NUGET.md` carrying the package-specific content — alongside the `<title>`, `<icon>` and `Rask.*.xml` docs from #236.
- No code changed (packaging metadata + two new `.md` files), so the unit/E2E suites are unaffected.

## Benchmarks
N/A — packaging metadata only.

## Changelog
`[Unreleased]` → new **Changed** entry (kept alongside #236's Added/Fixed on rebase).