### PR TITLE
perf(build,test): faster local & CI test loop (WASM gate, shared e2e build, per-host server limits)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,9 +79,13 @@ jobs:
           fi
 
       - name: Build (no WASM bundle)
-        # -m:1 (serial) prevents the parallel ProjectReference copy race on Rask.Core.dll
-        # (MSB3026 copy-retry / MSB3030 not-found) rather than masking the warning.
-        run: dotnet build Rask.slnx -c Release --no-restore -p:RaskWasm=false -p:WasmBuildNative=false -m:1
+        # -p:RaskWasm=false now genuinely skips the nested WASM publish: Rask.Wasm.Hosting.targets
+        # gates _RaskPublishWasmBundle on the effective $(RaskWasm) property (the XmlPeek probe
+        # alone can't be turned off from the outer build). With that publish gone there is no second
+        # writer of Rask.Core.dll, so the MSB3026/MSB3030 copy race can't occur and the build runs
+        # in parallel (dropping the old -m:1). This also stops the "fast" gate silently paying for a
+        # full WASM publish it believed -p:RaskWasm=false had disabled.
+        run: dotnet build Rask.slnx -c Release --no-restore -p:RaskWasm=false -p:WasmBuildNative=false
 
       - name: Unit & integration tests
         run: >-
@@ -130,10 +134,11 @@ jobs:
           dotnet restore benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj
 
       - name: Build benchmark projects
-        # -m:1 (serial) avoids the parallel ProjectReference copy race on Rask.Core.dll, matching `unit`.
+        # The benchmark projects reference no WASM host, so no nested WASM publish fires and there is
+        # no Rask.Core.dll copy race — they build in parallel (no -m:1).
         run: |
-          dotnet build benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj -c Release --no-restore -m:1
-          dotnet build benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj -c Release --no-restore -m:1
+          dotnet build benchmarks/Rask.Benchmarks/Rask.Benchmarks.csproj -c Release --no-restore
+          dotnet build benchmarks/Rask.Benchmarks.VsBlazor/Rask.Benchmarks.VsBlazor.csproj -c Release --no-restore
 
       - name: Payload-bytes regression gate (standalone codec)
         run: >-
@@ -147,12 +152,64 @@ jobs:
         run: >-
           dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor --no-build -- mem-footprint
 
-  # Browser journeys: exactly one comprehensive [Fact] journey per hosting project.
-  # Sharded one host per runner so all fixtures boot in parallel — wall-clock is the
-  # slowest single host's cold boot + its journey, not 4 serial batches on one runner.
-  # (Future optimization: a shared `build` job + artifact to avoid rebuilding the WASM
-  # bundles on each shard; kept simple/robust here in favor of independent shards.)
+  # Build the whole E2E graph ONCE and hand the output to every browser-journey shard, instead of
+  # each of the 10 shards rebuilding the entire solution (the E2E test project references every
+  # sample host, so a shard can't build a narrower graph). The shards then run `--no-build` off the
+  # downloaded output, so the expensive build — including the nested WASM publishes that touch
+  # emscripten — happens a single time.
+  # -m:1 stays on this one build: the RaskWasm bundle's nested `dotnet publish` still double-builds
+  # Rask.Core.dll (net10.0-browser) against the top-level WASM build, and serial is the correctness
+  # insurance against that copy race (MSB3026/MSB3030) for the single build that triggers it. (The
+  # `unit`/`benchmarks` jobs drop -m:1 because -p:RaskWasm=false now genuinely skips that publish.)
+  e2e-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install wasm-tools workload
+        run: dotnet workload install wasm-tools
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Build.targets') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Restore
+        run: dotnet restore Rask.slnx
+
+      - name: Build
+        run: dotnet build Rask.slnx -c Release --no-restore -m:1
+
+      - name: Package build output
+        # Tar every bin/ and obj/: the shards need the built test + sample assemblies, the published
+        # WASM wwwroot bundles the WASM fixtures serve, and the restore assets that `dotnet run
+        # --no-build` and the two publish-based fixtures require. Plain tar — upload-artifact
+        # compresses. -prune stops the walk from descending into a matched dir (no nested dup).
+        run: |
+          find . -type d \( -name bin -o -name obj \) -prune -print0 \
+            | tar --null --files-from=- -cf build-output.tar
+
+      - name: Upload build output
+        uses: actions/upload-artifact@v7
+        with:
+          name: e2e-build-output
+          path: build-output.tar
+          retention-days: 1
+
+  # Browser journeys: exactly one comprehensive [Fact] journey per hosting project. Sharded one host
+  # per runner so all fixtures boot in parallel. Each shard consumes the shared `e2e-build` output and
+  # runs --no-build (no rebuild) — trading a little wall-clock (build-then-fan-out) for ~9× fewer
+  # runner-minutes than every shard rebuilding the solution.
   e2e:
+    needs: e2e-build
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -178,6 +235,9 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      # `dotnet test --no-build` still evaluates the project graph, which imports the wasm-tools
+      # targets for the net10.0-browser project references; the two publish-based fixtures
+      # (Server/NativeServerSmoke) also `dotnet publish` at runtime. Keep the workload + NuGet cache.
       - name: Install wasm-tools workload
         run: dotnet workload install wasm-tools
 
@@ -195,14 +255,14 @@ jobs:
           key: playwright-${{ runner.os }}-${{ hashFiles('tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj') }}
           restore-keys: playwright-${{ runner.os }}-
 
-      - name: Restore
-        run: dotnet restore Rask.slnx
+      - name: Download build output
+        uses: actions/download-artifact@v7
+        with:
+          name: e2e-build-output
 
-      - name: Build
-        # -m:1 (serial) eliminates the parallel copy race: the WASM AppBundle's nested
-        # `dotnet publish` no longer overlaps another project copying Rask.Core.dll
-        # (MSB3026 copy-retry / MSB3030 not-found). Fixes the cause, not the annotation.
-        run: dotnet build Rask.slnx -c Release --no-restore -m:1
+      - name: Extract build output
+        # Overlay the shared bin/ + obj/ onto the fresh checkout so --no-build sees the built graph.
+        run: tar -xf build-output.tar
 
       - name: E2E journey (${{ matrix.host }})
         # Namespace-anchored so the leading dot prevents substring collisions

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,8 +32,10 @@ jobs:
       - name: Restore
         run: dotnet restore Rask.slnx
       - name: Build (no WASM bundle)
-        # -m:1 (serial) prevents the parallel ProjectReference copy race on Rask.Core.dll.
-        run: dotnet build Rask.slnx -c Release --no-restore -p:RaskWasm=false -p:WasmBuildNative=false -m:1
+        # -p:RaskWasm=false now genuinely skips the nested WASM publish (Rask.Wasm.Hosting.targets
+        # gates _RaskPublishWasmBundle on the effective property), so the Rask.Core.dll copy race
+        # against that publish can't occur here and the build runs in parallel (no -m:1).
+        run: dotnet build Rask.slnx -c Release --no-restore -p:RaskWasm=false -p:WasmBuildNative=false
       - name: Unit & integration tests
         run: >-
           dotnet test Rask.slnx -c Release --no-build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,22 @@ them until tagged releases begin.
   in a mobile-emulated WebView context, confirming the thin-native-shell scenario renders and reacts live
   over the WebSocket.
 
+### Changed
+- **Per-host server limits (no more process-global statics).** The WebSocket safety caps and session
+  grace periods (`RaskServerOptions`) are now projected into a per-host `RaskServerLimits` singleton
+  that the WS endpoint resolves once per connection, instead of eight mutable `static` fields shared
+  across every host in a process. Two hosts in one process each carry their own limits (the old code
+  had the last `configureServer` win for all of them), and the server test suite no longer serialises
+  around that shared state — cutting `Rask.Server.Tests` wall-clock substantially by letting its
+  integration tests run in parallel. No API change; behaviour is unchanged for a single-host process.
+- **Faster tests, locally and in CI.** (1) The `-p:RaskWasm=false` "fast" build now genuinely skips the
+  nested WASM publish — it was gated by an `XmlPeek` of the csproj rather than the property, so the
+  `unit`/`benchmarks` jobs silently ran a full WASM publish they believed disabled — which also lets
+  those builds run in parallel again (the `-m:1` Rask.Core.dll copy-race workaround is no longer needed
+  there). (2) CI now builds the E2E graph **once** in a shared `e2e-build` job and hands the output to
+  every browser-journey shard via artifact (`--no-build`), instead of each of the ten shards rebuilding
+  the whole solution. (3) The documented local inner loop is build-once / test-with-`--no-build`.
+
 ### Fixed
 - **Native `IJSRuntime` invokes with arguments, and native WebView history.** Both were bugs the new
   native E2E surfaced. (1) An out-of-render `IJSRuntime` invoke (one issued from an event handler that

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -15,8 +15,16 @@ Every change passes this gate before a PR (the `rask-ship` skill):
    `EnforceCodeStyleInBuild`), so a plain build enforces it too. See [code-analysis.md](code-analysis.md).
 3. **Tests** — unit-test every feature/fix (`tests/Rask.*.Tests`); add E2E only when a unit test
    can't reach the path. **Every `samples/` change gets an E2E** journey update
-   (`tests/Rask.Examples.E2E.Tests`). Inner loop:
-   `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"`.
+   (`tests/Rask.Examples.E2E.Tests`). Inner loop — **build once, then test with `--no-build`** so
+   each run doesn't rebuild the whole solution (test execution itself is fast; the build dominates):
+   ```bash
+   dotnet build Rask.slnx -c Release
+   dotnet test Rask.slnx -c Release --no-build --filter "FullyQualifiedName!~Rask.Examples.E2E"
+   ```
+   Narrow further to one project (`dotnet test tests/Rask.Core.Tests --no-build`) or one class
+   (`--filter FullyQualifiedName~ATests`) while iterating. The build runs in parallel by default —
+   don't add `-m:1` (the former WASM copy-race workaround is fixed at the source in
+   `Rask.Wasm.Hosting.targets`).
 4. **Benchmarks** — any render/live-runtime hot-path change runs `benchmarks/Rask.Benchmarks`
    before/after and quotes the `Allocated` delta in the PR.
 5. **Docs & examples** — user-facing changes update a `samples/` app, the relevant `docs/*.md`,
@@ -39,7 +47,8 @@ Every change passes this gate before a PR (the `rask-ship` skill):
 
 ## CI
 
-- `ci.yml` — unit gate + sharded E2E matrix (one host per runner) on PRs/`main`.
+- `ci.yml` — unit gate + a shared `e2e-build` job whose output a sharded E2E matrix (one host per
+  runner) consumes with `--no-build`, so the solution builds once instead of once per shard.
 - `commitlint.yml` — Conventional Commits check on PRs.
 - `nightly.yml` — prerelease publish on `main`.
 - `release.yml` — tag-triggered stable publish.

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -52,57 +52,12 @@ public static class RaskEndpointExtensions
     internal const string ManifestPath = "/rask/manifest.webmanifest";
     internal const string ServiceWorkerPath = "/rask-sw.js";
 
-    // Hard cap on a single reassembled inbound WS frame. Client→server messages (hello / event
-    // dispatch / jsResult / navigate / dotNetInvoke args) are small, and file uploads use the HTTP
-    // endpoint — never the socket — so this is generous headroom. It bounds a per-socket memory DoS
-    // where a client streams an unbounded fragmented frame the server would otherwise buffer whole
-    // before JsonDocument.Parse. Seeded from RaskServerOptions.MaxInboundFrameBytes by AddRask; the
-    // static is the DI-free hot-path source of truth (tests also set it directly).
-    internal static int MaxInboundFrameBytes = 8 * 1024 * 1024;
-
+    // The WS receive-loop / session-lifecycle safety limits (frame size &amp; rate caps, pending-handler
+    // count &amp; bytes, handler + idle-socket timeouts, reconnect grace periods) live on a per-host
+    // RaskServerLimits singleton — resolved once per connection, read on the hot path via instance
+    // fields — instead of process-global statics. See RaskServerLimits / RaskServerOptions.
     private static FileSystemWatcher? _sourceWatcher;
     private static long _lastSourceChangeTicks;
-
-    internal static TimeSpan SessionGracePeriod = TimeSpan.FromSeconds(30);
-
-    // Grace for a session that was minted by the GET shell but has not yet received a WS
-    // `hello`. The runtime script connects within a second of page load, so a much shorter
-    // window than the 30s reconnect grace is enough — and it stops a flood of GETs that never
-    // open a socket (scanners, prefetchers, an unauthenticated DoS) from pinning a full DI
-    // scope + component tree for 30s each. A real `hello` cancels this removal (LiveSessionStore
-    // .Get) and any later disconnect re-arms the full SessionGracePeriod via DetachSocket.
-    internal static TimeSpan UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(10);
-
-    // Maximum handler dispatches that may be queued (awaiting their turn in WS-arrival order)
-    // before the receive loop trips the backpressure circuit-breaker and closes the socket.
-    // Each queued dispatch holds a cloned JsonElement; without a bound, a client sending faster
-    // than handlers drain — or a single hung handler stalling the chain head — would grow the
-    // queue (and retained memory) without limit. 512 is far above any legitimate burst. 0 = off.
-    internal static int MaxPendingHandlers = 512;
-
-    // Maximum inbound WS messages per second on a single connection before the receive loop trips
-    // and closes the socket. MaxInboundFrameBytes bounds one frame's SIZE and MaxPendingHandlers
-    // bounds queued HANDLER dispatches, but neither bounds the rate of small NON-handler frames
-    // (jsResult / navigate / dotNetInvoke / malformed), each of which still costs a JSON parse — so
-    // a flood of them is a CPU DoS those caps miss. Counted over a sliding one-second window. A
-    // realistic interaction peak (rapid typing with per-keystroke handlers, a 60 Hz scroll handler)
-    // is well under 100/s, so 1000 is far above any legitimate burst. Mutable static so a test can
-    // lower it. Seeded from RaskServerOptions.MaxInboundFramesPerSecond by AddRask; operators can also
-    // tune ingress with a reverse-proxy rate limiter. 0 = off.
-    internal static int MaxInboundFramesPerSecond = 1000;
-
-    // Close a connected socket that sends no inbound frame for this long (the session survives for
-    // reconnect under SessionGracePeriod). Seeded from RaskServerOptions.IdleSocketTimeout. Zero = off.
-    internal static TimeSpan IdleSocketTimeout = TimeSpan.Zero;
-
-    // Cancel a handler dispatch's CancellationToken after this long, so a cooperative handler that
-    // observes it unwinds instead of pinning the render pipeline. Seeded from
-    // RaskServerOptions.HandlerTimeout. Zero = off.
-    internal static TimeSpan HandlerTimeout = TimeSpan.Zero;
-
-    // Aggregate-bytes companion to MaxPendingHandlers: bounds the queued cloned-payload memory, not just
-    // the queue count. Seeded from RaskServerOptions.MaxPendingHandlerBytes. 0 = off.
-    internal static long MaxPendingHandlerBytes;
 
     // A fixed, content-free payload — written as a literal rather than JsonSerializer.Serialize(anonymous)
     // so it needs no reflection-based serialization. Under NativeAOT (reflection JSON disabled) the
@@ -181,23 +136,19 @@ public static class RaskEndpointExtensions
             maxSessions = liveOptions.MaxSessions;
         }
 
-        // Seed the server-only WS / grace-period safety limits from RaskServerOptions. Defaults match
-        // the statics, so an absent callback is a no-op. The statics are the DI-free hot-path source of
-        // truth read by the WS receive loop; tests also set them directly.
+        // Seed the server-only WS / grace-period safety limits from RaskServerOptions into a per-host
+        // RaskServerLimits singleton. An absent callback registers the framework defaults (which match
+        // RaskServerOptions' defaults). The singleton — not a process-global static — is the hot-path
+        // source of truth: the WS endpoint resolves it once per connection so concurrent hosts each
+        // carry their own limits. Validate only when configured (defaults are in range).
+        var serverOptions = new RaskServerOptions();
         if (configureServer is not null)
         {
-            var serverOptions = new RaskServerOptions();
             configureServer(serverOptions);
             serverOptions.Validate();
-            MaxInboundFrameBytes = serverOptions.MaxInboundFrameBytes;
-            MaxPendingHandlers = serverOptions.MaxPendingHandlers;
-            MaxInboundFramesPerSecond = serverOptions.MaxInboundFramesPerSecond;
-            SessionGracePeriod = serverOptions.SessionGracePeriod;
-            UnconnectedSessionGracePeriod = serverOptions.UnconnectedSessionGracePeriod;
-            IdleSocketTimeout = serverOptions.IdleSocketTimeout;
-            HandlerTimeout = serverOptions.HandlerTimeout;
-            MaxPendingHandlerBytes = serverOptions.MaxPendingHandlerBytes;
         }
+
+        services.AddSingleton(RaskServerLimits.From(serverOptions));
 
         // Metrics singleton (Meter "Rask.Server"). TryAdd so a host can pre-register its own.
         services.TryAddSingleton<RaskMetrics>();
@@ -358,6 +309,7 @@ public static class RaskEndpointExtensions
         endpoints.MapGet(scopedPattern, (RequestDelegate)(async httpContext =>
         {
             var store = httpContext.RequestServices.GetRequiredService<LiveSessionStore>();
+            var limits = httpContext.RequestServices.GetRequiredService<RaskServerLimits>();
             var path = StripPathBase(httpContext.Request.Path.Value ?? "/", pathBaseNormalized);
             var user = httpContext.User ?? new ClaimsPrincipal(new ClaimsIdentity());
 
@@ -426,7 +378,7 @@ public static class RaskEndpointExtensions
             // that never sends `hello` is almost certainly a probe / abandoned load and should
             // not pin a DI scope + tree for the full 30s reconnect window. A real hello cancels
             // this removal (LiveSessionStore.Get) and DetachSocket later re-arms the full grace.
-            store.ScheduleRemoval(session.Id, UnconnectedSessionGracePeriod);
+            store.ScheduleRemoval(session.Id, limits.UnconnectedSessionGracePeriod);
         }));
         return endpoints;
     }
@@ -497,6 +449,9 @@ public static class RaskEndpointExtensions
             {
                 var store = ctx.RequestServices.GetRequiredService<LiveSessionStore>();
                 var lifetime = ctx.RequestServices.GetRequiredService<IHostApplicationLifetime>();
+                // Resolve the per-host safety limits once per connection (not per frame) — the receive
+                // loop reads them via instance fields on the hot path.
+                var limits = ctx.RequestServices.GetRequiredService<RaskServerLimits>();
                 if (!ctx.WebSockets.IsWebSocketRequest)
                 {
                     ctx.Response.StatusCode = StatusCodes.Status400BadRequest;
@@ -527,7 +482,7 @@ public static class RaskEndpointExtensions
                     new WebSocketAcceptContext { DangerousEnableCompression = true });
                 using var linked = CancellationTokenSource.CreateLinkedTokenSource(
                     ctx.RequestAborted, lifetime.ApplicationStopping);
-                await RunSocketLoop(ws, store, wsUser, linked.Token, lifetime.ApplicationStopping);
+                await RunSocketLoop(ws, store, limits, wsUser, linked.Token, lifetime.ApplicationStopping);
             }));
 
         var script = LoadEmbeddedScript();
@@ -686,8 +641,8 @@ public static class RaskEndpointExtensions
         }
     }
 
-    private static async Task RunSocketLoop(WebSocket ws, LiveSessionStore store, ClaimsPrincipal wsUser,
-        CancellationToken ct, CancellationToken stopping)
+    private static async Task RunSocketLoop(WebSocket ws, LiveSessionStore store, RaskServerLimits limits,
+        ClaimsPrincipal wsUser, CancellationToken ct, CancellationToken stopping)
     {
         using var abortReg = stopping.Register(() =>
         {
@@ -699,7 +654,7 @@ public static class RaskEndpointExtensions
         var buffer = new byte[16 * 1024];
         var message = new ArrayBufferWriter<byte>(16 * 1024);
 
-        // Sliding one-second window for the inbound frame-rate cap (MaxInboundFramesPerSecond).
+        // Sliding one-second window for the inbound frame-rate cap (limits.MaxInboundFramesPerSecond).
         var rateWindowStartTick = Environment.TickCount64;
         var framesInWindow = 0;
 
@@ -707,7 +662,7 @@ public static class RaskEndpointExtensions
         // whole inbound message — first frame and every continuation fragment — and disarmed while the
         // message is dispatched, so a mid-fragment stall is reclaimed too and we don't allocate a CTS
         // per message. CancelAfter just reschedules the one internal timer.
-        using var idleCts = IdleSocketTimeout > TimeSpan.Zero
+        using var idleCts = limits.IdleSocketTimeout > TimeSpan.Zero
             ? CancellationTokenSource.CreateLinkedTokenSource(ct)
             : null;
 
@@ -722,7 +677,7 @@ public static class RaskEndpointExtensions
                 // before dispatch so a slow handler doesn't trip it. A fired timer (not a shutdown)
                 // means the client went silent mid-stream — close the socket (the session survives for
                 // reconnect under the grace period).
-                idleCts?.CancelAfter(IdleSocketTimeout);
+                idleCts?.CancelAfter(limits.IdleSocketTimeout);
                 var receiveToken = idleCts?.Token ?? ct;
                 try
                 {
@@ -763,7 +718,7 @@ public static class RaskEndpointExtensions
 
                             // Abort a socket that streams a frame past the cap rather than buffering it
                             // whole — bounds per-socket memory against a fragmented-frame DoS.
-                            if (message.WrittenCount > MaxInboundFrameBytes)
+                            if (message.WrittenCount > limits.MaxInboundFrameBytes)
                             {
                                 metrics?.FrameRejected("size");
                                 try { ws.Abort(); }
@@ -793,7 +748,7 @@ public static class RaskEndpointExtensions
                 // a small-frame CPU DoS that the size cap and handler backpressure don't cover. The
                 // client reconnects (hello) against the intact session and resumes from current
                 // state, same as the handler-backlog breaker.
-                if (MaxInboundFramesPerSecond > 0)
+                if (limits.MaxInboundFramesPerSecond > 0)
                 {
                     var nowTick = Environment.TickCount64;
                     if (nowTick - rateWindowStartTick >= 1000)
@@ -802,7 +757,7 @@ public static class RaskEndpointExtensions
                         framesInWindow = 0;
                     }
 
-                    if (++framesInWindow > MaxInboundFramesPerSecond)
+                    if (++framesInWindow > limits.MaxInboundFramesPerSecond)
                     {
                         metrics?.FrameRejected("rate");
                         await ClosePolicyViolationAsync(ws, "frame rate").ConfigureAwait(false);
@@ -949,8 +904,8 @@ public static class RaskEndpointExtensions
                 var payloadBytes = (long)payload.Length;
                 var pending = capturedSession.IncrementPendingHandlers();
                 var pendingBytes = capturedSession.AddPendingHandlerBytes(payloadBytes);
-                if ((MaxPendingHandlers > 0 && pending > MaxPendingHandlers)
-                    || (MaxPendingHandlerBytes > 0 && pendingBytes > MaxPendingHandlerBytes))
+                if ((limits.MaxPendingHandlers > 0 && pending > limits.MaxPendingHandlers)
+                    || (limits.MaxPendingHandlerBytes > 0 && pendingBytes > limits.MaxPendingHandlerBytes))
                 {
                     capturedSession.DecrementPendingHandlers();
                     capturedSession.SubtractPendingHandlerBytes(payloadBytes);
@@ -969,6 +924,7 @@ public static class RaskEndpointExtensions
                     capturedRoot,
                     payloadBytes,
                     metrics,
+                    limits.HandlerTimeout,
                     ct);
             }
         }
@@ -979,7 +935,7 @@ public static class RaskEndpointExtensions
             if (session is not null)
             {
                 session.DetachSocket();
-                store.ScheduleRemoval(session.Id, SessionGracePeriod);
+                store.ScheduleRemoval(session.Id, limits.SessionGracePeriod);
             }
 
             if (ws.State == WebSocketState.Open || ws.State == WebSocketState.CloseReceived)
@@ -1013,6 +969,7 @@ public static class RaskEndpointExtensions
         JsonElement root,
         long payloadBytes,
         RaskMetrics? metrics,
+        TimeSpan handlerTimeout,
         CancellationToken ct)
     {
         try
@@ -1028,7 +985,7 @@ public static class RaskEndpointExtensions
                 // prevent this dispatch from running. The chain is for ordering only.
             }
 
-            await DispatchHandlerAsync(session, handlerId, root, metrics, ct).ConfigureAwait(false);
+            await DispatchHandlerAsync(session, handlerId, root, metrics, handlerTimeout, ct).ConfigureAwait(false);
 
             // Acknowledge the handler so the client's slow-link pending indicator can
             // resolve — crucially even when the render deduped and no frame was sent
@@ -1077,6 +1034,7 @@ public static class RaskEndpointExtensions
         string handlerId,
         JsonElement root,
         RaskMetrics? metrics,
+        TimeSpan handlerTimeout,
         CancellationToken ct)
     {
         try
@@ -1094,14 +1052,14 @@ public static class RaskEndpointExtensions
         metrics?.HandlerDispatched();
         var dispatchStart = Stopwatch.GetTimestamp();
 
-        // Handler timeout: cancel the dispatch's CancellationToken after HandlerTimeout (linked to
+        // Handler timeout: cancel the dispatch's CancellationToken after handlerTimeout (linked to
         // the socket so a close cancels it too). A handler that threads CancellationToken into its
         // async work unwinds cooperatively; one that ignores it can't be force-aborted (the timeout is
         // still logged + metered). Null when the timeout is disabled, so the default path allocates nothing.
-        using var handlerCts = HandlerTimeout > TimeSpan.Zero
+        using var handlerCts = handlerTimeout > TimeSpan.Zero
             ? CancellationTokenSource.CreateLinkedTokenSource(ct)
             : null;
-        handlerCts?.CancelAfter(HandlerTimeout);
+        handlerCts?.CancelAfter(handlerTimeout);
         var dispatchToken = handlerCts?.Token ?? default;
         try
         {
@@ -1177,7 +1135,7 @@ public static class RaskEndpointExtensions
                 activity?.SetStatus(ActivityStatusCode.Error, "handler timed out");
                 RaskDiagnostics.Report(
                     RaskLogLevel.Warning, "Rask.Live",
-                    $"Rask Live handler '{handlerId}' cancelled after HandlerTimeout ({HandlerTimeout})");
+                    $"Rask Live handler '{handlerId}' cancelled after HandlerTimeout ({handlerTimeout})");
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {

--- a/src/Rask.Server/RaskServerLimits.cs
+++ b/src/Rask.Server/RaskServerLimits.cs
@@ -1,0 +1,51 @@
+namespace Rask.Server;
+
+/// <summary>
+///     Per-host snapshot of the WebSocket receive-loop and session-lifecycle safety limits — the
+///     DoS-protection caps (inbound frame size / rate, pending-handler count &amp; bytes, handler and
+///     idle-socket timeouts) and the reconnect grace periods. Seeded from <see cref="RaskServerOptions" />
+///     when <c>AddRask</c> runs and registered as a singleton; the WebSocket endpoint resolves it once
+///     per connection (and the GET shell once per request), then the receive loop reads it via instance
+///     fields on the hot path. This replaces the former process-global mutable statics, so two hosts in
+///     one process — and parallel tests — each carry their own limits instead of clobbering shared state.
+///     Mirrors the per-store <c>LiveSessionStore.MaxSessions</c> pattern.
+/// </summary>
+internal sealed class RaskServerLimits
+{
+    /// <summary>Hard cap (bytes) on a single reassembled inbound WebSocket frame. See <see cref="RaskServerOptions.MaxInboundFrameBytes" />.</summary>
+    public int MaxInboundFrameBytes { get; init; } = 8 * 1024 * 1024;
+
+    /// <summary>Max handler dispatches queued before the backpressure breaker closes the socket. 0 = off.</summary>
+    public int MaxPendingHandlers { get; init; } = 512;
+
+    /// <summary>Max inbound WS messages/second over a sliding window before the socket is closed. 0 = off.</summary>
+    public int MaxInboundFramesPerSecond { get; init; } = 1000;
+
+    /// <summary>How long a disconnected session is retained for reconnect against the same tree.</summary>
+    public TimeSpan SessionGracePeriod { get; init; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>Grace for a GET-minted session that has not yet sent its first WS <c>hello</c> (probe defence).</summary>
+    public TimeSpan UnconnectedSessionGracePeriod { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>Close a connected socket that sends no inbound frame for this long. Zero = off.</summary>
+    public TimeSpan IdleSocketTimeout { get; init; } = TimeSpan.Zero;
+
+    /// <summary>Cancel a handler dispatch's token after this long (cooperative). Zero = off.</summary>
+    public TimeSpan HandlerTimeout { get; init; } = TimeSpan.Zero;
+
+    /// <summary>Aggregate queued cloned-payload bytes before the backpressure breaker closes the socket. 0 = off.</summary>
+    public long MaxPendingHandlerBytes { get; init; }
+
+    /// <summary>Projects a validated <see cref="RaskServerOptions" /> into the per-host limit snapshot.</summary>
+    public static RaskServerLimits From(RaskServerOptions o) => new()
+    {
+        MaxInboundFrameBytes = o.MaxInboundFrameBytes,
+        MaxPendingHandlers = o.MaxPendingHandlers,
+        MaxInboundFramesPerSecond = o.MaxInboundFramesPerSecond,
+        SessionGracePeriod = o.SessionGracePeriod,
+        UnconnectedSessionGracePeriod = o.UnconnectedSessionGracePeriod,
+        IdleSocketTimeout = o.IdleSocketTimeout,
+        HandlerTimeout = o.HandlerTimeout,
+        MaxPendingHandlerBytes = o.MaxPendingHandlerBytes,
+    };
+}

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -16,10 +16,9 @@ namespace Rask.Server;
 ///     <see cref="ArgumentOutOfRangeException" /> on an out-of-range one (a negative grace period, a
 ///     non-positive frame-size cap), so a misconfiguration fails fast at startup rather than at runtime.
 ///     <para>
-///         These are applied to process-global state read by the WebSocket receive loop, so in a
-///         multi-host process the last <c>configureServer</c> wins for every host (the framework's
-///         original constants were likewise process-wide). Per-app limits would need a per-connection
-///         options lookup; configure one set of limits per process.
+///         Each host carries its own limits: <c>AddRask</c> projects these values into a per-host
+///         <c>RaskServerLimits</c> singleton that the WebSocket endpoint resolves once per connection,
+///         so two hosts in one process (or parallel tests) do not share this state.
 ///     </para>
 /// </summary>
 public sealed class RaskServerOptions

--- a/src/Rask.Wasm.Hosting/build/Rask.Wasm.Hosting.targets
+++ b/src/Rask.Wasm.Hosting/build/Rask.Wasm.Hosting.targets
@@ -72,9 +72,26 @@
   <Target Name="_RaskPublishWasmBundle"
           BeforeTargets="BeforeBuild"
           DependsOnTargets="_RaskComputeWasmBundleDir">
+    <PropertyGroup>
+      <!--
+        Whether to actually run the (expensive, emscripten-relinking) nested WASM publish.
+        The bundle-dir probe (_RaskWasmAppBundleDir) is an XmlPeek of the referenced csproj,
+        which always reads <RaskWasm>true</RaskWasm> — so it can't be turned off from the
+        outer build. Gate additionally on the effective $(RaskWasm) property so an outer
+        `-p:RaskWasm=false` genuinely skips the publish: the CI `unit`/`benchmarks` jobs
+        pass it because no unit test consumes the published browser bundle. Before this gate
+        those jobs silently paid for a full WASM native relink they believed they had disabled,
+        and needed -m:1 to dodge the Rask.Core.dll copy race against the top-level WASM build.
+        A blank $(RaskWasm) (the normal build/e2e case) still publishes.
+      -->
+      <_RaskDoWasmPublish Condition=" '$(_RaskWasmAppBundleDir)' != '' AND '$(RaskWasm)' != 'false' ">true</_RaskDoWasmPublish>
+    </PropertyGroup>
     <Message Importance="high"
              Text="Rask.Wasm.Hosting: publishing %(_RaskWasmRef.FullPath) ($(Configuration))"
-             Condition=" '$(_RaskWasmAppBundleDir)' != '' "/>
+             Condition=" '$(_RaskDoWasmPublish)' == 'true' "/>
+    <Message Importance="high"
+             Text="Rask.Wasm.Hosting: skipping WASM publish for %(_RaskWasmRef.FullPath) (RaskWasm=false)"
+             Condition=" '$(_RaskWasmAppBundleDir)' != '' AND '$(RaskWasm)' == 'false' "/>
     <!--
       -nodeReuse:false on the nested publish — without this, its MSBuild workers stick around
       with the default nodeReuse=true, reparent to init when the publish process exits, and
@@ -89,7 +106,7 @@
     -->
     <Exec Command="dotnet publish &quot;%(_RaskWasmRef.FullPath)&quot; -c $(Configuration) --nologo -v:minimal -nodeReuse:false"
           ContinueOnError="WarnAndContinue"
-          Condition=" '$(_RaskWasmAppBundleDir)' != '' "/>
+          Condition=" '$(_RaskDoWasmPublish)' == 'true' "/>
   </Target>
 
   <Target Name="_RaskSetWasmBundleMetadata"

--- a/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
@@ -3,12 +3,12 @@ using Microsoft.Extensions.DependencyInjection;
 
 namespace Rask.Server.Tests.Configuration;
 
-// Serialized with the other tests that read/write the process-global WS/grace-period statics.
-[Collection("SessionGracePeriod")]
+// No shared global state to serialize on any more — each test builds its own provider and reads the
+// per-host RaskServerLimits singleton, so this class runs in parallel with the rest of the suite.
 public class ConfigurableLimitsTests
 {
     [Fact]
-    public void RaskServerOptions_Defaults_MatchTheShippedStaticLimits()
+    public void RaskServerOptions_Defaults_MatchTheShippedDefaults()
     {
         var o = new RaskServerOptions();
 
@@ -20,51 +20,32 @@ public class ConfigurableLimitsTests
     }
 
     [Fact]
-    public void AddRask_ConfigureServer_SeedsTheServerStaticLimits()
+    public void AddRask_ConfigureServer_SeedsThePerHostLimits()
     {
-        var saved = (
-            RaskEndpointExtensions.MaxInboundFrameBytes,
-            RaskEndpointExtensions.MaxPendingHandlers,
-            RaskEndpointExtensions.MaxInboundFramesPerSecond,
-            RaskEndpointExtensions.SessionGracePeriod,
-            RaskEndpointExtensions.UnconnectedSessionGracePeriod,
-            RaskEndpointExtensions.IdleSocketTimeout,
-            RaskEndpointExtensions.MaxPendingHandlerBytes,
-            RaskEndpointExtensions.HandlerTimeout);
-        try
+        // configureServer projects RaskServerOptions into the per-host RaskServerLimits singleton —
+        // no process-global statics, so this is fully isolated from every other test.
+        using var provider = new ServiceCollection().AddRask(configureServer: o =>
         {
-            new ServiceCollection().AddRask(configureServer: o =>
-            {
-                o.MaxInboundFrameBytes = 1234;
-                o.MaxPendingHandlers = 7;
-                o.MaxInboundFramesPerSecond = 42;
-                o.SessionGracePeriod = TimeSpan.FromSeconds(5);
-                o.UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(2);
-                o.IdleSocketTimeout = TimeSpan.FromSeconds(90);
-                o.MaxPendingHandlerBytes = 4096;
-                o.HandlerTimeout = TimeSpan.FromSeconds(7);
-            });
+            o.MaxInboundFrameBytes = 1234;
+            o.MaxPendingHandlers = 7;
+            o.MaxInboundFramesPerSecond = 42;
+            o.SessionGracePeriod = TimeSpan.FromSeconds(5);
+            o.UnconnectedSessionGracePeriod = TimeSpan.FromSeconds(2);
+            o.IdleSocketTimeout = TimeSpan.FromSeconds(90);
+            o.MaxPendingHandlerBytes = 4096;
+            o.HandlerTimeout = TimeSpan.FromSeconds(7);
+        }).BuildServiceProvider();
 
-            Assert.Equal(1234, RaskEndpointExtensions.MaxInboundFrameBytes);
-            Assert.Equal(7, RaskEndpointExtensions.MaxPendingHandlers);
-            Assert.Equal(42, RaskEndpointExtensions.MaxInboundFramesPerSecond);
-            Assert.Equal(TimeSpan.FromSeconds(5), RaskEndpointExtensions.SessionGracePeriod);
-            Assert.Equal(TimeSpan.FromSeconds(2), RaskEndpointExtensions.UnconnectedSessionGracePeriod);
-            Assert.Equal(TimeSpan.FromSeconds(90), RaskEndpointExtensions.IdleSocketTimeout);
-            Assert.Equal(4096, RaskEndpointExtensions.MaxPendingHandlerBytes);
-            Assert.Equal(TimeSpan.FromSeconds(7), RaskEndpointExtensions.HandlerTimeout);
-        }
-        finally
-        {
-            (RaskEndpointExtensions.MaxInboundFrameBytes,
-                RaskEndpointExtensions.MaxPendingHandlers,
-                RaskEndpointExtensions.MaxInboundFramesPerSecond,
-                RaskEndpointExtensions.SessionGracePeriod,
-                RaskEndpointExtensions.UnconnectedSessionGracePeriod,
-                RaskEndpointExtensions.IdleSocketTimeout,
-                RaskEndpointExtensions.MaxPendingHandlerBytes,
-                RaskEndpointExtensions.HandlerTimeout) = saved;
-        }
+        var limits = provider.GetRequiredService<RaskServerLimits>();
+
+        Assert.Equal(1234, limits.MaxInboundFrameBytes);
+        Assert.Equal(7, limits.MaxPendingHandlers);
+        Assert.Equal(42, limits.MaxInboundFramesPerSecond);
+        Assert.Equal(TimeSpan.FromSeconds(5), limits.SessionGracePeriod);
+        Assert.Equal(TimeSpan.FromSeconds(2), limits.UnconnectedSessionGracePeriod);
+        Assert.Equal(TimeSpan.FromSeconds(90), limits.IdleSocketTimeout);
+        Assert.Equal(4096, limits.MaxPendingHandlerBytes);
+        Assert.Equal(TimeSpan.FromSeconds(7), limits.HandlerTimeout);
     }
 
     [Fact]
@@ -89,21 +70,20 @@ public class ConfigurableLimitsTests
     }
 
     [Fact]
-    public void AddRask_NoConfigureServer_DoesNotResetStaticLimits()
+    public void AddRask_NoConfigureServer_RegistersDefaultLimits()
     {
-        var saved = RaskEndpointExtensions.MaxInboundFramesPerSecond;
-        try
-        {
-            // Set a sentinel, then a bare AddRask() must leave it untouched (it would catch a
-            // regression that reset the statics to defaults on the no-callback path).
-            RaskEndpointExtensions.MaxInboundFramesPerSecond = 777;
-            new ServiceCollection().AddRask();
-            Assert.Equal(777, RaskEndpointExtensions.MaxInboundFramesPerSecond);
-        }
-        finally
-        {
-            RaskEndpointExtensions.MaxInboundFramesPerSecond = saved;
-        }
+        // A bare AddRask() registers a RaskServerLimits carrying the framework defaults.
+        using var provider = new ServiceCollection().AddRask().BuildServiceProvider();
+        var limits = provider.GetRequiredService<RaskServerLimits>();
+
+        Assert.Equal(8 * 1024 * 1024, limits.MaxInboundFrameBytes);
+        Assert.Equal(512, limits.MaxPendingHandlers);
+        Assert.Equal(1000, limits.MaxInboundFramesPerSecond);
+        Assert.Equal(TimeSpan.FromSeconds(30), limits.SessionGracePeriod);
+        Assert.Equal(TimeSpan.FromSeconds(10), limits.UnconnectedSessionGracePeriod);
+        Assert.Equal(TimeSpan.Zero, limits.IdleSocketTimeout);
+        Assert.Equal(TimeSpan.Zero, limits.HandlerTimeout);
+        Assert.Equal(0, limits.MaxPendingHandlerBytes);
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/Diagnostics/WsLoopMetricsTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/WsLoopMetricsTests.cs
@@ -3,7 +3,6 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.Diagnostics;
 
-[Collection("SessionGracePeriod")]
 public class WsLoopMetricsTests
 {
     [Fact]

--- a/tests/Rask.Server.Tests/Infrastructure/HangingApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/HangingApp.cs
@@ -7,7 +7,7 @@ namespace Rask.Server.Tests.Infrastructure;
 
 // App whose click handler blocks on a test-controlled gate, stalling the handler-dispatch
 // chain head so queued dispatches pile up — used to exercise the backpressure circuit-breaker
-// (RaskEndpointExtensions.MaxPendingHandlers).
+// (RaskServerOptions.MaxPendingHandlers).
 public sealed class HangingApp : Component
 {
     // Released by the test to let the hung handler complete. Static so the test can signal it

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -39,13 +39,17 @@ internal sealed class RaskTestHost : IDisposable
     public static RaskTestHost Create<TApp>(
         Action<IServiceCollection>? configureServices = null,
         Action<IApplicationBuilder>? configureMiddleware = null,
-        string pathBase = "")
+        string pathBase = "",
+        Action<RaskServerOptions>? configureServer = null)
         where TApp : Component
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddRouting();
-        builder.Services.AddRask();
+        // Per-host WS / grace-period limits (RaskServerLimits) are seeded here, so each TestServer
+        // carries its own — tests set short grace periods / caps via configureServer instead of a
+        // process-global static, which lets these tests run in parallel.
+        builder.Services.AddRask(configureServer: configureServer);
         configureServices?.Invoke(builder.Services);
 
         var app = builder.Build();

--- a/tests/Rask.Server.Tests/Security/ResourceLimitTests.cs
+++ b/tests/Rask.Server.Tests/Security/ResourceLimitTests.cs
@@ -5,118 +5,90 @@ namespace Rask.Server.Tests.Security;
 
 // Phase-4 resource-exhaustion limits: an idle connected socket is reclaimed, and the pending-handler
 // queue is bounded by aggregate bytes (not just count). Both close the socket; the session survives.
-[Collection("SessionGracePeriod")]
 public class ResourceLimitTests
 {
     [Fact]
     public async Task IdleSocket_NoInboundFrames_IsClosedAfterTheTimeout()
     {
-        var prev = RaskEndpointExtensions.IdleSocketTimeout;
-        RaskEndpointExtensions.IdleSocketTimeout = TimeSpan.FromMilliseconds(300);
-        try
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.IdleSocketTimeout = TimeSpan.FromMilliseconds(300));
+        var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        // Send nothing further — the server must close the idle socket within the timeout window.
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
-
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-
-            // Send nothing further — the server must close the idle socket within the timeout window.
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
-            while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
+            if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
+                && ws.State == WebSocketState.Open)
             {
-                if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
-                    && ws.State == WebSocketState.Open)
-                {
-                    await Task.Delay(20);
-                }
+                await Task.Delay(20);
             }
+        }
 
-            Assert.NotEqual(WebSocketState.Open, ws.State);
-        }
-        finally
-        {
-            RaskEndpointExtensions.IdleSocketTimeout = prev;
-        }
+        Assert.NotEqual(WebSocketState.Open, ws.State);
     }
 
     [Fact]
     public async Task ActiveSocket_UnderIdleTimeout_StaysOpen()
     {
-        var prev = RaskEndpointExtensions.IdleSocketTimeout;
         // Comfortably larger than the inter-send gap below, so only genuine inactivity trips it.
-        RaskEndpointExtensions.IdleSocketTimeout = TimeSpan.FromSeconds(5);
-        try
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.IdleSocketTimeout = TimeSpan.FromSeconds(5));
+        var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(html);
+        var handlerId = Markup.FirstHandlerId(html);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500));
+
+        // Keep sending well within the 5 s window — the socket must stay open across a span
+        // (~3 s) that would have tripped a naive total-lifetime timeout.
+        for (var i = 0; i < 4; i++)
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
-            var sessionId = Markup.SessionId(html);
-            var handlerId = Markup.FirstHandlerId(html);
-
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500));
-
-            // Keep sending well within the 5 s window — the socket must stay open across a span
-            // (~3 s) that would have tripped a naive total-lifetime timeout.
-            for (var i = 0; i < 4; i++)
-            {
-                await Task.Delay(800);
-                await ws.SendJsonAsync(new { id = handlerId });
-                _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-            }
-
-            Assert.Equal(WebSocketState.Open, ws.State);
+            await Task.Delay(800);
+            await ws.SendJsonAsync(new { id = handlerId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
         }
-        finally
-        {
-            RaskEndpointExtensions.IdleSocketTimeout = prev;
-        }
+
+        Assert.Equal(WebSocketState.Open, ws.State);
     }
 
     [Fact]
     public async Task PendingHandlerBytes_ExceedsCap_ClosesSocket()
     {
-        var prevBytes = RaskEndpointExtensions.MaxPendingHandlerBytes;
-        var prevCount = RaskEndpointExtensions.MaxPendingHandlers;
         // 1 byte: the first handler frame's payload exceeds it, so the byte cap trips immediately
         // (the count cap is left generous so this isolates the byte path).
-        RaskEndpointExtensions.MaxPendingHandlerBytes = 1;
-        RaskEndpointExtensions.MaxPendingHandlers = 10_000;
-        try
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => { o.MaxPendingHandlerBytes = 1; o.MaxPendingHandlers = 10_000; });
+        var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(html);
+        var handlerId = Markup.FirstHandlerId(html);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        for (var i = 0; i < 20; i++)
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
-            var sessionId = Markup.SessionId(html);
-            var handlerId = Markup.FirstHandlerId(html);
-
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-
-            for (var i = 0; i < 20; i++)
-            {
-                try { await ws.SendJsonAsync(new { id = handlerId }); }
-                catch { break; }
-            }
-
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
-            while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
-            {
-                if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
-                    && ws.State == WebSocketState.Open)
-                {
-                    await Task.Delay(20);
-                }
-            }
-
-            Assert.NotEqual(WebSocketState.Open, ws.State);
+            try { await ws.SendJsonAsync(new { id = handlerId }); }
+            catch { break; }
         }
-        finally
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(3);
+        while (ws.State == WebSocketState.Open && DateTime.UtcNow < deadline)
         {
-            RaskEndpointExtensions.MaxPendingHandlerBytes = prevBytes;
-            RaskEndpointExtensions.MaxPendingHandlers = prevCount;
+            if (await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(100)) is null
+                && ws.State == WebSocketState.Open)
+            {
+                await Task.Delay(20);
+            }
         }
+
+        Assert.NotEqual(WebSocketState.Open, ws.State);
     }
 }

--- a/tests/Rask.Server.Tests/Security/WebSocketFrameRateTests.cs
+++ b/tests/Rask.Server.Tests/Security/WebSocketFrameRateTests.cs
@@ -7,62 +7,48 @@ namespace Rask.Server.Tests.Security;
 // handler-backlog breaker don't bound — each non-handler frame (jsResult / navigate / malformed)
 // still costs a JSON parse. The receive loop counts inbound frames over a sliding one-second window
 // (MaxInboundFramesPerSecond) and closes the socket on a flood.
-//
-// In SessionGracePeriod (DisableParallelization) so the static MaxInboundFramesPerSecond write can't
-// leak onto a parallel test's connection: a low cap here would otherwise trip the breaker on an
-// unrelated socket mid-run (e.g. CheckboxBindingDiffTests sends 6 frames and would be closed at the
-// 6th). Same rationale that puts HandlerBackpressureTests (MaxPendingHandlers) in this collection.
-[Collection("SessionGracePeriod")]
 public class WebSocketFrameRateTests
 {
     [Fact]
     public async Task InboundFrameFlood_ClosesSocket()
     {
-        var prev = RaskEndpointExtensions.MaxInboundFramesPerSecond;
-        RaskEndpointExtensions.MaxInboundFramesPerSecond = 5; // small cap for the test
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.MaxInboundFramesPerSecond = 5); // small cap for the test
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var closed = false;
         try
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            var closed = false;
-            try
+            // Fire well past the cap within the one-second window. Tiny valid-JSON frames are
+            // counted before any handler routing, so they trip the rate breaker.
+            for (var i = 0; i < 50; i++)
             {
-                // Fire well past the cap within the one-second window. Tiny valid-JSON frames are
-                // counted before any handler routing, so they trip the rate breaker.
-                for (var i = 0; i < 50; i++)
-                {
-                    await ws.SendJsonAsync(new { type = "noop" });
-                }
+                await ws.SendJsonAsync(new { type = "noop" });
+            }
 
-                var buf = new byte[1024];
-                while (true)
+            var buf = new byte[1024];
+            while (true)
+            {
+                var r = await ws.ReceiveAsync(buf, cts.Token);
+                if (r.MessageType == WebSocketMessageType.Close)
                 {
-                    var r = await ws.ReceiveAsync(buf, cts.Token);
-                    if (r.MessageType == WebSocketMessageType.Close)
-                    {
-                        closed = true;
-                        break;
-                    }
+                    closed = true;
+                    break;
                 }
             }
-            catch (OperationCanceledException)
-            {
-                // Timed out without the socket closing → the cap did not fire.
-            }
-            catch (Exception)
-            {
-                // The server closed/aborted mid-send → the cap fired.
-                closed = true;
-            }
-
-            Assert.True(closed, "server must close the socket on an inbound frame flood");
         }
-        finally
+        catch (OperationCanceledException)
         {
-            RaskEndpointExtensions.MaxInboundFramesPerSecond = prev;
+            // Timed out without the socket closing → the cap did not fire.
         }
+        catch (Exception)
+        {
+            // The server closed/aborted mid-send → the cap fired.
+            closed = true;
+        }
+
+        Assert.True(closed, "server must close the socket on an inbound frame flood");
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/Security/WebSocketFrameSizeTests.cs
+++ b/tests/Rask.Server.Tests/Security/WebSocketFrameSizeTests.cs
@@ -6,60 +6,46 @@ namespace Rask.Server.Tests.Security;
 // M1: a client must not be able to stream an unbounded fragmented WS frame and force the server to
 // buffer it whole before parsing. The receive loop caps reassembly at MaxInboundFrameBytes and
 // aborts the socket past it.
-//
-// In SessionGracePeriod (DisableParallelization) so the static MaxInboundFrameBytes write doesn't
-// leak onto a parallel test's connection (same rationale as WebSocketFrameRateTests / the
-// MaxPendingHandlers tests). The 32 KB cap is benign for typical small-frame tests, but serialising
-// the global mutation keeps it from ever applying to traffic another test depends on.
-[Collection("SessionGracePeriod")]
 public class WebSocketFrameSizeTests
 {
     [Fact]
     public async Task OversizedInboundFrame_AbortsSocket()
     {
-        var prev = RaskEndpointExtensions.MaxInboundFrameBytes;
-        RaskEndpointExtensions.MaxInboundFrameBytes = 32 * 1024; // small cap for the test
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.MaxInboundFrameBytes = 32 * 1024); // small cap for the test
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+
+        // Larger than both the 16KB server receive buffer (forces the multi-fragment reassembly
+        // path) and the cap. The cap is enforced before JSON parsing, so raw bytes suffice.
+        var big = new byte[256 * 1024];
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var aborted = false;
         try
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-
-            // Larger than both the 16KB server receive buffer (forces the multi-fragment reassembly
-            // path) and the cap. The cap is enforced before JSON parsing, so raw bytes suffice.
-            var big = new byte[256 * 1024];
-
-            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
-            var aborted = false;
-            try
+            await ws.SendAsync(big, WebSocketMessageType.Text, true, cts.Token);
+            var buf = new byte[1024];
+            while (true)
             {
-                await ws.SendAsync(big, WebSocketMessageType.Text, true, cts.Token);
-                var buf = new byte[1024];
-                while (true)
+                var r = await ws.ReceiveAsync(buf, cts.Token);
+                if (r.MessageType == WebSocketMessageType.Close)
                 {
-                    var r = await ws.ReceiveAsync(buf, cts.Token);
-                    if (r.MessageType == WebSocketMessageType.Close)
-                    {
-                        aborted = true;
-                        break;
-                    }
+                    aborted = true;
+                    break;
                 }
             }
-            catch (OperationCanceledException)
-            {
-                // Timed out without the socket being torn down → the cap did not fire.
-            }
-            catch (Exception)
-            {
-                // WebSocketException / IOException etc. — the server aborted the connection.
-                aborted = true;
-            }
-
-            Assert.True(aborted, "server must abort the socket on an over-cap inbound frame");
         }
-        finally
+        catch (OperationCanceledException)
         {
-            RaskEndpointExtensions.MaxInboundFrameBytes = prev;
+            // Timed out without the socket being torn down → the cap did not fire.
         }
+        catch (Exception)
+        {
+            // WebSocketException / IOException etc. — the server aborted the connection.
+            aborted = true;
+        }
+
+        Assert.True(aborted, "server must abort the socket on an over-cap inbound frame");
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/WebSockets/AsyncValidationDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/AsyncValidationDispatchTests.cs
@@ -4,7 +4,7 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class AsyncValidationDispatchTests
 {
     // Asserts against the `html` payload field — force the legacy full-HTML wire

--- a/tests/Rask.Server.Tests/WebSockets/HandlerBackpressureTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerBackpressureTests.cs
@@ -3,22 +3,20 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-// Backpressure circuit-breaker (RaskEndpointExtensions.MaxPendingHandlers): a hung handler
+// Backpressure circuit-breaker (RaskServerOptions.MaxPendingHandlers): a hung handler
 // stalls the dispatch chain head, so queued dispatches — each retaining a cloned JsonElement —
 // accumulate. Once the queue exceeds the bound the receive loop must close the socket instead of
 // growing memory without limit.
-[Collection("SessionGracePeriod")]
 public class HandlerBackpressureTests
 {
     [Fact]
     public async Task QueueExceedsBound_WhileHandlerHung_ClosesSocket()
     {
-        var prevMax = RaskEndpointExtensions.MaxPendingHandlers;
-        RaskEndpointExtensions.MaxPendingHandlers = 4;
         HangingApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         try
         {
-            using var host = RaskTestHost.Create<HangingApp>();
+            using var host = RaskTestHost.Create<HangingApp>(
+                configureServer: o => o.MaxPendingHandlers = 4);
             var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
             var sessionId = Markup.SessionId(initialHtml);
             var handlerId = Markup.FirstHandlerId(initialHtml);
@@ -57,38 +55,29 @@ public class HandlerBackpressureTests
         finally
         {
             HangingApp.Gate.TrySetResult(); // unblock the hung handler so teardown is clean
-            RaskEndpointExtensions.MaxPendingHandlers = prevMax;
         }
     }
 
     [Fact]
     public async Task UnderBound_NormalTraffic_StaysOpen()
     {
-        var prevMax = RaskEndpointExtensions.MaxPendingHandlers;
-        RaskEndpointExtensions.MaxPendingHandlers = 512;
-        try
-        {
-            using var host = RaskTestHost.Create<TestApp>();
-            var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
-            var sessionId = Markup.SessionId(initialHtml);
-            var handlerId = Markup.FirstHandlerId(initialHtml);
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.MaxPendingHandlers = 512);
+        var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = Markup.SessionId(initialHtml);
+        var handlerId = Markup.FirstHandlerId(initialHtml);
 
-            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        // These drain quickly (no hung handler), so pending never approaches the bound.
+        for (var i = 0; i < 10; i++)
+        {
+            await ws.SendJsonAsync(new { id = handlerId });
             _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-
-            // These drain quickly (no hung handler), so pending never approaches the bound.
-            for (var i = 0; i < 10; i++)
-            {
-                await ws.SendJsonAsync(new { id = handlerId });
-                _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-            }
-
-            Assert.Equal(WebSocketState.Open, ws.State);
         }
-        finally
-        {
-            RaskEndpointExtensions.MaxPendingHandlers = prevMax;
-        }
+
+        Assert.Equal(WebSocketState.Open, ws.State);
     }
 }

--- a/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
@@ -7,7 +7,7 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class HandlerDispatchTests
 {
     // Asserts against the `html` payload field — force the legacy full-HTML wire

--- a/tests/Rask.Server.Tests/WebSockets/HandlerExceptionIsolationTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerExceptionIsolationTests.cs
@@ -15,7 +15,7 @@ namespace Rask.Server.Tests.WebSockets;
 //  - The dispatch lock (session.Lock) is distinct from the render lock (_renderLock), and AttachSocket
 //    takes neither — so a handler parked under the dispatch lock across a disconnect can't block the
 //    reconnect, and once it clears the queued work drains through the reconnected socket.
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class HandlerExceptionIsolationTests
 {
     // Assert against the legacy full-HTML `html` field (framework default is now diff mode).

--- a/tests/Rask.Server.Tests/WebSockets/HandlerOrderingTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerOrderingTests.cs
@@ -21,7 +21,7 @@ namespace Rask.Server.Tests.WebSockets;
 // async handlers awaiting jsResult / dotNetInvoke don't deadlock the loop),
 // but the *start order* of dispatches now matches WS arrival order
 // deterministically.
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class HandlerOrderingTests
 {
     // These tests assert against the `html` field in the payload — the legacy

--- a/tests/Rask.Server.Tests/WebSockets/HandlerTimeoutTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerTimeoutTests.cs
@@ -6,18 +6,16 @@ namespace Rask.Server.Tests.WebSockets;
 
 // RaskServerOptions.HandlerTimeout: a cooperative handler that threads CancellationToken into its
 // async work is cancelled when the timeout elapses, so it unwinds instead of pinning the render lock.
-[Collection("SessionGracePeriod")]
 public class HandlerTimeoutTests
 {
     [Fact]
     public async Task CooperativeHandler_PastTimeout_IsCancelled_AndMetered_SessionSurvives()
     {
-        var prev = RaskEndpointExtensions.HandlerTimeout;
-        RaskEndpointExtensions.HandlerTimeout = TimeSpan.FromMilliseconds(300);
         CooperativeTimeoutApp.Cancelled = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
         try
         {
-            using var host = RaskTestHost.Create<CooperativeTimeoutApp>();
+            using var host = RaskTestHost.Create<CooperativeTimeoutApp>(
+                configureServer: o => o.HandlerTimeout = TimeSpan.FromMilliseconds(300));
             using var capture = MeterCapture.For(host.Store.Metrics!.Meter);
 
             var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
@@ -46,7 +44,6 @@ public class HandlerTimeoutTests
         }
         finally
         {
-            RaskEndpointExtensions.HandlerTimeout = prev;
             CooperativeTimeoutApp.Cancelled.TrySetResult(false);
         }
     }

--- a/tests/Rask.Server.Tests/WebSockets/InitialRenderDiffTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/InitialRenderDiffTests.cs
@@ -12,7 +12,7 @@ namespace Rask.Server.Tests.WebSockets;
 //
 // In SessionGracePeriod so the static LiveOptions.DiffMode write serialises with the other
 // DiffMode-mutating WS test classes.
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class InitialRenderDiffTests
 {
     // Auto is the framework default; a counter's text diff is far smaller than the body, so

--- a/tests/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
@@ -10,7 +10,7 @@ namespace Rask.Server.Tests.WebSockets;
 // the offsets were captured, shifting every byte position after the head — so without the
 // offset adjustment the inserted row's HTML was garbled (sliced mid-attribute). Keyed insert
 // is the only op that carries an HTML slice, which is why delete/move were unaffected.
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class KeyedInsertNavTests
 {
     public KeyedInsertNavTests() => LiveOptions.DiffMode = LiveDiffMode.Forced;

--- a/tests/Rask.Server.Tests/WebSockets/MalformedMessageTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/MalformedMessageTests.cs
@@ -12,7 +12,7 @@ namespace Rask.Server.Tests.WebSockets;
 // loop, detached the socket and scheduled the session for removal — one buggy or adversarial
 // frame dropped the whole session. These tests assert each bad frame is dropped and the loop
 // keeps dispatching.
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class MalformedMessageTests
 {
     // Assert against the full-HTML `html` field — force the legacy wire shape.

--- a/tests/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
@@ -13,7 +13,7 @@ namespace Rask.Server.Tests.WebSockets;
 //
 // In SessionGracePeriod so the static LiveOptions.DiffMode write serialises with the other
 // DiffMode-mutating WS test classes.
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class NavigationDiffGateTests
 {
     // Forced pins the diff path so the assertions don't depend on payload sizing; the

--- a/tests/Rask.Server.Tests/WebSockets/SessionDisposeRaceTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/SessionDisposeRaceTests.cs
@@ -16,7 +16,6 @@ namespace Rask.Server.Tests.WebSockets;
 // The fix makes Dispose/DisposeAsync acquire _renderLock around the walk, so disposal and render
 // are mutually exclusive. This test gates a render in flight and asserts disposal blocks until the
 // render releases the lock — deterministic where a raw stress loop would only catch it sometimes.
-[Collection("SessionGracePeriod")]
 public class SessionDisposeRaceTests
 {
     [Fact]

--- a/tests/Rask.Server.Tests/WebSockets/SocketLifecycleTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/SocketLifecycleTests.cs
@@ -6,12 +6,12 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-[Collection("SessionGracePeriod")]
+[Collection("LiveDiffMode")]
 public class SocketLifecycleTests
 {
-    // Asserts against the `html` payload field — force the legacy full-HTML wire
-    // shape. The SessionGracePeriod collection already disables parallelization
-    // for this class, so the static-field assignment is single-threaded here.
+    // Asserts against the `html` payload field — force the legacy full-HTML wire shape. The
+    // LiveDiffMode collection disables parallelization for this class, so this global-static
+    // assignment is single-threaded and can't race another class that sets a different DiffMode.
     public SocketLifecycleTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
 
     [Fact]
@@ -27,97 +27,73 @@ public class SocketLifecycleTests
     [Fact]
     public async Task SocketDisconnect_SchedulesRemoval_SessionRemovedAfterShortenedGracePeriod()
     {
-        var prevGrace = RaskEndpointExtensions.SessionGracePeriod;
-        RaskEndpointExtensions.SessionGracePeriod = TimeSpan.FromMilliseconds(50);
-        try
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.SessionGracePeriod = TimeSpan.FromMilliseconds(50));
+        var initial = await host.Http.GetAsync("/start");
+        var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            var initial = await host.Http.GetAsync("/start");
-            var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
-            var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-
-            await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
-
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-            while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
-            {
-                await Task.Delay(20);
-            }
-
-            Assert.Equal(0, host.Store.Count);
+            await Task.Delay(20);
         }
-        finally
-        {
-            RaskEndpointExtensions.SessionGracePeriod = prevGrace;
-        }
+
+        Assert.Equal(0, host.Store.Count);
     }
 
     [Fact]
     public async Task Reconnect_BeforeGracePeriodDeadline_AttachesToExistingSession()
     {
-        var prev = RaskEndpointExtensions.SessionGracePeriod;
-        RaskEndpointExtensions.SessionGracePeriod = TimeSpan.FromSeconds(2);
-        try
-        {
-            using var host = RaskTestHost.Create<TestApp>();
-            var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.SessionGracePeriod = TimeSpan.FromSeconds(2));
+        var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
 
-            var ws1 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws1.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws1.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-            await ws1.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+        var ws1 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws1.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws1.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        await ws1.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
 
-            // Reconnect well inside the grace window.
-            using var ws2 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws2.SendJsonAsync(new { type = "hello", session = sessionId });
-            var rerender = await ws2.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        // Reconnect well inside the grace window.
+        using var ws2 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws2.SendJsonAsync(new { type = "hello", session = sessionId });
+        var rerender = await ws2.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
 
-            Assert.NotNull(rerender);
-            Assert.Contains("count=", rerender);
-            Assert.Equal(1, host.Store.Count);
-        }
-        finally
-        {
-            RaskEndpointExtensions.SessionGracePeriod = prev;
-        }
+        Assert.NotNull(rerender);
+        Assert.Contains("count=", rerender);
+        Assert.Equal(1, host.Store.Count);
     }
 
     [Fact]
     public async Task Reconnect_AfterGracePeriodExpires_HelloIsRejected()
     {
-        var prev = RaskEndpointExtensions.SessionGracePeriod;
-        RaskEndpointExtensions.SessionGracePeriod = TimeSpan.FromMilliseconds(50);
-        try
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.SessionGracePeriod = TimeSpan.FromMilliseconds(50));
+        var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+
+        var ws1 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws1.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws1.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        await ws1.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
-
-            var ws1 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws1.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws1.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-            await ws1.CloseAsync(WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
-
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-            while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
-            {
-                await Task.Delay(20);
-            }
-
-            Assert.Equal(0, host.Store.Count);
-
-            using var ws2 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws2.SendJsonAsync(new { type = "hello", session = sessionId });
-            var reply = await ws2.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-
-            Assert.NotNull(reply);
-            Assert.Contains("\"status\":\"unknown\"", reply);
+            await Task.Delay(20);
         }
-        finally
-        {
-            RaskEndpointExtensions.SessionGracePeriod = prev;
-        }
+
+        Assert.Equal(0, host.Store.Count);
+
+        using var ws2 = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws2.SendJsonAsync(new { type = "hello", session = sessionId });
+        var reply = await ws2.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(reply);
+        Assert.Contains("\"status\":\"unknown\"", reply);
     }
 
     [Fact]
@@ -148,36 +124,33 @@ public class SocketLifecycleTests
     [Fact]
     public async Task Close_WithCustomReason_RemovesSessionAfterGrace()
     {
-        var prev = RaskEndpointExtensions.SessionGracePeriod;
-        RaskEndpointExtensions.SessionGracePeriod = TimeSpan.FromMilliseconds(50);
-        try
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.SessionGracePeriod = TimeSpan.FromMilliseconds(50));
+        var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
+
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        await ws.CloseAsync(WebSocketCloseStatus.PolicyViolation, "policy-violation-bye",
+            CancellationToken.None);
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
+        while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
         {
-            using var host = RaskTestHost.Create<TestApp>();
-            var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
-
-            var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
-            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
-            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
-
-            await ws.CloseAsync(WebSocketCloseStatus.PolicyViolation, "policy-violation-bye",
-                CancellationToken.None);
-
-            var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(2);
-            while (host.Store.Count > 0 && DateTime.UtcNow < deadline)
-            {
-                await Task.Delay(20);
-            }
-
-            Assert.Equal(0, host.Store.Count);
+            await Task.Delay(20);
         }
-        finally
-        {
-            RaskEndpointExtensions.SessionGracePeriod = prev;
-        }
+
+        Assert.Equal(0, host.Store.Count);
     }
 }
 
-[CollectionDefinition("SessionGracePeriod", DisableParallelization = true)]
-public class SessionGracePeriodCollectionDef
+// Serializes the test classes that force a non-default wire shape via the process-global
+// LiveOptions.DiffMode static in their constructor (Auto / Forced / DisabledFull). They set
+// conflicting values and assert on the resulting payload, so they must run one at a time and never
+// overlap each other. (The former per-host WS/grace-period limits are on RaskServerLimits now, so
+// that reason for serializing is gone — this is purely about the LiveOptions.DiffMode global.)
+[CollectionDefinition("LiveDiffMode", DisableParallelization = true)]
+public class LiveDiffModeCollectionDef
 {
 }


### PR DESCRIPTION
## Summary
Make the test/build loop faster locally and in CI. Profiling showed **test execution is already fast** (e.g. Rask.Core.Tests: 1830 tests in ~1s) — the cost is the **build**, plus one CI job silently doing work it thought it had disabled, and one test project serialized on global statics.

Four independent workstreams:

- **A — Fix the WASM-publish gate, restore parallel builds.** `_RaskPublishWasmBundle` was gated by an `XmlPeek` of the referenced csproj, so `-p:RaskWasm=false` never suppressed it — the CI `unit`/`benchmarks` jobs ran a full nested WASM publish they believed disabled, and needed `-m:1` to dodge the `Rask.Core.dll` copy race. Now gated on the effective `$(RaskWasm)` property; those jobs truly skip it and build in **parallel** (`-m:1` dropped). *Verified: cold parallel `RaskWasm=false` build skips all 3 publishes cleanly (12s, no MSB3026/3030); the `RaskWasm=true` bundle stays intact.*
- **B — Share the E2E build.** The 10 browser-journey shards each rebuilt the whole solution (the E2E project references every sample host, so a shard can't build a narrower graph). Now a single `e2e-build` job builds once, tars `bin/`+`obj/`, and every shard consumes it with `--no-build`. Trades a little wall-clock for ~9× fewer runner-minutes. `-m:1` stays on that one build as race insurance.
- **C — Per-host server limits → parallelize Server.Tests.** The 8 WS/grace-period safety limits were process-global mutable statics; now a per-host `RaskServerLimits` singleton resolved once per connection (fixes the documented "last `configureServer` wins for every host" limitation). Tests configure per host via `RaskTestHost.Create(configureServer:)`, freeing the classes serialized only for the grace-period static. Server.Tests **118s → ~100s**.
  - Follow-up (deliberately not here): a *second* global static, `LiveOptions.DiffMode` (Core render hot path, shared with WASM), still serializes 9 heavy WS classes — kept under `[Collection("LiveDiffMode")]`. Making it per-host is its own PR (render benchmarks + Server & WASM E2E).
- **D — Inner-loop docs.** Documented build-once / test-with-`--no-build`, per-project runs, and the now-parallel build.

## Testing
- `dotnet format --verify-no-changes` — clean (changed projects).
- Full warnings-as-errors build — clean.
- Full unit suite (`--filter "FullyQualifiedName!~Rask.Examples.E2E"`) — all green.
- `Rask.Server.Tests` — **248 passed, run twice** (no flakiness after freeing classes / renaming the collection).
- `dotnet test --no-build` reuse validated locally (E2E shard mechanic); full E2E flow validated by this PR's CI.

## Benchmarks
Payload-bytes regression gate — **no change** (this change is off the render payload path):
```
CounterOnLargePage  diff 45B (0) ops 1 (0) [ok]
KeyedList100Reorder diff 47B (0) ops 1 (0) [ok]
TextNodeUpdate      diff 54B (0) ops 1 (0) [ok]
AppendRowToList100  diff 46B (0) ops 1 (0) [ok]
```

## Changelog
`CHANGELOG.md` `[Unreleased]` → **Changed** (per-host server limits; faster tests locally & in CI).
