### PR TITLE
feat(server): navigation progress bar + focus and aria-live announce on route change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@ them until tagged releases begin.
   sibling on reorder — a latent state-corruption bug, not a cosmetic nit. The one-time diagnostic
   (routed through the `RaskDiagnostics` seam, deduplicated per key) now logs at `Error` so it surfaces
   loudly. No behavior change beyond the log level; fix the duplicate keys to silence it.
+- **Navigation now shows progress and is accessible.** On the Server live runtime, a client-side route
+  change (`navigate`) carries no handler seq/ack, so a slow server-side render used to show **no progress
+  indicator at all**, and on commit focus stayed on the now-removed nav link with no announcement — a
+  screen-reader user got no "navigated to X". Now a forward or back/forward navigation reuses the top
+  progress bar (after the same ~300 ms grace as a slow handler round-trip, so a fast nav never flashes
+  it), and a forward, whole-page navigation moves focus into the new page's `<main>` (or first `<h1>`) and
+  announces the new page title through a polite `aria-live` region. The bar stays up while either a
+  handler round-trip or a navigation is outstanding. Server host only for now (the WASM navigation path is
+  a follow-up). See [docs/accessibility.md](docs/accessibility.md#navigation).
 
 ## [0.14.1] - 2026-07-07
 

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -120,6 +120,21 @@ its title, or `aria-label` from the title text), and dismisses on `Escape` (exce
 which keeps `Escape` inert per Bootstrap). Build your own overlay the same way — add `data-rask-focus-trap`
 (via the `Data` dictionary) and mark your close control with `data-rask-dismiss`.
 
+## Navigation
+
+Client-side (SPA) route changes on the Server live runtime are handled accessibly without any wiring:
+
+- **Progress.** A slow server-side route render surfaces the top progress bar (the same one a slow
+  handler round-trip uses), after a ~300 ms grace so a fast navigation never flashes it.
+- **Focus.** A forward, whole-page navigation moves focus into the new page's `<main>` (or its first
+  `<h1>`), so a keyboard user continues from the new page instead of the now-removed nav link at the top
+  of the document. Give your layout a `<main>` (`Main(...)`) to anchor this.
+- **Announcement.** The new page's `<title>` is announced through a polite `aria-live` region, so a
+  screen-reader user hears the route changed.
+
+Back/Forward (popstate) navigation leaves focus and scroll to the browser's native restoration. (Server
+host today; the WASM navigation path is a follow-up.)
+
 ## What's not covered yet
 
 This is the framework primitive layer. Higher-level affordances — skip links, ARIA `tablist`/`tab`

--- a/llms.txt
+++ b/llms.txt
@@ -28,7 +28,7 @@ This file helps AI coding assistants build apps with Rask. Start with AGENTS.md 
 - [Authentication](docs/authentication.md): cookie/JWT, Authorize, route guards.
 - [Observability](docs/observability.md): structured logging, the `Rask.Server` meter + activity source, `AddRaskLiveSessions()` health check.
 - [Configuration](docs/configuration.md): `RaskLiveOptions` (shared: diff mode, path base, session cap) + `RaskServerOptions` (server-only WS/grace/idle/backpressure limits) + `RaskUploadOptions` (upload size + per-session quota), appsettings binding + startup validation.
-- [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023).
+- [Accessibility](docs/accessibility.md): ARIA via the `Aria` dictionary, `Role`/`TabIndex`, the `Img` alt-text analyzer (RASK023), and automatic navigation a11y on the Server host (SPA route changes show a progress bar, move focus into the new page's `<main>`, and announce the route via `aria-live`).
 - [Migration from Blazor](docs/migration-from-blazor.md): mapping Blazor concepts to Rask.
 - [Diagnostics](docs/diagnostics.md): RASK001–031 compile-time diagnostics + fixes, including IDE quick-fixes (lightbulb) for RASK001 (add `required`) and RASK023 (insert `Alt: ""`), shipped in `Rask.Generators.CodeFixes`.
 - [Testing](docs/testing.md): the `Rask.Testing` package (`RaskTest.Render(component)` → `RenderedComponent`; `.ClickAsync()`/`.InvokeAsync(handlerId, json?)` dispatch handlers + re-render; `.Html`/`.HandlerId`/`.Attr` query) for in-process component unit tests, plus Playwright E2E patterns.

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -410,6 +410,120 @@
     let pendingVisible = false;
     const pendingBar = installPendingBar();
 
+    // Navigation reuses the same top progress bar as a handler round-trip, tracked separately so a slow
+    // route render surfaces progress even though a `navigate` frame carries no handler seq/ack. The bar
+    // stays up while EITHER a handler seq or a navigation is outstanding (see hideBarIfIdle).
+    let navInFlight = false;
+    let navBarTimer = null;
+    let navHardTimer = null;
+    // Polite live region that announces the new page on a forward navigation (keyboard/SR users get told
+    // the route changed; the visible bar alone is silent to assistive tech).
+    const routeAnnouncer = installRouteAnnouncer();
+
+    function beginNav() {
+        navInFlight = true;
+        if (navBarTimer === null && !pendingVisible) {
+            navBarTimer = setTimeout(showPendingBar, PENDING_LATENCY_MS);
+        }
+        // Backstop, mirroring the handler forcePendingTimeout: if no navigation reply ever arrives (the
+        // route render threw server-side and sent no frame, or deduped to nothing), settle so the bar
+        // can't wedge navigation AND every subsequent handler round-trip.
+        if (navHardTimer !== null) {
+            clearTimeout(navHardTimer);
+        }
+        navHardTimer = setTimeout(endNav, PENDING_HARD_TIMEOUT_MS);
+    }
+
+    function endNav() {
+        navInFlight = false;
+        if (navHardTimer !== null) {
+            clearTimeout(navHardTimer);
+            navHardTimer = null;
+        }
+        hideBarIfIdle();
+    }
+
+    // Retire the progress bar only when nothing needs it — a handler round-trip (ackedSeq < outstandingSeq)
+    // or an in-flight navigation keeps it visible.
+    function hideBarIfIdle() {
+        if (ackedSeq < outstandingSeq || navInFlight) {
+            return;
+        }
+
+        if (navBarTimer !== null) {
+            clearTimeout(navBarTimer);
+            navBarTimer = null;
+        }
+
+        hidePendingBar();
+    }
+
+    function installRouteAnnouncer() {
+        const el = document.createElement("div");
+        el.setAttribute("data-rask-managed", "");
+        el.setAttribute("aria-live", "polite");
+        el.setAttribute("aria-atomic", "true");
+        el.className = "rask-route-announcer";
+        el.style.cssText = "position:absolute;width:1px;height:1px;margin:-1px;padding:0;overflow:hidden;"
+            + "clip:rect(0 0 0 0);white-space:nowrap;border:0;";
+        document.documentElement.appendChild(el);
+        return el;
+    }
+
+    // Forward navigation committed: announce the new page (its <title>, morphed in) and move focus into
+    // the new page so keyboard/SR users continue from it rather than the now-removed link. `preferred` is
+    // the in-page anchor a fragment nav scrolled to (focus it), else the main content is used.
+    function focusAndAnnounceRoute(preferred) {
+        if (routeAnnouncer) {
+            routeAnnouncer.textContent = "";
+            const title = document.title || location.pathname;
+            // Defer so the reset registers before the new text (some SRs coalesce same-tick changes).
+            setTimeout(function () { routeAnnouncer.textContent = title; }, 50);
+        }
+
+        const target = preferred
+            || document.querySelector("main, [role=main]")
+            || document.querySelector("h1");
+        if (!target) {
+            return;
+        }
+
+        // Make it programmatically focusable if it isn't already. Add the blur cleanup only AFTER a
+        // successful focus, and back the tabindex out if focus throws, so a detached target can't leak a
+        // client-injected tabindex + dangling listener onto server-owned DOM.
+        const addedTabindex = !target.hasAttribute("tabindex");
+        if (addedTabindex) {
+            target.setAttribute("tabindex", "-1");
+        }
+
+        let focused = false;
+        try {
+            target.focus({preventScroll: true});
+            focused = true;
+        } catch (e) {
+            try {
+                target.focus();
+                focused = true;
+            } catch (e2) {
+                // focus target vanished
+            }
+        }
+
+        if (!focused) {
+            if (addedTabindex) {
+                target.removeAttribute("tabindex");
+            }
+            return;
+        }
+
+        if (addedTabindex) {
+            target.addEventListener("blur", function onBlur() {
+                target.removeAttribute("tabindex");
+                target.removeEventListener("blur", onBlur);
+            });
+        }
+    }
+
     function stampSeq(payload) {
         // Only genuine handler events get a seq: they carry an `id` and dispatch through
         // the server's handler chain, which acks the seq. jsResult also carries an id but
@@ -440,13 +554,16 @@
             clearTimeout(pendingHardTimer);
             pendingHardTimer = null;
         }
-        hidePendingBar();
+        // A navigation may still need the bar even though this handler round-trip settled.
+        hideBarIfIdle();
     }
 
     function resetPending() {
         // On disconnect the reconnect overlay takes over; drop the bar and treat every
-        // outstanding handler as settled so a pre-drop seq can't wedge the next session.
+        // outstanding handler AND any in-flight navigation as settled so a pre-drop seq/nav
+        // can't wedge the next session.
         ackedSeq = outstandingSeq = seqCounter;
+        navInFlight = false;
         clearPending();
     }
 
@@ -654,26 +771,36 @@
     // carried a "#fragment" matching an element, scroll there instead of the top.
     // Call this only after the new body has committed so the anchor target exists.
     function applyNavScroll(history) {
+        // A navigation reply committed (push or replace) — retire the loading bar. Only when `history`
+        // is present: an out-of-band / non-nav frame (no history) must NOT clear an in-flight nav's bar.
+        if (history && navInFlight) {
+            endNav();
+        }
+
         if (!history || history.action === "replace") {
             _pendingScrollHash = "";
             return;
         }
         const hash = _pendingScrollHash;
         _pendingScrollHash = "";
+        let anchor = null;
         if (hash && hash.length > 1) {
-            let el = null;
             try {
-                el = document.querySelector(hash) ||
+                anchor = document.querySelector(hash) ||
                     document.getElementById(decodeURIComponent(hash.slice(1)));
             } catch (e) {
-                el = null;
-            }
-            if (el) {
-                el.scrollIntoView();
-                return;
+                anchor = null;
             }
         }
-        window.scrollTo(0, 0);
+
+        if (anchor) {
+            anchor.scrollIntoView();
+        } else {
+            window.scrollTo(0, 0);
+        }
+        // Forward navigation: focus the anchor the link targeted (else the main content) and announce the
+        // route — a fragment deep-link is still a route change for keyboard/SR users.
+        focusAndAnnounceRoute(anchor);
     }
 
     // Diff-mode render application (wire format matches LivePayload.BuildPayloadUtf8Diff).
@@ -904,11 +1031,13 @@
         // the new page commits (the fragment is not sent to the server).
         _pendingScrollHash = url.hash || "";
         flushInputsNow();
+        beginNav();
         send({type: "navigate", path: stripBase(url.pathname), query: url.search});
     });
 
     window.addEventListener("popstate", () => {
         flushInputsNow();
+        beginNav();
         send({type: "navigate", path: stripBase(location.pathname), query: location.search, replace: true});
     });
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -161,6 +161,18 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("main .markdown-body h1").First).ToContainTextAsync("CQRS",
             new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
 
+        // Forward navigation moves focus into the new page's <main> and announces the route via the
+        // aria-live region, so keyboard/screen-reader users continue from the new page (not the stale
+        // nav link) and hear the change. Server live-runtime only (rask.js) for now; the WASM host's
+        // navigation path is a follow-up.
+        if (FixtureName == "Server")
+        {
+            await Expect(Page.Locator("main.page-main")).ToBeFocusedAsync(
+                new LocatorAssertionsToBeFocusedOptions { Timeout = 5_000 });
+            await Expect(Page.Locator(".rask-route-announcer")).Not.ToBeEmptyAsync(
+                new LocatorAssertionsToBeEmptyOptions { Timeout = 3_000 });
+        }
+
         var count = Page.Locator("#cqrs-count");
         await Expect(count).ToHaveTextAsync("0", new LocatorAssertionsToHaveTextOptions { Timeout = 15_000 });
 


### PR DESCRIPTION
## Summary

A client-side route change (`navigate`) carries no handler seq/ack, so on the Server live runtime a slow server-side render showed **no progress indicator at all**, and on commit focus stayed on the now-removed nav link with **no announcement** — a screen-reader user got no "navigated to X".

Now:
- **Progress** — a navigation reuses the top progress bar, shown after the same ~300 ms grace as a slow handler round-trip (so a fast nav never flashes it). The bar stays up while **either** a handler round-trip or a navigation is outstanding.
- **Focus** — a forward navigation moves focus into the new page: the fragment anchor the link targeted, else the `<main>` (or first `<h1>`).
- **Announcement** — the new page's `<title>` is announced through a polite `aria-live` region.

Back/Forward (popstate) leaves focus and scroll to the browser's native restoration.

## Review fixes (state machine)

- **Hard-timeout backstop** — `endNav` mirrors the handler `forcePendingTimeout`, so a navigate that never yields a frame (render threw server-side, or deduped to nothing) can't wedge the bar for navigation *and* all subsequent handler round-trips.
- **Conditional retire** — `applyNavScroll` clears `navInFlight` only when a nav reply (`history`) is present, so an out-of-band/non-nav frame can't retire the bar mid-navigation.
- **Fragment deep-links** — now also focus + announce (previously they scrolled and returned early).
- **No DOM leak** — the injected `tabindex=-1`/blur listener is backed out if `focus()` throws, so it never lingers on server-owned DOM.

## Testing

- `ServerExampleTests.Journey` E2E — **passes**: asserts `<main>` is focused and the `aria-live` announcer is populated after a forward nav (Server-guarded), and the **existing pending-bar handler assertions still pass** (the shared bar machinery isn't regressed).
- `node --check` on `rask.js`.

## Scope / docs

Server host only for now (`rask.js`); the WASM navigation path is a follow-up. `docs/accessibility.md` (new Navigation section), `llms.txt`, CHANGELOG.