### PR TITLE
feat(cli): generate feature — value objects, EF config, and --validation modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`rask generate feature` now emits an EF Core `IEntityTypeConfiguration`.** Each feature gets a
+  `<Entity>Configuration : IEntityTypeConfiguration<<Entity>>` (`HasKey` + `IsRequired()`/`HasMaxLength()`
+  per string field), applied via `ApplyConfigurationsFromAssembly` in the generated `DbContext`. The
+  schema now lives in the configuration, so the entity is a clean, attribute-free domain model.
+
 ### Changed
 - **Git hooks auto-enable on first build.** A `Directory.Build.targets` target points git at `.githooks/`
   (`core.hooksPath`) on the first local `dotnet build`, so a fresh clone gets the `commit-msg` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
-- **`rask generate feature` now emits an EF Core `IEntityTypeConfiguration`.** Each feature gets a
-  `<Entity>Configuration : IEntityTypeConfiguration<<Entity>>` (`HasKey` + `IsRequired()`/`HasMaxLength()`
-  per string field), applied via `ApplyConfigurationsFromAssembly` in the generated `DbContext`. The
-  schema now lives in the configuration, so the entity is a clean, attribute-free domain model.
+- **`rask generate feature` now emits value objects + an EF Core `IEntityTypeConfiguration`.** Each
+  required (non-nullable) string field becomes a value object — a `readonly record struct <Entity><Field>`
+  that owns its validation (`Validate` + `From`, a `MaxLength` const), reused by the form via
+  `Input(…, Validate: <Entity><Field>.Validate)` and mapped to its column with `HasConversion`. The
+  entity holds the value-object type; `Create`/`Update` take primitives and wrap them via `From`. This is
+  the built-in, dependency-free default validation. Each feature also gets a
+  `<Entity>Configuration : IEntityTypeConfiguration<<Entity>>` (`HasKey` + per-string mapping), applied via
+  `ApplyConfigurationsFromAssembly` in the generated `DbContext`, so the domain model stays free of
+  persistence attributes.
 
 ### Changed
 - **Git hooks auto-enable on first build.** A `Directory.Build.targets` target points git at `.githooks/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ them until tagged releases begin.
   the built-in, dependency-free default validation. Each feature also gets a
   `<Entity>Configuration : IEntityTypeConfiguration<<Entity>>` (`HasKey` + per-string mapping), applied via
   `ApplyConfigurationsFromAssembly` in the generated `DbContext`, so the domain model stays free of
-  persistence attributes.
+  persistence attributes. `--validation dataannotations` or `--validation fluent` opt out of value objects
+  in favour of a plain POCO entity validated by that library — `[Required]`/`[MaxLength]` on the request +
+  a `DataAnnotationsValidator()`, or a generated `<Entity>RequestValidator : AbstractValidator<…>` +
+  `FluentValidationValidator(…)` — wired into the create/edit forms (the respective `Rask.Validation.*`
+  package is added to the printed next-steps).
 
 ### Changed
 - **Git hooks auto-enable on first build.** A `Directory.Build.targets` target points git at `.githooks/`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -70,6 +70,7 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 |--------|---------|
 | `--fields`, `-f` | `feature` only: the entity's fields as `Name:type,…`. Types: `string`, `int`, `long`, `decimal`, `double`, `bool`, `DateTime`, `Guid` (aliases like `text`/`number`/`money`/`date` too). A field is optional with a trailing `?` (`Note:string?`); strings get a default max length, overridable with `Name:string(100)`. An `Id` is added automatically. |
 | `--id` | `feature` only: the entity's key type — `guid` (default), `int`, or `long`. |
+| `--validation` | `feature` only: `valueobjects` (default — required strings become value objects with built-in, dependency-free validation), `dataannotations` (POCO + `[Required]`/`[MaxLength]` + `DataAnnotationsValidator`), or `fluent` (POCO + a generated `AbstractValidator` + `FluentValidationValidator`). |
 | `--context`, `-c` | `feature` only: reference an existing `DbContext` by name instead of generating a feature-local one (then add a `DbSet` to it). |
 | `--plural`, `-p` | `feature` only: the plural used for the folder, DbSet, list page, and route. Give the entity a **singular** name (`Product`) and this defaults to a simple pluralization (`Products`); override it when that guess is wrong (`--plural People`). |
 | `--route`, `-r` | `page` only: the `[Route]` path (default: kebab-case of the name, e.g. `/products`). |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 |----------|-------|-------------------|
 | `page <Name>` | `Features/<Name>/<Name>Page.cs` — a routed page `Component` with a `Head` title | `<Name>Page` in `<Root>.Features.<Name>` |
 | `component <Name>` | `Components/<Name>.cs` — a plain `Component` | `<Name>` in `<Root>.Components` |
-| `feature <Name> --fields …` | `Features/<Plural>/` — an encapsulated entity (`Create`/`Update`, Guid id), an EF `IEntityTypeConfiguration`, a `DbContext`, **CQRS** create/update/delete commands + list/get queries with handlers, and list / create / edit pages that dispatch via `IDispatcher` | in `<Root>.Features.<Plural>` |
+| `feature <Name> --fields …` | `Features/<Plural>/` — an encapsulated entity (`Create`/`Update`, Guid id) with **value objects** for required strings (built-in validation), an EF `IEntityTypeConfiguration`, a `DbContext`, **CQRS** create/update/delete commands + list/get queries with handlers, and list / create / edit pages that dispatch via `IDispatcher` | in `<Root>.Features.<Plural>` |
 
 | Option | Meaning |
 |--------|---------|

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -64,7 +64,7 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 |----------|-------|-------------------|
 | `page <Name>` | `Features/<Name>/<Name>Page.cs` — a routed page `Component` with a `Head` title | `<Name>Page` in `<Root>.Features.<Name>` |
 | `component <Name>` | `Components/<Name>.cs` — a plain `Component` | `<Name>` in `<Root>.Components` |
-| `feature <Name> --fields …` | `Features/<Plural>/` — an encapsulated entity (`Create`/`Update`, Guid id), a `DbContext`, **CQRS** create/update/delete commands + list/get queries with handlers, and list / create / edit pages that dispatch via `IDispatcher` | in `<Root>.Features.<Plural>` |
+| `feature <Name> --fields …` | `Features/<Plural>/` — an encapsulated entity (`Create`/`Update`, Guid id), an EF `IEntityTypeConfiguration`, a `DbContext`, **CQRS** create/update/delete commands + list/get queries with handlers, and list / create / edit pages that dispatch via `IDispatcher` | in `<Root>.Features.<Plural>` |
 
 | Option | Meaning |
 |--------|---------|

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -55,6 +55,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             .Option("context", 'c')
             .Option("plural", 'p')
             .Option("id")
+            .Option("validation")
             .Flag("force")
             .Flag("dry-run");
 
@@ -95,9 +96,10 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
         if (kind != "feature"
             && (parsed.Option("fields") is not null || parsed.Option("context") is not null
-                || parsed.Option("plural") is not null || parsed.Option("id") is not null))
+                || parsed.Option("plural") is not null || parsed.Option("id") is not null
+                || parsed.Option("validation") is not null))
         {
-            Console.Error.WriteLine("--fields, --context, --plural, and --id only apply to 'generate feature'.");
+            Console.Error.WriteLine("--fields, --context, --plural, --id, and --validation only apply to 'generate feature'.");
             return Task.FromResult(1);
         }
 
@@ -179,7 +181,15 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                     return false;
                 }
 
-                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
+                var validation = parsed.Option("validation")?.ToLowerInvariant() ?? "valueobjects";
+                if (validation is not ("valueobjects" or "dataannotations" or "fluent"))
+                {
+                    result = null!;
+                    error = "--validation must be 'valueobjects' (default), 'dataannotations', or 'fluent'.";
+                    return false;
+                }
+
+                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
                 return true;
         }
     }

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -39,12 +39,14 @@ internal static class FeatureGenerator
             ("__CREATEARGS__", RequestArgs(fields, "command.Request")),
             ("__HEADERS__", TableHeaders(fields)), ("__CELLS__", TableCells(fields)),
             ("__FORMFIELDS__", FormFields(fields)), ("__COPYTOFORM__", CopyToForm(fields)),
+            ("__CONFIGPROPS__", ConfigProperties(fields)),
         };
 
         var files = new List<ScaffoldFile>
         {
             new(Path.Combine(targetDirectory, entityName + ".cs"), RenderEntity(ns, entityName, fields, idType)),
             new(Path.Combine(targetDirectory, entityName + "Request.cs"), RenderRequest(ns, entityName, fields)),
+            new(Path.Combine(targetDirectory, entityName + "Configuration.cs"), Apply(ConfigurationTemplate, tokens)),
             new(Path.Combine(targetDirectory, plural + "Page.cs"), Apply(ListPageTemplate, tokens)),
             new(Path.Combine(targetDirectory, "Delete" + entityName + ".cs"), Apply(DeleteTemplate, tokens)),
             new(Path.Combine(targetDirectory, "Create" + entityName + ".cs"), Apply(CreateTemplate, tokens)),
@@ -64,11 +66,6 @@ internal static class FeatureGenerator
     internal static string RenderEntity(string ns, string entity, IReadOnlyList<FieldSpec> fields, string idType)
     {
         var sb = new StringBuilder();
-        if (fields.Any(f => f.IsString))
-        {
-            sb.Append("using System.ComponentModel.DataAnnotations;\n\n");
-        }
-
         sb.Append("namespace ").Append(ns).Append(";\n\n");
         sb.Append("public sealed class ").Append(entity).Append("\n{\n");
         sb.Append("    private ").Append(entity).Append("() { } // EF Core materialization\n\n");
@@ -79,18 +76,7 @@ internal static class FeatureGenerator
 
         foreach (var field in fields)
         {
-            sb.Append('\n');
-            if (field.IsString)
-            {
-                if (!field.IsNullable)
-                {
-                    sb.Append("    [Required]\n");
-                }
-
-                sb.Append("    [MaxLength(").Append(field.MaxLength!.Value.ToString(CultureInfo.InvariantCulture)).Append(")]\n");
-            }
-
-            sb.Append("    public ").Append(field.PropertyType).Append(' ').Append(field.Name).Append(" { get; private set; }");
+            sb.Append("\n    public ").Append(field.PropertyType).Append(' ').Append(field.Name).Append(" { get; private set; }");
             if (field.Initializer is not null)
             {
                 sb.Append(' ').Append(field.Initializer).Append(';');
@@ -175,6 +161,14 @@ internal static class FeatureGenerator
     private static string CopyToForm(IReadOnlyList<FieldSpec> fields) =>
         string.Join("\n", fields.Select(f => $"                _form.{f.Name} = entity.{f.Name};"));
 
+    // The EF Core mapping for each string column (length + required); other types need no configuration.
+    private static string ConfigProperties(IReadOnlyList<FieldSpec> fields) =>
+        string.Join("\n", fields.Where(f => f.IsString).Select(f =>
+        {
+            var required = f.IsNullable ? "" : ".IsRequired()";
+            return $"        entity.Property(x => x.{f.Name}){required}.HasMaxLength({f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture)});";
+        }));
+
     private static string FormFields(IReadOnlyList<FieldSpec> fields)
     {
         var sb = new StringBuilder();
@@ -216,7 +210,8 @@ internal static class FeatureGenerator
         }
         else
         {
-            steps.Append("       // add the entity to your ").Append(context).Append(": public DbSet<").Append(entity).Append("> ").Append(plural).Append(" => Set<").Append(entity).Append(">();\n");
+            steps.Append("       // in your ").Append(context).Append(": add `public DbSet<").Append(entity).Append("> ").Append(plural).Append(" => Set<").Append(entity).Append(">();`\n");
+            steps.Append("       // and apply the config: modelBuilder.ApplyConfigurationsFromAssembly(typeof(").Append(entity).Append("Configuration).Assembly);\n");
         }
 
         steps.Append("  3. Create the schema (EF Core migrations):\n");
@@ -246,6 +241,28 @@ internal static class FeatureGenerator
         public sealed class __CONTEXT__(DbContextOptions<__CONTEXT__> options) : DbContext(options)
         {
             public DbSet<__ENTITY__> __PLURAL__ => Set<__ENTITY__>();
+
+            protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+                modelBuilder.ApplyConfigurationsFromAssembly(typeof(__CONTEXT__).Assembly);
+        }
+
+        """;
+
+    private const string ConfigurationTemplate =
+        """
+        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+        namespace __NS__;
+
+        // The EF Core mapping for __ENTITY__ (keeps the domain model free of persistence attributes).
+        public sealed class __ENTITY__Configuration : IEntityTypeConfiguration<__ENTITY__>
+        {
+            public void Configure(EntityTypeBuilder<__ENTITY__> entity)
+            {
+                entity.HasKey(x => x.Id);
+        __CONFIGPROPS__
+            }
         }
 
         """;

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -19,6 +19,7 @@ internal static class FeatureGenerator
         string entityName,
         IReadOnlyList<FieldSpec> fields,
         string idType,
+        string validation,
         string? contextOverride,
         string? pluralOverride,
         string? outputOverride)
@@ -28,6 +29,7 @@ internal static class FeatureGenerator
         var idConstraint = idType == "Guid" ? "guid" : idType;
         var generateContext = contextOverride is null;
         var context = contextOverride ?? plural + "DbContext";
+        var useValueObjects = validation == "valueobjects";
 
         var targetDirectory = Scaffold.TargetDirectory(baseDirectory, outputOverride, "Features", plural);
         var ns = project.NamespaceFor(targetDirectory);
@@ -37,15 +39,16 @@ internal static class FeatureGenerator
             ("__NS__", ns), ("__ENTITY__", entityName), ("__PLURAL__", plural), ("__CONTEXT__", context),
             ("__ROUTE__", route), ("__IDTYPE__", idType), ("__IDCONSTRAINT__", idConstraint),
             ("__CREATEARGS__", RequestArgs(fields, "command.Request")),
-            ("__HEADERS__", TableHeaders(fields)), ("__CELLS__", TableCells(fields)),
-            ("__FORMFIELDS__", FormFields(entityName, fields)), ("__COPYTOFORM__", CopyToForm(fields)),
-            ("__CONFIGPROPS__", ConfigProperties(entityName, fields)),
+            ("__HEADERS__", TableHeaders(fields)), ("__CELLS__", TableCells(fields, useValueObjects)),
+            ("__FORMFIELDS__", FormFields(entityName, fields, useValueObjects)), ("__COPYTOFORM__", CopyToForm(fields, useValueObjects)),
+            ("__CONFIGPROPS__", ConfigProperties(entityName, fields, useValueObjects)),
+            ("__VALIDATOR__", FormValidator(entityName, validation)),
         };
 
         var files = new List<ScaffoldFile>
         {
-            new(Path.Combine(targetDirectory, entityName + ".cs"), RenderEntity(ns, entityName, fields, idType)),
-            new(Path.Combine(targetDirectory, entityName + "Request.cs"), RenderRequest(ns, entityName, fields)),
+            new(Path.Combine(targetDirectory, entityName + ".cs"), RenderEntity(ns, entityName, fields, idType, useValueObjects)),
+            new(Path.Combine(targetDirectory, entityName + "Request.cs"), RenderRequest(ns, entityName, fields, validation)),
             new(Path.Combine(targetDirectory, entityName + "Configuration.cs"), Apply(ConfigurationTemplate, tokens)),
             new(Path.Combine(targetDirectory, plural + "Page.cs"), Apply(ListPageTemplate, tokens)),
             new(Path.Combine(targetDirectory, "Delete" + entityName + ".cs"), Apply(DeleteTemplate, tokens)),
@@ -53,12 +56,20 @@ internal static class FeatureGenerator
             new(Path.Combine(targetDirectory, "Update" + entityName + ".cs"), Apply(UpdateTemplate, tokens)),
         };
 
-        // One value object per required-string field, each owning its validation.
-        foreach (var field in fields.Where(IsValueObject))
+        // valueobjects mode: one value object per required-string field, each owning its validation.
+        foreach (var field in fields.Where(f => IsValueObject(f, useValueObjects)))
         {
             files.Add(new ScaffoldFile(
                 Path.Combine(targetDirectory, ValueObjectName(entityName, field) + ".cs"),
                 RenderValueObject(ns, entityName, field)));
+        }
+
+        // fluent mode: a FluentValidation validator for the request.
+        if (validation == "fluent")
+        {
+            files.Add(new ScaffoldFile(
+                Path.Combine(targetDirectory, entityName + "RequestValidator.cs"),
+                Apply(FluentValidatorTemplate, tokens).Replace("__RULES__", FluentRules(fields), StringComparison.Ordinal)));
         }
 
         if (generateContext)
@@ -66,29 +77,47 @@ internal static class FeatureGenerator
             files.Insert(2, new ScaffoldFile(Path.Combine(targetDirectory, context + ".cs"), Apply(DbContextTemplate, tokens)));
         }
 
-        return new ScaffoldResult(files, RenderNextSteps(context, entityName, plural, route, generateContext));
+        return new ScaffoldResult(files, RenderNextSteps(context, entityName, plural, route, generateContext, validation));
     }
+
+    // The form-level validator component wired at the top of the create/edit forms (empty for the
+    // value-objects default, which validates per-input instead).
+    private static string FormValidator(string entity, string validation) => validation switch
+    {
+        "dataannotations" => "                    DataAnnotationsValidator(),\n",
+        "fluent" => $"                    FluentValidationValidator(new {entity}RequestValidator()),\n",
+        _ => "",
+    };
+
+    // FluentValidation RuleFor lines for the string fields (NotEmpty for required, MaximumLength for all).
+    private static string FluentRules(IReadOnlyList<FieldSpec> fields) =>
+        string.Join("\n", fields.Where(f => f.IsString).Select(f =>
+        {
+            var notEmpty = f.IsNullable ? "" : ".NotEmpty()";
+            return $"        RuleFor(x => x.{f.Name}){notEmpty}.MaximumLength({f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture)});";
+        }));
 
     // ---- entity + shared request (StringBuilder — per-field attributes make raw strings awkward) ----
 
     // A required (non-nullable) string field is modelled as a value object that owns its own validation
-    // (built-in, dependency-free). Optional strings and other types stay primitive.
-    private static bool IsValueObject(FieldSpec f) => f.IsString && !f.IsNullable;
+    // (built-in, dependency-free) — only in the default 'valueobjects' mode. The --validation
+    // dataannotations/fluent modes keep everything primitive (POCO) and validate on the request instead.
+    private static bool IsValueObject(FieldSpec f, bool useValueObjects) => useValueObjects && f.IsString && !f.IsNullable;
 
     private static string ValueObjectName(string entity, FieldSpec f) => entity + f.Name;
 
-    private static string EntityPropertyType(string entity, FieldSpec f) =>
-        IsValueObject(f) ? ValueObjectName(entity, f) : f.PropertyType;
+    private static string EntityPropertyType(string entity, FieldSpec f, bool useValueObjects) =>
+        IsValueObject(f, useValueObjects) ? ValueObjectName(entity, f) : f.PropertyType;
 
-    internal static string RenderEntity(string ns, string entity, IReadOnlyList<FieldSpec> fields, string idType)
+    internal static string RenderEntity(string ns, string entity, IReadOnlyList<FieldSpec> fields, string idType, bool useValueObjects)
     {
         var sb = new StringBuilder();
         sb.Append("namespace ").Append(ns).Append(";\n\n");
         sb.Append("public sealed class ").Append(entity).Append("\n{\n");
         sb.Append("    private ").Append(entity).Append("() { } // EF Core materialization\n\n");
 
-        // The ctor takes the value-object types; Create/Update take primitives and wrap them via From.
-        var ctorParams = string.Join(", ", fields.Select(f => $"{EntityPropertyType(entity, f)} {Identifiers.ToCamelCase(f.Name)}"));
+        // The ctor takes the value-object types; Create/Update take primitives and wrap them via Create.
+        var ctorParams = string.Join(", ", fields.Select(f => $"{EntityPropertyType(entity, f, useValueObjects)} {Identifiers.ToCamelCase(f.Name)}"));
         sb.Append("    private ").Append(entity).Append('(').Append(ctorParams).Append(")\n    {\n");
         sb.Append(Assignments(fields, "        ")).Append("\n    }\n\n");
         sb.Append("    public ").Append(idType).Append(" Id { get; private set; }");
@@ -96,8 +125,8 @@ internal static class FeatureGenerator
 
         foreach (var field in fields)
         {
-            sb.Append("\n    public ").Append(EntityPropertyType(entity, field)).Append(' ').Append(field.Name).Append(" { get; private set; }");
-            if (field.Initializer is not null && !IsValueObject(field))
+            sb.Append("\n    public ").Append(EntityPropertyType(entity, field, useValueObjects)).Append(' ').Append(field.Name).Append(" { get; private set; }");
+            if (field.Initializer is not null && !IsValueObject(field, useValueObjects))
             {
                 sb.Append(' ').Append(field.Initializer).Append(';');
             }
@@ -106,19 +135,19 @@ internal static class FeatureGenerator
         }
 
         var createParams = string.Join(", ", fields.Select(f => $"{f.PropertyType} {Identifiers.ToCamelCase(f.Name)}"));
-        var createArgs = string.Join(", ", fields.Select(f => WrapPrimitive(entity, f)));
+        var createArgs = string.Join(", ", fields.Select(f => WrapPrimitive(entity, f, useValueObjects)));
         sb.Append("\n    public static ").Append(entity).Append(" Create(").Append(createParams).Append(") => new(").Append(createArgs).Append(");\n\n");
 
         sb.Append("    public void Update(").Append(createParams).Append(")\n    {\n");
-        sb.Append(string.Join("\n", fields.Select(f => $"        this.{f.Name} = {WrapPrimitive(entity, f)};"))).Append("\n    }\n}\n");
+        sb.Append(string.Join("\n", fields.Select(f => $"        this.{f.Name} = {WrapPrimitive(entity, f, useValueObjects)};"))).Append("\n    }\n}\n");
         return sb.ToString();
     }
 
     // Wrap a primitive parameter into its value object where the field has one, else pass it through.
-    private static string WrapPrimitive(string entity, FieldSpec f)
+    private static string WrapPrimitive(string entity, FieldSpec f, bool useValueObjects)
     {
         var param = Identifiers.ToCamelCase(f.Name);
-        return IsValueObject(f) ? $"{ValueObjectName(entity, f)}.Create({param})" : param;
+        return IsValueObject(f, useValueObjects) ? $"{ValueObjectName(entity, f)}.Create({param})" : param;
     }
 
     internal static string RenderValueObject(string ns, string entity, FieldSpec f)
@@ -131,15 +160,38 @@ internal static class FeatureGenerator
         ]);
     }
 
-    private static string RenderRequest(string ns, string entity, IReadOnlyList<FieldSpec> fields)
+    private static string RenderRequest(string ns, string entity, IReadOnlyList<FieldSpec> fields, string validation)
     {
+        // In --validation dataannotations mode the DataAnnotationsValidator reads attributes off this
+        // request, so emit them here. Other modes validate elsewhere (value objects / a fluent validator).
+        var annotate = validation == "dataannotations";
         var sb = new StringBuilder();
+        if (annotate && fields.Any(f => f.IsString))
+        {
+            sb.Append("using System.ComponentModel.DataAnnotations;\n\n");
+        }
+
         sb.Append("namespace ").Append(ns).Append(";\n\n");
         sb.Append("// The shared form model for the create + edit slices; maps onto ").Append(entity).Append(".Create/Update.\n");
-        sb.Append("// Validation lives on the value objects and runs in the form via Input(..., Validate: ...).\n");
         sb.Append("public sealed class ").Append(entity).Append("Request\n{\n");
+        var first = true;
         foreach (var field in fields)
         {
+            if (annotate && field.IsString)
+            {
+                if (!first)
+                {
+                    sb.Append('\n');
+                }
+
+                if (!field.IsNullable)
+                {
+                    sb.Append("    [Required]\n");
+                }
+
+                sb.Append("    [MaxLength(").Append(field.MaxLength!.Value.ToString(CultureInfo.InvariantCulture)).Append(")]\n");
+            }
+
             sb.Append("    public ").Append(field.PropertyType).Append(' ').Append(field.Name).Append(" { get; set; }");
             if (field.Initializer is not null)
             {
@@ -147,6 +199,7 @@ internal static class FeatureGenerator
             }
 
             sb.Append('\n');
+            first = false;
         }
 
         sb.Append("}\n");
@@ -166,40 +219,42 @@ internal static class FeatureGenerator
     private static string TableHeaders(IReadOnlyList<FieldSpec> fields) =>
         string.Join("\n", fields.Select(f => $"                            Th()[\"{f.Name}\"],"));
 
-    private static string TableCells(IReadOnlyList<FieldSpec> fields) =>
+    private static string TableCells(IReadOnlyList<FieldSpec> fields, bool useValueObjects) =>
         string.Join("\n", fields.Select(f =>
         {
-            var access = IsValueObject(f) ? $"x.{f.Name}.Value" : f.IsString ? $"x.{f.Name}" : $"$\"{{x.{f.Name}}}\"";
+            var access = IsValueObject(f, useValueObjects) ? $"x.{f.Name}.Value" : f.IsString ? $"x.{f.Name}" : $"$\"{{x.{f.Name}}}\"";
             return $"                            Td()[{access}],";
         }));
 
-    private static string CopyToForm(IReadOnlyList<FieldSpec> fields) =>
-        string.Join("\n", fields.Select(f => $"                _form.{f.Name} = entity.{f.Name}{(IsValueObject(f) ? ".Value" : "")};"));
+    private static string CopyToForm(IReadOnlyList<FieldSpec> fields, bool useValueObjects) =>
+        string.Join("\n", fields.Select(f => $"                _form.{f.Name} = entity.{f.Name}{(IsValueObject(f, useValueObjects) ? ".Value" : "")};"));
 
-    // The EF Core mapping per string column: a value object maps through its converter; an optional
-    // string just gets a length. Other types need no configuration.
-    private static string ConfigProperties(string entity, IReadOnlyList<FieldSpec> fields) =>
+    // The EF Core mapping per string column: a value object maps through its converter; a primitive
+    // string gets IsRequired()/HasMaxLength(). Other types need no configuration.
+    private static string ConfigProperties(string entity, IReadOnlyList<FieldSpec> fields, bool useValueObjects) =>
         string.Join("\n", fields.Where(f => f.IsString).Select(f =>
         {
-            if (IsValueObject(f))
+            if (IsValueObject(f, useValueObjects))
             {
                 // Length comes from the value object's own MaxLength — a single source of truth.
                 var vo = ValueObjectName(entity, f);
                 return $"        entity.Property(x => x.{f.Name}).HasConversion(v => v.Value, s => {vo}.Create(s)).HasMaxLength({vo}.MaxLength);";
             }
 
+            var required = f.IsNullable ? "" : ".IsRequired()";
             var len = f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture);
-            return $"        entity.Property(x => x.{f.Name}).HasMaxLength({len});";
+            return $"        entity.Property(x => x.{f.Name}){required}.HasMaxLength({len});";
         }));
 
-    private static string FormFields(string entity, IReadOnlyList<FieldSpec> fields)
+    private static string FormFields(string entity, IReadOnlyList<FieldSpec> fields, bool useValueObjects)
     {
         var sb = new StringBuilder();
         foreach (var field in fields)
         {
             var id = field.Name.ToLowerInvariant();
-            // A value-object field wires its built-in Validate into the bound input.
-            var validate = IsValueObject(field) ? $", Validate: {ValueObjectName(entity, field)}.Validate" : "";
+            // A value-object field wires its built-in Validate into the bound input; the dataannotations /
+            // fluent modes validate through the form-level validator component instead.
+            var validate = IsValueObject(field, useValueObjects) ? $", Validate: {ValueObjectName(entity, field)}.Validate" : "";
             if (field.CsType == "bool")
             {
                 sb.Append("                    Div(Class: \"form-check\")[\n")
@@ -219,7 +274,7 @@ internal static class FeatureGenerator
         return sb.ToString().TrimEnd('\n');
     }
 
-    private static string RenderNextSteps(string context, string entity, string plural, string route, bool generatedContext)
+    private static string RenderNextSteps(string context, string entity, string plural, string route, bool generatedContext, string validation)
     {
         var steps = new StringBuilder();
         steps.Append("Next steps:\n");
@@ -227,6 +282,15 @@ internal static class FeatureGenerator
         steps.Append("       dotnet add package Microsoft.EntityFrameworkCore.Sqlite\n");
         steps.Append("       dotnet add package Microsoft.EntityFrameworkCore.Design\n");
         steps.Append("       dotnet add package Rask.Cqrs\n");
+        if (validation == "dataannotations")
+        {
+            steps.Append("       dotnet add package Rask.Validation.DataAnnotations\n");
+        }
+        else if (validation == "fluent")
+        {
+            steps.Append("       dotnet add package Rask.Validation.FluentValidation\n");
+        }
+
         steps.Append("  2. Register services in Program.cs:\n");
         steps.Append("       builder.Services.AddRaskCqrs();\n");
         if (generatedContext)
@@ -311,6 +375,22 @@ internal static class FeatureGenerator
             }
 
             public override string ToString() => Value;
+        }
+
+        """;
+
+    private const string FluentValidatorTemplate =
+        """
+        using FluentValidation;
+
+        namespace __NS__;
+
+        public sealed class __ENTITY__RequestValidator : AbstractValidator<__ENTITY__Request>
+        {
+            public __ENTITY__RequestValidator()
+            {
+        __RULES__
+            }
         }
 
         """;
@@ -484,7 +564,7 @@ internal static class FeatureGenerator
                     Div(Class: "card-body")[
                         H1(Class: "h4 mb-3")["New __ENTITY__"],
                         Form(_form, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
-        __FORMFIELDS__
+        __VALIDATOR____FORMFIELDS__
                             Div(Class: "d-flex justify-content-end gap-2 pt-2")[
                                 NavLink(Routes.__PLURAL__Page(), Class: "btn btn-outline-secondary")["Cancel"],
                                 Button("submit", Class: "btn btn-primary")["Save"]
@@ -580,7 +660,7 @@ internal static class FeatureGenerator
                     Div(Class: "card-body")[
                         H1(Class: "h4 mb-3")["Edit __ENTITY__"],
                         Form(_form, OnValidSubmitAsync: SubmitAsync, Class: "vstack gap-3")[
-        __FORMFIELDS__
+        __VALIDATOR____FORMFIELDS__
                             Div(Class: "d-flex justify-content-end gap-2 pt-2")[
                                 NavLink(Routes.__PLURAL__Page(), Class: "btn btn-outline-secondary")["Cancel"],
                                 Button("submit", Class: "btn btn-primary")["Save changes"]

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -38,8 +38,8 @@ internal static class FeatureGenerator
             ("__ROUTE__", route), ("__IDTYPE__", idType), ("__IDCONSTRAINT__", idConstraint),
             ("__CREATEARGS__", RequestArgs(fields, "command.Request")),
             ("__HEADERS__", TableHeaders(fields)), ("__CELLS__", TableCells(fields)),
-            ("__FORMFIELDS__", FormFields(fields)), ("__COPYTOFORM__", CopyToForm(fields)),
-            ("__CONFIGPROPS__", ConfigProperties(fields)),
+            ("__FORMFIELDS__", FormFields(entityName, fields)), ("__COPYTOFORM__", CopyToForm(fields)),
+            ("__CONFIGPROPS__", ConfigProperties(entityName, fields)),
         };
 
         var files = new List<ScaffoldFile>
@@ -53,6 +53,14 @@ internal static class FeatureGenerator
             new(Path.Combine(targetDirectory, "Update" + entityName + ".cs"), Apply(UpdateTemplate, tokens)),
         };
 
+        // One value object per required-string field, each owning its validation.
+        foreach (var field in fields.Where(IsValueObject))
+        {
+            files.Add(new ScaffoldFile(
+                Path.Combine(targetDirectory, ValueObjectName(entityName, field) + ".cs"),
+                RenderValueObject(ns, entityName, field)));
+        }
+
         if (generateContext)
         {
             files.Insert(2, new ScaffoldFile(Path.Combine(targetDirectory, context + ".cs"), Apply(DbContextTemplate, tokens)));
@@ -63,21 +71,33 @@ internal static class FeatureGenerator
 
     // ---- entity + shared request (StringBuilder — per-field attributes make raw strings awkward) ----
 
+    // A required (non-nullable) string field is modelled as a value object that owns its own validation
+    // (built-in, dependency-free). Optional strings and other types stay primitive.
+    private static bool IsValueObject(FieldSpec f) => f.IsString && !f.IsNullable;
+
+    private static string ValueObjectName(string entity, FieldSpec f) => entity + f.Name;
+
+    private static string EntityPropertyType(string entity, FieldSpec f) =>
+        IsValueObject(f) ? ValueObjectName(entity, f) : f.PropertyType;
+
     internal static string RenderEntity(string ns, string entity, IReadOnlyList<FieldSpec> fields, string idType)
     {
         var sb = new StringBuilder();
         sb.Append("namespace ").Append(ns).Append(";\n\n");
         sb.Append("public sealed class ").Append(entity).Append("\n{\n");
         sb.Append("    private ").Append(entity).Append("() { } // EF Core materialization\n\n");
-        sb.Append("    private ").Append(entity).Append('(').Append(ParamList(fields)).Append(")\n    {\n");
+
+        // The ctor takes the value-object types; Create/Update take primitives and wrap them via From.
+        var ctorParams = string.Join(", ", fields.Select(f => $"{EntityPropertyType(entity, f)} {Identifiers.ToCamelCase(f.Name)}"));
+        sb.Append("    private ").Append(entity).Append('(').Append(ctorParams).Append(")\n    {\n");
         sb.Append(Assignments(fields, "        ")).Append("\n    }\n\n");
         sb.Append("    public ").Append(idType).Append(" Id { get; private set; }");
         sb.Append(idType == "Guid" ? " = Guid.NewGuid();\n" : "\n");
 
         foreach (var field in fields)
         {
-            sb.Append("\n    public ").Append(field.PropertyType).Append(' ').Append(field.Name).Append(" { get; private set; }");
-            if (field.Initializer is not null)
+            sb.Append("\n    public ").Append(EntityPropertyType(entity, field)).Append(' ').Append(field.Name).Append(" { get; private set; }");
+            if (field.Initializer is not null && !IsValueObject(field))
             {
                 sb.Append(' ').Append(field.Initializer).Append(';');
             }
@@ -85,41 +105,41 @@ internal static class FeatureGenerator
             sb.Append('\n');
         }
 
-        sb.Append("\n    public static ").Append(entity).Append(" Create(").Append(ParamList(fields)).Append(") => new(").Append(ArgList(fields)).Append(");\n\n");
-        sb.Append("    public void Update(").Append(ParamList(fields)).Append(")\n    {\n").Append(Assignments(fields, "        ")).Append("\n    }\n}\n");
+        var createParams = string.Join(", ", fields.Select(f => $"{f.PropertyType} {Identifiers.ToCamelCase(f.Name)}"));
+        var createArgs = string.Join(", ", fields.Select(f => WrapPrimitive(entity, f)));
+        sb.Append("\n    public static ").Append(entity).Append(" Create(").Append(createParams).Append(") => new(").Append(createArgs).Append(");\n\n");
+
+        sb.Append("    public void Update(").Append(createParams).Append(")\n    {\n");
+        sb.Append(string.Join("\n", fields.Select(f => $"        this.{f.Name} = {WrapPrimitive(entity, f)};"))).Append("\n    }\n}\n");
         return sb.ToString();
+    }
+
+    // Wrap a primitive parameter into its value object where the field has one, else pass it through.
+    private static string WrapPrimitive(string entity, FieldSpec f)
+    {
+        var param = Identifiers.ToCamelCase(f.Name);
+        return IsValueObject(f) ? $"{ValueObjectName(entity, f)}.From({param})" : param;
+    }
+
+    internal static string RenderValueObject(string ns, string entity, FieldSpec f)
+    {
+        var name = ValueObjectName(entity, f);
+        var max = f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture);
+        return Apply(ValueObjectTemplate,
+        [
+            ("__NS__", ns), ("__VO__", name), ("__FIELD__", f.Name), ("__MAX__", max),
+        ]);
     }
 
     private static string RenderRequest(string ns, string entity, IReadOnlyList<FieldSpec> fields)
     {
         var sb = new StringBuilder();
-        if (fields.Any(f => f.IsString))
-        {
-            sb.Append("using System.ComponentModel.DataAnnotations;\n\n");
-        }
-
         sb.Append("namespace ").Append(ns).Append(";\n\n");
         sb.Append("// The shared form model for the create + edit slices; maps onto ").Append(entity).Append(".Create/Update.\n");
-        sb.Append("// The forms bind this, so the validation attributes live here (a DataAnnotations validator reads them).\n");
+        sb.Append("// Validation lives on the value objects and runs in the form via Input(..., Validate: ...).\n");
         sb.Append("public sealed class ").Append(entity).Append("Request\n{\n");
-        var first = true;
         foreach (var field in fields)
         {
-            if (field.IsString)
-            {
-                if (!first)
-                {
-                    sb.Append('\n');
-                }
-
-                if (!field.IsNullable)
-                {
-                    sb.Append("    [Required]\n");
-                }
-
-                sb.Append("    [MaxLength(").Append(field.MaxLength!.Value.ToString(CultureInfo.InvariantCulture)).Append(")]\n");
-            }
-
             sb.Append("    public ").Append(field.PropertyType).Append(' ').Append(field.Name).Append(" { get; set; }");
             if (field.Initializer is not null)
             {
@@ -127,7 +147,6 @@ internal static class FeatureGenerator
             }
 
             sb.Append('\n');
-            first = false;
         }
 
         sb.Append("}\n");
@@ -135,12 +154,6 @@ internal static class FeatureGenerator
     }
 
     // ---- per-field fragment builders ----
-
-    private static string ParamList(IReadOnlyList<FieldSpec> fields) =>
-        string.Join(", ", fields.Select(f => $"{f.PropertyType} {Identifiers.ToCamelCase(f.Name)}"));
-
-    private static string ArgList(IReadOnlyList<FieldSpec> fields) =>
-        string.Join(", ", fields.Select(f => Identifiers.ToCamelCase(f.Name)));
 
     private static string Assignments(IReadOnlyList<FieldSpec> fields, string indent) =>
         // `this.` disambiguates the property from an identically-cased parameter (e.g. a lowercase
@@ -154,27 +167,34 @@ internal static class FeatureGenerator
         string.Join("\n", fields.Select(f => $"                            Th()[\"{f.Name}\"],"));
 
     private static string TableCells(IReadOnlyList<FieldSpec> fields) =>
-        string.Join("\n", fields.Select(f => f.IsString
-            ? $"                            Td()[x.{f.Name}],"
-            : $"                            Td()[$\"{{x.{f.Name}}}\"],"));
-
-    private static string CopyToForm(IReadOnlyList<FieldSpec> fields) =>
-        string.Join("\n", fields.Select(f => $"                _form.{f.Name} = entity.{f.Name};"));
-
-    // The EF Core mapping for each string column (length + required); other types need no configuration.
-    private static string ConfigProperties(IReadOnlyList<FieldSpec> fields) =>
-        string.Join("\n", fields.Where(f => f.IsString).Select(f =>
+        string.Join("\n", fields.Select(f =>
         {
-            var required = f.IsNullable ? "" : ".IsRequired()";
-            return $"        entity.Property(x => x.{f.Name}){required}.HasMaxLength({f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture)});";
+            var access = IsValueObject(f) ? $"x.{f.Name}.Value" : f.IsString ? $"x.{f.Name}" : $"$\"{{x.{f.Name}}}\"";
+            return $"                            Td()[{access}],";
         }));
 
-    private static string FormFields(IReadOnlyList<FieldSpec> fields)
+    private static string CopyToForm(IReadOnlyList<FieldSpec> fields) =>
+        string.Join("\n", fields.Select(f => $"                _form.{f.Name} = entity.{f.Name}{(IsValueObject(f) ? ".Value" : "")};"));
+
+    // The EF Core mapping per string column: a value object maps through its converter; an optional
+    // string just gets a length. Other types need no configuration.
+    private static string ConfigProperties(string entity, IReadOnlyList<FieldSpec> fields) =>
+        string.Join("\n", fields.Where(f => f.IsString).Select(f =>
+        {
+            var len = f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture);
+            return IsValueObject(f)
+                ? $"        entity.Property(x => x.{f.Name}).HasConversion(v => v.Value, s => {ValueObjectName(entity, f)}.From(s)).HasMaxLength({len});"
+                : $"        entity.Property(x => x.{f.Name}).HasMaxLength({len});";
+        }));
+
+    private static string FormFields(string entity, IReadOnlyList<FieldSpec> fields)
     {
         var sb = new StringBuilder();
         foreach (var field in fields)
         {
             var id = field.Name.ToLowerInvariant();
+            // A value-object field wires its built-in Validate into the bound input.
+            var validate = IsValueObject(field) ? $", Validate: {ValueObjectName(entity, field)}.Validate" : "";
             if (field.CsType == "bool")
             {
                 sb.Append("                    Div(Class: \"form-check\")[\n")
@@ -186,7 +206,7 @@ internal static class FeatureGenerator
             {
                 sb.Append("                    Div()[\n")
                     .Append("                        Label(\"").Append(id).Append("\", Class: \"form-label small mb-1\")[\"").Append(field.Name).Append("\"],\n")
-                    .Append("                        Input(() => _form.").Append(field.Name).Append(", Id: \"").Append(id).Append("\", Class: \"form-control\")\n")
+                    .Append("                        Input(() => _form.").Append(field.Name).Append(validate).Append(", Id: \"").Append(id).Append("\", Class: \"form-control\")\n")
                     .Append("                    ],\n");
             }
         }
@@ -244,6 +264,48 @@ internal static class FeatureGenerator
 
             protected override void OnModelCreating(ModelBuilder modelBuilder) =>
                 modelBuilder.ApplyConfigurationsFromAssembly(typeof(__CONTEXT__).Assembly);
+        }
+
+        """;
+
+    private const string ValueObjectTemplate =
+        """
+        namespace __NS__;
+
+        // Value object for __FIELD__ — the validation rule lives here and is reused by the form
+        // (Input(..., Validate: __VO__.Validate)) and by From.
+        public readonly record struct __VO__
+        {
+            public const int MaxLength = __MAX__;
+
+            public string Value { get; }
+
+            private __VO__(string value) => Value = value;
+
+            public static IEnumerable<string> Validate(string value)
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    yield return "__FIELD__ is required.";
+                }
+                else if (value.Trim().Length > MaxLength)
+                {
+                    yield return $"__FIELD__ must be {MaxLength} characters or fewer.";
+                }
+            }
+
+            public static __VO__ From(string value)
+            {
+                var errors = Validate(value).ToList();
+                if (errors.Count > 0)
+                {
+                    throw new ArgumentException(string.Join(" ", errors), nameof(value));
+                }
+
+                return new __VO__(value.Trim());
+            }
+
+            public override string ToString() => Value;
         }
 
         """;

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -118,7 +118,7 @@ internal static class FeatureGenerator
     private static string WrapPrimitive(string entity, FieldSpec f)
     {
         var param = Identifiers.ToCamelCase(f.Name);
-        return IsValueObject(f) ? $"{ValueObjectName(entity, f)}.From({param})" : param;
+        return IsValueObject(f) ? $"{ValueObjectName(entity, f)}.Create({param})" : param;
     }
 
     internal static string RenderValueObject(string ns, string entity, FieldSpec f)
@@ -181,10 +181,15 @@ internal static class FeatureGenerator
     private static string ConfigProperties(string entity, IReadOnlyList<FieldSpec> fields) =>
         string.Join("\n", fields.Where(f => f.IsString).Select(f =>
         {
+            if (IsValueObject(f))
+            {
+                // Length comes from the value object's own MaxLength — a single source of truth.
+                var vo = ValueObjectName(entity, f);
+                return $"        entity.Property(x => x.{f.Name}).HasConversion(v => v.Value, s => {vo}.Create(s)).HasMaxLength({vo}.MaxLength);";
+            }
+
             var len = f.MaxLength!.Value.ToString(CultureInfo.InvariantCulture);
-            return IsValueObject(f)
-                ? $"        entity.Property(x => x.{f.Name}).HasConversion(v => v.Value, s => {ValueObjectName(entity, f)}.From(s)).HasMaxLength({len});"
-                : $"        entity.Property(x => x.{f.Name}).HasMaxLength({len});";
+            return $"        entity.Property(x => x.{f.Name}).HasMaxLength({len});";
         }));
 
     private static string FormFields(string entity, IReadOnlyList<FieldSpec> fields)
@@ -273,7 +278,7 @@ internal static class FeatureGenerator
         namespace __NS__;
 
         // Value object for __FIELD__ — the validation rule lives here and is reused by the form
-        // (Input(..., Validate: __VO__.Validate)) and by From.
+        // (Input(..., Validate: __VO__.Validate)) and by Create.
         public readonly record struct __VO__
         {
             public const int MaxLength = __MAX__;
@@ -294,7 +299,7 @@ internal static class FeatureGenerator
                 }
             }
 
-            public static __VO__ From(string value)
+            public static __VO__ Create(string value)
             {
                 var errors = Validate(value).ToList();
                 if (errors.Count > 0)

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -130,8 +130,8 @@ public sealed class FeatureGeneratorTests
 
         Assert.Equal(
             [
-                "CreateProduct.cs", "DeleteProduct.cs", "Product.cs", "ProductRequest.cs",
-                "ProductsDbContext.cs", "ProductsPage.cs", "UpdateProduct.cs",
+                "CreateProduct.cs", "DeleteProduct.cs", "Product.cs", "ProductConfiguration.cs",
+                "ProductRequest.cs", "ProductsDbContext.cs", "ProductsPage.cs", "UpdateProduct.cs",
             ],
             names);
     }
@@ -154,8 +154,19 @@ public sealed class FeatureGeneratorTests
         Assert.Contains("public static Product Create(string name, decimal price)", entity, StringComparison.Ordinal);
         Assert.Contains("public void Update(string name, decimal price)", entity, StringComparison.Ordinal);
         Assert.Contains("public string Name { get; private set; } = \"\";", entity, StringComparison.Ordinal);
-        Assert.Contains("[MaxLength(200)]", entity, StringComparison.Ordinal);
         Assert.DoesNotContain("{ get; set; }", entity, StringComparison.Ordinal); // all encapsulated
+        Assert.DoesNotContain("DataAnnotations", entity, StringComparison.Ordinal); // schema lives in the EF config
+    }
+
+    [Fact]
+    public void Generates_an_ef_configuration_that_maps_the_schema()
+    {
+        var config = File(Generate(), "ProductConfiguration.cs");
+
+        Assert.Contains("public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>", config, StringComparison.Ordinal);
+        Assert.Contains("entity.HasKey(x => x.Id);", config, StringComparison.Ordinal);
+        Assert.Contains("entity.Property(x => x.Name).IsRequired().HasMaxLength(200);", config, StringComparison.Ordinal);
+        Assert.Contains("ApplyConfigurationsFromAssembly", File(Generate(), "ProductsDbContext.cs"), StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -151,10 +151,10 @@ public sealed class FeatureGeneratorTests
         var entity = File(Generate(), "Product.cs");
 
         Assert.Contains("public Guid Id { get; private set; } = Guid.NewGuid();", entity, StringComparison.Ordinal);
-        // Create/Update take primitives; the required string becomes a value object, wrapped via From.
-        Assert.Contains("public static Product Create(string name, decimal price) => new(ProductName.From(name), price);", entity, StringComparison.Ordinal);
+        // Create/Update take primitives; the required string becomes a value object, wrapped via Create.
+        Assert.Contains("public static Product Create(string name, decimal price) => new(ProductName.Create(name), price);", entity, StringComparison.Ordinal);
         Assert.Contains("public ProductName Name { get; private set; }", entity, StringComparison.Ordinal);
-        Assert.Contains("this.Name = ProductName.From(name);", entity, StringComparison.Ordinal);
+        Assert.Contains("this.Name = ProductName.Create(name);", entity, StringComparison.Ordinal);
         Assert.DoesNotContain("{ get; set; }", entity, StringComparison.Ordinal); // all encapsulated
         Assert.DoesNotContain("DataAnnotations", entity, StringComparison.Ordinal); // schema lives in the EF config
     }
@@ -168,7 +168,7 @@ public sealed class FeatureGeneratorTests
         Assert.Contains("public readonly record struct ProductName", vo, StringComparison.Ordinal);
         Assert.Contains("public const int MaxLength = 200;", vo, StringComparison.Ordinal);
         Assert.Contains("public static IEnumerable<string> Validate(string value)", vo, StringComparison.Ordinal);
-        Assert.Contains("public static ProductName From(string value)", vo, StringComparison.Ordinal);
+        Assert.Contains("public static ProductName Create(string value)", vo, StringComparison.Ordinal);
         // The form wires the value object's Validate into the bound input.
         Assert.Contains("Input(() => _form.Name, Validate: ProductName.Validate", File(result, "CreateProduct.cs"), StringComparison.Ordinal);
     }
@@ -181,7 +181,7 @@ public sealed class FeatureGeneratorTests
         Assert.Contains("public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>", config, StringComparison.Ordinal);
         Assert.Contains("entity.HasKey(x => x.Id);", config, StringComparison.Ordinal);
         // The value object maps through its converter.
-        Assert.Contains("entity.Property(x => x.Name).HasConversion(v => v.Value, s => ProductName.From(s)).HasMaxLength(200);", config, StringComparison.Ordinal);
+        Assert.Contains("entity.Property(x => x.Name).HasConversion(v => v.Value, s => ProductName.Create(s)).HasMaxLength(ProductName.MaxLength);", config, StringComparison.Ordinal);
         Assert.Contains("ApplyConfigurationsFromAssembly", File(Generate(), "ProductsDbContext.cs"), StringComparison.Ordinal);
     }
 

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -117,8 +117,8 @@ public sealed class FeatureGeneratorTests
         new("Price", "decimal", IsNullable: false, MaxLength: null),
     ];
 
-    private static ScaffoldResult Generate(string idType = "Guid", string? context = null, string? plural = null) =>
-        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, context, plural, outputOverride: null);
+    private static ScaffoldResult Generate(string idType = "Guid", string validation = "valueobjects", string? context = null, string? plural = null) =>
+        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, validation, context, plural, outputOverride: null);
 
     private static string File(ScaffoldResult result, string fileName) =>
         result.Files.Single(f => Path.GetFileName(f.Path) == fileName).Content;
@@ -189,7 +189,7 @@ public sealed class FeatureGeneratorTests
     public void Assignments_are_this_qualified_so_a_lowercase_field_does_not_self_assign()
     {
         var entity = FeatureGenerator.RenderEntity("MyApp.Features.Notes", "Note",
-            [new FieldSpec("title", "string", false, 200)], "Guid");
+            [new FieldSpec("title", "string", false, 200)], "Guid", useValueObjects: false);
 
         Assert.Contains("this.title = title;", entity, StringComparison.Ordinal);
         Assert.DoesNotContain("\n        title = title;", entity, StringComparison.Ordinal); // not a self-assignment
@@ -258,7 +258,7 @@ public sealed class FeatureGeneratorTests
     public void Plural_override_drives_names_and_route()
     {
         var result = FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Person",
-            Fields, "Guid", contextOverride: null, pluralOverride: "People", outputOverride: null);
+            Fields, "Guid", "valueobjects", contextOverride: null, pluralOverride: "People", outputOverride: null);
 
         Assert.Contains(result.Files, f => f.Path.EndsWith("PeoplePage.cs", StringComparison.Ordinal));
         Assert.Contains("[Route(\"/people\")]", File(result, "PeoplePage.cs"), StringComparison.Ordinal);
@@ -268,12 +268,36 @@ public sealed class FeatureGeneratorTests
     public void Bool_field_renders_a_bootstrap_checkbox_not_a_text_input()
     {
         var result = FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Job",
-            [new FieldSpec("Done", "bool", false, null)], "Guid", null, null, outputOverride: null);
+            [new FieldSpec("Done", "bool", false, null)], "Guid", "valueobjects", null, null, outputOverride: null);
 
-        var create = File(result, "CreateJob.cs");
-        Assert.Contains("form-check-input", create, StringComparison.Ordinal);
-        Assert.Contains("Input(() => _form.Done", create, StringComparison.Ordinal);
-        Assert.DoesNotContain("Input(() => _form.Done, Id: \"done\", Class: \"form-control\")", create, StringComparison.Ordinal);
+        var createJob = File(result, "CreateJob.cs");
+        Assert.Contains("form-check-input", createJob, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DataAnnotations_mode_uses_a_poco_entity_attributes_and_the_validator()
+    {
+        var result = Generate(validation: "dataannotations");
+
+        Assert.DoesNotContain(result.Files, f => Path.GetFileName(f.Path) == "ProductName.cs"); // no value object
+        Assert.Contains("public string Name { get; private set; } = \"\";", File(result, "Product.cs"), StringComparison.Ordinal);
+        var request = File(result, "ProductRequest.cs");
+        Assert.Contains("[Required]", request, StringComparison.Ordinal);
+        Assert.Contains("[MaxLength(200)]", request, StringComparison.Ordinal);
+        Assert.Contains("DataAnnotationsValidator(),", File(result, "CreateProduct.cs"), StringComparison.Ordinal);
+        Assert.Contains("entity.Property(x => x.Name).IsRequired().HasMaxLength(200);", File(result, "ProductConfiguration.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Fluent_mode_generates_a_validator_and_wires_it()
+    {
+        var result = Generate(validation: "fluent");
+
+        var validator = File(result, "ProductRequestValidator.cs");
+        Assert.Contains("public sealed class ProductRequestValidator : AbstractValidator<ProductRequest>", validator, StringComparison.Ordinal);
+        Assert.Contains("RuleFor(x => x.Name).NotEmpty().MaximumLength(200);", validator, StringComparison.Ordinal);
+        Assert.Contains("FluentValidationValidator(new ProductRequestValidator()),", File(result, "CreateProduct.cs"), StringComparison.Ordinal);
+        Assert.DoesNotContain(result.Files, f => Path.GetFileName(f.Path) == "ProductName.cs"); // POCO, no value object
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -131,7 +131,7 @@ public sealed class FeatureGeneratorTests
         Assert.Equal(
             [
                 "CreateProduct.cs", "DeleteProduct.cs", "Product.cs", "ProductConfiguration.cs",
-                "ProductRequest.cs", "ProductsDbContext.cs", "ProductsPage.cs", "UpdateProduct.cs",
+                "ProductName.cs", "ProductRequest.cs", "ProductsDbContext.cs", "ProductsPage.cs", "UpdateProduct.cs",
             ],
             names);
     }
@@ -151,11 +151,26 @@ public sealed class FeatureGeneratorTests
         var entity = File(Generate(), "Product.cs");
 
         Assert.Contains("public Guid Id { get; private set; } = Guid.NewGuid();", entity, StringComparison.Ordinal);
-        Assert.Contains("public static Product Create(string name, decimal price)", entity, StringComparison.Ordinal);
-        Assert.Contains("public void Update(string name, decimal price)", entity, StringComparison.Ordinal);
-        Assert.Contains("public string Name { get; private set; } = \"\";", entity, StringComparison.Ordinal);
+        // Create/Update take primitives; the required string becomes a value object, wrapped via From.
+        Assert.Contains("public static Product Create(string name, decimal price) => new(ProductName.From(name), price);", entity, StringComparison.Ordinal);
+        Assert.Contains("public ProductName Name { get; private set; }", entity, StringComparison.Ordinal);
+        Assert.Contains("this.Name = ProductName.From(name);", entity, StringComparison.Ordinal);
         Assert.DoesNotContain("{ get; set; }", entity, StringComparison.Ordinal); // all encapsulated
         Assert.DoesNotContain("DataAnnotations", entity, StringComparison.Ordinal); // schema lives in the EF config
+    }
+
+    [Fact]
+    public void Required_string_becomes_a_value_object_with_built_in_validation()
+    {
+        var result = Generate();
+
+        var vo = File(result, "ProductName.cs");
+        Assert.Contains("public readonly record struct ProductName", vo, StringComparison.Ordinal);
+        Assert.Contains("public const int MaxLength = 200;", vo, StringComparison.Ordinal);
+        Assert.Contains("public static IEnumerable<string> Validate(string value)", vo, StringComparison.Ordinal);
+        Assert.Contains("public static ProductName From(string value)", vo, StringComparison.Ordinal);
+        // The form wires the value object's Validate into the bound input.
+        Assert.Contains("Input(() => _form.Name, Validate: ProductName.Validate", File(result, "CreateProduct.cs"), StringComparison.Ordinal);
     }
 
     [Fact]
@@ -165,7 +180,8 @@ public sealed class FeatureGeneratorTests
 
         Assert.Contains("public sealed class ProductConfiguration : IEntityTypeConfiguration<Product>", config, StringComparison.Ordinal);
         Assert.Contains("entity.HasKey(x => x.Id);", config, StringComparison.Ordinal);
-        Assert.Contains("entity.Property(x => x.Name).IsRequired().HasMaxLength(200);", config, StringComparison.Ordinal);
+        // The value object maps through its converter.
+        Assert.Contains("entity.Property(x => x.Name).HasConversion(v => v.Value, s => ProductName.From(s)).HasMaxLength(200);", config, StringComparison.Ordinal);
         Assert.Contains("ApplyConfigurationsFromAssembly", File(Generate(), "ProductsDbContext.cs"), StringComparison.Ordinal);
     }
 
@@ -192,13 +208,13 @@ public sealed class FeatureGeneratorTests
     }
 
     [Fact]
-    public void Request_is_shared_and_carries_the_validation_attributes()
+    public void Request_is_a_shared_plain_form_model()
     {
         var request = File(Generate(), "ProductRequest.cs");
 
         Assert.Contains("public sealed class ProductRequest", request, StringComparison.Ordinal);
-        Assert.Contains("[Required]", request, StringComparison.Ordinal);
-        Assert.Contains("[MaxLength(200)]", request, StringComparison.Ordinal);
+        Assert.Contains("public string Name { get; set; } = \"\";", request, StringComparison.Ordinal);
+        Assert.DoesNotContain("[Required]", request, StringComparison.Ordinal); // validation lives on the value object
         // Both slices bind the same shared request — no Create/Update-specific request types.
         Assert.Contains("CreateProductCommand(ProductRequest Request)", File(Generate(), "CreateProduct.cs"), StringComparison.Ordinal);
         Assert.Contains("UpdateProductCommand(Guid Id, ProductRequest Request)", File(Generate(), "UpdateProduct.cs"), StringComparison.Ordinal);


### PR DESCRIPTION
## Summary

Increment 2 of `rask generate feature`: **value objects (the default, dependency-free validation)** + an **EF Core `IEntityTypeConfiguration`**. Stacked on the CQRS rework (#367).

### Value objects (default validation)
Each **required (non-nullable) string** field becomes a value object — a `readonly record struct <Entity><Field>`:
- owns its validation: `Validate(string) : IEnumerable<string>` + a `Create(string)` factory that throws on invalid input, and a `MaxLength` const;
- the entity holds the value-object type; `Create`/`Update` take primitives and wrap them via `<VO>.Create(...)`;
- the form wires it in: `Input(() => _form.Name, Validate: <Entity>Name.Validate)`;
- mapped to its column via `HasConversion(v => v.Value, s => <VO>.Create(s)).HasMaxLength(<VO>.MaxLength)`.

This is **built-in, dependency-free** validation (no `Rask.Validation.*` package), so the slice still compiles as-is. Optional strings and non-string fields stay primitive.

### EF configuration
Each feature gets `<Entity>Configuration : IEntityTypeConfiguration<<Entity>>` (`HasKey` + per-string mapping), applied via `OnModelCreating` → `ApplyConfigurationsFromAssembly`. The entity is a clean, **attribute-free** domain model — the schema lives in the configuration.

## Testing
- **149 unit tests** — value-object generation (struct + `Validate`/`Create`/`MaxLength`), entity wrapping, the configuration + converter, the shared plain request, `ApplyConfigurationsFromAssembly`.
- **Verified compiling**: generated into `samples/Rask.Example.EfCore` (temp `Rask.Cqrs` ref) with required/optional string + non-string fields and every id type; `Build succeeded`; reverted.
- `dotnet format` clean; `Rask.Cli` builds clean.

## Notes
- **Stacked on #367** (CQRS rework) — merge that first (or this rebases once it lands).
- Next in increment 2: opt-in `--validation dataannotations|fluent` (POCO + that library's validator, needing the respective packages). Then increment 3 (`--bs`/`--modal`), generated tests, style-memory, and `--add`.