### PR TITLE
fix(core): preserve foreign head nodes across re-renders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,16 @@ them until tagged releases begin.
   over the WebSocket.
 
 ### Changed
+- **Head reconciliation preserves foreign (third-party-injected) head nodes.** Libraries routinely inject
+  `<style>`/`<link>`/`<script>` into `<head>` at runtime — Monaco's theme colours, Chart.js, syntax
+  highlighters, analytics. Previously the live-diff morph trimmed any such node on the next re-render (it
+  wasn't in the .NET-rendered head), so e.g. a mounted code editor lost all its styling on the first state
+  change. The client morph now tags the head nodes it owns (inline, as each rendered node is placed) and
+  leaves any it doesn't (nodes injected since the last render) in place — the same effect `data-rask-managed`
+  gives, but automatic, so a third-party library that injects into `<head>` "just works". The first head
+  reconciliation (boot-shell hydration) is unchanged, and `data-rask-key` nodes (the framework's own keyed
+  head links, incl. the scoped-CSS FOUC preload clone) always reconcile by key rather than duplicate. This
+  let the playground drop its bespoke Monaco head-guard.
 - **Showcase restructure: a "Mobile & devices" guide group, a Welcome-free root, and a Bootstrapped
   Todos app.** The on-site `GuideCatalog` now groups **Browser APIs**, **Mobile & PWA**, and the
   newly-surfaced **Native (iOS/Android)** guide (`docs/native.md`, previously embedded but never listed)

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -302,6 +302,15 @@ the bundle, so it paints the instant it mounts — no per-component fetch, no FO
 
 <!-- demo:asset-lazy-mount -->
 
+### Third-party libraries that inject into `<head>`
+
+Some JS libraries add their own `<style>`/`<link>`/`<script>` to `<head>` at runtime — a code editor's
+theme colours, a charting library, a syntax highlighter. Rask **preserves these automatically**: the
+live-diff reconciler tracks the head nodes it renders itself and leaves any others in place, so a library
+that injects into `<head>` keeps working across re-renders with no extra wiring. If you ever need to opt a
+node out of reconciliation explicitly (e.g. one you add yourself and manage entirely from JS), give it the
+`data-rask-managed` attribute and the morph will never touch it.
+
 ---
 
 See also: [Composition](composition.md) for component-to-component communication, and the

--- a/samples/Rask.Example.Playground/PlaygroundView.js
+++ b/samples/Rask.Example.Playground/PlaygroundView.js
@@ -46,46 +46,13 @@ function loadMonaco() {
     return loadPromise;
 }
 
-// Monaco injects its theme colours as a <style class="monaco-colors"> (and its CSS as a <link>) into
-// <head>. Rask's live-diff morph reconciles <head> on every re-render and removes any child that isn't
-// marked data-rask-managed — the same marker the framework uses for its own scoped-asset head tags — so
-// without this the editor loses all colour the first time the app re-renders (e.g. after Run). Stamp
-// Monaco's head nodes as managed, and keep watching <head> so any it adds later is protected too.
-let headGuardInstalled = false;
-
-function isMonacoHeadNode(n) {
-    if (!n || n.nodeType !== 1) return false;
-    const cls = typeof n.className === "string" ? n.className : "";
-    if (cls.indexOf("monaco") !== -1) return true;
-    if (n.tagName === "STYLE" && n.textContent && n.textContent.indexOf(".mtk") !== -1) return true;
-    if (n.tagName === "LINK" && n.href && n.href.indexOf("/monaco/") !== -1) return true;
-    return false;
-}
-
-function markManaged(n) {
-    if (isMonacoHeadNode(n) && !n.hasAttribute("data-rask-managed")) {
-        n.setAttribute("data-rask-managed", "");
-    }
-}
-
-function protectMonacoHeadNodes() {
-    // Idempotent sweep of anything already in <head>.
-    document.head.querySelectorAll("style, link").forEach(markManaged);
-    // Install the ongoing guard exactly once.
-    if (headGuardInstalled) return;
-    headGuardInstalled = true;
-    new MutationObserver((records) => {
-        for (const r of records) for (const n of r.addedNodes) markManaged(n);
-    }).observe(document.head, { childList: true });
-}
-
 export async function mountEditor(host, code) {
     if (!host || editor || host.__fallback) return;
     try {
         const monaco = await loadMonaco();
-        // Start protecting head nodes before create so the color <style> Monaco injects during create is
-        // caught by the observer and marked managed from the outset.
-        protectMonacoHeadNodes();
+        // Monaco injects its theme colours as a <style> into <head>. The framework's morph preserves
+        // head nodes it didn't render (see rask-morph.js markHeadOwned), so no extra guarding is needed —
+        // the editor keeps its colours across re-renders (e.g. after Run).
         editor = monaco.editor.create(host, {
             value: code,
             language: "csharp",
@@ -98,8 +65,6 @@ export async function mountEditor(host, code) {
             renderLineHighlight: "line",
             fixedOverflowWidgets: true
         });
-        // Re-sweep after create in case any node landed synchronously before the observer registered.
-        protectMonacoHeadNodes();
     } catch {
         // Monaco unavailable — degrade to a textarea so the playground still compiles and runs code.
         const ta = document.createElement("textarea");

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -139,6 +139,26 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// Third-party head preservation. Libraries commonly inject <style>/<link>/<script> into <head> at
+// runtime (Monaco's theme colours, Chart.js, syntax highlighters, analytics). Those nodes aren't in the
+// .NET-rendered head, so a naive reconcile would trim them on the next render — the framework already
+// exposes data-rask-managed to opt a node out, but foreign libraries can't be expected to tag what they
+// inject. Instead the morph tags every head node it PRODUCES (a __raskHead property set inline as each
+// rendered node is placed) and, on later head morphs, skips any head element it never produced — leaving
+// the foreign node in place exactly like a data-rask-managed one.
+//
+// Two invariants make this safe:
+//   * The `raskHeadReconciled` gate keeps the FIRST head morph byte-identical to before, so boot-shell
+//     hydration (importmap/base/preload/scoped placeholders) reconciles exactly as it used to.
+//   * data-rask-key nodes are NEVER treated as foreign, so the framework's own keyed head nodes — most
+//     importantly the scoped-CSS FOUC preload clone (rask-scoped.js), whose __raskHead expando does not
+//     survive cloneNode — still reconcile by key instead of duplicating.
+//
+// Because ownership is marked inline on exactly the nodes derived from the render tree (not by a post-hoc
+// sweep of all children), a sibling that a rendered inline <script> injects mid-morph is left unmarked and
+// therefore preserved, rather than adopted-as-owned and trimmed on the following render.
+let raskHeadReconciled = false;
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -194,9 +214,22 @@ function morph(from, to) {
     // the Server overlay (reconnect spinner sibling of <html>) and the WASM
     // scoped-css / scoped-js bundle tags (head children that don't appear in
     // the .NET-rendered HTML payload).
+    // Foreign-head preservation (see the note above raskHeadReconciled): once the head has been
+    // reconciled at least once, pull out any head element the morph never produced (a third-party lib
+    // injected it since the last render) so it's left in place, exactly like a data-rask-managed node.
+    // data-rask-key nodes are NOT foreign — they're framework keyed nodes (e.g. the scoped-CSS FOUC
+    // clone) that must reconcile by key rather than duplicate.
+    const isHead = from.nodeName === "HEAD";
+    const skipForeign = isHead && raskHeadReconciled;
+    // Tag a node the morph produces as Rask-owned (head only) so later morphs don't mistake it for a
+    // foreign injection. Applied inline to exactly the nodes derived from the render tree.
+    const own = isHead ? (n) => { n.__raskHead = true; return n; } : (n) => n;
     const fc = [], tc = [];
     for (let n = from.firstChild; n; n = n.nextSibling) {
         if (n.nodeType === 1 && n.hasAttribute("data-rask-managed")) continue;
+        if (skipForeign && n.nodeType === 1 && n.__raskHead !== true && !n.hasAttribute("data-rask-key")) {
+            continue;
+        }
         fc.push(n);
     }
     for (let m = to.firstChild; m; m = m.nextSibling) tc.push(m);
@@ -235,9 +268,9 @@ function morph(from, to) {
                 src = unkeyedFrom[unkeyedCursor++] || null;
             }
             if (src === null) {
-                _raskInsertBefore(from, reviveScript(dst), anchor);
+                _raskInsertBefore(from, own(reviveScript(dst)), anchor);
             } else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) {
-                _raskInsertBefore(from, reviveScript(dst), anchor);
+                _raskInsertBefore(from, own(reviveScript(dst)), anchor);
                 // If the from-node we're about to remove IS the anchor, advance the anchor past it
                 // first — otherwise the next insert/move would pass a reference node no longer in
                 // `from` and insertBefore throws "reference node is not a child". This happens when a
@@ -250,6 +283,7 @@ function morph(from, to) {
                 if (src !== anchor) _raskMoveBefore(from, src, anchor);
                 else anchor = anchor.nextSibling;
                 morph(src, dst);
+                own(src);
             }
         }
         // Drop any from-side keyed nodes that were not claimed by the new tree.
@@ -261,15 +295,17 @@ function morph(from, to) {
             const leftover = unkeyedFrom[unkeyedCursor++];
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
+        if (isHead) raskHeadReconciled = true;
         return;
     }
 
     const max = Math.max(fc.length, tc.length);
     for (let k = 0; k < max; k++) {
         const src = fc[k], dst = tc[k];
-        if (!src) _raskAppendChild(from, reviveScript(dst));
+        if (!src) _raskAppendChild(from, own(reviveScript(dst)));
         else if (!dst) _raskRemoveChild(from, src);
-        else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, reviveScript(dst), src);
-        else morph(src, dst);
+        else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, own(reviveScript(dst)), src);
+        else { morph(src, dst); own(src); }
     }
+    if (isHead) raskHeadReconciled = true;
 }

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1943,6 +1943,26 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// Third-party head preservation. Libraries commonly inject <style>/<link>/<script> into <head> at
+// runtime (Monaco's theme colours, Chart.js, syntax highlighters, analytics). Those nodes aren't in the
+// .NET-rendered head, so a naive reconcile would trim them on the next render — the framework already
+// exposes data-rask-managed to opt a node out, but foreign libraries can't be expected to tag what they
+// inject. Instead the morph tags every head node it PRODUCES (a __raskHead property set inline as each
+// rendered node is placed) and, on later head morphs, skips any head element it never produced — leaving
+// the foreign node in place exactly like a data-rask-managed one.
+//
+// Two invariants make this safe:
+//   * The `raskHeadReconciled` gate keeps the FIRST head morph byte-identical to before, so boot-shell
+//     hydration (importmap/base/preload/scoped placeholders) reconciles exactly as it used to.
+//   * data-rask-key nodes are NEVER treated as foreign, so the framework's own keyed head nodes — most
+//     importantly the scoped-CSS FOUC preload clone (rask-scoped.js), whose __raskHead expando does not
+//     survive cloneNode — still reconcile by key instead of duplicating.
+//
+// Because ownership is marked inline on exactly the nodes derived from the render tree (not by a post-hoc
+// sweep of all children), a sibling that a rendered inline <script> injects mid-morph is left unmarked and
+// therefore preserved, rather than adopted-as-owned and trimmed on the following render.
+let raskHeadReconciled = false;
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -1998,9 +2018,22 @@ function morph(from, to) {
     // the Server overlay (reconnect spinner sibling of <html>) and the WASM
     // scoped-css / scoped-js bundle tags (head children that don't appear in
     // the .NET-rendered HTML payload).
+    // Foreign-head preservation (see the note above raskHeadReconciled): once the head has been
+    // reconciled at least once, pull out any head element the morph never produced (a third-party lib
+    // injected it since the last render) so it's left in place, exactly like a data-rask-managed node.
+    // data-rask-key nodes are NOT foreign — they're framework keyed nodes (e.g. the scoped-CSS FOUC
+    // clone) that must reconcile by key rather than duplicate.
+    const isHead = from.nodeName === "HEAD";
+    const skipForeign = isHead && raskHeadReconciled;
+    // Tag a node the morph produces as Rask-owned (head only) so later morphs don't mistake it for a
+    // foreign injection. Applied inline to exactly the nodes derived from the render tree.
+    const own = isHead ? (n) => { n.__raskHead = true; return n; } : (n) => n;
     const fc = [], tc = [];
     for (let n = from.firstChild; n; n = n.nextSibling) {
         if (n.nodeType === 1 && n.hasAttribute("data-rask-managed")) continue;
+        if (skipForeign && n.nodeType === 1 && n.__raskHead !== true && !n.hasAttribute("data-rask-key")) {
+            continue;
+        }
         fc.push(n);
     }
     for (let m = to.firstChild; m; m = m.nextSibling) tc.push(m);
@@ -2039,9 +2072,9 @@ function morph(from, to) {
                 src = unkeyedFrom[unkeyedCursor++] || null;
             }
             if (src === null) {
-                _raskInsertBefore(from, reviveScript(dst), anchor);
+                _raskInsertBefore(from, own(reviveScript(dst)), anchor);
             } else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) {
-                _raskInsertBefore(from, reviveScript(dst), anchor);
+                _raskInsertBefore(from, own(reviveScript(dst)), anchor);
                 // If the from-node we're about to remove IS the anchor, advance the anchor past it
                 // first — otherwise the next insert/move would pass a reference node no longer in
                 // `from` and insertBefore throws "reference node is not a child". This happens when a
@@ -2054,6 +2087,7 @@ function morph(from, to) {
                 if (src !== anchor) _raskMoveBefore(from, src, anchor);
                 else anchor = anchor.nextSibling;
                 morph(src, dst);
+                own(src);
             }
         }
         // Drop any from-side keyed nodes that were not claimed by the new tree.
@@ -2065,17 +2099,19 @@ function morph(from, to) {
             const leftover = unkeyedFrom[unkeyedCursor++];
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
+        if (isHead) raskHeadReconciled = true;
         return;
     }
 
     const max = Math.max(fc.length, tc.length);
     for (let k = 0; k < max; k++) {
         const src = fc[k], dst = tc[k];
-        if (!src) _raskAppendChild(from, reviveScript(dst));
+        if (!src) _raskAppendChild(from, own(reviveScript(dst)));
         else if (!dst) _raskRemoveChild(from, src);
-        else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, reviveScript(dst), src);
-        else morph(src, dst);
+        else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, own(reviveScript(dst)), src);
+        else { morph(src, dst); own(src); }
     }
+    if (isHead) raskHeadReconciled = true;
 }
 
 

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2469,6 +2469,26 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// Third-party head preservation. Libraries commonly inject <style>/<link>/<script> into <head> at
+// runtime (Monaco's theme colours, Chart.js, syntax highlighters, analytics). Those nodes aren't in the
+// .NET-rendered head, so a naive reconcile would trim them on the next render — the framework already
+// exposes data-rask-managed to opt a node out, but foreign libraries can't be expected to tag what they
+// inject. Instead the morph tags every head node it PRODUCES (a __raskHead property set inline as each
+// rendered node is placed) and, on later head morphs, skips any head element it never produced — leaving
+// the foreign node in place exactly like a data-rask-managed one.
+//
+// Two invariants make this safe:
+//   * The `raskHeadReconciled` gate keeps the FIRST head morph byte-identical to before, so boot-shell
+//     hydration (importmap/base/preload/scoped placeholders) reconciles exactly as it used to.
+//   * data-rask-key nodes are NEVER treated as foreign, so the framework's own keyed head nodes — most
+//     importantly the scoped-CSS FOUC preload clone (rask-scoped.js), whose __raskHead expando does not
+//     survive cloneNode — still reconcile by key instead of duplicating.
+//
+// Because ownership is marked inline on exactly the nodes derived from the render tree (not by a post-hoc
+// sweep of all children), a sibling that a rendered inline <script> injects mid-morph is left unmarked and
+// therefore preserved, rather than adopted-as-owned and trimmed on the following render.
+let raskHeadReconciled = false;
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -2524,9 +2544,22 @@ function morph(from, to) {
     // the Server overlay (reconnect spinner sibling of <html>) and the WASM
     // scoped-css / scoped-js bundle tags (head children that don't appear in
     // the .NET-rendered HTML payload).
+    // Foreign-head preservation (see the note above raskHeadReconciled): once the head has been
+    // reconciled at least once, pull out any head element the morph never produced (a third-party lib
+    // injected it since the last render) so it's left in place, exactly like a data-rask-managed node.
+    // data-rask-key nodes are NOT foreign — they're framework keyed nodes (e.g. the scoped-CSS FOUC
+    // clone) that must reconcile by key rather than duplicate.
+    const isHead = from.nodeName === "HEAD";
+    const skipForeign = isHead && raskHeadReconciled;
+    // Tag a node the morph produces as Rask-owned (head only) so later morphs don't mistake it for a
+    // foreign injection. Applied inline to exactly the nodes derived from the render tree.
+    const own = isHead ? (n) => { n.__raskHead = true; return n; } : (n) => n;
     const fc = [], tc = [];
     for (let n = from.firstChild; n; n = n.nextSibling) {
         if (n.nodeType === 1 && n.hasAttribute("data-rask-managed")) continue;
+        if (skipForeign && n.nodeType === 1 && n.__raskHead !== true && !n.hasAttribute("data-rask-key")) {
+            continue;
+        }
         fc.push(n);
     }
     for (let m = to.firstChild; m; m = m.nextSibling) tc.push(m);
@@ -2565,9 +2598,9 @@ function morph(from, to) {
                 src = unkeyedFrom[unkeyedCursor++] || null;
             }
             if (src === null) {
-                _raskInsertBefore(from, reviveScript(dst), anchor);
+                _raskInsertBefore(from, own(reviveScript(dst)), anchor);
             } else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) {
-                _raskInsertBefore(from, reviveScript(dst), anchor);
+                _raskInsertBefore(from, own(reviveScript(dst)), anchor);
                 // If the from-node we're about to remove IS the anchor, advance the anchor past it
                 // first — otherwise the next insert/move would pass a reference node no longer in
                 // `from` and insertBefore throws "reference node is not a child". This happens when a
@@ -2580,6 +2613,7 @@ function morph(from, to) {
                 if (src !== anchor) _raskMoveBefore(from, src, anchor);
                 else anchor = anchor.nextSibling;
                 morph(src, dst);
+                own(src);
             }
         }
         // Drop any from-side keyed nodes that were not claimed by the new tree.
@@ -2591,17 +2625,19 @@ function morph(from, to) {
             const leftover = unkeyedFrom[unkeyedCursor++];
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
+        if (isHead) raskHeadReconciled = true;
         return;
     }
 
     const max = Math.max(fc.length, tc.length);
     for (let k = 0; k < max; k++) {
         const src = fc[k], dst = tc[k];
-        if (!src) _raskAppendChild(from, reviveScript(dst));
+        if (!src) _raskAppendChild(from, own(reviveScript(dst)));
         else if (!dst) _raskRemoveChild(from, src);
-        else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, reviveScript(dst), src);
-        else morph(src, dst);
+        else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, own(reviveScript(dst)), src);
+        else { morph(src, dst); own(src); }
     }
+    if (isHead) raskHeadReconciled = true;
 }
 
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -74,6 +74,8 @@ public abstract partial class SharedSmokeTests
         // The SPA sentinel must have survived the entire in-SPA walk.
         Assert.Equal("alive", await Page.EvaluateAsync<string?>("() => window.__raskSentinel"));
 
+        await AssertNoDuplicateScopedHeadLinksAsync();
+
         await RunUnusualActivityAsync(opts);
     }
 
@@ -100,6 +102,29 @@ public abstract partial class SharedSmokeTests
     // ToastDemo.cs / ToasterDemo.cs source whose "Danger"/"Error" message is literally "Something went wrong.".
     protected async Task AssertNoGlobalCrashAsync() =>
         Assert.Equal(0, await Page.Locator(".rask-error-boundary").CountAsync());
+
+    // After walking every page, each scoped component's keyed stylesheet (<link data-rask-key>) must
+    // appear in <head> exactly once. On hosts that deliver scoped CSS per component via a full reply
+    // (Server), the FOUC preload (rask-scoped.js clones the incoming keyed <link> before the morph)
+    // must reconcile against the clone by key rather than duplicate it — a regression here silently
+    // leaks one <link> per scoped component ever mounted and re-applies unmounted pages' CSS. On the
+    // bundled-CSS hosts (WASM) there is a single keyed link, so this is trivially satisfied.
+    protected async Task AssertNoDuplicateScopedHeadLinksAsync()
+    {
+        var duplicateKeys = await Page.EvaluateAsync<string[]>(
+            """
+            () => {
+                const counts = {};
+                for (const l of document.querySelectorAll('head link[rel="stylesheet"][data-rask-key]')) {
+                    const k = l.getAttribute('data-rask-key');
+                    counts[k] = (counts[k] || 0) + 1;
+                }
+                return Object.keys(counts).filter(k => counts[k] > 1);
+            }
+            """);
+        Assert.True(duplicateKeys.Length == 0,
+            $"Duplicate scoped stylesheet <link>s in <head> (leaked): {string.Join(", ", duplicateKeys)}");
+    }
 
     // The redesigned sidebar: collapsible groups (only the active route's group open by default), a
     // search filter, and — below md — a hamburger-driven offcanvas drawer. Exercised once per host.


### PR DESCRIPTION
## Summary
Makes Rask's `<head>` reconciliation **preserve foreign (third-party-injected) head nodes** instead of trimming them on re-render. Libraries routinely inject `<style>`/`<link>`/`<script>` into `<head>` at runtime (Monaco's theme colours, Chart.js, syntax highlighters, analytics); previously the live-diff morph removed any such node on the next re-render (it isn't in the .NET-rendered head), so e.g. a mounted code editor lost all its styling on the first state change.

The client morph (`rask-morph.js`, shared by Server/WASM/Native) now tags the head nodes it owns (`__raskHead`) and preserves any head element it doesn't (nodes that appeared since the last render) — the same effect as `data-rask-managed`, but automatic. A `raskHeadReconciled` gate keeps the **first** head reconciliation (boot-shell hydration: importmap / `<base>` / preload / scoped placeholders) byte-identical to before; preservation applies only to nodes injected *after* a render. Scoped to `<head>` — body reconciliation is unchanged.

This is the framework-level version of the playground's Monaco head-strip fix (#333), which is dropped in favour of the framework doing it for everyone.

## Testing
- E2E: **PlaygroundExampleTests** — pass, with the app-level Monaco head-guard removed, so it now validates the framework fix (asserts Monaco's head `<style>` survives Run). Verified before/after Run in both **Chromium and WebKit** (Safari's engine): token stays `rgb(86,156,214)`, head style count stays 1.
- E2E regression: **StandaloneWasmExampleTests** (the comprehensive WASM journey — every page, scoped-CSS delivery, shell reload, live-ticker publish-render) — pass, confirming no head-hydration regression.
- `dotnet format` clean; full solution builds warnings-as-errors clean; materialized WASM/Native client bundles regenerated.
- The full CI E2E matrix (Server, WASM, SubPath, Standalone, Playground, Auth×4) exercises head hydration across every host.

## Benchmarks
n/a — the change is client-side DOM morph JS (not the .NET render/diff hot path the benchmarks measure). Added work is an O(head-children) marking pass (~7–10 nodes) per head morph.

## CHANGELOG
- [Unreleased] → Changed: "Head reconciliation preserves foreign (third-party-injected) head nodes."
