### PR TITLE
perf(live): diff Raw-tainted levels with a scoped MorphSubtree, not a full-document morph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,9 +122,20 @@ them until tagged releases begin.
   form. The diff codec now trusts the safe subset: a **pure tail append/truncate at a nested,
   replace-free level**, where the client's positional apply is provably identical to the full-HTML morph
   (Rask serialises nested content without the whitespace/comment nodes that would shift the client's
-  `childNodes` slot). Mid-list replacements, top-level ops (where the WASM shell's comment nodes live),
-  and `Raw`-tainted levels still take the full-HTML path, so DOM identity is preserved exactly as before.
+  `childNodes` slot). Mid-list replacements and top-level ops (where the WASM shell's comment nodes live)
+  still take the full-HTML path, so DOM identity is preserved exactly as before.
   Measured effect: a form-validation-churn update drops from ~1.4 KB (full form) to ~110 B on the wire.
+- **`Raw`/CodeSample-heavy pages now ship a scoped subtree morph instead of re-rendering the whole
+  document.** When a `Raw` frame shares a sibling level with other nodes (the shape of every guide,
+  markdown, or syntax-highlighted-code page), its verbatim markup parses into an unknown DOM-node count,
+  so the following siblings' positional paths can't be trusted — the diff used to discard the whole render
+  and morph `document.documentElement`. It now emits one trusted `MorphSubtree` op at the Raw-owning
+  parent, carrying just that element's new inner HTML; the client reconciles only that subtree with the
+  same `morph()` engine (correctness identical to the old full-document morph, localised). Benefits all
+  three hosts — biggest win on **native**, where the frequent full-document morph on complex pages was the
+  expensive, historically flaky update path. Measured on a minimal guide shell: the wire payload drops
+  from a 1770 B full-document frame to a 661 B single-op diff (and the gap widens with the surrounding
+  shell, since the diff stays proportional to just the changed container).
 - **Leaf elements retain less memory: three cold reference fields moved off the base `Component`.** The
   error-boundary pointer, render handle, and lifetime-token source are only ever set on live-render
   roots and user components (which already allocate a lazy `LiveState`), yet every `Element` in a mounted

--- a/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
+++ b/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
@@ -2,4 +2,5 @@ Scenario,FullPayloadBytes,DiffPayloadBytes,DiffOpCount
 CounterOnLargePage,66838,45,1
 KeyedList100Reorder,6691,47,1
 TextNodeUpdate,66721,54,1
-AppendRowToList100,6759,46,1
+AppendRowToList100,6759,112,1
+RawGuidePage,1770,661,1

--- a/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/FrameDifferBenchmarks.cs
@@ -41,6 +41,22 @@ public class FrameDifferBenchmarks
 
     private RenderFrame[] _before = null!;
 
+    // Raw-tainted guide-page shape: a "sample" container mixing a Raw block (highlighted code) with a
+    // sibling status node whose text changes. Pre-fix this forced a full-document morph on EVERY such
+    // update (the flaky, expensive path on guide/CodeSample pages); now the differ ships one scoped
+    // MorphSubtree op. Measures the diff-time cost of that path (walk + rollback + single op emit).
+    private const string HighlightedCode =
+        "<span class=\"k\">public</span> <span class=\"k\">class</span> <span class=\"t\">Counter</span>" +
+        " : <span class=\"t\">Component</span> { <span class=\"k\">public</span> <span class=\"k\">int</span>" +
+        " <span class=\"p\">Count</span> { <span class=\"k\">get</span>; <span class=\"k\">set</span>; }" +
+        " <span class=\"k\">public</span> <span class=\"k\">override</span> <span class=\"t\">Component</span>" +
+        " <span class=\"m\">Render</span>() =&gt; <span class=\"m\">Div</span>()[<span class=\"m\">Span</span>()" +
+        "[<span class=\"p\">Count</span>.<span class=\"m\">ToString</span>()]]; }";
+
+    private RenderFrame[] _beforeGuide = null!;
+    private RenderFrame[] _afterGuide = null!;
+    private string _afterGuideHtml = "";
+
     // Insert scenario: a sparse list (even keys only) grows into the full list, so every odd
     // key is an InsertSubtree carrying its freshly-sliced HTML fragment. _fullHtml is the diff's
     // newHtml source, so each insert op runs FrameDiffer.SliceHtml (one Substring per inserted row).
@@ -117,6 +133,10 @@ public class FrameDifferBenchmarks
         }
 
         (_afterAppendDel, _afterAppendDelHtml) = FramesAndHtmlOf(BuildKeyedList(kept.ToArray(), -1));
+
+        // Raw-tainted guide page: only the status text changes; the Raw code block is unchanged.
+        _beforeGuide = FramesOf(BuildGuidePage(1));
+        (_afterGuide, _afterGuideHtml) = FramesAndHtmlOf(BuildGuidePage(2));
     }
 
     [Benchmark(Baseline = true)]
@@ -192,6 +212,26 @@ public class FrameDifferBenchmarks
         FrameDiffer.Diff(_beforeSparse, _afterFull, _ops, _scratch, out _, _fullHtml);
         return _ops.Count;
     }
+
+    [Benchmark]
+    public int RawGuidePage_ReusedScratch()
+    {
+        // The status node changed at a Raw-tainted level → the differ rolls back the positional ops and
+        // emits ONE scoped MorphSubtree at the sample container. Pre-fix this whole render was discarded
+        // and the full document shipped; now it's a single trusted diff op.
+        _ops.Clear();
+        FrameDiffer.Diff(_beforeGuide, _afterGuide, _ops, _scratch, out _, _afterGuideHtml);
+        return _ops.Count;
+    }
+
+    // A guide-page section: a "sample" container mixing a Raw code block with a sibling status node.
+    private static Component BuildGuidePage(int status) =>
+        C.Div(Class: "guide")[
+            C.Div(Class: "sample", Id: "sample")[
+                C.Raw(HighlightedCode),
+                C.Div(Class: "status", Id: "demo-status")[$"count: {status}"]
+            ]
+        ];
 
     private static Component BuildKeyedList(int[] order, int textRow)
     {

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -49,7 +49,14 @@ internal static class PayloadBytesReport
             // InsertSubtree op with the new row's HTML fragment as op.Value.
             Report("AppendRowToList100", writer,
                 BuildKeyedListTree(MakeKeyedOrder(100)),
-                BuildKeyedListTree(MakeKeyedOrder(101)))
+                BuildKeyedListTree(MakeKeyedOrder(101))),
+            // Raw-tainted guide page: a sample container mixes a Raw code block with a sibling status
+            // node whose text changes. Pre-fix this shipped the WHOLE document (full-HTML morph); now it
+            // ships one scoped MorphSubtree carrying just the sample container's inner HTML — the diff
+            // drops from full-page to one subtree.
+            Report("RawGuidePage", writer,
+                BuildGuideDocument(1),
+                BuildGuideDocument(2))
         };
 
         return check ? CheckAgainstBaseline(rows) : 0;
@@ -150,22 +157,23 @@ internal static class PayloadBytesReport
         Component after)
     {
         // Full-HTML payload size — what the server ships TODAY for every state change.
-        var html = after.RenderAsLiveRoot();
+        var fullHtml = after.RenderAsLiveRoot();
         writer.ResetWrittenCount();
-        LivePayload.BuildPayloadUtf8WithRoot(writer, html, "session-bench", null, false);
+        LivePayload.BuildPayloadUtf8WithRoot(writer, fullHtml, "session-bench", null, false);
         var fullBytes = writer.WrittenCount;
 
-        // Diff payload size — what the server WILL ship once the diff codec wires in.
-        // Build the previous-render frame stream + current-render frame stream, diff them,
-        // serialize as the diff wire format. Pass `html` so InsertSubtree ops carry
-        // their HTML fragment (key for keyed-list / structural-change scenarios).
-        var beforeFrames = CaptureFrames(before);
-        var afterFrames = CaptureFrames(after);
+        // Diff payload size — build the previous- and current-render frame streams, diff them, and
+        // serialize as the diff wire format. The frames' HtmlStart/HtmlEnd offsets index into the SAME
+        // serialized string (afterHtml) they were captured against, so that string — not the injected
+        // RenderAsLiveRoot output — is the slice source for InsertSubtree / MorphSubtree fragments,
+        // mirroring how the live session pairs its frames with its render HTML.
+        var (beforeFrames, _) = CaptureFrames(before);
+        var (afterFrames, afterHtml) = CaptureFrames(after);
         var ops = new List<EditOp>();
-        FrameDiffer.Diff(beforeFrames, afterFrames, ops, html);
+        FrameDiffer.Diff(beforeFrames, afterFrames, ops, afterHtml);
 
         writer.ResetWrittenCount();
-        LivePayload.BuildPayloadUtf8Diff(writer, ops);
+        LivePayload.BuildPayloadUtf8Diff(writer, ops, newHtml: afterHtml);
         var diffBytes = writer.WrittenCount;
 
         Console.WriteLine(string.Format(
@@ -176,7 +184,7 @@ internal static class PayloadBytesReport
         return new Row(name, fullBytes, diffBytes, ops.Count);
     }
 
-    private static RenderFrame[] CaptureFrames(Component tree)
+    private static (RenderFrame[] Frames, string Html) CaptureFrames(Component tree)
     {
         var sb = new StringBuilder();
         var fw = new FrameWriter();
@@ -185,7 +193,7 @@ internal static class PayloadBytesReport
             HtmlSerializer.Serialize(tree, sb);
         }
 
-        return fw.WrittenSpan.ToArray();
+        return (fw.WrittenSpan.ToArray(), sb.ToString());
     }
 
     private static int[] SwapKeyed(int[] order, int a, int b)
@@ -248,6 +256,44 @@ internal static class PayloadBytesReport
         return [
             C.Doctype(),
             C.Html()[C.Body()[C.Div(Class: "list")[rows]]]
+        ];
+    }
+
+    // A guide/CodeSample page: a nav + sidebar shell plus a "sample" container that mixes a Raw code
+    // block with a sibling status node. Only the status text changes between renders — a Raw-tainted
+    // level, so the diff ships one scoped MorphSubtree carrying the sample container's inner HTML
+    // (the code + status), never the whole document.
+    private static Component BuildGuideDocument(int status)
+    {
+        const string highlightedCode =
+            "<span class=\"k\">public</span> <span class=\"k\">class</span> <span class=\"t\">Counter</span>" +
+            " : <span class=\"t\">Component</span> { <span class=\"k\">public</span> <span class=\"k\">int</span>" +
+            " <span class=\"p\">Count</span> { <span class=\"k\">get</span>; <span class=\"k\">set</span>; }" +
+            " <span class=\"k\">public</span> <span class=\"k\">override</span> <span class=\"t\">Component</span>" +
+            " <span class=\"m\">Render</span>() =&gt; <span class=\"m\">Div</span>()[<span class=\"m\">Span</span>()" +
+            "[<span class=\"p\">Count</span>.<span class=\"m\">ToString</span>()]]; }";
+
+        var nav = new List<Component>(12);
+        for (var i = 0; i < 12; i++)
+        {
+            nav.Add(C.A($"/guides/{i}", Class: "nav-link", Key: i)[$"Guide {i}"]);
+        }
+
+        return [
+            C.Doctype(),
+            C.Html()[
+                C.Body()[
+                    C.Nav(Class: "sidebar")[nav],
+                    C.Main(Class: "content")[
+                        C.H1()["Counter guide"],
+                        C.P()["A counter component highlighted below, with a live status line."],
+                        C.Div(Class: "sample", Id: "sample")[
+                            C.Raw(highlightedCode),
+                            C.Div(Class: "status", Id: "demo-status")[$"count: {status}"]
+                        ]
+                    ]
+                ]
+            ]
         ];
     }
 

--- a/docs/native.md
+++ b/docs/native.md
@@ -32,7 +32,10 @@ unchanged.
 ## How it fits
 
 Rask has three client "dialects" that all speak one frame contract — a minimal diff (or full-HTML morph)
-the client applies to the DOM:
+the client applies to the DOM. Even `Raw`/CodeSample-heavy pages (guides, markdown, highlighted code)
+stay on the diff path: a changed sibling of a `Raw` block ships a scoped `MorphSubtree` op that re-morphs
+only that one container's children, rather than falling back to a full-document morph — the same fix
+benefits all three hosts but matters most here, where the full-document re-render was the costliest path.
 
 | Host | Transport | Where the app runs |
 | --- | --- | --- |

--- a/src/Rask.Core/Live/FrameDiffer.cs
+++ b/src/Rask.Core/Live/FrameDiffer.cs
@@ -70,7 +70,24 @@ public enum EditOpKind : byte
     ///     reorder. Like <see cref="MoveSubtree" /> it only ever comes from the keyed path and
     ///     preserves DOM identity.
     /// </summary>
-    PermutationBatch = 7
+    PermutationBatch = 7,
+
+    /// <summary>
+    ///     Reconcile the CHILDREN of the element at <see cref="EditOp.Path" /> against a fresh HTML
+    ///     fragment (that element's new inner HTML) via the client's <c>morph()</c> engine. Emitted
+    ///     when a sibling level mixes a <see cref="RenderFrameKind.Raw" /> frame with other siblings
+    ///     and changed: a Raw's verbatim markup parses into an unknown number of DOM nodes, so the
+    ///     positional <c>childNodes[slot]</c> paths of the following siblings can't be trusted — but
+    ///     the Raw-owning PARENT is still addressable by a clean path (every ancestor level is
+    ///     untainted by construction, else the morph would have been emitted higher up). So instead of
+    ///     bailing the whole render to a full-document morph, we localise it to this one parent. The
+    ///     fragment travels as the <see cref="EditOp.HtmlStart" />/<see cref="EditOp.HtmlEnd" /> char
+    ///     range into the render HTML (sliced at wire-write time, like
+    ///     <see cref="InsertSubtree" />), or as a verbatim <see cref="EditOp.Value" /> string. Always
+    ///     <see cref="EditOp.Trusted" /> — a morph handles arbitrary node counts and preserves keyed /
+    ///     focus / IDL state — so it ships as a diff rather than routing to the full-HTML fallback.
+    /// </summary>
+    MorphSubtree = 8
 }
 
 /// <summary>
@@ -432,8 +449,76 @@ public static class FrameDiffer
 
         if (rawTaintedLevel && output.Count != opCountAtEntry)
         {
-            scratch.ForceFullHtml = true;
+            // The positional ops just emitted for this Raw-tainted level (and everything its subtree
+            // produced) can't be trusted — a Raw parses into an unknown DOM-node count, drifting every
+            // following sibling's childNodes[slot]. Roll them all back and ship ONE scoped morph at the
+            // Raw-owning parent instead: the parent is addressable by a clean path (every ancestor level
+            // is untainted, else the morph would already have been emitted higher up), and one morph of
+            // its children subsumes every op below — including any deeper MorphSubtree and the earlier
+            // pre-Raw siblings, which are also this parent's children. Correctness is identical to the
+            // old full-document morph, just localised to the tainted subtree.
+            output.RemoveRange(opCountAtEntry, output.Count - opCountAtEntry);
+
+            var (innerStart, innerEnd) = ChildrenHtmlRange(newFrames, newStart, newEnd, newHtml);
+            if (path.Count >= 1 && !newHtml.IsEmpty && innerStart >= 0)
+            {
+                // path is the parent element's DOM path; the client morphs its children against the
+                // sliced inner-HTML fragment. Trusted so DiffOpsAreClientSupported ships it as a diff.
+                output.Add(new EditOp(EditOpKind.MorphSubtree, path.ToArray(), null, null,
+                    trusted: true, htmlStart: innerStart, htmlEnd: innerEnd));
+                scratch.ForceFullHtml = false;
+            }
+            else if (path.Count >= 1 && !newHtml.IsEmpty && newStart >= newEnd)
+            {
+                // The Raw-tainted parent legitimately emptied (its Raw + siblings were all removed).
+                // A verbatim empty-string fragment morphs its children to nothing — no full-doc fallback.
+                output.Add(new EditOp(EditOpKind.MorphSubtree, path.ToArray(), null, string.Empty,
+                    trusted: true));
+                scratch.ForceFullHtml = false;
+            }
+            else
+            {
+                // Degenerate: taint at the document root (path empty — no addressable parent) or no
+                // render HTML supplied (one-shot / test callers that inspect ops without a wire build).
+                // Keep the full-HTML fallback, exactly as before.
+                scratch.ForceFullHtml = true;
+            }
         }
+    }
+
+    // Char range of a parent's inner HTML: from the first DOM-relevant child's HtmlStart to the last
+    // top-level child's HtmlEnd. Rask serialises children contiguously (no inter-node whitespace/comment
+    // nodes), so that span IS the parent's inner HTML. Returns (-1, -1) when there are no children (the
+    // parent legitimately emptied — the caller ships an empty fragment that clears the children) or the
+    // offsets are degenerate / out of range. Mirrors InsertHtmlRange's defensive bounds.
+    private static (int Start, int End) ChildrenHtmlRange(
+        ReadOnlySpan<RenderFrame> frames, int start, int end, ReadOnlySpan<char> newHtml)
+    {
+        var first = -1;
+        var lastEnd = -1;
+        var i = start;
+        while (i < end)
+        {
+            ref readonly var f = ref frames[i];
+            if (f.Kind != RenderFrameKind.Attribute)
+            {
+                if (first < 0)
+                {
+                    first = f.HtmlStart;
+                }
+
+                lastEnd = f.HtmlEnd;
+            }
+
+            i += f.SubtreeLength;
+        }
+
+        if (first < 0 || lastEnd <= first || newHtml.IsEmpty || (uint)lastEnd > (uint)newHtml.Length)
+        {
+            return (-1, -1);
+        }
+
+        return (first, lastEnd);
     }
 
     // True when this sibling level contains a Raw frame alongside at least one other DOM-relevant

--- a/src/Rask.Core/Live/LiveDiffGate.cs
+++ b/src/Rask.Core/Live/LiveDiffGate.cs
@@ -18,6 +18,9 @@ internal static class LiveDiffGate
     // Positional structural ops can replace mid-list elements that the morph would have
     // preserved, which broke 83/430 e2e tests in an earlier iteration that ungated them
     // unconditionally — that's why we still route those through the full-HTML path.
+    // EditOpKind.MorphSubtree is NOT listed here: it's a trusted, path-scoped morph (the Raw-tainted
+    // fallback shrunk from a full-document morph to one parent's children), always safe to ship as a
+    // diff — a morph handles arbitrary node counts and preserves keyed / focus / IDL state.
     internal static bool DiffOpsAreClientSupported(List<EditOp> ops)
     {
         for (var i = 0; i < ops.Count; i++)

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -392,6 +392,26 @@ public static class LivePayload
 
                     writer.WriteNumberValue(op.Length);
                     break;
+                case EditOpKind.MorphSubtree:
+                    // [8, path, innerHtml] — the parent's new inner HTML. Prefer a verbatim Value
+                    // (directly-constructed ops, incl. the emptied-parent "" fragment); otherwise slice
+                    // it out of the render HTML by the op's deferred char range (the FrameDiffer hot
+                    // path), exactly like InsertSubtree but with no trailing domCount.
+                    if (op.Value is not null)
+                    {
+                        writer.WriteStringValue(op.Value);
+                    }
+                    else if (!newHtml.IsEmpty && op.HtmlStart >= 0 && op.HtmlEnd > op.HtmlStart
+                             && op.HtmlEnd <= newHtml.Length)
+                    {
+                        writer.WriteStringValue(newHtml.Slice(op.HtmlStart, op.HtmlEnd - op.HtmlStart));
+                    }
+                    else
+                    {
+                        writer.WriteStringValue(string.Empty);
+                    }
+
+                    break;
                 case EditOpKind.RemoveSubtree:
                 case EditOpKind.MoveSubtree:
                     writer.WriteNumberValue(op.Length);

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -32,6 +32,7 @@
 //   5 RemoveSubtree    [k, path, domCount]
 //   6 MoveSubtree      [k, path, sourceSlot]
 //   7 PermutationBatch [k, parentPath, moves]
+//   8 MorphSubtree     [k, path, innerHtml]
 //
 // Names for SetAttribute/RemoveAttribute may arrive as either a string (inline) or
 // a number that indexes into the optional payload-level "names" array — the server
@@ -255,6 +256,24 @@ function applyDiff(ops, names) {
                     const pbRef = relevantChildSkipping(pbParent, pbDst, pbNode);
                     moveChildBefore(pbParent, pbNode, pbRef);
                 }
+                break;
+            }
+            case 8: { // MorphSubtree [k, path, innerHtml]
+                // The Raw-tainted fallback, scoped: reconcile the CHILDREN of the element at `path`
+                // against fresh inner HTML via the same morph() the full-document path uses — but
+                // localised to this one subtree the server could still address by a clean path. A Raw's
+                // markup expands into an unknown DOM-node count, so the server can't emit reliable
+                // positional child ops here; a morph reparses it correctly and preserves keyed / focus /
+                // IDL state on everything it doesn't need to touch (incl. the rest of the document).
+                const msEl = resolvePath(path);
+                if (!msEl) break;
+                // Shallow-clone the ACTUAL parent (not a generic <template>) so innerHTML parses in the
+                // element's own context — correct for <table>/<select>/<tr>/… children. The clone carries
+                // msEl's current attributes (already reconciled by any SetAttribute ops applied before
+                // this one), so morph sees them matching and only touches the children.
+                const model = msEl.cloneNode(false);
+                model.innerHTML = op[2] == null ? "" : op[2];
+                morph(msEl, model);
                 break;
             }
             default:

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1092,6 +1092,7 @@ window.__raskWakeLock = window.__raskWakeLock || (() => {
 //   5 RemoveSubtree    [k, path, domCount]
 //   6 MoveSubtree      [k, path, sourceSlot]
 //   7 PermutationBatch [k, parentPath, moves]
+//   8 MorphSubtree     [k, path, innerHtml]
 //
 // Names for SetAttribute/RemoveAttribute may arrive as either a string (inline) or
 // a number that indexes into the optional payload-level "names" array — the server
@@ -1315,6 +1316,24 @@ function applyDiff(ops, names) {
                     const pbRef = relevantChildSkipping(pbParent, pbDst, pbNode);
                     moveChildBefore(pbParent, pbNode, pbRef);
                 }
+                break;
+            }
+            case 8: { // MorphSubtree [k, path, innerHtml]
+                // The Raw-tainted fallback, scoped: reconcile the CHILDREN of the element at `path`
+                // against fresh inner HTML via the same morph() the full-document path uses — but
+                // localised to this one subtree the server could still address by a clean path. A Raw's
+                // markup expands into an unknown DOM-node count, so the server can't emit reliable
+                // positional child ops here; a morph reparses it correctly and preserves keyed / focus /
+                // IDL state on everything it doesn't need to touch (incl. the rest of the document).
+                const msEl = resolvePath(path);
+                if (!msEl) break;
+                // Shallow-clone the ACTUAL parent (not a generic <template>) so innerHTML parses in the
+                // element's own context — correct for <table>/<select>/<tr>/… children. The clone carries
+                // msEl's current attributes (already reconciled by any SetAttribute ops applied before
+                // this one), so morph sees them matching and only touches the children.
+                const model = msEl.cloneNode(false);
+                model.innerHTML = op[2] == null ? "" : op[2];
+                morph(msEl, model);
                 break;
             }
             default:

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2678,6 +2678,7 @@ function applyNavScroll(history) {
 //   5 RemoveSubtree    [k, path, domCount]
 //   6 MoveSubtree      [k, path, sourceSlot]
 //   7 PermutationBatch [k, parentPath, moves]
+//   8 MorphSubtree     [k, path, innerHtml]
 //
 // Names for SetAttribute/RemoveAttribute may arrive as either a string (inline) or
 // a number that indexes into the optional payload-level "names" array — the server
@@ -2901,6 +2902,24 @@ function applyDiff(ops, names) {
                     const pbRef = relevantChildSkipping(pbParent, pbDst, pbNode);
                     moveChildBefore(pbParent, pbNode, pbRef);
                 }
+                break;
+            }
+            case 8: { // MorphSubtree [k, path, innerHtml]
+                // The Raw-tainted fallback, scoped: reconcile the CHILDREN of the element at `path`
+                // against fresh inner HTML via the same morph() the full-document path uses — but
+                // localised to this one subtree the server could still address by a clean path. A Raw's
+                // markup expands into an unknown DOM-node count, so the server can't emit reliable
+                // positional child ops here; a morph reparses it correctly and preserves keyed / focus /
+                // IDL state on everything it doesn't need to touch (incl. the rest of the document).
+                const msEl = resolvePath(path);
+                if (!msEl) break;
+                // Shallow-clone the ACTUAL parent (not a generic <template>) so innerHTML parses in the
+                // element's own context — correct for <table>/<select>/<tr>/… children. The clone carries
+                // msEl's current attributes (already reconciled by any SetAttribute ops applied before
+                // this one), so morph sees them matching and only touches the children.
+                const model = msEl.cloneNode(false);
+                model.innerHTML = op[2] == null ? "" : op[2];
+                morph(msEl, model);
                 break;
             }
             default:

--- a/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameDifferTests.cs
@@ -170,11 +170,12 @@ public class FrameDifferTests
     }
 
     [Fact]
-    public void Diff_RawWithChangingSibling_ForcesFullHtmlMorph()
+    public void Diff_RawWithChangingSibling_EmitsScopedMorphSubtree_NotFullHtml()
     {
         // A Raw's markup parses into an unknown number of DOM nodes, so a sibling after it can't be
-        // patched positionally (the domSlot index assumes Raw == 1 node). Changing such a sibling
-        // must route to the full-HTML morph — NOT ship a mis-targeted, ungated UpdateText.
+        // patched positionally (the domSlot index assumes Raw == 1 node). Instead of bailing the whole
+        // document to a full-HTML morph, the differ ships ONE trusted MorphSubtree at the Raw-owning
+        // parent, carrying its new inner HTML — the client morphs just that subtree.
         var before = Frames(Div()[Raw("<a></a><b></b>"), Span()["x"]]);
         var (after, afterHtml) = FramesAndHtml(Div()[Raw("<a></a><b></b>"), Span()["y"]]);
 
@@ -182,7 +183,80 @@ public class FrameDifferTests
         var scratch = new FrameDiffer.DiffScratch();
         FrameDiffer.Diff(before, after, ops, scratch, out _, afterHtml);
 
+        Assert.False(scratch.ForceFullHtml);
+        var morph = Assert.Single(ops);
+        Assert.Equal(EditOpKind.MorphSubtree, morph.Kind);
+        Assert.True(morph.Trusted);
+        Assert.True(LiveDiffGate.DiffOpsAreClientSupported(ops));
+        // Targets the Raw-owning parent (the div at slot 0), NOT a mis-targeted child slot.
+        Assert.Equal(new[] { 0 }, morph.Path);
+        // Carries the parent's new inner HTML as a deferred char range (sliced into the wire at write
+        // time) — verified against both the range and a full BuildPayloadUtf8Diff round-trip.
+        Assert.Null(morph.Value);
+        Assert.True(morph.HtmlStart >= 0 && morph.HtmlEnd > morph.HtmlStart);
+        Assert.Equal("<a></a><b></b><span>y</span>",
+            afterHtml.Substring(morph.HtmlStart, morph.HtmlEnd - morph.HtmlStart));
+        Assert.Equal("<a></a><b></b><span>y</span>", WireMorphHtml(ops, afterHtml));
+    }
+
+    [Fact]
+    public void Diff_RawWithChangingSibling_WithoutNewHtml_ForcesFullHtml()
+    {
+        // The scoped morph needs the render HTML to slice the fragment. One-shot / test callers that
+        // inspect ops without a wire build pass no newHtml — the differ then keeps the full-HTML
+        // fallback (ForceFullHtml) exactly as before, rather than emitting a fragment-less morph.
+        var before = Frames(Div()[Raw("<a></a><b></b>"), Span()["x"]]);
+        var after = Frames(Div()[Raw("<a></a><b></b>"), Span()["y"]]);
+
+        var ops = new List<EditOp>();
+        var scratch = new FrameDiffer.DiffScratch();
+        FrameDiffer.Diff(before, after, ops, scratch, out _);
+
         Assert.True(scratch.ForceFullHtml);
+        Assert.Empty(ops);
+    }
+
+    [Fact]
+    public void Diff_RawTaintedLevel_NestedUnderElement_MorphsAtInnerParent()
+    {
+        // The taint is one level deep: the inner div mixes a Raw with a <span>. The morph must target
+        // the INNER div (the Raw-owning parent), not the outer div — the outer level is untainted, so
+        // its positional path stays reliable and only the tainted subtree is re-morphed.
+        var before = Frames(Div()[Div()[Raw("<a></a><b></b>"), Span()["x"]]]);
+        var (after, afterHtml) = FramesAndHtml(Div()[Div()[Raw("<a></a><b></b>"), Span()["y"]]]);
+
+        var ops = new List<EditOp>();
+        var scratch = new FrameDiffer.DiffScratch();
+        FrameDiffer.Diff(before, after, ops, scratch, out _, afterHtml);
+
+        Assert.False(scratch.ForceFullHtml);
+        var morph = Assert.Single(ops);
+        Assert.Equal(EditOpKind.MorphSubtree, morph.Kind);
+        Assert.True(morph.Trusted);
+        // outer div(0) -> inner div(0)
+        Assert.Equal(new[] { 0, 0 }, morph.Path);
+        Assert.Equal("<a></a><b></b><span>y</span>", WireMorphHtml(ops, afterHtml));
+    }
+
+    [Fact]
+    public void Diff_RawTaintedParent_Emptied_EmitsMorphSubtreeWithEmptyFragment()
+    {
+        // The Raw-tainted parent lost all its children (Raw + span removed). A verbatim empty-string
+        // fragment morphs its children to nothing — still a scoped diff op, no full-document fallback.
+        var before = Frames(Div()[Raw("<a></a><b></b>"), Span()["x"]]);
+        var (after, afterHtml) = FramesAndHtml(Div());
+
+        var ops = new List<EditOp>();
+        var scratch = new FrameDiffer.DiffScratch();
+        FrameDiffer.Diff(before, after, ops, scratch, out _, afterHtml);
+
+        Assert.False(scratch.ForceFullHtml);
+        var morph = Assert.Single(ops);
+        Assert.Equal(EditOpKind.MorphSubtree, morph.Kind);
+        Assert.True(morph.Trusted);
+        Assert.Equal(new[] { 0 }, morph.Path);
+        Assert.Equal(string.Empty, morph.Value);
+        Assert.Equal(string.Empty, WireMorphHtml(ops, afterHtml));
     }
 
     [Fact]
@@ -479,6 +553,24 @@ public class FrameDifferTests
         foreach (var op in doc.RootElement.GetProperty("ops").EnumerateArray())
         {
             if (op[0].GetInt32() == (int)EditOpKind.InsertSubtree)
+            {
+                return op[2].ValueKind == System.Text.Json.JsonValueKind.Null ? null : op[2].GetString();
+            }
+        }
+
+        return null;
+    }
+
+    // Build the diff payload as the live session does and pull the first MorphSubtree op's html field
+    // ([8, path, innerHtml]) back out of the wire JSON — what the client's `case 8` actually receives.
+    private static string? WireMorphHtml(IReadOnlyList<EditOp> ops, string newHtml)
+    {
+        var buffer = new System.Buffers.ArrayBufferWriter<byte>();
+        LivePayload.BuildPayloadUtf8Diff(buffer, ops, newHtml: newHtml);
+        using var doc = System.Text.Json.JsonDocument.Parse(buffer.WrittenMemory);
+        foreach (var op in doc.RootElement.GetProperty("ops").EnumerateArray())
+        {
+            if (op[0].GetInt32() == (int)EditOpKind.MorphSubtree)
             {
                 return op[2].ValueKind == System.Text.Json.JsonValueKind.Null ? null : op[2].GetString();
             }

--- a/tests/Rask.Core.Tests/Live/LiveDiffGateTests.cs
+++ b/tests/Rask.Core.Tests/Live/LiveDiffGateTests.cs
@@ -139,4 +139,19 @@ public class LiveDiffGateTests
 
         Assert.False(LiveDiffGate.DiffOpsAreClientSupported(ops));
     }
+
+    [Fact]
+    public void DiffOpsAreClientSupported_MorphSubtree_ReturnsTrue()
+    {
+        // MorphSubtree is the Raw-tainted fallback shrunk to one parent's children — a trusted, scoped
+        // morph that always ships as a diff (never routes to the full-HTML path), even mixed with the
+        // untrusted-structural gate cases around it.
+        Assert.True(LiveDiffGate.DiffOpsAreClientSupported([Op(EditOpKind.MorphSubtree, false)]));
+        Assert.True(LiveDiffGate.DiffOpsAreClientSupported(
+        [
+            Op(EditOpKind.SetAttribute),
+            Op(EditOpKind.MorphSubtree, true),
+            Op(EditOpKind.UpdateText)
+        ]));
+    }
 }

--- a/tests/Rask.Core.Tests/Live/LivePayloadDiffTests.cs
+++ b/tests/Rask.Core.Tests/Live/LivePayloadDiffTests.cs
@@ -55,6 +55,46 @@ public class LivePayloadDiffTests
     }
 
     [Fact]
+    public void BuildPayloadUtf8Diff_MorphSubtree_SerializesInnerHtmlFromRange()
+    {
+        // MorphSubtree: [8, path, innerHtml]. The fragment is sliced from the render HTML by the op's
+        // deferred char range (like InsertSubtree, minus the trailing domCount).
+        const string html = "<section><a></a><b></b><span>y</span></section>";
+        var start = html.IndexOf("<a>", StringComparison.Ordinal);
+        var end = html.IndexOf("</section>", StringComparison.Ordinal);
+        var ops = new List<EditOp>
+        {
+            new(EditOpKind.MorphSubtree, new[] { 0 }, null, null, trusted: true, htmlStart: start, htmlEnd: end)
+        };
+
+        var output = new ArrayBufferWriter<byte>(256);
+        LivePayload.BuildPayloadUtf8Diff(output, ops, newHtml: html);
+
+        using var doc = JsonDocument.Parse(Encoding.UTF8.GetString(output.WrittenSpan));
+        var op = doc.RootElement.GetProperty("ops").EnumerateArray().Single();
+        Assert.Equal((int)EditOpKind.MorphSubtree, op[0].GetInt32());
+        Assert.Equal(new[] { 0 }, op[1].EnumerateArray().Select(e => e.GetInt32()).ToArray());
+        Assert.Equal("<a></a><b></b><span>y</span>", op[2].GetString());
+        Assert.Equal(3, op.GetArrayLength()); // [k, path, innerHtml] — no trailing slot
+    }
+
+    [Fact]
+    public void BuildPayloadUtf8Diff_MorphSubtree_VerbatimEmptyValue_ClearsChildren()
+    {
+        // An emptied Raw-tainted parent ships a verbatim "" fragment (Value set, no char range) so the
+        // client morphs its children to nothing.
+        var ops = new List<EditOp> { new(EditOpKind.MorphSubtree, new[] { 0 }, null, string.Empty, trusted: true) };
+
+        var output = new ArrayBufferWriter<byte>(256);
+        LivePayload.BuildPayloadUtf8Diff(output, ops);
+
+        using var doc = JsonDocument.Parse(Encoding.UTF8.GetString(output.WrittenSpan));
+        var op = doc.RootElement.GetProperty("ops").EnumerateArray().Single();
+        Assert.Equal((int)EditOpKind.MorphSubtree, op[0].GetInt32());
+        Assert.Equal(string.Empty, op[2].GetString());
+    }
+
+    [Fact]
     public void BuildPayloadUtf8Diff_WithJsInvokes_EmitsJsInvokesArray()
     {
         // Fire-and-forget IJSRuntime invokes ride the diff payload the same way they

--- a/tests/Rask.Core.Tests/Live/MorphSubtreeFixture.mjs
+++ b/tests/Rask.Core.Tests/Live/MorphSubtreeFixture.mjs
@@ -1,0 +1,172 @@
+// Node-driven fixture for the shared diff interpreter's MorphSubtree op
+// (Rask.Core/Resources/rask-dom.js applyDiff `case 8`, which delegates to
+// Rask.Core/Resources/rask-morph.js `morph`).
+//
+// MorphSubtree is the Raw-tainted fallback shrunk from a full-document morph to ONE
+// parent's children: instead of re-morphing document.documentElement (the flaky,
+// expensive path on every guide/CodeSample page), the server ships a trusted op that
+// carries the Raw-owning parent's new inner HTML, and the client morphs just that
+// subtree. This fixture drives the production applyDiff+morph in a Node subprocess with
+// a stub DOM (a minimal HTML parser backs innerHTML) and asserts three things:
+//   1. the op is recognised (no location.reload fallback),
+//   2. the tainted subtree converges — a Raw-expanded multi-node run reconciles and the
+//      changed sibling's text updates, including a node-count change,
+//   3. a focused node OUTSIDE the morphed parent keeps focus (morph is scoped, not global).
+//
+// The C# test (MorphSubtreeTests) runs this and asserts the single JSON line on stdout.
+// Real-browser coverage of the same op lives in the Playwright E2E guide journeys.
+import {readFileSync} from "node:fs";
+
+const morphPath = process.argv[2];
+const domPath = process.argv[3];
+if (!morphPath || !domPath) {
+    console.error("usage: node MorphSubtreeFixture.mjs <rask-morph.js> <rask-dom.js>");
+    process.exit(2);
+}
+
+let reloaded = false;
+globalThis.window = globalThis;
+globalThis.location = {reload: () => { reloaded = true; }};
+// Deliberately NO MutationObserver and NO document.addEventListener: rask-dom.js's
+// install* IIFEs (focus trap / popover / reload) then early-return on load, so the
+// fixture exercises only applyDiff + morph.
+
+// ----- Minimal DOM stub with a tiny HTML parser behind innerHTML -----------------
+function makeText(value) {
+    return {
+        nodeType: 3, nodeName: "#text", nodeValue: value,
+        parentNode: null, nextSibling: null, previousSibling: null
+    };
+}
+
+function makeEl(nodeName, attrs) {
+    const a = new Map(Object.entries(attrs || {}));
+    const kids = [];
+
+    function relink() {
+        for (let i = 0; i < kids.length; i++) {
+            kids[i].nextSibling = kids[i + 1] || null;
+            kids[i].previousSibling = kids[i - 1] || null;
+        }
+    }
+
+    const el = {
+        nodeType: 1, nodeName, tagName: nodeName, parentNode: null,
+        nextSibling: null, previousSibling: null,
+        get firstChild() { return kids[0] || null; },
+        get childNodes() { return kids; },
+        get attributes() { return [...a.entries()].map(([name, value]) => ({name, value})); },
+        hasAttribute: (n) => a.has(n),
+        getAttribute: (n) => (a.has(n) ? a.get(n) : null),
+        setAttribute: (n, v) => a.set(n, String(v)),
+        removeAttribute: (n) => a.delete(n),
+        cloneNode() { return makeEl(nodeName, Object.fromEntries(a)); }, // shallow: attrs, no kids
+        set innerHTML(html) {
+            while (kids.length) el.removeChild(kids[0]);
+            for (const n of parseHtml(html)) el.appendChild(n);
+        },
+        insertBefore(node, ref) {
+            if (node.parentNode) node.parentNode.removeChild(node);
+            const idx = ref === null ? kids.length : kids.indexOf(ref);
+            kids.splice(idx < 0 ? kids.length : idx, 0, node);
+            node.parentNode = el;
+            relink();
+            return node;
+        },
+        appendChild(node) { return el.insertBefore(node, null); },
+        removeChild(node) {
+            kids.splice(kids.indexOf(node), 1);
+            node.parentNode = null;
+            relink();
+            return node;
+        },
+        replaceChild(newNode, oldNode) {
+            el.insertBefore(newNode, oldNode);
+            el.removeChild(oldNode);
+            return oldNode;
+        },
+        _kids: kids
+    };
+    return el;
+}
+
+// Tiny well-formed-HTML parser — enough for the flat tag/text fragments this fixture
+// feeds (no attributes needed). Returns an array of top-level nodes.
+function parseHtml(str) {
+    const roots = [];
+    const stack = [];
+    const push = (node) => { if (stack.length) stack[stack.length - 1].appendChild(node); else roots.push(node); };
+    let i = 0;
+    while (i < str.length) {
+        if (str[i] === "<") {
+            const gt = str.indexOf(">", i);
+            let tag = str.slice(i + 1, gt).trim();
+            i = gt + 1;
+            if (tag.startsWith("/")) { stack.pop(); continue; }
+            const selfClose = tag.endsWith("/");
+            if (selfClose) tag = tag.slice(0, -1).trim();
+            const el = makeEl(tag.split(/\s+/)[0].toUpperCase());
+            push(el);
+            if (!selfClose) stack.push(el);
+        } else {
+            const lt = str.indexOf("<", i);
+            const end = lt < 0 ? str.length : lt;
+            const text = str.slice(i, end);
+            i = end;
+            if (text.length) push(makeText(text));
+        }
+    }
+    return roots;
+}
+
+globalThis.document = {
+    activeElement: null,
+    createElement: (name) => makeEl(String(name).toUpperCase())
+};
+// resolvePath starts at `document` and walks childNodes — give the document a child list.
+const docKids = [];
+Object.defineProperty(document, "childNodes", {get: () => docKids});
+
+// ----- Load the production interpreter (morph + applyDiff, spliced order) --------
+const src = readFileSync(morphPath, "utf8") + "\n" + readFileSync(domPath, "utf8");
+const {applyDiff} = new Function(src + "\n;return { applyDiff };")();
+
+// ----- Build the "before" tree ---------------------------------------------------
+// document
+//   [0] <div id=container>  ← the Raw-owning parent (Raw expanded to <a><b>, plus <span>x)
+//         <a></a><b></b><span>x</span>
+//   [1] <input id=focused>  ← a focused sibling OUTSIDE the morphed parent
+const container = makeEl("DIV", {id: "container"});
+container.innerHTML = "<a></a><b></b><span>x</span>";
+const focused = makeEl("INPUT", {id: "focused"});
+docKids.push(container, focused);
+container.parentNode = document;
+focused.parentNode = document;
+document.activeElement = focused;
+
+// ----- Apply the MorphSubtree op -------------------------------------------------
+// [8, [0], innerHtml] — the container's NEW inner HTML: the Raw run changed shape (the
+// <b> is gone) and the sibling <span> text flipped x → y. A full-document morph is what
+// this used to be; now it's scoped to the container.
+let threw = false;
+let error = "";
+try {
+    applyDiff([[8, [0], "<a></a><span>y</span>"]], null);
+} catch (e) {
+    threw = true;
+    error = String((e && e.stack) || (e && e.message) || e);
+}
+
+process.stdout.write(JSON.stringify({
+    threw,
+    error,
+    reloaded,
+    // container children after the scoped morph: the <b> removed, <span> kept.
+    children: container._kids.map((c) => c.nodeName),
+    spanText: (() => {
+        const span = container._kids.find((c) => c.nodeName === "SPAN");
+        return span && span._kids[0] ? span._kids[0].nodeValue : null;
+    })(),
+    // the focused input outside the morphed parent must keep focus (identity + activeElement).
+    focusKept: document.activeElement === focused && focused.parentNode === document
+}) + "\n");

--- a/tests/Rask.Core.Tests/Live/MorphSubtreeTests.cs
+++ b/tests/Rask.Core.Tests/Live/MorphSubtreeTests.cs
@@ -1,0 +1,113 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Rask.Core.Tests.Live;
+
+// Client-behaviour guard for the MorphSubtree diff op (rask-dom.js applyDiff `case 8` →
+// rask-morph.js `morph`). MorphSubtree is the Raw-tainted fallback shrunk from a
+// full-document morph to one parent's children: the server emits it (FrameDifferTests
+// pins the op) and the client morphs just that subtree. This exercises the production
+// applyDiff + morph in a Node subprocess and asserts the scoped morph converges without
+// touching a focused node outside the morphed parent. Real-browser coverage of the same
+// op rides the Playwright E2E guide journeys.
+public sealed class MorphSubtreeTests
+{
+    [Fact]
+    public void MorphSubtree_ReconcilesTaintedSubtree_WithoutDisturbingOutsideFocus()
+    {
+        var node = ResolveNode();
+        if (node is null)
+        {
+            // No node on PATH — the JS-driven reproduction can't run. Don't hard-fail;
+            // the guide-page E2E covers the user-observable side.
+            return;
+        }
+
+        var repoRoot = LocateRepoRoot();
+        var dir = Path.Combine(repoRoot, "tests", "Rask.Core.Tests", "Live");
+        var fixtureScript = Path.Combine(dir, "MorphSubtreeFixture.mjs");
+        var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
+        var domPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-dom.js");
+        Assert.True(File.Exists(fixtureScript), $"Fixture script missing: {fixtureScript}");
+        Assert.True(File.Exists(morphPath), $"Morph source missing: {morphPath}");
+        Assert.True(File.Exists(domPath), $"Dom source missing: {domPath}");
+
+        var psi = new ProcessStartInfo(node, $"\"{fixtureScript}\" \"{morphPath}\" \"{domPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        Assert.True(proc.ExitCode == 0,
+            $"Fixture exited with code {proc.ExitCode}. stderr:\n{stderr}\nstdout:\n{stdout}");
+
+        var jsonLine = stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(s => s.StartsWith('{') && s.EndsWith('}'));
+        Assert.False(jsonLine is null,
+            $"Fixture didn't emit a JSON line. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(jsonLine!);
+        var root = doc.RootElement;
+
+        Assert.False(root.GetProperty("threw").GetBoolean(),
+            $"applyDiff threw: {root.GetProperty("error").GetString()}");
+        // The op kind must be recognised — a fall-through to the default branch reloads the page.
+        Assert.False(root.GetProperty("reloaded").GetBoolean(), "MorphSubtree must not trigger a full reload");
+
+        // The Raw-expanded run reconciled: the <b> was dropped (node-count change) and the sibling
+        // <span> text flipped x → y — exactly what a full-document morph would have done, scoped.
+        var children = root.GetProperty("children").EnumerateArray().Select(e => e.GetString()).ToArray();
+        Assert.Equal(new[] { "A", "SPAN" }, children);
+        Assert.Equal("y", root.GetProperty("spanText").GetString());
+
+        // The focused <input> OUTSIDE the morphed parent kept focus and its place — the morph is
+        // scoped to the tainted subtree, never the whole document.
+        Assert.True(root.GetProperty("focusKept").GetBoolean(),
+            "a focused node outside the morphed parent must keep focus");
+    }
+
+    private static string? ResolveNode()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "node.exe", "node.cmd" } : new[] { "node" };
+        foreach (var dir in path.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in exeNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}


### PR DESCRIPTION
## Summary

On **Raw/CodeSample-heavy pages** — every guide, markdown, or syntax-highlighted-code page — a `Raw` frame that shares a sibling level with other nodes used to force the diff to discard the whole render and morph `document.documentElement`. A `Raw`'s verbatim markup parses into an *unknown* DOM-node count, so the following siblings' positional `childNodes[slot]` paths can't be trusted. That full-document morph is the expensive, historically flaky **native** update path (the frequent re-render behind the #304/#305 guide-journey whack-a-mole).

`FrameDiffer` now rolls back the mis-targeted positional ops for the tainted level and emits **one trusted `MorphSubtree` op (kind 8)** at the Raw-owning parent, carrying just that element's new inner HTML. The client (`rask-dom.js` `applyDiff` `case 8`) shallow-clones the parent, sets its `innerHTML`, and reconciles with the **same `morph()`** the full-document path uses — correctness identical, localised to the tainted subtree. The parent's path is reliable by construction (every ancestor level is untainted, else the morph would have been emitted higher up). Benefits all three hosts; biggest win on native. No public API change; backward-compatible op addition (an older client hits the existing `default:` reload branch only if a newer server talks to it).

Degenerate cases keep the full-HTML fallback: taint at the document root (no addressable parent) or a diff built without render HTML (one-shot/test callers).

## Changes
- `FrameDiffer.cs` — `EditOpKind.MorphSubtree = 8`; scoped-morph emission (rollback + `ChildrenHtmlRange`) replacing the blanket `ForceFullHtml`.
- `LivePayload.cs` — `MorphSubtree` wire case `[8, path, innerHtml]` (deferred char-range slice, like `InsertSubtree`).
- `LiveDiffGate.cs` — comment: `MorphSubtree` is a trusted, always-ships-as-diff op (not in the untrusted-structural list).
- `rask-dom.js` — `applyDiff` `case 8`, spliced into all three clients (Server/WASM/Native bundles regenerated).

## Testing
- **Unit** — `FrameDifferTests` (op emission, path, `Trusted`, rollback, nested taint → outermost parent, emptied parent, no-`newHtml` fallback), `LivePayloadDiffTests` (wire shape + empty fragment), `LiveDiffGateTests` (trusted → shippable).
- **Client JS** — new Node fixture `MorphSubtreeFixture.mjs` drives the real `applyDiff`+`morph` over a Raw-expanded multi-node subtree (node-count change), asserting the subtree converges, a focused sibling *outside* the parent keeps focus, and no `location.reload`.
- **Splice guards** green (re-spliced bundles == committed).
- **Integration** — full **Native guide E2E journey** green (the exact path the full-document morph flake lived on); Core 319 / Server 248 / Wasm 197 / Native 14 all green.

## Benchmarks
- `PayloadBytesReport` **RawGuidePage**: **1770 B full-document frame → 661 B single-op diff** (the gap widens with the surrounding shell — the diff stays proportional to the changed container). The report now passes `newHtml` to `BuildPayloadUtf8Diff` so `DiffPayloadBytes` is the true wire size, matching `LiveSessionBase.WritePayload`; `AppendRowToList100` 46→112 B reflects the now-counted row fragment (baseline refreshed).
- `FrameDifferBenchmarks` **RawGuidePage_ReusedScratch**: ~112 ns, 72 B; existing keyed scenarios unchanged (no regression).

## Changelog
Added under `[Unreleased] → Changed`.