### PR TITLE
build(deps): pin Roslyn generator packages to the SDK compiler version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
     commit-message:
       prefix: build
       include: scope
+    ignore:
+      # The Roslyn compiler API consumed by the source generators (Rask.Generators,
+      # Rask.Cqrs.Generators) must not exceed the compiler shipped with the build SDK — an
+      # analyzer that references a newer Roslyn than the running csc fails with CS9057, and it
+      # would raise the compiler floor for every downstream Rask consumer. Keep these pinned to
+      # the SDK's Roslyn version; bump them by hand alongside a global.json / SDK-band update.
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     groups:
       microsoft-extensions:
         patterns:


### PR DESCRIPTION
## Summary

Dependabot opened two bumps for the Roslyn packages — #281 (`Microsoft.CodeAnalysis.CSharp` 5.3.0 → 5.6.0) and #282 (`Microsoft.CodeAnalysis.CSharp.Workspaces` 5.3.0 → 5.6.0). Both are red on every build-dependent check, and they cannot be merged — separately or together.

**Why they fail:**
- These packages consumed by the **source generators** (`Rask.Generators`, `Rask.Cqrs.Generators`). An analyzer/generator that references a newer Roslyn than the running `csc` fails to load with **`CS9057`**. The build SDK here (10.0.201) ships Roslyn **5.3.0**, so a 5.6.0 reference breaks the build — on CI too, same SDK band.
- The referenced Roslyn version is also the **compiler floor** for every downstream Rask consumer, so bumping the generator's Roslyn ref past what we need is a compatibility regression independent of the local SDK.
- The two packages pin exact-version deps on each other (+`Microsoft.CodeAnalysis.Common`), so neither can move alone (`NU1608`), and together they still hit `CS9057`.

**Fix:** add a dependabot `ignore` for both packages so they stay pinned to the SDK's Roslyn and get bumped by hand alongside a global.json / SDK-band update, instead of churning broken PRs weekly.

## Testing

- No source or build input changed — only `.github/dependabot.yml`. Working tree is back to the known-green 5.3.0 state.
- Validated `dependabot.yml` parses as YAML.

## Changelog

Not user-facing (CI/repo hygiene) — no CHANGELOG entry.

## Follow-up

Close #281 and #282 as won't-merge.