### PR TITLE
perf(live): carry diff mode per-session, not a process-global static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,18 @@ them until tagged releases begin.
   had the last `configureServer` win for all of them), and the server test suite no longer serialises
   around that shared state — cutting `Rask.Server.Tests` wall-clock substantially by letting its
   integration tests run in parallel. No API change; behaviour is unchanged for a single-host process.
+- **Per-session diff mode (no more process-global `LiveOptions.DiffMode` static).** The wire-payload
+  shape (`LiveDiffMode`) is now snapshotted onto each `LiveSession` at construction — from the host's
+  `RaskLiveOptions` (Server carries it on the `LiveSessionStore`, WASM/Native on the host builder) — and
+  read from that instance field on the render hot path, instead of a mutable `static` every render read.
+  This matters most for the native host, which fans render continuations onto the thread pool: a shared
+  mutable static read mid-render was doubly wrong there. Two hosts in one process — and parallel tests —
+  now each render in their own mode; `Rask.Server.Tests`' nine diff-mode WebSocket classes drop their
+  `[Collection("LiveDiffMode")]` serialization and run in parallel, and the native/WASM session tests no
+  longer pin the global. The configuration surface is unchanged (`AddRask(o => o.DiffMode = …)` /
+  `WasmHostBuilder.CreateDefault` / `NativeAppHost.CreateDefault`); `PathBase` / `MinifyScopedAssets`
+  stay on `LiveOptions` (they back the process-wide content-addressed asset registries). Render
+  benchmarks unchanged — allocation-neutral (a branch-condition read moved from a static to a field).
 - **Faster tests, locally and in CI.** (1) The `-p:RaskWasm=false` "fast" build now genuinely skips the
   nested WASM publish — it was gated by an `XmlPeek` of the csproj rather than the property, so the
   `unit`/`benchmarks` jobs silently ran a full WASM publish they believed disabled — which also lets

--- a/docs/architecture/live-rendering.md
+++ b/docs/architecture/live-rendering.md
@@ -156,6 +156,13 @@ mis-targeted positional op.
 - **`Forced`** — always diff when one is computable, even when larger than the body;
   for tests/benchmarks.
 
+The chosen mode is snapshotted onto **each `LiveSession`** at construction (from the host's
+`RaskLiveOptions` — the Server carries it on the `LiveSessionStore`, WASM/Native on the host builder),
+and read from that instance field on the render hot path. It is **not** a process-global static, so two
+hosts in one process — and parallel tests — each render in their own mode instead of racing a shared
+field. (`PathBase` / `MinifyScopedAssets` remain on the static `LiveOptions` because they back the
+process-wide content-addressed asset registries, which build one shared bundle per process.)
+
 The actual decision lives in `LiveSession.RenderAndSendAsync` (server) and the
 equivalent WASM path. Sketch (`Rask.Server/LiveSession.cs`):
 

--- a/samples/Rask.Example.Server/Program.cs
+++ b/samples/Rask.Example.Server/Program.cs
@@ -11,20 +11,25 @@ using Rask.Server.Diagnostics;
 // lives in this app assembly, not Rask.Example.Shared, so register it with EmbeddedSource.
 EmbeddedSource.RegisterAssembly(System.Reflection.Assembly.GetExecutingAssembly());
 
-// The framework default since AddRask gained an options shape is
-// LiveDiffMode.Auto, so `services.AddRask()` already ships the diff codec out of
-// the box. The RASK_DIFF_MODE env var lets the Playwright suite (and curious
-// developers) flip modes without recompiling — useful for diff-vs-morph A/B
-// debugging.
-if (Environment.GetEnvironmentVariable("RASK_DIFF_MODE") is { } diffModeName
-    && Enum.TryParse<LiveDiffMode>(diffModeName, true, out var diffMode))
-{
-    LiveOptions.DiffMode = diffMode;
-}
+// The framework default is LiveDiffMode.Auto, so `services.AddRask()` already ships the diff codec
+// out of the box. The RASK_DIFF_MODE env var lets the Playwright suite (and curious developers) flip
+// modes without recompiling — useful for diff-vs-morph A/B debugging. DiffMode is per-host now (it
+// rides the LiveSessionStore), so it is passed through AddRask rather than a process-global static.
+LiveDiffMode? envDiffMode =
+    Environment.GetEnvironmentVariable("RASK_DIFF_MODE") is { } diffModeName
+    && Enum.TryParse<LiveDiffMode>(diffModeName, true, out var parsed)
+        ? parsed
+        : null;
 
 var builder = WebApplication.CreateBuilder(args);
 
-builder.Services.AddRask();
+builder.Services.AddRask(configure: o =>
+{
+    if (envDiffMode is { } mode)
+    {
+        o.DiffMode = mode;
+    }
+});
 // Opt into PWA on the Server host: serves the manifest + service worker, emits the manifest link and
 // auto-registers the SW into the server-rendered <head>, so this showcase is an installable PWA. It is
 // installable + push-capable but NOT an offline app (offline navigations show wwwroot/offline.html) —

--- a/src/Rask.Core/Live/LiveOptions.cs
+++ b/src/Rask.Core/Live/LiveOptions.cs
@@ -98,17 +98,19 @@ public sealed class RaskLiveOptions
 }
 
 /// <summary>
-///     Static accessor for the active live options. Set by <c>AddRask()</c> /
-///     <c>UseRask&lt;TApp&gt;()</c> from the configured <see cref="RaskLiveOptions" />;
-///     the live-session runtime (server + WASM) reads from here on every render so
-///     the option flow stays trivially fast — no DI lookup in the hot path. Hosts
-///     that don't go through <c>AddRask()</c> (some standalone WASM bootstraps)
-///     can also write these properties directly.
+///     Static accessor for the process-wide live options that back the content-addressed asset
+///     registries. Set by <c>AddRask()</c> / <c>UseRask&lt;TApp&gt;()</c> from the configured
+///     <see cref="RaskLiveOptions" />. <see cref="PathBase" /> and <see cref="MinifyScopedAssets" />
+///     live here because the <see cref="ScopedAssets.ScopedAssetRegistry" /> and
+///     <c>HeadAssetRegistry</c> build one shared, content-hashed bundle per process — not per session.
+///     The per-render <c>DiffMode</c>, by contrast, is carried on each <c>LiveSession</c>
+///     (see <see cref="LiveSessionBase" />) so concurrent hosts and parallel tests don't race a
+///     shared mutable field. Hosts that don't go through <c>AddRask()</c> (some standalone WASM
+///     bootstraps) can also write these properties directly.
 /// </summary>
 public static class LiveOptions
 {
     private static string _pathBase = string.Empty;
-    public static LiveDiffMode DiffMode { get; set; } = LiveDiffMode.Auto;
 
     /// <summary>
     ///     Resolved scoped-CSS minification switch read by <see cref="ScopedAssets.ScopedAssetRegistry" />

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -22,8 +22,8 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     // swaps it with _writeBuffer after each send, so neither the baseline nor the emit copies a byte[].
     protected ArrayBufferWriter<byte>? _lastSentBuffer;
 
-    // Diff-codec state, lazily allocated only when LiveOptions.DiffMode opts in — the default
-    // (DisabledFull) path pays nothing for these.
+    // Diff-codec state, lazily allocated only when DiffMode opts in — the DisabledFull path pays
+    // nothing for these.
     protected List<EditOp>? _diffOps;
     protected SessionRenderCache? _renderCache;
 
@@ -38,10 +38,18 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     // loop reads and clears it to rebuild the payload before releasing the dispatch lock.
     protected bool _pendingRenderInScope;
 
-    protected LiveSessionBase(Component view, IServiceProvider services)
+    // The wire-payload shape for THIS session, snapshotted from the host's RaskLiveOptions at
+    // construction and read on the render hot path (RenderTreeToHtml / WritePayload) instead of the
+    // former process-global LiveOptions.DiffMode static. Per-session so two hosts in one process — and
+    // parallel tests — each render in their own mode instead of racing a shared mutable static. Mirrors
+    // the per-host RaskServerLimits pattern.
+    protected LiveDiffMode DiffMode { get; }
+
+    protected LiveSessionBase(Component view, IServiceProvider services, LiveDiffMode diffMode)
     {
         View = view;
         Services = services;
+        DiffMode = diffMode;
         view.RenderHandle = this;
         // RootErrorBoundary wraps the user's App; forward the handle to the inner so its
         // StateHasChanged() reaches the session even before the first GetOrCreate would attach it.
@@ -188,7 +196,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     {
         frameWriter = null;
         FrameSinkScope.Popper popper = default;
-        if (LiveOptions.DiffMode != LiveDiffMode.DisabledFull)
+        if (DiffMode != LiveDiffMode.DisabledFull)
         {
             _renderCache ??= new SessionRenderCache();
             frameWriter = _renderCache.PrepareCurrentBuffer();
@@ -256,7 +264,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
                 // Ship the diff whenever it isn't larger than re-sending the body, or unconditionally
                 // under Forced. Only the pathological case (nearly every node changed on a tiny page,
                 // so op-list framing exceeds the body) falls back to full HTML on size.
-                if (LiveOptions.DiffMode == LiveDiffMode.Forced || _writeBuffer.WrittenCount < html.Length)
+                if (DiffMode == LiveDiffMode.Forced || _writeBuffer.WrittenCount < html.Length)
                 {
                     usedDiff = true;
                 }

--- a/src/Rask.Native/NativeAppHost.cs
+++ b/src/Rask.Native/NativeAppHost.cs
@@ -33,6 +33,13 @@ namespace Rask.Native;
 /// </summary>
 public sealed class NativeAppHost
 {
+    // The wire-payload shape the in-process session renders with, snapshotted from RaskLiveOptions in
+    // CreateDefault and handed to the NativeLiveSession — a per-session value instead of the former
+    // process-global LiveOptions.DiffMode static. Native fans render continuations onto the thread pool,
+    // so a shared mutable static would be doubly wrong here; carrying it on the session also lets the
+    // native session tests run without serializing on the global.
+    private LiveDiffMode _diffMode = LiveDiffMode.Auto;
+
     private NativeAppHost()
     {
         Services = new ServiceCollection();
@@ -99,14 +106,15 @@ public sealed class NativeAppHost
     /// <summary>Creates a host, optionally overriding the diff mode (e.g. <c>o =&gt; o.DiffMode = LiveDiffMode.DisabledFull</c>).</summary>
     public static NativeAppHost CreateDefault(Action<RaskLiveOptions>? configureLive)
     {
+        var host = new NativeAppHost();
         if (configureLive is not null)
         {
             var opts = new RaskLiveOptions();
             configureLive(opts);
-            LiveOptions.DiffMode = opts.DiffMode;
+            host._diffMode = opts.DiffMode;
         }
 
-        return new NativeAppHost();
+        return host;
     }
 
     /// <summary>
@@ -160,7 +168,7 @@ public sealed class NativeAppHost
             }
         }
 
-        var session = new NativeLiveSession(root, provider, webView);
+        var session = new NativeLiveSession(root, provider, webView, _diffMode);
         var nativeApp = new NativeApp(session, provider);
 
         // The WebView drives everything through this single message channel: the initial-render handshake

--- a/src/Rask.Native/NativeLiveSession.cs
+++ b/src/Rask.Native/NativeLiveSession.cs
@@ -39,8 +39,8 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
     // invokes still need to reach the client (where they run after applyDiff).
     private bool _lastBuildHadJsInvokes;
 
-    public NativeLiveSession(Component view, IServiceProvider services, INativeWebView webView)
-        : base(view, services)
+    public NativeLiveSession(Component view, IServiceProvider services, INativeWebView webView, LiveDiffMode diffMode)
+        : base(view, services, diffMode)
     {
         _webView = webView;
 

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -76,8 +76,8 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // thread-pool worker) run on different threads. Mirrors the detached-socket early-return.
     private volatile bool _disposed;
 
-    public LiveSession(string id, Component view, IServiceScope scope)
-        : base(view, scope.ServiceProvider)
+    public LiveSession(string id, Component view, IServiceScope scope, LiveDiffMode diffMode)
+        : base(view, scope.ServiceProvider, diffMode)
     {
         Id = id;
         Scope = scope;
@@ -244,7 +244,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     internal string RenderInitialRoot()
     {
         string html;
-        if (LiveOptions.DiffMode != LiveDiffMode.DisabledFull)
+        if (DiffMode != LiveDiffMode.DisabledFull)
         {
             _renderCache ??= new SessionRenderCache();
             var frameWriter = _renderCache.PrepareCurrentBuffer();

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Rask.Core;
+using Rask.Core.Live;
 using Rask.Server.Diagnostics;
 using Rask.Server.Files;
 using Rask.Server.JSInterop;
@@ -61,6 +62,15 @@ public sealed class LiveSessionStore : IAsyncDisposable
     ///     resolved singleton.
     /// </summary>
     public int MaxSessions { get; set; }
+
+    /// <summary>
+    ///     The wire-payload shape (<see cref="LiveDiffMode" />) every session this store mints is
+    ///     built with. Seeded once from <see cref="Rask.Core.Live.RaskLiveOptions.DiffMode" /> at
+    ///     registration and handed to each <see cref="LiveSession" /> at construction — a per-host
+    ///     value, not a process-global static, so concurrent hosts and parallel tests each render in
+    ///     their own mode. Defaults to <see cref="LiveDiffMode.Auto" /> (diff codec on).
+    /// </summary>
+    public LiveDiffMode DiffMode { get; init; } = LiveDiffMode.Auto;
 
     /// <summary>
     ///     True when a new session would exceed <see cref="MaxSessions" />. A fast advisory
@@ -175,7 +185,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
             throw;
         }
 
-        var session = new LiveSession(sessionId, view, scope);
+        var session = new LiveSession(sessionId, view, scope, DiffMode);
         // Bind the per-scope LiveSessionAccessor so RaskJSRuntime (resolved from the same
         // scope) can find this session when components inject IJSRuntime.
         if (scope.ServiceProvider.GetService<LiveSessionAccessor>() is { } accessor)

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -102,22 +102,21 @@ public static class RaskEndpointExtensions
         Action<RaskLiveOptions>? configure = null,
         Action<RaskServerOptions>? configureServer = null)
     {
-        // Per-app live runtime options. The framework default for DiffMode is
-        // LiveDiffMode.Auto (set on the static LiveOptions.DiffMode at class init),
-        // so a fresh `AddRask()` ships the diff codec out of the box. Override:
+        // Per-app live runtime options. The framework default for DiffMode is LiveDiffMode.Auto, so a
+        // fresh `AddRask()` ships the diff codec out of the box. Override:
         //     services.AddRask(o => o.DiffMode = LiveDiffMode.DisabledFull);
         //
-        // Only write the static field when the caller provided a configure
-        // callback — otherwise we'd clobber a value the host (or a test) already
-        // set explicitly before AddRask was called. The static field starts at
-        // Auto via its initializer, so the "no configure, no prior write" path
-        // still lands on Auto without us re-writing it here.
+        // DiffMode is a per-host value carried on the LiveSessionStore (and handed to each LiveSession),
+        // NOT a process-global static — so two hosts in one process, and parallel tests, each render in
+        // their own mode instead of racing shared state. PathBase / MinifyScopedAssets stay on the
+        // static LiveOptions because they back the process-wide content-addressed asset registries.
         var maxSessions = 0;
+        var diffMode = LiveDiffMode.Auto;
         if (configure is not null)
         {
             var liveOptions = new RaskLiveOptions();
             configure(liveOptions);
-            LiveOptions.DiffMode = liveOptions.DiffMode;
+            diffMode = liveOptions.DiffMode;
             // PathBase normalization happens on assignment to RaskLiveOptions,
             // and a second normalize on the static accessor is a cheap no-op.
             // UseRask<TApp>(pathBase: ...) can still override this if the user
@@ -156,7 +155,7 @@ public static class RaskEndpointExtensions
             sp.GetRequiredService<IServiceScopeFactory>(),
             sp.GetService<IHostApplicationLifetime>(),
             sp.GetService<RaskMetrics>())
-        { MaxSessions = maxSessions });
+        { MaxSessions = maxSessions, DiffMode = diffMode });
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -89,6 +89,12 @@ public sealed class WasmHostBuilder
 
     private WebAppManifest? _manifest;
 
+    // The wire-payload shape this app renders with, snapshotted from RaskLiveOptions in CreateDefault
+    // and handed to the WasmLiveSession — a per-session value instead of the former process-global
+    // LiveOptions.DiffMode static. WASM is single-threaded so it never raced, but carrying it on the
+    // session keeps all three hosts on one uniform mechanism.
+    private LiveDiffMode _diffMode = LiveDiffMode.Auto;
+
     /// <summary>The DI container for the app. Register your services here before calling <see cref="RunAsync{TApp}" />.</summary>
     public IServiceCollection Services { get; }
 
@@ -135,11 +141,12 @@ public sealed class WasmHostBuilder
     /// </summary>
     public static WasmHostBuilder CreateDefault(Action<RaskLiveOptions>? configureLive)
     {
+        var builder = new WasmHostBuilder();
         if (configureLive is not null)
         {
             var opts = new RaskLiveOptions();
             configureLive(opts);
-            LiveOptions.DiffMode = opts.DiffMode;
+            builder._diffMode = opts.DiffMode;
             // Only propagate a non-empty user-supplied PathBase; an explicit
             // override should win over the auto-detect that RunAsync performs
             // later. An empty value here means "I didn't set one — auto-detect
@@ -149,11 +156,9 @@ public sealed class WasmHostBuilder
                 LiveOptions.PathBase = opts.PathBase;
             }
         }
-        // No configure → leave LiveOptions.DiffMode at whatever the framework default
-        // is (LiveDiffMode.Auto). Don't write to it here: a test or host that pre-set
-        // the field before calling CreateDefault() would otherwise be clobbered.
+        // No configure → the session renders in the framework default (LiveDiffMode.Auto).
 
-        return new WasmHostBuilder();
+        return builder;
     }
 
     /// <summary>
@@ -210,7 +215,7 @@ public sealed class WasmHostBuilder
             }
         }
 
-        var session = new WasmLiveSession(root, provider);
+        var session = new WasmLiveSession(root, provider, _diffMode);
         JSInterop.Init(session);
 
         // InitialRenderAsync builds and pushes the first frame to JS itself (zero-copy applyRender);

--- a/src/Rask.Wasm/WasmLiveSession.cs
+++ b/src/Rask.Wasm/WasmLiveSession.cs
@@ -42,8 +42,8 @@ internal sealed class WasmLiveSession : LiveSessionBase, IDisposable
     // invokes still need to reach the client (where they run after applyDiff).
     private bool _lastBuildHadJsInvokes;
 
-    public WasmLiveSession(Component view, IServiceProvider services)
-        : base(view, services)
+    public WasmLiveSession(Component view, IServiceProvider services, LiveDiffMode diffMode)
+        : base(view, services, diffMode)
     {
         // Bind this session to the runtime so its BeginInvokeJS queues onto JsInvokes.
         (services.GetService<WasmJSRuntime>())?.AttachHost(this);

--- a/tests/Rask.Core.Tests/Lifecycle/DisposeErrorTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/DisposeErrorTests.cs
@@ -17,7 +17,7 @@ public class DisposeErrorTests
         var faulty = new FaultingDisposable();
         var ok = new RecordingDisposable();
         var root = new TwoChildHost(faulty, ok) { Include = true };
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
 
         using var stderr = new StringWriter();
@@ -39,7 +39,7 @@ public class DisposeErrorTests
         var faulty = new FaultingAsyncDisposable();
         var ok = new RecordingDisposable();
         var root = new TwoChildHost(faulty, ok) { Include = true };
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
 
         using var stderr = new StringWriter();

--- a/tests/Rask.Core.Tests/Lifecycle/DisposeTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/DisposeTests.cs
@@ -15,7 +15,7 @@ public class DisposeTests
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var disposable = new DisposableLeaf();
         var root = new SwitchableHost(disposable);
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         root.IncludeChild = true;
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
@@ -33,7 +33,7 @@ public class DisposeTests
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var disposable = new DisposableLeaf();
         var root = new SwitchableHost(disposable) { IncludeChild = true };
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
         Assert.Equal(0, disposable.DisposeCount);
@@ -50,7 +50,7 @@ public class DisposeTests
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var disposable = new AsyncDisposableLeaf();
         var root = new AsyncSwitchableHost(disposable);
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
         Assert.Equal(0, disposable.DisposeCount);
@@ -68,7 +68,7 @@ public class DisposeTests
         var grandchild = new DisposableLeaf();
         var middle = new DisposableMiddle(grandchild);
         var root = new SwitchableHost(middle);
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         root.IncludeChild = true;
         session.View.RenderAsLiveRoot(scope.ServiceProvider);

--- a/tests/Rask.Core.Tests/Lifecycle/RenderedTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/RenderedTests.cs
@@ -14,7 +14,7 @@ public class RenderedTests
         var sp = RenderHarness.EmptyServices();
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var root = new ChildHostingRoot(new LifecycleTrackingComponent());
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
@@ -30,7 +30,7 @@ public class RenderedTests
         var sp = RenderHarness.EmptyServices();
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var root = new LifecycleTrackingComponent();
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
         session.View.RenderAsLiveRoot(scope.ServiceProvider);

--- a/tests/Rask.Core.Tests/Lifecycle/UnmountTests.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/UnmountTests.cs
@@ -75,7 +75,7 @@ public class UnmountTests
         var childDisposeCount = 0;
         var child = new CountingDisposable(() => childDisposeCount++);
         var host = new ClearChildrenOnUnmountHost(child);
-        var session = new LiveSession("test", host, scope);
+        var session = new LiveSession("test", host, scope, LiveDiffMode.Auto);
 
         host.IncludeChild = true;
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
@@ -136,7 +136,7 @@ public class UnmountTests
         var leaf = new OrderingUnmount(order, "leaf");
         var middle = new OrderingMiddle(order, "middle", leaf);
         var root = new SwitchableHost(middle);
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         root.IncludeChild = true;
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
@@ -153,7 +153,7 @@ public class UnmountTests
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var leaf = new LifecycleTrackingComponent();
         var root = new SwitchableHost(leaf);
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         root.IncludeChild = true;
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
@@ -230,7 +230,7 @@ public class UnmountTests
         };
         var sibling = new LifecycleTrackingComponent();
         var root = new TwoChildHost(throwing, sibling) { IncludeChildren = true };
-        var session = new LiveSession("test", root, scope);
+        var session = new LiveSession("test", root, scope, LiveDiffMode.Auto);
 
         session.View.RenderAsLiveRoot(scope.ServiceProvider);
 

--- a/tests/Rask.Core.Tests/Live/ComponentHotReloadTests.cs
+++ b/tests/Rask.Core.Tests/Live/ComponentHotReloadTests.cs
@@ -111,7 +111,8 @@ public class ComponentHotReloadTests
         public int RenderRequests;
         public bool Throw;
 
-        public TestLiveSession(Component view, IServiceProvider services) : base(view, services)
+        public TestLiveSession(Component view, IServiceProvider services)
+            : base(view, services, LiveDiffMode.Auto)
         {
         }
 

--- a/tests/Rask.Core.Tests/Live/StateHasChangedTests.cs
+++ b/tests/Rask.Core.Tests/Live/StateHasChangedTests.cs
@@ -85,6 +85,6 @@ public class StateHasChangedTests
     {
         var sp = RenderHarness.EmptyServices();
         scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
-        return new LiveSession("test-session", new StubComponent(Span()), scope);
+        return new LiveSession("test-session", new StubComponent(Span()), scope, LiveDiffMode.Auto);
     }
 }

--- a/tests/Rask.Native.Tests/Infrastructure/NativeSessionHarness.cs
+++ b/tests/Rask.Native.Tests/Infrastructure/NativeSessionHarness.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
+using Rask.Core.Live;
 
 namespace Rask.Native.Tests.Infrastructure;
 
@@ -13,16 +14,18 @@ namespace Rask.Native.Tests.Infrastructure;
 internal static class NativeSessionHarness
 {
     public static Task<(NativeApp app, FakeNativeWebView webView, byte[] initialFrame)> NewSessionAsync(
-        string initialPath = "/", Action<IServiceCollection>? configure = null) =>
-        NewSessionAsync<NativeStubApp>(initialPath, configure);
+        string initialPath = "/", Action<IServiceCollection>? configure = null,
+        LiveDiffMode diffMode = LiveDiffMode.Auto) =>
+        NewSessionAsync<NativeStubApp>(initialPath, configure, diffMode);
 
     public static async Task<(NativeApp app, FakeNativeWebView webView, byte[] initialFrame)> NewSessionAsync<
         [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicConstructors)] TApp>(
-        string initialPath = "/", Action<IServiceCollection>? configure = null)
+        string initialPath = "/", Action<IServiceCollection>? configure = null,
+        LiveDiffMode diffMode = LiveDiffMode.Auto)
         where TApp : Component
     {
-        // CreateDefault() leaves LiveOptions.DiffMode at whatever ResettingTestBase pinned it to.
-        var host = NativeAppHost.CreateDefault();
+        // Per-session wire shape (was the process-global LiveOptions.DiffMode the tests pinned).
+        var host = NativeAppHost.CreateDefault(o => o.DiffMode = diffMode);
         configure?.Invoke(host.Services);
 
         var webView = new FakeNativeWebView();
@@ -35,6 +38,10 @@ internal static class NativeSessionHarness
     }
 }
 
-/// <summary>Serializes native session tests — they mutate process-global <c>LiveOptions.DiffMode</c>.</summary>
+/// <summary>
+///     Serializes native session tests — they reset the process-global
+///     <c>ScopedAssetRegistry</c> (via <c>ResettingTestBase</c>), which is shared process-wide.
+///     (DiffMode is per-session now, so that is no longer a reason to serialize.)
+/// </summary>
 [CollectionDefinition("NativeSession")]
 public sealed class NativeSessionCollection;

--- a/tests/Rask.Native.Tests/Session/NativeDispatchTests.cs
+++ b/tests/Rask.Native.Tests/Session/NativeDispatchTests.cs
@@ -11,7 +11,7 @@ public class NativeDispatchTests() : ResettingTestBase(LiveDiffMode.DisabledFull
     [Fact]
     public async Task ReadyHandshake_TriggersFirstRender_WithNativeRootId()
     {
-        var (_, _, initial) = await NewSessionAsync();
+        var (_, _, initial) = await NewSessionAsync(diffMode: DiffMode);
 
         using var doc = JsonDocument.Parse(initial.AsMemory());
         var html = doc.RootElement.GetProperty("html").GetString()!;
@@ -23,7 +23,7 @@ public class NativeDispatchTests() : ResettingTestBase(LiveDiffMode.DisabledFull
     {
         // Drive the host directly (bypass the harness, which posts `ready`) to prove the first frame is
         // gated on the client's readiness — a real WebView isn't ready to receive applyRender until loaded.
-        var host = NativeAppHost.CreateDefault();
+        var host = NativeAppHost.CreateDefault(o => o.DiffMode = DiffMode);
         var webView = new FakeNativeWebView();
         _ = await host.RunLocalAsync<NativeStubApp>(webView);
 
@@ -37,7 +37,7 @@ public class NativeDispatchTests() : ResettingTestBase(LiveDiffMode.DisabledFull
     [Fact]
     public async Task ClickHandler_IncrementsCounter_AndPushesUpdatedFrame()
     {
-        var (_, webView, initial) = await NewSessionAsync();
+        var (_, webView, initial) = await NewSessionAsync(diffMode: DiffMode);
         var handlerId = Markup.FirstHandlerId(initial);
 
         await webView.PostAsync($$"""{"id":"{{handlerId}}","type":"click"}""");
@@ -50,7 +50,7 @@ public class NativeDispatchTests() : ResettingTestBase(LiveDiffMode.DisabledFull
     [Fact]
     public async Task Navigate_UpdatesRouteState_AndReflectsNewPath()
     {
-        var (_, webView, _) = await NewSessionAsync();
+        var (_, webView, _) = await NewSessionAsync(diffMode: DiffMode);
 
         await webView.PostAsync("""{"type":"navigate","path":"/foo","query":""}""");
 
@@ -62,7 +62,7 @@ public class NativeDispatchTests() : ResettingTestBase(LiveDiffMode.DisabledFull
     [Fact]
     public async Task MalformedMessage_IsSwallowed_NoThrow_NoExtraFrame()
     {
-        var (_, webView, _) = await NewSessionAsync();
+        var (_, webView, _) = await NewSessionAsync(diffMode: DiffMode);
         var framesBefore = webView.Frames.Count;
 
         await webView.PostAsync("this is not json");
@@ -73,7 +73,7 @@ public class NativeDispatchTests() : ResettingTestBase(LiveDiffMode.DisabledFull
     [Fact]
     public async Task UnknownHandlerId_ProducesNoFrame()
     {
-        var (_, webView, _) = await NewSessionAsync();
+        var (_, webView, _) = await NewSessionAsync(diffMode: DiffMode);
         var framesBefore = webView.Frames.Count;
 
         await webView.PostAsync("""{"id":"h999","type":"click"}""");

--- a/tests/Rask.Native.Tests/Session/NativeJsInteropTests.cs
+++ b/tests/Rask.Native.Tests/Session/NativeJsInteropTests.cs
@@ -20,7 +20,7 @@ public class NativeJsInteropTests() : ResettingTestBase(LiveDiffMode.DisabledFul
     [Fact]
     public async Task Handler_awaiting_js_result_resumes_when_jsResult_posts()
     {
-        var (_, webView, initial) = await NewSessionAsync<NativeJsInteropApp>();
+        var (_, webView, initial) = await NewSessionAsync<NativeJsInteropApp>(diffMode: DiffMode);
         var handlerId = Markup.FirstHandlerId(initial);
 
         // The handler awaits js.InvokeAsync<string>, so this dispatch won't complete until we post the

--- a/tests/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
@@ -1,5 +1,6 @@
 using System.Net.WebSockets;
 using Rask.Core;
+using Rask.Core.Live;
 
 namespace Rask.Server.Tests.Infrastructure;
 
@@ -40,9 +41,10 @@ internal sealed class ConnectedSession : IAsyncDisposable
         Host.Dispose();
     }
 
-    public static async Task<ConnectedSession> Connect<TApp>() where TApp : Component
+    public static async Task<ConnectedSession> Connect<TApp>(LiveDiffMode diffMode = LiveDiffMode.Auto)
+        where TApp : Component
     {
-        var host = RaskTestHost.Create<TApp>();
+        var host = RaskTestHost.Create<TApp>(diffMode: diffMode);
         var initial = await host.Http.GetAsync("/start");
         var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
         var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -40,16 +40,18 @@ internal sealed class RaskTestHost : IDisposable
         Action<IServiceCollection>? configureServices = null,
         Action<IApplicationBuilder>? configureMiddleware = null,
         string pathBase = "",
-        Action<RaskServerOptions>? configureServer = null)
+        Action<RaskServerOptions>? configureServer = null,
+        LiveDiffMode diffMode = LiveDiffMode.Auto)
         where TApp : Component
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
         builder.Services.AddRouting();
-        // Per-host WS / grace-period limits (RaskServerLimits) are seeded here, so each TestServer
-        // carries its own — tests set short grace periods / caps via configureServer instead of a
-        // process-global static, which lets these tests run in parallel.
-        builder.Services.AddRask(configureServer: configureServer);
+        // Per-host WS / grace-period limits (RaskServerLimits) AND the wire-payload shape (DiffMode,
+        // carried on the LiveSessionStore) are seeded here, so each TestServer carries its own — tests
+        // that assert on a specific diff/full payload pass diffMode instead of writing a process-global
+        // static, which lets them run in parallel.
+        builder.Services.AddRask(configure: live => live.DiffMode = diffMode, configureServer: configureServer);
         configureServices?.Invoke(builder.Services);
 
         var app = builder.Build();

--- a/tests/Rask.Server.Tests/Live/LiveSessionDirectTests.cs
+++ b/tests/Rask.Server.Tests/Live/LiveSessionDirectTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Components;
+using Rask.Core.Live;
 
 namespace Rask.Server.Tests.Live;
 
@@ -20,7 +21,7 @@ public class LiveSessionDirectTests
         var sp = new ServiceCollection().BuildServiceProvider();
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var disposable = new TrackingDisposable();
-        var session = new LiveSession("id", disposable, scope);
+        var session = new LiveSession("id", disposable, scope, LiveDiffMode.Auto);
 
         session.Dispose();
 
@@ -33,7 +34,7 @@ public class LiveSessionDirectTests
         var sp = new ServiceCollection().BuildServiceProvider();
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var disposable = new TrackingAsyncDisposable();
-        var session = new LiveSession("id", disposable, scope);
+        var session = new LiveSession("id", disposable, scope, LiveDiffMode.Auto);
 
         await session.DisposeAsync();
 
@@ -47,7 +48,7 @@ public class LiveSessionDirectTests
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
         var view = new BasicComponent();
 
-        using var session = new LiveSession("id", view, scope);
+        using var session = new LiveSession("id", view, scope, LiveDiffMode.Auto);
 
         await view.StateHasChangedAsync();
     }
@@ -56,7 +57,7 @@ public class LiveSessionDirectTests
     {
         var sp = new ServiceCollection().BuildServiceProvider();
         var scope = sp.GetRequiredService<IServiceScopeFactory>().CreateScope();
-        return new LiveSession(Guid.NewGuid().ToString("N"), view, scope);
+        return new LiveSession(Guid.NewGuid().ToString("N"), view, scope, LiveDiffMode.Auto);
     }
 
     private sealed class BasicComponent : Component

--- a/tests/Rask.Server.Tests/WebSockets/AsyncValidationDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/AsyncValidationDispatchTests.cs
@@ -4,13 +4,11 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-[Collection("LiveDiffMode")]
 public class AsyncValidationDispatchTests
 {
     // Asserts against the `html` payload field — force the legacy full-HTML wire
     // shape (framework default is LiveDiffMode.Auto). SessionGracePeriod collection
     // serialises with the other DiffMode-touching test classes.
-    public AsyncValidationDispatchTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
 
     // Mirrors the failing E2E test Validation_AsyncDemo_ShowsCheckingThenTakenMessage:
     // OnInput "admin" then OnChange (blur). The async validator delays 20ms and then adds
@@ -19,7 +17,7 @@ public class AsyncValidationDispatchTests
     [Fact]
     public async Task AsyncValidator_PostHandlerFrame_ShowsMessage_AndNoIndicator()
     {
-        using var host = RaskTestHost.Create<AsyncValidationApp>();
+        using var host = RaskTestHost.Create<AsyncValidationApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);

--- a/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
@@ -7,17 +7,15 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-[Collection("LiveDiffMode")]
 public class HandlerDispatchTests
 {
     // Asserts against the `html` payload field — force the legacy full-HTML wire
     // shape (framework default is now LiveDiffMode.Auto).
-    public HandlerDispatchTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
 
     [Fact]
     public async Task HandlerId_KnownHandler_InvokesAndSendsRender()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
@@ -39,7 +37,7 @@ public class HandlerDispatchTests
     [Fact]
     public async Task HandlerId_UnknownHandler_NoPayload()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
 
@@ -57,7 +55,7 @@ public class HandlerDispatchTests
     [Fact]
     public async Task Message_NoIdAndNoType_Ignored()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
 
@@ -78,7 +76,7 @@ public class HandlerDispatchTests
         // unguarded JsonDocument.Parse threw JsonException out of the receive loop, detaching
         // the socket and scheduling the session for removal — one bad (buggy or adversarial)
         // frame dropped the whole session. Now it is dropped and the loop keeps serving.
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
@@ -107,7 +105,7 @@ public class HandlerDispatchTests
     [Fact]
     public async Task Message_MissingType_ButHasOtherFields_Ignored()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
 
         using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
@@ -124,7 +122,7 @@ public class HandlerDispatchTests
     [Fact]
     public async Task ConcurrentHandlerInvocations_SerialisedByPerSessionLock()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
@@ -156,7 +154,7 @@ public class HandlerDispatchTests
     [Fact]
     public async Task HandlerThatThrows_TripsImplicitRootBoundary_AndDispatcherKeepsRunning()
     {
-        using var host = RaskTestHost.Create<ThrowingApp>();
+        using var host = RaskTestHost.Create<ThrowingApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);

--- a/tests/Rask.Server.Tests/WebSockets/HandlerExceptionIsolationTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerExceptionIsolationTests.cs
@@ -15,16 +15,14 @@ namespace Rask.Server.Tests.WebSockets;
 //  - The dispatch lock (session.Lock) is distinct from the render lock (_renderLock), and AttachSocket
 //    takes neither — so a handler parked under the dispatch lock across a disconnect can't block the
 //    reconnect, and once it clears the queued work drains through the reconnected socket.
-[Collection("LiveDiffMode")]
 public class HandlerExceptionIsolationTests
 {
     // Assert against the legacy full-HTML `html` field (framework default is now diff mode).
-    public HandlerExceptionIsolationTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
 
     [Fact]
     public async Task FaultingHandler_TripsRootErrorBoundary_KeepsSocketOpen()
     {
-        using var host = RaskTestHost.Create<ThrowingHandlerApp>();
+        using var host = RaskTestHost.Create<ThrowingHandlerApp>(diffMode: LiveDiffMode.DisabledFull);
         var html = await (await host.Http.GetAsync("/")).Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(html);
         var boom = HandlerIdFor(html, "boom");
@@ -50,7 +48,7 @@ public class HandlerExceptionIsolationTests
         GatedCounterApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         try
         {
-            using var host = RaskTestHost.Create<GatedCounterApp>();
+            using var host = RaskTestHost.Create<GatedCounterApp>(diffMode: LiveDiffMode.DisabledFull);
             var html = await (await host.Http.GetAsync("/")).Content.ReadAsStringAsync();
             var sessionId = Markup.SessionId(html);
             var hang = HandlerIdFor(html, "hang");

--- a/tests/Rask.Server.Tests/WebSockets/HandlerOrderingTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerOrderingTests.cs
@@ -21,16 +21,13 @@ namespace Rask.Server.Tests.WebSockets;
 // async handlers awaiting jsResult / dotNetInvoke don't deadlock the loop),
 // but the *start order* of dispatches now matches WS arrival order
 // deterministically.
-[Collection("LiveDiffMode")]
 public class HandlerOrderingTests
 {
     // These tests assert against the `html` field in the payload — the legacy
-    // ship-full-HTML wire shape. The framework default since AddRask gained an
-    // options shape is LiveDiffMode.Auto, which ships diff payloads (`kind: "diff"`
-    // with ops). Force the legacy mode for this class so the parse-html assertions
-    // remain meaningful. SessionGracePeriod collection serialises with other tests
-    // that touch the static LiveOptions.DiffMode so the field assignment is safe.
-    public HandlerOrderingTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
+    // ship-full-HTML wire shape. The framework default is LiveDiffMode.Auto, which ships
+    // diff payloads (`kind: "diff"` with ops). Each test host is created with
+    // diffMode: DisabledFull (per-host on the LiveSessionStore, not a global) so the
+    // parse-html assertions remain meaningful and the class still runs in parallel.
 
     [Fact]
     public async Task TenHandlers_SentRapidly_DispatchInArrivalOrder()
@@ -43,7 +40,7 @@ public class HandlerOrderingTests
         // chaining is broken by injecting that contention here.
         using var stress = new ThreadPoolStress(8);
 
-        using var host = RaskTestHost.Create<OrderedDispatchApp>();
+        using var host = RaskTestHost.Create<OrderedDispatchApp>(diffMode: LiveDiffMode.DisabledFull);
         var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
         var handlerIds = ExtractAllHandlerIds(initialHtml);
@@ -96,7 +93,7 @@ public class HandlerOrderingTests
         // alternating in arrival order.
         using var stress = new ThreadPoolStress(8);
 
-        using var host = RaskTestHost.Create<OrderedDispatchApp>();
+        using var host = RaskTestHost.Create<OrderedDispatchApp>(diffMode: LiveDiffMode.DisabledFull);
         var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
         var handlerIds = ExtractAllHandlerIds(initialHtml);

--- a/tests/Rask.Server.Tests/WebSockets/InitialRenderDiffTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/InitialRenderDiffTests.cs
@@ -9,15 +9,11 @@ namespace Rask.Server.Tests.WebSockets;
 // holds instead of re-shipping the whole document. Previously the frame cache was seeded
 // only by the first full-HTML interactive send, so the first state change after page load
 // always shipped the body in full.
-//
-// In SessionGracePeriod so the static LiveOptions.DiffMode write serialises with the other
-// DiffMode-mutating WS test classes.
-[Collection("LiveDiffMode")]
 public class InitialRenderDiffTests
 {
-    // Auto is the framework default; a counter's text diff is far smaller than the body, so
-    // it takes the diff path under the choose-smaller heuristic.
-    public InitialRenderDiffTests() => LiveOptions.DiffMode = LiveDiffMode.Auto;
+    // Auto is the framework default (the test host is created without a diffMode override); a
+    // counter's text diff is far smaller than the body, so it takes the diff path under the
+    // choose-smaller heuristic.
 
     [Fact]
     public async Task FirstInteraction_TextOnlyChange_ShipsDiffNotFullHtml()

--- a/tests/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/KeyedInsertNavTests.cs
@@ -10,10 +10,8 @@ namespace Rask.Server.Tests.WebSockets;
 // the offsets were captured, shifting every byte position after the head — so without the
 // offset adjustment the inserted row's HTML was garbled (sliced mid-attribute). Keyed insert
 // is the only op that carries an HTML slice, which is why delete/move were unaffected.
-[Collection("LiveDiffMode")]
 public class KeyedInsertNavTests
 {
-    public KeyedInsertNavTests() => LiveOptions.DiffMode = LiveDiffMode.Forced;
 
     // The keyed list is seeded [10,20,30]; navigating inserts a row at the head, middle, or tail.
     // Every position rides the same post-head-splice HTML-slice path, so all three must ship the
@@ -25,7 +23,7 @@ public class KeyedInsertNavTests
     [InlineData("/add-tail", 40)]
     public async Task KeyedInsertDuringNavigation_ShipsCorrectRowHtml(string path, int key)
     {
-        await using var fixture = await ConnectedSession.Connect<KeyedNavApp>();
+        await using var fixture = await ConnectedSession.Connect<KeyedNavApp>(LiveDiffMode.Forced);
 
         // Seed the diff baseline (first interaction ships full HTML).
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/list", query = "" });

--- a/tests/Rask.Server.Tests/WebSockets/MalformedMessageTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/MalformedMessageTests.cs
@@ -12,11 +12,9 @@ namespace Rask.Server.Tests.WebSockets;
 // loop, detached the socket and scheduled the session for removal — one buggy or adversarial
 // frame dropped the whole session. These tests assert each bad frame is dropped and the loop
 // keeps dispatching.
-[Collection("LiveDiffMode")]
 public class MalformedMessageTests
 {
     // Assert against the full-HTML `html` field — force the legacy wire shape.
-    public MalformedMessageTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
 
     public static TheoryData<string> BadFrames() =>
     [
@@ -34,7 +32,7 @@ public class MalformedMessageTests
     [MemberData(nameof(BadFrames))]
     public async Task BadFrame_IsDropped_SessionSurvivesAndKeepsDispatching(string badFrame)
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
@@ -63,7 +61,7 @@ public class MalformedMessageTests
     [InlineData("id")]   // handler id as a non-string is treated as absent
     public async Task WrongFieldType_IsIgnored_NoTeardown(string field)
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
 
         using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
@@ -83,7 +81,7 @@ public class MalformedMessageTests
     [Fact]
     public async Task ManyBadFramesInARow_DoNotDropTheSession()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);

--- a/tests/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/NavigationDiffGateTests.cs
@@ -10,20 +10,16 @@ namespace Rask.Server.Tests.WebSockets;
 // to the last sent document — diff+history instead of the full doc. Head-changing
 // navigations (a per-route <title>) still fall back to full HTML so the title/scoped-asset
 // delta reaches the client.
-//
-// In SessionGracePeriod so the static LiveOptions.DiffMode write serialises with the other
-// DiffMode-mutating WS test classes.
-[Collection("LiveDiffMode")]
 public class NavigationDiffGateTests
 {
     // Forced pins the diff path so the assertions don't depend on payload sizing; the
-    // head/structural gates are independent of size.
-    public NavigationDiffGateTests() => LiveOptions.DiffMode = LiveDiffMode.Forced;
+    // head/structural gates are independent of size. It's a per-host value (passed to
+    // ConnectedSession.Connect), so this class still runs in parallel with the others.
 
     [Fact]
     public async Task Navigate_SameHead_ShipsDiffWithHistory()
     {
-        await using var fixture = await ConnectedSession.Connect<NavigateInHandlerStateHasChangedApp>();
+        await using var fixture = await ConnectedSession.Connect<NavigateInHandlerStateHasChangedApp>(LiveDiffMode.Forced);
 
         // Navigate to /seed first so the asserted transition below is /seed -> /destination
         // (a same-<head> change). The GET render already seeded the diff baseline, so this
@@ -48,7 +44,7 @@ public class NavigationDiffGateTests
     [Fact]
     public async Task Navigate_QueryOnlyNoBodyChange_ShipsHistoryOnlyDiff()
     {
-        await using var fixture = await ConnectedSession.Connect<NavigateInHandlerStateHasChangedApp>();
+        await using var fixture = await ConnectedSession.Connect<NavigateInHandlerStateHasChangedApp>(LiveDiffMode.Forced);
 
         // Navigate to /page first so the re-navigation below is a same-path query-only change.
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/page", query = "" });
@@ -73,7 +69,7 @@ public class NavigationDiffGateTests
     [Fact]
     public async Task Navigate_HeadChanges_ShipsDiffWithHeadFragment()
     {
-        await using var fixture = await ConnectedSession.Connect<RouteTitleNavApp>();
+        await using var fixture = await ConnectedSession.Connect<RouteTitleNavApp>(LiveDiffMode.Forced);
 
         // Navigate to /seed first so the asserted transition below is /seed -> /destination.
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/seed", query = "" });
@@ -99,7 +95,7 @@ public class NavigationDiffGateTests
     [Fact]
     public async Task Navigate_HeadChangesWithStructuralBody_StillShipsFullHtml()
     {
-        await using var fixture = await ConnectedSession.Connect<RouteTitleStructuralNavApp>();
+        await using var fixture = await ConnectedSession.Connect<RouteTitleStructuralNavApp>(LiveDiffMode.Forced);
 
         await fixture.Ws.SendJsonAsync(new { type = "navigate", path = "/seed", query = "" });
         _ = await DrainToLastFrame(fixture.Ws);

--- a/tests/Rask.Server.Tests/WebSockets/SocketLifecycleTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/SocketLifecycleTests.cs
@@ -6,18 +6,16 @@ using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.WebSockets;
 
-[Collection("LiveDiffMode")]
 public class SocketLifecycleTests
 {
     // Asserts against the `html` payload field — force the legacy full-HTML wire shape. The
     // LiveDiffMode collection disables parallelization for this class, so this global-static
     // assignment is single-threaded and can't race another class that sets a different DiffMode.
-    public SocketLifecycleTests() => LiveOptions.DiffMode = LiveDiffMode.DisabledFull;
 
     [Fact]
     public async Task NonWebSocketGet_To_RaskWs_Returns400()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
 
         var response = await host.Http.GetAsync("/rask/ws");
 
@@ -27,7 +25,7 @@ public class SocketLifecycleTests
     [Fact]
     public async Task SocketDisconnect_SchedulesRemoval_SessionRemovedAfterShortenedGracePeriod()
     {
-        using var host = RaskTestHost.Create<TestApp>(
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull,
             configureServer: o => o.SessionGracePeriod = TimeSpan.FromMilliseconds(50));
         var initial = await host.Http.GetAsync("/start");
         var sessionId = Markup.SessionId(await initial.Content.ReadAsStringAsync());
@@ -49,7 +47,7 @@ public class SocketLifecycleTests
     [Fact]
     public async Task Reconnect_BeforeGracePeriodDeadline_AttachesToExistingSession()
     {
-        using var host = RaskTestHost.Create<TestApp>(
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull,
             configureServer: o => o.SessionGracePeriod = TimeSpan.FromSeconds(2));
         var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
 
@@ -71,7 +69,7 @@ public class SocketLifecycleTests
     [Fact]
     public async Task Reconnect_AfterGracePeriodExpires_HelloIsRejected()
     {
-        using var host = RaskTestHost.Create<TestApp>(
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull,
             configureServer: o => o.SessionGracePeriod = TimeSpan.FromMilliseconds(50));
         var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
 
@@ -99,7 +97,7 @@ public class SocketLifecycleTests
     [Fact]
     public async Task Reconnect_WhileExistingSocketAttached_NewSocketBecomesAuthoritative()
     {
-        using var host = RaskTestHost.Create<TestApp>();
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
         var initial = await host.Http.GetAsync("/start");
         var initialHtml = await initial.Content.ReadAsStringAsync();
         var sessionId = Markup.SessionId(initialHtml);
@@ -124,7 +122,7 @@ public class SocketLifecycleTests
     [Fact]
     public async Task Close_WithCustomReason_RemovesSessionAfterGrace()
     {
-        using var host = RaskTestHost.Create<TestApp>(
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull,
             configureServer: o => o.SessionGracePeriod = TimeSpan.FromMilliseconds(50));
         var sessionId = Markup.SessionId(await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync());
 
@@ -143,14 +141,4 @@ public class SocketLifecycleTests
 
         Assert.Equal(0, host.Store.Count);
     }
-}
-
-// Serializes the test classes that force a non-default wire shape via the process-global
-// LiveOptions.DiffMode static in their constructor (Auto / Forced / DisabledFull). They set
-// conflicting values and assert on the resulting payload, so they must run one at a time and never
-// overlap each other. (The former per-host WS/grace-period limits are on RaskServerLimits now, so
-// that reason for serializing is gone — this is purely about the LiveOptions.DiffMode global.)
-[CollectionDefinition("LiveDiffMode", DisableParallelization = true)]
-public class LiveDiffModeCollectionDef
-{
 }

--- a/tests/Rask.TestSupport/ResettingTestBase.cs
+++ b/tests/Rask.TestSupport/ResettingTestBase.cs
@@ -4,15 +4,21 @@ using Rask.Core.ScopedAssets;
 namespace Rask.TestSupport;
 
 /// <summary>
-///     Base for session tests that mutate process-global live state. The constructor resets
-///     the <see cref="ScopedAssetRegistry" /> and pins <see cref="LiveOptions.DiffMode" /> to a
-///     subclass-chosen value, replacing the hand-written reset constructors those tests carried.
+///     Base for session tests that touch process-wide live state. The constructor resets the
+///     process-global <see cref="ScopedAssetRegistry" /> (why these subclasses run under a
+///     serialized collection) and records the wire-payload shape the subclass wants. DiffMode is
+///     no longer a static — it is <b>per session</b> now — so subclasses pass <see cref="DiffMode" />
+///     to the harness that builds their session (NativeAppHost / WasmSessionHarness) rather than
+///     relying on a shared global.
 /// </summary>
 public abstract class ResettingTestBase
 {
+    /// <summary>The wire-payload shape this test's sessions should render with. Hand it to the session factory.</summary>
+    protected LiveDiffMode DiffMode { get; }
+
     protected ResettingTestBase(LiveDiffMode diffMode = LiveDiffMode.Auto)
     {
+        DiffMode = diffMode;
         ScopedAssetRegistry.InvalidateAll();
-        LiveOptions.DiffMode = diffMode;
     }
 }

--- a/tests/Rask.Wasm.Tests/Infrastructure/WasmSessionHarness.cs
+++ b/tests/Rask.Wasm.Tests/Infrastructure/WasmSessionHarness.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
+using Rask.Core.Live;
 using Rask.Core.Routing;
 
 namespace Rask.Wasm.Tests.Infrastructure;
@@ -13,12 +14,14 @@ namespace Rask.Wasm.Tests.Infrastructure;
 /// </summary>
 internal static class WasmSessionHarness
 {
-    public static (WasmLiveSession session, IServiceProvider services) NewSession() =>
-        NewSession<StubApp>();
+    public static (WasmLiveSession session, IServiceProvider services) NewSession(
+        LiveDiffMode diffMode = LiveDiffMode.Auto) =>
+        NewSession<StubApp>(diffMode: diffMode);
 
     public static (WasmLiveSession session, IServiceProvider services) NewSession<TApp>(
         Func<IServiceProvider, TApp>? appFactory = null,
-        Action<IServiceCollection>? configure = null)
+        Action<IServiceCollection>? configure = null,
+        LiveDiffMode diffMode = LiveDiffMode.Auto)
         where TApp : Component
     {
         var services = new ServiceCollection();
@@ -27,7 +30,8 @@ internal static class WasmSessionHarness
         configure?.Invoke(services);
         var provider = services.BuildServiceProvider();
         var app = appFactory is null ? ActivatorUtilities.CreateInstance<TApp>(provider) : appFactory(provider);
-        var session = new WasmLiveSession(app, provider);
+        // Per-session wire shape (was the process-global LiveOptions.DiffMode).
+        var session = new WasmLiveSession(app, provider, diffMode);
         JSInterop.Init(session);
         return (session, provider);
     }

--- a/tests/Rask.Wasm.Tests/Session/DispatchAsyncRoutingTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DispatchAsyncRoutingTests.cs
@@ -16,7 +16,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_EmptyJson_ReturnsEmptyBytes()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
 
         var result = await session.DispatchAsync(Array.Empty<byte>());
 
@@ -26,7 +26,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_TypeNavigate_RoutesToNavigateBranch_AndUpdatesRouteState()
     {
-        var (session, services) = NewSession();
+        var (session, services) = NewSession(diffMode: DiffMode);
         var routeState = services.GetRequiredService<RouteState>();
         await session.InitialRenderAsync();
 
@@ -43,7 +43,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_NavigateEmptyPath_ReturnsEmpty()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
 
         var result = await session.DispatchAsync(Utf8("""{"type":"navigate","path":""}"""));
 
@@ -53,7 +53,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_NavigateReplaceTrue_EmitsHistoryReplace()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         var result = await session.DispatchAsync(Utf8("""{"type":"navigate","path":"/x","replace":true}"""));
@@ -65,7 +65,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_NoHandlerIdAndNoType_ReturnsEmpty()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
 
         var result = await session.DispatchAsync(Utf8("""{"foo":"bar"}"""));
 
@@ -75,7 +75,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_UnknownHandlerId_ReturnsEmpty()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         var result = await session.DispatchAsync(Utf8("""{"id":"h999"}"""));
@@ -86,7 +86,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_KnownHandler_ReturnsPayloadWithUpdatedHtml()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         var initial = await session.InitialRenderAsync();
 
         var handlerId = Markup.FirstHandlerId(initial);
@@ -101,7 +101,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_NavigateWithEmptyQuery_NoQuestionMarkInHistoryUrl()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         var result = await session.DispatchAsync(Utf8("""{"type":"navigate","path":"/x","query":""}"""));
@@ -113,7 +113,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_ConcurrentCalls_SerialisedByLock()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         var initial = await session.InitialRenderAsync();
         var handlerId = Markup.FirstHandlerId(initial);
 
@@ -136,7 +136,7 @@ public class DispatchAsyncRoutingTests() : ResettingTestBase(LiveDiffMode.Disabl
     [Fact]
     public async Task Dispatch_HandlerThatThrows_ReturnsEmpty_AndSessionStaysUsable()
     {
-        var (session, _) = NewSession<ThrowingStubApp>();
+        var (session, _) = NewSession<ThrowingStubApp>(diffMode: DiffMode);
 
         var initial = await session.InitialRenderAsync();
         var handlerId = Markup.FirstHandlerId(initial);

--- a/tests/Rask.Wasm.Tests/Session/DisposalTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/DisposalTests.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Authentication;
+using Rask.Core.Live;
 using Rask.Core.Routing;
 using Rask.Wasm.Files;
 using static Rask.Core.Components.Generated;
@@ -27,7 +28,7 @@ public class DisposalTests
         services.AddSingleton<IUserProvider>(provider);
         var sp = services.BuildServiceProvider();
 
-        var session = new WasmLiveSession(new MiniApp(), sp);
+        var session = new WasmLiveSession(new MiniApp(), sp, LiveDiffMode.Auto);
         Assert.Equal(1, provider.SubscriberCount); // session subscribed in the ctor
 
         session.Dispose();

--- a/tests/Rask.Wasm.Tests/Session/NavigationDiffGateTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/NavigationDiffGateTests.cs
@@ -19,7 +19,7 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task Navigate_SameHead_ShipsDiffWithHistory()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         var result = await session.DispatchAsync(Utf8("""{"type":"navigate","path":"/destination","query":""}"""));
@@ -37,7 +37,7 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task Navigate_WithQuery_ShipsDiffCarryingQueryInHistory()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         // Path changes (body diff) and the head is unchanged → diff path. The history URL
@@ -53,7 +53,7 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task Navigate_QueryOnlyNoBodyChange_ShipsHistoryOnlyDiff()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         // StubApp renders only the path, never the query — navigating to the same path
@@ -75,7 +75,7 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task Navigate_HeadChanges_ShipsDiffWithHeadFragment()
     {
-        var (session, _) = NewSession<RouteTitleStubApp>();
+        var (session, _) = NewSession<RouteTitleStubApp>(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         // RouteTitleStubApp changes the <title> AND an H1 text per route. The body delta is a
@@ -98,7 +98,7 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task Navigate_HeadChangesWithStructuralBody_StillShipsFullHtml()
     {
-        var (session, _) = NewSession<RouteTitleStructuralStubApp>();
+        var (session, _) = NewSession<RouteTitleStructuralStubApp>(diffMode: DiffMode);
         await session.InitialRenderAsync();
 
         // The body restructures per route (div ↔ unkeyed list) → untrusted positional
@@ -118,7 +118,7 @@ public class NavigationDiffGateTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task ReactiveTitleChange_NoNavigation_ShipsDiffWithHeadAndNoHistory()
     {
-        var (session, _) = NewSession<ReactiveTitleStubApp>();
+        var (session, _) = NewSession<ReactiveTitleStubApp>(diffMode: DiffMode);
         var initial = await session.InitialRenderAsync();
 
         // A handler bumps a counter that drives BOTH the <title> and an H1 — no navigation.

--- a/tests/Rask.Wasm.Tests/Session/PayloadShapeTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/PayloadShapeTests.cs
@@ -12,7 +12,7 @@ public class PayloadShapeTests() : ResettingTestBase(LiveDiffMode.DisabledFull)
     [Fact]
     public async Task InitialRender_AlwaysIncludesDataRaskRootEqualsWasm()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
 
         var payload = await session.InitialRenderAsync();
 
@@ -24,7 +24,7 @@ public class PayloadShapeTests() : ResettingTestBase(LiveDiffMode.DisabledFull)
     [Fact]
     public async Task InitialRender_NoCssRegistered_DoesNotIncludeCssText()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
 
         var payload = await session.InitialRenderAsync();
 
@@ -35,7 +35,7 @@ public class PayloadShapeTests() : ResettingTestBase(LiveDiffMode.DisabledFull)
     [Fact]
     public async Task InitialRender_FollowedByHandlerDispatch_DoesNotResendCssText_WhenHashUnchanged()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         var initial = await session.InitialRenderAsync();
         var handlerId = Markup.FirstHandlerId(initial);
 

--- a/tests/Rask.Wasm.Tests/Session/WasmDiffPathTests.cs
+++ b/tests/Rask.Wasm.Tests/Session/WasmDiffPathTests.cs
@@ -18,7 +18,7 @@ public class WasmDiffPathTests() : ResettingTestBase(LiveDiffMode.Forced)
     [Fact]
     public async Task ClickCounter_ThreeIncrements_ProducesDiffsWithCorrectUpdateText()
     {
-        var (session, _) = NewSession();
+        var (session, _) = NewSession(diffMode: DiffMode);
         var initial = await session.InitialRenderAsync();
 
         // Initial render is full HTML (first render of the session, no prior to diff).


### PR DESCRIPTION
## What

`LiveDiffMode` was a mutable `static LiveOptions.DiffMode` read on the render hot path. This snapshots it onto each `LiveSession` at construction — from the host's `RaskLiveOptions` — and reads it from an instance field instead. It's the deferred follow-up to #306 (the memory/PR both name `LiveOptions.DiffMode` as "the real `Rask.Server.Tests` serialization bottleneck").

**Stacked on #306** (base = `worktree-faster-tests-local-ci`) because it shares that PR's battleground — `RaskEndpointExtensions` session setup and the Server test collections. Rebase onto `main` once #306 lands.

## Why

Two faces of one disease — shared mutable state the render pipeline reads without synchronization:
- **Native** fans render continuations onto the thread pool (`HandlerSyncContext.Post` → `Task.Run`), so a static read mid-render is doubly wrong (this is the sibling of the concurrent-render race fixed in #305).
- **Tests**: nine Server WebSocket classes set conflicting `DiffMode` values and had to run serialized under `[Collection("LiveDiffMode")]`.

## How

- `LiveSessionBase` gains a `protected LiveDiffMode DiffMode` set from a new ctor arg; the two hot-path reads (`RenderTreeToHtml`, `WritePayload`) + `LiveSession.RenderInitialRoot` read it.
- **Server** carries it on the per-host `LiveSessionStore` (mirrors `MaxSessions`), seeded from `RaskLiveOptions.DiffMode` in `AddRask`. **WASM/Native** carry it on the host builder, set in `CreateDefault`.
- `LiveOptions.DiffMode` static is **removed**. `PathBase` / `MinifyScopedAssets` stay — they back the process-wide content-addressed asset registries (one shared bundle per process).
- Tests: `RaskTestHost.Create` / `ConnectedSession.Connect` / the native + WASM session harnesses / `ResettingTestBase` thread `diffMode` per-host. The nine Server WS classes drop `[Collection("LiveDiffMode")]` and run in parallel. Native/WASM session collections stay (they serialize on the `ScopedAssetRegistry` reset, a genuinely process-wide concern — comments updated).

## Compatibility

Configuration surface unchanged: `AddRask(o => o.DiffMode = …)`, `WasmHostBuilder.CreateDefault`, `NativeAppHost.CreateDefault` all work as before. No public API a normal app touches changes.

## Verification

- Full non-E2E suite green: **Core 1829, Server 248 (now parallel, ~30 s), Wasm 197, Native 14**, +everything else.
- `dotnet format` clean; `dotnet build -warnaserror` clean.
- Render benchmarks unchanged — allocation-neutral (a branch-condition read moved from a static to an instance field): RenderOnce 80.2 KB · RenderTenTimes 150.51 KB · RenderKeyedList100 76.07 KB · RenderDeep_50 72.42 KB.