### PR TITLE
docs(samples): showcase demo for the gesture bridge

### DIFF
--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -353,6 +353,13 @@ shell. For a code-driven share on the in-process hosts, inject **`IShare`** (`Ra
 
 <!-- demo:browser-share -->
 
+**`GestureTrigger` / `FullscreenTrigger` / `EyeDropperTrigger`** *(`Rask.Core` — all hosts)* — headless
+gesture bridge: hand *your* element the `data-rask-gesture` attribute and its click runs an activation-gated
+API (fullscreen, the eyedropper, …) in the gesture, so it works on Server too, where the imperative service
+can't be injected. See [Gesture bridge](#gesture-bridge-activation-gated-apis-on-the-server-host).
+
+<!-- demo:browser-gesture-bridge -->
+
 ## Notes
 
 - **Secure context.** Clipboard, geolocation, notifications, push, `crypto.subtle`, and others require

--- a/samples/Rask.Example.Shared/Features/Browser/GestureBridgeDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/GestureBridgeDemo.cs
@@ -1,0 +1,50 @@
+using Rask.Core;
+using Rask.Core.Components;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     <c>GestureTrigger</c> family (Rask.Core) — the headless gesture bridge. <c>FullscreenTrigger</c> /
+///     <c>EyeDropperTrigger</c> hand <b>your</b> element a <c>data-rask-gesture</c> attribute; the shared
+///     client runs the activation-gated browser API <b>inside the click gesture</b>, so these work on
+///     <b>every</b> host — the Server included, where the imperative <c>IFullscreen</c> / <c>IEyeDropper</c>
+///     services can't be injected (a round-trip would lose the transient user activation). The eyedropper's
+///     picked colour is pushed back to the <c>OnColor</c> callback.
+/// </summary>
+public sealed class GestureBridgeDemo : Component
+{
+    private string? _color;
+
+    protected override Component? Render() =>
+        BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
+            BsCardBody()[
+                Div(Class: "d-flex gap-2 flex-wrap align-items-center mb-2")[
+                    // Headless: we render our own buttons; the triggers just supply the gesture attribute.
+                    FullscreenTrigger(g =>
+                        Button(Type: "button", Class: "btn btn-primary btn-sm", Id: "fullscreen-btn", Data: g)[
+                            "Enter fullscreen"]),
+                    EyeDropperTrigger(
+                        OnColor: hex =>
+                        {
+                            _color = hex;
+                            StateHasChanged(); // sanctioned pattern for an externally-pushed result
+                            return Task.CompletedTask;
+                        },
+                        Template: g =>
+                            Button(Type: "button", Class: "btn btn-outline-secondary btn-sm", Id: "eyedropper-btn",
+                                Data: g)["Pick a colour"]),
+                    _color is null
+                        ? Span(Class: "small text-secondary")["no colour picked"]
+                        : Span(Class: "d-inline-flex align-items-center gap-2 small")[
+                            Span(Id: "eyedropper-swatch",
+                                Style: "display:inline-block;width:1.25rem;height:1.25rem;border-radius:.25rem;"
+                                       + $"border:1px solid #ccc;background:{_color}"),
+                            Code(Id: "eyedropper-value")[_color]]
+                ],
+                Div(Class: "small text-secondary")[
+                    "Both run inside the click gesture, so they work on every host — including Server, where ",
+                    Code()["IFullscreen"], " / ", Code()["IEyeDropper"],
+                    " can't be injected. The eyedropper needs a Chromium browser; fullscreen is near-universal."]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -133,6 +133,17 @@ public static class DemoRegistry
                 + "upgrades to a native UIActivityViewController / ACTION_SEND backend. For a code-driven share "
                 + "on the in-process hosts, inject IShare from Rask.Client.Browser.",
                 Result: ShareDemo()),
+            ["browser-gesture-bridge"] = () => CodeSample(
+                ["GestureBridgeDemo.cs"],
+                Notes:
+                "GestureTrigger / FullscreenTrigger / EyeDropperTrigger (Rask.Core) are headless like Shareable: "
+                + "they hand your element a data-rask-gesture attribute and the shared client runs the "
+                + "activation-gated API inside the click gesture. That makes normally-WASM-only APIs like "
+                + "fullscreen and the eyedropper reachable on every host, the Server included — where the "
+                + "imperative IFullscreen / IEyeDropper services can't be injected, because a round-trip would "
+                + "lose the transient user activation. Capabilities that return a value (the eyedropper's hex) "
+                + "post it back to the OnColor / OnResult callback.",
+                Result: GestureBridgeDemo()),
 
             // --- Forms guide: the remaining two-way-binding variants (their standalone /binding page
             //     folded into docs/forms.md). ---


### PR DESCRIPTION
## Summary

The showcase demo #349 deferred. Adds `GestureBridgeDemo` to the shared showcase's Browser APIs section: a `FullscreenTrigger` and an `EyeDropperTrigger` (whose picked colour updates a swatch via the sanctioned `StateHasChanged` push pattern).

It's the **first fullscreen/eyedropper demo that can live in the *shared* showcase** — the imperative `IFullscreen` / `IEyeDropper` services can't be injected on the Server host, but the declarative triggers work everywhere, which is exactly the gesture bridge's point.

Registered in `DemoRegistry` (`browser-gesture-bridge`) and embedded in the `browser-apis.md` gesture-bridge section.

## Testing
- Server sample + shared showcase build clean; `Rask.Example.Shared.Tests` green (285).
- (Fullscreen/eyedropper can't be asserted in a headless E2E — they need a real display + user gesture — but the trigger's exact `data-rask-gesture` attribute and the one-shot result routing are unit-tested in #349, and the Server bundle was verified to ship the helpers + dispatch.)