### PR TITLE
ci(native): nightly on-device iOS Appium E2E (XCUITest simulator on macOS)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -326,7 +326,8 @@ jobs:
         # RaskNativeHeads=true makes Rask.Native build its platform heads. Android does a full build.
         # For iOS we COMPILE-ONLY (Roslyn): the full app's native link needs the exact Xcode/iOS SDK the
         # Microsoft.iOS workload wants, which trails the GitHub runner's Xcode (MT0180). Compile-only still
-        # catches iOS head compile breaks; the full iOS build + on-device run is verified locally (docs/native.md).
+        # catches iOS head compile breaks; the full iOS build + on-device XCUITest run happens nightly in
+        # native-ios-e2e.yml (and locally; see docs/native.md).
         run: |
           if [[ "${{ matrix.tfm }}" == *-ios ]]; then
             dotnet build ${{ matrix.project }} -c Release -f ${{ matrix.tfm }} -p:RaskNativeHeads=true -p:ValidateXcodeVersion=false -t:Compile
@@ -339,7 +340,7 @@ jobs:
   # Bootstrap (served through NativeOriginAssets) — the device-level replacement for the removed headless
   # shim. Runs on Ubuntu + KVM (GitHub's reliable path for the Android emulator; the macOS runners time out
   # booting it). -p:RaskNativeHeads=android builds ONLY the Android head, so the APK builds on Linux with no
-  # iOS workload. The iOS variant (XCUITest + simulator) runs locally; see docs/native.md.
+  # iOS workload. The iOS variant (XCUITest + simulator on macOS) runs nightly in native-ios-e2e.yml.
   native-appium:
     runs-on: ubuntu-latest
     # A hung emulator teardown can otherwise stall the job for the 6h default; fail fast instead.

--- a/.github/workflows/native-ios-e2e.yml
+++ b/.github/workflows/native-ios-e2e.yml
@@ -1,0 +1,104 @@
+name: native-ios-e2e
+
+# On-device iOS native E2E — the macOS counterpart of ci.yml's Ubuntu `native-appium` (Android). Appium
+# drives the REAL Native + Local showcase (samples/Rask.Example.Native) on an iOS Simulator via XCUITest,
+# switches into the WKWebView, and asserts the showcase rendered with its scoped CSS + Bootstrap (served
+# through NativeOriginAssets) — the device-level proof for iOS that native-appium gives for Android.
+#
+# It lives in its OWN workflow (nightly cron + manual dispatch), NOT per-PR and NOT in nightly.yml, because:
+#   * macOS runners cost ~10x Linux minutes and the full net10.0-ios build rides the Microsoft.iOS <-> Xcode
+#     SDK coupling (MT0180), too fragile to gate every PR on — MAUI/Appium likewise schedule device UI tests
+#     nightly rather than per-commit. Per-PR iOS coverage stays the compile-only `native` job in ci.yml.
+#   * Keeping it out of nightly.yml means a manual/branch dispatch can validate it WITHOUT triggering that
+#     workflow's package publish.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 4 * * *" # nightly at 04:00 UTC
+
+permissions:
+  contents: read
+
+concurrency:
+  group: native-ios-e2e
+  cancel-in-progress: true
+
+jobs:
+  native-appium-ios:
+    # All GitHub macOS runners are Apple silicon (arm64) -> iossimulator-arm64 below.
+    runs-on: macos-15
+    timeout-minutes: 50
+    env:
+      RASK_APPIUM_SERVER: http://127.0.0.1:4723
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      # Pin the newest non-beta Xcode on the image so the Microsoft.iOS workload's native link finds a
+      # matching SDK (the MT0180 mismatch the compile-only `native` job dodges). Paired with
+      # ValidateXcodeVersion=false below, this is the closest CI gets to the local Xcode used to run iOS.
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: latest-stable
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Install iOS + Android workloads
+        # Both: Rask.Native builds all its heads under -p:RaskNativeHeads=true, so restore needs both.
+        run: dotnet workload install ios android
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v6
+        with:
+          path: ~/.nuget/packages
+          key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Build.targets') }}
+          restore-keys: nuget-${{ runner.os }}-
+
+      - name: Build the iOS-simulator showcase .app
+        # Full build (NOT -t:Compile) to produce a runnable simulator bundle. ValidateXcodeVersion=false
+        # tolerates the Microsoft.iOS <-> runner-Xcode drift; no code signing is needed for the simulator.
+        run: >-
+          dotnet build samples/Rask.Example.Native/Rask.Example.Native.csproj
+          -c Release -f net10.0-ios
+          -p:RaskNativeHeads=true
+          -p:RuntimeIdentifier=iossimulator-arm64
+          -p:ValidateXcodeVersion=false
+
+      - name: Resolve the built .app path
+        # Publish the absolute .app path to the job env so it reaches `dotnet test` (AppiumEnv.IosApp).
+        run: |
+          APP=$(find "$PWD/samples/Rask.Example.Native/bin/Release/net10.0-ios/iossimulator-arm64" -maxdepth 2 -name '*.app' | head -1)
+          test -n "$APP" || { echo "No .app produced by the iOS-simulator build"; exit 1; }
+          echo "Resolved .app: $APP"
+          echo "RASK_APPIUM_IOS_APP=$APP" >> "$GITHUB_ENV"
+
+      - name: Boot the iOS Simulator
+        id: sim
+        uses: futureware-tech/simulator-action@v5
+        with:
+          model: iPhone 15
+
+      - name: Pin the booted simulator (UDID + name)
+        # Explicit UDID targeting: name-only Appium device selection is unreliable on ARM64 macOS runners
+        # (the reason MAUI's XHarness passes --device UDID). simulator-action exposes the booted UDID.
+        run: |
+          echo "RASK_APPIUM_IOS_UDID=${{ steps.sim.outputs.udid }}" >> "$GITHUB_ENV"
+          echo "RASK_APPIUM_IOS_DEVICE=iPhone 15" >> "$GITHUB_ENV"
+
+      - name: Start Appium (XCUITest) and run the iOS E2E
+        run: |
+          npm install -g appium
+          appium driver install xcuitest
+          appium server --port 4723 --log appium.log &
+          for i in $(seq 1 30); do curl -sf http://127.0.0.1:4723/status && break || sleep 2; done
+          dotnet test tests/Rask.Native.Appium.Tests/Rask.Native.Appium.Tests.csproj --filter "FullyQualifiedName~Ios" --logger "console;verbosity=normal"
+
+      - name: Upload Appium log on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: appium-ios-log
+          path: appium.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,14 @@ them until tagged releases begin.
   **`NativeAssetHttpHandler`** (serves the in-process demo `HttpClient` from the same table, so data-driven
   pages work offline). A real native app now serves scoped CSS + Bootstrap with a one-line interceptor instead
   of the boot-only two-file handler.
+- **On-device iOS E2E (nightly).** A new `native-ios-e2e.yml` workflow (nightly cron + manual
+  `workflow_dispatch`) drives the *real* Native + Local showcase on an **iOS Simulator via Appium/XCUITest**
+  on macOS — the iOS counterpart of the Ubuntu `native-appium` (Android) job, asserting the same on-device
+  render (WebView + scoped CSS + Bootstrap through `NativeOriginAssets`). It is deliberately **off the per-PR
+  path** (macOS minutes + the Microsoft.iOS↔Xcode SDK coupling are too costly/fragile to gate every PR — the
+  nightly cadence MAUI uses for device UI tests); per-PR iOS stays the compile-only `native` job. The iOS
+  Appium test now pins the booted simulator by **UDID** (`RASK_APPIUM_IOS_UDID`) — name-only device selection
+  is unreliable on the ARM64 macOS runners, the reason MAUI's XHarness passes an explicit `--device UDID`.
 - **Native + Server head — a remote Server app reaches device natives (the "superpower").** The
   `rask-native` template gains a **`--host server|local`** parameter. `--host server` scaffolds a thin native
   shell (`Platforms/{Android/ServerActivity,iOS/ServerAppDelegate}.cs`) that points its WebView at a remote

--- a/docs/native.md
+++ b/docs/native.md
@@ -348,8 +348,11 @@ sandbox, and real background execution — without giving up "the same component
    over `Rask.Example.Server`). They serve the full showcase's assets on-device through the framework's
    [`NativeOriginAssets`](#serving-a-full-apps-assets). E2E is **Appium** (`tests/Rask.Native.Appium.Tests`):
    it installs and drives the *real* app on an Android emulator / iOS simulator, switches into the WebView,
-   and asserts the showcase rendered with its scoped CSS + Bootstrap — run in the macOS `native-appium`
-   CI job (a `native` job additionally compiles both examples for both TFMs). Appium replaced an earlier
+   and asserts the showcase rendered with its scoped CSS + Bootstrap. **Android** runs per-PR in the Ubuntu
+   `native-appium` CI job (KVM emulator); **iOS** (XCUITest on a macOS simulator) runs nightly + on-demand
+   in `native-ios-e2e.yml` — kept off the per-PR path because macOS minutes and the Microsoft.iOS↔Xcode SDK
+   coupling make it too costly/fragile to gate every PR, the same nightly cadence MAUI uses for device UI
+   tests. A per-PR `native` job additionally compiles both examples for both TFMs. Appium replaced an earlier
    headless Playwright-in-Chromium shim, and immediately surfaced a device-only bug the shim had masked
    (the boot shell loads at `/index.native.html`, a path `NativeOriginAssets` now serves).
    *(Native + Server needs no separate suite: in that mode the WebView loads a remote Rask Server and

--- a/tests/Rask.Native.Appium.Tests/AppiumEnv.cs
+++ b/tests/Rask.Native.Appium.Tests/AppiumEnv.cs
@@ -22,6 +22,14 @@ internal static class AppiumEnv
     /// <summary>The booted iOS simulator name, e.g. "iPhone 17 Pro".</summary>
     public static string IosDeviceName => Get("RASK_APPIUM_IOS_DEVICE") ?? "iPhone 15";
 
+    /// <summary>
+    ///     The booted iOS simulator's UDID. When present it is passed as <c>appium:udid</c> for EXPLICIT
+    ///     device targeting — on ARM64 macOS runners (every GitHub macOS runner) Appium/XCUITest device
+    ///     selection by name alone is unreliable, so the CI job resolves the UDID and pins it (the same
+    ///     reason .NET MAUI's XHarness passes an explicit <c>--device UDID</c>).
+    /// </summary>
+    public static string? IosUdid => Get("RASK_APPIUM_IOS_UDID");
+
     private static string? Get(string name)
     {
         var value = Environment.GetEnvironmentVariable(name);

--- a/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
+++ b/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
@@ -48,6 +48,12 @@ public sealed class NativeShowcaseAppiumTests
         };
         options.AddAdditionalAppiumOption("appium:deviceName", AppiumEnv.IosDeviceName);
         options.AddAdditionalAppiumOption("appium:newCommandTimeout", 180);
+        // Explicit UDID targeting when the CI job resolved it: name-only selection is flaky on the ARM64
+        // macOS runners (same reason MAUI's XHarness pins --device UDID). Locally, unset → attach by name.
+        if (AppiumEnv.IosUdid is not null)
+        {
+            options.AddAdditionalAppiumOption("appium:udid", AppiumEnv.IosUdid);
+        }
 
         using var driver = new IOSDriver(new Uri(AppiumEnv.ServerUrl!), options, TimeSpan.FromMinutes(3));
         AssertShowcaseRendered(driver);


### PR DESCRIPTION
Adds **`native-ios-e2e.yml`** — the iOS counterpart of the Ubuntu `native-appium` (Android) job. Appium/XCUITest drives the *real* Native + Local showcase (`samples/Rask.Example.Native`) on an **iOS Simulator** on macOS, switches into the WKWebView, and asserts the on-device render (scoped CSS + Bootstrap served via `NativeOriginAssets`) — the same evidence the Android job proves.

## Cadence — nightly + manual, not per-PR
macOS runners cost ~10× Linux minutes and the full `net10.0-ios` build rides the Microsoft.iOS↔Xcode SDK coupling (`MT0180`), too fragile to gate every PR on. So it's a **dedicated workflow** (`schedule` cron nightly + `workflow_dispatch`), separate from `nightly.yml` so a branch dispatch can validate it **without** triggering the package publish. This is the same cadence MAUI/Appium use for device UI tests. Per-PR iOS coverage stays the existing compile-only `native` job.

## Grounded in how the ecosystem does it
- **Appium's own `appium-xcuitest-driver` CI:** `macos` runner + `maxim-lobanov/setup-xcode` + `futureware-tech/simulator-action` + `appium driver install xcuitest`.
- **MAUI/XHarness:** boots the sim and passes an **explicit `--device UDID`** because name-only selection is unreliable on ARM64 Macs. → the iOS Appium test now pins `appium:udid` (`RASK_APPIUM_IOS_UDID`) when CI provides it (local runs still attach by name).

## Changes
- New `native-ios-e2e.yml`: setup-xcode `latest-stable` → build sim `.app` (`iossimulator-arm64`, `ValidateXcodeVersion=false`) → boot sim → Appium XCUITest → `dotnet test --filter ~Ios`.
- `AppiumEnv`/test: optional `RASK_APPIUM_IOS_UDID` → `appium:udid` for arm64-reliable targeting.
- Stale `ci.yml` comments + `docs/native.md` now point to the nightly iOS workflow; CHANGELOG entry.

_Note: the iOS job can't run on this PR's CI (nightly-triggered). I'll validate it via `workflow_dispatch` on this branch — which is publish-free by design._