### PR TITLE
perf(core): splice head assets in place to halve live-root render allocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **The live-root render no longer allocates the whole page twice.** Every server/WASM live
+  render — the initial GET, every event re-render, reconnect recovery, and hot reload — went
+  through `Component.ToHtml()` (one full-page `string`) and then `HeadAssetRegistry.ApplyTo`,
+  which copied the entire page into a second builder to splice the deduplicated `<head>` assets
+  in at the sentinel (a second full-page `string` + a whole-body `IndexOf` scan). The path now
+  serializes straight into a pooled `StringBuilder`, records the sentinel offset as it is written
+  (no scan), and splices the head-asset block in place (`ApplyInPlace`), so the page is
+  materialized to a `string` exactly once. Measured on the live-root benchmark (ShortRun,
+  net10.0): per-render allocation drops **~48%** on a small page (7.7 KB → 4.0 KB), **~50%** on a
+  500-row page (171.8 KB → 86.0 KB), and **~33%** on a 1500-row page (788.7 KB → 528.1 KB), with
+  ~16–17% less wall-clock on the large pages. Output HTML and diff-frame offsets are byte-identical
+  (existing serializer/diff replay tests validate both). A new `RenderPageXLarge` benchmark isolates
+  the per-render cost at scale.
+
 ## [0.13.0] - 2026-07-06
 
 ### Added

--- a/benchmarks/Rask.Benchmarks/HtmlSerializerLiveRootBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/HtmlSerializerLiveRootBenchmarks.cs
@@ -18,6 +18,7 @@ public class HtmlSerializerLiveRootBenchmarks
 {
     private Component _small = null!;
     private Component _large = null!;
+    private Component _xlarge = null!;
     private IServiceProvider _services = null!;
 
     [GlobalSetup]
@@ -30,6 +31,7 @@ public class HtmlSerializerLiveRootBenchmarks
 
         _small = BuildPage(20);
         _large = BuildPage(500);
+        _xlarge = BuildPage(1500);
     }
 
     [Benchmark]
@@ -37,6 +39,14 @@ public class HtmlSerializerLiveRootBenchmarks
 
     [Benchmark]
     public string RenderPageLarge() => _large.RenderAsLiveRoot(_services);
+
+    // A large page re-render: RenderAsLiveRoot re-serializes the whole tree and splices the
+    // head-asset block on every call (the diff hot path pre-subtree-short-circuit). At 1500
+    // rows the page string dominates allocation, so the head-splice change — page materialized
+    // to a string once (in-place splice) instead of twice (serialize + copy) — is visible as a
+    // large Allocated drop that scales with page size.
+    [Benchmark]
+    public string RenderPageXLarge() => _xlarge.RenderAsLiveRoot(_services);
 
     private static Component BuildPage(int rowCount)
     {

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1349,27 +1349,46 @@ public abstract class Component
         // root, never re-binding closure-captured state or reading external mutable state.
         Live.StateDirty = true;
         RaiseLifecycleBeforeRender(false);
-        var html = ToHtml();
-        // Splice component-declared <head> contributions into the RaskHeadAssets sentinel.
-        // The registry was populated by HtmlSerializer as it descended through user
-        // components; we resolve the active context (still live before the using-disposal
-        // below) and apply once.
-        if (LiveRenderContext.Current is { } liveCtx)
+
+        // Serialize straight into a pooled builder and splice the head-asset block in place,
+        // so the page materializes to a string exactly once (the final ToString). The previous
+        // path allocated the page TWICE — ToHtml() produced one full-page string, then ApplyTo
+        // copied the whole page into a second builder to inject the head assets.
+        var pageBuilder = RaskStringBuilderPool.Shared.Get();
+        string html;
+        try
         {
-            // ApplyTo replaces the head-asset sentinel in place, shifting every byte position
-            // after it. The diff codec's frame offsets were captured against the pre-splice
-            // HTML, so when a frame stream is being captured (diff path) we must move the
-            // offsets past the sentinel by the same delta — otherwise an InsertSubtree fragment
-            // (sliced from this post-splice HTML via those offsets) reads the wrong bytes.
-            var sentinelIdx = html.IndexOf(HeadAssetRegistry.Sentinel, StringComparison.Ordinal);
-            var preLen = html.Length;
-            html = liveCtx.HeadAssets.ApplyTo(html, sentinelIdx, liveCtx.Services);
-            if (sentinelIdx >= 0 && FrameSinkScope.Current is { } frameSink)
+            HtmlSerializer.Serialize(this, pageBuilder);
+
+            // Splice component-declared <head> contributions into the RaskHeadAssets sentinel.
+            // The registry was populated by HtmlSerializer as it descended through user
+            // components; we resolve the active context (still live before the using-disposal
+            // below) and apply once. The sentinel offset was recorded during serialization
+            // (HeadSentinelIndex), so no whole-page IndexOf scan is needed here.
+            if (LiveRenderContext.Current is { } liveCtx)
             {
-                frameSink.AdjustOffsetsFrom(
-                    sentinelIdx + HeadAssetRegistry.Sentinel.Length,
-                    html.Length - preLen);
+                // ApplyInPlace replaces the head-asset sentinel in place, shifting every byte
+                // position after it. The diff codec's frame offsets were captured against the
+                // pre-splice HTML, so when a frame stream is being captured (diff path) we must
+                // move the offsets past the sentinel by the same delta — otherwise an
+                // InsertSubtree fragment (sliced from this post-splice HTML via those offsets)
+                // reads the wrong bytes.
+                var sentinelIdx = liveCtx.HeadSentinelIndex;
+                var preLen = pageBuilder.Length;
+                liveCtx.HeadAssets.ApplyInPlace(pageBuilder, sentinelIdx, liveCtx.Services);
+                if (sentinelIdx >= 0 && FrameSinkScope.Current is { } frameSink)
+                {
+                    frameSink.AdjustOffsetsFrom(
+                        sentinelIdx + HeadAssetRegistry.Sentinel.Length,
+                        pageBuilder.Length - preLen);
+                }
             }
+
+            html = pageBuilder.ToString();
+        }
+        finally
+        {
+            RaskStringBuilderPool.Shared.Return(pageBuilder);
         }
 
         // Fail-fast backstop for a malformed root: the App must render the full page shell

--- a/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
+++ b/src/Rask.Core/HeadAssets/HeadAssetRegistry.cs
@@ -191,37 +191,66 @@ internal sealed class HeadAssetRegistry
     /// </param>
     public string ApplyTo(string html, int sentinelIdx, IServiceProvider? services = null)
     {
-        _ = services; // see XML comment: parameter retained for ABI; no host strategy needed.
         if (sentinelIdx < 0)
         {
             return html;
         }
 
-        // Scoped-asset emission: one <link> for the whole scoped-CSS bundle and one <script defer>
-        // for the whole scoped-JS bundle (ScopedAssetRegistry concatenates every registered entry
-        // into a single content-hashed asset). Emitting the entire bundle up front means a later
-        // client-side mount finds its styles/script already present — no navigation FOUC — so the
-        // previous per-component <link>s + the rel="prefetch" pre-warming block are both gone.
-        // Bundle hashes read straight off the registry (no LiveRenderContext needed); empty when no
-        // scoped asset of that kind is registered. Built through a pooled StringBuilder.
-        string? scopedHtml = null;
-        var scopedSb = RaskStringBuilderPool.Shared.Get();
-        EmitScopedBundles(scopedSb);
-        if (scopedSb.Length > 0)
+        // Delegate to the in-place splice so there is a single splice implementation: the live-root
+        // render path (ApplyInPlace, no whole-page copy) and this string entry point (used by the
+        // head-asset unit tests) share the same Remove+Insert body and AppendHeadBlock, so they
+        // cannot drift. The whole-page copy here is paid only by the string overload, never the
+        // live hot path.
+        var page = RaskStringBuilderPool.Shared.Get();
+        page.Append(html);
+        ApplyInPlace(page, sentinelIdx, services);
+        var result = page.ToString();
+        RaskStringBuilderPool.Shared.Return(page);
+        return result;
+    }
+
+    /// <summary>
+    ///     Splices the deduplicated head-asset block into the <see cref="StringBuilder" /> that
+    ///     already holds the freshly serialized page (with the sentinel still present), replacing
+    ///     the sentinel in place instead of copying the whole page into a second builder. The
+    ///     live-root render path uses this so the page is materialized to a <c>string</c> exactly
+    ///     once (the final <c>ToString</c>) rather than twice — the serialize output and the
+    ///     post-splice copy were both full-page allocations.
+    /// </summary>
+    /// <param name="page">The serialized page; mutated in place (sentinel replaced by the block).</param>
+    /// <param name="sentinelIdx">
+    ///     Offset of <see cref="Sentinel" /> in <paramref name="page" /> (recorded during
+    ///     serialization). Negative → no-op, matching an absent sentinel.
+    /// </param>
+    /// <param name="services">Accepted for symmetry with <see cref="ApplyTo(string, int, IServiceProvider?)" />; not consulted.</param>
+    public void ApplyInPlace(StringBuilder page, int sentinelIdx, IServiceProvider? services = null)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+        _ = services;
+        if (sentinelIdx < 0)
         {
-            scopedHtml = scopedSb.ToString();
+            return;
         }
 
-        RaskStringBuilderPool.Shared.Return(scopedSb);
-
-        if (_orderedHtml.Count == 0 && scopedHtml is null)
+        var block = RaskStringBuilderPool.Shared.Get();
+        AppendHeadBlock(block);
+        page.Remove(sentinelIdx, Sentinel.Length);
+        if (block.Length > 0)
         {
-            return html.Remove(sentinelIdx, Sentinel.Length);
+            // No StringBuilder.Insert(int, StringBuilder) overload exists; the block is small
+            // (a handful of <head> tags), so materializing it once is far cheaper than the
+            // whole-page copy this method replaces.
+            page.Insert(sentinelIdx, block.ToString());
         }
 
-        var sb = RaskStringBuilderPool.Shared.Get();
-        sb.Append(html, 0, sentinelIdx);
+        RaskStringBuilderPool.Shared.Return(block);
+    }
 
+    // Appends the deduplicated head-asset block — user-declared Component.Head contributions
+    // (each keyed for the client morph) followed by the scoped-CSS/JS bundle tags — to the
+    // target builder. Shared by ApplyTo (copy-splice) and ApplyInPlace (in-place splice).
+    private void AppendHeadBlock(StringBuilder sb)
+    {
         // Key each user-declared entry. Singleton entries (title, base) use the singleton key
         // so the morph matches them across renders even when their content/attrs change; other
         // entries get a content-derived hash so an unchanged asset (Bootstrap link, viewport
@@ -237,16 +266,9 @@ internal sealed class HeadAssetRegistry
         }
 
         // The scoped bundle emits AFTER user Head contributions so scoped CSS overrides
-        // global CDN imports declared via Component.Head.
-        if (scopedHtml is not null)
-        {
-            sb.Append(scopedHtml);
-        }
-
-        sb.Append(html, sentinelIdx + Sentinel.Length, html.Length - sentinelIdx - Sentinel.Length);
-        var result = sb.ToString();
-        RaskStringBuilderPool.Shared.Return(sb);
-        return result;
+        // global CDN imports declared via Component.Head. Empty when no scoped asset of that
+        // kind is registered — reads bundle hashes straight off ScopedAssetRegistry.
+        EmitScopedBundles(sb);
     }
 
     // Appends html with data-rask-key="..." spliced in right after the opening tag name. The

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -244,6 +244,19 @@ internal static class HtmlSerializer
                 // slip past the RASK019 analyzer) render first; the sentinel follows.
                 if (tagName == "head" && live is not null)
                 {
+                    // Record where the sentinel lands so RenderAsLiveRoot splices the head-asset
+                    // block in place (StringBuilder.Insert) without re-scanning the whole page for
+                    // the sentinel. The sentinel is byte-stable, so its start offset is all the
+                    // splice needs. Record only the FIRST head — the framework shell renders exactly
+                    // one <head> (RASK019/021), but a stray nested <head> from a component that
+                    // slipped the analyzer would emit a second sentinel; first-wins matches the
+                    // previous html.IndexOf(Sentinel) behaviour (splice the shell head, leave any
+                    // duplicate sentinel as a literal) rather than mis-splicing the stray one.
+                    if (live.HeadSentinelIndex < 0)
+                    {
+                        live.HeadSentinelIndex = sb.Length;
+                    }
+
                     sb.Append(HeadAssetRegistry.Sentinel);
 
                     // Host-registered head markup (e.g. the Server PWA <link rel="manifest"> +

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -96,6 +96,16 @@ public sealed class LiveRenderContext : IDisposable
     internal HeadAssetRegistry HeadAssets { get; }
 
     /// <summary>
+    ///     Byte offset of the <see cref="HeadAssetRegistry.Sentinel" /> within the freshly
+    ///     serialized page, recorded by <c>HtmlSerializer</c> the moment it emits the sentinel
+    ///     (the <c>&lt;head&gt;</c> branch). <see cref="Component.RenderAsLiveRoot()" /> reads it
+    ///     to splice the head-asset block in place without a second whole-body <c>IndexOf</c>
+    ///     scan. <c>-1</c> when no framework-managed <c>&lt;head&gt;</c> was serialized (e.g. the
+    ///     partial-tree test path), matching an absent sentinel.
+    /// </summary>
+    internal int HeadSentinelIndex { get; set; } = -1;
+
+    /// <summary>
     ///     Every user-component type observed during this render walk. Populated
     ///     unconditionally by <see cref="PushScope" /> on each component entry — covers
     ///     components with scoped CSS, scoped JS, both, and neither. Read by

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetRegistryTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetRegistryTests.cs
@@ -1,5 +1,6 @@
 #pragma warning disable RASK014 // private test Component subclass — no generated factory needed
 
+using System.Text;
 using Rask.Core.HeadAssets;
 
 namespace Rask.Core.Tests.HeadAssets;
@@ -192,6 +193,35 @@ public class HeadAssetRegistryTests
         var registry = new HeadAssetRegistry();
         var input = $"<head>{HeadAssetRegistry.Sentinel}</head>";
         Assert.Equal("<head></head>", registry.ApplyTo(input));
+    }
+
+    // Regression for the in-place splice: RenderAsLiveRoot records the FIRST head's sentinel
+    // offset and ApplyInPlace must replace exactly that one occurrence, leaving any later
+    // sentinel (a stray nested <head> that slipped the RASK019 analyzer) as a literal — matching
+    // the old html.IndexOf(Sentinel) first-occurrence behaviour rather than mis-splicing a
+    // duplicate. Both the live-root path and ApplyTo funnel through ApplyInPlace, so this locks
+    // the shared splice body's "one sentinel at the given index" contract.
+    [Fact]
+    public void ApplyInPlace_SplicesOnlyTheSentinelAtTheGivenIndex()
+    {
+        var registry = new HeadAssetRegistry();
+        registry.Add(Link(Rel: "stylesheet", Href: "/a.css"));
+
+        var raw = $"<head>{HeadAssetRegistry.Sentinel}</head>"
+                  + $"<body><head>{HeadAssetRegistry.Sentinel}</head></body>";
+        var firstIdx = raw.IndexOf(HeadAssetRegistry.Sentinel, StringComparison.Ordinal);
+        var page = new StringBuilder(raw);
+
+        registry.ApplyInPlace(page, firstIdx);
+        var result = page.ToString();
+
+        // The first sentinel became the asset; exactly one (the later, un-targeted) sentinel remains.
+        Assert.Equal(1, CountOccurrences(result, HeadAssetRegistry.Sentinel));
+        Assert.Contains("/a.css", result);
+        Assert.True(
+            result.IndexOf("/a.css", StringComparison.Ordinal)
+            < result.IndexOf(HeadAssetRegistry.Sentinel, StringComparison.Ordinal),
+            "asset should splice at the first head; the surviving sentinel is the later one");
     }
 
     private static int CountOccurrences(string haystack, string needle)


### PR DESCRIPTION
## Summary

Every live-root render (initial GET, every event re-render, reconnect recovery, hot reload) allocated the full page **twice**: `Component.ToHtml()` produced one full-page `string`, then `HeadAssetRegistry.ApplyTo` copied the whole page into a second builder to splice the deduplicated `<head>` assets in at the sentinel (plus a whole-body `IndexOf` scan).

This change serializes straight into a pooled `StringBuilder`, records the sentinel offset as it is written (`LiveRenderContext.HeadSentinelIndex`), and splices the head-asset block in place (`HeadAssetRegistry.ApplyInPlace`), so the page materializes to a `string` exactly **once**. `ApplyTo` now delegates to `ApplyInPlace`, leaving a single splice implementation shared by the live path and the head-asset unit tests.

- First-head-wins recording preserves the previous `IndexOf`-first behaviour for the degenerate multi-`<head>` case (a stray head that slips the RASK019 analyzer): the framework shell head is still the one spliced.
- Output HTML and diff-codec frame offsets are byte-identical (existing serializer/diff replay tests + `KeyedInsertNavTests` validate both paths).

## Benchmarks

Live-root render (`HtmlSerializerLiveRootBenchmarks`, ShortRun, Apple M4 Pro, net10.0), allocation per render:

| Benchmark | Before | After | Δ |
|---|---|---|---|
| RenderPageSmall (20 rows) | 7.70 KB | 3.98 KB | **−48%** |
| RenderPageLarge (500 rows) | 171.76 KB | 86.02 KB | **−50%** |
| RenderPageXLarge (1500 rows) | 788.65 KB | 528.09 KB | **−33%** |

Wall-clock: −17% (500 rows), −16% (1500 rows). New `RenderPageXLarge` benchmark isolates the per-render cost at scale.

## Testing

- `dotnet test tests/Rask.Core.Tests` — 1813 passed, 1 skipped
- `dotnet test tests/Rask.Server.Tests` — 248 passed
- Strict `-warnaserror` build clean on touched projects
- New regression test: `ApplyInPlace_SplicesOnlyTheSentinelAtTheGivenIndex`

## Changelog

Added under `[Unreleased] → Changed`.