### PR TITLE
fix(bootstrap): floating-label overlap in BsMultiSelect + floated-label top spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@ them until tagged releases begin.
   the whole solution. (3) The documented local inner loop is build-once / test-with-`--no-build`.
 
 ### Fixed
+- **`BsMultiSelect` floating label no longer overlaps the placeholder.** In floating mode the empty control
+  still rendered its `Select…` placeholder span *inside* the box, and the floating CSS centres the label
+  in that same box — so the two texts collided. It now blanks the box when floating + empty (the centred
+  floating label serves as the placeholder), matching `BsSelect` and native `.form-floating`.
+- **Floated `.bs-floating` label now straddles the top border like a native floating input.** The custom
+  floating-label controls (`BsSelect`/`BsMultiSelect`/pickers) zero the label's top padding in the empty
+  state to flex-centre the placeholder, but never restored it when the label floated — so the shrunk label
+  translated up from a `0` baseline and hugged/crossed the top border. The filled/`:focus-within` rule now
+  restores the native `padding-top: 1rem`, so the floated label sits the same small gap below the border as
+  a normal Bootstrap floating input.
 - **`BsSelect`/date-time picker clear (×) no longer shows through another select's open dropdown.** The
   clear × carried a hard `z-index: 1000` (so an *open* control's × stays clickable above its own
   click-outside backdrop at 999). But Bootstrap's open `.dropdown-menu.show` is *also* `z-index: 1000`,

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -86,8 +86,11 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         var filteredList = filtered as IReadOnlyList<TItem> ?? filtered.ToList();
 
         var hasChips = selected is not null && selected.Count > 0;
+        var floating = Floating is true && Label is not null;
 
         // The control box holds the selected chips (BsBadge + BsCloseButton), or a placeholder when empty.
+        // While floating + empty the box stays blank: the centred floating label acts as the placeholder
+        // (matching BsSelect and native .form-floating), so a leftover "Select…" span can't overlap it.
         var box = new List<Component>();
         if (hasChips)
         {
@@ -103,7 +106,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                 i++;
             }
         }
-        else
+        else if (!floating)
         {
             box.Add(Span(Class: "text-secondary")[Placeholder ?? "Select…"]);
         }
@@ -156,7 +159,6 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             OnClick: disabled ? null : () => { _open = !_open; if (!_open) { _filter = null; } },
             OnKeyDown: disabled ? null : OnBoxKeyDown)[box];
 
-        var floating = Floating is true && Label is not null;
         var labelNode = Label is null
             ? null
             : Rask.Core.Components.Generated.Label(Class: floating ? null : "form-label")[Label];

--- a/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
+++ b/src/Rask.Bootstrap/wwwroot/css/rask-bootstrap.css
@@ -67,9 +67,13 @@
 .form-floating.bs-floating:focus-within > .form-control ~ label {
   /* Drop the empty-state flex centering and pin the scale origin to the top-left corner so the
      shrunk label straddles the top border exactly like a native .form-floating label (a centred
-     origin scaled it inwards from the middle → it landed too low/misaligned). */
+     origin scaled it inwards from the middle → it landed too low/misaligned). Restore the native
+     1rem top padding the empty-state rule zeroed: without it the -0.5rem float measures from a 0
+     baseline and lands ABOVE the top border (hugging/crossing it); with it the label sits ~0.35rem
+     below the border, the same gap as a native floating input. */
   display: block;
   height: auto;
+  padding-top: 1rem;
   transform-origin: 0 0;
   transform: scale(0.85) translateY(-0.5rem) translateX(0.15rem);
   opacity: 0.65;

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -40,6 +40,29 @@ public class BsMultiSelectTests
             BsMultiSelect<string>(Options: [], Value: new List<string>(), Placeholder: "Pick tags").ToHtml());
 
     [Fact]
+    public void MultiSelect_FloatingEmpty_WrapsInFormFloatingWithBlankBox()
+    {
+        // Float-only-when-filled: the empty box carries NO "Select…" placeholder span (the centred floating
+        // label is the placeholder) — otherwise the two texts overlap. Wrapper is .form-floating.bs-floating
+        // with no .bs-floating-filled. Guards the regression where the leftover placeholder overlapped the label.
+        var html = BsMultiSelect<string>(Options: [], Value: new List<string>(),
+            Label: "Interests", Floating: true).ToHtml();
+        Assert.Contains("<div class=\"form-floating bs-floating position-relative\">", html);
+        Assert.Contains("role=\"combobox\" tabindex=\"0\"></div><label>Interests</label>", html);
+        Assert.DoesNotContain("Select&#x2026;", html);
+        Assert.DoesNotContain("bs-floating-filled", html);
+    }
+
+    [Fact]
+    public void MultiSelect_FloatingWithChips_AddsFilledMarker()
+    {
+        var html = BsMultiSelect<string>(Options: ["a"], Value: new List<string> { "a" },
+            Label: "Interests", Floating: true).ToHtml();
+        Assert.Contains("<div class=\"form-floating bs-floating bs-floating-filled position-relative\">", html);
+        Assert.DoesNotContain("Select&#x2026;", html);
+    }
+
+    [Fact]
     public void MultiSelect_RequiresExactlyOneOfBindOrValue() =>
         // Neither Bind nor Value set → the mode guard throws when the control renders.
         Assert.Throws<InvalidOperationException>(() => BsMultiSelect<string>(Options: ["a"]).ToHtml());


### PR DESCRIPTION
## Summary
Two floating-label rendering fixes for the custom `.bs-floating` Bootstrap controls so they match a normal Bootstrap floating input:

- **`BsMultiSelect` overlap** — in floating mode the empty control still rendered its `Select…` placeholder span *inside* the box, and the floating CSS centres the label in that same box, so the two texts collided. It now blanks the box when floating + empty (the centred label is the placeholder), matching `BsSelect` and native `.form-floating`.
- **Floated-label top spacing (all `.bs-floating` controls)** — the empty-state rule zeroes the label's top padding to flex-centre the placeholder but never restored it when the label floated, so the shrunk label translated up from a `0` baseline and hugged/crossed the top border. The filled/`:focus-within` rule now restores the native `padding-top: 1rem`, so the label sits the same small gap below the border as a native floating input.

## Testing
- Unit: `dotnet test` (Rask.Bootstrap.Tests, `BsMultiSelectTests`/`BsSelectTests`) — **20/20 passed**, incl. 2 new `BsMultiSelect` floating tests (empty→blank box/no `Select…`; filled→`bs-floating-filled`). Verified the new empty-floating test fails on pre-fix code and passes after.
- Visual (drove the running Server sample over CDP): empty multi-select shows a single centred "Interests (floating)" label with no overlap; when filled, both `BsSelect` "Plan (floating)" and `BsMultiSelect` "Interests (floating)" labels float to the top-left straddling the border — pixel-matching a genuinely native `.form-floating` `<select>`.
- No `samples/` code changed (demos already exist and are covered by the shared E2E forms journey), so no new E2E.

## Benchmarks
n/a — Bootstrap component conditional + a CSS rule; not a Core render/diff hotpath.

## CHANGELOG
- [Unreleased] → Fixed: `BsMultiSelect` floating label overlap; floated `.bs-floating` label now straddles the top border like a native floating input.
