### PR TITLE
feat(native): phase-2 native backends (speech, screen, orientation, motion)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ them until tagged releases begin.
 
 ### Added
 - **Native iOS/Android backends for the browser/device APIs, wired with one line.** `Rask.Native` now
-  ships native C# implementations of six interfaces and a platform module that installs them:
+  ships native C# implementations of ten interfaces and a platform module that installs them:
   `host.UsePlatform(new ApplePlatform(() => rootVc))` / `new AndroidPlatform(this)`. Injecting the
   ordinary interface then resolves the native backend on device — `IGeolocation` → `CLLocationManager` /
   `LocationManager`, `IClipboard` → `UIPasteboard` / `ClipboardManager`, `IVibration` → system vibration /
   `Vibrator`, `IWakeLock` → idle-timer / `FLAG_KEEP_SCREEN_ON`, `INetworkInfo` → `NWPathMonitor` /
-  `ConnectivityManager`, and `IShare` (already native) — instead of the WebView's JS, which is often
-  gesture-gated or absent on the platform. Everything else falls back to the WebView automatically. The
-  `rask-native` sample uses the new modules (and adds the location / network-state / vibrate permissions).
+  `ConnectivityManager`, `ISpeechSynthesis` → `AVSpeechSynthesizer` / `TextToSpeech`, `IScreenInfo` →
+  `UIScreen` / `DisplayMetrics`, `IDeviceOrientation` / `IDeviceMotion` → CoreMotion / `SensorManager`, and
+  `IShare` (already native) — instead of the WebView's JS, which is often gesture-gated or absent on the
+  platform. Everything else falls back to the WebView automatically. The `rask-native` sample uses the new
+  modules (and adds the location / network-state / vibrate permissions).
 - **Central registration for the typed browser/device APIs, with native-first resolution.** The
   interface → implementation map for the 43 browser wrappers, previously hand-duplicated across the
   Server, WASM, and Native hosts, now lives in one place per assembly: `AddCoreBrowserApis` (the 31

--- a/docs/native.md
+++ b/docs/native.md
@@ -289,6 +289,10 @@ The shipped native backends (both platforms):
 | `IVibration` | system vibration (AudioToolbox) | `Vibrator` / `VibratorManager` |
 | `IWakeLock` | `UIApplication.IdleTimerDisabled` | window `FLAG_KEEP_SCREEN_ON` |
 | `INetworkInfo` | `NWPathMonitor` | `ConnectivityManager` |
+| `ISpeechSynthesis` | `AVSpeechSynthesizer` | `TextToSpeech` |
+| `IScreenInfo` | `UIScreen` | `DisplayMetrics` |
+| `IDeviceOrientation` | CoreMotion (`CMMotionManager`) | `SensorManager` (rotation vector) |
+| `IDeviceMotion` | CoreMotion (`CMMotionManager`) | `SensorManager` (accelerometer + gyroscope) |
 
 So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real permission prompt +
 `CLLocationManager` / `LocationManager` accuracy) instead of `navigator.geolocation`, `clipboard.WriteTextAsync`

--- a/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
@@ -10,8 +10,10 @@ namespace Rask.Native;
 ///     The Android platform module. Pass it to <see cref="NativeAppHost.UsePlatform" /> and the host wires
 ///     these native C# backends for the browser/device API interfaces — <c>IShare</c> (ACTION_SEND chooser),
 ///     <c>IGeolocation</c> (LocationManager), <c>IClipboard</c> (ClipboardManager), <c>IVibration</c>
-///     (Vibrator), <c>IWakeLock</c> (FLAG_KEEP_SCREEN_ON), and <c>INetworkInfo</c> (ConnectivityManager) — so
-///     injecting any of them resolves the native implementation and every other interface falls back to the
+///     (Vibrator), <c>IWakeLock</c> (FLAG_KEEP_SCREEN_ON), <c>INetworkInfo</c> (ConnectivityManager),
+///     <c>ISpeechSynthesis</c> (TextToSpeech), <c>IScreenInfo</c> (DisplayMetrics), and
+///     <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (SensorManager) — so injecting any of them resolves the
+///     native implementation and every other interface falls back to the
 ///     WebView's JS. The app writes one line (<c>host.UsePlatform(new AndroidPlatform(this))</c>) instead of
 ///     registering each backend by hand. Geolocation needs <c>ACCESS_FINE_LOCATION</c> and network info needs
 ///     <c>ACCESS_NETWORK_STATE</c> in the manifest.
@@ -30,5 +32,9 @@ public sealed class AndroidPlatform(Activity activity) : INativePlatform
         services.TryAddSingleton<IVibration>(_ => new NativeVibration(activity));
         services.TryAddSingleton<IWakeLock>(_ => new NativeWakeLock(activity));
         services.TryAddSingleton<INetworkInfo>(_ => new NativeNetworkInfo(activity));
+        services.TryAddSingleton<ISpeechSynthesis>(_ => new NativeSpeechSynthesis(activity));
+        services.TryAddSingleton<IScreenInfo>(_ => new NativeScreenInfo(activity));
+        services.TryAddSingleton<IDeviceOrientation>(_ => new NativeDeviceOrientation(activity));
+        services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion(activity));
     }
 }

--- a/src/Rask.Native/Platforms/Android/NativeDeviceMotion.cs
+++ b/src/Rask.Native/Platforms/Android/NativeDeviceMotion.cs
@@ -1,0 +1,88 @@
+using Android.App;
+using Android.Content;
+using Android.Hardware;
+using Android.Runtime;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IDeviceMotion — SensorManager's linear accelerometer (gravity excluded, m/s²,
+// matching the web `acceleration`) plus the gyroscope (rad/s → °/s), instead of the WebView's devicemotion
+// events. Registered by AndroidPlatform; no runtime permission needed for these sensors.
+internal sealed class NativeDeviceMotion(Activity activity) : IDeviceMotion
+{
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(Manager()?.GetDefaultSensor(SensorType.Accelerometer) is not null);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<MotionReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(Manager(), onReading));
+    }
+
+    private SensorManager? Manager() => (SensorManager?)activity.GetSystemService(Context.SensorService);
+
+    private sealed class Watch : Java.Lang.Object, ISensorEventListener, IAsyncDisposable
+    {
+        private readonly SensorManager? _mgr;
+        private readonly Func<MotionReading, Task> _onReading;
+        private double _ax, _ay, _az, _ralpha, _rbeta, _rgamma;
+
+        public Watch(SensorManager? mgr, Func<MotionReading, Task> onReading)
+        {
+            _mgr = mgr;
+            _onReading = onReading;
+            // Prefer linear acceleration (gravity removed) to match the web `acceleration`; fall back to the
+            // raw accelerometer where the fused sensor isn't present.
+            var accel = mgr?.GetDefaultSensor(SensorType.LinearAcceleration)
+                        ?? mgr?.GetDefaultSensor(SensorType.Accelerometer);
+            var gyro = mgr?.GetDefaultSensor(SensorType.Gyroscope);
+            if (accel is not null)
+            {
+                mgr!.RegisterListener(this, accel, SensorDelay.Game);
+            }
+
+            if (gyro is not null)
+            {
+                mgr!.RegisterListener(this, gyro, SensorDelay.Game);
+            }
+        }
+
+        public void OnAccuracyChanged(Sensor? sensor, [GeneratedEnum] SensorStatus accuracy) { }
+
+        public void OnSensorChanged(SensorEvent? e)
+        {
+            if (e?.Sensor is null || e.Values is null || e.Values.Count < 3)
+            {
+                return;
+            }
+
+            switch (e.Sensor.Type)
+            {
+                case SensorType.LinearAcceleration or SensorType.Accelerometer:
+                    _ax = e.Values[0];
+                    _ay = e.Values[1];
+                    _az = e.Values[2];
+                    break;
+                case SensorType.Gyroscope:
+                    _ralpha = RadToDeg(e.Values[2]);
+                    _rbeta = RadToDeg(e.Values[0]);
+                    _rgamma = RadToDeg(e.Values[1]);
+                    break;
+            }
+
+            _ = _onReading(new MotionReading(_ax, _ay, _az, _ralpha, _rbeta, _rgamma, null));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr?.UnregisterListener(this);
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/Android/NativeDeviceOrientation.cs
+++ b/src/Rask.Native/Platforms/Android/NativeDeviceOrientation.cs
@@ -1,0 +1,79 @@
+using Android.App;
+using Android.Content;
+using Android.Hardware;
+using Android.Runtime;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IDeviceOrientation — SensorManager's TYPE_ROTATION_VECTOR (fused compass +
+// gyro), converted to the web deviceorientation alpha/beta/gamma, instead of the WebView's deviceorientation
+// events. Registered by AndroidPlatform. Android needs no runtime permission for these sensors.
+internal sealed class NativeDeviceOrientation(Activity activity) : IDeviceOrientation
+{
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(Manager()?.GetDefaultSensor(SensorType.RotationVector) is not null);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<OrientationReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(Manager(), onReading));
+    }
+
+    private SensorManager? Manager() => (SensorManager?)activity.GetSystemService(Context.SensorService);
+
+    private sealed class Watch : Java.Lang.Object, ISensorEventListener, IAsyncDisposable
+    {
+        private readonly SensorManager? _mgr;
+        private readonly Func<OrientationReading, Task> _onReading;
+
+        public Watch(SensorManager? mgr, Func<OrientationReading, Task> onReading)
+        {
+            _mgr = mgr;
+            _onReading = onReading;
+            var sensor = mgr?.GetDefaultSensor(SensorType.RotationVector);
+            if (sensor is not null)
+            {
+                mgr!.RegisterListener(this, sensor, SensorDelay.Ui);
+            }
+        }
+
+        public void OnAccuracyChanged(Sensor? sensor, [GeneratedEnum] SensorStatus accuracy) { }
+
+        public void OnSensorChanged(SensorEvent? e)
+        {
+            if (e?.Values is null || e.Values.Count < 4)
+            {
+                return;
+            }
+
+            var vector = new float[4];
+            for (var i = 0; i < 4; i++)
+            {
+                vector[i] = e.Values[i];
+            }
+
+            var matrix = new float[9];
+            SensorManager.GetRotationMatrixFromVector(matrix, vector);
+            var angles = new float[3]; // [azimuth, pitch, roll] radians
+            SensorManager.GetOrientation(matrix, angles);
+
+            _ = _onReading(new OrientationReading(
+                Alpha: (RadToDeg(angles[0]) + 360) % 360, // compass heading, 0–360
+                Beta: RadToDeg(angles[1]),
+                Gamma: RadToDeg(angles[2]),
+                Absolute: true));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr?.UnregisterListener(this);
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/Android/NativeScreenInfo.cs
+++ b/src/Rask.Native/Platforms/Android/NativeScreenInfo.cs
@@ -1,0 +1,20 @@
+using Android.App;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IScreenInfo — the app's DisplayMetrics (Density = device-pixel ratio) instead
+// of window.screen. Registered by AndroidPlatform. Uses Resources.DisplayMetrics (no deprecated Display API).
+internal sealed class NativeScreenInfo(Activity activity) : IScreenInfo
+{
+    public ValueTask<ScreenInfo> GetAsync()
+    {
+        var dm = activity.Resources!.DisplayMetrics!;
+        var density = dm.Density <= 0 ? 1f : dm.Density;
+        // WidthPixels/HeightPixels are physical pixels; divide by density to get CSS pixels. Android has no
+        // separate "available" area distinct from the app window, and no color-depth API (24 is universal).
+        var cssWidth = (int)Math.Round(dm.WidthPixels / density);
+        var cssHeight = (int)Math.Round(dm.HeightPixels / density);
+        return ValueTask.FromResult(new ScreenInfo(cssWidth, cssHeight, cssWidth, cssHeight, 24, density));
+    }
+}

--- a/src/Rask.Native/Platforms/Android/NativeSpeechSynthesis.cs
+++ b/src/Rask.Native/Platforms/Android/NativeSpeechSynthesis.cs
@@ -1,0 +1,66 @@
+using Android.App;
+using Android.Runtime;
+using Android.Speech.Tts;
+using Java.Util;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for ISpeechSynthesis — the platform TextToSpeech engine instead of the WebView's
+// speechSynthesis. The engine initializes asynchronously; IsSupportedAsync/SpeakAsync await that. Registered
+// by AndroidPlatform (held for the app lifetime).
+internal sealed class NativeSpeechSynthesis : Java.Lang.Object, ISpeechSynthesis, TextToSpeech.IOnInitListener
+{
+    private readonly TextToSpeech _tts;
+    private readonly TaskCompletionSource<bool> _ready = new();
+
+    public NativeSpeechSynthesis(Activity activity) => _tts = new TextToSpeech(activity, this);
+
+    public void OnInit([GeneratedEnum] OperationResult status) =>
+        _ready.TrySetResult(status == OperationResult.Success);
+
+    public ValueTask<bool> IsSupportedAsync() => new(_ready.Task);
+
+    public async ValueTask SpeakAsync(string text, SpeechOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (!await _ready.Task)
+        {
+            return;
+        }
+
+        if (options?.Lang is { } lang)
+        {
+            _tts.SetLanguage(Locale.ForLanguageTag(lang));
+        }
+
+        if (options?.Rate is { } rate)
+        {
+            _tts.SetSpeechRate((float)rate);
+        }
+
+        if (options?.Pitch is { } pitch)
+        {
+            _tts.SetPitch((float)pitch);
+        }
+
+        // Queue behind anything already speaking, matching the web queueing behaviour.
+        _tts.Speak(text, QueueMode.Add, null, Guid.NewGuid().ToString());
+    }
+
+    public ValueTask CancelAsync()
+    {
+        _tts.Stop();
+        return default;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _tts.Shutdown();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
+++ b/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
@@ -10,8 +10,10 @@ namespace Rask.Native;
 ///     The iOS platform module. Pass it to <see cref="NativeAppHost.UsePlatform" /> and the host wires these
 ///     native C# backends for the browser/device API interfaces — <c>IShare</c> (system share sheet),
 ///     <c>IGeolocation</c> (CoreLocation), <c>IClipboard</c> (UIPasteboard), <c>IVibration</c>,
-///     <c>IWakeLock</c>, and <c>INetworkInfo</c> — so injecting any of them resolves the native
-///     implementation, and every other interface falls back to the WebView's JS. The app writes one line
+///     <c>IWakeLock</c>, <c>INetworkInfo</c> (NWPathMonitor), <c>ISpeechSynthesis</c> (AVSpeechSynthesizer),
+///     <c>IScreenInfo</c> (UIScreen), and <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (CoreMotion) — so
+///     injecting any of them resolves the native implementation, and every other interface falls back to the
+///     WebView's JS. The app writes one line
 ///     (<c>host.UsePlatform(new ApplePlatform(() =&gt; Window?.RootViewController))</c>) instead of
 ///     registering each backend by hand.
 /// </summary>
@@ -33,5 +35,9 @@ public sealed class ApplePlatform(Func<UIViewController?> presenter) : INativePl
         services.TryAddSingleton<IVibration>(_ => new NativeVibration());
         services.TryAddSingleton<IWakeLock>(_ => new NativeWakeLock());
         services.TryAddSingleton<INetworkInfo>(_ => new NativeNetworkInfo());
+        services.TryAddSingleton<ISpeechSynthesis>(_ => new NativeSpeechSynthesis());
+        services.TryAddSingleton<IScreenInfo>(_ => new NativeScreenInfo());
+        services.TryAddSingleton<IDeviceOrientation>(_ => new NativeDeviceOrientation());
+        services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion());
     }
 }

--- a/src/Rask.Native/Platforms/iOS/NativeDeviceMotion.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeDeviceMotion.cs
@@ -1,0 +1,67 @@
+using CoreMotion;
+using Foundation;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for IDeviceMotion — CoreMotion (CMMotionManager) instead of the WebView's devicemotion
+// events. UserAcceleration excludes gravity (matching the web `acceleration`) and is in g, converted to
+// m/s²; RotationRate is rad/s, converted to °/s. Registered by ApplePlatform; no permission needed on iOS.
+internal sealed class NativeDeviceMotion : IDeviceMotion
+{
+    private const double GravityMetersPerSecondSquared = 9.80665;
+
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(new CMMotionManager().DeviceMotionAvailable);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<MotionReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(onReading));
+    }
+
+    private sealed class Watch : IAsyncDisposable
+    {
+        private readonly CMMotionManager _mgr = new() { DeviceMotionUpdateInterval = 1.0 / 60 };
+
+        public Watch(Func<MotionReading, Task> onReading)
+        {
+            if (!_mgr.DeviceMotionAvailable)
+            {
+                return;
+            }
+
+            var intervalMs = _mgr.DeviceMotionUpdateInterval * 1000;
+            _mgr.StartDeviceMotionUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), (motion, err) =>
+            {
+                _ = err;
+                if (motion is null)
+                {
+                    return;
+                }
+
+                var acc = motion.UserAcceleration; // g, gravity excluded
+                var rot = motion.RotationRate;      // rad/s
+                _ = onReading(new MotionReading(
+                    AccelerationX: acc.X * GravityMetersPerSecondSquared,
+                    AccelerationY: acc.Y * GravityMetersPerSecondSquared,
+                    AccelerationZ: acc.Z * GravityMetersPerSecondSquared,
+                    RotationAlpha: RadToDeg(rot.z),
+                    RotationBeta: RadToDeg(rot.x),
+                    RotationGamma: RadToDeg(rot.y),
+                    Interval: intervalMs));
+            });
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr.StopDeviceMotionUpdates();
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/iOS/NativeDeviceOrientation.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeDeviceOrientation.cs
@@ -1,0 +1,61 @@
+using CoreMotion;
+using Foundation;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for IDeviceOrientation — CoreMotion (CMMotionManager device-motion attitude) instead of
+// the WebView's deviceorientation events, which WKWebView gates/withholds. Registered by ApplePlatform. iOS
+// needs no separate permission for attitude, so RequestPermissionAsync returns Granted. Absolute is true
+// (device-motion attitude is referenced to a fixed frame). Angles are radians → degrees.
+internal sealed class NativeDeviceOrientation : IDeviceOrientation
+{
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(new CMMotionManager().DeviceMotionAvailable);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<OrientationReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(onReading));
+    }
+
+    private sealed class Watch : IAsyncDisposable
+    {
+        private readonly CMMotionManager _mgr = new() { DeviceMotionUpdateInterval = 1.0 / 60 };
+
+        public Watch(Func<OrientationReading, Task> onReading)
+        {
+            if (!_mgr.DeviceMotionAvailable)
+            {
+                return;
+            }
+
+            _mgr.StartDeviceMotionUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), (motion, err) =>
+            {
+                _ = err;
+                if (motion?.Attitude is not { } attitude)
+                {
+                    return;
+                }
+
+                // Map CoreMotion yaw/pitch/roll to the web deviceorientation alpha/beta/gamma.
+                _ = onReading(new OrientationReading(
+                    Alpha: RadToDeg(attitude.Yaw),
+                    Beta: RadToDeg(attitude.Pitch),
+                    Gamma: RadToDeg(attitude.Roll),
+                    Absolute: true));
+            });
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr.StopDeviceMotionUpdates();
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/iOS/NativeScreenInfo.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeScreenInfo.cs
@@ -1,0 +1,25 @@
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Rask.Native;
+
+// Native iOS backend for IScreenInfo — UIScreen (true device metrics + scale) instead of window.screen.
+// Registered by ApplePlatform. Read on the main thread.
+internal sealed class NativeScreenInfo : IScreenInfo
+{
+    public ValueTask<ScreenInfo> GetAsync()
+    {
+        var tcs = new TaskCompletionSource<ScreenInfo>();
+        UIApplication.SharedApplication.InvokeOnMainThread(() =>
+        {
+            var screen = UIScreen.MainScreen;
+            var bounds = screen.Bounds; // points == CSS pixels
+            var width = (int)Math.Round(bounds.Width);
+            var height = (int)Math.Round(bounds.Height);
+            // iOS has no per-app "available" area distinct from the screen, and no color-depth API (24 is the
+            // universal effective value); Scale is the device-pixel ratio (2/3 on retina).
+            tcs.TrySetResult(new ScreenInfo(width, height, width, height, 24, screen.Scale));
+        });
+        return new ValueTask<ScreenInfo>(tcs.Task);
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/NativeSpeechSynthesis.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeSpeechSynthesis.cs
@@ -1,0 +1,52 @@
+using AVFoundation;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for ISpeechSynthesis — AVSpeechSynthesizer instead of the WebView's speechSynthesis
+// (which is unreliable inside WKWebView). Registered by ApplePlatform. The synthesizer is held for the app
+// lifetime so queued utterances survive across calls.
+internal sealed class NativeSpeechSynthesis : ISpeechSynthesis
+{
+    private readonly AVSpeechSynthesizer _synth = new();
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask SpeakAsync(string text, SpeechOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        var utterance = new AVSpeechUtterance(text);
+        if (options?.Lang is { } lang)
+        {
+            utterance.Voice = AVSpeechSynthesisVoice.FromLanguage(lang);
+        }
+
+        if (options?.Rate is { } rate)
+        {
+            // Web rate is 0.1–10 (1 = normal); AVSpeechUtterance rate is [Min..Max] with ~0.5 the default.
+            utterance.Rate = (float)Math.Clamp(
+                rate * AVSpeechUtterance.DefaultSpeechRate,
+                AVSpeechUtterance.MinimumSpeechRate,
+                AVSpeechUtterance.MaximumSpeechRate);
+        }
+
+        if (options?.Pitch is { } pitch)
+        {
+            utterance.PitchMultiplier = (float)pitch;
+        }
+
+        if (options?.Volume is { } volume)
+        {
+            utterance.Volume = (float)volume;
+        }
+
+        _synth.SpeakUtterance(utterance);
+        return default;
+    }
+
+    public ValueTask CancelAsync()
+    {
+        _synth.StopSpeaking(AVSpeechBoundary.Immediate);
+        return default;
+    }
+}


### PR DESCRIPTION
## Summary

Extends the native backend set (#344) with four more `Rask.Core.Browser` interfaces, each a clear native win over the WebView. Stacked on the api-consolidation branch (which already carries #343 + #344).

| Interface | iOS | Android | Why native |
|---|---|---|---|
| `ISpeechSynthesis` | `AVSpeechSynthesizer` | `TextToSpeech` | WKWebView speech is unreliable |
| `IScreenInfo` | `UIScreen` | `DisplayMetrics` | true device metrics + pixel ratio |
| `IDeviceOrientation` | CoreMotion `CMMotionManager` | `SensorManager` (rotation vector) | WebView orientation events gated/withheld |
| `IDeviceMotion` | CoreMotion `CMMotionManager` | `SensorManager` (accel + gyro) | same |

Same native-first wiring: registered by `ApplePlatform` / `AndroidPlatform` via `TryAdd`, resolved over the JS default. The subscription APIs (orientation/motion) push each reading straight to the C# callback from the native sensor manager. Backends `internal`; users inject the interface.

**Deliberately kept on the JS fallback** (documented): `IBadge` (no universal Android launcher-badge API), `IPageVisibility` (WebView visibility tracks app background acceptably), `IPermissions` (`navigator.permissions` works in the WebView).

## Testing
- Both heads compile against the real iOS/Android bindings — 0 errors; base `net10.0` build + `Rask.Native.Tests` (48) green.
- Sensor mapping is standard (radians→degrees, g→m/s², CoreMotion attitude / Android rotation-vector → web alpha/beta/gamma). Behavioural device verification is the Appium E2E follow-up.

## Benchmarks
N/A — native device code, no render hot-path.

## Changelog
`[Unreleased]` native-backends bullet updated to the full ten-interface set; `docs/native.md` table extended.