### PR TITLE
test: harden flaky LiveTicker lifecycle timeouts against cold CI thread pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,13 @@ them until tagged releases begin.
   drops ~35% (69.4 KB → 45.3 KB per update).
 
 ### Fixed
+- **Flaky `LiveTicker` lifecycle tests no longer time out on a cold CI thread pool.** The
+  background-async waits in `LiveTickerTests` gave the synthetic poll loop only 2 s to land its
+  first tick; on the nightly `unit` job — which compiles every WASM sample bundle immediately
+  before running tests — the thread-pool hill-climber injects workers slowly, so a correct-but-slow
+  continuation occasionally slipped past that deadline and failed the run. The waits now use
+  generous named budgets (`Settle` 10 s, `FillToCapacity` 20 s); since `WaitFor.True` returns the
+  instant the condition holds, a healthy run is unaffected. Test-only change — no framework code touched.
 - **Bs dropdown-family popovers no longer get clipped by an `overflow` ancestor.** The Popper-less
   `.dropdown-menu` of `BsDatePicker`/`BsTimePicker`/`BsDateTimePicker`, `BsDropdown`, and `BsMultiSelect`
   was `position: absolute`, so opening one inside a card or scroll region (anything with

--- a/tests/Rask.Example.Shared.Tests/Demos/LiveTickerTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/LiveTickerTests.cs
@@ -14,6 +14,20 @@ namespace Rask.Example.Shared.Tests.Demos;
 // HTML rather than through an IJSRuntime stub.
 public sealed class LiveTickerTests
 {
+    // These are background-async lifecycle waits: OnMountAsync spins up a poll loop
+    // whose first tick lands only after a 50 ms Task.Delay, and WaitFor polls the
+    // rendered HTML on its own delay. On a cold/starved thread pool (e.g. the nightly
+    // unit job runs right after compiling every WASM sample bundle), the thread-pool
+    // hill-climber injects worker threads slowly, so those continuations can slip past
+    // a tight deadline even though the code is correct. WaitFor.True returns the instant
+    // the condition holds, so these generous budgets never slow a healthy run — they
+    // only keep a momentarily-starved runner from flaking.
+    private static readonly TimeSpan Settle = TimeSpan.FromSeconds(10);
+
+    // The cap test must accumulate 60 ticks (≈60 × 65 ms of real delay) before the
+    // buffer fills, so it needs a proportionally larger budget than a single-tick wait.
+    private static readonly TimeSpan FillToCapacity = TimeSpan.FromSeconds(20);
+
     [Fact]
     public async Task OnMountAsync_PopulatesHistoryFromSyntheticFeed()
     {
@@ -23,7 +37,7 @@ public sealed class LiveTickerTests
         host.RenderAsLiveRoot();
         await WaitFor.True(
             () => PointCount(host.RenderAsLiveRoot()) >= 1,
-            TimeSpan.FromSeconds(2),
+            Settle,
             "the synthetic feed never populated the history");
 
         Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnMount:"));
@@ -40,11 +54,11 @@ public sealed class LiveTickerTests
         var host = BuildHost(symbol, 30);
 
         host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnPropsChangedAsync"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => host.Log.Contains("OnPropsChangedAsync"), Settle);
 
         symbol.Value = "ETH";
         host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("Symbol BTC → ETH"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => host.Log.Contains("Symbol BTC → ETH"), Settle);
 
         Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnPropsChanged: Symbol BTC → ETH"));
         Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnPropsChangedAsync: switched to ETH"));
@@ -57,11 +71,11 @@ public sealed class LiveTickerTests
         var host = BuildHost(symbol, 30);
 
         host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnMountAsync"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => host.Log.Contains("OnMountAsync"), Settle);
 
         host.Mounted = false;
         host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnUnmountAsync: flushed"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => host.Log.Contains("OnUnmountAsync: flushed"), Settle);
 
         Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnUnmount: stopping"));
         Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnUnmountAsync: flushed"));
@@ -78,14 +92,14 @@ public sealed class LiveTickerTests
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1, TimeSpan.FromSeconds(2),
+            () => PointCount(host.RenderAsLiveRoot()) >= 1, Settle,
             "the poll loop never produced a tick");
 
         host.Mounted = false;
         host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnUnmountAsync: flushed"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => host.Log.Contains("OnUnmountAsync: flushed"), Settle);
         await WaitFor.True(
-            () => host.Log.Contains("poll loop cancelled"), TimeSpan.FromSeconds(2),
+            () => host.Log.Contains("poll loop cancelled"), Settle,
             "the poll loop did not stop after unmount");
     }
 
@@ -103,7 +117,7 @@ public sealed class LiveTickerTests
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 60, TimeSpan.FromSeconds(8),
+            () => PointCount(host.RenderAsLiveRoot()) >= 60, FillToCapacity,
             "the history never filled to capacity");
 
         Assert.Equal(60, PointCount(host.RenderAsLiveRoot()));
@@ -112,7 +126,7 @@ public sealed class LiveTickerTests
         // the increasing feed) yet the count stays pinned at 60 — the oldest rolled off.
         var price = PriceFromHtml(host.RenderAsLiveRoot());
         await WaitFor.True(
-            () => PriceFromHtml(host.RenderAsLiveRoot()) > price + 5m, TimeSpan.FromSeconds(4),
+            () => PriceFromHtml(host.RenderAsLiveRoot()) > price + 5m, Settle,
             "the poll loop stopped ticking after reaching capacity");
 
         Assert.Equal(60, PointCount(host.RenderAsLiveRoot()));
@@ -138,7 +152,7 @@ public sealed class LiveTickerTests
         host.RenderAsLiveRoot();
 
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1, TimeSpan.FromSeconds(2),
+            () => PointCount(host.RenderAsLiveRoot()) >= 1, Settle,
             "the symbol switch did not wake the poll loop");
 
         // The only price that landed is ETH-magnitude (seed ≈2 500); a stale
@@ -159,7 +173,7 @@ public sealed class LiveTickerTests
 
         host.RenderAsLiveRoot();
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1, TimeSpan.FromSeconds(2),
+            () => PointCount(host.RenderAsLiveRoot()) >= 1, Settle,
             "first poll never ran");
 
         symbol.Value = "ETH";
@@ -172,7 +186,7 @@ public sealed class LiveTickerTests
                 var html = host.RenderAsLiveRoot();
                 return PointCount(html) >= 1 && PriceFromHtml(html) < 10_000m;
             },
-            TimeSpan.FromSeconds(2),
+            Settle,
             "symbol switch did not wake the poll loop for an immediate tick");
     }
 
@@ -189,7 +203,7 @@ public sealed class LiveTickerTests
         host.RenderAsLiveRoot();
         await WaitFor.True(
             () => host.RenderAsLiveRoot().Contains("Feed error: feed offline"),
-            TimeSpan.FromSeconds(2),
+            Settle,
             "a throwing price source never surfaced the #ticker-error alert");
 
         var html = host.RenderAsLiveRoot();


### PR DESCRIPTION
## Summary

The nightly `unit` job failed on `main` (commit `dc5a227`, right after #290) with a single flaky test:

```
Rask.Example.Shared.Tests.Demos.LiveTickerTests.OnMountAsync_PopulatesHistoryFromSyntheticFeed
  System.TimeoutException : WaitFor timed out after 00:00:02: the synthetic feed never populated the history
```

The parallel `ci` run passed all unit tests on the **same commit**, and the test passes reliably locally — so this is a timing flake, not a regression.

**Root cause.** `OnMountAsync` starts a synthetic poll loop whose first tick only lands after a `Task.Delay(50)`, and `WaitFor` polls the rendered HTML on its own delay. The nightly `unit` job compiles *every* WASM sample bundle immediately before running the tests, so the test-host thread pool is cold when these run. The thread-pool hill-climber injects worker threads slowly, and a correct-but-slow continuation can slip past the tight 2 s deadline.

**Fix.** Replace the tight per-wait literals with two generous named budgets — `Settle` (10 s) for single-event lifecycle waits and `FillToCapacity` (20 s) for the 60-tick cap test. `WaitFor.True` returns the instant its condition holds, so a healthy run is unaffected; only a momentarily-starved runner benefits. A comment documents why the budgets are generous.

Test-only change — no framework, render, or runtime code touched.

## Testing

- `dotnet test tests/Rask.Example.Shared.Tests --filter FullyQualifiedName~LiveTickerTests` → 9/9 passed
- `dotnet format --verify-no-changes` on the test project → clean

## Benchmarks

Not applicable — no render/runtime hot-path code changed.

## Changelog

Added under `[Unreleased] → Fixed`.