### PR TITLE
chore(release): v0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.14.1] - 2026-07-07
+
 ### Fixed
 - **`BsDropdown` inside a scrollable `BsTable` is no longer clipped.** A row-level dropdown menu was cut
   off by the `.table-responsive` scroll container (Bootstrap's `overflow-x:auto` forces `overflow-y:auto`,


### PR DESCRIPTION
Promote CHANGELOG [Unreleased] → 0.14.1. Fix: BsDropdown inside a scrollable BsTable no longer clipped (#265).