### PR TITLE
fix(native): pad the template body by safe-area insets (notch/status bar)

### DIFF
--- a/src/Rask.Templates/content/rask-native/App.cs
+++ b/src/Rask.Templates/content/rask-native/App.cs
@@ -18,7 +18,10 @@ public sealed class App : Component
         Doctype(),
         Html("en")[
             Head(),
-            Body()[
+            // Pad the body by the device safe-area insets so content clears the status bar / notch /
+            // home indicator (the boot shell requests an edge-to-edge viewport with viewport-fit=cover).
+            Body(Style: "margin:0;padding:env(safe-area-inset-top) env(safe-area-inset-right) " +
+                        "env(safe-area-inset-bottom) env(safe-area-inset-left)")[
                 Nav()[
                     NavLink(HomePage())["Home"],
                     " | ",


### PR DESCRIPTION
## Summary

Small follow-up to the merged native-mobile PRs. The `rask-native` boot shell requests an edge-to-edge viewport (`viewport-fit=cover`), so on notched devices the App's nav renders **under** the status bar / Dynamic Island / home indicator. Apply `env(safe-area-inset-*)` padding to the App body so content clears the insets.

## Testing

Template content only (not solution-built). The native app was already verified rendering + interacting on both the Android emulator and the iOS simulator; this is a CSS-only inset fix to the generated `App`.

## Benchmarks

N/A — template CSS only.