### PR TITLE
fix(bootstrap): escape overflow-clipping ancestors for all Bs dropdown popovers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **Bs dropdown-family popovers no longer get clipped by an `overflow` ancestor.** The Popper-less
+  `.dropdown-menu` of `BsDatePicker`/`BsTimePicker`/`BsDateTimePicker`, `BsDropdown`, and `BsMultiSelect`
+  was `position: absolute`, so opening one inside a card or scroll region (anything with
+  `overflow: hidden/auto`) cut it off. A tiny declarative runtime helper (`data-rask-popover`, alongside
+  the focus trap) now re-anchors an open menu with `position: fixed` and viewport-computed coordinates —
+  below the trigger, flipping above when it doesn't fit, clamped into the viewport, right-aligned for
+  `BsDropdown(AlignEnd: true)` — so it escapes every overflow-clipping ancestor and tracks the trigger on
+  scroll/resize. (Caveat: an ancestor with a CSS `transform`/`filter`/`contain` becomes the fixed
+  containing block and re-clips the popover — a browser rule.) Added a `BsDropdown` showcase demo.
+
 ## [0.15.1] - 2026-07-08
 
 ### Changed

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -120,6 +120,11 @@ its title, or `aria-label` from the title text), and dismisses on `Escape` (exce
 which keeps `Escape` inert per Bootstrap). Build your own overlay the same way — add `data-rask-focus-trap`
 (via the `Data` dictionary) and mark your close control with `data-rask-dismiss`.
 
+A sibling runtime helper keys off `data-rask-popover` to place the Bs dropdown-family menus (the
+date/time pickers, `BsDropdown`, `BsMultiSelect`) with `position: fixed` while open, so the menu escapes
+any `overflow: hidden/auto` ancestor instead of being clipped. It is placement only — the components'
+keyboard navigation, ARIA roles, and focus behavior are unchanged.
+
 ## Navigation
 
 Client-side (SPA) route changes on the Server live runtime are handled accessibly without any wiring:

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -23,9 +23,8 @@ protected override Component? Head =>
 
 `BootstrapStyles(Icons: false)` skips the Bootstrap Icons stylesheet. It also always links a tiny
 `rask-bootstrap.css` (after Bootstrap, so it wins the cascade) with fixes for the zero-JS components:
-a `BsDropdown` inside a `BsTable(Responsive: true)` would otherwise be clipped by the scroll
-container's overflow, and `BsDropdown(AlignEnd: true)` would otherwise be a no-op because Bootstrap
-gates its alignment classes on a Popper-only attribute. The assets are served by the host's static-file pipeline (`app.UseStaticFiles()` /
+`BsDropdown(AlignEnd: true)` would otherwise be a no-op because Bootstrap gates its alignment classes
+on a Popper-only attribute. The assets are served by the host's static-file pipeline (`app.UseStaticFiles()` /
 `app.MapStaticAssets()` on Server; the WASM static-web-asset pipeline bakes them into the published
 `wwwroot` automatically).
 
@@ -115,6 +114,19 @@ order/names and month label from `CultureInfo.CurrentCulture`, and constrain sel
 `<input type=date|time|datetime-local>`:
 
 <!-- demo:bootstrap-pickers -->
+
+**Dropdowns** — `BsDropdown`(+`BsDropdownItem`) is a controlled, Popper-less menu: you own the `Open`
+state and wire `OnToggle`, and each item's handler closes it on selection. `AlignEnd` right-aligns the
+menu:
+
+<!-- demo:bootstrap-dropdown -->
+
+Every Bs `.dropdown-menu` popover — the pickers, `BsDropdown`, and `BsMultiSelect` — is re-anchored with
+`position: fixed` while open by a tiny runtime helper (declarative, opt-in via `data-rask-popover`), so
+it escapes any `overflow: hidden/auto` ancestor (a card, a scroll region) instead of being clipped, and
+tracks the trigger on scroll/resize. The one exception is a browser rule, not a Rask bug: an ancestor
+with a CSS `transform`/`filter`/`perspective`/`will-change`/`contain` becomes the containing block for
+`position: fixed`, so a popover inside it is clamped to that box rather than the viewport.
 
 ## Utility classes
 

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsDropdownDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsDropdownDemo.cs
@@ -1,0 +1,41 @@
+namespace Rask.Example.Shared.Features;
+
+// BsDropdown is controlled (zero-JS): _open is a plain field, OnToggle flips it, and each BsDropdownItem's
+// OnClick sets it back to false on selection. The menu is a Popper-less .dropdown-menu — Rask re-anchors
+// it with position:fixed while open, so it escapes this overflow:hidden sample card instead of being
+// clipped. The right-aligned variant shows AlignEnd working without Popper.
+public sealed class BsDropdownDemo : Component
+{
+    private bool _open;
+    private bool _alignOpen;
+    private string _picked = "—";
+
+    protected override Component? Render() =>
+    [
+        Div(Class: Bs.Join(Display.Flex(), Flex.Gap(3), Flex.Wrap()))[
+            BsDropdown(Id: "demo-dropdown", Label: "Actions", Color: BsColor.Primary,
+                Open: _open, OnToggle: () => _open = !_open)[
+                BsDropdownItem(Header: true)["Manage"],
+                BsDropdownItem(OnClick: () => Pick("Edit"))["Edit"],
+                BsDropdownItem(OnClick: () => Pick("Duplicate"))["Duplicate"],
+                BsDropdownItem(Divider: true),
+                BsDropdownItem(OnClick: () => Pick("Archive"))["Archive"]
+            ],
+            BsDropdown(Id: "demo-dropdown-end", Label: "Right-aligned", Color: BsColor.Secondary,
+                AlignEnd: true, Open: _alignOpen, OnToggle: () => _alignOpen = !_alignOpen)[
+                BsDropdownItem(OnClick: () => Pick("Share"))["Share"],
+                BsDropdownItem(OnClick: () => Pick("Export"))["Export"]
+            ]
+        ],
+        BsAlert(Color: BsColor.Info, Class: "mt-3 mb-0")[
+            Span(Id: "demo-dropdown-out")["Last action: ", Strong()[_picked]]
+        ]
+    ];
+
+    private void Pick(string action)
+    {
+        _picked = action;
+        _open = false;
+        _alignOpen = false;
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -245,6 +245,7 @@ public static class DemoRegistry
             ["bootstrap-icons"] = () => CodeSample(["BsIconsDemo.cs"], Result: BsIconsDemo()),
             ["bootstrap-modal"] = () => CodeSample(["BsModalDemo.cs"], Result: BsModalDemo()),
             ["bootstrap-tabs"] = () => CodeSample(["BsTabsDemo.cs"], Result: BsTabsDemo()),
+            ["bootstrap-dropdown"] = () => CodeSample(["BsDropdownDemo.cs"], Result: BsDropdownDemo()),
             ["bootstrap-forms"] = () => CodeSample(["BsFormsDemo.cs"], Result: BsFormsDemo()),
             ["bootstrap-pickers"] = () => CodeSample(["BsPickersDemo.cs"], Result: BsPickersDemo()),
             ["bootstrap-utilities"] = () => CodeSample(["BsUtilitiesDemo.cs"], Result: BsUtilitiesDemo()),

--- a/src/Rask.Bootstrap/BsDropdown.cs
+++ b/src/Rask.Bootstrap/BsDropdown.cs
@@ -22,7 +22,8 @@ public sealed class BsDropdown : BsBlock
         var open = Open is true;
         var expanded = new Dictionary<string, string?> { ["expanded"] = open ? "true" : "false" };
 
-        return Div(Id: Id, Class: BsClass.Join("dropdown", Class))[
+        return Div(Id: Id, Class: BsClass.Join("dropdown", Class),
+            Data: BsPopover.WrapperFor(AlignEnd is true))[
             BsButton(Color: Color, Outline: Outline, Size: Size, Class: "dropdown-toggle",
                 Aria: expanded, OnClick: OnToggle, OnClickAsync: OnToggleAsync)[Label ?? ""],
             Ul(Class: BsClass.Join("dropdown-menu", AlignEnd is true ? "dropdown-menu-end" : null,

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -110,6 +110,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         var boxDiv = Div(
             Class: BsClass.Join("form-select", Sizing.HAuto, Display.Flex(), Flex.Wrap(),
                 Flex.Align(BsAlign.Center), Flex.Gap(1), disabled ? "disabled pe-none" : null),
+            Data: BsPopover.Anchor,
             TabIndex: disabled ? null : 0,
             OnClick: disabled ? null : () => _open = !_open,
             OnKeyDown: disabled ? null : OnBoxKeyDown)[box];
@@ -146,7 +147,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                 msgs => Div(Class: BsClass.Join("invalid-feedback", Display.Block()))[msgs[0]]));
         }
 
-        return Div(Class: BsClass.Join("dropdown", Class), Id: Id)[children];
+        return Div(Class: BsClass.Join("dropdown", Class), Id: Id, Data: BsPopover.Wrapper)[children];
     }
 
     private void OnBoxKeyDown(KeyboardEventArgs e)

--- a/src/Rask.Bootstrap/BsPickerBase.cs
+++ b/src/Rask.Bootstrap/BsPickerBase.cs
@@ -111,6 +111,7 @@ public abstract class BsPickerBase<T> : BsFormControl<T>
                 Display.Flex(), Flex.Align(BsAlign.Center),
                 b.Invalid ? "is-invalid" : null, disabled ? "disabled pe-none" : null, Class),
             Id: controlId,
+            Data: BsPopover.Anchor,
             Role: "combobox",
             TabIndex: disabled ? null : 0,
             Aria: boxAria,
@@ -140,7 +141,7 @@ public abstract class BsPickerBase<T> : BsFormControl<T>
 
         // The popover is always in the DOM (like BsMultiSelect's menu); the picker toggles .show/.d-block
         // from Open, so a closed picker still renders the grid (hidden) and its markup is testable.
-        var control = Div(Class: BsClass.Join("dropdown", Position.Relative))[
+        var control = Div(Class: BsClass.Join("dropdown", Position.Relative), Data: BsPopover.Wrapper)[
             box,
             clear,
             popover,

--- a/src/Rask.Bootstrap/BsPopover.cs
+++ b/src/Rask.Bootstrap/BsPopover.cs
@@ -1,0 +1,26 @@
+namespace Rask.Bootstrap;
+
+// Shared opt-in markers for the declarative fixed-position popover helper (installRaskPopover in
+// Rask.Core's rask-dom.js). Every Popper-less .dropdown-menu component (the date/time pickers,
+// BsDropdown, BsMultiSelect) marks its .dropdown wrapper with data-rask-popover and its trigger with
+// data-rask-anchor. While the menu carries .show the client JS re-anchors it with position:fixed and
+// viewport-computed coordinates, so it escapes any overflow-clipping ancestor (a card, a scroll region)
+// instead of being cut off like a plain position:absolute menu. Attribute-only — no render hot-path
+// cost; the dictionaries are shared immutable singletons.
+internal static class BsPopover
+{
+    // Marks the .dropdown wrapper the helper manages (it resolves the .show menu + the anchor inside it).
+    internal static readonly IReadOnlyDictionary<string, string?> Wrapper =
+        new Dictionary<string, string?> { ["rask-popover"] = "" };
+
+    // Wrapper variant that asks the helper to right-align the menu to the trigger (BsDropdown AlignEnd).
+    private static readonly IReadOnlyDictionary<string, string?> WrapperEnd =
+        new Dictionary<string, string?> { ["rask-popover"] = "", ["rask-popover-align"] = "end" };
+
+    // Marks the trigger element the menu anchors to (falls back to .dropdown-toggle / firstElementChild).
+    internal static readonly IReadOnlyDictionary<string, string?> Anchor =
+        new Dictionary<string, string?> { ["rask-anchor"] = "" };
+
+    internal static IReadOnlyDictionary<string, string?> WrapperFor(bool alignEnd) =>
+        alignEnd ? WrapperEnd : Wrapper;
+}

--- a/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
+++ b/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
@@ -18,21 +18,12 @@
   left: 0;
 }
 
-/* A dropdown menu inside a scrollable table is clipped by the scroll container: Bootstrap's
-   .table-responsive sets overflow-x:auto, and per the CSS overflow spec a non-visible value on one
-   axis forces the other axis to auto — so the menu, which overflows downward, is cut off. Rask
-   dropdowns are Popper-less (no JS to portal the menu out), so while a menu is open let the container
-   overflow so the menu shows.
-
-   This must be `overflow: visible` (both axes). The narrower `overflow-x: clip; overflow-y: visible`
-   is tempting — it would keep a wide table from spilling horizontally — and it works in Chromium, but
-   WebKit/Safari clips the "visible" axis too and the menu vanishes. `overflow: visible` is honoured
-   everywhere; pair it with a right-aligned menu (AlignEnd, above) so the menu itself stays within the
-   row. A very wide table can momentarily spill horizontally while a menu is open — keep
-   `overflow-x: hidden` on the page body if that matters to your layout. */
-.table-responsive:has(.dropdown-menu.show) {
-  overflow: visible;
-}
+/* (A dropdown menu inside a scrollable ancestor — .table-responsive, a card, any overflow:auto/hidden
+   region — used to be clipped, and was un-clipped here by forcing the container to overflow:visible.
+   That is superseded by the runtime popover helper (data-rask-popover in rask-dom.js), which re-anchors
+   an open menu with position:fixed so it escapes every overflow ancestor without the container having to
+   spill. No CSS override is needed — and forcing overflow:visible on a wide responsive table would have
+   let it spill horizontally for no benefit now that the menu is fixed.) */
 
 /* Date/time pickers (BsDatePicker/BsTimePicker/BsDateTimePicker). The popover is a plain
    .dropdown-menu we position with live-diff state (no Popper); these rules only style the calendar

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -431,6 +431,200 @@ function applyFrameInvokes(reply, dispatchOne) {
     sync(); // a trap already present at load
 })();
 
+// ----- Overflow-escaping popover (data-rask-popover) ---------------------
+// The Popper-less .dropdown-menu components (BsDatePicker/BsTimePicker/BsDateTimePicker, BsDropdown,
+// BsMultiSelect) render their menu as position:absolute inside a .dropdown wrapper, so any ancestor
+// with overflow:hidden/auto (a card, a scroll region) clips it — the menu opens but is cut off. This
+// helper re-anchors an open menu with position:fixed + viewport-computed coordinates, which resolves
+// against the viewport and so escapes every overflow-clipping ancestor. A component opts in by marking
+// its .dropdown wrapper with data-rask-popover and its trigger with data-rask-anchor; while the
+// wrapper's .dropdown-menu carries .show the menu is placed below the trigger (flipping above when it
+// doesn't fit), clamped into the viewport, right-aligned when data-rask-popover-align="end". A single
+// document MutationObserver watches the .show class toggle (the menus persist in the DOM), and
+// capture-phase scroll + resize keep the menu pinned to the trigger.
+//
+// Caveat: position:fixed only escapes overflow when NO ancestor establishes a fixed containing block
+// (a non-none transform / filter / perspective / backdrop-filter / will-change of those, or contain:
+// paint/layout/strict/content). Inside such an ancestor the menu is clamped to that box instead of the
+// viewport — a browser rule, not a Rask bug. Selectors here carry no escaped quotes/backslashes (the
+// WASM client-JS splice mangles them, as noted on the focus trap above).
+(function installRaskPopover() {
+    if (typeof document === "undefined" || typeof MutationObserver === "undefined"
+        || window.__raskPopover) {
+        return;
+    }
+    window.__raskPopover = true;
+
+    const GAP = 2;      // px between the trigger and the menu
+    const MARGIN = 8;   // min px kept between the menu and every viewport edge
+    const Z = 1000;     // above the components' fixed click-outside backdrop (z-index 999)
+
+    // Every opted-in wrapper that currently has an open (.show) menu, paired with that menu.
+    function openMenus() {
+        const pairs = [];
+        const wraps = document.querySelectorAll("[data-rask-popover]");
+        for (let i = 0; i < wraps.length; i++) {
+            const menu = wraps[i].querySelector(".dropdown-menu.show");
+            if (menu) {
+                pairs.push({ wrap: wraps[i], menu: menu });
+            }
+        }
+        return pairs;
+    }
+
+    function anchorOf(wrap) {
+        return wrap.querySelector("[data-rask-anchor]")
+            || wrap.querySelector(".dropdown-toggle")
+            || wrap.firstElementChild;
+    }
+
+    function place(wrap, menu) {
+        const anchor = anchorOf(wrap);
+        if (!anchor) {
+            return;
+        }
+        // Clear our own height cap before measuring so the menu's natural size drives placement — else
+        // each reposition would feed the previous frame's cap back in. (Width is pinned and stable below,
+        // so it needs no such reset.)
+        menu.style.maxHeight = "";
+        // Measure BEFORE switching to fixed: a menu sized with w-100 (BsMultiSelect) still reports the
+        // trigger width here, but would stretch to the viewport once position:fixed — so pin that width.
+        const a = anchor.getBoundingClientRect();
+        const m = menu.getBoundingClientRect();
+        const natH = menu.scrollHeight; // full content height, unaffected by the maxHeight we apply below
+        const vw = document.documentElement.clientWidth;
+        const vh = document.documentElement.clientHeight;
+        const alignEnd = wrap.getAttribute("data-rask-popover-align") === "end";
+
+        // Vertical: below by default; flip above only when it doesn't fit below and there is more room up.
+        const roomBelow = vh - a.bottom - GAP - MARGIN;
+        const roomAbove = a.top - GAP - MARGIN;
+        let top = (natH <= roomBelow || roomBelow >= roomAbove)
+            ? a.bottom + GAP
+            : a.top - GAP - natH;
+        if (top < MARGIN) {
+            top = MARGIN;
+        }
+
+        // Horizontal: align to the trigger's start (or end), then clamp into the viewport.
+        let left = alignEnd ? (a.right - m.width) : a.left;
+        if (left + m.width > vw - MARGIN) {
+            left = vw - MARGIN - m.width;
+        }
+        if (left < MARGIN) {
+            left = MARGIN;
+        }
+
+        menu.style.position = "fixed";
+        menu.style.margin = "0";
+        menu.style.zIndex = "" + Z;
+        menu.style.width = m.width + "px";
+        menu.style.left = left + "px";
+        menu.style.top = top + "px";
+        // Cap the height to the space between the menu top and the viewport bottom and scroll internally,
+        // so a menu taller than the viewport (a long list, a calendar on a short window) stays fully
+        // reachable instead of overflowing off-screen — a fixed element can't be revealed by page scroll
+        // the way the old position:absolute menu could.
+        menu.style.maxHeight = (vh - top - MARGIN) + "px";
+        menu.style.overflowY = "auto";
+        // A fixed menu no longer clips together with its trigger, so hide it while the trigger is scrolled
+        // entirely out of the viewport rather than leaving it floating detached over unrelated content.
+        menu.style.visibility =
+            (a.bottom <= 0 || a.top >= vh || a.right <= 0 || a.left >= vw) ? "hidden" : "";
+    }
+
+    // Return a closed menu to its normal in-flow (position:absolute) rendering.
+    function reset(menu) {
+        menu.style.position = "";
+        menu.style.margin = "";
+        menu.style.zIndex = "";
+        menu.style.width = "";
+        menu.style.left = "";
+        menu.style.top = "";
+        menu.style.maxHeight = "";
+        menu.style.overflowY = "";
+        menu.style.visibility = "";
+    }
+
+    // Re-place every open menu; returns how many were open so callers can track whether any remain.
+    function reposition() {
+        const pairs = openMenus();
+        for (let i = 0; i < pairs.length; i++) {
+            place(pairs[i].wrap, pairs[i].menu);
+        }
+        return pairs.length;
+    }
+
+    // True while at least one popover menu is open. Kept so the observer can cheaply skip idle morphs
+    // (no open menu, nothing popover-related changed) without a document query.
+    let hasOpen = false;
+
+    // Coalesce the high-frequency scroll/resize path to one run per animation frame so a burst doesn't
+    // thrash layout (each place() reads geometry then writes styles).
+    let scheduled = false;
+    function scheduleReposition() {
+        if (scheduled) {
+            return;
+        }
+        scheduled = true;
+        requestAnimationFrame(function () {
+            scheduled = false;
+            hasOpen = reposition() > 0;
+        });
+    }
+
+    // Scroll doesn't bubble, but a capture-phase listener on window still receives it from any ancestor
+    // scroller, so the menu tracks the trigger when a card / scroll region (not just the page) scrolls.
+    window.addEventListener("scroll", scheduleReposition, true);
+    window.addEventListener("resize", scheduleReposition);
+
+    // Does a mutation batch touch a popover (a menu's class toggled, or a subtree add/remove containing
+    // one)? Used only to detect the open transition when nothing was open before.
+    function touchesPopover(nodes) {
+        for (let i = 0; i < nodes.length; i++) {
+            const n = nodes[i];
+            if (n.nodeType === 1
+                && (n.matches("[data-rask-popover],.dropdown-menu")
+                    || n.querySelector("[data-rask-popover],.dropdown-menu"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // The live-diff morph reconciles each element's attributes back to the rendered output, and the
+    // rendered menu carries no inline style — so ANY re-render of a component with an open menu strips the
+    // fixed positioning we wrote (an unrelated style-attribute write the class-only observer never sees).
+    // So while a menu is open we must re-place after every morph batch, not only when the menu node itself
+    // changed — hence `hasOpen` in the gate. When nothing is open and nothing popover-related changed, the
+    // gate skips the document query entirely, so idle live-diff churn stays free. Runs synchronously (in
+    // the mutation microtask) so a just-opened menu is fixed before anything can read it as absolute.
+    const observer = new MutationObserver(function (records) {
+        let touched = false;
+        for (let i = 0; i < records.length; i++) {
+            const r = records[i];
+            if (r.type === "attributes") {
+                const t = r.target;
+                if (t.nodeType === 1 && t.classList && t.classList.contains("dropdown-menu")) {
+                    touched = true;
+                    if (!t.classList.contains("show") && t.closest("[data-rask-popover]")) {
+                        reset(t); // just closed — drop the fixed inline styles
+                    }
+                }
+            } else if (touchesPopover(r.addedNodes) || touchesPopover(r.removedNodes)) {
+                touched = true;
+            }
+        }
+        if (touched || hasOpen) {
+            hasOpen = reposition() > 0;
+        }
+    });
+    observer.observe(document.documentElement,
+        { subtree: true, childList: true, attributes: true, attributeFilter: ["class"] });
+
+    hasOpen = reposition() > 0; // a menu already open at load
+})();
+
 // ----- Recovery affordance (data-rask-reload) ----------------------------
 // A click on any element carrying data-rask-reload reloads the page. Used by the default error page so a
 // user stranded on an uncaught fault has an in-app way back without hunting for the browser's reload.

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -3055,6 +3055,200 @@ function applyFrameInvokes(reply, dispatchOne) {
     sync(); // a trap already present at load
 })();
 
+// ----- Overflow-escaping popover (data-rask-popover) ---------------------
+// The Popper-less .dropdown-menu components (BsDatePicker/BsTimePicker/BsDateTimePicker, BsDropdown,
+// BsMultiSelect) render their menu as position:absolute inside a .dropdown wrapper, so any ancestor
+// with overflow:hidden/auto (a card, a scroll region) clips it — the menu opens but is cut off. This
+// helper re-anchors an open menu with position:fixed + viewport-computed coordinates, which resolves
+// against the viewport and so escapes every overflow-clipping ancestor. A component opts in by marking
+// its .dropdown wrapper with data-rask-popover and its trigger with data-rask-anchor; while the
+// wrapper's .dropdown-menu carries .show the menu is placed below the trigger (flipping above when it
+// doesn't fit), clamped into the viewport, right-aligned when data-rask-popover-align="end". A single
+// document MutationObserver watches the .show class toggle (the menus persist in the DOM), and
+// capture-phase scroll + resize keep the menu pinned to the trigger.
+//
+// Caveat: position:fixed only escapes overflow when NO ancestor establishes a fixed containing block
+// (a non-none transform / filter / perspective / backdrop-filter / will-change of those, or contain:
+// paint/layout/strict/content). Inside such an ancestor the menu is clamped to that box instead of the
+// viewport — a browser rule, not a Rask bug. Selectors here carry no escaped quotes/backslashes (the
+// WASM client-JS splice mangles them, as noted on the focus trap above).
+(function installRaskPopover() {
+    if (typeof document === "undefined" || typeof MutationObserver === "undefined"
+        || window.__raskPopover) {
+        return;
+    }
+    window.__raskPopover = true;
+
+    const GAP = 2;      // px between the trigger and the menu
+    const MARGIN = 8;   // min px kept between the menu and every viewport edge
+    const Z = 1000;     // above the components' fixed click-outside backdrop (z-index 999)
+
+    // Every opted-in wrapper that currently has an open (.show) menu, paired with that menu.
+    function openMenus() {
+        const pairs = [];
+        const wraps = document.querySelectorAll("[data-rask-popover]");
+        for (let i = 0; i < wraps.length; i++) {
+            const menu = wraps[i].querySelector(".dropdown-menu.show");
+            if (menu) {
+                pairs.push({ wrap: wraps[i], menu: menu });
+            }
+        }
+        return pairs;
+    }
+
+    function anchorOf(wrap) {
+        return wrap.querySelector("[data-rask-anchor]")
+            || wrap.querySelector(".dropdown-toggle")
+            || wrap.firstElementChild;
+    }
+
+    function place(wrap, menu) {
+        const anchor = anchorOf(wrap);
+        if (!anchor) {
+            return;
+        }
+        // Clear our own height cap before measuring so the menu's natural size drives placement — else
+        // each reposition would feed the previous frame's cap back in. (Width is pinned and stable below,
+        // so it needs no such reset.)
+        menu.style.maxHeight = "";
+        // Measure BEFORE switching to fixed: a menu sized with w-100 (BsMultiSelect) still reports the
+        // trigger width here, but would stretch to the viewport once position:fixed — so pin that width.
+        const a = anchor.getBoundingClientRect();
+        const m = menu.getBoundingClientRect();
+        const natH = menu.scrollHeight; // full content height, unaffected by the maxHeight we apply below
+        const vw = document.documentElement.clientWidth;
+        const vh = document.documentElement.clientHeight;
+        const alignEnd = wrap.getAttribute("data-rask-popover-align") === "end";
+
+        // Vertical: below by default; flip above only when it doesn't fit below and there is more room up.
+        const roomBelow = vh - a.bottom - GAP - MARGIN;
+        const roomAbove = a.top - GAP - MARGIN;
+        let top = (natH <= roomBelow || roomBelow >= roomAbove)
+            ? a.bottom + GAP
+            : a.top - GAP - natH;
+        if (top < MARGIN) {
+            top = MARGIN;
+        }
+
+        // Horizontal: align to the trigger's start (or end), then clamp into the viewport.
+        let left = alignEnd ? (a.right - m.width) : a.left;
+        if (left + m.width > vw - MARGIN) {
+            left = vw - MARGIN - m.width;
+        }
+        if (left < MARGIN) {
+            left = MARGIN;
+        }
+
+        menu.style.position = "fixed";
+        menu.style.margin = "0";
+        menu.style.zIndex = "" + Z;
+        menu.style.width = m.width + "px";
+        menu.style.left = left + "px";
+        menu.style.top = top + "px";
+        // Cap the height to the space between the menu top and the viewport bottom and scroll internally,
+        // so a menu taller than the viewport (a long list, a calendar on a short window) stays fully
+        // reachable instead of overflowing off-screen — a fixed element can't be revealed by page scroll
+        // the way the old position:absolute menu could.
+        menu.style.maxHeight = (vh - top - MARGIN) + "px";
+        menu.style.overflowY = "auto";
+        // A fixed menu no longer clips together with its trigger, so hide it while the trigger is scrolled
+        // entirely out of the viewport rather than leaving it floating detached over unrelated content.
+        menu.style.visibility =
+            (a.bottom <= 0 || a.top >= vh || a.right <= 0 || a.left >= vw) ? "hidden" : "";
+    }
+
+    // Return a closed menu to its normal in-flow (position:absolute) rendering.
+    function reset(menu) {
+        menu.style.position = "";
+        menu.style.margin = "";
+        menu.style.zIndex = "";
+        menu.style.width = "";
+        menu.style.left = "";
+        menu.style.top = "";
+        menu.style.maxHeight = "";
+        menu.style.overflowY = "";
+        menu.style.visibility = "";
+    }
+
+    // Re-place every open menu; returns how many were open so callers can track whether any remain.
+    function reposition() {
+        const pairs = openMenus();
+        for (let i = 0; i < pairs.length; i++) {
+            place(pairs[i].wrap, pairs[i].menu);
+        }
+        return pairs.length;
+    }
+
+    // True while at least one popover menu is open. Kept so the observer can cheaply skip idle morphs
+    // (no open menu, nothing popover-related changed) without a document query.
+    let hasOpen = false;
+
+    // Coalesce the high-frequency scroll/resize path to one run per animation frame so a burst doesn't
+    // thrash layout (each place() reads geometry then writes styles).
+    let scheduled = false;
+    function scheduleReposition() {
+        if (scheduled) {
+            return;
+        }
+        scheduled = true;
+        requestAnimationFrame(function () {
+            scheduled = false;
+            hasOpen = reposition() > 0;
+        });
+    }
+
+    // Scroll doesn't bubble, but a capture-phase listener on window still receives it from any ancestor
+    // scroller, so the menu tracks the trigger when a card / scroll region (not just the page) scrolls.
+    window.addEventListener("scroll", scheduleReposition, true);
+    window.addEventListener("resize", scheduleReposition);
+
+    // Does a mutation batch touch a popover (a menu's class toggled, or a subtree add/remove containing
+    // one)? Used only to detect the open transition when nothing was open before.
+    function touchesPopover(nodes) {
+        for (let i = 0; i < nodes.length; i++) {
+            const n = nodes[i];
+            if (n.nodeType === 1
+                && (n.matches("[data-rask-popover],.dropdown-menu")
+                    || n.querySelector("[data-rask-popover],.dropdown-menu"))) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    // The live-diff morph reconciles each element's attributes back to the rendered output, and the
+    // rendered menu carries no inline style — so ANY re-render of a component with an open menu strips the
+    // fixed positioning we wrote (an unrelated style-attribute write the class-only observer never sees).
+    // So while a menu is open we must re-place after every morph batch, not only when the menu node itself
+    // changed — hence `hasOpen` in the gate. When nothing is open and nothing popover-related changed, the
+    // gate skips the document query entirely, so idle live-diff churn stays free. Runs synchronously (in
+    // the mutation microtask) so a just-opened menu is fixed before anything can read it as absolute.
+    const observer = new MutationObserver(function (records) {
+        let touched = false;
+        for (let i = 0; i < records.length; i++) {
+            const r = records[i];
+            if (r.type === "attributes") {
+                const t = r.target;
+                if (t.nodeType === 1 && t.classList && t.classList.contains("dropdown-menu")) {
+                    touched = true;
+                    if (!t.classList.contains("show") && t.closest("[data-rask-popover]")) {
+                        reset(t); // just closed — drop the fixed inline styles
+                    }
+                }
+            } else if (touchesPopover(r.addedNodes) || touchesPopover(r.removedNodes)) {
+                touched = true;
+            }
+        }
+        if (touched || hasOpen) {
+            hasOpen = reposition() > 0;
+        }
+    });
+    observer.observe(document.documentElement,
+        { subtree: true, childList: true, attributes: true, attributeFilter: ["class"] });
+
+    hasOpen = reposition() > 0; // a menu already open at load
+})();
+
 // ----- Recovery affordance (data-rask-reload) ----------------------------
 // A click on any element carrying data-rask-reload reloads the page. Used by the default error page so a
 // user stranded on an uncaught fault has an in-app way back without hunting for the browser's reload.

--- a/tests/Rask.Bootstrap.Tests/BsDropdownTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDropdownTests.cs
@@ -6,7 +6,7 @@ public class BsDropdownTests
     [Fact]
     public void Dropdown_Closed_RendersToggleAndHiddenMenu() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\">" +
             "<button class=\"btn btn-primary dropdown-toggle\" aria-expanded=\"false\" type=\"button\">Menu</button>" +
             "<ul class=\"dropdown-menu\">" +
             "<li><a class=\"dropdown-item\" href=\"/a\">A</a></li>" +
@@ -22,7 +22,7 @@ public class BsDropdownTests
     [Fact]
     public void Dropdown_Open_ShowsMenuAndExpandsToggle() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\">" +
             "<button class=\"btn btn-secondary dropdown-toggle\" aria-expanded=\"true\" type=\"button\">Actions</button>" +
             "<ul class=\"dropdown-menu show\"></ul></div>",
             BsDropdown(Label: "Actions", Color: BsColor.Secondary, Open: true).ToHtml());
@@ -30,7 +30,7 @@ public class BsDropdownTests
     [Fact]
     public void Dropdown_AlignEnd_RightAlignsMenu() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\" data-rask-popover-align=\"end\">" +
             "<button class=\"btn btn-primary dropdown-toggle\" aria-expanded=\"false\" type=\"button\">M</button>" +
             "<ul class=\"dropdown-menu dropdown-menu-end\"></ul></div>",
             BsDropdown(Label: "M", Color: BsColor.Primary, AlignEnd: true).ToHtml());

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -8,8 +8,9 @@ public class BsMultiSelectTests
     [Fact]
     public void MultiSelect_Empty_ShowsPlaceholderAndUncheckedOptions() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
-            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" tabindex=\"0\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\">" +
+            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" " +
+            "data-rask-anchor=\"\" tabindex=\"0\">" +
             "<span class=\"text-secondary\">Select&#x2026;</span></div>" +
             "<div class=\"dropdown-menu\">" +
             "<button class=\"dropdown-item d-flex align-items-center gap-2\" data-rask-key=\"0\" type=\"button\">" +
@@ -22,8 +23,9 @@ public class BsMultiSelectTests
     [Fact]
     public void MultiSelect_WithSelection_RendersChipsAndChecksSelectedOptions() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
-            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" tabindex=\"0\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\">" +
+            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" " +
+            "data-rask-anchor=\"\" tabindex=\"0\">" +
             "<span class=\"badge text-bg-primary d-inline-flex align-items-center\" data-rask-key=\"0\">a" +
             "<button class=\"btn-close btn-close-white ms-1\" aria-label=\"Close\" type=\"button\"></button></span>" +
             "<span class=\"badge text-bg-primary d-inline-flex align-items-center\" data-rask-key=\"1\">c" +
@@ -42,9 +44,10 @@ public class BsMultiSelectTests
     [Fact]
     public void MultiSelect_Label_SitsAboveTheControl() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\">" +
             "<label class=\"form-label\">Tags</label>" +
-            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" tabindex=\"0\">" +
+            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" " +
+            "data-rask-anchor=\"\" tabindex=\"0\">" +
             "<span class=\"text-secondary\">Select&#x2026;</span></div>" +
             "<div class=\"dropdown-menu\"></div></div>",
             BsMultiSelect<string>(Options: [], Value: new List<string>(), Label: "Tags").ToHtml());
@@ -52,8 +55,9 @@ public class BsMultiSelectTests
     [Fact]
     public void MultiSelect_CustomPlaceholder_ReplacesDefault() =>
         Assert.Equal(
-            "<div class=\"dropdown\">" +
-            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" tabindex=\"0\">" +
+            "<div class=\"dropdown\" data-rask-popover=\"\">" +
+            "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" " +
+            "data-rask-anchor=\"\" tabindex=\"0\">" +
             "<span class=\"text-secondary\">Pick tags</span></div>" +
             "<div class=\"dropdown-menu\"></div></div>",
             BsMultiSelect<string>(Options: [], Value: new List<string>(), Placeholder: "Pick tags").ToHtml());

--- a/tests/Rask.Bootstrap.Tests/BsPickerTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsPickerTests.cs
@@ -44,6 +44,16 @@ public class BsPickerTests
     }
 
     [Fact]
+    public void Date_OptsIntoTheFixedPopoverHelper()
+    {
+        // The .dropdown wrapper is marked data-rask-popover and the combobox box data-rask-anchor, so the
+        // runtime re-anchors the open popover with position:fixed (escapes overflow-clipping ancestors).
+        var html = Html(Us, () => BsDatePicker<DateOnly>(Value: Jul7, Id: "d"));
+        Assert.Contains("class=\"dropdown position-relative\" data-rask-popover=\"\"", html);
+        Assert.Contains("data-rask-anchor=\"\" role=\"combobox\"", html);
+    }
+
+    [Fact]
     public void Date_Grid_HasGridRolesSelectedDayAndSevenHeaders()
     {
         var html = Html(Us, () => BsDatePicker<DateOnly>(Value: Jul7, Id: "d"));

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -285,8 +285,29 @@ public abstract partial class SharedSmokeTests
         await Page.Locator("#pick-date").First.ClickAsync();
         await Expect(Page.Locator("#pick-date-cal.bs-cal[role=\"grid\"]").First)
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        // The popover escapes the .sample-card { overflow:hidden } wrapper: the runtime helper
+        // (data-rask-popover in rask-dom.js, spliced into both hosts) re-anchors the open .dropdown-menu
+        // with position:fixed. Under the old position:absolute the card would clip it. Assert the menu is
+        // fixed and within the viewport — the regression guard for the overflow-clipping bug.
+        var pickMenu = Page.Locator(".dropdown-menu.show:has(#pick-date-cal)").First;
+        Assert.Equal("fixed", await pickMenu.EvaluateAsync<string>("el => getComputedStyle(el).position"));
+        await Expect(pickMenu).ToBeInViewportAsync(
+            new LocatorAssertionsToBeInViewportOptions { Timeout = 10_000 });
         await Page.Locator($"#pick-date-d-{ym}01").First.ClickAsync();
         await Expect(Page.Locator("#pick-readout")).ToContainTextAsync(firstIso,
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // Dropdown (Popper-less, controlled) opened inside the same overflow:hidden card — the menu is
+        // re-anchored position:fixed by the same helper so it isn't clipped. Selecting an item closes the
+        // menu (its handler sets Open=false) and updates the readout. AlignEnd is covered by the unit test.
+        await Page.Locator("#demo-dropdown .dropdown-toggle").First.ClickAsync();
+        var ddMenu = Page.Locator("#demo-dropdown .dropdown-menu.show").First;
+        await Expect(ddMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        Assert.Equal("fixed", await ddMenu.EvaluateAsync<string>("el => getComputedStyle(el).position"));
+        await Expect(ddMenu).ToBeInViewportAsync(
+            new LocatorAssertionsToBeInViewportOptions { Timeout = 10_000 });
+        await ddMenu.Locator("button").Filter(new LocatorFilterOptions { HasText = "Archive" }).First.ClickAsync();
+        await Expect(Page.Locator("#demo-dropdown-out")).ToContainTextAsync("Archive",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
     }
 
@@ -829,6 +850,8 @@ public abstract partial class SharedSmokeTests
         // The menu stays open across selections; Escape closes it (the focusable box handles keydown — no JS).
         var openMenu = Page.Locator("#ms-interests .dropdown-menu.show");
         await Expect(openMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        // Same overflow-escape helper: the open menu is re-anchored position:fixed (data-rask-popover).
+        Assert.Equal("fixed", await openMenu.EvaluateAsync<string>("el => getComputedStyle(el).position"));
         await multi.Locator(".form-select").FocusAsync();
         await Page.Keyboard.PressAsync("Escape");
         await Expect(openMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });


### PR DESCRIPTION
## Summary

Bootstrap `.dropdown-menu` popovers across the whole Bs family — `BsDatePicker`/`BsTimePicker`/`BsDateTimePicker`, `BsDropdown`, `BsMultiSelect` — were `position: absolute` (Popper-less, no portal), so opening one inside a card or scroll region (any `overflow: hidden/auto` ancestor) clipped it: the menu opened but was cut off. Every showcase demo sits in `.sample-card { overflow: hidden }`, which is exactly the clipping the date controls showed on GitHub Pages.

The reporter asked for **one abstract solution for the whole dropdown family**, not a per-component patch.

## Approach

A single declarative runtime helper `installRaskPopover` (in `rask-dom.js`, modeled on the existing `installRaskFocusTrap`) re-anchors an open menu with `position: fixed` + viewport-computed coordinates, which escapes **every** overflow-clipping ancestor:

- below the trigger by default, flipping above when it doesn't fit;
- clamped into the viewport, height-capped with internal scroll when taller than the viewport;
- right-aligned for `BsDropdown(AlignEnd: true)`; hidden while the trigger scrolls off-screen;
- tracked on scroll (capture-phase, any ancestor) and resize, rAF-coalesced.

Components opt in through one shared seam — the `BsPopover` marker dict: `data-rask-popover` on the `.dropdown` wrapper, `data-rask-anchor` on the trigger. No per-component positioning code.

Note: the live-diff morph reconciles the menu's `style` attribute back to the rendered output (which has none), stripping the inline fixed positioning on any re-render of a component with an open menu — so the observer re-applies after every morph batch **while a menu is open**, and skips the document query entirely when idle.

Removes the now-superseded `.table-responsive:has(.dropdown-menu.show){overflow:visible}` override (fixed positioning escapes the scroll container without forcing the whole responsive table to spill horizontally).

**Caveat (documented):** `position: fixed` only escapes overflow when no ancestor establishes a fixed containing block (a CSS `transform`/`filter`/`contain`); inside such an ancestor the menu is clamped to that box — a browser rule, not a Rask bug.

## Changes
- New `src/Rask.Bootstrap/BsPopover.cs` marker dicts, wired into `BsPickerBase`, `BsDropdown`, `BsMultiSelect` (one/two `Data:` markers each).
- `installRaskPopover` in `src/Rask.Core/Resources/rask-dom.js` (auto-spliced into the Server `rask.js` and the committed WASM `rask.wasm.js`).
- New `BsDropdownDemo` sample + `bootstrap-dropdown` registry slug (BsDropdown had no showcase).
- Docs (`bootstrap.md`, `accessibility.md`), CHANGELOG, dead-CSS removal.

## Testing
- Unit: `Rask.Bootstrap.Tests` markup assertions per family (opt-in markers) — all green.
- E2E (Playwright, **both hosts**): the showcase journey opens a picker, a dropdown, and a multiselect inside the `overflow:hidden` card and asserts each menu's computed `position` is `fixed` and in-viewport. Server journey ✅ and WASM host (11 tests) ✅.
- `dotnet format` clean; `dotnet build -warnaserror` clean; full non-E2E unit suite green.
- No render hot-path change (JS + markup only) → benchmarks not required.

## Changelog
Added a `### Fixed` entry under `[Unreleased]`.