### PR TITLE
ci: gate diff-payload-bytes regressions against the committed baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,41 @@ jobs:
           path: |
             **/TestResults/**
 
+  # Deterministic perf-regression gate. The diff codec's wire-bytes-per-update for a fixed set of
+  # scenarios is noise-free (no timing — every render emits the same payload shape with one small value
+  # differing), so we compare it byte-for-byte against benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
+  # and fail the PR on a regression (more diff bytes or more ops). An improvement passes with a
+  # "refresh the baseline" notice. Fast (no BDN, no WASM, no browser) so it runs on every PR; the full
+  # BenchmarkDotNet timing suites stay hand-run — they're too noisy on shared runners to gate on.
+  benchmarks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Build.targets') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj
+
+      - name: Build benchmark project
+        # -m:1 (serial) avoids the parallel ProjectReference copy race on Rask.Core.dll, matching `unit`.
+        run: dotnet build benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj -c Release --no-restore -m:1
+
+      - name: Payload-bytes regression gate
+        run: >-
+          dotnet run -c Release --project benchmarks/Rask.Benchmarks --no-build -- payload-bytes --check
+
   # Browser journeys: exactly one comprehensive [Fact] journey per hosting project.
   # Sharded one host per runner so all fixtures boot in parallel — wall-clock is the
   # slowest single host's cold boot + its journey, not 4 serial batches on one runner.

--- a/benchmarks/Rask.Benchmarks/Baselines/README.md
+++ b/benchmarks/Rask.Benchmarks/Baselines/README.md
@@ -3,8 +3,19 @@
 Reference numbers from the live-render diff codec. Each future PR touching the
 render path should compare against these and quote the delta in its description.
 
-Hardware: Apple M4 Pro (Arm64), 14 logical / 14 physical cores, .NET 10.0.5,
-BenchmarkDotNet v0.14.0, Concurrent Server GC.
+> **`payload-bytes.csv` is enforced by CI.** The `benchmarks` job in
+> `.github/workflows/ci.yml` runs
+> `dotnet run -c Release --project benchmarks/Rask.Benchmarks -- payload-bytes --check`
+> on every PR and **fails on a regression** — more diff bytes or more diff ops than the
+> committed baseline, for any scenario. These metrics are deterministic (no timing noise),
+> so the comparison is byte-exact. An *improvement* passes with a "refresh the baseline"
+> notice; when you improve the codec, regenerate the CSV (command below) in the same PR so
+> the gate keeps tracking reality. `FullPayloadBytes` is informational only (it moves
+> whenever the scenario markup or runtime script changes) and is **not** gated.
+
+Hardware: Apple M4 (Arm64), .NET 10, Concurrent Server GC. The gated columns
+(`DiffPayloadBytes`, `DiffOpCount`) are machine-independent — they're exact byte counts of
+a deterministic payload, so the CI runner reproduces them regardless of hardware.
 
 ## Headline metric — `payload-bytes.csv`
 
@@ -30,17 +41,17 @@ dotnet run -c Release --project Rask.Benchmarks -- payload-bytes
 
 | Scenario            | Full payload | Diff payload | Diff ops |  Reduction |
 |---------------------|-------------:|-------------:|---------:|-----------:|
-| CounterOnLargePage  |       62,577 |           45 |        1 | **1,391×** |
-| KeyedList100Reorder |        6,720 |           57 |        2 |   **118×** |
-| TextNodeUpdate      |       62,460 |           54 |        1 | **1,157×** |
-| AppendRowToList100  |        6,788 |          112 |        1 |    **61×** |
+| CounterOnLargePage  |       66,838 |           45 |        1 | **1,485×** |
+| KeyedList100Reorder |        6,691 |           47 |        1 |   **142×** |
+| TextNodeUpdate      |       66,721 |           54 |        1 | **1,236×** |
+| AppendRowToList100  |        6,759 |           46 |        1 |   **147×** |
 
 All four scenarios beat the plan's targets:
 
-- `CounterOnLargePage`  target ≤ **200** bytes → **45**  ✓ (positional per-op JSON shaved ~12 B)
-- `KeyedList100Reorder` target ≤ **500** bytes → **57**  ✓ (LIS-minimal `MoveSubtree` pair, positional encoded)
-- `TextNodeUpdate`      target ≤ **100** bytes → **54**  ✓
-- `AppendRowToList100`  target ≤ **300** bytes → **112** ✓ (UnsafeRelaxedJsonEscaping halved the HTML-fragment bytes)
+- `CounterOnLargePage`  target ≤ **200** bytes → **45** ✓ (positional per-op JSON shaved ~12 B)
+- `KeyedList100Reorder` target ≤ **500** bytes → **47** ✓ (keyed minimal-moves collapse the reorder to one op)
+- `TextNodeUpdate`      target ≤ **100** bytes → **54** ✓
+- `AppendRowToList100`  target ≤ **300** bytes → **46** ✓ (relaxed JSON escaping + tighter fragment slice)
 
 Full-payload bytes also dropped ~40% across the board after the WS writer switched
 to `UnsafeRelaxedJsonEscaping` — the default `Utf8JsonWriter` escaping rewrites
@@ -216,7 +227,7 @@ in the step-5 inner-attribute diff (`NoChange_ReusedScratch` sits at the same
 intentional wire-shaped allocation left untouched; a lazy-`PathPlus` follow-up
 could reclaim it.
 
-The diff **output** is unchanged: `payload-bytes.csv` (`45/1, 57/2, 54/1, 112/1`)
+The diff **output** is unchanged: `payload-bytes.csv` (diff bytes/ops per scenario)
 is byte-identical before/after, and all `FrameDifferTests` (incl. the random-
 permutation replay theory and a new nested-keyed-list recursion guard),
 `LisAlgorithmTests`, and `SessionRenderCacheTests` pass — pure allocation win, no

--- a/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
+++ b/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
@@ -1,5 +1,5 @@
 Scenario,FullPayloadBytes,DiffPayloadBytes,DiffOpCount
-CounterOnLargePage,62577,45,1
-KeyedList100Reorder,6720,57,2
-TextNodeUpdate,62460,54,1
-AppendRowToList100,6788,112,1
+CounterOnLargePage,66838,45,1
+KeyedList100Reorder,6691,47,1
+TextNodeUpdate,66721,54,1
+AppendRowToList100,6759,46,1

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -23,31 +23,127 @@ namespace Rask.Benchmarks;
 // — the targets that justify the "Rask is a real Blazor competitor" claim.
 internal static class PayloadBytesReport
 {
+    private const string Header = "Scenario,FullPayloadBytes,DiffPayloadBytes,DiffOpCount";
+
+    private readonly record struct Row(string Scenario, int FullBytes, int DiffBytes, int DiffOps);
+
     public static int Run(string[] args)
     {
         var writer = new ArrayBufferWriter<byte>(64 * 1024);
+        var check = Array.Exists(args, a => a == "--check");
 
-        Console.WriteLine("Scenario,FullPayloadBytes,DiffPayloadBytes,DiffOpCount");
+        Console.WriteLine(Header);
 
-        Report("CounterOnLargePage", writer,
-            BuildLargePageWithCounter(1),
-            BuildLargePageWithCounter(2));
-        Report("KeyedList100Reorder", writer,
-            BuildKeyedListTree(MakeKeyedOrder(100)),
-            BuildKeyedListTree(SwapKeyed(MakeKeyedOrder(100), 5, 95)));
-        Report("TextNodeUpdate", writer,
-            BuildLargePageWithDeepTextCell(1),
-            BuildLargePageWithDeepTextCell(2));
-        // Structural change: append one row to a 100-row list. Triggers an
-        // InsertSubtree op with the new row's HTML fragment as op.Value.
-        Report("AppendRowToList100", writer,
-            BuildKeyedListTree(MakeKeyedOrder(100)),
-            BuildKeyedListTree(MakeKeyedOrder(101)));
+        var rows = new List<Row>
+        {
+            Report("CounterOnLargePage", writer,
+                BuildLargePageWithCounter(1),
+                BuildLargePageWithCounter(2)),
+            Report("KeyedList100Reorder", writer,
+                BuildKeyedListTree(MakeKeyedOrder(100)),
+                BuildKeyedListTree(SwapKeyed(MakeKeyedOrder(100), 5, 95))),
+            Report("TextNodeUpdate", writer,
+                BuildLargePageWithDeepTextCell(1),
+                BuildLargePageWithDeepTextCell(2)),
+            // Structural change: append one row to a 100-row list. Triggers an
+            // InsertSubtree op with the new row's HTML fragment as op.Value.
+            Report("AppendRowToList100", writer,
+                BuildKeyedListTree(MakeKeyedOrder(100)),
+                BuildKeyedListTree(MakeKeyedOrder(101)))
+        };
 
-        return 0;
+        return check ? CheckAgainstBaseline(rows) : 0;
     }
 
-    private static void Report(
+    // Compares the deterministic diff-codec metrics (diff wire bytes + op count — the values that only
+    // move when the render/diff path itself changes) against the committed baseline, and fails the CI
+    // gate on a regression. FullPayloadBytes is informational (it moves whenever the scenario markup
+    // changes) and is not gated. An improvement (fewer bytes/ops) passes but asks for a baseline refresh
+    // so the file keeps tracking reality; a scenario missing from the baseline also fails, so a new
+    // scenario can't slip in ungated.
+    private static int CheckAgainstBaseline(List<Row> current)
+    {
+        var baselinePath = Path.Combine(AppContext.BaseDirectory, "Baselines", "payload-bytes.csv");
+        if (!File.Exists(baselinePath))
+        {
+            Console.Error.WriteLine($"::error::Baseline not found at {baselinePath}");
+            return 1;
+        }
+
+        var baseline = ParseBaseline(baselinePath);
+
+        var regressed = false;
+        var improved = false;
+        Console.WriteLine();
+        Console.WriteLine("Regression check vs Baselines/payload-bytes.csv (diff bytes / op count):");
+        foreach (var row in current)
+        {
+            if (!baseline.TryGetValue(row.Scenario, out var b))
+            {
+                Console.Error.WriteLine(
+                    $"::error::Scenario '{row.Scenario}' is missing from the baseline — " +
+                    "add it (regenerate with `payload-bytes`) so it can't regress ungated.");
+                regressed = true;
+                continue;
+            }
+
+            var byteDelta = row.DiffBytes - b.DiffBytes;
+            var opDelta = row.DiffOps - b.DiffOps;
+            var status = byteDelta > 0 || opDelta > 0 ? "REGRESSED" : byteDelta < 0 || opDelta < 0 ? "improved" : "ok";
+            Console.WriteLine(
+                $"  {row.Scenario,-22} diff {row.DiffBytes,6}B ({byteDelta,+0}) " +
+                $"ops {row.DiffOps} ({opDelta,+0})  [{status}]");
+
+            if (byteDelta > 0 || opDelta > 0)
+            {
+                Console.Error.WriteLine(
+                    $"::error::{row.Scenario} regressed: diff bytes {b.DiffBytes}→{row.DiffBytes}, " +
+                    $"ops {b.DiffOps}→{row.DiffOps}.");
+                regressed = true;
+            }
+            else if (byteDelta < 0 || opDelta < 0)
+            {
+                improved = true;
+            }
+        }
+
+        if (improved && !regressed)
+        {
+            Console.WriteLine(
+                "::notice::Diff payload improved vs baseline — refresh Baselines/payload-bytes.csv " +
+                "(`dotnet run -c Release --project benchmarks/Rask.Benchmarks -- payload-bytes`) so it keeps tracking reality.");
+        }
+
+        return regressed ? 1 : 0;
+    }
+
+    private static Dictionary<string, Row> ParseBaseline(string path)
+    {
+        var map = new Dictionary<string, Row>(StringComparer.Ordinal);
+        foreach (var line in File.ReadLines(path))
+        {
+            if (line.Length == 0 || line.StartsWith("Scenario,", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var cells = line.Split(',');
+            if (cells.Length < 4)
+            {
+                continue;
+            }
+
+            map[cells[0]] = new Row(
+                cells[0],
+                int.Parse(cells[1], CultureInfo.InvariantCulture),
+                int.Parse(cells[2], CultureInfo.InvariantCulture),
+                int.Parse(cells[3], CultureInfo.InvariantCulture));
+        }
+
+        return map;
+    }
+
+    private static Row Report(
         string name,
         ArrayBufferWriter<byte> writer,
         Component before,
@@ -76,6 +172,8 @@ internal static class PayloadBytesReport
             CultureInfo.InvariantCulture,
             "{0},{1},{2},{3}",
             name, fullBytes, diffBytes, ops.Count));
+
+        return new Row(name, fullBytes, diffBytes, ops.Count);
     }
 
     private static RenderFrame[] CaptureFrames(Component tree)

--- a/benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj
+++ b/benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj
@@ -17,6 +17,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Copied to the output dir so the payload-bytes regression check can read the committed baseline
+         at runtime regardless of the working directory (resolved from AppContext.BaseDirectory in CI). -->
+    <None Include="Baselines\payload-bytes.csv" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Cqrs\Rask.Cqrs.csproj"/>


### PR DESCRIPTION
## Summary

Runs benchmarks in CI as a **deterministic perf-regression gate**. The diff codec's wire-bytes-per-update for a fixed set of scenarios is noise-free — every render emits the same payload shape with one small value differing — so it can be compared byte-for-byte against the committed baseline. A new `benchmarks` job in `ci.yml` runs it on every PR and **fails on a regression**.

Full BenchmarkDotNet timing suites stay hand-run: timing is too noisy on shared runners to gate on. This gates only the deterministic wire-byte metrics.

## What's gated

`benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv` — for each scenario (`CounterOnLargePage`, `KeyedList100Reorder`, `TextNodeUpdate`, `AppendRowToList100`):
- **`DiffPayloadBytes`** and **`DiffOpCount`** — these only move when the render/diff path itself changes. A PR that increases either for any scenario **fails** (exit 1) with a `::error::` naming the scenario and the before→after.
- **`FullPayloadBytes`** is informational only (it moves whenever scenario markup or the runtime script changes) and is **not** gated.

An *improvement* (fewer bytes/ops) passes with a `::notice::` asking to refresh the baseline, so the file keeps tracking reality.

## Changes

- **`payload-bytes --check`** mode added to `PayloadBytesReport` — runs the existing deterministic report, then compares each scenario's diff metrics against the baseline and returns a non-zero exit code on regression. Baseline is copied to the output dir (csproj `<None ... CopyToOutputDirectory>`) so it resolves from `AppContext.BaseDirectory` regardless of the working directory.
- **`benchmarks` CI job** in `.github/workflows/ci.yml` — restore + build `Rask.Benchmarks` (no WASM, no browser, no BDN → fast) and run the check.
- **Baseline refreshed** to current numbers. The committed baseline was stale (looser than reality — the diff codec had improved since it was recorded, e.g. `KeyedList100Reorder` 57B/2ops → 47B/1op, `AppendRowToList100` 112B → 46B); refreshing makes the gate tight from day one.
- **`Baselines/README.md`** notes the gate, the refresh command, and the updated numbers.

## Testing

- Gate **passes** clean against the refreshed baseline (exit 0).
- Gate **catches a regression**: artificially lowering a baseline value below current output produces `[REGRESSED]` + `::error::` and exit 1 (verified locally).
- `dotnet build benchmarks/Rask.Benchmarks -warnaserror` clean; `dotnet format` clean; workflow YAML validated.
