### PR TITLE
perf(ci): publish the Server E2E host once, share it across both server shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,11 +188,19 @@ jobs:
       - name: Build
         run: dotnet build Rask.slnx -c Release --no-restore -m:1
 
+      - name: Publish Server sample (shared by the ServerExampleTests + NativeServerSmokeTests shards)
+        # Both server shards' fixtures boot the *published* Rask.Example.Server host. Publish it ONCE here,
+        # off the graph we just built, so neither shard repeats a from-scratch restore+compile+publish at
+        # fixture startup (that duplicated ~15 min was the whole reason those two shards dwarfed the rest).
+        # Default output → bin/Release/net10.0/publish, picked up verbatim by the tar below; the fixture
+        # launches this prebuilt DLL when it's present and only publishes on demand as a local-dev fallback.
+        run: dotnet publish samples/Rask.Example.Server -c Release --no-build --no-restore --nologo
+
       - name: Package build output
         # Tar every bin/ and obj/: the shards need the built test + sample assemblies, the published
-        # WASM wwwroot bundles the WASM fixtures serve, and the restore assets that `dotnet run
-        # --no-build` and the two publish-based fixtures require. Plain tar — upload-artifact
-        # compresses. -prune stops the walk from descending into a matched dir (no nested dup).
+        # WASM wwwroot bundles the WASM fixtures serve, the published Server host the two server shards
+        # boot, and the restore assets that `dotnet run --no-build` and the publish-based fixtures require.
+        # Plain tar — upload-artifact compresses. -prune stops the walk from descending into a matched dir.
         run: |
           find . -type d \( -name bin -o -name obj \) -prune -print0 \
             | tar --null --files-from=- -cf build-output.tar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@ them until tagged releases begin.
   there). (2) CI now builds the E2E graph **once** in a shared `e2e-build` job and hands the output to
   every browser-journey shard via artifact (`--no-build`), instead of each of the ten shards rebuilding
   the whole solution. (3) The documented local inner loop is build-once / test-with-`--no-build`.
+  (4) The two server E2E shards (`ServerExampleTests`, `NativeServerSmokeTests`) each `dotnet publish`-ed
+  the *same* `Rask.Example.Server` host from scratch at fixture startup — a duplicated restore+compile+
+  publish that made them ~15 min while every other shard was 1–3.5 min. The `e2e-build` job now publishes
+  that host **once** (`--no-build`, off the graph it just built) into the shared artifact, and the fixture
+  boots that prebuilt DLL when present (falling back to an on-demand publish for local dev), cutting both
+  shards to browser-journey time.
 
 ### Fixed
 - **`BsSelect`/date-time picker clear (×) no longer shows through another select's open dropdown.** The

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
@@ -152,13 +152,24 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         }
     }
 
-    // Publishes the host once into a temp folder and returns a ProcessStartInfo that runs the published
-    // DLL *from that folder* — the working directory becomes the content root, so MapStaticAssets
-    // resolves the published wwwroot/_content assets. Running the DLL from anywhere else would point the
-    // content root at the wrong place and the asset endpoints would serve empty bodies.
+    // Returns a ProcessStartInfo that runs the *published* host. Prefers the folder CI published once in
+    // the `e2e-build` job; if that isn't present (local dev), publishes the host on demand into a temp
+    // folder first. Either way the DLL is launched from its publish folder — see RunPublishedDllStartInfo.
     private ProcessStartInfo PublishAndBuildStartInfo(string repoRoot, string projectPath)
     {
         var appName = Path.GetFileName(ProjectRelativePath.TrimEnd('/', '\\'));
+
+        // CI publishes each publish-based host once in the `e2e-build` job (default output folder), ships
+        // it in the shared build artifact, and every shard boots that prebuilt DLL — so the shards don't
+        // each repeat a from-scratch restore+compile+publish. Prefer it when present; multiple fixtures
+        // (e.g. Server + NativeServerSmoke) share the one folder and just launch it on their own ports.
+        var prebuiltDir = Path.Combine(projectPath, "bin", Configuration, "net10.0", "publish");
+        if (File.Exists(Path.Combine(prebuiltDir, $"{appName}.dll")))
+        {
+            return RunPublishedDllStartInfo(prebuiltDir, appName);
+        }
+
+        // Local-dev fallback: no CI prebuild present, so publish the host on demand into a temp folder.
         var publishDir = Path.Combine(Path.GetTempPath(), "rask-e2e-publish", $"{appName}-{Port}");
         Directory.CreateDirectory(publishDir);
 
@@ -184,15 +195,20 @@ public abstract class ExampleAppFixture : IAsyncLifetime
             }
         }
 
-        return new ProcessStartInfo("dotnet")
-        {
-            ArgumentList = { Path.Combine(publishDir, $"{appName}.dll"), "--urls", BaseUrl },
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-            WorkingDirectory = publishDir
-        };
+        return RunPublishedDllStartInfo(publishDir, appName);
     }
+
+    // Runs the published host DLL *from its own folder* — the working directory becomes the content root,
+    // so MapStaticAssets resolves the published wwwroot/_content assets. Running it from anywhere else
+    // would point the content root at the wrong place and the asset endpoints would serve empty bodies.
+    private ProcessStartInfo RunPublishedDllStartInfo(string publishDir, string appName) => new("dotnet")
+    {
+        ArgumentList = { Path.Combine(publishDir, $"{appName}.dll"), "--urls", BaseUrl },
+        RedirectStandardOutput = true,
+        RedirectStandardError = true,
+        UseShellExecute = false,
+        WorkingDirectory = publishDir
+    };
 
     // Plain `dotnet run --no-build` launch — serves a host the main test-suite build already built.
     // (For WASM hosts that build must pass -p:WasmBuildNative=false so the prebuilt .NET-WASM runtime


### PR DESCRIPTION
## Summary

CI's `e2e` job shards one host per runner. Two shards dwarfed the rest:

| shard | before |
|---|---|
| `e2e (ServerExampleTests)` | **18.4 min** |
| `e2e (NativeServerSmokeTests)` | **16.5 min** |
| every other shard | 0.9–3.5 min |

Both fixtures boot the **published** `samples/Rask.Example.Server` host, and each ran a full `dotnet publish` of that same project **at fixture startup** with no `--no-build`/`--no-restore` — so each shard repeated a from-scratch restore + recompile of the whole graph even though the `e2e-build` job already built it and ships `bin`/`obj` in the shared artifact. That duplicated ~15 min is the entire gap. (`NativeServerSmokeTests` does no native build — it's a thin smoke that just boots the same host.)

## Change

- **`e2e-build` publishes the Server host once** (`dotnet publish … -c Release --no-build --no-restore`), off the graph it just built. The default output (`bin/Release/net10.0/publish`) is captured verbatim by the existing `find … -name bin | tar` step — no artifact/tar changes.
- **`ExampleAppFixture`** prefers that prebuilt DLL when present and only publishes on demand as a local-dev fallback (the prior code path, unchanged). The DLL launch is factored into a shared `RunPublishedDllStartInfo` helper.

Coverage is identical — only *where/when* the publish happens moves. Expected: both shards drop to browser-journey time (~3 min); `e2e-build` gains ~1–2 min for the one incremental publish.

## Testing

- `dotnet build tests/Rask.Examples.E2E.Tests -c Release` — succeeds (0 errors).
- `dotnet format … --verify-no-changes` — clean.
- Manually ran `dotnet publish samples/Rask.Example.Server -c Release --no-build --no-restore` → output at the exact path the fixture checks; booted the DLL from its folder → HTTP 200.
- `dotnet test … --filter ~NativeServerSmokeTests --no-build` → **passed in 5.6 s total**, proving the fixture takes the prebuilt-DLL branch end-to-end (an on-demand publish would have added ~15 min at fixture startup) and the host renders + reacts live over the WebSocket.

## Benchmarks

N/A — no render/runtime hot-path touched (CI + test-fixture only).

## Changelog

Extended the existing `[Unreleased] › Changed › Faster tests` entry with sub-point (4).
