### PR TITLE
feat(sqlite): auto-download the litestream binary at build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`Rask.SQLite.Litestream` now fetches the `litestream` binary for you.** MSBuild `build/` targets in
+  the package download the litestream binary for the target runtime at build/publish time (Linux
+  x64/arm64/armv7, macOS x64/arm64, Windows x64/arm64), SHA-256-verify it against a pinned checksum,
+  cache it under `~/.rask/litestream/<version>/<rid>`, and copy it next to the app — so a published app
+  (and its Docker image) has litestream with nothing to install. The package stays tiny (no binaries
+  shipped). The default `ExecutablePath` resolves to the bundled binary, then falls back to `PATH`. Opt
+  out with `-p:RaskLitestreamDownload=false`; pin a different version with `RaskLitestreamVersion` +
+  `RaskLitestreamSha256`. See [docs/sqlite.md](docs/sqlite.md#the-litestream-binary-is-fetched-for-you).
 - **The live playground is now a real in-browser IDE.** The `samples/Rask.Example.Playground` editor gains
   three IDE features, all powered by Roslyn compiled to WebAssembly:
   - **IntelliSense** — Roslyn's `CompletionService` (via a new `Microsoft.CodeAnalysis.CSharp.Features`

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -123,8 +123,23 @@ driven through [CliWrap](https://github.com/Tyrrrz/CliWrap); a backup failure is
 but never crashes the app it protects. Point `ConfigPath` at a full `litestream.yml` for multiple
 databases or custom retention.
 
-> You need the `litestream` binary on the host — install it, bundle it with your deployment and set
-> `ExecutablePath`, or use a container image that includes it.
+### The litestream binary is fetched for you
+
+By default the package **downloads the `litestream` binary at build/publish time** and drops it next to
+your app, so there's nothing to install — the default `ExecutablePath` finds it automatically. The
+binary for the target runtime (Linux x64/arm64/armv7, macOS x64/arm64, Windows x64/arm64) is fetched
+once into a per-user cache (`~/.rask/litestream/<version>/<rid>`), **SHA-256-verified** against a pinned
+checksum, and reused by later builds. Knobs (in your project or with `-p:`):
+
+| Property | Purpose |
+|---|---|
+| `RaskLitestreamDownload` | `false` to skip the download (air-gapped builds); provide your own binary via `ExecutablePath`. |
+| `RaskLitestreamVersion` | Pin a different litestream version (also set `RaskLitestreamSha256`). |
+| `RaskLitestreamSha256` | The expected checksum when you override the version. |
+
+> Building on a platform litestream doesn't ship (or with the download off)? Install `litestream`
+> yourself and point `ExecutablePath` at it — a bundled binary next to the app always wins, otherwise a
+> bare `"litestream"` falls back to `PATH`.
 
 ### Deploying on Azure App Service Linux (and other ephemeral containers)
 

--- a/src/Rask.SQLite.Litestream/CliWrapLitestreamExecutor.cs
+++ b/src/Rask.SQLite.Litestream/CliWrapLitestreamExecutor.cs
@@ -26,7 +26,7 @@ internal sealed class CliWrapLitestreamExecutor : ILitestreamExecutor
     {
         ArgumentNullException.ThrowIfNull(arguments);
 
-        var command = Cli.Wrap(_options.ExecutablePath)
+        var command = Cli.Wrap(LitestreamExecutableResolver.Resolve(_options.ExecutablePath))
             .WithArguments(arguments)
             .WithValidation(CommandResultValidation.None)
             .WithStandardOutputPipe(PipeTarget.ToDelegate(line => _logger.LogInformation("litestream: {Line}", line)))

--- a/src/Rask.SQLite.Litestream/LitestreamExecutableResolver.cs
+++ b/src/Rask.SQLite.Litestream/LitestreamExecutableResolver.cs
@@ -1,0 +1,42 @@
+namespace Rask.SQLite.Litestream;
+
+/// <summary>
+/// Resolves the litestream executable to run. When the package's build target has dropped a
+/// <c>litestream</c> binary next to the app (the default), a bare executable name resolves to that
+/// bundled copy; otherwise it is left as-is for a normal <c>PATH</c> lookup. An absolute path, a path
+/// with a directory separator, or a name that already exists as a file is always used verbatim.
+/// </summary>
+internal static class LitestreamExecutableResolver
+{
+    public static string Resolve(string configured)
+    {
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return configured;
+        }
+
+        // An explicit path (rooted or containing a separator) wins as given. A bare name is intentionally
+        // NOT treated as a working-directory file here: the runner resolves a bare name via PATH, so we
+        // must hand it an absolute path (below) for a bundled binary to actually run.
+        if (Path.IsPathRooted(configured)
+            || configured.Contains('/', StringComparison.Ordinal)
+            || configured.Contains(Path.DirectorySeparatorChar))
+        {
+            return configured;
+        }
+
+        // Prefer a binary bundled next to the app by the build target.
+        var baseDirectory = AppContext.BaseDirectory;
+        foreach (var candidateName in new[] { configured, configured + ".exe" })
+        {
+            var candidate = Path.Combine(baseDirectory, candidateName);
+            if (File.Exists(candidate))
+            {
+                return candidate;
+            }
+        }
+
+        // Nothing bundled — fall back to a PATH lookup on the bare name.
+        return configured;
+    }
+}

--- a/src/Rask.SQLite.Litestream/LitestreamOptions.cs
+++ b/src/Rask.SQLite.Litestream/LitestreamOptions.cs
@@ -7,8 +7,10 @@ namespace Rask.SQLite.Litestream;
 public sealed class LitestreamOptions
 {
     /// <summary>
-    /// Path to the <c>litestream</c> executable. Defaults to <c>"litestream"</c> (resolved from
-    /// <c>PATH</c>); set an absolute path if it lives somewhere else (e.g. <c>/usr/local/bin/litestream</c>).
+    /// Path to the <c>litestream</c> executable. Defaults to <c>"litestream"</c>, which resolves to the
+    /// binary the package drops next to your app at build time (see <c>RaskLitestreamDownload</c>), then
+    /// falls back to a <c>PATH</c> lookup. Set an absolute path to use a specific binary
+    /// (e.g. <c>/usr/local/bin/litestream</c>).
     /// </summary>
     public string ExecutablePath { get; set; } = "litestream";
 

--- a/src/Rask.SQLite.Litestream/NUGET.md
+++ b/src/Rask.SQLite.Litestream/NUGET.md
@@ -9,7 +9,9 @@ Pairs with [`Rask.SQLite`](https://www.nuget.org/packages/Rask.SQLite), whose WA
 what Litestream requires. Standalone otherwise: it depends only on the Microsoft.Extensions
 hosting/DI abstractions and [CliWrap](https://github.com/Tyrrrz/CliWrap).
 
-> Requires the `litestream` binary on the host (or a path you set via `ExecutablePath`).
+> The `litestream` binary is **downloaded at build time** and dropped next to your app (SHA-256-verified,
+> cached, tiny package) — nothing to install. Opt out with `-p:RaskLitestreamDownload=false` and set your
+> own `ExecutablePath`.
 
 ## Install
 

--- a/src/Rask.SQLite.Litestream/Rask.SQLite.Litestream.csproj
+++ b/src/Rask.SQLite.Litestream/Rask.SQLite.Litestream.csproj
@@ -28,4 +28,13 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
   </ItemGroup>
 
+  <!-- Ship the MSBuild props/targets that download the litestream binary into a consumer's output. -->
+  <ItemGroup>
+    <None Include="build\**" Pack="true" PackagePath="build\"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Rask.SQLite.Litestream.Tests"/>
+  </ItemGroup>
+
 </Project>

--- a/src/Rask.SQLite.Litestream/build/Rask.SQLite.Litestream.props
+++ b/src/Rask.SQLite.Litestream/build/Rask.SQLite.Litestream.props
@@ -1,0 +1,25 @@
+<Project>
+
+  <!--
+    Consumer-facing knobs for the litestream binary that Rask.SQLite.Litestream downloads at build.
+    Override any of these in your project (or with -p:) — e.g. set RaskLitestreamDownload=false in an
+    air-gapped build and provide your own binary via LitestreamOptions.ExecutablePath.
+  -->
+  <PropertyGroup>
+    <!-- Master switch. When false, nothing is downloaded and no binary is copied to the output. -->
+    <RaskLitestreamDownload Condition="'$(RaskLitestreamDownload)' == ''">true</RaskLitestreamDownload>
+
+    <!-- The litestream release to fetch (no leading 'v'). Change this AND supply the matching SHA-256
+         via RaskLitestreamSha256 to pin a different version; otherwise the checksum verification for the
+         default version below is used. -->
+    <RaskLitestreamVersion Condition="'$(RaskLitestreamVersion)' == ''">0.5.14</RaskLitestreamVersion>
+
+    <!-- Where releases are downloaded from (override for a mirror). -->
+    <RaskLitestreamReleaseBaseUrl Condition="'$(RaskLitestreamReleaseBaseUrl)' == ''">https://github.com/benbjohnson/litestream/releases/download</RaskLitestreamReleaseBaseUrl>
+
+    <!-- Optional: pin the SHA-256 yourself (required when RaskLitestreamVersion is changed from the
+         default, since the built-in checksums only cover that version). -->
+    <RaskLitestreamSha256 Condition="'$(RaskLitestreamSha256)' == ''"></RaskLitestreamSha256>
+  </PropertyGroup>
+
+</Project>

--- a/src/Rask.SQLite.Litestream/build/Rask.SQLite.Litestream.targets
+++ b/src/Rask.SQLite.Litestream/build/Rask.SQLite.Litestream.targets
@@ -1,0 +1,117 @@
+<Project>
+
+  <!--
+    Downloads the litestream binary for the target runtime at build/publish time and copies it next to
+    the app, so a Rask.SQLite.Litestream consumer needs no separate install. The binary is fetched once
+    into a per-user cache (~/.rask/litestream/<version>/<rid>), SHA-256-verified against the pinned
+    checksum, and reused by later builds. Disable with RaskLitestreamDownload=false (then supply your own
+    litestream via LitestreamOptions.ExecutablePath). See build/Rask.SQLite.Litestream.props for knobs.
+  -->
+
+  <Target Name="_RaskResolveLitestreamAsset" Condition="'$(RaskLitestreamDownload)' == 'true'">
+    <PropertyGroup>
+      <!-- Target RID, or the build host when building portable (no RID). -->
+      <_RaskLsRid>$(RuntimeIdentifier)</_RaskLsRid>
+      <_RaskLsHostArch>$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString().ToLowerInvariant())</_RaskLsHostArch>
+      <_RaskLsRid Condition="'$(_RaskLsRid)' == '' and $([MSBuild]::IsOSPlatform('Linux'))">linux-$(_RaskLsHostArch)</_RaskLsRid>
+      <_RaskLsRid Condition="'$(_RaskLsRid)' == '' and $([MSBuild]::IsOSPlatform('OSX'))">osx-$(_RaskLsHostArch)</_RaskLsRid>
+      <_RaskLsRid Condition="'$(_RaskLsRid)' == '' and $([MSBuild]::IsOSPlatform('Windows'))">win-$(_RaskLsHostArch)</_RaskLsRid>
+
+      <!-- Map the RID to litestream's os/arch tokens. -->
+      <_RaskLsOs Condition="$(_RaskLsRid.StartsWith('linux'))">linux</_RaskLsOs>
+      <_RaskLsOs Condition="$(_RaskLsRid.StartsWith('osx'))">darwin</_RaskLsOs>
+      <_RaskLsOs Condition="$(_RaskLsRid.StartsWith('win'))">windows</_RaskLsOs>
+
+      <_RaskLsArch Condition="$(_RaskLsRid.EndsWith('arm64'))">arm64</_RaskLsArch>
+      <_RaskLsArch Condition="$(_RaskLsRid.EndsWith('x64'))">x86_64</_RaskLsArch>
+      <_RaskLsArch Condition="$(_RaskLsRid.EndsWith('arm')) and !$(_RaskLsRid.EndsWith('arm64'))">armv7</_RaskLsArch>
+
+      <_RaskLsIsZip>false</_RaskLsIsZip>
+      <_RaskLsIsZip Condition="'$(_RaskLsOs)' == 'windows'">true</_RaskLsIsZip>
+      <_RaskLsExt>.tar.gz</_RaskLsExt>
+      <_RaskLsExt Condition="'$(_RaskLsIsZip)' == 'true'">.zip</_RaskLsExt>
+      <_RaskLsExeSuffix Condition="'$(_RaskLsOs)' == 'windows'">.exe</_RaskLsExeSuffix>
+
+      <!-- Which os/arch combos litestream actually ships. -->
+      <_RaskLsSupported>false</_RaskLsSupported>
+      <_RaskLsSupported Condition="'$(_RaskLsOs)' == 'linux' and ('$(_RaskLsArch)' == 'x86_64' or '$(_RaskLsArch)' == 'arm64' or '$(_RaskLsArch)' == 'armv7')">true</_RaskLsSupported>
+      <_RaskLsSupported Condition="'$(_RaskLsOs)' == 'darwin' and ('$(_RaskLsArch)' == 'x86_64' or '$(_RaskLsArch)' == 'arm64')">true</_RaskLsSupported>
+      <_RaskLsSupported Condition="'$(_RaskLsOs)' == 'windows' and ('$(_RaskLsArch)' == 'x86_64' or '$(_RaskLsArch)' == 'arm64')">true</_RaskLsSupported>
+
+      <_RaskLsAsset>litestream-$(RaskLitestreamVersion)-$(_RaskLsOs)-$(_RaskLsArch)$(_RaskLsExt)</_RaskLsAsset>
+      <_RaskLsUrl>$(RaskLitestreamReleaseBaseUrl)/v$(RaskLitestreamVersion)/$(_RaskLsAsset)</_RaskLsUrl>
+
+      <_RaskLsHome Condition="$([MSBuild]::IsOSPlatform('Windows'))">$([System.Environment]::GetEnvironmentVariable('USERPROFILE'))</_RaskLsHome>
+      <_RaskLsHome Condition="!$([MSBuild]::IsOSPlatform('Windows'))">$([System.Environment]::GetEnvironmentVariable('HOME'))</_RaskLsHome>
+      <_RaskLsCacheDir>$([System.IO.Path]::Combine('$(_RaskLsHome)', '.rask', 'litestream', '$(RaskLitestreamVersion)', '$(_RaskLsRid)'))$([System.IO.Path]::DirectorySeparatorChar)</_RaskLsCacheDir>
+      <_RaskLsArchivePath>$(_RaskLsCacheDir)$(_RaskLsAsset)</_RaskLsArchivePath>
+      <_RaskLsBinary>$(_RaskLsCacheDir)litestream$(_RaskLsExeSuffix)</_RaskLsBinary>
+
+      <!-- Pinned SHA-256s for the default version. A user-supplied RaskLitestreamSha256 always wins. -->
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'linux-x86_64'">32083dd2af13840b273c538360b828368d7b82bbaa2c641106052dc7814ed956</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'linux-arm64'">b49b3d01fb0a8b4d426ee613c080fba44acae0551587dc43525dcd93eee64b4f</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'linux-armv7'">2e4410f6fa03f4d86ea77fbe5443587239ec4907c68166d2a9d48e680e0dd52a</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'darwin-x86_64'">7432fc0a8c796c6a86f57d13a771d01795c3ea90da124c37e5af501cd08db0e4</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'darwin-arm64'">d4a1f810387d66264e4c9b0c3a29aa3d5dff2d6f53cb4c55ec093594d2ef94c3</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'windows-x86_64'">3fbbecb41e41fb03869551ba141835981e93a86805501cc73ee51eac62d92793</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamVersion)' == '0.5.14' and '$(_RaskLsOs)-$(_RaskLsArch)' == 'windows-arm64'">ded574465f77a5b703bf06800e20079b2c02a016f26925b59543abdd5ca02ed0</_RaskLsSha>
+      <_RaskLsSha Condition="'$(RaskLitestreamSha256)' != ''">$(RaskLitestreamSha256)</_RaskLsSha>
+    </PropertyGroup>
+  </Target>
+
+  <Target Name="_RaskDownloadLitestream"
+          Condition="'$(RaskLitestreamDownload)' == 'true' and '$(DesignTimeBuild)' != 'true'"
+          DependsOnTargets="_RaskResolveLitestreamAsset"
+          BeforeTargets="AssignTargetPaths">
+
+    <Warning Condition="'$(_RaskLsSupported)' != 'true'"
+             Text="Rask.SQLite.Litestream: litestream ships no binary for runtime '$(_RaskLsRid)'. Install litestream and set LitestreamOptions.ExecutablePath, or set RaskLitestreamDownload=false." />
+
+    <MakeDir Condition="'$(_RaskLsSupported)' == 'true'" Directories="$(_RaskLsCacheDir)" />
+
+    <DownloadFile Condition="'$(_RaskLsSupported)' == 'true' and !Exists('$(_RaskLsBinary)')"
+                  SourceUrl="$(_RaskLsUrl)"
+                  DestinationFolder="$(_RaskLsCacheDir)"
+                  DestinationFileName="$(_RaskLsAsset)"
+                  SkipUnchangedFiles="true" />
+
+    <GetFileHash Condition="'$(_RaskLsSupported)' == 'true' and '$(_RaskLsSha)' != '' and !Exists('$(_RaskLsBinary)')"
+                 Files="$(_RaskLsArchivePath)" Algorithm="SHA256">
+      <Output TaskParameter="Hash" PropertyName="_RaskLsActualSha" />
+    </GetFileHash>
+    <Error Condition="'$(_RaskLsSupported)' == 'true' and '$(_RaskLsSha)' != '' and !Exists('$(_RaskLsBinary)') and '$(_RaskLsActualSha.ToLowerInvariant())' != '$(_RaskLsSha.ToLowerInvariant())'"
+           Text="Rask.SQLite.Litestream: checksum mismatch for $(_RaskLsAsset). Expected $(_RaskLsSha), got $(_RaskLsActualSha). The download may be corrupt or tampered with." />
+    <Warning Condition="'$(_RaskLsSupported)' == 'true' and '$(_RaskLsSha)' == '' and !Exists('$(_RaskLsBinary)')"
+             Text="Rask.SQLite.Litestream: no pinned checksum for litestream $(RaskLitestreamVersion) on $(_RaskLsRid); set RaskLitestreamSha256 to verify the download." />
+
+    <!-- Extract the binary (litestream / litestream.exe) into the cache. -->
+    <Exec Condition="'$(_RaskLsSupported)' == 'true' and '$(_RaskLsIsZip)' != 'true' and !Exists('$(_RaskLsBinary)')"
+          Command="tar -xzf &quot;$(_RaskLsArchivePath)&quot; -C &quot;$(_RaskLsCacheDir)&quot;" />
+    <Unzip Condition="'$(_RaskLsSupported)' == 'true' and '$(_RaskLsIsZip)' == 'true' and !Exists('$(_RaskLsBinary)')"
+           SourceFiles="$(_RaskLsArchivePath)" DestinationFolder="$(_RaskLsCacheDir)" />
+
+    <!-- Copy it next to the app on build and publish. -->
+    <ItemGroup Condition="'$(_RaskLsSupported)' == 'true' and Exists('$(_RaskLsBinary)')">
+      <None Include="$(_RaskLsBinary)">
+        <Link>litestream$(_RaskLsExeSuffix)</Link>
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+        <Visible>false</Visible>
+      </None>
+    </ItemGroup>
+  </Target>
+
+  <!-- MSBuild's copy doesn't carry the Unix exec bit, so restore it on the copied binary. -->
+  <Target Name="_RaskChmodLitestreamBuild"
+          AfterTargets="Build"
+          Condition="'$(RaskLitestreamDownload)' == 'true' and !$([MSBuild]::IsOSPlatform('Windows'))">
+    <Exec Condition="Exists('$(TargetDir)litestream')" Command="chmod +x &quot;$(TargetDir)litestream&quot;" />
+  </Target>
+
+  <Target Name="_RaskChmodLitestreamPublish"
+          AfterTargets="Publish"
+          Condition="'$(RaskLitestreamDownload)' == 'true' and !$([MSBuild]::IsOSPlatform('Windows'))">
+    <Exec Condition="Exists('$(PublishDir)litestream')" Command="chmod +x &quot;$(PublishDir)litestream&quot;" />
+  </Target>
+
+</Project>

--- a/tests/Rask.SQLite.Litestream.Tests/LitestreamExecutableResolverTests.cs
+++ b/tests/Rask.SQLite.Litestream.Tests/LitestreamExecutableResolverTests.cs
@@ -1,0 +1,40 @@
+namespace Rask.SQLite.Litestream.Tests;
+
+public sealed class LitestreamExecutableResolverTests
+{
+    [Fact]
+    public void Resolve_returns_an_absolute_path_verbatim()
+    {
+        var path = OperatingSystem.IsWindows() ? @"C:\tools\litestream.exe" : "/usr/local/bin/litestream";
+        Assert.Equal(path, LitestreamExecutableResolver.Resolve(path));
+    }
+
+    [Fact]
+    public void Resolve_returns_a_relative_path_with_a_separator_verbatim()
+    {
+        Assert.Equal("tools/litestream", LitestreamExecutableResolver.Resolve("tools/litestream"));
+    }
+
+    [Fact]
+    public void Resolve_falls_back_to_the_bare_name_when_nothing_is_bundled()
+    {
+        // A name that isn't present next to the app resolves unchanged, for a normal PATH lookup.
+        Assert.Equal("litestream-not-bundled", LitestreamExecutableResolver.Resolve("litestream-not-bundled"));
+    }
+
+    [Fact]
+    public void Resolve_prefers_a_binary_bundled_next_to_the_app()
+    {
+        var probeName = $"litestream-probe-{Guid.NewGuid():N}";
+        var bundledPath = Path.Combine(AppContext.BaseDirectory, probeName);
+        File.WriteAllText(bundledPath, "stub");
+        try
+        {
+            Assert.Equal(bundledPath, LitestreamExecutableResolver.Resolve(probeName));
+        }
+        finally
+        {
+            File.Delete(bundledPath);
+        }
+    }
+}


### PR DESCRIPTION
> **Stacked on #352** (base = `worktree-rask-sqlite-pragmas`). Merge #352 first; rebases onto `main` after.

## Summary

`Rask.SQLite.Litestream` now **fetches the `litestream` binary for you at build time** and drops it next to the app — so a consumer needs nothing installed, and the default `ExecutablePath` finds it automatically. The package stays tiny (no binaries shipped, just two small MSBuild files).

**Build target (`build/Rask.SQLite.Litestream.targets` + `.props`):**
- Maps the target RID → litestream **v0.5.14** release asset: Linux `x64`/`arm64`/`armv7` + macOS `x64`/`arm64` (`.tar.gz`), Windows `x64`/`arm64` (`.zip`).
- Downloads once into a per-user cache (`~/.rask/litestream/<version>/<rid>`), **SHA-256-verifies** against a per-asset pinned checksum, extracts (`tar`/`Unzip`), and copies to the **build + publish** output as `litestream`(`.exe`) with `chmod +x` on Unix.
- Cached across builds; runs only on real builds (not design-time).
- Knobs: `RaskLitestreamDownload` (default `true`; `false` for air-gapped), `RaskLitestreamVersion` + `RaskLitestreamSha256` (pin another version), `RaskLitestreamReleaseBaseUrl` (mirror). Unsupported RID → warning + PATH fallback.

**Runtime (`LitestreamExecutableResolver`):** a bare `ExecutablePath` resolves to the bundled binary next to the app as an **absolute path** (the runner resolves bare names via `PATH`, not the working dir — so a bundled binary in CWD wouldn't otherwise run); falls back to `PATH` when nothing is bundled; rooted/separator paths pass through verbatim.

## Testing
- `LitestreamExecutableResolverTests` (4): absolute passthrough, separator passthrough, PATH fallback, and prefers-bundled-binary. (`InternalsVisibleTo` the test project.) All 30 Litestream tests green.
- **End-to-end verified** on osx-arm64 via a scratch consumer importing the targets: build downloads darwin-arm64, checksum passes, binary lands in output with the exec bit, `litestream version` → `0.5.14`; a rebuild hits the cache (no re-download); `-p:RaskLitestreamDownload=false` copies nothing.
- Confirmed the `.nupkg` ships only the two `build/` files (~10 KB) — no binaries. Full solution builds clean under warnings-as-errors.

## Docs
`docs/sqlite.md` gains a **"The litestream binary is fetched for you"** section (knobs table); `LitestreamOptions.ExecutablePath` xmldoc, NUGET.md, and CHANGELOG updated.

## Note
Why not test the `build/` auto-import in-repo? NuGet only auto-imports `build/*.targets` for **package** references, not `ProjectReference`s, so it can't be exercised by an in-repo consumer — hence the scratch-project verification above.