### PR TITLE
perf(core): build the live-diff attribute path lazily, not per element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **The live-diff codec no longer allocates a path array for every element it walks.** `DiffAttributes`
+  received a freshly-built `int[]` element path on each call — one per element, every render — even
+  though the overwhelmingly common case is an element whose attributes are unchanged, which emits no op
+  and never uses the path. On a large page where a single text node mutates, that speculative
+  allocation dominated the whole diff's managed footprint. The path is now built lazily on the first
+  emitted attribute op and reused for any further ops on the same element, so an idle element's
+  attribute pass is allocation-free. The emitted op stream is byte-identical (all ops on one element
+  still share one path instance). Measured on the 200-row counter-update benchmark: the diff step's
+  allocation drops ~96% (25.2 KB → 1.1 KB per update) and the end-to-end serialize+diff+payload cycle
+  drops ~35% (69.4 KB → 45.3 KB per update).
+
 ### Fixed
 - **Bs dropdown-family popovers no longer get clipped by an `overflow` ancestor.** The Popper-less
   `.dropdown-menu` of `BsDatePicker`/`BsTimePicker`/`BsDateTimePicker`, `BsDropdown`, and `BsMultiSelect`

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -337,10 +337,11 @@ public static class FrameDiffer
                     var newChildStart = ni + 1;
                     var newChildEnd = ni + newFrame.SubtreeLength;
 
-                    // Attributes diff against the current element path.
+                    // Attributes diff against the current element path (built lazily inside
+                    // DiffAttributes only if an attribute op is actually emitted).
                     DiffAttributes(oldFrames, ref oldChildStart, oldChildEnd,
                         newFrames, ref newChildStart, newChildEnd,
-                        PathPlus(path, domSlot), output);
+                        path, domSlot, output);
 
                     // Recurse into children. Push domSlot onto path, then diff inside.
                     path.Add(domSlot);
@@ -466,13 +467,23 @@ public static class FrameDiffer
     private static void DiffAttributes(
         ReadOnlySpan<RenderFrame> oldFrames, ref int oldCursor, int oldEnd,
         ReadOnlySpan<RenderFrame> newFrames, ref int newCursor, int newEnd,
-        int[] elementPath,
+        List<int> basePath, int slot,
         List<EditOp> output)
     {
         var oldAttrStart = oldCursor;
         var newAttrStart = newCursor;
         var oldAttrs = CountLeadingAttributes(oldFrames, oldAttrStart, oldEnd);
         var newAttrs = CountLeadingAttributes(newFrames, newAttrStart, newEnd);
+
+        // The element's path array is built lazily on the FIRST emitted op and reused for
+        // any further ops on this same element. The overwhelmingly common case is an element
+        // whose attributes are unchanged across renders — it emits nothing, so materialising
+        // its path up front (a fresh int[] per element, every render) was pure waste: on a
+        // large page where one text node mutated, that speculative allocation dominated the
+        // whole diff's managed footprint. Deferring it makes an idle element's attribute pass
+        // allocation-free while keeping the emitted ops byte-identical (all ops on one element
+        // still share one path instance, exactly as before).
+        int[]? elementPath = null;
 
         // Name-keyed reconcile — NOT positional. Attributes can be conditionally present
         // (e.g. `checked` on a checkbox appears/disappears as it toggles, and it's emitted
@@ -489,7 +500,8 @@ public static class FrameDiffer
             var oldValue = FindAttribute(oldFrames, oldAttrStart, oldAttrs, na.Name, out var inOld);
             if (!inOld || !string.Equals(oldValue, na.Value, StringComparison.Ordinal))
             {
-                output.Add(new EditOp(EditOpKind.SetAttribute, elementPath, na.Name, na.Value));
+                output.Add(new EditOp(EditOpKind.SetAttribute, elementPath ??= PathPlus(basePath, slot),
+                    na.Name, na.Value));
             }
         }
 
@@ -499,7 +511,8 @@ public static class FrameDiffer
             FindAttribute(newFrames, newAttrStart, newAttrs, oa.Name, out var inNew);
             if (!inNew)
             {
-                output.Add(new EditOp(EditOpKind.RemoveAttribute, elementPath, oa.Name, null));
+                output.Add(new EditOp(EditOpKind.RemoveAttribute, elementPath ??= PathPlus(basePath, slot),
+                    oa.Name, null));
             }
         }
 
@@ -952,7 +965,7 @@ public static class FrameDiffer
 
             DiffAttributes(oldFrames, ref oldChildStart, oldChildEnd,
                 newFrames, ref newChildStart, newChildEnd,
-                PathPlus(path, j), output);
+                path, j, output);
 
             path.Add(j);
             DiffSiblings(oldFrames, oldChildStart, oldChildEnd,


### PR DESCRIPTION
## Summary

The live-diff codec (`FrameDiffer`) allocated a fresh `int[]` element path — via `PathPlus(path, slot)` — for **every element it walked, on every render**, and handed it to `DiffAttributes`. But the overwhelmingly common case is an element whose attributes are unchanged across renders: it emits no attribute op and never touches that path. So the array was pure speculative waste.

This defers the allocation: `DiffAttributes` now builds the path **lazily on the first emitted attribute op** (`elementPath ??= PathPlus(basePath, slot)`) and reuses it for any further ops on the same element. An idle element's attribute pass is now allocation-free.

The emitted op stream is **byte-identical** — all ops on one element still share a single path instance, exactly as before; only the walk that produces them got cheaper.

## Why this instead of the "cached-subtree short-circuit" (P4)

This started as the deferred P4 flagship (short-circuit re-serialization of cache-clean subtrees). Profiling the headline benchmark (`LiveDiffPayload_CounterOnLargePageBenchmarks` — 200-row page, one counter cell mutates) with a per-iteration allocation probe showed P4 targeted the wrong cost:

| Cost | B/iter | Share |
|---|---|---|
| `_htmlBuffer.ToString()` (full HTML string) | 44,208 | 64% |
| **diff + payload** | ~25,000 | 35% |
| serialize (walk 200 rows + ~1000 frames) | **816** | **1.2%** |

Serialization — what P4 set out to eliminate — already costs only 816 B/iter (prior pooling + no-alloc encode work won that). The real avoidable cost was the diff's per-element path allocation (~604 arrays ≈ the 25 KB). This fix captures it with **zero protocol risk**, whereas P4 would have changed DOM-slot bookkeeping on every render for a sub-2% target.

## Benchmark

`LiveDiffPayload_CounterOnLargePageBenchmarks`, allocated per update (GC.GetAllocatedBytesForCurrentThread, steady state):

- **Diff step in isolation: 25.2 KB → 1.1 KB (−96%)**
- **End-to-end serialize+diff+payload: 69.4 KB → 45.3 KB (−35%)**

(The remaining 44 KB is the full-HTML `ToString` the diff path materializes each update — a separate, larger, lower-risk optimization for a future PR.)

## Testing

- Full `Rask.Core.Tests` suite: 1814 passed, 1 skipped (incl. all 296 `Live` diff tests — the output-preservation gate).
- Full non-E2E solution suite green (Server 248, Generators 225, etc.).
- `dotnet format` clean; `dotnet build src/Rask.Core -warnaserror` clean (0 warnings).

## Changelog

`[Unreleased] → Changed` entry added.
