### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-06
+
 ### Added
 - **NuGet packages now ship XML documentation, an icon, and per-package titles.** Every framework
   package emits its `///` API docs (`GenerateDocumentationFile`), so `AddRask`/`UseRask`, the `Bs*`


### PR DESCRIPTION
Promote the CHANGELOG `[Unreleased]` section to **v0.13.0** and open a fresh empty `[Unreleased]`.

Minor bump (pre-1.0): the release adds a new `### Added` entry (packages now ship XML docs, icon, per-package titles) plus behavioral Changed/Fixed items.

## Highlights
- **Added** — framework NuGet packages ship `///` XML docs, a gallery/IDE icon, and human-readable titles (IntelliSense lights up for consumers).
- **Changed** — per-package NuGet identity/tags + package-specific `NUGET.md` for the standalone packages; `rask-server` template README points to the WASM variants; form controls auto-opt-out of the render cache when they read validation state.
- **Fixed** — corrected malformed XML doc comments; `dotnet pack` now fails loud if the generator DLL is missing; `Rask.Wasm.Tasks` marked `IsPackable=false`; diagnostic-range refs updated to `RASK001–029`.

## Release mechanics
CHANGELOG-only change. After merge, tag `v0.13.0` on the merged commit → `release.yml` runs the unit gate + sharded E2E, then packs and pushes the eight NuGet packages and creates the GitHub release (MinVer derives the version from the tag).