### PR TITLE
fix(native): make the rask-native template actually build + run (packaging + manifest)

### DIFF
--- a/docs/native.md
+++ b/docs/native.md
@@ -129,8 +129,12 @@ sandbox, and real background execution — without giving up "the same component
 
 1. ✅ **Foundation** — `NativeAppHost` / `NativeLiveSession` / `NativeJSRuntime`, the `INativeWebView`
    bridge, the `rask.native.js` client dialect + boot shell, unit-tested on `net10.0`.
-2. **Platform heads** — reference `WKWebView` (iOS) and `WebView` (Android) implementations of
-   `INativeWebView`, with custom-scheme / asset-loader serving and the UI-thread bridge.
+2. ✅ **Platform heads + template** — the `rask-native` template ships `WKWebView` (iOS) and `WebView`
+   (Android) implementations of `INativeWebView`, with custom-scheme / asset-loader serving and the
+   UI-thread bridge. **Verified end-to-end on Android**: a signed APK boots the app in the emulator,
+   renders the component tree over the native bridge, routes, and updates live (the Counter increments via
+   a diff on tap). The iOS head compiles against the Microsoft.iOS bindings; a full iOS build/simulator run
+   awaits an Xcode-provisioned environment.
 3. **Client parity** — lift the transport-neutral DOM helpers (rAF input/scroll coalescing, keyboard/drag/
    file events, scoped-CSS FOUC gating, scoped-JS invoke gating) shared with `rask.wasm.js` into a common
    module so the native client reaches full parity instead of re-copying them.

--- a/docs/native.md
+++ b/docs/native.md
@@ -131,10 +131,11 @@ sandbox, and real background execution — without giving up "the same component
    bridge, the `rask.native.js` client dialect + boot shell, unit-tested on `net10.0`.
 2. ✅ **Platform heads + template** — the `rask-native` template ships `WKWebView` (iOS) and `WebView`
    (Android) implementations of `INativeWebView`, with custom-scheme / asset-loader serving and the
-   UI-thread bridge. **Verified end-to-end on Android**: a signed APK boots the app in the emulator,
-   renders the component tree over the native bridge, routes, and updates live (the Counter increments via
-   a diff on tap). The iOS head compiles against the Microsoft.iOS bindings; a full iOS build/simulator run
-   awaits an Xcode-provisioned environment.
+   UI-thread bridge. **Verified end-to-end on both platforms**: the app boots, serves the shell + client
+   from the app origin, renders the component tree over the native bridge, routes, and updates live (the
+   Counter increments via a diff on click). Android: a signed APK on the emulator (verified by screenshot).
+   iOS: on the simulator, verified by reading `document.body.innerText` and dispatching a click — `simctl`
+   screenshots don't capture `WKWebView`'s out-of-process content, so the DOM is inspected directly.
 3. **Client parity** — lift the transport-neutral DOM helpers (rAF input/scroll coalescing, keyboard/drag/
    file events, scoped-CSS FOUC gating, scoped-JS invoke gating) shared with `rask.wasm.js` into a common
    module so the native client reaches full parity instead of re-copying them.

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -35,6 +35,13 @@
     <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Microsoft.Extensions.Logging"/>
+    <!-- Rask.Core's package dependencies must be surfaced at THIS package boundary: Core is bundled with
+         PrivateAssets="all" (its DLL is packed into lib/ directly, not as a nuget dep), so its transitive
+         deps don't flow to consumers. Without these, a native app fails at runtime with FileNotFoundException
+         (e.g. Microsoft.JSInterop at NativeAppHost.CreateDefault). Mirrors Rask.Wasm/Rask.Server. -->
+    <PackageReference Include="Microsoft.JSInterop"/>
+    <PackageReference Include="Microsoft.Extensions.Primitives"/>
+    <PackageReference Include="Microsoft.Extensions.ObjectPool"/>
     <!-- Rask.Core uses Microsoft.AspNetCore.Authorization (RouteAuthorizationGuard); surface it at
          the package boundary so native heads (no Microsoft.AspNetCore.App) can restore it. -->
     <PackageReference Include="Microsoft.AspNetCore.Authorization"/>

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -45,6 +45,27 @@
   </ItemGroup>
 
   <!--
+    Deliver Rask.Core + the Rask source generators to consumers of this package, exactly like Rask.Wasm
+    and Rask.Server: the generator/analyzer/code-fixes are packed to analyzers/dotnet/cs/ (so a consuming
+    app gets the Generated.{Tag}() factories, the Routes registry, and the RASK diagnostics), and
+    Rask.Core.dll/.xml are bundled into lib/net10.0/. PrivateAssets="all" on the Core ProjectReference
+    keeps Rask.Core out of the nuspec dependency list — we pack its DLL explicitly here. Without this,
+    `dotnet new rask-native` + build cannot resolve Component, the element factories, or [Route].
+  -->
+  <Import Project="..\RaskAnalyzerPack.targets"/>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_RaskAddCoreToLib</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+
+  <Target Name="_RaskAddCoreToLib">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)Rask.Core.dll" PackagePath="lib/net10.0/"/>
+      <TfmSpecificPackageFile Include="$(OutputPath)Rask.Core.xml" PackagePath="lib/net10.0/"/>
+    </ItemGroup>
+  </Target>
+
+  <!--
     The native client runtime (Resources/rask.native.js) is assembled at build the same way as
     rask.wasm.js: splice the shared Rask.Core/Resources modules into the template at the @@RASK_*@@
     markers, then embed the result so the platform WebView can serve it via a custom scheme handler

--- a/src/Rask.Native/build/Rask.Native.props
+++ b/src/Rask.Native/build/Rask.Native.props
@@ -1,0 +1,11 @@
+<Project>
+  <!-- Global usings every Rask app relies on, matching Rask.Wasm/Rask.Server: `Component` and the
+       generated element factories / routing helpers resolve without per-file usings. -->
+  <ItemGroup>
+    <Using Include="Rask.Core"/>
+    <!-- Auto-generated HTML tag factories live in Rask.Core.Components.Generated. -->
+    <Using Include="Rask.Core.Components.Generated" Static="true"/>
+    <!-- Routing helpers (Router/Outlet/Route<T>) come from the generator in Rask.Core.Routing.Generated. -->
+    <Using Include="Rask.Core.Routing.Generated" Static="true"/>
+  </ItemGroup>
+</Project>

--- a/src/Rask.Templates/content/rask-native/Company.RaskNative.csproj
+++ b/src/Rask.Templates/content/rask-native/Company.RaskNative.csproj
@@ -30,6 +30,7 @@
 
   <PropertyGroup Condition="$(TargetFramework.Contains('-android'))">
     <SupportedOSPlatformVersion>24.0</SupportedOSPlatformVersion>
+    <AndroidManifest>Platforms/Android/AndroidManifest.xml</AndroidManifest>
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,10 +43,6 @@
   </ItemGroup>
   <ItemGroup Condition="!$(TargetFramework.Contains('-android'))">
     <Compile Remove="Platforms/Android/**/*.cs"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework.Contains('-android'))">
-    <AndroidManifest>Platforms/Android/AndroidManifest.xml</AndroidManifest>
   </ItemGroup>
 
 </Project>

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/AppDelegate.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/AppDelegate.cs
@@ -10,7 +10,7 @@ public class AppDelegate : UIApplicationDelegate
     public override UIWindow? Window { get; set; }
     private NativeApp? _app;
 
-    public override bool FinishedLaunching(UIApplication application, NSDictionary launchOptions)
+    public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
     {
         Window = new UIWindow(UIScreen.MainScreen.Bounds);
 

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/RaskWkWebView.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/RaskWkWebView.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using CoreFoundation;
 using Foundation;
 using Rask.Native;
+using UIKit;
 using WebKit;
 
 namespace Company.RaskNative;
@@ -35,7 +36,13 @@ public sealed class RaskWkWebView : NSObject, INativeWebView, IWKScriptMessageHa
         controller.AddScriptMessageHandler(this, "rask");
         config.UserContentController = controller;
 
-        View = new WKWebView(CoreGraphics.CGRect.Empty, config);
+        // Size to the screen with flexible autoresizing so the WebView fills the window (and follows
+        // rotation). Assigning a WKWebView built with an empty frame straight to a view controller's View
+        // leaves it at a default size, painting the app content into a small box on a black screen.
+        View = new WKWebView(UIScreen.MainScreen.Bounds, config)
+        {
+            AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight
+        };
     }
 
     /// <summary>Load the boot shell once the session is wired (called from the AppDelegate).</summary>


### PR DESCRIPTION
## Summary

Follow-up to #292. Installing the iOS/Android SDK workloads and **building + running the `rask-native` template on an Android emulator** surfaced four defects that prevented the template from building and running. All are fixed here; with them, `dotnet new rask-native` produces a **signed Android APK that boots the Rask app and updates live over the native WebView bridge**.

1. **`AndroidManifest` in an `<ItemGroup>`** → MSB4232 (it's an MSBuild *property*). Moved to the Android `<PropertyGroup>`.
2. **Package didn't ship `Rask.Core` / generators** → consumers couldn't resolve `Component`, factories, `Routes`. Now bundles `Rask.Core.dll`/`.xml` into `lib/net10.0/` and packs the generator + code-fixes into `analyzers/dotnet/cs/` (via `RaskAnalyzerPack.targets`).
3. **No `build/Rask.Native.props`** → the Rask global usings weren't injected. Added it, matching `Rask.Wasm`/`Rask.Server`.
4. **Core's transitive package deps didn't flow** (Core is bundled `PrivateAssets=all`) → runtime `FileNotFoundException: Microsoft.JSInterop` at `NativeAppHost.CreateDefault`. Surface `Microsoft.JSInterop` / `Microsoft.Extensions.Primitives` / `Microsoft.Extensions.ObjectPool` on the package.

## Testing — verified on a real Android emulator

Packed `Rask.Native` locally, consumed it from the template's Android head, built a **signed APK** against the `net10.0-android` SDK, deployed it to an `android-35` arm64 emulator, and drove it:

- **App boots and renders** the Rask `HomePage` in the WebView ("Hello, Rask — natively!", nav bar) — the render → diff → payload pipeline pushing frames over the native bridge.
- **Routing works** — booting on `/counter` renders the Counter page.
- **Live interaction works** — tapping **Click me** twice takes `Current count:` from **0 → 2**, i.e. WebView click → `window.__raskBridge` (`@JavascriptInterface`) → `NativeAppHost.RouteMessageAsync` → `NativeLiveSession.DispatchAsync` → handler → **diff** → `applyDiff` → DOM updated. End-to-end on-device.
- Package contents verified (`lib/net10.0/Rask.Core.dll`, `analyzers/dotnet/cs/Rask.Generators.dll`, `build/Rask.Native.props`); `Rask.Native.Tests` green (11/11); 0-warning build.

iOS: the head compiles against the Microsoft.iOS bindings; a full iOS build needs Xcode (now installed but its license isn't accepted in this env), so the iOS packaged build/simulator run is not verified here.

## Benchmarks

N/A — packaging/build-config only.