### PR TITLE
fix(core): harden foreign-head-node preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -255,6 +255,12 @@ them until tagged releases begin.
   shards to browser-journey time.
 
 ### Fixed
+- **Foreign-`<head>` preservation hardening.** Follow-up to the head-injection preservation added above:
+  the head `MutationObserver` now installs eagerly when the client bundle loads (so a library that injects
+  into `<head>` before the first head morph is still caught, not only after it), re-arms if the live
+  `<head>` element is ever replaced rather than morphed in place, and `applyDiff` flushes pending foreign
+  injections before its end-of-frame discard so a library node injected during the same task as a diff
+  isn't dropped instead of preserved.
 - **Sign-in landing page rendered stale (pre-sign-in) identity data.** After `IAuthSignIn.SignInAsync(principal, returnUrl)`,
   the server applied the `returnUrl` navigation immediately in the handler-dispatch tail — mounting the
   destination page **before** the reconnect re-seeded `SessionUserProvider`, so its `OnMount`/`OnMountAsync`

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -137,6 +137,11 @@ function applyDiff(ops, names) {
         return raw;
     }
 
+    // Symmetric with the discard below: tag any foreign head node injected before this diff (still pending,
+    // not yet delivered to the async observer) so the end-of-diff discard only drops the framework's own
+    // head insertions, never a coincidentally-pending library injection.
+    _raskTagForeignHeadNodes();
+
     for (const op of ops) {
         const k = op[0];
         const path = op[1] || [];

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -149,17 +149,24 @@ function raskShouldSuppressChecked(el, incoming) {
 // from the observer queue so they're never mistaken for foreign. data-rask-key nodes (the framework's keyed
 // head links, incl. the scoped-CSS FOUC preload clone) are never tagged — they must reconcile by key.
 let _raskHeadObserver = null;
+let _raskObservedHead = null;
 
 function _raskEnsureHeadObserver() {
-    if (_raskHeadObserver || typeof MutationObserver === "undefined"
-        || typeof document === "undefined" || !document.head) {
+    if (typeof MutationObserver === "undefined" || typeof document === "undefined" || !document.head) {
         return;
     }
+    // Already watching the live <head> — nothing to do.
+    if (_raskHeadObserver && _raskObservedHead === document.head) {
+        return;
+    }
+    // First install, or the <head> element was replaced (not morphed in place) — (re)arm on the live head.
+    if (_raskHeadObserver) _raskHeadObserver.disconnect();
+    _raskObservedHead = document.head;
     // The callback receives the pending records as its argument — do NOT call takeRecords() here (it would
     // return empty, since delivery already drained them). takeRecords() is only for the synchronous flush
-    // at a head morph, where the records are still pending.
+    // at a head morph / applyDiff, where the records are still pending.
     _raskHeadObserver = new MutationObserver((records) => _raskTagHeadRecords(records));
-    _raskHeadObserver.observe(document.head, { childList: true });
+    _raskHeadObserver.observe(_raskObservedHead, { childList: true });
 }
 
 // Tag the nodes added by these mutation records — a <style>/<link>/<script> a library injected — with
@@ -187,6 +194,12 @@ function _raskTagForeignHeadNodes() {
 function _raskDiscardFrameworkHeadMutations() {
     if (_raskHeadObserver) _raskHeadObserver.takeRecords();
 }
+
+// Install eagerly when the client bundle loads, so a library that injects into <head> before the first
+// head morph is still observed (the lazy install inside morph() is the fallback for when document.head
+// isn't ready at load time). The observer only tags nodes ADDED after it arms — the boot-shell head is
+// left alone.
+_raskEnsureHeadObserver();
 
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1197,6 +1197,11 @@ function applyDiff(ops, names) {
         return raw;
     }
 
+    // Symmetric with the discard below: tag any foreign head node injected before this diff (still pending,
+    // not yet delivered to the async observer) so the end-of-diff discard only drops the framework's own
+    // head insertions, never a coincidentally-pending library injection.
+    _raskTagForeignHeadNodes();
+
     for (const op of ops) {
         const k = op[0];
         const path = op[1] || [];
@@ -1957,17 +1962,24 @@ function raskShouldSuppressChecked(el, incoming) {
 // from the observer queue so they're never mistaken for foreign. data-rask-key nodes (the framework's keyed
 // head links, incl. the scoped-CSS FOUC preload clone) are never tagged — they must reconcile by key.
 let _raskHeadObserver = null;
+let _raskObservedHead = null;
 
 function _raskEnsureHeadObserver() {
-    if (_raskHeadObserver || typeof MutationObserver === "undefined"
-        || typeof document === "undefined" || !document.head) {
+    if (typeof MutationObserver === "undefined" || typeof document === "undefined" || !document.head) {
         return;
     }
+    // Already watching the live <head> — nothing to do.
+    if (_raskHeadObserver && _raskObservedHead === document.head) {
+        return;
+    }
+    // First install, or the <head> element was replaced (not morphed in place) — (re)arm on the live head.
+    if (_raskHeadObserver) _raskHeadObserver.disconnect();
+    _raskObservedHead = document.head;
     // The callback receives the pending records as its argument — do NOT call takeRecords() here (it would
     // return empty, since delivery already drained them). takeRecords() is only for the synchronous flush
-    // at a head morph, where the records are still pending.
+    // at a head morph / applyDiff, where the records are still pending.
     _raskHeadObserver = new MutationObserver((records) => _raskTagHeadRecords(records));
-    _raskHeadObserver.observe(document.head, { childList: true });
+    _raskHeadObserver.observe(_raskObservedHead, { childList: true });
 }
 
 // Tag the nodes added by these mutation records — a <style>/<link>/<script> a library injected — with
@@ -1995,6 +2007,12 @@ function _raskTagForeignHeadNodes() {
 function _raskDiscardFrameworkHeadMutations() {
     if (_raskHeadObserver) _raskHeadObserver.takeRecords();
 }
+
+// Install eagerly when the client bundle loads, so a library that injects into <head> before the first
+// head morph is still observed (the lazy install inside morph() is the fallback for when document.head
+// isn't ready at load time). The observer only tags nodes ADDED after it arms — the boot-shell head is
+// left alone.
+_raskEnsureHeadObserver();
 
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2479,17 +2479,24 @@ function raskShouldSuppressChecked(el, incoming) {
 // from the observer queue so they're never mistaken for foreign. data-rask-key nodes (the framework's keyed
 // head links, incl. the scoped-CSS FOUC preload clone) are never tagged — they must reconcile by key.
 let _raskHeadObserver = null;
+let _raskObservedHead = null;
 
 function _raskEnsureHeadObserver() {
-    if (_raskHeadObserver || typeof MutationObserver === "undefined"
-        || typeof document === "undefined" || !document.head) {
+    if (typeof MutationObserver === "undefined" || typeof document === "undefined" || !document.head) {
         return;
     }
+    // Already watching the live <head> — nothing to do.
+    if (_raskHeadObserver && _raskObservedHead === document.head) {
+        return;
+    }
+    // First install, or the <head> element was replaced (not morphed in place) — (re)arm on the live head.
+    if (_raskHeadObserver) _raskHeadObserver.disconnect();
+    _raskObservedHead = document.head;
     // The callback receives the pending records as its argument — do NOT call takeRecords() here (it would
     // return empty, since delivery already drained them). takeRecords() is only for the synchronous flush
-    // at a head morph, where the records are still pending.
+    // at a head morph / applyDiff, where the records are still pending.
     _raskHeadObserver = new MutationObserver((records) => _raskTagHeadRecords(records));
-    _raskHeadObserver.observe(document.head, { childList: true });
+    _raskHeadObserver.observe(_raskObservedHead, { childList: true });
 }
 
 // Tag the nodes added by these mutation records — a <style>/<link>/<script> a library injected — with
@@ -2517,6 +2524,12 @@ function _raskTagForeignHeadNodes() {
 function _raskDiscardFrameworkHeadMutations() {
     if (_raskHeadObserver) _raskHeadObserver.takeRecords();
 }
+
+// Install eagerly when the client bundle loads, so a library that injects into <head> before the first
+// head morph is still observed (the lazy install inside morph() is the fallback for when document.head
+// isn't ready at load time). The observer only tags nodes ADDED after it arms — the boot-shell head is
+// left alone.
+_raskEnsureHeadObserver();
 
 function morph(from, to) {
     if (from.nodeType !== to.nodeType || from.nodeName !== to.nodeName) {
@@ -2841,6 +2854,11 @@ function applyDiff(ops, names) {
         if (typeof raw === "number" && names) return names[raw];
         return raw;
     }
+
+    // Symmetric with the discard below: tag any foreign head node injected before this diff (still pending,
+    // not yet delivered to the async observer) so the end-of-diff discard only drops the framework's own
+    // head insertions, never a coincidentally-pending library injection.
+    _raskTagForeignHeadNodes();
 
     for (const op of ops) {
         const k = op[0];


### PR DESCRIPTION
## Summary
Follow-up hardening to #337 (foreign `<head>` preservation). #337 was merged while the review was still in flight; the review surfaced three **PLAUSIBLE** robustness gaps in the head `MutationObserver` (not correctness breaks — the merged version passes E2E + manual Monaco/Server checks). This addresses all three, leaving the reconciliation untouched:

1. **Eager install** — the observer was installed lazily on the first head morph, so a library injecting into `<head>` before that first morph (an app whose first render is a body-only diff) would be missed. It now installs when the client bundle loads.
2. **Re-arm on `<head>` replacement** — if the live `<head>` element is ever replaced rather than morphed in place, the observer re-binds to the new head instead of staying attached to the detached old one.
3. **`applyDiff` start-flush** — `applyDiff`'s end-of-frame discard had no paired start-flush, so a foreign node injected in the same JS task as a diff could be drained before the async observer tagged it. It now flushes pending foreign injections first, symmetric with the head-morph flush/discard.

## Testing
- Re-verified after the fixes: **Monaco survives Run** (playground, no app-level guard) in Chromium *and* WebKit; **Server** navigated scoped pages 9× — no scoped-`<link>` leak *and* `<title>` still reconciles across 5 navs; **StandaloneWasm journey** + Playground E2E pass.
- `dotnet format` clean; full solution builds warnings-as-errors clean; WASM/Native bundles regenerated.

## Benchmarks
n/a — client-side DOM morph JS.

## CHANGELOG
- [Unreleased] → Fixed: "Foreign-`<head>` preservation hardening."
