### PR TITLE
feat(core): add a "Reload this page" recovery button to the default error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ them until tagged releases begin.
   silently rebind such a call. The first one or two positional arguments (the primary content) stay
   idiomatic. Hidden severity: no build output and no effect on the warnings-as-errors build — the IDE
   surfaces it as a suggestion. See [docs/diagnostics.md](docs/diagnostics.md#rask030).
+- **The default error page now offers a recovery affordance.** After an uncaught fault the root error
+  boundary rendered "Something went wrong" (plus the exception, and in development a stack) but no way
+  back — the user was stranded and had to hunt for the browser's reload. It now shows a **"Reload this
+  page"** button; the runtime wires any `data-rask-reload` element to `location.reload()` (delegated and
+  CSP-clean, on both the Server and WASM hosts), and if the runtime never loaded the browser's own reload
+  remains the fallback. Present in production too, where it's the primary recovery (no stack is shown).
 - **RASK031 — two pages resolving to the same route are now flagged.** Two different top-level pages that
   resolve to the same URL made the active one arbitrary — a silent bug the generator didn't catch (it
   only deduped by type name and enforced a single `[NotFound]`). The `RoutesGenerator` now warns

--- a/src/Rask.Core/Components/DefaultErrorPage.cs
+++ b/src/Rask.Core/Components/DefaultErrorPage.cs
@@ -25,6 +25,10 @@ public sealed class DefaultErrorPage : Component
     private const string CausedByStyle =
         "cursor:pointer;margin-top:1rem;font-size:0.85rem;color:#7f1d1d;font-weight:600;";
 
+    private const string ReloadButtonStyle =
+        "margin:0.25rem 0 1rem;padding:0.5rem 1rem;border:1px solid #b42323;border-radius:0.375rem;"
+        + "background:#b42323;color:#fff;font:inherit;font-size:0.9rem;cursor:pointer;";
+
     // How many source lines to show on each side of the throwing line.
     private const int SourceRadius = 5;
 
@@ -52,7 +56,14 @@ public sealed class DefaultErrorPage : Component
     {
         var children = new List<Component>
         {
-            Generated.H1(Style: "margin:0 0 0.75rem;font-size:1.5rem;color:#b42323;")["Something went wrong"]
+            Generated.H1(Style: "margin:0 0 0.75rem;font-size:1.5rem;color:#b42323;")["Something went wrong"],
+            // In-app recovery so the user isn't stranded on the fault: the runtime wires data-rask-reload
+            // to location.reload() (CSP-clean, both hosts). If the runtime never loaded, the browser's own
+            // reload is the fallback.
+            Generated.Button(
+                Type: "button",
+                Style: ReloadButtonStyle,
+                Data: new Dictionary<string, string?> { ["rask-reload"] = "" })["Reload this page"]
         };
 
         var chain = Unwind(_error);

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -430,3 +430,23 @@ function applyFrameInvokes(reply, dispatchOne) {
     observer.observe(document.documentElement, { childList: true, subtree: true });
     sync(); // a trap already present at load
 })();
+
+// ----- Recovery affordance (data-rask-reload) ----------------------------
+// A click on any element carrying data-rask-reload reloads the page. Used by the default error page so a
+// user stranded on an uncaught fault has an in-app way back without hunting for the browser's reload.
+// Delegated + CSP-clean (no inline handler); a no-op if the runtime never loaded (the browser's own
+// reload remains the ultimate fallback).
+(function installRaskReload() {
+    if (typeof document === "undefined" || typeof document.addEventListener !== "function"
+        || typeof window === "undefined" || window.__raskReload) {
+        return;
+    }
+    window.__raskReload = true;
+    document.addEventListener("click", function (e) {
+        const t = e.target;
+        if (t && t.closest && t.closest("[data-rask-reload]")) {
+            e.preventDefault();
+            location.reload();
+        }
+    });
+})();

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -3055,6 +3055,26 @@ function applyFrameInvokes(reply, dispatchOne) {
     sync(); // a trap already present at load
 })();
 
+// ----- Recovery affordance (data-rask-reload) ----------------------------
+// A click on any element carrying data-rask-reload reloads the page. Used by the default error page so a
+// user stranded on an uncaught fault has an in-app way back without hunting for the browser's reload.
+// Delegated + CSP-clean (no inline handler); a no-op if the runtime never loaded (the browser's own
+// reload remains the ultimate fallback).
+(function installRaskReload() {
+    if (typeof document === "undefined" || typeof document.addEventListener !== "function"
+        || typeof window === "undefined" || window.__raskReload) {
+        return;
+    }
+    window.__raskReload = true;
+    document.addEventListener("click", function (e) {
+        const t = e.target;
+        if (t && t.closest && t.closest("[data-rask-reload]")) {
+            e.preventDefault();
+            location.reload();
+        }
+    });
+})();
+
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;

--- a/tests/Rask.Core.Tests/Components/DefaultErrorPageTests.cs
+++ b/tests/Rask.Core.Tests/Components/DefaultErrorPageTests.cs
@@ -37,6 +37,17 @@ public class DefaultErrorPageTests
     }
 
     [Fact]
+    public void Always_OffersAReloadRecoveryButton()
+    {
+        // A user stranded on the fault needs an in-app way back — the runtime wires data-rask-reload to
+        // location.reload(). Present in production too (the primary recovery when no stack is shown).
+        var html = Render(Thrown("boom"), isDevelopment: false);
+        Assert.Contains("data-rask-reload", html);
+        Assert.Contains("Reload this page", html);
+        Assert.Contains("<button", html);
+    }
+
+    [Fact]
     public void Development_RendersParsedStackFrames()
     {
         var html = Render(Thrown("dev-boom"), isDevelopment: true);


### PR DESCRIPTION
## Summary

After an uncaught fault the root error boundary rendered "Something went wrong" (plus the exception, and in development a stack) but gave the user **no way back** — they were stranded and had to hunt for the browser's reload.

The default error page now shows a **"Reload this page"** button. The runtime wires any `data-rask-reload` element to `location.reload()` — **delegated and CSP-clean** (no inline handler), in the shared `rask-dom.js` so it works on **both the Server and WASM hosts**. If the runtime never loaded, the browser's own reload remains the fallback. Present in production too, where it's the primary recovery (no stack is shown).

## Note

The reload IIFE guards against a non-browser environment (`typeof document.addEventListener !== "function"`) so the `MorphCheckedGuard` **Node fixture — which loads `rask-dom.js`** — keeps passing. (Caught while running the full Core suite; the mock `document` has no `addEventListener`.)

## Testing

- `dotnet test tests/Rask.Core.Tests` — 1814 passed, 1 skipped (incl. the `MorphCheckedGuard` fixture that loads `rask-dom.js`, and a new `DefaultErrorPage` test asserting the button + `data-rask-reload`)
- `node --check` on `rask-dom.js`; `Browser/rask.wasm.js` regenerated from source and verified
- Self-reviewed (small, CSP-clean delegated handler + a button; attribute-order preserved via the `Data` dict)

## Changelog

Added under `[Unreleased] → Added`.