### PR TITLE
feat(native): native geolocation backend (CoreLocation / LocationManager)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Native geolocation backend.** The `rask-native` template's `--host local` heads add a
+  `NativeGeolocation : IGeolocation` (iOS **CoreLocation** `CLLocationManager`, Android **`LocationManager`**),
+  registered on `host.Services` before `RunLocalAsync` to override Rask's JS-backed `navigator.geolocation`
+  default — the same *framework-default → native-head-override* pattern as the share sheet, now proven for a
+  request/**response** (+ subscription: `WatchAsync`) capability. So `await geolocation.GetCurrentPositionAsync()`
+  returns a native fix with the real OS permission prompt and `CLLocationManager` / `LocationManager` accuracy.
+  The template adds `ACCESS_FINE_LOCATION` / `NSLocationWhenInUseUsageDescription` (Local-mode only) and
+  `MainActivity` requests the runtime grant. **Verified on the Android emulator:** a mock GPS fix
+  (`adb emu geo fix`) round-tripped through `IGeolocation` → `NativeGeolocation` → `LocationManager` and
+  displayed the exact lat/long; both platform backends compile.
 - **Native + Server head — a remote Server app reaches device natives (the "superpower").** The
   `rask-native` template gains a **`--host server|local`** parameter. `--host server` scaffolds a thin native
   shell (`Platforms/{Android/ServerActivity,iOS/ServerAppDelegate}.cs`) that points its WebView at a remote

--- a/docs/native.md
+++ b/docs/native.md
@@ -12,9 +12,10 @@ unchanged.
 > end-to-end on both platforms** — a scaffolded app boots, renders the component tree over the native
 > bridge, routes, and updates live (see [Roadmap](#roadmap) for the verification detail). It's still
 > pre-1.0: APIs may shift. **Native device *backends*** have started landing — the OS **share sheet**
-> (`IShare`) now has a native `UIActivityViewController` / `Intent.ACTION_SEND` head backend (see
-> [Native device backends](#native-device-backends)) — with native geolocation/push/biometrics still to
-> come. The native client now shares the
+> (`IShare` → `UIActivityViewController` / `Intent.ACTION_SEND`) and **native geolocation** (`IGeolocation` →
+> `CLLocationManager` / `LocationManager`) both have native head backends (see
+> [Native device backends](#native-device-backends)) — with biometrics/push still to come. The native client
+> now shares the
 > transport-neutral DOM behaviour — rAF input/scroll coalescing, keyboard + drag events, and
 > scoped-CSS FOUC gating — with the Server and WASM clients (see [Roadmap](#roadmap)); only the
 > scoped-JS invoke gate and file uploads remain host-specific.
@@ -227,9 +228,10 @@ Sharing has two entrypoints, both reaching the **native** sheet on device. The a
 **`Shareable`** (`Rask.Core`) attaches `data-rask-share` to your element; on the Native host its click is
 routed through the **capability bridge** (`window.__raskNative.invoke`) to the registered `IShare` — so it
 hits the head's native backend, not the WebView's `navigator.share`. The imperative **`IShare`**
-(`Rask.Client.Browser`) shares from code — with the same **native** backend a head registers (below). Further
-**native C# backends** (P/Invoke to CoreLocation / Android APIs, biometrics, native push via APNs/FCM)
-behind the *same* interfaces — plus new native-only capabilities — are a follow-up (see [Roadmap](#roadmap)).
+(`Rask.Client.Browser`) shares from code — with the same **native** backend a head registers (below).
+**Geolocation** likewise has a native backend: `IGeolocation` → `CLLocationManager` / `LocationManager` in
+the head. Further **native C# backends** (biometrics, native push via APNs/FCM) behind the *same* interfaces
+— plus new native-only capabilities — are a follow-up (see [Roadmap](#roadmap)).
 
 ## Native device backends
 
@@ -265,8 +267,22 @@ So a plain `Shareable` button pops the native sheet on device with no host-speci
 bridge into a remote page, so a plain Server app reaches device natives too — see
 [Native device APIs from a Server app](#native-device-apis-from-a-server-app-the-capability-bridge).
 
-The **same recipe** is how the remaining backends (native geolocation, biometrics, push) will land — a
-framework-registered default, overridden by a native head implementation.
+The **second shipped backend is native geolocation** — and it shows the recipe holds for a
+request/**response** (plus subscription) capability, not just fire-and-forget. `NativeGeolocation` (in the
+`--host local` template heads) implements `Rask.Core.Browser.IGeolocation` with **CoreLocation**
+(`CLLocationManager`) on iOS and the platform **`LocationManager`** on Android, registered the same way:
+
+```csharp
+host.Services.AddSingleton<IGeolocation>(_ => new NativeGeolocation(/* activity, iOS: none */));
+```
+
+So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real permission prompt +
+`CLLocationManager` / `LocationManager` accuracy) instead of the WebView's `navigator.geolocation`, and
+`WatchAsync` streams updates. It needs the platform location permission — the template adds
+`ACCESS_FINE_LOCATION` / `NSLocationWhenInUseUsageDescription` and `MainActivity` requests the runtime grant.
+
+The **same recipe** carries the remaining backends (biometrics, native push) — a framework-registered
+default, overridden by a native head implementation.
 
 ## Honest framing
 
@@ -315,12 +331,13 @@ sandbox, and real background execution — without giving up "the same component
    speaks the ordinary Server (`rask.js`/WS) protocol — the native client isn't involved — so it's
    already covered by `ServerExampleTests`; its only native-specific surface, the real platform
    WebView, is a device-only concern.)*
-5. **Native device backends** — *first one shipped.* The OS **share sheet** (`IShare`, in
-   `Rask.Client.Browser`) now has a native head backend (iOS `UIActivityViewController`, Android
-   `Intent.ACTION_SEND`), overriding the JS-backed default via a head registration before `RunLocalAsync`
-   (see [Native device backends](#native-device-backends)). This establishes the reusable
-   framework-default-→-native-head-override pattern; CoreLocation/Android geolocation, biometrics, and
-   native push (APNs/FCM) follow behind the same seam.
+5. **Native device backends** — *two shipped.* The OS **share sheet** (`IShare`, iOS
+   `UIActivityViewController` / Android `Intent.ACTION_SEND`) and **native geolocation** (`IGeolocation`, iOS
+   `CLLocationManager` / Android `LocationManager`) both have native head backends that override the
+   JS-backed default via a head registration before `RunLocalAsync` (see
+   [Native device backends](#native-device-backends)) — the second proving the pattern holds for a
+   request/response + subscription capability, not just fire-and-forget. This establishes the reusable
+   framework-default-→-native-head-override seam; biometrics and native push (APNs/FCM) follow behind it.
 6. **In-process interop + history** — ✅ *fixed (surfaced by item 4's E2E).* (a) An out-of-render
    `IJSRuntime` invoke that carries arguments was embedding `argsJson` as a raw JS literal instead of a
    string, so the client's `JSON.parse(argsJson)` choked — every handler-issued invoke *with args*

--- a/src/Rask.Templates/content/rask-native/.template.config/template.json
+++ b/src/Rask.Templates/content/rask-native/.template.config/template.json
@@ -50,8 +50,10 @@
             "HomePage.cs",
             "Platforms/iOS/AppDelegate.cs",
             "Platforms/iOS/RaskWkWebView.cs",
+            "Platforms/iOS/NativeGeolocation.cs",
             "Platforms/Android/MainActivity.cs",
-            "Platforms/Android/RaskAndroidWebView.cs"
+            "Platforms/Android/RaskAndroidWebView.cs",
+            "Platforms/Android/NativeGeolocation.cs"
           ]
         },
         {

--- a/src/Rask.Templates/content/rask-native/AGENTS.md
+++ b/src/Rask.Templates/content/rask-native/AGENTS.md
@@ -34,8 +34,10 @@ https://github.com/pal-tamas/rask/tree/main/docs — native specifics: docs/nati
   inject `IShare` (`Rask.Client.Browser`) to share from code. Both hit the OS share sheet.
 - **Native backends** override a JS default with real platform code. The head registers one on
   `host.Services` **before `RunLocalAsync`** (last-wins). The template ships `NativeShare` for `IShare`
-  (iOS `UIActivityViewController`, Android `Intent.ACTION_SEND`) under `Platforms/`; register your own the
-  same way. Further native backends (geolocation, biometrics, push) are a framework work-in-progress.
+  (iOS `UIActivityViewController`, Android `Intent.ACTION_SEND`) and `NativeGeolocation` for `IGeolocation`
+  (iOS `CLLocationManager`, Android `LocationManager`) under `Platforms/`; register your own the same way.
+  Geolocation needs the location permission (already in `AndroidManifest.xml` / `Info.plist`; `MainActivity`
+  requests the runtime grant). Further native backends (biometrics, push) are a framework work-in-progress.
 
 ## Build & run (needs the iOS/Android SDK workloads)
 ```bash

--- a/src/Rask.Templates/content/rask-native/Platforms/Android/AndroidManifest.xml
+++ b/src/Rask.Templates/content/rask-native/Platforms/Android/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<uses-permission android:name="android.permission.INTERNET"/>
+	<!--#if (IsLocal) -->
+	<!-- Required by NativeGeolocation (the IGeolocation backend). Remove if you don't use native location. -->
+	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+	<!--#endif -->
 	<application android:label="Rask App" android:allowBackup="true" android:supportsRtl="true"/>
 </manifest>

--- a/src/Rask.Templates/content/rask-native/Platforms/Android/MainActivity.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/Android/MainActivity.cs
@@ -1,7 +1,9 @@
 using Android.App;
+using Android.Content.PM;
 using Android.OS;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Client.Browser;
+using Rask.Core.Browser;
 using Rask.Native;
 
 namespace Company.RaskNative;
@@ -17,6 +19,13 @@ public class MainActivity : Activity
     {
         base.OnCreate(savedInstanceState);
 
+        // NativeGeolocation (registered below) needs the runtime location grant — request it up front so a
+        // later GetCurrentPositionAsync finds it granted (declare ACCESS_FINE_LOCATION in AndroidManifest.xml).
+        if (CheckSelfPermission(Android.Manifest.Permission.AccessFineLocation) != Permission.Granted)
+        {
+            RequestPermissions([Android.Manifest.Permission.AccessFineLocation], 100);
+        }
+
         _webView = new RaskAndroidWebView(this);
         SetContentView(_webView.View);
 
@@ -28,10 +37,11 @@ public class MainActivity : Activity
     private async Task StartAsync(RaskAndroidWebView webView)
     {
         var host = NativeAppHost.CreateDefault();
-        // Native device backend: hand IShare to the Android OS share sheet (ACTION_SEND chooser), overriding
-        // Rask.Native's JS-backed default. Register any native backend on host.Services before RunLocalAsync
-        // — the last registration wins. See docs/native.md "Native device backends".
-        host.Services.AddSingleton<IShare>(_ => new NativeShare(this));
+        // Native device backends: override Rask.Native's JS-backed defaults with the platform APIs. Register
+        // any native backend on host.Services before RunLocalAsync — the last registration wins. See
+        // docs/native.md "Native device backends".
+        host.Services.AddSingleton<IShare>(_ => new NativeShare(this));                  // OS share sheet
+        host.Services.AddSingleton<IGeolocation>(_ => new NativeGeolocation(this));       // LocationManager
         // host.Services.AddSingleton<IMyService, MyService>();   // register app services here
         _app = await host.RunLocalAsync<App>(webView);
         webView.LoadShell();

--- a/src/Rask.Templates/content/rask-native/Platforms/Android/NativeGeolocation.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/Android/NativeGeolocation.cs
@@ -1,0 +1,140 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Locations;
+using Android.OS;
+using Android.Runtime;
+using Rask.Core.Browser;
+
+namespace Company.RaskNative;
+
+// Native Android backend for IGeolocation — the platform LocationManager instead of the WebView's
+// navigator.geolocation. Registered in MainActivity before RunLocalAsync (overrides Rask's JS-backed
+// default). Needs ACCESS_FINE_LOCATION in AndroidManifest.xml + a runtime grant (MainActivity requests it
+// on launch). Same framework-default → native-head-override pattern as NativeShare, for a request/response
+// (+ subscription) capability.
+public sealed class NativeGeolocation(Activity activity) : IGeolocation
+{
+    public ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null)
+    {
+        var tcs = new TaskCompletionSource<GeolocationPosition>();
+        activity.RunOnUiThread(() =>
+        {
+            if (!HasPermission())
+            {
+                tcs.TrySetException(new InvalidOperationException("Location permission not granted."));
+                return;
+            }
+
+            var manager = LocationManagerFor();
+            var provider = BestProvider(manager, options?.EnableHighAccuracy ?? false);
+            if (provider is null)
+            {
+                tcs.TrySetException(new InvalidOperationException("No enabled location provider."));
+                return;
+            }
+
+            // One-shot: subscribe, take the first fix, then unsubscribe.
+            OneShotListener? listener = null;
+            listener = new OneShotListener(fix =>
+            {
+                manager.RemoveUpdates(listener!);
+                tcs.TrySetResult(fix);
+            });
+            manager.RequestLocationUpdates(provider, 0L, 0f, listener, Looper.MainLooper);
+        });
+        return new ValueTask<GeolocationPosition>(tcs.Task);
+    }
+
+    public ValueTask<IAsyncDisposable> WatchAsync(
+        Func<GeolocationPosition, Task> onPosition, GeolocationOptions? options = null)
+    {
+        var watch = new Watch(activity, HasPermission, onPosition, options?.EnableHighAccuracy ?? false);
+        return new ValueTask<IAsyncDisposable>(watch);
+    }
+
+    private bool HasPermission() =>
+        activity.CheckSelfPermission(Android.Manifest.Permission.AccessFineLocation) == Permission.Granted;
+
+    private LocationManager LocationManagerFor() =>
+        (LocationManager)activity.GetSystemService(Context.LocationService)!;
+
+    private static string? BestProvider(LocationManager manager, bool highAccuracy)
+    {
+        // Prefer GPS for high accuracy; otherwise take whatever's enabled (network is faster/cheaper).
+        var order = highAccuracy
+            ? new[] { LocationManager.GpsProvider, LocationManager.NetworkProvider }
+            : new[] { LocationManager.NetworkProvider, LocationManager.GpsProvider };
+        foreach (var p in order)
+        {
+            if (manager.IsProviderEnabled(p))
+            {
+                return p;
+            }
+        }
+
+        return null;
+    }
+
+    private static GeolocationPosition Map(Location l) => new(
+        Latitude: l.Latitude,
+        Longitude: l.Longitude,
+        Accuracy: l.HasAccuracy ? l.Accuracy : 0,
+        Altitude: l.HasAltitude ? l.Altitude : null,
+        AltitudeAccuracy: l is { HasVerticalAccuracy: true } ? l.VerticalAccuracyMeters : null,
+        Heading: l.HasBearing ? l.Bearing : null,
+        Speed: l.HasSpeed ? l.Speed : null,
+        TimestampMs: l.Time);
+
+    private sealed class OneShotListener(Action<GeolocationPosition> onFix) : Java.Lang.Object, ILocationListener
+    {
+        public void OnLocationChanged(Location location) => onFix(Map(location));
+
+        public void OnProviderDisabled(string provider) { }
+
+        public void OnProviderEnabled(string provider) { }
+
+        public void OnStatusChanged(string? provider, [GeneratedEnum] Availability status, Bundle? extras) { }
+    }
+
+    private sealed class Watch : Java.Lang.Object, ILocationListener, IAsyncDisposable
+    {
+        private readonly Activity _activity;
+        private readonly Func<GeolocationPosition, Task> _onPosition;
+        private LocationManager? _manager;
+
+        public Watch(Activity activity, Func<bool> hasPermission, Func<GeolocationPosition, Task> onPosition, bool highAccuracy)
+        {
+            _activity = activity;
+            _onPosition = onPosition;
+            activity.RunOnUiThread(() =>
+            {
+                if (!hasPermission())
+                {
+                    return;
+                }
+
+                _manager = (LocationManager)activity.GetSystemService(Context.LocationService)!;
+                var provider = BestProvider(_manager, highAccuracy);
+                if (provider is not null)
+                {
+                    _manager.RequestLocationUpdates(provider, 1000L, 0f, this, Looper.MainLooper);
+                }
+            });
+        }
+
+        public void OnLocationChanged(Location location) => _ = _onPosition(Map(location));
+
+        public void OnProviderDisabled(string provider) { }
+
+        public void OnProviderEnabled(string provider) { }
+
+        public void OnStatusChanged(string? provider, [GeneratedEnum] Availability status, Bundle? extras) { }
+
+        public ValueTask DisposeAsync()
+        {
+            _activity.RunOnUiThread(() => _manager?.RemoveUpdates(this));
+            return default;
+        }
+    }
+}

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/AppDelegate.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/AppDelegate.cs
@@ -1,6 +1,7 @@
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Client.Browser;
+using Rask.Core.Browser;
 using Rask.Native;
 using UIKit;
 
@@ -29,10 +30,11 @@ public class AppDelegate : UIApplicationDelegate
     private async Task StartAsync(RaskWkWebView webView)
     {
         var host = NativeAppHost.CreateDefault();
-        // Native device backend: hand IShare to the iOS OS share sheet (UIActivityViewController), overriding
-        // Rask.Native's JS-backed default. Register any native backend on host.Services before RunLocalAsync
-        // — the last registration wins. See docs/native.md "Native device backends".
-        host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));
+        // Native device backends: override Rask.Native's JS-backed defaults with the platform APIs. Register
+        // any native backend on host.Services before RunLocalAsync — the last registration wins. See
+        // docs/native.md "Native device backends".
+        host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));  // share sheet
+        host.Services.AddSingleton<IGeolocation>(_ => new NativeGeolocation());                     // CoreLocation
         // host.Services.AddSingleton<IMyService, MyService>();   // register app services here
         _app = await host.RunLocalAsync<App>(webView);
         webView.LoadShell();

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/Info.plist
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/Info.plist
@@ -21,6 +21,12 @@
 	</array>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<!--#if (IsLocal) -->
+	<!-- Shown in the iOS location prompt for NativeGeolocation (the IGeolocation backend). -->
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Shows your current location in the app.</string>
+	<!--#endif -->
+
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/NativeGeolocation.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/NativeGeolocation.cs
@@ -1,0 +1,151 @@
+using CoreLocation;
+using Foundation;
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Company.RaskNative;
+
+// Native iOS backend for IGeolocation — CoreLocation instead of the WebView's navigator.geolocation.
+// Registered in AppDelegate before RunLocalAsync (overrides Rask's JS-backed default). Native location
+// gives the real iOS permission prompt (Info.plist NSLocationWhenInUseUsageDescription) and CLLocationManager
+// accuracy, and works even where the WebView's geolocation is restricted.
+//
+// This is the same framework-default → native-head-override pattern as NativeShare, for a request/response
+// (+ subscription) capability: GetCurrentPositionAsync resolves one fix; WatchAsync streams them.
+public sealed class NativeGeolocation : IGeolocation
+{
+    public ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null)
+    {
+        var tcs = new TaskCompletionSource<GeolocationPosition>();
+        UIApplication.SharedApplication.InvokeOnMainThread(() =>
+        {
+            // The delegate keeps the manager alive until it fires (or faults), then tears it down.
+            var manager = new CLLocationManager
+            {
+                DesiredAccuracy = (options?.EnableHighAccuracy ?? false)
+                    ? CLLocation.AccuracyBest
+                    : CLLocation.AccuracyHundredMeters
+            };
+            manager.Delegate = new OneShotDelegate(manager, tcs);
+            manager.RequestWhenInUseAuthorization();
+            RequestWhenAuthorized(manager);
+        });
+        return new ValueTask<GeolocationPosition>(tcs.Task);
+    }
+
+    public ValueTask<IAsyncDisposable> WatchAsync(
+        Func<GeolocationPosition, Task> onPosition, GeolocationOptions? options = null)
+    {
+        var watch = new Watch(onPosition, options?.EnableHighAccuracy ?? false);
+        return new ValueTask<IAsyncDisposable>(watch);
+    }
+
+    // RequestLocation only works once authorization is at least WhenInUse; if it's still NotDetermined the
+    // delegate re-requests from DidChangeAuthorization once the user answers the prompt.
+    private static void RequestWhenAuthorized(CLLocationManager manager)
+    {
+        if (manager.AuthorizationStatus is CLAuthorizationStatus.AuthorizedWhenInUse
+            or CLAuthorizationStatus.AuthorizedAlways)
+        {
+            manager.RequestLocation();
+        }
+    }
+
+    private sealed class OneShotDelegate(CLLocationManager manager, TaskCompletionSource<GeolocationPosition> tcs)
+        : CLLocationManagerDelegate
+    {
+        public override void AuthorizationChanged(CLLocationManager mgr, CLAuthorizationStatus status)
+        {
+            if (status is CLAuthorizationStatus.AuthorizedWhenInUse or CLAuthorizationStatus.AuthorizedAlways)
+            {
+                mgr.RequestLocation();
+            }
+            else if (status is CLAuthorizationStatus.Denied or CLAuthorizationStatus.Restricted)
+            {
+                Finish(() => tcs.TrySetException(new InvalidOperationException("Location permission denied.")));
+            }
+        }
+
+        public override void LocationsUpdated(CLLocationManager mgr, CLLocation[] locations)
+        {
+            if (locations.Length > 0)
+            {
+                Finish(() => tcs.TrySetResult(Map(locations[^1])));
+            }
+        }
+
+        public override void Failed(CLLocationManager mgr, NSError error) =>
+            Finish(() => tcs.TrySetException(new InvalidOperationException(error.LocalizedDescription)));
+
+        private void Finish(Action complete)
+        {
+            manager.Delegate = null;   // release the retain cycle so the manager can be collected
+            complete();
+        }
+    }
+
+    // A watchPosition subscription: streams every CLLocation update until disposed.
+    private sealed class Watch : CLLocationManagerDelegate, IAsyncDisposable
+    {
+        private readonly Func<GeolocationPosition, Task> _onPosition;
+        private CLLocationManager? _manager;
+
+        public Watch(Func<GeolocationPosition, Task> onPosition, bool highAccuracy)
+        {
+            _onPosition = onPosition;
+            UIApplication.SharedApplication.InvokeOnMainThread(() =>
+            {
+                _manager = new CLLocationManager
+                {
+                    DesiredAccuracy = highAccuracy ? CLLocation.AccuracyBest : CLLocation.AccuracyHundredMeters,
+                    Delegate = this
+                };
+                _manager.RequestWhenInUseAuthorization();
+                if (_manager.AuthorizationStatus is CLAuthorizationStatus.AuthorizedWhenInUse
+                    or CLAuthorizationStatus.AuthorizedAlways)
+                {
+                    _manager.StartUpdatingLocation();
+                }
+            });
+        }
+
+        public override void AuthorizationChanged(CLLocationManager mgr, CLAuthorizationStatus status)
+        {
+            if (status is CLAuthorizationStatus.AuthorizedWhenInUse or CLAuthorizationStatus.AuthorizedAlways)
+            {
+                mgr.StartUpdatingLocation();
+            }
+        }
+
+        public override void LocationsUpdated(CLLocationManager mgr, CLLocation[] locations)
+        {
+            if (locations.Length > 0)
+            {
+                _ = _onPosition(Map(locations[^1]));
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            UIApplication.SharedApplication.InvokeOnMainThread(() =>
+            {
+                _manager?.StopUpdatingLocation();
+                if (_manager is not null)
+                {
+                    _manager.Delegate = null;
+                }
+            });
+            return default;
+        }
+    }
+
+    private static GeolocationPosition Map(CLLocation l) => new(
+        Latitude: l.Coordinate.Latitude,
+        Longitude: l.Coordinate.Longitude,
+        Accuracy: l.HorizontalAccuracy,
+        Altitude: l.VerticalAccuracy > 0 ? l.EllipsoidalAltitude : null,
+        AltitudeAccuracy: l.VerticalAccuracy > 0 ? l.VerticalAccuracy : null,
+        Heading: l.Course >= 0 ? l.Course : null,
+        Speed: l.Speed >= 0 ? l.Speed : null,
+        TimestampMs: (l.Timestamp.SecondsSince1970) * 1000.0);
+}


### PR DESCRIPTION
## Summary

The **second native device backend**, extending the *framework-default → native-head-override* pattern (from the share sheet) to a **request/response + subscription** capability.

The `rask-native` `--host local` heads add **`NativeGeolocation : IGeolocation`** — iOS **`CLLocationManager`**, Android **`LocationManager`** — registered on `host.Services` before `RunLocalAsync`, overriding Rask's JS-backed `navigator.geolocation`. So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real OS permission prompt + platform accuracy), and `WatchAsync` streams updates. No framework change — `IGeolocation` already lives in `Rask.Core.Browser`.

Permissions are **Local-mode only** (template `#if (IsLocal)`): `ACCESS_FINE_LOCATION` / `NSLocationWhenInUseUsageDescription`, and `MainActivity` requests the runtime grant. `NativeGeolocation.cs` is excluded from `--host server` scaffolds.

## Verification

- **Template** — scaffolded both modes: `--host local` includes `NativeGeolocation` + both permissions (no leaked `#if` markers); `--host server` excludes them (0 location permissions). Correct.
- **Compile** — both platform backends build against the packaged `Rask.Native`: Android `0 errors`, iOS `0 errors`.
- **On-device (Android emulator)** — set a mock GPS fix (`adb emu geo fix 19.0402 47.4979`), tapped a demo button → `IGeolocation.GetCurrentPositionAsync()` → `NativeGeolocation` → `LocationManager` → the UI rendered **`lat=47.49790, lng=19.04020, acc=5m`** (the exact fix; `acc=5m` is real provider data).

## Notes

- Template head code is not CI-compiled (needs the iOS/Android workloads), same as the other heads — verified by scaffold + build above.
- **Benchmarks: N/A** — no framework render/runtime code changed (template content + docs only).

## Changelog

`[Unreleased]` updated.