### PR TITLE
fix(native): pack + publish the Rask.Native package (release + nightly)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -185,6 +185,7 @@ jobs:
           dotnet pack src/Rask.Server/Rask.Server.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Wasm/Rask.Wasm.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Native/Rask.Native.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Templates/Rask.Templates.csproj -c Release -o ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,6 +162,9 @@ jobs:
       - name: Pack Rask.Wasm.Hosting
         run: dotnet pack src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj -c Release --no-build -o ./artifacts
 
+      - name: Pack Rask.Native
+        run: dotnet pack src/Rask.Native/Rask.Native.csproj -c Release --no-build -o ./artifacts
+
       - name: Pack Rask.Validation.DataAnnotations
         run: dotnet pack src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj -c Release --no-build -o ./artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ them until tagged releases begin.
   requests an edge-to-edge viewport (`viewport-fit=cover`), so the template's `App.cs` now pads `Body`
   by the device safe-area insets — `padding:env(safe-area-inset-top) … env(safe-area-inset-left)` — to
   clear the status bar, notch / Dynamic Island, and home indicator.
+- **`Rask.Native` is now packed and published.** The package was never in the release/nightly pack
+  lists, so `dotnet add package Rask.Native` (and `dotnet new rask-native`, whose generated project
+  references it) would fail to restore from nuget.org. The `release.yml` and `nightly.yml` pipelines now
+  pack and push `Rask.Native`, and the project is marked `IsPackable` with a package-specific `NUGET.md`
+  — matching the other host packages.
 
 ## [0.15.1] - 2026-07-08
 

--- a/src/Rask.Native/NUGET.md
+++ b/src/Rask.Native/NUGET.md
@@ -1,0 +1,57 @@
+# Rask.Native
+
+**Native mobile host for [Rask](https://github.com/pal-tamas/rask) *(preview)*.** Ship the *same* C#
+component code that runs on the Rask Server and in the browser as a real, store-distributable
+**iOS/Android app**. It's a **WebView hybrid**: your C# runs natively on the device, and the UI
+renders in a platform WebView driven by Rask's live diff pipeline — the same render → diff → payload
+path (`LiveSessionBase`) the Server and WASM hosts use.
+
+The library is transport-agnostic and targets plain `net10.0` (no iOS/Android workloads to build/test);
+the platform WebView lives behind the `INativeWebView` bridge, implemented per platform in the app
+head. Includes `Rask.Core` and the Rask source generators.
+
+## Get started
+
+The `rask-native` template scaffolds both platform heads for you:
+
+```bash
+dotnet new install Rask.Templates
+dotnet new rask-native -n MyApp
+cd MyApp
+
+dotnet workload install ios android          # the iOS/Android SDK workloads (one-time)
+dotnet build -t:Run -f net10.0-android       # Android emulator
+dotnet build -t:Run -f net10.0-ios           # iOS simulator (macOS + Xcode)
+```
+
+To add the host to an existing app head instead:
+
+```bash
+dotnet add package Rask.Native
+```
+
+## Use
+
+```csharp
+using Rask.Native;
+
+// Native + Local — the app runs in-process on the device (offline, store-distributable).
+var host = NativeAppHost.CreateDefault();
+// host.Services.AddSingleton<IMyService, MyService>();   // register app services before RunLocalAsync
+NativeApp app = await host.RunLocalAsync<App>(webView);   // webView: your INativeWebView
+
+// Native + Server — the WebView is a thin native shell over a remote Rask Server (wss://).
+NativeServerShell shell = NativeAppHost.ConnectToServer(new Uri("https://app.example.com/"));
+```
+
+## Notes
+
+- **Preview / pre-1.0** — the host + template + iOS/Android heads run end-to-end; APIs may still shift,
+  and native device *backends* (native geolocation/push/biometrics) are a follow-up.
+- **WebView hybrid, not a native-control renderer** — C# runs native, the view is a WebView (same
+  architecture as MAUI Blazor Hybrid / Capacitor). What it buys over a PWA: App Store / Play Store
+  distribution, native device APIs, and real background execution.
+- The typed `Rask.Core.Browser` device wrappers (`IGeolocation`, `IClipboard`, `IVibration`, …) work
+  through the WebView's JS engine with no extra code.
+
+Full documentation: <https://github.com/pal-tamas/rask/blob/main/docs/native.md>

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -18,6 +18,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Rask.Native</RootNamespace>
+    <IsPackable>true</IsPackable>
     <!--
       Not AOT-analyzed here (like Rask.Server): this host uses DotNetDispatcher for JS↔.NET interop,
       the same as the Server host. iOS requires full AOT, but that is validated at the app-head publish
@@ -29,7 +30,16 @@
     <PackageId>Rask.Native</PackageId>
     <Title>Rask — Native Mobile Host</Title>
     <Description>Rask native-mobile host. Boots a Rask App on iOS/Android inside a platform WebView, driven by the same render/diff pipeline as the Server and WASM hosts — either in-process (offline, Native+Local) or over a remote WebSocket (Native+Server). Ships the native client runtime, the boot shell, and the INativeWebView bridge the app head implements per platform. Includes Rask.Core and the Rask source generators.</Description>
+    <!-- Override the framework default tags (web/component/wasm) — Rask.Native is the native mobile host. -->
+    <PackageTags>native mobile ios android webview hybrid dotnet net10</PackageTags>
   </PropertyGroup>
+
+  <!-- Ship a package-specific README (this project's NUGET.md) instead of the shared framework
+       overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
+  <ItemGroup>
+    <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
+    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>


### PR DESCRIPTION
## Summary

`Rask.Native` is in the solution but was **never in either workflow's per-project pack list**, so it is never pushed to nuget.org. Consequences:

- `dotnet add package Rask.Native` → 404.
- `dotnet new rask-native` → the generated project pins a `Rask.Native` `PackageReference` (`RASK_PKG_VERSION` → the released version), so `dotnet restore` fails with **NU1101**. The native template is effectively unusable.

The docs (badge, package table, `dotnet add package`) advertise the package, so this was a live gap — surfaced while documenting the native host. This wires it into the release + nightly pipelines and brings the project up to the packaging convention the other host packages follow.

## Changes

- **`.github/workflows/release.yml` + `nightly.yml`** — add a `dotnet pack src/Rask.Native/...` step (grouped after `Rask.Wasm.Hosting`); the existing `dotnet nuget push "./artifacts/*.nupkg"` then publishes it.
- **`src/Rask.Native/Rask.Native.csproj`** — mark `<IsPackable>true</IsPackable>`, add native `<PackageTags>`, and ship a package-specific `NUGET.md` (`PackageReadmeFile` inherited from `Directory.Build.props`) instead of the shared framework README — matching `Rask.WebPush`/`Rask.Cqrs`.
- **`src/Rask.Native/NUGET.md`** (new) — package landing page: pitch, `dotnet new rask-native` / `dotnet add package` install, Local/Server usage, preview framing.

## Testing

`dotnet pack src/Rask.Native/Rask.Native.csproj -c Release` produces a valid `.nupkg`, verified to contain:
- `NUGET.md` as the package `<readme>` (the package-specific one, not the root),
- `lib/net10.0/Rask.Core.dll` + `Rask.Native.dll` (Core bundled, as with Wasm/Server),
- `analyzers/dotnet/cs/Rask.Generators.dll` + `Rask.Generators.CodeFixes.dll`,
- `build/Rask.Native.props`, `LICENSE`, icon; `<tags>native mobile ios android webview hybrid …</tags>`.

The package only appears on nuget.org after the next `nightly`/`release` run publishes it. No framework/source-code changes.