### PR TITLE
fix(server): register framework endpoints as RequestDelegate + root TApp ctor for NativeAOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,7 +52,19 @@ them until tagged releases begin.
   `InvalidOperationException` under NativeAOT (reflection-based JSON is disabled) and took down `UseRask`
   before the host started. It is now a UTF-8 string literal — byte-identical, no serializer, no
   reflection. (This removes the *first* NativeAOT startup blocker; full AOT boot additionally requires
-  the framework's in-library endpoint registrations to be AOT-safe — tracked separately.)
+  the framework's in-library endpoint registrations to be AOT-safe — see the next entry.)
+- **A Rask Server app now NativeAOT-compiles, boots, and renders.** The framework's own endpoints
+  (WebSocket, runtime script, PWA manifest/service-worker, content-addressed assets, upload/download,
+  auth redeem) were registered via the minimal-API `Map*(…, Delegate)` overloads, which route through
+  `RequestDelegateFactory` (`RequiresDynamicCode`). Since the Request Delegate Generator only covers the
+  app assembly, these library endpoints fell back to the runtime factory and a `Task`-returning handler
+  crashed at startup under NativeAOT. They are now registered as `RequestDelegate`s (services resolved
+  from `HttpContext.RequestServices`, route values from `RouteValues`), which also clears the 16 `Map*`
+  `IL3050` warnings. `UseRask<TApp>` additionally annotates `TApp` with
+  `[DynamicallyAccessedMembers(PublicConstructors)]` so the app component's constructor survives trimming
+  for `ActivatorUtilities.CreateInstance`. `Rask.Server` is now IL-warning-clean under the AOT analyzer;
+  verified end-to-end — `dotnet publish -p:PublishAot=true` produces a native binary that boots and
+  serves `HTTP 200`.
 
 ## [0.13.0] - 2026-07-06
 

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Net.WebSockets;
 using System.Security.Claims;
@@ -292,7 +293,7 @@ public static class RaskEndpointExtensions
     ///     (e.g. <c>/app1</c>). Overrides any path base set via <see cref="AddRask" />.
     /// </param>
     /// <returns>The same <paramref name="app" /> instance, for chaining.</returns>
-    public static WebApplication UseRask<TApp>(
+    public static WebApplication UseRask<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(
         this WebApplication app,
         string pattern = "/{**path}",
         string pathBase = "")
@@ -329,7 +330,7 @@ public static class RaskEndpointExtensions
     /// <param name="pattern">Catch-all route pattern Rask serves (default <c>/{**path}</c>).</param>
     /// <param name="pathBase">Optional URL prefix; see the <see cref="WebApplication" /> overload.</param>
     /// <returns>The same <paramref name="endpoints" /> instance, for chaining.</returns>
-    public static IEndpointRouteBuilder UseRask<TApp>(
+    public static IEndpointRouteBuilder UseRask<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(
         this IEndpointRouteBuilder endpoints,
         string pattern = "/{**path}",
         string pathBase = "")
@@ -354,8 +355,9 @@ public static class RaskEndpointExtensions
             ? pattern
             : pathBaseNormalized + (pattern.StartsWith('/') ? pattern : "/" + pattern);
 
-        endpoints.MapGet(scopedPattern, async (HttpContext httpContext, LiveSessionStore store) =>
+        endpoints.MapGet(scopedPattern, (RequestDelegate)(async httpContext =>
         {
+            var store = httpContext.RequestServices.GetRequiredService<LiveSessionStore>();
             var path = StripPathBase(httpContext.Request.Path.Value ?? "/", pathBaseNormalized);
             var user = httpContext.User ?? new ClaimsPrincipal(new ClaimsIdentity());
 
@@ -425,7 +427,7 @@ public static class RaskEndpointExtensions
             // not pin a DI scope + tree for the full 30s reconnect window. A real hello cancels
             // this removal (LiveSessionStore.Get) and DetachSocket later re-arms the full grace.
             store.ScheduleRemoval(session.Id, UnconnectedSessionGracePeriod);
-        });
+        }));
         return endpoints;
     }
 
@@ -487,9 +489,14 @@ public static class RaskEndpointExtensions
 
         marker.RuntimeMapped = true;
 
-        endpoints.Map(pathBase + WebSocketPath,
-            async (HttpContext ctx, LiveSessionStore store, IHostApplicationLifetime lifetime) =>
+        // Registered as a RequestDelegate (services resolved from ctx.RequestServices) rather than a
+        // minimal-API Delegate, so it does NOT go through RequestDelegateFactory — which is
+        // RequiresDynamicCode and, for a library-registered endpoint (not covered by the app's Request
+        // Delegate Generator), crashes at startup under NativeAOT. See the other framework endpoints below.
+        endpoints.Map(pathBase + WebSocketPath, (RequestDelegate)(async ctx =>
             {
+                var store = ctx.RequestServices.GetRequiredService<LiveSessionStore>();
+                var lifetime = ctx.RequestServices.GetRequiredService<IHostApplicationLifetime>();
                 if (!ctx.WebSockets.IsWebSocketRequest)
                 {
                     ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -521,10 +528,11 @@ public static class RaskEndpointExtensions
                 using var linked = CancellationTokenSource.CreateLinkedTokenSource(
                     ctx.RequestAborted, lifetime.ApplicationStopping);
                 await RunSocketLoop(ws, store, wsUser, linked.Token, lifetime.ApplicationStopping);
-            });
+            }));
 
         var script = LoadEmbeddedScript();
-        endpoints.MapGet(pathBase + RuntimePath, () => Results.Text(script, "text/javascript; charset=utf-8"));
+        endpoints.MapGet(pathBase + RuntimePath, (RequestDelegate)(ctx =>
+            Results.Text(script, "text/javascript; charset=utf-8").ExecuteAsync(ctx)));
 
         // PWA endpoints — wired only when AddRaskPwa registered a manifest (off by default). The manifest
         // JSON is rooted at pathBase here (a manifest's members resolve relative to the manifest's own URL,
@@ -533,12 +541,12 @@ public static class RaskEndpointExtensions
         if (endpoints.ServiceProvider.GetService<RaskPwaState>() is { } pwa)
         {
             var manifestJson = pwa.Manifest.ToJson(pathBase);
-            endpoints.MapGet(pathBase + ManifestPath,
-                () => Results.Text(manifestJson, "application/manifest+json; charset=utf-8"));
+            endpoints.MapGet(pathBase + ManifestPath, (RequestDelegate)(ctx =>
+                Results.Text(manifestJson, "application/manifest+json; charset=utf-8").ExecuteAsync(ctx)));
 
             var serviceWorker = LoadEmbeddedServiceWorker();
-            endpoints.MapGet(pathBase + ServiceWorkerPath,
-                () => Results.Text(serviceWorker, "text/javascript; charset=utf-8"));
+            endpoints.MapGet(pathBase + ServiceWorkerPath, (RequestDelegate)(ctx =>
+                Results.Text(serviceWorker, "text/javascript; charset=utf-8").ExecuteAsync(ctx)));
         }
 
         // Per-component content-addressed asset endpoint. URL is immutable (hash is a
@@ -556,20 +564,24 @@ public static class RaskEndpointExtensions
                 static ctx => ServeAssetAsync(ctx, AssetKind.Js))
             .AllowAnonymous();
 
-        endpoints.MapPost(pathBase + "/_rask/auth/redeem",
-                (HttpContext ctx, IAuthTicketStore tickets) => RedeemAuthTicketAsync(ctx, tickets))
+        endpoints.MapPost(pathBase + "/_rask/auth/redeem", (RequestDelegate)(ctx =>
+                RedeemAuthTicketAsync(ctx, ctx.RequestServices.GetRequiredService<IAuthTicketStore>())))
             .DisableAntiforgery();
 
-        endpoints.MapPost(pathBase + "/_rask/upload/{sessionId}",
-                (HttpContext ctx, string sessionId, LiveSessionStore sessionStore,
-                        SessionUploadStore uploadStore, RaskUploadOptions options) =>
-                    HandleUploadAsync(ctx, sessionId, sessionStore, uploadStore, options))
+        endpoints.MapPost(pathBase + "/_rask/upload/{sessionId}", (RequestDelegate)(ctx =>
+                HandleUploadAsync(ctx,
+                    (string)ctx.Request.RouteValues["sessionId"]!,
+                    ctx.RequestServices.GetRequiredService<LiveSessionStore>(),
+                    ctx.RequestServices.GetRequiredService<SessionUploadStore>(),
+                    ctx.RequestServices.GetRequiredService<RaskUploadOptions>())))
             .DisableAntiforgery();
 
-        endpoints.MapGet(pathBase + "/_rask/download/{sessionId}/{token}",
-            (HttpContext ctx, string sessionId, string token, LiveSessionStore sessionStore,
-                    SessionDownloadStore downloads) =>
-                HandleDownloadAsync(ctx, sessionId, token, sessionStore, downloads));
+        endpoints.MapGet(pathBase + "/_rask/download/{sessionId}/{token}", (RequestDelegate)(ctx =>
+            HandleDownloadAsync(ctx,
+                (string)ctx.Request.RouteValues["sessionId"]!,
+                (string)ctx.Request.RouteValues["token"]!,
+                ctx.RequestServices.GetRequiredService<LiveSessionStore>(),
+                ctx.RequestServices.GetRequiredService<SessionDownloadStore>())));
 
         var sessionStore = endpoints.ServiceProvider.GetRequiredService<LiveSessionStore>();
         SubscribeAssetChangedDebounced(sessionStore);


### PR DESCRIPTION
## Summary

Makes a **Rask Server app NativeAOT-compile, boot, and render**. Builds on #249 (the static-init
`.cctor` fix); this addresses the two remaining framework blockers found by actually booting the
native binary.

## The blockers (found by running a real `PublishAot`)

1. **In-library endpoints fell back to the runtime `RequestDelegateFactory`.** The framework registers
   its own endpoints (WebSocket, runtime script, PWA manifest/service-worker, content-addressed assets,
   upload/download, auth redeem) via the minimal-API `Map*(…, Delegate)` overloads, which route through
   `RequestDelegateFactory` (`RequiresDynamicCode`). The Request Delegate Generator only covers the
   **app** assembly, so these library endpoints used the runtime factory — and a `Task`-returning
   handler crashed at startup under NativeAOT (`AuthorizationPolicyCache` eagerly builds the endpoint
   graph → `RequestDelegateFactory` → `GetTypeInfo(Task)` → no metadata).
2. **The app component's constructor was trimmed.** `UseRask<TApp>` didn't annotate `TApp`, so
   `ActivatorUtilities.CreateInstance<TApp>` couldn't find `App`'s ctor under AOT (500 on every render).

## The fix

- Register every framework endpoint as a **`RequestDelegate`** (services resolved from
  `HttpContext.RequestServices`, route values from `HttpContext.Request.RouteValues`, `IResult`s
  executed via `ExecuteAsync`), so they **bypass `RequestDelegateFactory` entirely**. This removes the
  `Task` startup crash *and* clears the 16 `Map*` `IL3050` warnings. The asset endpoints already used
  this pattern.
- Annotate `UseRask<TApp>` with `[DynamicallyAccessedMembers(PublicConstructors)]` on `TApp` (matching
  the WASM host) so the app component's ctor survives trimming.

`Rask.Server` is now **zero IL warnings** under the AOT analyzer (was 18).

## Proof (real NativeAOT publish)

`dotnet publish samples/Rask.Example.Server -c Release -r osx-arm64 -p:PublishAot=true` →
self-contained native `Mach-O arm64` binary that:

- **boots** — `Now listening… / Application started` (previously crashed at startup),
- serves `GET /rask/rask.js` → **200**,
- serves `GET /` → **200** with a fully-rendered Rask page (`<!DOCTYPE html><html lang="en">…`).

(The showcase sample's opt-in Web Push demo and `/_diag` endpoint still need app-level JSON contexts —
those are app-level, not framework, and were stubbed only for this boot proof.)

## Testing

- Full `Rask.Server` suite (**248 tests**) green — the `RequestDelegate` conversion preserves behavior
  across WS hello/dispatch, upload, download, auth redeem, assets, and the page shell.
- `dotnet format` + warnings-as-errors build.

## Changelog

`[Unreleased] → Fixed`.

## Follow-ups

- App-level AOT guidance/sample hardening: source-gen `JsonSerializerContext` for `Results.Json`,
  public request DTOs (RDG012), a context for `Rask.WebPush.PushSubscription`.
- Optional: a nightly CI job that AOT-publishes a minimal Server app and smoke-tests `HTTP 200`
  (mirrors the WASM AOT nightly), to guard against regression.
