### PR TITLE
fix(bootstrap): keep a closed select's clear × behind another select's open menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,13 @@ them until tagged releases begin.
   over the WebSocket.
 
 ### Fixed
+- **`BsSelect`/date-time picker clear (×) no longer shows through another select's open dropdown.** The
+  clear × carried a hard `z-index: 1000` (so an *open* control's × stays clickable above its own
+  click-outside backdrop at 999). But Bootstrap's open `.dropdown-menu.show` is *also* `z-index: 1000`,
+  and nothing isolates each control's stacking context — so a *closed* select whose × came later in the
+  DOM painted over another select's open menu. The raised z-index now lives on a `.bs-clear-open`
+  modifier applied to the × only while its own control is open; a closed control's × drops to
+  `z-index: auto` and sits behind any open menu.
 - **Native concurrent-render race (`Collection was modified` under the root error boundary).** The native
   host runs async lifecycle/handler continuations on the thread pool (`HandlerSyncContext.Post` uses
   `Task.Run`), so a mid-await render (`RenderInScopeCoreAsync`, or a second continuation's render) could run

--- a/src/Rask.Bootstrap/BsPickerBase.cs
+++ b/src/Rask.Bootstrap/BsPickerBase.cs
@@ -179,7 +179,7 @@ public abstract class BsPickerBase<T> : BsFormControl<T>
         var clear = showClear
             ? BsCloseButton(
                 Class: BsClass.Join(Position.Absolute, Position.End0, Position.Top50,
-                    Position.TranslateMiddleY, Margin.End(2), "bs-picker-clear"),
+                    Position.TranslateMiddleY, Margin.End(2), "bs-picker-clear", Open ? "bs-clear-open" : null),
                 AriaLabel: "Clear",
                 OnClickAsync: clearAsync)
             : null;

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -154,7 +154,8 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
 
         var clear = showClear
             ? BsCloseButton(
-                Class: BsClass.Join(Position.Absolute, Position.Top50, Position.TranslateMiddleY, "bs-select-clear"),
+                Class: BsClass.Join(Position.Absolute, Position.Top50, Position.TranslateMiddleY,
+                    "bs-select-clear", _open ? "bs-clear-open" : null),
                 AriaLabel: "Clear",
                 OnClickAsync: () => WriteAsync(b, default!))
             : null;

--- a/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
+++ b/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
@@ -33,11 +33,13 @@
 }
 .bs-select-clear {
   right: 2.25rem;
-  /* Above the open popover's full-screen backdrop (z-index 999) so it stays clickable while open. */
-  z-index: 1000;
 }
-/* The date/time pickers' clear (×) — same: keep it above the backdrop so an open picker can be cleared. */
-.bs-picker-clear {
+/* The × only needs to beat its OWN open-menu backdrop (z-index 999), and only while its control is
+   open — so the raised z-index lives on .bs-clear-open, applied to the × just for the open state.
+   A *closed* select's × stays at z-index:auto and therefore paints *behind* another (open) select's
+   dropdown menu; otherwise both would sit at z-index 1000 and DOM order would let the stray × win.
+   (.bs-picker-clear positions itself via the end-0/me-2 utilities, so it needs no rule of its own.) */
+.bs-clear-open {
   z-index: 1000;
 }
 

--- a/tests/Rask.Bootstrap.Tests/BsPickerTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsPickerTests.cs
@@ -105,8 +105,13 @@ public class BsPickerTests
     }
 
     [Fact]
-    public void Date_NullableWithValue_ShowsClearButton() =>
-        Assert.Contains("btn-close", Html(Us, () => BsDatePicker<DateOnly?>(Value: Jul7)));
+    public void Date_NullableWithValue_ShowsClearButton()
+    {
+        var html = Html(Us, () => BsDatePicker<DateOnly?>(Value: Jul7));
+        Assert.Contains("btn-close", html);
+        // Closed picker's × has no raised z-index (.bs-clear-open) — see the BsSelect equivalent.
+        Assert.DoesNotContain("bs-clear-open", html);
+    }
 
     [Fact]
     public void Date_NonFloating_WrapsBoxAndCaretInPositionRelative()

--- a/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
@@ -78,6 +78,9 @@ public class BsSelectTests
         Assert.Contains(
             "<button class=\"btn-close position-absolute top-50 translate-middle-y bs-select-clear\" " +
             "aria-label=\"Clear\" type=\"button\"></button>", html);
+        // A *closed* select's × never carries the raised z-index (.bs-clear-open) — that hook is added only
+        // while open, so a stray × can't paint over another (open) select's dropdown menu.
+        Assert.DoesNotContain("bs-clear-open", html);
     }
 
     [Fact]

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -441,6 +441,33 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("#sel-readout")).ToContainTextAsync("Tier: Team",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
+        // Stacking regression: the clear × must not paint over ANOTHER select's open dropdown menu. Both a ×
+        // and an open .dropdown-menu.show default to z-index 1000, so with the × always raised the later-in-DOM
+        // × won the tie and showed through. Fix: the × gets its raised z-index (needed to clear its OWN
+        // click-outside backdrop at 999) ONLY while its own control is open, via .bs-clear-open — so a *closed*
+        // select's × drops to z-index:auto and sits behind any open menu. Assert the computed z-index in both
+        // states on the clearable Seats select (giving it a value surfaces the ×).
+        var galSeats = Page.Locator("#sel-seats");
+        await galSeats.ScrollIntoViewIfNeededAsync();
+        await galSeats.ClickAsync();
+        await Page.Locator(".dropdown:has(#sel-seats) .dropdown-menu.show .dropdown-item")
+            .Filter(new LocatorFilterOptions { HasText = "2 seats" }).First.ClickAsync();
+        var galSeatsClear = Page.Locator(".dropdown:has(#sel-seats) .bs-select-clear");
+        await Expect(galSeatsClear).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        // Closed: no raised-z-index hook, so the × computes to z-index:auto (paints behind any open menu).
+        Assert.DoesNotContain("bs-clear-open", await galSeatsClear.GetAttributeAsync("class") ?? "");
+        Assert.Equal("auto", await galSeatsClear.EvaluateAsync<string>("x => getComputedStyle(x).zIndex"));
+        // Re-open this select: its OWN × must rise to z-index 1000 to stay clickable above its backdrop (999).
+        await galSeats.ClickAsync();
+        await Expect(Page.Locator(".dropdown:has(#sel-seats) .dropdown-menu.show"))
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        Assert.Contains("bs-clear-open", await galSeatsClear.GetAttributeAsync("class") ?? "");
+        Assert.Equal("1000", await galSeatsClear.EvaluateAsync<string>("x => getComputedStyle(x).zIndex"));
+        // Close via the backdrop so it doesn't intercept the next click.
+        await Page.Locator(".dropdown:has(#sel-seats) .position-fixed").DispatchEventAsync("click");
+        await Expect(Page.Locator(".dropdown:has(#sel-seats) .dropdown-menu.show"))
+            .ToBeHiddenAsync(new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
+
         // BsMultiSelect variant gallery — ticking two options in the basic control shows them as chips and
         // the gallery readout lists them.
         var msBasic = Page.Locator("#ms-basic");


### PR DESCRIPTION
## Summary
Opening a `BsSelect` (or date/time picker) let a **different, closed** select's clear "×" show *through* the open dropdown, instead of behind it.

**Root cause** (stacking order): the clear "×" (`.bs-select-clear` / `.bs-picker-clear`) carried a hardcoded `z-index: 1000` — needed so an *open* control's × stays clickable above its own full-screen click-outside backdrop (`z-index: 999`). But Bootstrap's open `.dropdown-menu.show` is **also** `z-index: 1000`, and nothing isolates each control's stacking context, so a *closed* select whose × appeared later in the DOM won the z-index tie and painted over another select's open menu.

**Fix:** move the raised z-index onto a new `.bs-clear-open` modifier that's applied to the × only while its own control is open. A closed control's × drops to `z-index: auto` (behind any open menu); an open control's × still rises to `1000` above its backdrop. `BsMultiSelect` is unaffected (it uses per-chip close buttons).

## Changes
- `wwwroot/css/rask-bootstrap.css` — z-index moved from the always-on `.bs-select-clear`/`.bs-picker-clear` to `.bs-clear-open`.
- `BsSelect.cs`, `BsPickerBase.cs` — apply `bs-clear-open` to the × only when the control is open.

## Testing
- **Unit** (`BsSelectTests`, `BsPickerTests`): regression guards that a *closed* control's × never carries `bs-clear-open`. 138 Bootstrap tests pass.
- **E2E** (shared showcase journey): asserts the ×'s computed z-index — `auto` when closed, `1000` when open. Full Server journey passes.
- `dotnet format` clean; `dotnet build -warnaserror` clean (analyzers pass).
- Benchmarks: N/A (CSS + one conditional class string; no render hot-path change).

## Changelog
Added under `[Unreleased] › Fixed`.