### PR TITLE
chore(release): v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-14
+
 ### Added
 - **Marketing landing site, built in Rask (`samples/Rask.Example.Site`).** The GitHub Pages front door
   at `https://pal-tamas.github.io/rask/` is now a standalone Rask WASM app that renders the whole page —


### PR DESCRIPTION
Promote the `[Unreleased]` changelog to **0.16.0** (2026-07-14).

Highlights since v0.15.1: Rask-built marketing landing site (#338), RASK033 route-URL analyzer (#331), the live in-browser playground (#329/#333), the retained-heap win that overtakes Blazor on every axis (#330/#328), the composed native-chrome family + host-awareness API (#325/#326), native geolocation (#317), and the OS share sheet (#312), plus assorted Bootstrap fixes and two pre-1.0 breaking renames (`IShare` namespace move, flash→toast).

Changelog-only. After merge, the `v0.16.0` tag is pushed to trigger `release.yml` (MinVer derives the version from the tag).