### PR TITLE
feat(bootstrap): trap focus in BsModal — autofocus, Tab cycle, Escape, restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,18 @@ them until tagged releases begin.
   `aria-describedby` to the help text. No API or visual change; attributes emit in the canonical
   `aria-*` slot so the documented attribute order is preserved. See
   [docs/accessibility.md](docs/accessibility.md#form-validation).
+- **Accessible focus trapping for overlays, and `BsModal` opts in.** A new runtime behavior (in the
+  shared `rask-dom.js`, so it works on both the Server and WASM hosts) manages focus for any element
+  carrying `data-rask-focus-trap`: focus moves into it on open (its `[autofocus]` element, else the
+  element itself), `Tab`/`Shift+Tab` cycle within it so focus can't reach the inert page behind, focus
+  returns to the previously-focused element on close, and `Escape` dismisses it by clicking a
+  `data-rask-dismiss` control (no per-keystroke server round-trip). A single document `MutationObserver`
+  tracks appear/disappear and only re-scans when a trap is actually added/removed, so it stays cheap on
+  unrelated diff morphs. `BsModal` now opts in automatically — an open modal traps focus, is labelled
+  (`aria-labelledby` its title when an `Id` is set, else `aria-label` from the title text), and closes on
+  `Escape` (kept inert for a static backdrop, matching Bootstrap). Previously a keyboard or screen-reader
+  user could `Tab` straight out of an open modal into the page behind, had no `Escape` to close it, and
+  lost their place when it closed. See [docs/accessibility.md](docs/accessibility.md#focus-trapping-overlays).
 
 ## [0.14.1] - 2026-07-07
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -106,10 +106,24 @@ Building your own control from the core `Input`/`ValidationMessage` primitives? 
 attributes: `Aria: new() { ["invalid"] = "true", ["describedby"] = errorId }` on the control, and render
 the message in a `Div(Id: errorId, Role: "alert")`. See [forms.md](forms.md#accessible-validation).
 
+## Focus trapping (overlays)
+
+Any element that carries `data-rask-focus-trap` gets accessible-overlay focus management from the
+runtime — no `bootstrap.js`, no per-component wiring. While the element is in the DOM, focus moves into
+it on open (its `[autofocus]` element, else the element itself), `Tab`/`Shift+Tab` cycle **within** it
+(focus can't reach the inert page behind), and focus returns to the previously-focused element when it
+closes. If the trap (or a descendant) carries `data-rask-dismiss`, `Escape` closes it by triggering that
+element's click handler — no per-keystroke server round-trip.
+
+`Rask.Bootstrap`'s `BsModal` opts in automatically: an open modal traps focus, is labelled (`aria-labelledby`
+its title, or `aria-label` from the title text), and dismisses on `Escape` (except with a static backdrop,
+which keeps `Escape` inert per Bootstrap). Build your own overlay the same way — add `data-rask-focus-trap`
+(via the `Data` dictionary) and mark your close control with `data-rask-dismiss`.
+
 ## What's not covered yet
 
-This is the framework primitive layer. Higher-level affordances — a focus-trapping modal dialog
-primitive, skip links, ARIA `tablist`/`tab` widgets, and automated axe-core scans in the sample E2E
-suite — are tracked as follow-up work. Today you build those from the `Aria`/`Role`/`TabIndex`
-primitives above plus standard semantic HTML (`Nav`, `Main`, `Aside`, `Label(For:)`,
+This is the framework primitive layer. Higher-level affordances — skip links, ARIA `tablist`/`tab`
+keyboard widgets (roving tabindex for `BsTabs`/`BsDropdown`), and automated axe-core scans in the sample
+E2E suite — are tracked as follow-up work. Today you build those from the `Aria`/`Role`/`TabIndex`
+primitives above (plus the focus trap) and standard semantic HTML (`Nav`, `Main`, `Aside`, `Label(For:)`,
 `Th(Scope:)`, …).

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -48,7 +48,7 @@ runtime, no `bootstrap.js`.
 
 ```csharp
 BsButton(Color: BsColor.Primary, Size: BsSize.Lg)["Save"]
-BsModal(Open: _open, Title: "Hi", OnClose: () => _open = false)[ /* body */ ]
+BsModal(Open: _open, Title: "Hi", OnClose: () => _open = false)[ /* body */ ]  // traps focus, Escape-closes, labelled — see accessibility.md
 BsModal(Open: _open, FullscreenBelow: Bp.Sm)[ /* edge-to-edge on phones, sized dialog at sm+ */ ]
 BsInput(() => model.Email, Label: "Email", Type: InputType.Email)   // .is-invalid + .invalid-feedback built in
 BsIcon(Name: BsIconName.HeartFill, Color: BsColor.Danger)

--- a/src/Rask.Bootstrap/BsModal.cs
+++ b/src/Rask.Bootstrap/BsModal.cs
@@ -32,9 +32,6 @@ public sealed class BsModal : BsBlock
     // Shields clicks inside the dialog from the outer close handler (nearest-handler delegation).
     private static readonly Callback Shield = () => { };
 
-    private static readonly IReadOnlyDictionary<string, string?> ModalAria =
-        new Dictionary<string, string?> { ["modal"] = "true" };
-
     protected override Component? Render()
     {
         if (Open is not true)
@@ -53,10 +50,33 @@ public sealed class BsModal : BsBlock
         var staticBackdrop = StaticBackdrop is true;
         var showHeader = Title is not null || HideClose is not true;
 
+        // Label the dialog for assistive tech: reference the visible title by id when we have one to
+        // anchor to, otherwise fall back to aria-label carrying the title text.
+        var titleId = Title is not null && Id is not null ? Id + "-title" : null;
+        var aria = new Dictionary<string, string?> { ["modal"] = "true" };
+        if (titleId is not null)
+        {
+            aria["labelledby"] = titleId;
+        }
+        else if (Title is not null)
+        {
+            aria["label"] = Title;
+        }
+
+        // Opt into the runtime focus trap (autofocus in, Tab cycling, focus restore on close, Escape to
+        // dismiss). data-rask-dismiss marks the click target Escape fires — the modal itself, whose
+        // backdrop-close handler is OnClose — and is omitted for a static backdrop, which (per Bootstrap)
+        // also disables Escape while keeping the close button working.
+        var data = new Dictionary<string, string?> { ["rask-focus-trap"] = "" };
+        if (!staticBackdrop)
+        {
+            data["rask-dismiss"] = "";
+        }
+
         var content = Div(Class: "modal-content")[
             showHeader
                 ? Div(Class: "modal-header")[
-                    Title is not null ? H5(Class: "modal-title")[Title] : null,
+                    Title is not null ? H5(Id: titleId, Class: "modal-title")[Title] : null,
                     HideClose is not true
                         ? BsCloseButton(OnClick: OnClose, OnClickAsync: OnCloseAsync)
                         : null]
@@ -65,7 +85,7 @@ public sealed class BsModal : BsBlock
             Footer is { } footer ? Div(Class: "modal-footer")[footer] : null];
 
         var modal = Div(Id: Id, Class: "modal fade show", Style: "display:block", TabIndex: -1,
-            Role: "dialog", Aria: ModalAria,
+            Role: "dialog", Aria: aria, Data: data,
             OnClick: staticBackdrop ? null : OnClose, OnClickAsync: staticBackdrop ? null : OnCloseAsync)[
                 Div(Class: dialogCls, OnClick: staticBackdrop ? null : Shield)[content]];
 

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -280,3 +280,153 @@ function applyFrameInvokes(reply, dispatchOne) {
         if (inv && typeof inv.identifier === "string") dispatchOne(inv);
     }
 }
+
+// ----- Focus trap (data-rask-focus-trap) ---------------------------------
+// Generic accessible-overlay focus management, driven declaratively so any overlay (Rask.Bootstrap's
+// BsModal, or your own) opts in with a single attribute. For as long as an element carrying
+// data-rask-focus-trap is in the DOM:
+//   * focus moves into it on appear (the [autofocus] element, else the element itself), remembering
+//     what had focus so it can be restored on close;
+//   * Tab / Shift+Tab cycle within it — focus can't escape to the inert page behind;
+//   * Escape closes it by clicking its own / a descendant [data-rask-dismiss] control (a real Rask
+//     click handler), so there is no per-keystroke server round-trip;
+//   * focus returns to the previously-focused element when the trap leaves the DOM.
+// A single document MutationObserver tracks appear/disappear (works with the diff morph that adds and
+// removes the overlay); keydown is handled at capture so it fires wherever focus currently sits.
+(function installRaskFocusTrap() {
+    if (typeof document === "undefined" || typeof MutationObserver === "undefined"
+        || window.__raskFocusTrap) {
+        return;
+    }
+    window.__raskFocusTrap = true;
+
+    // No escaped quotes in this selector on purpose: the WASM client-JS splice mangles a backslash in a
+    // spliced body, so the negative-tabindex exclusion is done in focusables() via el.tabIndex instead of
+    // a [tabindex="-1"] attribute selector (which also correctly excludes tabindex=-1 on any element).
+    const FOCUSABLE = "a[href],area[href],button:not([disabled]),"
+        + "input:not([disabled]):not([type=hidden]),select:not([disabled]),textarea:not([disabled]),"
+        + "[tabindex],[contenteditable=true]";
+
+    let currentTrap = null;
+    let restoreTo = null;
+
+    // The topmost trap in the DOM (last in document order) wins when several are open (stacked modals).
+    function activeTrap() {
+        const traps = document.querySelectorAll("[data-rask-focus-trap]");
+        return traps.length ? traps[traps.length - 1] : null;
+    }
+
+    function focusables(trap) {
+        return Array.prototype.filter.call(
+            trap.querySelectorAll(FOCUSABLE),
+            (el) => el.tabIndex >= 0
+                && (el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement));
+    }
+
+    function enter(trap) {
+        // Focus the [autofocus] element if the author marked one, else the trap itself (it carries
+        // tabindex=-1 so screen readers announce the dialog). Deferred to rAF so the just-morphed-in
+        // element is laid out before we move focus.
+        const target = trap.querySelector("[autofocus]") || trap;
+        requestAnimationFrame(function () {
+            try {
+                target.focus();
+            } catch (e) {
+                // element may have been removed again already
+            }
+        });
+    }
+
+    function restore() {
+        const el = restoreTo;
+        restoreTo = null;
+        if (el && typeof el.focus === "function") {
+            try {
+                el.focus();
+            } catch (e) {
+                // previously-focused element is gone
+            }
+        }
+    }
+
+    function sync() {
+        const trap = activeTrap();
+        if (trap === currentTrap) {
+            return;
+        }
+
+        if (!currentTrap && trap) {
+            restoreTo = document.activeElement; // first trap opened over the page
+        }
+
+        currentTrap = trap;
+        if (trap) {
+            enter(trap);
+        } else {
+            restore(); // last trap closed
+        }
+    }
+
+    document.addEventListener("keydown", function (e) {
+        const trap = currentTrap;
+        if (!trap) {
+            return;
+        }
+
+        if (e.key === "Escape") {
+            const dismiss = trap.hasAttribute("data-rask-dismiss")
+                ? trap
+                : trap.querySelector("[data-rask-dismiss]");
+            if (dismiss) {
+                e.preventDefault();
+                dismiss.click();
+            }
+            return;
+        }
+
+        if (e.key !== "Tab") {
+            return;
+        }
+
+        const items = focusables(trap);
+        if (!items.length) {
+            e.preventDefault(); // nothing to move to — keep focus off the page behind
+            return;
+        }
+
+        const first = items[0];
+        const last = items[items.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && (active === first || active === trap || !trap.contains(active))) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && (active === last || !trap.contains(active))) {
+            e.preventDefault();
+            first.focus();
+        }
+    }, true);
+
+    // Only re-scan when a mutation actually adds or removes a trap (or a subtree containing one), so the
+    // observer stays cheap on the frequent unrelated morphs.
+    function touchesTrap(nodes) {
+        for (let i = 0; i < nodes.length; i++) {
+            const n = nodes[i];
+            if (n.nodeType === 1
+                && (n.matches("[data-rask-focus-trap]") || n.querySelector("[data-rask-focus-trap]"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    const observer = new MutationObserver(function (records) {
+        for (let i = 0; i < records.length; i++) {
+            if (touchesTrap(records[i].addedNodes) || touchesTrap(records[i].removedNodes)) {
+                sync();
+                return;
+            }
+        }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    sync(); // a trap already present at load
+})();

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2905,6 +2905,156 @@ function applyFrameInvokes(reply, dispatchOne) {
     }
 }
 
+// ----- Focus trap (data-rask-focus-trap) ---------------------------------
+// Generic accessible-overlay focus management, driven declaratively so any overlay (Rask.Bootstrap's
+// BsModal, or your own) opts in with a single attribute. For as long as an element carrying
+// data-rask-focus-trap is in the DOM:
+//   * focus moves into it on appear (the [autofocus] element, else the element itself), remembering
+//     what had focus so it can be restored on close;
+//   * Tab / Shift+Tab cycle within it — focus can't escape to the inert page behind;
+//   * Escape closes it by clicking its own / a descendant [data-rask-dismiss] control (a real Rask
+//     click handler), so there is no per-keystroke server round-trip;
+//   * focus returns to the previously-focused element when the trap leaves the DOM.
+// A single document MutationObserver tracks appear/disappear (works with the diff morph that adds and
+// removes the overlay); keydown is handled at capture so it fires wherever focus currently sits.
+(function installRaskFocusTrap() {
+    if (typeof document === "undefined" || typeof MutationObserver === "undefined"
+        || window.__raskFocusTrap) {
+        return;
+    }
+    window.__raskFocusTrap = true;
+
+    // No escaped quotes in this selector on purpose: the WASM client-JS splice mangles a backslash in a
+    // spliced body, so the negative-tabindex exclusion is done in focusables() via el.tabIndex instead of
+    // a [tabindex="-1"] attribute selector (which also correctly excludes tabindex=-1 on any element).
+    const FOCUSABLE = "a[href],area[href],button:not([disabled]),"
+        + "input:not([disabled]):not([type=hidden]),select:not([disabled]),textarea:not([disabled]),"
+        + "[tabindex],[contenteditable=true]";
+
+    let currentTrap = null;
+    let restoreTo = null;
+
+    // The topmost trap in the DOM (last in document order) wins when several are open (stacked modals).
+    function activeTrap() {
+        const traps = document.querySelectorAll("[data-rask-focus-trap]");
+        return traps.length ? traps[traps.length - 1] : null;
+    }
+
+    function focusables(trap) {
+        return Array.prototype.filter.call(
+            trap.querySelectorAll(FOCUSABLE),
+            (el) => el.tabIndex >= 0
+                && (el.offsetWidth > 0 || el.offsetHeight > 0 || el === document.activeElement));
+    }
+
+    function enter(trap) {
+        // Focus the [autofocus] element if the author marked one, else the trap itself (it carries
+        // tabindex=-1 so screen readers announce the dialog). Deferred to rAF so the just-morphed-in
+        // element is laid out before we move focus.
+        const target = trap.querySelector("[autofocus]") || trap;
+        requestAnimationFrame(function () {
+            try {
+                target.focus();
+            } catch (e) {
+                // element may have been removed again already
+            }
+        });
+    }
+
+    function restore() {
+        const el = restoreTo;
+        restoreTo = null;
+        if (el && typeof el.focus === "function") {
+            try {
+                el.focus();
+            } catch (e) {
+                // previously-focused element is gone
+            }
+        }
+    }
+
+    function sync() {
+        const trap = activeTrap();
+        if (trap === currentTrap) {
+            return;
+        }
+
+        if (!currentTrap && trap) {
+            restoreTo = document.activeElement; // first trap opened over the page
+        }
+
+        currentTrap = trap;
+        if (trap) {
+            enter(trap);
+        } else {
+            restore(); // last trap closed
+        }
+    }
+
+    document.addEventListener("keydown", function (e) {
+        const trap = currentTrap;
+        if (!trap) {
+            return;
+        }
+
+        if (e.key === "Escape") {
+            const dismiss = trap.hasAttribute("data-rask-dismiss")
+                ? trap
+                : trap.querySelector("[data-rask-dismiss]");
+            if (dismiss) {
+                e.preventDefault();
+                dismiss.click();
+            }
+            return;
+        }
+
+        if (e.key !== "Tab") {
+            return;
+        }
+
+        const items = focusables(trap);
+        if (!items.length) {
+            e.preventDefault(); // nothing to move to — keep focus off the page behind
+            return;
+        }
+
+        const first = items[0];
+        const last = items[items.length - 1];
+        const active = document.activeElement;
+        if (e.shiftKey && (active === first || active === trap || !trap.contains(active))) {
+            e.preventDefault();
+            last.focus();
+        } else if (!e.shiftKey && (active === last || !trap.contains(active))) {
+            e.preventDefault();
+            first.focus();
+        }
+    }, true);
+
+    // Only re-scan when a mutation actually adds or removes a trap (or a subtree containing one), so the
+    // observer stays cheap on the frequent unrelated morphs.
+    function touchesTrap(nodes) {
+        for (let i = 0; i < nodes.length; i++) {
+            const n = nodes[i];
+            if (n.nodeType === 1
+                && (n.matches("[data-rask-focus-trap]") || n.querySelector("[data-rask-focus-trap]"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    const observer = new MutationObserver(function (records) {
+        for (let i = 0; i < records.length; i++) {
+            if (touchesTrap(records[i].addedNodes) || touchesTrap(records[i].removedNodes)) {
+                sync();
+                return;
+            }
+        }
+    });
+    observer.observe(document.documentElement, { childList: true, subtree: true });
+    sync(); // a trap already present at load
+})();
+
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;

--- a/tests/Rask.Bootstrap.Tests/BsComponentTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsComponentTests.cs
@@ -74,13 +74,39 @@ public class BsComponentTests
     [Fact]
     public void Modal_Open_RendersDialogAndBackdrop() =>
         Assert.Equal(
-            "<div class=\"modal fade show\" style=\"display:block\" role=\"dialog\" tabindex=\"-1\" aria-modal=\"true\">"
+            "<div class=\"modal fade show\" style=\"display:block\" data-rask-focus-trap=\"\" "
+            + "data-rask-dismiss=\"\" role=\"dialog\" tabindex=\"-1\" aria-modal=\"true\" aria-label=\"Hi\">"
             + "<div class=\"modal-dialog\"><div class=\"modal-content\">"
             + "<div class=\"modal-header\"><h5 class=\"modal-title\">Hi</h5>"
             + "<button class=\"btn-close\" aria-label=\"Close\" type=\"button\"></button></div>"
             + "<div class=\"modal-body\">body</div></div></div></div>"
             + "<div class=\"modal-backdrop fade show\"></div>",
             BsModal(Open: true, Title: "Hi")["body"].ToHtml());
+
+    [Fact]
+    public void Modal_LabelledByTitle_WhenIdGiven()
+    {
+        var html = BsModal(Open: true, Title: "Edit", Id: "m")["body"].ToHtml();
+        Assert.Contains("aria-labelledby=\"m-title\"", html);
+        Assert.Contains("<h5 id=\"m-title\" class=\"modal-title\">Edit</h5>", html);
+        Assert.DoesNotContain("aria-label=", html.Split("btn-close")[0]); // no aria-label fallback on the dialog
+    }
+
+    [Fact]
+    public void Modal_FocusTrap_AndEscapeDismiss_ByDefault()
+    {
+        var html = BsModal(Open: true, Title: "Hi")["body"].ToHtml();
+        Assert.Contains("data-rask-focus-trap=\"\"", html);
+        Assert.Contains("data-rask-dismiss=\"\"", html); // Escape dismisses via the backdrop-close handler
+    }
+
+    [Fact]
+    public void Modal_StaticBackdrop_OmitsDismiss_KeepingEscapeInert()
+    {
+        var html = BsModal(Open: true, Title: "Hi", StaticBackdrop: true)["body"].ToHtml();
+        Assert.Contains("data-rask-focus-trap=\"\"", html);   // still traps focus
+        Assert.DoesNotContain("data-rask-dismiss", html);      // but Escape is inert (matches Bootstrap)
+    }
 
     [Fact]
     public void Modal_Fullscreen_AddsFullscreenClass() =>

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -230,13 +230,21 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator(".guide-demo .sample-result-body button.btn.btn-primary").First)
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
-        // Modal — open + close driven by Rask state, no bootstrap.js loaded.
-        await Page.Locator(".guide-demo button:has-text(\"Launch demo modal\")").First.ClickAsync();
-        await Expect(Page.Locator("div.modal.show").First)
-            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
-        await Page.Locator("div.modal .btn-close").First.ClickAsync();
+        // Modal — open + close driven by Rask state, no bootstrap.js loaded. The runtime focus trap
+        // (data-rask-focus-trap in rask-dom.js) moves focus into the dialog on open, Escape dismisses
+        // it via the backdrop-close handler, and focus returns to the trigger on close.
+        var launchModal = Page.Locator(".guide-demo button:has-text(\"Launch demo modal\")").First;
+        await launchModal.ClickAsync();
+        var dialog = Page.Locator("div.modal.show").First;
+        await Expect(dialog).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
+        // Focus was trapped into the dialog — the trap focuses the modal element itself (tabindex=-1).
+        await Expect(dialog).ToBeFocusedAsync(new LocatorAssertionsToBeFocusedOptions { Timeout = 5_000 });
+        // Escape closes it — no bootstrap.js, no btn-close click.
+        await Page.Keyboard.PressAsync("Escape");
         await Expect(Page.Locator("div.modal.show")).ToHaveCountAsync(0,
             new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
+        // Focus returned to the trigger button.
+        await Expect(launchModal).ToBeFocusedAsync(new LocatorAssertionsToBeFocusedOptions { Timeout = 5_000 });
 
         // Full-screen-below-sm modal — FullscreenBelow: Bp.Sm adds .modal-fullscreen-sm-down.
         await Page.Locator(".guide-demo button:has-text(\"Full-screen on phones\")").First.ClickAsync();


### PR DESCRIPTION
## Summary

`BsModal` rendered `role="dialog"`/`aria-modal` but a keyboard or screen-reader user could **Tab straight out** of an open modal into the page behind, had **no Escape** to close it, and **lost their place** when it closed.

This adds a **generic runtime focus trap** (`data-rask-focus-trap`) in the shared `rask-dom.js`, so it works on **both the Server and WASM hosts** and any overlay can opt in. While a trap element is in the DOM:
- focus moves into it on open (its `[autofocus]` element, else the element itself);
- `Tab`/`Shift+Tab` cycle within it — focus can't reach the inert page behind;
- focus returns to the previously-focused element on close;
- `Escape` dismisses it by clicking a `data-rask-dismiss` control (no per-keystroke server round-trip).

A single document `MutationObserver` tracks appear/disappear and only re-scans when a trap is actually added/removed, so it stays cheap on unrelated diff morphs.

`BsModal` opts in automatically: an open modal traps focus, is **labelled** (`aria-labelledby` its title when an `Id` is set, else `aria-label` from the title text), and closes on `Escape` (kept inert for a static backdrop, matching Bootstrap).

## Review follow-up (WASM)

The first draft used `[tabindex="-1"]` in the focusable selector; the review caught that the **WASM client-JS splice mangles a backslash** in a spliced body, corrupting the generated `Browser/rask.wasm.js` (`\"`→`/"`) and breaking `Tab` on WASM only. Fixed by dropping the escaped-quote selector and doing the negative-tabindex exclusion in `focusables()` via `el.tabIndex` (also correctly excludes `tabindex=-1` on any element). The committed `Browser/rask.wasm.js` artifact is regenerated from source by the splice target and verified corruption-free.

## Testing

- `dotnet test tests/Rask.Bootstrap.Tests` — 101 passed (emitted attributes: focus-trap, dismiss, static-backdrop-inert, aria-labelledby / aria-label)
- `ServerExampleTests.Journey` E2E — **passes**: asserts focus is trapped in the open modal, `Escape` closes it, and focus returns to the trigger button
- `node --check` on `rask-dom.js` and the regenerated `rask.wasm.js`

## Docs / scope

`docs/accessibility.md` (new Focus trapping section, removed modal from "not covered yet"), `docs/bootstrap.md`, CHANGELOG. `BsTabs`/`BsDropdown` roving-tabindex keyboard nav is a noted follow-up (this PR is the flagship modal widget).