### PR TITLE
test(native): drive & assert the native header/tab bar on device + trim native CI timeouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,8 +343,10 @@ jobs:
   # iOS workload. The iOS variant (XCUITest + simulator on macOS) runs nightly in native-ios-e2e.yml.
   native-appium:
     runs-on: ubuntu-latest
-    # A hung emulator teardown can otherwise stall the job for the 6h default; fail fast instead.
-    timeout-minutes: 35
+    # A hung emulator teardown can otherwise stall the job for the 6h default; fail fast instead. Recent
+    # successful runs land at ~17 min (build + boot + Appium test), so 24 leaves headroom while cutting the
+    # wasted wall-clock when the emulator or its teardown wedges.
+    timeout-minutes: 24
     # The emulator-runner runs each `script` line in a SEPARATE `sh -c`, so shell vars/exports don't
     # persist across lines. Pass the test's env at the job/step level (process env) instead, so it reaches
     # `dotnet test` — otherwise the test silently SKIPS (Skip.IfNot) and the job is a false pass.

--- a/.github/workflows/native-ios-e2e.yml
+++ b/.github/workflows/native-ios-e2e.yml
@@ -31,7 +31,10 @@ jobs:
     # macos-15 image caps at Xcode 26.3, so that link can never be satisfied there; macos-26 ships Xcode
     # 26.5 (default) + 26.6, matching the workload (and the Xcode 26.6 used locally to run iOS).
     runs-on: macos-26
-    timeout-minutes: 50
+    # A green run is ~19 min including the cold WebDriverAgent build; 35 stays well clear of that while
+    # failing a wedged WDA/simulator ~15 min sooner than the old 50 (a stuck run once dragged to ~40 min).
+    # The in-test wdaLaunchTimeout/wdaConnectionTimeout (360s) still cover the legitimate cold build.
+    timeout-minutes: 35
     env:
       RASK_APPIUM_SERVER: http://127.0.0.1:4723
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,12 @@ them until tagged releases begin.
   route. The `samples/Rask.Example.Native` showcase composes a native title bar + tab bar around the shared
   shell (dropping its web `BsNavbar` under `IsNative`). The `rask-native` template (`--host local`) scaffolds it
   too: the heads host `webView.ChromeView` + register `INativeChrome`, and the default `App` composes a native
-  title bar + Home/Counter tab bar around a `NativeWebView`.
+  title bar + Home/Counter tab bar around a `NativeWebView`. Each projected bar view carries a stable
+  **accessibility identifier** (the tab/button title, or `rask-native-header`) — addressable by screen readers
+  and UI tests — and the **Appium on-device E2E now drives the native bars**: it asserts the native header + tab
+  bar rendered as real platform views and that tapping a native tab navigates the WebView's route (the round
+  trip through the bridge into the router). The `native-appium` (24 min) and nightly `native-appium-ios`
+  (35 min) CI job timeouts were trimmed to match observed run durations.
 - **Native geolocation backend.** The `rask-native` template's `--host local` heads add a
   `NativeGeolocation : IGeolocation` (iOS **CoreLocation** `CLLocationManager`, Android **`LocationManager`**),
   registered on `host.Services` before `RunLocalAsync` to override Rask's JS-backed `navigator.geolocation`

--- a/docs/native.md
+++ b/docs/native.md
@@ -344,7 +344,9 @@ protected override Component? Render() =>
   curated member (`NativeIcon.Home`) or an escape hatch (`NativeIcon.Custom(sfSymbol, drawable)` /
   `NativeIcon.SfSymbol(...)` / `NativeIcon.Drawable(...)`). Routes are type-safe too (`Features.Routes.*`).
 - **Bar buttons** run their `OnClick` on the render thread and re-render, like any Rask callback. **Tabs**
-  navigate to their route; the page recomputes `Selected` from the current route on the next render.
+  navigate to their route; the page recomputes `Selected` from the current route on the next render. Each
+  projected bar view carries a stable **accessibility identifier** (the tab/button title, or
+  `rask-native-header`), so screen readers — and UI tests like the Appium on-device E2E — can address it.
 - **Bars render no HTML** — they are collected during the render walk (so their factories are DI-correct and
   callbacks wire to their owner); the last bar of a kind wins. Only the settled build's chrome is pushed, and
   an unchanged bar never re-pushes (no flicker on a counter tick).
@@ -389,8 +391,11 @@ sandbox, and real background execution — without giving up "the same component
    (Native + Local, in-process) and `samples/Rask.Example.Native.Server` (Native + Server, a thin shell
    over `Rask.Example.Server`). They serve the full showcase's assets on-device through the framework's
    [`NativeOriginAssets`](#serving-a-full-apps-assets). E2E is **Appium** (`tests/Rask.Native.Appium.Tests`):
-   it installs and drives the *real* app on an Android emulator / iOS simulator, switches into the WebView,
-   and asserts the showcase rendered with its scoped CSS + Bootstrap. **Android** runs per-PR in the Ubuntu
+   it installs and drives the *real* app on an Android emulator / iOS simulator. In the **WebView** context it
+   asserts the showcase rendered with its scoped CSS + Bootstrap; in the **native** context it asserts the
+   [native header/tab bar](#native-header--footer) projected to real platform bars and that **tapping a native
+   tab navigates the WebView** (the round trip through the bridge into the router, read back from
+   `document.location`). **Android** runs per-PR in the Ubuntu
    `native-appium` CI job (KVM emulator); **iOS** (XCUITest on a macOS simulator) runs nightly + on-demand
    in `native-ios-e2e.yml` — kept off the per-PR path because macOS minutes and the Microsoft.iOS↔Xcode SDK
    coupling make it too costly/fragile to gate every PR, the same nightly cadence MAUI uses for device UI

--- a/src/Rask.Native/Platforms/Android/RaskAndroidWebView.Chrome.cs
+++ b/src/Rask.Native/Platforms/Android/RaskAndroidWebView.Chrome.cs
@@ -78,7 +78,13 @@ public sealed partial class RaskAndroidWebView
             _topBar.AddView(BuildBarButton(leading));
         }
 
-        var title = new TextView(_context) { Text = header.Title ?? string.Empty, TextSize = 18f };
+        var title = new TextView(_context)
+        {
+            Text = header.Title ?? string.Empty,
+            TextSize = 18f,
+            // Stable content-desc so screen readers + the Appium E2E can address the native header.
+            ContentDescription = "rask-native-header",
+        };
         title.SetPadding(Dp(12), Dp(12), Dp(12), Dp(12));
         _topBar.AddView(title, new LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WrapContent, weight: 1f));
 
@@ -121,7 +127,8 @@ public sealed partial class RaskAndroidWebView
         for (var i = 0; i < tabs.Count; i++)
         {
             var tab = tabs[i];
-            var button = new Button(_context) { Text = tab.Title };
+            // Address each tab by its title (content-desc) for screen readers + the Appium E2E.
+            var button = new Button(_context) { Text = tab.Title, ContentDescription = tab.Title };
             var path = tab.Path;
             button.Click += (_, _) => Raise($$"""{"type":"navigate","path":"{{Escape(path)}}"}""");
             _bottomBar.AddView(button, EqualWeight());
@@ -130,9 +137,12 @@ public sealed partial class RaskAndroidWebView
 
     private Android.Views.View BuildBarButton(NativeBarItemDescriptor item)
     {
+        var isBack = string.Equals(item.Kind, "back", StringComparison.Ordinal);
         var button = new Button(_context)
         {
-            Text = string.Equals(item.Kind, "back", StringComparison.Ordinal) ? "‹" : item.Title ?? "•",
+            Text = isBack ? "‹" : item.Title ?? "•",
+            // Address the button by its tap id (back → a stable token) for screen readers + the E2E.
+            ContentDescription = isBack ? "rask-native-back" : item.Id ?? item.Title,
         };
 
         var id = item.Id;

--- a/src/Rask.Native/Platforms/iOS/RaskWkWebView.Chrome.cs
+++ b/src/Rask.Native/Platforms/iOS/RaskWkWebView.Chrome.cs
@@ -66,7 +66,8 @@ internal sealed class RaskChromeContainerView : UIView
     public RaskChromeContainerView(WKWebView webView)
     {
         _webView = webView;
-        _navBar = new UINavigationBar { Hidden = true };
+        // A stable, localization-independent handle for screen readers and the Appium on-device E2E.
+        _navBar = new UINavigationBar { Hidden = true, AccessibilityIdentifier = "rask-native-header" };
         _tabBar = new UITabBar { Hidden = true };
         _toolbar = new UIToolbar { Hidden = true };
         BackgroundColor = UIColor.SystemBackground;
@@ -179,7 +180,11 @@ internal sealed class RaskChromeContainerView : UIView
         _tabItems = new UITabBarItem[tabs.Count];
         for (var i = 0; i < tabs.Count; i++)
         {
-            _tabItems[i] = new UITabBarItem(tabs[i].Title, ImageFor(tabs[i].IosIcon), i);
+            _tabItems[i] = new UITabBarItem(tabs[i].Title, ImageFor(tabs[i].IosIcon), i)
+            {
+                // Address each tab by its title (screen readers + the Appium E2E), independent of the icon.
+                AccessibilityIdentifier = tabs[i].Title,
+            };
         }
 
         _tabBar.Items = _tabItems;
@@ -194,10 +199,11 @@ internal sealed class RaskChromeContainerView : UIView
         if (string.Equals(item.Kind, "back", StringComparison.Ordinal))
         {
             // A plain back chevron — a navigation host provides the actual pop; emit nothing extra here.
-            return new UIBarButtonItem(UIBarButtonSystemItem.Cancel);
+            return new UIBarButtonItem(UIBarButtonSystemItem.Cancel) { AccessibilityIdentifier = "rask-native-back" };
         }
 
-        var button = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
+        // Address the button by its tap id (falling back to its title) for screen readers + the E2E.
+        var button = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain, AccessibilityIdentifier = item.Id ?? item.Title };
         if (ImageFor(item.IosIcon) is { } image)
         {
             button.Image = image;

--- a/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
+++ b/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
@@ -6,11 +6,17 @@ using OpenQA.Selenium.Appium.iOS;
 namespace Rask.Native.Appium.Tests;
 
 // On-device E2E for the Native + Local showcase (samples/Rask.Example.Native): Appium installs and launches
-// the REAL app on an Android emulator / iOS simulator, switches into the WebView, and asserts the full
-// asset pipeline rendered — the boot shell + client + scoped CSS/JS + Bootstrap all served through
-// Rask.Native's NativeOriginAssets. This is the device-level replacement for the old headless shim.
+// the REAL app on an Android emulator / iOS simulator, then asserts two things. (1) In the WebView context:
+// the full asset pipeline rendered — the boot shell + client + scoped CSS/JS + Bootstrap all served through
+// Rask.Native's NativeOriginAssets. (2) In the NATIVE context: NativeShowcaseApp's NativeHeaderBar/NativeTabBar
+// projected to REAL platform bars (iOS UINavigationBar/UITabBar, Android top/bottom bars), and tapping a
+// native tab drives the WebView's route over the bridge. This is the device-level replacement for the old
+// headless shim.
 public sealed class NativeShowcaseAppiumTests
 {
+    // Appium's synthetic context for the app's native view tree (vs. the WEBVIEW_*/CHROMIUM contexts).
+    private const string NativeContext = "NATIVE_APP";
+
     [SkippableFact]
     public void Android_showcase_renders_and_serves_scoped_assets()
     {
@@ -32,7 +38,8 @@ public sealed class NativeShowcaseAppiumTests
         options.AddAdditionalAppiumOption("appium:chromedriverAutodownload", true);
 
         using var driver = new AndroidDriver(new Uri(AppiumEnv.ServerUrl!), options, TimeSpan.FromMinutes(3));
-        AssertShowcaseRendered(driver);
+        var webContext = AssertShowcaseRendered(driver);
+        AssertNativeChromeAndNavigation(driver, webContext);
     }
 
     [SkippableFact]
@@ -64,12 +71,14 @@ public sealed class NativeShowcaseAppiumTests
         // The client's HTTP command timeout must outlast that cold WDA build too, or POST /session times
         // out (180s was too short) before the session is even created.
         using var driver = new IOSDriver(new Uri(AppiumEnv.ServerUrl!), options, TimeSpan.FromMinutes(8));
-        AssertShowcaseRendered(driver);
+        var webContext = AssertShowcaseRendered(driver);
+        AssertNativeChromeAndNavigation(driver, webContext);
     }
 
     // Switch into the app's WebView and assert the showcase rendered with its assets — the same evidence
-    // the headless suite used to check, now against a real on-device WebView.
-    private static void AssertShowcaseRendered(AppiumDriver driver)
+    // the headless suite used to check, now against a real on-device WebView. Returns the WebView context
+    // name so the native-chrome flow can hop back into it to read the route.
+    private static string AssertShowcaseRendered(AppiumDriver driver)
     {
         var webContext = WaitForWebViewContext(driver);
         driver.Context = webContext;
@@ -104,6 +113,87 @@ public sealed class NativeShowcaseAppiumTests
         Assert.Contains("Rask", bodyText, StringComparison.OrdinalIgnoreCase);
         // Scoped CSS + Bootstrap were served through NativeOriginAssets → stylesheets are present.
         Assert.True(sheets > 0, "Scoped/Bootstrap stylesheets should have loaded via NativeOriginAssets." + diag);
+        return webContext;
+    }
+
+    // Assert NativeShowcaseApp's native chrome projected to REAL platform bars, then prove a native tab tap
+    // navigates the WebView. The bars live in the NATIVE context (not the WebView); the route it drives is
+    // read back in the WebView context (native history keeps document.location in sync — Rask.Native's
+    // applyHistory). Runs on both platforms — the a11y ids the projection sets resolve via AccessibilityId
+    // (iOS accessibilityIdentifier / Android content-desc).
+    private static void AssertNativeChromeAndNavigation(AppiumDriver driver, string webContext)
+    {
+        driver.Context = NativeContext;
+
+        // The native header + the three native tabs render (NativeHeaderBar + NativeTabBar → real bars).
+        WaitForNativeElement(driver, "rask-native-header");
+        WaitForNativeElement(driver, "Home");
+        WaitForNativeElement(driver, "Guides");
+        WaitForNativeElement(driver, "Todos");
+
+        // A native tab tap raises a `navigate` event over the bridge → NativeLiveSession → router → re-render;
+        // native history moves the URL, so the WebView's pathname follows. Verify the full round trip and
+        // that re-selecting tabs works (Home → Guides → Todos → Home).
+        TapNativeTabAndAssertRoute(driver, webContext, "Guides", "/guides");
+        TapNativeTabAndAssertRoute(driver, webContext, "Todos", "/todos");
+        TapNativeTabAndAssertRoute(driver, webContext, "Home", "/");
+    }
+
+    private static void TapNativeTabAndAssertRoute(
+        AppiumDriver driver, string webContext, string tab, string expectedPath)
+    {
+        driver.Context = NativeContext;
+        WaitForNativeElement(driver, tab).Click();
+
+        driver.Context = webContext;
+        var pathname = string.Empty;
+        for (var attempt = 0; attempt < 40; attempt++)
+        {
+            pathname = ExecuteScript(driver, "return document.location ? document.location.pathname : ''");
+            if (string.Equals(pathname, expectedPath, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(500));
+        }
+
+        // Assert (not just fail) so the message shows the route the tap actually produced.
+        Assert.Equal(expectedPath, pathname);
+    }
+
+    // Poll for a native element, addressing it by the a11y id the projection sets (AccessibilityId maps to
+    // accessibilityIdentifier on iOS / content-desc on Android), and fall back to its visible name/text so a
+    // platform that doesn't surface the identifier on a bar item still resolves it.
+    private static AppiumElement WaitForNativeElement(AppiumDriver driver, string idOrText)
+    {
+        for (var attempt = 0; attempt < 30; attempt++)
+        {
+            if (TryFindNativeElement(driver, idOrText) is { } element)
+            {
+                return element;
+            }
+
+            Thread.Sleep(TimeSpan.FromMilliseconds(500));
+        }
+
+        throw new InvalidOperationException(
+            $"The native element '{idOrText}' never appeared in the NATIVE context. The native chrome " +
+            "(NativeHeaderBar/NativeTabBar) should project to real platform bars via INativeChrome.");
+    }
+
+    private static AppiumElement? TryFindNativeElement(AppiumDriver driver, string idOrText)
+    {
+        var byId = driver.FindElements(MobileBy.AccessibilityId(idOrText));
+        if (byId.Count > 0)
+        {
+            return byId.First();
+        }
+
+        var byText = driver is IOSDriver
+            ? driver.FindElements(MobileBy.IosNSPredicate($"name == '{idOrText}' OR label == '{idOrText}'"))
+            : driver.FindElements(MobileBy.AndroidUIAutomator($"new UiSelector().text(\"{idOrText}\")"));
+        return byText.Count > 0 ? byText.First() : null;
     }
 
     private static string WaitForWebViewContext(AppiumDriver driver)


### PR DESCRIPTION
## Summary

PR #325 shipped the native header/footer bars, but the Appium **on-device** E2E only switched into the **WebView** and asserted the HTML rendered — the real `UINavigationBar`/`UITabBar` (iOS) and top/bottom bars (Android) the projection creates, and the tab-tap → route round trip, were unverified on a device. This closes that loop and trims the two native CI job timeouts to what recent runs actually take.

- **Accessibility identifiers on the native bar projections.** iOS sets `AccessibilityIdentifier` on the `UITabBarItem`s (the tab title), the `UINavigationBar` (`rask-native-header`), and the `UIBarButtonItem`s (tap id / title); Android sets the equivalent `ContentDescription` on the tab buttons, the title `TextView`, and the bar buttons. Stable, localization- and icon-independent handles — addressable by screen readers **and** UI tests. No descriptor/wire change.
- **E2E now drives the native bars.** `NativeShowcaseAppiumTests` switches into the **NATIVE** context and asserts the header + the three tabs (Home/Guides/Todos) rendered as real platform views, then taps each native tab and polls `document.location.pathname` (native history keeps it in sync) to prove the tap drives the WebView's route through the bridge into the router. Runs on **both** the Android (per-PR) and iOS (nightly) facts. Locates elements via `AccessibilityId` with a name/text fallback.
- **Trimmed CI timeouts** to observed durations: `native-appium` **35 → 24 min** (steady ~17 min runs), nightly `native-appium-ios` **50 → 35 min** (~19 min runs incl. the cold WebDriverAgent build; still well clear of a green run, fails a wedged WDA ~15 min sooner).

## Testing

- `dotnet build Rask.slnx -warnaserror` → 0 warnings / 0 errors.
- `dotnet format Rask.slnx --verify-no-changes` → clean.
- Unit tests: `Rask.Native.Tests` (47) + `Rask.Generators.Tests` (229, incl. the RASK032 analyzer) → all pass.
- Native heads compile under both TFMs (validates the projection edits): `dotnet build src/Rask.Native/Rask.Native.csproj -p:RaskNativeHeads=true` (iOS) and `-p:RaskNativeHeads=android` (Android) → succeed.
- Appium project builds; both facts SKIP without `RASK_APPIUM_SERVER` (local/CI safe). The new native assertions run on-device in the `native-appium` job (Android) and the nightly `native-ios-e2e` (iOS).

## Benchmarks

Not a render-hotpath change (native head views + test + CI) — no benchmark required.

## Changelog

Appended to the existing `[Unreleased]` native header/footer entry (a11y ids + on-device E2E + CI timeout trims).