### PR TITLE
ci(native): green the nightly iOS Appium E2E (macos-26 SDK match, iPhone 17, Debug, WDA)

### DIFF
--- a/.github/workflows/native-ios-e2e.yml
+++ b/.github/workflows/native-ios-e2e.yml
@@ -25,8 +25,12 @@ concurrency:
 
 jobs:
   native-appium-ios:
-    # All GitHub macOS runners are Apple silicon (arm64) -> iossimulator-arm64 below.
-    runs-on: macos-15
+    # All GitHub macOS runners are Apple silicon (arm64) -> iossimulator-arm64 below. macos-26 (not
+    # macos-15) because the Microsoft.iOS workload auto-tracks the newest SDK: `dotnet workload install
+    # ios` pulls Microsoft.iOS 26.5, which hard-requires the iOS 26.5 SDK (Xcode 26.5, MT0180). The
+    # macos-15 image caps at Xcode 26.3, so that link can never be satisfied there; macos-26 ships Xcode
+    # 26.5 (default) + 26.6, matching the workload (and the Xcode 26.6 used locally to run iOS).
+    runs-on: macos-26
     timeout-minutes: 50
     env:
       RASK_APPIUM_SERVER: http://127.0.0.1:4723

--- a/.github/workflows/native-ios-e2e.yml
+++ b/.github/workflows/native-ios-e2e.yml
@@ -62,11 +62,15 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       - name: Build the iOS-simulator showcase .app
-        # Full build (NOT -t:Compile) to produce a runnable simulator bundle. ValidateXcodeVersion=false
-        # tolerates the Microsoft.iOS <-> runner-Xcode drift; no code signing is needed for the simulator.
+        # Debug (NOT Release), full build (NOT -t:Compile) to produce a runnable simulator bundle. Debug is
+        # right for a functional Appium E2E: the simulator runs under the Mono interpreter, so this skips
+        # both the ILLink trimmer and AOT — cutting a ~35-min Release build to a couple of minutes and
+        # sidestepping the Microsoft.iOS <-> Xcode SDK coupling (MT0180) that only the trimmer trips. This
+        # mirrors the local `-t:Run` inner loop. ValidateXcodeVersion=false tolerates any residual Xcode
+        # drift; simulator apps need no code signing. (Release/AOT trim-cleanliness is proven by Rask.Example.Wasm.)
         run: >-
           dotnet build samples/Rask.Example.Native/Rask.Example.Native.csproj
-          -c Release -f net10.0-ios
+          -c Debug -f net10.0-ios
           -p:RaskNativeHeads=true
           -p:RuntimeIdentifier=iossimulator-arm64
           -p:ValidateXcodeVersion=false
@@ -74,7 +78,7 @@ jobs:
       - name: Resolve the built .app path
         # Publish the absolute .app path to the job env so it reaches `dotnet test` (AppiumEnv.IosApp).
         run: |
-          APP=$(find "$PWD/samples/Rask.Example.Native/bin/Release/net10.0-ios/iossimulator-arm64" -maxdepth 2 -name '*.app' | head -1)
+          APP=$(find "$PWD/samples/Rask.Example.Native/bin/Debug/net10.0-ios/iossimulator-arm64" -maxdepth 2 -name '*.app' | head -1)
           test -n "$APP" || { echo "No .app produced by the iOS-simulator build"; exit 1; }
           echo "Resolved .app: $APP"
           echo "RASK_APPIUM_IOS_APP=$APP" >> "$GITHUB_ENV"

--- a/.github/workflows/native-ios-e2e.yml
+++ b/.github/workflows/native-ios-e2e.yml
@@ -83,14 +83,17 @@ jobs:
         id: sim
         uses: futureware-tech/simulator-action@v5
         with:
-          model: iPhone 15
+          # macos-26 (Xcode 26.x) pre-creates only the current generation of simulator devices for its
+          # iOS 26.x runtime — the iPhone 17 family. "iPhone 15" no longer has an available device
+          # instance here, so simulator-action's name match returns "No devices found".
+          model: iPhone 17
 
       - name: Pin the booted simulator (UDID + name)
         # Explicit UDID targeting: name-only Appium device selection is unreliable on ARM64 macOS runners
         # (the reason MAUI's XHarness passes --device UDID). simulator-action exposes the booted UDID.
         run: |
           echo "RASK_APPIUM_IOS_UDID=${{ steps.sim.outputs.udid }}" >> "$GITHUB_ENV"
-          echo "RASK_APPIUM_IOS_DEVICE=iPhone 15" >> "$GITHUB_ENV"
+          echo "RASK_APPIUM_IOS_DEVICE=iPhone 17" >> "$GITHUB_ENV"
 
       - name: Start Appium (XCUITest) and run the iOS E2E
         run: |

--- a/tests/Rask.Native.Appium.Tests/AppiumEnv.cs
+++ b/tests/Rask.Native.Appium.Tests/AppiumEnv.cs
@@ -20,7 +20,7 @@ internal static class AppiumEnv
     public static string? IosApp => Get("RASK_APPIUM_IOS_APP");
 
     /// <summary>The booted iOS simulator name, e.g. "iPhone 17 Pro".</summary>
-    public static string IosDeviceName => Get("RASK_APPIUM_IOS_DEVICE") ?? "iPhone 15";
+    public static string IosDeviceName => Get("RASK_APPIUM_IOS_DEVICE") ?? "iPhone 17";
 
     /// <summary>
     ///     The booted iOS simulator's UDID. When present it is passed as <c>appium:udid</c> for EXPLICIT

--- a/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
+++ b/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
@@ -50,6 +50,10 @@ public sealed class NativeShowcaseAppiumTests
             DeviceName = AppiumEnv.IosDeviceName
         };
         options.AddAdditionalAppiumOption("appium:newCommandTimeout", 180);
+        // First session on a fresh runner builds WebDriverAgent from source (xcodebuild build-for-testing),
+        // which takes minutes — give the server a matching launch window so it doesn't abort mid-build.
+        options.AddAdditionalAppiumOption("appium:wdaLaunchTimeout", 360_000);
+        options.AddAdditionalAppiumOption("appium:wdaConnectionTimeout", 360_000);
         // Explicit UDID targeting when the CI job resolved it: name-only selection is flaky on the ARM64
         // macOS runners (same reason MAUI's XHarness pins --device UDID). Locally, unset → attach by name.
         if (AppiumEnv.IosUdid is not null)
@@ -57,7 +61,9 @@ public sealed class NativeShowcaseAppiumTests
             options.AddAdditionalAppiumOption("appium:udid", AppiumEnv.IosUdid);
         }
 
-        using var driver = new IOSDriver(new Uri(AppiumEnv.ServerUrl!), options, TimeSpan.FromMinutes(3));
+        // The client's HTTP command timeout must outlast that cold WDA build too, or POST /session times
+        // out (180s was too short) before the session is even created.
+        using var driver = new IOSDriver(new Uri(AppiumEnv.ServerUrl!), options, TimeSpan.FromMinutes(8));
         AssertShowcaseRendered(driver);
     }
 

--- a/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
+++ b/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
@@ -44,9 +44,11 @@ public sealed class NativeShowcaseAppiumTests
         {
             PlatformName = "iOS",
             AutomationName = "XCUITest",
-            App = AppiumEnv.IosApp
+            App = AppiumEnv.IosApp,
+            // deviceName is a reserved capability on AppiumOptions — setting it via
+            // AddAdditionalAppiumOption("appium:deviceName", ...) throws; assign the property instead.
+            DeviceName = AppiumEnv.IosDeviceName
         };
-        options.AddAdditionalAppiumOption("appium:deviceName", AppiumEnv.IosDeviceName);
         options.AddAdditionalAppiumOption("appium:newCommandTimeout", 180);
         // Explicit UDID targeting when the CI job resolved it: name-only selection is flaky on the ARM64
         // macOS runners (same reason MAUI's XHarness pins --device UDID). Locally, unset → attach by name.


### PR DESCRIPTION
## Summary
The nightly `native-ios-e2e` workflow was failing (Jul 11 & 12 scheduled runs on `main`). Root-caused and fixed the whole chain; each fix was validated by dispatching the workflow on this branch. Final dispatch is **green** — `Ios_showcase_renders_and_serves_scoped_assets` **Passed** in ~19 min (well under the 50-min cap).

Four distinct issues, surfacing one after another as each was cleared:

1. **Build — `MT0180` / `NETSDK1144`.** `dotnet workload install ios` auto-tracks the newest SDK (Microsoft.iOS **26.5**, requires the iOS 26.5 SDK / Xcode 26.5), but the `macos-15` image caps at **Xcode 26.3**. → Move the job to **`macos-26`** (ships Xcode 26.5 default + 26.6, matching the workload and the Xcode used locally).

2. **Boot — "No devices found".** `simulator-action` matched `model: iPhone 15`, which has no available device instance on Xcode 26.x (only the current **iPhone 17** family is pre-created for the iOS 26.x runtime). → Boot & pin **iPhone 17**.

3. **Build cost / fragility.** The Release simulator build runs the ILLink trimmer + AOT (~**35 min**, and the trimmer is what tripped `MT0180`). A functional Appium E2E only needs a runnable bundle. → Build in **Debug** (Mono interpreter, no trim/AOT) — ~35 min → a couple of minutes, and independently sidesteps the SDK coupling. Mirrors the local `-t:Run` loop; Release/AOT trim-cleanliness stays covered by `Rask.Example.Wasm`.

4. **Test — duplicate capability + cold-WDA timeout.** `AddAdditionalAppiumOption("appium:deviceName", …)` throws (`deviceName` is the reserved `DeviceName` property); and the first session builds WebDriverAgent from source (~7 min), outlasting the 180 s client timeout. → Set `DeviceName` via the property; raise the client HTTP timeout to 8 min and add `wdaLaunchTimeout`/`wdaConnectionTimeout` (360 s).

## Testing
`gh workflow run native-ios-e2e.yml` on this branch → **success** (run 29225746851): build ✓, boot iPhone 17 ✓, XCUITest session ✓, `Ios_showcase_renders_and_serves_scoped_assets` **Passed [7m43s]**. All PR checks green, including the Android `native-appium` E2E (verifies the shared test-file edit didn't regress Android).

## Changelog
CI-internal only (no user-facing surface) — no CHANGELOG entry, matching prior `ci(native)` commits.