### PR TITLE
feat(forms): form-control accessibility, attribute passthrough, tests & docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ them until tagged releases begin.
   `nginx:alpine` with a bundled `nginx.conf` (SPA fallback, `application/wasm` MIME, `gzip_static`).
   New `docs/deployment.md` covers containerizing each template (TLS-at-proxy, WebSocket upgrade,
   sub-paths) and why `rask-native` (a mobile app) isn't containerized.
+- **Full HTML-attribute passthrough on the Bootstrap `BsInput`/`BsTextarea`.** `BsInput` now forwards
+  `Min`/`Max`/`Step`/`Pattern`/`MaxLength`/`MinLength`/`List`/`Autofocus` (constraints & affordances),
+  `Accept`/`Capture`/`Multiple` (file inputs), and `InputMode`/`EnterKeyHint`/`Spellcheck` (mobile-keyboard
+  & a11y hints) to the core `Input`; `BsTextarea` forwards `Cols`/`MaxLength`/`MinLength`/`Autocomplete`/
+  `Autofocus`. Previously a Bootstrap number/date/range/file field could not set any of these. (The HTML
+  `size` attribute stays unexposed on `BsInput` — the base `Size` is Bootstrap control sizing.)
+- **New mobile / accessibility attributes on the core `Input`.** `InputMode` (on-screen keyboard),
+  `EnterKeyHint` (action-key label), `Spellcheck` (the enumerated `spellcheck="true|false"`), `Capture`
+  (camera/mic for file inputs), and `Dirname` (submit text direction) join the `<input>` surface.
 - **Gesture bridge — activation-gated browser APIs on the Server host.** New headless `GestureTrigger`
   and six typed wrappers generalise `Shareable`'s trick: they hand your element a `data-rask-gesture`
   bundle and the shared client runs the capability **inside the click gesture**, so the browser's transient

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,13 @@ them until tagged releases begin.
   `aria-describedby` (with `aria-invalid` on each) — matching the `BsFormControl` field contract.
 
 ### Documentation
+- **Forms guide: full input-type set, file inputs, and the new form-control surface.**
+  [`docs/forms.md`](docs/forms.md) now enumerates every `InputType` (and flags the string-only family
+  as [RASK025](docs/diagnostics.md#rask025)), documents file inputs (`OnFiles`/`Accept`/`Capture`/
+  `Multiple`) with a cross-link to [http-and-files.md](docs/http-and-files.md), and lists the mobile/a11y
+  input attributes. [`docs/bootstrap-forms.md`](docs/bootstrap-forms.md) documents the `BsInput`/
+  `BsTextarea` attribute passthrough and the accessible-group `Label`. The `FormControls` radio/checkbox
+  samples showcase the named-group `<fieldset>`/`<legend>`.
 - **Browser/device API capability matrix + per-API reference pages.** New
   [`docs/browser-capabilities.md`](docs/browser-capabilities.md) is a single table of all 43 wrappers
   showing where each works (Web / PWA / Native) and which have a native iOS/Android backend, linking to a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,17 @@ them until tagged releases begin.
   version — a fallback version otherwise breaks the routes registry's cross-assembly load at startup. No
   gate changed — same tests, filters, warnings-as-errors build, and byte-regression benchmark gate.
 
+### Fixed
+- **Accessible names + validation semantics for the Bootstrap group/combobox form controls.** `BsSelect`
+  (custom combobox) and `BsMultiSelect` named their visible label with a `<label for>` pointing at a
+  `<div role="combobox">` — void, since a div is not a labelable element — so the control had no accessible
+  name; both now associate the label via `aria-labelledby`, and `BsMultiSelect` gained the
+  `aria-haspopup`/`aria-expanded`/`aria-controls` (+ `aria-invalid`/`aria-describedby`) contract `BsSelect`
+  already had. `BsRadioGroup`/`BsCheckboxGroup` gained an optional `Label` that wraps the options in a
+  `<fieldset>` named by a `<legend>` (the correct group semantics + accessible name), and their invalid
+  feedback is now a `role="alert"` live region carrying an id the option inputs reference via
+  `aria-describedby` (with `aria-invalid` on each) — matching the `BsFormControl` field contract.
+
 ### Documentation
 - **Browser/device API capability matrix + per-API reference pages.** New
   [`docs/browser-capabilities.md`](docs/browser-capabilities.md) is a single table of all 43 wrappers

--- a/docs/bootstrap-forms.md
+++ b/docs/bootstrap-forms.md
@@ -12,11 +12,40 @@ The data-driven comboboxes and the date/time controls have their own pages:
 ```csharp
 BsInput(() => model.Email, Label: "Email", Type: InputType.Email)   // .is-invalid + .invalid-feedback built in
 BsCheck(() => model.AcceptTerms, Label: "I accept the terms")
-BsRadioGroup(() => model.Plan, options)
+BsRadioGroup(() => model.Plan, options, Label: "Plan")              // <fieldset>/<legend> group
 ```
 
 `BsFormGroup`, `BsFormLabel` and `BsInputGroup`(+`BsInputGroupText`) compose labels, help text and
 input add-ons around any control.
+
+## Attribute passthrough
+
+`BsInput` forwards the full constraint / affordance surface of the core `Input` to the underlying
+`<input>`, so a Bootstrap number, date, range, or file field is fully configurable:
+
+```csharp
+BsInput(() => model.Age, Label: "Age", Min: "0", Max: "120", Step: "1")
+BsInput(() => model.Code, Label: "Code", Pattern: "[A-Z]{3}", MaxLength: 3, InputMode: "text")
+BsInput(Type: InputType.File, Label: "Avatar", Accept: "image/*", Capture: "user", Multiple: true,
+        OnFilesAsync: SaveAsync)
+```
+
+- **Constraints & affordances**: `Min`, `Max`, `Step`, `Pattern`, `MaxLength`, `MinLength`, `List`
+  (datalist), `Autofocus`, `Autocomplete`.
+- **File inputs**: `Accept`, `Capture`, `Multiple`.
+- **Mobile / a11y hints**: `InputMode` (on-screen keyboard), `EnterKeyHint` (action-key label),
+  `Spellcheck`.
+- The HTML `size` attribute is intentionally *not* surfaced — `Size` on the Bootstrap controls is
+  Bootstrap's control sizing (`form-control-sm` / `-lg`).
+
+`BsTextarea` likewise forwards `Cols`, `MaxLength`, `MinLength`, `Autocomplete`, and `Autofocus`.
+
+## Accessible groups
+
+`BsRadioGroup`/`BsCheckboxGroup` take an optional `Label:` that names the group: the options are
+wrapped in a `<fieldset>` titled by a `<legend>` (the correct grouping semantics + accessible name),
+their `.invalid-feedback` is a `role="alert"` region, and each option carries `aria-invalid` +
+`aria-describedby` when the field is invalid. Omit `Label` to keep the bare per-item fragment.
 
 ## Live example
 

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -38,9 +38,35 @@ derives everything from the bound property:
 - **Input type** ← the property's CLR type (`BindingHelpers.DefaultInputType`):
   `bool → checkbox`, every numeric primitive `→ number`, `DateOnly → date`,
   `DateTime`/`DateTimeOffset` `→ datetime-local`, `TimeOnly`/`TimeSpan` `→ time`, everything else
-  `→ text`. Override with `Type:` (an `InputType` enum value — `InputType.Email`, `InputType.Password`, …).
+  `→ text`. Override with `Type:` — an `InputType` enum value. The full set is
+  `Text`, `Search`, `Tel`, `Url`, `Email`, `Password`, `Number`, `Checkbox`, `Radio`, `File`, `Range`,
+  `Color`, `Date`, `DatetimeLocal` (renders `datetime-local`), `Time`, `Week`, `Month`, `Hidden`,
+  `Button`, `Submit`, `Reset`, `Image`. The *string-only* family (`Text`/`Search`/`Tel`/`Url`/`Email`/
+  `Password`) only makes sense on an `Input<string>`; setting one on a non-string bound input is
+  [RASK025](diagnostics.md#rask025).
 - **Update timing** — `string` fields update on every keystroke (`OnInput`); every other type
   updates on `OnChange` (blur). `Textarea(Bind: …)` always streams on `OnInput`.
+
+Beyond the constraint/affordance attributes shared with plain HTML (`Min`/`Max`/`Step`/`Pattern`/
+`MaxLength`/`MinLength`/`Multiple`/`Accept`/`List`/`Autocomplete`/`Autofocus`), the core `Input` also
+carries the mobile & accessibility hints `InputMode` (on-screen keyboard), `EnterKeyHint` (action-key
+label), `Spellcheck` (the enumerated `spellcheck="true|false"`), `Capture` (camera/mic for a file
+input), and `Dirname`. The Bootstrap `BsInput`/`BsTextarea` forward all of these (see
+[bootstrap-forms.md](bootstrap-forms.md)).
+
+### File inputs
+
+`InputType.File` turns an `<input>` into a file picker. Instead of binding a value, hand it an
+`OnFiles` (or `OnFilesAsync`) callback that receives the selected `RaskFile`s (`Name`/`Size`/
+`ContentType`/`OpenReadStream()`), and constrain the picker with `Accept`, `Multiple`, and `Capture`:
+
+```csharp
+Input(Type: InputType.File, Accept: "image/*", Multiple: true,
+      OnFilesAsync: async files => { foreach (var f in files) await Save(f); })
+```
+
+Uploading the bytes (streaming to a server endpoint, size limits, progress) is covered end-to-end in
+[http-and-files.md](http-and-files.md).
 
 ```csharp
 Input(Bind: () => _model.Subscribe)   // bool     → checkbox
@@ -188,12 +214,19 @@ floating-label markup with the label derived from the bound property, and surfac
 
 ### Accessible validation
 
-The `Rask.Bootstrap` controls (`BsInput`, `BsTextarea`, `BsSelect`, `BsCheck`) expose validation to
-assistive tech automatically — no extra props. When a bound field has messages, the control renders
-`aria-invalid="true"`, an `aria-describedby` that points at the error message's `id` (and the help-text
-`id` when `HelpText:` is set), and the `.invalid-feedback` as a `role="alert"` live region so screen
-readers announce the error the moment it appears, associated with the field rather than detached from
-it. Valid fields with `HelpText:` still get `aria-describedby` to the help text.
+The `Rask.Bootstrap` controls (`BsInput`, `BsTextarea`, `BsSelect`, `BsCheck`, `BsMultiSelect`,
+`BsRadioGroup`, `BsCheckboxGroup`) expose validation to assistive tech automatically — no extra props.
+When a bound field has messages, the control renders `aria-invalid="true"`, an `aria-describedby` that
+points at the error message's `id` (and the help-text `id` when `HelpText:` is set), and the
+`.invalid-feedback` as a `role="alert"` live region so screen readers announce the error the moment it
+appears, associated with the field rather than detached from it. Valid fields with `HelpText:` still get
+`aria-describedby` to the help text.
+
+The combobox controls (`BsSelect`'s custom dropdown, `BsMultiSelect`) are a `<div role="combobox">`,
+which is not a labelable element — so their visible label is tied to them with `aria-labelledby` (not a
+void `<label for>`), alongside the `aria-haspopup`/`aria-expanded`/`aria-controls` popup contract. Give
+`BsRadioGroup`/`BsCheckboxGroup` a `Label:` and the options are wrapped in a `<fieldset>` named by a
+`<legend>` — the correct grouping semantics and accessible name for a set of related radios/checkboxes.
 
 If you build your own control from the core `Input`/`ValidationMessage` primitives (§9), mirror the same
 three attributes so the field stays accessible: `aria-invalid` on the control, `aria-describedby` from
@@ -514,6 +547,11 @@ CheckboxGroup<string>(interests, Value: _interests, OnChange: next => _interests
   [check markup](https://getbootstrap.com/docs/5.3/forms/checks-radios/) — a
   `<div class="form-check">` wrapping a `.form-check-input` and a `.form-check-label` tied together by
   `id`/`for`. `ItemClass` adds extra classes (e.g. `"form-check-inline"`); `OptionLabel` customizes the label.
+- On the `Rask.Bootstrap` `BsRadioGroup`/`BsCheckboxGroup`, pass `Label:` to give the group an accessible
+  name: the options are then wrapped in a `<fieldset>` titled by a `<legend>`, which is the correct
+  grouping semantics for a set of related radios/checkboxes. Without a `Label` you get the bare per-item
+  fragment (so you can supply your own `<fieldset>`/heading). An unnamed control derives a page-unique
+  fallback `name`, so two on one page are never merged into a single browser radio group.
 - They are **Components** (their own re-render boundary), so a toggle re-renders the control itself; for
   host-side derived UI (a live summary) use **controlled** mode — the auto-wrapped `OnChange` re-renders
   the host. (In bound mode, feedback lives inside the control via the embedded `ValidationMessage`.)

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsCheckboxDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsCheckboxDemo.cs
@@ -28,8 +28,10 @@ public sealed class FormControlsCheckboxDemo : Component
             Div(Class: "col-md-6", Id: "fc-checkbox-bound")[
                 Label(Class: "form-label fw-semibold d-block")["Bound (two-way)"],
                 Form(_model)[
+                    // Label: names the group — the options render inside a <fieldset>/<legend> for the
+                    // correct accessible grouping semantics.
                     BsCheckboxGroup(() => _model.Interests, AllInterests, Name: "fc-checkbox-b",
-                        ItemClass: "form-check-inline")
+                        Label: "Interests", ItemClass: "form-check-inline")
                 ],
                 P(Class: "small text-secondary mb-0", Id: "fc-checkbox-bound-out")[
                     "Interests: ",

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsRadioDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsRadioDemo.cs
@@ -28,7 +28,10 @@ public sealed class FormControlsRadioDemo : Component
             Div(Class: "col-md-6", Id: "fc-radio-bound")[
                 Label(Class: "form-label fw-semibold d-block")["Bound (two-way)"],
                 Form(_model)[
-                    BsRadioGroup(() => _model.Plan, AllPlans, Name: "fc-radio-b", ItemClass: "form-check-inline")
+                    // Label: names the group — the options render inside a <fieldset>/<legend> for the
+                    // correct accessible grouping semantics.
+                    BsRadioGroup(() => _model.Plan, AllPlans, Name: "fc-radio-b", Label: "Plan",
+                        ItemClass: "form-check-inline")
                 ],
                 P(Class: "small text-secondary mb-0", Id: "fc-radio-bound-out")[
                     "Plan: ", Strong()[_model.Plan.ToString()]

--- a/src/Rask.Bootstrap/BsCheckboxGroup.cs
+++ b/src/Rask.Bootstrap/BsCheckboxGroup.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using Rask.Core.Forms;
 
@@ -33,6 +34,10 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
     public string? ItemClass { get; set; }
     public bool? Disabled { get; set; }
 
+    // Unique suffix for the auto-generated group name of an UNNAMED group, so two id-less controlled
+    // checkbox groups on one page don't both fall back to name="checkbox-group" and collide their ids.
+    private readonly int _instanceId = BsInstanceId.Next();
+
     protected override Component? Render()
     {
         ArgumentNullException.ThrowIfNull(Options);
@@ -63,7 +68,8 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
         }
 
         var disabled = Disabled == true;
-        var groupName = Name ?? acc?.PropertyName ?? "checkbox-group";
+        var groupName = Name ?? acc?.PropertyName
+            ?? "checkbox-group-" + _instanceId.ToString(CultureInfo.InvariantCulture);
         var wrapperClass = BsClass.Join("form-check", ItemClass);
 
         // Reading GetValidationMessages here latches the render-cache opt-out (see BsFormControl) so the group
@@ -72,9 +78,7 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
         IReadOnlyList<string> messages = bound && ctx is not null ? ctx.GetValidationMessages(fid) : [];
         var invalid = messages.Count > 0;
         var errorId = invalid ? groupName + "-error" : null;
-        var optionAria = invalid
-            ? new Dictionary<string, string?> { ["invalid"] = "true", ["describedby"] = errorId }
-            : null;
+        var optionAria = BsClass.FieldAria(invalid, errorId);
 
         var children = new List<Component>();
         var index = 0;
@@ -107,7 +111,9 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
         {
             var content = new List<Component> { Legend(Class: "form-label fs-6")[Label] };
             content.AddRange(children);
-            return Fieldset(Disabled: Disabled, Class: "border-0 p-0 m-0")[content];
+            // Disabled is NOT set on the fieldset: a disabled fieldset disables ALL descendants, which would
+            // also disable interactive content in a rich OptionLabel. The checkboxes carry their own Disabled.
+            return Fieldset(Class: "border-0 p-0 m-0")[content];
         }
 
         return [.. children];

--- a/src/Rask.Bootstrap/BsCheckboxGroup.cs
+++ b/src/Rask.Bootstrap/BsCheckboxGroup.cs
@@ -25,6 +25,11 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
 
     public Func<TItem, Component>? OptionLabel { get; set; }
     public string? Name { get; set; }
+
+    // The group's accessible name. When set, the checkboxes are wrapped in a <fieldset> named by a <legend>
+    // (the correct grouping semantics + accessible name for a set of related checkboxes); when null, the bare
+    // per-item fragment is kept so callers that supply their own fieldset/heading aren't double-wrapped.
+    public string? Label { get; set; }
     public string? ItemClass { get; set; }
     public bool? Disabled { get; set; }
 
@@ -61,6 +66,16 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
         var groupName = Name ?? acc?.PropertyName ?? "checkbox-group";
         var wrapperClass = BsClass.Join("form-check", ItemClass);
 
+        // Reading GetValidationMessages here latches the render-cache opt-out (see BsFormControl) so the group
+        // repaints its aria-invalid + feedback when a rule fails on submit, instead of serving a stale cache.
+        // The error is a role="alert" live region carrying a stable id the boxes point at via aria-describedby.
+        IReadOnlyList<string> messages = bound && ctx is not null ? ctx.GetValidationMessages(fid) : [];
+        var invalid = messages.Count > 0;
+        var errorId = invalid ? groupName + "-error" : null;
+        var optionAria = invalid
+            ? new Dictionary<string, string?> { ["invalid"] = "true", ["describedby"] = errorId }
+            : null;
+
         var children = new List<Component>();
         var index = 0;
         foreach (var option in Options)
@@ -74,6 +89,7 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
                 Input<string>(
                     InputType.Checkbox, groupName, BindingHelpers.FormatValue(option),
                     Checked: isChecked, Disabled: Disabled, Class: "form-check-input", Id: optionId,
+                    Aria: optionAria,
                     OnChangeAsync: disabled
                         ? null
                         : value => ToggleAsync(acc, ctx, fid, optionValue, comparer, bool.TryParse(value, out var b) && b)),
@@ -82,9 +98,16 @@ public sealed class BsCheckboxGroup<TItem> : Component, IFormControl<ICollection
             index++;
         }
 
-        if (bound)
+        if (invalid)
         {
-            children.Add(ValidationMessage(Bind!, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]]));
+            children.Add(Div(Id: errorId, Class: "invalid-feedback d-block", Role: "alert")[messages[0]]);
+        }
+
+        if (Label is not null)
+        {
+            var content = new List<Component> { Legend(Class: "form-label fs-6")[Label] };
+            content.AddRange(children);
+            return Fieldset(Disabled: Disabled, Class: "border-0 p-0 m-0")[content];
         }
 
         return [.. children];

--- a/src/Rask.Bootstrap/BsInput.cs
+++ b/src/Rask.Bootstrap/BsInput.cs
@@ -13,6 +13,25 @@ public sealed class BsInput<T> : BsFormControl<T>
     public bool? ReadOnly { get; set; }
     public string? Autocomplete { get; set; }
 
+    // Constraint + input-affordance attributes forwarded verbatim to the core Input, so a Bootstrap
+    // number/date/range input can set Min/Max/Step, a text field a Pattern/MaxLength/MinLength, a file
+    // field Accept/Capture/Multiple, and any field the mobile-keyboard hints. (The HTML `size` attribute is
+    // not exposed — the base `Size` is Bootstrap's control sizing, which is the far more common intent.)
+    public string? Min { get; set; }
+    public string? Max { get; set; }
+    public string? Step { get; set; }
+    public string? Pattern { get; set; }
+    public int? MaxLength { get; set; }
+    public int? MinLength { get; set; }
+    public bool? Autofocus { get; set; }
+    public string? List { get; set; }
+    public string? Accept { get; set; }
+    public string? Capture { get; set; }
+    public bool? Multiple { get; set; }
+    public string? InputMode { get; set; }
+    public string? EnterKeyHint { get; set; }
+    public bool? Spellcheck { get; set; }
+
     protected override Component? Render()
     {
         var b = Resolve();
@@ -28,7 +47,10 @@ public sealed class BsInput<T> : BsFormControl<T>
             Name: Name ?? b.Accessor?.PropertyName,
             Value: BindingHelpers.FormatValue(b.Current),
             Placeholder: placeholder, Disabled: Disabled, ReadOnly: ReadOnly, Required: Required,
-            Autocomplete: Autocomplete, Class: cls, Id: controlId, Aria: FieldAria(b, controlId),
+            Min: Min, Max: Max, Step: Step, Pattern: Pattern, MaxLength: MaxLength, MinLength: MinLength,
+            Multiple: Multiple, Accept: Accept, Capture: Capture, List: List, Autofocus: Autofocus,
+            Autocomplete: Autocomplete, InputMode: InputMode, EnterKeyHint: EnterKeyHint, Spellcheck: Spellcheck,
+            Class: cls, Id: controlId, Aria: FieldAria(b, controlId),
             OnInputAsync: Disabled == true ? null : StringChangeHandler(b));
 
         return Field(controlId, b, control);

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -45,9 +45,9 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
     private string? _filter;
 
     // A per-instance suffix so two id-less multiselects still emit unique list/label ids for the
-    // combobox aria-controls / aria-labelledby wiring (mirrors BsSelectBase).
-    private static int _seq;
-    private readonly int _instanceId = System.Threading.Interlocked.Increment(ref _seq);
+    // combobox aria-controls / aria-labelledby wiring. Uses the shared non-generic counter so two
+    // id-less multiselects of different TItem don't both start at 1 and collide.
+    private readonly int _instanceId = BsInstanceId.Next();
 
     protected override Component? Render()
     {
@@ -179,10 +179,14 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             boxAria["labelledby"] = labelId;
         }
 
-        if (invalid)
+        // Merge the shared aria-invalid/aria-describedby contract (the same builder BsSelect/BsFormControl
+        // use) so the four controls stay in lockstep if it ever grows.
+        if (BsClass.FieldAria(invalid, errorId) is { } fa)
         {
-            boxAria["invalid"] = "true";
-            boxAria["describedby"] = errorId;
+            foreach (var kv in fa)
+            {
+                boxAria[kv.Key] = kv.Value;
+            }
         }
 
         var boxDiv = Div(

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using Rask.Core.Forms;
 using Rask.Core.Live;
@@ -43,6 +44,11 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
     private bool _open;
     private string? _filter;
 
+    // A per-instance suffix so two id-less multiselects still emit unique list/label ids for the
+    // combobox aria-controls / aria-labelledby wiring (mirrors BsSelectBase).
+    private static int _seq;
+    private readonly int _instanceId = System.Threading.Interlocked.Increment(ref _seq);
+
     protected override Component? Render()
     {
         ArgumentNullException.ThrowIfNull(Options);
@@ -73,6 +79,18 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         {
             selected = Value;
         }
+
+        // Stable ids for the combobox aria wiring: aria-controls → the listbox menu, aria-labelledby → the
+        // visible label (the box is a <div role="combobox">, not a labelable element, so <label for> is void),
+        // and aria-describedby → the error feedback. Reading GetValidationMessages here auto-latches the
+        // render-cache opt-out (see BsFormControl), so a message added during submit repaints the box's
+        // aria-invalid instead of being served stale.
+        var prefix = Id ?? acc?.PropertyName ?? "bsms" + _instanceId.ToString(CultureInfo.InvariantCulture);
+        var listId = prefix + "-list";
+        var labelId = Label is not null ? prefix + "-label" : null;
+        IReadOnlyList<string> messages = bound && ctx is not null ? ctx.GetValidationMessages(fid) : [];
+        var invalid = messages.Count > 0;
+        var errorId = invalid ? prefix + "-error" : null;
 
         Component LabelOf(TItem item) =>
             OptionLabel is not null ? OptionLabel(item) : item?.ToString() ?? string.Empty;
@@ -150,18 +168,37 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             }
         }
 
+        var boxAria = new Dictionary<string, string?>
+        {
+            ["haspopup"] = "listbox",
+            ["expanded"] = _open ? "true" : "false",
+            ["controls"] = listId,
+        };
+        if (labelId is not null)
+        {
+            boxAria["labelledby"] = labelId;
+        }
+
+        if (invalid)
+        {
+            boxAria["invalid"] = "true";
+            boxAria["describedby"] = errorId;
+        }
+
         var boxDiv = Div(
             Class: BsClass.Join("form-select", Sizing.HAuto, Display.Flex(), Flex.Wrap(),
-                Flex.Align(BsAlign.Center), Flex.Gap(1), disabled ? "disabled pe-none" : null),
+                Flex.Align(BsAlign.Center), Flex.Gap(1), invalid ? "is-invalid" : null,
+                disabled ? "disabled pe-none" : null),
             Data: BsPopover.Anchor,
             Role: "combobox",
             TabIndex: disabled ? null : 0,
+            Aria: boxAria,
             OnClick: disabled ? null : () => { _open = !_open; if (!_open) { _filter = null; } },
             OnKeyDown: disabled ? null : OnBoxKeyDown)[box];
 
         var labelNode = Label is null
             ? null
-            : Rask.Core.Components.Generated.Label(Class: floating ? null : "form-label")[Label];
+            : Rask.Core.Components.Generated.Label(Id: labelId, Class: floating ? null : "form-label")[Label];
 
         var children = new List<Component?>();
         if (labelNode is not null && !floating)
@@ -176,7 +213,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             ? Div(Class: BsClass.Join("form-floating bs-floating", hasChips ? "bs-floating-filled" : null,
                 Position.Relative))[boxDiv, labelNode]
             : boxDiv);
-        children.Add(Div(Class: _open
+        children.Add(Div(Id: listId, Role: "listbox", Class: _open
             ? BsClass.Join("dropdown-menu show", Display.Block(), Sizing.W(100))
             : "dropdown-menu")[rows]);
 
@@ -188,10 +225,14 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                 OnClick: () => { _open = false; _filter = null; }));
         }
 
-        if (bound)
+        // The error is a role="alert" live region carrying the id the box's aria-describedby points at, so a
+        // screen reader announces it on submit/blur associated with — not detached from — the control. Read
+        // directly from the messages resolved above (which latched the cache opt-out) rather than via a
+        // headless ValidationMessage, so the error id and the box's aria-describedby stay in lockstep.
+        if (invalid)
         {
-            children.Add(ValidationMessage(Bind!,
-                msgs => Div(Class: BsClass.Join("invalid-feedback", Display.Block()))[msgs[0]]));
+            children.Add(Div(Id: errorId, Class: BsClass.Join("invalid-feedback", Display.Block()),
+                Role: "alert")[messages[0]]);
         }
 
         return Div(Class: BsClass.Join("dropdown", Class), Id: Id, Data: BsPopover.Wrapper)[children];

--- a/src/Rask.Bootstrap/BsRadioGroup.cs
+++ b/src/Rask.Bootstrap/BsRadioGroup.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq.Expressions;
 using Rask.Core.Forms;
 
@@ -36,6 +37,11 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
     public string? ItemClass { get; set; }
     public bool? Disabled { get; set; }
 
+    // Unique suffix for the auto-generated group name of an UNNAMED group, so two id-less controlled
+    // radio groups on one page don't both fall back to name="radio-group" — which would make the browser
+    // treat them as one radio group (selecting in one clears the other) and collide their option ids.
+    private readonly int _instanceId = BsInstanceId.Next();
+
     protected override Component? Render()
     {
         ArgumentNullException.ThrowIfNull(Options);
@@ -66,7 +72,8 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
         }
 
         var disabled = Disabled == true;
-        var groupName = Name ?? acc?.PropertyName ?? "radio-group";
+        var groupName = Name ?? acc?.PropertyName
+            ?? "radio-group-" + _instanceId.ToString(CultureInfo.InvariantCulture);
         var wrapperClass = BsClass.Join("form-check", ItemClass);
 
         // Reading GetValidationMessages here latches the render-cache opt-out (see BsFormControl) so the group
@@ -75,9 +82,7 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
         IReadOnlyList<string> messages = bound && ctx is not null ? ctx.GetValidationMessages(fid) : [];
         var invalid = messages.Count > 0;
         var errorId = invalid ? groupName + "-error" : null;
-        var optionAria = invalid
-            ? new Dictionary<string, string?> { ["invalid"] = "true", ["describedby"] = errorId }
-            : null;
+        var optionAria = BsClass.FieldAria(invalid, errorId);
 
         var children = new List<Component>();
         var index = 0;
@@ -108,7 +113,9 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
         {
             var content = new List<Component> { Legend(Class: "form-label fs-6")[Label] };
             content.AddRange(children);
-            return Fieldset(Disabled: Disabled, Class: "border-0 p-0 m-0")[content];
+            // Disabled is NOT set on the fieldset: a disabled fieldset disables ALL descendants, which would
+            // also disable interactive content in a rich OptionLabel. The radios carry their own Disabled.
+            return Fieldset(Class: "border-0 p-0 m-0")[content];
         }
 
         return [.. children];

--- a/src/Rask.Bootstrap/BsRadioGroup.cs
+++ b/src/Rask.Bootstrap/BsRadioGroup.cs
@@ -27,6 +27,11 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
     public Func<TValue, Component>? OptionLabel { get; set; }
     public string? Name { get; set; }
 
+    // The group's accessible name. When set, the radios are wrapped in a <fieldset> named by a <legend>
+    // (the correct grouping semantics + accessible name for a set of related radios); when null, the bare
+    // per-item fragment is kept so callers that supply their own fieldset/heading aren't double-wrapped.
+    public string? Label { get; set; }
+
     // Extra wrapper classes per item, e.g. "form-check-inline".
     public string? ItemClass { get; set; }
     public bool? Disabled { get; set; }
@@ -64,6 +69,16 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
         var groupName = Name ?? acc?.PropertyName ?? "radio-group";
         var wrapperClass = BsClass.Join("form-check", ItemClass);
 
+        // Reading GetValidationMessages here latches the render-cache opt-out (see BsFormControl) so the group
+        // repaints its aria-invalid + feedback when a rule fails on submit, instead of serving a stale cache.
+        // The error is a role="alert" live region carrying a stable id the radios point at via aria-describedby.
+        IReadOnlyList<string> messages = bound && ctx is not null ? ctx.GetValidationMessages(fid) : [];
+        var invalid = messages.Count > 0;
+        var errorId = invalid ? groupName + "-error" : null;
+        var optionAria = invalid
+            ? new Dictionary<string, string?> { ["invalid"] = "true", ["describedby"] = errorId }
+            : null;
+
         var children = new List<Component>();
         var index = 0;
         foreach (var option in Options)
@@ -77,15 +92,23 @@ public sealed class BsRadioGroup<TValue> : Component, IFormControl<TValue>
                 Input<string>(
                     InputType.Radio, groupName, BindingHelpers.FormatValue(option),
                     Checked: isChecked, Disabled: Disabled, Class: "form-check-input", Id: optionId,
+                    Aria: optionAria,
                     OnChangeAsync: disabled ? null : _ => SelectAsync(acc, ctx, fid, optionValue)),
                 Rask.Core.Components.Generated.Label(Class: "form-check-label", For: optionId)[label]
             ]);
             index++;
         }
 
-        if (bound)
+        if (invalid)
         {
-            children.Add(ValidationMessage(Bind!, msgs => Div(Class: "invalid-feedback d-block")[msgs[0]]));
+            children.Add(Div(Id: errorId, Class: "invalid-feedback d-block", Role: "alert")[messages[0]]);
+        }
+
+        if (Label is not null)
+        {
+            var content = new List<Component> { Legend(Class: "form-label fs-6")[Label] };
+            content.AddRange(children);
+            return Fieldset(Disabled: Disabled, Class: "border-0 p-0 m-0")[content];
         }
 
         return [.. children];

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -107,6 +107,12 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         var selectedIdx = SelectedIndex(b, opts);
         var floating = Floating is true && Label is not null;
 
+        // The combobox is a <div role="combobox">, which is NOT a labelable element, so a <label for>
+        // pointing at it is void (the accessible name is never computed). Give the visible label a stable
+        // id and name the combobox with aria-labelledby instead. controlId can be null (no Id/Name/bound
+        // property) — fall back to the always-present prefix so the id is stable across renders.
+        var labelId = Label is not null ? (controlId ?? prefix) + "-label" : null;
+
         // Filtering is opt-in: only a supplied Filter predicate shows the search field and narrows the list.
         var searchable = Filter is not null;
         var filtered = searchable && !string.IsNullOrEmpty(_filter)
@@ -124,6 +130,11 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             ["expanded"] = _open ? "true" : "false",
             ["controls"] = listId,
         };
+        if (labelId is not null)
+        {
+            aria["labelledby"] = labelId;
+        }
+
         if (_open && _cursor >= 0 && _cursor < filtered.Count)
         {
             aria["activedescendant"] = OptId(prefix, _cursor);
@@ -211,7 +222,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
 
         var labelNode = Label is null
             ? null
-            : Rask.Core.Components.Generated.Label(For: controlId, Class: floating ? null : "form-label")[
+            : Rask.Core.Components.Generated.Label(Id: labelId, Class: floating ? null : "form-label")[
                 Label,
                 Required is true ? Span(Class: "text-danger ms-1")["*"] : null];
 

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -49,8 +49,9 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
     private static bool CanClear => Nullable.GetUnderlyingType(typeof(TValue)) is not null;
 
     // A per-instance suffix so two id-less selects still emit unique option ids for aria-activedescendant.
-    private static int _seq;
-    private readonly int _instanceId = System.Threading.Interlocked.Increment(ref _seq);
+    // Uses the shared non-generic counter so two id-less selects of different generic arguments don't both
+    // start at 1 and collide.
+    private readonly int _instanceId = BsInstanceId.Next();
 
     protected override Component? Render()
     {

--- a/src/Rask.Bootstrap/BsTextarea.cs
+++ b/src/Rask.Bootstrap/BsTextarea.cs
@@ -10,6 +10,14 @@ public sealed class BsTextarea<T> : BsFormControl<T>
     public int? Rows { get; set; }
     public bool? ReadOnly { get; set; }
 
+    // Sizing + constraint attributes forwarded verbatim to the core Textarea. (The core Textarea's `wrap`
+    // attribute is not surfaced here — the name collides with BsBlock.Wrap; use the core Textarea for it.)
+    public int? Cols { get; set; }
+    public int? MaxLength { get; set; }
+    public int? MinLength { get; set; }
+    public string? Autocomplete { get; set; }
+    public bool? Autofocus { get; set; }
+
     protected override Component? Render()
     {
         var b = Resolve();
@@ -19,7 +27,9 @@ public sealed class BsTextarea<T> : BsFormControl<T>
         var control = Textarea<string>(
             Name: Name ?? b.Accessor?.PropertyName,
             Value: BindingHelpers.FormatValue(b.Current),
-            Placeholder: Placeholder, Rows: Rows, Disabled: Disabled, ReadOnly: ReadOnly, Required: Required,
+            Placeholder: Placeholder, Rows: Rows, Cols: Cols, Disabled: Disabled, ReadOnly: ReadOnly,
+            Required: Required, MaxLength: MaxLength, MinLength: MinLength,
+            Autocomplete: Autocomplete, Autofocus: Autofocus,
             Class: cls, Id: controlId, Aria: FieldAria(b, controlId),
             OnInputAsync: Disabled == true ? null : StringChangeHandler(b));
 

--- a/src/Rask.Bootstrap/Enums.cs
+++ b/src/Rask.Bootstrap/Enums.cs
@@ -180,3 +180,14 @@ internal static class BsClass
         return sb.Length == 0 ? null : sb.ToString();
     }
 }
+
+// A process-wide counter for controls that need a page-unique id suffix when the caller gives no id
+// (id-less comboboxes/groups derive list/label/error ids from it). It lives on a NON-generic type on
+// purpose: a `static` field on a generic control is per-closed-type, so `BsMultiSelect<string>` and
+// `BsMultiSelect<int>` would each restart at 1 and collide — this shared counter never does.
+internal static class BsInstanceId
+{
+    private static int _seq;
+
+    public static int Next() => System.Threading.Interlocked.Increment(ref _seq);
+}

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -58,6 +58,16 @@ public sealed class Input<T> : Element, IFormControl<T>
     public int? Width { get; set; }
     public int? Height { get; set; }
 
+    // Mobile / accessibility hints. InputMode picks the on-screen keyboard (numeric/decimal/email/…),
+    // EnterKeyHint labels its action key (done/go/search/…), Spellcheck toggles the enumerated
+    // spellcheck attribute ("true"/"false"), Capture asks a file input for the camera/mic ("user"/
+    // "environment"), and Dirname submits the field's text direction alongside its value.
+    public string? InputMode { get; set; }
+    public string? EnterKeyHint { get; set; }
+    public bool? Spellcheck { get; set; }
+    public string? Capture { get; set; }
+    public string? Dirname { get; set; }
+
     // DOM event handlers in the legacy declaration order so positional factory calls keep working.
     // OnChange/OnChangeAsync are the IFormControl<T> controlled callbacks (typed T); OnInput/OnFiles are the
     // string/file DOM handlers, not part of the interface.
@@ -209,6 +219,11 @@ public sealed class Input<T> : Element, IFormControl<T>
             AppendAttr(sb, "accept", Accept);
         }
 
+        if (Capture is not null)
+        {
+            AppendAttr(sb, "capture", Capture);
+        }
+
         if (Alt is not null)
         {
             AppendAttr(sb, "alt", Alt);
@@ -217,6 +232,26 @@ public sealed class Input<T> : Element, IFormControl<T>
         if (Autocomplete is not null)
         {
             AppendAttr(sb, "autocomplete", Autocomplete);
+        }
+
+        if (InputMode is not null)
+        {
+            AppendAttr(sb, "inputmode", InputMode);
+        }
+
+        if (EnterKeyHint is not null)
+        {
+            AppendAttr(sb, "enterkeyhint", EnterKeyHint);
+        }
+
+        if (Spellcheck is not null)
+        {
+            AppendAttr(sb, "spellcheck", Spellcheck.Value ? "true" : "false");
+        }
+
+        if (Dirname is not null)
+        {
+            AppendAttr(sb, "dirname", Dirname);
         }
 
         if (Autofocus is true)

--- a/src/Rask.Core/Components/InputType.cs
+++ b/src/Rask.Core/Components/InputType.cs
@@ -1,7 +1,7 @@
 namespace Rask.Core;
 
 // The HTML <input> type, as a closed set instead of a free string — so the type is validated at compile
-// time and the analyzer (RASK023) can check it against a bound Input<T>'s value type. When an Input<T> is
+// time and the analyzer (RASK025) can check it against a bound Input<T>'s value type. When an Input<T> is
 // bound and no Type is given, the type is derived from T (bool→Checkbox, numeric→Number, DateOnly→Date, …);
 // an explicit Type overrides that.
 public enum InputType
@@ -34,15 +34,9 @@ public enum InputType
 
 public static class InputTypeExtensions
 {
-    // The HTML attribute string for an InputType. All members are their lower-cased name except
-    // DatetimeLocal, which renders as the hyphenated "datetime-local".
+    // The HTML attribute string for an InputType: each member's lower-cased name, except DatetimeLocal
+    // which renders as the hyphenated "datetime-local" (the only multi-word HTML input type).
     public static string ToHtml(this InputType type) => type switch
-    {
-        InputType.DatetimeLocal => "datetime-local",
-        _ => ToLowerName(type)
-    };
-
-    private static string ToLowerName(InputType type) => type switch
     {
         InputType.Text => "text",
         InputType.Search => "search",
@@ -57,6 +51,7 @@ public static class InputTypeExtensions
         InputType.Range => "range",
         InputType.Color => "color",
         InputType.Date => "date",
+        InputType.DatetimeLocal => "datetime-local",
         InputType.Time => "time",
         InputType.Week => "week",
         InputType.Month => "month",

--- a/tests/Rask.Bootstrap.Tests/BsCheckboxGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsCheckboxGroupTests.cs
@@ -65,6 +65,34 @@ public class BsCheckboxGroupTests
     }
 
     [Fact]
+    public async Task CheckboxGroup_Bound_TogglesCollectionMembership()
+    {
+        // End-to-end through the control's ToggleAsync: unchecking option "a" removes it from the bound
+        // collection; re-checking it adds it back (checkbox change handlers report the box's "true"/"false").
+        var model = new TagModel { Tags = { "a" } };
+        var view = new StubComponent(() => Form(model)[
+            BsCheckboxGroup(() => model.Tags, ["a", "b"], Name: "tags")
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+        var aChangeId = Markup.Attr(html, "data-rask-on-change")!; // first checkbox = option "a"
+
+        using (var off = JsonDocument.Parse("{\"value\":\"false\"}"))
+        {
+            await view.TryInvokeHandlerAsync(aChangeId, off.RootElement);
+        }
+
+        Assert.Empty(model.Tags);
+
+        using (var on = JsonDocument.Parse("{\"value\":\"true\"}"))
+        {
+            await view.TryInvokeHandlerAsync(aChangeId, on.RootElement);
+        }
+
+        Assert.Equal(new[] { "a" }, model.Tags);
+    }
+
+    [Fact]
     public void CheckboxGroup_NeitherBindNorValue_Throws() =>
         Assert.Throws<InvalidOperationException>(() => BsCheckboxGroup(Options: ["a"]).ToHtml());
 

--- a/tests/Rask.Bootstrap.Tests/BsCheckboxGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsCheckboxGroupTests.cs
@@ -1,0 +1,75 @@
+#pragma warning disable RASK014 // StubComponent constructed directly in tests
+
+using System.Text.Json;
+
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for BsCheckboxGroup. Each option is a <div class="form-check"> holding a
+// labelable checkbox whose <label for> associates by id; selection reflects ICollection membership. A
+// group Label wraps the set in a <fieldset> named by a <legend>; without it the bare per-item fragment
+// is kept. Validation surfaces as a role="alert" live region the boxes point at via aria-describedby.
+public class BsCheckboxGroupTests
+{
+    [Fact]
+    public void CheckboxGroup_Controlled_ReflectsMembershipWithPerItemLabels()
+    {
+        var html = BsCheckboxGroup(Options: ["a", "b"], Value: new List<string> { "a" }, Name: "tags").ToHtml();
+        Assert.DoesNotContain("<fieldset", html);
+        Assert.StartsWith("<div class=\"form-check\" data-rask-key=\"0\">", html);
+        Assert.Contains(
+            "<input id=\"tags-0\" class=\"form-check-input\" type=\"checkbox\" name=\"tags\" value=\"a\" checked />",
+            html);
+        Assert.Contains("<label class=\"form-check-label\" for=\"tags-0\">a</label>", html);
+        Assert.Contains(
+            "<input id=\"tags-1\" class=\"form-check-input\" type=\"checkbox\" name=\"tags\" value=\"b\" />", html);
+    }
+
+    [Fact]
+    public void CheckboxGroup_WithLabel_WrapsInFieldsetNamedByLegend()
+    {
+        var html = BsCheckboxGroup(Options: ["a", "b"], Value: new List<string>(), Name: "tags",
+            Label: "Tags").ToHtml();
+        Assert.StartsWith("<fieldset class=\"border-0 p-0 m-0\">", html);
+        Assert.Contains("<legend class=\"form-label fs-6\">Tags</legend>", html);
+        Assert.EndsWith("</fieldset>", html);
+    }
+
+    [Fact]
+    public void CheckboxGroup_Disabled_DisablesEveryBox()
+    {
+        var html = BsCheckboxGroup(Options: ["a", "b"], Value: new List<string>(), Name: "tags",
+            Disabled: true).ToHtml();
+        Assert.Contains("value=\"a\" disabled />", html);
+        Assert.Contains("value=\"b\" disabled />", html);
+    }
+
+    [Fact]
+    public async Task CheckboxGroup_Bound_Invalid_WiresAriaInvalidDescribedbyAndAlertFeedback()
+    {
+        var model = new TagModel();
+        var view = new StubComponent(() => Form(model)[
+            BsCheckboxGroup(() => model.Tags, ["a", "b"], Label: "Tags",
+                Validate: v => v.Count == 0 ? new[] { "pick at least one" } : Array.Empty<string>())
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+        var submitId = Markup.Attr(html, "data-rask-on-submit")!;
+        using var payload = JsonDocument.Parse("{\"form\":{}}");
+        await view.TryInvokeHandlerAsync(submitId, payload.RootElement);
+
+        var after = view.RenderAsLiveRoot();
+        Assert.Contains("aria-invalid=\"true\" aria-describedby=\"Tags-error\"", after);
+        Assert.Contains(
+            "<div id=\"Tags-error\" class=\"invalid-feedback d-block\" role=\"alert\">pick at least one</div>",
+            after);
+    }
+
+    [Fact]
+    public void CheckboxGroup_NeitherBindNorValue_Throws() =>
+        Assert.Throws<InvalidOperationException>(() => BsCheckboxGroup(Options: ["a"]).ToHtml());
+
+    private sealed class TagModel
+    {
+        public List<string> Tags { get; set; } = [];
+    }
+}

--- a/tests/Rask.Bootstrap.Tests/BsFormControlTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsFormControlTests.cs
@@ -1,6 +1,7 @@
 #pragma warning disable RASK014 // StubComponent constructed directly in tests
 
 using System.Text.Json;
+using Rask.Core;
 
 namespace Rask.Bootstrap.Tests;
 
@@ -36,6 +37,38 @@ public class BsFormControlTests
     [Fact]
     public void Textarea_RendersFormControl() =>
         Assert.Contains("class=\"form-control\"", BsTextarea<string>(Value: "hi", Rows: 3).ToHtml());
+
+    [Fact]
+    public void Input_NumericConstraints_ForwardMinMaxStepToCoreInput() =>
+        Assert.Contains("min=\"0\" max=\"120\" step=\"1\"",
+            BsInput<int>(Value: 5, Min: "0", Max: "120", Step: "1").ToHtml());
+
+    [Fact]
+    public void Input_TextConstraints_ForwardPatternAndLengths() =>
+        Assert.Contains("pattern=\"[a-z]&#x2B;\" maxlength=\"10\" minlength=\"2\"",
+            BsInput<string>(Value: "x", Pattern: "[a-z]+", MaxLength: 10, MinLength: 2).ToHtml());
+
+    [Fact]
+    public void Input_File_ForwardsAcceptCaptureAndMultiple()
+    {
+        var html = BsInput<string>(Value: "", Type: InputType.File, Accept: ".png,.jpg", Capture: "user",
+            Multiple: true).ToHtml();
+        Assert.Contains("type=\"file\"", html);
+        Assert.Contains("multiple accept=\".png,.jpg\" capture=\"user\"", html);
+    }
+
+    [Fact]
+    public void Input_ForwardsListAndInputMode()
+    {
+        var html = BsInput<string>(Value: "", List: "cities", InputMode: "search").ToHtml();
+        Assert.Contains("inputmode=\"search\"", html);
+        Assert.Contains("list=\"cities\"", html);
+    }
+
+    [Fact]
+    public void Textarea_ForwardsColsAndLengthConstraints() =>
+        Assert.Contains("cols=\"40\" maxlength=\"200\" minlength=\"10\"",
+            BsTextarea<string>(Value: "hi", Cols: 40, MaxLength: 200, MinLength: 10).ToHtml());
 
     [Fact]
     public void Check_Switch_RendersFormSwitchAndRole()

--- a/tests/Rask.Bootstrap.Tests/BsFormGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsFormGroupTests.cs
@@ -1,0 +1,25 @@
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for the hand-composition layout helpers: BsFormGroup (the .mb-3 field
+// spacer) and BsFormLabel (a .form-label whose For ties it to a control id).
+public class BsFormGroupTests
+{
+    [Fact]
+    public void FormGroup_WrapsItemsInMb3() =>
+        Assert.Equal("<div class=\"mb-3\"><span>x</span></div>", BsFormGroup()[Span()["x"]].ToHtml());
+
+    [Fact]
+    public void FormGroup_MergesUserClassAndId() =>
+        Assert.Equal("<div id=\"g\" class=\"mb-3 border\"><span>x</span></div>",
+            BsFormGroup(Id: "g", Class: "border")[Span()["x"]].ToHtml());
+
+    [Fact]
+    public void FormLabel_RendersFormLabelTiedToControl() =>
+        Assert.Equal("<label class=\"form-label\" for=\"email\">Email</label>",
+            BsFormLabel(For: "email")["Email"].ToHtml());
+
+    [Fact]
+    public void FormLabel_MergesUserClassAndId() =>
+        Assert.Equal("<label id=\"l\" class=\"form-label fw-bold\" for=\"e\">E</label>",
+            BsFormLabel(For: "e", Id: "l", Class: "fw-bold")["E"].ToHtml());
+}

--- a/tests/Rask.Bootstrap.Tests/BsInputGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsInputGroupTests.cs
@@ -1,0 +1,26 @@
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for BsInputGroup (the .input-group wrapper, with Size → input-group-sm/lg)
+// and its BsInputGroupText add-on (.input-group-text for a leading/trailing "@", "$", unit, …).
+public class BsInputGroupTests
+{
+    [Fact]
+    public void InputGroup_WrapsItems() =>
+        Assert.Equal("<div class=\"input-group\"><span class=\"input-group-text\">@</span></div>",
+            BsInputGroup()[BsInputGroupText()["@"]].ToHtml());
+
+    [Fact]
+    public void InputGroup_Size_AddsSuffixClass() =>
+        Assert.Equal(
+            "<div class=\"input-group input-group-lg\"><span class=\"input-group-text\">$</span></div>",
+            BsInputGroup(Size: BsSize.Lg)[BsInputGroupText()["$"]].ToHtml());
+
+    [Fact]
+    public void InputGroup_MergesUserClassAndId() =>
+        Assert.StartsWith("<div id=\"ig\" class=\"input-group mb-2\">",
+            BsInputGroup(Id: "ig", Class: "mb-2")[BsInputGroupText()["x"]].ToHtml());
+
+    [Fact]
+    public void InputGroupText_RendersSpan() =>
+        Assert.Equal("<span class=\"input-group-text\">kg</span>", BsInputGroupText()["kg"].ToHtml());
+}

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -1,3 +1,7 @@
+#pragma warning disable RASK014 // StubComponent constructed directly in tests
+
+using System.Text.Json;
+
 namespace Rask.Bootstrap.Tests;
 
 // Rendered-HTML assertions for BsMultiSelect (controlled mode). The `.form-select` box shows the selected
@@ -77,4 +81,32 @@ public class BsMultiSelectTests
     public void MultiSelect_RequiresExactlyOneOfBindOrValue() =>
         // Neither Bind nor Value set → the mode guard throws when the control renders.
         Assert.Throws<InvalidOperationException>(() => BsMultiSelect<string>(Options: ["a"]).ToHtml());
+
+    [Fact]
+    public async Task MultiSelect_Bound_Invalid_WiresAriaInvalidDescribedbyAndAlertFeedback()
+    {
+        // A bound multiselect that fails validation must expose the failure to assistive tech: is-invalid +
+        // aria-invalid + aria-describedby on the combobox box, and a role="alert" error region with the id.
+        var model = new TagModel();
+        var view = new StubComponent(() => Form(model)[
+            BsMultiSelect(() => model.Tags, ["a", "b"], Id: "m",
+                Validate: v => v.Count == 0 ? new[] { "pick a tag" } : Array.Empty<string>())
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+        var submitId = Markup.Attr(html, "data-rask-on-submit")!;
+        using var payload = JsonDocument.Parse("{\"form\":{}}");
+        await view.TryInvokeHandlerAsync(submitId, payload.RootElement);
+
+        var after = view.RenderAsLiveRoot();
+        Assert.Contains("is-invalid", after);
+        Assert.Contains("aria-invalid=\"true\" aria-describedby=\"m-error\"", after);
+        Assert.Contains(
+            "<div id=\"m-error\" class=\"invalid-feedback d-block\" role=\"alert\">pick a tag</div>", after);
+    }
+
+    private sealed class TagModel
+    {
+        public List<string> Tags { get; set; } = [];
+    }
 }

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -9,10 +9,14 @@ public class BsMultiSelectTests
     [Fact]
     public void MultiSelect_Empty_ShowsPlaceholderBoxAndUncheckedOptions()
     {
-        var html = BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string>()).ToHtml();
+        var html = BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string>(), Id: "m").ToHtml();
+        // The box is a role="combobox" naming its listbox via aria-controls (id pinned so the derived
+        // list id is deterministic).
         Assert.Contains(
             "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" data-rask-anchor=\"\" " +
-            "role=\"combobox\" tabindex=\"0\"><span class=\"text-secondary\">Select&#x2026;</span></div>", html);
+            "role=\"combobox\" tabindex=\"0\" aria-haspopup=\"listbox\" aria-expanded=\"false\" " +
+            "aria-controls=\"m-list\"><span class=\"text-secondary\">Select&#x2026;</span></div>", html);
+        Assert.Contains("<div id=\"m-list\" class=\"dropdown-menu\" role=\"listbox\">", html);
         Assert.Contains(
             "<button class=\"dropdown-item d-flex align-items-center gap-2\" data-rask-key=\"0\" type=\"button\">" +
             "<input class=\"form-check-input m-0 pe-none\" type=\"checkbox\" />a</button>", html);
@@ -30,9 +34,14 @@ public class BsMultiSelectTests
     }
 
     [Fact]
-    public void MultiSelect_Label_SitsAboveTheControl() =>
-        Assert.Contains("<label class=\"form-label\">Tags</label>",
-            BsMultiSelect<string>(Options: [], Value: new List<string>(), Label: "Tags").ToHtml());
+    public void MultiSelect_Label_SitsAboveTheControl()
+    {
+        // The label is associated with the combobox via aria-labelledby (the box is a <div role="combobox">,
+        // not a labelable element for <label for>).
+        var html = BsMultiSelect<string>(Options: [], Value: new List<string>(), Label: "Tags", Id: "m").ToHtml();
+        Assert.Contains("<label id=\"m-label\" class=\"form-label\">Tags</label>", html);
+        Assert.Contains("aria-labelledby=\"m-label\"", html);
+    }
 
     [Fact]
     public void MultiSelect_CustomPlaceholder_ReplacesDefault() =>
@@ -46,9 +55,11 @@ public class BsMultiSelectTests
         // label is the placeholder) — otherwise the two texts overlap. Wrapper is .form-floating.bs-floating
         // with no .bs-floating-filled. Guards the regression where the leftover placeholder overlapped the label.
         var html = BsMultiSelect<string>(Options: [], Value: new List<string>(),
-            Label: "Interests", Floating: true).ToHtml();
+            Label: "Interests", Floating: true, Id: "m").ToHtml();
         Assert.Contains("<div class=\"form-floating bs-floating position-relative\">", html);
-        Assert.Contains("role=\"combobox\" tabindex=\"0\"></div><label>Interests</label>", html);
+        Assert.Contains(
+            "aria-controls=\"m-list\" aria-labelledby=\"m-label\"></div><label id=\"m-label\">Interests</label>",
+            html);
         Assert.DoesNotContain("Select&#x2026;", html);
         Assert.DoesNotContain("bs-floating-filled", html);
     }

--- a/tests/Rask.Bootstrap.Tests/BsRadioGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsRadioGroupTests.cs
@@ -1,0 +1,89 @@
+#pragma warning disable RASK014 // StubComponent constructed directly in tests
+
+using System.Text.Json;
+
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for BsRadioGroup. Each option is a <div class="form-check"> holding a
+// labelable radio (<input type="radio">) whose <label for> associates by id. A group Label wraps the
+// set in a <fieldset> named by a <legend> (the accessible name for the group); without it the bare
+// per-item fragment is kept. Validation surfaces as a role="alert" live region the radios point at
+// via aria-describedby, with aria-invalid on each input.
+public class BsRadioGroupTests
+{
+    [Fact]
+    public void RadioGroup_Controlled_RendersRadiosWithPerItemLabelAssociation()
+    {
+        var html = BsRadioGroup(Options: ["Free", "Pro"], Value: "Free", Name: "plan", OnChange: _ => { }).ToHtml();
+        // No group Label ⇒ bare fragment, no fieldset/legend wrapper.
+        Assert.DoesNotContain("<fieldset", html);
+        Assert.DoesNotContain("<legend", html);
+        Assert.StartsWith("<div class=\"form-check\" data-rask-key=\"0\">", html);
+        Assert.Contains(
+            "<input id=\"plan-0\" class=\"form-check-input\" type=\"radio\" name=\"plan\" value=\"Free\" checked />",
+            html);
+        Assert.Contains("<label class=\"form-check-label\" for=\"plan-0\">Free</label>", html);
+        Assert.Contains("<input id=\"plan-1\" class=\"form-check-input\" type=\"radio\" name=\"plan\" value=\"Pro\" />",
+            html);
+    }
+
+    [Fact]
+    public void RadioGroup_WithLabel_WrapsInFieldsetNamedByLegend()
+    {
+        var html = BsRadioGroup(Options: ["Free", "Pro"], Value: "Free", Name: "plan", Label: "Plan",
+            OnChange: _ => { }).ToHtml();
+        // A set of related radios becomes a <fieldset> whose <legend> is the group's accessible name.
+        Assert.StartsWith("<fieldset class=\"border-0 p-0 m-0\">", html);
+        Assert.Contains("<legend class=\"form-label fs-6\">Plan</legend>", html);
+        Assert.EndsWith("</fieldset>", html);
+        Assert.Contains("<label class=\"form-check-label\" for=\"plan-0\">Free</label>", html);
+    }
+
+    [Fact]
+    public void RadioGroup_Disabled_DisablesEveryRadio()
+    {
+        var html = BsRadioGroup(Options: ["Free", "Pro"], Value: "Free", Name: "plan", Disabled: true,
+            OnChange: _ => { }).ToHtml();
+        Assert.Contains("value=\"Free\" disabled checked />", html);
+        Assert.Contains("value=\"Pro\" disabled />", html);
+    }
+
+    [Fact]
+    public void RadioGroup_OptionLabel_RendersRichLabels() =>
+        Assert.Contains("<label class=\"form-check-label\" for=\"plan-0\"><strong>Free</strong></label>",
+            BsRadioGroup(Options: ["Free"], Value: "Free", Name: "plan",
+                OptionLabel: p => Strong()[p], OnChange: _ => { }).ToHtml());
+
+    [Fact]
+    public async Task RadioGroup_Bound_Invalid_WiresAriaInvalidDescribedbyAndAlertFeedback()
+    {
+        // A bound radio group that fails validation must expose the failure to assistive tech: aria-invalid
+        // + aria-describedby on each radio, and the error as a role="alert" live region with the matching id.
+        var model = new PlanModel();
+        var view = new StubComponent(() => Form(model)[
+            BsRadioGroup(() => model.Plan, ["Free", "Pro"], Label: "Plan",
+                Validate: v => string.IsNullOrEmpty(v) ? new[] { "pick a plan" } : Array.Empty<string>())
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+        var submitId = Markup.Attr(html, "data-rask-on-submit")!;
+        using var payload = JsonDocument.Parse("{\"form\":{}}");
+        await view.TryInvokeHandlerAsync(submitId, payload.RootElement);
+
+        var after = view.RenderAsLiveRoot();
+        Assert.Contains("aria-invalid=\"true\" aria-describedby=\"Plan-error\"", after);
+        Assert.Contains(
+            "<div id=\"Plan-error\" class=\"invalid-feedback d-block\" role=\"alert\">pick a plan</div>",
+            after);
+    }
+
+    [Fact]
+    public void RadioGroup_NeitherBindNorHandler_Throws() =>
+        Assert.Throws<InvalidOperationException>(() =>
+            BsRadioGroup(Options: ["a"], Value: "a").ToHtml());
+
+    private sealed class PlanModel
+    {
+        public string Plan { get; set; } = "";
+    }
+}

--- a/tests/Rask.Bootstrap.Tests/BsRadioGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsRadioGroupTests.cs
@@ -78,6 +78,17 @@ public class BsRadioGroupTests
     }
 
     [Fact]
+    public void RadioGroup_TwoUnnamedControlled_GetDistinctGroupNames()
+    {
+        // Two id-less controlled groups must not both fall back to name="radio-group": the browser would
+        // treat them as ONE radio group (selecting in one clears the other) and their ids would collide.
+        var nameA = Markup.Attr(BsRadioGroup(Options: ["x"], Value: "x", OnChange: _ => { }).ToHtml(), "name");
+        var nameB = Markup.Attr(BsRadioGroup(Options: ["x"], Value: "x", OnChange: _ => { }).ToHtml(), "name");
+        Assert.StartsWith("radio-group-", nameA);
+        Assert.NotEqual(nameA, nameB);
+    }
+
+    [Fact]
     public void RadioGroup_NeitherBindNorHandler_Throws() =>
         Assert.Throws<InvalidOperationException>(() =>
             BsRadioGroup(Options: ["a"], Value: "a").ToHtml());

--- a/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
@@ -34,14 +34,17 @@ public class BsSelectTests
     public void Select_CustomPlaceholderAndLabel_LabelSitsAboveTheBox()
     {
         var html = BsSelect<string>(Options: [], Value: null, Label: "Plan", Placeholder: "Pick one", Id: "p").ToHtml();
-        Assert.Contains("<label class=\"form-label\" for=\"p\">Plan</label>", html);
+        // The combobox is a <div role="combobox"> (not labelable), so the label is associated by id via the
+        // box's aria-labelledby rather than a void <label for> pointing at the div.
+        Assert.Contains("<label id=\"p-label\" class=\"form-label\">Plan</label>", html);
+        Assert.Contains("aria-labelledby=\"p-label\"", html);
         Assert.Contains("<span class=\"text-secondary\">Pick one</span>", html);
     }
 
     [Fact]
     public void Select_Required_AppendsAsteriskToLabel() =>
         Assert.Contains(
-            "<label class=\"form-label\" for=\"s\">Plan<span class=\"text-danger ms-1\">*</span></label>",
+            "<label id=\"s-label\" class=\"form-label\">Plan<span class=\"text-danger ms-1\">*</span></label>",
             BsSelect<string>(Options: [], Value: null, Label: "Plan", Required: true, Id: "s").ToHtml());
 
     [Fact]
@@ -51,7 +54,8 @@ public class BsSelectTests
         // the wrapper is .form-floating.bs-floating, and .bs-floating-filled is absent.
         var html = BsSelect<string>(Options: [], Value: null, Label: "Plan", Floating: true, Id: "s").ToHtml();
         Assert.Contains("<div class=\"form-floating bs-floating position-relative\">", html);
-        Assert.Contains("aria-controls=\"s-list\"></div><label for=\"s\">Plan</label>", html);
+        Assert.Contains(
+            "aria-controls=\"s-list\" aria-labelledby=\"s-label\"></div><label id=\"s-label\">Plan</label>", html);
     }
 
     [Fact]

--- a/tests/Rask.Core.Tests/Components/InputTests.cs
+++ b/tests/Rask.Core.Tests/Components/InputTests.cs
@@ -37,6 +37,15 @@ public class InputTests
         Assert.Equal($"<input type=\"{html}\" />", Input<string>(type).ToHtml());
 
     [Fact]
+    public void Render_HonorsCallerAriaRoleAndTabIndex() =>
+        // Global attributes come through Element in the canonical slot order (role, tabindex, aria-*) BEFORE
+        // the tag-specific `type` — a caller can wire an accessible name / role onto a bare input.
+        Assert.Equal(
+            "<input role=\"switch\" tabindex=\"0\" aria-label=\"volume\" type=\"range\" />",
+            Input<string>(InputType.Range, Role: "switch", TabIndex: 0,
+                Aria: new Dictionary<string, string?> { ["label"] = "volume" }).ToHtml());
+
+    [Fact]
     public void Render_SpellcheckFalse_EmitsEnumeratedValue() =>
         // spellcheck is an enumerated attribute, not a boolean-presence one — false must render explicitly.
         Assert.Equal("<input spellcheck=\"false\" />", Input<string>(Spellcheck: false).ToHtml());

--- a/tests/Rask.Core.Tests/Components/InputTests.cs
+++ b/tests/Rask.Core.Tests/Components/InputTests.cs
@@ -12,11 +12,41 @@ public class InputTests
     public void Render_AllPropsSet_EmitsExpectedAttributes()
     {
         Assert.Equal(
-            "<input id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" type=\"text\" name=\"n\" value=\"v\" placeholder=\"p\" required disabled readonly checked min=\"1\" max=\"10\" step=\"1\" pattern=\"[a-z]&#x2B;\" size=\"20\" maxlength=\"100\" minlength=\"1\" multiple accept=\".png\" alt=\"alt\" autocomplete=\"off\" autofocus form=\"f\" formaction=\"/a\" formenctype=\"multipart/form-data\" formmethod=\"post\" formnovalidate formtarget=\"_blank\" list=\"l\" src=\"/s\" width=\"80\" height=\"40\" />",
+            "<input id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" type=\"text\" name=\"n\" value=\"v\" placeholder=\"p\" required disabled readonly checked min=\"1\" max=\"10\" step=\"1\" pattern=\"[a-z]&#x2B;\" size=\"20\" maxlength=\"100\" minlength=\"1\" multiple accept=\".png\" capture=\"user\" alt=\"alt\" autocomplete=\"off\" inputmode=\"numeric\" enterkeyhint=\"done\" spellcheck=\"false\" dirname=\"d\" autofocus form=\"f\" formaction=\"/a\" formenctype=\"multipart/form-data\" formmethod=\"post\" formnovalidate formtarget=\"_blank\" list=\"l\" src=\"/s\" width=\"80\" height=\"40\" />",
             Input<string>(InputType.Text, "n", "v", "p", true, true, true, true, "1", "10", "1", "[a-z]+", 20, 100, 1, true, ".png",
                 "alt", "off", true, "f", "/a", "multipart/form-data", "post", true, "_blank", "l", "/s", 80, 40,
+                InputMode: "numeric", EnterKeyHint: "done", Spellcheck: false, Capture: "user", Dirname: "d",
                 Id: "i", Class: "c", Style: "s", Data: new Dictionary<string, string?> { ["k"] = "v" }).ToHtml());
     }
+
+    [Theory]
+    [InlineData(InputType.Email, "email")]
+    [InlineData(InputType.Password, "password")]
+    [InlineData(InputType.Tel, "tel")]
+    [InlineData(InputType.Url, "url")]
+    [InlineData(InputType.Search, "search")]
+    [InlineData(InputType.Range, "range")]
+    [InlineData(InputType.Color, "color")]
+    [InlineData(InputType.File, "file")]
+    [InlineData(InputType.Week, "week")]
+    [InlineData(InputType.Month, "month")]
+    [InlineData(InputType.Hidden, "hidden")]
+    [InlineData(InputType.Radio, "radio")]
+    [InlineData(InputType.DatetimeLocal, "datetime-local")]
+    public void Render_ExplicitType_EmitsTypeAttribute(InputType type, string html) =>
+        Assert.Equal($"<input type=\"{html}\" />", Input<string>(type).ToHtml());
+
+    [Fact]
+    public void Render_SpellcheckFalse_EmitsEnumeratedValue() =>
+        // spellcheck is an enumerated attribute, not a boolean-presence one — false must render explicitly.
+        Assert.Equal("<input spellcheck=\"false\" />", Input<string>(Spellcheck: false).ToHtml());
+
+    [Fact]
+    public void Render_FileCaptureAndKeyboardHints_EmitInDeclaredOrder() =>
+        Assert.Equal(
+            "<input type=\"file\" capture=\"environment\" inputmode=\"none\" enterkeyhint=\"send\" dirname=\"d\" />",
+            Input<string>(InputType.File, Capture: "environment", InputMode: "none", EnterKeyHint: "send",
+                Dirname: "d").ToHtml());
 
     [Fact]
     public void Render_OnInputOutsideLiveContext_OmitsHandlerAttribute()

--- a/tests/Rask.Core.Tests/Components/InputTypeExtensionsTests.cs
+++ b/tests/Rask.Core.Tests/Components/InputTypeExtensionsTests.cs
@@ -1,0 +1,49 @@
+namespace Rask.Core.Tests.Components;
+
+// InputType.ToHtml() is the single source of truth for the HTML `type` token (the analyzer RASK025 and
+// the input-type derivation both lean on it). Pin every member's token so a rename or a dropped switch
+// arm can't silently regress to the "text" fallback.
+public class InputTypeExtensionsTests
+{
+    [Theory]
+    [InlineData(InputType.Text, "text")]
+    [InlineData(InputType.Search, "search")]
+    [InlineData(InputType.Tel, "tel")]
+    [InlineData(InputType.Url, "url")]
+    [InlineData(InputType.Email, "email")]
+    [InlineData(InputType.Password, "password")]
+    [InlineData(InputType.Number, "number")]
+    [InlineData(InputType.Checkbox, "checkbox")]
+    [InlineData(InputType.Radio, "radio")]
+    [InlineData(InputType.File, "file")]
+    [InlineData(InputType.Range, "range")]
+    [InlineData(InputType.Color, "color")]
+    [InlineData(InputType.Date, "date")]
+    [InlineData(InputType.DatetimeLocal, "datetime-local")]
+    [InlineData(InputType.Time, "time")]
+    [InlineData(InputType.Week, "week")]
+    [InlineData(InputType.Month, "month")]
+    [InlineData(InputType.Hidden, "hidden")]
+    [InlineData(InputType.Button, "button")]
+    [InlineData(InputType.Submit, "submit")]
+    [InlineData(InputType.Reset, "reset")]
+    [InlineData(InputType.Image, "image")]
+    public void ToHtml_MapsEveryMemberToItsHtmlToken(InputType type, string expected) =>
+        Assert.Equal(expected, type.ToHtml());
+
+    [Fact]
+    public void ToHtml_CoversEveryEnumMember_WithoutFallingBackToText()
+    {
+        // Only InputType.Text is allowed to yield "text"; any other member doing so means it slipped through
+        // the switch to the default arm (i.e. someone added an enum value but forgot to map it).
+        foreach (var type in Enum.GetValues<InputType>())
+        {
+            var html = type.ToHtml();
+            Assert.False(string.IsNullOrEmpty(html));
+            if (type != InputType.Text)
+            {
+                Assert.NotEqual("text", html);
+            }
+        }
+    }
+}

--- a/tests/Rask.Core.Tests/Forms/PrimitiveBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/PrimitiveBindingTests.cs
@@ -189,6 +189,63 @@ public class PrimitiveBindingTests
     }
 
     [Fact]
+    public async Task GuidProperty_InvalidInput_LeavesPriorValue()
+    {
+        var known = Guid.NewGuid();
+        var p = new IdentityHolder { Token = known };
+        var view = new StubComponent(() => Form(p)[Input(() => p.Token)]);
+        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+
+        using var doc = JsonDocument.Parse("{\"value\":\"not-a-guid\"}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        // Unparseable Guid text must NOT zero the field — TrySetTyped returns false, setter never runs.
+        Assert.Equal(known, p.Token);
+    }
+
+    [Fact]
+    public async Task CharProperty_MultiCharInput_LeavesPriorValue()
+    {
+        var p = new IdentityHolder { Letter = 'a' };
+        var view = new StubComponent(() => Form(p)[Input(() => p.Letter)]);
+        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+
+        // char.TryParse only accepts a single character — a two-char string fails to parse.
+        using var doc = JsonDocument.Parse("{\"value\":\"ab\"}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Equal('a', p.Letter);
+    }
+
+    [Fact]
+    public async Task EnumProperty_OnChange_RoundTripsCaseInsensitively()
+    {
+        var p = new IdentityHolder { Level = Priority.Low };
+        var view = new StubComponent(() => Form(p)[Input(() => p.Level)]);
+        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+
+        // Enum binding goes through Enum.TryParse(ignoreCase: true), so a lower-cased member name binds.
+        using var doc = JsonDocument.Parse("{\"value\":\"high\"}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Equal(Priority.High, p.Level);
+    }
+
+    [Fact]
+    public async Task EnumProperty_InvalidInput_LeavesPriorValue()
+    {
+        var p = new IdentityHolder { Level = Priority.High };
+        var view = new StubComponent(() => Form(p)[Input(() => p.Level)]);
+        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+
+        // A string that is not a member name leaves the model untouched.
+        using var doc = JsonDocument.Parse("{\"value\":\"medium\"}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Equal(Priority.High, p.Level);
+    }
+
+    [Fact]
     public async Task NullableNumericProperty_EmptyInput_SetsNull()
     {
         var p = new NumericHolder { OptionalDouble = 9.9 };
@@ -309,5 +366,12 @@ public class PrimitiveBindingTests
     {
         public Guid Token { get; set; }
         public char Letter { get; set; }
+        public Priority Level { get; set; }
+    }
+
+    private enum Priority
+    {
+        Low,
+        High
     }
 }

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -1154,6 +1154,9 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // BsRadioGroup — bound (Component control): the derived readout sits OUTSIDE the Form yet updates.
+        // The bound group passes Label:, so the radios are wrapped in an accessible <fieldset>/<legend>.
+        await Expect(Page.Locator("#fc-radio-bound fieldset > legend")).ToHaveTextAsync("Plan",
+            new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
         await Page.Locator("input[type=radio][name='fc-radio-b'][value='Team']").CheckAsync();
         await Expect(Page.Locator("#fc-radio-bound-out")).ToContainTextAsync("Team",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });

--- a/tests/Rask.Validation.FluentValidation.Tests/FluentValidationValidatorTests.cs
+++ b/tests/Rask.Validation.FluentValidation.Tests/FluentValidationValidatorTests.cs
@@ -55,10 +55,56 @@ public class FluentValidationValidatorTests
         Assert.Contains(msgs, m => m.Contains("could not be completed"));
     }
 
+    [Fact]
+    public async Task MustAsync_FailingRule_SurfacesMessageForField()
+    {
+        // The async rule path (MustAsync) must be awaited and its failure surfaced per field, exactly like a
+        // sync rule — this is the headline reason FluentValidation registers an IAsyncFieldValidator.
+        var p = new Person { Name = "taken", Age = 1 };
+        var ctx = RegisterValidator(p, new AsyncNameValidator());
+
+        await ctx.ValidateFieldAsync(new FieldIdentifier(p, "Name"));
+
+        Assert.Contains("Name taken", ctx.GetValidationMessages(new FieldIdentifier(p, "Name")));
+    }
+
+    [Fact]
+    public async Task MustAsync_PassingRule_LeavesFieldClean()
+    {
+        var p = new Person { Name = "free", Age = 1 };
+        var ctx = RegisterValidator(p, new AsyncNameValidator());
+
+        await ctx.ValidateFieldAsync(new FieldIdentifier(p, "Name"));
+
+        Assert.Empty(ctx.GetValidationMessages(new FieldIdentifier(p, "Name")));
+    }
+
+    [Fact]
+    public async Task ValidateAsync_RunsAsyncRuleAcrossTheWholeForm()
+    {
+        var p = new Person { Name = "taken", Age = 1 };
+        var ctx = RegisterValidator(p, new AsyncNameValidator());
+
+        var ok = await ctx.ValidateAsync();
+
+        Assert.False(ok);
+        Assert.Contains("Name taken", ctx.GetValidationMessages(new FieldIdentifier(p, "Name")));
+    }
+
     private sealed class Person
     {
         public string Name { get; set; } = "";
         public int Age { get; set; }
+    }
+
+    private sealed class AsyncNameValidator : AbstractValidator<Person>
+    {
+        public AsyncNameValidator() =>
+            RuleFor(x => x.Name).MustAsync(async (name, _) =>
+            {
+                await Task.Yield();
+                return name != "taken";
+            }).WithMessage("Name taken");
     }
 
     private sealed class PersonValidator : AbstractValidator<Person>


### PR DESCRIPTION
## Summary

A focused quality pass on the **form controls** — core (`Input`/`Textarea`) and the `Rask.Bootstrap`
`Bs*` controls — closing accessibility bugs, attribute gaps, test holes, and documentation gaps. No
new feature controls; the mature parts (binding, `EditContext`, validation) are untouched.

Organised as five reviewable commits:

1. **`fix(bootstrap)` — accessible names + validation aria for group/combobox controls.** `BsSelect`
   (custom combobox) and `BsMultiSelect` named their label with a void `<label for>` on a
   `<div role="combobox">`; both now use `aria-labelledby`, and `BsMultiSelect` gained the full
   `aria-haspopup`/`expanded`/`controls` + `aria-invalid`/`describedby` contract. `BsRadioGroup`/
   `BsCheckboxGroup` gained an optional `Label` → `<fieldset>`/`<legend>` group with a `role="alert"`
   error region wired to the inputs via `aria-describedby`.
2. **`feat(forms)` — attribute passthrough.** `BsInput` forwards `Min`/`Max`/`Step`/`Pattern`/
   `MaxLength`/`MinLength`/`List`/`Autofocus`/`Accept`/`Capture`/`Multiple`/`InputMode`/`EnterKeyHint`/
   `Spellcheck`; `BsTextarea` forwards `Cols`/`MaxLength`/`MinLength`/`Autocomplete`/`Autofocus`. Core
   `Input` gains `InputMode`/`EnterKeyHint`/`Spellcheck`/`Capture`/`Dirname`. Merged the duplicated
   `InputType.ToHtml` switch; fixed a stale `RASK023`→`RASK025` comment.
3. **`fix(bootstrap)` — review fixes.** Page-unique group ids (unnamed groups derive a per-instance
   fallback name so two on a page aren't merged into one browser radio group); a non-generic shared
   instance counter (so id-less controls of different generic args don't collide); `BsClass.FieldAria`
   reuse; the group `<fieldset>` no longer sets `disabled` (it would disable interactive `OptionLabel`
   content).
4. **`test(forms)` — coverage.** New `BsRadioGroup`/`BsCheckboxGroup`/`BsFormGroup`/`BsInputGroup`
   tests (were untested), a direct `InputTypeExtensions` test + input-type render tests, binding
   parse-failure edges (Guid/char/enum) + enum round-trip, a `BsCheckboxGroup` bound-toggle membership
   test, a core-`Input` aria/role/tabindex render-order guard, and FluentValidation `MustAsync`
   coverage.
5. **`docs(forms)` — completeness.** `forms.md` enumerates every `InputType`, documents file inputs,
   and lists the mobile/a11y attributes; `bootstrap-forms.md` documents the passthrough + accessible
   `Label`. The `FormControls` radio/checkbox samples showcase the `<fieldset>`/`<legend>` grouping.

## Testing

- `dotnet build Rask.slnx -warnaserror` — clean (analyzers included).
- Full non-E2E suite green: **Rask.Core 1925**, **Rask.Bootstrap 168**, plus all validation,
  generators, and sample suites.
- New/updated tests exercise the consumers (samples, `Bs*` wrappers) of every changed surface, not
  just the units in isolation.
- E2E: the shared forms journey gains an assertion for the bound radio group's accessible
  `<legend>`; the pre-existing selectors are name/id/value-based and unaffected by the additive
  `<fieldset>` wrapper (runs on CI).

## Benchmarks

Not applicable — no render/runtime hot-path (`HtmlSerializer`/`Element`/diff codec) changed; the edits
are to Bootstrap component render logic and the `Input` attribute surface.

## Changelog

`[Unreleased]` updated under Added / Fixed / Documentation.

## Note

The plan called for phased PRs; delivered here as five separated commits on one branch (online-only,
single-worktree). Happy to split into stacked PRs if preferred.
