### PR TITLE
feat(core): Server gesture bridge — activation-gated browser APIs via GestureTrigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Gesture bridge — activation-gated browser APIs on the Server host.** New headless `GestureTrigger`
+  (and typed `FullscreenTrigger` / `EyeDropperTrigger`) generalise `Shareable`'s trick: they hand your
+  element a `data-rask-gesture` bundle and the shared client runs the capability **inside the click
+  gesture**, so the browser's transient user activation survives. That makes normally-WASM-only APIs like
+  fullscreen and the eyedropper reachable **declaratively on the Server host** (where a round-tripped
+  service call would lose the activation). Capabilities that return a value post it back to an
+  `OnResult` / `OnColor` callback via a new `[JSInvokable]`. The `__raskFullscreen` / `__raskEyeDropper`
+  DOM helpers moved from `rask-wasm-api.js` into the shared `rask-api.js` so they ship to Server too.
+
 ### Documentation
 - **Browser/device API capability matrix + per-API reference pages.** New
   [`docs/browser-capabilities.md`](docs/browser-capabilities.md) is a single table of all 43 wrappers

--- a/docs/apis/eye-dropper.md
+++ b/docs/apis/eye-dropper.md
@@ -8,9 +8,9 @@
 - **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
 - **Native backend:** — (WebView JS)
 
-Needs activation → WASM-only; Server gesture bridge planned.
+Needs activation, so the imperative `IEyeDropper` service is WASM-only. On the **Server** host, use the declarative **`EyeDropperTrigger`** component — its click opens the picker inside the gesture and posts the chosen colour back to your `OnColor` callback.
 
-> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+> 🟡 On the Server host, reachable declaratively via `EyeDropperTrigger` (a click-gesture component), not as an injected service.
 
 ## See also
 

--- a/docs/apis/fullscreen.md
+++ b/docs/apis/fullscreen.md
@@ -8,9 +8,9 @@
 - **Availability:** Web/Server 🟡 · PWA/WASM ✅ · Native ⬜
 - **Native backend:** — (WebView JS)
 
-Needs transient activation → WASM-only imperatively; a Server `FullscreenTrigger` (declarative gesture bridge) is planned.
+Needs transient activation, so the imperative `IFullscreen` service is WASM-only. On the **Server** host, use the declarative **`FullscreenTrigger`** component — its click requests fullscreen inside the gesture (the activation survives, unlike a round-tripped service call).
 
-> 🟡 On the Server host this is reachable declaratively via the planned gesture bridge, not as an injected service.
+> 🟡 On the Server host, reachable declaratively via `FullscreenTrigger` (a click-gesture component), not as an injected service.
 
 ## See also
 

--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -126,6 +126,24 @@ the **WASM and Native** hosts (`Rask.Native` can't reference the browser-only `R
 | `Shareable` | `Rask.Core` | **all** (Server too) | Headless declarative share — attaches `data-rask-share` to your element; fires `navigator.share` in the gesture |
 | `IShare` | `Rask.Client.Browser` | WASM + Native | Imperative share from code; native backend on Native |
 
+### Gesture bridge — activation-gated APIs on the Server host
+
+`Shareable`'s trick — run the call **inside the click gesture** so the transient user activation survives —
+generalises. **`GestureTrigger`** (and the typed **`FullscreenTrigger`** / **`EyeDropperTrigger`**) are headless
+the same way: they hand your element a `data-rask-gesture` bundle, and the shared client runs the capability in
+the gesture. That makes normally-WASM-only, activation-gated APIs reachable **declaratively on the Server host**
+(they're still not injectable there). Capabilities that return a value (the eyedropper's hex) post it back to an
+`OnResult` / `OnColor` callback.
+
+```csharp
+FullscreenTrigger(g => Button(Type: "button", Data: g)["Full screen"])
+EyeDropperTrigger(OnColor: hex => { picked = hex; return Task.CompletedTask; },
+    g => Button(Type: "button", Data: g)["Pick a colour"])
+```
+
+Shipped capabilities: fullscreen and the eyedropper; screen-orientation, picture-in-picture, install-prompt, and
+media capture are planned on the same mechanism. See the [capability matrix](browser-capabilities.md).
+
 ## WASM-only APIs — `Rask.Wasm.Browser`
 
 Registered only by the WASM host. Each needs something neither the Server transport nor a native WebView

--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -5,8 +5,9 @@ framework resolves the best implementation for the host — a native iOS/Android
 exists, the WebView's JS otherwise. Each API links to its own reference page; the narrative overview
 (with the three-homes rationale and the subscription pattern) is [browser-apis.md](browser-apis.md).
 
-**Legend** — ✅ implemented · 🟡 planned via the Server gesture bridge · ⬜ not available · — n/a. A
-**★** in the Native column marks an API with a native C# backend (the rest run through the WebView's JS).
+**Legend** — ✅ injectable service · 🟡 reachable on Server via a declarative **gesture component** (runs the
+activation-gated call inside a click), not as an injected service · ⬜ not available · — n/a. A **★** in the
+Native column marks an API with a native C# backend (the rest run through the WebView's JS).
 
 | API | Web / Server | PWA / WASM | Native | Native backend |
 |-----|:---:|:---:|:---:|-----|
@@ -58,7 +59,10 @@ exists, the WebView's JS otherwise. Each API links to its own reference page; th
 
 - **Web / Server** is the ASP.NET host (per-session, over WebSocket). The 31 transport-agnostic
   wrappers register there; the activation-gated ones (🟡) can't be injected but are reachable through
-  declarative gesture components (planned — see the roadmap in [browser-apis.md](browser-apis.md)).
+  declarative **gesture components** that run the call inside the click gesture. Shipped today:
+  [`FullscreenTrigger`](apis/fullscreen.md) and [`EyeDropperTrigger`](apis/eye-dropper.md) (plus the
+  generic `GestureTrigger`); triggers for screen-orientation, picture-in-picture, install-prompt, and
+  media capture are planned on the same mechanism.
 - **PWA / WASM** is the in-browser WebAssembly host, which registers the full set.
 - **Native** is the `Rask.Native` host. Every ★ API has a first-class native backend wired by
   `ApplePlatform` / `AndroidPlatform` (see [native.md](native.md)); the rest run through the WebView.

--- a/src/Rask.Core/Browser/RaskBrowserJsonContext.cs
+++ b/src/Rask.Core/Browser/RaskBrowserJsonContext.cs
@@ -14,6 +14,7 @@ namespace Rask.Core.Browser;
 [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
 [JsonSerializable(typeof(GeolocationPosition))]
 [JsonSerializable(typeof(ShareData))]
+[JsonSerializable(typeof(Rask.Core.Components.GesturePayload))]
 [JsonSerializable(typeof(PushSubscription))]
 [JsonSerializable(typeof(NotificationOptions))]
 [JsonSerializable(typeof(NetworkReading))]

--- a/src/Rask.Core/Components/GestureTrigger.cs
+++ b/src/Rask.Core/Components/GestureTrigger.cs
@@ -1,0 +1,108 @@
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Rask.Core.Browser;
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Components;
+
+/// <summary>
+///     Headless <b>gesture bridge</b> — hands your own markup a <c>data-rask-gesture</c> attribute so the
+///     element's click runs an activation-gated browser API <b>inside the click's own gesture</b>. That's the
+///     one thing a Server round-trip can't do (the transient user activation is gone by the time C# runs), so
+///     APIs like fullscreen, the eyedropper, or picture-in-picture — normally WASM-only — become reachable
+///     declaratively on the <b>Server</b> host too, the same way <see cref="Shareable" /> makes sharing work
+///     everywhere. Spread the bundle onto any element via its <c>Data</c> prop:
+///     <code>
+///     GestureTrigger(Capability: "fullscreen.request",
+///         trigger => Button(Type: "button", Data: trigger)["Go fullscreen"])
+///     </code>
+///     For the common capabilities, prefer the typed wrappers (<see cref="FullscreenTrigger" />,
+///     <see cref="EyeDropperTrigger" />). For a <b>code-driven</b> call on the in-process WASM host, inject the
+///     matching service (<c>IFullscreen</c>, <c>IEyeDropper</c>, …) instead.
+/// </summary>
+public sealed class GestureTrigger : Component
+{
+    /// <summary>The capability to run in the gesture — e.g. <c>"fullscreen.request"</c>, <c>"eyedropper.open"</c>.</summary>
+    public required string Capability { get; set; }
+
+    /// <summary>
+    ///     Optional callback for capabilities that return a value (the eyedropper's hex, the install outcome).
+    ///     When set, the client posts the result back to it; leave <c>null</c> for fire-and-forget capabilities.
+    /// </summary>
+    public Func<string?, Task>? OnResult { get; set; }
+
+    /// <summary>Renders your trigger element, given the attribute bundle to apply via its <c>Data</c> prop.</summary>
+    public required Func<IReadOnlyDictionary<string, string?>, Component> Template { get; set; }
+
+    /// <inheritdoc />
+    protected override Component Render() => Template(GestureBridge.Attr(Capability, OnResult));
+}
+
+/// <summary>Present an element/page fullscreen from a click gesture (works on Server, unlike the imperative <c>IFullscreen</c>).</summary>
+public sealed class FullscreenTrigger : Component
+{
+    /// <summary>Renders your trigger element; its click requests fullscreen for the whole page.</summary>
+    public required Func<IReadOnlyDictionary<string, string?>, Component> Template { get; set; }
+
+    /// <inheritdoc />
+    protected override Component Render() => Template(GestureBridge.Attr("fullscreen.request", null));
+}
+
+/// <summary>Open the eyedropper from a click gesture and receive the picked colour (hex, or <c>null</c> if cancelled).</summary>
+public sealed class EyeDropperTrigger : Component
+{
+    /// <summary>Invoked with the picked colour as <c>#rrggbb</c>, or <c>null</c> when the user cancels.</summary>
+    public Func<string?, Task>? OnColor { get; set; }
+
+    /// <summary>Renders your trigger element; its click opens the eyedropper.</summary>
+    public required Func<IReadOnlyDictionary<string, string?>, Component> Template { get; set; }
+
+    /// <inheritdoc />
+    protected override Component Render() => Template(GestureBridge.Attr("eyedropper.open", OnColor));
+}
+
+// Shared payload for the data-rask-gesture attribute: the capability plus, when a result is expected, the
+// id the client posts the result back under (RaskGestureResult). Serialized with the trim-safe source-gen
+// context (Web defaults → { "cap": …, "rid": … }).
+internal sealed record GesturePayload(string Cap, int? Rid);
+
+internal static class GestureBridge
+{
+    // Roots GestureResultInterop's [JSInvokable] for the WASM trimmer — it's reached only via the JS
+    // DotNet dispatcher (reflection), so without this the Result method could be trimmed away.
+    [DynamicDependency(DynamicallyAccessedMemberTypes.PublicMethods, typeof(GestureResultInterop))]
+    public static IReadOnlyDictionary<string, string?> Attr(string capability, Func<string?, Task>? onResult)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(capability);
+        var rid = onResult is null ? (int?)null : GestureResultInterop.Register(onResult);
+        var json = JsonSerializer.Serialize(
+            new GesturePayload(capability, rid), RaskBrowserJsonContext.Default.GesturePayload);
+        return new Dictionary<string, string?>(StringComparer.Ordinal) { ["rask-gesture"] = json };
+    }
+}
+
+/// <summary>
+///     Infrastructure for the gesture bridge — routes a result the client posts after running a gesture
+///     capability back to the right C# callback by id. <b>Not for application use;</b> invoked only by the
+///     framework client via <c>window.DotNet.invokeMethodAsync("Rask.Core", "RaskGestureResult", …)</c>.
+/// </summary>
+[EditorBrowsable(EditorBrowsableState.Never)]
+public static class GestureResultInterop
+{
+    private static int _nextId;
+    private static readonly ConcurrentDictionary<int, Func<string?, Task>> Handlers = new();
+
+    internal static int Register(Func<string?, Task> handler)
+    {
+        var id = Interlocked.Increment(ref _nextId);
+        Handlers[id] = handler;
+        return id;
+    }
+
+    /// <summary>Infrastructure. Invoked by the client with a gesture's result (one-shot); do not call.</summary>
+    [JSInvokable("RaskGestureResult")]
+    public static Task Result(int id, string? value) =>
+        Handlers.TryRemove(id, out var handler) ? handler(value) : Task.CompletedTask;
+}

--- a/src/Rask.Core/Resources/rask-api.js
+++ b/src/Rask.Core/Resources/rask-api.js
@@ -888,3 +888,25 @@ window.__raskWebAuthn = window.__raskWebAuthn || (() => {
         }
     };
 })();
+
+// Gesture-bridge DOM helpers — moved here from rask-wasm-api.js so they ship to the Server client too.
+// They drive activation-gated browser APIs that must run inside a click gesture; the declarative
+// FullscreenTrigger / EyeDropperTrigger components (and the data-rask-gesture click handler in
+// rask-events.js) call these synchronously in the gesture, which is why they work even on the Server
+// transport. The imperative IFullscreen / IEyeDropper services (WASM-only) call the same helpers.
+
+// Fullscreen: with no element the whole page goes fullscreen (document.documentElement); exit is a no-op
+// when nothing is fullscreen.
+window.__raskFullscreen = window.__raskFullscreen || {
+    isSupported: () => !!document.fullscreenEnabled,
+    isActive: () => document.fullscreenElement != null,
+    request: (el) => (el || document.documentElement).requestFullscreen(),
+    exit: () => document.fullscreenElement ? document.exitFullscreen() : Promise.resolve()
+};
+
+// EyeDropper: open() resolves to the picked colour (#rrggbb); the picker rejects with AbortError when the
+// user cancels (Escape) — map that to null rather than surfacing an error.
+window.__raskEyeDropper = window.__raskEyeDropper || {
+    isSupported: () => "EyeDropper" in window,
+    open: () => new EyeDropper().open().then((r) => r.sRGBHex, () => null)
+};

--- a/src/Rask.Core/Resources/rask-events.js
+++ b/src/Rask.Core/Resources/rask-events.js
@@ -235,3 +235,37 @@ document.addEventListener("click", function (e) {
         try { var p = navigator.share(data); if (p && p["catch"]) { p["catch"](function () {}); } } catch (err) {}
     }
 });
+
+// ----- Gesture bridge (client-only) ------------------------------------------
+// GestureTrigger / FullscreenTrigger / EyeDropperTrigger emit data-rask-gesture="{cap,rid}". The capability
+// MUST run inside the click's own call stack so the browser's transient user activation is still live — a
+// server round-trip would lose it. That's what lets activation-gated APIs (fullscreen, eyedropper, …) work
+// even on the Server transport. When a result-callback id (rid) is set, the resolved value is posted back to
+// C# via the shared DotNet shim (static [JSInvokable] GestureResultInterop.Result in Rask.Core).
+var raskGestureCaps = {
+    "fullscreen.request": function () { return window.__raskFullscreen ? window.__raskFullscreen.request() : null; },
+    "eyedropper.open": function () { return window.__raskEyeDropper ? window.__raskEyeDropper.open() : null; }
+};
+function raskPostGestureResult(rid, value) {
+    if (window.DotNet && window.DotNet.invokeMethodAsync) {
+        window.DotNet.invokeMethodAsync("Rask.Core", "RaskGestureResult", rid, value == null ? null : value);
+    }
+}
+document.addEventListener("click", function (e) {
+    var t = (e.target && e.target.closest) ? e.target.closest("[data-rask-gesture]") : null;
+    if (!t || !inRoot(t)) { return; }
+    var raw = t.getAttribute("data-rask-gesture");
+    if (!raw) { return; }
+    var spec;
+    try { spec = JSON.parse(raw); } catch (err) { return; }
+    var run = raskGestureCaps[spec.cap];
+    if (!run) { return; }
+    var result;
+    try { result = run(); } catch (err) { if (spec.rid != null) { raskPostGestureResult(spec.rid, null); } return; }
+    if (spec.rid != null && result && typeof result.then === "function") {
+        result.then(function (value) { raskPostGestureResult(spec.rid, value); },
+            function () { raskPostGestureResult(spec.rid, null); });
+    } else if (result && result["catch"]) {
+        result["catch"](function () {});
+    }
+});

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -915,6 +915,28 @@ window.__raskWebAuthn = window.__raskWebAuthn || (() => {
     };
 })();
 
+// Gesture-bridge DOM helpers — moved here from rask-wasm-api.js so they ship to the Server client too.
+// They drive activation-gated browser APIs that must run inside a click gesture; the declarative
+// FullscreenTrigger / EyeDropperTrigger components (and the data-rask-gesture click handler in
+// rask-events.js) call these synchronously in the gesture, which is why they work even on the Server
+// transport. The imperative IFullscreen / IEyeDropper services (WASM-only) call the same helpers.
+
+// Fullscreen: with no element the whole page goes fullscreen (document.documentElement); exit is a no-op
+// when nothing is fullscreen.
+window.__raskFullscreen = window.__raskFullscreen || {
+    isSupported: () => !!document.fullscreenEnabled,
+    isActive: () => document.fullscreenElement != null,
+    request: (el) => (el || document.documentElement).requestFullscreen(),
+    exit: () => document.fullscreenElement ? document.exitFullscreen() : Promise.resolve()
+};
+
+// EyeDropper: open() resolves to the picked colour (#rrggbb); the picker rejects with AbortError when the
+// user cancels (Escape) — map that to null rather than surfacing an error.
+window.__raskEyeDropper = window.__raskEyeDropper || {
+    isSupported: () => "EyeDropper" in window,
+    open: () => new EyeDropper().open().then((r) => r.sRGBHex, () => null)
+};
+
 
 // ----- Transport-agnostic PWA helpers (__raskPush/__raskNotify/__raskBadge/__raskWakeLock) -----
 // Transport-agnostic PWA framework helpers, spliced into BOTH the Server client (rask.js) and the WASM
@@ -2489,6 +2511,40 @@ document.addEventListener("click", function (e) {
         try { data = JSON.parse(raw); } catch (err) { return; }
         // Fire in the gesture; swallow rejections (user cancel / unsupported payload).
         try { var p = navigator.share(data); if (p && p["catch"]) { p["catch"](function () {}); } } catch (err) {}
+    }
+});
+
+// ----- Gesture bridge (client-only) ------------------------------------------
+// GestureTrigger / FullscreenTrigger / EyeDropperTrigger emit data-rask-gesture="{cap,rid}". The capability
+// MUST run inside the click's own call stack so the browser's transient user activation is still live — a
+// server round-trip would lose it. That's what lets activation-gated APIs (fullscreen, eyedropper, …) work
+// even on the Server transport. When a result-callback id (rid) is set, the resolved value is posted back to
+// C# via the shared DotNet shim (static [JSInvokable] GestureResultInterop.Result in Rask.Core).
+var raskGestureCaps = {
+    "fullscreen.request": function () { return window.__raskFullscreen ? window.__raskFullscreen.request() : null; },
+    "eyedropper.open": function () { return window.__raskEyeDropper ? window.__raskEyeDropper.open() : null; }
+};
+function raskPostGestureResult(rid, value) {
+    if (window.DotNet && window.DotNet.invokeMethodAsync) {
+        window.DotNet.invokeMethodAsync("Rask.Core", "RaskGestureResult", rid, value == null ? null : value);
+    }
+}
+document.addEventListener("click", function (e) {
+    var t = (e.target && e.target.closest) ? e.target.closest("[data-rask-gesture]") : null;
+    if (!t || !inRoot(t)) { return; }
+    var raw = t.getAttribute("data-rask-gesture");
+    if (!raw) { return; }
+    var spec;
+    try { spec = JSON.parse(raw); } catch (err) { return; }
+    var run = raskGestureCaps[spec.cap];
+    if (!run) { return; }
+    var result;
+    try { result = run(); } catch (err) { if (spec.rid != null) { raskPostGestureResult(spec.rid, null); } return; }
+    if (spec.rid != null && result && typeof result.then === "function") {
+        result.then(function (value) { raskPostGestureResult(spec.rid, value); },
+            function () { raskPostGestureResult(spec.rid, null); });
+    } else if (result && result["catch"]) {
+        result["catch"](function () {});
     }
 });
 

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -899,6 +899,28 @@ window.__raskWebAuthn = window.__raskWebAuthn || (() => {
     };
 })();
 
+// Gesture-bridge DOM helpers — moved here from rask-wasm-api.js so they ship to the Server client too.
+// They drive activation-gated browser APIs that must run inside a click gesture; the declarative
+// FullscreenTrigger / EyeDropperTrigger components (and the data-rask-gesture click handler in
+// rask-events.js) call these synchronously in the gesture, which is why they work even on the Server
+// transport. The imperative IFullscreen / IEyeDropper services (WASM-only) call the same helpers.
+
+// Fullscreen: with no element the whole page goes fullscreen (document.documentElement); exit is a no-op
+// when nothing is fullscreen.
+window.__raskFullscreen = window.__raskFullscreen || {
+    isSupported: () => !!document.fullscreenEnabled,
+    isActive: () => document.fullscreenElement != null,
+    request: (el) => (el || document.documentElement).requestFullscreen(),
+    exit: () => document.fullscreenElement ? document.exitFullscreen() : Promise.resolve()
+};
+
+// EyeDropper: open() resolves to the picked colour (#rrggbb); the picker rejects with AbortError when the
+// user cancels (Escape) — map that to null rather than surfacing an error.
+window.__raskEyeDropper = window.__raskEyeDropper || {
+    isSupported: () => "EyeDropper" in window,
+    open: () => new EyeDropper().open().then((r) => r.sRGBHex, () => null)
+};
+
 
 // Transport-agnostic PWA helpers (__raskPush/__raskNotify/__raskBadge/__raskWakeLock) spliced from
 // Rask.Core/Resources/rask-pwa.js — the same source the Server client uses.
@@ -1165,15 +1187,9 @@ window.__raskOrientation = window.__raskOrientation || {
     unlock: () => { screen.orientation.unlock(); }
 };
 
-// Fullscreen (driven by IFullscreen). requestFullscreen needs transient activation, so this is WASM-only.
-// The element arg is resolved from an ElementRef by the JSON reviver; with no element the whole page goes
-// fullscreen (document.documentElement). exit is a no-op when nothing is fullscreen.
-window.__raskFullscreen = window.__raskFullscreen || {
-    isSupported: () => !!document.fullscreenEnabled,
-    isActive: () => document.fullscreenElement != null,
-    request: (el) => (el || document.documentElement).requestFullscreen(),
-    exit: () => document.fullscreenElement ? document.exitFullscreen() : Promise.resolve()
-};
+// __raskFullscreen moved to Rask.Core/Resources/rask-api.js so it also ships to the Server client (the
+// declarative FullscreenTrigger drives it inside the click gesture there). The imperative IFullscreen
+// service stays WASM-only.
 
 // Media Capture / getUserMedia (driven by IMediaDevices). getUserMedia needs transient activation + a
 // secure context, so this is WASM-only. The live MediaStream can't cross interop, so each is held here
@@ -1222,12 +1238,9 @@ window.__raskMedia = window.__raskMedia || (() => {
     };
 })();
 
-// EyeDropper (driven by IEyeDropper). open() needs transient activation, so this is WASM-only. The picker
-// rejects with AbortError when the user cancels (Escape) — map that to null rather than surfacing an error.
-window.__raskEyeDropper = window.__raskEyeDropper || {
-    isSupported: () => "EyeDropper" in window,
-    open: () => new EyeDropper().open().then((r) => r.sRGBHex, () => null)
-};
+// __raskEyeDropper moved to Rask.Core/Resources/rask-api.js so it also ships to the Server client (the
+// declarative EyeDropperTrigger drives it inside the click gesture there). The imperative IEyeDropper
+// service stays WASM-only.
 
 // Picture-in-Picture (driven by IPictureInPicture). requestPictureInPicture needs transient activation, so
 // this is WASM-only. The element arg is resolved from an ElementRef by the JSON reviver; exit is a no-op
@@ -4049,6 +4062,40 @@ document.addEventListener("click", function (e) {
         try { data = JSON.parse(raw); } catch (err) { return; }
         // Fire in the gesture; swallow rejections (user cancel / unsupported payload).
         try { var p = navigator.share(data); if (p && p["catch"]) { p["catch"](function () {}); } } catch (err) {}
+    }
+});
+
+// ----- Gesture bridge (client-only) ------------------------------------------
+// GestureTrigger / FullscreenTrigger / EyeDropperTrigger emit data-rask-gesture="{cap,rid}". The capability
+// MUST run inside the click's own call stack so the browser's transient user activation is still live — a
+// server round-trip would lose it. That's what lets activation-gated APIs (fullscreen, eyedropper, …) work
+// even on the Server transport. When a result-callback id (rid) is set, the resolved value is posted back to
+// C# via the shared DotNet shim (static [JSInvokable] GestureResultInterop.Result in Rask.Core).
+var raskGestureCaps = {
+    "fullscreen.request": function () { return window.__raskFullscreen ? window.__raskFullscreen.request() : null; },
+    "eyedropper.open": function () { return window.__raskEyeDropper ? window.__raskEyeDropper.open() : null; }
+};
+function raskPostGestureResult(rid, value) {
+    if (window.DotNet && window.DotNet.invokeMethodAsync) {
+        window.DotNet.invokeMethodAsync("Rask.Core", "RaskGestureResult", rid, value == null ? null : value);
+    }
+}
+document.addEventListener("click", function (e) {
+    var t = (e.target && e.target.closest) ? e.target.closest("[data-rask-gesture]") : null;
+    if (!t || !inRoot(t)) { return; }
+    var raw = t.getAttribute("data-rask-gesture");
+    if (!raw) { return; }
+    var spec;
+    try { spec = JSON.parse(raw); } catch (err) { return; }
+    var run = raskGestureCaps[spec.cap];
+    if (!run) { return; }
+    var result;
+    try { result = run(); } catch (err) { if (spec.rid != null) { raskPostGestureResult(spec.rid, null); } return; }
+    if (spec.rid != null && result && typeof result.then === "function") {
+        result.then(function (value) { raskPostGestureResult(spec.rid, value); },
+            function () { raskPostGestureResult(spec.rid, null); });
+    } else if (result && result["catch"]) {
+        result["catch"](function () {});
     }
 });
 

--- a/src/Rask.Wasm/Resources/rask-wasm-api.js
+++ b/src/Rask.Wasm/Resources/rask-wasm-api.js
@@ -118,15 +118,9 @@ window.__raskOrientation = window.__raskOrientation || {
     unlock: () => { screen.orientation.unlock(); }
 };
 
-// Fullscreen (driven by IFullscreen). requestFullscreen needs transient activation, so this is WASM-only.
-// The element arg is resolved from an ElementRef by the JSON reviver; with no element the whole page goes
-// fullscreen (document.documentElement). exit is a no-op when nothing is fullscreen.
-window.__raskFullscreen = window.__raskFullscreen || {
-    isSupported: () => !!document.fullscreenEnabled,
-    isActive: () => document.fullscreenElement != null,
-    request: (el) => (el || document.documentElement).requestFullscreen(),
-    exit: () => document.fullscreenElement ? document.exitFullscreen() : Promise.resolve()
-};
+// __raskFullscreen moved to Rask.Core/Resources/rask-api.js so it also ships to the Server client (the
+// declarative FullscreenTrigger drives it inside the click gesture there). The imperative IFullscreen
+// service stays WASM-only.
 
 // Media Capture / getUserMedia (driven by IMediaDevices). getUserMedia needs transient activation + a
 // secure context, so this is WASM-only. The live MediaStream can't cross interop, so each is held here
@@ -175,12 +169,9 @@ window.__raskMedia = window.__raskMedia || (() => {
     };
 })();
 
-// EyeDropper (driven by IEyeDropper). open() needs transient activation, so this is WASM-only. The picker
-// rejects with AbortError when the user cancels (Escape) — map that to null rather than surfacing an error.
-window.__raskEyeDropper = window.__raskEyeDropper || {
-    isSupported: () => "EyeDropper" in window,
-    open: () => new EyeDropper().open().then((r) => r.sRGBHex, () => null)
-};
+// __raskEyeDropper moved to Rask.Core/Resources/rask-api.js so it also ships to the Server client (the
+// declarative EyeDropperTrigger drives it inside the click gesture there). The imperative IEyeDropper
+// service stays WASM-only.
 
 // Picture-in-Picture (driven by IPictureInPicture). requestPictureInPicture needs transient activation, so
 // this is WASM-only. The element arg is resolved from an ElementRef by the JSON reviver; exit is a no-op

--- a/tests/Rask.Core.Tests/Components/GestureTriggerTests.cs
+++ b/tests/Rask.Core.Tests/Components/GestureTriggerTests.cs
@@ -1,0 +1,56 @@
+using System.Text.RegularExpressions;
+using Rask.Core.Components;
+
+namespace Rask.Core.Tests.Components;
+
+// GestureTrigger (and the typed FullscreenTrigger / EyeDropperTrigger) are headless like Shareable: they
+// render whatever the Template returns and hand it the data-rask-gesture bundle. The shared client runs the
+// capability inside the click gesture — so activation-gated APIs work even on the Server transport — and
+// posts any result back through GestureResultInterop. No IJSRuntime, no host-specific registration.
+public class GestureTriggerTests
+{
+    [Fact]
+    public void FullscreenTrigger_StampsCapWithNullRid_DataAttrBeforeTagSpecific()
+    {
+        // Fire-and-forget (no result) → rid is null. Attribute order: data-* before tag-specific (type).
+        Assert.Equal(
+            "<button data-rask-gesture=\"{&quot;cap&quot;:&quot;fullscreen.request&quot;,&quot;rid&quot;:null}\" type=\"button\">Full screen</button>",
+            FullscreenTrigger(g => Button(Type: "button", Data: g)["Full screen"]).ToHtml());
+    }
+
+    [Fact]
+    public void GestureTrigger_GenericCapability_StampsTheGivenCap()
+    {
+        Assert.Equal(
+            "<a data-rask-gesture=\"{&quot;cap&quot;:&quot;pip.request&quot;,&quot;rid&quot;:null}\" href=\"#\">PiP</a>",
+            GestureTrigger(Capability: "pip.request", Template: g => A(Href: "#", Data: g)["PiP"]).ToHtml());
+    }
+
+    [Fact]
+    public void EyeDropperTrigger_WithCallback_StampsCapAndANumericResultId()
+    {
+        var html = EyeDropperTrigger(
+            OnColor: _ => Task.CompletedTask,
+            Template: g => Button(Type: "button", Data: g)["Pick"]).ToHtml();
+
+        Assert.Matches(@"data-rask-gesture=""\{&quot;cap&quot;:&quot;eyedropper\.open&quot;,&quot;rid&quot;:\d+\}""", html);
+    }
+
+    [Fact]
+    public async Task GestureResultInterop_RoutesTheResultToTheTriggersCallback_ThenIsOneShot()
+    {
+        string? received = null;
+        var html = EyeDropperTrigger(
+            OnColor: value => { received = value; return Task.CompletedTask; },
+            Template: g => Button(Type: "button", Data: g)["Pick"]).ToHtml();
+        var rid = int.Parse(Regex.Match(html, @"rid&quot;:(\d+)").Groups[1].Value);
+
+        await GestureResultInterop.Result(rid, "#ff8800");
+        Assert.Equal("#ff8800", received);
+
+        // One-shot: the handler is removed after the first result, so a second post is a no-op.
+        received = null;
+        await GestureResultInterop.Result(rid, "#000000");
+        Assert.Null(received);
+    }
+}


### PR DESCRIPTION
## Summary

The flagship of the API-consolidation effort: makes **activation-gated browser APIs work on the Server host**, declaratively. Stacked on the umbrella branch (which now carries #343/#344/#347/#348).

`Shareable` already proves the trick — run the call **inside the click's own gesture** so the browser's transient user activation is still live (a WebSocket round-trip would lose it). This PR generalises that:

- **`GestureTrigger`** (headless) + typed **`FullscreenTrigger`** / **`EyeDropperTrigger`** stamp a `data-rask-gesture` bundle onto *your* element; the shared client runs the capability in the gesture. So fullscreen and the eyedropper — normally WASM-only because they need activation — become reachable on the **Server** host, where the imperative `IFullscreen` / `IEyeDropper` services can't work.
- Results (the eyedropper's hex) post back to your `OnResult` / `OnColor` via **`GestureResultInterop`** (`[JSInvokable] RaskGestureResult` in `Rask.Core`) — the same client→C# push channel the observers use, so it works on both transports.
- **Client**: a `data-rask-gesture` click dispatch added to `rask-events.js` (ES5, alongside the share handler); the `__raskFullscreen` / `__raskEyeDropper` DOM helpers **moved** from `rask-wasm-api.js` into the shared `rask-api.js` so they ship to Server too (no new splice marker). Regenerated the checked-in WASM/Native bundles.

## Testing
- **4 new unit tests**: exact serialized attribute + render order, result-id, and one-shot `GestureResultInterop` routing.
- Full solution build warnings-as-errors clean; full unit suite green (Core 1877, Server 249, …).
- `Rask.Example.Wasm` Release publish — **0 IL warnings** (the new `[JSInvokable]` is rooted via `DynamicDependency`).
- **Verified the generated Server bundle** now contains both the `__raskFullscreen`/`__raskEyeDropper` helpers **and** the `data-rask-gesture` dispatch + `RaskGestureResult` — the capabilities actually ship to Server.

## Benchmarks
Not applicable — client-JS event dispatch + an opt-in component; the C# render/diff hot-path (`Element`/`HtmlSerializer`) is untouched.

## Follow-ups
- Showcase demo + Playwright E2E driving a Server-host trigger end-to-end in a browser.
- Typed triggers for screen-orientation, PiP, install-prompt, and media capture (same mechanism: add a cap to the dispatch table + a wrapper).