### PR TITLE
feat(generators): RASK031 — warn when two pages resolve to the same route

### DIFF
--- a/.claude/skills/add-diagnostic/SKILL.md
+++ b/.claude/skills/add-diagnostic/SKILL.md
@@ -6,7 +6,7 @@ description: Add a new RASK0xx compile-time diagnostic to the Rask Roslyn genera
 # add-diagnostic
 
 ## 1. Pick the next ID
-RASK001–RASK022 are in use → **next free is RASK023**. Confirm with:
+RASK001–RASK031 are in use (028/029 in Rask.Cqrs.Generators) → **next free is RASK032**. Confirm with:
 ```bash
 grep -rhoE 'RASK[0-9]{3}' src/Rask.Generators | sort -u | tail
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **RASK031 — two pages resolving to the same route are now flagged.** Two different top-level pages that
+  resolve to the same URL made the active one arbitrary — a silent bug the generator didn't catch (it
+  only deduped by type name and enforced a single `[NotFound]`). The `RoutesGenerator` now warns
+  (`RASK031`) on every colliding page after the first, naming the page it collides with. Templates are
+  compared the way the runtime router matches them — case-insensitive literals, trimmed slashes, and
+  parameter names/`:constraints` ignored — so `/Products` ↔ `/products`, `/x` ↔ `x/`, and
+  `/item/{id:int}` ↔ `/item/{id:guid}` all collide. It's a **warning**, not an error, so upgrading never
+  hard-breaks a build that compiled before (the app still runs, just picks arbitrarily). Restricted to
+  pages without a `[ParentRoute]` (whose template is the full path); parent-composed paths aren't
+  resolved, so the check under-reports rather than risk a false positive.
+  See [docs/diagnostics.md](docs/diagnostics.md#rask031).
+
 ## [0.14.1] - 2026-07-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,10 +60,10 @@ dotnet run --project samples/Rask.Example.Server
 Routing/lifecycle (`docs/routing.md`, `docs/lifecycle.md`), scoped CSS/JS + typed browser APIs
 (`docs/js-interop.md`, `docs/browser-apis.md` — the 43-wrapper map), forms +
 validation (`docs/forms.md`), auth (`docs/authentication.md`), context/callbacks (`docs/composition.md`),
-diagnostics RASK001–029 (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
+diagnostics RASK001–031 (`docs/diagnostics.md` — analyzer descriptors are the source of truth), getting
 started / migration / testing / architecture (`docs/`). Trimming: `samples/Rask.Example.Wasm` must
 `dotnet publish -c Release` with zero IL warnings — new reflection needs a DAM annotation or justified suppression.
 
 ## Conventions
 - **New HTML tag** → `add-html-tag` skill (`src/Rask.Core/Components/{Tag}.cs` + `tests/Rask.Core.Tests/Components/{Tag}Tests.cs`).
-- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–029 are documented in `docs/diagnostics.md`.
+- **New diagnostic** → `add-diagnostic` skill. Diagnostic IDs RASK001–031 are documented in `docs/diagnostics.md`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,7 +29,7 @@ interactive app. Want the pitch and a quick demo first? See the project [README]
 
 | Reference | What it covers |
 |-----------|----------------|
-| [Diagnostics (RASK001–029)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
+| [Diagnostics (RASK001–031)](diagnostics.md) | Every analyzer/generator diagnostic, what triggers it, and how to fix it. |
 | [Code analysis](code-analysis.md) | Analyzers, warnings-as-errors, and the per-PR adoption procedure. |
 
 ## Contributing

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -5,7 +5,7 @@ collects the patterns that keep a Rask app correct, secure, and fast as it grows
 framework rewards, the foot-guns it can't stop for you, and where each one is enforced.
 
 Every item is short on purpose: a rule, *why* it matters, and a link to the deep dive. Many of these
-are also compile-time diagnostics ([RASK001–029](diagnostics.md)) — when the analyzer can catch a
+are also compile-time diagnostics ([RASK001–031](diagnostics.md)) — when the analyzer can catch a
 mistake, the rule notes the ID.
 
 - [Component design](#component-design)

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -1,4 +1,4 @@
-# Rask diagnostics (RASK001–RASK029)
+# Rask diagnostics (RASK001–RASK031)
 
 Every Rask diagnostic, what triggers it, and how to fix it. Errors block the build; warnings don't
 but flag a real problem; one is hidden (informational, surfaced only as an IDE suggestion).
@@ -38,6 +38,7 @@ build once.
 | [RASK027](#rask027) | Error | Both the sync and async handler are set for one event |
 | [RASK028](#rask028) | Error | Ambiguous request handler (more than one handler for a query/command) |
 | [RASK029](#rask029) | Warning | Handler cannot be registered (open generic or no public constructor) |
+| [RASK031](#rask031) | Warning | Two pages resolve to the same route |
 
 ---
 
@@ -398,3 +399,25 @@ public sealed class PrivateHandler : IQueryHandler<GetValue, int>
 **Fix:** give the handler a public constructor, or make it a closed (non-generic) type. A request with
 *no* handler at all is not flagged (the handler may live in another assembly) — it throws a clear
 `InvalidOperationException` when dispatched.
+
+## RASK031
+**Two pages resolve to the same route** · Warning
+
+Two different top-level pages resolve to the same route, so both match the same URL and which one renders
+is arbitrary. Templates are compared the way the **runtime router** matches them, not by raw string — so
+these all collide: `/Products` ↔ `/products` (literals match case-insensitively), `/products` ↔
+`products/` (surrounding slashes trimmed), and `/item/{id:int}` ↔ `/item/{id:guid}` ↔ `/item/{slug}`
+(the router ignores parameter names and `:constraints`). The check covers pages **without** a
+`[ParentRoute]` (whose template is the full path); parent-composed paths are not resolved here, so
+nested-route collisions are not flagged (the check under-reports rather than risk a false positive).
+
+```csharp
+[Route("/products")] public sealed class ProductList : Component { }   // first — canonical
+[Route("/Products")] public sealed class ProductGrid : Component { }   // ✗ RASK031: same URL as ProductList
+```
+
+A warning, not an error — a collision is a real bug, but the app still runs (it just picks arbitrarily),
+so upgrading Rask never hard-breaks a build that compiled before.
+
+**Fix:** give one page a distinct route, or merge the two. Reported on every colliding page after the
+first (ordered by fully-qualified name), naming the page it collides with.

--- a/llms.txt
+++ b/llms.txt
@@ -30,7 +30,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.
 - [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
-- [Diagnostics](docs/diagnostics.md): RASK001–029 compile-time diagnostics + fixes.
+- [Diagnostics](docs/diagnostics.md): RASK001–031 compile-time diagnostics + fixes.
 - [Testing](docs/testing.md): unit + Playwright E2E patterns.
 
 ## Contributing to Rask itself

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -115,6 +115,18 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         true,
         helpLinkUri: DiagnosticHelp.Link("RASK012"));
 
+    private static readonly DiagnosticDescriptor Rask031 = new(
+        "RASK031",
+        "Duplicate route template",
+        "Route template '{0}' matches the same URL as another page ('{1}') — which one renders is "
+        + "arbitrary; give this page a distinct route",
+        "Rask.Generators",
+        // Warning, not Error: a route collision is a real bug, but promoting it to Error would hard-break
+        // apps that compile today the moment they upgrade (and the app still runs, just picks arbitrarily).
+        DiagnosticSeverity.Warning,
+        true,
+        helpLinkUri: DiagnosticHelp.Link("RASK031"));
+
     private static readonly DiagnosticDescriptor Rask013 = new(
         "RASK013",
         "[NotFound] cannot be combined with [Route]",
@@ -286,6 +298,46 @@ public sealed class RoutesGenerator : IIncrementalGenerator
             new LocationInfo(firstRouteAttrLocation),
             false,
             true);
+    }
+
+    // Normalize a route template to the shape the runtime router matches on (mirrors
+    // Rask.Core.Routing.RoutePattern, which can't be referenced from this netstandard2.0 generator):
+    // trim surrounding slashes, lowercase literal segments (literals match OrdinalIgnoreCase), and
+    // collapse each parameter to a positional placeholder — the router ignores the parameter's name and
+    // its `:constraint`, and distinguishes only required vs optional vs catch-all. Two templates that
+    // normalize equal match the same set of URLs.
+    private static string NormalizeTemplate(string template)
+    {
+        var raw = template.Trim('/');
+        if (raw.Length == 0)
+        {
+            return string.Empty;
+        }
+
+        var parts = raw.Split('/');
+        for (var i = 0; i < parts.Length; i++)
+        {
+            var p = parts[i];
+            if (p.Length >= 2 && p[0] == '{' && p[p.Length - 1] == '}')
+            {
+                var inner = p.Substring(1, p.Length - 2);
+                if (inner.StartsWith("**", StringComparison.Ordinal)
+                    || (inner.Length > 0 && inner[0] == '*'))
+                {
+                    parts[i] = "{**}"; // catch-all — name ignored
+                }
+                else
+                {
+                    parts[i] = inner.Length > 0 && inner[inner.Length - 1] == '?' ? "{?}" : "{}";
+                }
+            }
+            else
+            {
+                parts[i] = p.ToLowerInvariant(); // literal — matched case-insensitively
+            }
+        }
+
+        return string.Join("/", parts);
     }
 
     private static bool InheritsFromComponent(INamedTypeSymbol symbol)
@@ -588,6 +640,58 @@ public sealed class RoutesGenerator : IIncrementalGenerator
             filtered = filtered
                 .Where(c => !c.IsNotFound || c.FullyQualifiedName == keepFqn)
                 .ToList();
+        }
+
+        // RASK031: two different top-level pages must not resolve to the same route — both would match
+        // the same URL and the winner would be arbitrary. Group by the NORMALIZED pattern the runtime
+        // router actually matches on (see NormalizeTemplate — case-insensitive literals, trimmed slashes,
+        // parameter name/constraint ignored), not the verbatim [Route] string, so /Products vs /products,
+        // /x vs x/, and /{id:int} vs /{id:guid} are all caught. Restricted to pages WITHOUT a
+        // [ParentRoute], whose full path IS the template; parent-composed paths aren't resolved here, so
+        // this deliberately under-reports rather than risk a false positive on a nested route.
+        var collisions = new Dictionary<string, List<(Candidate Page, string Template)>>(StringComparer.Ordinal);
+        var seenFqns = new Dictionary<string, HashSet<string>>(StringComparer.Ordinal);
+        foreach (var c in filtered)
+        {
+            if (c.IsNotFound || c.ParentTypeFqn is not null)
+            {
+                continue;
+            }
+
+            foreach (var template in c.Templates)
+            {
+                var key = NormalizeTemplate(template);
+                if (!seenFqns.TryGetValue(key, out var fqns))
+                {
+                    fqns = new HashSet<string>(StringComparer.Ordinal);
+                    seenFqns[key] = fqns;
+                    collisions[key] = new List<(Candidate, string)>();
+                }
+
+                // A partial class re-declares the same FQN — only distinct pages count as a collision.
+                if (fqns.Add(c.FullyQualifiedName))
+                {
+                    collisions[key].Add((c, template));
+                }
+            }
+        }
+
+        foreach (var entry in collisions.OrderBy(e => e.Key, StringComparer.Ordinal))
+        {
+            if (entry.Value.Count < 2)
+            {
+                continue;
+            }
+
+            // Report on every colliding page after the first (ordered by fully-qualified name for a
+            // stable canonical page), naming this page's own template and the page it collides with.
+            var ordered = entry.Value.OrderBy(x => x.Page.FullyQualifiedName, StringComparer.Ordinal).ToList();
+            var firstFqn = ordered[0].Page.FullyQualifiedName;
+            foreach (var dup in ordered.Skip(1))
+            {
+                spc.ReportDiagnostic(Diagnostic.Create(Rask031, dup.Page.RouteAttrLocation.ToLocation(),
+                    dup.Template, firstFqn));
+            }
         }
 
         if (filtered.Count == 0)

--- a/tests/Rask.Generators.Tests/RouteCollisionTests.cs
+++ b/tests/Rask.Generators.Tests/RouteCollisionTests.cs
@@ -1,0 +1,125 @@
+using Microsoft.CodeAnalysis;
+
+namespace Rask.Generators.Tests;
+
+public class RouteCollisionTests
+{
+    [Fact]
+    public void TwoTopLevelPages_SameTemplate_ReportsRask031()
+    {
+        const string src = """
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("/products")] public sealed class ProductsA : Component { }
+            [Route("/products")] public sealed class ProductsB : Component { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        var d = run.Diagnostics.FirstOrDefault(x => x.Id == "RASK031");
+        Assert.NotNull(d);
+        Assert.Contains("/products", d!.GetMessage());
+        // Names the page it collides with (the first by FQN, ProductsA).
+        Assert.Contains("ProductsA", d.GetMessage());
+        // Reported on exactly one page — the second (RunResult surfaces each generator diagnostic under
+        // both the run and its result, so dedupe by source location before counting).
+        var distinctLocations = run.Diagnostics
+            .Where(x => x.Id == "RASK031")
+            .Select(x => x.Location)
+            .Distinct()
+            .Count();
+        Assert.Equal(1, distinctLocations);
+    }
+
+    [Theory]
+    [InlineData("/Products", "/products")]      // literals match case-insensitively
+    [InlineData("/products", "products/")]       // surrounding slashes are trimmed
+    [InlineData("/item/{id:int}", "/item/{id:guid}")] // constraints aren't enforced at runtime
+    [InlineData("/item/{id}", "/item/{slug}")]   // parameter names don't affect matching
+    public void RuntimeEquivalentTemplates_Collide(string a, string b)
+    {
+        var src = $$"""
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("{{a}}")] public sealed class PageA : Component { }
+            [Route("{{b}}")] public sealed class PageB : Component { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        Assert.Contains(run.Diagnostics, x => x.Id == "RASK031");
+    }
+
+    [Fact]
+    public void RequiredVsOptionalParam_DoNotCollide()
+    {
+        // A required and an optional parameter in the same position match different URL sets.
+        const string src = """
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("/x/{a}")] public sealed class Req : Component { }
+            [Route("/x/{a?}")] public sealed class Opt : Component { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        Assert.DoesNotContain(run.Diagnostics, x => x.Id == "RASK031");
+    }
+
+    [Fact]
+    public void Collision_IsWarning_NotError()
+    {
+        const string src = """
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("/dup")] public sealed class A : Component { }
+            [Route("/dup")] public sealed class B : Component { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        var d = run.Diagnostics.First(x => x.Id == "RASK031");
+        Assert.Equal(DiagnosticSeverity.Warning, d.Severity);
+    }
+
+    [Fact]
+    public void DistinctTemplates_NoDiagnostic()
+    {
+        const string src = """
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("/a")] public sealed class PageA : Component { }
+            [Route("/b")] public sealed class PageB : Component { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        Assert.DoesNotContain(run.Diagnostics, x => x.Id == "RASK031");
+    }
+
+    [Fact]
+    public void SameTemplate_UnderParentRoute_NotFlagged()
+    {
+        // A page with a [ParentRoute] composes its parent's path, so the local template alone isn't the
+        // full URL — those are deliberately excluded to avoid false positives.
+        const string src = """
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("/shop")] public sealed class Shop : Component { }
+            [Route("/list")] public sealed class TopList : Component { }
+            [Route("/list")][ParentRoute(typeof(Shop))] public sealed class NestedList : Component { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        Assert.DoesNotContain(run.Diagnostics, x => x.Id == "RASK031");
+    }
+
+    [Fact]
+    public void SamePage_DeclaredPartialTwice_NoFalsePositive()
+    {
+        const string src = """
+            using Rask.Core;
+            using Rask.Core.Routing;
+            namespace Demo;
+            [Route("/home")] public sealed partial class Home : Component { }
+            public sealed partial class Home { }
+            """;
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        Assert.DoesNotContain(run.Diagnostics, x => x.Id == "RASK031");
+    }
+}


### PR DESCRIPTION
## Summary

Two different top-level pages resolving to the same URL made the active one **arbitrary** — a silent bug the generator didn't catch (it only deduped by type name and enforced a single `[NotFound]`).

`RoutesGenerator` now warns (**RASK031**) on every colliding page after the first, naming the page it collides with.

## Matching (from review)

Templates are grouped by the **normalized pattern the runtime router actually matches on** — a generator-side mirror of `RoutePattern` (which can't be referenced from this `netstandard2.0` project). It normalizes:
- **case** — literals match `OrdinalIgnoreCase` → `/Products` collides with `/products`;
- **slashes** — trimmed → `/products` collides with `products/`;
- **parameter names + `:constraints`** — ignored by the router → `/item/{id:int}` collides with `/item/{id:guid}` and `/item/{slug}`.

Required vs optional vs catch-all params stay distinct (they match different URL sets).

## Severity

**Warning, not Error** (review): a collision is a real bug, but the app still runs (just picks arbitrarily), so upgrading Rask never hard-breaks a build that compiled before.

## Scope

Restricted to pages **without** a `[ParentRoute]` (whose template is the full path); parent-composed paths aren't resolved here, so the check under-reports rather than risk a false positive on a nested route.

## Testing

- `dotnet test tests/Rask.Generators.Tests` — 207 passed. New tests: the case/slash/constraint/param-name normalization theory, required-vs-optional non-collision, parent-route exclusion, partial-class-same-FQN non-collision, and Warning severity.
- Verified **0 RASK031** across the Server/Shared samples (no false positives on the repo's own routes).
- Strict `-warnaserror` generator build clean; format clean.

## Note on numbering

Uses **RASK031**; **RASK030** is claimed by the parallel PR #263 (factory named-args). If that lands after this, there's a temporary `…029, 031` gap in the docs range that #263 fills — no ID collision either way.

## Docs

`docs/diagnostics.md` (TOC + `## RASK031` section), CHANGELOG, and the RASK-range / `add-diagnostic` next-free bump.