### PR TITLE
docs(browser-apis): capability matrix + per-API reference pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ them until tagged releases begin.
 
 ### Added
 - **Native iOS/Android backends for the browser/device APIs, wired with one line.** `Rask.Native` now
-  ships native C# implementations of six interfaces and a platform module that installs them:
+  ships native C# implementations of ten interfaces and a platform module that installs them:
   `host.UsePlatform(new ApplePlatform(() => rootVc))` / `new AndroidPlatform(this)`. Injecting the
   ordinary interface then resolves the native backend on device — `IGeolocation` → `CLLocationManager` /
   `LocationManager`, `IClipboard` → `UIPasteboard` / `ClipboardManager`, `IVibration` → system vibration /
   `Vibrator`, `IWakeLock` → idle-timer / `FLAG_KEEP_SCREEN_ON`, `INetworkInfo` → `NWPathMonitor` /
-  `ConnectivityManager`, and `IShare` (already native) — instead of the WebView's JS, which is often
-  gesture-gated or absent on the platform. Everything else falls back to the WebView automatically. The
-  `rask-native` sample uses the new modules (and adds the location / network-state / vibrate permissions).
+  `ConnectivityManager`, `ISpeechSynthesis` → `AVSpeechSynthesizer` / `TextToSpeech`, `IScreenInfo` →
+  `UIScreen` / `DisplayMetrics`, `IDeviceOrientation` / `IDeviceMotion` → CoreMotion / `SensorManager`, and
+  `IShare` (already native) — instead of the WebView's JS, which is often gesture-gated or absent on the
+  platform. Everything else falls back to the WebView automatically. The `rask-native` sample uses the new
+  modules (and adds the location / network-state / vibrate permissions).
 - **Central registration for the typed browser/device APIs, with native-first resolution.** The
   interface → implementation map for the 43 browser wrappers, previously hand-duplicated across the
   Server, WASM, and Native hosts, now lives in one place per assembly: `AddCoreBrowserApis` (the 31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Documentation
+- **Browser/device API capability matrix + per-API reference pages.** New
+  [`docs/browser-capabilities.md`](docs/browser-capabilities.md) is a single table of all 43 wrappers
+  showing where each works (Web / PWA / Native) and which have a native iOS/Android backend, linking to a
+  dedicated reference page per API under `docs/apis/`. Reconciled the stale WASM-only classification of
+  `IWebPush`/`INotifications`/`IBadge`/`IWakeLock` (they are transport-agnostic and register on Server).
+
 ### Added
 - **Native iOS/Android backends for the browser/device APIs, wired with one line.** `Rask.Native` now
   ships native C# implementations of ten interfaces and a platform module that installs them:

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ interactive app. Want the pitch and a quick demo first? See the project [README]
 | [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), toast messages (`IToaster`/`ToastOutlet`), `VirtualizeModel`, drag-and-drop. |
 | [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), typed browser APIs, asset delivery. |
 | [Browser APIs](browser-apis.md) | The map of all 43 typed Web-API wrappers — shared vs WASM-only, one-shot vs subscription, the inject-from-ctor and push/`[JSInvokable]` patterns. |
+| [Capability matrix](browser-capabilities.md) | Where each of the 43 APIs works (Web / PWA / Native) and which have a native iOS/Android backend — links to a reference page per API under [`apis/`](apis/). |
 | [📱 Mobile & PWA](pwa.md) | Build installable, offline mobile apps in C# (WASM): web app manifest, service worker, Web Push (`IWebPush`), `dotnet new rask-wasm --pwa`. |
 | [📱 Native mobile (iOS/Android)](native.md) | Ship the same components as a native iOS/Android app with `Rask.Native` (preview): the WebView-hybrid host, the `rask-native` template + platform heads, `NativeAppHost` Local/Server modes, `INativeWebView`, safe-area insets. |
 | [AOT compilation](aot.md) | Opt-in full WASM AOT (`-p:RaskWasmAot=true`): the reflection-free binding registry, registering custom `IParsable` types, `InvokeAsync<T>` under AOT, and the continuous analyzer gate. |

--- a/docs/apis/badge.md
+++ b/docs/apis/badge.md
@@ -1,0 +1,17 @@
+# IBadge
+
+> Set/clear the count on the installed app icon.
+
+- **Wraps:** Badging API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+`setAppBadge` needs an installed PWA instance. Kept on the WebView on Native (no universal launcher-badge API).
+
+## See also
+
+- Source: [`IBadge.cs`](../../src/Rask.Core/Browser/IBadge.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/bluetooth.md
+++ b/docs/apis/bluetooth.md
@@ -1,0 +1,17 @@
+# IBluetooth
+
+> Pair a BLE device and read/write GATT.
+
+- **Wraps:** Web Bluetooth API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ⬜ · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+WASM-only by design (stateful, activation-gated chooser).
+
+## See also
+
+- Source: [`IBluetooth.cs`](../../src/Rask.Wasm/Browser/IBluetooth.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/broadcast-channel.md
+++ b/docs/apis/broadcast-channel.md
@@ -1,0 +1,15 @@
+# IBroadcastChannel
+
+> Cross-tab messaging.
+
+- **Wraps:** Broadcast Channel API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IBroadcastChannel.cs`](../../src/Rask.Core/Browser/IBroadcastChannel.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/clipboard.md
+++ b/docs/apis/clipboard.md
@@ -1,0 +1,17 @@
+# IClipboard
+
+> Copy text to, and read text from, the system clipboard.
+
+- **Wraps:** Async Clipboard API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** UIPasteboard / ClipboardManager
+
+In the browser, reads need a user gesture and/or a `clipboard-read` grant; the native backend has neither restriction.
+
+## See also
+
+- Source: [`IClipboard.cs`](../../src/Rask.Core/Browser/IClipboard.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/cookies.md
+++ b/docs/apis/cookies.md
@@ -1,0 +1,15 @@
+# ICookies
+
+> Read and write cookies with typed `CookieOptions`.
+
+- **Wraps:** `document.cookie`
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`ICookies.cs`](../../src/Rask.Core/Browser/ICookies.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/crypto.md
+++ b/docs/apis/crypto.md
@@ -1,0 +1,17 @@
+# ICrypto
+
+> Random UUID/bytes and SHA digests.
+
+- **Wraps:** Web Crypto (random + digest)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Runs in the WebView's Web Crypto; no native backend needed.
+
+## See also
+
+- Source: [`ICrypto.cs`](../../src/Rask.Core/Browser/ICrypto.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/device-motion.md
+++ b/docs/apis/device-motion.md
@@ -1,0 +1,17 @@
+# IDeviceMotion
+
+> Accelerometer + gyroscope readings pushed to a callback.
+
+- **Wraps:** Device Motion events
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** CoreMotion / SensorManager
+
+Native backend uses linear acceleration (gravity excluded) + gyroscope; the WebView equivalent is permission-gated and often blocked.
+
+## See also
+
+- Source: [`IDeviceMotion.cs`](../../src/Rask.Core/Browser/IDeviceMotion.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/device-orientation.md
+++ b/docs/apis/device-orientation.md
@@ -1,0 +1,17 @@
+# IDeviceOrientation
+
+> Gyroscope/compass tilt (alpha/beta/gamma) pushed to a callback.
+
+- **Wraps:** Device Orientation events
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** CoreMotion / SensorManager
+
+iOS requires a gesture-triggered permission grant in the browser; the native backend needs none. Readings come from CoreMotion attitude / the Android rotation-vector sensor.
+
+## See also
+
+- Source: [`IDeviceOrientation.cs`](../../src/Rask.Core/Browser/IDeviceOrientation.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/eye-dropper.md
+++ b/docs/apis/eye-dropper.md
@@ -1,0 +1,19 @@
+# IEyeDropper
+
+> Pick a colour from anywhere on screen.
+
+- **Wraps:** EyeDropper API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Needs activation → WASM-only; Server gesture bridge planned.
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IEyeDropper.cs`](../../src/Rask.Wasm/Browser/IEyeDropper.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/file-system-access.md
+++ b/docs/apis/file-system-access.md
@@ -1,0 +1,17 @@
+# IFileSystemAccess
+
+> Open/save a file back to disk and read directories.
+
+- **Wraps:** File System Access API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Chromium-family browsers.
+
+## See also
+
+- Source: [`IFileSystemAccess.cs`](../../src/Rask.Core/Browser/IFileSystemAccess.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/fullscreen.md
+++ b/docs/apis/fullscreen.md
@@ -1,0 +1,19 @@
+# IFullscreen
+
+> Present an element or the page fullscreen.
+
+- **Wraps:** Fullscreen API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Needs transient activation → WASM-only imperatively; a Server `FullscreenTrigger` (declarative gesture bridge) is planned.
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IFullscreen.cs`](../../src/Rask.Wasm/Browser/IFullscreen.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/gamepad.md
+++ b/docs/apis/gamepad.md
@@ -1,0 +1,17 @@
+# IGamepad
+
+> Connected controllers and their state.
+
+- **Wraps:** Gamepad API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Prefer the WASM host for twitch input.
+
+## See also
+
+- Source: [`IGamepad.cs`](../../src/Rask.Core/Browser/IGamepad.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/geolocation.md
+++ b/docs/apis/geolocation.md
@@ -1,0 +1,17 @@
+# IGeolocation
+
+> One-shot position (`GetCurrentPositionAsync`) or a live `WatchAsync` stream of fixes.
+
+- **Wraps:** Geolocation API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** CLLocationManager / LocationManager
+
+Needs a secure context and the location permission. The native backend gives the real OS prompt and sensor accuracy; add `NSLocationWhenInUseUsageDescription` / `ACCESS_FINE_LOCATION`.
+
+## See also
+
+- Source: [`IGeolocation.cs`](../../src/Rask.Core/Browser/IGeolocation.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/hid.md
+++ b/docs/apis/hid.md
@@ -1,0 +1,17 @@
+# IHid
+
+> Talk to a HID device; input reports push to a callback.
+
+- **Wraps:** WebHID API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ⬜ · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+WASM-only by design (stateful, activation-gated chooser).
+
+## See also
+
+- Source: [`IHid.cs`](../../src/Rask.Wasm/Browser/IHid.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/idle-detector.md
+++ b/docs/apis/idle-detector.md
@@ -1,0 +1,17 @@
+# IIdleDetector
+
+> Detect user idle / screen lock.
+
+- **Wraps:** Idle Detection API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ⬜ · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Needs an activation-gated permission and a live document — WASM-only.
+
+## See also
+
+- Source: [`IIdleDetector.cs`](../../src/Rask.Wasm/Browser/IIdleDetector.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/indexeddb.md
+++ b/docs/apis/indexeddb.md
@@ -1,0 +1,15 @@
+# IIndexedDb
+
+> Large async key/value store.
+
+- **Wraps:** IndexedDB
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IIndexedDb.cs`](../../src/Rask.Core/Browser/IIndexedDb.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/install-prompt.md
+++ b/docs/apis/install-prompt.md
@@ -1,0 +1,19 @@
+# IInstallPrompt
+
+> Capture and replay the PWA install prompt.
+
+- **Wraps:** `beforeinstallprompt`
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Needs activation + live document → WASM-only; Server gesture bridge planned (PWA-gated).
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IInstallPrompt.cs`](../../src/Rask.Wasm/Browser/IInstallPrompt.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/intersection-observer.md
+++ b/docs/apis/intersection-observer.md
@@ -1,0 +1,17 @@
+# IIntersectionObserver
+
+> Notifies when an element enters/leaves the viewport.
+
+- **Wraps:** IntersectionObserver
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Inherently DOM — always the WebView on Native.
+
+## See also
+
+- Source: [`IIntersectionObserver.cs`](../../src/Rask.Core/Browser/IIntersectionObserver.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/media-devices.md
+++ b/docs/apis/media-devices.md
@@ -1,0 +1,19 @@
+# IMediaDevices
+
+> Capture camera/mic/screen into a `<video>`.
+
+- **Wraps:** Media Capture (getUserMedia)
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Capture needs activation → WASM-only; Server gesture bridge planned.
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IMediaDevices.cs`](../../src/Rask.Wasm/Browser/IMediaDevices.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/media-query.md
+++ b/docs/apis/media-query.md
@@ -1,0 +1,15 @@
+# IMediaQuery
+
+> Evaluate a media query (dark mode, reduced motion, …).
+
+- **Wraps:** `matchMedia`
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IMediaQuery.cs`](../../src/Rask.Core/Browser/IMediaQuery.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/media-session.md
+++ b/docs/apis/media-session.md
@@ -1,0 +1,15 @@
+# IMediaSession
+
+> Now-playing metadata and hardware media-key action handlers.
+
+- **Wraps:** Media Session API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IMediaSession.cs`](../../src/Rask.Core/Browser/IMediaSession.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/mutation-observer.md
+++ b/docs/apis/mutation-observer.md
@@ -1,0 +1,17 @@
+# IMutationObserver
+
+> Notifies on children/attribute/text changes.
+
+- **Wraps:** MutationObserver
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Inherently DOM — always the WebView on Native.
+
+## See also
+
+- Source: [`IMutationObserver.cs`](../../src/Rask.Core/Browser/IMutationObserver.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/navigator-info.md
+++ b/docs/apis/navigator-info.md
@@ -1,0 +1,15 @@
+# INavigatorInfo
+
+> Read `OnLine`, `Language`, and `UserAgent`.
+
+- **Wraps:** `navigator` (online/language/userAgent)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`INavigatorInfo.cs`](../../src/Rask.Core/Browser/INavigatorInfo.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/network-info.md
+++ b/docs/apis/network-info.md
@@ -1,0 +1,17 @@
+# INetworkInfo
+
+> Effective connection class, downlink, RTT, and Data-Saver.
+
+- **Wraps:** Network Information API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** NWPathMonitor / ConnectivityManager
+
+`navigator.connection` is Chromium-only; the native backend maps the OS reachability/transport instead.
+
+## See also
+
+- Source: [`INetworkInfo.cs`](../../src/Rask.Core/Browser/INetworkInfo.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/notifications.md
+++ b/docs/apis/notifications.md
@@ -1,0 +1,17 @@
+# INotifications
+
+> Show a local notification from the page.
+
+- **Wraps:** Notifications API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Transport-agnostic; the JS helper ships on Server only under `AddRaskPwa`.
+
+## See also
+
+- Source: [`INotifications.cs`](../../src/Rask.Core/Browser/INotifications.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/page-visibility.md
+++ b/docs/apis/page-visibility.md
@@ -1,0 +1,15 @@
+# IPageVisibility
+
+> Whether the page is foregrounded, with a change subscription.
+
+- **Wraps:** Page Visibility API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IPageVisibility.cs`](../../src/Rask.Core/Browser/IPageVisibility.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/performance.md
+++ b/docs/apis/performance.md
@@ -1,0 +1,15 @@
+# IPerformance
+
+> High-resolution clock and navigation timing.
+
+- **Wraps:** `performance` (clock + navigation)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IPerformance.cs`](../../src/Rask.Core/Browser/IPerformance.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/permissions.md
+++ b/docs/apis/permissions.md
@@ -1,0 +1,15 @@
+# IPermissions
+
+> Query a permission's state (`granted`/`denied`/`prompt`) before prompting.
+
+- **Wraps:** Permissions API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IPermissions.cs`](../../src/Rask.Core/Browser/IPermissions.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/picture-in-picture.md
+++ b/docs/apis/picture-in-picture.md
@@ -1,0 +1,19 @@
+# IPictureInPicture
+
+> Float a `<video>` into a mini-player.
+
+- **Wraps:** Picture-in-Picture API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Needs activation → WASM-only; Server gesture bridge planned.
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IPictureInPicture.cs`](../../src/Rask.Wasm/Browser/IPictureInPicture.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/resize-observer.md
+++ b/docs/apis/resize-observer.md
@@ -1,0 +1,17 @@
+# IResizeObserver
+
+> Notifies when an element's size changes.
+
+- **Wraps:** ResizeObserver
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Inherently DOM — always the WebView on Native.
+
+## See also
+
+- Source: [`IResizeObserver.cs`](../../src/Rask.Core/Browser/IResizeObserver.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/screen-info.md
+++ b/docs/apis/screen-info.md
@@ -1,0 +1,17 @@
+# IScreenInfo
+
+> Display size, colour depth, and device-pixel ratio.
+
+- **Wraps:** Screen API + `devicePixelRatio`
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** UIScreen / DisplayMetrics
+
+The native backend reports true device metrics from `UIScreen` / `DisplayMetrics`.
+
+## See also
+
+- Source: [`IScreenInfo.cs`](../../src/Rask.Core/Browser/IScreenInfo.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/screen-orientation.md
+++ b/docs/apis/screen-orientation.md
@@ -1,0 +1,19 @@
+# IScreenOrientation
+
+> Read/lock the screen orientation.
+
+- **Wraps:** Screen Orientation API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Lock needs fullscreen + activation → WASM-only; Server gesture bridge planned.
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IScreenOrientation.cs`](../../src/Rask.Wasm/Browser/IScreenOrientation.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/serial.md
+++ b/docs/apis/serial.md
@@ -1,0 +1,17 @@
+# ISerial
+
+> Talk to a serial device (Arduino/GPS).
+
+- **Wraps:** Web Serial API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ⬜ · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+The device chooser needs activation and the session is stateful/low-latency — WASM-only by design.
+
+## See also
+
+- Source: [`ISerial.cs`](../../src/Rask.Wasm/Browser/ISerial.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/share.md
+++ b/docs/apis/share.md
@@ -1,0 +1,19 @@
+# IShare
+
+> Share text/URL from code to the OS share sheet.
+
+- **Wraps:** Web Share API
+- **Home:** `Rask.Client.Browser` (WASM + Native)
+- **Shape:** one-shot
+- **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ✅
+- **Native backend:** UIActivityViewController / ACTION_SEND
+
+Imperative sharing needs transient activation, so it's WASM+Native only. On Server, use the headless `Shareable` component, whose click fires the share inside the gesture.
+
+> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+
+## See also
+
+- Source: [`IShare.cs`](../../src/Rask.Client/Browser/IShare.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/speech-synthesis.md
+++ b/docs/apis/speech-synthesis.md
@@ -1,0 +1,17 @@
+# ISpeechSynthesis
+
+> Speak text aloud; cancel the queue.
+
+- **Wraps:** SpeechSynthesis API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** AVSpeechSynthesizer / TextToSpeech
+
+The native backend uses the platform TTS voices (WKWebView speech is unreliable).
+
+## See also
+
+- Source: [`ISpeechSynthesis.cs`](../../src/Rask.Core/Browser/ISpeechSynthesis.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/storage-estimator.md
+++ b/docs/apis/storage-estimator.md
@@ -1,0 +1,15 @@
+# IStorageEstimator
+
+> Quota and usage, to budget caches.
+
+- **Wraps:** `navigator.storage.estimate`
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IStorageEstimator.cs`](../../src/Rask.Core/Browser/IStorageEstimator.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/storage.md
+++ b/docs/apis/storage.md
@@ -1,0 +1,17 @@
+# IBrowserStorage
+
+> Typed get/set/remove/clear over `localStorage` and `sessionStorage`.
+
+- **Wraps:** Web Storage (local/session)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Values are strings — serialise your own objects. The WebView persists these on Native, so no native backend is needed.
+
+## See also
+
+- Source: [`IBrowserStorage.cs`](../../src/Rask.Core/Browser/IBrowserStorage.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/usb.md
+++ b/docs/apis/usb.md
@@ -1,0 +1,17 @@
+# IUsb
+
+> Drive a USB device.
+
+- **Wraps:** WebUSB API
+- **Home:** `Rask.Wasm.Browser` (WASM only)
+- **Shape:** one-shot
+- **Availability:** Web/Server ⬜ · PWA/WASM ✅ · Native ⬜
+- **Native backend:** — (WebView JS)
+
+Chooser needs activation; stateful transfers — WASM-only by design.
+
+## See also
+
+- Source: [`IUsb.cs`](../../src/Rask.Wasm/Browser/IUsb.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/vibration.md
+++ b/docs/apis/vibration.md
@@ -1,0 +1,17 @@
+# IVibration
+
+> Buzz the device following a vibrate/pause pattern.
+
+- **Wraps:** Vibration API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** AudioToolbox / Vibrator
+
+`navigator.vibrate` is Android-Chromium only and absent in iOS WKWebView; the native backend works on both (iOS maps to a single system vibration).
+
+## See also
+
+- Source: [`IVibration.cs`](../../src/Rask.Core/Browser/IVibration.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/visual-viewport.md
+++ b/docs/apis/visual-viewport.md
@@ -1,0 +1,15 @@
+# IVisualViewport
+
+> Visible size/offset/zoom after the soft keyboard opens.
+
+- **Wraps:** Visual Viewport API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IVisualViewport.cs`](../../src/Rask.Core/Browser/IVisualViewport.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/wake-lock.md
+++ b/docs/apis/wake-lock.md
@@ -1,0 +1,17 @@
+# IWakeLock
+
+> Keep the screen awake; release by disposing the sentinel.
+
+- **Wraps:** Screen Wake Lock API
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** IdleTimerDisabled / FLAG_KEEP_SCREEN_ON
+
+The native backend keeps the screen on without the Wake Lock API the WebView restricts.
+
+## See also
+
+- Source: [`IWakeLock.cs`](../../src/Rask.Core/Browser/IWakeLock.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/web-push.md
+++ b/docs/apis/web-push.md
@@ -1,0 +1,17 @@
+# IWebPush
+
+> Subscribe to Web Push; send from your backend with `Rask.WebPush`.
+
+- **Wraps:** Push API (subscribe)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** subscription (pushes to a callback)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Transport-agnostic — works on Server too; the JS helper ships on Server only under `AddRaskPwa`.
+
+## See also
+
+- Source: [`IWebPush.cs`](../../src/Rask.Core/Browser/IWebPush.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/apis/webauthn.md
+++ b/docs/apis/webauthn.md
@@ -1,0 +1,15 @@
+# IWebAuthn
+
+> Register and sign in with passkeys.
+
+- **Wraps:** Web Authentication (passkeys)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+## See also
+
+- Source: [`IWebAuthn.cs`](../../src/Rask.Core/Browser/IWebAuthn.cs)
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -6,10 +6,13 @@ shape right yourself. Each is a thin, awaitable layer over the same unified
 [`IJSRuntime`](js-interop.md#calling-js-from-c-ijsruntime), so it works the same way whether your
 app runs on the **Server** (WebSocket) or **WASM** (`JSImport`/`JSExport`) transport.
 
-This page is the **map of the whole surface**. For the deeper "why" — user activation, the
-transport seam, element refs — see [JS interop → Typed browser APIs](js-interop.md#typed-browser-apis);
-for the mobile/PWA angle see the [Mobile & PWA guide](pwa.md). Every wrapper has a runnable demo in
-the **Browser APIs** section of the [showcase](https://pal-tamas.github.io/rask/demo/).
+This page is the **map of the whole surface**. For an at-a-glance view of *where each API works*
+(Web / PWA / Native, and which have a native backend), see the
+[**capability matrix**](browser-capabilities.md) — it links to a dedicated reference page per API
+under [`docs/apis/`](apis/). For the deeper "why" — user activation, the transport seam, element
+refs — see [JS interop → Typed browser APIs](js-interop.md#typed-browser-apis); for the mobile/PWA
+angle see the [Mobile & PWA guide](pwa.md). Every wrapper has a runnable demo in the **Browser APIs**
+section of the [showcase](https://pal-tamas.github.io/rask/demo/).
 
 ## Three homes, one rule
 
@@ -86,6 +89,15 @@ Work identically on Server and WASM. **Shape** is *one-shot* (a request/response
 | `IResizeObserver` | `ResizeObserver` | Element's size changes (container-responsive layout) | **subscription** |
 | `IMutationObserver` | `MutationObserver` | Element's children/attributes/text change (react to externally-written DOM) | **subscription** |
 | `IGamepad` | Gamepad API | Connected controllers — sticks / triggers / buttons (browser games) | **subscription** |
+| `IWebPush` | Push API | Subscribe to Web Push (returns a `PushSubscription`); send from the backend with [`Rask.WebPush`](pwa.md#sending-from-your-backend-raskwebpush) | one-shot |
+| `INotifications` | Notifications API | Show a local notification from the page | one-shot |
+| `IBadge` | Badging API | Set/clear a count on the installed app icon | one-shot |
+| `IWakeLock` | Screen Wake Lock API | Keep the screen awake (sentinel; dispose to release) | one-shot |
+
+The last four are **PWA** APIs but transport-agnostic (`IJSRuntime`-backed, no transient activation), so they
+register on Server too — their JS helpers just ship on the Server client only under `AddRaskPwa` (see
+[pwa.md](pwa.md)). On Native, several Shared APIs resolve to a **native C# backend** instead of the WebView —
+see the [capability matrix](browser-capabilities.md) and the [Native guide](native.md#native-device-backends).
 
 ## Sharing — declarative (all hosts) vs imperative (in-process)
 
@@ -122,10 +134,6 @@ provides — the installed-PWA instance / live document, or a browser-only devic
 | Service | Wraps | What it does | Why WASM-only |
 | --- | --- | --- | --- |
 | `IFullscreen` | Fullscreen API | Present an element/page fullscreen | transient activation |
-| `IWebPush` | Push API | Subscribe to Web Push (returns a `PushSubscription`); send from the backend with [`Rask.WebPush`](pwa.md#sending-from-your-backend-raskwebpush) | service worker + installed PWA |
-| `INotifications` | Notifications API | Show a local notification from the page | permission needs a live gesture |
-| `IBadge` | Badging API | Set/clear a count on the installed app icon | installed-PWA instance |
-| `IWakeLock` | Screen Wake Lock API | Keep the screen awake (sentinel; dispose to release) | tied to the live document |
 | `IScreenOrientation` | Screen Orientation API | Read / lock orientation (lock needs fullscreen) | live document |
 | `IInstallPrompt` | `beforeinstallprompt` | Custom "Install app" button: capture + replay the deferred prompt | live document + activation |
 | `IMediaDevices` | `getUserMedia` / `getDisplayMedia` | Capture camera / mic / screen into a `<video>` (calls, capture) | transient activation + secure context |

--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -1,0 +1,66 @@
+# Browser & device API capability matrix
+
+Every typed browser/device API wrapper Rask ships, and where it works. Inject the interface; the
+framework resolves the best implementation for the host — a native iOS/Android backend where one
+exists, the WebView's JS otherwise. Each API links to its own reference page; the narrative overview
+(with the three-homes rationale and the subscription pattern) is [browser-apis.md](browser-apis.md).
+
+**Legend** — ✅ implemented · 🟡 planned via the Server gesture bridge · ⬜ not available · — n/a. A
+**★** in the Native column marks an API with a native C# backend (the rest run through the WebView's JS).
+
+| API | Web / Server | PWA / WASM | Native | Native backend |
+|-----|:---:|:---:|:---:|-----|
+| [`IBrowserStorage`](apis/storage.md) | ✅ | ✅ | ✅ | — |
+| [`ICookies`](apis/cookies.md) | ✅ | ✅ | ✅ | — |
+| [`IClipboard`](apis/clipboard.md) | ✅ | ✅ | ✅&nbsp;★ | UIPasteboard / ClipboardManager |
+| [`IGeolocation`](apis/geolocation.md) | ✅ | ✅ | ✅&nbsp;★ | CLLocationManager / LocationManager |
+| [`IPermissions`](apis/permissions.md) | ✅ | ✅ | ✅ | — |
+| [`IVibration`](apis/vibration.md) | ✅ | ✅ | ✅&nbsp;★ | AudioToolbox / Vibrator |
+| [`IPageVisibility`](apis/page-visibility.md) | ✅ | ✅ | ✅ | — |
+| [`INavigatorInfo`](apis/navigator-info.md) | ✅ | ✅ | ✅ | — |
+| [`INetworkInfo`](apis/network-info.md) | ✅ | ✅ | ✅&nbsp;★ | NWPathMonitor / ConnectivityManager |
+| [`IMediaQuery`](apis/media-query.md) | ✅ | ✅ | ✅ | — |
+| [`ISpeechSynthesis`](apis/speech-synthesis.md) | ✅ | ✅ | ✅&nbsp;★ | AVSpeechSynthesizer / TextToSpeech |
+| [`IMediaSession`](apis/media-session.md) | ✅ | ✅ | ✅ | — |
+| [`IDeviceOrientation`](apis/device-orientation.md) | ✅ | ✅ | ✅&nbsp;★ | CoreMotion / SensorManager |
+| [`IDeviceMotion`](apis/device-motion.md) | ✅ | ✅ | ✅&nbsp;★ | CoreMotion / SensorManager |
+| [`IScreenInfo`](apis/screen-info.md) | ✅ | ✅ | ✅&nbsp;★ | UIScreen / DisplayMetrics |
+| [`IStorageEstimator`](apis/storage-estimator.md) | ✅ | ✅ | ✅ | — |
+| [`IVisualViewport`](apis/visual-viewport.md) | ✅ | ✅ | ✅ | — |
+| [`ICrypto`](apis/crypto.md) | ✅ | ✅ | ✅ | — |
+| [`IPerformance`](apis/performance.md) | ✅ | ✅ | ✅ | — |
+| [`IIndexedDb`](apis/indexeddb.md) | ✅ | ✅ | ✅ | — |
+| [`IFileSystemAccess`](apis/file-system-access.md) | ✅ | ✅ | ✅ | — |
+| [`IWebAuthn`](apis/webauthn.md) | ✅ | ✅ | ✅ | — |
+| [`IBroadcastChannel`](apis/broadcast-channel.md) | ✅ | ✅ | ✅ | — |
+| [`IIntersectionObserver`](apis/intersection-observer.md) | ✅ | ✅ | ✅ | — |
+| [`IResizeObserver`](apis/resize-observer.md) | ✅ | ✅ | ✅ | — |
+| [`IMutationObserver`](apis/mutation-observer.md) | ✅ | ✅ | ✅ | — |
+| [`IGamepad`](apis/gamepad.md) | ✅ | ✅ | ✅ | — |
+| [`IWebPush`](apis/web-push.md) | ✅ | ✅ | ✅ | — |
+| [`INotifications`](apis/notifications.md) | ✅ | ✅ | ✅ | — |
+| [`IBadge`](apis/badge.md) | ✅ | ✅ | ✅ | — |
+| [`IWakeLock`](apis/wake-lock.md) | ✅ | ✅ | ✅&nbsp;★ | IdleTimerDisabled / FLAG_KEEP_SCREEN_ON |
+| [`IShare`](apis/share.md) | 🟡 | ✅ | ✅&nbsp;★ | UIActivityViewController / ACTION_SEND |
+| [`IFullscreen`](apis/fullscreen.md) | 🟡 | ✅ | ⬜ | — |
+| [`IScreenOrientation`](apis/screen-orientation.md) | 🟡 | ✅ | ⬜ | — |
+| [`IEyeDropper`](apis/eye-dropper.md) | 🟡 | ✅ | ⬜ | — |
+| [`IPictureInPicture`](apis/picture-in-picture.md) | 🟡 | ✅ | ⬜ | — |
+| [`IInstallPrompt`](apis/install-prompt.md) | 🟡 | ✅ | ⬜ | — |
+| [`IMediaDevices`](apis/media-devices.md) | 🟡 | ✅ | ⬜ | — |
+| [`IIdleDetector`](apis/idle-detector.md) | ⬜ | ✅ | ⬜ | — |
+| [`ISerial`](apis/serial.md) | ⬜ | ✅ | ⬜ | — |
+| [`IUsb`](apis/usb.md) | ⬜ | ✅ | ⬜ | — |
+| [`IHid`](apis/hid.md) | ⬜ | ✅ | ⬜ | — |
+| [`IBluetooth`](apis/bluetooth.md) | ⬜ | ✅ | ⬜ | — |
+
+## Notes
+
+- **Web / Server** is the ASP.NET host (per-session, over WebSocket). The 31 transport-agnostic
+  wrappers register there; the activation-gated ones (🟡) can't be injected but are reachable through
+  declarative gesture components (planned — see the roadmap in [browser-apis.md](browser-apis.md)).
+- **PWA / WASM** is the in-browser WebAssembly host, which registers the full set.
+- **Native** is the `Rask.Native` host. Every ★ API has a first-class native backend wired by
+  `ApplePlatform` / `AndroidPlatform` (see [native.md](native.md)); the rest run through the WebView.
+- Push subscription (`IWebPush`) and the PWA APIs (`INotifications`, `IBadge`, `IWakeLock`) work on
+  Server too, but their JS helpers ship only under `AddRaskPwa` — see [pwa.md](pwa.md).

--- a/docs/native.md
+++ b/docs/native.md
@@ -289,6 +289,10 @@ The shipped native backends (both platforms):
 | `IVibration` | system vibration (AudioToolbox) | `Vibrator` / `VibratorManager` |
 | `IWakeLock` | `UIApplication.IdleTimerDisabled` | window `FLAG_KEEP_SCREEN_ON` |
 | `INetworkInfo` | `NWPathMonitor` | `ConnectivityManager` |
+| `ISpeechSynthesis` | `AVSpeechSynthesizer` | `TextToSpeech` |
+| `IScreenInfo` | `UIScreen` | `DisplayMetrics` |
+| `IDeviceOrientation` | CoreMotion (`CMMotionManager`) | `SensorManager` (rotation vector) |
+| `IDeviceMotion` | CoreMotion (`CMMotionManager`) | `SensorManager` (accelerometer + gyroscope) |
 
 So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real permission prompt +
 `CLLocationManager` / `LocationManager` accuracy) instead of `navigator.geolocation`, `clipboard.WriteTextAsync`

--- a/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
@@ -10,8 +10,10 @@ namespace Rask.Native;
 ///     The Android platform module. Pass it to <see cref="NativeAppHost.UsePlatform" /> and the host wires
 ///     these native C# backends for the browser/device API interfaces — <c>IShare</c> (ACTION_SEND chooser),
 ///     <c>IGeolocation</c> (LocationManager), <c>IClipboard</c> (ClipboardManager), <c>IVibration</c>
-///     (Vibrator), <c>IWakeLock</c> (FLAG_KEEP_SCREEN_ON), and <c>INetworkInfo</c> (ConnectivityManager) — so
-///     injecting any of them resolves the native implementation and every other interface falls back to the
+///     (Vibrator), <c>IWakeLock</c> (FLAG_KEEP_SCREEN_ON), <c>INetworkInfo</c> (ConnectivityManager),
+///     <c>ISpeechSynthesis</c> (TextToSpeech), <c>IScreenInfo</c> (DisplayMetrics), and
+///     <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (SensorManager) — so injecting any of them resolves the
+///     native implementation and every other interface falls back to the
 ///     WebView's JS. The app writes one line (<c>host.UsePlatform(new AndroidPlatform(this))</c>) instead of
 ///     registering each backend by hand. Geolocation needs <c>ACCESS_FINE_LOCATION</c> and network info needs
 ///     <c>ACCESS_NETWORK_STATE</c> in the manifest.
@@ -30,5 +32,9 @@ public sealed class AndroidPlatform(Activity activity) : INativePlatform
         services.TryAddSingleton<IVibration>(_ => new NativeVibration(activity));
         services.TryAddSingleton<IWakeLock>(_ => new NativeWakeLock(activity));
         services.TryAddSingleton<INetworkInfo>(_ => new NativeNetworkInfo(activity));
+        services.TryAddSingleton<ISpeechSynthesis>(_ => new NativeSpeechSynthesis(activity));
+        services.TryAddSingleton<IScreenInfo>(_ => new NativeScreenInfo(activity));
+        services.TryAddSingleton<IDeviceOrientation>(_ => new NativeDeviceOrientation(activity));
+        services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion(activity));
     }
 }

--- a/src/Rask.Native/Platforms/Android/NativeDeviceMotion.cs
+++ b/src/Rask.Native/Platforms/Android/NativeDeviceMotion.cs
@@ -1,0 +1,88 @@
+using Android.App;
+using Android.Content;
+using Android.Hardware;
+using Android.Runtime;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IDeviceMotion — SensorManager's linear accelerometer (gravity excluded, m/s²,
+// matching the web `acceleration`) plus the gyroscope (rad/s → °/s), instead of the WebView's devicemotion
+// events. Registered by AndroidPlatform; no runtime permission needed for these sensors.
+internal sealed class NativeDeviceMotion(Activity activity) : IDeviceMotion
+{
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(Manager()?.GetDefaultSensor(SensorType.Accelerometer) is not null);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<MotionReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(Manager(), onReading));
+    }
+
+    private SensorManager? Manager() => (SensorManager?)activity.GetSystemService(Context.SensorService);
+
+    private sealed class Watch : Java.Lang.Object, ISensorEventListener, IAsyncDisposable
+    {
+        private readonly SensorManager? _mgr;
+        private readonly Func<MotionReading, Task> _onReading;
+        private double _ax, _ay, _az, _ralpha, _rbeta, _rgamma;
+
+        public Watch(SensorManager? mgr, Func<MotionReading, Task> onReading)
+        {
+            _mgr = mgr;
+            _onReading = onReading;
+            // Prefer linear acceleration (gravity removed) to match the web `acceleration`; fall back to the
+            // raw accelerometer where the fused sensor isn't present.
+            var accel = mgr?.GetDefaultSensor(SensorType.LinearAcceleration)
+                        ?? mgr?.GetDefaultSensor(SensorType.Accelerometer);
+            var gyro = mgr?.GetDefaultSensor(SensorType.Gyroscope);
+            if (accel is not null)
+            {
+                mgr!.RegisterListener(this, accel, SensorDelay.Game);
+            }
+
+            if (gyro is not null)
+            {
+                mgr!.RegisterListener(this, gyro, SensorDelay.Game);
+            }
+        }
+
+        public void OnAccuracyChanged(Sensor? sensor, [GeneratedEnum] SensorStatus accuracy) { }
+
+        public void OnSensorChanged(SensorEvent? e)
+        {
+            if (e?.Sensor is null || e.Values is null || e.Values.Count < 3)
+            {
+                return;
+            }
+
+            switch (e.Sensor.Type)
+            {
+                case SensorType.LinearAcceleration or SensorType.Accelerometer:
+                    _ax = e.Values[0];
+                    _ay = e.Values[1];
+                    _az = e.Values[2];
+                    break;
+                case SensorType.Gyroscope:
+                    _ralpha = RadToDeg(e.Values[2]);
+                    _rbeta = RadToDeg(e.Values[0]);
+                    _rgamma = RadToDeg(e.Values[1]);
+                    break;
+            }
+
+            _ = _onReading(new MotionReading(_ax, _ay, _az, _ralpha, _rbeta, _rgamma, null));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr?.UnregisterListener(this);
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/Android/NativeDeviceOrientation.cs
+++ b/src/Rask.Native/Platforms/Android/NativeDeviceOrientation.cs
@@ -1,0 +1,79 @@
+using Android.App;
+using Android.Content;
+using Android.Hardware;
+using Android.Runtime;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IDeviceOrientation — SensorManager's TYPE_ROTATION_VECTOR (fused compass +
+// gyro), converted to the web deviceorientation alpha/beta/gamma, instead of the WebView's deviceorientation
+// events. Registered by AndroidPlatform. Android needs no runtime permission for these sensors.
+internal sealed class NativeDeviceOrientation(Activity activity) : IDeviceOrientation
+{
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(Manager()?.GetDefaultSensor(SensorType.RotationVector) is not null);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<OrientationReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(Manager(), onReading));
+    }
+
+    private SensorManager? Manager() => (SensorManager?)activity.GetSystemService(Context.SensorService);
+
+    private sealed class Watch : Java.Lang.Object, ISensorEventListener, IAsyncDisposable
+    {
+        private readonly SensorManager? _mgr;
+        private readonly Func<OrientationReading, Task> _onReading;
+
+        public Watch(SensorManager? mgr, Func<OrientationReading, Task> onReading)
+        {
+            _mgr = mgr;
+            _onReading = onReading;
+            var sensor = mgr?.GetDefaultSensor(SensorType.RotationVector);
+            if (sensor is not null)
+            {
+                mgr!.RegisterListener(this, sensor, SensorDelay.Ui);
+            }
+        }
+
+        public void OnAccuracyChanged(Sensor? sensor, [GeneratedEnum] SensorStatus accuracy) { }
+
+        public void OnSensorChanged(SensorEvent? e)
+        {
+            if (e?.Values is null || e.Values.Count < 4)
+            {
+                return;
+            }
+
+            var vector = new float[4];
+            for (var i = 0; i < 4; i++)
+            {
+                vector[i] = e.Values[i];
+            }
+
+            var matrix = new float[9];
+            SensorManager.GetRotationMatrixFromVector(matrix, vector);
+            var angles = new float[3]; // [azimuth, pitch, roll] radians
+            SensorManager.GetOrientation(matrix, angles);
+
+            _ = _onReading(new OrientationReading(
+                Alpha: (RadToDeg(angles[0]) + 360) % 360, // compass heading, 0–360
+                Beta: RadToDeg(angles[1]),
+                Gamma: RadToDeg(angles[2]),
+                Absolute: true));
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr?.UnregisterListener(this);
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/Android/NativeScreenInfo.cs
+++ b/src/Rask.Native/Platforms/Android/NativeScreenInfo.cs
@@ -1,0 +1,20 @@
+using Android.App;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IScreenInfo — the app's DisplayMetrics (Density = device-pixel ratio) instead
+// of window.screen. Registered by AndroidPlatform. Uses Resources.DisplayMetrics (no deprecated Display API).
+internal sealed class NativeScreenInfo(Activity activity) : IScreenInfo
+{
+    public ValueTask<ScreenInfo> GetAsync()
+    {
+        var dm = activity.Resources!.DisplayMetrics!;
+        var density = dm.Density <= 0 ? 1f : dm.Density;
+        // WidthPixels/HeightPixels are physical pixels; divide by density to get CSS pixels. Android has no
+        // separate "available" area distinct from the app window, and no color-depth API (24 is universal).
+        var cssWidth = (int)Math.Round(dm.WidthPixels / density);
+        var cssHeight = (int)Math.Round(dm.HeightPixels / density);
+        return ValueTask.FromResult(new ScreenInfo(cssWidth, cssHeight, cssWidth, cssHeight, 24, density));
+    }
+}

--- a/src/Rask.Native/Platforms/Android/NativeSpeechSynthesis.cs
+++ b/src/Rask.Native/Platforms/Android/NativeSpeechSynthesis.cs
@@ -1,0 +1,66 @@
+using Android.App;
+using Android.Runtime;
+using Android.Speech.Tts;
+using Java.Util;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for ISpeechSynthesis — the platform TextToSpeech engine instead of the WebView's
+// speechSynthesis. The engine initializes asynchronously; IsSupportedAsync/SpeakAsync await that. Registered
+// by AndroidPlatform (held for the app lifetime).
+internal sealed class NativeSpeechSynthesis : Java.Lang.Object, ISpeechSynthesis, TextToSpeech.IOnInitListener
+{
+    private readonly TextToSpeech _tts;
+    private readonly TaskCompletionSource<bool> _ready = new();
+
+    public NativeSpeechSynthesis(Activity activity) => _tts = new TextToSpeech(activity, this);
+
+    public void OnInit([GeneratedEnum] OperationResult status) =>
+        _ready.TrySetResult(status == OperationResult.Success);
+
+    public ValueTask<bool> IsSupportedAsync() => new(_ready.Task);
+
+    public async ValueTask SpeakAsync(string text, SpeechOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        if (!await _ready.Task)
+        {
+            return;
+        }
+
+        if (options?.Lang is { } lang)
+        {
+            _tts.SetLanguage(Locale.ForLanguageTag(lang));
+        }
+
+        if (options?.Rate is { } rate)
+        {
+            _tts.SetSpeechRate((float)rate);
+        }
+
+        if (options?.Pitch is { } pitch)
+        {
+            _tts.SetPitch((float)pitch);
+        }
+
+        // Queue behind anything already speaking, matching the web queueing behaviour.
+        _tts.Speak(text, QueueMode.Add, null, Guid.NewGuid().ToString());
+    }
+
+    public ValueTask CancelAsync()
+    {
+        _tts.Stop();
+        return default;
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _tts.Shutdown();
+        }
+
+        base.Dispose(disposing);
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
+++ b/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
@@ -10,8 +10,10 @@ namespace Rask.Native;
 ///     The iOS platform module. Pass it to <see cref="NativeAppHost.UsePlatform" /> and the host wires these
 ///     native C# backends for the browser/device API interfaces — <c>IShare</c> (system share sheet),
 ///     <c>IGeolocation</c> (CoreLocation), <c>IClipboard</c> (UIPasteboard), <c>IVibration</c>,
-///     <c>IWakeLock</c>, and <c>INetworkInfo</c> — so injecting any of them resolves the native
-///     implementation, and every other interface falls back to the WebView's JS. The app writes one line
+///     <c>IWakeLock</c>, <c>INetworkInfo</c> (NWPathMonitor), <c>ISpeechSynthesis</c> (AVSpeechSynthesizer),
+///     <c>IScreenInfo</c> (UIScreen), and <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (CoreMotion) — so
+///     injecting any of them resolves the native implementation, and every other interface falls back to the
+///     WebView's JS. The app writes one line
 ///     (<c>host.UsePlatform(new ApplePlatform(() =&gt; Window?.RootViewController))</c>) instead of
 ///     registering each backend by hand.
 /// </summary>
@@ -33,5 +35,9 @@ public sealed class ApplePlatform(Func<UIViewController?> presenter) : INativePl
         services.TryAddSingleton<IVibration>(_ => new NativeVibration());
         services.TryAddSingleton<IWakeLock>(_ => new NativeWakeLock());
         services.TryAddSingleton<INetworkInfo>(_ => new NativeNetworkInfo());
+        services.TryAddSingleton<ISpeechSynthesis>(_ => new NativeSpeechSynthesis());
+        services.TryAddSingleton<IScreenInfo>(_ => new NativeScreenInfo());
+        services.TryAddSingleton<IDeviceOrientation>(_ => new NativeDeviceOrientation());
+        services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion());
     }
 }

--- a/src/Rask.Native/Platforms/iOS/NativeDeviceMotion.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeDeviceMotion.cs
@@ -1,0 +1,67 @@
+using CoreMotion;
+using Foundation;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for IDeviceMotion — CoreMotion (CMMotionManager) instead of the WebView's devicemotion
+// events. UserAcceleration excludes gravity (matching the web `acceleration`) and is in g, converted to
+// m/s²; RotationRate is rad/s, converted to °/s. Registered by ApplePlatform; no permission needed on iOS.
+internal sealed class NativeDeviceMotion : IDeviceMotion
+{
+    private const double GravityMetersPerSecondSquared = 9.80665;
+
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(new CMMotionManager().DeviceMotionAvailable);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<MotionReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(onReading));
+    }
+
+    private sealed class Watch : IAsyncDisposable
+    {
+        private readonly CMMotionManager _mgr = new() { DeviceMotionUpdateInterval = 1.0 / 60 };
+
+        public Watch(Func<MotionReading, Task> onReading)
+        {
+            if (!_mgr.DeviceMotionAvailable)
+            {
+                return;
+            }
+
+            var intervalMs = _mgr.DeviceMotionUpdateInterval * 1000;
+            _mgr.StartDeviceMotionUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), (motion, err) =>
+            {
+                _ = err;
+                if (motion is null)
+                {
+                    return;
+                }
+
+                var acc = motion.UserAcceleration; // g, gravity excluded
+                var rot = motion.RotationRate;      // rad/s
+                _ = onReading(new MotionReading(
+                    AccelerationX: acc.X * GravityMetersPerSecondSquared,
+                    AccelerationY: acc.Y * GravityMetersPerSecondSquared,
+                    AccelerationZ: acc.Z * GravityMetersPerSecondSquared,
+                    RotationAlpha: RadToDeg(rot.z),
+                    RotationBeta: RadToDeg(rot.x),
+                    RotationGamma: RadToDeg(rot.y),
+                    Interval: intervalMs));
+            });
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr.StopDeviceMotionUpdates();
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/iOS/NativeDeviceOrientation.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeDeviceOrientation.cs
@@ -1,0 +1,61 @@
+using CoreMotion;
+using Foundation;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for IDeviceOrientation — CoreMotion (CMMotionManager device-motion attitude) instead of
+// the WebView's deviceorientation events, which WKWebView gates/withholds. Registered by ApplePlatform. iOS
+// needs no separate permission for attitude, so RequestPermissionAsync returns Granted. Absolute is true
+// (device-motion attitude is referenced to a fixed frame). Angles are radians → degrees.
+internal sealed class NativeDeviceOrientation : IDeviceOrientation
+{
+    public ValueTask<bool> IsSupportedAsync() =>
+        ValueTask.FromResult(new CMMotionManager().DeviceMotionAvailable);
+
+    public ValueTask<SensorPermission> RequestPermissionAsync() =>
+        ValueTask.FromResult(SensorPermission.Granted);
+
+    public ValueTask<IAsyncDisposable> WatchAsync(Func<OrientationReading, Task> onReading)
+    {
+        ArgumentNullException.ThrowIfNull(onReading);
+        return new ValueTask<IAsyncDisposable>(new Watch(onReading));
+    }
+
+    private sealed class Watch : IAsyncDisposable
+    {
+        private readonly CMMotionManager _mgr = new() { DeviceMotionUpdateInterval = 1.0 / 60 };
+
+        public Watch(Func<OrientationReading, Task> onReading)
+        {
+            if (!_mgr.DeviceMotionAvailable)
+            {
+                return;
+            }
+
+            _mgr.StartDeviceMotionUpdates(NSOperationQueue.CurrentQueue ?? new NSOperationQueue(), (motion, err) =>
+            {
+                _ = err;
+                if (motion?.Attitude is not { } attitude)
+                {
+                    return;
+                }
+
+                // Map CoreMotion yaw/pitch/roll to the web deviceorientation alpha/beta/gamma.
+                _ = onReading(new OrientationReading(
+                    Alpha: RadToDeg(attitude.Yaw),
+                    Beta: RadToDeg(attitude.Pitch),
+                    Gamma: RadToDeg(attitude.Roll),
+                    Absolute: true));
+            });
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            _mgr.StopDeviceMotionUpdates();
+            return default;
+        }
+    }
+
+    private static double RadToDeg(double radians) => radians * 180.0 / Math.PI;
+}

--- a/src/Rask.Native/Platforms/iOS/NativeScreenInfo.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeScreenInfo.cs
@@ -1,0 +1,25 @@
+using Rask.Core.Browser;
+using UIKit;
+
+namespace Rask.Native;
+
+// Native iOS backend for IScreenInfo — UIScreen (true device metrics + scale) instead of window.screen.
+// Registered by ApplePlatform. Read on the main thread.
+internal sealed class NativeScreenInfo : IScreenInfo
+{
+    public ValueTask<ScreenInfo> GetAsync()
+    {
+        var tcs = new TaskCompletionSource<ScreenInfo>();
+        UIApplication.SharedApplication.InvokeOnMainThread(() =>
+        {
+            var screen = UIScreen.MainScreen;
+            var bounds = screen.Bounds; // points == CSS pixels
+            var width = (int)Math.Round(bounds.Width);
+            var height = (int)Math.Round(bounds.Height);
+            // iOS has no per-app "available" area distinct from the screen, and no color-depth API (24 is the
+            // universal effective value); Scale is the device-pixel ratio (2/3 on retina).
+            tcs.TrySetResult(new ScreenInfo(width, height, width, height, 24, screen.Scale));
+        });
+        return new ValueTask<ScreenInfo>(tcs.Task);
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/NativeSpeechSynthesis.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeSpeechSynthesis.cs
@@ -1,0 +1,52 @@
+using AVFoundation;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native iOS backend for ISpeechSynthesis — AVSpeechSynthesizer instead of the WebView's speechSynthesis
+// (which is unreliable inside WKWebView). Registered by ApplePlatform. The synthesizer is held for the app
+// lifetime so queued utterances survive across calls.
+internal sealed class NativeSpeechSynthesis : ISpeechSynthesis
+{
+    private readonly AVSpeechSynthesizer _synth = new();
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask SpeakAsync(string text, SpeechOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        var utterance = new AVSpeechUtterance(text);
+        if (options?.Lang is { } lang)
+        {
+            utterance.Voice = AVSpeechSynthesisVoice.FromLanguage(lang);
+        }
+
+        if (options?.Rate is { } rate)
+        {
+            // Web rate is 0.1–10 (1 = normal); AVSpeechUtterance rate is [Min..Max] with ~0.5 the default.
+            utterance.Rate = (float)Math.Clamp(
+                rate * AVSpeechUtterance.DefaultSpeechRate,
+                AVSpeechUtterance.MinimumSpeechRate,
+                AVSpeechUtterance.MaximumSpeechRate);
+        }
+
+        if (options?.Pitch is { } pitch)
+        {
+            utterance.PitchMultiplier = (float)pitch;
+        }
+
+        if (options?.Volume is { } volume)
+        {
+            utterance.Volume = (float)volume;
+        }
+
+        _synth.SpeakUtterance(utterance);
+        return default;
+    }
+
+    public ValueTask CancelAsync()
+    {
+        _synth.StopSpeaking(AVSpeechBoundary.Immediate);
+        return default;
+    }
+}


### PR DESCRIPTION
## Summary

Delivers the two documentation asks of the API-consolidation effort: **one canonical matrix** and **a dedicated page per API**. Stacked on #347.

- **`docs/browser-capabilities.md`** — a single table of all 43 browser/device wrappers with columns **Web/Server · PWA/WASM · Native**, ✅/🟡/⬜ cells, a **★** marking the APIs with a native iOS/Android C# backend, and the backend names. Each row links to that API's reference page.
- **`docs/apis/*.md`** — 43 reference pages (one per API): summary, what it wraps, home/tier, one-shot vs subscription, per-platform availability, native backend, notes (permissions/gesture/secure-context), and links back to the source file + matrix + narrative map.
- Both are generated from a **single data table**, so the matrix and the per-API pages can't drift.
- **Reconciled** the stale WASM-only classification in `browser-apis.md`: `IWebPush` / `INotifications` / `IBadge` / `IWakeLock` are transport-agnostic and register on Server, so they move into the Shared table. Linked the matrix from `browser-apis.md` and `docs/README.md`.

## Testing
- Docs-only change. Verified every per-API page's source link resolves to an existing `.cs` file, and the matrix ✅/🟡/⬜/★ cells match the actual host registrations and native backends shipped in #344/#347.

## Notes
- The 🟡 cells (Fullscreen, ScreenOrientation, EyeDropper, PiP, InstallPrompt, MediaDevices) are marked *planned via the Server gesture bridge* — that's the next PR in the series.