### PR TITLE
perf(core): skip the per-component scope lookup when no scoped CSS is registered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,16 @@ them until tagged releases begin.
   user could `Tab` straight out of an open modal into the page behind, had no `Escape` to close it, and
   lost their place when it closed. See [docs/accessibility.md](docs/accessibility.md#focus-trapping-overlays).
 
+### Changed
+- **The per-component render walk skips a guaranteed-miss scope lookup when no scoped CSS exists.**
+  `LiveRenderContext.PushScope` runs for every user component on every render and called
+  `ScopedAssetRegistry.TryGetScopeId` (a `ConcurrentDictionary` probe) unconditionally — but on the
+  common app with no scoped CSS that probe always misses. It now short-circuits behind a lock-free
+  `ScopedAssetRegistry.HasAnyScopedCss` (`IsEmpty`) check, removing the probe on the hot path (e.g.
+  ~30k eliminated probes/second on a 500-component page at 60 fps). The `MountedTypes` set is still
+  populated for every component (a public per-render contract), so behavior is unchanged; the saving
+  is per-component wasted work rather than a single measurable render delta.
+
 ## [0.14.1] - 2026-07-07
 
 ### Fixed

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -135,12 +135,13 @@ public sealed class LiveRenderContext : IDisposable
     internal ContextScope PushScope(Component instance)
     {
         var type = instance.GetType();
-        // Record the type unconditionally — head emission iterates this set and decides
-        // per-type whether to emit a <link>/<script> based on registry hit. Doing the add
-        // before the scope-id lookup keeps JS-only and asset-free components in the set.
+        // Record the type unconditionally — MountedTypes is a public per-render contract populated for
+        // every user component (with or without assets), so it can't be short-circuited.
         MountedTypes.Add(type);
 
-        if (!ScopedAssetRegistry.TryGetScopeId(type, out var scopeId))
+        // The by-type scope lookup, however, always misses when no component has registered scoped CSS
+        // (the common case), so skip the ConcurrentDictionary probe behind a cheap IsEmpty check.
+        if (!ScopedAssetRegistry.HasAnyScopedCss || !ScopedAssetRegistry.TryGetScopeId(type, out var scopeId))
         {
             return default;
         }

--- a/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
+++ b/src/Rask.Core/ScopedAssets/ScopedAssetRegistry.cs
@@ -85,6 +85,11 @@ public static class ScopedAssetRegistry
 
     public static event Action<Type, AssetKind>? AssetChanged;
 
+    // True when at least one component has registered scoped CSS (so a scope id exists to push). A
+    // lock-free ConcurrentDictionary.IsEmpty check the per-component render walk uses to skip the by-type
+    // scope lookup entirely on the common app that has no scoped CSS — the lookup would always miss.
+    internal static bool HasAnyScopedCss => !_scopeIdByType.IsEmpty;
+
     private static long _version;
 
     /// <summary>


### PR DESCRIPTION
## Summary

`LiveRenderContext.PushScope` runs for **every user component on every render** and called `ScopedAssetRegistry.TryGetScopeId` (a `ConcurrentDictionary` probe) unconditionally. On the common app with no scoped CSS, that probe always misses. It now short-circuits behind a lock-free `ScopedAssetRegistry.HasAnyScopedCss` (`IsEmpty`) check, removing the probe from the hot path — e.g. ~30k eliminated probes/second on a 500-component page at 60 fps.

## Honesty note

`MountedTypes` — populated unconditionally in `PushScope` — is a **public per-render contract** asserted by `MountedTypesTests` (including the no-asset `UniformContract` case with the registry empty), so it can't be short-circuited; only the scope *lookup* is skipped. The per-op saving is **below the render benchmark's noise floor** (RenderDeep is ~100 µs ± 20 µs; the saving is a few hundred ns), so there's no headline number to quote — this removes guaranteed-wasted per-component work rather than moving a single measurable render delta. I'm not claiming a benchmark win I can't measure; the change stands on removing a guaranteed-miss probe from a per-component-per-render path.

(Aside surfaced while investigating: `MountedTypes` has no remaining *production* reader — head emission is bundle-based now — so it's a candidate for a future breaking-change removal that *would* remove the per-component `HashSet.Add`. Out of scope here.)

## Testing

- `dotnet test tests/Rask.Core.Tests` — 1813 passed, 1 skipped (MountedTypes + scoped-asset contract tests green)
- Strict `-warnaserror` build clean; format clean
- Behavior-preserving; self-reviewed (2 files, ~10 lines).

## Changelog

Added under `[Unreleased] → Changed`.