### PR TITLE
feat(generators): end route/param diagnostics with an actionable fix clause

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,12 @@ them until tagged releases begin.
   lost their place when it closed. See [docs/accessibility.md](docs/accessibility.md#focus-trapping-overlays).
 
 ### Changed
+- **Routing diagnostics now tell you how to fix them, not just what's wrong.** The route/param analyzers
+  RASK004–RASK010 and RASK012 previously stated the problem but stopped there (e.g. *"Route segment
+  '{seg}' has no matching public settable property"*). Each message now ends with the remedy — add the
+  property, adjust the constraint, remove the conflicting attribute, break the `[ParentRoute]` cycle,
+  etc. — so the fix is visible in the IDE error list and build output without opening the docs. Message
+  text only; the diagnostic IDs, severities, and `docs/diagnostics.md` `**Fix:**` guidance are unchanged.
 - **The per-component render walk skips a guaranteed-miss scope lookup when no scoped CSS exists.**
   `LiveRenderContext.PushScope` runs for every user component on every render and called
   `ScopedAssetRegistry.TryGetScopeId` (a `ConcurrentDictionary` probe) unconditionally — but on the

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -37,7 +37,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask004 = new(
         "RASK004",
         "Route segment has no matching property",
-        "Route segment '{{{0}}}' on '{1}' has no matching public settable property",
+        "Route segment '{{{0}}}' on '{1}' has no matching public settable property — add a public "
+        + "settable property named '{0}' to '{1}', or remove '{{{0}}}' from the route template",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -46,7 +47,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask005 = new(
         "RASK005",
         "Property type does not match route constraint",
-        "Property '{0}.{1}' has type '{2}', incompatible with route constraint '{3}'",
+        "Property '{0}.{1}' has type '{2}', incompatible with route constraint '{3}' — change the property "
+        + "type to one the '{3}' constraint accepts, or adjust the constraint in the route template",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -55,7 +57,9 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask006 = new(
         "RASK006",
         "[QueryParam] applied to a path-segment property",
-        "Property '{0}.{1}' has [QueryParam] but is also bound by path segment '{{{2}}}'",
+        "Property '{0}.{1}' has [QueryParam] but is also bound by path segment '{{{2}}}' — a value can't "
+        + "come from both; remove [QueryParam] to bind it from the path, or rename the property or segment "
+        + "so they don't collide",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -64,7 +68,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask007 = new(
         "RASK007",
         "[ParentRoute] cycle",
-        "[ParentRoute] forms a cycle starting at '{0}'",
+        "[ParentRoute] forms a cycle starting at '{0}' — break the cycle so the [ParentRoute] chain ends "
+        + "at a page with no parent",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -73,7 +78,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask008 = new(
         "RASK008",
         "[RouteParam] without matching path segment",
-        "Property '{0}.{1}' has [RouteParam] but no path segment matches '{2}'",
+        "Property '{0}.{1}' has [RouteParam] but no path segment matches '{2}' — add a '{{{2}}}' segment "
+        + "to the route template, or remove [RouteParam] from the property",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -82,7 +88,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask009 = new(
         "RASK009",
         "[RouteParam] on a non-routed class",
-        "Property '{0}.{1}' has [RouteParam] but '{0}' is not a valid route target ({2})",
+        "Property '{0}.{1}' has [RouteParam] but '{0}' is not a valid route target ({2}) — mark '{0}' with "
+        + "[Route] (a concrete Component subclass), or remove [RouteParam]",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -91,7 +98,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask010 = new(
         "RASK010",
         "[QueryParam] on a non-routed class",
-        "Property '{0}.{1}' has [QueryParam] but '{0}' is not a valid route target ({2})",
+        "Property '{0}.{1}' has [QueryParam] but '{0}' is not a valid route target ({2}) — mark '{0}' with "
+        + "[Route] (a concrete Component subclass), or remove [QueryParam]",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -109,7 +117,8 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask012 = new(
         "RASK012",
         "Multiple [NotFound] components",
-        "Multiple [NotFound] components found in this assembly; only one is allowed ('{0}' is a duplicate)",
+        "Multiple [NotFound] components found in this assembly; only one is allowed ('{0}' is a duplicate) "
+        + "— remove [NotFound] from all but one component",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,

--- a/tests/Rask.Generators.Tests/RoutesGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/RoutesGeneratorTests.cs
@@ -112,6 +112,28 @@ public class RoutesGeneratorTests
     }
 
     [Fact]
+    public void Rask004_Message_StatesHowToFix()
+    {
+        var src = """
+                  using Rask.Core;
+                  using Rask.Core.Routing;
+                  namespace Demo;
+                  [Route("/users/{id:int}")]
+                  public sealed class UserPage : Component
+                  {
+                      public override Component? Render() => this;
+                  }
+                  """;
+
+        var run = GeneratorDriverFixture.RunRoutes(src);
+        var message = run.Diagnostics.First(d => d.Id == "RASK004").GetMessage();
+
+        // The message must carry the remedy, not just the problem (D6 actionable-clause audit).
+        Assert.Contains(" — ", message);
+        Assert.Contains("add a public settable property", message);
+    }
+
+    [Fact]
     public void QueryParam_EmitsOptionalParameter()
     {
         var src = """


### PR DESCRIPTION
## D6 — Actionable-clause audit of the diagnostic messages

Polish pass over every `RASKxxx` `messageFormat` (paired with D2's code-fixes): some diagnostics
stated the *problem* but not the *fix*, so a developer saw the error in the IDE / build output and
still had to open the docs to learn what to change.

Audited all 31 descriptors. The analyzer diagnostics (RASK001/002, RASK014, RASK019–027, RASK030/031)
and the scoped-asset ones (RASK015–020) already ended with a remedy. The gap was the **route/param
diagnostics** — this PR closes it:

| ID | Now ends with |
|----|---------------|
| RASK004 | *…add a public settable property named 'x' to 'Page', or remove '{x}' from the route template* |
| RASK005 | *…change the property type to one the ':int' constraint accepts, or adjust the constraint* |
| RASK006 | *…remove [QueryParam] to bind it from the path, or rename the property or segment* |
| RASK007 | *…break the cycle so the [ParentRoute] chain ends at a page with no parent* |
| RASK008 | *…add a '{x}' segment to the route template, or remove [RouteParam]* |
| RASK009 / RASK010 | *…mark 'Page' with [Route] (a concrete Component subclass), or remove [RouteParam]/[QueryParam]* |
| RASK012 | *…remove [NotFound] from all but one component* |

### Scope / safety
- **Message text only** — IDs, severities, categories, and argument counts are unchanged (every added
  clause reuses existing `{N}` placeholders, so `.WithArguments(...)` call sites and arg counts are
  untouched).
- The `{2}` reason substrings that the RASK009/RASK010 tests assert on (*"not marked [Route]"*,
  *"does not inherit from Component"*, *"class is abstract"*) are preserved.
- `docs/diagnostics.md` already carried a `**Fix:**` line for each of these — the messages now match that
  guidance, so nothing in the docs needed to change.

### Verification
All 219 `Rask.Generators.Tests` pass (route + not-found suites assert by ID and by the preserved reason
substrings). Added `Rask004_Message_StatesHowToFix` asserting the remedy is present. `dotnet format`
clean, `-warnaserror` build clean. CHANGELOG `[Unreleased] → Changed`.
