### PR TITLE
perf(core): move three cold reference fields off leaf elements into LiveState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **Leaf elements retain less memory: three cold reference fields moved off the base `Component`.** The
+  error-boundary pointer, render handle, and lifetime-token source are only ever set on live-render
+  roots and user components (which already allocate a lazy `LiveState`), yet every `Element` in a mounted
+  tree — the bulk of a rendered page — carried all three as mostly-null references. They now live in
+  `LiveState`, so a plain `Div`/`Span`/text node sheds 24 bytes each and a component that never touches
+  its cancellation token allocates no `LiveState` at all. Reduces retained heap for a mounted tree
+  (~9% on the 100-row keyed-list footprint benchmark), narrowing the one axis where Blazor's dense frame
+  structs still lead. No behavioural change — the fields are read through the same members, now backed by
+  `LiveState`.
 - **A live update no longer allocates the whole page as a string.** Every render materialised the full
   document via `StringBuilder.ToString()` — the dominant managed allocation of a small update on a large
   page — even when the shipped payload was one `UpdateText` op that never reads the HTML. The session now

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -46,15 +46,13 @@ public abstract class Component
     // Latched on: once a reader, always a reader (its Render path can read different
     // context/edit-context state across renders).
     private bool _readsAmbientState;
-    private CancellationTokenSource? _lifetimeCts;
 
-    // All live-render-only state — handlers, child reconciliation, root alive sets,
-    // edit-context pool, the dirty/lifecycle flags — is hoisted off the base Component
-    // class into a lazy container. Plain Elements (Div, Span, …) never engage any of
-    // these paths and so keep `_live` null forever: their per-instance footprint drops
-    // to ~24 B (object header + Children + Boundary refs) versus the pre-hoist ~96 B.
-    // User components and live-render roots pay one LiveState allocation on first use;
-    // subsequent renders reuse it via the pooled dictionaries inside.
+    // All live-render-only state — handlers, child reconciliation, root alive sets, the error
+    // boundary + render handle + lifetime token, edit-context pool, the dirty/lifecycle flags — is
+    // hoisted off the base Component class into a lazy container. Plain Elements (Div, Span, …) never
+    // engage any of these paths and so keep `_live` null forever: their per-instance footprint is just
+    // the object header + a Children ref. User components and live-render roots pay one LiveState
+    // allocation on first use; subsequent renders reuse it via the pooled dictionaries inside.
     private LiveState? _live;
 
     private LiveState Live => _live ??= new LiveState();
@@ -205,8 +203,22 @@ public abstract class Component
 
     // Nearest enclosing ErrorBoundary, stamped during the render walk (HtmlSerializer
     // default branch). Async lifecycle continuations + dispatcher catch sites consult this
-    // pointer to trip the right boundary; null means no ancestor boundary registered.
-    internal ErrorBoundary? Boundary { get; set; }
+    // pointer to trip the right boundary; null means no ancestor boundary registered. Hoisted
+    // into LiveState — only user components get one stamped, and the null-guard keeps a
+    // boundaryless component (or a plain Element) from allocating a LiveState just to store null.
+    internal ErrorBoundary? Boundary
+    {
+        get => _live?.Boundary;
+        set
+        {
+            if (value is null && _live is null)
+            {
+                return;
+            }
+
+            Live.Boundary = value;
+        }
+    }
 
     // Components that read mutable state the framework doesn't observe (e.g. RouteState in
     // Router/Outlet) must opt out of render caching: without this their cached subtree gets
@@ -298,9 +310,24 @@ public abstract class Component
     // The raw, stable lifetime token — cancelled once on unmount. Used internally to seed the linked
     // per-dispatch token without re-entering the context-aware CancellationToken getter above.
     private CancellationToken LifetimeToken =>
-        LazyInitializer.EnsureInitialized(ref _lifetimeCts, () => new CancellationTokenSource()).Token;
+        LazyInitializer.EnsureInitialized(ref Live.LifetimeCts, () => new CancellationTokenSource()).Token;
 
-    internal IRenderHandle? RenderHandle { get; set; }
+    // Hoisted into LiveState like Boundary: set only on the live-render root and on GetOrCreate'd
+    // user components (both of which already carry a LiveState); the null-guard keeps a `?? =` with a
+    // null handle, or a plain Element, from allocating one.
+    internal IRenderHandle? RenderHandle
+    {
+        get => _live?.RenderHandle;
+        set
+        {
+            if (value is null && _live is null)
+            {
+                return;
+            }
+
+            Live.RenderHandle = value;
+        }
+    }
 
     internal IReadOnlyDictionary<(Type, int), Component> PersistedChildren => _live?.Children ?? _emptyChildren;
 
@@ -576,7 +603,9 @@ public abstract class Component
 
     internal void CancelLifetimeToken()
     {
-        var cts = Volatile.Read(ref _lifetimeCts);
+        // No LiveState → LifetimeToken was never accessed → no CTS to cancel (plain Elements never
+        // reach here). Read the ref off LiveState only once we know it exists.
+        var cts = _live is null ? null : Volatile.Read(ref _live.LifetimeCts);
         if (cts is null)
         {
             return;
@@ -588,7 +617,7 @@ public abstract class Component
 
     internal void DisposeLifetimeToken()
     {
-        var cts = Interlocked.Exchange(ref _lifetimeCts, null);
+        var cts = _live is null ? null : Interlocked.Exchange(ref _live.LifetimeCts, null);
         cts?.Dispose();
     }
 
@@ -1653,6 +1682,11 @@ public abstract class Component
     {
         public HashSet<Component>? AliveNow;
         public HashSet<Component>? AlivePrev;
+        // Hoisted off the base Component: only ever set on live-render roots and user components
+        // (which allocate a LiveState anyway), so plain Elements shed these three refs entirely.
+        public ErrorBoundary? Boundary;
+        public IRenderHandle? RenderHandle;
+        public CancellationTokenSource? LifetimeCts;
         public Component? CachedRenderResult;
         public int ChildPositions;
         public Dictionary<(Type, int), Component>? Children;

--- a/tests/Rask.Core.Tests/Lifecycle/ComponentCancellationTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/ComponentCancellationTests.cs
@@ -88,15 +88,26 @@ public class ComponentCancellationTests
     public void CancellationToken_NeverAccessed_NoCtsAllocated()
     {
         var c = new CancellationProbe();
-        var field = typeof(Component)
-            .GetField("_lifetimeCts", BindingFlags.Instance | BindingFlags.NonPublic);
-        Assert.NotNull(field);
-
-        Assert.Null(field!.GetValue(c));
+        // The lifetime CTS is hoisted into the lazy LiveState container. A component that never
+        // touches its token (nor any other live-render path) allocates no LiveState at all up front —
+        // a stronger guarantee than the pre-hoist "field stays null": there is no container to hold it.
+        var liveField = typeof(Component)
+            .GetField("_live", BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.NotNull(liveField);
+        Assert.Null(liveField!.GetValue(c));
 
         ComponentLifecycle.DisposeComponentTree(c);
 
-        Assert.Null(field.GetValue(c));
+        // Dispose stamps lifecycle flags, so a LiveState may now exist — but it must never have
+        // allocated a CancellationTokenSource for a token that was never observed.
+        var live = liveField.GetValue(c);
+        if (live is not null)
+        {
+            var cts = live.GetType()
+                .GetField("LifetimeCts", BindingFlags.Instance | BindingFlags.Public)!
+                .GetValue(live);
+            Assert.Null(cts);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The one axis where Blazor still leads is **retained heap per mounted tree** — Rask keeps a `Component` object graph (one heap object per element) where Blazor packs dense `RenderTreeFrame` structs. This narrows that gap by moving three reference fields that leaf elements never use off the base `Component` and into the already-lazy `LiveState`:

- `Boundary` (nearest `ErrorBoundary`) — stamped only on user components during the render walk.
- `RenderHandle` — set only on the live-render root and `GetOrCreate`'d user components.
- the lifetime `CancellationTokenSource` — allocated only when a component observes its cancellation token.

All three are only ever set on live-render roots and user components, which already allocate a `LiveState`, so moving them costs those components nothing — while every plain `Div`/`Span`/text node in a rendered page (the bulk of a tree) sheds **24 bytes**. A component that never touches its cancellation token now allocates no `LiveState` at all.

The reads/writes go through the same members (now `LiveState`-backed, with a null-guard so a boundaryless component or a `?? =` with a null handle never allocates a `LiveState` just to store null). **No behavioural change.**

## Measurement (honest)

The change is a **provable** −24 B per leaf element (three fewer reference fields — deterministic from the object layout). The `mem-footprint` retained-heap benchmark is GC-counter noisy (±~13%, bimodal, correlated across both frameworks), so treat its tree-level percentages as approximate:

- **KeyedList_100Rows: 157,356 → 143,042 B (−9.1%)** — the most stable signal, and the worst-ratio scenario; ratio 0.38× → 0.42× vs Blazor.
- **LargePage_200Rows: reduced (~330 KB warm), but within the benchmark's cross-run noise** — reported as directional, not precise.

This doesn't flip the axis (Blazor's frame density still leads); it narrows it, which is the honest ceiling for a field-level trim.

## Testing

- `Rask.Core.Tests`: 1,823 passed, 1 skipped — including the updated `CancellationToken_NeverAccessed_NoCtsAllocated` (now asserts no `LiveState`/CTS is allocated when the token is never observed — a stronger guarantee).
- `Rask.Server.Tests`: 248 passed (dispatch + disposal, the paths these fields sit on).
- **E2E `ServerExampleTests`: 2/2.**
- `dotnet build -warnaserror` clean on Core/Server/Wasm; `dotnet format` clean.

## Changelog

`[Unreleased] → Changed` entry added.