### PR TITLE
fix(test): update native Appium E2E to the current two-tab bar (Guides/Todos)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -245,6 +245,11 @@ them until tagged releases begin.
   shards to browser-journey time.
 
 ### Fixed
+- **Native Appium E2E asserted a stale native tab layout.** The on-device `NativeShowcaseAppiumTests`
+  still expected a three-tab `Home`/`Guides`/`Todos` bar (with `Guides → /guides`), but the guides-first
+  pivot dropped the Welcome/Home page and made `Guides` the site root (`/`), so `NativeShowcaseApp` now
+  ships two tabs (`Guides → /`, `Todos → /todos`). The test failed at `WaitForNativeElement("Home")`. It
+  now asserts the current two-tab bar and its round-trip (`Guides "/" → Todos "/todos" → Guides "/"`).
 - **Sign-in landing page rendered stale (pre-sign-in) identity data.** After `IAuthSignIn.SignInAsync(principal, returnUrl)`,
   the server applied the `returnUrl` navigation immediately in the handler-dispatch tail — mounting the
   destination page **before** the reconnect re-seeded `SessionUserProvider`, so its `OnMount`/`OnMountAsync`

--- a/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
+++ b/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
@@ -125,18 +125,17 @@ public sealed class NativeShowcaseAppiumTests
     {
         driver.Context = NativeContext;
 
-        // The native header + the three native tabs render (NativeHeaderBar + NativeTabBar → real bars).
+        // The native header + the two native tabs render (NativeHeaderBar + NativeTabBar → real bars).
+        // Guides is the site root ("/") now that the Welcome landing page is gone, so it doubles as Home.
         WaitForNativeElement(driver, "rask-native-header");
-        WaitForNativeElement(driver, "Home");
         WaitForNativeElement(driver, "Guides");
         WaitForNativeElement(driver, "Todos");
 
         // A native tab tap raises a `navigate` event over the bridge → NativeLiveSession → router → re-render;
         // native history moves the URL, so the WebView's pathname follows. Verify the full round trip and
-        // that re-selecting tabs works (Home → Guides → Todos → Home).
-        TapNativeTabAndAssertRoute(driver, webContext, "Guides", "/guides");
+        // that re-selecting tabs works (Guides "/" → Todos "/todos" → back to Guides "/").
         TapNativeTabAndAssertRoute(driver, webContext, "Todos", "/todos");
-        TapNativeTabAndAssertRoute(driver, webContext, "Home", "/");
+        TapNativeTabAndAssertRoute(driver, webContext, "Guides", "/");
     }
 
     private static void TapNativeTabAndAssertRoute(


### PR DESCRIPTION
## Summary
The native Appium showcase E2E was asserting a stale tab layout and failing in CI at `WaitForNativeElement("Home")`:

```
System.InvalidOperationException : The native element 'Home' never appeared in the NATIVE context.
```

The native bars + this test landed in #325 when `NativeShowcaseApp` had three tabs (`Home`/`Guides`/`Todos`, `Guides → /guides`). The guides-first pivot (#327) then removed the Welcome/Home page and made **Guides the site root (`/`)**, so the app now ships two tabs:

- `Guides → /`
- `Todos → /todos`

The test was never updated. This aligns it with the shipped app:
- Drops the `Home` native-element assertion; asserts the `Guides` + `Todos` tabs.
- Fixes the navigation round-trip to `Guides "/" → Todos "/todos" → Guides "/"`.

No framework/runtime change — test-only + CHANGELOG.

## Testing
- `dotnet build tests/Rask.Native.Appium.Tests -warnaserror` — clean (0 warnings).
- The on-device Appium run is gated to CI runners with an emulator/simulator (`SkippableFact`); the assertions now match `samples/Rask.Example.Native/NativeShowcaseApp.cs`.

## Changelog
Added a `Fixed` entry under `[Unreleased]`.