### PR TITLE
fix(bootstrap): dropdown menu inside a scrollable table no longer clipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **`BsDropdown` inside a scrollable `BsTable` is no longer clipped.** A row-level dropdown menu was cut
+  off by the `.table-responsive` scroll container (Bootstrap's `overflow-x:auto` forces `overflow-y:auto`,
+  and Rask dropdowns are Popper-less so the menu can't be portalled out). `BootstrapStyles()` now also
+  links a small supplemental `rask-bootstrap.css` that lets the container overflow vertically while a menu
+  is open (clipping horizontally so wide tables can't spill). No consumer change beyond picking up the
+  release.
+
 ## [0.14.0] - 2026-07-07
 
 ### Added

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -21,9 +21,12 @@ protected override Component? Head =>
 ];
 ```
 
-`BootstrapStyles(Icons: false)` skips the Bootstrap Icons stylesheet. The assets are served by the
-host's static-file pipeline (`app.UseStaticFiles()` / `app.MapStaticAssets()` on Server; the WASM
-static-web-asset pipeline bakes them into the published `wwwroot` automatically).
+`BootstrapStyles(Icons: false)` skips the Bootstrap Icons stylesheet. It also always links a tiny
+`rask-bootstrap.css` (after Bootstrap, so it wins the cascade) with fixes for the zero-JS components —
+e.g. a `BsDropdown` inside a `BsTable(Responsive: true)` would otherwise be clipped by the scroll
+container's overflow. The assets are served by the host's static-file pipeline (`app.UseStaticFiles()` /
+`app.MapStaticAssets()` on Server; the WASM static-web-asset pipeline bakes them into the published
+`wwwroot` automatically).
 
 The `Bs*` factories are available unqualified — the package ships a `build/*.props` that adds the
 global `using static Rask.Bootstrap.Generated`, exactly like the validation packages.

--- a/src/Rask.Bootstrap/BootstrapStyles.cs
+++ b/src/Rask.Bootstrap/BootstrapStyles.cs
@@ -2,10 +2,11 @@ using Rask.Core.Live;
 
 namespace Rask.Bootstrap;
 
-// Links the bundled Bootstrap (and, by default, Bootstrap Icons) stylesheets. The CSS ships as static
-// web assets under _content/Rask.Bootstrap and is served by the host's MapStaticAssets() on Server and
-// by the static-web-assets pipeline on WASM. Drop BootstrapStyles() in your App's Head. URLs are
-// prefixed with LiveOptions.PathBase so sub-path deploys resolve.
+// Links the bundled Bootstrap (and, by default, Bootstrap Icons) stylesheets plus rask-bootstrap.css —
+// a small supplemental sheet with fixes for the zero-JS components (linked after Bootstrap so it wins).
+// The CSS ships as static web assets under _content/Rask.Bootstrap and is served by the host's
+// MapStaticAssets() on Server and by the static-web-assets pipeline on WASM. Drop BootstrapStyles() in
+// your App's Head. URLs are prefixed with LiveOptions.PathBase so sub-path deploys resolve.
 public sealed class BootstrapStyles : Component
 {
     private const string Base = "/_content/Rask.Bootstrap/";
@@ -17,9 +18,11 @@ public sealed class BootstrapStyles : Component
     {
         var prefix = LiveOptions.PathBase;
         var core = Link(Rel: "stylesheet", Href: prefix + Base + "css/bootstrap.min.css");
+        // Rask's own fixes for the Popper-less components; must come after Bootstrap to win the cascade.
+        var fixes = Link(Rel: "stylesheet", Href: prefix + Base + "css/rask-bootstrap.css");
 
         return Icons is false
-            ? core
-            : [core, Link(Rel: "stylesheet", Href: prefix + Base + "icons/bootstrap-icons.min.css")];
+            ? [core, fixes]
+            : [core, Link(Rel: "stylesheet", Href: prefix + Base + "icons/bootstrap-icons.min.css"), fixes];
     }
 }

--- a/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
+++ b/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
@@ -1,0 +1,15 @@
+/* Rask.Bootstrap — supplemental styles for the zero-JS (Popper-less) components, layered on top of
+   the bundled Bootstrap by BootstrapStyles(). Keep this minimal: only fixes that a consumer would
+   otherwise have to re-add in every app. */
+
+/* A dropdown menu inside a scrollable table is clipped by the scroll container: Bootstrap's
+   .table-responsive sets overflow-x:auto, and per the CSS overflow spec a non-visible value on one
+   axis forces the other axis to auto — so the menu, which overflows downward, is cut off. Rask
+   dropdowns are Popper-less (no JS to portal the menu out), so fix it in CSS: while a menu is open,
+   let the container overflow vertically so the menu shows, and clip horizontally so a wide table
+   still can't spill or trigger page scroll. (`overflow: clip` is the one value that does NOT force
+   the other axis to auto, so this pairing is valid.) */
+.table-responsive:has(.dropdown-menu.show) {
+  overflow-x: clip;
+  overflow-y: visible;
+}

--- a/tests/Rask.Bootstrap.Tests/BsComponentTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsComponentTests.cs
@@ -165,4 +165,24 @@ public class BsComponentTests
         Assert.Contains("class=\"offcanvas-md offcanvas-start show\"", html);
         Assert.Contains("class=\"offcanvas-backdrop fade show d-md-none\"", html);
     }
+
+    [Fact]
+    public void BootstrapStyles_LinksBootstrapIconsAndRaskFixesLast()
+    {
+        var html = BootstrapStyles().ToHtml();
+        Assert.Contains("_content/Rask.Bootstrap/css/bootstrap.min.css", html);
+        Assert.Contains("_content/Rask.Bootstrap/icons/bootstrap-icons.min.css", html);
+        Assert.Contains("_content/Rask.Bootstrap/css/rask-bootstrap.css", html);
+        // rask-bootstrap.css must come after Bootstrap so it wins the cascade.
+        Assert.True(html.IndexOf("rask-bootstrap.css", StringComparison.Ordinal)
+            > html.IndexOf("bootstrap.min.css", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void BootstrapStyles_IconsFalse_OmitsIconsButKeepsRaskFixes()
+    {
+        var html = BootstrapStyles(Icons: false).ToHtml();
+        Assert.Contains("_content/Rask.Bootstrap/css/rask-bootstrap.css", html);
+        Assert.DoesNotContain("bootstrap-icons", html);
+    }
 }


### PR DESCRIPTION
A row-level `BsDropdown` inside `BsTable(Responsive: true)` was clipped by the `.table-responsive` scroll container (Bootstrap's `overflow-x:auto` forces `overflow-y:auto`; Rask dropdowns are Popper-less so the menu can't be portalled out).

Ship `rask-bootstrap.css` (a small zero-JS-component fixes layer, linked by `BootstrapStyles` after Bootstrap) with:
```css
.table-responsive:has(.dropdown-menu.show) { overflow-x: clip; overflow-y: visible; }
```
While a menu is open the container overflows vertically (menu shows) and clips horizontally (wide table can't spill).

Unit tests for the emitted links + docs + CHANGELOG. Verified in a real consumer (the Ta app): the Letöltés/Feltöltés menus now render fully.