### PR TITLE
chore(release): v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-07-07
+
 ### Added
 - **`BsModal` full-screen dialogs.** `Fullscreen: true` renders an edge-to-edge `.modal-fullscreen` at
   every width; `FullscreenBelow: Bp.Sm` (or any `Bp`) renders `.modal-fullscreen-{bp}-down` so the dialog


### PR DESCRIPTION
Promote CHANGELOG [Unreleased] → 0.14.0.

**Added**
- `BsModal` full-screen dialogs (`Fullscreen` / `FullscreenBelow`) — #257
- `Sizing.MinVW100` / `Sizing.MinVH100` utilities — #259

**Changed**
- Live-root render allocates the page once (perf) — #255