### PR TITLE
perf(core): render live updates into a reused char buffer, no per-update page string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **A live update no longer allocates the whole page as a string.** Every render materialised the full
+  document via `StringBuilder.ToString()` — the dominant managed allocation of a small update on a large
+  page — even when the shipped payload was one `UpdateText` op that never reads the HTML. The session now
+  renders into a reused, double-buffered `char[]` (`RenderedHtmlBuffers`) and threads
+  `ReadOnlySpan<char>` through the no-op-render dedup, the diff-vs-full head-compare, and the
+  `InsertSubtree` fragment slice; only the first-render / full-HTML-fallback path (which ships the whole
+  body anyway) still materialises a string. The wire payload is byte-identical. Measured on the 200-row
+  counter-update benchmark, the end-to-end serialize+diff+payload cycle drops from ~45.3 KB to ~1.1 KB
+  per update (−97%); combined with the lazy attribute-path change it is ~98% below the pre-optimisation
+  baseline.
 - **The live-diff codec no longer allocates a path array for every element it walks.** `DiffAttributes`
   received a freshly-built `int[]` element path on each call — one per element, every render — even
   though the overwhelmingly common case is an element whose attributes are unchanged, which emits no op

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/RaskHarness.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Infrastructure/RaskHarness.cs
@@ -25,6 +25,11 @@ public sealed class RaskHarness : IDisposable
     private readonly List<EditOp> _ops = new(32);
     private readonly ArrayBufferWriter<byte> _payloadBuffer = new(64 * 1024);
 
+    // Reused char buffer mirroring the live session's RenderedHtmlBuffers: the diff path reads the
+    // rendered page as a span, never materialising a per-update string (the dominant managed
+    // allocation before that change).
+    private char[] _htmlChars = new char[64 * 1024];
+
     public void Dispose() => _cache.Dispose();
 
     /// <summary>
@@ -62,10 +67,19 @@ public sealed class RaskHarness : IDisposable
         }
 
         _ops.Clear();
-        // newHtml lets InsertSubtree ops carry the HTML fragment for structural inserts
-        // (otherwise the caller would have to fall back to the full-HTML payload — that
-        // gate is enforced in production by LiveSession; here we just pass the HTML).
-        _cache.TryComputeDiff(_ops, _htmlBuffer.ToString());
+        // newHtml lets InsertSubtree ops carry the HTML fragment for structural inserts. Copy the page
+        // into a reused char[] and diff over the span — exactly the production path (RenderedHtmlBuffers),
+        // so this measures the diff codec without a per-update page-string allocation.
+        var len = _htmlBuffer.Length;
+        if (_htmlChars.Length < len)
+        {
+            _htmlChars = new char[len];
+        }
+
+        _htmlBuffer.CopyTo(0, _htmlChars, 0, len);
+        var html = _htmlChars.AsSpan(0, len);
+
+        _cache.TryComputeDiff(_ops, html);
 
         _payloadBuffer.ResetWrittenCount();
         LivePayload.BuildPayloadUtf8Diff(_payloadBuffer, _ops);

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1294,14 +1294,25 @@ public abstract class Component
         }
     }
 
-    internal string RenderAsLiveRoot() => RenderAsLiveRootCore(null, false);
+    internal string RenderAsLiveRoot() => RenderAsLiveRootCore(null, false, sink: null)!;
 
-    internal string RenderAsLiveRoot(IServiceProvider services) => RenderAsLiveRootCore(services, false);
+    internal string RenderAsLiveRoot(IServiceProvider services) => RenderAsLiveRootCore(services, false, sink: null)!;
 
     internal string RenderAsLiveRoot(IServiceProvider services, bool publishOnly) =>
-        RenderAsLiveRootCore(services, publishOnly);
+        RenderAsLiveRootCore(services, publishOnly, sink: null)!;
 
-    private string RenderAsLiveRootCore(IServiceProvider? services, bool publishOnly)
+    /// <summary>
+    ///     Live-update variant of <see cref="RenderAsLiveRoot(IServiceProvider, bool)" /> that renders the
+    ///     page into <paramref name="sink" />'s reused char buffer instead of a fresh string, so a live
+    ///     session's diff path allocates nothing for the page HTML. The session reads the rendered chars
+    ///     back via <see cref="RenderedHtmlBuffers.Current" />.
+    /// </summary>
+    internal void RenderAsLiveRootInto(IServiceProvider services, bool publishOnly, RenderedHtmlBuffers sink) =>
+        RenderAsLiveRootCore(services, publishOnly, sink);
+
+    // Returns the rendered page as a string when sink is null; when a sink is supplied the page is
+    // copied into it instead and null is returned (the caller reads sink.Current).
+    private string? RenderAsLiveRootCore(IServiceProvider? services, bool publishOnly, RenderedHtmlBuffers? sink)
     {
         // Reuse the handler dictionary across renders — IDs are reissued from 0 every
         // root render, so the prior frame's contents are irrelevant. Lazy-init only on
@@ -1356,7 +1367,7 @@ public abstract class Component
         // path allocated the page TWICE — ToHtml() produced one full-page string, then ApplyTo
         // copied the whole page into a second builder to inject the head assets.
         var pageBuilder = RaskStringBuilderPool.Shared.Get();
-        string html;
+        string? html = null;
         try
         {
             HtmlSerializer.Serialize(this, pageBuilder);
@@ -1385,7 +1396,16 @@ public abstract class Component
                 }
             }
 
-            html = pageBuilder.ToString();
+            // Materialise the page exactly once: into the session's reused char buffer on the live-update
+            // path (zero GC), or into a fresh string for the first-render / test / full-HTML-fallback path.
+            if (sink is not null)
+            {
+                sink.CopyFrom(pageBuilder);
+            }
+            else
+            {
+                html = pageBuilder.ToString();
+            }
         }
         finally
         {
@@ -1402,7 +1422,7 @@ public abstract class Component
         // helper path, used to render partial component trees) are intentionally exempt.
         if (this is RootErrorBoundary)
         {
-            ValidateRootShell(html);
+            ValidateRootShell(sink is not null ? sink.CurrentSpan : html.AsSpan());
         }
 
         // Post-render alive set: union of _children across the whole tree, reachable from root.
@@ -1485,7 +1505,7 @@ public abstract class Component
         }
     }
 
-    private static void ValidateRootShell(string html)
+    private static void ValidateRootShell(ReadOnlySpan<char> html)
     {
         List<string>? missing = null;
         foreach (var (token, factory) in _requiredShell)

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -206,7 +206,7 @@ public static class FrameDiffer
         ReadOnlySpan<RenderFrame> oldFrames,
         ReadOnlySpan<RenderFrame> newFrames,
         List<EditOp> output,
-        string? newHtml = null)
+        ReadOnlySpan<char> newHtml = default)
         => Diff(oldFrames, newFrames, output, out _, newHtml);
 
     /// <summary>
@@ -222,7 +222,7 @@ public static class FrameDiffer
         ReadOnlySpan<RenderFrame> newFrames,
         List<EditOp> output,
         out bool usedKeyedPath,
-        string? newHtml = null)
+        ReadOnlySpan<char> newHtml = default)
         => Diff(oldFrames, newFrames, output, new DiffScratch(), out usedKeyedPath, newHtml);
 
     /// <summary>
@@ -240,7 +240,7 @@ public static class FrameDiffer
         List<EditOp> output,
         DiffScratch scratch,
         out bool usedKeyedPath,
-        string? newHtml = null)
+        ReadOnlySpan<char> newHtml = default)
     {
         var startCount = output.Count;
         scratch.ResetForDiff();
@@ -255,7 +255,7 @@ public static class FrameDiffer
         ReadOnlySpan<RenderFrame> oldFrames, int oldStart, int oldEnd,
         ReadOnlySpan<RenderFrame> newFrames, int newStart, int newEnd,
         List<EditOp> output,
-        string? newHtml,
+        ReadOnlySpan<char> newHtml,
         DiffScratch scratch)
     {
         var path = scratch.Path;
@@ -452,11 +452,11 @@ public static class FrameDiffer
     // deferred slice" — when no render HTML was supplied (one-shot / test callers that inspect
     // ops without a wire build) or the frame's offsets are degenerate, so the codec then ships a
     // null fragment exactly as the old null-Value path did.
-    private static (int Start, int End) InsertHtmlRange(string? newHtml, in RenderFrame frame)
+    private static (int Start, int End) InsertHtmlRange(ReadOnlySpan<char> newHtml, in RenderFrame frame)
     {
         var start = frame.HtmlStart;
         var end = frame.HtmlEnd;
-        if (newHtml is null || end <= start || (uint)end > (uint)newHtml.Length)
+        if (newHtml.IsEmpty || end <= start || (uint)end > (uint)newHtml.Length)
         {
             return (-1, -1);
         }
@@ -697,7 +697,7 @@ public static class FrameDiffer
     private static void DiffKeyedSiblings(
         ReadOnlySpan<RenderFrame> oldFrames,
         ReadOnlySpan<RenderFrame> newFrames,
-        List<EditOp> output, string? newHtml,
+        List<EditOp> output, ReadOnlySpan<char> newHtml,
         DiffScratch scratch, KeyedBundle bundle)
     {
         // All working collections come from the pooled bundle (cleared on rent), so a keyed

--- a/src/Rask.Core/Live/LiveDiffGate.cs
+++ b/src/Rask.Core/Live/LiveDiffGate.cs
@@ -46,7 +46,7 @@ internal static class LiveDiffGate
     // (data-rask-root is spliced onto <body> only at payload-write time), so the
     // comparison is stable. A missing </head> in either string returns false (treat as
     // changed → full HTML), never an unsafe true.
-    internal static bool HeadUnchanged(string html, string baseline)
+    internal static bool HeadUnchanged(ReadOnlySpan<char> html, ReadOnlySpan<char> baseline)
     {
         const string headClose = "</head>";
         var a = html.IndexOf(headClose, StringComparison.Ordinal);
@@ -68,7 +68,7 @@ internal static class LiveDiffGate
             return false;
         }
 
-        return html.AsSpan(0, a).SequenceEqual(baseline.AsSpan(0, b));
+        return html.Slice(0, a).SequenceEqual(baseline.Slice(0, b));
     }
 
     // Slice the full <head ...>...</head> element out of the rendered document so the diff
@@ -76,7 +76,7 @@ internal static class LiveDiffGate
     // (no scope attr) and data-rask-root is spliced onto <body> only, so the slice is clean.
     // Returns null when there's no recognizable head (defensive — caller then omits the
     // field and the body diff still ships).
-    internal static string? ExtractHead(string html)
+    internal static string? ExtractHead(ReadOnlySpan<char> html)
     {
         var open = html.IndexOf("<head", StringComparison.Ordinal);
         if (open < 0)
@@ -92,6 +92,6 @@ internal static class LiveDiffGate
         }
 
         close += headClose.Length;
-        return close <= open ? null : html.Substring(open, close - open);
+        return close <= open ? null : html.Slice(open, close - open).ToString();
     }
 }

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -260,7 +260,7 @@ public static class LivePayload
         bool replace = false,
         IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
         string? headHtml = null,
-        string? newHtml = null)
+        ReadOnlySpan<char> newHtml = default)
     {
         // Pass 1: build the attribute-name symbol table. Intern when the name appears
         // 3+ times — break-even with the table overhead lands around there for typical
@@ -380,10 +380,10 @@ public static class LivePayload
                     {
                         writer.WriteStringValue(op.Value);
                     }
-                    else if (newHtml is not null && op.HtmlStart >= 0 && op.HtmlEnd > op.HtmlStart
+                    else if (!newHtml.IsEmpty && op.HtmlStart >= 0 && op.HtmlEnd > op.HtmlStart
                              && op.HtmlEnd <= newHtml.Length)
                     {
-                        writer.WriteStringValue(newHtml.AsSpan(op.HtmlStart, op.HtmlEnd - op.HtmlStart));
+                        writer.WriteStringValue(newHtml.Slice(op.HtmlStart, op.HtmlEnd - op.HtmlStart));
                     }
                     else
                     {

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -27,9 +27,12 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     protected List<EditOp>? _diffOps;
     protected SessionRenderCache? _renderCache;
 
-    // Last rendered HTML, the dedup baseline that suppresses noop renders which would otherwise
-    // re-morph identical HTML and strip JS-applied DOM state (e.g. hljs's `.hljs` class).
-    protected string? _lastAppliedHtml;
+    // Double-buffered rendered-page chars: the current render + the last-applied baseline. Backs the
+    // noop-render dedup (suppresses re-morphing identical HTML, which would strip JS-applied DOM state
+    // like hljs's `.hljs` class) and the diff-vs-full head-compare, both read-only over the chars — so
+    // the page is rendered into a reused buffer instead of a fresh per-update string. Committed (swapped)
+    // by the hosts only when a frame is actually sent, mirroring _writeBuffer/_lastSentBuffer.
+    protected readonly RenderedHtmlBuffers _htmlBuffers = new();
 
     // Set when an in-handler StateHasChanged lands mid-dispatch (InHandlerScope=true); the coalescing
     // loop reads and clears it to rebuild the payload before releasing the dispatch lock.
@@ -181,7 +184,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     ///     Default (DisabledFull) bypasses entirely — null frame sink, a single null check per
     ///     HtmlSerializer branch.
     /// </summary>
-    protected string RenderTreeToHtml(bool publishOnly, out FrameWriter? frameWriter)
+    protected ReadOnlyMemory<char> RenderTreeToHtml(bool publishOnly, out FrameWriter? frameWriter)
     {
         frameWriter = null;
         FrameSinkScope.Popper popper = default;
@@ -194,7 +197,10 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 
         try
         {
-            return View.RenderAsLiveRoot(Services, publishOnly);
+            // Render into the session's reused char buffer (no per-update page string); the caller
+            // consumes the chars synchronously before the next render overwrites them.
+            View.RenderAsLiveRootInto(Services, publishOnly, _htmlBuffers);
+            return _htmlBuffers.Current;
         }
         finally
         {
@@ -217,7 +223,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     ///     <paramref name="commitCache" /> (false during a coalescing loop, so intermediate rebuilds
     ///     diff against the stable last-sent baseline and the caller Snapshots once after).
     /// </summary>
-    protected void WritePayload(string html, FrameWriter? frameWriter, PendingDownload? download,
+    protected void WritePayload(ReadOnlyMemory<char> html, FrameWriter? frameWriter, PendingDownload? download,
         PendingJsInvoke[]? jsInvokes, string? historyUrl, bool replace, bool commitCache,
         AuthInstruction? auth, string sessionId)
     {
@@ -234,18 +240,18 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
         {
             _diffOps ??= new List<EditOp>();
             diffPathEntered = true;
-            var headChanged = _lastAppliedHtml is not null && !LiveDiffGate.HeadUnchanged(html, _lastAppliedHtml);
+            var headChanged = _htmlBuffers.HasPrevious && !LiveDiffGate.HeadUnchanged(html.Span, _htmlBuffers.PreviousSpan);
             // Ship the diff when it carries DOM ops, OR when it carries none but a navigation or a
             // head change must still flow (a query-only nav pushes the URL; a head-only change ships
             // the head fragment). Zero ops + no history + unchanged head means nothing to send.
-            if (_renderCache.TryComputeDiff(_diffOps, commitCache, html)
+            if (_renderCache.TryComputeDiff(_diffOps, commitCache, html.Span)
                 && (_diffOps.Count > 0 || historyUrl is not null || headChanged)
                 && LiveDiffGate.DiffOpsAreClientSupported(_diffOps)
                 && !_renderCache.LastDiffForcedFullHtml)
             {
-                var headHtml = headChanged ? LiveDiffGate.ExtractHead(html) : null;
+                var headHtml = headChanged ? LiveDiffGate.ExtractHead(html.Span) : null;
                 LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes,
-                    headHtml, html);
+                    headHtml, html.Span);
 
                 // Ship the diff whenever it isn't larger than re-sending the body, or unconditionally
                 // under Forced. Only the pathological case (nearly every node changed on a tiny page,
@@ -263,8 +269,10 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 
         if (!usedDiff)
         {
-            LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, html, sessionId, historyUrl, replace,
-                auth, download, jsInvokes);
+            // Full-HTML path (first render, structural change, out-of-band side effect, size fallback):
+            // this ships the whole body anyway, so materialising it as a string here is not wasted.
+            LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, new string(html.Span), sessionId, historyUrl,
+                replace, auth, download, jsInvokes);
             // Keep the cache in lockstep with the client even when shipping full HTML: promote
             // current → previous so the NEXT diff's baseline matches what the client received. Skip
             // when TryComputeDiff already rotated (diffPathEntered), or when the caller defers the

--- a/src/Rask.Core/Live/RenderedHtmlBuffers.cs
+++ b/src/Rask.Core/Live/RenderedHtmlBuffers.cs
@@ -1,0 +1,106 @@
+using System.Buffers;
+using System.Text;
+
+namespace Rask.Core.Live;
+
+/// <summary>
+///     Double-buffered holder for a live session's rendered page HTML. It exists to keep the
+///     per-update cost of the diff path off the GC: previously every render materialised the whole
+///     page as a fresh <see cref="string" /> via <c>StringBuilder.ToString()</c> — the dominant
+///     managed allocation of a small live update on a large page — purely so the session could
+///     (a) dedup a byte-identical no-op render, (b) head-compare for the diff-vs-full decision, and
+///     (c) slice an <c>InsertSubtree</c> fragment. All three are read-only over the chars, so we
+///     render into a reused <see cref="char" /><c>[]</c> and hand out <see cref="ReadOnlyMemory{T}" />
+///     / <see cref="ReadOnlySpan{T}" /> instead.
+///     <para>
+///         Two arrays ping-pong: <c>_cur</c> receives the just-rendered page; <c>_prev</c> is the
+///         baseline the last <em>applied</em> render left behind. <see cref="Commit" /> swaps them
+///         after a successful send, exactly mirroring the existing double-buffers for the wire bytes
+///         (<c>_writeBuffer</c>/<c>_lastSentBuffer</c>) and the frame streams
+///         (<see cref="SessionRenderCache" />). A session renders and consumes single-threaded under
+///         its render lock, so the buffers never overlap two renders.
+///     </para>
+/// </summary>
+internal sealed class RenderedHtmlBuffers : IDisposable
+{
+    private char[] _cur;
+    private char[] _prev;
+    private int _curLen;
+    private int _prevLen;
+
+    public RenderedHtmlBuffers(int initialCapacity = 8 * 1024)
+    {
+        _cur = ArrayPool<char>.Shared.Rent(initialCapacity);
+        _prev = ArrayPool<char>.Shared.Rent(initialCapacity);
+    }
+
+    /// <summary>True once at least one render has been committed as the baseline.</summary>
+    public bool HasPrevious { get; private set; }
+
+    /// <summary>The just-rendered page, valid until the next <see cref="CopyFrom" />.</summary>
+    public ReadOnlyMemory<char> Current => _cur.AsMemory(0, _curLen);
+
+    /// <summary>Span view of <see cref="Current" />.</summary>
+    public ReadOnlySpan<char> CurrentSpan => _cur.AsSpan(0, _curLen);
+
+    /// <summary>The last committed (applied) render, or empty when <see cref="HasPrevious" /> is false.</summary>
+    public ReadOnlySpan<char> PreviousSpan => _prev.AsSpan(0, _prevLen);
+
+    /// <summary>Copy the freshly serialized page out of <paramref name="sb" /> into the current buffer.</summary>
+    public void CopyFrom(StringBuilder sb)
+    {
+        var len = sb.Length;
+        EnsureCapacity(ref _cur, len);
+        sb.CopyTo(0, _cur, 0, len);
+        _curLen = len;
+    }
+
+    /// <summary>True when the current render is byte-identical to the committed baseline (a no-op render).</summary>
+    public bool CurrentEqualsPrevious() => HasPrevious && CurrentSpan.SequenceEqual(PreviousSpan);
+
+    /// <summary>Promote the current render to the baseline for the next dedup / head-compare (zero-copy swap).</summary>
+    public void Commit()
+    {
+        (_cur, _prev) = (_prev, _cur);
+        (_curLen, _prevLen) = (_prevLen, _curLen);
+        HasPrevious = true;
+    }
+
+    /// <summary>
+    ///     Drop the baseline so the next render is treated as changed (used on reconnect resend, where the
+    ///     freshly attached socket must receive a full catch-up frame regardless of byte equality).
+    /// </summary>
+    public void Invalidate() => HasPrevious = false;
+
+    /// <summary>
+    ///     Seed the baseline from an already-materialised HTML string — the initial GET render, whose
+    ///     string is produced through the ordinary <c>ToString</c> path and shipped in the HTTP body, so
+    ///     the first live update can dedup/head-compare against it.
+    /// </summary>
+    public void SeedPrevious(ReadOnlySpan<char> html)
+    {
+        EnsureCapacity(ref _prev, html.Length);
+        html.CopyTo(_prev);
+        _prevLen = html.Length;
+        HasPrevious = true;
+    }
+
+    public void Dispose()
+    {
+        ArrayPool<char>.Shared.Return(_cur);
+        ArrayPool<char>.Shared.Return(_prev);
+        _cur = _prev = Array.Empty<char>();
+        _curLen = _prevLen = 0;
+    }
+
+    private static void EnsureCapacity(ref char[] buffer, int needed)
+    {
+        if (buffer.Length >= needed)
+        {
+            return;
+        }
+
+        ArrayPool<char>.Shared.Return(buffer);
+        buffer = ArrayPool<char>.Shared.Rent(needed);
+    }
+}

--- a/src/Rask.Core/Live/SessionRenderCache.cs
+++ b/src/Rask.Core/Live/SessionRenderCache.cs
@@ -73,7 +73,7 @@ public sealed class SessionRenderCache : IDisposable
     ///     lets <c>FrameDiffer.Diff</c> attach HTML fragments to
     ///     <see cref="EditOpKind.InsertSubtree" /> ops for the client interpreter.
     /// </summary>
-    public bool TryComputeDiff(List<EditOp> output, string? newHtml = null)
+    public bool TryComputeDiff(List<EditOp> output, ReadOnlySpan<char> newHtml = default)
         => TryComputeDiff(output, out _, newHtml);
 
     /// <summary>
@@ -86,7 +86,7 @@ public sealed class SessionRenderCache : IDisposable
     ///     without promoting <c>_current</c>; the caller commits exactly once via
     ///     <see cref="Snapshot" /> after the loop settles.
     /// </summary>
-    public bool TryComputeDiff(List<EditOp> output, bool rotate, string? newHtml = null)
+    public bool TryComputeDiff(List<EditOp> output, bool rotate, ReadOnlySpan<char> newHtml = default)
         => TryComputeDiff(output, out _, newHtml, rotate);
 
     /// <summary>
@@ -97,10 +97,10 @@ public sealed class SessionRenderCache : IDisposable
     ///     identity on surviving nodes (focus, IDL state, listeners), so they're safe to
     ///     ship as diff; positional structural ops still route to the full-HTML morph path.
     /// </summary>
-    public bool TryComputeDiff(List<EditOp> output, out bool usedKeyedPath, string? newHtml = null)
+    public bool TryComputeDiff(List<EditOp> output, out bool usedKeyedPath, ReadOnlySpan<char> newHtml = default)
         => TryComputeDiff(output, out usedKeyedPath, newHtml, true);
 
-    public bool TryComputeDiff(List<EditOp> output, out bool usedKeyedPath, string? newHtml, bool rotate)
+    public bool TryComputeDiff(List<EditOp> output, out bool usedKeyedPath, ReadOnlySpan<char> newHtml, bool rotate)
     {
         output.Clear();
         usedKeyedPath = false;

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -229,7 +229,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     ///     identical-state renders the same way WASM's <c>InitialRenderAsync</c> does
     ///     via <c>_lastAppliedHtml</c>.
     /// </summary>
-    internal void SeedInitialHtml(string html) => _lastAppliedHtml = html;
+    internal void SeedInitialHtml(string html) => _htmlBuffers.SeedPrevious(html);
 
     /// <summary>
     ///     Render the initial root for the HTTP-GET response, seeding BOTH the dedup
@@ -386,7 +386,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             {
                 _forceResend = false;
                 _lastSentBuffer = null;
-                _lastAppliedHtml = null;
+                _htmlBuffers.Invalidate();
             }
 
             // Render + decide diff-vs-full + write the frame — shared with the WASM host (LiveSessionBase).
@@ -400,7 +400,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             // class) across noop publish-renders, and lets a fresh socket dedup against the GET HTML.
             if (jsInvokes is null
                 && historyUrl is null && auth is null && download is null
-                && _lastAppliedHtml is not null && string.Equals(html, _lastAppliedHtml, StringComparison.Ordinal))
+                && _htmlBuffers.CurrentEqualsPrevious())
             {
                 return;
             }
@@ -430,7 +430,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
 
             if (sent)
             {
-                _lastAppliedHtml = html;
+                _htmlBuffers.Commit();
             }
         }
         finally

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -85,10 +85,10 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         SynchronizationContext.SetSynchronizationContext(null);
         try
         {
-            var html = await BuildPayloadAsync(null, false).ConfigureAwait(false);
+            await BuildPayloadAsync(null, false).ConfigureAwait(false);
             if (await TryEmitFrameAsync(false).ConfigureAwait(false))
             {
-                _lastAppliedHtml = html;
+                _htmlBuffers.Commit();
             }
         }
         finally
@@ -113,7 +113,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         InHandlerScope = true;
         try
         {
-            var html = await BuildPayloadCoalescingRerendersAsync(null, false, publishOnly)
+            await BuildPayloadCoalescingRerendersAsync(null, false, publishOnly)
                 .ConfigureAwait(false);
 
             // Noop publish-render guard: an auto-publish triggered by a completed
@@ -124,8 +124,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
             // previous frame's dispatch. Skip such frames entirely.
             if (publishOnly
                 && !_lastBuildHadJsInvokes
-                && _lastAppliedHtml is not null
-                && string.Equals(html, _lastAppliedHtml, StringComparison.Ordinal))
+                && _htmlBuffers.CurrentEqualsPrevious())
             {
                 return;
             }
@@ -135,7 +134,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
             // didn't change visible output — no per-frame byte[].
             if (await TryEmitFrameAsync(false).ConfigureAwait(false))
             {
-                _lastAppliedHtml = html;
+                _htmlBuffers.Commit();
             }
         }
         finally
@@ -153,13 +152,13 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         InHandlerScope = true;
         try
         {
-            var html = await BuildPayloadAsync(null, false).ConfigureAwait(false);
+            await BuildPayloadAsync(null, false).ConfigureAwait(false);
             if (!await TryEmitFrameAsync(true).ConfigureAwait(false))
             {
                 return Array.Empty<byte>();
             }
 
-            _lastAppliedHtml = html;
+            _htmlBuffers.Commit();
             // The bootstrap caller wants the initial frame bytes; ToArray once per page load.
             return _lastSentBuffer!.WrittenSpan.ToArray();
         }
@@ -229,7 +228,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                         historyReplace = replace;
                     }
 
-                    var html = await BuildPayloadCoalescingRerendersAsync(historyUrl, historyReplace)
+                    await BuildPayloadCoalescingRerendersAsync(historyUrl, historyReplace)
                         .ConfigureAwait(false);
                     // EmitFrame pushes the frame (zero-copy) unless it's byte-identical to the last
                     // sent one; force the send when a navigation URL must flow even if the rendered
@@ -239,7 +238,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                         return Array.Empty<byte>();
                     }
 
-                    _lastAppliedHtml = html;
+                    _htmlBuffers.Commit();
                     // Return the sent frame's bytes for the test seam; ToArray once per event.
                     return _lastSentBuffer!.WrittenSpan.ToArray();
                 }
@@ -292,15 +291,14 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
 
             try
             {
-                var html =
-                    await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
+                await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
                 // Navigation always flows — force the send even when the rendered output is unchanged.
                 if (!await TryEmitFrameAsync(true).ConfigureAwait(false))
                 {
                     return Array.Empty<byte>();
                 }
 
-                _lastAppliedHtml = html;
+                _htmlBuffers.Commit();
                 return _lastSentBuffer!.WrittenSpan.ToArray();
             }
             catch (Exception ex)
@@ -320,7 +318,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         }
     }
 
-    private async Task<string> BuildPayloadCoalescingRerendersAsync(string? historyUrl,
+    private async Task BuildPayloadCoalescingRerendersAsync(string? historyUrl,
         bool replace, bool publishOnly = false)
     {
         // First build emits any pending history navigation. If a dispose callback (or other
@@ -340,17 +338,18 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         // historyUrl here is a local captured before the call, not a fresh navigator
         // consumption — passing it twice still lands exactly one pushState on the client.
         // commitCache:false — every iteration diffs against the SAME (last-sent) baseline
-        // rather than promoting its own render. Only the LAST build is returned and sent, so
-        // committing each intermediate rotation would make the final build diff against an
-        // un-sent render — shipping a tiny stale diff (e.g. a head-only diff after a real page
-        // swap) that never updates the body. We commit the final render once, after the loop.
+        // rather than promoting its own render. Only the LAST build is sent, so committing each
+        // intermediate rotation would make the final build diff against an un-sent render —
+        // shipping a tiny stale diff (e.g. a head-only diff after a real page swap) that never
+        // updates the body. We commit the final render once, after the loop. Each rebuild
+        // overwrites _htmlBuffers.Current, so it holds the final render when the loop settles.
         _pendingRenderInScope = false;
-        var result = await BuildPayloadAsync(historyUrl, replace, publishOnly, false).ConfigureAwait(false);
+        await BuildPayloadAsync(historyUrl, replace, publishOnly, false).ConfigureAwait(false);
         var budget = 2;
         while (_pendingRenderInScope && budget-- > 0)
         {
             _pendingRenderInScope = false;
-            result = await BuildPayloadAsync(historyUrl, replace, publishOnly, false).ConfigureAwait(false);
+            await BuildPayloadAsync(historyUrl, replace, publishOnly, false).ConfigureAwait(false);
         }
 
         // Commit the final, actually-sent render as the new diff baseline exactly once.
@@ -369,8 +368,6 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
                 "that re-trigger StateHasChanged in OnRenderedAsync / dispose " +
                 "callbacks during this dispatch.");
         }
-
-        return result;
     }
 
     // commitCache=false defers the render-cache rotation to the caller (the coalescing loop),
@@ -378,7 +375,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
     // each other. Only the final, actually-sent build's render becomes the new baseline (the
     // loop calls Snapshot once after it settles). Direct senders (RenderInScopeAsync,
     // InitialRenderAsync) leave it true: their payload reaches the client, so it must commit.
-    internal async Task<string> BuildPayloadAsync(string? historyUrl, bool replace,
+    internal async Task BuildPayloadAsync(string? historyUrl, bool replace,
         bool publishOnly = false, bool commitCache = true)
     {
         await Task.Yield();
@@ -429,8 +426,7 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
         WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
             commitCache, auth: null, sessionId: "wasm");
 
-        // The built frame lives in _writeBuffer; EmitFrame pushes it zero-copy. Return only the HTML
-        // (used for the publish-render noop guard and as the diff-cache baseline).
-        return html;
+        // The built frame lives in _writeBuffer; EmitFrame pushes it zero-copy. The rendered chars stay
+        // in _htmlBuffers.Current for the caller's noop-guard / diff-cache baseline (committed on send).
     }
 }

--- a/tests/Rask.Core.Tests/Live/RenderedHtmlBuffersTests.cs
+++ b/tests/Rask.Core.Tests/Live/RenderedHtmlBuffersTests.cs
@@ -1,0 +1,113 @@
+using System.Text;
+using Rask.Core.Live;
+
+namespace Rask.Core.Tests.Live;
+
+public class RenderedHtmlBuffersTests
+{
+    private static RenderedHtmlBuffers WithCurrent(string html)
+    {
+        var b = new RenderedHtmlBuffers(16);
+        b.CopyFrom(new StringBuilder(html));
+        return b;
+    }
+
+    [Fact]
+    public void FreshBuffers_HaveNoPrevious()
+    {
+        using var b = new RenderedHtmlBuffers(16);
+        Assert.False(b.HasPrevious);
+        // With no baseline a render can never dedup as a no-op — it must always be treated as changed.
+        b.CopyFrom(new StringBuilder("<p>x</p>"));
+        Assert.False(b.CurrentEqualsPrevious());
+    }
+
+    [Fact]
+    public void CopyFrom_ExposesTheRenderedCharsAsCurrent()
+    {
+        using var b = WithCurrent("<div>hello</div>");
+        Assert.Equal("<div>hello</div>", b.CurrentSpan.ToString());
+        Assert.Equal("<div>hello</div>", b.Current.ToString());
+    }
+
+    [Fact]
+    public void Commit_PromotesCurrentToBaseline_ThenIdenticalRenderDedups()
+    {
+        using var b = WithCurrent("<p>same</p>");
+        b.Commit();
+        Assert.True(b.HasPrevious);
+        Assert.Equal("<p>same</p>", b.PreviousSpan.ToString());
+
+        // A byte-identical next render is a no-op that must dedup.
+        b.CopyFrom(new StringBuilder("<p>same</p>"));
+        Assert.True(b.CurrentEqualsPrevious());
+    }
+
+    [Fact]
+    public void Commit_ThenChangedRender_DoesNotDedup()
+    {
+        using var b = WithCurrent("<p>a</p>");
+        b.Commit();
+        b.CopyFrom(new StringBuilder("<p>b</p>"));
+        Assert.False(b.CurrentEqualsPrevious());
+    }
+
+    [Fact]
+    public void DifferentLength_DoesNotDedup()
+    {
+        using var b = WithCurrent("<p>a</p>");
+        b.Commit();
+        b.CopyFrom(new StringBuilder("<p>aa</p>"));
+        Assert.False(b.CurrentEqualsPrevious());
+    }
+
+    [Fact]
+    public void Commit_IsAZeroCopySwap_KeepingBothRendersDistinct()
+    {
+        // First render committed as baseline; second render is current. Both must remain readable and
+        // distinct — the swap must not alias current onto previous.
+        using var b = WithCurrent("<p>one</p>");
+        b.Commit();
+        b.CopyFrom(new StringBuilder("<p>two</p>"));
+        Assert.Equal("<p>two</p>", b.CurrentSpan.ToString());
+        Assert.Equal("<p>one</p>", b.PreviousSpan.ToString());
+    }
+
+    [Fact]
+    public void Invalidate_DropsBaseline_SoNextRenderIsAlwaysChanged()
+    {
+        using var b = WithCurrent("<p>x</p>");
+        b.Commit();
+        b.Invalidate();
+        Assert.False(b.HasPrevious);
+        b.CopyFrom(new StringBuilder("<p>x</p>"));
+        Assert.False(b.CurrentEqualsPrevious());
+    }
+
+    [Fact]
+    public void SeedPrevious_SetsBaselineFromAString_ForTheGetRenderHandoff()
+    {
+        using var b = new RenderedHtmlBuffers(16);
+        b.SeedPrevious("<html><head></head><body>x</body></html>");
+        Assert.True(b.HasPrevious);
+        // The first live update after the GET must dedup a byte-identical re-render against the seed.
+        b.CopyFrom(new StringBuilder("<html><head></head><body>x</body></html>"));
+        Assert.True(b.CurrentEqualsPrevious());
+    }
+
+    [Fact]
+    public void GrowsBeyondInitialCapacity_WithoutTruncating()
+    {
+        using var b = new RenderedHtmlBuffers(8);
+        var big = new string('a', 5000);
+        b.CopyFrom(new StringBuilder(big));
+        Assert.Equal(5000, b.CurrentSpan.Length);
+        Assert.Equal(big, b.CurrentSpan.ToString());
+
+        b.Commit();
+        var bigger = new string('b', 9000);
+        b.CopyFrom(new StringBuilder(bigger));
+        Assert.Equal(bigger, b.CurrentSpan.ToString());
+        Assert.Equal(big, b.PreviousSpan.ToString());
+    }
+}


### PR DESCRIPTION
## Summary

A live update used to materialize the **entire page** as a fresh `string` via `StringBuilder.ToString()` on every render — the dominant managed allocation of a small update on a large page — even when the shipped payload was one `UpdateText` op that never reads the HTML. Profiling the `CounterOnLargePage` benchmark showed this single string was ~44 KB of the ~45 KB per-update allocation (after #284).

This renders the page into a **reused, double-buffered `char[]`** (`RenderedHtmlBuffers`) and threads `ReadOnlySpan<char>` through the three things that read the rendered HTML on the hot path:
- the no-op-render dedup (`string.Equals(html, _lastAppliedHtml)` → span `SequenceEqual`),
- the diff-vs-full head-compare (`LiveDiffGate.HeadUnchanged`/`ExtractHead`),
- the `InsertSubtree` fragment slice (`LivePayload.BuildPayloadUtf8Diff`).

Only the paths that genuinely need a `string` still make one: initial GET render (HTTP body), full-HTML fallback/morph (ships the whole body anyway), and the public `Rask.Testing` API (unchanged). The **wire payload is byte-identical** — only the intermediate representation changed.

The two buffers ping-pong: the current render + the last-applied baseline, swapped on a successful send — exactly mirroring the existing `_writeBuffer`/`_lastSentBuffer` and frame-stream double-buffers.

## Why a double-buffer (not head-only)

`_lastAppliedHtml` turned out to back a **full-page** no-op dedup (both hosts: `LiveSession.cs`, `WasmLiveSession.cs`), not just the head-compare — so the baseline must retain the whole previous page. The double-buffer keeps that at zero per-update allocation via a swap.

Buffer lifetime is safe: `RenderAndSendAsync` holds `_renderLock` (`SemaphoreSlim(1,1)`) across the whole render→consume→send→commit sequence, so renders never interleave; WASM is single-threaded. `WritePayload` consumes the span synchronously before the first `await`.

## Benchmark

`LiveDiffPayload_CounterOnLargePageBenchmarks`, allocated per update (`GC.GetAllocatedBytesForCurrentThread`, steady state; the harness now mirrors the production buffer path):

- **End-to-end serialize+diff+payload: 45.3 KB → 1.1 KB (−97.6%)**
- Combined with #284, from the pre-optimisation baseline: **69.4 KB → 1.1 KB (−98.5%)**

## Testing

- `Rask.Core.Tests`: 1,814 + **9 new `RenderedHtmlBuffers` unit tests** (swap/dedup/seed/invalidate/grow).
- `Rask.Server.Tests`: 248 — exercises the WebSocket dedup/commit path.
- `Rask.Wasm.Tests`: 197 — the host that changed most.
- **E2E `ServerExampleTests`: 2/2** — real WS-over-the-wire correctness.
- The 296 FrameDiffer/diff-gate asserts pass **unchanged** (output preservation): using `ReadOnlySpan<char>` for the leaf helpers means `string` implicitly converts, so no test call site changed.
- `dotnet format` clean; `dotnet build -warnaserror` clean on Core/Server/Wasm.

## Changelog

`[Unreleased] → Changed` entry added.
