### PR TITLE
test(cqrs): cover notification publish failure modes

### DIFF
--- a/tests/Rask.Cqrs.Tests/DispatcherTests.cs
+++ b/tests/Rask.Cqrs.Tests/DispatcherTests.cs
@@ -149,4 +149,46 @@ public sealed class DispatcherTests
         // The behavior wrapped the handler exactly once, not twice.
         Assert.Equal(new[] { "trace-in:Add", "trace-out:Add" }, recorder.Entries);
     }
+
+    [Fact]
+    public async Task Sequential_publish_stops_on_the_first_handler_failure_and_rethrows()
+    {
+        var recorder = new Recorder();
+        // Default fan-out: Sequential + StopOnFirstNotificationException = true.
+        await using var sp = Build(recorder: recorder);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sp.GetRequiredService<IDispatcher>().PublishAsync(new Grumble("x")));
+
+        Assert.StartsWith("boom-", ex.Message); // the handler's own exception, rethrown as-is
+        // Halted: the run stopped at the first failure, so not every handler recorded.
+        Assert.True(
+            recorder.Entries.Count < 3,
+            $"Expected the run to halt before all three handlers ran; saw [{string.Join(", ", recorder.Entries)}].");
+    }
+
+    [Fact]
+    public async Task Sequential_publish_without_stop_runs_all_handlers_and_aggregates_failures()
+    {
+        var recorder = new Recorder();
+        await using var sp = Build(o => o.StopOnFirstNotificationException = false, recorder);
+
+        var ex = await Assert.ThrowsAsync<AggregateException>(
+            () => sp.GetRequiredService<IDispatcher>().PublishAsync(new Grumble("x")));
+
+        Assert.Equal(2, ex.InnerExceptions.Count); // both throwing handlers surfaced
+        Assert.Equal(3, recorder.Entries.Count);   // every handler ran despite the earlier failure
+    }
+
+    [Fact]
+    public async Task WhenAll_publish_starts_every_handler_then_surfaces_a_failure()
+    {
+        var recorder = new Recorder();
+        await using var sp = Build(o => o.NotificationPublishStrategy = NotificationPublishStrategy.WhenAll, recorder);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => sp.GetRequiredService<IDispatcher>().PublishAsync(new Grumble("x")));
+
+        Assert.Equal(3, recorder.Entries.Count); // all handlers were started before any faulted
+    }
 }

--- a/tests/Rask.Cqrs.Tests/TestMessages.cs
+++ b/tests/Rask.Cqrs.Tests/TestMessages.cs
@@ -102,3 +102,37 @@ public sealed class ShortCircuitAdd(Recorder recorder) : IPipelineBehavior<Add, 
 
 // ---- A request with no registered handler (to prove the clear runtime error) ----
 public sealed record Orphan : IQuery<int>;
+
+// ---- A notification whose handlers fail, for the publish failure-mode tests. One succeeds and two
+// throw; the throwing handlers are async (record, yield, then throw) so under WhenAll every handler's
+// task is started before any of them faults. ----
+public sealed record Grumble(string Tag) : INotification;
+
+public sealed class GrumbleOk(Recorder recorder) : INotificationHandler<Grumble>
+{
+    public Task HandleAsync(Grumble notification, CancellationToken cancellationToken)
+    {
+        recorder.Add($"ok:{notification.Tag}");
+        return Task.CompletedTask;
+    }
+}
+
+public sealed class GrumbleBoomOne(Recorder recorder) : INotificationHandler<Grumble>
+{
+    public async Task HandleAsync(Grumble notification, CancellationToken cancellationToken)
+    {
+        recorder.Add($"boom1:{notification.Tag}");
+        await Task.Yield();
+        throw new InvalidOperationException("boom-1");
+    }
+}
+
+public sealed class GrumbleBoomTwo(Recorder recorder) : INotificationHandler<Grumble>
+{
+    public async Task HandleAsync(Grumble notification, CancellationToken cancellationToken)
+    {
+        recorder.Add($"boom2:{notification.Tag}");
+        await Task.Yield();
+        throw new InvalidOperationException("boom-2");
+    }
+}


### PR DESCRIPTION
## Summary
Tier-3 follow-up — covers the notification fan-out **failure paths**, which had no tests (the existing suite only covered the happy path + `WhenAll` success).

Adds a `Grumble` notification with one succeeding handler and two async-throwing ones (record → yield → throw, so under `WhenAll` every handler's task is started before any faults), then tests the three modes in `NotificationDispatch.PublishAll`:

- **Sequential + `StopOnFirstNotificationException`** (default) — the first handler failure rethrows as-is and **halts** the run (later handlers don't run).
- **Sequential without stop-on-first** — every handler runs and failures are collected into an `AggregateException`.
- **`WhenAll`** — every handler is started before any faults, then a failure surfaces.

Assertions are **order-agnostic** (halt = fewer than all three ran; aggregate = both booms in `InnerExceptions`; whenall = all three started) so they don't pin the source generator's handler registration order.

## Testing
- `Rask.Cqrs.Tests` — **16/16 pass** (13 existing + 3 new).
- `dotnet format --verify-no-changes` on the changed files — clean.
- Tests only — no product change.

## Roadmap
This closes out the clean Tier-3 test-coverage items (Bootstrap interactive components #246/#248, Cqrs/WebPush validation #247, and this). The one remaining roadmap item is **2c** — the deferred order-statistics tree for the O(n²) keyed reorder.