### PR TITLE
fix(server): build session-unknown payload as a literal (NativeAOT static-init crash)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,14 @@ them until tagged releases begin.
   Internal refactor, no behavior or public-API change; removes the duplicated buffer bookkeeping the
   WASM zero-copy work had introduced. WASM's send stays synchronous (allocation-free).
 
+### Fixed
+- **`Rask.Server` no longer crashes at static-init under NativeAOT.** `RaskEndpointExtensions` built its
+  constant "session unknown" WebSocket payload with `JsonSerializer.Serialize(anonymous)`, which throws
+  `InvalidOperationException` under NativeAOT (reflection-based JSON is disabled) and took down `UseRask`
+  before the host started. It is now a UTF-8 string literal — byte-identical, no serializer, no
+  reflection. (This removes the *first* NativeAOT startup blocker; full AOT boot additionally requires
+  the framework's in-library endpoint registrations to be AOT-safe — tracked separately.)
+
 ## [0.13.0] - 2026-07-06
 
 ### Added

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -103,8 +103,11 @@ public static class RaskEndpointExtensions
     // the queue count. Seeded from RaskServerOptions.MaxPendingHandlerBytes. 0 = off.
     internal static long MaxPendingHandlerBytes;
 
+    // A fixed, content-free payload — written as a literal rather than JsonSerializer.Serialize(anonymous)
+    // so it needs no reflection-based serialization. Under NativeAOT (reflection JSON disabled) the
+    // serializer call threw at static-init and crashed UseRask before the host could start.
     private static readonly byte[] SessionUnknownPayload =
-        Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new { type = "session", status = "unknown" }));
+        Encoding.UTF8.GetBytes("""{"type":"session","status":"unknown"}""");
 
     // 50ms trailing-edge debounce for ScopedAssetRegistry.AssetChanged. A multi-file edit
     // (or a single hot-reload UpdateApplication burst that re-registers every component


### PR DESCRIPTION
## Summary

`Rask.Server`'s `RaskEndpointExtensions` static constructor built its constant *"session unknown"*
WebSocket payload with `JsonSerializer.Serialize(new { type = "session", status = "unknown" })`. Under
**NativeAOT** (`PublishAot`, where reflection-based JSON is disabled) that throws at static-init and
crashes `UseRask` before the host can bind a port. It's now a UTF-8 **string literal** — byte-identical,
no serializer, no reflection.

## How it was found and proven

A real `dotnet publish -c Release -r osx-arm64 -p:PublishAot=true` of `Rask.Example.Server`:

- **Compiles + links** to a 29 MB self-contained native binary (ILC + clang, no linker errors).
- **Before:** boots then crashes — `InvalidOperationException: Reflection-based serialization has been
  disabled` at `Rask.Server.RaskEndpointExtensions..cctor()`.
- **After (this change):** that crash is gone — startup proceeds past `RaskEndpointExtensions` init.

## Scope (honest)

This removes the **first** NativeAOT startup blocker. It does **not** on its own make a Server app fully
AOT-boot. Running it for real surfaced a deeper, separate issue: the framework registers its own
endpoints (WS, assets, download) **inside the library**, so they bypass the app's Request Delegate
Generator and fall back to the runtime `RequestDelegateFactory` (`RequiresDynamicCode`); a
`Task`-returning framework endpoint then crashes at startup when the endpoint graph is built
(`AuthorizationPolicyCache` → `RouteEndpointDataSource.get_Endpoints` → `RequestDelegateFactory`). That
endpoint-registration AOT-hardening is a larger change — see follow-ups.

## Testing

- `dotnet format` + `Rask.Server` warnings-as-errors build.
- Existing `HelloMessageTests.Hello_UnknownSessionId_SendsSessionUnknownPayload` asserts the exact
  payload bytes on the WS reconnect path — still green (the literal is byte-identical to the old
  serializer output, so it's already covered).

## Changelog

`[Unreleased] → Fixed`.

## Follow-ups discovered by the real AOT publish

- **The real Server-AOT-boot gate:** make the framework's in-library endpoint registrations AOT-safe so
  they don't fall back to the runtime `RequestDelegateFactory` (the `Task`-returning WS handler at
  `RaskEndpointExtensions.cs:490`).
- `UseRask` IL2091 generic-DAM annotation gap.
- App-level guidance for AOT: source-gen `JsonSerializerContext` for `Results.Json`, public request DTOs
  (RDG012), a context for `Rask.WebPush.PushSubscription`.
