### PR TITLE
fix(nuget): guard generator packing, mark Wasm.Tasks unpackable, fix doc ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,25 @@ them until tagged releases begin.
   no longer tagged `wasm`/`component`. `Rask.Cqrs` and `Rask.WebPush` also ship a **package-specific
   `NUGET.md`** (install + quickstart for that package) rather than the shared framework overview a
   consumer landed on before.
+- **The `rask-server` template README points to the WASM variants** — since the bare `dotnet new rask`
+  alias resolves to the server template, the generated README now notes `rask-wasm` / `rask-wasm-hosted`
+  for a client-side app.
 
 ### Fixed
 - **Corrected pre-existing malformed XML doc comments** exposed once `GenerateDocumentationFile` turned
   on doc validation — a dangling `<summary>` on `Component.ToHtml`, `paramref`s to non-existent
   parameters, an `&nbsp;` entity undefined in XML, and several unresolved/ambiguous `cref`s across
   `Rask.Core`, `Rask.Server`, `Rask.Wasm` and `Rask.Wasm.Hosting`.
+- **`dotnet pack` now fails loud if the source generator DLL is missing** from the host packages
+  (`Rask.Server`/`Rask.Wasm`) instead of silently shipping a package with no analyzer — a `<None>`
+  include of an absent file packs nothing and emits no error, which would leave a consumer's factories
+  never generating. A pack-time guard errors clearly if the hardcoded `Rask.Generators.dll` path is
+  empty (build-order itself is already ensured via `Rask.Core`'s analyzer reference).
+- **`Rask.Wasm.Tasks` is now `IsPackable=false`** — a `dotnet pack` over the whole solution no longer
+  emits a stray, empty package for the build-only MSBuild task assembly.
+- **Diagnostic-range references now read `RASK001–029`** (the current maximum), fixing stale
+  `RASK001–024`/`–026`/`–022` strings in `docs/README.md`, `docs/best-practices.md`, `llms.txt`,
+  `CONTRIBUTING.md` and `CLAUDE.md`.
 
 ## [0.12.1] - 2026-07-04
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,10 @@ dotnet run --project samples/Rask.Example.Server
 Routing/lifecycle (`docs/routing.md`, `docs/lifecycle.md`), scoped CSS/JS + typed browser APIs
 (`docs/js-interop.md`, `docs/browser-apis.md` — the 43-wrapper map), forms +
 validation (`docs/forms.md`), auth (`docs/authentication.md`), context/callbacks (`docs/composition.md`),
-diagnostics RASK001–026 (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
+diagnostics RASK001–029 (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
 started / migration / testing / architecture (`docs/`). Trimming: `samples/Rask.Example.Wasm` must
 `dotnet publish -c Release` with zero IL warnings — new reflection needs a DAM annotation or justified suppression.
 
 ## Conventions
 - **New HTML tag** → `add-html-tag` skill (`src/Rask.Core/Components/{Tag}.cs` + `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`).
-- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–026 are documented in `docs/diagnostics.md`.
+- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–029 are documented in `docs/diagnostics.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ a `[DynamicallyAccessedMembers]` annotation or a justified `[UnconditionalSuppre
 | Path | What lives there |
 |------|------------------|
 | `src/Rask.Core/` | Rendering, live diff codec, routing, lifecycle, scoped CSS/JS, primitives. |
-| `src/Rask.Generators/` | Roslyn factory/route generators and analyzers (RASK001–022). |
+| `src/Rask.Generators/` | Roslyn factory/route generators and analyzers (RASK001–029). |
 | `src/Rask.Server/`, `src/Rask.Wasm/`, `src/Rask.Wasm.Hosting/` | The three hosts. |
 | `src/Rask.Templates/` | `dotnet new` templates (`rask-server`, `rask-wasm`, `rask-wasm-hosted`). |
 | `samples/` | Runnable feature showcases. | 
@@ -65,7 +65,7 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   `tests/Rask.Core.Tests/Components/{Tag}Tests.cs` asserting exact attribute order
   (id, class, style, data-*, then tag-specific). The factory is generated automatically.
 - **Don't `new` a `Component`** outside `Rask.Core` — use the generated factory (RASK014).
-- Diagnostics RASK001–022 are documented in [docs/diagnostics.md](docs/diagnostics.md);
+- Diagnostics RASK001–029 are documented in [docs/diagnostics.md](docs/diagnostics.md);
   the analyzer descriptors are the source of truth.
 
 ## Commits & pull requests

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,7 @@ interactive app. Want the pitch and a quick demo first? See the project [README]
 
 | Reference | What it covers |
 |-----------|----------------|
-| [Diagnostics (RASK001–024)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
+| [Diagnostics (RASK001–029)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
 | [Code analysis](code-analysis.md) | Analyzers, warnings-as-errors, and the per-PR adoption procedure. |
 
 ## Contributing

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -5,7 +5,7 @@ collects the patterns that keep a Rask app correct, secure, and fast as it grows
 framework rewards, the foot-guns it can't stop for you, and where each one is enforced.
 
 Every item is short on purpose: a rule, *why* it matters, and a link to the deep dive. Many of these
-are also compile-time diagnostics ([RASK001–024](diagnostics.md)) — when the analyzer can catch a
+are also compile-time diagnostics ([RASK001–029](diagnostics.md)) — when the analyzer can catch a
 mistake, the rule notes the ID.
 
 - [Component design](#component-design)

--- a/llms.txt
+++ b/llms.txt
@@ -29,7 +29,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
-- [Diagnostics](docs/diagnostics.md): RASK001–024 compile-time diagnostics + fixes.
+- [Diagnostics](docs/diagnostics.md): RASK001–029 compile-time diagnostics + fixes.
 - [Testing](docs/testing.md): unit + Playwright E2E patterns.
 
 ## Contributing to Rask itself

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -114,7 +114,17 @@
     <None Include="..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll"
           Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false"/>
   </ItemGroup>
-  <ItemGroup>
-  </ItemGroup>
+
+  <!--
+    Fail loud at pack time if the source generator DLL is missing from the hardcoded path above,
+    instead of silently shipping a package with no analyzer — a <None Include> of an absent file
+    packs nothing and emits no error, so consumers' factories would just never generate. Build order
+    is already ensured by Rask.Core's analyzer ProjectReference to Rask.Generators; this guard also
+    catches the path drifting (e.g. a Rask.Generators TFM change) or a no-build pack.
+  -->
+  <Target Name="_RaskVerifyGeneratorPacked" BeforeTargets="GenerateNuspec">
+    <Error Condition="!Exists('..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll')"
+           Text="Rask.Generators.dll not found at '..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll' — build Rask.Generators before packing so the source generator ships in analyzers/dotnet/cs/." />
+  </Target>
 
 </Project>

--- a/src/Rask.Templates/content/rask-server/README.md
+++ b/src/Rask.Templates/content/rask-server/README.md
@@ -3,6 +3,9 @@
 A server-side [Rask](https://github.com/pal-tamas/rask) app. The browser holds a thin
 client; renders and events flow over a WebSocket and Rask ships a minimal diff per update.
 
+> Scaffolded from the `rask-server` template — also what the bare `dotnet new rask` selects.
+> For a client-side WebAssembly app instead, use `dotnet new rask-wasm` (or `rask-wasm-hosted`).
+
 ## Run
 
 ```bash

--- a/src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj
+++ b/src/Rask.Wasm.Tasks/Rask.Wasm.Tasks.csproj
@@ -20,6 +20,10 @@
     -->
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <!-- Build-only MSBuild task assembly shipped inside Rask.Wasm's build/ folder; it is never a
+         package of its own. Without this, a `dotnet pack` over the whole solution would emit a
+         stray, empty Rask.Wasm.Tasks package. -->
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -154,6 +154,18 @@
           Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false"/>
   </ItemGroup>
 
+  <!--
+    Fail loud at pack time if the source generator DLL is missing from the hardcoded path above,
+    instead of silently shipping a package with no analyzer — a <None Include> of an absent file
+    packs nothing and emits no error, so consumers' factories would just never generate. Build order
+    is already ensured by Rask.Core's analyzer ProjectReference to Rask.Generators; this guard also
+    catches the path drifting (e.g. a Rask.Generators TFM change) or a no-build pack.
+  -->
+  <Target Name="_RaskVerifyGeneratorPacked" BeforeTargets="GenerateNuspec">
+    <Error Condition="!Exists('..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll')"
+           Text="Rask.Generators.dll not found at '..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll' — build Rask.Generators before packing so the source generator ships in analyzers/dotnet/cs/." />
+  </Target>
+
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_RaskAddCoreToLib</TargetsForTfmSpecificContentInPackage>
   </PropertyGroup>


### PR DESCRIPTION
## Summary
Final Tier-1 PR — packaging robustness + doc-consistency cleanup.

- **Pack-time generator guard.** `Rask.Server`/`Rask.Wasm` pack `Rask.Generators.dll` from a hardcoded `bin` path; a `<None Include>` of an absent file packs *nothing* and emits *no error*, so a broken/drifted path would silently ship a package with no analyzer (consumer factories would never generate). Added a `BeforeTargets="GenerateNuspec"` guard that **errors loudly** if the DLL is missing. (Build *order* is already ensured transitively via `Rask.Core`'s analyzer `ProjectReference` to `Rask.Generators` — so copying `Rask.Cqrs`'s `OutputItemType="Analyzer"` would have been wrong here, it'd make the component generator *run on* the host projects. The guard is the right fix and also catches path drift / a no-build pack.)
- **`Rask.Wasm.Tasks` → `IsPackable=false`.** A whole-solution `dotnet pack` no longer emits a stray, empty package for the build-only MSBuild task assembly.
- **Diagnostic ranges → `RASK001–029`** (verified current max in `docs/diagnostics.md` and the analyzer descriptors). Fixed stale `–024`/`–026`/`–022` strings in `docs/README.md`, `docs/best-practices.md`, `llms.txt`, `CONTRIBUTING.md`, `CLAUDE.md`.
- **`rask-server` template README** now points to `rask-wasm`/`rask-wasm-hosted`, since the bare `dotnet new rask` alias resolves to the server template (the alias is kept — server is the sensible default).

_Note: the plan's "remove dead `src/Rask.Html` stub" was a no-op — it's an untracked `bin/obj` artifact, not a tracked file, so there's nothing to delete in git._

## Testing
- `dotnet build Rask.slnx` — **0 warnings, 0 errors**
- **Guard verified both ways** — invoked the target with the generator DLL absent → errors with the descriptive message; present → passes silently. Normal `dotnet pack Rask.Server` still ships `analyzers/dotnet/cs/Rask.Generators.dll`.
- **`Rask.Wasm.Tasks` pack** produces no package (confirmed).
- No product code changed, so the unit/E2E suites are unaffected.

## Benchmarks
N/A — packaging/docs only.

## Changelog
`[Unreleased]` → Fixed + Changed entries (consolidated with #236/#237 on rebase).