### PR TITLE
feat(native): ship native iOS/Android backends for the browser APIs via UsePlatform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Native iOS/Android backends for the browser/device APIs, wired with one line.** `Rask.Native` now
+  ships native C# implementations of six interfaces and a platform module that installs them:
+  `host.UsePlatform(new ApplePlatform(() => rootVc))` / `new AndroidPlatform(this)`. Injecting the
+  ordinary interface then resolves the native backend on device — `IGeolocation` → `CLLocationManager` /
+  `LocationManager`, `IClipboard` → `UIPasteboard` / `ClipboardManager`, `IVibration` → system vibration /
+  `Vibrator`, `IWakeLock` → idle-timer / `FLAG_KEEP_SCREEN_ON`, `INetworkInfo` → `NWPathMonitor` /
+  `ConnectivityManager`, and `IShare` (already native) — instead of the WebView's JS, which is often
+  gesture-gated or absent on the platform. Everything else falls back to the WebView automatically. The
+  `rask-native` sample uses the new modules (and adds the location / network-state / vibrate permissions).
 - **Central registration for the typed browser/device APIs, with native-first resolution.** The
   interface → implementation map for the 43 browser wrappers, previously hand-duplicated across the
   Server, WASM, and Native hosts, now lives in one place per assembly: `AddCoreBrowserApis` (the 31

--- a/docs/native.md
+++ b/docs/native.md
@@ -11,9 +11,9 @@ unchanged.
 > `WKWebView` and Android `WebView` app heads), and the native client runtime **ship and run
 > end-to-end on both platforms** — a scaffolded app boots, renders the component tree over the native
 > bridge, routes, and updates live (see [Roadmap](#roadmap) for the verification detail). It's still
-> pre-1.0: APIs may shift. **Native device *backends*** have started landing — the OS **share sheet**
-> (`IShare` → `UIActivityViewController` / `Intent.ACTION_SEND`) and **native geolocation** (`IGeolocation` →
-> `CLLocationManager` / `LocationManager`) both have native head backends (see
+> pre-1.0: APIs may shift. **Native device *backends*** ship for share, geolocation, clipboard, vibration,
+> wake lock, and network info — one `host.UsePlatform(new ApplePlatform(…))` / `new AndroidPlatform(this)`
+> wires them all, and the framework resolves each native-first over the WebView's JS (see
 > [Native device backends](#native-device-backends)) — with biometrics/push still to come. The native client
 > now shares the
 > transport-neutral DOM behaviour — rAF input/scroll coalescing, keyboard + drag events, and
@@ -218,7 +218,7 @@ pieces — the WebView bridge, the [native share backend](#native-device-backend
 // Android MainActivity / iOS AppDelegate (Native + Local):
 var webView = new RaskAndroidWebView(this);          // or new RaskWkWebView() on iOS
 var host = NativeAppHost.CreateDefault();
-host.Services.AddSingleton<IShare>(_ => new NativeShare(this));   // native share sheet (shipped)
+host.UsePlatform(new AndroidPlatform(this));         // native backends: share, geolocation, clipboard, …
 var app = await host.RunLocalAsync<App>(webView);
 webView.LoadShell();
 ```
@@ -250,68 +250,64 @@ over **`NativeAssetHttpHandler`** with the same reader and `BaseAddress` = your 
 
 ## Device capabilities
 
-The 27 `IJSRuntime`-backed browser wrappers in `Rask.Core.Browser` (`IGeolocation`, `IClipboard`,
-`IVibration`, storage, notifications, badge, wake lock, …) work **through the WebView's JS engine** with
-no extra code — `NativeAppHost` registers them and `NativeJSRuntime` dispatches them over the bridge.
-Sharing has two entrypoints, both reaching the **native** sheet on device. The all-host, headless
-**`Shareable`** (`Rask.Core`) attaches `data-rask-share` to your element; on the Native host its click is
-routed through the **capability bridge** (`window.__raskNative.invoke`) to the registered `IShare` — so it
-hits the head's native backend, not the WebView's `navigator.share`. The imperative **`IShare`**
-(`Rask.Client.Browser`) shares from code — with the same **native** backend a head registers (below).
-**Geolocation** likewise has a native backend: `IGeolocation` → `CLLocationManager` / `LocationManager` in
-the head. Further **native C# backends** (biometrics, native push via APNs/FCM) behind the *same* interfaces
-— plus new native-only capabilities — are a follow-up (see [Roadmap](#roadmap)).
+The `IJSRuntime`-backed browser wrappers in `Rask.Core.Browser` (storage, media query, the observers,
+crypto, …) work **through the WebView's JS engine** with no extra code — `NativeAppHost` registers them and
+`NativeJSRuntime` dispatches them over the bridge. On top of that, `Rask.Native` **ships native C# backends**
+for the interfaces where a native API beats the WebView (or the WebView doesn't expose one at all); the
+framework wires them ahead of the JS defaults, so you inject the ordinary interface and get the native
+implementation. See [Native device backends](#native-device-backends).
 
 ## Native device backends
 
-`Rask.Native` stays workload-free (plain `net10.0`), so it can't contain iOS/Android P/Invoke. A **native
-backend** is therefore a small piece of code in the **platform head** (which carries the workload) that
-implements a device interface and registers it on `host.Services` **before `RunLocalAsync`**. DI is
-last-registration-wins, so the head's implementation overrides the default the framework registered.
-
-The shipped example is the OS **share sheet**. `IShare` / `ShareData` live in `Rask.Client.Browser` (the
-home for in-process client APIs the WASM and Native hosts share; `Rask.Native` can't reference the
-browser-targeted `Rask.Wasm`). The default backing is the Web Share API over the WebView; the
-`rask-native` template's heads replace it with a native one:
+A **native backend** is a C# class that implements a `Rask.Core.Browser` (or `Rask.Client.Browser`)
+interface against the platform SDK — `CLLocationManager`, `UIPasteboard`, `ClipboardManager`, and friends —
+instead of the WebView's JS. These live in `Rask.Native/Platforms/{iOS,Android}` and compile only for the
+head TFMs (the base `net10.0` build stays workload-free). You never register them one by one: a **platform
+module** does it, and the framework resolves native-first.
 
 ```csharp
 // Platforms/iOS/AppDelegate.cs — before RunLocalAsync
-host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));
+host.UsePlatform(new ApplePlatform(() => Window?.RootViewController));
 
 // Platforms/Android/MainActivity.cs — before RunLocalAsync
-host.Services.AddSingleton<IShare>(_ => new NativeShare(this));
+host.UsePlatform(new AndroidPlatform(this));
 ```
 
-`NativeShare` (also in the template heads) implements `IShare` with `UIActivityViewController` on iOS and an
-`Intent.ACTION_SEND` chooser on Android — no transient user activation needed, and it works even where the
-WebView doesn't expose `navigator.share`. **The recipe generalises:** to add a native backend for any device
-interface, implement it in the head against the platform API and register it before `RunLocalAsync`.
+`ApplePlatform` / `AndroidPlatform` implement `INativePlatform`; `NativeAppHost.RunLocalAsync` invokes them
+**before** wiring the JS-backed fallbacks, and every registration uses `TryAdd`. So an interface a platform
+backs natively **wins** (native-first), an explicit `host.Services` registration you add yourself wins over
+even that, and every interface no one backed falls back to the WebView's JS — the framework picks the best
+implementation per interface with no per-API wiring.
 
-The **imperative** `IShare` calls this directly. The **declarative** `Shareable` reaches it through the
-**capability bridge**: the native client advertises `window.__raskNative.capabilities` and an `invoke(name,
-data)` that posts a `{ type: "capability" }` message; `NativeAppHost` routes it (via
-`NativeCapabilities.TryHandleAsync`) to the registered service (`invoke("share", …)` → `IShare.ShareAsync`).
-So a plain `Shareable` button pops the native sheet on device with no host-specific code. The **same**
-`NativeCapabilities` toolkit (`BridgeScript` + `TryHandleAsync`) lets a **Native + Server** head inject the
-bridge into a remote page, so a plain Server app reaches device natives too — see
-[Native device APIs from a Server app](#native-device-apis-from-a-server-app-the-capability-bridge).
+The shipped native backends (both platforms):
 
-The **second shipped backend is native geolocation** — and it shows the recipe holds for a
-request/**response** (plus subscription) capability, not just fire-and-forget. `NativeGeolocation` (in the
-`--host local` template heads) implements `Rask.Core.Browser.IGeolocation` with **CoreLocation**
-(`CLLocationManager`) on iOS and the platform **`LocationManager`** on Android, registered the same way:
-
-```csharp
-host.Services.AddSingleton<IGeolocation>(_ => new NativeGeolocation(/* activity, iOS: none */));
-```
+| Interface | iOS | Android |
+|---|---|---|
+| `IShare` | `UIActivityViewController` | `Intent.ACTION_SEND` |
+| `IGeolocation` | `CLLocationManager` | `LocationManager` |
+| `IClipboard` | `UIPasteboard` | `ClipboardManager` |
+| `IVibration` | system vibration (AudioToolbox) | `Vibrator` / `VibratorManager` |
+| `IWakeLock` | `UIApplication.IdleTimerDisabled` | window `FLAG_KEEP_SCREEN_ON` |
+| `INetworkInfo` | `NWPathMonitor` | `ConnectivityManager` |
 
 So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real permission prompt +
-`CLLocationManager` / `LocationManager` accuracy) instead of the WebView's `navigator.geolocation`, and
-`WatchAsync` streams updates. It needs the platform location permission — the template adds
-`ACCESS_FINE_LOCATION` / `NSLocationWhenInUseUsageDescription` and `MainActivity` requests the runtime grant.
+`CLLocationManager` / `LocationManager` accuracy) instead of `navigator.geolocation`, `clipboard.WriteTextAsync`
+hits `UIPasteboard` / `ClipboardManager` (no WebView gesture gate), and so on. Geolocation and network info
+need platform permissions — add `ACCESS_FINE_LOCATION` / `ACCESS_NETWORK_STATE` (Android) and
+`NSLocationWhenInUseUsageDescription` (iOS), and the head requests the location runtime grant.
 
-The **same recipe** carries the remaining backends (biometrics, native push) — a framework-registered
-default, overridden by a native head implementation.
+The **declarative** `Shareable` still reaches the native share sheet through the **capability bridge**: the
+native client advertises `window.__raskNative.capabilities` and an `invoke(name, data)` that posts a
+`{ type: "capability" }` message; `NativeAppHost` routes it (via `NativeCapabilities.TryHandleAsync`) to the
+resolved `IShare` (`invoke("share", …)` → `IShare.ShareAsync`) — so a plain `Shareable` button pops the
+native sheet with no host-specific code. The **same** `NativeCapabilities` toolkit lets a **Native + Server**
+head inject the bridge into a remote page, so a plain Server app reaches device natives too — see
+[Native device APIs from a Server app](#native-device-apis-from-a-server-app-the-capability-bridge).
+
+**To add your own backend** (or override a shipped one), implement the interface in your head and register it
+on `host.Services` before `RunLocalAsync` — it wins over the platform module's version. Further native
+backends behind the *same* interfaces (biometrics, native push via APNs/FCM) are a follow-up (see
+[Roadmap](#roadmap)).
 
 ## Native header & footer
 

--- a/samples/Rask.Example.Native/Platforms/Android/AndroidManifest.xml
+++ b/samples/Rask.Example.Native/Platforms/Android/AndroidManifest.xml
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<uses-permission android:name="android.permission.INTERNET"/>
+	<!-- Native device backends wired by AndroidPlatform: IGeolocation (LocationManager), INetworkInfo
+	     (ConnectivityManager), IVibration (Vibrator). Clipboard and wake-lock need no permission. -->
+	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+	<uses-permission android:name="android.permission.VIBRATE"/>
 	<!-- Native + Server mode loads a local dev server over http (http://10.0.2.2:5080). Cleartext is a
 	     DEVELOPMENT convenience only — a real deployment is https and would not need this. -->
 	<application android:label="Rask Showcase" android:allowBackup="true" android:supportsRtl="true"

--- a/samples/Rask.Example.Native/Platforms/Android/MainActivity.cs
+++ b/samples/Rask.Example.Native/Platforms/Android/MainActivity.cs
@@ -2,7 +2,6 @@ using Android.App;
 using Android.OS;
 using Android.Webkit;
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Client.Browser;
 using Rask.Example.Shared;
 using Rask.Native;
 
@@ -44,9 +43,11 @@ public class MainActivity : Activity
         var host = NativeAppHost.CreateDefault();
         host.Services.AddExampleServices(_ => new Uri(RaskAndroidWebView.DefaultOrigin));
 
-        // Native device backend: hand IShare to the Android OS share sheet (ACTION_SEND chooser). Register
-        // native backends on host.Services BEFORE RunLocalAsync — the last registration wins.
-        host.Services.AddSingleton<IShare>(_ => new NativeShare(this));
+        // Native device backends: the Android platform module wires IShare (ACTION_SEND chooser),
+        // IGeolocation (LocationManager), IClipboard, IVibration, IWakeLock, and INetworkInfo to their native
+        // C# impls. The framework resolves each over the JS-backed default (native-first); everything else
+        // falls back to the WebView's JS. Call UsePlatform before RunLocalAsync.
+        host.UsePlatform(new AndroidPlatform(this));
 
         // Native header/footer chrome: the same RaskAndroidWebView instance is the INativeChrome backend.
         host.Services.AddSingleton<INativeChrome>(webView);

--- a/samples/Rask.Example.Native/Platforms/iOS/AppDelegate.cs
+++ b/samples/Rask.Example.Native/Platforms/iOS/AppDelegate.cs
@@ -1,6 +1,5 @@
 using Foundation;
 using Microsoft.Extensions.DependencyInjection;
-using Rask.Client.Browser;
 using Rask.Example.Shared;
 using Rask.Native;
 using UIKit;
@@ -46,9 +45,11 @@ public class AppDelegate : UIApplicationDelegate
         var host = NativeAppHost.CreateDefault();
         host.Services.AddExampleServices(_ => new Uri(RaskWkWebView.DefaultOrigin));
 
-        // Native device backend: hand IShare to the iOS OS share sheet (UIActivityViewController). Register
-        // native backends on host.Services BEFORE RunLocalAsync — the last registration wins.
-        host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));
+        // Native device backends: the iOS platform module wires IShare (system share sheet), IGeolocation
+        // (CoreLocation), IClipboard, IVibration, IWakeLock, and INetworkInfo to their native C# impls. The
+        // framework resolves each over the JS-backed default (native-first); everything else falls back to
+        // the WebView's JS. Call UsePlatform before RunLocalAsync.
+        host.UsePlatform(new ApplePlatform(() => Window?.RootViewController));
 
         // Native header/footer chrome: the same RaskWkWebView instance is the INativeChrome backend, so the
         // NativeShowcaseApp's NativeHeader/NativeFooter drive its UINavigationBar/UITabBar.

--- a/samples/Rask.Example.Native/Platforms/iOS/Info.plist
+++ b/samples/Rask.Example.Native/Platforms/iOS/Info.plist
@@ -33,5 +33,9 @@
 	<!-- Native + Local serves everything from the raskapp:// custom scheme and never loads plain http, so
 	     no App Transport Security exception is needed here. (The Native + Server sample, which loads a dev
 	     server over http, is the one that relaxes ATS.) -->
+	<!-- Native IGeolocation (ApplePlatform → CoreLocation) shows the system location prompt; iOS requires a
+	     purpose string. Clipboard / vibration / wake-lock / network-info need no usage description. -->
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>The showcase reads your location to demo the native IGeolocation backend.</string>
 </dict>
 </plist>

--- a/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
@@ -1,0 +1,34 @@
+using Android.App;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rask.Client.Browser;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+/// <summary>
+///     The Android platform module. Pass it to <see cref="NativeAppHost.UsePlatform" /> and the host wires
+///     these native C# backends for the browser/device API interfaces — <c>IShare</c> (ACTION_SEND chooser),
+///     <c>IGeolocation</c> (LocationManager), <c>IClipboard</c> (ClipboardManager), <c>IVibration</c>
+///     (Vibrator), <c>IWakeLock</c> (FLAG_KEEP_SCREEN_ON), and <c>INetworkInfo</c> (ConnectivityManager) — so
+///     injecting any of them resolves the native implementation and every other interface falls back to the
+///     WebView's JS. The app writes one line (<c>host.UsePlatform(new AndroidPlatform(this))</c>) instead of
+///     registering each backend by hand. Geolocation needs <c>ACCESS_FINE_LOCATION</c> and network info needs
+///     <c>ACCESS_NETWORK_STATE</c> in the manifest.
+/// </summary>
+/// <param name="activity">The host <see cref="Activity" /> the backends run against (UI thread, services).</param>
+public sealed class AndroidPlatform(Activity activity) : INativePlatform
+{
+    /// <inheritdoc />
+    public void Register(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        // TryAdd + direct construction: native-first (an explicit app registration still wins) and trim-safe.
+        services.TryAddSingleton<IShare>(_ => new NativeShare(activity));
+        services.TryAddSingleton<IGeolocation>(_ => new NativeGeolocation(activity));
+        services.TryAddSingleton<IClipboard>(_ => new NativeClipboard(activity));
+        services.TryAddSingleton<IVibration>(_ => new NativeVibration(activity));
+        services.TryAddSingleton<IWakeLock>(_ => new NativeWakeLock(activity));
+        services.TryAddSingleton<INetworkInfo>(_ => new NativeNetworkInfo(activity));
+    }
+}

--- a/src/Rask.Native/Platforms/Android/NativeClipboard.cs
+++ b/src/Rask.Native/Platforms/Android/NativeClipboard.cs
@@ -1,0 +1,39 @@
+using Android.App;
+using Android.Content;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IClipboard — ClipboardManager instead of the WebView's navigator.clipboard.
+// Clipboard access must happen on the UI thread. Registered by AndroidPlatform.
+internal sealed class NativeClipboard(Activity activity) : IClipboard
+{
+    public ValueTask WriteTextAsync(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        var tcs = new TaskCompletionSource();
+        activity.RunOnUiThread(() =>
+        {
+            Manager().PrimaryClip = ClipData.NewPlainText("text", text);
+            tcs.TrySetResult();
+        });
+        return new ValueTask(tcs.Task);
+    }
+
+    public ValueTask<string> ReadTextAsync()
+    {
+        var tcs = new TaskCompletionSource<string>();
+        activity.RunOnUiThread(() =>
+        {
+            var clip = Manager().PrimaryClip;
+            var text = clip is { ItemCount: > 0 }
+                ? clip.GetItemAt(0)?.CoerceToText(activity)?.ToString()
+                : null;
+            tcs.TrySetResult(text ?? string.Empty);
+        });
+        return new ValueTask<string>(tcs.Task);
+    }
+
+    private ClipboardManager Manager() =>
+        (ClipboardManager)activity.GetSystemService(Context.ClipboardService)!;
+}

--- a/src/Rask.Native/Platforms/Android/NativeGeolocation.cs
+++ b/src/Rask.Native/Platforms/Android/NativeGeolocation.cs
@@ -1,0 +1,142 @@
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.Locations;
+using Android.OS;
+using Android.Runtime;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IGeolocation — the platform LocationManager instead of the WebView's
+// navigator.geolocation. Needs ACCESS_FINE_LOCATION in AndroidManifest.xml + a runtime grant (the host
+// Activity requests it). Registered by AndroidPlatform; the framework resolves it over the JS default.
+internal sealed class NativeGeolocation(Activity activity) : IGeolocation
+{
+    public ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null)
+    {
+        var tcs = new TaskCompletionSource<GeolocationPosition>();
+        activity.RunOnUiThread(() =>
+        {
+            if (!HasPermission())
+            {
+                tcs.TrySetException(new InvalidOperationException("Location permission not granted."));
+                return;
+            }
+
+            var manager = LocationManagerFor();
+            var provider = BestProvider(manager, options?.EnableHighAccuracy ?? false);
+            if (provider is null)
+            {
+                tcs.TrySetException(new InvalidOperationException("No enabled location provider."));
+                return;
+            }
+
+            // One-shot: subscribe, take the first fix, then unsubscribe.
+            OneShotListener? listener = null;
+            listener = new OneShotListener(fix =>
+            {
+                manager.RemoveUpdates(listener!);
+                tcs.TrySetResult(fix);
+            });
+            manager.RequestLocationUpdates(provider, 0L, 0f, listener, Looper.MainLooper);
+        });
+        return new ValueTask<GeolocationPosition>(tcs.Task);
+    }
+
+    public ValueTask<IAsyncDisposable> WatchAsync(
+        Func<GeolocationPosition, Task> onPosition, GeolocationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(onPosition);
+        var watch = new Watch(activity, HasPermission, onPosition, options?.EnableHighAccuracy ?? false);
+        return new ValueTask<IAsyncDisposable>(watch);
+    }
+
+    private bool HasPermission() =>
+        activity.CheckSelfPermission(Android.Manifest.Permission.AccessFineLocation) == Permission.Granted;
+
+    private LocationManager LocationManagerFor() =>
+        (LocationManager)activity.GetSystemService(Context.LocationService)!;
+
+    private static string? BestProvider(LocationManager manager, bool highAccuracy)
+    {
+        // Prefer GPS for high accuracy; otherwise take whatever's enabled (network is faster/cheaper).
+        var order = highAccuracy
+            ? new[] { LocationManager.GpsProvider, LocationManager.NetworkProvider }
+            : new[] { LocationManager.NetworkProvider, LocationManager.GpsProvider };
+        foreach (var p in order)
+        {
+            if (manager.IsProviderEnabled(p))
+            {
+                return p;
+            }
+        }
+
+        return null;
+    }
+
+    private static GeolocationPosition Map(Location l) => new(
+        Latitude: l.Latitude,
+        Longitude: l.Longitude,
+        Accuracy: l.HasAccuracy ? l.Accuracy : 0,
+        Altitude: l.HasAltitude ? l.Altitude : null,
+        AltitudeAccuracy: OperatingSystem.IsAndroidVersionAtLeast(26) && l.HasVerticalAccuracy
+            ? l.VerticalAccuracyMeters
+            : null,
+        Heading: l.HasBearing ? l.Bearing : null,
+        Speed: l.HasSpeed ? l.Speed : null,
+        TimestampMs: l.Time);
+
+    private sealed class OneShotListener(Action<GeolocationPosition> onFix) : Java.Lang.Object, ILocationListener
+    {
+        public void OnLocationChanged(Location location) => onFix(Map(location));
+
+        public void OnProviderDisabled(string provider) { }
+
+        public void OnProviderEnabled(string provider) { }
+
+        public void OnStatusChanged(string? provider, [GeneratedEnum] Availability status, Bundle? extras) { }
+    }
+
+    private sealed class Watch : Java.Lang.Object, ILocationListener, IAsyncDisposable
+    {
+        private readonly Activity _activity;
+        private readonly Func<GeolocationPosition, Task> _onPosition;
+        private LocationManager? _manager;
+
+        public Watch(Activity activity, Func<bool> hasPermission, Func<GeolocationPosition, Task> onPosition,
+            bool highAccuracy)
+        {
+            _activity = activity;
+            _onPosition = onPosition;
+            activity.RunOnUiThread(() =>
+            {
+                if (!hasPermission())
+                {
+                    return;
+                }
+
+                _manager = (LocationManager)activity.GetSystemService(Context.LocationService)!;
+                var provider = BestProvider(_manager, highAccuracy);
+                if (provider is not null)
+                {
+                    _manager.RequestLocationUpdates(provider, 1000L, 0f, this, Looper.MainLooper);
+                }
+            });
+        }
+
+        public void OnLocationChanged(Location location) => _ = _onPosition(Map(location));
+
+        public void OnProviderDisabled(string provider) { }
+
+        public void OnProviderEnabled(string provider) { }
+
+        public void OnStatusChanged(string? provider, [GeneratedEnum] Availability status, Bundle? extras) { }
+
+        public ValueTask DisposeAsync()
+        {
+            _activity.RunOnUiThread(() => _manager?.RemoveUpdates(this));
+            return default;
+        }
+    }
+}

--- a/src/Rask.Native/Platforms/Android/NativeNetworkInfo.cs
+++ b/src/Rask.Native/Platforms/Android/NativeNetworkInfo.cs
@@ -1,0 +1,43 @@
+using Android.App;
+using Android.Content;
+using Android.Net;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for INetworkInfo — ConnectivityManager (needs ACCESS_NETWORK_STATE) instead of
+// navigator.connection. Maps the active network's transport + reported downstream bandwidth to the typed
+// snapshot. Registered by AndroidPlatform.
+internal sealed class NativeNetworkInfo(Activity activity) : INetworkInfo
+{
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask<NetworkStatus?> GetStatusAsync()
+    {
+        var cm = (ConnectivityManager?)activity.GetSystemService(Context.ConnectivityService);
+        var network = cm?.ActiveNetwork;
+        var caps = network is null ? null : cm!.GetNetworkCapabilities(network);
+        if (caps is null)
+        {
+            return ValueTask.FromResult<NetworkStatus?>(
+                new NetworkStatus(EffectiveConnectionType.Unknown, 0, 0, false));
+        }
+
+        var fast = caps.HasTransport(TransportType.Wifi) || caps.HasTransport(TransportType.Ethernet);
+        var downKbps = caps.LinkDownstreamBandwidthKbps;
+        var effective = fast ? EffectiveConnectionType.FourG : ClassifyCellular(downKbps);
+        var saveData = OperatingSystem.IsAndroidVersionAtLeast(24)
+            && cm!.RestrictBackgroundStatus == RestrictBackgroundStatus.Enabled;
+        return ValueTask.FromResult<NetworkStatus?>(
+            new NetworkStatus(effective, downKbps / 1000.0, 0, saveData));
+    }
+
+    private static EffectiveConnectionType ClassifyCellular(int downKbps) => downKbps switch
+    {
+        <= 0 => EffectiveConnectionType.Unknown,
+        < 100 => EffectiveConnectionType.Slow2g,
+        < 300 => EffectiveConnectionType.TwoG,
+        < 1500 => EffectiveConnectionType.ThreeG,
+        _ => EffectiveConnectionType.FourG
+    };
+}

--- a/src/Rask.Native/Platforms/Android/NativeVibration.cs
+++ b/src/Rask.Native/Platforms/Android/NativeVibration.cs
@@ -1,0 +1,61 @@
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IVibration — Vibrator / VibratorManager (API 31+). Honors the full
+// vibrate/pause pattern (unlike iOS). Registered by AndroidPlatform.
+internal sealed class NativeVibration(Activity activity) : IVibration
+{
+    public ValueTask<bool> VibrateAsync(params int[] pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        var vibrator = GetVibrator();
+        if (vibrator is null || !vibrator.HasVibrator || pattern.Length == 0)
+        {
+            return ValueTask.FromResult(false);
+        }
+
+        // Web pattern semantics are [vibrate, pause, vibrate, …]; Android waveform timings start with an OFF
+        // segment, so prepend a 0-length wait to align them.
+        var timings = new long[pattern.Length + 1];
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            timings[i + 1] = Math.Max(0, pattern[i]);
+        }
+
+        if (OperatingSystem.IsAndroidVersionAtLeast(26))
+        {
+            vibrator.Vibrate(VibrationEffect.CreateWaveform(timings, -1));
+        }
+        else
+        {
+#pragma warning disable CA1422 // legacy vibrate for API < 26
+            vibrator.Vibrate(timings, -1);
+#pragma warning restore CA1422
+        }
+
+        return ValueTask.FromResult(true);
+    }
+
+    public ValueTask<bool> CancelAsync()
+    {
+        GetVibrator()?.Cancel();
+        return ValueTask.FromResult(true);
+    }
+
+    private Vibrator? GetVibrator()
+    {
+        if (OperatingSystem.IsAndroidVersionAtLeast(31))
+        {
+            var manager = (VibratorManager?)activity.GetSystemService(Context.VibratorManagerService);
+            return manager?.DefaultVibrator;
+        }
+
+#pragma warning disable CA1422 // Context.VibratorService is the pre-31 path
+        return (Vibrator?)activity.GetSystemService(Context.VibratorService);
+#pragma warning restore CA1422
+    }
+}

--- a/src/Rask.Native/Platforms/Android/NativeWakeLock.cs
+++ b/src/Rask.Native/Platforms/Android/NativeWakeLock.cs
@@ -1,0 +1,53 @@
+using Android.App;
+using Android.Views;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IWakeLock — the Window FLAG_KEEP_SCREEN_ON (keeps the screen awake with no
+// WAKE_LOCK permission) instead of the Screen Wake Lock API the WebView restricts. Ref-counted so
+// overlapping sentinels compose. Registered by AndroidPlatform.
+internal sealed class NativeWakeLock(Activity activity) : IWakeLock
+{
+    private int _held;
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask<IWakeLockSentinel> RequestAsync()
+    {
+        activity.RunOnUiThread(() =>
+        {
+            _held++;
+            activity.Window?.AddFlags(WindowManagerFlags.KeepScreenOn);
+        });
+        return ValueTask.FromResult<IWakeLockSentinel>(new Sentinel(this));
+    }
+
+    private void Release()
+    {
+        activity.RunOnUiThread(() =>
+        {
+            if (--_held <= 0)
+            {
+                _held = 0;
+                activity.Window?.ClearFlags(WindowManagerFlags.KeepScreenOn);
+            }
+        });
+    }
+
+    private sealed class Sentinel(NativeWakeLock owner) : IWakeLockSentinel
+    {
+        private bool _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (!_released)
+            {
+                _released = true;
+                owner.Release();
+            }
+
+            return default;
+        }
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
+++ b/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
@@ -1,0 +1,37 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Rask.Client.Browser;
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Rask.Native;
+
+/// <summary>
+///     The iOS platform module. Pass it to <see cref="NativeAppHost.UsePlatform" /> and the host wires these
+///     native C# backends for the browser/device API interfaces — <c>IShare</c> (system share sheet),
+///     <c>IGeolocation</c> (CoreLocation), <c>IClipboard</c> (UIPasteboard), <c>IVibration</c>,
+///     <c>IWakeLock</c>, and <c>INetworkInfo</c> — so injecting any of them resolves the native
+///     implementation, and every other interface falls back to the WebView's JS. The app writes one line
+///     (<c>host.UsePlatform(new ApplePlatform(() =&gt; Window?.RootViewController))</c>) instead of
+///     registering each backend by hand.
+/// </summary>
+/// <param name="presenter">
+///     Supplies the <see cref="UIViewController" /> the system share sheet presents from (typically the
+///     window's root view controller). Evaluated lazily on each share.
+/// </param>
+public sealed class ApplePlatform(Func<UIViewController?> presenter) : INativePlatform
+{
+    /// <inheritdoc />
+    public void Register(IServiceCollection services)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        // TryAdd + direct construction: native-first (an explicit app registration still wins) and AOT-safe
+        // (no reflection-based activation on the iOS full-AOT head).
+        services.TryAddSingleton<IShare>(_ => new NativeShare(presenter));
+        services.TryAddSingleton<IGeolocation>(_ => new NativeGeolocation());
+        services.TryAddSingleton<IClipboard>(_ => new NativeClipboard());
+        services.TryAddSingleton<IVibration>(_ => new NativeVibration());
+        services.TryAddSingleton<IWakeLock>(_ => new NativeWakeLock());
+        services.TryAddSingleton<INetworkInfo>(_ => new NativeNetworkInfo());
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/NativeClipboard.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeClipboard.cs
@@ -1,0 +1,19 @@
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Rask.Native;
+
+// Native iOS backend for IClipboard — UIPasteboard instead of the WebView's navigator.clipboard (which
+// WKWebView gates behind a user gesture and, for reads, a permission banner). Registered by ApplePlatform.
+internal sealed class NativeClipboard : IClipboard
+{
+    public ValueTask WriteTextAsync(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        UIPasteboard.General.String = text;
+        return default;
+    }
+
+    public ValueTask<string> ReadTextAsync() =>
+        ValueTask.FromResult(UIPasteboard.General.String ?? string.Empty);
+}

--- a/src/Rask.Native/Platforms/iOS/NativeGeolocation.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeGeolocation.cs
@@ -1,0 +1,150 @@
+using CoreLocation;
+using Foundation;
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Rask.Native;
+
+// Native iOS backend for IGeolocation — CoreLocation instead of the WebView's navigator.geolocation. Gives
+// the real iOS permission prompt (Info.plist NSLocationWhenInUseUsageDescription) and CLLocationManager
+// accuracy, and works even where the WebView's geolocation is restricted. Registered by ApplePlatform; the
+// framework resolves it over the JS-backed default (native-first). GetCurrentPositionAsync resolves one fix;
+// WatchAsync streams them.
+internal sealed class NativeGeolocation : IGeolocation
+{
+    public ValueTask<GeolocationPosition> GetCurrentPositionAsync(GeolocationOptions? options = null)
+    {
+        var tcs = new TaskCompletionSource<GeolocationPosition>();
+        UIApplication.SharedApplication.InvokeOnMainThread(() =>
+        {
+            // The delegate keeps the manager alive until it fires (or faults), then tears it down.
+            var manager = new CLLocationManager
+            {
+                DesiredAccuracy = (options?.EnableHighAccuracy ?? false)
+                    ? CLLocation.AccuracyBest
+                    : CLLocation.AccuracyHundredMeters
+            };
+            manager.Delegate = new OneShotDelegate(manager, tcs);
+            manager.RequestWhenInUseAuthorization();
+            RequestWhenAuthorized(manager);
+        });
+        return new ValueTask<GeolocationPosition>(tcs.Task);
+    }
+
+    public ValueTask<IAsyncDisposable> WatchAsync(
+        Func<GeolocationPosition, Task> onPosition, GeolocationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(onPosition);
+        var watch = new Watch(onPosition, options?.EnableHighAccuracy ?? false);
+        return new ValueTask<IAsyncDisposable>(watch);
+    }
+
+    // RequestLocation only works once authorization is at least WhenInUse; if it's still NotDetermined the
+    // delegate re-requests from AuthorizationChanged once the user answers the prompt.
+    private static void RequestWhenAuthorized(CLLocationManager manager)
+    {
+        if (manager.AuthorizationStatus is CLAuthorizationStatus.AuthorizedWhenInUse
+            or CLAuthorizationStatus.AuthorizedAlways)
+        {
+            manager.RequestLocation();
+        }
+    }
+
+    private sealed class OneShotDelegate(CLLocationManager manager, TaskCompletionSource<GeolocationPosition> tcs)
+        : CLLocationManagerDelegate
+    {
+        public override void AuthorizationChanged(CLLocationManager mgr, CLAuthorizationStatus status)
+        {
+            if (status is CLAuthorizationStatus.AuthorizedWhenInUse or CLAuthorizationStatus.AuthorizedAlways)
+            {
+                mgr.RequestLocation();
+            }
+            else if (status is CLAuthorizationStatus.Denied or CLAuthorizationStatus.Restricted)
+            {
+                Finish(() => tcs.TrySetException(new InvalidOperationException("Location permission denied.")));
+            }
+        }
+
+        public override void LocationsUpdated(CLLocationManager mgr, CLLocation[] locations)
+        {
+            if (locations.Length > 0)
+            {
+                Finish(() => tcs.TrySetResult(Map(locations[^1])));
+            }
+        }
+
+        public override void Failed(CLLocationManager mgr, NSError error) =>
+            Finish(() => tcs.TrySetException(new InvalidOperationException(error.LocalizedDescription)));
+
+        private void Finish(Action complete)
+        {
+            manager.Delegate = null!;   // release the retain cycle so the manager can be collected
+            complete();
+        }
+    }
+
+    // A watchPosition subscription: streams every CLLocation update until disposed.
+    private sealed class Watch : CLLocationManagerDelegate, IAsyncDisposable
+    {
+        private readonly Func<GeolocationPosition, Task> _onPosition;
+        private CLLocationManager? _manager;
+
+        public Watch(Func<GeolocationPosition, Task> onPosition, bool highAccuracy)
+        {
+            _onPosition = onPosition;
+            UIApplication.SharedApplication.InvokeOnMainThread(() =>
+            {
+                _manager = new CLLocationManager
+                {
+                    DesiredAccuracy = highAccuracy ? CLLocation.AccuracyBest : CLLocation.AccuracyHundredMeters,
+                    Delegate = this
+                };
+                _manager.RequestWhenInUseAuthorization();
+                if (_manager.AuthorizationStatus is CLAuthorizationStatus.AuthorizedWhenInUse
+                    or CLAuthorizationStatus.AuthorizedAlways)
+                {
+                    _manager.StartUpdatingLocation();
+                }
+            });
+        }
+
+        public override void AuthorizationChanged(CLLocationManager mgr, CLAuthorizationStatus status)
+        {
+            if (status is CLAuthorizationStatus.AuthorizedWhenInUse or CLAuthorizationStatus.AuthorizedAlways)
+            {
+                mgr.StartUpdatingLocation();
+            }
+        }
+
+        public override void LocationsUpdated(CLLocationManager mgr, CLLocation[] locations)
+        {
+            if (locations.Length > 0)
+            {
+                _ = _onPosition(Map(locations[^1]));
+            }
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            UIApplication.SharedApplication.InvokeOnMainThread(() =>
+            {
+                _manager?.StopUpdatingLocation();
+                if (_manager is not null)
+                {
+                    _manager.Delegate = null!;
+                }
+            });
+            return default;
+        }
+    }
+
+    private static GeolocationPosition Map(CLLocation l) => new(
+        Latitude: l.Coordinate.Latitude,
+        Longitude: l.Coordinate.Longitude,
+        Accuracy: l.HorizontalAccuracy,
+        Altitude: l.VerticalAccuracy > 0 ? l.EllipsoidalAltitude : null,
+        AltitudeAccuracy: l.VerticalAccuracy > 0 ? l.VerticalAccuracy : null,
+        Heading: l.Course >= 0 ? l.Course : null,
+        Speed: l.Speed >= 0 ? l.Speed : null,
+        TimestampMs: l.Timestamp.SecondsSince1970 * 1000.0);
+}

--- a/src/Rask.Native/Platforms/iOS/NativeNetworkInfo.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeNetworkInfo.cs
@@ -1,0 +1,41 @@
+using CoreFoundation;
+using Network;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for INetworkInfo — NWPathMonitor (Network.framework) instead of navigator.connection,
+// which iOS/WebKit does not implement. One-shot: read the first path snapshot, then cancel the monitor. iOS
+// doesn't surface a 2g/3g/4g class or downlink/rtt to apps, so the reachability + interface type are mapped
+// to an approximate EffectiveConnectionType and bandwidth/rtt are left at 0. Registered by ApplePlatform.
+internal sealed class NativeNetworkInfo : INetworkInfo
+{
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask<NetworkStatus?> GetStatusAsync()
+    {
+        var tcs = new TaskCompletionSource<NetworkStatus?>();
+        var monitor = new NWPathMonitor();
+        monitor.SnapshotHandler = path =>
+        {
+            var status = Map(path);
+            monitor.Cancel();
+            tcs.TrySetResult(status);
+        };
+        monitor.SetQueue(DispatchQueue.DefaultGlobalQueue);
+        monitor.Start();
+        return new ValueTask<NetworkStatus?>(tcs.Task);
+    }
+
+    private static NetworkStatus Map(NWPath path)
+    {
+        var online = path.Status == NWPathStatus.Satisfied;
+        var wired = path.UsesInterfaceType(NWInterfaceType.Wifi) || path.UsesInterfaceType(NWInterfaceType.Wired);
+        var effective = !online
+            ? EffectiveConnectionType.Unknown
+            : wired
+                ? EffectiveConnectionType.FourG      // Wi-Fi / Ethernet: treat as fast
+                : EffectiveConnectionType.ThreeG;    // cellular: iOS won't say the generation — approximate
+        return new NetworkStatus(effective, 0, 0, path.IsConstrained);
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/NativeVibration.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeVibration.cs
@@ -1,0 +1,25 @@
+using AudioToolbox;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for IVibration. iOS exposes no arbitrary vibration-pattern API to third-party apps and
+// WKWebView has no navigator.vibrate at all, so map any non-empty pattern to the system vibration
+// (AudioToolbox kSystemSoundID_Vibrate). Precise pattern timings and cancellation aren't expressible on iOS.
+internal sealed class NativeVibration : IVibration
+{
+    public ValueTask<bool> VibrateAsync(params int[] pattern)
+    {
+        ArgumentNullException.ThrowIfNull(pattern);
+        if (pattern.Length == 0 || (pattern.Length == 1 && pattern[0] == 0))
+        {
+            return ValueTask.FromResult(false);
+        }
+
+        SystemSound.Vibrate.PlaySystemSound();
+        return ValueTask.FromResult(true);
+    }
+
+    // iOS has no API to cancel an in-progress system vibration.
+    public ValueTask<bool> CancelAsync() => ValueTask.FromResult(false);
+}

--- a/src/Rask.Native/Platforms/iOS/NativeWakeLock.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeWakeLock.cs
@@ -1,0 +1,49 @@
+using CoreFoundation;
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Rask.Native;
+
+// Native iOS backend for IWakeLock — UIApplication.IdleTimerDisabled keeps the screen awake, instead of the
+// Screen Wake Lock API that WKWebView restricts. Ref-counted so overlapping sentinels compose: the idle
+// timer is re-enabled only when the last one is disposed. Registered by ApplePlatform.
+internal sealed class NativeWakeLock : IWakeLock
+{
+    private static int _held;
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask<IWakeLockSentinel> RequestAsync()
+    {
+        DispatchQueue.MainQueue.DispatchAsync(() =>
+        {
+            _held++;
+            UIApplication.SharedApplication.IdleTimerDisabled = true;
+        });
+        return ValueTask.FromResult<IWakeLockSentinel>(new Sentinel());
+    }
+
+    private sealed class Sentinel : IWakeLockSentinel
+    {
+        private bool _released;
+
+        public ValueTask DisposeAsync()
+        {
+            if (_released)
+            {
+                return default;
+            }
+
+            _released = true;
+            DispatchQueue.MainQueue.DispatchAsync(() =>
+            {
+                if (--_held <= 0)
+                {
+                    _held = 0;
+                    UIApplication.SharedApplication.IdleTimerDisabled = false;
+                }
+            });
+            return default;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Wires the existing `Rask.Core.Browser` interfaces to **real native iOS/Android implementations** so, on device, injecting `IGeolocation`/`IClipboard`/… resolves a native C# backend instead of the WebView's JS (which is often gesture-gated or absent on the platform). Second PR in the series — **stacked on #343** (base is that branch; retarget to `main` once #343 merges).

Ships in `Rask.Native/Platforms/{iOS,Android}` (compiled only for the head TFMs):

| Interface | iOS | Android |
|---|---|---|
| `IGeolocation` | `CLLocationManager` | `LocationManager` |
| `IClipboard` | `UIPasteboard` | `ClipboardManager` |
| `IVibration` | system vibration (AudioToolbox) | `Vibrator` / `VibratorManager` |
| `IWakeLock` | `UIApplication.IdleTimerDisabled` | window `FLAG_KEEP_SCREEN_ON` |
| `INetworkInfo` | `NWPathMonitor` | `ConnectivityManager` |
| `IShare` | `UIActivityViewController` | `Intent.ACTION_SEND` (already native) |

**One-line wiring.** `ApplePlatform` / `AndroidPlatform` implement `INativePlatform` (added in #343); the app calls `host.UsePlatform(new ApplePlatform(() => Window?.RootViewController))` / `new AndroidPlatform(this)`. `RunLocalAsync` applies the module before the JS fallbacks, all via `TryAdd`, so a natively-backed interface wins (native-first), an explicit app registration wins over even that, and everything else falls back to the WebView — no per-API wiring. Backends are `internal`; users inject the interface.

The `rask-native` sample uses the modules and adds the location / network-state / vibrate permissions. `docs/native.md` updated to the shipped-backend + `UsePlatform` model.

## Testing
- **Both heads compile** against the real iOS (net10.0-ios) and Android (net10.0-android) bindings — 0 errors; the base `net10.0` build stays workload-free and warnings-clean.
- **Device smoke test:** the `rask-native` sample builds, installs, and launches on the Android emulator, rendering the showcase through the native-first DI path (`AndroidPlatform.Register` → tier fallbacks → `BuildServiceProvider` → first frame) with no crash — confirming the wiring executes end-to-end on a real runtime.
- Native-first / registration mechanism unit-tested in #343 (incl. a `UsePlatform` resolution test via the session harness).
- Full base unit suite green (Native 48, …).

## Benchmarks
Not applicable — native device code, no render hot-path.

## Changelog
`[Unreleased]` updated (Added: native iOS/Android backends + `UsePlatform`).

## Follow-ups (per plan)
- Phase-2 backends (SpeechSynthesis, DeviceMotion/Orientation, Badge, ScreenInfo, PageVisibility, Permissions).
- Notifications backend (deferred — Android 13+ runtime-permission dialog needs Activity-result plumbing).
- Canonical availability matrix + per-API docs; Server gesture bridge.
- Full Appium E2E driving each native backend on both platforms.