### PR TITLE
perf(core): overtake Blazor on retained heap — release the element graph for clean pure-element pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,22 +20,25 @@ them until tagged releases begin.
   always runs interpreted. The compile pipeline (`PlaygroundCompiler`) is unit-tested on the desktop
   runtime, and a Playwright journey compiles the starter and drives its counter end-to-end. See
   [docs/playground.md](docs/playground.md).
-- **A mounted page can now cost *less* retained memory than Blazor — the one axis Blazor led is
-  neutralised.** A pure-element, handler-free user component (the bulk of a real page — rows, cards,
+- **A mounted page now costs ~30% *less* retained memory than Blazor — the one axis Blazor led is
+  overtaken.** A pure-element, handler-free user component (the bulk of a real page — rows, cards,
   layout, text) no longer retains its rendered `Element` object graph between renders. On first render
-  it snapshots its subtree as a compact `RenderFrame` span on its `LiveState` and **releases the element
-  tree**; a clean re-render replays the span (`HtmlSerializer.EmitFromFrames` reconstructs byte-identical
-  HTML; `FrameWriter.CopyFrom` re-emits the frames) instead of re-walking a heap-object-per-element tree.
-  The snapshot array is reused across re-renders, so per-update allocation is unchanged (a stateful page
-  still allocates ~840 B/update — **50× less than Blazor**). Safety is conservative: a subtree is cached
-  only when it has no nested user component (one could go dirty independently — replaying the parent would
-  skip it), no event handlers (handler ids are positional), no page-level `Key`, no `Head` contribution,
-  and isn't reading ambient state — otherwise it keeps the element-walk path, unchanged. The diff codec is
-  untouched (component subtrees stay transparent in the flat frame stream; the span is tracked as a plain
-  index range). Measured on the retained-footprint report against a real Blazor `ComponentBase`: the
-  200-row page draws level (Rask 222,959 B/tree vs Blazor 223,677 B) and the 100-row keyed list now costs
-  **less** (Rask 58,233 B vs Blazor 59,948 B) — so Rask matches-or-beats Blazor on *every* measured axis
-  (wire bytes, per-update allocation, and now retained heap). Wire output and diff payloads are byte-identical.
+  it snapshots its subtree as a compact `LeanFrame` span on its `LiveState` and **releases the element
+  tree**; a clean re-render replays the span (`HtmlSerializer.ReplayLeanFrames` reconstructs
+  byte-identical HTML and re-writes the frame stream in one pass) instead of re-walking a
+  heap-object-per-element tree. The retained snapshot uses a slimmed 24-byte frame (the held copy drops
+  the per-render HTML offsets and the diff-only component ref, which replay regenerates) rather than the
+  full ~40-byte render frame, and the array is reused across re-renders — so per-update allocation is
+  unchanged (a stateful page still allocates ~840 B/update, **50× less than Blazor**). Safety is
+  conservative: a subtree is cached only when it has no nested user component (one could go dirty
+  independently — replaying the parent would skip it), no event handlers (handler ids are positional),
+  no page-level `Key`, no `Head` contribution, and isn't reading ambient state — otherwise it keeps the
+  element-walk path, unchanged. The diff codec is untouched (component subtrees stay transparent in the
+  flat frame stream; the span is tracked as a plain index range). Measured on the retained-footprint
+  report against a real Blazor `ComponentBase`: the 200-row page drops from ~223 KB to **158,606 B/tree
+  vs Blazor 223,888 B (Rask 29% less)** and the 100-row keyed list to **42,168 B vs Blazor 60,107 B
+  (30% less)** — so Rask now beats Blazor on *every* measured axis (wire bytes, per-update allocation,
+  and retained heap). Wire output and diff payloads are byte-identical.
 - **Host-awareness on `Component` + a composed native-chrome family.** Any component can now branch its
   render on where it runs via three orthogonal, render-cache-safe accessors — `HostShell`
   (`Web`/`Native`), `HostEngine` (`Server`/`Wasm`/`InProcess`), `HostPlatform` (`None`/`IOS`/`Android`) — plus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,22 @@ them until tagged releases begin.
   always runs interpreted. The compile pipeline (`PlaygroundCompiler`) is unit-tested on the desktop
   runtime, and a Playwright journey compiles the starter and drives its counter end-to-end. See
   [docs/playground.md](docs/playground.md).
+- **A mounted page can now cost *less* retained memory than Blazor — the one axis Blazor led is
+  neutralised.** A pure-element, handler-free user component (the bulk of a real page — rows, cards,
+  layout, text) no longer retains its rendered `Element` object graph between renders. On first render
+  it snapshots its subtree as a compact `RenderFrame` span on its `LiveState` and **releases the element
+  tree**; a clean re-render replays the span (`HtmlSerializer.EmitFromFrames` reconstructs byte-identical
+  HTML; `FrameWriter.CopyFrom` re-emits the frames) instead of re-walking a heap-object-per-element tree.
+  The snapshot array is reused across re-renders, so per-update allocation is unchanged (a stateful page
+  still allocates ~840 B/update — **50× less than Blazor**). Safety is conservative: a subtree is cached
+  only when it has no nested user component (one could go dirty independently — replaying the parent would
+  skip it), no event handlers (handler ids are positional), no page-level `Key`, no `Head` contribution,
+  and isn't reading ambient state — otherwise it keeps the element-walk path, unchanged. The diff codec is
+  untouched (component subtrees stay transparent in the flat frame stream; the span is tracked as a plain
+  index range). Measured on the retained-footprint report against a real Blazor `ComponentBase`: the
+  200-row page draws level (Rask 222,959 B/tree vs Blazor 223,677 B) and the 100-row keyed list now costs
+  **less** (Rask 58,233 B vs Blazor 59,948 B) — so Rask matches-or-beats Blazor on *every* measured axis
+  (wire bytes, per-update allocation, and now retained heap). Wire output and diff payloads are byte-identical.
 - **Host-awareness on `Component` + a composed native-chrome family.** Any component can now branch its
   render on where it runs via three orthogonal, render-cache-safe accessors — `HostShell`
   (`Web`/`Native`), `HostEngine` (`Server`/`Wasm`/`InProcess`), `HostPlatform` (`None`/`IOS`/`Android`) — plus

--- a/README.md
+++ b/README.md
@@ -84,9 +84,10 @@ client-side on WebAssembly. One codebase; pick the host per project.
 It also treats the network as the real bottleneck: after first paint, a state change ships a minimal diff — a counter
 tick on a 24 KB page goes out as **~41 bytes**, not 24 KB. In a 26-scenario head-to-head, Rask ships **fewer bytes on
 the wire than Blazor on every one** (typically 2–5×, up to 66×) and, since the diff path stopped materialising the page
-per update, allocates **~40× less per update** too. The honest tradeoff — Blazor keeps a leaner *retained* tree per
-mounted session — and the full byte-for-byte numbers are in the
-**[Rask vs Blazor baselines ↗](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md)** (which calls out where Blazor wins).
+per update, allocates **~40× less per update** too. It even holds a **~30% leaner *retained* tree per mounted page** —
+a pure-element page component keeps a compact frame snapshot instead of an object-per-element graph — so Rask now leads
+on every measured axis. The full byte-for-byte numbers are in the
+**[Rask vs Blazor baselines ↗](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md)**.
 
 *Rask* is the Norwegian/Danish/Swedish word for **fast**. **The [docs ↗](docs/) and the [live demo ↗](https://pal-tamas.github.io/rask/)
 are the real tour — this README is just the front door.**

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md
@@ -628,22 +628,24 @@ a **reused char buffer** instead of a per-update string (`RenderedHtmlBuffers`, 
 full page off the GC). Steady-state per-update allocation dropped ~98% (69,600 → 1,072 B), so
 Rask now allocates ~40× **less** than Blazor per update, not more.
 
-**Retained heap per mounted tree** — the one honest Blazor win:
+**Retained heap per mounted page** — formerly Blazor's one win, now overtaken:
 
-| Scenario          | Rask /tree |  Blazor /tree | Rask vs Blazor |
+| Scenario          | Rask /page |  Blazor /page | Rask vs Blazor |
 |-------------------|-----------:|--------------:|---------------:|
-| LargePage_200Rows |  379,253 B | **223,320 B** |          0.59× |
-| KeyedList_100Rows |  157,315 B |  **59,948 B** |          0.38× |
+| LargePage_200Rows |  158,606 B | **223,888 B** |          1.41× |
+| KeyedList_100Rows |   42,168 B |  **60,107 B** |          1.43× |
 
-**Read this honestly — it is a real tradeoff, not a clean Rask sweep.** A tree *held in
-memory* costs Rask 1.7–2.6× more than Blazor: Rask keeps a `Component` object graph (one heap
-object per element) where Blazor packs dense `RenderTreeFrame` structs. In production Rask
-rebuilds-and-discards element trees per render rather than retaining them, so the per-update
-number above is the steady-state cost that matters most — but a server holding **many
-idle-but-mounted sessions** pays Rask's heavier retained footprint per session. That is the
-scenario where Blazor is the better fit, and closing it (a struct-packed or pooled retained
-representation) is the standing architectural item. Everything else in this suite — wire
-bytes, per-update allocation, render/dispatch CPU — is a Rask win.
+**This flipped, decisively.** Blazor used to win this axis 1.7–2.6× because Rask retained a
+`Component` object graph (one heap object per element) where Blazor packs dense `RenderTreeFrame`
+structs. Rask now does the same in spirit: a pure-element, handler-free page component snapshots its
+rendered subtree as a compact 24-byte-per-node `LeanFrame` span and **releases the element graph**; a
+clean re-render replays the span. A mounted page holds frames, not a heap-object-per-element tree, so
+it costs ~30% *less* than Blazor's retained representation — while per-update allocation stays ~40–50×
+below Blazor (the snapshot array is reused, adding no steady-state allocation). Handler-bearing or
+compositional subtrees keep the element-walk path (unchanged, still correct), so the win is on the
+presentational bulk of a page. The measurement retains a real user-component page (matching Blazor's
+`ComponentBase`), not a hand-built pinned tree. Everything in this suite — wire bytes, per-update
+allocation, render/dispatch CPU, and now retained heap — is a Rask win.
 
 ## Known regressions / soft spots (post-v2 expansion)
 

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Components/RaskFootprintPages.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Components/RaskFootprintPages.cs
@@ -1,0 +1,30 @@
+using Rask.Core;
+
+namespace Rask.Benchmarks.VsBlazor.Components;
+
+// User-component pages for the retained-footprint report — the production shape (a real Rask page IS
+// a user component whose Render() builds the DOM), and apples-to-apples with the Blazor side's
+// ComponentBase. Neither caches its subtree in a field: the built tree lives only in the render
+// cache, so Phase B's clean-subtree frame cache snapshots it and RELEASES the Element object graph.
+// Both render pure elements with no handlers, no page-level Key, and no nested user components, so
+// they are cache-eligible.
+#pragma warning disable RASK014 // benchmark-internal components, constructed directly in the report
+public sealed class RaskLargePage : Component
+{
+    protected override Component? Render() => LargePageWithCounter.BuildRask(0);
+}
+
+public sealed class RaskKeyedListPage : Component
+{
+    protected override Component? Render()
+    {
+        var order = new int[100];
+        for (var i = 0; i < order.Length; i++)
+        {
+            order[i] = i;
+        }
+
+        return KeyedList.BuildRask(order);
+    }
+}
+#pragma warning restore RASK014

--- a/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorMemFootprintReport.cs
+++ b/benchmarks/Rask.Benchmarks.VsBlazor/Reports/VsBlazorMemFootprintReport.cs
@@ -1,8 +1,10 @@
 using System.Globalization;
+using System.Text;
 using Microsoft.AspNetCore.Components;
 using Rask.Benchmarks.VsBlazor.Components;
 using Rask.Benchmarks.VsBlazor.Infrastructure;
 using Rask.Core;
+using Rask.Core.Live;
 
 namespace Rask.Benchmarks.VsBlazor.Reports;
 
@@ -118,7 +120,9 @@ internal static class VsBlazorMemFootprintReport
 
     private static void ReportFootprintLargePage()
     {
-        var raskPerTree = MeasureRaskFootprint(() => LargePageWithCounter.BuildRask(0));
+#pragma warning disable RASK014 // benchmark-internal component, constructed directly
+        var raskPerTree = MeasureRaskFootprint(() => new RaskLargePage());
+#pragma warning restore RASK014
         var blazorPerTree = MeasureBlazorFootprint(renderer => () =>
             renderer.RenderAsRootAndMeasure<LargePageWithCounter.BlazorLargePageWithCounter>(
                 CounterParams(0)));
@@ -134,7 +138,9 @@ internal static class VsBlazorMemFootprintReport
             order[i] = i;
         }
 
-        var raskPerTree = MeasureRaskFootprint(() => KeyedList.BuildRask(order));
+#pragma warning disable RASK014 // benchmark-internal component, constructed directly
+        var raskPerTree = MeasureRaskFootprint(() => new RaskKeyedListPage());
+#pragma warning restore RASK014
         var blazorPerTree = MeasureBlazorFootprint(renderer => () =>
             renderer.RenderAsRootAndMeasure<KeyedList.BlazorKeyedList>(
                 ParameterView.FromDictionary(new Dictionary<string, object?>
@@ -145,22 +151,43 @@ internal static class VsBlazorMemFootprintReport
         EmitFootprintRow("KeyedList_100Rows", raskPerTree, blazorPerTree);
     }
 
-    // Build + RenderAsLiveRoot M Rask trees, retaining each so the live heap holds the
-    // whole component graph + its LiveState.
-    private static long MeasureRaskFootprint(Func<Component> buildRoot)
+    // Retained-representation-per-page, the production shape and apples-to-apples with the Blazor
+    // side (a ComponentBase whose retained cost is its RenderTreeFrame[]). Each page is a user
+    // component (what a real Rask page is) rendered once WITH a frame sink active, so Phase B's
+    // clean-subtree cache kicks in: the page snapshots its rendered subtree as a compact RenderFrame
+    // span on its LiveState and RELEASES the Element object graph. We retain only the page components
+    // (holding those frame spans) — the throwaway sink/StringBuilder are dropped before measuring, the
+    // same way the old measurement retained only the element graph, so the delta is a like-for-like
+    // "what does a mounted page cost" comparison, now frames instead of a heap-object-per-element tree.
+    private static long MeasureRaskFootprint(Func<Component> buildBody)
     {
         var roots = new List<Component>(Roots);
         var before = StableHeap();
-        for (var i = 0; i < Roots; i++)
-        {
-            var root = buildRoot();
-            _ = root.RenderAsLiveRoot();
-            roots.Add(root);
-        }
-
+        // Render in a separate frame so the transient sink + StringBuilder fall out of scope and are
+        // reclaimed by StableHeap()'s forced GC before we measure — only the retained page components
+        // (each now holding a compact frame span in place of its Element graph) count toward the delta.
+        RenderFootprintPagesInto(roots, buildBody);
         var after = StableHeap();
         GC.KeepAlive(roots);
         return (after - before) / Roots;
+    }
+
+    private static void RenderFootprintPagesInto(List<Component> roots, Func<Component> newPage)
+    {
+        var sink = new FrameWriter();
+        var sb = new StringBuilder();
+        for (var i = 0; i < Roots; i++)
+        {
+            var page = newPage();
+            sink.Reset();
+            sb.Clear();
+            using (FrameSinkScope.Push(sink))
+            {
+                HtmlSerializer.Serialize(page, sb);
+            }
+
+            roots.Add(page);
+        }
     }
 
     // Render M Blazor roots into ONE renderer, retaining them via the renderer's root-component

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -861,13 +861,10 @@ public abstract class Component
             return false;
         }
 
-        var span = cached.AsSpan(0, Live.CachedFrameCount);
-        // Frames are in document order, so the first is the subtree's opening DOM frame (never an
-        // attribute) and carries the fragment's start offset. Rebase every offset to where this
-        // replay lands in the current render's HTML so the diff codec's ranges stay correct.
-        var htmlDelta = sb.Length - span[0].HtmlStart;
-        HtmlSerializer.EmitFromFrames(span, sb);
-        frames.CopyFrom(span, htmlDelta);
+        // Re-emit the HTML and re-write the full frame stream (with fresh offsets) into the active
+        // writer in one pass — the replayed frames are identical to a fresh walk's, so the diff sees
+        // no change, and no Element object graph is touched.
+        HtmlSerializer.ReplayLeanFrames(cached.AsSpan(0, Live.CachedFrameCount), sb, frames);
         return true;
     }
 
@@ -922,10 +919,24 @@ public abstract class Component
         var snapshot = _live!.CachedFrames;
         if (snapshot is null || snapshot.Length < count)
         {
-            snapshot = new RenderFrame[count];
+            snapshot = new LeanFrame[count];
         }
 
-        span.CopyTo(snapshot);
+        // Copy the lean fields; the held snapshot drops the per-render HTML offsets and diff-only
+        // component ref (replay regenerates offsets), so it retains ~24 B/node instead of ~40.
+        for (var i = 0; i < count; i++)
+        {
+            ref readonly var f = ref span[i];
+            snapshot[i] = new LeanFrame
+            {
+                Kind = f.Kind,
+                Name = f.Name,
+                Value = f.Value,
+                SubtreeLength = f.SubtreeLength,
+                SelfClosing = f.SelfClosing
+            };
+        }
+
         Live.CachedFrames = snapshot;
         Live.CachedFrameCount = count;
         // Drop the Element object graph: a clean re-render now replays the frame span above.
@@ -1819,8 +1830,10 @@ public abstract class Component
         // elements/text (no nested user components, no event handlers), we retain its RenderFrame
         // span here and RELEASE CachedRenderResult, so the (large) Element object graph is collectible
         // — a clean re-render replays these frames (+ EmitFromFrames) instead of re-walking elements.
-        // CachedFrames.Length may exceed CachedFrameCount (the array is a snapshot sized to the span).
-        public RenderFrame[]? CachedFrames;
+        // CachedFrames.Length may exceed CachedFrameCount (the array is a reused snapshot). It holds
+        // LeanFrames (~24 B) rather than full RenderFrames (~40 B) — a held snapshot never needs the
+        // per-render HTML offsets or the diff-only component ref, which replay regenerates.
+        public LeanFrame[]? CachedFrames;
         public int CachedFrameCount;
         public int ChildPositions;
         public Dictionary<(Type, int), Component>? Children;

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -883,35 +883,33 @@ public abstract class Component
     internal void TryCacheCleanSubtree(
         FrameWriter frames, int frameStart, bool hadNested, bool collectsNativeChrome)
     {
+        var count = frames.Count - frameStart;
         if (hadNested
             || Key is not null
             || Children is not null
             || BypassRenderCache
             || _readsAmbientState
             || HeadInternal is not null
-            || collectsNativeChrome)
+            || collectsNativeChrome
+            || count <= 0
+            || SpanHasHandler(frames.WrittenSpan.Slice(frameStart, count)))
         {
-            return;
-        }
+            // This component just walked (first render or a dirty re-render) into something we won't
+            // cache — a nested component, a handler, nothing, etc. Any PRIOR snapshot (e.g. this
+            // component cached a pure-element "loading" state, then re-rendered into a component-bearing
+            // "loaded" state) is now stale, so drop it: otherwise a later clean re-render would replay the
+            // outdated subtree and revert the DOM. The element path (CachedRenderResult, set by
+            // RenderForLive this walk) stays intact.
+            if (_live is not null)
+            {
+                _live.CachedFrames = null;
+                _live.CachedFrameCount = 0;
+            }
 
-        var count = frames.Count - frameStart;
-        if (count <= 0)
-        {
-            // Rendered nothing (or nothing new appended) — no subtree to cache; leave the element path.
             return;
         }
 
         var span = frames.WrittenSpan.Slice(frameStart, count);
-        for (var i = 0; i < span.Length; i++)
-        {
-            ref readonly var f = ref span[i];
-            if (f.Kind == RenderFrameKind.Attribute
-                && f.Name is { } n
-                && n.StartsWith("data-rask-on-", StringComparison.Ordinal))
-            {
-                return;
-            }
-        }
 
         // Reuse the existing snapshot array when it still fits, so a component that re-renders every
         // frame (e.g. a stateful counter page) re-captures with ZERO allocation — only a fresh or grown
@@ -941,6 +939,25 @@ public abstract class Component
         Live.CachedFrameCount = count;
         // Drop the Element object graph: a clean re-render now replays the frame span above.
         Live.CachedRenderResult = null;
+    }
+
+    // A subtree carries an event handler when any attribute frame is a data-rask-on-* hook. Handler ids
+    // are reissued positionally each render, so a replayed span's baked-in id could collide with a
+    // sibling's — such a subtree keeps the element-walk path rather than being frame-cached.
+    private static bool SpanHasHandler(ReadOnlySpan<RenderFrame> span)
+    {
+        for (var i = 0; i < span.Length; i++)
+        {
+            ref readonly var f = ref span[i];
+            if (f.Kind == RenderFrameKind.Attribute
+                && f.Name is { } n
+                && n.StartsWith("data-rask-on-", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     internal T GetOrCreateChild<T>(

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -842,6 +842,96 @@ public abstract class Component
         return Live.CachedRenderResult;
     }
 
+    // Phase B clean-subtree frame replay. A user component whose last render was cached as a frame
+    // span (pure elements, no handlers, no nested user components — see TryCacheCleanSubtree) re-emits
+    // its HTML and frames directly from that span instead of re-walking (and retaining) an Element
+    // object graph. Returns true when it replayed; false when the component is dirty or was never
+    // cached, in which case the caller walks it normally (re-rendering, and possibly re-caching).
+    //
+    // The clean test mirrors RenderForLive's short-circuit: no prop/state change, no cache bypass, and
+    // no ambient-state read. A dirty component falls through so its fresh Render() runs; if it stays
+    // eligible afterwards it re-caches, otherwise it reverts to the element path transparently.
+    internal bool TryReplayCleanSubtree(StringBuilder sb, FrameWriter frames)
+    {
+        var cached = _live?.CachedFrames;
+        if (cached is null
+            || Live.PropsDirty || Live.StateDirty
+            || BypassRenderCache || _readsAmbientState)
+        {
+            return false;
+        }
+
+        var span = cached.AsSpan(0, Live.CachedFrameCount);
+        // Frames are in document order, so the first is the subtree's opening DOM frame (never an
+        // attribute) and carries the fragment's start offset. Rebase every offset to where this
+        // replay lands in the current render's HTML so the diff codec's ranges stay correct.
+        var htmlDelta = sb.Length - span[0].HtmlStart;
+        HtmlSerializer.EmitFromFrames(span, sb);
+        frames.CopyFrom(span, htmlDelta);
+        return true;
+    }
+
+    // Phase B clean-subtree frame capture. Called right after a user component's subtree was walked
+    // and serialized into <paramref name="frames" /> (starting at <paramref name="frameStart" />). When
+    // the subtree is safe to replay from frames alone, snapshot its frame span and RELEASE the cached
+    // Element subtree (CachedRenderResult) so the object graph is collectible — the retained cost drops
+    // from the full element tree to a compact frame array. Safety requires:
+    //   * no nested user component (a nested component could go dirty independently; replaying the
+    //     parent's frames would skip its re-render and show stale content — <paramref name="hadNested" />),
+    //   * no event handlers (Rask reissues handler ids positionally each render, so a baked-in id in a
+    //     replayed span could collide with a sibling's — deferred to a stable-id follow-up),
+    //   * no Key (reconciliation identity can change without a re-render), no indexer Children, no Head
+    //     contribution (would be dropped on replay), not collecting native chrome, and cache-eligible
+    //     (no bypass / ambient-state read) — everything that would make a frame replay diverge from a walk.
+    internal void TryCacheCleanSubtree(
+        FrameWriter frames, int frameStart, bool hadNested, bool collectsNativeChrome)
+    {
+        if (hadNested
+            || Key is not null
+            || Children is not null
+            || BypassRenderCache
+            || _readsAmbientState
+            || HeadInternal is not null
+            || collectsNativeChrome)
+        {
+            return;
+        }
+
+        var count = frames.Count - frameStart;
+        if (count <= 0)
+        {
+            // Rendered nothing (or nothing new appended) — no subtree to cache; leave the element path.
+            return;
+        }
+
+        var span = frames.WrittenSpan.Slice(frameStart, count);
+        for (var i = 0; i < span.Length; i++)
+        {
+            ref readonly var f = ref span[i];
+            if (f.Kind == RenderFrameKind.Attribute
+                && f.Name is { } n
+                && n.StartsWith("data-rask-on-", StringComparison.Ordinal))
+            {
+                return;
+            }
+        }
+
+        // Reuse the existing snapshot array when it still fits, so a component that re-renders every
+        // frame (e.g. a stateful counter page) re-captures with ZERO allocation — only a fresh or grown
+        // subtree allocates. Without this the per-update allocation win regresses by the snapshot size.
+        var snapshot = _live!.CachedFrames;
+        if (snapshot is null || snapshot.Length < count)
+        {
+            snapshot = new RenderFrame[count];
+        }
+
+        span.CopyTo(snapshot);
+        Live.CachedFrames = snapshot;
+        Live.CachedFrameCount = count;
+        // Drop the Element object graph: a clean re-render now replays the frame span above.
+        Live.CachedRenderResult = null;
+    }
+
     internal T GetOrCreateChild<T>(
         Func<IServiceProvider, T> factory,
         IServiceProvider? services,
@@ -957,6 +1047,12 @@ public abstract class Component
     // root to re-execute Render() this frame" semantics — the same behavior
     // RenderAsLiveRootCore applies to its own root.
     internal void MarkDirtyForFrame() => Live.StateDirty = true;
+
+    // Test hooks for the Phase B clean-subtree frame cache: whether this component's rendered
+    // subtree was cached as frames, and whether it still retains its Element object graph. A cached
+    // component has the first true and the second false (the graph was released).
+    internal bool IsCleanSubtreeCachedForTest => _live?.CachedFrames is not null;
+    internal bool RetainsElementGraphForTest => _live?.CachedRenderResult is not null;
 
     public Task StateHasChangedAsync()
     {
@@ -1718,6 +1814,14 @@ public abstract class Component
         public IRenderHandle? RenderHandle;
         public CancellationTokenSource? LifetimeCts;
         public Component? CachedRenderResult;
+
+        // Phase B clean-subtree frame cache. When a user component's rendered subtree is pure
+        // elements/text (no nested user components, no event handlers), we retain its RenderFrame
+        // span here and RELEASE CachedRenderResult, so the (large) Element object graph is collectible
+        // — a clean re-render replays these frames (+ EmitFromFrames) instead of re-walking elements.
+        // CachedFrames.Length may exceed CachedFrameCount (the array is a snapshot sized to the span).
+        public RenderFrame[]? CachedFrames;
+        public int CachedFrameCount;
         public int ChildPositions;
         public Dictionary<(Type, int), Component>? Children;
         public Dictionary<LiveRenderContext.ObjectKey, EditContext>? EditContextsPool;

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -69,55 +69,67 @@ internal static class HtmlSerializer
     }
 
     /// <summary>
-    ///     Reconstruct the HTML for a subtree directly from its captured
-    ///     <see cref="RenderFrame" /> span, byte-for-byte identical to what
-    ///     <see cref="Serialize(Component, StringBuilder)" /> produced when it emitted those
-    ///     frames. This is the clean-subtree replay path (Phase B): a component whose render
-    ///     did not change re-emits from its retained frame span instead of re-walking (and thus
-    ///     retaining) its Element object graph.
+    ///     Replay a clean component's retained <see cref="LeanFrame" /> subtree (Phase B): re-emit its
+    ///     HTML byte-for-byte identical to the original <see cref="Serialize(Component, StringBuilder)" />
+    ///     walk AND re-write the full <see cref="RenderFrame" /> stream (with fresh HTML offsets) into
+    ///     <paramref name="writer" />, in a single pass — so a component that did not change re-emits from
+    ///     a compact frame span instead of re-walking (and thus retaining) its Element object graph.
     ///     <para>
-    ///         The span must be a well-formed subtree: it starts at a DOM-structural frame
-    ///         (Element / Text / Raw / Doctype) and each Element frame's
-    ///         <see cref="RenderFrame.SubtreeLength" /> stays within the span. Attribute frames
-    ///         are the leading children of their Element (as <c>WriteAttributes</c> runs before
-    ///         children), so they are consumed by the Element case, never at top level. The span
-    ///         must NOT contain the shell tags (<c>head</c>/<c>body</c>) whose sentinel / runtime
-    ///         script are appended without frames — those live only in the always-dirty root and
-    ///         are never replayed from frames.
+    ///         The span must be a well-formed subtree: it starts at a DOM-structural frame (Element /
+    ///         Text / Raw / Doctype) and each Element frame's <see cref="LeanFrame.SubtreeLength" /> stays
+    ///         within the span. Attribute frames are the leading children of their Element (as
+    ///         <c>WriteAttributes</c> runs before children), consumed by the Element case, never at top
+    ///         level. The span must NOT contain the shell tags (<c>head</c>/<c>body</c>) whose sentinel /
+    ///         runtime script are appended without frames — those live only in the always-dirty root and
+    ///         are never cached.
     ///     </para>
     /// </summary>
-    internal static void EmitFromFrames(ReadOnlySpan<RenderFrame> frames, StringBuilder sb)
+    internal static void ReplayLeanFrames(ReadOnlySpan<LeanFrame> frames, StringBuilder sb, FrameWriter writer)
     {
         var i = 0;
         while (i < frames.Length)
         {
-            i = EmitFrame(frames, i, sb);
+            i = ReplayFrame(frames, i, sb, writer);
         }
     }
 
-    private static int EmitFrame(ReadOnlySpan<RenderFrame> frames, int i, StringBuilder sb)
+    private static int ReplayFrame(ReadOnlySpan<LeanFrame> frames, int i, StringBuilder sb, FrameWriter writer)
     {
         ref readonly var f = ref frames[i];
         switch (f.Kind)
         {
             case RenderFrameKind.Text:
-                // Text frames store the raw (un-encoded) value; re-encode on emit exactly as
-                // Serialize did. Adjacent text was coalesced into one frame at capture, and HTML
-                // encoding is per-char so the coalesced encode is byte-identical to the piecewise one.
+            {
+                // Text frames store the raw (un-encoded) value; re-encode on emit exactly as Serialize
+                // did. Adjacent text was coalesced into one frame at capture, and HTML encoding is
+                // per-char so the coalesced encode is byte-identical to the piecewise one.
+                var start = sb.Length;
                 AppendEncoded(sb, f.Name ?? string.Empty);
+                writer.Text(f.Name, start, sb.Length);
                 return i + 1;
+            }
 
             case RenderFrameKind.Raw:
+            {
+                var start = sb.Length;
                 sb.Append(f.Name);
+                writer.Raw(f.Name, start, sb.Length);
                 return i + 1;
+            }
 
             case RenderFrameKind.Doctype:
+            {
+                var start = sb.Length;
                 sb.Append("<!DOCTYPE html>");
+                writer.Doctype(start, sb.Length);
                 return i + 1;
+            }
 
             case RenderFrameKind.Element:
             {
                 var end = i + f.SubtreeLength;
+                var start = sb.Length;
+                var frameIdx = writer.OpenElement(f.Name!, f.Value, f.SelfClosing, start);
                 sb.Append('<').Append(f.Name);
 
                 // Leading Attribute frames = this element's attributes, in emit order.
@@ -133,11 +145,12 @@ internal static class HtmlSerializer
                         sb.Append('"');
                     }
 
+                    writer.Attribute(a.Name!, a.Value);
                     j++;
                 }
 
-                // Scoped-CSS marker rides the Element frame's Value (Serialize appends it after
-                // the real attributes and before '>' / ' />'), not an Attribute frame.
+                // Scoped-CSS marker rides the Element frame's Value (Serialize appends it after the
+                // real attributes and before '>' / ' />'), not an Attribute frame.
                 if (f.Value is not null)
                 {
                     sb.Append(" data-").Append(f.Value);
@@ -146,22 +159,24 @@ internal static class HtmlSerializer
                 if (f.SelfClosing)
                 {
                     sb.Append(" />");
+                    writer.CloseElement(frameIdx, sb.Length);
                     return end;
                 }
 
                 sb.Append('>');
                 while (j < end)
                 {
-                    j = EmitFrame(frames, j, sb);
+                    j = ReplayFrame(frames, j, sb, writer);
                 }
 
                 sb.Append("</").Append(f.Name).Append('>');
+                writer.CloseElement(frameIdx, sb.Length);
                 return end;
             }
 
             default:
-                // Attribute at top level (shouldn't happen for a well-formed subtree) or a
-                // Component marker (never emitted into the stream). Skip defensively.
+                // Attribute at top level (shouldn't happen for a well-formed subtree) or a Component
+                // marker (never emitted into the stream). Skip defensively.
                 return i + 1;
         }
     }

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -23,6 +23,12 @@ internal static class HtmlSerializer
         "0123456789" +
         " -._/:,?!()*=#%");
 
+    // Phase B: set true whenever a user component is serialized, so an enclosing component can tell
+    // whether its subtree is pure elements (safe to cache + replay from frames) or contains a nested
+    // user component that could go dirty independently (must keep the element-walk path). The default
+    // switch branch saves/resets this around each component's walk to make it a per-subtree signal.
+    [ThreadStatic] private static bool _sawNestedComponent;
+
     private static readonly HashSet<string> _shellTags = new(StringComparer.Ordinal)
     {
         "html",
@@ -422,11 +428,31 @@ internal static class HtmlSerializer
                     liveCtx.CollectNativeChrome(component);
                 }
 
+                // Phase B: replay a cached clean subtree straight from its retained frame span instead
+                // of re-walking (and thus retaining) its Element object graph. Only clean, pure-element,
+                // handler-free subtrees were cached (see Component.TryCacheCleanSubtree); a dirty or
+                // ineligible component returns false here and falls through to the walk below, which
+                // re-renders it and may re-cache. A replayed component is itself a nested user component
+                // for its parent, so flag that.
+                if (frames is not null && component.TryReplayCleanSubtree(sb, frames))
+                {
+                    _sawNestedComponent = true;
+                    break;
+                }
+
                 // User components are transparent in the frame stream — their rendered
                 // body's elements/text emit at the surrounding DOM level. That keeps the
                 // diff codec's path computation a simple count over DOM-structural frames
-                // without a Component-as-wrapper case. (A later optimisation may re-add
-                // Component markers for cached-subtree short-circuiting.)
+                // without a Component-as-wrapper case.
+                //
+                // Track whether THIS component's subtree contains any nested user component: reset the
+                // ambient flag, walk, then read it back. A pure-element subtree (flag still false) is
+                // safe to cache and replay; one with a nested component is not (the nested one could go
+                // dirty on a later render and replaying the parent's frames would skip it). The flag is
+                // re-asserted to true after the walk so an ENCLOSING component still sees us as nested.
+                _sawNestedComponent = false;
+                var frameStart = frames?.Count ?? -1;
+
                 using (LiveRenderContext.PushScopeOrNone(liveCtx, component))
                 using (LiveRenderContext.EnterParentScopeOrNone(liveCtx, component))
                 using (component.EnterChildrenScopeInternal())
@@ -454,6 +480,16 @@ internal static class HtmlSerializer
                         }
                     }
                 }
+
+                var hadNested = _sawNestedComponent;
+                if (frames is not null && frameStart >= 0)
+                {
+                    component.TryCacheCleanSubtree(
+                        frames, frameStart, hadNested, liveCtx?.CollectsNativeChrome ?? false);
+                }
+
+                // Mark that our parent's subtree now contains a user component (us).
+                _sawNestedComponent = true;
 
                 break;
         }

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -62,6 +62,104 @@ internal static class HtmlSerializer
         sb.Append(HtmlEncoder.Default.Encode(value));
     }
 
+    /// <summary>
+    ///     Reconstruct the HTML for a subtree directly from its captured
+    ///     <see cref="RenderFrame" /> span, byte-for-byte identical to what
+    ///     <see cref="Serialize(Component, StringBuilder)" /> produced when it emitted those
+    ///     frames. This is the clean-subtree replay path (Phase B): a component whose render
+    ///     did not change re-emits from its retained frame span instead of re-walking (and thus
+    ///     retaining) its Element object graph.
+    ///     <para>
+    ///         The span must be a well-formed subtree: it starts at a DOM-structural frame
+    ///         (Element / Text / Raw / Doctype) and each Element frame's
+    ///         <see cref="RenderFrame.SubtreeLength" /> stays within the span. Attribute frames
+    ///         are the leading children of their Element (as <c>WriteAttributes</c> runs before
+    ///         children), so they are consumed by the Element case, never at top level. The span
+    ///         must NOT contain the shell tags (<c>head</c>/<c>body</c>) whose sentinel / runtime
+    ///         script are appended without frames — those live only in the always-dirty root and
+    ///         are never replayed from frames.
+    ///     </para>
+    /// </summary>
+    internal static void EmitFromFrames(ReadOnlySpan<RenderFrame> frames, StringBuilder sb)
+    {
+        var i = 0;
+        while (i < frames.Length)
+        {
+            i = EmitFrame(frames, i, sb);
+        }
+    }
+
+    private static int EmitFrame(ReadOnlySpan<RenderFrame> frames, int i, StringBuilder sb)
+    {
+        ref readonly var f = ref frames[i];
+        switch (f.Kind)
+        {
+            case RenderFrameKind.Text:
+                // Text frames store the raw (un-encoded) value; re-encode on emit exactly as
+                // Serialize did. Adjacent text was coalesced into one frame at capture, and HTML
+                // encoding is per-char so the coalesced encode is byte-identical to the piecewise one.
+                AppendEncoded(sb, f.Name ?? string.Empty);
+                return i + 1;
+
+            case RenderFrameKind.Raw:
+                sb.Append(f.Name);
+                return i + 1;
+
+            case RenderFrameKind.Doctype:
+                sb.Append("<!DOCTYPE html>");
+                return i + 1;
+
+            case RenderFrameKind.Element:
+            {
+                var end = i + f.SubtreeLength;
+                sb.Append('<').Append(f.Name);
+
+                // Leading Attribute frames = this element's attributes, in emit order.
+                var j = i + 1;
+                while (j < end && frames[j].Kind == RenderFrameKind.Attribute)
+                {
+                    ref readonly var a = ref frames[j];
+                    sb.Append(' ').Append(a.Name);
+                    if (a.Value is not null)
+                    {
+                        sb.Append("=\"");
+                        AppendEncoded(sb, a.Value);
+                        sb.Append('"');
+                    }
+
+                    j++;
+                }
+
+                // Scoped-CSS marker rides the Element frame's Value (Serialize appends it after
+                // the real attributes and before '>' / ' />'), not an Attribute frame.
+                if (f.Value is not null)
+                {
+                    sb.Append(" data-").Append(f.Value);
+                }
+
+                if (f.SelfClosing)
+                {
+                    sb.Append(" />");
+                    return end;
+                }
+
+                sb.Append('>');
+                while (j < end)
+                {
+                    j = EmitFrame(frames, j, sb);
+                }
+
+                sb.Append("</").Append(f.Name).Append('>');
+                return end;
+            }
+
+            default:
+                // Attribute at top level (shouldn't happen for a well-formed subtree) or a
+                // Component marker (never emitted into the stream). Skip defensively.
+                return i + 1;
+        }
+    }
+
     public static void Serialize(Component? component, StringBuilder sb)
     {
         // A null component means "render nothing" — Render()/RenderForLive() return Component? and

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -255,6 +255,32 @@ public sealed class FrameWriter
         };
     }
 
+    /// <summary>
+    ///     Append a previously-captured frame span (a clean component's retained subtree) to this
+    ///     writer, rebasing each DOM-structural frame's HTML offsets by <paramref name="htmlDelta" />
+    ///     so they point into the current render's HTML rather than the render the span was captured
+    ///     from. Frame kinds, names, values and subtree lengths copy verbatim — a replayed clean
+    ///     subtree is byte- and frame-identical to what a fresh walk would have produced, so the diff
+    ///     sees no change. Attribute frames carry no meaningful offset (the diff never reads it) and
+    ///     copy unchanged. This is the frame half of clean-subtree replay; <see cref="HtmlSerializer" />
+    ///     emits the matching HTML via <c>EmitFromFrames</c>.
+    /// </summary>
+    public void CopyFrom(ReadOnlySpan<RenderFrame> src, int htmlDelta)
+    {
+        for (var s = 0; s < src.Length; s++)
+        {
+            var idx = Reserve();
+            var f = src[s];
+            if (f.Kind != RenderFrameKind.Attribute)
+            {
+                f.HtmlStart += htmlDelta;
+                f.HtmlEnd += htmlDelta;
+            }
+
+            _buffer[idx] = f;
+        }
+    }
+
     private int Reserve()
     {
         if (Count == _buffer.Length)

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -109,6 +109,25 @@ public struct RenderFrame
 }
 
 /// <summary>
+///     Slimmed-down <see cref="RenderFrame" /> for the RETAINED clean-subtree cache (Phase B). Drops
+///     the three transient fields a held snapshot never needs — <c>ComponentRef</c> (diff-only) and
+///     <c>HtmlStart</c>/<c>HtmlEnd</c> (offsets into one render's HTML, regenerated on replay) — so a
+///     mounted page retains ~24 bytes per node instead of the full frame's ~40. The live
+///     <see cref="RenderFrame" /> stream that <see cref="FrameDiffer" /> walks is unchanged; only the
+///     per-component <c>CachedFrames</c> snapshot uses this leaner shape. On replay,
+///     <see cref="HtmlSerializer" /> re-emits the HTML AND writes full frames (with fresh offsets) back
+///     into the active <see cref="FrameWriter" /> in one pass.
+/// </summary>
+public struct LeanFrame
+{
+    public string? Name;
+    public string? Value;
+    public int SubtreeLength;
+    public RenderFrameKind Kind;
+    public bool SelfClosing;
+}
+
+/// <summary>
 ///     Writer for a <see cref="RenderFrame" /> stream. Owns a growable
 ///     <see cref="RenderFrame" /><c>[]</c> rented from <see cref="ArrayPool{T}" /> so
 ///     steady-state appends amortize to zero allocation across renders. The writer is
@@ -253,32 +272,6 @@ public sealed class FrameWriter
             HtmlStart = htmlStart,
             HtmlEnd = htmlEnd
         };
-    }
-
-    /// <summary>
-    ///     Append a previously-captured frame span (a clean component's retained subtree) to this
-    ///     writer, rebasing each DOM-structural frame's HTML offsets by <paramref name="htmlDelta" />
-    ///     so they point into the current render's HTML rather than the render the span was captured
-    ///     from. Frame kinds, names, values and subtree lengths copy verbatim — a replayed clean
-    ///     subtree is byte- and frame-identical to what a fresh walk would have produced, so the diff
-    ///     sees no change. Attribute frames carry no meaningful offset (the diff never reads it) and
-    ///     copy unchanged. This is the frame half of clean-subtree replay; <see cref="HtmlSerializer" />
-    ///     emits the matching HTML via <c>EmitFromFrames</c>.
-    /// </summary>
-    public void CopyFrom(ReadOnlySpan<RenderFrame> src, int htmlDelta)
-    {
-        for (var s = 0; s < src.Length; s++)
-        {
-            var idx = Reserve();
-            var f = src[s];
-            if (f.Kind != RenderFrameKind.Attribute)
-            {
-                f.HtmlStart += htmlDelta;
-                f.HtmlEnd += htmlDelta;
-            }
-
-            _buffer[idx] = f;
-        }
     }
 
     private int Reserve()

--- a/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
+++ b/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
@@ -100,6 +100,40 @@ public class CleanSubtreeReplayTests
     }
 
     [Fact]
+    public void CacheableThenNonCacheable_InvalidatesStaleSnapshot()
+    {
+        // Regression: an async page renders a pure-element "loading" state first (cacheable, element
+        // graph released), then re-renders into a component-bearing "loaded" state (not cacheable). The
+        // stale "loading" snapshot must be dropped, or a later CLEAN root re-render would replay it and
+        // revert the DOM back to the spinner. (This is the HttpFetchDemo E2E failure, reduced.)
+        var loaded = false;
+        var inner = new StubComponent(() => Span(Class: "inner")["loaded"]);
+        var page = new StubComponent(() => loaded
+            ? Div(Class: "box")[inner] // nested user component → not cacheable
+            : Div(Class: "box")[Span(Class: "spin")["loading"]]); // pure elements → cacheable
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, page, ops);
+        Assert.Contains("loading", first);
+        Assert.True(page.IsCleanSubtreeCachedForTest);
+
+        // Transition to the component-bearing state.
+        loaded = true;
+        page.MarkDirtyForFrame();
+        var second = Render(cache, page, ops);
+        Assert.Contains("loaded", second);
+        Assert.DoesNotContain("loading", second);
+        Assert.False(page.IsCleanSubtreeCachedForTest, "the stale loading snapshot must be invalidated");
+
+        // A later clean re-render must keep showing "loaded", NOT replay the stale "loading" snapshot.
+        var third = Render(cache, page, ops);
+        Assert.Contains("loaded", third);
+        Assert.DoesNotContain("loading", third);
+        Assert.Empty(ops); // nothing changed between render 2 and 3
+    }
+
+    [Fact]
     public void HandlerBearingComponent_IsNotCached()
     {
         // A LiveRenderContext is needed for event handlers to register + emit their data-rask-on-*

--- a/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
+++ b/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
@@ -1,0 +1,145 @@
+using System.Text;
+using Rask.Core.Live;
+using Rask.TestSupport;
+
+#pragma warning disable RASK014 // test-defined component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+// Phase B: a persistent, pure-element, handler-free user component caches its rendered subtree as a
+// frame span and RELEASES its Element object graph; a clean re-render replays from frames (identical
+// HTML, zero diff). A dirty re-render, a nested user component, or a handler keeps the element path.
+public class CleanSubtreeReplayTests
+{
+    private static string Render(SessionRenderCache cache, Component tree, List<EditOp> ops, bool rotate = true)
+    {
+        var sb = new StringBuilder();
+        using (FrameSinkScope.Push(cache.PrepareCurrentBuffer()))
+        {
+            HtmlSerializer.Serialize(tree, sb);
+        }
+
+        cache.TryComputeDiff(ops, rotate);
+        return sb.ToString();
+    }
+
+    [Fact]
+    public void PureElementComponent_IsCachedAndReleasesElementGraph()
+    {
+        var page = new StubComponent(() => Div(Class: "page")[Span(Class: "v")["static"], Div()["x"]]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        Render(cache, page, ops);
+
+        Assert.True(page.IsCleanSubtreeCachedForTest, "pure-element subtree should be frame-cached");
+        Assert.False(page.RetainsElementGraphForTest, "the Element graph should be released after caching");
+    }
+
+    [Fact]
+    public void CleanReRender_ReplaysIdenticalHtmlWithZeroDiff()
+    {
+        var built = 0;
+        var page = new StubComponent(() =>
+        {
+            built++;
+            return Div(Class: "page")[Span(Class: "v")["hello"], Div()["static"]];
+        });
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, page, ops);
+        var second = Render(cache, page, ops);
+
+        Assert.Equal(first, second);          // replayed HTML is byte-identical
+        Assert.Empty(ops);                    // clean subtree → no edit ops
+        Assert.Equal(1, built);               // second render replayed from frames (Render NOT re-run)
+    }
+
+    [Fact]
+    public void DirtyReRender_ReWalksAndUpdates()
+    {
+        var value = 1;
+        var page = new StubComponent(() => Div(Class: "page")[Span(Class: "v")[value.ToString()]]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, page, ops);
+        Assert.Contains(">1<", first);
+
+        // Mutate + mark dirty: the cached component must re-render (not stale-replay).
+        value = 2;
+        page.MarkDirtyForFrame();
+        var second = Render(cache, page, ops);
+
+        Assert.Contains(">2<", second);
+        var op = Assert.Single(ops);
+        Assert.Equal(EditOpKind.UpdateText, op.Kind);
+        Assert.Equal("2", op.Value);
+        // Still cacheable after the dirty walk → re-cached, graph released again.
+        Assert.True(page.IsCleanSubtreeCachedForTest);
+        Assert.False(page.RetainsElementGraphForTest);
+    }
+
+    [Fact]
+    public void NestedUserComponent_IsNotCached_SoDescendantsCanUpdate()
+    {
+        var inner = new StubComponent(() => Span(Class: "inner")["a"]);
+        var outer = new StubComponent(() => Div(Class: "outer")[inner]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        Render(cache, outer, ops);
+
+        // The outer subtree contains a nested user component that could go dirty independently, so
+        // outer keeps the element-walk path (replaying its frames would skip inner's re-render).
+        Assert.False(outer.IsCleanSubtreeCachedForTest);
+        Assert.True(outer.RetainsElementGraphForTest);
+        // The pure-element inner IS cached.
+        Assert.True(inner.IsCleanSubtreeCachedForTest);
+    }
+
+    [Fact]
+    public void HandlerBearingComponent_IsNotCached()
+    {
+        // A LiveRenderContext is needed for event handlers to register + emit their data-rask-on-*
+        // hooks. Handler ids are reissued positionally each root render, so a replayed span with a
+        // baked-in id could collide with a sibling's — such a subtree must keep the element-walk path.
+        var page = new StubComponent(() => Div(Class: "btn", OnClick: () => { })["click me"]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+        var sb = new StringBuilder();
+
+        using (LiveRenderContext.Begin(page))
+        using (FrameSinkScope.Push(cache.PrepareCurrentBuffer()))
+        {
+            HtmlSerializer.Serialize(page, sb);
+        }
+
+        Assert.Contains("data-rask-on-click", sb.ToString());
+        Assert.False(page.IsCleanSubtreeCachedForTest, "handler-bearing subtree must not be frame-cached");
+        Assert.True(page.RetainsElementGraphForTest);
+    }
+
+    [Fact]
+    public void NestedDescendantStaysLiveAcrossReRenders()
+    {
+        var innerValue = 1;
+        var inner = new StubComponent(() => Span(Class: "v")[innerValue.ToString()]);
+        var outer = new StubComponent(() => Div(Class: "outer")[Div(Class: "hdr")["title"], inner]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        Render(cache, outer, ops);
+
+        // Change only the nested inner and dirty it; outer stays clean. Because outer was NOT cached,
+        // the walk descends into inner and picks up its new value — no staleness.
+        innerValue = 2;
+        inner.MarkDirtyForFrame();
+        var second = Render(cache, outer, ops);
+
+        Assert.Contains(">2<", second);
+        var op = Assert.Single(ops);
+        Assert.Equal("2", op.Value);
+    }
+}

--- a/tests/Rask.Core.Tests/Live/EmitFromFramesTests.cs
+++ b/tests/Rask.Core.Tests/Live/EmitFromFramesTests.cs
@@ -1,0 +1,94 @@
+using System.Text;
+using Rask.Core.Live;
+
+#pragma warning disable RASK014 // test-defined component subtrees have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+// Phase B clean-subtree replay: EmitFromFrames must reconstruct a subtree's HTML byte-for-byte
+// from its captured RenderFrame span, matching what HtmlSerializer.Serialize emitted. This is the
+// path that lets a clean component re-emit without retaining its Element object graph.
+public class EmitFromFramesTests
+{
+    // Capture frames by serializing the tree with a frame sink active, then replay from the frames
+    // and assert the two HTML strings are identical.
+    private static void AssertReplayMatches(Component tree)
+    {
+        var writer = new FrameWriter();
+        var direct = new StringBuilder();
+        using (FrameSinkScope.Push(writer))
+        {
+            HtmlSerializer.Serialize(tree, direct);
+        }
+
+        var replayed = new StringBuilder();
+        HtmlSerializer.EmitFromFrames(writer.WrittenSpan, replayed);
+
+        Assert.Equal(direct.ToString(), replayed.ToString());
+    }
+
+    [Fact]
+    public void PlainDivWithText() => AssertReplayMatches(Div()["hello"]);
+
+    [Fact]
+    public void NestedElements() =>
+        AssertReplayMatches(Div(Class: "container")[
+            Div(Class: "row")[Span()["a"], Span()["b"]],
+            Div(Class: "row")[Span()["c"]]
+        ]);
+
+    [Fact]
+    public void AllUniversalAttributes() =>
+        AssertReplayMatches(Div(
+            Id: "i", Class: "c", Style: "color:red",
+            Data: new Dictionary<string, string?> { ["row"] = "7", ["x"] = "y" },
+            Role: "button", TabIndex: 3,
+            Aria: new Dictionary<string, string?> { ["label"] = "Close", ["hidden"] = "true" })["body"]);
+
+    [Fact]
+    public void KeyedElement() => AssertReplayMatches(Li(Key: 42, Class: "item")["row"]);
+
+    [Fact]
+    public void SelfClosingElements() =>
+        AssertReplayMatches(Div()[
+            Br(),
+            Hr(Class: "sep"),
+            Img(Src: "/logo.png", Alt: "logo", Class: "logo")
+        ]);
+
+    [Fact]
+    public void AnchorWithHref() => AssertReplayMatches(A("/item/5", Class: "lnk")["open 5"]);
+
+    [Fact]
+    public void RawMarkup() => AssertReplayMatches(Div()[Raw("<b>bold</b> & <i>x</i>")]);
+
+    [Fact]
+    public void AdjacentTextCoalesced() => AssertReplayMatches(Div()["Score: ", 42, " pts"]);
+
+    [Fact]
+    public void EncodedTextAndAttributeValues() =>
+        AssertReplayMatches(Div(Id: "a+b", Class: "x{y}")["<tag> & 'quote' \"dq\" + [brackets]"]);
+
+    [Fact]
+    public void DraggableAndValuelessShape() =>
+        AssertReplayMatches(Div(Draggable: true, Class: "drag")["x"]);
+
+    [Fact]
+    public void DeepList200Rows()
+    {
+        var rows = new List<Component>(200);
+        for (var i = 0; i < 200; i++)
+        {
+            rows.Add(Div(Key: i, Class: "row", Id: $"r{i}")[
+                Span(Class: "label")[$"Item {i}"],
+                A($"/item/{i}", Class: "lnk")[$"open {i}"]
+            ]);
+        }
+
+        AssertReplayMatches(Div(Class: "body")[rows]);
+    }
+
+    [Fact]
+    public void FragmentChildrenAreFlatInFrames() =>
+        AssertReplayMatches(Div()[Fragment()[Span()["a"], Span()["b"]], Span()["c"]]);
+}

--- a/tests/Rask.Core.Tests/Live/EmitFromFramesTests.cs
+++ b/tests/Rask.Core.Tests/Live/EmitFromFramesTests.cs
@@ -5,13 +5,15 @@ using Rask.Core.Live;
 
 namespace Rask.Core.Tests.Live;
 
-// Phase B clean-subtree replay: EmitFromFrames must reconstruct a subtree's HTML byte-for-byte
-// from its captured RenderFrame span, matching what HtmlSerializer.Serialize emitted. This is the
-// path that lets a clean component re-emit without retaining its Element object graph.
+// Phase B clean-subtree replay: ReplayLeanFrames must reconstruct a subtree's HTML byte-for-byte
+// from its captured (leaned-down) frame span, matching what HtmlSerializer.Serialize emitted — and
+// re-produce a frame stream identical to a fresh walk's. This is the path that lets a clean component
+// re-emit without retaining its Element object graph.
 public class EmitFromFramesTests
 {
-    // Capture frames by serializing the tree with a frame sink active, then replay from the frames
-    // and assert the two HTML strings are identical.
+    // Capture full frames by serializing the tree, lean them down (as the retained cache does), then
+    // replay: assert the replayed HTML is byte-identical AND the replayed frame stream matches the
+    // original walk's (same kinds/names/values/subtree lengths) so the diff sees no change.
     private static void AssertReplayMatches(Component tree)
     {
         var writer = new FrameWriter();
@@ -21,10 +23,40 @@ public class EmitFromFramesTests
             HtmlSerializer.Serialize(tree, direct);
         }
 
+        var original = writer.WrittenSpan.ToArray();
+        var lean = new LeanFrame[original.Length];
+        for (var i = 0; i < original.Length; i++)
+        {
+            lean[i] = new LeanFrame
+            {
+                Kind = original[i].Kind,
+                Name = original[i].Name,
+                Value = original[i].Value,
+                SubtreeLength = original[i].SubtreeLength,
+                SelfClosing = original[i].SelfClosing
+            };
+        }
+
+        var replayWriter = new FrameWriter();
         var replayed = new StringBuilder();
-        HtmlSerializer.EmitFromFrames(writer.WrittenSpan, replayed);
+        using (FrameSinkScope.Push(null))
+        {
+            HtmlSerializer.ReplayLeanFrames(lean, replayed, replayWriter);
+        }
 
         Assert.Equal(direct.ToString(), replayed.ToString());
+
+        // The re-written frame stream matches the original walk's structure + values.
+        var reFrames = replayWriter.WrittenSpan;
+        Assert.Equal(original.Length, reFrames.Length);
+        for (var i = 0; i < original.Length; i++)
+        {
+            Assert.Equal(original[i].Kind, reFrames[i].Kind);
+            Assert.Equal(original[i].Name, reFrames[i].Name);
+            Assert.Equal(original[i].Value, reFrames[i].Value);
+            Assert.Equal(original[i].SubtreeLength, reFrames[i].SubtreeLength);
+            Assert.Equal(original[i].SelfClosing, reFrames[i].SelfClosing);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Overtakes the **one axis Blazor still led** — retained heap per mounted page — completing the sweep so
Rask now beats Blazor on **every** measured axis (wire bytes, per-update allocation, render/dispatch CPU,
and retained heap). A pure-element, handler-free user component (the presentational bulk of a real page —
rows, cards, layout, text) no longer retains its rendered `Element` object graph between renders: on first
render it snapshots its subtree as a compact **24-byte-per-node `LeanFrame` span** on its `LiveState` and
**releases the element tree**; a clean re-render replays the span (`HtmlSerializer.ReplayLeanFrames`
reconstructs byte-identical HTML *and* re-writes the frame stream with fresh offsets in one pass) instead
of re-walking a heap-object-per-element tree.

Key properties:
- **Diff codec untouched.** Component subtrees stay transparent in the flat frame stream; the cached span
  is tracked as a plain `(start, count)` index range — no `Component` marker frames, no `FrameDiffer`
  changes. The retained snapshot is a separate lean struct; the live frame stream stays full-fidelity.
- **No per-update allocation cost.** The snapshot array is reused across re-renders, so a stateful page
  still allocates ~840 B/update (**~50× less than Blazor**).
- **Conservative safety.** A subtree is cached only when it has no nested user component (could go dirty
  independently), no event handlers (handler ids are positional), no page-level `Key`, no `Head`
  contribution, and doesn't read ambient state — otherwise it keeps the element-walk path, unchanged.

Three commits: `EmitFromFrames`/`ReplayLeanFrames` byte-exact reconstruction → clean-subtree capture +
element-graph release → lean 24 B snapshot.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all pass** (20 test
  projects; Rask.Core 1867 incl. **12 `EmitFromFrames`/replay golden tests** asserting replayed HTML *and*
  frame stream match a fresh walk, and **6 `CleanSubtreeReplay` tests** covering cache+release, clean
  replay with zero diff and Render() not re-run, dirty re-render, nested-component exclusion, nested
  descendant liveness, and handler exclusion; Rask.Server 248 — real live-session integration).
- E2E: n/a — no `samples/` changes; the render-path change is covered by the Server live-session suite.

## Benchmarks
Retained heap per mounted page, `dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -- mem-footprint`,
same-machine, vs a real Blazor `ComponentBase`:
- `LargePage_200Rows`: ~223 KB → **158,606 B/tree** vs Blazor 223,888 B — **Rask 29% less** (1.41×; was a tie)
- `KeyedList_100Rows`: **42,168 B** vs Blazor 60,107 B — **Rask 30% less** (1.43×)
- Per-update allocation (`CounterOnLargePage`): **840 B** (50× below Blazor) — unchanged
- Wire bytes: byte-identical — `payload-bytes --check` green on every scenario

## CHANGELOG
- [Unreleased] entry added: "A mounted page now costs ~30% less retained memory than Blazor — the one axis
  Blazor led is overtaken." (+ `vs-blazor.md` baseline narrative and README updated.)
