### PR TITLE
fix(playground): keep Monaco editor theme across re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -201,6 +201,13 @@ them until tagged releases begin.
   shards to browser-journey time.
 
 ### Fixed
+- **Playground editor lost its syntax colouring after the first Run.** Monaco injects its theme colours as
+  a `<style class="monaco-colors">` in `<head>`; the live-diff morph reconciles `<head>` on every re-render
+  and removes any child not marked `data-rask-managed`, so the first re-render (e.g. after clicking Run)
+  stripped it and every token fell back to the inherited body colour — a faint, uncoloured editor. The
+  playground now stamps Monaco's head-injected `<style>`/`<link>` nodes as `data-rask-managed` (the same
+  marker the framework uses for its own scoped-asset head tags) and keeps a `MutationObserver` on `<head>`
+  so any it adds later stays protected. An E2E assertion guards it.
 - **Native `IJSRuntime` calls threw `NotSupportedException` on iOS.** Any component invoking a browser API
   with arguments (e.g. the guide-chrome scroll-spy) failed on iOS with *"JsonTypeInfo metadata for type
   'System.Object[]' was not provided"*. `NativeJSRuntime` added the reflection-based JSON resolver only when

--- a/samples/Rask.Example.Playground/PlaygroundView.js
+++ b/samples/Rask.Example.Playground/PlaygroundView.js
@@ -46,10 +46,46 @@ function loadMonaco() {
     return loadPromise;
 }
 
+// Monaco injects its theme colours as a <style class="monaco-colors"> (and its CSS as a <link>) into
+// <head>. Rask's live-diff morph reconciles <head> on every re-render and removes any child that isn't
+// marked data-rask-managed — the same marker the framework uses for its own scoped-asset head tags — so
+// without this the editor loses all colour the first time the app re-renders (e.g. after Run). Stamp
+// Monaco's head nodes as managed, and keep watching <head> so any it adds later is protected too.
+let headGuardInstalled = false;
+
+function isMonacoHeadNode(n) {
+    if (!n || n.nodeType !== 1) return false;
+    const cls = typeof n.className === "string" ? n.className : "";
+    if (cls.indexOf("monaco") !== -1) return true;
+    if (n.tagName === "STYLE" && n.textContent && n.textContent.indexOf(".mtk") !== -1) return true;
+    if (n.tagName === "LINK" && n.href && n.href.indexOf("/monaco/") !== -1) return true;
+    return false;
+}
+
+function markManaged(n) {
+    if (isMonacoHeadNode(n) && !n.hasAttribute("data-rask-managed")) {
+        n.setAttribute("data-rask-managed", "");
+    }
+}
+
+function protectMonacoHeadNodes() {
+    // Idempotent sweep of anything already in <head>.
+    document.head.querySelectorAll("style, link").forEach(markManaged);
+    // Install the ongoing guard exactly once.
+    if (headGuardInstalled) return;
+    headGuardInstalled = true;
+    new MutationObserver((records) => {
+        for (const r of records) for (const n of r.addedNodes) markManaged(n);
+    }).observe(document.head, { childList: true });
+}
+
 export async function mountEditor(host, code) {
     if (!host || editor || host.__fallback) return;
     try {
         const monaco = await loadMonaco();
+        // Start protecting head nodes before create so the color <style> Monaco injects during create is
+        // caught by the observer and marked managed from the outset.
+        protectMonacoHeadNodes();
         editor = monaco.editor.create(host, {
             value: code,
             language: "csharp",
@@ -62,6 +98,8 @@ export async function mountEditor(host, code) {
             renderLineHighlight: "line",
             fixedOverflowWidgets: true
         });
+        // Re-sweep after create in case any node landed synchronously before the observer registered.
+        protectMonacoHeadNodes();
     } catch {
         // Monaco unavailable — degrade to a textarea so the playground still compiles and runs code.
         const ta = document.createElement("textarea");

--- a/tests/Rask.Examples.E2E.Tests/PlaygroundExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/PlaygroundExampleTests.cs
@@ -47,6 +47,14 @@ public sealed class PlaygroundExampleTests
             await page.ClickAsync(".pg-preview .card .btn");
             await Expect(page.Locator(".pg-preview .card p"))
                 .ToContainTextAsync("1 times", new LocatorAssertionsToContainTextOptions { Timeout = 15_000 });
+
+            // Regression guard: Monaco injects its theme colours as a <style> in <head>; the live-diff
+            // morph on each re-render (Run + this click) must preserve it (it's marked data-rask-managed),
+            // or the editor loses all syntax colouring and renders faint. Assert it survived.
+            var monacoHeadStyles = await page.EvaluateAsync<int>(
+                "() => document.querySelectorAll('head style.monaco-colors, head style[class*=\"monaco\"]').length");
+            Assert.True(monacoHeadStyles > 0,
+                "Monaco's head-injected theme <style> was stripped on re-render — the editor would render uncoloured.");
         }
         finally
         {


### PR DESCRIPTION
## Summary
Fixes the live playground editor losing all syntax colouring after the first **Run** (a faint, uncoloured editor). Monaco injects its theme colours as a `<style class="monaco-colors">` in `<head>`; Rask's live-diff morph reconciles `<head>` on every re-render and removes any child not marked `data-rask-managed`, so the first re-render (Run, or the compiled component's own click) stripped it and every token fell back to the inherited body colour. The playground now stamps Monaco's head-injected `<style>`/`<link>` nodes as `data-rask-managed` — the same marker the framework uses for its own scoped-asset head tags (`rask-morph.js`) — and keeps a `MutationObserver` on `<head>` so any Monaco adds later stays protected.

Root-caused in a real browser (WebKit/Safari engine): before Run a token was `mtk8` `rgb(86,156,214)` with 1 `monaco-colors` head style; after Run the same token was `rgb(31,36,48)` (body colour) with 0 head styles. With the fix, the token stays `rgb(86,156,214)` and the head style survives.

## Testing
- E2E (samples changed): host **PlaygroundExampleTests** — pass. Extended the journey to assert Monaco's head-injected theme `<style>` survives the post-Run re-render (the regression guard).
- Verified end-to-end in WebKit against both the local bundle and the live deploy: editor keeps full syntax colouring after Run + counter clicks.
- `dotnet format` clean.

## Benchmarks
n/a — playground sample + editor JS only; no `Rask.Core`/`Rask.Server` change.

## CHANGELOG
- [Unreleased] → Fixed: "Playground editor lost its syntax colouring after the first Run."
