### PR TITLE
refactor(core): hoist the double-buffered send into LiveSessionBase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ them until tagged releases begin.
   step is ~2× faster; the one remaining copy is a JS-side `.slice()` that materialises the frame for
   `TextDecoder`. Intermediate publish-renders are fully allocation-free; the two byte-returning entry
   points (`InitialRenderAsync`/`DispatchAsync`) keep a single `ToArray` for their unit-test seam.
+- **Unified the double-buffered send between the Server and WASM hosts.** The dedup-and-swap mechanic
+  (skip byte-identical frames, hand the buffer to the transport, swap the sent buffer to the dedup
+  baseline) now lives once in `LiveSessionBase.TryEmitFrameAsync`, with the transport as an abstract
+  `SendFrameAsync` seam — a WebSocket send on Server, a zero-copy `MemoryView` `applyRender` on WASM.
+  Internal refactor, no behavior or public-API change; removes the duplicated buffer bookkeeping the
+  WASM zero-copy work had introduced. WASM's send stays synchronous (allocation-free).
 
 ## [0.13.0] - 2026-07-06
 

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -15,8 +15,12 @@ namespace Rask.Core.Live;
 internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 {
     // Pooled across the session lifetime; ResetWrittenCount between frames keeps the rented backing
-    // array hot. Non-readonly: Server swaps it with its previous-frame buffer for zero-copy dedup.
+    // array hot. Non-readonly: TryEmitFrameAsync swaps it with the previous-frame buffer for zero-copy dedup.
     protected ArrayBufferWriter<byte> _writeBuffer = new(4096);
+
+    // The buffer holding the last frame we sent — the double-buffer dedup baseline. TryEmitFrameAsync
+    // swaps it with _writeBuffer after each send, so neither the baseline nor the emit copies a byte[].
+    protected ArrayBufferWriter<byte>? _lastSentBuffer;
 
     // Diff-codec state, lazily allocated only when LiveOptions.DiffMode opts in — the default
     // (DisabledFull) path pays nothing for these.
@@ -134,6 +138,42 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 
     /// <summary>The framework's mid-await intermediate render (see Component.InvokeWithRenderingAsync).</summary>
     protected abstract Task RenderInScopeCoreAsync();
+
+    /// <summary>
+    ///     Double-buffered zero-copy send, shared by both hosts. Skips the frame currently in
+    ///     <see cref="_writeBuffer" /> when it's byte-identical to the last one sent (dedup), otherwise
+    ///     hands its bytes to the host transport via <see cref="SendFrameAsync" /> and swaps the buffers
+    ///     so the sent frame becomes the next dedup baseline and the old baseline is recycled as the
+    ///     next write target (<see cref="WritePayload" /> resets its <c>WrittenCount</c> before writing).
+    ///     <paramref name="force" /> bypasses the dedup for frames that must flow even when the rendered
+    ///     output is unchanged (navigation / auth / download). Returns whether a frame was sent.
+    /// </summary>
+    protected async ValueTask<bool> TryEmitFrameAsync(bool force)
+    {
+        if (_writeBuffer.WrittenCount == 0)
+        {
+            return false;
+        }
+
+        if (!force
+            && _lastSentBuffer is not null
+            && _writeBuffer.WrittenSpan.SequenceEqual(_lastSentBuffer.WrittenSpan))
+        {
+            return false;
+        }
+
+        await SendFrameAsync(_writeBuffer.WrittenMemory).ConfigureAwait(false);
+
+        (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>(4096));
+        return true;
+    }
+
+    /// <summary>
+    ///     Push one built frame's bytes to the host transport: Server writes them to the WebSocket
+    ///     (<c>ReadOnlyMemory&lt;byte&gt;</c>, zero-copy); WASM pushes them to JS via a zero-copy
+    ///     <c>MemoryView</c>. WASM's is synchronous — it returns a completed <see cref="ValueTask" />.
+    /// </summary>
+    protected abstract ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame);
 
     /// <summary>
     ///     Render the component tree to HTML, capturing the parallel <c>RenderFrame</c> stream when

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -46,11 +46,6 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // reconnect always renders.
     private bool _hasAttachedBefore;
 
-    // Previous-frame buffer for the zero-copy send dedup: after SendAsync, _writeBuffer (base) and
-    // this swap, so the just-sent bytes become the dedup baseline without a copy. Server-specific —
-    // WASM ToArrays each frame for the JSImport boundary instead.
-    private ArrayBufferWriter<byte>? _lastSentBuffer;
-
     // Set true whenever a render request lands with no live socket — async lifecycle
     // continuations from OnMountAsync / OnRenderedAsync that resolve during the HTTP-GET-
     // to-WS-hello handoff window, or while a session is between sockets across a
@@ -366,6 +361,12 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         }
     }
 
+    // Host transport for LiveSessionBase.TryEmitFrameAsync: write the frame's bytes to the WebSocket
+    // (ReadOnlyMemory<byte>, zero-copy). RenderAndSendAsync guards _socket non-null/Open before the
+    // shared send runs, and the render lock serialises teardown, so _socket is valid here.
+    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) =>
+        _socket!.SendAsync(frame, WebSocketMessageType.Text, true, _socketCt);
+
     internal async Task RenderAndSendAsync(string? historyUrl, bool replace, AuthInstruction? auth = null,
         bool publishOnly = false)
     {
@@ -407,22 +408,14 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
                 commitCache: true, auth, Id);
 
-            // Skip the frame when the payload is byte-identical to the previous one AND nothing
-            // out-of-band (navigation, auth instruction) needs to flow. Catches handler invocations
-            // that ended up not modifying tracked state. SequenceEqual is SIMD-accelerated and
-            // Utf8JsonWriter is deterministic, so byte equality is equivalent to the previous
-            // string-Ordinal compare.
-            if (historyUrl is null && auth is null && download is null
-                && _lastSentBuffer is not null
-                && _writeBuffer.WrittenSpan.SequenceEqual(_lastSentBuffer.WrittenSpan))
-            {
-                return;
-            }
-
+            // Emit via the shared double-buffered send (dedup + swap in LiveSessionBase). Force the
+            // send when something out-of-band (navigation, auth, download) must flow even if the
+            // rendered bytes are byte-identical to the previous frame — otherwise the dedup skips it.
+            var force = historyUrl is not null || auth is not null || download is not null;
+            bool sent;
             try
             {
-                await _socket.SendAsync(_writeBuffer.WrittenMemory, WebSocketMessageType.Text, true, _socketCt)
-                    .ConfigureAwait(false);
+                sent = await TryEmitFrameAsync(force).ConfigureAwait(false);
             }
             catch (Exception ex) when (jsInvokes is not null)
             {
@@ -435,10 +428,10 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
                 throw;
             }
 
-            // Swap: the buffer we just sent becomes next frame's dedup baseline; the previous
-            // baseline (or a fresh writer on first send) is reused as the next write target.
-            (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>(4096));
-            _lastAppliedHtml = html;
+            if (sent)
+            {
+                _lastAppliedHtml = html;
+            }
         }
         finally
         {

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -27,38 +27,14 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
     // multi-session / re-init path.
     private readonly IUserProvider? _userProvider;
 
-    // The buffer holding the last frame ApplyRender pushed — WASM's dedup baseline. Mirrors the
-    // Rask.Server double-buffer: the sent frame is retained here (no per-frame byte[] copy), the
-    // next render writes into _writeBuffer, and EmitFrame swaps the two after each send.
-    private ArrayBufferWriter<byte>? _lastSentBuffer;
-
-    // Push the frame currently in _writeBuffer to JS zero-copy (a MemoryView over the buffer, no
-    // per-frame byte[]), unless it's byte-identical to the last frame we sent (dedup) — mirrors
-    // Rask.Server's double-buffered send. `force` bypasses the dedup for navigation frames that must
-    // flow even when the rendered output is unchanged. Returns whether a frame was actually sent.
-    private bool EmitFrame(bool force)
+    // Host transport for LiveSessionBase.TryEmitFrameAsync: push the built frame to JS zero-copy via a
+    // MemoryView over the write buffer. The JS applyRender reads the bytes synchronously (decode +
+    // JSON.parse) within this call, so the view never outlives it — hence a synchronous, completed
+    // ValueTask (no interop-boundary await on the browser's single thread).
+    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame)
     {
-        if (_writeBuffer.WrittenCount == 0)
-        {
-            return false;
-        }
-
-        if (!force
-            && _lastSentBuffer is not null
-            && _writeBuffer.WrittenSpan.SequenceEqual(_lastSentBuffer.WrittenSpan))
-        {
-            return false;
-        }
-
-        // MemoryView marshals a view over the buffer's bytes; the JS applyRender reads them
-        // synchronously (decode + JSON.parse) within this call, so the view never outlives it.
-        JSInterop.ApplyRender(MemoryMarshal.AsMemory(_writeBuffer.WrittenMemory).Span);
-
-        // Swap: the buffer we just sent becomes next frame's dedup baseline; the previous baseline
-        // (or a fresh writer on first send) is recycled as the next write target (WritePayload resets
-        // its WrittenCount before writing).
-        (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>(4096));
-        return true;
+        JSInterop.ApplyRender(MemoryMarshal.AsMemory(frame).Span);
+        return default;
     }
 
     // Set by BuildPayloadAsync when the frame it built carries queued IJSRuntime calls. The
@@ -110,7 +86,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         try
         {
             var html = await BuildPayloadAsync(null, false).ConfigureAwait(false);
-            if (EmitFrame(force: false))
+            if (await TryEmitFrameAsync(false).ConfigureAwait(false))
             {
                 _lastAppliedHtml = html;
             }
@@ -157,7 +133,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
             // Push the built frame unless it's byte-identical to the last sent frame. EmitFrame's
             // double-buffered span compare (SIMD-accelerated) catches StateHasChanged calls that
             // didn't change visible output — no per-frame byte[].
-            if (EmitFrame(force: false))
+            if (await TryEmitFrameAsync(false).ConfigureAwait(false))
             {
                 _lastAppliedHtml = html;
             }
@@ -178,7 +154,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         try
         {
             var html = await BuildPayloadAsync(null, false).ConfigureAwait(false);
-            if (!EmitFrame(force: true))
+            if (!await TryEmitFrameAsync(true).ConfigureAwait(false))
             {
                 return Array.Empty<byte>();
             }
@@ -258,7 +234,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                     // EmitFrame pushes the frame (zero-copy) unless it's byte-identical to the last
                     // sent one; force the send when a navigation URL must flow even if the rendered
                     // output is unchanged. No send → no-op (empty byte array to the test seam).
-                    if (!EmitFrame(force: historyUrl is not null))
+                    if (!await TryEmitFrameAsync(historyUrl is not null).ConfigureAwait(false))
                     {
                         return Array.Empty<byte>();
                     }
@@ -319,7 +295,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                 var html =
                     await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
                 // Navigation always flows — force the send even when the rendered output is unchanged.
-                if (!EmitFrame(force: true))
+                if (!await TryEmitFrameAsync(true).ConfigureAwait(false))
                 {
                     return Array.Empty<byte>();
                 }

--- a/tests/Rask.Core.Tests/Live/ComponentHotReloadTests.cs
+++ b/tests/Rask.Core.Tests/Live/ComponentHotReloadTests.cs
@@ -127,5 +127,8 @@ public class ComponentHotReloadTests
         }
 
         protected override Task RenderInScopeCoreAsync() => Task.CompletedTask;
+
+        // No transport in this test double — the render-request recorder never emits a frame.
+        protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) => default;
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #241. After the WASM zero-copy work, the double-buffered send *mechanic* — skip byte-identical frames (dedup), hand the buffer's bytes to the transport, swap the sent buffer to become the next dedup baseline — was duplicated in `Rask.Server`'s `RenderAndSendAsync` and `Rask.Wasm`'s `EmitFrame`. This hoists it into `LiveSessionBase.TryEmitFrameAsync` (Core), with the transport behind an abstract seam:

```csharp
protected abstract ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame);
```

- **Server** `SendFrameAsync` → `_socket.SendAsync(frame, …)` (WebSocket, `ReadOnlyMemory<byte>`, zero-copy). Its `jsInvokes` send-failure handling stays as a `try/catch` wrapper around `TryEmitFrameAsync`.
- **WASM** `SendFrameAsync` → `ApplyRender(MemoryMarshal.AsMemory(frame).Span)` (zero-copy `MemoryView`), returning a completed `ValueTask`.
- `_lastSentBuffer` moves from both hosts to the base.

Behavior-preserving, no public-API change.

## Allocation
Allocation-neutral by construction. WASM's `SendFrameAsync` returns `default`, so `TryEmitFrameAsync` (an `async ValueTask<bool>`) completes **synchronously** on the browser's single thread — no state-machine box, no added allocation on the perf-critical path. Server's path already awaited the socket send.

## Testing
- **All host suites pass: `Rask.Core` 1778, `Rask.Server` 248, `Rask.Wasm` 197** — the refactor preserves the dedup semantics (force-on-navigation/auth/download, empty-on-noop, buffer swap) on both hosts.
- CI's WASM E2E matrix re-validates the browser send path end-to-end (the WASM call path changed from sync `EmitFrame` to `await TryEmitFrameAsync`).
- `WsDispatchBenchmarks` unchanged (it measures the frame codec, not the hoisted send — no benchmark isolates `RenderAndSendAsync`'s send/swap; a pre-existing coverage gap).

## Benchmarks
N/A for allocation delta — pure refactor of existing operations; see the Allocation note. The WASM per-frame win itself was measured in #241 (0 B vs 536–4120 B/frame).