### PR TITLE
feat(generators): ship IDE quick-fixes for RASK001 and RASK023

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -8,6 +8,7 @@ Committed, shareable playbooks for the recurring Rask workflows. They auto-surfa
 | [`rask-ship`](rask-ship/SKILL.md) | Before any commit/PR — the definition-of-done gate (format → warnings-as-errors build → tests → benchmarks → CHANGELOG → review → PR). |
 | [`add-html-tag`](add-html-tag/SKILL.md) | Adding an HTML element to `Rask.Core` (component + ordered-attribute test; factory auto-generated). |
 | [`add-diagnostic`](add-diagnostic/SKILL.md) | Adding a RASK0xx generator/analyzer diagnostic (descriptor + `docs/diagnostics.md` + test). |
+| [`add-codefix`](add-codefix/SKILL.md) | Adding an IDE quick-fix (CodeFixProvider) for a RASK0xx diagnostic in `Rask.Generators.CodeFixes` + test. |
 | [`run-benchmarks`](run-benchmarks/SKILL.md) | Changing render/live-runtime hotpath — before/after `Allocated` delta. |
 | [`rask-review`](rask-review/SKILL.md) | Reviewing a diff/PR for security, performance, memory, and .NET/C# best practices. |
 | [`open-pr`](open-pr/SKILL.md) | Opening a PR (branch off main, Conventional-Commit, no AI attribution, delete branch after merge). |

--- a/.claude/skills/add-codefix/SKILL.md
+++ b/.claude/skills/add-codefix/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: add-codefix
+description: Add a Roslyn CodeFixProvider (IDE lightbulb quick-fix) for an existing RASK0xx diagnostic. Use when a diagnostic has a single obvious mechanical fix. Implements the provider in src/Rask.Generators.CodeFixes, adds an apply-and-compare test in tests/Rask.Generators.Tests, notes the quick-fix in docs/diagnostics.md.
+---
+
+# add-codefix
+
+Quick-fixes live in **`src/Rask.Generators.CodeFixes`** — a SEPARATE assembly from `Rask.Generators`
+because code fixes reference `Microsoft.CodeAnalysis.Workspaces`, which an analyzer assembly must not
+(RS1038 / csc load failure). It contains no analyzers/generators, only `CodeFixProvider`s, and is packed
+into `analyzers/dotnet/cs/` by `Rask.Server` and `Rask.Wasm` (build-order-only ProjectReference, so
+`-warnaserror` is unaffected).
+
+**Only add a fix when there is ONE unambiguous mechanical edit.** Skip diagnostics whose fix depends on
+intent (e.g. a `Key:` value) or context (e.g. removing a statement vs. an expression-lambda body).
+
+## 1. Implement the provider
+`src/Rask.Generators.CodeFixes/{Name}CodeFixProvider.cs`. Derive from the shared
+`RaskCodeFixProvider<TNode>` base (it owns the find-node/register/apply skeleton) — mirror
+`ImgMissingAltCodeFixProvider` / `RequiredFactoryParamCodeFixProvider`:
+```csharp
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(FooCodeFixProvider))]
+[Shared]
+public sealed class FooCodeFixProvider : RaskCodeFixProvider<TNodeSyntax>
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create("RASK0xx");
+    protected override string Title => "…";
+    protected override string EquivalenceKey => "RASK0xx_…";
+
+    // Optional: withhold the fix when applying it would trade this diagnostic for a worse one
+    // (e.g. RequiredFactoryParamCodeFixProvider suppresses when `required` would trip RASK002).
+    protected override Task<bool> CanFixAsync(CodeFixContext context, TNodeSyntax node) => …;
+
+    protected override Task<Document> FixAsync(Document document, TNodeSyntax node, CancellationToken ct) =>
+        ReplaceNodeAsync(document, node, /* rewritten node */, ct);
+}
+```
+The base finds the nearest enclosing `TNode` at the diagnostic span (analyzer diagnostics point at the
+flagged node; generator diagnostics like RASK001 point at the declaration via `MakeLocation`). Keep edits
+trivia-correct (e.g. a new modifier needs `WithTrailingTrivia(Space)`). Use `CanFixAsync` with the
+`SemanticModel` when the fix is only valid under some symbol condition.
+
+## 2. Test it — `tests/Rask.Generators.Tests/CodeFixProviderTests.cs`
+Use `CodeFixHarness`: `ApplyAnalyzerFixAsync(analyzer, provider, "RASK0xx", source)` for analyzer
+diagnostics, `ApplyGeneratorFixAsync(generator, provider, "RASK0xx", source)` for generator ones. Assert
+the rewritten text `Contains` the fixed form, covering each argument/declaration shape.
+
+## 3. Document it — `docs/diagnostics.md`
+Add the ID to the "IDE quick-fix" sentence in the intro, and append "(**quick-fix available** …)" to that
+diagnostic's **Fix:** line.
+
+## 4. Finish
+Run the **`rask-ship`** gate. Verify packaging survives: `dotnet pack src/Rask.Server` and confirm the
+codefix DLL is in `analyzers/dotnet/cs/`. The IDE lightbulb itself can only be smoke-tested manually —
+the unit tests prove the transform.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,14 @@ them until tagged releases begin.
   pages without a `[ParentRoute]` (whose template is the full path); parent-composed paths aren't
   resolved, so the check under-reports rather than risk a false positive.
   See [docs/diagnostics.md](docs/diagnostics.md#rask031).
+- **IDE quick-fixes for Rask diagnostics.** A new `Rask.Generators.CodeFixes` assembly ships Roslyn
+  `CodeFixProvider`s (the lightbulb / `Ctrl`+`.`) for two diagnostics: **RASK001** adds the `required`
+  modifier to a property the generator already treats as a required factory parameter, and **RASK023**
+  inserts `Alt: ""` on an `Img` missing its alt text. The code-fix assembly is packed alongside the
+  analyzers in the `Rask.Server` and `Rask.Wasm` packages, so consumers get the fixes with no extra
+  reference. It is a separate assembly from `Rask.Generators` (code fixes reference
+  `Microsoft.CodeAnalysis.Workspaces`, which an analyzer assembly must not) and is wired in build-order
+  only, so the warnings-as-errors build is unaffected. See [docs/diagnostics.md](docs/diagnostics.md).
 
 ## [0.14.1] - 2026-07-07
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ the `docs/`, and the tests for depth. Keep this file small; put how-to detail in
 `.claude/skills/` holds the committed playbooks; apply the matching one without being asked.
 - **rask-ship** — definition-of-done gate before any commit/PR: `dotnet format` (.editorconfig) →
   `dotnet build -warnaserror` (analyzers clean) → tests → benchmarks → CHANGELOG → review → PR.
-- **add-html-tag** · **add-diagnostic** — scaffolding (component+test / RASK0xx+docs+test).
+- **add-html-tag** · **add-diagnostic** · **add-codefix** — scaffolding (component+test / RASK0xx+docs+test / IDE quick-fix+test).
 - **run-benchmarks** — before/after `Allocated` delta for render-hotpath changes (required evidence).
 - **rask-review** — security / performance / memory / .NET-C# review lens (wraps /code-review, /security-review).
 - **open-pr** — branch off main, Conventional-Commit, **no AI-attribution footers**, delete branch after merge.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,6 +15,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -22,6 +22,7 @@
         <Project Path="src/Rask.Cqrs/Rask.Cqrs.csproj"/>
         <Project Path="src/Rask.Cqrs.Generators/Rask.Cqrs.Generators.csproj"/>
         <Project Path="src/Rask.Generators/Rask.Generators.csproj"/>
+        <Project Path="src/Rask.Generators.CodeFixes/Rask.Generators.CodeFixes.csproj"/>
         <Project Path="src/Rask.Server/Rask.Server.csproj"/>
         <Project Path="src/Rask.Templates/Rask.Templates.csproj"/>
         <Project Path="src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj"/>

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -7,6 +7,10 @@ These come from the Rask source generator and analyzers (`Rask.Generators`). The
 factories don't exist until a build runs, so if an ID below isn't recognised by your IDE yet,
 build once.
 
+Some diagnostics ship an **IDE quick-fix** (the lightbulb / `Ctrl`+`.`): **RASK001** adds the
+`required` modifier, **RASK023** inserts `Alt: ""`. These are delivered by `Rask.Generators.CodeFixes`,
+packed alongside the analyzers in the `Rask.Server` / `Rask.Wasm` packages — no extra reference needed.
+
 | ID | Severity | Summary |
 |----|----------|---------|
 | [RASK001](#rask001) | Hidden | Property is treated as a required factory parameter |
@@ -57,7 +61,8 @@ public sealed class Badge : Component
 }
 ```
 
-**Fix (optional):** add `required` for language-level enforcement, or make the property nullable
+**Fix (optional):** add `required` for language-level enforcement (**quick-fix available** — the IDE
+lightbulb inserts it), or make the property nullable
 (`string? Label`) if it should be optional. HTML-attribute props are intentionally declared nullable
 to stay ergonomic. See [factory generation rules](getting-started.md).
 
@@ -268,7 +273,8 @@ announcing the file name (or nothing), failing [WCAG 1.1.1](https://www.w3.org/W
 ```
 
 **Fix:** pass a meaningful `Alt:`, or the empty string `Alt: ""` for a purely decorative image so
-assistive technology skips it. See [accessibility](accessibility.md).
+assistive technology skips it (**quick-fix available** — the IDE lightbulb inserts `Alt: ""`, which you
+then fill in for informative images). See [accessibility](accessibility.md).
 
 ## RASK024
 **`UseAuthentication()` must precede `UseRask()`** · Warning

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
-- [Diagnostics](docs/diagnostics.md): RASK001–031 compile-time diagnostics + fixes.
+- [Diagnostics](docs/diagnostics.md): RASK001–031 compile-time diagnostics + fixes, including IDE quick-fixes (lightbulb) for RASK001 (add `required`) and RASK023 (insert `Alt: ""`), shipped in `Rask.Generators.CodeFixes`.
 - [Testing](docs/testing.md): unit + Playwright E2E patterns.
 
 ## Contributing to Rask itself

--- a/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ImgMissingAltCodeFixProvider.cs
@@ -1,0 +1,39 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Rask.Generators.CodeFixes;
+
+// Quick-fix for RASK023 (Img is missing Alt): append `Alt: ""` so the image is treated as decorative
+// and assistive tech skips it. The empty string is the safe default the analyzer message itself
+// suggests — the developer replaces it with real alt text when the image is informative. Appending a
+// named argument is always valid here because the analyzer fires only when no Alt was supplied.
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ImgMissingAltCodeFixProvider))]
+[Shared]
+public sealed class ImgMissingAltCodeFixProvider : RaskCodeFixProvider<InvocationExpressionSyntax>
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create("RASK023");
+
+    protected override string Title => "Add Alt: \"\" (decorative image)";
+
+    protected override string EquivalenceKey => "RASK023_AddEmptyAlt";
+
+    protected override Task<Document> FixAsync(
+        Document document, InvocationExpressionSyntax invocation, CancellationToken cancellationToken)
+    {
+        var altArgument = SyntaxFactory.Argument(
+            SyntaxFactory.NameColon("Alt"),
+            default,
+            SyntaxFactory.LiteralExpression(
+                SyntaxKind.StringLiteralExpression,
+                SyntaxFactory.Literal(string.Empty)));
+
+        var newInvocation = invocation.WithArgumentList(invocation.ArgumentList.AddArguments(altArgument));
+        return ReplaceNodeAsync(document, invocation, newInvocation, cancellationToken);
+    }
+}

--- a/src/Rask.Generators.CodeFixes/Rask.Generators.CodeFixes.csproj
+++ b/src/Rask.Generators.CodeFixes/Rask.Generators.CodeFixes.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    IDE-only code-fix providers for the Rask analyzers/generators (the lightbulb quick-fixes).
+    A SEPARATE assembly from Rask.Generators on purpose: code fixes reference
+    Microsoft.CodeAnalysis.Workspaces, and an analyzer assembly that references Workspaces trips
+    RS1038 and can fail to load under csc. This assembly contains NO analyzers/generators, only
+    CodeFixProviders, so csc never instantiates its types — it is loaded by the IDE, which has
+    Workspaces. Packed into analyzers/dotnet/cs/ alongside Rask.Generators.dll by the host packages
+    (Rask.Server / Rask.Wasm), so NuGet consumers get the quick-fixes automatically.
+  -->
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <NoWarn>$(NoWarn);RS2008</NoWarn>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" PrivateAssets="all"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Rask.Generators.CodeFixes/RaskCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/RaskCodeFixProvider.cs
@@ -1,0 +1,59 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Rask.Generators.CodeFixes;
+
+// Shared skeleton for the Rask code fixes: locate the nearest enclosing <typeparamref name="TNode"/>
+// at the diagnostic span, optionally gate on a semantic check, then register a single CodeAction that
+// rewrites the document. Keeps each concrete provider down to its title and the actual edit.
+public abstract class RaskCodeFixProvider<TNode> : CodeFixProvider
+    where TNode : SyntaxNode
+{
+    protected abstract string Title { get; }
+
+    protected abstract string EquivalenceKey { get; }
+
+    public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return;
+        }
+
+        var diagnostic = context.Diagnostics[0];
+        if (root.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true)
+                .FirstAncestorOrSelf<TNode>() is not { } node)
+        {
+            return;
+        }
+
+        if (!await CanFixAsync(context, node).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        context.RegisterCodeFix(
+            CodeAction.Create(Title, ct => FixAsync(context.Document, node, ct), EquivalenceKey),
+            diagnostic);
+    }
+
+    // Semantic guard hook — return false to withhold the fix (e.g. when applying it would trade the
+    // current diagnostic for a worse one). Default: always offer.
+    protected virtual Task<bool> CanFixAsync(CodeFixContext context, TNode node) => Task.FromResult(true);
+
+    protected abstract Task<Document> FixAsync(Document document, TNode node, CancellationToken cancellationToken);
+
+    // Shared helper: swap a node for its rewritten form and return the updated document.
+    private protected static async Task<Document> ReplaceNodeAsync(
+        Document document, SyntaxNode oldNode, SyntaxNode newNode, CancellationToken cancellationToken)
+    {
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        return root is null ? document : document.WithSyntaxRoot(root.ReplaceNode(oldNode, newNode));
+    }
+}

--- a/src/Rask.Generators.CodeFixes/RequiredFactoryParamCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/RequiredFactoryParamCodeFixProvider.cs
@@ -1,0 +1,61 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Rask.Generators.CodeFixes;
+
+// Quick-fix for RASK001 (a non-nullable, no-initializer property becomes a required factory
+// parameter): add the `required` modifier so the language enforces at every call site what the
+// generated factory already enforces. Exactly the "consider also marking it 'required'" the diagnostic
+// message recommends.
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RequiredFactoryParamCodeFixProvider))]
+[Shared]
+public sealed class RequiredFactoryParamCodeFixProvider : RaskCodeFixProvider<PropertyDeclarationSyntax>
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ImmutableArray.Create("RASK001");
+
+    protected override string Title => "Add 'required' modifier";
+
+    protected override string EquivalenceKey => "RASK001_AddRequired";
+
+    protected override async Task<bool> CanFixAsync(CodeFixContext context, PropertyDeclarationSyntax property)
+    {
+        if (property.Modifiers.Any(SyntaxKind.RequiredKeyword))
+        {
+            return false;
+        }
+
+        // Guard against trading RASK001 (a benign hint) for RASK002: when the component is built through
+        // a dependency-injected constructor with no public parameterless ctor, the generated factory uses
+        // ActivatorUtilities.CreateInstance and cannot set a `required` property — the generator would then
+        // emit RASK002 and the DI constructor's services would be null. Only offer the fix when `required`
+        // can actually be honored (mirrors the RASK002 trigger in ComponentFactoryGenerator).
+        var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
+        if (model?.GetDeclaredSymbol(property, context.CancellationToken) is not { ContainingType: { } type })
+        {
+            return true; // no semantic info — best-effort offer, matching the always-on prior behavior
+        }
+
+        var instanceCtors = type.InstanceConstructors.Where(c => !c.IsStatic).ToArray();
+        var hasParameterless = instanceCtors.Any(c => c.Parameters.Length == 0);
+        var hasDIConstructor = instanceCtors.Any(c => c.Parameters.Length > 0);
+        return !(hasDIConstructor && !hasParameterless);
+    }
+
+    protected override Task<Document> FixAsync(
+        Document document, PropertyDeclarationSyntax property, CancellationToken cancellationToken)
+    {
+        var required = SyntaxFactory.Token(SyntaxKind.RequiredKeyword)
+            .WithTrailingTrivia(SyntaxFactory.Space);
+        // Appended to the modifier list; for the public settable properties that RASK001 targets this
+        // yields the conventional `public required T`.
+        var newProperty = property.AddModifiers(required);
+        return ReplaceNodeAsync(document, property, newProperty, cancellationToken);
+    }
+}

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -98,11 +98,11 @@
   </ItemGroup>
 
   <!--
-    Bundle Rask.Core.dll into lib/net10.0/ alongside Rask.Server.dll, and pack the source
-    generator at analyzers/dotnet/cs/. PrivateAssets="all" on the Core ProjectReference
-    keeps the Rask.Core "package" out of the nuspec dependency list — we explicitly pack
-    its DLL here. Microsoft.AspNetCore.App (declared as a FrameworkReference) covers all
-    of Core's runtime needs at consume time on net10.0.
+    Bundle Rask.Core.dll into lib/net10.0/ alongside Rask.Server.dll. PrivateAssets="all" on the Core
+    ProjectReference keeps the Rask.Core "package" out of the nuspec dependency list — we explicitly pack
+    its DLL here. Microsoft.AspNetCore.App (declared as a FrameworkReference) covers all of Core's runtime
+    needs at consume time on net10.0. The analyzer/generator/code-fix payload is packed by the shared
+    RaskAnalyzerPack.targets import below.
   -->
   <ItemGroup>
     <None Include="$(OutputPath)Rask.Core.dll"
@@ -111,20 +111,8 @@
          Element, factories, forms, routing) surfaces IntelliSense for consumers too. -->
     <None Include="$(OutputPath)Rask.Core.xml"
           Pack="true" PackagePath="lib/net10.0/" Visible="false"/>
-    <None Include="..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll"
-          Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false"/>
   </ItemGroup>
 
-  <!--
-    Fail loud at pack time if the source generator DLL is missing from the hardcoded path above,
-    instead of silently shipping a package with no analyzer — a <None Include> of an absent file
-    packs nothing and emits no error, so consumers' factories would just never generate. Build order
-    is already ensured by Rask.Core's analyzer ProjectReference to Rask.Generators; this guard also
-    catches the path drifting (e.g. a Rask.Generators TFM change) or a no-build pack.
-  -->
-  <Target Name="_RaskVerifyGeneratorPacked" BeforeTargets="GenerateNuspec">
-    <Error Condition="!Exists('..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll')"
-           Text="Rask.Generators.dll not found at '..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll' — build Rask.Generators before packing so the source generator ships in analyzers/dotnet/cs/." />
-  </Target>
+  <Import Project="..\RaskAnalyzerPack.targets"/>
 
 </Project>

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -153,22 +153,8 @@
     analyzers/dotnet/cs/ (the generator project sets IncludeBuildOutput=false so it does
     not flow with the consumer's build output).
   -->
-  <ItemGroup>
-    <None Include="..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll"
-          Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false"/>
-  </ItemGroup>
-
-  <!--
-    Fail loud at pack time if the source generator DLL is missing from the hardcoded path above,
-    instead of silently shipping a package with no analyzer — a <None Include> of an absent file
-    packs nothing and emits no error, so consumers' factories would just never generate. Build order
-    is already ensured by Rask.Core's analyzer ProjectReference to Rask.Generators; this guard also
-    catches the path drifting (e.g. a Rask.Generators TFM change) or a no-build pack.
-  -->
-  <Target Name="_RaskVerifyGeneratorPacked" BeforeTargets="GenerateNuspec">
-    <Error Condition="!Exists('..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll')"
-           Text="Rask.Generators.dll not found at '..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll' — build Rask.Generators before packing so the source generator ships in analyzers/dotnet/cs/." />
-  </Target>
+  <!-- Analyzer + generator + IDE code-fix payload packed into analyzers/dotnet/cs/ (shared with Rask.Server). -->
+  <Import Project="..\RaskAnalyzerPack.targets"/>
 
   <PropertyGroup>
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_RaskAddCoreToLib</TargetsForTfmSpecificContentInPackage>

--- a/src/RaskAnalyzerPack.targets
+++ b/src/RaskAnalyzerPack.targets
@@ -1,0 +1,41 @@
+<Project>
+
+  <!--
+    Shared packing of the Rask Roslyn analyzers + generator + IDE code-fixes into analyzers/dotnet/cs/.
+    Imported by the host packages (Rask.Server, Rask.Wasm). Both live at src/<Name>/, so the
+    ..\Rask.Generators* relative paths (evaluated relative to the IMPORTING project's directory) resolve
+    identically from either — keeping the two packages' analyzer payload in lockstep from one place.
+  -->
+  <ItemGroup>
+    <None Include="..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll"
+          Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false"/>
+    <!-- IDE-only code-fix providers (the lightbulb quick-fixes) ship next to the generator. They live in
+         a SEPARATE assembly because they reference Microsoft.CodeAnalysis.Workspaces, which an analyzer
+         assembly must not (RS1038 / csc load failure). -->
+    <None Include="..\Rask.Generators.CodeFixes\bin\$(Configuration)\netstandard2.0\Rask.Generators.CodeFixes.dll"
+          Pack="true" PackagePath="analyzers/dotnet/cs/" Visible="false"/>
+  </ItemGroup>
+
+  <!--
+    Build-order-only reference so the code-fix DLL exists before pack WITHOUT csc loading a
+    Workspaces-referencing assembly (which would break the warnings-as-errors build). The generator's
+    build order is already ensured via Rask.Core's analyzer ProjectReference to Rask.Generators.
+  -->
+  <ItemGroup>
+    <ProjectReference Include="..\Rask.Generators.CodeFixes\Rask.Generators.CodeFixes.csproj"
+                      ReferenceOutputAssembly="false" PrivateAssets="all"/>
+  </ItemGroup>
+
+  <!--
+    Fail loud at pack time if either analyzer DLL is missing from the hardcoded path above, instead of
+    silently shipping a package with no analyzer/quick-fixes — a <None Include> of an absent file packs
+    nothing and emits no error. Also catches the path drifting (e.g. a TFM change) or a no-build pack.
+  -->
+  <Target Name="_RaskVerifyAnalyzersPacked" BeforeTargets="GenerateNuspec">
+    <Error Condition="!Exists('..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll')"
+           Text="Rask.Generators.dll not found at '..\Rask.Generators\bin\$(Configuration)\netstandard2.0\Rask.Generators.dll' — build Rask.Generators before packing so the source generator ships in analyzers/dotnet/cs/." />
+    <Error Condition="!Exists('..\Rask.Generators.CodeFixes\bin\$(Configuration)\netstandard2.0\Rask.Generators.CodeFixes.dll')"
+           Text="Rask.Generators.CodeFixes.dll not found at '..\Rask.Generators.CodeFixes\bin\$(Configuration)\netstandard2.0\Rask.Generators.CodeFixes.dll' — build Rask.Generators.CodeFixes before packing so the code-fix providers ship in analyzers/dotnet/cs/." />
+  </Target>
+
+</Project>

--- a/tests/Rask.Generators.Tests/CodeFixHarness.cs
+++ b/tests/Rask.Generators.Tests/CodeFixHarness.cs
@@ -1,0 +1,106 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Rask.Generators.Tests;
+
+// Drives a CodeFixProvider end-to-end: build a Document over the same references the generator tests
+// use, obtain the target diagnostic (from an analyzer or from a source generator so its Location sits
+// in the Document's tree), register the fix, apply the first CodeAction, and return the rewritten text.
+internal static class CodeFixHarness
+{
+    // Applies the fix for an analyzer-produced diagnostic (e.g. RASK023).
+    public static async Task<string> ApplyAnalyzerFixAsync(
+        DiagnosticAnalyzer analyzer, CodeFixProvider provider, string diagnosticId, string source)
+    {
+        var document = CreateDocument(source);
+        var compilation = (CSharpCompilation)(await document.Project.GetCompilationAsync())!;
+        var diagnostics = await compilation
+            .WithAnalyzers(ImmutableArray.Create(analyzer))
+            .GetAnalyzerDiagnosticsAsync();
+        return await ApplyAsync(provider, document, FirstOf(diagnostics, diagnosticId));
+    }
+
+    // Applies the fix for a source-generator-produced diagnostic (e.g. RASK001).
+    public static async Task<string> ApplyGeneratorFixAsync(
+        IIncrementalGenerator generator, CodeFixProvider provider, string diagnosticId, string source)
+    {
+        var (document, diagnostic) = await GeneratorDiagnosticAsync(generator, diagnosticId, source);
+        return await ApplyAsync(provider, document, diagnostic);
+    }
+
+    // True when the provider offers a fix for a generator diagnostic — lets a test assert that a fix is
+    // deliberately withheld (e.g. the RASK001 fix is suppressed for a DI-constructor component).
+    public static async Task<bool> IsGeneratorFixOfferedAsync(
+        IIncrementalGenerator generator, CodeFixProvider provider, string diagnosticId, string source)
+    {
+        var (document, diagnostic) = await GeneratorDiagnosticAsync(generator, diagnosticId, source);
+        return (await CollectActionsAsync(provider, document, diagnostic)).Count > 0;
+    }
+
+    private static async Task<(Document, Diagnostic)> GeneratorDiagnosticAsync(
+        IIncrementalGenerator generator, string diagnosticId, string source)
+    {
+        var document = CreateDocument(source);
+        var compilation = (CSharpCompilation)(await document.Project.GetCompilationAsync())!;
+        var runResult = CSharpGeneratorDriver
+            .Create(generator)
+            .WithUpdatedParseOptions(new CSharpParseOptions(LanguageVersion.Latest))
+            .RunGenerators(compilation)
+            .GetRunResult();
+        var diagnostics = runResult.Diagnostics
+            .Concat(runResult.Results.SelectMany(r => r.Diagnostics))
+            .ToImmutableArray();
+        return (document, FirstOf(diagnostics, diagnosticId));
+    }
+
+    private static Diagnostic FirstOf(ImmutableArray<Diagnostic> diagnostics, string id)
+    {
+        var match = diagnostics.FirstOrDefault(d => d.Id == id);
+        Assert.True(match is not null, $"Expected a {id} diagnostic; got [{string.Join(", ", diagnostics.Select(d => d.Id))}]");
+        return match!;
+    }
+
+    private static async Task<List<CodeAction>> CollectActionsAsync(
+        CodeFixProvider provider, Document document, Diagnostic diagnostic)
+    {
+        var actions = new List<CodeAction>();
+        var context = new CodeFixContext(
+            document, diagnostic, (action, _) => actions.Add(action), CancellationToken.None);
+        await provider.RegisterCodeFixesAsync(context);
+        return actions;
+    }
+
+    private static async Task<string> ApplyAsync(CodeFixProvider provider, Document document, Diagnostic diagnostic)
+    {
+        var actions = await CollectActionsAsync(provider, document, diagnostic);
+        Assert.NotEmpty(actions);
+
+        var operations = await actions[0].GetOperationsAsync(CancellationToken.None);
+        var applied = operations.OfType<ApplyChangesOperation>().Single();
+        var changedDocument = applied.ChangedSolution.GetDocument(document.Id)!;
+        var text = await changedDocument.GetTextAsync();
+        return text.ToString();
+    }
+
+    private static Document CreateDocument(string source)
+    {
+        var workspace = new AdhocWorkspace();
+        var project = workspace.AddProject(ProjectInfo.Create(
+            ProjectId.CreateNewId(),
+            VersionStamp.Create(),
+            "Test",
+            "Test",
+            LanguageNames.CSharp,
+            compilationOptions: new CSharpCompilationOptions(
+                OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable),
+            parseOptions: new CSharpParseOptions(LanguageVersion.Latest),
+            metadataReferences: GeneratorDriverFixture.BuildReferences()));
+        return workspace.AddDocument(project.Id, "Test.cs", SourceText.From(source));
+    }
+}

--- a/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
+++ b/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
@@ -1,0 +1,108 @@
+using Rask.Generators.Analyzers;
+using Rask.Generators.CodeFixes;
+
+namespace Rask.Generators.Tests;
+
+public class CodeFixProviderTests
+{
+    private static string App(string body) => $$"""
+        using Rask.Core;
+        using static Rask.Core.Components.Generated;
+        namespace Demo;
+        public sealed class App : Component
+        {
+            protected override Component? Render()
+            {
+                {{body}}
+            }
+        }
+        """;
+
+    // ---- RASK023: Img missing Alt -> insert Alt: "" ----
+
+    [Fact]
+    public async Task Rask023_InsertsEmptyAlt_AfterNamedSrc()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img(Src: \"/a.png\");"));
+        Assert.Contains("Img(Src: \"/a.png\", Alt: \"\")", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask023_InsertsAlt_WhenNoArguments()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img();"));
+        Assert.Contains("Img(Alt: \"\")", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask023_InsertsAlt_AfterPositionalSrc()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ImgMissingAltAnalyzer(), new ImgMissingAltCodeFixProvider(), "RASK023",
+            App("return Img(\"/a.png\");"));
+        Assert.Contains("Img(\"/a.png\", Alt: \"\")", fixhed);
+    }
+
+    // ---- RASK001: property becomes a required factory param -> add `required` ----
+
+    [Fact]
+    public async Task Rask001_AddsRequiredModifier_AfterAccessibility()
+    {
+        var source = """
+            using Rask.Core;
+            namespace Demo;
+            public sealed class Card : Component
+            {
+                public string Title { get; set; }
+            }
+            """;
+        var fixhed = await CodeFixHarness.ApplyGeneratorFixAsync(
+            new ComponentFactoryGenerator(), new RequiredFactoryParamCodeFixProvider(), "RASK001", source);
+        Assert.Contains("public required string Title { get; set; }", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask001_NotOffered_WhenAddingRequiredWouldTripRask002()
+    {
+        // The component has a DI constructor and no parameterless ctor, so the generated factory builds it
+        // via ActivatorUtilities and cannot set a `required` property. Adding `required` would trade the
+        // Hidden RASK001 for a RASK002 warning (null services), so the fix must be withheld.
+        var source = """
+            using Rask.Core;
+            namespace Demo;
+            public sealed class Card : Component
+            {
+                private readonly string _svc;
+                public Card(string svc) => _svc = svc;
+                public string Title { get; set; }
+            }
+            """;
+        var offered = await CodeFixHarness.IsGeneratorFixOfferedAsync(
+            new ComponentFactoryGenerator(), new RequiredFactoryParamCodeFixProvider(), "RASK001", source);
+        Assert.False(offered);
+    }
+
+    [Fact]
+    public async Task Rask001_Offered_WhenDIConstructorHasParameterlessSibling()
+    {
+        // A parameterless ctor exists alongside the DI ctor, so the factory can `new Card()` + set the
+        // property — RASK002 does not fire, so the fix stays available.
+        var source = """
+            using Rask.Core;
+            namespace Demo;
+            public sealed class Card : Component
+            {
+                public Card() { }
+                public Card(string svc) { }
+                public string Title { get; set; }
+            }
+            """;
+        var offered = await CodeFixHarness.IsGeneratorFixOfferedAsync(
+            new ComponentFactoryGenerator(), new RequiredFactoryParamCodeFixProvider(), "RASK001", source);
+        Assert.True(offered);
+    }
+}

--- a/tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj
+++ b/tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp"/>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio">
@@ -23,6 +24,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators.CodeFixes\Rask.Generators.CodeFixes.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <!-- Rask.Server (and, transitively, the ASP.NET Core shared framework) so AuthBeforeRaskAnalyzer
          tests can resolve the real UseRask / UseAuthentication symbols in their test compilations. -->


### PR DESCRIPTION
## Summary

Every Rask diagnostic carried a help link but no automated fix. Two map to a single unambiguous mechanical edit, so this adds Roslyn **code-fix providers** (the IDE lightbulb / `Ctrl`+`.`):

- **RASK001** → add the `required` modifier to a property the generator already treats as a required factory parameter.
- **RASK023** → insert `Alt: ""` on an `Img` missing its alt text.

## Design

- New **`Rask.Generators.CodeFixes`** assembly, separate from `Rask.Generators` — code fixes reference `Microsoft.CodeAnalysis.Workspaces`, which an analyzer assembly must not (RS1038 / csc load failure). Contains only `CodeFixProvider`s, so csc never instantiates its types.
- Both providers derive from a shared **`RaskCodeFixProvider<TNode>`** base (find-node → optional semantic gate → register → apply).
- **Semantic guard on RASK001** (from review): the fix is withheld when the component is built through a DI constructor with no parameterless ctor — there, adding `required` would trip RASK002 and leave injected services null. Mirrors the RASK002 trigger.
- Packed into `analyzers/dotnet/cs/` by a shared **`RaskAnalyzerPack.targets`** imported by `Rask.Server` and `Rask.Wasm` (build-order-only `ProjectReference`, `ReferenceOutputAssembly=false` — so `-warnaserror` never loads the Workspaces-dependent assembly). The shared targets also de-duplicate the pre-existing generator-packaging block.

## Testing

- `dotnet test tests/Rask.Generators.Tests` — 203 passed (6 new code-fix tests: every arg/declaration shape + DI-guard withheld/offered cases)
- Verified `dotnet pack` puts `Rask.Generators.CodeFixes.dll` in `analyzers/dotnet/cs/` for the Server package; Wasm import parses + guard target passes
- New `CodeFixHarness` drives fixes over both analyzer and generator diagnostics (apply-and-compare + fix-offered assertions)
- Strict `-warnaserror` build clean; format clean

## Docs / artifacts

`docs/diagnostics.md` (quick-fix intro + per-diagnostic notes), `llms.txt`, `CHANGELOG` `[Unreleased]`, new **`add-codefix`** skill (+ CLAUDE.md / skills README).

## Reviewer follow-ups addressed

Adds the DI-constructor semantic guard (correctness), the `RaskCodeFixProvider<TNode>` base (skeleton dedup), and the shared `RaskAnalyzerPack.targets` (packaging dedup).