### PR TITLE
feat(bootstrap): min-vh-100 / min-vw-100 sizing utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ them until tagged releases begin.
   every width; `FullscreenBelow: Bp.Sm` (or any `Bp`) renders `.modal-fullscreen-{bp}-down` so the dialog
   fills the screen below that breakpoint and stays a sized, centered dialog above it — ideal for forms on
   phones. Composes with `Size` (sized at/above the breakpoint, full-screen below).
+- **`Sizing.MinVW100` / `Sizing.MinVH100`** typed utility tokens (`min-vw-100` / `min-vh-100`) — completes
+  the viewport-sizing family (alongside `VW100`/`VH100`) for min-height layouts such as a sticky footer.
 
 ### Changed
 - **The live-root render no longer allocates the whole page twice.** Every server/WASM live

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -132,7 +132,7 @@ Bs.Join(Display.Flex(Bp.Lg), Margin.Bottom(4, Bp.Md))   // → "d-lg-flex mb-md-
 | `Rounded` | `Default` `None` `Pill` `Circle` `Top/End/Bottom/Start` `Size(int)` |
 | `Txt` | `Start/Center/End(Bp?)` `Color(BsColor)` `Muted` `Truncate/Wrap/Nowrap/Break` `Uppercase/Lowercase/Capitalize` `DecorationNone/Underline` |
 | `Font` | `Bold/Bolder/Semibold/Medium/Normal/Light/Lighter` `Italic/NotItalic` `Size(int)` (→ `fw-*`, `fst-*`, `fs-{n}`) |
-| `Sizing` | `W(int)` `H(int)` `WAuto` `HAuto` `MaxW100` `MaxH100` `VW100` `VH100` |
+| `Sizing` | `W(int)` `H(int)` `WAuto` `HAuto` `MaxW100` `MaxH100` `VW100` `VH100` `MinVW100` `MinVH100` |
 | `Position` | `Static/Relative/Absolute/Fixed/Sticky` `Top0/Top50/Bottom0/Start0/…` `TranslateMiddle(+X/Y)` |
 | `Bg` | `Color(BsColor)` `Body` `BodyTertiary` `White` `Transparent` |
 

--- a/src/Rask.Bootstrap/Utilities.cs
+++ b/src/Rask.Bootstrap/Utilities.cs
@@ -244,6 +244,8 @@ public static class Sizing
     public const string MaxH100 = "mh-100";
     public const string VW100 = "vw-100";
     public const string VH100 = "vh-100";
+    public const string MinVW100 = "min-vw-100";
+    public const string MinVH100 = "min-vh-100";
 }
 
 // Bootstrap grid: the .row container and its column spans (.col / .col-auto / .col-{bp?}-{1..12}).

--- a/tests/Rask.Bootstrap.Tests/BsUtilityTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsUtilityTests.cs
@@ -47,4 +47,11 @@ public class BsUtilityTests
         Assert.Equal("text-md-center", Txt.Center(Bp.Md));
         Assert.Equal("fw-bold rounded-pill w-100", Bs.Join(Font.Bold, Rounded.Pill, Sizing.W(100)));
     }
+
+    [Fact]
+    public void Sizing_MinViewport()
+    {
+        Assert.Equal("min-vh-100", Sizing.MinVH100);
+        Assert.Equal("min-vw-100", Sizing.MinVW100);
+    }
 }


### PR DESCRIPTION
Adds `Sizing.MinVW100` and `Sizing.MinVH100` (`min-vw-100` / `min-vh-100`), completing the viewport-sizing family alongside `VW100`/`VH100`. `min-vh-100` is the missing token for min-height layouts (e.g. a sticky footer: a full-height flex column whose content row grows to push the footer to the bottom).

Unit test + docs + CHANGELOG. Motivating consumer: the Ta app shell.