### PR TITLE
fix(bootstrap): picker/select UI issues + native <select> bind, all-variant examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,12 @@ them until tagged releases begin.
   drops ~35% (69.4 KB → 45.3 KB per update).
 
 ### Fixed
+- **Bound/controlled native `<select>` no longer snaps back to its old value after a change.** When
+  marking the matching `<option>` selected, `Select<T>` cloned it but dropped its reconciliation `Key`,
+  so the selected option's key shifted on every render, keyed diffing mismatched, and the browser's live
+  `selected` IDL property was never synced — the model updated but the box reverted visually. The marked
+  `<option>`/`<optgroup>` now keeps its `Key`. Affects every bound/controlled `Select<T>` (and so
+  `BsSelect(Native: true)`).
 - **Flaky `LiveTicker` lifecycle tests no longer time out on a cold CI thread pool.** The
   background-async waits in `LiveTickerTests` gave the synthetic poll loop only 2 s to land its
   first tick; on the nightly `unit` job — which compiles every WASM sample bundle immediately
@@ -133,6 +139,16 @@ them until tagged releases begin.
   Mono AOT; it is now computed fresh, and the composed value is boxed to the bound property's actual type.
 - **Time-picker selection now uses the brand colour** (`var(--bs-primary)`) instead of Bootstrap's baked-in
   blue, with a slimmer scrollbar and tighter item padding.
+- **Picker/select UI polish.** The floating label now anchors to the top-left corner (a centred scale origin
+  made it land low/misaligned); the `×` clear on a non-floating `BsSelect`, and the caret/`×` on a
+  non-floating picker, now centre vertically in the box (they were anchored to the whole `.dropdown` — label
+  above included — so they rode up onto the box's top edge); the editable-picker caret is larger; and in the
+  `BsDateTimePicker` popover the hour/minute columns now match the calendar grid's height instead of stopping
+  short.
+- **New variant-gallery examples** for `BsSelect` (basic, floating, searchable, clearable, `OptionValue`
+  projected id, native, native-nullable, disabled), `BsMultiSelect` (basic, searchable, floating, disabled),
+  and the date/time pickers (default, floating, native, min/max/disable, nullable) — each bound with a live
+  readout, in the Bootstrap guide (`docs/bootstrap.md`).
 
 ## [0.15.1] - 2026-07-08
 

--- a/docs/bootstrap.md
+++ b/docs/bootstrap.md
@@ -112,6 +112,17 @@ OptionLabel: p => Text(p.Name))` binds the id but renders/searches the whole `Pe
 
 <!-- demo:bootstrap-forms -->
 
+**`BsSelect<T>` variants** — the same control across every option: basic (binds the option), `Floating`
+label, searchable (`Filter`), nullable + `×` clear, `OptionValue` projected-id binding, `Native` OS
+`<select>`, native + nullable, and `Disabled`. Each is bound and echoed by a live readout:
+
+<!-- demo:bootstrap-select -->
+
+**`BsMultiSelect<T>` variants** — chips + a checkable dropdown bound to a collection: basic, searchable
+(`Filter`), `Floating`, and `Disabled`:
+
+<!-- demo:bootstrap-multiselect -->
+
 **Date & time pickers** — `BsDatePicker<T>`/`BsTimePicker<T>`/`BsDateTimePicker<T>` are **hand-editable**:
 the box is a text `<input>` you can type into (parsed live per keystroke in `CultureInfo.CurrentCulture`;
 a partial/invalid entry is kept, not reverted, and blur normalises it), and focusing it opens a custom

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsFormsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsFormsDemo.cs
@@ -48,6 +48,16 @@ public sealed class BsFormsDemo : Component
             BsCheck(() => _model.Agree, Switch: true, Label: "I accept the terms"),
             BsButton(Color: BsColor.Primary, Type: "submit")["Create account"]
         ],
+        // A live echo OUTSIDE the Form — every bound write (custom or native <select>) re-renders the
+        // expression's owner (this demo), so it tracks each field with no StateHasChanged.
+        BsAlert(Color: BsColor.Secondary, Class: "mt-3 mb-0")[
+            Span(Id: "bs-readout")[
+                $"Plan: {(_model.Plan is "" ? "—" : PlanLabel(_model.Plan))} · " +
+                $"Seats: {(_model.Seats is { } n ? SeatLabel(n) : "—")} · " +
+                $"Team: {(_model.TeamId is { } id ? Teams.First(t => t.Id == id).Name : "—")} · " +
+                $"Tier: {PlanLabel(_model.Tier)} · Agree: {(_model.Agree ? "yes" : "no")}"
+            ]
+        ],
         _result is null
             ? null
             : BsAlert(Color: BsColor.Success, Class: "mt-3 mb-0")[

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsMultiSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsMultiSelectDemo.cs
@@ -1,0 +1,47 @@
+namespace Rask.Example.Shared.Features;
+
+// Every BsMultiSelect<TItem> variant: a dropdown of checkable options with the picks shown as removable
+// chips, bound to a model collection. Filter adds an in-dropdown search field; Floating wraps the label like
+// a form-floating; Disabled makes it read-only. A live readout OUTSIDE the Form echoes each selection with no
+// StateHasChanged (a bound write re-renders the expression's owner).
+public sealed class BsMultiSelectDemo : Component
+{
+    private static readonly string[] Interests = ["Web", "Mobile", "AI", "Games", "DevOps", "Data"];
+
+    private readonly Model _m = new();
+
+    protected override Component? Render() =>
+    [
+        Form<Model>(_m, Class: "vstack gap-3")[
+            // 1. Basic — chips + checkable dropdown, bound to a List<string>.
+            BsMultiSelect<string>(() => _m.Basic, Interests,
+                Label: "Interests (basic)", Placeholder: "Pick a few…", Id: "ms-basic"),
+            // 2. Searchable — a Filter predicate adds a search field that narrows the options.
+            BsMultiSelect<string>(() => _m.Searchable, Interests,
+                Filter: (i, t) => i.Contains(t, StringComparison.OrdinalIgnoreCase),
+                Label: "Interests (searchable)", Placeholder: "Search…", Id: "ms-search"),
+            // 3. Floating — the label floats up once anything is picked (or while focused).
+            BsMultiSelect<string>(() => _m.Floating, Interests,
+                Label: "Interests (floating)", Floating: true, Id: "ms-float"),
+            // 4. Disabled — non-interactive, still shows its bound chips.
+            BsMultiSelect<string>(() => _m.Locked, Interests,
+                Label: "Interests (disabled)", Disabled: true, Id: "ms-locked")
+        ],
+        BsAlert(Color: BsColor.Secondary, Class: "mt-3 mb-0")[
+            Span(Id: "ms-readout")[
+                $"Basic: {Join(_m.Basic)} · Search: {Join(_m.Searchable)} · " +
+                $"Floating: {Join(_m.Floating)} · Locked: {Join(_m.Locked)}"
+            ]
+        ]
+    ];
+
+    private static string Join(ICollection<string> items) => items.Count == 0 ? "—" : string.Join(", ", items);
+
+    private sealed class Model
+    {
+        public List<string> Basic { get; } = [];
+        public List<string> Searchable { get; } = [];
+        public List<string> Floating { get; } = [];
+        public List<string> Locked { get; } = ["AI", "Data"];
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsPickersDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsPickersDemo.cs
@@ -1,11 +1,12 @@
 namespace Rask.Example.Shared.Features;
 
-// The custom-popover date/time pickers, bound to a model. BsDatePicker/BsTimePicker/BsDateTimePicker
-// implement IFormControl<T>, so two-way binding is automatic — and the readout OUTSIDE the Form updates
-// on every change with no StateHasChanged, because a bound write re-renders the expression's owner. Each
-// box is a hand-editable <input>: type a date/time (parsed live in the current culture) OR focus it to open
-// the calendar/clock popover (pure live-diff view state, zero bootstrap.js). A nullable DateOnly? gets a
-// clear (×) button.
+// Every variant of the custom-popover date/time pickers, bound to one model. BsDatePicker/BsTimePicker/
+// BsDateTimePicker implement IFormControl<T>, so two-way binding is automatic — and the readout OUTSIDE the
+// Form updates on every change with no StateHasChanged, because a bound write re-renders the expression's
+// owner. Each box is hand-editable: type a date/time (parsed live in the current culture) OR focus it to open
+// the calendar/clock popover (pure live-diff view state, zero bootstrap.js). Floating wraps the label like a
+// form-floating; Native drops to the OS <input>; Min/Max/Disable constrain the calendar; a nullable T gets an
+// × clear button.
 public sealed class BsPickersDemo : Component
 {
     private readonly Booking _model = new()
@@ -13,15 +14,32 @@ public sealed class BsPickersDemo : Component
         Day = DateOnly.FromDateTime(DateTime.Today),
         Time = new TimeOnly(9, 0),
         When = DateTime.Today.AddHours(9),
+        DayFloat = DateOnly.FromDateTime(DateTime.Today),
+        WhenFloat = DateTime.Today.AddHours(9),
     };
+
+    private static readonly DateOnly Today = DateOnly.FromDateTime(DateTime.Today);
 
     protected override Component? Render() =>
     [
         Form<Booking>(_model, Class: "vstack gap-3")[
+            // Date — default, floating, native, and range-constrained (next 30 days, no weekends).
             BsDatePicker(() => _model.Day, Label: "Date", Id: "pick-date"),
-            BsTimePicker(() => _model.Time, Label: "Time", MinuteStep: 15, Id: "pick-time"),
+            BsDatePicker(() => _model.DayFloat, Label: "Date (floating)", Floating: true, Id: "pick-date-float"),
+            BsDatePicker(() => _model.DayNative, Label: "Date (native)", Native: true, Id: "pick-date-native"),
+            BsDatePicker(() => _model.DayRange, Label: "Date (next 30 days, weekdays only)",
+                Min: Today, Max: Today.AddDays(30),
+                Disable: d => d.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday, Id: "pick-date-range"),
+            BsDatePicker<DateOnly?>(() => _model.Deadline, Label: "Deadline (nullable, clearable)", Id: "pick-deadline"),
+
+            // Time — stepped, floating, and native.
+            BsTimePicker(() => _model.Time, Label: "Time (15-min steps)", MinuteStep: 15, Id: "pick-time"),
+            BsTimePicker(() => _model.TimeNative, Label: "Time (native)", Native: true, Id: "pick-time-native"),
+
+            // Date & time — default, floating, and native.
             BsDateTimePicker(() => _model.When, Label: "Date & time", Id: "pick-datetime"),
-            BsDatePicker<DateOnly?>(() => _model.Deadline, Label: "Deadline (optional, clearable)", Id: "pick-deadline")
+            BsDateTimePicker(() => _model.WhenFloat, Label: "Date & time (floating)", Floating: true, Id: "pick-datetime-float"),
+            BsDateTimePicker(() => _model.WhenNative, Label: "Date & time (native)", Native: true, Id: "pick-datetime-native")
         ],
         BsAlert(Color: BsColor.Info, Class: "mt-3 mb-0")[
             Span(Id: "pick-readout")[
@@ -34,11 +52,16 @@ public sealed class BsPickersDemo : Component
     private sealed class Booking
     {
         public DateOnly Day { get; set; }
+        public DateOnly DayFloat { get; set; }
+        public DateOnly DayNative { get; set; }
+        public DateOnly DayRange { get; set; }
+        public DateOnly? Deadline { get; set; }
 
         public TimeOnly Time { get; set; }
+        public TimeOnly TimeNative { get; set; }
 
         public DateTime When { get; set; }
-
-        public DateOnly? Deadline { get; set; }
+        public DateTime WhenFloat { get; set; }
+        public DateTime WhenNative { get; set; }
     }
 }

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsSelectDemo.cs
@@ -1,0 +1,82 @@
+namespace Rask.Example.Shared.Features;
+
+// Every BsSelect<T> variant side by side, each bound to one model and echoed by a live readout OUTSIDE the
+// Form (a bound write re-renders the expression's owner, so the readout tracks each pick with no
+// StateHasChanged). BsSelect renders a custom .dropdown-menu combobox by default; Filter adds an in-dropdown
+// search field; a nullable value type gets an × that clears it; OptionValue binds a projected field while the
+// options stay whole objects; Native drops to the OS <select>; Floating wraps the label like a form-floating.
+public sealed class BsSelectDemo : Component
+{
+    private static readonly string[] Plans = ["free", "pro", "team"];
+    private static readonly int?[] Seats = [1, 2, 5, 10];
+    private static readonly Team[] Teams = [new(1, "Platform"), new(2, "Growth"), new(3, "Data")];
+
+    private readonly Model _m = new();
+
+    private static string PlanLabel(string p) => p switch
+    {
+        "free" => "Free",
+        "pro" => "Pro",
+        "team" => "Team",
+        _ => p,
+    };
+
+    private static string SeatLabel(int? n) => $"{n} seat{(n == 1 ? "" : "s")}";
+
+    protected override Component? Render() =>
+    [
+        Form<Model>(_m, Class: "vstack gap-3")[
+            // 1. Basic — binds the chosen option itself; a muted placeholder shows when empty.
+            BsSelect(() => _m.Plan, Plans, OptionLabel: p => Text(PlanLabel(p)),
+                Placeholder: "— choose —", Label: "Plan (basic)", Id: "sel-plan"),
+            // 2. Floating — the label rides inside the box and floats up on focus / when filled.
+            BsSelect(() => _m.PlanFloat, Plans, OptionLabel: p => Text(PlanLabel(p)),
+                Label: "Plan (floating)", Floating: true, Id: "sel-plan-float"),
+            // 3. Searchable — a Filter predicate adds a search field that narrows the options.
+            BsSelect(() => _m.PlanSearch, Plans, OptionLabel: p => Text(PlanLabel(p)),
+                Filter: (p, t) => PlanLabel(p).Contains(t, StringComparison.OrdinalIgnoreCase),
+                Placeholder: "Search a plan…", Label: "Plan (searchable)", Id: "sel-plan-search"),
+            // 4. Clearable — a nullable int? gets an × that resets it to null (the Placeholder state).
+            BsSelect(() => _m.Seats, Seats, OptionLabel: n => Text(SeatLabel(n)),
+                Placeholder: "Any", Label: "Seats (nullable, clearable)", Id: "sel-seats"),
+            // 5. Value selector — options are Team objects, but the bound value is the projected id.
+            BsSelect(() => _m.TeamId, Options: Teams, OptionValue: t => t.Id, OptionLabel: t => Text(t.Name),
+                Filter: (t, q) => t.Name.Contains(q, StringComparison.OrdinalIgnoreCase),
+                Placeholder: "No team", Label: "Team (binds to id)", Id: "sel-team"),
+            // 6. Native — the OS <select>; handy on mobile.
+            BsSelect(() => _m.Tier, Plans, OptionLabel: p => Text(PlanLabel(p)), Native: true,
+                Label: "Tier (native)", Id: "sel-tier"),
+            // 7. Native + nullable — the leading empty option is a selectable "None" that round-trips null.
+            BsSelect(() => _m.NativeSeats, Seats, OptionLabel: n => Text(SeatLabel(n)), Native: true,
+                Placeholder: "None", Label: "Seats (native, nullable)", Id: "sel-nseats"),
+            // 8. Disabled — non-interactive, still shows its bound value.
+            BsSelect(() => _m.Locked, Plans, OptionLabel: p => Text(PlanLabel(p)),
+                Label: "Plan (disabled)", Disabled: true, Id: "sel-locked")
+        ],
+        BsAlert(Color: BsColor.Secondary, Class: "mt-3 mb-0")[
+            Span(Id: "sel-readout")[
+                $"Plan: {(_m.Plan is "" ? "—" : PlanLabel(_m.Plan))} · " +
+                $"Floating: {PlanLabel(_m.PlanFloat)} · " +
+                $"Search: {(_m.PlanSearch is "" ? "—" : PlanLabel(_m.PlanSearch))} · " +
+                $"Seats: {(_m.Seats is { } s ? SeatLabel(s) : "—")} · " +
+                $"Team: {(_m.TeamId is { } id ? Teams.First(t => t.Id == id).Name : "—")} · " +
+                $"Tier: {PlanLabel(_m.Tier)} · " +
+                $"NativeSeats: {(_m.NativeSeats is { } ns ? SeatLabel(ns) : "—")}"
+            ]
+        ]
+    ];
+
+    private sealed class Model
+    {
+        public string Plan { get; set; } = "";
+        public string PlanFloat { get; set; } = "pro";
+        public string PlanSearch { get; set; } = "";
+        public int? Seats { get; set; }
+        public int? TeamId { get; set; }
+        public string Tier { get; set; } = "free";
+        public int? NativeSeats { get; set; }
+        public string Locked { get; set; } = "team";
+    }
+
+    private sealed record Team(int Id, string Name);
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -247,6 +247,8 @@ public static class DemoRegistry
             ["bootstrap-tabs"] = () => CodeSample(["BsTabsDemo.cs"], Result: BsTabsDemo()),
             ["bootstrap-dropdown"] = () => CodeSample(["BsDropdownDemo.cs"], Result: BsDropdownDemo()),
             ["bootstrap-forms"] = () => CodeSample(["BsFormsDemo.cs"], Result: BsFormsDemo()),
+            ["bootstrap-select"] = () => CodeSample(["BsSelectDemo.cs"], Result: BsSelectDemo()),
+            ["bootstrap-multiselect"] = () => CodeSample(["BsMultiSelectDemo.cs"], Result: BsMultiSelectDemo()),
             ["bootstrap-pickers"] = () => CodeSample(["BsPickersDemo.cs"], Result: BsPickersDemo()),
             ["bootstrap-utilities"] = () => CodeSample(["BsUtilitiesDemo.cs"], Result: BsUtilitiesDemo()),
 

--- a/src/Rask.Bootstrap/BsPickerBase.cs
+++ b/src/Rask.Bootstrap/BsPickerBase.cs
@@ -205,8 +205,9 @@ public abstract class BsPickerBase<T> : BsFormControl<T>
         }
 
         // Floating wraps box + label (+ the absolutely-placed caret/×) in a position-relative .form-floating;
-        // the popover/backdrop stay direct children of the .dropdown. Non-floating: box + caret/× sit in the
-        // .dropdown (position-relative), so the caret/× anchor to the box (popover/backdrop are out of flow).
+        // the popover/backdrop stay direct children of the .dropdown. Non-floating: box + caret/× go in their
+        // OWN position-relative wrapper so the caret/× centre on the box alone — anchoring them to the whole
+        // .dropdown would centre them over the label-above + box stack, dropping them onto the box's top edge.
         if (floating)
         {
             children.Add(Div(
@@ -215,9 +216,7 @@ public abstract class BsPickerBase<T> : BsFormControl<T>
         }
         else
         {
-            children.Add(box);
-            children.Add(caret);
-            children.Add(clear);
+            children.Add(Div(Class: Position.Relative)[box, caret, clear]);
         }
 
         // The popover is always in the DOM (like BsMultiSelect's menu); the picker toggles .show/.d-block

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -221,18 +221,23 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         }
 
         // Floating wraps box + label in .form-floating (label after → the CSS floats it); the × rides along
-        // inside so it anchors to the box. Non-floating: the × is a sibling of the box in the .dropdown
-        // (whose menu/backdrop are out of flow, so .dropdown's height is the box's — the × centres on it).
+        // inside so it anchors to the box. Non-floating with a clear ×: box + × go in their OWN
+        // position-relative wrapper so the absolutely-placed × centres on the box alone — anchoring it to the
+        // whole .dropdown would centre it over the label-above + box stack, dropping it onto the box's top
+        // edge. With no ×, the box needs no wrapper.
         if (floating)
         {
             children.Add(Div(
                 Class: BsClass.Join("form-floating bs-floating",
                     selectedIdx >= 0 ? "bs-floating-filled" : null, Position.Relative))[box, labelNode, clear]);
         }
+        else if (clear is not null)
+        {
+            children.Add(Div(Class: Position.Relative)[box, clear]);
+        }
         else
         {
             children.Add(box);
-            children.Add(clear);
         }
 
         children.Add(menu);

--- a/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
+++ b/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
@@ -63,7 +63,12 @@
 .form-floating.bs-floating.bs-floating-filled > .form-control ~ label,
 .form-floating.bs-floating:focus-within > .form-select ~ label,
 .form-floating.bs-floating:focus-within > .form-control ~ label {
+  /* Drop the empty-state flex centering and pin the scale origin to the top-left corner so the
+     shrunk label straddles the top border exactly like a native .form-floating label (a centred
+     origin scaled it inwards from the middle → it landed too low/misaligned). */
+  display: block;
   height: auto;
+  transform-origin: 0 0;
   transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
   opacity: 0.65;
 }
@@ -119,14 +124,26 @@
 }
 .bs-picker-caret {
   pointer-events: none;
-  /* Roughly matches the size of the native .form-select caret glyph. */
-  font-size: 0.9rem;
+  /* Sized to read clearly as a dropdown affordance, a touch larger than the native .form-select
+     caret glyph so the editable pickers don't look like a plain text input. */
+  font-size: 1.25rem;
   line-height: 1;
   color: var(--bs-secondary-color);
 }
 .bs-time {
   /* Fixed per-item height so the two columns line up and the popover height is stable (6 items visible). */
   --bs-time-item-h: 2rem;
+}
+/* In the BsDateTimePicker popover the calendar and the time columns sit side by side, so the time
+   list must be exactly as tall as the calendar grid — otherwise it stops short and leaves a gap.
+   The grid is the weekday header (1.75rem, see .bs-cal-head) plus 6 week rows of --bs-cal-cell
+   (2.25rem). The standalone BsTimePicker keeps the default 6-item height above. */
+.bs-datetime {
+  --bs-cal-grid-h: calc(1.75rem + (6 * 2.25rem));
+  align-items: stretch;
+}
+.bs-datetime .bs-time-col {
+  max-height: var(--bs-cal-grid-h);
 }
 .bs-time-col {
   max-height: calc(6 * var(--bs-time-item-h));

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -83,6 +83,12 @@ public sealed class Select<T> : Element, IFormControl<T>
 
         return new Option
         {
+            // Preserve Key: the marked option must keep the same reconciliation identity as the original,
+            // otherwise the selected option's key shifts every render (the marked one loses its key while
+            // the previously-marked one regains it). Keyed reconciliation then mismatches and the browser's
+            // live `selected` IDL property is never synced — the <select> visually snaps back to the old
+            // value even though the `selected` attribute is written to the right option.
+            Key = opt.Key,
             Value = opt.Value,
             Selected = true,
             Disabled = opt.Disabled,
@@ -106,6 +112,8 @@ public sealed class Select<T> : Element, IFormControl<T>
             c is Option o ? MarkOption(o, current) : c).ToArray();
         return new Optgroup
         {
+            // Preserve Key for stable reconciliation identity (see MarkOption).
+            Key = og.Key,
             Disabled = og.Disabled,
             Label = og.Label,
             Id = og.Id,

--- a/tests/Rask.Bootstrap.Tests/BsFormControlTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsFormControlTests.cs
@@ -28,7 +28,9 @@ public class BsFormControlTests
     {
         var html = BsSelect<string>(Options: ["a", "b"], Value: "a", Native: true).ToHtml();
         Assert.Contains("class=\"form-select\"", html);
-        Assert.Contains("<option value=\"a\"", html);
+        // The selected option keeps its reconciliation key (data-rask-key) so keyed diffing stays stable and
+        // the browser's live `selected` property syncs — see SelectTests.BoundSelect_MarkedOption_KeepsItsKey.
+        Assert.Contains("data-rask-key=\"0\" value=\"a\" selected", html);
     }
 
     [Fact]

--- a/tests/Rask.Bootstrap.Tests/BsPickerTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsPickerTests.cs
@@ -109,6 +109,17 @@ public class BsPickerTests
         Assert.Contains("btn-close", Html(Us, () => BsDatePicker<DateOnly?>(Value: Jul7)));
 
     [Fact]
+    public void Date_NonFloating_WrapsBoxAndCaretInPositionRelative()
+    {
+        // The caret/× are absolutely placed; a position-relative wrapper around the box (inside the .dropdown)
+        // anchors them to the box alone. Without it they'd centre over the label-above + box stack and land on
+        // the box's top edge instead of vertically centred in it.
+        var html = Html(Us, () => BsDatePicker<DateOnly>(Value: Jul7, Label: "Day", Id: "d"));
+        Assert.Contains("<div class=\"position-relative\"><input", html);
+        Assert.Contains("bs-picker-caret", html);
+    }
+
+    [Fact]
     public void Date_NonNullableWithValue_HasNoClearButton() =>
         Assert.DoesNotContain("btn-close", Html(Us, () => BsDatePicker<DateOnly>(Value: Jul7)));
 

--- a/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
@@ -110,11 +110,26 @@ public class BsSelectTests
 
     [Fact]
     public void Select_Native_RendersPlainSelectWithSelectedOptionAndPlaceholder() =>
+        // The selected option KEEPS its reconciliation key (data-rask-key="0"): dropping it when marking the
+        // option selected shifts every option's key across renders, breaks keyed diffing, and leaves the
+        // browser's live `selected` property desynced so the <select> snaps back to the old value.
         Assert.Equal(
             "<div><select id=\"t\" class=\"form-select\">" +
             "<option data-rask-key=\"placeholder\" value=\"\" disabled>Pick</option>" +
-            "<option value=\"a\" selected>a</option>" +
+            "<option data-rask-key=\"0\" value=\"a\" selected>a</option>" +
             "<option data-rask-key=\"1\" value=\"b\">b</option>" +
             "</select></div>",
             BsSelect<string>(Options: ["a", "b"], Value: "a", Native: true, Placeholder: "Pick", Id: "t").ToHtml());
+
+    [Fact]
+    public void Select_Nullable_NonFloating_WrapsBoxAndClearInPositionRelative()
+    {
+        // The × is absolutely placed; wrapping just the box + × in a position-relative div anchors it to the
+        // box alone. Without the wrapper it would centre over the label-above + box and land on the box's top
+        // edge. (A non-clearable select needs no wrapper — see Select_Empty_… which has the box bare.)
+        var html = BsSelect<int?>(Options: new int?[] { 1, 2 }, Value: 2, Label: "Seats", Id: "s").ToHtml();
+        Assert.Contains(
+            "<div class=\"position-relative\"><div id=\"s\" class=\"form-select bs-select-clearable\"", html);
+        Assert.Contains("bs-select-clear", html);
+    }
 }

--- a/tests/Rask.Core.Tests/Components/SelectTests.cs
+++ b/tests/Rask.Core.Tests/Components/SelectTests.cs
@@ -183,6 +183,30 @@ public class SelectTests
     }
 
     [Fact]
+    public void BoundSelect_MarkedOption_KeepsItsReconciliationKey()
+    {
+        // Marking an option selected must preserve its Key. Dropping it shifts the selected option's key on
+        // every render (the marked one loses its key while the previously-marked one regains it), so keyed
+        // reconciliation mismatches and the browser's live `selected` IDL property is never synced — the
+        // <select> visually snaps back to the old value even though the `selected` attribute is correct.
+        var model = new ColorPicker { Color = "red" };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Color)[
+                Option(Value: "", Key: "e")["none"],
+                Option(Value: "red", Key: "r")["red"],
+                Option(Value: "blue", Key: "b")["blue"]
+            ]
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.Contains("data-rask-key=\"r\" value=\"red\" selected", html);
+        // The unselected keyed siblings still carry their keys too.
+        Assert.Contains("data-rask-key=\"e\"", html);
+        Assert.Contains("data-rask-key=\"b\"", html);
+    }
+
+    [Fact]
     public void Render_NullProps_ReturnsOpenAndCloseTags() =>
         Assert.Equal("<select></select>", Select<string>().ToHtml());
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -378,6 +378,13 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
         await Expect(tier.Locator("option").Filter(new LocatorFilterOptions { HasText = "Team" }))
             .ToHaveCountAsync(1, new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        // Picking an option two-way-binds: the model updates (the readout echoes it) AND the <select> HOLDS
+        // the new value — it must not snap back. (Regression: the selected <option> used to lose its
+        // reconciliation key, desyncing the browser's live `selected` property so the box reverted.)
+        await tier.SelectOptionAsync("team");
+        await Expect(Page.Locator("#bs-readout")).ToContainTextAsync("Tier: Team",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await Expect(tier).ToHaveValueAsync("team", new LocatorAssertionsToHaveValueOptions { Timeout = 10_000 });
 
         // Nullable select (#bs-seats, int?) — a plain dropdown (no Filter → no search field). Pick a value;
         // the × clear then resets it to null so the box shows the "Any" placeholder again.
@@ -388,6 +395,35 @@ public abstract partial class SharedSmokeTests
         await Expect(seats).ToContainTextAsync("2 seats", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Page.Locator(".dropdown:has(#bs-seats) .bs-select-clear").First.ClickAsync();
         await Expect(seats).ToContainTextAsync("Any", new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // BsSelect variant gallery — the native variant binds and holds its pick; a custom basic pick writes
+        // the model. Both are echoed by the gallery's own readout.
+        var selTier = Page.Locator("select#sel-tier");
+        await Expect(selTier).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await selTier.SelectOptionAsync("team");
+        await Expect(selTier).ToHaveValueAsync("team", new LocatorAssertionsToHaveValueOptions { Timeout = 10_000 });
+        var selPlan = Page.Locator("#sel-plan");
+        await selPlan.ClickAsync();
+        await Page.Locator(".dropdown:has(#sel-plan) .dropdown-menu.show .dropdown-item").First.ClickAsync();
+        await Expect(Page.Locator("#sel-readout")).ToContainTextAsync("Plan: Free",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await Expect(Page.Locator("#sel-readout")).ToContainTextAsync("Tier: Team",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // BsMultiSelect variant gallery — ticking two options in the basic control shows them as chips and
+        // the gallery readout lists them.
+        var msBasic = Page.Locator("#ms-basic");
+        await msBasic.ClickAsync();
+        var msMenu = Page.Locator("#ms-basic .dropdown-menu.show");
+        await Expect(msMenu).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        await msMenu.Locator(".dropdown-item").Nth(0).ClickAsync();
+        await msMenu.Locator(".dropdown-item").Nth(1).ClickAsync();
+        await Expect(Page.Locator("#ms-readout")).ToContainTextAsync("Web, Mobile",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        // A multiselect stays open while you tick items — close it so its full-viewport backdrop doesn't
+        // intercept the next navigation click.
+        await Page.Locator("#ms-basic .position-fixed").DispatchEventAsync("click");
+        await Expect(msMenu).ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
     }
 
     private async Task WalkUserComponentsGuideAsync()


### PR DESCRIPTION
## Summary

Fixes five defects surfaced while testing the Bootstrap guide's forms & pickers, and adds all-variant example galleries.

### Fixes
- **Native `<select>` reverted to its old value on change.** Core `Select.MarkOption`/`MarkOptgroup` dropped the reconciliation `Key` when cloning an option to mark it selected, so the selected option's key shifted every render, keyed diffing mismatched, and the browser's live `selected` IDL property never synced — the model updated but the box snapped back. The marked `<option>`/`<optgroup>` now keeps its `Key`. **Affects every bound/controlled `Select<T>`** (and `BsSelect(Native: true)`).
- **Floating label mispositioned.** The scaled label had no `transform-origin` and kept its empty-state flex centring, so it landed low/off. It now pins to the top-left corner like a native `.form-floating`.
- **Clear `×` / picker caret detached to the box top.** On non-floating controls the affordance anchored to the whole `.dropdown` (label-above included), so `top:50%` landed on the box's top edge. Box + affordance now share a `position-relative` wrapper and centre in the box.
- **Editable-picker caret enlarged** (`0.9rem → 1.25rem`).
- **`BsDateTimePicker` time columns now match the calendar height** (shared `--bs-cal-grid-h`, scoped to `.bs-datetime`) instead of stopping short.

### Examples
New variant galleries in `docs/bootstrap.md` — `BsSelectDemo` (basic / floating / searchable / clearable / `OptionValue` projected / native / native-nullable / disabled), `BsMultiSelectDemo` (basic / searchable / floating / disabled), and an expanded `BsPickersDemo` (default / floating / native / min-max-disable / nullable). Each is bound with a live readout; the signup form gains a `#bs-readout`.

## Testing
- **Unit:** `SelectTests` gains a `Key`-preservation regression; `BsSelectTests`/`BsPickerTests` cover the non-floating affordance wrapper and the native selected-option key. All green (`Rask.Bootstrap.Tests` 36, `Rask.Core.Tests` `SelectTests` 17). Full non-E2E suite passes; solution builds warnings-as-errors clean.
- **E2E:** the showcase journey now selects the native Tier and asserts it two-way binds **and holds** its pick, and exercises the new galleries' readouts. Verified end-to-end in a real browser (Playwright): native select holds `team` (`domHeldTeam: true`), `×` centres in the box (`clearMidY == boxMidY`), calendar and time columns are equal height (both 244px), and the floating label anchors top-left.

## Benchmarks
Not run: the only render-path change (`Select.MarkOption/MarkOptgroup`) copies one already-present reference field onto an object that was already being allocated — allocation-neutral by construction, and no benchmark exercises the bound-`<select>` preselection path.

## Changelog
`[Unreleased]` updated (core `<select>` bind fix under **Fixed**; UI polish + galleries under **Bootstrap**).