### PR TITLE
perf(wasm): eliminate per-frame byte[] on the live render path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **The WASM live runtime no longer allocates a `byte[]` per rendered frame.** `WasmLiveSession` used
+  to `ToArray()` its write buffer on every frame to hand the payload across the `applyRender` JS
+  boundary and to dedup against the previous frame. It now double-buffers two `ArrayBufferWriter`s and
+  compares spans directly (mirroring `Rask.Server`), and pushes the payload to JS zero-copy via a
+  `MemoryView` (`ApplyRender(Span<byte>)`) instead of a marshalled `byte[]`. The per-frame allocation
+  drops to **0 B** (was the full payload size — e.g. ~4 KB for a document frame) and the emit/dedup
+  step is ~2× faster; the one remaining copy is a JS-side `.slice()` that materialises the frame for
+  `TextDecoder`. Intermediate publish-renders are fully allocation-free; the two byte-returning entry
+  points (`InitialRenderAsync`/`DispatchAsync`) keep a single `ToArray` for their unit-test seam.
+
 ## [0.13.0] - 2026-07-06
 
 ### Added

--- a/benchmarks/Rask.Benchmarks/WasmFrameEmitBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/WasmFrameEmitBenchmarks.cs
@@ -1,0 +1,55 @@
+using System.Buffers;
+using BenchmarkDotNet.Attributes;
+
+namespace Rask.Benchmarks;
+
+// Guards the per-frame allocation on the WASM outbound path. WasmLiveSession currently
+// materializes a byte[] every rendered frame (`_writeBuffer.WrittenSpan.ToArray()`) to both
+// (a) hand to the `ApplyRender(byte[])` JSImport and (b) compare against `_lastAppliedPayload`
+// for the no-op dedup. The Server host avoids the equivalent copy by double-buffering two
+// ArrayBufferWriters and comparing spans directly (LiveSession.cs), sending WrittenMemory to the
+// socket with no intermediate array.
+//
+// This isolates the .NET-side allocation the double-buffer port removes: the ToArray copy
+// scales linearly with payload size and happens on every frame; the span compare allocates
+// nothing. (The zero-copy hand-off to JS via a MemoryView marshalling is a JS-boundary change
+// out of a BDN harness's reach — this captures the managed allocation drop only.)
+[MemoryDiagnoser]
+public class WasmFrameEmitBenchmarks
+{
+    private readonly ArrayBufferWriter<byte> _current = new(8192);
+    private readonly ArrayBufferWriter<byte> _previous = new(8192);
+
+    // A small keyed-list diff vs a full-document WASM frame — the two ends of the payload range.
+    [Params(512, 4096)]
+    public int PayloadBytes;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // Deterministic identical content in both buffers — the steady-state dedup-hit case,
+        // where the current path's only cost is the per-frame byte[] the fix eliminates.
+        Span<byte> payload = stackalloc byte[256];
+        for (var written = 0; written < PayloadBytes;)
+        {
+            var chunk = Math.Min(payload.Length, PayloadBytes - written);
+            for (var i = 0; i < chunk; i++)
+            {
+                payload[i] = (byte)((written + i) & 0x7F | 0x20); // printable-ASCII-ish, deterministic
+            }
+
+            _current.Write(payload[..chunk]);
+            _previous.Write(payload[..chunk]);
+            written += chunk;
+        }
+    }
+
+    // Current WASM path: a fresh byte[] every frame for ApplyRender(byte[]) + the dedup baseline.
+    [Benchmark(Baseline = true)]
+    public int CurrentToArrayPerFrame() => _current.WrittenSpan.ToArray().Length;
+
+    // Proposed double-buffer path (mirrors Rask.Server): compare the two buffers' spans directly,
+    // no per-frame byte[]. Allocation-free.
+    [Benchmark]
+    public bool DoubleBufferSpanCompare() => _current.WrittenSpan.SequenceEqual(_previous.WrittenSpan);
+}

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2183,17 +2183,19 @@ export function setExports(exports) {
 }
 
 // Called by .NET (via [JSImport]) for both the initial paint and subsequent
-// background re-renders. `payload` is a Uint8Array carrying the UTF-8 JSON
-// frame the C# side built via LivePayload.BuildPayloadUtf8WithRoot — same
-// shape as the WS frame the server emits. One TextDecoder pass + JSON.parse
-// replaces the previous 5-string marshal across the JS boundary.
+// background re-renders. `payload` is a MemoryView — a zero-copy view over the
+// UTF-8 JSON frame in the C# write buffer (built via LivePayload.BuildPayloadUtf8WithRoot,
+// same shape as the WS frame the server emits). `.slice()` materialises a Uint8Array
+// copy on the JS side (the one unavoidable copy, replacing the prior per-frame byte[]
+// the C# side used to allocate); TextDecoder + JSON.parse then run on that. `.slice()`
+// is also valid on a Uint8Array, so this stays correct if ever called with one directly.
 const _payloadDecoder = new TextDecoder("utf-8");
 
 export function applyRender(payload) {
     if (!payload || payload.length === 0) return;
     let reply;
     try {
-        reply = JSON.parse(_payloadDecoder.decode(payload));
+        reply = JSON.parse(_payloadDecoder.decode(payload.slice()));
     } catch (e) {
         console.error("[Rask] applyRender: malformed payload", e);
         return;

--- a/src/Rask.Wasm/JSInterop.cs
+++ b/src/Rask.Wasm/JSInterop.cs
@@ -39,16 +39,10 @@ internal static partial class JSInterop
     {
         if (_session is null) return;
 
-        // Push the result back through the existing applyRender JSImport instead of
-        // returning Task<byte[]> (unsupported by the JSExport source generator). One
-        // boundary crossing each way, both byte[] — total interop cost is the same as
-        // the prior Task<string> pull model but without the per-event JSON.stringify in
-        // JS + UTF-16 transcode in the marshalling layer.
-        var payload = await _session.DispatchAsync(json).ConfigureAwait(false);
-        if (payload.Length > 0)
-        {
-            ApplyRender(payload);
-        }
+        // DispatchAsync builds the frame and pushes it to JS itself — zero-copy via applyRender
+        // (a MemoryView over its write buffer), with a double-buffered dedup. There is nothing to
+        // apply here; the byte[] it returns is retained only as a unit-test seam.
+        await _session.DispatchAsync(json).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -125,8 +119,10 @@ internal static partial class JSInterop
     [JSImport("setExports", ModuleName)]
     public static partial void SetExports(JSObject exports);
 
+    // MemoryView marshals a zero-copy view over the caller's buffer (no byte[] per frame); the JS
+    // applyRender reads it synchronously within this call.
     [JSImport("applyRender", ModuleName)]
-    public static partial void ApplyRender(byte[] payload);
+    public static partial void ApplyRender([JSMarshalAs<JSType.MemoryView>] Span<byte> payload);
 
     [JSImport("getLocation", ModuleName)]
     public static partial string GetLocation();
@@ -188,7 +184,7 @@ internal static partial class JSInterop
         return _session?.DispatchAsync(json) ?? Task.CompletedTask;
     }
 
-    public static void ApplyRender(byte[] payload) { }
+    public static void ApplyRender(Span<byte> payload) { }
     public static string GetLocation() => "/";
     public static string GetBaseAddress() => "/";
     public static void PushHistory(string url, bool replace) { }

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -339,17 +339,19 @@ export function setExports(exports) {
 }
 
 // Called by .NET (via [JSImport]) for both the initial paint and subsequent
-// background re-renders. `payload` is a Uint8Array carrying the UTF-8 JSON
-// frame the C# side built via LivePayload.BuildPayloadUtf8WithRoot — same
-// shape as the WS frame the server emits. One TextDecoder pass + JSON.parse
-// replaces the previous 5-string marshal across the JS boundary.
+// background re-renders. `payload` is a MemoryView — a zero-copy view over the
+// UTF-8 JSON frame in the C# write buffer (built via LivePayload.BuildPayloadUtf8WithRoot,
+// same shape as the WS frame the server emits). `.slice()` materialises a Uint8Array
+// copy on the JS side (the one unavoidable copy, replacing the prior per-frame byte[]
+// the C# side used to allocate); TextDecoder + JSON.parse then run on that. `.slice()`
+// is also valid on a Uint8Array, so this stays correct if ever called with one directly.
 const _payloadDecoder = new TextDecoder("utf-8");
 
 export function applyRender(payload) {
     if (!payload || payload.length === 0) return;
     let reply;
     try {
-        reply = JSON.parse(_payloadDecoder.decode(payload));
+        reply = JSON.parse(_payloadDecoder.decode(payload.slice()));
     } catch (e) {
         console.error("[Rask] applyRender: malformed payload", e);
         return;

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -213,13 +213,10 @@ public sealed class WasmHostBuilder
         var session = new WasmLiveSession(root, provider);
         JSInterop.Init(session);
 
+        // InitialRenderAsync builds and pushes the first frame to JS itself (zero-copy applyRender);
+        // the returned bytes are just for the diagnostic below.
         var payload = await session.InitialRenderAsync().ConfigureAwait(false);
         Console.WriteLine($"[Rask.Wasm] first render payload bytes={payload.Length}");
-        if (payload.Length > 0)
-        {
-            JSInterop.ApplyRender(payload);
-        }
-
         Console.WriteLine("[Rask.Wasm] first render applied");
 
         // Inject the typed web app manifest (if configured) — a data: URL <link rel="manifest"> with

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Runtime.InteropServices;
 using System.Security.Claims;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -26,9 +27,39 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
     // multi-session / re-init path.
     private readonly IUserProvider? _userProvider;
 
-    // The last payload bytes ApplyRender pushed — WASM's dedup baseline (it ToArrays each frame for
-    // the JSExport boundary, where the Server double-buffers instead).
-    private byte[]? _lastAppliedPayload;
+    // The buffer holding the last frame ApplyRender pushed — WASM's dedup baseline. Mirrors the
+    // Rask.Server double-buffer: the sent frame is retained here (no per-frame byte[] copy), the
+    // next render writes into _writeBuffer, and EmitFrame swaps the two after each send.
+    private ArrayBufferWriter<byte>? _lastSentBuffer;
+
+    // Push the frame currently in _writeBuffer to JS zero-copy (a MemoryView over the buffer, no
+    // per-frame byte[]), unless it's byte-identical to the last frame we sent (dedup) — mirrors
+    // Rask.Server's double-buffered send. `force` bypasses the dedup for navigation frames that must
+    // flow even when the rendered output is unchanged. Returns whether a frame was actually sent.
+    private bool EmitFrame(bool force)
+    {
+        if (_writeBuffer.WrittenCount == 0)
+        {
+            return false;
+        }
+
+        if (!force
+            && _lastSentBuffer is not null
+            && _writeBuffer.WrittenSpan.SequenceEqual(_lastSentBuffer.WrittenSpan))
+        {
+            return false;
+        }
+
+        // MemoryView marshals a view over the buffer's bytes; the JS applyRender reads them
+        // synchronously (decode + JSON.parse) within this call, so the view never outlives it.
+        JSInterop.ApplyRender(MemoryMarshal.AsMemory(_writeBuffer.WrittenMemory).Span);
+
+        // Swap: the buffer we just sent becomes next frame's dedup baseline; the previous baseline
+        // (or a fresh writer on first send) is recycled as the next write target (WritePayload resets
+        // its WrittenCount before writing).
+        (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>(4096));
+        return true;
+    }
 
     // Set by BuildPayloadAsync when the frame it built carries queued IJSRuntime calls. The
     // publish-render noop guard must NOT drop such a frame even when the HTML is unchanged — the
@@ -78,15 +109,11 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         SynchronizationContext.SetSynchronizationContext(null);
         try
         {
-            var (payload, html) = await BuildPayloadAsync(null, false).ConfigureAwait(false);
-            if (_lastAppliedPayload is not null && payload.AsSpan().SequenceEqual(_lastAppliedPayload))
+            var html = await BuildPayloadAsync(null, false).ConfigureAwait(false);
+            if (EmitFrame(force: false))
             {
-                return;
+                _lastAppliedHtml = html;
             }
-
-            JSInterop.ApplyRender(payload);
-            _lastAppliedPayload = payload;
-            _lastAppliedHtml = html;
         }
         finally
         {
@@ -110,7 +137,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         InHandlerScope = true;
         try
         {
-            var (payload, html) = await BuildPayloadCoalescingRerendersAsync(null, false, publishOnly)
+            var html = await BuildPayloadCoalescingRerendersAsync(null, false, publishOnly)
                 .ConfigureAwait(false);
 
             // Noop publish-render guard: an auto-publish triggered by a completed
@@ -127,17 +154,13 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                 return;
             }
 
-            // Skip the JS interop call when nothing changed since the last apply. Catches
-            // StateHasChanged calls that didn't ultimately modify any visible output.
-            // SequenceEqual is SIMD-accelerated on byte[] — equivalent to the prior string compare.
-            if (_lastAppliedPayload is not null && payload.AsSpan().SequenceEqual(_lastAppliedPayload))
+            // Push the built frame unless it's byte-identical to the last sent frame. EmitFrame's
+            // double-buffered span compare (SIMD-accelerated) catches StateHasChanged calls that
+            // didn't change visible output — no per-frame byte[].
+            if (EmitFrame(force: false))
             {
-                return;
+                _lastAppliedHtml = html;
             }
-
-            JSInterop.ApplyRender(payload);
-            _lastAppliedPayload = payload;
-            _lastAppliedHtml = html;
         }
         finally
         {
@@ -154,10 +177,15 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         InHandlerScope = true;
         try
         {
-            var (payload, html) = await BuildPayloadAsync(null, false).ConfigureAwait(false);
-            _lastAppliedPayload = payload;
+            var html = await BuildPayloadAsync(null, false).ConfigureAwait(false);
+            if (!EmitFrame(force: true))
+            {
+                return Array.Empty<byte>();
+            }
+
             _lastAppliedHtml = html;
-            return payload;
+            // The bootstrap caller wants the initial frame bytes; ToArray once per page load.
+            return _lastSentBuffer!.WrittenSpan.ToArray();
         }
         finally
         {
@@ -225,20 +253,19 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                         historyReplace = replace;
                     }
 
-                    var (payload, html) = await BuildPayloadCoalescingRerendersAsync(historyUrl, historyReplace)
+                    var html = await BuildPayloadCoalescingRerendersAsync(historyUrl, historyReplace)
                         .ConfigureAwait(false);
-                    // Suppress the JS-side apply when nothing changed AND no navigation needs to flow.
-                    // The JS host treats an empty byte array as "no-op." Always send when historyUrl is set.
-                    if (historyUrl is null
-                        && _lastAppliedPayload is not null
-                        && payload.AsSpan().SequenceEqual(_lastAppliedPayload))
+                    // EmitFrame pushes the frame (zero-copy) unless it's byte-identical to the last
+                    // sent one; force the send when a navigation URL must flow even if the rendered
+                    // output is unchanged. No send → no-op (empty byte array to the test seam).
+                    if (!EmitFrame(force: historyUrl is not null))
                     {
                         return Array.Empty<byte>();
                     }
 
-                    _lastAppliedPayload = payload;
                     _lastAppliedHtml = html;
-                    return payload;
+                    // Return the sent frame's bytes for the test seam; ToArray once per event.
+                    return _lastSentBuffer!.WrittenSpan.ToArray();
                 }
             }
             catch (Exception ex)
@@ -289,11 +316,16 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
 
             try
             {
-                var (payload, html) =
+                var html =
                     await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
-                _lastAppliedPayload = payload;
+                // Navigation always flows — force the send even when the rendered output is unchanged.
+                if (!EmitFrame(force: true))
+                {
+                    return Array.Empty<byte>();
+                }
+
                 _lastAppliedHtml = html;
-                return payload;
+                return _lastSentBuffer!.WrittenSpan.ToArray();
             }
             catch (Exception ex)
             {
@@ -312,7 +344,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         }
     }
 
-    private async Task<(byte[] Payload, string Html)> BuildPayloadCoalescingRerendersAsync(string? historyUrl,
+    private async Task<string> BuildPayloadCoalescingRerendersAsync(string? historyUrl,
         bool replace, bool publishOnly = false)
     {
         // First build emits any pending history navigation. If a dispose callback (or other
@@ -370,7 +402,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
     // each other. Only the final, actually-sent build's render becomes the new baseline (the
     // loop calls Snapshot once after it settles). Direct senders (RenderInScopeAsync,
     // InitialRenderAsync) leave it true: their payload reaches the client, so it must commit.
-    internal async Task<(byte[] Payload, string Html)> BuildPayloadAsync(string? historyUrl, bool replace,
+    internal async Task<string> BuildPayloadAsync(string? historyUrl, bool replace,
         bool publishOnly = false, bool commitCache = true)
     {
         await Task.Yield();
@@ -421,7 +453,8 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
             commitCache, auth: null, sessionId: "wasm");
 
-        // ToArray for the JSExport byte[] boundary (PR6 will swap that for ReadOnlyMemory<byte>).
-        return (_writeBuffer.WrittenSpan.ToArray(), html);
+        // The built frame lives in _writeBuffer; EmitFrame pushes it zero-copy. Return only the HTML
+        // (used for the publish-render noop guard and as the diff-cache baseline).
+        return html;
     }
 }


### PR DESCRIPTION
## Summary
Brings the WASM live runtime to parity with `Rask.Server`, which already double-buffers and sends zero-copy. `WasmLiveSession` used to `ToArray()` its write buffer on **every rendered frame** — to both hand the payload across the `applyRender` JS boundary and dedup against the previous frame.

Now it:
- **Double-buffers** two `ArrayBufferWriter`s and compares spans directly (`EmitFrame`), mirroring `Rask.Server.LiveSession` — no `byte[]` for the dedup baseline.
- **Pushes to JS zero-copy** via a `MemoryView` (`ApplyRender([JSMarshalAs<JSType.MemoryView>] Span<byte>)`) instead of a marshalled `byte[]`. `rask.wasm.js` `applyRender` slices the view to a `Uint8Array` for `TextDecoder` (the one unavoidable copy, now on the JS side).
- Intermediate publish-renders (the per-frame hot path) are **fully allocation-free**. The two byte-returning entry points (`InitialRenderAsync`/`DispatchAsync`) keep a single `ToArray` for their unit-test seam (once per page / per event, not per frame).

## Benchmarks
New guard `WasmFrameEmitBenchmarks` (`[MemoryDiagnoser]`), before → after:

| Payload | Current (`ToArray`/frame) | Double-buffer (span compare) |
|---|---|---|
| 512 B | **536 B**, 23.5 ns | **0 B**, 8.8 ns |
| 4096 B | **4120 B**, 186.9 ns | **0 B**, 84.6 ns |

Per-frame allocation → **0 B** (was the full payload size); emit/dedup ~2× faster.

## Testing
- `dotnet build Rask.slnx` — 0 warnings, 0 errors
- **197/197 `Rask.Wasm.Tests` pass**, including all 43 `DispatchAsync`/`InitialRenderAsync` return-value assertions (dedup semantics, empty-on-noop, `historyUrl` force-send, buffer swap) — a strong gate for the .NET refactor.
- **WASM E2E** validates the `MemoryView` JS contract end-to-end via CI's sharded browser matrix (`WasmExampleTests`, `StandaloneWasmExampleTests`, `WasmSubPathExampleTests`, …) — the unit stub for `ApplyRender` is a no-op, so the browser path is only reachable there.

## Notes
- **Server needs no change** — it already double-buffers (`_lastSentBuffer`) and sends `WrittenMemory` zero-copy over the WebSocket (`LiveSession.cs:424`); the WebSocket API natively takes `ReadOnlyMemory<byte>`, whereas the WASM→JS boundary required this `MemoryView` switch.
- Follow-up: the shared double-buffer mechanic can be hoisted into `LiveSessionBase` (Core) with an abstract transport send — planned as a separate PR.