### PR TITLE
fix(generators): RASK002 no longer fires for a DI-ctor component with a required factory param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,19 @@ them until tagged releases begin.
   type-match step drops to **0 B allocated** (was 40 B) and is ~34% faster (8.5 ns → 5.7 ns); behavior
   is unchanged (`handlerId` still resolves via `GetString`, which is a genuine dictionary key).
 
+### Fixed
+- **RASK002 no longer fires for a component that has a DI constructor and a `required` factory
+  parameter.** The diagnostic wrongly treated "DI constructor, no parameterless constructor" as unable
+  to honor `required`. In fact the generated factory builds such a component with
+  `ActivatorUtilities.CreateInstance` (which runs the DI constructor, so injected services are set) and
+  then post-assigns every factory parameter — so a `required` property with no member initializer *is*
+  honored at runtime. RASK002 now fires only in the genuinely broken shape: a component with **both** a
+  DI constructor and a parameterless constructor **and** a `required` property carrying a member
+  initializer (the factory emits `new C() { … }` whose object initializer excludes the initializer-
+  carrying property, so the consumer build hits `CS9035`). The RASK001 quick-fix, which was withheld in
+  the mis-flagged case, is now offered there too. See
+  [docs/diagnostics.md](docs/diagnostics.md#rask002).
+
 ## [0.14.1] - 2026-07-07
 
 ### Fixed

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -69,23 +69,20 @@ to stay ergonomic. See [factory generation rules](getting-started.md).
 ## RASK002
 **`required` property cannot be honored by the generated factory** · Warning
 
-A property is marked `required`, but the generated factory can't set it. This fires when the
-component has a dependency-injected constructor **and** either:
+A property is marked `required`, but the generated factory can't set it. This fires in exactly one
+shape: the component has **both** a dependency-injected constructor **and** a parameterless
+constructor, **and** the `required` property carries a member initializer. The factory then builds
+the component with `new C() { … }`, but an initializer-carrying property is excluded from the factory
+parameters, so the object initializer never assigns it and the consumer build fails with `CS9035`.
 
-- it has no parameterless constructor — the factory builds the component with
-  `ActivatorUtilities.CreateInstance`, which can't satisfy a `required` member; or
-- the `required` property carries a member initializer — that excludes it from the factory
-  parameters, so the generated object initializer never assigns it (the consumer build then fails
-  with `CS9035`).
+> A DI constructor with **no** parameterless constructor is fine: the factory builds the component
+> with `ActivatorUtilities.CreateInstance` (which runs your DI constructor, so injected services are
+> set) and then post-assigns each factory param — so a `required` property with no member initializer
+> is honored. RASK002 does **not** fire in that case.
 
-> **Adding a parameterless constructor is _not_ a safe fix while you keep the DI constructor.** The
-> factory prefers the parameterless ctor, so it builds the component with `new C()` and the DI
-> constructor never runs — your injected services stay `null` at render time. Only add a
-> parameterless constructor if you also remove the DI constructor.
-
-**Fix:** remove `required`, **or** move the value to a constructor parameter (with no member
-initializer on it), **or** drop the DI constructor. Framework services (`RouteState`, `Navigator`,
-`HttpClient`, `IJSRuntime`) should come through the constructor, never as settable properties.
+**Fix:** remove the member initializer so the `required` property becomes a plain factory parameter,
+**or** remove `required`. Framework services (`RouteState`, `Navigator`, `HttpClient`, `IJSRuntime`)
+should come through the constructor, never as settable properties.
 
 ## RASK003
 **Malformed route template** · Error

--- a/src/Rask.Generators.CodeFixes/RequiredFactoryParamCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/RequiredFactoryParamCodeFixProvider.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
@@ -24,28 +23,14 @@ public sealed class RequiredFactoryParamCodeFixProvider : RaskCodeFixProvider<Pr
 
     protected override string EquivalenceKey => "RASK001_AddRequired";
 
-    protected override async Task<bool> CanFixAsync(CodeFixContext context, PropertyDeclarationSyntax property)
+    protected override Task<bool> CanFixAsync(CodeFixContext context, PropertyDeclarationSyntax property)
     {
-        if (property.Modifiers.Any(SyntaxKind.RequiredKeyword))
-        {
-            return false;
-        }
-
-        // Guard against trading RASK001 (a benign hint) for RASK002: when the component is built through
-        // a dependency-injected constructor with no public parameterless ctor, the generated factory uses
-        // ActivatorUtilities.CreateInstance and cannot set a `required` property — the generator would then
-        // emit RASK002 and the DI constructor's services would be null. Only offer the fix when `required`
-        // can actually be honored (mirrors the RASK002 trigger in ComponentFactoryGenerator).
-        var model = await context.Document.GetSemanticModelAsync(context.CancellationToken).ConfigureAwait(false);
-        if (model?.GetDeclaredSymbol(property, context.CancellationToken) is not { ContainingType: { } type })
-        {
-            return true; // no semantic info — best-effort offer, matching the always-on prior behavior
-        }
-
-        var instanceCtors = type.InstanceConstructors.Where(c => !c.IsStatic).ToArray();
-        var hasParameterless = instanceCtors.Any(c => c.Parameters.Length == 0);
-        var hasDIConstructor = instanceCtors.Any(c => c.Parameters.Length > 0);
-        return !(hasDIConstructor && !hasParameterless);
+        // RASK001 only targets a non-nullable, no-initializer factory param, and the generated factory
+        // always honors `required` on such a prop — the DI-ctor path builds via ActivatorUtilities and
+        // post-assigns it, the object-init path sets it in the initializer. RASK002 only fires for a
+        // required prop carrying a member initializer, which is never the RASK001 case, so adding
+        // `required` here can never trade the hint for a RASK002 warning. Always offer the fix.
+        return Task.FromResult(!property.Modifiers.Any(SyntaxKind.RequiredKeyword));
     }
 
     protected override Task<Document> FixAsync(

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -827,11 +827,14 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
             foreach (var p in c.Properties)
             {
                 var location = MakeLocation(p);
-                // A parameterless ctor only rescues `required` props that are actually factory
-                // params. A `required` property carrying a member initializer is excluded from the
-                // factory params (IsParamProperty), so the generated object initializer never
-                // assigns it and the consumer build fails with CS9035 — keep warning in that case.
-                if (p.UserMarkedRequired && c.HasDIConstructor && (!c.HasParameterlessCtor || p.HasInitializer))
+                // RASK002 only fires when the generated factory genuinely cannot honor `required`.
+                // A DI ctor alone is fine: with no parameterless ctor the factory builds via
+                // ActivatorUtilities.CreateInstance (reflection bypasses the CS9035 check) and then
+                // post-assigns every factory param, so a required no-initializer prop IS set. The one
+                // broken shape is a parameterless ctor present *and* a required prop carrying a member
+                // initializer: the factory then emits `new T() { … }` whose object initializer excludes
+                // the initializer-carrying prop (IsParamProperty), so the consumer build hits CS9035.
+                if (p.UserMarkedRequired && c.HasDIConstructor && c.HasParameterlessCtor && p.HasInitializer)
                 {
                     spc.ReportDiagnostic(Diagnostic.Create(Rask002, location, c.FullyQualifiedName, p.Name));
                 }

--- a/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
+++ b/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
@@ -66,11 +66,10 @@ public class CodeFixProviderTests
     }
 
     [Fact]
-    public async Task Rask001_NotOffered_WhenAddingRequiredWouldTripRask002()
+    public async Task Rask001_Offered_WithDIConstructorAndNoParameterless()
     {
-        // The component has a DI constructor and no parameterless ctor, so the generated factory builds it
-        // via ActivatorUtilities and cannot set a `required` property. Adding `required` would trade the
-        // Hidden RASK001 for a RASK002 warning (null services), so the fix must be withheld.
+        // A DI ctor with no parameterless ctor builds via ActivatorUtilities and post-assigns the prop,
+        // so a required no-initializer prop is honored and RASK002 does not fire. The fix stays available.
         var source = """
             using Rask.Core;
             namespace Demo;
@@ -83,7 +82,7 @@ public class CodeFixProviderTests
             """;
         var offered = await CodeFixHarness.IsGeneratorFixOfferedAsync(
             new ComponentFactoryGenerator(), new RequiredFactoryParamCodeFixProvider(), "RASK001", source);
-        Assert.False(offered);
+        Assert.True(offered);
     }
 
     [Fact]

--- a/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
+++ b/tests/Rask.Generators.Tests/ComponentFactoryGeneratorTests.cs
@@ -352,8 +352,11 @@ public class ComponentFactoryGeneratorTests
     }
 
     [Fact]
-    public void UserMarkedRequiredWithDI_RaisesRask002()
+    public void UserMarkedRequiredWithDI_NoRask002()
     {
+        // A DI ctor with no parameterless ctor builds via ActivatorUtilities.CreateInstance
+        // (reflection bypasses the CS9035 `required` check) and then post-assigns every factory
+        // param — so a required no-initializer prop IS honored. RASK002 must not fire.
         var src = """
                   using Rask.Core;
                   namespace Demo;
@@ -366,7 +369,12 @@ public class ComponentFactoryGeneratorTests
                   """;
 
         var run = GeneratorDriverFixture.Run(src);
-        Assert.Contains(run.Diagnostics, d => d.Id == "RASK002");
+        Assert.DoesNotContain(run.Diagnostics, d => d.Id == "RASK002");
+
+        // The value is honored at runtime via post-construction assignment after ActivatorUtilities.
+        var output = run.GeneratedSource("Demo.Generated.g.cs");
+        Assert.Contains("ActivatorUtilities.CreateInstance", output);
+        Assert.Contains("__c.Name = Name;", output);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

RASK002 (\"'required' property cannot be honored by the generated factory\") is a **false positive** for the common shape of a component that injects services through its constructor and exposes a `required` factory parameter:

```csharp
public sealed class Delete(IDispatcher dispatcher) : Component
{
    public required SomeId Id { get; set; }   // ← wrongly flagged RASK002
}
```

The diagnostic assumed that a DI constructor with **no** parameterless constructor cannot honor `required`. In reality the generated factory builds such a component with `ActivatorUtilities.CreateInstance<T>` (reflection — the C# `required`/CS9035 check does not apply) **and then post-assigns every factory parameter** (`__c.Id = Id;` via `EmitSnapshotsAndAssignments`). So the DI constructor runs (services are set) *and* the required value is honored at runtime. Under `TreatWarningsAsErrors`, the bogus warning breaks the consumer build.

## Fix

One-line condition change in `ComponentFactoryGenerator` — flip `!c.HasParameterlessCtor ||` to `c.HasParameterlessCtor &&`:

```csharp
// before
if (p.UserMarkedRequired && c.HasDIConstructor && (!c.HasParameterlessCtor || p.HasInitializer))
// after
if (p.UserMarkedRequired && c.HasDIConstructor && c.HasParameterlessCtor && p.HasInitializer)
```

RASK002 now fires in exactly one shape — the genuinely broken one: a component with **both** a DI ctor and a parameterless ctor **and** a `required` property carrying a member initializer. There the factory emits `new C() { … }`, whose object initializer excludes the initializer-carrying property (`IsParamProperty`), so the consumer build correctly hits CS9035.

The RASK001 quick-fix (`RequiredFactoryParamCodeFixProvider`) mirrored the old condition to withhold itself in the mis-flagged case; since adding `required` to a RASK001-flagged (no-initializer) prop can never trip the new RASK002, that guard is removed and the fix is now offered.

## Tests / docs

- Flipped `UserMarkedRequiredWithDI_RaisesRask002` → `UserMarkedRequiredWithDI_NoRask002`, asserting no RASK002 *and* that the generated factory post-assigns the prop after `ActivatorUtilities.CreateInstance`.
- Updated `Rask001_NotOffered_WhenAddingRequiredWouldTripRask002` → `Rask001_Offered_WithDIConstructorAndNoParameterless` (now offered).
- The other three RASK002 tests and `Rask001_Offered_WhenDIConstructorHasParameterlessSibling` are unchanged and green.
- Corrected the RASK002 section of `docs/diagnostics.md`; added a `## [Unreleased] → ### Fixed` CHANGELOG entry.

## Verification

- `dotnet build Rask.slnx -c Release -warnaserror -p:EnforceCodeStyleInBuild=true` — 0 warnings, 0 errors.
- `dotnet format Rask.slnx --verify-no-changes` — clean.
- `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — all green (Generators 219, Core 1813, Server 248, …).

## Known residual (out of scope)

A type with both a required-no-initializer prop and a required-*const*-initializer prop can still over-fire on the latter; tightening that needs sibling-aware reasoning for near-zero real incidence.