### PR TITLE
feat(cli): generate feature --tests + automatic NuGet package add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`rask generate feature` now adds the required NuGet packages automatically.** After writing the
+  slice it runs `dotnet add package` for EF Core + SQLite and `Rask.Cqrs` (plus `Rask.Bootstrap` with
+  `--bs`, and the validation library with `--validation dataannotations`/`fluent`) so the code compiles
+  without a manual reference step; pass `--no-restore` to skip. A failed add degrades to a warning — the
+  files are written and the packages are still listed in the printed next-steps.
+- **`rask generate feature --tests` scaffolds xunit tests for the slice.** A sibling `<Project>.Tests`
+  project gets a domain test (`Create`/`Update` set every property; each value object rejects a blank
+  value and accepts a valid one) and, when the `DbContext` is generated, a persistence test that
+  round-trips the entity through a real SQLite file (proving the configuration + value-object converters).
 - **`rask generate feature --bs` scaffolds with Rask.Bootstrap; without it the pages are plain HTML.**
   By default the generated pages are now plain, unstyled semantic HTML (no CSS classes at all), so they
   compile and work in any project regardless of its stylesheet. The `--bs` flag renders the pages with

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,8 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 | `--modal` | `feature` only (implies `--bs`): create + update happen in a `BsModal` on the list page, instead of separate create/edit pages. |
 | `--bs` | `feature` only: render the pages with Rask.Bootstrap `Bs*` components (`BsCard`/`BsTable`/`BsButton`/`BsInput`/`BsCheck`/`BsIcon`) + `Bs.Join(...)` utility classes instead of raw core + Bootstrap class strings. |
 | `--validation` | `feature` only: `valueobjects` (default — required strings become value objects with built-in, dependency-free validation), `dataannotations` (POCO + `[Required]`/`[MaxLength]` + `DataAnnotationsValidator`), or `fluent` (POCO + a generated `AbstractValidator` + `FluentValidationValidator`). |
+| `--tests` | `feature` only: also emit xunit tests in a sibling `<Project>.Tests` project — a domain test (`Create`/`Update` + value-object validation) and, when the `DbContext` is generated, a SQLite round-trip persistence test. |
+| `--no-restore` | `feature` only: don't add the NuGet packages automatically (just print them). |
 | `--context`, `-c` | `feature` only: reference an existing `DbContext` by name instead of generating a feature-local one (then add a `DbSet` to it). |
 | `--plural`, `-p` | `feature` only: the plural used for the folder, DbSet, list page, and route. Give the entity a **singular** name (`Product`) and this defaults to a simple pluralization (`Products`); override it when that guess is wrong (`--plural People`). |
 | `--route`, `-r` | `page` only: the `[Route]` path (default: kebab-case of the name, e.g. `/products`). |
@@ -82,8 +84,10 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 
 The generated code compiles as-is in any `dotnet new rask-*` project — the factory methods and the
 `Component` base come from Rask's implicit usings, and pages navigate with the type-safe generated
-`Routes.*()` URLs. A generated `feature` needs **EF Core + `Rask.Cqrs`** referenced; after scaffolding,
-`rask generate` prints the DI registration (`AddRaskCqrs()` + `AddDbContextFactory`) and the `dotnet ef`
+`Routes.*()` URLs. A generated `feature` needs **EF Core + `Rask.Cqrs`** referenced, so `rask generate`
+**adds those packages to the project for you** (`dotnet add package` for EF Core + SQLite, `Rask.Cqrs`,
+and — with `--bs`/`--validation` — `Rask.Bootstrap` / the validation library; pass `--no-restore` to
+skip). It then prints the DI registration (`AddRaskCqrs()` + `AddDbContextFactory`) and the `dotnet ef`
 migration to run before it works.
 
 Every command has short aliases: `rask g` = `rask generate`, and `g f` / `g c` / `g p` scaffold a

--- a/src/Rask.Cli/CliApplication.cs
+++ b/src/Rask.Cli/CliApplication.cs
@@ -25,7 +25,7 @@ internal sealed class CliApplication
         [
             new NewCommand(console, process),
             new DevCommand(console, process),
-            new GenerateCommand(console, fileSystem, Environment.CurrentDirectory),
+            new GenerateCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new InfoCommand(console, process),
         ]);
 

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -8,7 +8,7 @@ namespace Rask.Cli.Commands;
 /// (<c>page</c>, <c>component</c>, or a full CRUD <c>feature</c>), refusing to clobber an existing file
 /// unless <c>--force</c>.
 /// </summary>
-internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, string workingDirectory)
+internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
     : CliCommand(console)
 {
     private static readonly string[] Kinds = ["page", "component", "feature"];
@@ -21,6 +21,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
     };
 
     private readonly IFileSystem _fileSystem = fileSystem;
+    private readonly IProcessRunner _process = process;
     private readonly string _workingDirectory = workingDirectory;
 
     public override string Name => "generate";
@@ -32,20 +33,20 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
     public override string Usage =>
         "rask generate <page|component|feature> <Name> [--fields \"Name:type,...\"] [--id guid|int|long] [--route <path>] [--context <Name>] [--plural <Name>] [--output <dir>] [--force] [--dry-run]";
 
-    public override Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
+    public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
         {
             Console.Error.WriteLine($"Specify what to generate: {string.Join(", ", Kinds)}.");
             Console.Error.WriteLine($"Usage: {Usage}");
-            return Task.FromResult(1);
+            return 1;
         }
 
         var kind = KindAliases.GetValueOrDefault(args[0], args[0]);
         if (!Kinds.Contains(kind))
         {
             Console.Error.WriteLine($"Unknown artifact '{args[0]}'. Generate one of: {string.Join(", ", Kinds)} (aliases: p, c, f).");
-            return Task.FromResult(1);
+            return 1;
         }
 
         var schema = new ArgumentSchema()
@@ -58,26 +59,28 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             .Option("validation")
             .Flag("bs")
             .Flag("modal")
+            .Flag("tests")
+            .Flag("no-restore")
             .Flag("force")
             .Flag("dry-run");
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)
         {
-            return Task.FromResult(Fail(parsed.Errors));
+            return Fail(parsed.Errors);
         }
 
         var name = parsed.Positionals.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(name))
         {
             Console.Error.WriteLine($"A name is required. Usage: {Usage}");
-            return Task.FromResult(1);
+            return 1;
         }
 
         if (!Identifiers.IsValidTypeName(name))
         {
             Console.Error.WriteLine($"'{name}' is not a valid C# type name (letters, digits, and '_'; not starting with a digit).");
-            return Task.FromResult(1);
+            return 1;
         }
 
         var route = parsed.Option("route");
@@ -86,23 +89,24 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             if (kind != "page")
             {
                 Console.Error.WriteLine("--route only applies to 'generate page'.");
-                return Task.FromResult(1);
+                return 1;
             }
 
             if (!Identifiers.IsValidRoutePath(route))
             {
                 Console.Error.WriteLine($"'{route}' is not a valid route path (no quotes, backslashes, or control characters).");
-                return Task.FromResult(1);
+                return 1;
             }
         }
 
         if (kind != "feature"
             && (parsed.Option("fields") is not null || parsed.Option("context") is not null
                 || parsed.Option("plural") is not null || parsed.Option("id") is not null
-                || parsed.Option("validation") is not null || parsed.HasFlag("bs") || parsed.HasFlag("modal")))
+                || parsed.Option("validation") is not null || parsed.HasFlag("bs") || parsed.HasFlag("modal")
+                || parsed.HasFlag("tests")))
         {
-            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, and --modal only apply to 'generate feature'.");
-            return Task.FromResult(1);
+            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, --modal, and --tests only apply to 'generate feature'.");
+            return 1;
         }
 
         foreach (var (option, value) in new[] { ("context", parsed.Option("context")), ("plural", parsed.Option("plural")) })
@@ -110,7 +114,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             if (value is not null && !Identifiers.IsValidTypeName(value))
             {
                 Console.Error.WriteLine($"'{value}' is not a valid C# type name for --{option}.");
-                return Task.FromResult(1);
+                return 1;
             }
         }
 
@@ -118,16 +122,45 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         if (project is null)
         {
             Console.Error.WriteLine($"Couldn't find a single .csproj at or above '{_workingDirectory}'. Run this inside a Rask project.");
-            return Task.FromResult(1);
+            return 1;
         }
 
         if (!TryBuild(kind, name, project, parsed, out var result, out var buildError))
         {
             Console.Error.WriteLine(buildError);
-            return Task.FromResult(1);
+            return 1;
         }
 
-        return Task.FromResult(Write(result, parsed.HasFlag("force"), parsed.HasFlag("dry-run")));
+        var dryRun = parsed.HasFlag("dry-run");
+        var written = Write(result, parsed.HasFlag("force"), dryRun);
+        if (written == 0 && !dryRun && result.Packages.Count > 0)
+        {
+            await AddPackagesAsync(project.ProjectDirectory, result.Packages, parsed.HasFlag("no-restore"), cancellationToken).ConfigureAwait(false);
+        }
+
+        return written;
+    }
+
+    // Add the packages the generated code needs straight into the project (dotnet add package). A failure
+    // (e.g. offline, or the package isn't on a configured feed yet) is a warning, not a hard error — the
+    // files are already written and the printed next-steps list the packages as a manual fallback.
+    private async Task AddPackagesAsync(string projectDirectory, IReadOnlyList<string> packages, bool noRestore, CancellationToken cancellationToken)
+    {
+        if (noRestore)
+        {
+            Console.Out.WriteLine($"Skipped adding packages (--no-restore): {string.Join(", ", packages)}");
+            return;
+        }
+
+        Console.Out.WriteLine($"Adding {packages.Count} package(s) to the project…");
+        foreach (var package in packages)
+        {
+            var exit = await _process.RunAsync("dotnet", ["add", "package", package], projectDirectory, cancellationToken).ConfigureAwait(false);
+            if (exit != 0)
+            {
+                Console.Error.WriteLine($"  Couldn't add {package} automatically — add it manually: dotnet add package {package}");
+            }
+        }
     }
 
     private bool TryBuild(string kind, string name, ProjectContext project, ParsedArguments parsed, out ScaffoldResult result, out string? error)
@@ -195,7 +228,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                 var useModal = parsed.HasFlag("modal");
                 var useBs = useModal || parsed.HasFlag("bs");
 
-                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
+                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, parsed.HasFlag("tests"), parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
                 return true;
         }
     }

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -22,6 +22,7 @@ internal static class FeatureGenerator
         string validation,
         bool useBs,
         bool useModal,
+        bool useTests,
         string? contextOverride,
         string? pluralOverride,
         string? outputOverride)
@@ -85,7 +86,31 @@ internal static class FeatureGenerator
             files.Insert(2, new ScaffoldFile(Path.Combine(targetDirectory, context + ".cs"), Apply(DbContextTemplate, tokens)));
         }
 
-        return new ScaffoldResult(files, RenderNextSteps(context, entityName, plural, route, generateContext, validation, useBs));
+        // --tests: a sibling <Project>.Tests project gets a domain test (Create/Update + value-object
+        // validation) and, when we own the DbContext, a SQLite round-trip persistence test.
+        if (useTests)
+        {
+            var trimmed = project.ProjectDirectory.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+            var testProjectDir = Path.Combine(Path.GetDirectoryName(trimmed) ?? trimmed, Path.GetFileName(trimmed) + ".Tests");
+            var testDirectory = Path.Combine(testProjectDir, "Features", plural);
+            var testNamespace = project.RootNamespace + ".Tests.Features." + plural;
+
+            files.Add(new ScaffoldFile(
+                Path.Combine(testDirectory, entityName + "Tests.cs"),
+                RenderDomainTests(testNamespace, ns, entityName, fields, useValueObjects)));
+
+            if (generateContext)
+            {
+                files.Add(new ScaffoldFile(
+                    Path.Combine(testDirectory, plural + "PersistenceTests.cs"),
+                    RenderPersistenceTests(testNamespace, ns, entityName, plural, context, idType, fields, useValueObjects)));
+            }
+        }
+
+        return new ScaffoldResult(files, RenderNextSteps(context, entityName, plural, route, generateContext, validation, useBs, useTests))
+        {
+            Packages = FeaturePackages(validation, useBs),
+        };
     }
 
     // The form-level validator component wired at the top of the create/edit forms (empty for the
@@ -214,6 +239,119 @@ internal static class FeatureGenerator
         return sb.ToString();
     }
 
+    // ---- generated tests (xunit): domain (pure) + persistence (SQLite round-trip) ----
+
+    // Pure domain tests: Create sets every property, Update overwrites them, and each value object
+    // rejects a blank value / accepts a valid one. No DB, no browser.
+    private static string RenderDomainTests(string testNs, string featureNs, string entity, IReadOnlyList<FieldSpec> fields, bool useValueObjects)
+    {
+        var sb = new StringBuilder();
+        sb.Append("using ").Append(featureNs).Append(";\n\n");
+        sb.Append("namespace ").Append(testNs).Append(";\n\n");
+        sb.Append("public sealed class ").Append(entity).Append("Tests\n{\n");
+
+        sb.Append("    [Fact]\n");
+        sb.Append("    public void Create_sets_every_property()\n    {\n");
+        sb.Append("        var entity = ").Append(entity).Append(".Create(").Append(SampleArgs(fields, second: false)).Append(");\n\n");
+        sb.Append(SampleAsserts("entity", fields, useValueObjects, second: false, indent: "        ")).Append("\n    }\n\n");
+
+        sb.Append("    [Fact]\n");
+        sb.Append("    public void Update_overwrites_every_property()\n    {\n");
+        sb.Append("        var entity = ").Append(entity).Append(".Create(").Append(SampleArgs(fields, second: false)).Append(");\n\n");
+        sb.Append("        entity.Update(").Append(SampleArgs(fields, second: true)).Append(");\n\n");
+        sb.Append(SampleAsserts("entity", fields, useValueObjects, second: true, indent: "        ")).Append("\n    }\n");
+
+        foreach (var field in fields.Where(f => IsValueObject(f, useValueObjects)))
+        {
+            var vo = ValueObjectName(entity, field);
+            sb.Append("\n    [Fact]\n");
+            sb.Append("    public void ").Append(vo).Append("_rejects_a_blank_value() => Assert.NotEmpty(").Append(vo).Append(".Validate(\"   \"));\n");
+            sb.Append("\n    [Fact]\n");
+            sb.Append("    public void ").Append(vo).Append("_accepts_a_valid_value() => Assert.Empty(").Append(vo).Append(".Validate(\"").Append(SampleString(field, second: false)).Append("\"));\n");
+        }
+
+        sb.Append("}\n");
+        return sb.ToString();
+    }
+
+    // Persistence test: the entity round-trips through a real SQLite file, proving the configuration's
+    // columns + value-object converters persist and rehydrate.
+    private static string RenderPersistenceTests(string testNs, string featureNs, string entity, string plural, string context, string idType, IReadOnlyList<FieldSpec> fields, bool useValueObjects)
+    {
+        var sb = new StringBuilder();
+        sb.Append("using Microsoft.EntityFrameworkCore;\n");
+        sb.Append("using ").Append(featureNs).Append(";\n\n");
+        sb.Append("namespace ").Append(testNs).Append(";\n\n");
+        sb.Append("public sealed class ").Append(plural).Append("PersistenceTests : IDisposable\n{\n");
+        sb.Append("    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $\"rask-test-{Guid.NewGuid():N}.db\");\n\n");
+        sb.Append("    private ").Append(context).Append(" NewContext()\n    {\n");
+        sb.Append("        var options = new DbContextOptionsBuilder<").Append(context).Append(">()\n");
+        sb.Append("            .UseSqlite($\"Data Source={_dbPath}\")\n");
+        sb.Append("            .Options;\n");
+        sb.Append("        return new ").Append(context).Append("(options);\n    }\n\n");
+
+        sb.Append("    [Fact]\n");
+        sb.Append("    public async Task ").Append(entity).Append("_round_trips_through_sqlite()\n    {\n");
+        sb.Append("        ").Append(idType).Append(" id;\n");
+        sb.Append("        await using (var db = NewContext())\n        {\n");
+        sb.Append("            await db.Database.EnsureCreatedAsync();\n");
+        sb.Append("            var entity = ").Append(entity).Append(".Create(").Append(SampleArgs(fields, second: false)).Append(");\n");
+        sb.Append("            db.").Append(plural).Append(".Add(entity);\n");
+        sb.Append("            await db.SaveChangesAsync();\n");
+        sb.Append("            id = entity.Id;\n        }\n\n");
+        sb.Append("        await using (var db = NewContext())\n        {\n");
+        sb.Append("            var entity = await db.").Append(plural).Append(".SingleAsync();\n");
+        sb.Append("            Assert.Equal(id, entity.Id);\n");
+        sb.Append(SampleAsserts("entity", fields, useValueObjects, second: false, indent: "            ")).Append("\n        }\n    }\n\n");
+
+        sb.Append("    public void Dispose()\n    {\n");
+        sb.Append("        if (File.Exists(_dbPath))\n        {\n");
+        sb.Append("            File.Delete(_dbPath);\n        }\n    }\n}\n");
+        return sb.ToString();
+    }
+
+    // The Create/Update argument list — one sample literal per field (the `second` set differs so an
+    // Update visibly changes every value).
+    private static string SampleArgs(IReadOnlyList<FieldSpec> fields, bool second) =>
+        string.Join(", ", fields.Select(f => SampleLiteral(f, second)));
+
+    // One assertion per field: value objects expose the primitive through `.Value`. Booleans use
+    // Assert.True/False (xUnit2004 forbids Assert.Equal on a bool).
+    private static string SampleAsserts(string entityVar, IReadOnlyList<FieldSpec> fields, bool useValueObjects, bool second, string indent) =>
+        string.Join("\n", fields.Select(f =>
+        {
+            var access = IsValueObject(f, useValueObjects) ? $"{entityVar}.{f.Name}.Value" : $"{entityVar}.{f.Name}";
+            if (f.CsType == "bool")
+            {
+                // The `first` sample is true, the `second` (update) sample is false.
+                return $"{indent}Assert.{(second ? "False" : "True")}({access});";
+            }
+
+            return $"{indent}Assert.Equal({SampleLiteral(f, second)}, {access});";
+        }));
+
+    // A deterministic sample value per field type (two sets so create ≠ update); the string fits the
+    // field's max length so value-object construction never rejects it.
+    private static string SampleLiteral(FieldSpec f, bool second) => f.CsType switch
+    {
+        "string" => "\"" + SampleString(f, second) + "\"",
+        "int" => second ? "2" : "1",
+        "long" => second ? "2L" : "1L",
+        "decimal" => second ? "20.50m" : "10.25m",
+        "double" => second ? "2.5d" : "1.5d",
+        "bool" => second ? "false" : "true",
+        "DateTime" => second ? "new DateTime(2025, 6, 15)" : "new DateTime(2024, 1, 1)",
+        "Guid" => second ? "Guid.Parse(\"22222222-2222-2222-2222-222222222222\")" : "Guid.Parse(\"11111111-1111-1111-1111-111111111111\")",
+        _ => "default",
+    };
+
+    // A sample string for a field, trimmed to its max length so a value object's own validation accepts it.
+    private static string SampleString(FieldSpec f, bool second)
+    {
+        var value = second ? "Updated" : "Sample";
+        return f.MaxLength is int max && value.Length > max ? value[..max] : value;
+    }
+
     // ---- per-field fragment builders ----
 
     private static string Assignments(IReadOnlyList<FieldSpec> fields, string indent) =>
@@ -283,26 +421,56 @@ internal static class FeatureGenerator
         return sb.ToString().TrimEnd('\n');
     }
 
-    private static string RenderNextSteps(string context, string entity, string plural, string route, bool generatedContext, string validation, bool useBs)
+    // The NuGet packages the generated slice references — the command adds these to the project.
+    private static IReadOnlyList<string> FeaturePackages(string validation, bool useBs)
     {
-        var steps = new StringBuilder();
-        steps.Append("Next steps:\n");
-        steps.Append("  1. Reference EF Core + SQLite and Rask.Cqrs if the project doesn't already:\n");
-        steps.Append("       dotnet add package Microsoft.EntityFrameworkCore.Sqlite\n");
-        steps.Append("       dotnet add package Microsoft.EntityFrameworkCore.Design\n");
-        steps.Append("       dotnet add package Rask.Cqrs\n");
+        var packages = new List<string>
+        {
+            "Microsoft.EntityFrameworkCore.Sqlite",
+            "Microsoft.EntityFrameworkCore.Design",
+            "Rask.Cqrs",
+        };
+
         if (useBs)
         {
-            steps.Append("       dotnet add package Rask.Bootstrap   # and link BootstrapStyles() in your Head\n");
+            packages.Add("Rask.Bootstrap");
         }
 
         if (validation == "dataannotations")
         {
-            steps.Append("       dotnet add package Rask.Validation.DataAnnotations\n");
+            packages.Add("Rask.Validation.DataAnnotations");
         }
         else if (validation == "fluent")
         {
-            steps.Append("       dotnet add package Rask.Validation.FluentValidation\n");
+            packages.Add("Rask.Validation.FluentValidation");
+        }
+
+        return packages;
+    }
+
+    private static string RenderNextSteps(string context, string entity, string plural, string route, bool generatedContext, string validation, bool useBs, bool generatedTests)
+    {
+        var steps = new StringBuilder();
+        steps.Append("Next steps:\n");
+        steps.Append("  1. The required packages were added for you (EF Core + SQLite, Rask.Cqrs");
+        if (useBs)
+        {
+            steps.Append(", Rask.Bootstrap");
+        }
+
+        if (validation == "dataannotations")
+        {
+            steps.Append(", Rask.Validation.DataAnnotations");
+        }
+        else if (validation == "fluent")
+        {
+            steps.Append(", Rask.Validation.FluentValidation");
+        }
+
+        steps.Append(").\n");
+        if (useBs)
+        {
+            steps.Append("     Link BootstrapStyles() in your Head.\n");
         }
 
         steps.Append("  2. Register services in Program.cs:\n");
@@ -320,6 +488,18 @@ internal static class FeatureGenerator
         steps.Append("  3. Create the schema (EF Core migrations):\n");
         steps.Append("       dotnet ef migrations add Add").Append(entity).Append(" && dotnet ef database update\n");
         steps.Append("  4. Run the app and browse to ").Append(route).Append('.');
+        if (generatedTests)
+        {
+            steps.Append("\n  5. The generated tests live in a sibling <Project>.Tests project — it needs xunit,\n");
+            steps.Append("     Microsoft.NET.Test.Sdk");
+            if (generatedContext)
+            {
+                steps.Append(" + Microsoft.EntityFrameworkCore.Sqlite");
+            }
+
+            steps.Append(", and a project reference to this app. Then: dotnet test");
+        }
+
         return steps.ToString();
     }
 

--- a/src/Rask.Cli/Scaffolding/ScaffoldResult.cs
+++ b/src/Rask.Cli/Scaffolding/ScaffoldResult.cs
@@ -1,10 +1,14 @@
 namespace Rask.Cli.Scaffolding;
 
 /// <summary>
-/// What a generator produced: the <see cref="Files"/> to write and optional <see cref="Notes"/> to print
-/// afterwards (e.g. a feature's "register the DbContext / run a migration" next steps).
+/// What a generator produced: the <see cref="Files"/> to write, optional <see cref="Notes"/> to print
+/// afterwards (e.g. a feature's "register the DbContext / run a migration" next steps), and the NuGet
+/// <see cref="Packages"/> the output needs — the command adds them to the project automatically.
 /// </summary>
 internal sealed record ScaffoldResult(IReadOnlyList<ScaffoldFile> Files, string? Notes = null)
 {
+    /// <summary>Packages the generated code references, added to the project via <c>dotnet add package</c>.</summary>
+    public IReadOnlyList<string> Packages { get; init; } = [];
+
     public static ScaffoldResult Single(ScaffoldFile file) => new([file]);
 }

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -117,8 +117,8 @@ public sealed class FeatureGeneratorTests
         new("Price", "decimal", IsNullable: false, MaxLength: null),
     ];
 
-    private static ScaffoldResult Generate(string idType = "Guid", string validation = "valueobjects", bool useBs = false, bool useModal = false, string? context = null, string? plural = null) =>
-        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, validation, useBs, useModal, context, plural, outputOverride: null);
+    private static ScaffoldResult Generate(string idType = "Guid", string validation = "valueobjects", bool useBs = false, bool useModal = false, bool useTests = false, string? context = null, string? plural = null) =>
+        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, validation, useBs, useModal, useTests, context, plural, outputOverride: null);
 
     private static string File(ScaffoldResult result, string fileName) =>
         result.Files.Single(f => Path.GetFileName(f.Path) == fileName).Content;
@@ -289,10 +289,50 @@ public sealed class FeatureGeneratorTests
     }
 
     [Fact]
+    public void Tests_flag_emits_domain_and_persistence_tests_in_a_sibling_test_project()
+    {
+        var result = Generate(useTests: true);
+
+        // A domain test (pure Create/Update + value-object validation) and a SQLite round-trip test,
+        // both under a sibling <Project>.Tests project mirroring the feature folder.
+        var domain = result.Files.Single(f => Path.GetFileName(f.Path) == "ProductTests.cs");
+        var persistence = result.Files.Single(f => Path.GetFileName(f.Path) == "ProductsPersistenceTests.cs");
+        Assert.Equal(Path.GetFullPath("/proj.Tests/Features/Products"), Path.GetFullPath(Path.GetDirectoryName(domain.Path)!));
+
+        Assert.Contains("namespace MyApp.Tests.Features.Products;", domain.Content, StringComparison.Ordinal);
+        Assert.Contains("using MyApp.Features.Products;", domain.Content, StringComparison.Ordinal);
+        Assert.Contains("var entity = Product.Create(\"Sample\", 10.25m);", domain.Content, StringComparison.Ordinal);
+        Assert.Contains("entity.Update(\"Updated\", 20.50m);", domain.Content, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(\"Sample\", entity.Name.Value);", domain.Content, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(10.25m, entity.Price);", domain.Content, StringComparison.Ordinal);
+        Assert.Contains("Assert.Empty(ProductName.Validate(\"Sample\"));", domain.Content, StringComparison.Ordinal);
+
+        Assert.Contains("public sealed class ProductsPersistenceTests : IDisposable", persistence.Content, StringComparison.Ordinal);
+        Assert.Contains(".UseSqlite($\"Data Source={_dbPath}\")", persistence.Content, StringComparison.Ordinal);
+        Assert.Contains("var entity = await db.Products.SingleAsync();", persistence.Content, StringComparison.Ordinal);
+        Assert.Contains("Assert.Equal(\"Sample\", entity.Name.Value);", persistence.Content, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Tests_flag_skips_persistence_test_when_reusing_an_existing_context()
+    {
+        var result = Generate(useTests: true, context: "AppDbContext");
+
+        Assert.Contains(result.Files, f => Path.GetFileName(f.Path) == "ProductTests.cs");
+        Assert.DoesNotContain(result.Files, f => Path.GetFileName(f.Path) == "ProductsPersistenceTests.cs");
+    }
+
+    [Fact]
+    public void Without_tests_flag_no_test_files_are_generated()
+    {
+        Assert.DoesNotContain(Generate().Files, f => Path.GetFileName(f.Path).EndsWith("Tests.cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public void Plural_override_drives_names_and_route()
     {
         var result = FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Person",
-            Fields, "Guid", "valueobjects", useBs: false, useModal: false, contextOverride: null, pluralOverride: "People", outputOverride: null);
+            Fields, "Guid", "valueobjects", useBs: false, useModal: false, useTests: false, contextOverride: null, pluralOverride: "People", outputOverride: null);
 
         Assert.Contains(result.Files, f => f.Path.EndsWith("PeoplePage.cs", StringComparison.Ordinal));
         Assert.Contains("[Route(\"/people\")]", File(result, "PeoplePage.cs"), StringComparison.Ordinal);
@@ -341,12 +381,24 @@ public sealed class FeatureGeneratorTests
     [Fact]
     public void Default_next_steps_register_cqrs_the_context_and_the_ef_design_package()
     {
-        var notes = Generate().Notes!;
+        var result = Generate();
+        var notes = result.Notes!;
 
         Assert.Contains("AddRaskCqrs();", notes, StringComparison.Ordinal);
         Assert.Contains("AddDbContextFactory<ProductsDbContext>", notes, StringComparison.Ordinal);
-        Assert.Contains("Microsoft.EntityFrameworkCore.Design", notes, StringComparison.Ordinal);
         Assert.Contains("dotnet ef migrations add AddProduct", notes, StringComparison.Ordinal);
+        // The packages are added to the project automatically (not just printed).
+        Assert.Equal(
+            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs"],
+            result.Packages);
+    }
+
+    [Fact]
+    public void Feature_packages_include_bootstrap_and_the_validation_library()
+    {
+        Assert.Contains("Rask.Bootstrap", Generate(useBs: true).Packages);
+        Assert.Contains("Rask.Validation.DataAnnotations", Generate(validation: "dataannotations").Packages);
+        Assert.Contains("Rask.Validation.FluentValidation", Generate(validation: "fluent").Packages);
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -98,6 +98,56 @@ public sealed class GenerateCommandTests
     }
 
     [Fact]
+    public async Task Feature_adds_the_required_nuget_packages_automatically()
+    {
+        var (_, _, process, command) = BuildWithProcess();
+
+        var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string,Price:decimal", "--bs"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        var adds = process.Invocations
+            .Where(i => i.Arguments is ["add", "package", _])
+            .Select(i => i.Arguments[2])
+            .ToArray();
+        Assert.Equal(
+            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Bootstrap"],
+            adds);
+    }
+
+    [Fact]
+    public async Task Feature_no_restore_skips_package_adds()
+    {
+        var (console, _, process, command) = BuildWithProcess();
+
+        var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string", "--no-restore"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain(process.Invocations, i => i.Arguments.Count > 0 && i.Arguments[0] == "add");
+        Assert.Contains("Skipped adding packages", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Feature_dry_run_adds_no_packages()
+    {
+        var (_, _, process, command) = BuildWithProcess();
+
+        var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string", "--dry-run"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(process.Invocations);
+    }
+
+    [Fact]
+    public async Task Page_generation_adds_no_packages()
+    {
+        var (_, _, process, command) = BuildWithProcess();
+
+        await command.ExecuteAsync(["page", "Products"], CancellationToken.None);
+
+        Assert.Empty(process.Invocations);
+    }
+
+    [Fact]
     public async Task Feature_without_fields_fails()
     {
         var (console, fs, command) = Build();
@@ -274,7 +324,7 @@ public sealed class GenerateCommandTests
     {
         var console = new StringConsole();
         var fs = new FakeFileSystem(); // no csproj seeded
-        var command = new GenerateCommand(console, fs, ProjectDir);
+        var command = new GenerateCommand(console, fs, new FakeProcessRunner(), ProjectDir);
 
         var exit = await command.ExecuteAsync(["component", "PriceTag"], CancellationToken.None);
 
@@ -284,9 +334,16 @@ public sealed class GenerateCommandTests
 
     private static (StringConsole Console, FakeFileSystem Fs, GenerateCommand Command) Build()
     {
+        var (console, fs, _, command) = BuildWithProcess();
+        return (console, fs, command);
+    }
+
+    private static (StringConsole Console, FakeFileSystem Fs, FakeProcessRunner Process, GenerateCommand Command) BuildWithProcess()
+    {
         var console = new StringConsole();
         var fs = new FakeFileSystem();
+        var process = new FakeProcessRunner();
         fs.Seed("/proj/MyApp.csproj", "<Project></Project>");
-        return (console, fs, new GenerateCommand(console, fs, ProjectDir));
+        return (console, fs, process, new GenerateCommand(console, fs, process, ProjectDir));
     }
 }


### PR DESCRIPTION
Increment 4 of the `rask generate feature` scaffolder (stacked on #370).

## `--tests`
Emits xunit tests for the slice into a sibling `<Project>.Tests` project:
- **Domain test** (`<Entity>Tests.cs`) — `Create`/`Update` set every property, and each value object rejects a blank value / accepts a valid one. Pure, no DB.
- **Persistence test** (`<Plural>PersistenceTests.cs`, when the `DbContext` is generated) — round-trips the entity through a real SQLite file, proving the EF configuration + value-object converters.

Booleans assert with `Assert.True`/`False` (xUnit2004-clean); sample strings fit each field's max length so value-object construction never rejects them.

## Automatic package add
`generate feature` now runs `dotnet add package` for what the slice needs — EF Core + SQLite, `Rask.Cqrs`, and (with `--bs` / `--validation`) `Rask.Bootstrap` / the validation library — so the output compiles without a manual reference step. `--no-restore` skips it; a failed add degrades to a warning (files are written; packages still listed in next-steps).

## Verified
- Generated tests **compile** (`-warnaserror`) and **pass** (5/5, incl. the SQLite round-trip) in the EfCore test project.
- Auto-add asserts the exact `dotnet add package` command line via the fake process runner.
- 161 CLI unit tests green; `dotnet format` clean.

Docs (`docs/cli.md`) + CHANGELOG updated.