### PR TITLE
feat(core): preserve third-party head-injected nodes automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,16 @@ them until tagged releases begin.
   over the WebSocket.
 
 ### Changed
+- **Third-party `<head>` injections are preserved automatically.** Rask treats `<head>` as authoritative
+  (the live-diff reconciler morphs it back to the rendered head every update), which used to trim a
+  `<style>`/`<link>`/`<script>` a JS library injects at runtime — a code editor's theme, a chart lib, a
+  syntax highlighter, an analytics tag — on the next re-render. The client now watches `<head>` and tags
+  whatever a library injects with `data-rask-managed` (the marker the reconciler already skips), so it
+  survives with no app code. The **reconciliation itself is unchanged**: framework head mutations (a head
+  morph, or an `applyDiff` InsertSubtree of a Head-declared script/link) are discarded from the observer's
+  queue so they still reconcile normally, and `data-rask-key` nodes (the framework's keyed head links,
+  incl. the scoped-CSS FOUC preload clone) are never tagged so they keep reconciling by key. The playground
+  drops its bespoke Monaco head-guard as a result. See [docs/js-interop.md](docs/js-interop.md).
 - **README refresh — a Rask-vs-Blazor scorecard, a wire-bytes chart, and a stale-number fix.** The `Why
   Rask` section now leads with an at-a-glance performance scorecard (wire bytes, allocation/update,
   retained heap, render hot path — sourced from the CI-enforced baselines) and a Mermaid bar chart of how

--- a/docs/js-interop.md
+++ b/docs/js-interop.md
@@ -302,6 +302,27 @@ the bundle, so it paints the instant it mounts — no per-component fetch, no FO
 
 <!-- demo:asset-lazy-mount -->
 
+## Third-party libraries that inject into `<head>`
+
+Rask treats `<head>` as **authoritative**: on every re-render the live-diff reconciler morphs the live
+head back to what your components rendered, which keeps `<title>`/`<meta>`/scoped-CSS links correct. A
+`<style>`/`<link>`/`<script>` that a **JS library injects into `<head>` at runtime** (a code editor's
+theme colours, a charting library, a syntax highlighter, an analytics tag) isn't part of that render —
+so **Rask preserves it for you automatically**. The reconciler watches `<head>` and tags anything a
+library injects with `data-rask-managed` (the same marker it uses for its own scoped-asset tags), so it
+survives every re-render with **no code on your side**. The [playground](playground.md) relies on this to
+keep Monaco's editor theme across each Run.
+
+The mechanism only preserves nodes injected *after* an initial render (the common case — libraries set up
+once your component has mounted). If you need to keep something present at first paint, or want to be
+explicit, mark it yourself — the reconciler never touches a head child carrying `data-rask-managed`:
+
+```js
+// You rarely need this — runtime-injected head nodes are preserved automatically. Use it only to opt a
+// node out explicitly (e.g. one present before the app's first render).
+styleEl.setAttribute("data-rask-managed", "");
+```
+
 ---
 
 See also: [Composition](composition.md) for component-to-component communication, and the

--- a/samples/Rask.Example.Playground/PlaygroundView.js
+++ b/samples/Rask.Example.Playground/PlaygroundView.js
@@ -46,46 +46,13 @@ function loadMonaco() {
     return loadPromise;
 }
 
-// Monaco injects its theme colours as a <style class="monaco-colors"> (and its CSS as a <link>) into
-// <head>. Rask's live-diff morph reconciles <head> on every re-render and removes any child that isn't
-// marked data-rask-managed — the same marker the framework uses for its own scoped-asset head tags — so
-// without this the editor loses all colour the first time the app re-renders (e.g. after Run). Stamp
-// Monaco's head nodes as managed, and keep watching <head> so any it adds later is protected too.
-let headGuardInstalled = false;
-
-function isMonacoHeadNode(n) {
-    if (!n || n.nodeType !== 1) return false;
-    const cls = typeof n.className === "string" ? n.className : "";
-    if (cls.indexOf("monaco") !== -1) return true;
-    if (n.tagName === "STYLE" && n.textContent && n.textContent.indexOf(".mtk") !== -1) return true;
-    if (n.tagName === "LINK" && n.href && n.href.indexOf("/monaco/") !== -1) return true;
-    return false;
-}
-
-function markManaged(n) {
-    if (isMonacoHeadNode(n) && !n.hasAttribute("data-rask-managed")) {
-        n.setAttribute("data-rask-managed", "");
-    }
-}
-
-function protectMonacoHeadNodes() {
-    // Idempotent sweep of anything already in <head>.
-    document.head.querySelectorAll("style, link").forEach(markManaged);
-    // Install the ongoing guard exactly once.
-    if (headGuardInstalled) return;
-    headGuardInstalled = true;
-    new MutationObserver((records) => {
-        for (const r of records) for (const n of r.addedNodes) markManaged(n);
-    }).observe(document.head, { childList: true });
-}
-
 export async function mountEditor(host, code) {
     if (!host || editor || host.__fallback) return;
     try {
         const monaco = await loadMonaco();
-        // Start protecting head nodes before create so the color <style> Monaco injects during create is
-        // caught by the observer and marked managed from the outset.
-        protectMonacoHeadNodes();
+        // Monaco injects its theme colours as a <style> into <head>. Rask preserves foreign head nodes
+        // automatically (its live-diff reconciler tags what a library injects), so the editor keeps its
+        // colours across re-renders (e.g. after Run) with no extra guarding here.
         editor = monaco.editor.create(host, {
             value: code,
             language: "csharp",
@@ -98,8 +65,6 @@ export async function mountEditor(host, code) {
             renderLineHighlight: "line",
             fixedOverflowWidgets: true
         });
-        // Re-sweep after create in case any node landed synchronously before the observer registered.
-        protectMonacoHeadNodes();
     } catch {
         // Monaco unavailable — degrade to a textarea so the playground still compiles and runs code.
         const ta = document.createElement("textarea");

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -284,6 +284,10 @@ function applyDiff(ops, names) {
                 return;
         }
     }
+    // A diff can insert Head-declared <script>/<link> into <head> (keyed InsertSubtree). Discard those
+    // framework mutations from the head observer's queue so they aren't tagged as foreign injections
+    // (see _raskHeadObserver in rask-morph.js).
+    _raskDiscardFrameworkHeadMutations();
 }
 
 // ----- Frame jsInvokes dispatch ------------------------------------------

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -139,6 +139,55 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
+// runtime (a code editor's theme colours, a charting lib, a syntax highlighter, analytics). Those nodes
+// aren't in the .NET-rendered head, so the reconciler below would trim them on the next head morph. Rather
+// than change the reconciliation (its invariants — keyed FOUC clones, boot-shell hydration, self-healing —
+// are load-bearing), we watch <head> and tag anything a library injects with data-rask-managed, which the
+// reconciler ALREADY skips (see the fc-building loop). The framework's own head mutations happen during an
+// apply (a head morph, or an applyDiff InsertSubtree of a Head-declared script/link); those are discarded
+// from the observer queue so they're never mistaken for foreign. data-rask-key nodes (the framework's keyed
+// head links, incl. the scoped-CSS FOUC preload clone) are never tagged — they must reconcile by key.
+let _raskHeadObserver = null;
+
+function _raskEnsureHeadObserver() {
+    if (_raskHeadObserver || typeof MutationObserver === "undefined"
+        || typeof document === "undefined" || !document.head) {
+        return;
+    }
+    // The callback receives the pending records as its argument — do NOT call takeRecords() here (it would
+    // return empty, since delivery already drained them). takeRecords() is only for the synchronous flush
+    // at a head morph, where the records are still pending.
+    _raskHeadObserver = new MutationObserver((records) => _raskTagHeadRecords(records));
+    _raskHeadObserver.observe(document.head, { childList: true });
+}
+
+// Tag the nodes added by these mutation records — a <style>/<link>/<script> a library injected — with
+// data-rask-managed so the reconciler's skip preserves them. Never tags data-rask-key nodes (the
+// framework's own keyed head links, e.g. the scoped-CSS FOUC clone, which must reconcile by key).
+function _raskTagHeadRecords(records) {
+    for (const r of records) {
+        for (const n of r.addedNodes) {
+            if (n.nodeType === 1 && !n.hasAttribute("data-rask-key") && !n.hasAttribute("data-rask-managed")) {
+                n.setAttribute("data-rask-managed", "");
+            }
+        }
+    }
+}
+
+// Synchronous flush at the start of a head morph: tag foreign nodes injected since the last drain that the
+// async observer callback hasn't processed yet, so this morph preserves them.
+function _raskTagForeignHeadNodes() {
+    if (_raskHeadObserver) _raskTagHeadRecords(_raskHeadObserver.takeRecords());
+}
+
+// Drop the head mutations the framework itself just made (during a morph or applyDiff) so the async
+// observer never tags framework-inserted head nodes as foreign. Called at the end of every head morph and
+// at the end of applyDiff (rask-dom.js).
+function _raskDiscardFrameworkHeadMutations() {
+    if (_raskHeadObserver) _raskHeadObserver.takeRecords();
+}
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -187,6 +236,14 @@ function morph(from, to) {
             const checked = to.hasAttribute("checked");
             if (!raskShouldSuppressChecked(from, checked) && from.checked !== checked) from.checked = checked;
         }
+    }
+    // Reconciling the live <head>: before pairing children, tag anything a third-party library injected
+    // (see the note above _raskHeadObserver) as data-rask-managed so the skip below preserves it. The
+    // observer is installed lazily on the first head morph — library injections happen after boot.
+    const isDocHead = typeof document !== "undefined" && from === document.head;
+    if (isDocHead) {
+        _raskEnsureHeadObserver();
+        _raskTagForeignHeadNodes();
     }
     // Skip JS-owned elements (marked data-rask-managed) — they're not part of
     // the .NET render tree, so pairing them against the incoming children would
@@ -261,6 +318,7 @@ function morph(from, to) {
             const leftover = unkeyedFrom[unkeyedCursor++];
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
+        if (isDocHead) _raskDiscardFrameworkHeadMutations();
         return;
     }
 
@@ -272,4 +330,5 @@ function morph(from, to) {
         else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, reviveScript(dst), src);
         else morph(src, dst);
     }
+    if (isDocHead) _raskDiscardFrameworkHeadMutations();
 }

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1344,6 +1344,10 @@ function applyDiff(ops, names) {
                 return;
         }
     }
+    // A diff can insert Head-declared <script>/<link> into <head> (keyed InsertSubtree). Discard those
+    // framework mutations from the head observer's queue so they aren't tagged as foreign injections
+    // (see _raskHeadObserver in rask-morph.js).
+    _raskDiscardFrameworkHeadMutations();
 }
 
 // ----- Frame jsInvokes dispatch ------------------------------------------
@@ -1943,6 +1947,55 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
+// runtime (a code editor's theme colours, a charting lib, a syntax highlighter, analytics). Those nodes
+// aren't in the .NET-rendered head, so the reconciler below would trim them on the next head morph. Rather
+// than change the reconciliation (its invariants — keyed FOUC clones, boot-shell hydration, self-healing —
+// are load-bearing), we watch <head> and tag anything a library injects with data-rask-managed, which the
+// reconciler ALREADY skips (see the fc-building loop). The framework's own head mutations happen during an
+// apply (a head morph, or an applyDiff InsertSubtree of a Head-declared script/link); those are discarded
+// from the observer queue so they're never mistaken for foreign. data-rask-key nodes (the framework's keyed
+// head links, incl. the scoped-CSS FOUC preload clone) are never tagged — they must reconcile by key.
+let _raskHeadObserver = null;
+
+function _raskEnsureHeadObserver() {
+    if (_raskHeadObserver || typeof MutationObserver === "undefined"
+        || typeof document === "undefined" || !document.head) {
+        return;
+    }
+    // The callback receives the pending records as its argument — do NOT call takeRecords() here (it would
+    // return empty, since delivery already drained them). takeRecords() is only for the synchronous flush
+    // at a head morph, where the records are still pending.
+    _raskHeadObserver = new MutationObserver((records) => _raskTagHeadRecords(records));
+    _raskHeadObserver.observe(document.head, { childList: true });
+}
+
+// Tag the nodes added by these mutation records — a <style>/<link>/<script> a library injected — with
+// data-rask-managed so the reconciler's skip preserves them. Never tags data-rask-key nodes (the
+// framework's own keyed head links, e.g. the scoped-CSS FOUC clone, which must reconcile by key).
+function _raskTagHeadRecords(records) {
+    for (const r of records) {
+        for (const n of r.addedNodes) {
+            if (n.nodeType === 1 && !n.hasAttribute("data-rask-key") && !n.hasAttribute("data-rask-managed")) {
+                n.setAttribute("data-rask-managed", "");
+            }
+        }
+    }
+}
+
+// Synchronous flush at the start of a head morph: tag foreign nodes injected since the last drain that the
+// async observer callback hasn't processed yet, so this morph preserves them.
+function _raskTagForeignHeadNodes() {
+    if (_raskHeadObserver) _raskTagHeadRecords(_raskHeadObserver.takeRecords());
+}
+
+// Drop the head mutations the framework itself just made (during a morph or applyDiff) so the async
+// observer never tags framework-inserted head nodes as foreign. Called at the end of every head morph and
+// at the end of applyDiff (rask-dom.js).
+function _raskDiscardFrameworkHeadMutations() {
+    if (_raskHeadObserver) _raskHeadObserver.takeRecords();
+}
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -1991,6 +2044,14 @@ function morph(from, to) {
             const checked = to.hasAttribute("checked");
             if (!raskShouldSuppressChecked(from, checked) && from.checked !== checked) from.checked = checked;
         }
+    }
+    // Reconciling the live <head>: before pairing children, tag anything a third-party library injected
+    // (see the note above _raskHeadObserver) as data-rask-managed so the skip below preserves it. The
+    // observer is installed lazily on the first head morph — library injections happen after boot.
+    const isDocHead = typeof document !== "undefined" && from === document.head;
+    if (isDocHead) {
+        _raskEnsureHeadObserver();
+        _raskTagForeignHeadNodes();
     }
     // Skip JS-owned elements (marked data-rask-managed) — they're not part of
     // the .NET render tree, so pairing them against the incoming children would
@@ -2065,6 +2126,7 @@ function morph(from, to) {
             const leftover = unkeyedFrom[unkeyedCursor++];
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
+        if (isDocHead) _raskDiscardFrameworkHeadMutations();
         return;
     }
 
@@ -2076,6 +2138,7 @@ function morph(from, to) {
         else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, reviveScript(dst), src);
         else morph(src, dst);
     }
+    if (isDocHead) _raskDiscardFrameworkHeadMutations();
 }
 
 

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2469,6 +2469,55 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
+// runtime (a code editor's theme colours, a charting lib, a syntax highlighter, analytics). Those nodes
+// aren't in the .NET-rendered head, so the reconciler below would trim them on the next head morph. Rather
+// than change the reconciliation (its invariants — keyed FOUC clones, boot-shell hydration, self-healing —
+// are load-bearing), we watch <head> and tag anything a library injects with data-rask-managed, which the
+// reconciler ALREADY skips (see the fc-building loop). The framework's own head mutations happen during an
+// apply (a head morph, or an applyDiff InsertSubtree of a Head-declared script/link); those are discarded
+// from the observer queue so they're never mistaken for foreign. data-rask-key nodes (the framework's keyed
+// head links, incl. the scoped-CSS FOUC preload clone) are never tagged — they must reconcile by key.
+let _raskHeadObserver = null;
+
+function _raskEnsureHeadObserver() {
+    if (_raskHeadObserver || typeof MutationObserver === "undefined"
+        || typeof document === "undefined" || !document.head) {
+        return;
+    }
+    // The callback receives the pending records as its argument — do NOT call takeRecords() here (it would
+    // return empty, since delivery already drained them). takeRecords() is only for the synchronous flush
+    // at a head morph, where the records are still pending.
+    _raskHeadObserver = new MutationObserver((records) => _raskTagHeadRecords(records));
+    _raskHeadObserver.observe(document.head, { childList: true });
+}
+
+// Tag the nodes added by these mutation records — a <style>/<link>/<script> a library injected — with
+// data-rask-managed so the reconciler's skip preserves them. Never tags data-rask-key nodes (the
+// framework's own keyed head links, e.g. the scoped-CSS FOUC clone, which must reconcile by key).
+function _raskTagHeadRecords(records) {
+    for (const r of records) {
+        for (const n of r.addedNodes) {
+            if (n.nodeType === 1 && !n.hasAttribute("data-rask-key") && !n.hasAttribute("data-rask-managed")) {
+                n.setAttribute("data-rask-managed", "");
+            }
+        }
+    }
+}
+
+// Synchronous flush at the start of a head morph: tag foreign nodes injected since the last drain that the
+// async observer callback hasn't processed yet, so this morph preserves them.
+function _raskTagForeignHeadNodes() {
+    if (_raskHeadObserver) _raskTagHeadRecords(_raskHeadObserver.takeRecords());
+}
+
+// Drop the head mutations the framework itself just made (during a morph or applyDiff) so the async
+// observer never tags framework-inserted head nodes as foreign. Called at the end of every head morph and
+// at the end of applyDiff (rask-dom.js).
+function _raskDiscardFrameworkHeadMutations() {
+    if (_raskHeadObserver) _raskHeadObserver.takeRecords();
+}
+
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
         _raskReplaceChild(from.parentNode, to, from);
@@ -2517,6 +2566,14 @@ function morph(from, to) {
             const checked = to.hasAttribute("checked");
             if (!raskShouldSuppressChecked(from, checked) && from.checked !== checked) from.checked = checked;
         }
+    }
+    // Reconciling the live <head>: before pairing children, tag anything a third-party library injected
+    // (see the note above _raskHeadObserver) as data-rask-managed so the skip below preserves it. The
+    // observer is installed lazily on the first head morph — library injections happen after boot.
+    const isDocHead = typeof document !== "undefined" && from === document.head;
+    if (isDocHead) {
+        _raskEnsureHeadObserver();
+        _raskTagForeignHeadNodes();
     }
     // Skip JS-owned elements (marked data-rask-managed) — they're not part of
     // the .NET render tree, so pairing them against the incoming children would
@@ -2591,6 +2648,7 @@ function morph(from, to) {
             const leftover = unkeyedFrom[unkeyedCursor++];
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
+        if (isDocHead) _raskDiscardFrameworkHeadMutations();
         return;
     }
 
@@ -2602,6 +2660,7 @@ function morph(from, to) {
         else if (src.nodeType !== dst.nodeType || src.nodeName !== dst.nodeName) _raskReplaceChild(from, reviveScript(dst), src);
         else morph(src, dst);
     }
+    if (isDocHead) _raskDiscardFrameworkHeadMutations();
 }
 
 
@@ -2930,6 +2989,10 @@ function applyDiff(ops, names) {
                 return;
         }
     }
+    // A diff can insert Head-declared <script>/<link> into <head> (keyed InsertSubtree). Discard those
+    // framework mutations from the head observer's queue so they aren't tagged as foreign injections
+    // (see _raskHeadObserver in rask-morph.js).
+    _raskDiscardFrameworkHeadMutations();
 }
 
 // ----- Frame jsInvokes dispatch ------------------------------------------

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -74,6 +74,8 @@ public abstract partial class SharedSmokeTests
         // The SPA sentinel must have survived the entire in-SPA walk.
         Assert.Equal("alive", await Page.EvaluateAsync<string?>("() => window.__raskSentinel"));
 
+        await AssertNoDuplicateScopedHeadLinksAsync();
+
         await RunUnusualActivityAsync(opts);
     }
 
@@ -100,6 +102,29 @@ public abstract partial class SharedSmokeTests
     // ToastDemo.cs / ToasterDemo.cs source whose "Danger"/"Error" message is literally "Something went wrong.".
     protected async Task AssertNoGlobalCrashAsync() =>
         Assert.Equal(0, await Page.Locator(".rask-error-boundary").CountAsync());
+
+    // After walking every page, each scoped component's keyed stylesheet (<link data-rask-key>) must
+    // appear in <head> exactly once. On hosts that deliver scoped CSS per component via a full reply
+    // (Server), the FOUC preload (rask-scoped.js clones the incoming keyed <link> before the morph)
+    // must reconcile against the clone by key rather than duplicate it — a regression here silently
+    // leaks one <link> per scoped component ever mounted and re-applies unmounted pages' CSS. This also
+    // guards the foreign-head-preservation observer against wrongly tagging a keyed framework link.
+    protected async Task AssertNoDuplicateScopedHeadLinksAsync()
+    {
+        var duplicateKeys = await Page.EvaluateAsync<string[]>(
+            """
+            () => {
+                const counts = {};
+                for (const l of document.querySelectorAll('head link[rel="stylesheet"][data-rask-key]')) {
+                    const k = l.getAttribute('data-rask-key');
+                    counts[k] = (counts[k] || 0) + 1;
+                }
+                return Object.keys(counts).filter(k => counts[k] > 1);
+            }
+            """);
+        Assert.True(duplicateKeys.Length == 0,
+            $"Duplicate scoped stylesheet <link>s in <head> (leaked): {string.Join(", ", duplicateKeys)}");
+    }
 
     // The redesigned sidebar: collapsible groups (only the active route's group open by default), a
     // search filter, and — below md — a hamburger-driven offcanvas drawer. Exercised once per host.


### PR DESCRIPTION
## Summary
Makes Rask preserve **third-party `<head>` injections automatically**. Rask treats `<head>` as authoritative (the live-diff reconciler morphs it back to the rendered head each update), so a `<style>`/`<link>`/`<script>` a JS library injects at runtime — a code editor's theme, a chart lib, a syntax highlighter, an analytics tag — used to get trimmed on the next re-render (this is what made the playground's Monaco editor go uncoloured after Run). The client now watches `<head>` (a `MutationObserver`, lazily installed on the first head morph) and tags whatever a library injects with `data-rask-managed` — the marker the reconciler already skips — so it survives with no app code.

**The reconciliation is untouched** (this is the key difference from the two earlier abandoned attempts, #334, that changed the morph): framework head mutations (a head morph, or an `applyDiff` InsertSubtree of a Head-declared script/link) are discarded from the observer's queue via `takeRecords()` at the head-morph and `applyDiff` ends, so they still reconcile normally; and `data-rask-key` nodes (the framework's keyed head links, incl. the scoped-CSS FOUC preload clone) are never tagged so they keep reconciling by key. Shared client only (`rask-morph.js` + `rask-dom.js`), regenerated into the WASM/Native bundles; Server splices at build. The playground drops its bespoke Monaco head-guard (dogfooding the framework); `docs/js-interop.md` documents it.

## Testing
- **Playground E2E** — pass, with the app-level Monaco head-guard removed, so it validates the framework fix (Monaco's theme `<style>` survives Run). Verified before/after Run in **Chromium and WebKit**: token stays `rgb(86,156,214)`, head style count stays 1.
- **Server** (the host where the prior morph-based attempt leaked): navigated across scoped pages 9× — **no duplicate scoped `<link>`s** (head bounded), **and** the `<title>` updated across 5 navigations, proving framework head nodes still reconcile (aren't wrongly frozen). No console errors.
- **StandaloneWasm journey** — pass (full page walk); added a shared-journey assertion that no scoped `<link data-rask-key>` duplicates in `<head>` (regression guard for the leak).
- `dotnet format` clean; full solution builds warnings-as-errors clean; materialized WASM/Native bundles regenerated.

## Benchmarks
n/a — client-side DOM morph JS (not the .NET render/diff hot path the benchmarks measure). Added work is a `from === document.head` reference-compare per morph plus an observer flush/discard only on head morphs (no per-node allocation).

## CHANGELOG
- [Unreleased] → Changed: "Third-party `<head>` injections are preserved automatically."
