### PR TITLE
ci(native): run native-appium on Ubuntu+KVM (macOS emulator boot timed out)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,22 +337,28 @@ jobs:
   # On-device native E2E: Appium drives the REAL Native + Local app (samples/Rask.Example.Native) on an
   # Android emulator, switches into its WebView, and asserts the showcase rendered with its scoped CSS +
   # Bootstrap (served through NativeOriginAssets) — the device-level replacement for the removed headless
-  # shim. The iOS variant (XCUITest + simulator) runs locally; see docs/native.md.
+  # shim. Runs on Ubuntu + KVM (GitHub's reliable path for the Android emulator; the macOS runners time out
+  # booting it). -p:RaskNativeHeads=android builds ONLY the Android head, so the APK builds on Linux with no
+  # iOS workload. The iOS variant (XCUITest + simulator) runs locally; see docs/native.md.
   native-appium:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
+      - name: Enable KVM (hardware acceleration for the emulator)
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
       - uses: actions/setup-dotnet@v5
         with:
           dotnet-version: 10.0.x
 
-      - name: Install iOS + Android workloads
-        # Both are needed even though only the Android APK is built: -p:RaskNativeHeads=true makes the
-        # build graph evaluate Rask.Native's net10.0-ios TFM, which requires the ios workload be present.
-        run: dotnet workload install ios android
+      - name: Install Android workload
+        run: dotnet workload install android
 
       - name: Cache NuGet packages
         uses: actions/cache@v6
@@ -361,29 +367,29 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
-      - name: Build the debug-signed showcase APK
-        # A Debug build is signed with the debug keystore (installable) and its WebView is inspectable, so
-        # Appium can attach to the WEBVIEW context. EmbedAssembliesIntoApk is required because a standalone
-        # `adb install` (what Appium does) launches without Fast Deployment's synced assemblies otherwise.
+      - name: Build the debug-signed x86_64 showcase APK
+        # Debug is signed with the debug keystore (installable) and its WebView is inspectable, so Appium can
+        # attach to the WEBVIEW context. android-x64 matches the Ubuntu x86_64 emulator; EmbedAssembliesIntoApk
+        # is required because a standalone `adb install` (what Appium does) otherwise launches without Fast
+        # Deployment's synced assemblies. RaskNativeHeads=android builds only Rask.Native's Android head.
         run: >-
           dotnet build samples/Rask.Example.Native/Rask.Example.Native.csproj
-          -c Debug -f net10.0-android -p:RaskNativeHeads=true -p:EmbedAssembliesIntoApk=true
-
-      - name: Install Appium + the UiAutomator2 driver
-        run: |
-          npm install -g appium
-          appium driver install uiautomator2
+          -c Debug -f net10.0-android -p:RaskNativeHeads=android
+          -p:RuntimeIdentifier=android-x64 -p:EmbedAssembliesIntoApk=true
 
       - name: Run the Appium showcase E2E on the emulator
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: 35
-          arch: arm64-v8a
-          profile: pixel_6
+          api-level: 34
+          arch: x86_64
+          target: google_apis
+          disable-animations: true
           script: |
+            npm install -g appium
+            appium driver install uiautomator2
             appium --allow-insecure=uiautomator2:chromedriver_autodownload --log appium.log &
             for i in $(seq 1 30); do curl -sf http://127.0.0.1:4723/status && break || sleep 2; done
-            APK=$(find samples/Rask.Example.Native/bin/Debug/net10.0-android -name '*-Signed.apk' | head -1)
+            APK=$(find samples/Rask.Example.Native/bin/Debug/net10.0-android/android-x64 -name '*-Signed.apk' | head -1)
             echo "Driving APK: $APK"
             RASK_APPIUM_SERVER=http://127.0.0.1:4723 \
             RASK_APPIUM_ANDROID_APP="$PWD/$APK" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,8 @@ jobs:
   # iOS workload. The iOS variant (XCUITest + simulator) runs locally; see docs/native.md.
   native-appium:
     runs-on: ubuntu-latest
+    # A hung emulator teardown can otherwise stall the job for the 6h default; fail fast instead.
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v7
         with:
@@ -385,16 +387,18 @@ jobs:
           target: google_apis
           disable-animations: true
           script: |
+            set -e
             npm install -g appium
             appium driver install uiautomator2
             appium --allow-insecure=uiautomator2:chromedriver_autodownload --log appium.log &
             for i in $(seq 1 30); do curl -sf http://127.0.0.1:4723/status && break || sleep 2; done
             APK=$(find samples/Rask.Example.Native/bin/Debug/net10.0-android/android-x64 -name '*-Signed.apk' | head -1)
             echo "Driving APK: $APK"
-            RASK_APPIUM_SERVER=http://127.0.0.1:4723 \
-            RASK_APPIUM_ANDROID_APP="$PWD/$APK" \
-              dotnet test tests/Rask.Native.Appium.Tests/Rask.Native.Appium.Tests.csproj \
-                --filter "FullyQualifiedName~Android" --logger "console;verbosity=normal"
+            # NOTE: exports on their own lines — a multi-line `VAR=x \`-continuation before dotnet test does
+            # not survive here, so the env vars never reached the test (it silently skipped).
+            export RASK_APPIUM_SERVER=http://127.0.0.1:4723
+            export RASK_APPIUM_ANDROID_APP="$PWD/$APK"
+            dotnet test tests/Rask.Native.Appium.Tests/Rask.Native.Appium.Tests.csproj --filter "FullyQualifiedName~Android" --logger "console;verbosity=normal"
 
       - name: Upload Appium log on failure
         if: failure()

--- a/samples/Rask.Example.Native/Rask.Example.Native.csproj
+++ b/samples/Rask.Example.Native/Rask.Example.Native.csproj
@@ -20,6 +20,9 @@
   -->
   <PropertyGroup>
     <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+    <!-- -p:RaskNativeHeads=android drops the iOS TFM so the app builds on Linux (no iOS workload), which
+         the Ubuntu+KVM native-appium CI job needs. Matches the same switch on Rask.Native. -->
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'android'">net10.0-android</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -17,8 +17,12 @@
     otherwise the published package is net10.0-only and the template's heads won't resolve.
   -->
   <PropertyGroup>
-    <TargetFramework Condition="'$(RaskNativeHeads)' != 'true'">net10.0</TargetFramework>
+    <!-- RaskNativeHeads: unset = plain net10.0 (CI/unit); `true` = all heads (macOS, needs ios+android
+         workloads); `android` = just the Android head (so an Ubuntu/KVM job can build the APK without the
+         iOS workload, which Linux can't install). -->
+    <TargetFramework Condition="'$(RaskNativeHeads)' != 'true' AND '$(RaskNativeHeads)' != 'android'">net10.0</TargetFramework>
     <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'true'">net10.0;net10.0-ios;net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'android'">net10.0;net10.0-android</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <RootNamespace>Rask.Native</RootNamespace>


### PR DESCRIPTION
Follow-up to #319. The `native-appium` job was merged running on `macos-latest`, where the Android
emulator **times out booting** (arm64 macOS runners are unreliable for it), so it fails on `main`.

Move it to **`ubuntu-latest` + KVM** — GitHub's supported path for `reactivecircus/android-emulator-runner`.
To build the APK on Linux (which can't install the iOS workload that `-p:RaskNativeHeads=true` would pull in
via `Rask.Native`'s `net10.0-ios` TFM), add a **`-p:RaskNativeHeads=android`** option to `Rask.Native` that
multi-targets only `net10.0;net10.0-android`, and build the APK as **`android-x64`** to match the Ubuntu
x86_64 emulator.

## Testing
- Verified locally: `-p:RaskNativeHeads=android` builds `Rask.Native` with only the `net10.0-android` head
  (no iOS TFM) and produces an `android-x64` `-Signed.apk`; the base `net10.0` build is unchanged.
- The Appium test logic itself was verified on a local Android emulator in #319; this only changes the
  runner/arch. CI on this PR exercises the ubuntu-KVM job end-to-end.