### PR TITLE
feat(native): --host server template + Server-mode heads — a Server app reaches device natives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Native + Server head — a remote Server app reaches device natives (the "superpower").** The
+  `rask-native` template gains a **`--host server|local`** parameter. `--host server` scaffolds a thin native
+  shell (`Platforms/{Android/ServerActivity,iOS/ServerAppDelegate}.cs`) that points its WebView at a remote
+  Rask Server (`NativeAppHost.ConnectToServer`) and injects the **capability bridge** — origin-gated
+  `NativeCapabilities.BridgeScript` at each navigation + the WebView's script-message handler routed to
+  `NativeCapabilities.TryHandleAsync` with a native `NativeShare`. So the *same* server-rendered `Shareable`
+  pops the device's native `UIActivityViewController` / `Intent.ACTION_SEND`. The bridge stays scoped to the
+  trusted origin (off-origin links open in the system browser). **Verified on the Android emulator:** a
+  server-rendered `Shareable`, loaded live from a remote host, fired the native chooser from `ServerActivity`;
+  both platform heads compile. `--host local` (default) is the existing in-process app.
 - **OS share sheet — declarative (all hosts) + imperative + native backend.** Two ways to share, one
   payload (`ShareData`, now in `Rask.Core.Browser`):
   - **`Shareable`** (`Rask.Core`, **all hosts including Server**) is a headless component — you render the

--- a/docs/native.md
+++ b/docs/native.md
@@ -59,7 +59,7 @@ Scaffold a native app from the template, then run it on an emulator/simulator:
 
 ```bash
 dotnet new install Rask.Templates
-dotnet new rask-native -n MyApp
+dotnet new rask-native -n MyApp              # --host local (default) | --host server
 cd MyApp
 
 dotnet workload install ios android          # the iOS/Android SDK workloads (one-time)
@@ -67,7 +67,13 @@ dotnet build -t:Run -f net10.0-android       # Android emulator
 dotnet build -t:Run -f net10.0-ios           # iOS simulator (macOS + Xcode)
 ```
 
-`dotnet new rask-native` scaffolds a project that multi-targets `net10.0-ios;net10.0-android`:
+The **`--host`** parameter picks the mode (see [Two modes](#two-modes-local-and-server)):
+`--host local` (default) scaffolds the in-process app below; `--host server` scaffolds a thin shell over a
+remote Rask Server with the [native capability bridge](#native-device-apis-from-a-server-app-the-capability-bridge)
+(its heads are `Platforms/{Android/ServerActivity,iOS/ServerAppDelegate}.cs`, and there are no `App.cs`
+components — the server renders them).
+
+`dotnet new rask-native --host local` scaffolds a project that multi-targets `net10.0-ios;net10.0-android`:
 
 ```
 MyApp.csproj                  # multi-targets net10.0-ios;net10.0-android; refs Rask.Native
@@ -146,24 +152,27 @@ NativeServerShell shell = NativeAppHost.ConnectToServer(new Uri("https://app.exa
 
 In Server mode the C# runs on the server and the device is a WebView, so a mid-handler `IShare` call can't
 work — but a plain **`Shareable`** button still pops the **native** sheet, because the head injects the
-[capability bridge](#native-device-backends) into the page. The head does two things (`NativeCapabilities`
-gives you both):
+[capability bridge](#native-device-backends) into the page. Scaffold the Server-mode head with the
+`--host` parameter:
 
-```csharp
-// 1. Inject at document-start so the page sees window.__raskNative.capabilities + invoke() —
-//    ONLY for your trusted origin (never for external navigations; that would expose native to any page).
-webView.InjectAtDocumentStart(NativeCapabilities.BridgeScript, forOrigin: shell.ServerBaseUrl);
-
-// 2. Route the WebView's script messages to the shared dispatcher, handing it a native backend.
-var share = new NativeShare(/* presenter / activity */);
-webView.OnScriptMessage = bytes => NativeCapabilities.TryHandleAsync(bytes, share);
+```bash
+dotnet new rask-native -n MyApp --host server   # (--host local is the default)
 ```
 
+The generated head (`Platforms/Android/ServerActivity.cs`, `Platforms/iOS/ServerAppDelegate.cs`) points its
+WebView at your `ConnectToServer(...)` URL and wires the bridge with the two `NativeCapabilities` helpers:
+
+- **`NativeCapabilities.BridgeScript`** — injected at each navigation **only for your trusted origin**, so
+  the page sees `window.__raskNative.capabilities` + `invoke(name, data)`.
+- **`NativeCapabilities.TryHandleAsync(messageJson, share)`** — the WebView's script-message handler routes
+  every posted message here with a native `IShare` (the scaffold's `NativeShare`).
+
 Now the *same* `Shareable` component that renders on the server fires the device's native
-`UIActivityViewController` / `Intent.ACTION_SEND` when run in the shell — the "superpower". **Security:**
-inject `BridgeScript` only for your origin, and open off-origin links in the system browser
-(`WKNavigationDelegate` / `shouldOverrideUrlLoading`); the bridge is a fixed component envelope, not open
-native RPC.
+`UIActivityViewController` / `Intent.ACTION_SEND` when run in the shell — the "superpower". **Security:** the
+generated head injects `BridgeScript` only for your origin and opens off-origin links in the system browser
+(`WKNavigationDelegate.decidePolicyForNavigationAction` / `shouldOverrideUrlLoading`), so the WebView never
+leaves your origin and no other page can reach native; the bridge is a fixed component envelope, not open
+native RPC. (For a local `http://10.0.2.2:<port>` dev server, allow cleartext in `AndroidManifest.xml`.)
 
 ## The `INativeWebView` bridge
 

--- a/src/Rask.Templates/content/rask-native/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-native/.template.config/template.json
@@ -4,7 +4,7 @@
   "classifications": [ "Mobile", "Rask", "iOS", "Android", "Native" ],
   "identity": "Rask.Templates.Native",
   "name": "Rask Native Mobile App (iOS + Android)",
-  "description": "A native iOS/Android app that runs a Rask app in-process inside a platform WebView (WebView hybrid). The same component code as the other Rask hosts, packaged for the App Store / Play Store.",
+  "description": "A native iOS/Android app that hosts a Rask app inside a platform WebView (WebView hybrid). Native + Local runs the component code in-process on the device; Native + Server is a thin native shell over a remote Rask Server with native device capabilities bridged to the page.",
   "shortName": [ "rask-native" ],
   "tags": {
     "language": "C#",
@@ -14,5 +14,54 @@
   "preferNameDirectory": true,
   "defaultName": "RaskApp",
   "symbols": {
-  }
+    "host": {
+      "type": "parameter",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "local",
+          "description": "Native + Local — the Rask component code runs in-process on the device (offline, store-distributable)."
+        },
+        {
+          "choice": "server",
+          "description": "Native + Server — a thin native shell over a remote Rask Server; the head bridges native device capabilities (e.g. the OS share sheet) to the loaded page."
+        }
+      ],
+      "defaultValue": "local",
+      "description": "Which Rask.Native host mode to scaffold."
+    },
+    "IsServer": {
+      "type": "computed",
+      "value": "(host == \"server\")"
+    },
+    "IsLocal": {
+      "type": "computed",
+      "value": "(host == \"local\")"
+    }
+  },
+  "sources": [
+    {
+      "modifiers": [
+        {
+          "condition": "(IsServer)",
+          "exclude": [
+            "App.cs",
+            "Counter.cs",
+            "HomePage.cs",
+            "Platforms/iOS/AppDelegate.cs",
+            "Platforms/iOS/RaskWkWebView.cs",
+            "Platforms/Android/MainActivity.cs",
+            "Platforms/Android/RaskAndroidWebView.cs"
+          ]
+        },
+        {
+          "condition": "(IsLocal)",
+          "exclude": [
+            "Platforms/iOS/ServerAppDelegate.cs",
+            "Platforms/Android/ServerActivity.cs"
+          ]
+        }
+      ]
+    }
+  ]
 }

--- a/src/Rask.Templates/content/rask-native/Platforms/Android/ServerActivity.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/Android/ServerActivity.cs
@@ -1,0 +1,88 @@
+using System.Text;
+using Android.App;
+using Android.Content;
+using Android.Graphics;
+using Android.OS;
+using Android.Webkit;
+using Java.Interop;
+using Rask.Client.Browser;
+using Rask.Native;
+
+namespace Company.RaskNative;
+
+// Native + Server mode: a thin native shell over a REMOTE Rask Server. The C# app runs on the server; this
+// WebView just loads it. There is no in-process session — instead the head injects the native
+// device-capability bridge (NativeCapabilities) so the remote page's Shareable / IShare reach the device's
+// native backends (the OS share sheet) — the "server superpower".
+//
+// SECURITY: the bridge is exposed only to your trusted origin. The WebViewClient keeps the WebView ON that
+// origin — every off-origin navigation opens in the system browser — so no other page can reach native.
+[Activity(Label = "Rask App", MainLauncher = true, Exported = true,
+    Theme = "@android:style/Theme.Material.Light.NoActionBar")]
+public class ServerActivity : Activity
+{
+    protected override void OnCreate(Bundle? savedInstanceState)
+    {
+        base.OnCreate(savedInstanceState);
+
+        // Your remote Rask Server. (Android emulator → host machine is http://10.0.2.2:<port>; a real
+        // deployment is https. For http during development, allow cleartext in AndroidManifest.xml.)
+        NativeServerShell shell = NativeAppHost.ConnectToServer(new Uri("https://app.example.com/"));
+
+        var webView = new WebView(this);
+        var settings = webView.Settings!;
+        settings.JavaScriptEnabled = true;
+        settings.DomStorageEnabled = true;
+
+        // The native backend the bridge routes "share" to (reused verbatim from Native + Local).
+        IShare share = new NativeShare(this);
+
+        // JS → native: window.__raskBridge.dispatch (used by NativeCapabilities.BridgeScript's send()).
+        webView.AddJavascriptInterface(new RaskServerBridge(share), "__raskBridge");
+        webView.SetWebViewClient(new RaskServerWebViewClient(shell.ServerBaseUrl));
+
+        SetContentView(webView);
+        webView.LoadUrl(shell.ServerBaseUrl.ToString());
+    }
+}
+
+// Routes a WebView → native message to the shared capability dispatcher with the head's native IShare.
+// Only { type:"capability" } envelopes are honoured; the WebViewClient guarantees only the trusted origin
+// can reach this interface.
+internal sealed class RaskServerBridge(IShare share) : Java.Lang.Object
+{
+    [JavascriptInterface]
+    [Export("dispatch")]
+    public void Dispatch(string message) =>
+        _ = NativeCapabilities.TryHandleAsync(Encoding.UTF8.GetBytes(message), share);
+}
+
+internal sealed class RaskServerWebViewClient(Uri origin) : WebViewClient
+{
+    // Inject the capability bridge (window.__raskNative) only for the trusted origin, as each page commits.
+    public override void OnPageStarted(WebView? view, string? url, Bitmap? favicon)
+    {
+        if (view is not null && IsTrusted(url))
+        {
+            view.EvaluateJavascript(NativeCapabilities.BridgeScript, null);
+        }
+    }
+
+    // Keep the WebView on the trusted origin; open everything else in the system browser so the bridge is
+    // never exposed to an untrusted page.
+    public override bool ShouldOverrideUrlLoading(WebView? view, IWebResourceRequest? request)
+    {
+        var url = request?.Url?.ToString();
+        if (url is not null && !IsTrusted(url) && view?.Context is { } ctx)
+        {
+            ctx.StartActivity(new Intent(Intent.ActionView, Android.Net.Uri.Parse(url)));
+            return true;
+        }
+
+        return false;
+    }
+
+    private bool IsTrusted(string? url) =>
+        url is not null && Uri.TryCreate(url, UriKind.Absolute, out var u) &&
+        string.Equals(u.Host, origin.Host, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/ServerAppDelegate.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/ServerAppDelegate.cs
@@ -1,0 +1,105 @@
+using System.Text;
+using Foundation;
+using Rask.Client.Browser;
+using Rask.Native;
+using UIKit;
+using WebKit;
+
+namespace Company.RaskNative;
+
+// Native + Server mode (iOS): a thin native shell over a REMOTE Rask Server. The C# app runs on the server;
+// this WKWebView just loads it. There is no in-process session — the head injects the native
+// device-capability bridge (NativeCapabilities) so the remote page's Shareable / IShare reach the device's
+// native backends (the OS share sheet) — the "server superpower".
+[Register("AppDelegate")]
+public class AppDelegate : UIApplicationDelegate
+{
+    public override UIWindow? Window { get; set; }
+
+    public override bool FinishedLaunching(UIApplication application, NSDictionary? launchOptions)
+    {
+        // Your remote Rask Server (a real deployment is https).
+        NativeServerShell shell = NativeAppHost.ConnectToServer(new Uri("https://app.example.com/"));
+
+        Window = new UIWindow(UIScreen.MainScreen.Bounds)
+        {
+            RootViewController = new RaskServerViewController(shell.ServerBaseUrl)
+        };
+        Window.MakeKeyAndVisible();
+        return true;
+    }
+}
+
+// A WKWebView that loads the remote Rask Server and exposes the native capability bridge to its trusted
+// origin only. SECURITY: BridgeScript (window.__raskNative) is injected per-navigation only for the trusted
+// origin, and off-origin links open in Safari — so no other page can reach native.
+public sealed class RaskServerViewController : UIViewController, IWKScriptMessageHandler, IWKNavigationDelegate
+{
+    private readonly Uri _origin;
+    private readonly IShare _share;
+
+    public RaskServerViewController(Uri origin)
+    {
+        _origin = origin;
+        _share = new NativeShare(() => this);   // presents UIActivityViewController from this VC
+    }
+
+    public override void ViewDidLoad()
+    {
+        base.ViewDidLoad();
+
+        var controller = new WKUserContentController();
+        // window.__raskSend forwards to the "rask" script-message handler (BridgeScript's send() uses it).
+        controller.AddUserScript(new WKUserScript(
+            new NSString("window.__raskSend = function (s) { window.webkit.messageHandlers.rask.postMessage(s); };"),
+            WKUserScriptInjectionTime.AtDocumentStart, isForMainFrameOnly: true));
+        controller.AddScriptMessageHandler(this, "rask");
+
+        var config = new WKWebViewConfiguration { UserContentController = controller };
+        var webView = new WKWebView(UIScreen.MainScreen.Bounds, config)
+        {
+            AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight,
+            NavigationDelegate = this
+        };
+        View = webView;
+        webView.LoadRequest(new NSUrlRequest(new NSUrl(_origin.ToString())));
+    }
+
+    // JS → native: capability messages (window.__raskNative.invoke).
+    public void DidReceiveScriptMessage(WKUserContentController userContentController, WKScriptMessage message)
+    {
+        if (message.Body is NSString s)
+        {
+            _ = NativeCapabilities.TryHandleAsync(Encoding.UTF8.GetBytes(s.ToString()), _share);
+        }
+    }
+
+    // Inject the capability bridge only for the trusted origin, once the page commits.
+    [Export("webView:didCommitNavigation:")]
+    public void DidCommitNavigation(WKWebView webView, WKNavigation navigation)
+    {
+        if (IsTrusted(webView.Url))
+        {
+            webView.EvaluateJavaScript(new NSString(NativeCapabilities.BridgeScript), null);
+        }
+    }
+
+    // Keep the WebView on the trusted origin; open everything else in Safari.
+    [Export("webView:decidePolicyForNavigationAction:decisionHandler:")]
+    public void DecidePolicyForNavigationAction(
+        WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
+    {
+        var url = navigationAction.Request.Url;
+        if (navigationAction.NavigationType == WKNavigationType.LinkActivated && !IsTrusted(url))
+        {
+            UIApplication.SharedApplication.OpenUrl(url!, new UIApplicationOpenUrlOptions(), null);
+            decisionHandler(WKNavigationActionPolicy.Cancel);
+            return;
+        }
+
+        decisionHandler(WKNavigationActionPolicy.Allow);
+    }
+
+    private bool IsTrusted(NSUrl? url) =>
+        url?.Host is { } host && string.Equals(host, _origin.Host, StringComparison.OrdinalIgnoreCase);
+}


### PR DESCRIPTION
## Summary

Completes the native device-backend story from #312: a plain Rask **Server** app, wrapped in the native
shell, reaches the device's **native** share sheet — the "server superpower". Builds on the
`NativeCapabilities` bridge shipped in #312.

The `rask-native` template gains a **`--host server|local`** parameter:

- **`--host server`** scaffolds a thin native shell over a remote Rask Server
  (`NativeAppHost.ConnectToServer`). Its heads — `Platforms/Android/ServerActivity.cs`,
  `Platforms/iOS/ServerAppDelegate.cs` — inject the capability bridge:
  - `NativeCapabilities.BridgeScript` at each navigation, **only for the trusted origin**, so the page sees
    `window.__raskNative.capabilities` + `invoke(name, data)`;
  - the WebView's script-message handler routed to `NativeCapabilities.TryHandleAsync(json, share)` with a
    native `NativeShare`.
  So the *same* server-rendered `Shareable` fires the device's native `UIActivityViewController` /
  `Intent.ACTION_SEND`.
- **`--host local`** (default) is the existing in-process app.

The template uses **conditional file inclusion** (`sources.modifiers`): `--host server` emits only the
Server heads (no `App.cs` / `MainActivity` / `INativeWebView` implementations — the server renders the
components); `--host local` emits the in-process heads.

**Security:** the head injects `BridgeScript` only for the configured origin and opens off-origin links in
the system browser (`WKNavigationDelegate.decidePolicyForNavigationAction` / `shouldOverrideUrlLoading`), so
the WebView never leaves the trusted origin and no other page can reach native. The bridge is a fixed
component envelope (`share`, …), not open native RPC.

## Verification

- **Template** — installed the template and scaffolded both modes: `--host server` generates only the Server
  heads + `NativeShare`; `--host local` generates the in-process heads + `App.cs`. Correct in both.
- **Compile** — both platform Server heads compile against the packaged `Rask.Native`: Android (`0 errors`),
  iOS (`0 errors`, `-p:ValidateXcodeVersion=false`).
- **On-device (Android emulator)** — scaffolded a `--host server` app pointed at a locally-published
  `Rask.Example.Server`; it loaded the remote showcase **live and styled** over the emulator↔host network,
  and tapping the server-rendered `Shareable` ("Share this page") fired the **native chooser** — logcat:
  `START … act=android.intent.action.CHOOSER … baseActivity=…/ServerActivity`. (The same `NativeShare`
  backend was screenshot-verified popping the native sheet with the exact payload in the #312 Native + Local
  run.)

## Notes

- Template head code is not CI-compiled (it needs the iOS/Android workloads), same as the existing heads —
  verified by scaffold + build above.
- **Benchmarks: N/A** — no framework render/runtime code changed (template content + docs only;
  `NativeCapabilities` shipped in #312).

## Changelog

`[Unreleased]` updated.
