### PR TITLE
feat(forms): auto-opt-out of render cache when reading EditContext state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ them until tagged releases begin.
   for a client-side app.
 - **Form controls auto-opt-out of the render cache when they read validation state.** Reading an
   `EditContext`'s per-field validation messages / entries / validating flags during `Render()` now
-  latches the same render-cache opt-out that `Context.Get` consumers get (`Component._consumesContext`),
+  latches the same render-cache opt-out that `Context.Get` consumers get (`Component._readsAmbientState`),
   so a control that bakes feedback into its own output always repaints when a message is produced later
   in the submit pipeline — instead of serving a stale pre-submit frame. This removes the need for the
   manual `BypassRenderCache` override on `ValidationMessage` / `ValidationSummary` / `ValidatingIndicator`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ them until tagged releases begin.
 - **The `rask-server` template README points to the WASM variants** — since the bare `dotnet new rask`
   alias resolves to the server template, the generated README now notes `rask-wasm` / `rask-wasm-hosted`
   for a client-side app.
+- **Form controls auto-opt-out of the render cache when they read validation state.** Reading an
+  `EditContext`'s per-field validation messages / entries / validating flags during `Render()` now
+  latches the same render-cache opt-out that `Context.Get` consumers get (`Component._consumesContext`),
+  so a control that bakes feedback into its own output always repaints when a message is produced later
+  in the submit pipeline — instead of serving a stale pre-submit frame. This removes the need for the
+  manual `BypassRenderCache` override on `ValidationMessage` / `ValidationSummary` / `ValidatingIndicator`
+  and the `Rask.Bootstrap` form controls, and — the DX win — means **custom** form controls that read
+  validation state need no `StateHasChanged()` or `BypassRenderCache` of their own. No public API change;
+  behavior is unchanged, the correctness now comes for free.
 
 ### Fixed
 - **Corrected pre-existing malformed XML doc comments** exposed once `GenerateDocumentationFile` turned

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -497,6 +497,11 @@ CheckboxGroup<string>(interests, Value: _interests, OnChange: next => _interests
 - They are **Components** (their own re-render boundary), so a toggle re-renders the control itself; for
   host-side derived UI (a live summary) use **controlled** mode — the auto-wrapped `OnChange` re-renders
   the host. (In bound mode, feedback lives inside the control via the embedded `ValidationMessage`.)
+- **Reading validation state in a custom control just works.** If you bake feedback straight into your
+  own `Render()` — reading `EditContext.GetValidationMessages(field)` / `GetValidationEntries()` /
+  `ShouldShowValidatingIndicator(field)` — the framework detects the read and opts that control out of
+  its render cache automatically, so a message produced later in the submit pipeline always repaints. No
+  `StateHasChanged()`, no `BypassRenderCache` override (the same auto-opt-out `Context.Get` consumers get).
 
 `RadioGroup` (single value) and `CheckboxGroup` (a collection), live:
 

--- a/src/Rask.Bootstrap/BsFormControl.cs
+++ b/src/Rask.Bootstrap/BsFormControl.cs
@@ -32,13 +32,11 @@ public abstract class BsFormControl<T> : BsBlock, IFormControl<T>
     public string? HelpText { get; set; }
     public string? Name { get; set; }
 
-    // Field() bakes the per-field .invalid-feedback straight into this control's own render output
-    // from the EditContext's mutable message list — state the render cache doesn't observe. Without
-    // opting out, the cache pins whichever message state an earlier render saw (e.g. the empty state
-    // captured before submit), so validation produced during the submit pipeline never repaints. Same
-    // rationale as ValidationMessage/ValidationSummary/ValidatingIndicator, which bundle the feedback
-    // as a separate bypassing component; the Bootstrap controls inline it, so they bypass here.
-    protected override bool BypassRenderCache => true;
+    // Field() bakes the per-field .invalid-feedback straight into this control's own render output from
+    // the EditContext's mutable message list. No manual BypassRenderCache: Resolve() reads
+    // EditContext.GetValidationMessages during Render(), which auto-latches the render-cache opt-out
+    // (see EditContext.MarkReader / Component._consumesContext), so validation produced during the submit
+    // pipeline always repaints instead of being served stale from a pre-submit cache.
 
     // Bootstrap floating label (https://getbootstrap.com/docs/5.0/forms/floating-labels/): wraps the
     // control + label in a .form-floating with the label AFTER the control, so the label floats over an

--- a/src/Rask.Bootstrap/BsFormControl.cs
+++ b/src/Rask.Bootstrap/BsFormControl.cs
@@ -35,7 +35,7 @@ public abstract class BsFormControl<T> : BsBlock, IFormControl<T>
     // Field() bakes the per-field .invalid-feedback straight into this control's own render output from
     // the EditContext's mutable message list. No manual BypassRenderCache: Resolve() reads
     // EditContext.GetValidationMessages during Render(), which auto-latches the render-cache opt-out
-    // (see EditContext.MarkReader / Component._consumesContext), so validation produced during the submit
+    // (see EditContext.MarkReader / Component._readsAmbientState), so validation produced during the submit
     // pipeline always repaints instead of being served stale from a pre-submit cache.
 
     // Bootstrap floating label (https://getbootstrap.com/docs/5.0/forms/floating-labels/): wraps the

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -322,7 +322,7 @@ public abstract class Component
     protected virtual Component? Head => null;
 
     internal Component? HeadInternal => Head;
-    internal void MarkConsumesContextInternal() => _readsAmbientState = true;
+    internal void MarkReadsAmbientStateInternal() => _readsAmbientState = true;
 
     internal void WriteAttributesInternal(StringBuilder sb) => WriteAttributes(sb);
     internal IEnumerable<Component?> RenderChildrenInternal() => RenderChildren();

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -43,9 +43,9 @@ public abstract class Component
     // via EditContext.MarkReader). Such a component depends on state the framework doesn't diff, so —
     // like BypassRenderCache — it must re-execute Render() on every walk to pick up a changed value.
     // This is why form controls that read validation state need no manual BypassRenderCache override.
-    // Latched on: once a consumer, always a consumer (its Render path can read different
+    // Latched on: once a reader, always a reader (its Render path can read different
     // context/edit-context state across renders).
-    private bool _consumesContext;
+    private bool _readsAmbientState;
     private CancellationTokenSource? _lifetimeCts;
 
     // All live-render-only state — handlers, child reconciliation, root alive sets,
@@ -322,7 +322,7 @@ public abstract class Component
     protected virtual Component? Head => null;
 
     internal Component? HeadInternal => Head;
-    internal void MarkConsumesContextInternal() => _consumesContext = true;
+    internal void MarkConsumesContextInternal() => _readsAmbientState = true;
 
     internal void WriteAttributesInternal(StringBuilder sb) => WriteAttributes(sb);
     internal IEnumerable<Component?> RenderChildrenInternal() => RenderChildren();
@@ -747,7 +747,7 @@ public abstract class Component
         // what lets composite wrappers (a Bs* card around dynamic content) behave like the inline
         // elements they replace without opting out of caching by hand.
         if (Live.CachedRenderResult is not null && !Live.PropsDirty && !Live.StateDirty
-            && !BypassRenderCache && !_consumesContext
+            && !BypassRenderCache && !_readsAmbientState
             && (Children is null || this is Element))
         {
             return Live.CachedRenderResult;

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -38,11 +38,13 @@ public abstract class Component
         ("<!DOCTYPE html>", "Doctype()"), ("<html", "Html(...)"), ("<head", "Head()"), ("<body", "Body()")
     };
 
-    // Set the first time this component reads a context value (Context.Get/Required/Has-via-Get).
-    // Such a component depends on ambient state the framework doesn't diff, so — like
-    // BypassRenderCache — it must re-execute Render() on every walk to pick up a changed value.
+    // Set the first time this component reads untracked ambient state during Render: a context value
+    // (Context.Get/Required/Has-via-Get) OR EditContext state (validation messages / validating flags,
+    // via EditContext.MarkReader). Such a component depends on state the framework doesn't diff, so —
+    // like BypassRenderCache — it must re-execute Render() on every walk to pick up a changed value.
+    // This is why form controls that read validation state need no manual BypassRenderCache override.
     // Latched on: once a consumer, always a consumer (its Render path can read different
-    // context types across renders).
+    // context/edit-context state across renders).
     private bool _consumesContext;
     private CancellationTokenSource? _lifetimeCts;
 

--- a/src/Rask.Core/Components/Context.cs
+++ b/src/Rask.Core/Components/Context.cs
@@ -99,5 +99,5 @@ public sealed class Context : Component
         return ContextStack.TryGet(typeof(T), name, out _);
     }
 
-    private static void MarkConsumer() => LiveRenderContext.CurrentSync?.MarkCurrentConsumesContext();
+    private static void MarkConsumer() => LiveRenderContext.CurrentSync?.MarkCurrentReadsAmbientState();
 }

--- a/src/Rask.Core/Components/ValidationMessage.cs
+++ b/src/Rask.Core/Components/ValidationMessage.cs
@@ -12,7 +12,7 @@ public sealed class ValidationMessage : Component
     public required Func<IReadOnlyList<string>, Component> Template { get; set; }
 
     // No manual BypassRenderCache: reading EditContext.GetValidationMessages in Render() auto-latches
-    // the render-cache opt-out (see EditContext.MarkReader / Component._consumesContext), so a message
+    // the render-cache opt-out (see EditContext.MarkReader / Component._readsAmbientState), so a message
     // added by a later (e.g. post-await) render is always observed instead of served stale from cache.
 
     [GenerateForwarderFactory]

--- a/src/Rask.Core/Components/ValidationMessage.cs
+++ b/src/Rask.Core/Components/ValidationMessage.cs
@@ -11,12 +11,9 @@ public sealed class ValidationMessage : Component
     // for the bound field; the empty case renders nothing.
     public required Func<IReadOnlyList<string>, Component> Template { get; set; }
 
-    // Reads mutable EditContext state (per-field message list) the framework doesn't observe.
-    // The cache would otherwise pin the messages seen during whichever earlier render
-    // populated it — e.g. the mid-await render captures the no-message state, and the post-
-    // handler render then reuses that stale subtree even after an async validator added a
-    // message. Same rationale as Router/Outlet opting out for RouteState.
-    protected override bool BypassRenderCache => true;
+    // No manual BypassRenderCache: reading EditContext.GetValidationMessages in Render() auto-latches
+    // the render-cache opt-out (see EditContext.MarkReader / Component._consumesContext), so a message
+    // added by a later (e.g. post-await) render is always observed instead of served stale from cache.
 
     [GenerateForwarderFactory]
     public static ValidationMessage Bound<TProp>(
@@ -50,8 +47,8 @@ public sealed class ValidationSummary : Component
     // with its error text.
     public required Func<IReadOnlyList<ValidationEntry>, Component?> Template { get; set; }
 
-    // Reads EditContext message state — see ValidationMessage for the rationale.
-    protected override bool BypassRenderCache => true;
+    // Reads EditContext.GetValidationEntries in Render() — auto-latches the cache opt-out; see
+    // ValidationMessage for the rationale.
 
     protected override Component? Render()
     {
@@ -87,8 +84,8 @@ public sealed class ValidatingIndicator : Component
 
     public required Func<Component> Template { get; set; }
 
-    // Reads EditContext.IsValidating(field) — see ValidationMessage for the rationale.
-    protected override bool BypassRenderCache => true;
+    // Reads EditContext.ShouldShowValidatingIndicator(field) in Render() — auto-latches the cache
+    // opt-out; see ValidationMessage for the rationale.
 
     [GenerateForwarderFactory]
     public static ValidatingIndicator Bound<TProp>(

--- a/src/Rask.Core/Forms/EditContext.cs
+++ b/src/Rask.Core/Forms/EditContext.cs
@@ -64,6 +64,7 @@ public sealed class EditContext : IDisposable
     {
         get
         {
+            MarkReader();
             foreach (var s in _states.Values)
             {
                 if (s.PendingCount > 0)
@@ -179,8 +180,18 @@ public sealed class EditContext : IDisposable
     // Form-level inline Validate delegate. Null clears.
     public void RegisterFormValidator(Delegate? validate) => _formDelegate = validate;
 
-    public bool IsValidating(FieldIdentifier field) =>
-        _states.TryGetValue(field, out var s) && s.PendingCount > 0;
+    // Latches the component currently mid-Render() as reading untracked EditContext state, so it
+    // permanently opts out of the render cache (Component.RenderForLive) and re-executes Render() to
+    // observe later validation-message / validating-state changes. Exactly the mechanism Context.Get
+    // uses (Context.MarkConsumer). CurrentSync is non-null only during an active live render, so calls
+    // from the validation/submit pipeline are no-ops — no over-marking, no allocation on the hot path.
+    private static void MarkReader() => Live.LiveRenderContext.CurrentSync?.MarkCurrentConsumesContext();
+
+    public bool IsValidating(FieldIdentifier field)
+    {
+        MarkReader();
+        return _states.TryGetValue(field, out var s) && s.PendingCount > 0;
+    }
 
     /// <summary>
     ///     <see cref="IsValidating(FieldIdentifier)" /> extended with a short
@@ -198,6 +209,7 @@ public sealed class EditContext : IDisposable
     /// </summary>
     public bool ShouldShowValidatingIndicator(FieldIdentifier field)
     {
+        MarkReader();
         if (!_states.TryGetValue(field, out var s))
         {
             return false;
@@ -211,26 +223,44 @@ public sealed class EditContext : IDisposable
         return s.StickyUntilUtc is { } until && until > DateTimeOffset.UtcNow;
     }
 
-    public bool IsModified(FieldIdentifier field) =>
-        _states.TryGetValue(field, out var s) && s.Modified;
+    public bool IsModified(FieldIdentifier field)
+    {
+        MarkReader();
+        return _states.TryGetValue(field, out var s) && s.Modified;
+    }
 
-    public bool IsTouched(FieldIdentifier field) =>
-        _states.TryGetValue(field, out var s) && s.Touched;
+    public bool IsTouched(FieldIdentifier field)
+    {
+        MarkReader();
+        return _states.TryGetValue(field, out var s) && s.Touched;
+    }
 
-    public IReadOnlyList<string> GetValidationMessages(FieldIdentifier field) =>
-        _states.TryGetValue(field, out var s) ? s.Messages : Array.Empty<string>();
+    public IReadOnlyList<string> GetValidationMessages(FieldIdentifier field)
+    {
+        MarkReader();
+        return _states.TryGetValue(field, out var s) ? s.Messages : Array.Empty<string>();
+    }
 
     public IEnumerable<string> GetValidationMessages()
     {
-        foreach (var s in _states.Values)
-            foreach (var m in s.Messages)
-            {
-                yield return m;
-            }
+        // Mark before returning the iterator: MarkReader() inside the yield body would only run on
+        // first MoveNext (deferred), missing a render that enumerates lazily or not at all.
+        MarkReader();
+        return Enumerate();
+
+        IEnumerable<string> Enumerate()
+        {
+            foreach (var s in _states.Values)
+                foreach (var m in s.Messages)
+                {
+                    yield return m;
+                }
+        }
     }
 
     public IReadOnlyList<ValidationEntry> GetValidationEntries()
     {
+        MarkReader();
         var entries = new List<ValidationEntry>();
         foreach (var pair in _states)
             foreach (var m in pair.Value.Messages)
@@ -241,8 +271,11 @@ public sealed class EditContext : IDisposable
         return entries;
     }
 
-    public bool HasValidationMessages() =>
-        _states.Values.Any(s => s.Messages.Count > 0);
+    public bool HasValidationMessages()
+    {
+        MarkReader();
+        return _states.Values.Any(s => s.Messages.Count > 0);
+    }
 
     // Records the consumer that owns a field's bind expression so a write can re-render it. Idempotent per
     // render; null owners (bindings closed over a non-component root) are ignored.

--- a/src/Rask.Core/Forms/EditContext.cs
+++ b/src/Rask.Core/Forms/EditContext.cs
@@ -185,7 +185,7 @@ public sealed class EditContext : IDisposable
     // observe later validation-message / validating-state changes. Exactly the mechanism Context.Get
     // uses (Context.MarkConsumer). CurrentSync is non-null only during an active live render, so calls
     // from the validation/submit pipeline are no-ops — no over-marking, no allocation on the hot path.
-    private static void MarkReader() => Live.LiveRenderContext.CurrentSync?.MarkCurrentConsumesContext();
+    private static void MarkReader() => Live.LiveRenderContext.CurrentSync?.MarkCurrentReadsAmbientState();
 
     public bool IsValidating(FieldIdentifier field)
     {

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -196,11 +196,12 @@ public sealed class LiveRenderContext : IDisposable
     public void NotifyParameters(Component component, bool propsChanged) =>
         component.RaiseLifecycleBeforeRender(propsChanged);
 
-    // Called from Context.Get/Required while a component is mid-Render (so the component sits on
-    // top of the parent stack). Flags it as a context consumer, which permanently opts it out of
-    // the render cache — a later change to a provided value must re-execute its Render() for it
-    // to observe the new value (same rationale as Router/ErrorBoundary's BypassRenderCache).
-    internal void MarkCurrentConsumesContext() => CurrentParent.MarkConsumesContextInternal();
+    // Called from Context.Get/Required and EditContext.MarkReader while a component is mid-Render (so
+    // the component sits on top of the parent stack). Flags it as reading untracked ambient state,
+    // which permanently opts it out of the render cache — a later change to a provided context value or
+    // to the EditContext's validation state must re-execute its Render() for it to observe the change
+    // (same rationale as Router/ErrorBoundary's BypassRenderCache).
+    internal void MarkCurrentReadsAmbientState() => CurrentParent.MarkReadsAmbientStateInternal();
 
     public EditContext GetOrCreateEditContext(object model, Func<EditContext>? factory = null)
     {

--- a/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
+++ b/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
@@ -48,7 +48,7 @@ public class ValidationMessageTests
         // ValidationMessage carries no manual BypassRenderCache override anymore. Its first render
         // reads EditContext.GetValidationMessages (no messages yet) and populates the render cache with
         // the empty result; that read auto-latches the component as a cache opt-out (EditContext
-        // .MarkReader -> Component._consumesContext). So when a message is added out-of-band and the
+        // .MarkReader -> Component._readsAmbientState). So when a message is added out-of-band and the
         // same pooled view is re-rendered with nothing marked prop/state-dirty, the second walk must
         // still re-execute Render() and surface the message rather than serve the stale empty frame.
         var p = new Person { Name = "" };

--- a/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
+++ b/tests/Rask.Core.Tests/Components/ValidationMessageTests.cs
@@ -43,6 +43,64 @@ public class ValidationMessageTests
     }
 
     [Fact]
+    public void ValidationMessage_MessageAddedAfterFirstRender_RepaintsOnReRender_ViaAutoLatch()
+    {
+        // ValidationMessage carries no manual BypassRenderCache override anymore. Its first render
+        // reads EditContext.GetValidationMessages (no messages yet) and populates the render cache with
+        // the empty result; that read auto-latches the component as a cache opt-out (EditContext
+        // .MarkReader -> Component._consumesContext). So when a message is added out-of-band and the
+        // same pooled view is re-rendered with nothing marked prop/state-dirty, the second walk must
+        // still re-execute Render() and surface the message rather than serve the stale empty frame.
+        var p = new Person { Name = "" };
+        var ctx = new EditContext(p);
+        var field = new FieldIdentifier(p, nameof(Person.Name));
+
+        var view = new StubComponent(() => Form(Context: ctx, Model: p)[
+            ValidationMessage(() => p.Name, msgs => Div(Class: "validation-message")[msgs[0]])
+        ]);
+
+        var first = view.RenderAsLiveRoot();
+        Assert.DoesNotContain("validation-message", first);
+
+        ctx.AddValidationMessage(field, "Name is required");
+
+        var second = view.RenderAsLiveRoot();
+        Assert.Contains("class=\"validation-message\"", second);
+        Assert.Contains("Name is required", second);
+    }
+
+    [Fact]
+    public void ValidationSummary_MessageAddedAfterFirstRender_RepaintsOnReRender_ViaAutoLatch()
+    {
+        // Same auto-latch guarantee for the GetValidationEntries read path (ValidationSummary). It
+        // must start non-empty so the first render caches a non-null <ul> (a null/empty render is never
+        // cached and would repaint regardless, proving nothing): render one message, add a second
+        // out-of-band, and require the stale one-item cache to be replaced by the two-item summary.
+        var p = new Person { Name = "" };
+        var ctx = new EditContext(p);
+        var name = new FieldIdentifier(p, nameof(Person.Name));
+        var email = new FieldIdentifier(p, nameof(Person.Email));
+        ctx.AddValidationMessage(name, "Name is required");
+
+        var view = new StubComponent(() => Form(Context: ctx, Model: p)[
+            ValidationSummary(entries =>
+                Ul(Class: "validation-summary")[
+                    entries.Select((e, i) => Li(Key: i)[e.Message])
+                ])
+        ]);
+
+        var first = view.RenderAsLiveRoot();
+        Assert.Contains("Name is required", first);
+        Assert.DoesNotContain("Email is required", first);
+
+        ctx.AddValidationMessage(email, "Email is required");
+
+        var second = view.RenderAsLiveRoot();
+        Assert.Contains("Name is required", second);
+        Assert.Contains("Email is required", second);
+    }
+
+    [Fact]
     public void ValidationSummary_WithMessages_RendersTemplate()
     {
         var p = new Person { Name = "" };
@@ -176,6 +234,7 @@ public class ValidationMessageTests
     private sealed class Person
     {
         public string Name { get; set; } = "";
+        public string Email { get; set; } = "";
     }
 
     private sealed class GatedValidator(Task wait) : IAsyncFieldValidator


### PR DESCRIPTION
## Summary

Form controls no longer need a manual `BypassRenderCache` override to stay correct — reading an `EditContext`'s validation state during `Render()` now auto-opts the reader out of the render cache, the same way `Context.Get` consumers already do.

**Why.** The live-render cache (`Component.RenderForLive`) skips re-executing `Render()` when nothing the framework *tracks* changed (props/state). Validation lives in the `EditContext`, which the cache doesn't diff, so components that read it had to hand-write `protected override bool BypassRenderCache => true` — and there was **no diagnostic** if a custom control author forgot, just silently stale validation UI. The framework already solves this exact class of problem automatically: reading a context value latches `_consumesContext` and permanently opts the component out of the cache (this is why Router/Outlet dropped their manual bypass). We just weren't wired into that latch for `EditContext` reads.

**What.** A small `EditContext.MarkReader()` calls the same marker `Context.Get` uses (`LiveRenderContext.CurrentSync?.MarkCurrentConsumesContext()`) from every render-affecting read method (`GetValidationMessages`, `GetValidationEntries`, `ShouldShowValidatingIndicator`, `IsValidating`/`IsValidatingAny`, `IsModified`, `IsTouched`, `HasValidationMessages`). Instrumenting at the source makes the guarantee total — a custom control that reads any of these during `Render()` is protected without knowing the rule exists.

The now-redundant `BypassRenderCache` overrides are removed from `ValidationMessage`, `ValidationSummary`, `ValidatingIndicator`, and `Rask.Bootstrap`'s `BsFormControl`. The `BypassRenderCache` escape hatch itself is untouched (still used by `DragDrop`/`ErrorBoundary`/`VirtualizeModel`/etc. for their own reasons).

No public API change; the render hot-path is untouched.

## Testing

- New unit tests in `ValidationMessageTests` pin the mechanism explicitly: a `ValidationMessage` / `ValidationSummary` renders once (populating the cache), a message is added out-of-band, and a second render of the same pooled view must repaint — proving the auto-latch replaces the deleted manual bypass. (The `ValidationSummary` case starts non-empty so the first render actually caches a non-null result.)
- Existing `AsyncFormBindingTests` (incl. under Router/Outlet) and the `ValidatingIndicator` sticky-window tests are the regression net for the removed overrides — all green.
- `dotnet format` clean · `dotnet build -warnaserror` clean (analyzers) · full unit suite green (one pre-existing flaky WS timing test, `HelloMessageTests.Hello_StateMutatedBeforeHello_EmitsCatchUpFrame`, passes in isolation and doesn't touch `EditContext`).

## Benchmarks

Render hot-path is byte-identical (the `Component.cs` change is comment-only). `LiveRenderRoundTripBenchmarks` before/after — `Allocated` unchanged:

| Method | Before | After |
| --- | --- | --- |
| RenderOnce | 82.53 KB | 82.53 KB |
| RenderTenTimes | 152.84 KB | 152.84 KB |
| RenderKeyedList100_ShuffledEachIteration | 85.54 KB | 85.54 KB |
| RenderDeep_50UserComponents | 73.71 KB | 72.54 KB (noise; no forms in this tree) |

`MarkReader()` is a null-checked static call with no allocation, and it replaces an equivalent virtual `BypassRenderCache` property read that's now gone — a wash.

## Changelog

Added an `[Unreleased] → Changed` entry.

## Docs

`docs/forms.md` custom-controls section gains a note that reading validation state auto-updates (no `StateHasChanged()`/`BypassRenderCache`).
