### PR TITLE
ci: pin macOS jobs to macos-26 and bump download-artifact to v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -311,7 +311,9 @@ jobs:
   # instead. We build every project × TFM — a green build proves the platform heads + the shared
   # NativeOriginAssets wiring compile. On-device behaviour is verified by the `native-appium` job below.
   native:
-    runs-on: macos-latest
+    # Pinned to macos-26 (not the moving macos-latest label) so the Microsoft.iOS workload lands on the
+    # matching Xcode SDK — same reason as native-ios-e2e.yml.
+    runs-on: macos-26
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -168,7 +168,9 @@ jobs:
   # with the mobile workloads (-p:RaskNativeHeads=true) and handed to publish-nightly as an artifact.
   pack-native-nightly:
     needs: [unit, aot-publish, e2e]
-    runs-on: macos-latest
+    # Pinned to macos-26 (not the moving macos-latest label) so the Microsoft.iOS workload lands on the
+    # matching Xcode SDK — same reason as native-ios-e2e.yml.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
         with:
@@ -225,7 +227,7 @@ jobs:
           dotnet pack src/Rask.WebPush/Rask.WebPush.csproj -c Release -o ./artifacts
 
       - name: Download Rask.Native package (macOS-built, with heads)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: native-nupkgs
           path: ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,9 @@ jobs:
   # here and handed to the publish job as an artifact.
   pack-native:
     needs: [unit, e2e]
-    runs-on: macos-latest
+    # Pinned to macos-26 (not the moving macos-latest label) so the Microsoft.iOS workload lands on the
+    # matching Xcode SDK — same reason as native-ios-e2e.yml.
+    runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
         with:
@@ -202,7 +204,7 @@ jobs:
       # Rask.Native is packed WITH its iOS/Android platform heads on macOS (the pack-native job) — this
       # Ubuntu runner has no ios/android workloads. Pull that .nupkg/.snupkg into ./artifacts.
       - name: Download Rask.Native package (macOS-built, with heads)
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: native-nupkgs
           path: ./artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,12 @@ Apply the matching playbook automatically:
 7. Open a PR (`type(scope): subject`, Conventional Commits — enforced by commitlint); delete the
    branch after squash-merge.
 
+## CI hygiene (`.github/workflows/`)
+Keep the annotation panel clean. Pin macOS jobs to an explicit image (`macos-26`), never the moving
+`macos-latest` label — the mobile jobs need the Xcode SDK the Microsoft.iOS workload auto-tracks. Keep
+`actions/*-artifact` (and other JS actions) on the current major so they run on the supported Node
+runtime, not a deprecated one.
+
 ## Principles
 Do your best on every PR. Hold UX, security, and performance together. Don't reinvent the wheel —
 use the BCL/framework. Automate what you can. Ask only when genuinely blocked.


### PR DESCRIPTION
Clears the two non-blocking annotations from the `v0.16.0` release run.

## Changes
- **`actions/download-artifact@v5` → `@v7`** in `release.yml` and `nightly.yml` — v5 targets the deprecated Node 20 runtime and was being force-run on Node 24. Now matches `ci.yml` and every `upload-artifact@v7`.
- **`macos-latest` → `macos-26`** on the three native macOS jobs (release `pack-native`, nightly `pack-native-nightly`, ci `native`). The `macos-latest` label migrates to macOS 26 on 2026-06-15; pinning explicitly matches `native-ios-e2e.yml`, which already runs on `macos-26` so the Microsoft.iOS workload lands on the right Xcode SDK.
- **`AGENTS.md`** — records the standing CI-hygiene convention (pin macOS images; keep artifact/JS actions on the current major).

## Testing
CI-only change; validated by this PR's own workflow run. No source, no user-facing change (no CHANGELOG entry).