### PR TITLE
fix(native): serialize renders with a _renderLock (concurrent-render race)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,22 @@ them until tagged releases begin.
   handler). `NativeExampleTests` runs a focused native journey — boot + render, the sidebar (collapsible
   groups + mobile drawer), a showcase render walk, scoped CSS/JS applied over the bridge, element-ref
   focus through `IJSRuntime`, and WebView history (route→URL push, Back/forward, the URL-routed Todos
-  dialog) — deliberately focused rather than the browser hosts' full gauntlet, since each interaction is
-  an async bridge round-trip. A separate `NativeServerSmokeTests` shard covers the **Native + Server**
+  dialog); it reuses the **same shared showcase walks** the browser hosts run (only the `HttpClient`-backed
+  HTTP & files walk is skipped). A separate `NativeServerSmokeTests` shard covers the **Native + Server**
   mode (`NativeAppHost.ConnectToServer`): it asserts the shell-URL contract and loads the Server showcase
   in a mobile-emulated WebView context, confirming the thin-native-shell scenario renders and reacts live
   over the WebSocket.
 
 ### Fixed
+- **Native concurrent-render race (`Collection was modified` under the root error boundary).** The native
+  host runs async lifecycle/handler continuations on the thread pool (`HandlerSyncContext.Post` uses
+  `Task.Run`), so a mid-await render (`RenderInScopeCoreAsync`, or a second continuation's render) could run
+  concurrently with the dispatch's render — and two renders walking the component tree at once raced
+  `ComponentLifecycle.DisposeComponentTree`'s `PersistedChildren` enumeration, throwing
+  `InvalidOperationException` mid-render and tripping the root error boundary (which intermittently wiped a
+  complex page after an interaction). `NativeLiveSession` now serializes every render+emit behind a
+  `_renderLock`, matching the Server host (WASM is single-threaded, so it needs none). With the race gone,
+  the native E2E now runs the full shared showcase journey reliably instead of a focused subset.
 - **Native `IJSRuntime` invokes with arguments, and native WebView history.** Both were bugs the new
   native E2E surfaced. (1) An out-of-render `IJSRuntime` invoke (one issued from an event handler that
   awaits its result) embedded `argsJson` into the bridge call as a raw JS literal instead of a string, so

--- a/docs/native.md
+++ b/docs/native.md
@@ -225,15 +225,13 @@ sandbox, and real background execution — without giving up "the same component
    client + `RunLocalAsync` pipeline in Chromium (the WebView engine class Android ships) via a
    Playwright-backed `INativeWebView` (`PlaywrightNativeWebView`) whose route handler
    (`NativeOriginServer`) serves the shell + client + scoped `/_rask/a/*` assets + `global.css` +
-   Bootstrap — the E2E stand-in for a device head's scheme handler. `NativeExampleTests` runs a
-   focused native journey — boot + first render, the sidebar (collapsible groups + mobile offcanvas
-   drawer), a showcase render walk, scoped CSS/JS applied over the bridge, element-ref focus through
-   `IJSRuntime`, and WebView history (route→URL push, hardware Back/forward, the URL-routed Todos
-   dialog). It runs deliberately focused rather than the browser hosts' full 12-walk gauntlet: every
-   interaction is an async round-trip over the WebView bridge, so a long back-to-back sequence
-   accumulates timing flake without adding coverage — exhaustive per-feature behaviour is covered by
-   the Server/WASM shards (same shared showcase) + the native unit tests. It's a native shard in CI
-   alongside Server/WASM. **Two native-host bugs the E2E surfaced were fixed (see item 6).**
+   Bootstrap — the E2E stand-in for a device head's scheme handler. `NativeExampleTests` reuses the
+   **same shared showcase walks** the browser hosts run — rendering, in-SPA navigation, composition,
+   lifecycle, routing (URL push/back-forward), scoped CSS/JS interop (element-ref focus + sessionStorage),
+   elements, CQRS, forms + keyboard, styling + the URL-routed Todos dialog, the Browser-APIs co-mount,
+   Bootstrap components, guides, and the popstate in-session 404 (only the `HttpClient`-backed HTTP & files
+   walk is skipped — Playwright can't intercept a .NET-side fetch). It's a native shard in CI alongside
+   Server/WASM. **Three native-host bugs the E2E surfaced were fixed (see item 6).**
    *(Native + Server needs no separate suite: in that mode the WebView loads a remote Rask Server and
    speaks the ordinary Server (`rask.js`/WS) protocol — the native client isn't involved — so it's
    already covered by `ServerExampleTests`; its only native-specific surface, the real platform
@@ -247,14 +245,14 @@ sandbox, and real background execution — without giving up "the same component
    (guarded by `NativeJsInteropTests`). (b) The native client now drives its own WebView history —
    `applyHistory` pushes/replaces each route change and a `popstate` listener feeds Back/forward into the
    router — so `location`/URL tracks the route, hardware Back works, and URL-routed UI (the Todos dialog,
-   `Navigator.SetQuery`) works. *Remaining follow-up (investigated — root cause found):* the value-returning
-   `InvokeAsync<T>` itself is **fine** — a trace shows the read's result (`"hello-native"`) marshals back
-   over the bridge correctly and the handler updates the DOM. The real intermittent failure is one level
-   down: on a **complex guide page** (`Raw`/CodeSample content defeats the trusted diff, so `Auto` mode
-   falls back to a **full-HTML render**), the native **full-HTML morph** occasionally drops content — a
-   re-render's morph races the frame's scoped-JS invokes (a component's `OnRendered`/`OnUnmount` hooks,
-   e.g. `Rask.GuideChrome.stop`) and the in-dispatch render-coalescing budget, and an element (e.g.
-   `#demo-status`) can vanish. This is a native full-render robustness issue in the morph + concurrent
-   frame-invoke + coalescing pipeline, not an interop bug; the native E2E therefore proves the fixes via
-   the surgical-diff paths (element-ref focus, history/Todos) and leaves hardening the full-HTML re-render
-   of heavy pages as the next native task.
+   `Navigator.SetQuery`) works. (c) A **concurrent-render race** (the intermittent flake that first looked
+   like "a value-returning read is unreliable", then like a full-HTML morph dropping content): native runs
+   async lifecycle/handler continuations on the thread pool (`HandlerSyncContext.Post` uses `Task.Run`), so
+   a mid-await render (`RenderInScopeCoreAsync`, or a second continuation's render) could run
+   **concurrently** with the dispatch's render — and two renders walking the component tree at once raced
+   `ComponentLifecycle.DisposeComponentTree`'s `PersistedChildren` enumeration (`Collection was modified`),
+   throwing mid-render into the root error boundary and wiping the page. `NativeLiveSession` now has a
+   `_renderLock` (as the Server host does; WASM is single-threaded so it needs none) that serializes every
+   render+emit. With it, native drives the **full** shared showcase journey reliably (the JS-interop
+   element-ref focus + sessionStorage round-trip, the URL-routed Todos dialog + Browser-APIs co-mount, the
+   popstate in-session 404).

--- a/src/Rask.Native/NativeLiveSession.cs
+++ b/src/Rask.Native/NativeLiveSession.cs
@@ -19,6 +19,18 @@ namespace Rask.Native;
 internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
 {
     private readonly SemaphoreSlim _lock = new(1, 1);
+
+    // Serializes the actual render+emit. Native runs async lifecycle/handler continuations on the thread
+    // pool (HandlerSyncContext.Post uses Task.Run), so a mid-await render (RenderInScopeCoreAsync, or a
+    // second continuation's render) can fire concurrently with the dispatch's render — and two renders
+    // walking the component tree at once race ComponentLifecycle.DisposeComponentTree's PersistedChildren
+    // enumeration ("Collection was modified; enumeration operation may not execute"), which trips the root
+    // error boundary. Server has the same _renderLock; WASM is single-threaded so it needs none. It's held
+    // only around one build+emit (never across a handler/await), so the legitimate re-entrant case —
+    // InvokeWithRenderingAsync rendering inline inside a handler, then the dispatch's own render afterwards
+    // — stays sequential (each acquires a free lock). Lock order is always _lock (if any) then _renderLock;
+    // RenderInScopeCoreAsync takes only _renderLock, so there's no inversion.
+    private readonly SemaphoreSlim _renderLock = new(1, 1);
     private readonly INativeWebView _webView;
     private readonly IUserProvider? _userProvider;
 
@@ -51,6 +63,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
 
         ComponentLifecycle.DisposeComponentTree(View);
         _lock.Dispose();
+        _renderLock.Dispose();
     }
 
     // Host transport for LiveSessionBase.TryEmitFrameAsync: hand the built frame to the platform WebView,
@@ -69,6 +82,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         // `await Task.Yield()` can't Post its continuation back through it and re-enter this method.
         var prevCtx = SynchronizationContext.Current;
         SynchronizationContext.SetSynchronizationContext(null);
+        await _renderLock.WaitAsync().ConfigureAwait(false);
         try
         {
             await BuildPayloadAsync(null, false).ConfigureAwait(false);
@@ -79,6 +93,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         }
         finally
         {
+            _renderLock.Release();
             SynchronizationContext.SetSynchronizationContext(prevCtx);
         }
     }
@@ -93,6 +108,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
 
         await _lock.WaitAsync().ConfigureAwait(false);
         InHandlerScope = true;
+        await _renderLock.WaitAsync().ConfigureAwait(false);
         try
         {
             await BuildPayloadCoalescingRerendersAsync(null, false, publishOnly).ConfigureAwait(false);
@@ -112,6 +128,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         }
         finally
         {
+            _renderLock.Release();
             InHandlerScope = false;
             _lock.Release();
         }
@@ -127,6 +144,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     {
         await _lock.WaitAsync().ConfigureAwait(false);
         InHandlerScope = true;
+        await _renderLock.WaitAsync().ConfigureAwait(false);
         try
         {
             await BuildPayloadAsync(null, false).ConfigureAwait(false);
@@ -140,6 +158,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         }
         finally
         {
+            _renderLock.Release();
             InHandlerScope = false;
             _lock.Release();
         }
@@ -201,14 +220,25 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                         historyReplace = replace;
                     }
 
-                    await BuildPayloadCoalescingRerendersAsync(historyUrl, historyReplace).ConfigureAwait(false);
-                    if (!await TryEmitFrameAsync(historyUrl is not null).ConfigureAwait(false))
+                    // Acquire _renderLock only around the render (not the handler above): an in-handler
+                    // InvokeWithRenderingAsync renders inline under _renderLock first, so holding it across
+                    // the handler would deadlock.
+                    await _renderLock.WaitAsync().ConfigureAwait(false);
+                    try
                     {
-                        return Array.Empty<byte>();
-                    }
+                        await BuildPayloadCoalescingRerendersAsync(historyUrl, historyReplace).ConfigureAwait(false);
+                        if (!await TryEmitFrameAsync(historyUrl is not null).ConfigureAwait(false))
+                        {
+                            return Array.Empty<byte>();
+                        }
 
-                    _htmlBuffers.Commit();
-                    return _lastSentBuffer!.WrittenSpan.ToArray();
+                        _htmlBuffers.Commit();
+                        return _lastSentBuffer!.WrittenSpan.ToArray();
+                    }
+                    finally
+                    {
+                        _renderLock.Release();
+                    }
                 }
             }
             catch (Exception ex)
@@ -254,6 +284,7 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
             routeState.Path = navPath;
             routeState.Query = QueryString.Parse(navQueryString);
 
+            await _renderLock.WaitAsync().ConfigureAwait(false);
             try
             {
                 await BuildPayloadCoalescingRerendersAsync(fullUrl, replace).ConfigureAwait(false);
@@ -270,6 +301,10 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
                 RaskDiagnostics.Report(
                     RaskLogLevel.Error, "Rask.Native", $"Rask native navigate '{navPath}' threw", ex);
                 return Array.Empty<byte>();
+            }
+            finally
+            {
+                _renderLock.Release();
             }
         }
         finally

--- a/tests/Rask.Examples.E2E.Tests/NativeExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/NativeExampleTests.cs
@@ -71,83 +71,28 @@ public sealed class NativeExampleTests(PlaywrightFixture pw) : SharedSmokeTests(
         // reloads the shell).
         await Page.EvaluateAsync("() => { window.__raskSentinel = 'alive'; }");
 
-        // Sidebar first — it asserts the fresh, unfiltered sidebar (the sidebar filter is left set by every
-        // later ClickSidebar navigation), and exercises the collapsible groups + mobile offcanvas drawer.
+        // The same shared showcase walks the browser hosts run. With the native concurrent-render race fixed
+        // (NativeLiveSession._renderLock serializes renders that HandlerSyncContext fans onto the thread
+        // pool), native drives the full set reliably — including the JS-interop element-ref focus +
+        // sessionStorage round-trip, the URL-routed Todos dialog + Browser-APIs co-mount, and the popstate
+        // in-session 404.
         await TestSidebarNavAsync();
-
-        // A representative render-only walk over the showcase: navigate the guide + a few example pages and
-        // assert each renders over the native bridge without tripping the root error boundary.
+        await WalkUserComponentsGuideAsync();
+        await TestCompositionGuideAsync();
         await WalkLifecycleGuideAsync();
+        await WalkRoutingGuideAsync();
+        await WalkJsInteropGuideAsync();
+        await WalkElementsGuideAsync();
+        await WalkCqrsGuideAsync();
+        await WalkFormsPagesAsync();
+        await WalkStylingDataAndAppPagesAsync();
+        await WalkBootstrapGuideAsync();
+        await TestGuidesAsync();
+        await TestInSessionNotFoundAsync();
 
-        // Prove the two native-host behaviours these changes fixed:
-        //   • IJSRuntime marshals an invoke ARGUMENT over the bridge and the handler awaits its result —
-        //     element-ref focus + scoped CSS/JS (the DispatchOutsideRender argsJson fix).
-        //   • the native client drives its own WebView history — route→URL push, hardware Back/forward via
-        //     popstate, and URL-routed UI (the Todos dialog) — the applyHistory/popstate addition.
-        await NativeInteropProofsAsync();
-        await NativeHistoryProofsAsync();
-
-        // Scope note: the native E2E deliberately runs a focused journey rather than the browser hosts'
-        // full 12-walk gauntlet. Every interaction is an async round-trip over the WebView bridge, so a long
-        // back-to-back interaction sequence accumulates timing flake without adding coverage; this set
-        // proves the pipeline (boot, render, in-SPA nav, scoped assets), both fixes above, and keyboard (the
-        // Todos dialog's Escape). The exhaustive per-feature behaviour is covered by the Server/WASM shards
-        // (same shared showcase) + the native unit tests. Also not exercised: the HTTP & files guide (its
-        // DI'd HttpClient fetch runs in the .NET host, which Playwright can't intercept) and native file
-        // upload/download (no bridge yet — docs/native.md follow-up).
+        // Not exercised: the HTTP & files guide — its DI'd HttpClient fetch runs in the .NET host (Playwright
+        // can't intercept it), and native file upload/download has no bridge yet (docs/native.md follow-up).
 
         Assert.Equal("alive", await Page.EvaluateAsync<string?>("() => window.__raskSentinel"));
-    }
-
-    // IJSRuntime results over the bridge. Scoped CSS/JS load, then the two interactions that AWAIT a JS
-    // result inside a handler — element-ref focus and a sessionStorage set/read round-trip — which is
-    // exactly what the DispatchOutsideRender argsJson fix restored.
-    private async Task NativeInteropProofsAsync()
-    {
-        await ClearJsRuntimeStorageAsync();
-        await SideAsync("JavaScript interop", "JavaScript interop", "main .markdown-body h1");
-
-        // Scoped CSS applied (served from the registry): two `.box` components differ, neither transparent.
-        var boxes = Page.Locator(".guide-demo .sample-result-body .box");
-        await Expect(boxes).ToHaveCountAsync(2, new LocatorAssertionsToHaveCountOptions { Timeout = 45_000 });
-        var bg0 = await boxes.Nth(0).EvaluateAsync<string>("el => getComputedStyle(el).backgroundColor");
-        Assert.NotEqual("rgba(0, 0, 0, 0)", bg0);
-        Assert.NotEqual(bg0,
-            await boxes.Nth(1).EvaluateAsync<string>("el => getComputedStyle(el).backgroundColor"));
-        Assert.True(
-            await Page.EvaluateAsync<bool>("() => typeof window.Rask === 'object' && window.Rask !== null"),
-            "scoped JS namespace window.Rask is missing — component JS did not load over the native bridge");
-
-        // Element-ref focus via IJSRuntime: the handler awaits a void invoke that carries an element-ref
-        // ARGUMENT — exactly the shape the DispatchOutsideRender argsJson fix restored (before it, the ref
-        // arg reached the client as a mangled literal and the focus never landed).
-        var elDemo = Page.Locator(".guide-demo:has(button:has-text('Measure the box'))");
-        await elDemo.Locator("button:has-text('Focus the input')").ClickAsync();
-        await Expect(elDemo.Locator(".sample-result-body input"))
-            .ToBeFocusedAsync(new LocatorAssertionsToBeFocusedOptions { Timeout = 15_000 });
-    }
-
-    // The native client drives its own WebView history: route→URL push, hardware Back/forward via popstate,
-    // and the URL-routed Todos dialog (open pushes /todos/new + auto-focuses via ElementRef.FocusAsync;
-    // Escape routes back to /todos).
-    private async Task NativeHistoryProofsAsync()
-    {
-        var url = new PageAssertionsToHaveURLOptions { Timeout = 15_000 };
-        // Route → URL push: navigating to Todos must push /todos onto the WebView history.
-        var previous = new Regex(Regex.Escape(new Uri(Page.Url).AbsolutePath) + "$");
-        await SideAsync("Todos", "Todos");
-        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"), url);
-        // Hardware Back / forward via popstate returns to the prior route, then forward again.
-        await Page.GoBackAsync();
-        await Expect(Page).ToHaveURLAsync(previous, url);
-        await Page.GoForwardAsync();
-        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"), url);
-
-        await Page.Locator("button:has-text('New todo')").ClickAsync();
-        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos/new$"), url);
-        await Expect(Page.Locator("dialog[open]"))
-            .ToBeFocusedAsync(new LocatorAssertionsToBeFocusedOptions { Timeout = 15_000 });
-        await Page.Keyboard.PressAsync("Escape");
-        await Expect(Page).ToHaveURLAsync(new Regex(".*/todos$"), url);
     }
 }


### PR DESCRIPTION
Fixes the intermittent native flake that first looked like "a value-returning `IJSRuntime` read is unreliable." Investigating it (bridge trace + frame capture + first-chance exception capture) showed it was **neither the read nor the value marshalling** — the read result comes back fine. The real bug is a **concurrent-render race**.

## Root cause
Native runs async lifecycle/handler continuations on the **thread pool**: `HandlerSyncContext.Post` uses `Task.Run`, and `RunWithRendersAsync` fires a render (`RenderInScopeCoreAsync`) from there. On a page with several async `OnRenderedAsync` hooks (a guide page: the JS-interop demo's `sessionStorage` read, `GuideChrome`'s scroll-spy, …), multiple continuations complete and each fires a mid-await render. Those renders ran with **no mutual exclusion**, so two renders walked the component tree at once and raced `ComponentLifecycle.DisposeComponentTree`'s `PersistedChildren` enumeration:

```
System.InvalidOperationException: Collection was modified; enumeration operation may not execute.
  at ComponentLifecycle.DisposeComponentTree(Component)
  at Component.RenderAsLiveRootCore(...)
  at LiveSessionBase.RenderTreeToHtml(...)
  at NativeLiveSession.BuildPayloadAsync(...)
  at NativeLiveSession.RenderInScopeCoreAsync()          ← one render …
  at Component.InvokeWithRenderingAsync(...)              ← … racing another
```

The exception escaped mid-render into the root error boundary, which intermittently wiped a complex page after an interaction — the "content vanished" symptom.

## Fix
`NativeLiveSession` now serializes every render+emit behind a **`_renderLock`** — the **Server host has the same lock**; WASM is single-threaded so it needs none. It's held only around one build+emit (never across a handler/await), so the legitimate re-entrant case (an in-handler `InvokeWithRenderingAsync` rendering inline, then the dispatch's own render afterwards) stays sequential, and lock order is always `_lock` → `_renderLock` (with `RenderInScopeCoreAsync` taking only `_renderLock`) so there's no inversion.

## Verification
- A frame-level repro that reproduced the race **~1 in 3** → **0 / 20** with the fix (0 `Collection was modified` exceptions captured).
- With the race gone, `NativeExampleTests` now runs the **full shared showcase journey** — the JS-interop element-ref focus + sessionStorage round-trip, the URL-routed Todos dialog + Browser-APIs co-mount, the popstate in-session 404 — **10 / 10 green** (restored from the focused subset it had to fall back to while the flake was unexplained).
- 14 native unit tests green; `dotnet format` clean; full `dotnet build Rask.slnx` warnings-as-errors clean.

## Benchmarks
Not applicable — adds a native-only serialization lock, no render-hot-path change.

## Notes
Supersedes the docs-only **#304** (whose "under investigation" follow-up this resolves); `docs/native.md` item 6 + the CHANGELOG are updated to mark it fixed.