### PR TITLE
perf(server): match inbound WS frame type via ValueEquals, no per-frame string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ them until tagged releases begin.
   ~30k eliminated probes/second on a 500-component page at 60 fps). The `MountedTypes` set is still
   populated for every component (a public per-render contract), so behavior is unchanged; the saving
   is per-component wasted work rather than a single measurable render delta.
+- **Inbound WebSocket dispatch no longer allocates a string per frame.** The server dispatch loop
+  (`RaskEndpointExtensions`) called `JsonElement.GetString()` on every inbound frame's `type` field —
+  a fresh heap string — only to `==`-compare it against four constants (`hello`/`navigate`/`jsResult`/
+  `dotNetInvoke`). It now matches the UTF-8 bytes in place with `JsonElement.ValueEquals(...u8)`. This
+  runs on every keystroke, 60 Hz scroll tick, and click, so the per-frame string was pure waste. The
+  type-match step drops to **0 B allocated** (was 40 B) and is ~34% faster (8.5 ns → 5.7 ns); behavior
+  is unchanged (`handlerId` still resolves via `GetString`, which is a genuine dictionary key).
 
 ## [0.14.1] - 2026-07-07
 

--- a/benchmarks/Rask.Benchmarks/WsInboundTypeMatchBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/WsInboundTypeMatchBenchmarks.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+
+namespace Rask.Benchmarks;
+
+// The inbound WS dispatch (Rask.Server/RaskEndpointExtensions.cs) matches each frame's "type" against
+// four constants to route it. The legacy path called JsonElement.GetString() — a fresh string per
+// frame — only to `==` those literals; the new path uses JsonElement.ValueEquals(...u8), which compares
+// the UTF-8 bytes in place with zero allocation. This runs on EVERY inbound frame (every keystroke,
+// 60 Hz scroll tick, click), so the per-frame string is pure waste. Both approaches live here so a
+// single run shows the allocation delta directly.
+[MemoryDiagnoser]
+public class WsInboundTypeMatchBenchmarks
+{
+    private JsonDocument _doc = null!;
+    private JsonElement _type;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        // A representative frame — a navigate, matching the second of the four type literals.
+        _doc = JsonDocument.Parse("{\"type\":\"navigate\",\"url\":\"/products/42\"}"u8.ToArray());
+        _type = _doc.RootElement.GetProperty("type");
+    }
+
+    [GlobalCleanup]
+    public void Cleanup() => _doc.Dispose();
+
+    [Benchmark(Baseline = true)]
+    public bool LegacyString_GetStringCompare()
+    {
+        var type = _type.GetString();
+        return type == "hello" || type == "navigate" || type == "jsResult" || type == "dotNetInvoke";
+    }
+
+    [Benchmark]
+    public bool Bytes_ValueEquals() =>
+        _type.ValueEquals("hello"u8) || _type.ValueEquals("navigate"u8)
+        || _type.ValueEquals("jsResult"u8) || _type.ValueEquals("dotNetInvoke"u8);
+}

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -835,11 +835,12 @@ public static class RaskEndpointExtensions
                 {
                     continue;
                 }
-                var type = root.TryGetProperty("type", out var t) && t.ValueKind == JsonValueKind.String
-                    ? t.GetString()
-                    : null;
+                // Match the frame "type" against the UTF-8 literals directly (ValueEquals) instead of
+                // materializing a string per frame — this runs on every inbound frame (keystroke,
+                // 60 Hz scroll, click), and the string was allocated only to == four constants.
+                var hasType = root.TryGetProperty("type", out var t) && t.ValueKind == JsonValueKind.String;
 
-                if (type == "hello")
+                if (hasType && t.ValueEquals("hello"u8))
                 {
                     var sessionId = root.TryGetProperty("session", out var sid) && sid.ValueKind == JsonValueKind.String
                         ? sid.GetString()
@@ -881,13 +882,13 @@ public static class RaskEndpointExtensions
                     continue;
                 }
 
-                if (type == "navigate")
+                if (hasType && t.ValueEquals("navigate"u8))
                 {
                     await HandleNavigateAsync(session, root, ct);
                     continue;
                 }
 
-                if (type == "jsResult")
+                if (hasType && t.ValueEquals("jsResult"u8))
                 {
                     // Round-trip reply for an IJSRuntime.InvokeAsync<T> call. The base
                     // JSRuntime class manages its own pending-task dictionary keyed by the
@@ -898,7 +899,7 @@ public static class RaskEndpointExtensions
                     continue;
                 }
 
-                if (type == "dotNetInvoke")
+                if (hasType && t.ValueEquals("dotNetInvoke"u8))
                 {
                     // JS-side DotNet.invokeMethodAsync calling into a [JSInvokable] method.
                     // Hand off to the public DotNetDispatcher; the runtime completes the


### PR DESCRIPTION
## Summary

The server WS dispatch loop (`RaskEndpointExtensions`) called `JsonElement.GetString()` on **every** inbound frame's `type` field — a fresh heap string — only to `==`-compare it against four routing constants (`hello`/`navigate`/`jsResult`/`dotNetInvoke`). Every keystroke, 60 Hz scroll tick, and click paid that allocation.

Now it matches the UTF-8 bytes in place with `JsonElement.ValueEquals("…"u8)`, guarded by a `hasType` check so a missing/non-string `type` falls through exactly as the old `null` did. `handlerId` keeps `GetString` — it's a genuine dictionary key.

## Benchmark

New `WsInboundTypeMatchBenchmarks` (both approaches in one run):

| Method | Mean | Allocated |
|---|---|---|
| `LegacyString_GetStringCompare` | 8.53 ns | 40 B |
| `Bytes_ValueEquals` | 5.66 ns | **0 B** |

−100% allocation, −34% time on the per-frame match step.

## Testing

- `dotnet test tests/Rask.Server.Tests --filter WebSocket|Dispatch|Navigate|Session` — 97 passed
- Strict `-warnaserror` build clean; format clean
- Behavior-preserving mechanical swap (4 literal comparisons); self-reviewed against the dispatch fall-through semantics.

## Changelog

Added under `[Unreleased] → Changed`.