### PR TITLE
chore(release): v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-07-06
+
 ### Added
 - **Opt-in full WASM AOT.** Publish with `-p:RaskWasmAot=true` (needs the `wasm-tools` workload) to
   AOT-compile the browser bundle IL→WASM; the default keeps the Mono interpreter, so existing builds


### PR DESCRIPTION
Promotes the `[Unreleased]` CHANGELOG section to **v0.13.0** and opens a fresh `[Unreleased]`.

Minor bump from 0.12.1 — the release bundles new features (opt-in full WASM AOT, NuGet XML docs/icon/titles, per-package NuGet identity, the Composition "Component tiers" section) alongside performance work (O(n log n) keyed-list reorders, per-render lambda elimination in form binding, zero-alloc WASM frame send) and fixes (render-cache ambient-state opt-out, NativeAOT server endpoints, nested-closure handler-owner resolution).

Once merged, `v0.13.0` is tagged so MinVer stamps the version and `release.yml` packs + pushes the eight NuGet packages and the GitHub release.