### PR TITLE
build: auto-enable git hooks on first dotnet build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **Git hooks auto-enable on first build.** A `Directory.Build.targets` target points git at `.githooks/`
+  (`core.hooksPath`) on the first local `dotnet build`, so a fresh clone gets the `commit-msg` /
+  `pre-commit` (format + unit) / `pre-push` (E2E) hooks with no manual `git config`. Idempotent and
+  best-effort; skipped in CI (`CI=true`), during IDE design-time builds, and outside a git working copy
+  (restored packages never trigger it). Hooks stay advisory (bypass with the git no-verify flag /
+  `RASK_SKIP_UNIT=1` / `RASK_SKIP_E2E=1`).
 - **Unit tests + formatting moved out of CI to a local pre-commit gate.** The unit/integration suite no
   longer runs in the ci/nightly/release pipelines. `scripts/run-unit-local.sh` builds the solution and runs
   every test except the browser E2E; a new `.githooks/pre-commit` hook runs `dotnet format

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,10 +74,13 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   `dotnet test` are green. Run `dotnet format` before committing.
 - **[Conventional Commits](https://www.conventionalcommits.org/)** are required and enforced by
   CI (`commitlint`): `type(scope): subject` with type ∈
-  `feat, fix, perf, refactor, docs, test, build, ci, chore, revert`. Enable the local guards with
-  `git config core.hooksPath .githooks` — this installs the `commit-msg` (Conventional Commits) hook, the
-  `pre-commit` hook that runs the local **unit** gate, and the `pre-push` hook that runs the local **E2E**
-  gate (see below).
+  `feat, fix, perf, refactor, docs, test, build, ci, chore, revert`. The local git hooks are **enabled
+  automatically on your first `dotnet build`** (a `Directory.Build.targets` target points git at
+  `.githooks/`; skipped in CI and for restored packages) — or enable them by hand with
+  `git config core.hooksPath .githooks`. That installs the `commit-msg` (Conventional Commits) hook, the
+  `pre-commit` hook that runs the local **format + unit** gate, and the `pre-push` hook that runs the local
+  **E2E** gate (see below). Hooks are advisory — bypass any with the git no-verify flag,
+  `RASK_SKIP_UNIT=1`, or `RASK_SKIP_E2E=1`.
 - **Tests run locally, not in CI.** The unit/integration suite and both E2E suites were moved out of the
   CI pipeline; CI keeps only the deterministic benchmark byte-gates, the native compile gate, commitlint,
   and CodeQL.

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,4 +16,24 @@
   <Import Project="$(MSBuildThisFileDirectory)src\Rask.Core\build\Rask.Core.targets"
           Condition=" Exists('$(MSBuildThisFileDirectory)src\Rask.Core\build\Rask.Core.targets') "/>
 
+  <!--
+    Auto-enable the repo's git hooks (pre-commit: dotnet format + unit; pre-push: browser E2E) so a fresh
+    clone picks them up on first build — no manual `git config core.hooksPath .githooks`. The hook contents
+    live in .githooks/; this only points git at them. Idempotent (git config is a no-op if already set) and
+    best-effort (ContinueOnError). Skipped in CI (GitHub sets CI=true) and during IDE design-time builds,
+    and only runs inside a git working copy (.git present — a directory in the main clone, a file in a
+    worktree), so a restored/consumed package never triggers it. Hooks stay advisory: bypass any with
+    the git no-verify flag, RASK_SKIP_UNIT=1, or RASK_SKIP_E2E=1. See CONTRIBUTING.md.
+  -->
+  <Target Name="RaskConfigureGitHooks" BeforeTargets="Build"
+          Condition=" '$(CI)' != 'true' And '$(DesignTimeBuild)' != 'true'
+                      And Exists('$(MSBuildThisFileDirectory).githooks')
+                      And Exists('$(MSBuildThisFileDirectory).git') ">
+    <Exec Command="git config core.hooksPath .githooks"
+          WorkingDirectory="$(MSBuildThisFileDirectory)"
+          ContinueOnError="true"
+          StandardOutputImportance="low"
+          StandardErrorImportance="low" />
+  </Target>
+
 </Project>


### PR DESCRIPTION
## Summary
Makes the local git hooks (moved out of CI in #362/#365) self-enabling: a `Directory.Build.targets` target sets `core.hooksPath=.githooks` on the first local `dotnet build`, so a fresh clone gets the `commit-msg` / `pre-commit` (format + unit) / `pre-push` (E2E) hooks with no manual `git config`.

Chosen for **speed + cost**: hooks stay advisory (the honest ceiling for client-side hooks — a required CI check is the only true enforcement, and that's what we deliberately removed). This just removes the "forgot to run `git config`" failure mode.

## Guards (idempotent + best-effort)
- Skipped in CI (`CI=true` on GitHub) — never mutates runner git config.
- Skipped for IDE design-time builds (`DesignTimeBuild=true`).
- Only runs inside a git working copy (`.git` present — dir in a clone, file in a worktree), so a restored/consumed NuGet package never triggers it.
- `ContinueOnError` + low log importance; `git config` is a no-op when already set.

## Testing (verified locally)
- Normal `dotnet build` → `core.hooksPath` becomes `.githooks`.
- `CI=true dotnet build` → `core.hooksPath` stays unset.

## Changelog
Added under `[Unreleased] → Changed`.