### PR TITLE
feat(native): native INotifications + IBadge backends for iOS/Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,14 @@ them until tagged releases begin.
   `IShare` (already native) — instead of the WebView's JS, which is often gesture-gated or absent on the
   platform. Everything else falls back to the WebView automatically. The `rask-native` sample uses the new
   modules (and adds the location / network-state / vibrate permissions).
+- **Native `INotifications` + `IBadge` backends — real OS notifications and app-icon badges on device.**
+  `ApplePlatform` / `AndroidPlatform` now also wire `INotifications` → `UNUserNotificationCenter` /
+  `NotificationManager` and `IBadge` → `UNUserNotificationCenter.SetBadgeCount` / a silent badge
+  notification — two APIs a WebView fundamentally can't deliver (`WKWebView` has no `Notification`
+  constructor; `navigator.setAppBadge` never touches a native app's icon). Injecting the ordinary
+  interface resolves the native backend on device; permission is the real OS prompt. Android 33+ needs the
+  `POST_NOTIFICATIONS` permission (declared in the sample/template manifests and requested up front by the
+  activity). A new co-mounted **Notifications + Badge** showcase demo exercises both.
 - **Central registration for the typed browser/device APIs, with native-first resolution.** The
   interface → implementation map for the 43 browser wrappers, previously hand-duplicated across the
   Server, WASM, and Native hosts, now lives in one place per assembly: `AddCoreBrowserApis` (the 31

--- a/docs/apis/badge.md
+++ b/docs/apis/badge.md
@@ -5,10 +5,14 @@
 - **Wraps:** Badging API
 - **Home:** `Rask.Core.Browser` (all hosts)
 - **Shape:** one-shot
-- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
-- **Native backend:** — (WebView JS)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅ ★
+- **Native backend:** SetBadgeCount / badge notification
 
-`setAppBadge` needs an installed PWA instance. Kept on the WebView on Native (no universal launcher-badge API).
+`setAppBadge` needs an installed PWA instance. In the native shell it resolves to the real app-icon badge:
+iOS uses `UNUserNotificationCenter.SetBadgeCount` (numeric only — there is no numberless dot, so `SetAsync(null)`
+maps to no badge); Android has no universal app-icon badge API, so the count rides a silent low-importance
+notification's number (`SetAsync(null)`/`SetAsync(0)` shows a plain dot, `ClearAsync` cancels it) — which means
+the Android badge needs `POST_NOTIFICATIONS` on API 33+, and the exact rendering is launcher-dependent.
 
 ## See also
 

--- a/docs/apis/notifications.md
+++ b/docs/apis/notifications.md
@@ -5,10 +5,13 @@
 - **Wraps:** Notifications API
 - **Home:** `Rask.Core.Browser` (all hosts)
 - **Shape:** one-shot
-- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
-- **Native backend:** — (WebView JS)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅ ★
+- **Native backend:** UNUserNotificationCenter / NotificationManager
 
-Transport-agnostic; the JS helper ships on Server only under `AddRaskPwa`.
+Transport-agnostic; the JS helper ships on Server only under `AddRaskPwa`. In the native shell it resolves to a
+native backend — a WebView has no `Notification` API. On Android 33+ this needs the `POST_NOTIFICATIONS`
+permission (declared in the manifest + granted at runtime, as the sample/template activities do); `Tag` maps to
+the notification identifier so a same-tag notification replaces the previous one.
 
 ## See also
 

--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -354,6 +354,13 @@ The push pattern above, one element at a time.
 
 <!-- demo:browser-broadcast-channel -->
 
+**`INotifications` + `IBadge`** — raise a local notification and set the app-icon badge from the page. In the
+[native shell](native.md) these resolve to real OS backends (UNUserNotificationCenter / NotificationManager and
+the native app-icon badge) that a WebView cannot provide; on Server/WASM they use the browser's Notifications
+and Badging APIs (a badge only shows on an installed PWA). On iOS the badge is numeric-only.
+
+<!-- demo:browser-notifications -->
+
 **`Shareable`** *(`Rask.Core` — all hosts)* — headless share: hand *your* element the `data-rask-share`
 attribute and its click opens the OS share sheet, on every host including Server (the shared client fires
 `navigator.share` in the click gesture, so the activation survives), upgrading to a native backend in the

--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -39,8 +39,8 @@ Native column marks an API with a native C# backend (the rest run through the We
 | [`IMutationObserver`](apis/mutation-observer.md) | ✅ | ✅ | ✅ | — |
 | [`IGamepad`](apis/gamepad.md) | ✅ | ✅ | ✅ | — |
 | [`IWebPush`](apis/web-push.md) | ✅ | ✅ | ✅ | — |
-| [`INotifications`](apis/notifications.md) | ✅ | ✅ | ✅ | — |
-| [`IBadge`](apis/badge.md) | ✅ | ✅ | ✅ | — |
+| [`INotifications`](apis/notifications.md) | ✅ | ✅ | ✅&nbsp;★ | UNUserNotificationCenter / NotificationManager |
+| [`IBadge`](apis/badge.md) | ✅ | ✅ | ✅&nbsp;★ | SetBadgeCount / badge notification |
 | [`IWakeLock`](apis/wake-lock.md) | ✅ | ✅ | ✅&nbsp;★ | IdleTimerDisabled / FLAG_KEEP_SCREEN_ON |
 | [`IShare`](apis/share.md) | 🟡 | ✅ | ✅&nbsp;★ | UIActivityViewController / ACTION_SEND |
 | [`IFullscreen`](apis/fullscreen.md) | 🟡 | ✅ | ⬜ | — |

--- a/docs/native.md
+++ b/docs/native.md
@@ -298,12 +298,15 @@ The shipped native backends (both platforms):
 | `IScreenInfo` | `UIScreen` | `DisplayMetrics` |
 | `IDeviceOrientation` | CoreMotion (`CMMotionManager`) | `SensorManager` (rotation vector) |
 | `IDeviceMotion` | CoreMotion (`CMMotionManager`) | `SensorManager` (accelerometer + gyroscope) |
+| `INotifications` | `UNUserNotificationCenter` | `NotificationManager` (+ channel) |
+| `IBadge` | `UNUserNotificationCenter.SetBadgeCount` | badge notification (`setNumber`) |
 
 So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real permission prompt +
 `CLLocationManager` / `LocationManager` accuracy) instead of `navigator.geolocation`, `clipboard.WriteTextAsync`
-hits `UIPasteboard` / `ClipboardManager` (no WebView gesture gate), and so on. Geolocation and network info
-need platform permissions — add `ACCESS_FINE_LOCATION` / `ACCESS_NETWORK_STATE` (Android) and
-`NSLocationWhenInUseUsageDescription` (iOS), and the head requests the location runtime grant.
+hits `UIPasteboard` / `ClipboardManager` (no WebView gesture gate), `notifications.ShowAsync(...)` raises a real
+OS notification where a WebView has no `Notification` API at all, and so on. Some backends need platform
+permissions — add `ACCESS_FINE_LOCATION` / `ACCESS_NETWORK_STATE` / `POST_NOTIFICATIONS` (Android) and
+`NSLocationWhenInUseUsageDescription` (iOS), and the head requests the location and notification runtime grants.
 
 The **declarative** `Shareable` still reaches the native share sheet through the **capability bridge**: the
 native client advertises `window.__raskNative.capabilities` and an `invoke(name, data)` that posts a

--- a/samples/Rask.Example.Native/Platforms/Android/AndroidManifest.xml
+++ b/samples/Rask.Example.Native/Platforms/Android/AndroidManifest.xml
@@ -2,10 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 	<uses-permission android:name="android.permission.INTERNET"/>
 	<!-- Native device backends wired by AndroidPlatform: IGeolocation (LocationManager), INetworkInfo
-	     (ConnectivityManager), IVibration (Vibrator). Clipboard and wake-lock need no permission. -->
+	     (ConnectivityManager), IVibration (Vibrator). INotifications AND IBadge (whose count rides a
+	     notification) both need POST_NOTIFICATIONS on API 33+. Clipboard and wake-lock need no permission. -->
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 	<uses-permission android:name="android.permission.VIBRATE"/>
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 	<!-- Native + Server mode loads a local dev server over http (http://10.0.2.2:5080). Cleartext is a
 	     DEVELOPMENT convenience only — a real deployment is https and would not need this. -->
 	<application android:label="Rask Showcase" android:allowBackup="true" android:supportsRtl="true"

--- a/samples/Rask.Example.Native/Platforms/Android/MainActivity.cs
+++ b/samples/Rask.Example.Native/Platforms/Android/MainActivity.cs
@@ -1,4 +1,5 @@
 using Android.App;
+using Android.Content.PM;
 using Android.OS;
 using Android.Webkit;
 using Microsoft.Extensions.DependencyInjection;
@@ -27,6 +28,14 @@ public class MainActivity : Activity
         // Make the WebView inspectable so the Appium on-device E2E can attach to its WEBVIEW context. This
         // is a showcase, not a shipping app; a real app would gate this on Debug (or omit it).
         WebView.SetWebContentsDebuggingEnabled(true);
+
+        // NativeNotifications (wired by AndroidPlatform) needs the POST_NOTIFICATIONS runtime grant on API 33+
+        // — request it up front so a later ShowAsync posts (declared in AndroidManifest.xml).
+        if (OperatingSystem.IsAndroidVersionAtLeast(33) &&
+            CheckSelfPermission(Android.Manifest.Permission.PostNotifications) != Permission.Granted)
+        {
+            RequestPermissions([Android.Manifest.Permission.PostNotifications], 101);
+        }
 
         var webView = new RaskAndroidWebView(this);
         // Use ChromeView (the container with the native header/footer bars) instead of the bare WebView, so the
@@ -74,6 +83,13 @@ public class MainActivity : Activity
 
         _app = await host.RunLocalAsync<NativeShowcaseApp>(webView);
         webView.LoadShell();
+    }
+
+    // Forward runtime-permission results so NativeNotifications' RequestPermissionAsync can await the grant.
+    public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
+    {
+        NativePermissions.OnResult(requestCode, grantResults);
+        base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     protected override void OnDestroy()

--- a/samples/Rask.Example.Shared/Features/Browser/NotificationsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/NotificationsDemo.cs
@@ -1,0 +1,78 @@
+using Rask.Core.Browser;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     <see cref="INotifications" /> + <see cref="IBadge" /> — raise a local notification and set the app-icon
+///     badge from the page. Both work on every host; in the native shell they resolve to real OS backends
+///     (UNUserNotificationCenter / NotificationManager and the native app-icon badge), which a WebView can't do.
+/// </summary>
+public sealed class NotificationsDemo(INotifications notifications, IBadge badge) : Component
+{
+    private string? _status;
+
+    protected override Component? Render() =>
+        BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
+            BsCardBody()[
+                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                    BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "notif-permission",
+                        OnClickAsync: RequestPermission)["Request permission"],
+                    BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "notif-show",
+                        OnClickAsync: Notify)["Notify"],
+                    BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "badge-set",
+                        OnClickAsync: SetBadge)["Set badge 3"],
+                    BsButton(Color: BsColor.Danger, Outline: true, Size: BsSize.Sm, Id: "badge-clear",
+                        OnClickAsync: ClearBadge)["Clear badge"]
+                ],
+                Div(Class: "small text-secondary")["Status: ", Code(Id: "notif-status")[_status ?? "(idle)"]]
+            ]
+        ];
+
+    private async Task RequestPermission()
+    {
+        if (!await notifications.IsSupportedAsync())
+        {
+            _status = "Notifications not supported on this host";
+            return;
+        }
+
+        _status = $"Permission: {await notifications.RequestPermissionAsync()}";
+    }
+
+    private async Task Notify()
+    {
+        if (!await notifications.IsSupportedAsync())
+        {
+            _status = "Notifications not supported on this host";
+            return;
+        }
+
+        // Showing without permission throws (matching the browser), so gate on it and prompt the user first.
+        if (await notifications.PermissionAsync() != NotificationPermission.Granted)
+        {
+            _status = "Grant permission first";
+            return;
+        }
+
+        await notifications.ShowAsync("Rask", new NotificationOptions { Body = "Hello from your Rask app.", Tag = "demo" });
+        _status = "Notification sent";
+    }
+
+    private async Task SetBadge()
+    {
+        if (!await badge.IsSupportedAsync())
+        {
+            _status = "Badge not supported on this host";
+            return;
+        }
+
+        await badge.SetAsync(3);
+        _status = "Badge set to 3";
+    }
+
+    private async Task ClearBadge()
+    {
+        await badge.ClearAsync();
+        _status = "Badge cleared";
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -123,6 +123,7 @@ public static class DemoRegistry
             ["browser-file-system"] = () => CodeSample(["FileSystemAccessDemo.cs"], Result: FileSystemAccessDemo()),
             ["browser-webauthn"] = () => CodeSample(["WebAuthnDemo.cs"], Result: WebAuthnDemo()),
             ["browser-broadcast-channel"] = () => CodeSample(["BroadcastChannelDemo.cs"], Result: BroadcastChannelDemo()),
+            ["browser-notifications"] = () => CodeSample(["NotificationsDemo.cs"], Result: NotificationsDemo()),
             ["browser-share"] = () => CodeSample(
                 ["ShareDemo.cs"],
                 Notes:

--- a/src/Rask.Native/Platforms/Android/AndroidNotifications.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidNotifications.cs
@@ -1,0 +1,47 @@
+using Android.App;
+using Android.Content;
+
+namespace Rask.Native;
+
+// Shared Android NotificationManager plumbing for NativeNotifications + NativeBadge: the version-gated
+// Notification.Builder construction, the system-service lookup, and once-only channel creation, so the two
+// backends don't duplicate it (and channels aren't re-created on every post).
+internal static class AndroidNotifications
+{
+    private static readonly HashSet<string> CreatedChannels = [];
+
+    public static NotificationManager Manager(Activity activity) =>
+        (NotificationManager)activity.GetSystemService(Context.NotificationService)!;
+
+    public static Notification.Builder Builder(Activity activity, string channelId)
+    {
+        if (OperatingSystem.IsAndroidVersionAtLeast(26))
+        {
+            return new Notification.Builder(activity, channelId);
+        }
+
+#pragma warning disable CA1422 // Channel-less ctor is obsoleted on Android 26; only reached on API 24-25.
+        return new Notification.Builder(activity);
+#pragma warning restore CA1422
+    }
+
+    // Channels exist on API 26+ and creating one is idempotent, but guard so we call CreateNotificationChannel
+    // once per id rather than on every notification.
+    public static void EnsureChannel(Activity activity, string id, string name, NotificationImportance importance)
+    {
+        if (!OperatingSystem.IsAndroidVersionAtLeast(26))
+        {
+            return;
+        }
+
+        lock (CreatedChannels)
+        {
+            if (!CreatedChannels.Add(id))
+            {
+                return;
+            }
+        }
+
+        Manager(activity).CreateNotificationChannel(new NotificationChannel(id, name, importance));
+    }
+}

--- a/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
@@ -11,12 +11,13 @@ namespace Rask.Native;
 ///     these native C# backends for the browser/device API interfaces — <c>IShare</c> (ACTION_SEND chooser),
 ///     <c>IGeolocation</c> (LocationManager), <c>IClipboard</c> (ClipboardManager), <c>IVibration</c>
 ///     (Vibrator), <c>IWakeLock</c> (FLAG_KEEP_SCREEN_ON), <c>INetworkInfo</c> (ConnectivityManager),
-///     <c>ISpeechSynthesis</c> (TextToSpeech), <c>IScreenInfo</c> (DisplayMetrics), and
-///     <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (SensorManager) — so injecting any of them resolves the
+///     <c>ISpeechSynthesis</c> (TextToSpeech), <c>IScreenInfo</c> (DisplayMetrics),
+///     <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (SensorManager), <c>INotifications</c>
+///     (NotificationManager), and <c>IBadge</c> (a badge notification) — so injecting any of them resolves the
 ///     native implementation and every other interface falls back to the
 ///     WebView's JS. The app writes one line (<c>host.UsePlatform(new AndroidPlatform(this))</c>) instead of
-///     registering each backend by hand. Geolocation needs <c>ACCESS_FINE_LOCATION</c> and network info needs
-///     <c>ACCESS_NETWORK_STATE</c> in the manifest.
+///     registering each backend by hand. Geolocation needs <c>ACCESS_FINE_LOCATION</c>, network info needs
+///     <c>ACCESS_NETWORK_STATE</c>, and notifications need <c>POST_NOTIFICATIONS</c> (API 33+) in the manifest.
 /// </summary>
 /// <param name="activity">The host <see cref="Activity" /> the backends run against (UI thread, services).</param>
 public sealed class AndroidPlatform(Activity activity) : INativePlatform
@@ -36,5 +37,7 @@ public sealed class AndroidPlatform(Activity activity) : INativePlatform
         services.TryAddSingleton<IScreenInfo>(_ => new NativeScreenInfo(activity));
         services.TryAddSingleton<IDeviceOrientation>(_ => new NativeDeviceOrientation(activity));
         services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion(activity));
+        services.TryAddSingleton<INotifications>(_ => new NativeNotifications(activity));
+        services.TryAddSingleton<IBadge>(_ => new NativeBadge(activity));
     }
 }

--- a/src/Rask.Native/Platforms/Android/NativeBadge.cs
+++ b/src/Rask.Native/Platforms/Android/NativeBadge.cs
@@ -1,0 +1,41 @@
+using Android.App;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IBadge. Android has no universal app-icon badge API; launchers surface a count
+// from an active notification's number (the notification "dot"). Zero-dep approach (no ShortcutBadger): keep a
+// single silent, low-importance badge notification — `SetNumber` for a count, no number for a plain dot;
+// ClearAsync cancels it. The exact dot/count rendering is launcher-dependent. Because the count rides a
+// notification, this needs POST_NOTIFICATIONS on API 33+ (like NativeNotifications). Registered by
+// AndroidPlatform (native-first).
+internal sealed class NativeBadge(Activity activity) : IBadge
+{
+    private const string ChannelId = "rask_badge";
+    private const int BadgeId = 0x7A5C; // "rask" — a stable id so updates replace the badge notification.
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask SetAsync(int? count = null)
+    {
+        AndroidNotifications.EnsureChannel(activity, ChannelId, "App badge", NotificationImportance.Min);
+        var builder = AndroidNotifications.Builder(activity, ChannelId)
+            .SetSmallIcon(Android.Resource.Drawable.IcDialogInfo)!
+            .SetOngoing(true)!;
+
+        // Web Badging semantics: a positive number shows that count; null/0 shows a plain dot (no number).
+        if (count is > 0)
+        {
+            builder.SetNumber(count.Value);
+        }
+
+        AndroidNotifications.Manager(activity).Notify(BadgeId, builder.Build());
+        return default;
+    }
+
+    public ValueTask ClearAsync()
+    {
+        AndroidNotifications.Manager(activity).Cancel(BadgeId);
+        return default;
+    }
+}

--- a/src/Rask.Native/Platforms/Android/NativeNotifications.cs
+++ b/src/Rask.Native/Platforms/Android/NativeNotifications.cs
@@ -1,0 +1,76 @@
+using System.Runtime.Versioning;
+using Android.App;
+using Android.Content.PM;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for INotifications — the platform NotificationManager instead of the WebView's
+// Notification constructor (android.webkit.WebView doesn't support it). Registered by AndroidPlatform; the
+// framework resolves it over the JS default (native-first). Needs POST_NOTIFICATIONS (API 33+) in the manifest
+// + a runtime grant. Icon/Badge URLs and RequireInteraction have no native equivalent here and are ignored;
+// Silent routes to a no-sound channel. Matches the JS default's contract: a denied permission throws.
+internal sealed class NativeNotifications(Activity activity) : INotifications
+{
+    private const string DefaultChannel = "rask_default";
+    private const string SilentChannel = "rask_silent";
+    private const int PostNotificationsRequest = 101;
+    private const int DefaultId = 1;
+    private static int _counter = DefaultId;
+
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask<NotificationPermission> PermissionAsync() => ValueTask.FromResult(CurrentPermission());
+
+    public async ValueTask<NotificationPermission> RequestPermissionAsync()
+    {
+        // Before API 33 notifications need no runtime permission; already-granted needs no prompt.
+        if (!OperatingSystem.IsAndroidVersionAtLeast(33) || CurrentPermission() == NotificationPermission.Granted)
+        {
+            return NotificationPermission.Granted;
+        }
+
+        var granted = await RequestPostNotificationsAsync().ConfigureAwait(false);
+        return granted ? NotificationPermission.Granted : NotificationPermission.Denied;
+    }
+
+    public ValueTask ShowAsync(string title, NotificationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(title);
+        options ??= new NotificationOptions();
+
+        // Mirror the JS default: showing without permission is an error callers try/catch, not a silent no-op.
+        if (CurrentPermission() != NotificationPermission.Granted)
+        {
+            throw new InvalidOperationException("Notification permission not granted.");
+        }
+
+        var silent = options.Silent == true;
+        var channelId = silent ? SilentChannel : DefaultChannel;
+        AndroidNotifications.EnsureChannel(activity, channelId, silent ? "Silent" : "Notifications",
+            silent ? NotificationImportance.Low : NotificationImportance.Default);
+
+        var notification = AndroidNotifications.Builder(activity, channelId)
+            .SetContentTitle(title)!
+            .SetContentText(options.Body)!
+            .SetSmallIcon(Android.Resource.Drawable.IcDialogInfo)!
+            .SetAutoCancel(true)!
+            .Build();
+
+        // Web semantics: a same-Tag notification replaces the previous one — key the id off the tag. No tag →
+        // a fresh id each time so every notification shows.
+        var id = string.IsNullOrEmpty(options.Tag) ? Interlocked.Increment(ref _counter) : DefaultId;
+        AndroidNotifications.Manager(activity).Notify(options.Tag, id, notification);
+        return default;
+    }
+
+    private NotificationPermission CurrentPermission() =>
+        !OperatingSystem.IsAndroidVersionAtLeast(33)
+        || activity.CheckSelfPermission(Android.Manifest.Permission.PostNotifications) == Permission.Granted
+            ? NotificationPermission.Granted
+            : NotificationPermission.Default;
+
+    [SupportedOSPlatform("android33.0")]
+    private Task<bool> RequestPostNotificationsAsync() =>
+        NativePermissions.RequestAsync(activity, Android.Manifest.Permission.PostNotifications, PostNotificationsRequest);
+}

--- a/src/Rask.Native/Platforms/Android/NativePermissions.cs
+++ b/src/Rask.Native/Platforms/Android/NativePermissions.cs
@@ -1,0 +1,73 @@
+using Android.App;
+using Android.Content.PM;
+
+namespace Rask.Native;
+
+/// <summary>
+///     Bridges an Android runtime-permission request to an awaitable result. A native backend (e.g.
+///     <c>NativeNotifications</c>) registers a request code via <see cref="RequestAsync" />, fires
+///     <c>Activity.RequestPermissions</c>, and awaits; the host <see cref="Activity" /> forwards its
+///     <c>OnRequestPermissionsResult</c> to <see cref="OnResult" />, which completes the awaiter. The wait is
+///     bounded by a timeout so a head that forgets to forward can't hang the caller forever (it then reports
+///     the current, un-updated status).
+/// </summary>
+/// <remarks>
+///     The host activity must forward results for the await to resolve:
+///     <code>
+///     public override void OnRequestPermissionsResult(int rc, string[] p, Permission[] r)
+///     {
+///         NativePermissions.OnResult(rc, r);
+///         base.OnRequestPermissionsResult(rc, p, r);
+///     }
+///     </code>
+/// </remarks>
+public static class NativePermissions
+{
+    private static readonly Lock Gate = new();
+    private static readonly Dictionary<int, TaskCompletionSource<bool>> Pending = [];
+
+    /// <summary>
+    ///     Requests <paramref name="permission" /> from <paramref name="activity" /> under
+    ///     <paramref name="requestCode" /> and completes with the user's decision once the activity forwards
+    ///     the result to <see cref="OnResult" /> (or <c>false</c> if the bounded wait elapses first).
+    /// </summary>
+    public static async Task<bool> RequestAsync(Activity activity, string permission, int requestCode)
+    {
+        ArgumentNullException.ThrowIfNull(activity);
+        var tcs = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+        lock (Gate)
+        {
+            Pending[requestCode] = tcs;
+        }
+
+        try
+        {
+            activity.RunOnUiThread(() => activity.RequestPermissions([permission], requestCode));
+            var winner = await Task.WhenAny(tcs.Task, Task.Delay(TimeSpan.FromSeconds(60))).ConfigureAwait(false);
+            return winner == tcs.Task && tcs.Task.Result;
+        }
+        finally
+        {
+            lock (Gate)
+            {
+                Pending.Remove(requestCode);
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Completes the awaiter registered for <paramref name="requestCode" /> with the granted state. Call
+    ///     this from the host activity's <c>OnRequestPermissionsResult</c>.
+    /// </summary>
+    public static void OnResult(int requestCode, Permission[] grantResults)
+    {
+        ArgumentNullException.ThrowIfNull(grantResults);
+        TaskCompletionSource<bool>? tcs;
+        lock (Gate)
+        {
+            Pending.TryGetValue(requestCode, out tcs);
+        }
+
+        tcs?.TrySetResult(grantResults.Length > 0 && grantResults[0] == Permission.Granted);
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
+++ b/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
@@ -11,7 +11,8 @@ namespace Rask.Native;
 ///     native C# backends for the browser/device API interfaces — <c>IShare</c> (system share sheet),
 ///     <c>IGeolocation</c> (CoreLocation), <c>IClipboard</c> (UIPasteboard), <c>IVibration</c>,
 ///     <c>IWakeLock</c>, <c>INetworkInfo</c> (NWPathMonitor), <c>ISpeechSynthesis</c> (AVSpeechSynthesizer),
-///     <c>IScreenInfo</c> (UIScreen), and <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (CoreMotion) — so
+///     <c>IScreenInfo</c> (UIScreen), <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (CoreMotion),
+///     <c>INotifications</c> (UNUserNotificationCenter), and <c>IBadge</c> (the app-icon badge) — so
 ///     injecting any of them resolves the native implementation, and every other interface falls back to the
 ///     WebView's JS. The app writes one line
 ///     (<c>host.UsePlatform(new ApplePlatform(() =&gt; Window?.RootViewController))</c>) instead of
@@ -39,5 +40,7 @@ public sealed class ApplePlatform(Func<UIViewController?> presenter) : INativePl
         services.TryAddSingleton<IScreenInfo>(_ => new NativeScreenInfo());
         services.TryAddSingleton<IDeviceOrientation>(_ => new NativeDeviceOrientation());
         services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion());
+        services.TryAddSingleton<INotifications>(_ => new NativeNotifications());
+        services.TryAddSingleton<IBadge>(_ => new NativeBadge());
     }
 }

--- a/src/Rask.Native/Platforms/iOS/NativeBadge.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeBadge.cs
@@ -1,0 +1,36 @@
+using Rask.Core.Browser;
+using UIKit;
+using UserNotifications;
+
+namespace Rask.Native;
+
+// Native iOS backend for IBadge — the real app-icon badge, instead of navigator.setAppBadge (which targets an
+// installed PWA and never touches a native app's icon). Registered by ApplePlatform; native-first over the JS
+// default. iOS badges are numeric only — there is no numberless "dot", so the web's dot (SetAsync(null)/0)
+// can't be shown and maps to no badge (0); a positive count shows that number.
+internal sealed class NativeBadge : IBadge
+{
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public ValueTask SetAsync(int? count = null) => Apply(count ?? 0);
+
+    public ValueTask ClearAsync() => Apply(0);
+
+    private static ValueTask Apply(int count)
+    {
+        if (OperatingSystem.IsIOSVersionAtLeast(16))
+        {
+            // iOS 16+ API; callable off the main thread, ignore the completion.
+            UNUserNotificationCenter.Current.SetBadgeCount(count, completionHandler: null);
+            return default;
+        }
+
+        // iOS 15 fallback: ApplicationIconBadgeNumber (obsoleted in iOS 17, hence the scoped suppression;
+        // only reached on iOS 15, where SetBadgeCount doesn't exist). Setter requires the main thread.
+        UIApplication.SharedApplication.InvokeOnMainThread(() =>
+#pragma warning disable CA1422 // Deprecated on iOS 17; guarded to the iOS 15 path above.
+            UIApplication.SharedApplication.ApplicationIconBadgeNumber = count);
+#pragma warning restore CA1422
+        return default;
+    }
+}

--- a/src/Rask.Native/Platforms/iOS/NativeNotifications.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeNotifications.cs
@@ -1,0 +1,67 @@
+using Foundation;
+using Rask.Core.Browser;
+using UserNotifications;
+
+namespace Rask.Native;
+
+// Native iOS backend for INotifications — the OS notification centre (UNUserNotificationCenter) instead of
+// the WebView's Notification constructor, which WKWebView doesn't expose at all. Registered by ApplePlatform;
+// the framework resolves it over the JS-backed default (native-first). ShowAsync posts a local notification
+// for immediate delivery; permission is the real iOS authorization prompt.
+internal sealed class NativeNotifications : INotifications
+{
+    public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+    public async ValueTask<NotificationPermission> PermissionAsync()
+    {
+        var settings = await UNUserNotificationCenter.Current.GetNotificationSettingsAsync().ConfigureAwait(false);
+        return Map(settings.AuthorizationStatus);
+    }
+
+    public async ValueTask<NotificationPermission> RequestPermissionAsync()
+    {
+        // Alert|Sound|Badge mirrors the web default (a visible, audible notification that can also badge).
+        await UNUserNotificationCenter.Current
+            .RequestAuthorizationAsync(UNAuthorizationOptions.Alert | UNAuthorizationOptions.Sound |
+                                       UNAuthorizationOptions.Badge)
+            .ConfigureAwait(false);
+        // Re-read for the definitive status (the request tuple only reports the Alert grant).
+        return await PermissionAsync().ConfigureAwait(false);
+    }
+
+    public async ValueTask ShowAsync(string title, NotificationOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(title);
+        options ??= new NotificationOptions();
+
+        // Mirror the JS default: showing without permission is an error callers try/catch, not a silent no-op.
+        if (await PermissionAsync().ConfigureAwait(false) != NotificationPermission.Granted)
+        {
+            throw new InvalidOperationException("Notification permission not granted.");
+        }
+
+        var content = new UNMutableNotificationContent { Title = title };
+        if (!string.IsNullOrEmpty(options.Body))
+        {
+            content.Body = options.Body;
+        }
+
+        // Silent suppresses sound (iOS has no per-notification vibration toggle); otherwise the default sound.
+        content.Sound = options.Silent == true ? null : UNNotificationSound.Default;
+
+        // Web semantics: a new notification with the same Tag replaces the previous one — map Tag to the
+        // request identifier (iOS coalesces same-identifier requests). No Tag → a unique id so each shows.
+        var id = string.IsNullOrEmpty(options.Tag) ? Guid.NewGuid().ToString("N") : options.Tag;
+        // trigger: null delivers immediately.
+        var request = UNNotificationRequest.FromIdentifier(id, content, trigger: null);
+        await UNUserNotificationCenter.Current.AddNotificationRequestAsync(request).ConfigureAwait(false);
+    }
+
+    private static NotificationPermission Map(UNAuthorizationStatus status) => status switch
+    {
+        UNAuthorizationStatus.Authorized or UNAuthorizationStatus.Provisional or UNAuthorizationStatus.Ephemeral
+            => NotificationPermission.Granted,
+        UNAuthorizationStatus.Denied => NotificationPermission.Denied,
+        _ => NotificationPermission.Default
+    };
+}

--- a/src/Rask.Templates/content/rask-native/AGENTS.md
+++ b/src/Rask.Templates/content/rask-native/AGENTS.md
@@ -35,10 +35,13 @@ https://github.com/pal-tamas/rask/tree/main/docs — native specifics: docs/nati
   inject `IShare` (`Rask.Client.Browser`) to share from code. Both hit the OS share sheet.
 - **Native backends** override a JS default with real platform code. The head registers one on
   `host.Services` **before `RunLocalAsync`** (last-wins). The template ships `NativeShare` for `IShare`
-  (iOS `UIActivityViewController`, Android `Intent.ACTION_SEND`) and `NativeGeolocation` for `IGeolocation`
-  (iOS `CLLocationManager`, Android `LocationManager`) under `Platforms/`; register your own the same way.
-  Geolocation needs the location permission (already in `AndroidManifest.xml` / `Info.plist`; `MainActivity`
-  requests the runtime grant). Further native backends (biometrics, push) are a framework work-in-progress.
+  (iOS `UIActivityViewController`, Android `Intent.ACTION_SEND`), `NativeGeolocation` for `IGeolocation`
+  (iOS `CLLocationManager`, Android `LocationManager`), and `NativeNotifications` / `NativeBadge` for
+  `INotifications` / `IBadge` (iOS `UNUserNotificationCenter`, Android `NotificationManager` + a badge
+  notification) under `Platforms/`; register your own the same way. Geolocation needs the location
+  permission and notifications need `POST_NOTIFICATIONS` on Android 33+ (both already in
+  `AndroidManifest.xml` / `Info.plist`; `MainActivity` requests the runtime grants). Further native
+  backends (biometrics, push) are a framework work-in-progress.
 
 ## Native header & footer bars
 - A native page is a small **composed tree**: the native bars (`NativeHeaderBar` / `NativeTabBar` /

--- a/src/Rask.Templates/content/rask-native/Platforms/Android/AndroidManifest.xml
+++ b/src/Rask.Templates/content/rask-native/Platforms/Android/AndroidManifest.xml
@@ -4,6 +4,8 @@
 	<!--#if (IsLocal) -->
 	<!-- Required by NativeGeolocation (the IGeolocation backend). Remove if you don't use native location. -->
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+	<!-- Required by NativeNotifications (the INotifications backend) on API 33+. Remove if unused. -->
+	<uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 	<!--#endif -->
 	<application android:label="Rask App" android:allowBackup="true" android:supportsRtl="true"/>
 </manifest>

--- a/src/Rask.Templates/content/rask-native/Platforms/Android/MainActivity.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/Android/MainActivity.cs
@@ -26,6 +26,14 @@ public class MainActivity : Activity
             RequestPermissions([Android.Manifest.Permission.AccessFineLocation], 100);
         }
 
+        // NativeNotifications (registered below) needs the POST_NOTIFICATIONS runtime grant on API 33+ —
+        // request it up front so a later ShowAsync posts (declare POST_NOTIFICATIONS in AndroidManifest.xml).
+        if (OperatingSystem.IsAndroidVersionAtLeast(33) &&
+            CheckSelfPermission(Android.Manifest.Permission.PostNotifications) != Permission.Granted)
+        {
+            RequestPermissions([Android.Manifest.Permission.PostNotifications], 101);
+        }
+
         _webView = new RaskAndroidWebView(this);
         // Host ChromeView (the container that lays the native header/footer bars around the WebView) rather
         // than the bare WebView, so the App's composed NativeHeaderBar/NativeTabBar become real top/bottom bars.
@@ -46,10 +54,19 @@ public class MainActivity : Activity
         // docs/native.md "Native device backends".
         host.Services.AddSingleton<IShare>(_ => new NativeShare(this));                  // OS share sheet
         host.Services.AddSingleton<IGeolocation>(_ => new NativeGeolocation(this));       // LocationManager
+        host.Services.AddSingleton<INotifications>(_ => new NativeNotifications(this));   // NotificationManager
+        host.Services.AddSingleton<IBadge>(_ => new NativeBadge(this));                   // app badge notification
         host.Services.AddSingleton<INativeChrome>(webView);                              // native header/footer bars
         // host.Services.AddSingleton<IMyService, MyService>();   // register app services here
         _app = await host.RunLocalAsync<App>(webView);
         webView.LoadShell();
+    }
+
+    // Forward runtime-permission results so NativeNotifications' RequestPermissionAsync can await the grant.
+    public override void OnRequestPermissionsResult(int requestCode, string[] permissions, Permission[] grantResults)
+    {
+        NativePermissions.OnResult(requestCode, grantResults);
+        base.OnRequestPermissionsResult(requestCode, permissions, grantResults);
     }
 
     protected override void OnDestroy()

--- a/src/Rask.Templates/content/rask-native/Platforms/iOS/AppDelegate.cs
+++ b/src/Rask.Templates/content/rask-native/Platforms/iOS/AppDelegate.cs
@@ -39,6 +39,8 @@ public class AppDelegate : UIApplicationDelegate
         // docs/native.md "Native device backends".
         host.Services.AddSingleton<IShare>(_ => new NativeShare(() => Window?.RootViewController));  // share sheet
         host.Services.AddSingleton<IGeolocation>(_ => new NativeGeolocation());                     // CoreLocation
+        host.Services.AddSingleton<INotifications>(_ => new NativeNotifications());                 // UNUserNotificationCenter
+        host.Services.AddSingleton<IBadge>(_ => new NativeBadge());                                 // app-icon badge
         host.Services.AddSingleton<INativeChrome>(webView);                                         // native header/footer bars
         // host.Services.AddSingleton<IMyService, MyService>();   // register app services here
         _app = await host.RunLocalAsync<App>(webView);

--- a/tests/Rask.Example.Shared.Tests/Demos/NotificationsDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/NotificationsDemoTests.cs
@@ -1,0 +1,59 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Browser;
+using Rask.Example.Shared.Features;
+
+#pragma warning disable RASK014 // test renders the demo component directly as a root
+
+namespace Rask.Example.Shared.Tests.Demos;
+
+// The Notifications + Badge showcase: it injects INotifications/IBadge and renders a button row that drives
+// them. Assert the demo mounts its live buttons (the OS notification/badge behaviour is device-specific and
+// covered by the native backends, not here) so a regression in the wiring is caught without an E2E.
+public sealed class NotificationsDemoTests
+{
+    [Fact]
+    public void Render_MountsPermissionNotifyAndBadgeButtons_Idle()
+    {
+        var html = Render();
+
+        Assert.Contains("id=\"notif-permission\"", html);
+        Assert.Contains("id=\"notif-show\"", html);
+        Assert.Contains("id=\"badge-set\"", html);
+        Assert.Contains("id=\"badge-clear\"", html);
+        // Starts idle until a button runs.
+        Assert.Contains("(idle)", html);
+    }
+
+    private static string Render()
+    {
+        INotifications notifications = new FakeNotifications();
+        IBadge badge = new FakeBadge();
+        var sp = new ServiceCollection()
+            .AddSingleton(notifications)
+            .AddSingleton(badge)
+            .BuildServiceProvider();
+        return new NotificationsDemo(notifications, badge).RenderAsLiveRoot(sp);
+    }
+
+    private sealed class FakeNotifications : INotifications
+    {
+        public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+        public ValueTask<NotificationPermission> PermissionAsync() =>
+            ValueTask.FromResult(NotificationPermission.Default);
+
+        public ValueTask<NotificationPermission> RequestPermissionAsync() =>
+            ValueTask.FromResult(NotificationPermission.Granted);
+
+        public ValueTask ShowAsync(string title, NotificationOptions? options = null) => default;
+    }
+
+    private sealed class FakeBadge : IBadge
+    {
+        public ValueTask<bool> IsSupportedAsync() => ValueTask.FromResult(true);
+
+        public ValueTask SetAsync(int? count = null) => default;
+
+        public ValueTask ClearAsync() => default;
+    }
+}


### PR DESCRIPTION
## Summary

Adds native iOS/Android backends for `INotifications` and `IBadge` — two APIs a WebView fundamentally
can't deliver (`WKWebView` has no `Notification` constructor; `navigator.setAppBadge` never touches a
native app's icon). `ApplePlatform` / `AndroidPlatform` now also wire `INotifications` →
`UNUserNotificationCenter` / `NotificationManager` and `IBadge` → `UNUserNotificationCenter.SetBadgeCount`
/ a silent badge notification, resolved native-first through the same `TryAddSingleton` seam as the
existing ten backends. Injecting the ordinary interface raises a real OS notification / app-icon badge on
device; permission is the real OS prompt. The backends match the browser contract: showing without
permission throws (like the JS default), `SetAsync(null)`/`SetAsync(0)` shows a dot (Android) rather than
clearing, and Android's `RequestPermissionAsync` awaits the actual grant (via a small
`OnRequestPermissionsResult` bridge wired into the sample/template activities). A co-mounted
**Notifications + Badge** showcase demo exercises both.

Android 33+ needs `POST_NOTIFICATIONS` (declared in the sample/template manifests and requested up front
by the activity); the Android badge rides a notification, so it needs the same permission. No `Rask.Core`
/ generator / render-path changes — purely additive device backends + docs + sample.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — pass (incl. new
  `NotificationsDemoTests` render check and `GuideEmbeddingTests` confirming the new
  `demo:browser-notifications` marker resolves to a registered demo).
- Platform heads: `dotnet build src/Rask.Native/Rask.Native.csproj -p:RaskNativeHeads=true` for
  **net10.0-ios** and **net10.0-android** — clean with `-warnaserror` (this is where the platform
  backends compile: `SetBadgeCount` iOS-16 guard + iOS-15 fallback, `[SupportedOSPlatform("android33.0")]`
  permission helper, version-gated `Notification.Builder`).
- Android sample (`Rask.Example.Native`) — compiles clean with the new activity override.
- E2E: the demo renders through the guide-embedding machinery (already E2E-covered by the shared
  journey's `TestGuidesAsync`); a bespoke Appium/Playwright step was deliberately skipped — the OS
  notification/badge outcome is device-specific and can only assert "no crash" headless, so the
  deterministic unit render test covers the wiring instead.

## Benchmarks
n/a — device backends only, no render/runtime hot-path change.

## CHANGELOG
- [Unreleased] entry added: "Native `INotifications` + `IBadge` backends — real OS notifications and
  app-icon badges on device."
