### PR TITLE
refactor(core): rename collection builder Create → __Fragment

### DIFF
--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -12,13 +12,13 @@ namespace Rask.Core;
 
 // [CollectionBuilder] makes `Component` itself a collection-expression target, so a render body
 // can be written as `Render() => [Doctype(), Html(...)]` (the items are built into a Fragment by
-// Create below). The builder is self-referential (typeof(Component)) and public so collection
+// __Fragment below). The builder is self-referential (typeof(Component)) and public so collection
 // expressions in *other* assemblies bind to it even though Fragment itself is internal. The
 // required iteration type comes from the *pattern* GetEnumerator below — Component deliberately
 // does NOT implement IEnumerable<Component>, because that would make the `this[IEnumerable<Component>]`
 // children indexer applicable to a bare component and silently rebind `Div()[Span()[...]]` from
 // "one child" to "the span's own children", collapsing nesting.
-[CollectionBuilder(typeof(Component), nameof(Create))]
+[CollectionBuilder(typeof(Component), "__Fragment")]
 public abstract class Component
 {
     // Pre-built "h0".."h255" so handler registration in the common case (small forms,
@@ -75,8 +75,9 @@ public abstract class Component
     // `Render()`/`Head` body written as `[Doctype(), Html(...)]` lands here and is wrapped in a
     // (tagless, internal) Fragment so the whole render pipeline keeps operating on a single
     // Component. Public because the compiler emits this call at each collection-expression site,
-    // including in user assemblies where Fragment is not visible.
-    public static Component Create(ReadOnlySpan<Component?> items) => new Fragment(items.ToArray());
+    // including in user assemblies where Fragment is not visible. NOT named `Create`: that would
+    // shadow a user component named `Create` (its generated factory) via base-member lookup.
+    public static Component __Fragment(ReadOnlySpan<Component?> items) => new Fragment(items.ToArray());
 
     // Heterogeneous-literal children: `Div()["Score: ", 42, Span()]`. These implicit conversions
     // (formerly on the deleted `Component` struct) let strings/primitives/dates flow into a children

--- a/tests/Rask.Core.Tests/Components/FragmentTests.cs
+++ b/tests/Rask.Core.Tests/Components/FragmentTests.cs
@@ -1,14 +1,14 @@
 namespace Rask.Core.Tests.Components;
 
 // A `[...]` collection expression targeting Component builds a tagless container (internally a
-// Fragment) via Component.Create. These pin the container's rendering: no children => empty string,
+// Fragment) via Component.__Fragment. These pin the container's rendering: no children => empty string,
 // single/multiple children => concatenated with no wrapping element, text children HTML-encoded.
 public class FragmentTests
 {
     [Fact]
     public void Render_NoChildren_EmitsEmptyString()
     {
-        Component empty = Component.Create([]);
+        Component empty = Component.__Fragment([]);
         Assert.Equal("", empty.ToHtml());
     }
 


### PR DESCRIPTION
## Summary

Renames the `Component` collection-expression builder from `Create` to `__Fragment`.

`[CollectionBuilder(typeof(Component), …)]` needs a public static so `[…]` render bodies in user
assemblies bind to it. Named `Create`, that public static was reachable via base-member lookup and
**shadowed the generated factory of a user component named `Create`** — its call resolved to the
fragment builder instead of the component. The double-underscore name keeps it out of the way of any
plausible user component name while remaining a valid `[CollectionBuilder]` target.

`[a, b]` render bodies are unaffected (the compiler emits the call from the attribute). The only
break is for the rare code that called `Component.Create(…)` explicitly — use `Component.__Fragment(…)`.

Scope is deliberately minimal: this is the anti-shadow rename only. A separate, more invasive
generator change (excluding cross-namespace shared factory names from the global usings) was
considered and dropped from this branch.

## Testing

- `dotnet build -warnaserror` → 0 warnings / 0 errors (proves the `[CollectionBuilder(…, "__Fragment")]`
  target still resolves and `[…]` collection expressions compile).
- `dotnet test` Fragment + children component tests → 10 passed (exercises `Component.__Fragment([])`).
- E2E: n/a — no `samples/` change.

## Benchmarks

n/a — pure rename, no render-hotpath change.

## CHANGELOG

No entry. `Component.Create`/`__Fragment` is a compiler-facing collection builder, not part of the
documented public authoring surface; explicit callers are effectively nonexistent pre-1.0. Happy to
add a `[Unreleased]` note if you'd prefer it documented as a breaking rename.
