### PR TITLE
fix(core): re-render generic components after their nested-closure callbacks (BsMultiSelect chip ×)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,14 @@ them until tagged releases begin.
   shards to browser-journey time.
 
 ### Fixed
+- **Event callbacks on generic components now re-render the component (`BsMultiSelect` chip × works again).**
+  A callback that captures `this` plus a local through a nested closure — e.g. `BsMultiSelect<T>`'s per-chip
+  `() => ToggleAsync(item)` behind a `BsCloseButton` — is lowered by Roslyn to *generic* display classes when
+  the owning component is generic. `DelegateOwner`'s closure-walk excluded generic types, so it never reached
+  the captured `<>4__this`, resolved no owner, and `AutoCallback` left the callback unwrapped: clicking a
+  chip's × removed the item from the model but the badge lingered on screen until an unrelated re-render
+  (e.g. reopening the dropdown). The walk now recurses into generic display classes, so any generic
+  component re-renders after its own nested-closure event fires. No API change.
 - **`BsMultiSelect` floating label no longer overlaps the placeholder.** In floating mode the empty control
   still rendered its `Select…` placeholder span *inside* the box, and the floating CSS centres the label
   in that same box — so the two texts collided. It now blanks the box when floating + empty (the centred

--- a/src/Rask.Core/DelegateOwner.cs
+++ b/src/Rask.Core/DelegateOwner.cs
@@ -120,8 +120,13 @@ internal static class DelegateOwner
 
     // Roslyn names capturing closures `<>c__DisplayClassN_M`; the shared non-capturing lambda cache is
     // `<>c`. Both begin with "<>c", which is enough to gate recursion to compiler-generated closures.
+    // Generic display classes are INCLUDED: a closure inside a generic component (e.g. BsMultiSelect<T>'s
+    // per-chip `() => ToggleAsync(item)`) is lowered to a generic display class (`<>c__DisplayClassN_M`1`),
+    // and its outer display class — the one holding the captured `<>4__this` — is generic too. Excluding
+    // generic types here stopped the walk before reaching that `<>4__this`, so Resolve returned null, the
+    // callback went unwrapped, and the generic component never re-rendered after its own event fired.
     private static bool IsDisplayClass(Type type) =>
-        type is { IsClass: true, IsGenericType: false } && type.Name.StartsWith("<>c", StringComparison.Ordinal);
+        type.IsClass && type.Name.StartsWith("<>c", StringComparison.Ordinal);
 
     private const int MaxClosureDepth = 4;
 

--- a/tests/Rask.Core.Tests/DelegateOwnerTests.cs
+++ b/tests/Rask.Core.Tests/DelegateOwnerTests.cs
@@ -45,6 +45,43 @@ public class DelegateOwnerTests
         }
     }
 
+    // A GENERIC component with the exact BsMultiSelect<T> chip shape: a foreach over a collection building
+    // an async handler that calls an instance method, capturing several method-locals AND the loop item AND
+    // `this`. Because the component is generic, Roslyn lowers the nested display classes to GENERIC types
+    // (`<>c__DisplayClassN_M`1`) — including the outer one holding the captured `<>4__this`. Resolve must
+    // still walk into that generic display class to recover the defining component; excluding generic types
+    // from the closure-walk (the original bug) returned null here, so the wrapped callback never re-rendered
+    // the generic component after its own event fired (e.g. removing a BsMultiSelect chip did nothing until
+    // an unrelated re-render). A NON-generic version of this shape resolves fine — the generic-ness is the bug.
+    private sealed class GenericChipShape<T> : Component
+    {
+        public Task ToggleAsync(object a, object b, int c, T item, object d, bool add) => Task.CompletedTask;
+
+        public CallbackAsync ChipRemoveHandler(IEnumerable<T> items)
+        {
+            var acc = new object();
+            var ctx = new object();
+            var fid = 7;
+            var comparer = new object();
+            CallbackAsync? result = null;
+            foreach (var item in items)
+            {
+                var captured = item;
+                CallbackAsync h = () => ToggleAsync(acc, ctx, fid, captured, comparer, add: false);
+                result ??= h;
+            }
+
+            return result!;
+        }
+    }
+
+    [Fact]
+    public void Resolve_GenericComponentLoopClosure_ReturnsDefiningComponent()
+    {
+        var component = new GenericChipShape<string>();
+        Assert.Same(component, DelegateOwner.Resolve(component.ChipRemoveHandler(["a", "b"])));
+    }
+
     [Fact]
     public void Resolve_MethodGroup_ReturnsComponent()
     {

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -112,6 +112,28 @@ public sealed class MultiSelectTests
     }
 
     [Fact]
+    public async Task RemoveChip_RerendersControl_DropsBadge()
+    {
+        // Regression: clicking a chip's × is a BsCloseButton (a wrapper) callback, so re-rendering the
+        // BsMultiSelect<T> relies on AutoCallback marking it dirty. Because the control is GENERIC, that
+        // path used to resolve no owner (DelegateOwner skipped the generic display class holding `this`),
+        // so the control never re-rendered and the badge lingered until an unrelated render (reopening the
+        // dropdown). A cache-aware second render must now drop the removed chip on its own.
+        var (host, model) = MountBound();
+        model.Tags.Add("a");
+        model.Tags.Add("b");
+        var ids = ClickIds(host.RenderAsLiveRoot()); // [toggle, chip-remove-a, chip-remove-b, opt-a, opt-b, opt-c]
+
+        await host.TryInvokeHandlerAsync(ids[1], Empty()); // remove the "a" chip
+        Assert.Equal(["b"], model.Tags);
+
+        // The cache-aware re-render must reflect the removal without any extra interaction.
+        var html = host.RenderAsLiveRoot();
+        Assert.Equal(1, CountOccurrences(html, "badge"));     // only the surviving "b" chip
+        Assert.Equal(1, CountOccurrences(html, " checked")); // exactly one option still ticked
+    }
+
+    [Fact]
     public async Task SelectingTwice_TogglesOff()
     {
         var (host, model) = MountBound();

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -1017,8 +1017,23 @@ public abstract partial class SharedSmokeTests
         var multi = Page.Locator("#ms-interests");
         await multi.Locator(".form-select").ClickAsync(); // open the dropdown
         await multi.Locator(".dropdown-item").Filter(new LocatorFilterOptions { HasText = "AI" }).ClickAsync();
-        await Expect(multi.Locator(".badge").Filter(new LocatorFilterOptions { HasText = "AI" }))
-            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        var aiChip = multi.Locator(".badge").Filter(new LocatorFilterOptions { HasText = "AI" });
+        await Expect(aiChip).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+
+        // Removing a chip via its × must drop the badge on its own — no reopening the dropdown. The × is a
+        // BsCloseButton (a wrapper) callback, so the GENERIC BsMultiSelect<T> re-renders only if AutoCallback
+        // resolves it as the owner; a regression there left the badge onscreen until an unrelated render.
+        // Close the dropdown first (its full-viewport backdrop otherwise intercepts the ×, and a closed
+        // dropdown is the exact scenario the bug was reported in — the badge lingered until reopening).
+        await multi.Locator(".position-fixed").DispatchEventAsync("click");
+        await Expect(Page.Locator("#ms-interests .dropdown-menu.show")).ToBeHiddenAsync(
+            new LocatorAssertionsToBeHiddenOptions { Timeout = 10_000 });
+        await aiChip.Locator(".btn-close").ClickAsync();
+        await Expect(aiChip).ToHaveCountAsync(0, new LocatorAssertionsToHaveCountOptions { Timeout = 10_000 });
+        // Re-open and re-select so the open-menu / Escape / backdrop steps below still exercise a filled control.
+        await multi.Locator(".form-select").ClickAsync();
+        await multi.Locator(".dropdown-item").Filter(new LocatorFilterOptions { HasText = "AI" }).ClickAsync();
+        await Expect(aiChip).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
         // The menu stays open across selections; Escape from the focusable box closes it (no bootstrap.js).
         // (Type-to-filter is opt-in via a Filter predicate and shares BsSelect's dropdown search field, which


### PR DESCRIPTION
## Summary

Clicking the **×** on a chip inside a `BsMultiSelect` removed the item from the model but the badge stayed on screen — it only disappeared on the next unrelated re-render (e.g. reopening the dropdown). This fixes the framework root cause: **event callbacks on generic components never re-rendered the component.**

## Root cause

A callback that captures `this` **plus a local** through a nested closure — e.g. `BsMultiSelect<T>`'s per-chip `() => ToggleAsync(item)`, rendered behind a `BsCloseButton` wrapper — is lowered by Roslyn to **generic** display classes when the owning component is generic (`<>c__DisplayClassN_M\`1`). `DelegateOwner.IsDisplayClass` gated its closure-walk on `IsGenericType: false`, so `FindThisInNestedClosures` refused to recurse into the (generic) outer display class holding the captured `<>4__this`. `Resolve` returned `null`, `AutoCallback.Wrap` left the callback **unwrapped**, and the control's `StateHasChanged()` was never called. The render cache then served the control's stale (pre-removal) subtree.

Options in the same control work because they use a native `Button` (an `Element`) whose owner is the `BsMultiSelect` directly; only the `BsCloseButton`-wrapped chip × relied on the (broken) `AutoCallback` owner resolution.

## Fix

`IsDisplayClass` now includes generic display classes (the `<>c` name prefix already scopes the walk to compiler-generated closures). One line; no API change. Fixes chip removal and **any** generic component that builds a loop/nested-closure callback calling an instance method.

## Testing

- `DelegateOwnerTests.Resolve_GenericComponentLoopClosure_ReturnsDefiningComponent` — the exact generic chip shape; **fails without the fix, passes with it**.
- `MultiSelectTests.RemoveChip_RerendersControl_DropsBadge` — a cache-aware re-render after the × click now drops the badge (reproduced the bug: 2 badges → asserts 1).
- New E2E step in the shared showcase journey clicks a chip's `.btn-close` and asserts the badge disappears without reopening the dropdown.
- Full `Rask.Core.Tests` (1837) and `Rask.Example.Shared.Tests` (287) suites green; `-warnaserror` clean.

## Benchmarks

`HandlerRegistrationBenchmarks` unchanged (the fix is off the handler-registration / render-serialize hot path — it only adds one recursion level on the generic nested-closure owner-resolution cold path): Register200 28.52 KB, Register1000 128.81 KB.

## Changelog

Added under `[Unreleased] → Fixed`.