### PR TITLE
feat(samples): build the Pages landing site in Rask (demo → /demo/)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,6 +203,13 @@ jobs:
         # default output, packaged by the tar step below and served by the shard's static host.
         run: dotnet publish samples/Rask.Example.Playground -c Release --no-restore -p:WasmBuildNative=false --nologo
 
+      - name: Publish landing site sample (served by the SiteExampleTests shard)
+        # The marketing landing page is a standalone Rask WASM app (no host project), so it isn't
+        # published by any nested Hosting publish — publish it explicitly here. WasmBuildNative=false
+        # uses the prebuilt .NET-WASM runtime (skips the flaky emscripten relink), matching the other
+        # WASM fixtures; the tar step below packages its bin/ for the shard's static host.
+        run: dotnet publish samples/Rask.Example.Site -c Release --no-restore -p:WasmBuildNative=false --nologo
+
       - name: Package build output
         # Tar every bin/ and obj/: the shards need the built test + sample assemblies, the published
         # WASM wwwroot bundles the WASM fixtures serve, the published Server host the two server shards
@@ -234,6 +241,7 @@ jobs:
           - ServerExampleTests
           - WasmExampleTests
           - StandaloneWasmExampleTests
+          - SiteExampleTests
           - WasmSubPathExampleTests
           - PlaygroundExampleTests
           - AuthExampleTests

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,57 +36,57 @@ jobs:
           key: nuget-${{ runner.os }}-${{ hashFiles('**/*.csproj', 'Directory.Build.props', 'Directory.Build.targets') }}
           restore-keys: nuget-${{ runner.os }}-
 
-      - name: Publish Rask.Example.Wasm
-        # Microsoft.NET.Sdk.WebAssembly fingerprints the framework assets and fills the
-        # index.html import map (with integrity) at publish — so GitHub Pages redeploys stay
-        # subresource-integrity-safe. /p:RaskPathBase=/<repo> drives the framework's
-        # _RaskRewriteBaseHref target to rewrite <base href> to /<repo>/ in the published
-        # wwwroot/index.html; every other asset URL + the import map is document-relative, so
-        # the corrected base href resolves them all under the GH-Pages sub-path.
-        run: dotnet publish samples/Rask.Example.Wasm -c Release /p:RaskPathBase=/${{ github.event.repository.name }}
+      # The Pages site is three Rask WASM apps: the marketing landing page (Rask.Example.Site) at the
+      # root /<repo>/, the live feature showcase (Rask.Example.Wasm) at /<repo>/demo/, and the live
+      # playground at /<repo>/playground/. Each is published with /p:RaskPathBase so the framework's
+      # _RaskRewriteBaseHref target rewrites its <base href> to the sub-path; every other asset URL +
+      # the SRI-pinned import map stays document-relative, so the corrected base resolves them all
+      # under the sub-path. (Microsoft.NET.Sdk.WebAssembly fingerprints the framework assets and fills
+      # the import map with integrity at publish, keeping static-host redeploys SRI-safe.)
+      - name: Publish the landing site (Rask.Example.Site → /)
+        run: dotnet publish samples/Rask.Example.Site -c Release /p:RaskPathBase=/${{ github.event.repository.name }}
 
-      # Expected, harmless: with DevTools open the Pages site logs a 404 for
-      # _framework/dotnet.runtime.js.map. The Release publish strips all .map files, but the
-      # fingerprinted dotnet.runtime.*.js keeps its trailing `//# sourceMappingURL=` comment, so
-      # the browser fetches a map that isn't shipped. It never loads on a normal page view and
-      # doesn't affect the app. We can't strip the comment post-publish: the runtime JS is
-      # SRI-pinned in the index.html import map (see #63), so changing its bytes breaks the
-      # integrity check and the runtime fails to load. Shipping the 270 KB map just to silence a
-      # DevTools-only 404 isn't worth it on a size-tuned bundle (we already drop ICU).
-      - name: Resolve bundle directory
-        id: bundle
-        run: |
-          BUNDLE=samples/Rask.Example.Wasm/bin/Release/net10.0-browser/publish/wwwroot
-          if [ ! -d "$BUNDLE" ]; then
-            echo "Could not locate the published wwwroot at $BUNDLE" >&2
-            find samples/Rask.Example.Wasm/bin -maxdepth 5 -type d
-            exit 1
-          fi
-          echo "--- index.html (head) ---"
-          head -n 20 "$BUNDLE/index.html"
-          echo "dir=$BUNDLE" >> "$GITHUB_OUTPUT"
+      - name: Publish the live demo (Rask.Example.Wasm → /demo/)
+        run: dotnet publish samples/Rask.Example.Wasm -c Release /p:RaskPathBase=/${{ github.event.repository.name }}/demo
 
-      - name: Copy index.html to 404.html for SPA fallback
-        run: cp "${{ steps.bundle.outputs.dir }}/index.html" "${{ steps.bundle.outputs.dir }}/404.html"
-
-      # The live playground is a separate WASM sub-app: it compiles Rask C# in the browser with Roslyn, so
-      # it ships untrimmed (Roslyn needs full assembly metadata as references) and is deliberately kept out
-      # of the size-tuned showcase bundle. Publish it under /<repo>/playground/ and fold its wwwroot into
-      # the same Pages artifact next to the showcase; the showcase navbar links out to it.
-      - name: Publish Rask.Example.Playground
+      # The playground is untrimmed (Roslyn needs full assembly metadata as references), so it is kept
+      # out of the size-tuned demo bundle and published to its own output dir.
+      - name: Publish the playground (→ /playground/)
         run: dotnet publish samples/Rask.Example.Playground -c Release /p:RaskPathBase=/${{ github.event.repository.name }}/playground -o playground-publish
 
-      - name: Fold the playground into the Pages bundle
+      # Expected, harmless: with DevTools open each WASM app logs a 404 for _framework/dotnet.runtime.js.map.
+      # The Release publish strips all .map files, but the fingerprinted dotnet.runtime.*.js keeps its
+      # trailing `//# sourceMappingURL=` comment, so the browser fetches a map that isn't shipped. It
+      # never loads on a normal page view and doesn't affect the app. We can't strip the comment
+      # post-publish: the runtime JS is SRI-pinned in the import map (see #63), so changing its bytes
+      # breaks the integrity check. Shipping the 270 KB map to silence a DevTools-only 404 isn't worth
+      # it on a size-tuned bundle (we already drop ICU).
+      - name: Assemble the Pages bundle (landing at root, demo + playground nested)
+        id: bundle
         run: |
+          LANDING=samples/Rask.Example.Site/bin/Release/net10.0-browser/publish/wwwroot
+          DEMO=samples/Rask.Example.Wasm/bin/Release/net10.0-browser/publish/wwwroot
           PLAYGROUND=playground-publish/wwwroot
-          if [ ! -d "$PLAYGROUND" ]; then
-            echo "Could not locate the published playground wwwroot at $PLAYGROUND" >&2
-            find playground-publish -maxdepth 3 -type d
-            exit 1
-          fi
-          cp -r "$PLAYGROUND" "${{ steps.bundle.outputs.dir }}/playground"
-          echo "--- playground/index.html <base> ---"
-          grep -i "<base" "${{ steps.bundle.outputs.dir }}/playground/index.html" || true
+          for d in "$LANDING" "$DEMO" "$PLAYGROUND"; do
+            if [ ! -d "$d" ]; then
+              echo "Could not locate published wwwroot: $d" >&2
+              find . -maxdepth 6 -type d -name wwwroot
+              exit 1
+            fi
+          done
+          SITE="$RUNNER_TEMP/site"
+          mkdir -p "$SITE"
+          cp -r "$LANDING"/. "$SITE"/                 # marketing landing app at the root
+          cp -r "$DEMO" "$SITE/demo"
+          cp -r "$PLAYGROUND" "$SITE/playground"
+          # GitHub Pages serves /404.html for any unknown path; boot the demo SPA (its <base href> is
+          # /<repo>/demo/, so it client-routes correctly) as the deep-link fallback — the landing page
+          # itself is a single route, so it needs none.
+          cp "$SITE/demo/index.html" "$SITE/404.html"
+          echo "--- landing <base> ---";      grep -i "<base"   "$SITE/index.html" || true
+          echo "--- demo <base> ---";         grep -i "<base"   "$SITE/demo/index.html" || true
+          echo "--- playground <base> ---";   grep -i "<base"   "$SITE/playground/index.html" || true
+          echo "dir=$SITE" >> "$GITHUB_OUTPUT"
 
       - uses: actions/configure-pages@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Marketing landing site, built in Rask (`samples/Rask.Example.Site`).** The GitHub Pages front door
+  at `https://pal-tamas.github.io/rask/` is now a standalone Rask WASM app that renders the whole page —
+  hero, an animated packet-race `<canvas>`, a Blazor-vs-Rask benchmark chart, host/feature grids, and
+  install tabs — dogfooding the framework it sells. The live counter and install tabs are genuine
+  stateful Rask components (click → diff → re-render); the hero canvas, scroll reveals and theme toggle
+  live in a sibling scoped `App.js`; the design system is a global stylesheet. The live feature showcase
+  moved to `/demo/` and the playground stays at `/playground/`; the Pages workflow publishes all three as
+  Rask WASM apps and the "live demo" links across README/NUGET/docs now point at `/demo/`. Covered by a
+  new `SiteExampleTests` Playwright journey (renders in Rask, counter increments, tabs switch).
 - **RASK033 — prefer the generated route URL over a hardcoded path for internal navigation.** A new
   analyzer (Warning) flags a string literal passed to internal navigation — `Navigator.NavigateTo("…")`
   or any `RouteUrl` slot (`NavLink`/`BsNavItem`/`NativeTab` `Href:`/`To:`, via the `string → RouteUrl`

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -101,9 +101,11 @@
       (Rask.Example.EfCore) uses Rask.Core's inline Validate: lambdas only — so skip those usings for them.
       The Native + Server example (Rask.Example.Native.Server) is a thin native shell over a remote server
       that references neither Rask.Example.Shared nor the validation/Bootstrap libs, so it skips them too.
+      The marketing landing site (Rask.Example.Site) is a standalone WASM app (its own hand-styled design,
+      no Shared/Bootstrap/validation), so it skips them as well.
     -->
     <_RaskExampleValidationUsings>$(_RaskInRepoImplicitUsings)</_RaskExampleValidationUsings>
-    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) OR $(MSBuildProjectName.StartsWith('Rask.Example.EfCore')) OR '$(MSBuildProjectName)' == 'Rask.Example.Native.Server' OR '$(MSBuildProjectName)' == 'Rask.Example.Playground' ">false</_RaskExampleValidationUsings>
+    <_RaskExampleValidationUsings Condition=" $(MSBuildProjectName.StartsWith('Rask.Example.Auth')) OR $(MSBuildProjectName.StartsWith('Rask.Example.EfCore')) OR '$(MSBuildProjectName)' == 'Rask.Example.Native.Server' OR '$(MSBuildProjectName)' == 'Rask.Example.Playground' OR '$(MSBuildProjectName)' == 'Rask.Example.Site' ">false</_RaskExampleValidationUsings>
     <!-- The showcase trio (Rask.Example.Shared + the Server/Wasm hosts that reference it) pulls in
          Rask.Bootstrap; the Auth/EfCore standalone samples don't reference it, so they must not get
          its global static usings (the namespace wouldn't resolve). Same set as the validation usings. -->

--- a/NUGET.md
+++ b/NUGET.md
@@ -74,7 +74,7 @@ the page). It's a craft project built in the open, deep on Roslyn source generat
   [Configuration](https://github.com/pal-tamas/rask/blob/main/docs/configuration.md) ·
   [Observability](https://github.com/pal-tamas/rask/blob/main/docs/observability.md) ·
   [Accessibility](https://github.com/pal-tamas/rask/blob/main/docs/accessibility.md)
-- 🚀 **[Live demo](https://pal-tamas.github.io/rask/)**
+- 🚀 **[Live demo](https://pal-tamas.github.io/rask/demo/)**
 - 💻 **[Source & README](https://github.com/pal-tamas/rask)**
 - 🤖 **[AI assistant guide](https://github.com/pal-tamas/rask/blob/main/llms.txt)**
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4)
 
-# ▶ **[Try the live demo ↗](https://pal-tamas.github.io/rask/)** &nbsp;·&nbsp; 🛝 **[Playground ↗](https://pal-tamas.github.io/rask/playground/)** &nbsp;·&nbsp; 📖 **[Read the docs ↗](docs/)** &nbsp;·&nbsp; 🧪 **[Browse the examples ↗](samples/)**
+# ▶ **[Try the live demo ↗](https://pal-tamas.github.io/rask/demo/)** &nbsp;·&nbsp; 🛝 **[Playground ↗](https://pal-tamas.github.io/rask/playground/)** &nbsp;·&nbsp; 📖 **[Read the docs ↗](docs/)** &nbsp;·&nbsp; 🧪 **[Browse the examples ↗](samples/)**
 
 </div>
 
@@ -41,7 +41,7 @@ public sealed class Counter : Component
 ```
 
 <sub>☝️ A complete, live, interactive component — routing, state, and event handling in a single C# class.
-**[See it running, and dozens more, in the live demo ↗](https://pal-tamas.github.io/rask/)**</sub>
+**[See it running, and dozens more, in the live demo ↗](https://pal-tamas.github.io/rask/demo/)**</sub>
 
 ---
 
@@ -58,7 +58,7 @@ device — **vibration, share sheet, geolocation, clipboard, orientation** — t
 dotnet new rask-wasm --pwa     # → an installable, offline PWA, ready to deploy
 ```
 
-**[📖 Build mobile apps with Rask →](docs/pwa.md)**  ·  **[Try the installable demo ↗](https://pal-tamas.github.io/rask/)**
+**[📖 Build mobile apps with Rask →](docs/pwa.md)**  ·  **[Try the installable demo ↗](https://pal-tamas.github.io/rask/demo/)**
 
 Going further than a PWA? **`Rask.Native`** *(preview)* ships the *same* component code as a real
 **native iOS/Android app** for App Store / Play Store distribution — a WebView hybrid where your C#
@@ -107,7 +107,7 @@ xychart-beta
 The full byte-for-byte table — including where and why each scenario lands — is in the
 **[Rask vs Blazor baselines ↗](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md)**.
 
-*Rask* is the Norwegian/Danish/Swedish word for **fast**. **The [docs ↗](docs/) and the [live demo ↗](https://pal-tamas.github.io/rask/)
+*Rask* is the Norwegian/Danish/Swedish word for **fast**. **The [docs ↗](docs/) and the [live demo ↗](https://pal-tamas.github.io/rask/demo/)
 are the real tour — this README is just the front door.**
 
 ## 📦 Install
@@ -161,7 +161,7 @@ host trade-offs, and sub-path hosting are covered in **[getting started](docs/ge
 
 **The fastest way to understand Rask is to click through a real app and read its source.**
 
-- **[Live demo ↗](https://pal-tamas.github.io/rask/)** — `Rask.Example.Wasm` is published to GitHub Pages on every push
+- **[Live demo ↗](https://pal-tamas.github.io/rask/demo/)** — `Rask.Example.Wasm` is published to GitHub Pages on every push
   to `main`; click through a full multi-page Rask app in the browser before cloning anything.
 - **[Playground ↗](https://pal-tamas.github.io/rask/playground/)** — write Rask component C# in the browser and see it
   compile & render live (Roslyn runs in WebAssembly, no server), with the framework's diagnostics inline. See
@@ -213,7 +213,7 @@ Rask is released under the [MIT License](LICENSE).
 
 ⚡ **Rask** — *Norwegian/Danish/Swedish for "fast".*
 
-**[Live demo ↗](https://pal-tamas.github.io/rask/)** · **[Docs ↗](docs/)** · **[Examples ↗](samples/)** · **[NuGet ↗](https://www.nuget.org/packages/Rask.Server)**
+**[Live demo ↗](https://pal-tamas.github.io/rask/demo/)** · **[Docs ↗](docs/)** · **[Examples ↗](samples/)** · **[NuGet ↗](https://www.nuget.org/packages/Rask.Server)**
 
 Built with .NET 10. Issues and PRs welcome.
 

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -17,6 +17,7 @@
              `native` CI job, and the on-device Appium E2E (tests/Rask.Native.Appium.Tests) drives them. -->
         <Project Path="samples/Rask.Example.Server/Rask.Example.Server.csproj"/>
         <Project Path="samples/Rask.Example.Shared/Rask.Example.Shared.csproj"/>
+        <Project Path="samples/Rask.Example.Site/Rask.Example.Site.csproj"/>
         <Project Path="samples/Rask.Example.Wasm.Host/Rask.Example.Wasm.Host.csproj"/>
         <Project Path="samples/Rask.Example.Wasm/Rask.Example.Wasm.csproj"/>
     </Folder>

--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -9,7 +9,7 @@ app runs on the **Server** (WebSocket) or **WASM** (`JSImport`/`JSExport`) trans
 This page is the **map of the whole surface**. For the deeper "why" — user activation, the
 transport seam, element refs — see [JS interop → Typed browser APIs](js-interop.md#typed-browser-apis);
 for the mobile/PWA angle see the [Mobile & PWA guide](pwa.md). Every wrapper has a runnable demo in
-the **Browser APIs** section of the [showcase](https://pal-tamas.github.io/rask/).
+the **Browser APIs** section of the [showcase](https://pal-tamas.github.io/rask/demo/).
 
 ## Three homes, one rule
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,7 +11,7 @@ Rask-specific ideas, not the language.
 
 > **Coming from Blazor?** Skim [migrating from Blazor](migration-from-blazor.md) for the concept
 > mapping (`@page` → `[Route]`, `[Parameter]` → a property, `EventCallback` → a plain delegate). **Just
-> want to look first?** Click through the [live demo](https://pal-tamas.github.io/rask/) — a full
+> want to look first?** Click through the [live demo](https://pal-tamas.github.io/rask/demo/) — a full
 > multi-page Rask app, no install needed.
 
 ## Before you start

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -5,7 +5,7 @@ your browser and see it render live, with the framework's own diagnostics as inl
 sent to a server: the C# is compiled entirely in WebAssembly.
 
 The playground is the `samples/Rask.Example.Playground` app, published to GitHub Pages next to the
-[feature showcase](https://pal-tamas.github.io/rask/) (the showcase's navbar links to it).
+[feature showcase](https://pal-tamas.github.io/rask/demo/) (the showcase's navbar links to it).
 
 ## How it works
 

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -372,4 +372,4 @@ dotnet publish -c Release /p:RaskPathBase=/my-repo
 The manifest's relative `start_url`/`scope` and the `<base href>`-relative SW registration handle the
 prefix automatically — the published app is installable and offline at `https://you.github.io/my-repo/`.
 The Rask showcase itself is a deployed WASM PWA — install it from
-[the live demo](https://pal-tamas.github.io/rask/).
+[the live demo](https://pal-tamas.github.io/rask/demo/).

--- a/samples/Rask.Example.Site/App.cs
+++ b/samples/Rask.Example.Site/App.cs
@@ -1,0 +1,298 @@
+using Microsoft.JSInterop;
+using Rask.Core.Components;
+using Rask.Core.Live;
+
+namespace Rask.Example.Site;
+
+/// <summary>
+/// Root of the Rask landing site — a WASM app that renders the whole marketing page in pure Rask
+/// (RASK021 full shell). The interactive tiles (<see cref="LiveCounter"/>, <see cref="InstallTabs"/>)
+/// are genuine stateful Rask components; the hero canvas packet-race, scroll reveals and the theme
+/// toggle are driven by the sibling scoped module <c>App.js</c>, wired up in <see cref="OnRenderedAsync"/>.
+/// Public + non-sealed to match the host's ActivatorUtilities + DAM contract.
+/// </summary>
+public class App : Component
+{
+    private readonly IJSRuntime _js;
+    private readonly ElementRef _canvas = ElementRef.New();
+
+    public App(IJSRuntime js) => _js = js;
+
+    protected override Component? Head =>
+    [
+        Title()["Rask — web and native apps in pure C#"],
+        Meta("utf-8"),
+        Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+        Meta(Name: "description", Content: "Rask is a C# component framework: one component model for the browser — server-rendered over WebSockets or client-side on WebAssembly — and native iOS/Android. No .razor, no XAML, no JSX, no JavaScript."),
+        Meta(Name: "theme-color", Content: "#7c3aed"),
+        Link(Rel: "icon", Type: "image/svg+xml", Href: LiveOptions.PathBase + "/icon.svg"),
+        Link(Rel: "stylesheet", Href: LiveOptions.PathBase + "/global.css")
+    ];
+
+    protected override async Task OnRenderedAsync(bool firstRender)
+    {
+        // Set up the hero canvas animation, IntersectionObserver reveals + bar growth, and the theme
+        // toggle listener once the page is in the DOM. Everything document-level lives in App.js;
+        // the counter and install tabs stay pure Rask state.
+        if (firstRender)
+            await _js.InvokeVoidAsync("Rask.App.init", _canvas);
+    }
+
+    private static Dictionary<string, string?> Attr(string key, string? value) => new() { [key] = value };
+
+    protected override Component? Render() =>
+    [
+        Doctype(),
+        Html("en")[
+            Head(),
+            Body()[
+                TopBar(),
+                Hero(),
+                CounterSection(),
+                BytesSection(),
+                HostsSection(),
+                FeaturesSection(),
+                InstallSection(),
+                FooterSection()
+            ]
+        ]
+    ];
+
+    // ---- top bar ----
+    private Component TopBar() =>
+        Div(Class: "topbar")[
+            Div(Class: "wrap")[
+                Span(Class: "brand")[Raw(BrandSvg), " Rask"],
+                Nav()[
+                    A(Class: "hide-sm", Href: "demo/", Target: "_blank", Rel: "noopener")["Demo"],
+                    A(Class: "hide-sm", Href: "playground/", Target: "_blank", Rel: "noopener")["Playground"],
+                    A(Class: "hide-sm", Href: "https://github.com/pal-tamas/rask/tree/main/docs", Target: "_blank", Rel: "noopener")["Docs"],
+                    A(Href: "https://github.com/pal-tamas/rask", Target: "_blank", Rel: "noopener")["GitHub ↗"],
+                    Button(Id: "themeToggle", Type: "button", Aria: Attr("label", "Toggle color theme"))["◐ theme"]
+                ]
+            ]
+        ];
+
+    // ---- hero ----
+    private Component Hero() =>
+        Section(Class: "hero")[
+            Div(Class: "wrap")[
+                Div(Class: "hero-grid")[
+                    Div()[
+                        P(Class: "eyebrow")["A C# component framework"],
+                        H1()["Web and native apps,", Br(), "in ", Span(Class: "lit")["pure C#"], "."],
+                        P(Class: "lede")["One component model for the browser and the phone — no ", Code()[".razor"], ", no XAML, no JSX, no JavaScript, no Swift or Kotlin."],
+                        P(Class: "sub")["The same component runs server-rendered over a WebSocket, fully client-side on WebAssembly, or as a native iOS/Android app. One codebase; pick the host per project."],
+                        Div(Class: "cta-row")[
+                            A(Class: "btn btn-primary", Href: "demo/", Target: "_blank", Rel: "noopener")["▶ Try the live demo"],
+                            A(Class: "btn btn-ghost", Href: "playground/", Target: "_blank", Rel: "noopener")["🛝 Playground"]
+                        ],
+                        Div(Class: "badges")[
+                            Span(Class: "badge")[B()[".NET 10"]],
+                            Span(Class: "badge")["MIT"],
+                            Span(Class: "badge")[B()["Server"], " · WASM · Native"],
+                            Span(Class: "badge")["Leads on ", B()["every measured axis"]]
+                        ]
+                    ],
+                    Div(Class: "wire")[
+                        Div(Class: "wire-head")[
+                            Span(Class: "lab")["wire · one state change"],
+                            Span(Class: "lab")["live diff"]
+                        ],
+                        Canvas(Width: 820, Height: 300, Class: "wire-cvs", Ref: _canvas,
+                            Aria: Attr("label", "A full 24 KB page versus Rask's tiny 41-byte diff traveling the wire")),
+                        Div(Class: "wire-legend")[
+                            Span()[Span(Class: "dot", Style: "background:var(--blazor)"), "full page ", B()["24 KB"]],
+                            Span()[Span(Class: "dot", Style: "background:var(--accent)"), "Rask diff ", B()["~41 B"]]
+                        ],
+                        Div(Class: "wire-tape")[
+                            Span(Class: "k")["counter tick on a 24 KB page"], Span(Class: "v")["24,114 B → ", B(Class: "mono")["41 B"]],
+                            Span(Class: "k")["smaller than re-sending the page"], Span(Class: "v win")["588×"],
+                            Span(Class: "k")["allocated / update"], Span(Class: "v win")["~40× less"],
+                            Span(Class: "k")["bytes that ever leave the server"], Span(Class: "v win")["just the diff"]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+    // ---- "one C# class" demo ----
+    private Component CounterSection() =>
+        Section()[
+            Div(Class: "wrap")[
+                Div(Class: "sec-head reveal")[
+                    P(Class: "eyebrow")["A component is a class that returns a tree"],
+                    H2()["Routing, state, and events — one C# class."],
+                    P()["No template dialect, no code-behind, no build step for markup. ", Code()["Div(...)[Span(...), \"hi\"]"], " is plain, refactor-safe, IDE-native C#. Here's a complete, routable, interactive component:"]
+                ],
+                Div(Class: "demo-grid reveal")[
+                    Div(Class: "card")[
+                        Div(Class: "card-bar")[
+                            Span(Class: "traf", Style: "background:#ff5f57"),
+                            Span(Class: "traf", Style: "background:#febc2e"),
+                            Span(Class: "traf", Style: "background:#28c840"),
+                            Span(Class: "fn")["Counter.cs"]
+                        ],
+                        Pre()[Code()[Raw(CounterCodeHtml)]]
+                    ],
+                    // The live tile is a real stateful Rask component — the page proving its own thesis.
+                    LiveCounter()
+                ]
+            ]
+        ];
+
+    // ---- bytes / benchmarks ----
+    private Component Bar(string kind, int h, string cap) =>
+        Div(Class: "bar " + kind, Data: Attr("h", h.ToString()))[Span(Class: "cap")[cap]];
+
+    private Component BarCol(string blazorCap, int blazorH, string raskCap, int raskH, string mult, string label) =>
+        Div(Class: "bar-col")[
+            Div(Class: "bar-stack")[Bar("blazor", blazorH, blazorCap), Bar("rask", raskH, raskCap)],
+            Span(Class: "x")[B()[mult], label]
+        ];
+
+    private static Component Stat(string kpi, string lab, string sub) =>
+        Div(Class: "stat")[Div(Class: "kpi")[kpi], Div(Class: "lab")[lab], Div(Class: "sub")[sub]];
+
+    private Component BytesSection() =>
+        Section()[
+            Div(Class: "wrap")[
+                Div(Class: "sec-head reveal")[
+                    P(Class: "eyebrow")["Rask vs Blazor · CI-enforced baselines"],
+                    H2()["Fewer bytes than Blazor — on every scenario."],
+                    P()["Rask treats the network as the real bottleneck: after first paint, a state change ships a minimal diff. Each pair is the ", B()["same"], " state change — Blazor's payload beside Rask's. The number is how many ", B()["× fewer bytes"], " Rask puts on the wire."]
+                ],
+                Div(Class: "bars-panel reveal")[
+                    Div(Id: "bars", Class: "bars")[
+                        BarCol("186 B", 240, "41 B", 53, "4.5×", "Counter / 24 KB page"),
+                        BarCol("1,722 B", 240, "137 B", 19, "12.6×", "Deep-tree tick"),
+                        BarCol("6,522 B", 240, "441 B", 16, "14.8×", "Deep mutation ×200"),
+                        BarCol("2,080 B", 240, "37 B", 5, "56×", "Remove 100 rows")
+                    ],
+                    Div(Class: "bars-legend")[
+                        Span()[Span(Class: "dot", Style: "background:var(--blazor)"), "Blazor — full payload"],
+                        Span()[Span(Class: "dot", Style: "background:var(--accent)"), "Rask — the diff"]
+                    ]
+                ],
+                Div(Class: "stat-row reveal")[
+                    Stat("~41 B", "Bytes on the wire", "counter on a 24 KB page · vs 186 B"),
+                    Stat("~40×", "Less allocated / update", "1,072 B · vs Blazor 42,972 B"),
+                    Stat("~30%", "Leaner retained heap", "158 KB · vs 224 KB (200 rows)"),
+                    Stat("1.76×", "Faster render hot path", "598 ns · vs 1,052 ns")
+                ],
+                P(Class: "honest reveal")["Retained heap used to be Blazor's one win — a pure-element page now keeps a compact frame snapshot instead of an object-per-element graph, so ", B()["Rask leads on every measured axis."], " Numbers from the CI-enforced ", A(Href: "https://github.com/pal-tamas/rask/blob/main/benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md", Target: "_blank", Rel: "noopener")["vs-blazor baselines"], " (Apple M4, .NET 10)."]
+            ]
+        ];
+
+    // ---- hosts ----
+    private static Component Host(string tag, string title, string prev, params Component?[] body) =>
+        Div(Class: "host")[
+            Span(Class: "tag")[tag],
+            H3()[title],
+            P()[body],
+            Span(Class: "prev")[prev]
+        ];
+
+    private Component HostsSection() =>
+        Section()[
+            Div(Class: "wrap")[
+                Div(Class: "sec-head reveal")[
+                    P(Class: "eyebrow")["One component model · three hosts"],
+                    H2()["Write it once. Ship it where you need it."],
+                    P()["The identical C# component runs unchanged across every host — you choose the runtime per project, not per component."]
+                ],
+                Div(Class: "hosts reveal")[
+                    Host("Rask.Server", "Server", "AddRask() · UseRask<TApp>()",
+                        "ASP.NET host. State lives on the server; a live diff streams to the browser over a WebSocket. Nothing to compile client-side."),
+                    Host("Rask.Wasm", "WebAssembly", "WasmHostBuilder.CreateDefault()",
+                        "The same component runs fully client-side on the browser's Mono/WASM runtime via JSImport/JSExport. Ships as an installable, offline PWA."),
+                    Host("Rask.Native · preview", "Native iOS / Android", "NativeAppHost.CreateDefault()",
+                        "A WebView-hybrid app head for App Store / Play Store — your C# runs natively on the device. Scaffold with ", Code()["dotnet new rask-native"], ".")
+                ]
+            ]
+        ];
+
+    // ---- features ----
+    private static Component Feature(string glyph, string title, params Component?[] desc) =>
+        Div(Class: "f")[
+            Div(Class: "fh")[Span(Class: "b")[glyph], " ", title],
+            P()[desc]
+        ];
+
+    private Component FeaturesSection() =>
+        Section()[
+            Div(Class: "wrap")[
+                Div(Class: "sec-head reveal")[
+                    P(Class: "eyebrow")["Batteries included · all type-safe"],
+                    H2()["A full framework, generated at compile time."],
+                    P()["Roslyn source generators build per-component factories and typed route URLs — trim-safe, reflection-free, and checked by 30+ compile-time diagnostics."]
+                ],
+                Div(Class: "feat reveal")[
+                    Feature("⌁", "Source generators", "Per-component ", Code()["{Type}(...)"], " factories and type-safe ", Code()["Routes.*"], " URL builders. Rename a route, break the build — never a dead link."),
+                    Feature("◑", "Scoped CSS & JS", "Drop a sibling ", Code()["{Component}.css"], "/", Code()[".js"], ". Auto-scoped, no leaks, no class-name discipline — a mismatch is a build error."),
+                    Feature("▤", "Forms & validation", Code()["Form<T>"], " with two-way binding, plus inline, DataAnnotations, FluentValidation, and async validators."),
+                    Feature("⚿", "Auth, four ways", "Cookie & JWT on both Server and WASM, route guards, and an ", Code()["--auth"], " template switch. Identity, Keycloak, Auth0, OIDC."),
+                    Feature("⇄", "CQRS", "Source-generated, trim-safe queries, commands, notifications and pipeline behaviors via ", Code()["AddRaskCqrs()"], " — standalone, zero reflection."),
+                    Feature("▚", "PWA & Web Push", "Typed manifest, a default service worker, and VAPID/RFC-8291 Web Push with zero external deps. ", Code()["--pwa"], " and you're installable."),
+                    Feature("◈", "43 typed browser APIs", "Storage, clipboard, geolocation, passkeys, share, sensors, observers, serial/USB/HID/Bluetooth — one awaitable C# layer, identical on Server & WASM."),
+                    Feature("⌂", "Secure by default", "Strings are HTML-encoded, URL attributes are scheme-sanitized (", Code()["javascript:"], " → ", Code()["about:blank"], "). Safe output is the default, not a flag."),
+                    Feature("↻", "C# Hot Reload", "Edit ", Code()["Render()"], " or scoped css/js under ", Code()["dotnet watch"], " and it re-renders live — the closest a compiled framework gets to a no-build loop.")
+                ]
+            ]
+        ];
+
+    // ---- install ----
+    private Component InstallSection() =>
+        Section()[
+            Div(Class: "wrap")[
+                Div(Class: "sec-head reveal", Style: "text-align:center; margin-left:auto; margin-right:auto;")[
+                    P(Class: "eyebrow", Style: "justify-content:center;")["Prerequisite · .NET 10 SDK"],
+                    H2()["Up and running in one command."]
+                ],
+                Div(Class: "reveal")[InstallTabs()]
+            ]
+        ];
+
+    // ---- footer ----
+    private Component FooterSection() =>
+        Footer()[
+            Div(Class: "wrap")[
+                Div(Class: "foot-cta reveal")[
+                    H2()["The docs and the live demo are the real tour."],
+                    P()["This is just the front door. Click through a full multi-page Rask app in the browser, or write a component live in the playground."],
+                    Div(Class: "cta-row", Style: "justify-content:center;")[
+                        A(Class: "btn btn-primary", Href: "demo/", Target: "_blank", Rel: "noopener")["▶ Open the live demo"],
+                        A(Class: "btn btn-ghost", Href: "https://github.com/pal-tamas/rask", Target: "_blank", Rel: "noopener")["★ Star on GitHub"]
+                    ],
+                    Div(Class: "foot-links")[
+                        A(Href: "demo/", Target: "_blank", Rel: "noopener")["Live demo"],
+                        A(Href: "playground/", Target: "_blank", Rel: "noopener")["Playground"],
+                        A(Href: "https://github.com/pal-tamas/rask/tree/main/docs", Target: "_blank", Rel: "noopener")["Docs"],
+                        A(Href: "https://www.nuget.org/packages/Rask.Server", Target: "_blank", Rel: "noopener")["NuGet"],
+                        A(Href: "https://github.com/pal-tamas/rask", Target: "_blank", Rel: "noopener")["GitHub"]
+                    ],
+                    P(Class: "foot-meta")[Span(Class: "bolt")["⚡"], " Rask — Norwegian / Danish / Swedish for ", B()["fast"], ". Built with .NET 10 · MIT."]
+                ]
+            ]
+        ];
+
+    private const string BrandSvg =
+        "<svg viewBox=\"0 0 128 128\" aria-hidden=\"true\"><defs><linearGradient id=\"tb\" x1=\"0\" y1=\"0\" x2=\"1\" y2=\"1\"><stop offset=\"0\" stop-color=\"#8b5cf6\"/><stop offset=\"1\" stop-color=\"#7c3aed\"/></linearGradient></defs><rect width=\"128\" height=\"128\" rx=\"28\" fill=\"url(#tb)\"/><path d=\"M74 24 L38 66 L58 66 L53 104 L92 58 L70 58 Z\" fill=\"#fff\"/></svg>";
+
+    // Static, trusted syntax-highlighted markup for the Counter.cs sample (global .t-* classes).
+    private const string CounterCodeHtml =
+        """
+        <span class="t-attr">[Route(<span class="t-str">"/counter"</span>)]</span>
+        <span class="t-key">public sealed class</span> <span class="t-type">Counter</span> : <span class="t-type">Component</span>
+        {
+            <span class="t-key">private int</span> _count;
+
+            <span class="t-key">protected override</span> <span class="t-type">Component</span>? <span class="t-fn">Render</span>() =&gt;
+            [
+                <span class="t-type">H1</span>()[<span class="t-str">"Counter"</span>],
+                <span class="t-type">P</span>()[<span class="t-str">$"Current count: {_count}"</span>],
+                <span class="t-type">Button</span>(<span class="t-attr">OnClick:</span> () =&gt; _count++)[<span class="t-str">"Click me"</span>]
+            ];
+        }
+        """;
+}

--- a/samples/Rask.Example.Site/App.js
+++ b/samples/Rask.Example.Site/App.js
@@ -1,0 +1,194 @@
+// Scoped module for the landing app (window.Rask.App.*). Everything document-level lives here; the
+// counter and install tabs are pure Rask state. `init` is called once from App.OnRenderedAsync with
+// the hero <canvas> (an ElementRef revived to the real DOM node).
+
+export function init(canvas) {
+  wireThemeToggle();
+  wireReveals();
+  wireBars();
+  wireHeroCanvas(canvas);
+}
+
+// ---- theme toggle: media query is the default; the toggle stamps data-theme on <html> ----
+function wireThemeToggle() {
+  var btn = document.getElementById('themeToggle');
+  if (!btn) return;
+  btn.addEventListener('click', function () {
+    var root = document.documentElement;
+    var cur = root.getAttribute('data-theme');
+    if (!cur) cur = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    root.setAttribute('data-theme', cur === 'dark' ? 'light' : 'dark');
+  });
+}
+
+// ---- scroll reveals ----
+function wireReveals() {
+  var io = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (!e.isIntersecting) return;
+      e.target.classList.add('in');
+      io.unobserve(e.target);
+    });
+  }, { threshold: 0.18 });
+  document.querySelectorAll('.reveal').forEach(function (el) { io.observe(el); });
+}
+
+// ---- benchmark bars grow when scrolled into view ----
+function wireBars() {
+  var wrap = document.getElementById('bars');
+  if (!wrap) return;
+  var io = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (!e.isIntersecting) return;
+      wrap.classList.add('run');
+      wrap.querySelectorAll('.bar').forEach(function (bar) { bar.style.height = bar.dataset.h + 'px'; });
+      io.unobserve(wrap);
+    });
+  }, { threshold: 0.3 });
+  io.observe(wrap);
+}
+
+// ---- hero wire visualization: the packet race ----
+function wireHeroCanvas(canvas) {
+  if (!canvas) return;
+  var reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  var ctx = canvas.getContext('2d');
+  var W = canvas.width, H = canvas.height;
+  function css(n) { return getComputedStyle(document.documentElement).getPropertyValue(n).trim(); }
+
+  var LB = H * 0.30;          // top lane — a full-page payload
+  var LR = H * 0.72;          // bottom lane — Rask's minimal diff
+  var X0 = 36, X1 = W - 36, span = X1 - X0;
+  var RASK_SPD = 0.60;        // ~1.7 s per crossing
+  var BLZ_SPD = 0.165;        // ~6 s — a lumbering, heavy payload
+
+  var trail = [], particles = [], rings = [], flashes = [];
+  var prevR = 0, prevB = 0, t0 = null, last = null;
+
+  function roundRect(x, y, w, h, r) {
+    ctx.beginPath();
+    ctx.moveTo(x + r, y);
+    ctx.arcTo(x + w, y, x + w, y + h, r);
+    ctx.arcTo(x + w, y + h, x, y + h, r);
+    ctx.arcTo(x, y + h, x, y, r);
+    ctx.arcTo(x, y, x + w, y, r);
+    ctx.closePath();
+  }
+  function wire(y) {
+    ctx.strokeStyle = css('--line'); ctx.lineWidth = 1;
+    ctx.beginPath(); ctx.moveTo(X0, y); ctx.lineTo(X1, y); ctx.stroke();
+    ctx.fillStyle = css('--muted');
+    ctx.beginPath(); ctx.arc(X0, y, 3.5, 0, 7); ctx.fill();
+    ctx.beginPath(); ctx.arc(X1, y, 3.5, 0, 7); ctx.fill();
+  }
+  function burst(x, y, col, n, speed) {
+    for (var i = 0; i < n; i++) {
+      var ang = Math.random() * Math.PI * 2;
+      var sp = speed * (0.25 + Math.random() * 0.75);
+      particles.push({ x: x, y: y, vx: Math.cos(ang) * sp, vy: Math.sin(ang) * sp - speed * 0.15,
+                       life: 1, col: col, r: 1 + Math.random() * 2.2 });
+    }
+    rings.push({ x: x, y: y, r: 4, life: 1, col: col });
+  }
+  function blazorBlock(x) {
+    var col = css('--blazor');
+    var w = 56, h = 26, xx = x - w / 2, yy = LB - h / 2;
+    ctx.save();
+    ctx.shadowBlur = 12; ctx.shadowColor = 'rgba(0,0,0,.55)';
+    ctx.fillStyle = col; roundRect(xx, yy, w, h, 5); ctx.fill();
+    ctx.shadowBlur = 0; ctx.strokeStyle = 'rgba(255,255,255,.14)'; ctx.lineWidth = 1;
+    for (var s = 1; s < 5; s++) { ctx.beginPath(); ctx.moveTo(xx + w * s / 5, yy + 4); ctx.lineTo(xx + w * s / 5, yy + h - 4); ctx.stroke(); }
+    ctx.restore();
+  }
+  function raskBolt(x) {
+    var col = css('--accent');
+    ctx.save(); ctx.lineCap = 'round';
+    for (var i = 1; i < trail.length; i++) {
+      var a = i / trail.length;
+      ctx.globalAlpha = a * 0.85; ctx.strokeStyle = col; ctx.lineWidth = a * 8;
+      ctx.beginPath(); ctx.moveTo(trail[i - 1].x, LR); ctx.lineTo(trail[i].x, LR); ctx.stroke();
+    }
+    ctx.restore();
+    ctx.save();
+    ctx.shadowBlur = 26; ctx.shadowColor = col; ctx.fillStyle = col;
+    ctx.beginPath(); ctx.arc(x, LR, 6, 0, 7); ctx.fill();
+    ctx.shadowBlur = 12; ctx.shadowColor = '#fff'; ctx.fillStyle = '#fff';
+    ctx.beginPath(); ctx.arc(x, LR, 2.4, 0, 7); ctx.fill();
+    ctx.restore();
+  }
+  function stepFx(dt) {
+    for (var i = rings.length - 1; i >= 0; i--) {
+      var rg = rings[i]; rg.r += 120 * dt; rg.life -= dt * 1.5;
+      if (rg.life <= 0) { rings.splice(i, 1); continue; }
+      ctx.save(); ctx.globalAlpha = Math.max(0, rg.life) * 0.6;
+      ctx.strokeStyle = rg.col; ctx.lineWidth = 2;
+      ctx.beginPath(); ctx.arc(rg.x, rg.y, rg.r, 0, 7); ctx.stroke(); ctx.restore();
+    }
+    ctx.save();
+    for (var j = particles.length - 1; j >= 0; j--) {
+      var p = particles[j];
+      p.x += p.vx * dt * 60; p.y += p.vy * dt * 60; p.vy += 46 * dt; p.life -= dt * 1.35;
+      if (p.life <= 0) { particles.splice(j, 1); continue; }
+      ctx.globalAlpha = Math.max(0, p.life); ctx.fillStyle = p.col;
+      ctx.shadowBlur = 8; ctx.shadowColor = p.col;
+      ctx.beginPath(); ctx.arc(p.x, p.y, p.r, 0, 7); ctx.fill();
+    }
+    ctx.restore();
+    ctx.save();
+    for (var k = flashes.length - 1; k >= 0; k--) {
+      var f = flashes[k]; f.life -= dt * 0.85; f.y -= 20 * dt;
+      if (f.life <= 0) { flashes.splice(k, 1); continue; }
+      ctx.globalAlpha = Math.max(0, f.life); ctx.fillStyle = f.col;
+      ctx.font = '700 13px ui-monospace, monospace'; ctx.textAlign = 'center';
+      ctx.fillText(f.txt, f.x, f.y);
+    }
+    ctx.restore();
+  }
+  function labels() {
+    ctx.textAlign = 'left';
+    ctx.fillStyle = css('--muted'); ctx.font = '11px ui-monospace, monospace';
+    ctx.fillText('Full page · 24 KB', X0, LB - 22);
+    ctx.fillStyle = css('--accent-ink'); ctx.font = '700 11px ui-monospace, monospace';
+    ctx.fillText('Rask diff · 41 B', X0, LR + 28);
+  }
+
+  function frame(ts) {
+    if (t0 === null) { t0 = ts; last = ts; }
+    var dt = Math.min(0.05, (ts - last) / 1000); last = ts;
+    var el = (ts - t0) / 1000;
+    ctx.clearRect(0, 0, W, H);
+    wire(LB); wire(LR);
+
+    var bph = (el * BLZ_SPD) % 1;
+    blazorBlock(X0 + bph * span);
+    if (bph < prevB) burst(X1, LB, css('--blazor'), 12, 55);
+    prevB = bph;
+
+    var rph = (el * RASK_SPD) % 1;
+    var rx = X0 + rph * span;
+    if (rph < prevR) {
+      trail = [{ x: rx }];
+      burst(X1, LR, css('--accent'), 24, 150);
+      flashes.push({ x: X1 - 8, y: LR - 18, txt: 'delivered · 41 B', col: css('--accent-ink'), life: 1 });
+    }
+    prevR = rph;
+    trail.push({ x: rx }); if (trail.length > 20) trail.shift();
+    raskBolt(rx);
+
+    labels();
+    stepFx(dt);
+    requestAnimationFrame(frame);
+  }
+
+  if (reduce) {
+    ctx.clearRect(0, 0, W, H); wire(LB); wire(LR);
+    blazorBlock(X0 + 0.34 * span);
+    trail = [];
+    for (var q = 0; q < 16; q++) trail.push({ x: X0 + (0.5 + q * 0.028) * span });
+    raskBolt(X0 + 0.94 * span);
+    rings.push({ x: X1, y: LR, r: 12, life: 0.85, col: css('--accent') });
+    stepFx(0.016); labels();
+  } else {
+    requestAnimationFrame(frame);
+  }
+}

--- a/samples/Rask.Example.Site/InstallTabs.cs
+++ b/samples/Rask.Example.Site/InstallTabs.cs
@@ -1,0 +1,58 @@
+namespace Rask.Example.Site;
+
+/// <summary>
+/// The "up and running in one command" install block — a stateful Rask component. Clicking a tab
+/// sets <c>_active</c> and re-renders the selected terminal; no JS, no hidden-toggling.
+/// </summary>
+public sealed class InstallTabs : Component
+{
+    private int _active; // 0 = Server, 1 = WASM, 2 = Native
+
+    private static readonly string[] Labels = ["Server", "WASM", "Native"];
+
+    private Component Tab(int i) =>
+        Button(
+            Class: "tab",
+            Type: "button",
+            Role: "tab",
+            Aria: new Dictionary<string, string?> { ["selected"] = i == _active ? "true" : "false" },
+            OnClick: () => _active = i)[Labels[i]];
+
+    private static Component Line(string prompt, string rest) =>
+        [Span(Class: "prompt")[prompt], rest + "\n"];
+
+    private Component Terminal() => _active switch
+    {
+        1 => Pre()[Code()[
+            Span(Class: "cmt")["# standalone browser-WASM SPA (add --pwa for offline)\n"],
+            Line("$", " dotnet new install Rask.Templates"),
+            Line("$", " dotnet new rask-wasm -n MyApp --pwa"),
+            Span(Class: "prompt")["$"], " cd MyApp && dotnet run"
+        ]],
+        2 => Pre()[Code()[
+            Span(Class: "cmt")["# native iOS + Android app (WebView hybrid, preview)\n"],
+            Line("$", " dotnet new install Rask.Templates"),
+            Line("$", " dotnet new rask-native -n MyApp"),
+            Span(Class: "prompt")["$"], " dotnet build -t:Run -f net10.0-android"
+        ]],
+        _ => Pre()[Code()[
+            Span(Class: "cmt")["# ASP.NET live-server app\n"],
+            Line("$", " dotnet new install Rask.Templates"),
+            Line("$", " dotnet new rask-server -n MyApp"),
+            Span(Class: "prompt")["$"], " cd MyApp && dotnet run"
+        ]]
+    };
+
+    protected override Component? Render() =>
+        Div(Class: "install-wrap")[
+            Div(Class: "tabs", Role: "tablist", Aria: new Dictionary<string, string?> { ["label"] = "Project template" })[
+                Tab(0), Tab(1), Tab(2)
+            ],
+            Div(Class: "term")[Terminal()],
+            P(Class: "install-foot")[
+                "Add ", Code()["--auth"], " for a cookie/JWT starter · full path in the ",
+                A(Href: "https://github.com/pal-tamas/rask/blob/main/docs/getting-started.md",
+                  Target: "_blank", Rel: "noopener")["getting-started guide"], "."
+            ]
+        ];
+}

--- a/samples/Rask.Example.Site/LiveCounter.cs
+++ b/samples/Rask.Example.Site/LiveCounter.cs
@@ -1,0 +1,27 @@
+namespace Rask.Example.Site;
+
+/// <summary>
+/// The live demo tile in the hero's second column — a genuine stateful Rask component. Each click
+/// mutates <c>_count</c> and the framework re-renders this subtree automatically (no StateHasChanged),
+/// shipping a minimal diff. It is the landing page proving its own thesis in place.
+/// </summary>
+public sealed class LiveCounter : Component
+{
+    private int _count;
+
+    protected override Component? Render() =>
+        Div(Class: "card live")[
+            Div(Class: "card-bar")[
+                Span(Class: "traf", Style: "background:var(--accent)"),
+                Span(Class: "fn")["running · /counter"]
+            ],
+            Div(Class: "live-body")[
+                H3()["Current count"],
+                Div(Class: "count")[_count],
+                Button(Class: "count-btn", Type: "button", OnClick: () => _count++)["Click me"]
+            ],
+            Div(Class: "live-note")[
+                "Each click ships a ", B()["~41-byte diff"], " — not a re-render of the page."
+            ]
+        ];
+}

--- a/samples/Rask.Example.Site/Program.cs
+++ b/samples/Rask.Example.Site/Program.cs
@@ -1,0 +1,9 @@
+using Rask.Example.Site;
+using Rask.Wasm;
+
+// PathBase is auto-detected at boot from <base href>. For the GitHub Pages sub-path deploy
+// (https://<user>.github.io/<repo>/), CI publishes with /p:RaskPathBase=/<repo> — the framework
+// rewrites the published index.html's <base href> so the runtime picks up the prefix on first paint.
+var host = WasmHostBuilder.CreateDefault();
+
+await host.RunAsync<App>();

--- a/samples/Rask.Example.Site/Rask.Example.Site.csproj
+++ b/samples/Rask.Example.Site/Rask.Example.Site.csproj
@@ -1,0 +1,48 @@
+<Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0-browser</TargetFramework>
+    <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+    <UseAppHost>false</UseAppHost>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <!-- Rask WASM marker: gates build/Rask.Wasm.targets (wwwroot staging + scoped-asset bake). -->
+    <RaskWasm>true</RaskWasm>
+    <!-- Fingerprint framework assets + fill the index.html import map / preload placeholders at
+         publish, so static-host (GitHub Pages) redeploys stay subresource-integrity-safe. -->
+    <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+    <!-- Full WASM AOT is opt-in (-p:RaskWasmAot=true); the default keeps the Mono interpreter.
+         Both are gated off the fast no-native build (-p:WasmBuildNative=false, used by the CI unit
+         gate), which records an empty runtime-pack default that conflicts with a relink. -->
+    <RunAOTCompilation Condition=" '$(RaskWasmAot)' == 'true' ">true</RunAOTCompilation>
+    <RunAOTCompilation Condition=" '$(RaskWasmAot)' != 'true' and '$(WasmBuildNative)' != 'false' ">false</RunAOTCompilation>
+    <!-- Enforce AOT/trim-safety on every build under warnings-as-errors, long before the slow relink. -->
+    <EnableAotAnalyzer>true</EnableAotAnalyzer>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
+    <!-- Trimming is safe: page types reach the runtime via the route registry's generated module
+         initialiser ([DynamicDependency] per registered page). -->
+    <PublishTrimmed>true</PublishTrimmed>
+    <TrimMode>full</TrimMode>
+    <!-- The landing page formats no culture-sensitive values, so drop the ~2.6 MB ICU data.
+         Gated off the fast no-native build for the same reason as RunAOTCompilation above. -->
+    <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+    <!-- Suppress IL2104 from Microsoft.JSInterop's reflection-driven [JSInvokable] scanner; this app
+         only INVOKES JS (never marks methods [JSInvokable]), so that path is never taken. -->
+    <NoWarn>$(NoWarn);IL2104</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Wasm\Rask.Wasm.csproj"/>
+    <!-- Rask.Wasm marks Rask.Core / Rask.Client PrivateAssets="all" (kept out of its nuspec deps),
+         so an in-repo consumer referencing the host by ProjectReference must pull them in directly. -->
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Client\Rask.Client.csproj"/>
+    <PackageReference Include="Microsoft.JSInterop"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+</Project>

--- a/samples/Rask.Example.Site/wwwroot/global.css
+++ b/samples/Rask.Example.Site/wwwroot/global.css
@@ -1,0 +1,293 @@
+  html { -webkit-text-size-adjust: 100%; }
+  :root {
+    /* violet-biased neutrals — chosen, not defaulted */
+    --ground: #0b0b12;
+    --panel: #14141f;
+    --panel-2: #1b1b2a;
+    --line: rgba(139, 92, 246, 0.14);
+    --grid: rgba(139, 92, 246, 0.05);
+    --ink: #e9e9f2;
+    --ink-soft: #c3c2d6;
+    --muted: #8a8aa4;
+    --accent: #8b5cf6;
+    --accent-2: #7c3aed;
+    --accent-ink: #c4b5fd;
+    --signal: #34d399;   /* semantic: "Rask wins" — not the accent */
+    --signal-soft: rgba(52, 211, 153, 0.14);
+    --blazor: #64607a;   /* the "other guy" bars — muted, deliberately quiet */
+    --radius: 14px;
+    --mono: "SFMono-Regular", "JetBrains Mono", "Cascadia Code", "Fira Code", ui-monospace, Menlo, Consolas, monospace;
+    --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --maxw: 1080px;
+  }
+  @media (prefers-color-scheme: light) {
+    :root {
+      --ground: #fbfbfe;
+      --panel: #f3f2fa;
+      --panel-2: #ececf6;
+      --line: rgba(124, 58, 237, 0.16);
+      --grid: rgba(124, 58, 237, 0.045);
+      --ink: #17131f;
+      --ink-soft: #3a3450;
+      --muted: #6b6683;
+      --accent: #7c3aed;
+      --accent-2: #6d28d9;
+      --accent-ink: #6d28d9;
+      --signal: #059669;
+      --signal-soft: rgba(5, 150, 105, 0.12);
+      --blazor: #b6b2c8;
+    }
+  }
+  :root[data-theme="dark"] {
+    --ground: #0b0b12; --panel: #14141f; --panel-2: #1b1b2a;
+    --line: rgba(139,92,246,.14); --grid: rgba(139,92,246,.05);
+    --ink: #e9e9f2; --ink-soft: #c3c2d6; --muted: #8a8aa4;
+    --accent: #8b5cf6; --accent-2: #7c3aed; --accent-ink: #c4b5fd;
+    --signal: #34d399; --signal-soft: rgba(52,211,153,.14); --blazor: #64607a;
+  }
+  :root[data-theme="light"] {
+    --ground: #fbfbfe; --panel: #f3f2fa; --panel-2: #ececf6;
+    --line: rgba(124,58,237,.16); --grid: rgba(124,58,237,.045);
+    --ink: #17131f; --ink-soft: #3a3450; --muted: #6b6683;
+    --accent: #7c3aed; --accent-2: #6d28d9; --accent-ink: #6d28d9;
+    --signal: #059669; --signal-soft: rgba(5,150,105,.12); --blazor: #b6b2c8;
+  }
+
+  * { box-sizing: border-box; }
+  body {
+    margin: 0;
+    background:
+      radial-gradient(1200px 600px at 78% -10%, rgba(124,58,237,.16), transparent 60%),
+      linear-gradient(var(--grid) 1px, transparent 1px) 0 0 / 100% 34px,
+      var(--ground);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 16px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    overflow-x: hidden;
+  }
+  .wrap { max-width: var(--maxw); margin: 0 auto; padding: 0 24px; }
+  section { padding: 92px 0; border-top: 1px solid var(--line); }
+  a { color: var(--accent-ink); text-decoration: none; }
+  a:hover { text-decoration: underline; text-underline-offset: 3px; }
+  h1, h2, h3 { font-family: var(--mono); font-weight: 700; letter-spacing: -0.02em; text-wrap: balance; margin: 0; }
+  code, .mono, .num { font-family: var(--mono); font-variant-numeric: tabular-nums; }
+
+  .eyebrow {
+    font-family: var(--mono); font-size: .74rem; letter-spacing: .22em;
+    text-transform: uppercase; color: var(--muted); margin: 0 0 18px;
+    display: flex; align-items: center; gap: 10px;
+  }
+  .eyebrow::before { content: ""; width: 26px; height: 1px; background: var(--accent); }
+
+  /* ---------- top bar ---------- */
+  .topbar {
+    position: sticky; top: 0; z-index: 40;
+    backdrop-filter: blur(12px);
+    background: color-mix(in srgb, var(--ground) 78%, transparent);
+    border-bottom: 1px solid var(--line);
+  }
+  .topbar .wrap { display: flex; align-items: center; gap: 16px; height: 62px; }
+  .brand { display: flex; align-items: center; gap: 10px; font-family: var(--mono); font-weight: 700; letter-spacing: -.02em; font-size: 1.05rem; color: var(--ink); }
+  .brand svg { width: 26px; height: 26px; display: block; }
+  .topbar nav { margin-left: auto; display: flex; align-items: center; gap: 22px; }
+  .topbar nav a { color: var(--ink-soft); font-size: .92rem; }
+  .topbar nav a.hide-sm { }
+  #themeToggle {
+    font-family: var(--mono); font-size: .8rem; cursor: pointer;
+    background: var(--panel); color: var(--ink-soft);
+    border: 1px solid var(--line); border-radius: 8px; padding: 6px 10px;
+  }
+  #themeToggle:hover { color: var(--ink); border-color: var(--accent); }
+
+  /* ---------- buttons ---------- */
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    font-family: var(--mono); font-weight: 600; font-size: .92rem;
+    padding: 12px 20px; border-radius: 10px; border: 1px solid transparent;
+    cursor: pointer; transition: transform .12s ease, box-shadow .2s ease, background .2s;
+  }
+  .btn-primary { background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #fff; box-shadow: 0 8px 30px -10px var(--accent); }
+  .btn-primary:hover { transform: translateY(-2px); text-decoration: none; }
+  .btn-ghost { background: var(--panel); color: var(--ink); border-color: var(--line); }
+  .btn-ghost:hover { border-color: var(--accent); text-decoration: none; transform: translateY(-2px); }
+
+  /* ---------- hero ---------- */
+  .hero { padding: 78px 0 96px; border-top: none; }
+  .hero-grid { display: grid; grid-template-columns: 1.05fr .95fr; gap: 54px; align-items: center; }
+  .hero h1 { font-size: clamp(2.3rem, 5.4vw, 3.75rem); line-height: 1.04; }
+  .hero h1 .lit { color: transparent; background: linear-gradient(120deg, var(--accent-ink), var(--accent)); -webkit-background-clip: text; background-clip: text; }
+  .hero .lede { color: var(--ink-soft); font-size: 1.14rem; max-width: 30ch; margin: 22px 0 6px; }
+  .hero .sub { color: var(--muted); font-size: .96rem; margin: 14px 0 30px; max-width: 44ch; }
+  .cta-row { display: flex; flex-wrap: wrap; gap: 12px; }
+  .badges { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 30px; }
+  .badge {
+    font-family: var(--mono); font-size: .72rem; letter-spacing: .04em;
+    color: var(--muted); border: 1px solid var(--line); border-radius: 999px;
+    padding: 5px 12px; background: color-mix(in srgb, var(--panel) 60%, transparent);
+  }
+  .badge b { color: var(--accent-ink); font-weight: 600; }
+
+  /* ---------- wire viz ---------- */
+  .wire {
+    background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 22px; position: relative; overflow: hidden;
+    box-shadow: 0 30px 80px -40px rgba(0,0,0,.7);
+  }
+  .wire-head { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 6px; }
+  .wire-head .lab { font-family: var(--mono); font-size: .72rem; letter-spacing: .16em; text-transform: uppercase; color: var(--muted); }
+  .wire-cvs { width: 100%; height: 196px; display: block; }
+  .wire-legend { display: flex; gap: 20px; margin-top: 8px; font-family: var(--mono); font-size: .76rem; color: var(--muted); }
+  .wire-legend b { color: var(--ink); font-weight: 600; }
+  .dot { display: inline-block; width: 8px; height: 8px; border-radius: 50%; margin-right: 6px; vertical-align: 1px; }
+  .wire-tape {
+    margin-top: 16px; padding-top: 14px; border-top: 1px dashed var(--line);
+    display: grid; grid-template-columns: 1fr 1fr; gap: 6px 18px;
+    font-family: var(--mono); font-size: .82rem;
+  }
+  .wire-tape .k { color: var(--muted); }
+  .wire-tape .v { color: var(--ink); text-align: right; }
+  .wire-tape .v.win { color: var(--signal); }
+
+  /* ---------- section headings ---------- */
+  .sec-head { max-width: 62ch; margin-bottom: 44px; }
+  .sec-head h2 { font-size: clamp(1.6rem, 3.4vw, 2.3rem); line-height: 1.1; }
+  .sec-head p { color: var(--ink-soft); margin: 16px 0 0; }
+
+  /* ---------- counter demo ---------- */
+  .demo-grid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 26px; align-items: stretch; }
+  .card {
+    background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+    overflow: hidden;
+  }
+  .card-bar { display: flex; align-items: center; gap: 8px; padding: 11px 16px; border-bottom: 1px solid var(--line); background: var(--panel-2); }
+  .card-bar .fn { font-family: var(--mono); font-size: .78rem; color: var(--muted); margin-left: 4px; }
+  .traf { width: 11px; height: 11px; border-radius: 50%; opacity: .8; }
+  pre { margin: 0; padding: 20px; overflow-x: auto; font-family: var(--mono); font-size: .86rem; line-height: 1.7; }
+  pre code { font-family: var(--mono); }
+  .t-key { color: #c084fc; }
+  .t-type { color: #67e8f9; }
+  .t-str { color: #86efac; }
+  .t-num { color: #fca5a5; }
+  .t-com { color: var(--muted); font-style: italic; }
+  .t-attr { color: #fbbf24; }
+  .t-fn { color: var(--ink); }
+  :root[data-theme="light"] .t-key { color: #7c3aed; }
+  :root[data-theme="light"] .t-type { color: #0e7490; }
+  :root[data-theme="light"] .t-str { color: #15803d; }
+  :root[data-theme="light"] .t-num { color: #b91c1c; }
+  :root[data-theme="light"] .t-attr { color: #b45309; }
+  @media (prefers-color-scheme: light) {
+    :root:not([data-theme]) .t-key { color: #7c3aed; }
+    :root:not([data-theme]) .t-type { color: #0e7490; }
+    :root:not([data-theme]) .t-str { color: #15803d; }
+    :root:not([data-theme]) .t-num { color: #b91c1c; }
+    :root:not([data-theme]) .t-attr { color: #b45309; }
+  }
+  .live { display: flex; flex-direction: column; height: 100%; }
+  .live .card-bar .fn { color: var(--accent-ink); }
+  .live-body { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 18px; padding: 34px 24px; text-align: center; }
+  .live-body h3 { font-size: 1.05rem; color: var(--muted); font-weight: 600; letter-spacing: .02em; }
+  .count { font-family: var(--mono); font-size: 4.2rem; font-weight: 700; line-height: 1; color: var(--ink); font-variant-numeric: tabular-nums; }
+  .count-btn {
+    font-family: var(--mono); font-weight: 600; font-size: .95rem;
+    padding: 12px 26px; border-radius: 10px; border: 1px solid var(--line);
+    background: linear-gradient(135deg, var(--accent), var(--accent-2)); color: #fff; cursor: pointer;
+    transition: transform .1s ease;
+  }
+  .count-btn:active { transform: scale(.94); }
+  .live-note { font-family: var(--mono); font-size: .72rem; color: var(--muted); border-top: 1px solid var(--line); padding: 10px 16px; text-align: center; }
+  .live-note b { color: var(--signal); }
+
+  /* ---------- bars (centerpiece) ---------- */
+  .bars-panel { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 30px 30px 18px; }
+  .bars { display: flex; align-items: flex-end; gap: clamp(14px, 4vw, 46px); height: 300px; padding: 0 6px; }
+  .bar-col { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: flex-end; gap: 12px; height: 100%; min-width: 0; }
+  .bar-stack { width: 100%; max-width: 96px; display: flex; align-items: flex-end; justify-content: center; gap: 10px; height: 240px; }
+  .bar {
+    width: 34px; border-radius: 7px 7px 0 0; height: 0;
+    transition: height 1.1s cubic-bezier(.16,1,.3,1);
+    position: relative;
+  }
+  .bar.blazor { background: var(--blazor); }
+  .bar.rask { background: linear-gradient(180deg, var(--accent), var(--accent-2)); box-shadow: 0 0 24px -6px var(--accent); }
+  .bar .cap { position: absolute; top: -22px; left: 50%; transform: translateX(-50%); font-family: var(--mono); font-size: .72rem; white-space: nowrap; color: var(--ink-soft); opacity: 0; transition: opacity .5s ease .5s; }
+  .bar.rask .cap { color: var(--accent-ink); font-weight: 600; }
+  .bars.run .bar .cap { opacity: 1; }
+  .bar-col .x { font-family: var(--mono); font-size: .78rem; color: var(--muted); text-align: center; text-wrap: balance; }
+  .bar-col .x b { color: var(--ink); display: block; font-size: .96rem; }
+  .bars-legend { display: flex; gap: 22px; justify-content: center; margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--line); font-family: var(--mono); font-size: .8rem; color: var(--muted); }
+
+  .stat-row { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-top: 26px; }
+  .stat { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 20px; }
+  .stat .kpi { font-family: var(--mono); font-size: 1.9rem; font-weight: 700; color: var(--signal); line-height: 1; font-variant-numeric: tabular-nums; }
+  .stat .lab { font-size: .82rem; color: var(--ink-soft); margin-top: 8px; }
+  .stat .sub { font-family: var(--mono); font-size: .72rem; color: var(--muted); margin-top: 6px; }
+  .honest { margin-top: 22px; font-size: .9rem; color: var(--muted); text-align: center; }
+  .honest b { color: var(--ink-soft); }
+
+  /* ---------- hosts ---------- */
+  .hosts { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+  .host { background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius); padding: 26px; transition: border-color .2s, transform .2s; }
+  .host:hover { border-color: var(--accent); transform: translateY(-3px); }
+  .host .tag { font-family: var(--mono); font-size: .7rem; letter-spacing: .14em; text-transform: uppercase; color: var(--accent-ink); }
+  .host h3 { font-size: 1.15rem; margin: 12px 0 8px; }
+  .host p { color: var(--ink-soft); font-size: .92rem; margin: 0; }
+  .host .prev { display: inline-block; margin-top: 12px; font-family: var(--mono); font-size: .68rem; color: var(--muted); border: 1px solid var(--line); border-radius: 6px; padding: 2px 8px; }
+
+  /* ---------- features ---------- */
+  .feat { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  .f {
+    background: var(--panel); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 22px; transition: border-color .2s;
+  }
+  .f:hover { border-color: var(--accent); }
+  .f .fh { font-family: var(--mono); font-weight: 600; font-size: .98rem; color: var(--ink); display: flex; align-items: center; gap: 9px; }
+  .f .fh .b { color: var(--accent); }
+  .f p { color: var(--muted); font-size: .87rem; margin: 10px 0 0; }
+
+  /* ---------- install ---------- */
+  .install-wrap { max-width: 760px; margin: 0 auto; }
+  .tabs { display: flex; gap: 6px; margin-bottom: -1px; position: relative; z-index: 2; flex-wrap: wrap; }
+  .tab {
+    font-family: var(--mono); font-size: .84rem; cursor: pointer;
+    padding: 10px 18px; border: 1px solid var(--line); border-bottom: none;
+    border-radius: 10px 10px 0 0; background: transparent; color: var(--muted);
+  }
+  .tab[aria-selected="true"] { background: var(--panel); color: var(--ink); border-color: var(--line); }
+  .term { background: var(--panel); border: 1px solid var(--line); border-radius: 0 var(--radius) var(--radius) var(--radius); overflow: hidden; }
+  .term pre { padding: 22px 24px; }
+  .term .prompt { color: var(--accent-ink); }
+  .term .cmt { color: var(--muted); }
+  .install-foot { text-align: center; color: var(--muted); font-size: .9rem; margin-top: 20px; font-family: var(--mono); }
+
+  /* ---------- footer ---------- */
+  footer { border-top: 1px solid var(--line); padding: 70px 0 60px; }
+  .foot-cta { text-align: center; }
+  .foot-cta h2 { font-size: clamp(1.6rem, 4vw, 2.4rem); }
+  .foot-cta p { color: var(--ink-soft); max-width: 46ch; margin: 16px auto 28px; }
+  .foot-links { display: flex; justify-content: center; flex-wrap: wrap; gap: 8px 24px; margin-top: 44px; font-family: var(--mono); font-size: .86rem; }
+  .foot-links a { color: var(--muted); }
+  .foot-meta { text-align: center; color: var(--muted); font-family: var(--mono); font-size: .78rem; margin-top: 26px; }
+  .foot-meta .bolt { color: var(--accent); }
+
+  .reveal { opacity: 0; transform: translateY(18px); transition: opacity .7s ease, transform .7s ease; }
+  .reveal.in { opacity: 1; transform: none; }
+
+  @media (max-width: 860px) {
+    .hero-grid, .demo-grid { grid-template-columns: 1fr; }
+    .hero-grid { gap: 40px; }
+    .stat-row, .hosts, .feat { grid-template-columns: 1fr 1fr; }
+    .topbar nav a.hide-sm { display: none; }
+  }
+  @media (max-width: 560px) {
+    section { padding: 66px 0; }
+    .stat-row, .hosts, .feat { grid-template-columns: 1fr; }
+    .wire-tape { grid-template-columns: 1fr; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    * { animation: none !important; transition: none !important; }
+    .reveal { opacity: 1; transform: none; }
+    .bar { transition: none; }
+  }

--- a/samples/Rask.Example.Site/wwwroot/icon.svg
+++ b/samples/Rask.Example.Site/wwwroot/icon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" width="128" height="128" role="img" aria-label="Rask">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#7C3AED"/>
+      <stop offset="100%" stop-color="#512BD4"/>
+    </linearGradient>
+  </defs>
+  <rect width="128" height="128" rx="28" fill="url(#bg)"/>
+  <!-- speed / lightning mark, centered -->
+  <path d="M74 24 L38 66 L58 66 L53 104 L92 58 L70 58 Z" fill="#ffffff"/>
+</svg>

--- a/samples/Rask.Example.Site/wwwroot/index.html
+++ b/samples/Rask.Example.Site/wwwroot/index.html
@@ -1,0 +1,88 @@
+<!--
+  Rask.Example.Site — the marketing landing page, built as a Rask WASM app and served at the
+  GitHub Pages root. This shell is intentionally minimal: the App component is the source of
+  truth for the real <head> and <body>; the runtime imports main.js, boots dotnet, and morphs
+  the App's rendered HTML onto document.documentElement on first paint.
+-->
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8"/>
+    <!-- <base href> is rewritten to /<repo>/ by the framework's _RaskRewriteBaseHref target when
+         published with -p:RaskPathBase=/<repo>; keeps main.js and _framework/* resolving under the
+         Pages sub-path. -->
+    <base href="/"/>
+    <meta content="width=device-width, initial-scale=1" name="viewport"/>
+    <title>Rask</title>
+    <!-- Asset-fingerprinting placeholders filled by Microsoft.NET.Sdk.WebAssembly at publish
+         (<OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>). -->
+    <link rel="preload" id="webassembly"/>
+    <script type="importmap"></script>
+    <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 128 128'%3E%3Crect width='128' height='128' rx='28' fill='%237c3aed'/%3E%3Cpath d='M74 24 L38 66 L58 66 L53 104 L92 58 L70 58 Z' fill='%23fff'/%3E%3C/svg%3E"
+          rel="icon" type="image/svg+xml"/>
+    <style id="rask-scoped"></style>
+    <style>
+        /* Dark boot screen so there's no white flash before the (dark-first) app paints. */
+        .rask-boot {
+            position: fixed;
+            inset: 0;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            gap: 1.25rem;
+            font-family: ui-monospace, "SFMono-Regular", Menlo, Consolas, monospace;
+            color: #c4b5fd;
+            background: #0b0b12;
+        }
+
+        .rask-boot svg {
+            width: 60px;
+            height: 60px;
+            animation: rask-pulse 1.4s ease-in-out infinite;
+        }
+
+        .rask-boot .rask-spin {
+            width: 24px;
+            height: 24px;
+            border-radius: 50%;
+            border: 3px solid rgba(139, 92, 246, 0.25);
+            border-top-color: #8b5cf6;
+            animation: rask-spin 0.8s linear infinite;
+        }
+
+        .rask-boot__label {
+            font-size: 0.8125rem;
+            letter-spacing: 0.12em;
+            text-transform: uppercase;
+            opacity: 0.7;
+        }
+
+        @keyframes rask-spin {
+            to { transform: rotate(360deg); }
+        }
+
+        @keyframes rask-pulse {
+            0%, 100% { opacity: 1; }
+            50% { opacity: 0.5; }
+        }
+    </style>
+</head>
+<body data-rask-root>
+<div class="rask-boot">
+    <svg aria-label="Rask" role="img" viewBox="0 0 128 128" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+            <linearGradient id="rask-boot-bolt" x1="0" x2="1" y1="0" y2="1">
+                <stop offset="0" stop-color="#8b5cf6"/>
+                <stop offset="1" stop-color="#7c3aed"/>
+            </linearGradient>
+        </defs>
+        <rect width="128" height="128" rx="28" fill="url(#rask-boot-bolt)"/>
+        <path d="M74 24 L38 66 L58 66 L53 104 L92 58 L70 58 Z" fill="#fff"/>
+    </svg>
+    <div class="rask-spin"></div>
+    <div class="rask-boot__label">Loading Rask…</div>
+</div>
+<script src="main.js" type="module"></script>
+</body>
+</html>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -29,6 +29,13 @@ public sealed class StandaloneWasmExampleCollection
 }
 
 [CollectionDefinition(Name)]
+public sealed class SiteExampleCollection
+    : ICollectionFixture<SiteWasmAppFixture>, ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "SiteExample";
+}
+
+[CollectionDefinition(Name)]
 public sealed class SubPathWasmExampleCollection
     : ICollectionFixture<SubPathWasmAppFixture>, ICollectionFixture<PlaywrightFixture>
 {

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/SiteWasmAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/SiteWasmAppFixture.cs
@@ -1,0 +1,37 @@
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+/// <summary>
+///     Serves the <em>published</em> <c>Rask.Example.Site</c> marketing landing app from the shared
+///     static-file host (<see cref="StaticWwwrootHostFixture" />) — the GitHub Pages front-door scenario.
+///     The landing page is itself a Rask WASM app, so this exercises the framework rendering a whole
+///     document shell (RASK021) plus its live counter/tabs and the scoped hero-canvas module.
+/// </summary>
+public sealed class SiteWasmAppFixture : StaticWwwrootHostFixture
+{
+    protected override int Port => 5101;
+
+    protected override string ProjectRelativePath => "samples/Rask.Example.Site";
+
+    protected override string MissingBundleMessage(string wwwroot) =>
+        $"Published {ProjectRelativePath} not found at '{wwwroot}'. The E2E build publishes it explicitly " +
+        "(see the 'Publish landing site sample' step in ci.yml's e2e-build job). Locally, run " +
+        "`dotnet publish samples/Rask.Example.Site -c Release -p:WasmBuildNative=false` first.";
+
+    /// <summary>
+    ///     Fail fast if the baked scoped-JS bundle is missing — the hero canvas animation lives in the
+    ///     sibling <c>App.js</c>, baked by <c>BakeScopedAssetsTask</c> into <c>wwwroot/_rask/a/{hash}.js</c>.
+    /// </summary>
+    protected override void OnBundleLocated(string wwwroot)
+    {
+        var scopedDir = Path.Combine(wwwroot, "_rask", "a");
+        var jsFile = Directory.Exists(scopedDir)
+            ? Directory.EnumerateFiles(scopedDir, "*.js").FirstOrDefault()
+            : null;
+        if (jsFile is null)
+        {
+            throw new InvalidOperationException(
+                $"Published {ProjectRelativePath} is missing its baked scoped-JS bundle under '{scopedDir}'. " +
+                "BakeScopedAssetsTask did not emit /_rask/a/*.js — the hero canvas would 404 on window.Rask.App.");
+        }
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/SiteExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SiteExampleTests.cs
@@ -1,0 +1,63 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+/// <summary>
+///     The marketing landing site (<c>Rask.Example.Site</c>), published and served from a plain static
+///     host (<see cref="SiteWasmAppFixture" />) — the GitHub Pages front door. The whole page is rendered
+///     by a Rask WASM app, so the journey proves the framework renders a full document shell, that the
+///     live counter and install tabs are genuine stateful Rask components (click → diff → re-render), and
+///     that the demo/playground links point at the nested sub-apps.
+/// </summary>
+[Collection(SiteExampleCollection.Name)]
+public sealed class SiteExampleTests
+{
+    private readonly SiteWasmAppFixture _app;
+    private readonly PlaywrightFixture _pw;
+
+    public SiteExampleTests(SiteWasmAppFixture app, PlaywrightFixture pw)
+    {
+        _app = app;
+        _pw = pw;
+    }
+
+    [Fact]
+    public async Task Journey_RendersInRaskWithLiveCounterAndTabs()
+    {
+        var context = await _pw.Browser.NewContextAsync(new BrowserNewContextOptions { BaseURL = _app.BaseUrl });
+        var page = await context.NewPageAsync();
+        try
+        {
+            await page.GotoAsync("/index.html");
+
+            // The hero is rendered by the WASM app and morphs onto the shell — wait for it to boot.
+            await Expect(page.Locator("h1")).ToContainTextAsync("pure C#",
+                new LocatorAssertionsToContainTextOptions { Timeout = 60_000 });
+            await Expect(page.Locator("h1")).ToContainTextAsync("Web and native apps");
+
+            // The live counter is a real stateful Rask component: each click ships a diff and re-renders.
+            var count = page.Locator(".count");
+            await Expect(count).ToHaveTextAsync("0");
+            var button = page.Locator("button.count-btn");
+            await button.ClickAsync();
+            await button.ClickAsync();
+            await button.ClickAsync();
+            await Expect(count).ToHaveTextAsync("3");
+
+            // The install tabs are Rask state too — switching re-renders the selected terminal.
+            await page.GetByRole(AriaRole.Tab, new PageGetByRoleOptions { Name = "WASM" }).ClickAsync();
+            await Expect(page.Locator(".term")).ToContainTextAsync("rask-wasm");
+            await page.GetByRole(AriaRole.Tab, new PageGetByRoleOptions { Name = "Native" }).ClickAsync();
+            await Expect(page.Locator(".term")).ToContainTextAsync("net10.0-android");
+
+            // The front door links into the nested demo + playground sub-apps.
+            await Expect(page.Locator("a.btn-primary").First).ToHaveAttributeAsync("href", "demo/");
+        }
+        finally
+        {
+            await context.CloseAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

The GitHub Pages front door (`https://pal-tamas.github.io/rask/`) is now a **standalone Rask WASM app** — `samples/Rask.Example.Site` — that renders the whole marketing landing page in pure Rask. The site that sells the framework is built with the framework.

- **Full page in Rask** — `App.cs` renders the whole document shell (RASK021): hero, an animated packet-race `<canvas>`, the Blazor-vs-Rask benchmark bars, host/feature grids, install block and footer, all via `Element` factories.
- **Genuine Rask interactivity** — the live **counter** (`LiveCounter`) and **install tabs** (`InstallTabs`) are real stateful components: click → diff → re-render, no hand JS.
- **Scoped assets** — the hero canvas animation, scroll reveals and theme toggle live in a sibling scoped `App.js`; the design system is a global stylesheet (`wwwroot/global.css`).
- **Pages restructure** — the live feature showcase moves to **`/demo/`**, the playground stays at **`/playground/`**, and `pages.yml` publishes all three as Rask WASM apps (each with its own `<base href>` via `-p:RaskPathBase`). "Live demo" links across README / NUGET.md / docs now point at `/demo/`.
- **Build wiring** — `Directory.Build.props` opts the standalone site out of the Bootstrap/validation implicit usings (same as Playground/Auth/Native.Server, which also don't reference those libs).

## Testing

- `dotnet build Rask.slnx -c Release -p:RaskWasm=false -p:WasmBuildNative=false` — **0 warnings, 0 errors** (warnings-as-errors).
- `dotnet publish samples/Rask.Example.Site -c Release` — publishes clean with **zero IL-trimming warnings**; `<base href>` rewrites under `-p:RaskPathBase`, `global.css` ships, and the scoped `App.js` bakes to `_rask/a/*.js`.
- New **`SiteExampleTests`** Playwright journey (added to the E2E shard matrix + an explicit publish step in `e2e-build`): asserts the page renders in Rask (hero text), the live counter increments 0→3, the install tabs switch, and the demo link resolves. **Passes locally.**

## Changelog

Added an `[Unreleased] → Added` entry.