### PR TITLE
fix(hooks): pre-commit uses dotnet format whitespace + single build

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -21,17 +21,12 @@ if ! git diff --cached --name-only | grep -qE '^(src/|tests/|benchmarks/|Rask\.s
 fi
 
 root="$(git rev-parse --show-toplevel)"
-cd "$root"
 
-echo "pre-commit: checking formatting (dotnet format --verify-no-changes)."
-echo "            bypass with 'git commit --no-verify' or RASK_SKIP_UNIT=1."
-if ! dotnet format Rask.slnx --verify-no-changes; then
-  echo "pre-commit: formatting check FAILED — run 'dotnet format Rask.slnx', restage, and commit again." >&2
-  exit 1
-fi
-
-echo "pre-commit: running the local unit gate (staged code changes detected)."
+echo "pre-commit: running the local format + unit gate (staged code changes detected)."
+echo "            build -> dotnet format whitespace --verify-no-changes -> tests. bypass with"
+echo "            'git commit --no-verify' or RASK_SKIP_UNIT=1."
 if ! "$root/scripts/run-unit-local.sh"; then
-  echo "pre-commit: unit gate FAILED — commit aborted. Fix the tests, or bypass with --no-verify." >&2
+  echo "pre-commit: format + unit gate FAILED — commit aborted. Fix it (e.g. 'dotnet format whitespace" >&2
+  echo "            Rask.slnx' then restage), or bypass with --no-verify." >&2
   exit 1
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@ them until tagged releases begin.
   (restored packages never trigger it). Hooks stay advisory (bypass with the git no-verify flag /
   `RASK_SKIP_UNIT=1` / `RASK_SKIP_E2E=1`).
 - **Unit tests + formatting moved out of CI to a local pre-commit gate.** The unit/integration suite no
-  longer runs in the ci/nightly/release pipelines. `scripts/run-unit-local.sh` builds the solution and runs
-  every test except the browser E2E; a new `.githooks/pre-commit` hook runs `dotnet format
-  --verify-no-changes` then that script whenever a commit stages code (`src/`, `tests/`, `benchmarks/`,
-  `Rask.slnx`, `Directory.*`) — docs-only commits skip it (bypass with `git commit --no-verify` or
-  `RASK_SKIP_UNIT=1`). CI now runs only the deterministic benchmark byte-gates, the native compile gate,
+  longer runs in the ci/nightly/release pipelines. `scripts/run-unit-local.sh` builds the solution once,
+  runs `dotnet format whitespace --verify-no-changes` (the whitespace pass, not full `dotnet format`, whose
+  style/analyzer passes recompile the `Routes.*` source generator through their own workspace and spuriously
+  flag CS1503 in the routing tests), then every test except the browser E2E; a new `.githooks/pre-commit`
+  hook runs it whenever a commit stages code (`src/`, `tests/`, `benchmarks/`, `Rask.slnx`, `Directory.*`) —
+  docs-only commits skip it (bypass with `git commit --no-verify` or `RASK_SKIP_UNIT=1`). CI now runs only the deterministic benchmark byte-gates, the native compile gate,
   commitlint, and CodeQL; branch protection no longer requires the `unit` check. (Releases and the nightly
   prerelease are no longer test-gated in CI — run `scripts/run-unit-local.sh` + `scripts/run-e2e-local.sh`
   locally before tagging.)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,11 +84,13 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
 - **Tests run locally, not in CI.** The unit/integration suite and both E2E suites were moved out of the
   CI pipeline; CI keeps only the deterministic benchmark byte-gates, the native compile gate, commitlint,
   and CodeQL.
-- **Format + unit tests — `pre-commit`.** The `pre-commit` hook runs `dotnet format --verify-no-changes`
-  and then `scripts/run-unit-local.sh` (build + every test except the browser E2E) when a commit stages
-  code (`src/`, `tests/`, `benchmarks/`, `Rask.slnx`, `Directory.*`); docs-only commits skip it. If the
-  format check fails, run `dotnet format Rask.slnx` and restage. Bypass with `git commit --no-verify` or
-  `RASK_SKIP_UNIT=1`.
+- **Format + unit tests — `pre-commit`.** The `pre-commit` hook runs `scripts/run-unit-local.sh` when a
+  commit stages code (`src/`, `tests/`, `benchmarks/`, `Rask.slnx`, `Directory.*`); docs-only commits skip
+  it. The script builds once, runs `dotnet format whitespace --verify-no-changes`, then every test except
+  the browser E2E. (It uses the *whitespace* pass, not full `dotnet format`: full format's style/analyzer
+  passes run their own compile of the `Routes.*` source generator and spuriously report CS1503 in the
+  routing tests. Run `dotnet format Rask.slnx` before a PR for the style pass — the warnings-as-errors build
+  already enforces error-severity analyzer rules.) Bypass with `git commit --no-verify` or `RASK_SKIP_UNIT=1`.
 - **E2E runs locally, not in CI.** The browser-journey E2E (`tests/Rask.Examples.E2E.Tests`, Playwright)
   and the on-device native E2E (`tests/Rask.Native.Appium.Tests`, Appium) are not part of the CI
   pipeline. Run the browser gate with `scripts/run-e2e-local.sh` (the `pre-push` hook runs it for you on

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -50,9 +50,13 @@ Every change passes this gate before a PR (the `rask-ship` skill):
 - `ci.yml` — the deterministic benchmark byte-gates and a native compile gate (both native samples ×
   android/ios). **Tests do not run in CI** — the unit/integration suite and the E2E suites run locally
   (see below).
-- **Unit tests run locally, enforced before commit.** `scripts/run-unit-local.sh` builds the solution and
-  runs every test except the browser E2E. The `.githooks/pre-commit` hook runs `dotnet format
-  --verify-no-changes` then that script whenever a commit stages code (enable hooks with
+- **Format + unit tests run locally, enforced before commit.** `scripts/run-unit-local.sh` builds the
+  solution once, runs `dotnet format whitespace --verify-no-changes`, then every test except the browser
+  E2E. (Whitespace pass, not full `dotnet format`: full format's style/analyzer passes recompile the
+  `Routes.*` source generator through their own workspace and spuriously flag CS1503 in the routing tests;
+  the whitespace pass is compile-independent and reliable. The warnings-as-errors build already enforces
+  error-severity analyzer rules — run full `dotnet format Rask.slnx` before a PR for the style pass.) The
+  `.githooks/pre-commit` hook runs it whenever a commit stages code (enable hooks with
   `git config core.hooksPath .githooks`; bypass with `git commit --no-verify` or `RASK_SKIP_UNIT=1`).
 - **E2E runs locally, enforced before push.** The browser-journey E2E
   (`tests/Rask.Examples.E2E.Tests`, Playwright) and the on-device native E2E

--- a/scripts/run-unit-local.sh
+++ b/scripts/run-unit-local.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
-# Local unit/integration gate.
+# Local format + unit/integration gate.
 #
-# The unit + integration suite no longer runs in CI — it runs here, locally, and the pre-commit hook
-# (.githooks/pre-commit) enforces it before a code commit. Mirrors the old ci.yml `unit` job: build the
-# solution once (no WASM bundle — no unit test consumes it), then run every test EXCEPT the browser E2E
-# (those are their own local gate — see scripts/run-e2e-local.sh).
+# Formatting and the unit suite no longer run in CI — they run here, locally, and the pre-commit hook
+# (.githooks/pre-commit) enforces this before a code commit. Steps: build once, run the whitespace
+# formatter, then run every test EXCEPT the browser E2E (that's its own gate — see run-e2e-local.sh).
+#
+# Why the WHITESPACE formatter and not full `dotnet format`: full format's style/analyzer passes compile
+# the whole solution through their own Roslyn workspace, which runs the `Routes.*` source generator
+# differently than `dotnet build` and spuriously reports CS1503 in the routing tests (the real compiler
+# builds them clean). The whitespace pass is compile-independent, so it's reliable AND still catches
+# indentation / spacing / final-newline violations. Run full `dotnet format Rask.slnx` before a PR for the
+# style pass (the build here is warnings-as-errors, so error-severity analyzer rules are already enforced).
 #
 # Usage:  scripts/run-unit-local.sh
 # Skip:   RASK_SKIP_UNIT=1 (also honoured by the pre-commit hook)
@@ -18,12 +24,15 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
-echo "==> Build (Release, no WASM bundle: -p:RaskWasm=false -p:WasmBuildNative=false)"
+echo "==> Build once (Release, no WASM bundle: -p:RaskWasm=false -p:WasmBuildNative=false)"
 dotnet build Rask.slnx -c Release -p:RaskWasm=false -p:WasmBuildNative=false -p:MinVerSkip=true
+
+echo "==> Formatting check (dotnet format whitespace --verify-no-changes)"
+dotnet format whitespace Rask.slnx --verify-no-changes --no-restore
 
 echo "==> Unit & integration tests (excludes the browser E2E)"
 dotnet test Rask.slnx -c Release --no-build \
   --filter "FullyQualifiedName!~Rask.Examples.E2E" \
   --logger "console;verbosity=normal"
 
-echo "==> Unit gate passed."
+echo "==> Format + unit gate passed."


### PR DESCRIPTION
## Summary
Fixes a false-positive in the pre-commit format gate found while verifying the hooks on a fresh clone.

The gate used full `dotnet format --verify-no-changes`, whose style/analyzer passes recompile the solution through their own Roslyn workspace. That workspace runs the `Routes.*` source generator differently than `dotnet build`, so it spuriously reports **CS1503** in the routing tests (`OutletTests`/`RouterTests` — 49 `new[] { Route<T>(...) }` sites infer `Route?[]`), even though the real compiler builds them clean. That could **block a legit commit** — notably when a new `.cs` file is staged.

## Fix
Consolidate the gate into `scripts/run-unit-local.sh`: **build once → `dotnet format whitespace --verify-no-changes` → tests.** The whitespace pass is compile-independent, so the source generator can't trip it, and it still catches indentation / spacing / final-newline violations. The pre-commit hook just calls the script. Full `dotnet format Rask.slnx` (style pass) is a pre-PR / rask-ship step; the warnings-as-errors build already enforces error-severity analyzer rules.

## Verified
- `dotnet format whitespace --verify-no-changes` with a newly-added `.cs` file present → **exit 0, no CS1503** (the exact case that tripped full format).
- Same with a real whitespace violation → **exit 2, flags the file** (still enforces).

## Changelog
Updated the existing `[Unreleased] → Changed` unit-gate entry.