### PR TITLE
feat(generators): add RASK030 to prefer named args on many-positional factory calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **RASK030 — prefer named arguments on factory calls with many positional args.** A new Hidden analyzer
+  flags a Rask factory call that passes three or more leading positional arguments (e.g.
+  `Div("main", "container", "color:red")`). Beyond one or two, positional calls read poorly and are
+  fragile: Rask orders generated factory parameters by inheritance depth then file ordinal + span, so a
+  later edit — adding a base-class property, renaming a partial file — can reorder parameters and
+  silently rebind such a call. The first one or two positional arguments (the primary content) stay
+  idiomatic. Hidden severity: no build output and no effect on the warnings-as-errors build — the IDE
+  surfaces it as a suggestion. See [docs/diagnostics.md](docs/diagnostics.md#rask030).
 - **RASK031 — two pages resolving to the same route are now flagged.** Two different top-level pages that
   resolve to the same URL made the active one arbitrary — a silent bug the generator didn't catch (it
   only deduped by type name and enforced a single `[NotFound]`). The `RoutesGenerator` now warns

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,7 +1,7 @@
 # Rask diagnostics (RASK001–RASK031)
 
 Every Rask diagnostic, what triggers it, and how to fix it. Errors block the build; warnings don't
-but flag a real problem; one is hidden (informational, surfaced only as an IDE suggestion).
+but flag a real problem; the hidden ones are informational, surfaced only as an IDE suggestion.
 
 These come from the Rask source generator and analyzers (`Rask.Generators`). The generated
 factories don't exist until a build runs, so if an ID below isn't recognised by your IDE yet,
@@ -38,6 +38,7 @@ build once.
 | [RASK027](#rask027) | Error | Both the sync and async handler are set for one event |
 | [RASK028](#rask028) | Error | Ambiguous request handler (more than one handler for a query/command) |
 | [RASK029](#rask029) | Warning | Handler cannot be registered (open generic or no public constructor) |
+| [RASK030](#rask030) | Hidden | Prefer named arguments on a factory call with 3+ positional args |
 | [RASK031](#rask031) | Warning | Two pages resolve to the same route |
 
 ---
@@ -399,6 +400,25 @@ public sealed class PrivateHandler : IQueryHandler<GetValue, int>
 **Fix:** give the handler a public constructor, or make it a closed (non-generic) type. A request with
 *no* handler at all is not flagged (the handler may live in another assembly) — it throws a clear
 `InvalidOperationException` when dispatched.
+
+## RASK030
+**Prefer named arguments on Rask factories** · Hidden
+
+A Rask factory call passes **three or more leading positional arguments**. Beyond one or two, positional
+calls both read poorly and are fragile: Rask orders generated factory parameters by inheritance depth,
+then by file ordinal + span, so a later edit — adding a property to a base class, renaming a partial
+file — can reorder parameters and silently rebind such a call. The first one or two positional arguments
+(the primary content — `A(href)`, `Div(id, class)`) are left alone as idiomatic.
+
+```csharp
+// ✗ Div("main", "container", "color:red")                 // three positional — order-fragile, hard to read
+// ✓ Div(Id: "main", Class: "container", Style: "color:red") // explicit, refactor-proof
+```
+
+**Fix:** name the arguments (`Prop: value`). Hidden by default (no build output, no effect on the
+warnings-as-errors build) — the IDE surfaces it as a suggestion. Suppress per call with
+`#pragma warning disable RASK030`, or globally in `.editorconfig`
+(`dotnet_diagnostic.RASK030.severity = none`) if you prefer a positional style.
 
 ## RASK031
 **Two pages resolve to the same route** · Warning

--- a/src/Rask.Generators/Analyzers/PreferNamedArgsAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/PreferNamedArgsAnalyzer.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Analyzers;
+
+// RASK030 — suggest named arguments on a Rask factory call once it passes three or more LEADING
+// positional arguments. Beyond one or two, positional calls get hard to read AND fragile: Rask orders
+// generated factory parameters by inheritance depth, then by file ordinal + span (see the
+// ComponentFactoryGenerator), so a later, unrelated edit — adding a property to a base class, renaming
+// a partial file — can reorder parameters and silently rebind a positional call (a `string Id` /
+// `string Class` swap compiles clean and misrenders). Naming the arguments (`Prop: value`) makes the
+// binding explicit and refactor-proof. The first one or two positional arguments (the primary content —
+// `A(href)`, `Div(id, class)`) are left alone as idiomatic. Hidden by default: no build noise, surfaced
+// as an IDE suggestion. Suppressible like any analyzer, or globally via `.editorconfig`.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public sealed class PreferNamedArgsAnalyzer : DiagnosticAnalyzer
+{
+    private const string ComponentFullName = "Rask.Core.Component";
+    private const string RaskCoreAssembly = "Rask.Core";
+    private const string GeneratedClassName = "Generated";
+
+    // Three or more positional arguments trips the hint — one or two (the primary content plus, say, a
+    // class) stay idiomatic. Deliberately a readability threshold, not a per-type swap analysis: the
+    // fix is the same regardless, and a low-noise line keeps the Hidden hint useful.
+    private const int PositionalThreshold = 3;
+
+    private static readonly DiagnosticDescriptor Rask030 = new(
+        "RASK030",
+        "Prefer named arguments on Rask factories",
+        "'{0}' is called with {1} positional arguments — name them ('Prop: value') so the call is readable "
+        + "and doesn't rebind silently if the generated parameter order shifts (a base-class property "
+        + "added, a partial file renamed)",
+        "Usage",
+        DiagnosticSeverity.Hidden,
+        true,
+        "Rask orders factory parameters by inheritance depth then file ordinal + span, so a call with "
+        + "several positional arguments both reads poorly and can silently rebind when that order changes. "
+        + "Naming the arguments makes the binding explicit and refactor-proof.",
+        DiagnosticHelp.Link("RASK030"));
+
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
+        ImmutableArray.Create(Rask030);
+
+    public override void Initialize(AnalysisContext context)
+    {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.RegisterCompilationStartAction(static start =>
+        {
+            if (string.Equals(start.Compilation.AssemblyName, RaskCoreAssembly, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            var component = start.Compilation.GetTypeByMetadataName(ComponentFullName);
+            if (component is null)
+            {
+                return;
+            }
+
+            start.RegisterSyntaxNodeAction(
+                ctx => Analyze(ctx, component),
+                SyntaxKind.InvocationExpression);
+        });
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, INamedTypeSymbol component)
+    {
+        var invocation = (InvocationExpressionSyntax)context.Node;
+        var model = context.SemanticModel;
+
+        // A Rask factory call: a static method on a class named `Generated` returning a Component subtype.
+        if (model.GetSymbolInfo(invocation, context.CancellationToken).Symbol is not IMethodSymbol method
+            || !method.IsStatic
+            || !string.Equals(method.ContainingType?.Name, GeneratedClassName, StringComparison.Ordinal)
+            || !InheritsFrom(method.ReturnType as INamedTypeSymbol, component))
+        {
+            return;
+        }
+
+        // Count the leading positional arguments (C# requires them before any named argument). The
+        // children indexer (`[...]`) is a separate ElementAccess, not part of the argument list, so it
+        // isn't counted. Three or more trips the hint.
+        var args = invocation.ArgumentList.Arguments;
+        var positional = 0;
+        while (positional < args.Count && args[positional].NameColon is null)
+        {
+            positional++;
+        }
+
+        if (positional < PositionalThreshold)
+        {
+            return;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(Rask030, NameLocation(invocation), method.Name, positional));
+    }
+
+    private static bool InheritsFrom(INamedTypeSymbol? type, INamedTypeSymbol target)
+    {
+        for (var t = type; t is not null; t = t.BaseType)
+        {
+            if (SymbolEqualityComparer.Default.Equals(t.OriginalDefinition, target))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Location NameLocation(InvocationExpressionSyntax inv) => inv.Expression switch
+    {
+        MemberAccessExpressionSyntax m => m.Name.GetLocation(),
+        _ => inv.Expression.GetLocation()
+    };
+}

--- a/tests/Rask.Generators.Tests/PreferNamedArgsAnalyzerTests.cs
+++ b/tests/Rask.Generators.Tests/PreferNamedArgsAnalyzerTests.cs
@@ -1,0 +1,69 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Rask.Generators.Analyzers;
+
+namespace Rask.Generators.Tests;
+
+public class PreferNamedArgsAnalyzerTests
+{
+    private static string App(string body) => $$"""
+        using Rask.Core;
+        using static Rask.Core.Components.Generated;
+        namespace Demo;
+        public sealed class App : Component
+        {
+            protected override Component? Render()
+            {
+                {{body}}
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task ThreePositionalArgs_ReportsRask030()
+    {
+        // Div(Id, Class, Style, …) — three leading positional strings: past the readable/idiomatic limit.
+        var d = Assert.Single(await Diagnostics(App("return Div(\"the-id\", \"the-class\", \"color:red\");")));
+        Assert.Equal("RASK030", d.Id);
+        Assert.Contains("3 positional", d.GetMessage());
+    }
+
+    [Fact]
+    public async Task TwoPositionalArgs_NoDiagnostic() =>
+        // One or two positional args (primary content + a class) stay idiomatic.
+        Assert.Empty(await Diagnostics(App("return Div(\"the-id\", \"the-class\");")));
+
+    [Fact]
+    public async Task SinglePositionalArg_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return A(\"/home\");")));
+
+    [Fact]
+    public async Task NamedArgs_NoDiagnostic() =>
+        Assert.Empty(await Diagnostics(App("return Div(Id: \"the-id\", Class: \"the-class\", Style: \"color:red\");")));
+
+    [Fact]
+    public async Task TwoPositionalThenNamed_NoDiagnostic() =>
+        // Only two positional arguments; the rest are explicit already.
+        Assert.Empty(await Diagnostics(App("return Div(\"the-id\", \"the-class\", Style: \"color:red\");")));
+
+    [Fact]
+    public async Task NonRaskCall_NoDiagnostic() =>
+        // string.Concat is not a Rask factory (three positional args, but not a Component factory).
+        Assert.Empty(await Diagnostics(App("_ = string.Concat(\"a\", \"b\", \"c\"); return null;")));
+
+    private static async Task<ImmutableArray<Diagnostic>> Diagnostics(string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "TestAssembly",
+            new[] { CSharpSyntaxTree.ParseText(source, new CSharpParseOptions(LanguageVersion.Latest)) },
+            GeneratorDriverFixture.BuildReferences(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary,
+                nullableContextOptions: NullableContextOptions.Enable));
+
+        var analyzers = ImmutableArray.Create<DiagnosticAnalyzer>(new PreferNamedArgsAnalyzer());
+        var all = await compilation.WithAnalyzers(analyzers).GetAnalyzerDiagnosticsAsync();
+        return all.Where(d => d.Id == "RASK030").ToImmutableArray();
+    }
+}


### PR DESCRIPTION
## Summary

Rask orders generated factory parameters by inheritance depth, then file ordinal + span, so a later edit — adding a base-class property, renaming a partial file — can reorder parameters and **silently rebind** a positional call. Beyond one or two positional args, such calls also just read poorly.

**RASK030** (Hidden) flags a Rask factory call with **three or more leading positional arguments**. The first one or two — the primary content (`A(href)`, `Div(id, class)`) — stay idiomatic. The fix is to name the arguments: `Div(Id: …, Class: …, Style: …)`.

A readability + refactor-safety threshold on positional **count**, not a per-type swap analysis — the fix is the same regardless, and a low-noise line keeps the Hidden hint useful.

## Severity

**Hidden** — no build output, no effect on `-warnaserror`; the IDE surfaces it as a suggestion. Suppressible per-call (`#pragma warning disable RASK030`) or globally (`.editorconfig`).

## Calibration (from review)

The first draft used a "2+ same-typed positional" rule, which the workflow review showed was mis-calibrated — it flagged the framework's own idiomatic 2-arg sample calls and had type-equality edge cases. Reworked to the count-based ≥3 rule: **verified 0 RASK030 hits across the Server, Auth, and Shared samples**, so the samples model (not violate) the guidance.

Note: a code-fix to auto-name the arguments is a natural follow-up via the `add-codefix` skill once the CodeFixes assembly (separate PR) lands; this PR ships the analyzer only and does not claim a quick-fix.

## Testing

- `dotnet test tests/Rask.Generators.Tests` — 203 passed (RASK030 threshold covered precisely: 1/2 positional → no, 3 → yes, named → no, non-Rask → no)
- Strict `-warnaserror` generator build clean; format clean
- Sample-impact measured by temporarily elevating RASK030 to warning: 0 hits.

## Docs / artifacts

`docs/diagnostics.md` (TOC + `## RASK030` section), CHANGELOG `[Unreleased]`, and the RASK-range bump across `CLAUDE.md` / `llms.txt` / `docs/README.md` / `docs/best-practices.md` / the `add-diagnostic` skill.