### PR TITLE
feat(bootstrap): full-screen BsModal dialogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`BsModal` full-screen dialogs.** `Fullscreen: true` renders an edge-to-edge `.modal-fullscreen` at
+  every width; `FullscreenBelow: Bp.Sm` (or any `Bp`) renders `.modal-fullscreen-{bp}-down` so the dialog
+  fills the screen below that breakpoint and stays a sized, centered dialog above it — ideal for forms on
+  phones. Composes with `Size` (sized at/above the breakpoint, full-screen below).
+
 ### Changed
 - **The live-root render no longer allocates the whole page twice.** Every server/WASM live
   render — the initial GET, every event re-render, reconnect recovery, and hot reload — went

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -46,6 +46,7 @@ runtime, no `bootstrap.js`.
 ```csharp
 BsButton(Color: BsColor.Primary, Size: BsSize.Lg)["Save"]
 BsModal(Open: _open, Title: "Hi", OnClose: () => _open = false)[ /* body */ ]
+BsModal(Open: _open, FullscreenBelow: Bp.Sm)[ /* edge-to-edge on phones, sized dialog at sm+ */ ]
 BsInput(() => model.Email, Label: "Email", Type: InputType.Email)   // .is-invalid + .invalid-feedback built in
 BsIcon(Name: BsIconName.HeartFill, Color: BsColor.Danger)
 

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsModalDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsModalDemo.cs
@@ -5,10 +5,14 @@ namespace Rask.Example.Shared.Features;
 public sealed class BsModalDemo : Component
 {
     private bool _open;
+    private bool _fullscreenOpen;
 
     protected override Component? Render() =>
     [
-        BsButton(Color: BsColor.Primary, OnClick: () => _open = true)["Launch demo modal"],
+        Div(Class: Bs.Join(Display.Flex(), Flex.Gap(2)))[
+            BsButton(Color: BsColor.Primary, OnClick: () => _open = true)["Launch demo modal"],
+            BsButton(Color: BsColor.Secondary, OnClick: () => _fullscreenOpen = true)["Full-screen on phones"]
+        ],
         BsModal(
             Open: _open,
             Title: "Zero-JS modal",
@@ -17,6 +21,18 @@ public sealed class BsModalDemo : Component
             Footer: BsButton(Color: BsColor.Secondary, OnClick: () => _open = false)["Close"])[
             P()["This modal — backdrop, show animation and click-outside-to-close — runs without "
                 + "bootstrap.js. State lives in your component; Rask diffs the DOM."]
+        ],
+        // FullscreenBelow makes the dialog edge-to-edge below the breakpoint (great for forms on
+        // phones) while staying a sized, centered dialog on larger screens.
+        BsModal(
+            Open: _fullscreenOpen,
+            Title: "Full-screen below sm",
+            Size: BsSize.Lg,
+            FullscreenBelow: Bp.Sm,
+            OnClose: () => _fullscreenOpen = false,
+            Footer: BsButton(Color: BsColor.Secondary, OnClick: () => _fullscreenOpen = false)["Close"])[
+            P()["Resize the window: below the sm breakpoint this dialog fills the screen edge-to-edge; "
+                + "at sm and up it is a centered modal-lg. Set Fullscreen: true for full-screen at every width."]
         ]
     ];
 }

--- a/src/Rask.Bootstrap/BsModal.cs
+++ b/src/Rask.Bootstrap/BsModal.cs
@@ -12,6 +12,14 @@ public sealed class BsModal : BsBlock
     public BsSize? Size { get; set; }
     public bool? Centered { get; set; }
     public bool? Scrollable { get; set; }
+
+    // Full-screen dialog (edge-to-edge, no margins/border-radius). Fullscreen=true is full-screen at
+    // every width (.modal-fullscreen); FullscreenBelow makes it full-screen only below the given
+    // breakpoint (.modal-fullscreen-{bp}-down, e.g. Bp.Sm for phones) and supersedes Fullscreen when
+    // both are set. Composes with Size: the dialog is sized at/above the breakpoint, full-screen below.
+    public bool? Fullscreen { get; set; }
+    public Bp? FullscreenBelow { get; set; }
+
     public bool? StaticBackdrop { get; set; }
     public bool? HideClose { get; set; }
 
@@ -36,6 +44,8 @@ public sealed class BsModal : BsBlock
 
         var dialogCls = BsClass.Join(
             "modal-dialog",
+            FullscreenBelow is { } below ? $"modal-fullscreen-{below.Token()}-down"
+                : Fullscreen is true ? "modal-fullscreen" : null,
             Centered is true ? "modal-dialog-centered" : null,
             Scrollable is true ? "modal-dialog-scrollable" : null,
             Size is { } s && s.Suffix() is { } suffix ? $"modal-{suffix}" : null);

--- a/tests/Rask.Bootstrap.Tests/BsComponentTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsComponentTests.cs
@@ -83,6 +83,18 @@ public class BsComponentTests
             BsModal(Open: true, Title: "Hi")["body"].ToHtml());
 
     [Fact]
+    public void Modal_Fullscreen_AddsFullscreenClass() =>
+        Assert.Contains(
+            "<div class=\"modal-dialog modal-fullscreen\">",
+            BsModal(Open: true, Title: "Hi", Fullscreen: true)["body"].ToHtml());
+
+    [Fact]
+    public void Modal_FullscreenBelow_AddsBreakpointDownClassAndComposesWithSize() =>
+        Assert.Contains(
+            "<div class=\"modal-dialog modal-fullscreen-sm-down modal-lg\">",
+            BsModal(Open: true, Title: "Hi", FullscreenBelow: Bp.Sm, Size: BsSize.Lg)["body"].ToHtml());
+
+    [Fact]
     public void Icon_RendersBiClassesAndHiddenByDefault() =>
         Assert.Equal(
             "<i class=\"bi bi-heart-fill\" aria-hidden=\"true\"></i>",

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -238,6 +238,14 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("div.modal.show")).ToHaveCountAsync(0,
             new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
 
+        // Full-screen-below-sm modal — FullscreenBelow: Bp.Sm adds .modal-fullscreen-sm-down.
+        await Page.Locator(".guide-demo button:has-text(\"Full-screen on phones\")").First.ClickAsync();
+        await Expect(Page.Locator("div.modal.show .modal-dialog.modal-fullscreen-sm-down").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
+        await Page.Locator("div.modal .btn-close").First.ClickAsync();
+        await Expect(Page.Locator("div.modal.show")).ToHaveCountAsync(0,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
+
         // Toast (its standalone /toast page folded in) — shown and dismissed entirely by live-diff state
         // (no bootstrap.js, no data-bs-dismiss). Showing renders class="toast show"; the × removes it.
         await Page.Locator(".guide-demo button:has-text('Show toast')").First.ClickAsync();


### PR DESCRIPTION
Add `Fullscreen` and `FullscreenBelow` props to `BsModal`.

- `Fullscreen: true` → `.modal-fullscreen` (edge-to-edge at every width)
- `FullscreenBelow: Bp.Sm` (any `Bp`) → `.modal-fullscreen-{bp}-down` — fills the screen below the breakpoint, stays a sized/centered dialog above it. Composes with `Size`; supersedes `Fullscreen` when both set.

Ideal for forms on phones (motivating use case: the Ta app's create/edit modals).

**rask-ship:** 2 unit tests (`.modal-fullscreen` and `.modal-fullscreen-sm-down` + Size composition), `BsModalDemo` sample gains a 'Full-screen on phones' trigger, shared E2E journey asserts it, docs/bootstrap.md + CHANGELOG updated. Build clean under warnings-as-errors.