### PR TITLE
perf(core): shed ~24 B/node retained (packed flags byte + leaner key slot)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,6 +311,20 @@ them until tagged releases begin.
   (~9% on the 100-row keyed-list footprint benchmark), narrowing the one axis where Blazor's dense frame
   structs still lead. No behavioural change — the fields are read through the same members, now backed by
   `LiveState`.
+- **Every node in a mounted tree sheds another ~24 bytes: packed per-node flags + a leaner key slot.**
+  Two more slices off the same retained-heap axis. (1) The per-node booleans — the reads-ambient-state
+  latch on `Component` and `Draggable` on `Element` — now live in a single packed `_flags` byte instead
+  of a `bool` plus a padded `Nullable<bool>` field, reclaiming the alignment padding each cost. (2) The
+  key slot dropped its two value→string cache fields (`_cachedKeyValue`/`_cachedKeyString`, 16 B on
+  *every* node): the cache only ever hit for a keyed component reused in place, but a keyed list rebuilds
+  its element instances each render, so it was cold-missing there anyway — a bad trade against a rare
+  `ToString` on reused nodes when this is a footprint path. `Key` stays inline and `KeyString` recomputes;
+  non-keyed nodes (the majority) still short-circuit to `null` and allocate nothing. No behavioural change,
+  no per-render allocation added. Measured before/after on one machine via the `mem-footprint` report,
+  retained heap per mounted tree drops a further **~13%** on the 200-row page and **~9%** on the 100-row
+  keyed list, and per-update allocation is unchanged-to-slightly-better; the pinned `Baselines/vs-blazor.md`
+  absolute figures will be refreshed by the dedicated run. Both rows still trail Blazor's dense frame
+  structs — closing that gap is the next, architectural step.
 - **A live update no longer allocates the whole page as a string.** Every render materialised the full
   document via `StringBuilder.ToString()` — the dominant managed allocation of a small update on a large
   page — even when the shipped payload was one `UpdateText` op that never reads the HTML. The session now

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -38,6 +38,16 @@ public abstract class Component
         ("<!DOCTYPE html>", "Doctype()"), ("<html", "Html(...)"), ("<head", "Head()"), ("<body", "Body()")
     };
 
+    // Per-node boolean state packed into one byte so it costs a single field slot instead of one
+    // (padded) slot per bool across the Component/Element pair. Bit 0 lives on the base; Element
+    // claims bits 1-2 (see Element.Draggable). GetFlag/SetFlag are private protected so a derived
+    // Element in this assembly can share the byte. Reserve new bits here to keep the allocation
+    // documented in one place.
+    //   bit 0 — reads-ambient-state (below)
+    //   bit 1 — Element: Draggable present
+    //   bit 2 — Element: Draggable value
+    private byte _flags;
+
     // Set the first time this component reads untracked ambient state during Render: a context value
     // (Context.Get/Required/Has-via-Get) OR EditContext state (validation messages / validating flags,
     // via EditContext.MarkReader). Such a component depends on state the framework doesn't diff, so —
@@ -45,7 +55,14 @@ public abstract class Component
     // This is why form controls that read validation state need no manual BypassRenderCache override.
     // Latched on: once a reader, always a reader (its Render path can read different
     // context/edit-context state across renders).
-    private bool _readsAmbientState;
+    private const byte FlagReadsAmbientState = 1 << 0;
+
+    private bool _readsAmbientState => (_flags & FlagReadsAmbientState) != 0;
+
+    private protected bool GetFlag(byte mask) => (_flags & mask) != 0;
+
+    private protected void SetFlag(byte mask, bool value) =>
+        _flags = value ? (byte)(_flags | mask) : (byte)(_flags & ~mask);
 
     // All live-render-only state — handlers, child reconciliation, root alive sets, the error
     // boundary + render handle + lifetime token, edit-context pool, the dirty/lifecycle flags — is
@@ -117,39 +134,22 @@ public abstract class Component
     // FrameWriter.AdjustOffsetsFrom and KeyedInsertNavTests).
     public object? Key { get; set; }
 
-    private object? _cachedKeyValue;
-    private string? _cachedKeyString;
-
     // Stringified Key for emit (data-rask-key) and key-forwarding, computed per render on every
-    // keyed node. A string key needs no allocation (ToString() returns itself); for boxed value
-    // keys (the common int/Guid keyed-list case) the factory re-boxes the same value each render,
-    // so we cache by value-equality and reuse the prior string instead of re-allocating it.
-    internal string? KeyString
+    // keyed node. A string key needs no allocation (ToString() returns itself); a value key
+    // (int/Guid) allocates a small string per render.
+    //
+    // We deliberately do NOT cache the value→string mapping: the cache only ever hit for a keyed
+    // instance that is REUSED across renders, but a keyed list rebuilds its element instances every
+    // render, so the cache was cold-missing there anyway. Keeping it cost two reference fields
+    // (16 B) on EVERY node in a mounted tree — a bad trade against a rare ToString on reused nodes,
+    // and this is a footprint-focused path. Non-keyed nodes (the majority) hit the null short-circuit
+    // and allocate nothing.
+    internal string? KeyString => Key switch
     {
-        get
-        {
-            var k = Key;
-            if (k is null)
-            {
-                return null;
-            }
-
-            if (k is string s)
-            {
-                return s;
-            }
-
-            if (_cachedKeyValue is not null && _cachedKeyValue.Equals(k))
-            {
-                return _cachedKeyString;
-            }
-
-            var str = k.ToString();
-            _cachedKeyValue = k;
-            _cachedKeyString = str;
-            return str;
-        }
-    }
+        null => null,
+        string s => s,
+        var k => k.ToString(),
+    };
 
     // Primary children indexer. `Div()[Span(...), "hi"]` is the call shape: literal lists of
     // components/strings (each implicitly a Component via the converters above). Overload
@@ -350,7 +350,7 @@ public abstract class Component
     protected virtual Component? Head => null;
 
     internal Component? HeadInternal => Head;
-    internal void MarkReadsAmbientStateInternal() => _readsAmbientState = true;
+    internal void MarkReadsAmbientStateInternal() => SetFlag(FlagReadsAmbientState, true);
 
     /// <summary>
     ///     Where this component is being presented — a web page (<see cref="RenderShell.Web" />) or a native

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -56,7 +56,20 @@ public abstract partial class Element : Component
     // draggable="true" (nullable so it stays an optional factory param — Blazor-parity with the other
     // HTML attrs). The drag *handlers* (OnDragStart/Over/Drop/End plus drag/dragenter/dragleave) live on
     // the unified GlobalEventHandlers surface in ElementEvents.cs, like every other event.
-    public bool? Draggable { get; set; }
+    // Backed by two bits of the base Component flags byte (present + value) instead of a dedicated
+    // Nullable<bool> field, so a drag-less element carries no extra slot — see Component._flags.
+    private const byte FlagDraggablePresent = 1 << 1;
+    private const byte FlagDraggableValue = 1 << 2;
+
+    public bool? Draggable
+    {
+        get => GetFlag(FlagDraggablePresent) ? GetFlag(FlagDraggableValue) : null;
+        set
+        {
+            SetFlag(FlagDraggablePresent, value.HasValue);
+            SetFlag(FlagDraggableValue, value.GetValueOrDefault());
+        }
+    }
 
     // Subclasses transform the `class` attribute value without re-implementing the universal
     // id/class/style/data-* walk. NavLink overrides this to splice in its active class.

--- a/tests/Rask.Core.Tests/Components/ElementDragTests.cs
+++ b/tests/Rask.Core.Tests/Components/ElementDragTests.cs
@@ -16,6 +16,23 @@ public class ElementDragTests
     }
 
     [Fact]
+    public void Draggable_Getter_RoundTripsTriState()
+    {
+        // Draggable is backed by two flag bits (present + value) rather than a Nullable<bool> field;
+        // the getter must still distinguish unset / false / true faithfully.
+        Assert.Null(Div().Draggable);
+        Assert.False(Div(Draggable: false).Draggable);
+        Assert.True(Div(Draggable: true).Draggable);
+
+        // Re-setting flips the value without leaking the previous state.
+        var d = Div(Draggable: true);
+        d.Draggable = false;
+        Assert.False(d.Draggable);
+        d.Draggable = null;
+        Assert.Null(d.Draggable);
+    }
+
+    [Fact]
     public void DragHandlers_OutsideLiveContext_NotEmitted() =>
         // No LiveRenderContext (plain ToHtml): handlers can't register, so only the
         // static draggable attribute survives.

--- a/tests/Rask.Core.Tests/KeyTests.cs
+++ b/tests/Rask.Core.Tests/KeyTests.cs
@@ -25,6 +25,19 @@ public class KeyTests
     public void Key_Null_EmitsNothing() => Assert.Equal("<div></div>", Div().ToHtml());
 
     [Fact]
+    public void Key_ValueKey_ReEmitsStablyAcrossRenders()
+    {
+        // KeyString dropped its value→string cache (a footprint win); a boxed value key must still
+        // stringify correctly on every render, not just the first.
+        var li = Li(Key: 42);
+        Assert.Equal("<li data-rask-key=\"42\"></li>", li.ToHtml());
+        Assert.Equal("<li data-rask-key=\"42\"></li>", li.ToHtml());
+
+        // Reading Key back returns the original boxed value unchanged.
+        Assert.Equal(42, li.Key);
+    }
+
+    [Fact]
     public void Key_AfterUserData_NoDuplicate()
     {
         // data-rask-key follows other data-* entries; a literal Data["rask-key"] is dropped


### PR DESCRIPTION
## Summary
Phase A of beating Blazor on **retained-tree memory footprint** — the one axis where Blazor's dense
`RenderTreeFrame` structs still lead Rask's `Component` object graph. Two safe, behaviour-preserving
per-node field-storage cuts: (1) pack the per-node booleans (Component's reads-ambient-state latch and
Element's `Draggable` tri-state) into a single `_flags` byte instead of a `bool` plus a padded
`Nullable<bool>`; (2) drop the key slot's two value→string cache fields (`_cachedKeyValue` /
`_cachedKeyString`, 16 B on **every** node) — the cache only ever hit for a keyed component reused in
place, but a keyed list rebuilds its instances each render so it was cold-missing there anyway. `Key`
stays inline; `KeyString` recomputes; no per-render allocation added. Together this sheds ~24 B off every
node in a mounted tree. The architectural collapse that actually overtakes Blazor is the follow-on Phase B.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all pass** (Rask.Core
  1848 incl. 2 new: flag-backed `Draggable` tri-state getter + value-key `KeyString` re-render; Rask.Server
  248; Example.Shared 287; others green).
- E2E: n/a — no `samples/` changes (framework-internal storage change only).

## Benchmarks
Retained heap per mounted tree, measured same-machine before/after via
`dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -- mem-footprint`:
- `LargePage_200Rows`: 330,439 → **288,634 B** (**−12.7%**)
- `KeyedList_100Rows`: 143,042 → **130,098 B** (**−9.0%**)
- Per-update allocation (`CounterOnLargePage`): 952 → **840 B** (better, no regression)

Both rows still trail Blazor (0.77× / 0.46×) — closing that gap is Phase B (frame-stream collapse). The
pinned `Baselines/vs-blazor.md` absolute figures will be refreshed by the dedicated M4 run.

## CHANGELOG
- [Unreleased] entry added: "Every node in a mounted tree sheds another ~24 bytes: packed per-node flags
  + a leaner key slot."
