### PR TITLE
docs: position Rask as "the .NET One Person Framework"

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,9 @@
 # AGENTS.md — contributing to Rask with an AI assistant
 
-Cross-tool guide for AI assistants working **on the Rask framework itself** (the Claude-specific
-map is `CLAUDE.md`; downstream app-authoring guidance ships as `AGENTS.md` inside the templates).
+Cross-tool guide for AI assistants working **on the Rask framework itself** — Rask is the .NET One Person
+Framework (build, run, and ship a whole product solo, in C#, on one server; see
+`docs/one-person-framework.md`). (The Claude-specific map is `CLAUDE.md`; downstream app-authoring
+guidance ships as `AGENTS.md` inside the templates.)
 GitHub is the source of truth — keep docs, examples, and these guides up to date with every change.
 
 ## Repo workflows (`.claude/skills/`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Rask is now positioned as "the .NET One Person Framework".** A new [doctrine doc](docs/one-person-framework.md)
+  and [roadmap](docs/roadmap.md) frame Rask as a full-stack, solo-developer framework — one C# codebase, one
+  server, SQLite as the production database — with the UI reach (Server/WASM/native) and the lean runtime as
+  supporting proof. The README hero, getting-started intro, docs index, `llms.txt`, and the template `AGENTS.md`
+  files lead with this identity.
 - **New `Rask.Data` package — a DDD base entity + EF Core interceptors.** A provider-agnostic data layer
   for Entity Framework Core apps: an `AggregateRoot<TId>` base (Id, `CreatedAt`/`UpdatedAt` audit stamps,
   and a domain-events buffer), opt-in marker interfaces (`ISoftDeletable`, `IVersioned`), and three
@@ -15,7 +20,7 @@ them until tagged releases begin.
   `DeletedAt` stamp behind a global query filter), and **after-commit domain-event publication** through
   `Rask.Cqrs`. `modelBuilder.ApplyRaskConventions()` wires the query filter + optimistic-concurrency token,
   and `AddRaskData()` registers the interceptors. This is the foundation the `rask generate feature`
-  scaffolder's upcoming `--soft-delete`/`--concurrency`/`--events` output builds on. See `docs/data.md`.
+  scaffolder's `--soft-delete`/`--concurrency`/`--events` output builds on. See `docs/data.md`.
 - **`rask generate feature` now adds the required NuGet packages automatically.** After writing the
   slice it runs `dotnet add package` for EF Core + SQLite and `Rask.Cqrs` (plus `Rask.Bootstrap` with
   `--bs`, and the validation library with `--validation dataannotations`/`fluent`) so the code compiles

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img alt="Rask" src="assets/rask-logo.svg" width="300">
 </picture>
 
-### Live apps in C#. One codebase — server-rendered over WebSockets, client-side in the browser via WebAssembly, or a native iOS/Android app.
+### The .NET One Person Framework — build, run, and ship a whole product solo, in C#, on one server.
 
 [![NuGet Rask.Server](https://img.shields.io/nuget/v/Rask.Server.svg?label=Rask.Server)](https://www.nuget.org/packages/Rask.Server)
 [![NuGet Rask.Wasm](https://img.shields.io/nuget/v/Rask.Wasm.svg?label=Rask.Wasm)](https://www.nuget.org/packages/Rask.Wasm)
@@ -21,9 +21,14 @@
 
 ---
 
-Write components as plain C# classes. Return a tree of HTML from `Render()`. **No `.razor`, no JSX, no JavaScript to
-write** — and the *same* component code runs server-rendered with live WebSocket updates or fully client-side on
-WebAssembly.
+**Rask is the .NET One Person Framework: one developer builds, runs, and ships a complete product — UI, data,
+auth, background work, deployment — from a single C# codebase on one server, with SQLite as the production
+database.** No PaaS, no assembled stack of services, no second language.
+
+It starts with the UI — write components as plain C# classes that return a tree of HTML from `Render()`, **no
+`.razor`, no JSX, no JavaScript to write** — and the *same* component runs server-rendered over a WebSocket,
+client-side on WebAssembly, or as a native iOS/Android app. Then come the batteries: a `rask` CLI that scaffolds a
+full CRUD vertical slice in one command, production-grade SQLite, auth, and one-command Docker deploy.
 
 ```csharp
 [Route("/counter")]
@@ -42,6 +47,16 @@ public sealed class Counter : Component
 
 <sub>☝️ A complete, live, interactive component — routing, state, and event handling in a single C# class.
 **[See it running, and dozens more, in the live demo ↗](https://pal-tamas.github.io/rask/demo/)**</sub>
+
+**Ship a whole feature in one command:**
+
+```bash
+rask new Shop                                             # scaffold the app
+rask generate feature Product --fields "Name:string,Price:decimal"   # a full CQRS + EF Core CRUD slice
+rask dev                                                  # run it with hot reload
+```
+
+**[📖 Read the doctrine → The .NET One Person Framework](docs/one-person-framework.md)**
 
 ---
 
@@ -74,18 +89,30 @@ Server/WASM samples: `samples/Rask.Example.Native` (in-process) and `samples/Ras
 
 ## ✨ Why Rask
 
-I've spent 15+ years building full-stack .NET apps, and the front end always meant a second world — another language,
-type system, and build chain, with a serialization seam in the middle. Blazor answers part of that, but `.razor` puts
-markup and code back in one file with its own templating dialect. So Rask is built around a single conviction: **a
-component is just a C# class that returns a tree.** No `.razor`, no JSX, no template language — `Div(...)[Span(...), "hi"]`
-is plain, refactor-safe, IDE-native C#, and the *same* component runs server-rendered over a WebSocket or fully
-client-side on WebAssembly. One codebase; pick the host per project.
+Building a product used to mean assembling a stack: a frontend framework in another language, a backend, a managed
+database, a queue, a cache, a blob store, a deploy pipeline — each rented, glued, and maintained. Rask collapses that
+into **one C# codebase on one server**. A single developer scaffolds a feature, stores it in SQLite, and ships it to a
+box — no PaaS, no glue, no second language to context-switch into.
 
-It also treats the network as the real bottleneck: after first paint, a state change ships a minimal diff — a counter
-tick on a 24 KB page goes out as **~41 bytes**, not 24 KB. Rask ships **fewer bytes on the wire than Blazor on *every*
-scenario** in the head-to-head suite (typically 2–5×, up to **56×**), allocates **~40× less per update**, and — because
-a pure-element page keeps a compact frame snapshot instead of an object-per-element graph — even holds a **~30% leaner
-*retained* tree per mounted page**, the one axis Blazor used to lead. **Rask now leads on every measured axis.**
+- **One codebase, every surface.** The *same* component runs server-rendered over a WebSocket, client-side on
+  WebAssembly, or as a native iOS/Android app. Pick the host per project; write the UI once.
+- **Batteries, not a menu.** `rask new` scaffolds the app, `rask generate feature Product --fields "…"` emits a full
+  **CQRS + EF Core vertical slice** (encapsulated entity, value objects, validation, list/create/edit pages, tests),
+  and `rask dev` hot-reloads it. **[The CLI is the front door →](docs/cli.md)**
+- **SQLite is the production database.** Correct, concurrent, continuously-backed-up SQLite by default — WAL,
+  busy-timeout, streaming replication — one file, one server, no managed DB to rent.
+  **[Why one server, no PaaS →](docs/sqlite.md)**
+- **It's the .NET One Person Framework.** **[Read the doctrine →](docs/one-person-framework.md)**
+
+### Why it's serious: the UI reach + the numbers
+
+A component is just a C# class that returns a tree — `Div(...)[Span(...), "hi"]` is plain, refactor-safe, IDE-native
+C#, no `.razor`, no template language. And Rask treats the network as the real bottleneck: after first paint, a state
+change ships a minimal diff — a counter tick on a 24 KB page goes out as **~41 bytes**, not 24 KB. Rask ships **fewer
+bytes on the wire than Blazor on *every* scenario** in the head-to-head suite (typically 2–5×, up to **56×**),
+allocates **~40× less per update**, and — because a pure-element page keeps a compact frame snapshot instead of an
+object-per-element graph — even holds a **~30% leaner *retained* tree per mounted page**, the one axis Blazor used to
+lead. **Rask leads on every measured axis.**
 
 | Per-render axis | Rask | Blazor | Rask advantage |
 |---|---:|---:|---|

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,17 @@
 # Rask documentation
 
-Guides and references for building with Rask. **New to Rask?** Read
+Guides and references for building with Rask, **the .NET One Person Framework** — build, run, and ship a
+whole product solo, in C#, on one server. **New to Rask?** Read
 [Getting started](getting-started.md) start to finish — it goes from zero to a running, routed,
-interactive app. Want the pitch and a quick demo first? See the project [README](../README.md).
+interactive app. Want the philosophy first? Read **[The .NET One Person Framework](one-person-framework.md)**.
+Want the pitch and a quick demo? See the project [README](../README.md).
+
+## Start here
+
+| Guide | What it covers |
+|-------|----------------|
+| [**The .NET One Person Framework**](one-person-framework.md) | The doctrine: one developer, a whole product, one C# codebase, one server, SQLite-first — and the batteries that make it real. |
+| [Roadmap](roadmap.md) | The One-Person-Framework pillars — shipped vs planned (DB-backed jobs, outbox, mail, cache, broadcast). |
 
 ## Guides
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,10 @@
 # Getting started with Rask
 
-Rask lets you build web UIs as plain C# classes — no `.razor`, no JSX, no JavaScript to write. A
-component is a class that returns a tree of HTML from `Render()`, and the *same* component runs either
-server-rendered (live updates over a WebSocket) or fully client-side in the browser on WebAssembly.
+Rask is **the .NET One Person Framework** — one developer builds, runs, and ships a whole product solo, in
+C#, on one server ([read the doctrine](one-person-framework.md)). It starts with the UI: you build it as
+plain C# classes — no `.razor`, no JSX, no JavaScript to write. A component is a class that returns a tree
+of HTML from `Render()`, and the *same* component runs either server-rendered (live updates over a
+WebSocket) or fully client-side in the browser on WebAssembly.
 
 This is a zero-to-running tutorial for someone new to Rask. By the end you'll have an app on screen,
 you'll understand the files the template gave you, and you'll have written your own component, an event
@@ -70,7 +72,7 @@ above three working pages: a welcome card, a counter you can click, and a weathe
 > **Edit-and-refresh with `dotnet watch`.** Run `dotnet watch` instead of `dotnet run` for a live
 > inner loop: edit a component's `Render()` (or its scoped `.css`/`.js`) and save, and **C# Hot Reload**
 > applies the change to the running app and Rask re-renders the open session in place — no manual rebuild
-> or browser refresh. It's the closest a compiled framework gets to Rails' no-build loop.
+> or browser refresh — about as close to a no-build inner loop as a compiled framework gets.
 
 > **First build is slower, and the IDE may look broken — that's expected.** The first build is when
 > Rask's source generators run. Until then your IDE may flag `HomePage()`, `Counter()`, or
@@ -336,7 +338,17 @@ The snags you're most likely to hit on a fresh project (the README has a
 
 ## Next steps
 
-You now have a running, routed, interactive app. Where to go for the next thing you need:
+You now have a running, routed, interactive app. From here, the One-Person-Framework path takes it to a
+shipped product:
+
+1. **Scaffold a feature** → [`rask generate feature`](cli.md) emits a full CQRS + EF Core CRUD vertical
+   slice (entity, value objects, validation, list/create/edit pages, tests) in one command.
+2. **Make SQLite production-ready** → [Why one server, no PaaS](sqlite.md) — WAL, busy-timeout, and
+   continuous backup so one SQLite file is your production database.
+3. **Ship to one server** → a `--docker` template emits a production Dockerfile; deploy the whole app to
+   one box.
+
+Read **[the doctrine](one-person-framework.md)** for the why. Reference guides for the next thing you need:
 
 - **Build a form** → [forms](forms.md) — `Form<T>`, `Input(Bind: ...)`, validation.
 - **Add more routes / layouts** → [routing](routing.md) — nested layouts, route/query params, `Navigator`.

--- a/docs/one-person-framework.md
+++ b/docs/one-person-framework.md
@@ -1,0 +1,80 @@
+# The .NET One Person Framework
+
+Rask is built on one conviction: **a single developer should be able to build, run, and ship a complete
+product — the UI, the data, the auth, the background work, and the deployment — from one C# codebase on
+one server.** No PaaS to rent, no stack of services to assemble and glue, no second language to
+context-switch into. That is what "One Person Framework" means here, and every design decision serves it.
+
+This page is the doctrine. The [getting-started tutorial](getting-started.md) is the hands-on path; the
+[docs index](README.md) is the full map.
+
+## The problem it removes
+
+Shipping a product the conventional way means assembling a stack: a frontend framework in one language, a
+backend in another, a managed database, a queue for background jobs, a cache, a blob store, and a
+deployment pipeline to tie them together. Each piece is rented, integrated, monitored, and paid for. For a
+team that division of labor pays off. For **one person**, it is mostly overhead — the integration seams,
+the context-switching, and the monthly bill for capacity you don't yet need.
+
+Rask's answer is to collapse the stack. One language (C#), one codebase, one database file, one server.
+
+## One codebase, every surface
+
+You write the UI once, as plain C# components that return a tree of HTML from `Render()`. The *same*
+component code runs on three hosts — you pick per project, not per component:
+
+- **Server** — rendered server-side, updated live over a WebSocket with a minimal diff.
+- **WASM** — the same component running fully client-side in the browser (and installable as an offline PWA).
+- **Native** — the same component shipped as a real iOS/Android app via `Rask.Native`.
+
+Behind the UI, features are **vertical slices**: [`Rask.Cqrs`](cqrs.md) gives you source-generated
+commands/queries/notifications, and [`Rask.Data`](data-access.md) gives every aggregate a base with identity,
+audit stamps, soft delete, optimistic concurrency, and domain events — driven by EF Core interceptors, not
+boilerplate you copy into each feature. You don't wire a mediator or write a repository; you describe the
+slice and the framework assembles it.
+
+## SQLite-first: one server, no PaaS
+
+Rask treats **SQLite as the production database**, not a toy or a test double. A single database file on
+the server's local disk, configured for real concurrent web traffic (WAL journaling, a busy-timeout,
+enforced foreign keys) and **continuously backed up** by streaming its write-ahead log to object storage —
+plus scheduled full-file snapshots as a second line of defence.
+
+The payoff: **one box runs the whole product.** No managed database to provision and pay for, no network
+hop to a database tier, no separate cache or queue service — because everything stateful can ride the same
+SQLite database. When you outgrow one box, the door to a client-server database is open; most solo products
+never need to walk through it.
+
+The full reasoning — why WAL, why a busy-timeout, why single-writer is fine for a web app, and how the
+continuous backup works — is in **[Why one server, no PaaS](sqlite.md)**.
+
+## The batteries
+
+Everything a solo developer needs to go from empty folder to shipped, in the box:
+
+| Battery | What it does |
+|---------|--------------|
+| **[The `rask` CLI](cli.md)** | `rask new` (scaffold), `rask dev` (watch + hot reload), `rask generate` (page/component/feature). The front door. |
+| **[`rask generate feature`](cli.md)** | One command emits a full CQRS + EF Core CRUD vertical slice — encapsulated entity, value objects, validation, list/create/edit pages, and tests. |
+| **[`Rask.Data`](data-access.md)** | `AggregateRoot<TId>` + EF interceptors: audit stamps, transparent soft delete, optimistic concurrency, domain events. |
+| **[`Rask.Cqrs`](cqrs.md)** | Source-generated, reflection-free CQRS/mediator — trim/AOT-safe, zero runtime scanning. |
+| **[Production SQLite](sqlite.md)** | WAL + busy-timeout pragmas, continuous backup (Litestream), scheduled snapshots. |
+| **[Auth](authentication.md)** | Cookie login/session scaffolding in the templates. |
+| **[PWA & native](pwa.md)** | Installable offline apps and real iOS/Android from the same components. |
+| **Deploy** | `--docker` emits a production Dockerfile — ship the one server to one box. |
+
+## DB-backed by default
+
+The through-line for everything stateful: **it rides the app's own SQLite database.** No external broker,
+no Redis, no separate infrastructure to stand up for a hello-world. Background jobs, the transactional
+outbox, cache, and mail are all designed to persist to the same database the app already has — so adding
+one is a package reference, not a new service to operate.
+
+See the **[roadmap](roadmap.md)** for what's shipped and what's next along this line.
+
+## Where to go next
+
+- **[Getting started](getting-started.md)** — zero to a running, routed, interactive app.
+- **[The `rask` CLI](cli.md)** — scaffold and run.
+- **[Why one server, no PaaS](sqlite.md)** — the SQLite production story.
+- **[Roadmap](roadmap.md)** — the DB-backed pillars, shipped vs planned.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,55 @@
+# Roadmap — the One Person Framework pillars
+
+Rask's north star is the [.NET One Person Framework](one-person-framework.md): one developer builds, runs,
+and ships a whole product from a single C# codebase on one server. This page tracks the pillars that serve
+that goal — what's shipped and what's next. The through-line for everything stateful is **DB-backed by
+default**: it rides the app's own SQLite database, so adding a capability is a package reference, not a new
+service to operate.
+
+## Shipped
+
+| Pillar | Status | Where |
+|--------|--------|-------|
+| **UI across three hosts** | ✅ | Server (WebSocket live diff), WASM (client-side + PWA), Native iOS/Android — one component. |
+| **The `rask` CLI** | ✅ | [`cli.md`](cli.md) — `new` / `dev` / `generate`. |
+| **CRUD scaffolder** | ✅ | [`rask generate feature`](cli.md) — CQRS + EF Core vertical slice, value objects, validation, pages, tests. |
+| **CQRS / mediator** | ✅ | [`Rask.Cqrs`](cqrs.md) — source-generated, reflection-free. |
+| **Data layer** | ✅ | [`Rask.Data`](data-access.md) — `AggregateRoot<TId>` + interceptors (audit, soft delete, concurrency, domain events). |
+| **Production SQLite** | ✅ | [`sqlite.md`](sqlite.md) — WAL/busy-timeout pragmas, continuous backup (Litestream), snapshots. |
+| **Auth** | ✅ | [`authentication.md`](authentication.md) — cookie login/session in the templates. |
+| **PWA & native** | ✅ | [`pwa.md`](pwa.md) / [`native.md`](native.md). |
+| **Deploy to one box** | ✅ | `--docker` template → a production Dockerfile. |
+
+## Planned — DB-backed pillars
+
+Each of these is designed to persist to the **same SQLite database the app already has** — no external
+broker, no Redis, no separate infrastructure for a hello-world. Ordered by leverage for shipping a product.
+
+### Background jobs
+Durable, recurring background work stored in the app's database, run by a hosted worker. At-least-once with
+retries/backoff. The worker polls the jobs table (SQLite is single-writer, so claiming is poll +
+sequential-write, not row-locking — WAL + a busy-timeout keep reads flowing during writes).
+
+### Transactional outbox
+Domain events persisted in the **same transaction** as the aggregate change that raised them — so an event
+is never lost and never fires for a change that rolled back (strict atomicity, because the outbox table
+lives in the same database). A background processor drains unprocessed rows and publishes them. `Rask.Data`
+already raises and buffers domain events; the outbox is the durable delivery path (the in-process
+publisher is the fast, non-durable alternative). See the `--events` / `--outbox` scaffolder flags.
+
+### Transactional email
+Send email from the backend, with the outbox pattern for reliable delivery, and Rask components rendered to
+HTML as the email templates (reusing the render pipeline).
+
+### Cache
+A developer-facing cache over the app's database, plus a render/fragment cache reusing the framework's
+existing subtree-cache machinery.
+
+### Broadcast
+Server-to-many-clients pub/sub over the existing WebSocket channel — subscribe to a topic, push a live diff
+to every subscriber. Unlocks realtime UI without new infrastructure.
+
+---
+
+Want to shape the direction? The framework is developed in the open — see
+[the development workflow](development-workflow.md).

--- a/llms.txt
+++ b/llms.txt
@@ -1,14 +1,19 @@
 # Rask
 
-> Rask is a C# component framework (Blazor-like) for .NET 10: a Roslyn factory generator,
-> scoped CSS/JS, routing, and a live diff runtime over WebSockets (Server), JSImport/JSExport
-> (WASM), or a native WebView bridge (native iOS/Android via Rask.Native). Components are plain C#
-> classes; markup is written with generated factory methods and a children indexer (`Div()[Span(), "hi"]`).
+> Rask is the .NET One Person Framework: one developer builds, runs, and ships a whole product — UI,
+> data, auth, background work, deployment — from a single C# codebase on one server, with SQLite as the
+> production database (no PaaS, no assembled service stack, no second language). The UI is plain C#
+> components (a Roslyn factory generator, scoped CSS/JS, routing) whose same code runs server-rendered
+> over WebSockets, client-side on WebAssembly, or native iOS/Android (Rask.Native); markup uses generated
+> factory methods + a children indexer (`Div()[Span(), "hi"]`). Batteries: the `rask` CLI, a
+> `generate feature` CQRS+EF CRUD scaffolder, Rask.Cqrs, Rask.Data, production SQLite (pragmas + backup),
+> auth, and `--docker` deploy.
 
 This file helps AI coding assistants build apps with Rask. Start with AGENTS.md (in any
 `dotnet new rask-*` project) for app-authoring conventions, then the docs below.
 
 ## Docs
+- [The .NET One Person Framework](docs/one-person-framework.md): the doctrine — one dev, whole product, one C# codebase on one server, SQLite-first; links the batteries + roadmap.
 - [Getting started](docs/getting-started.md): install, first app, project layout.
 - [The `rask` CLI](docs/cli.md): the optional `Rask.Cli` .NET tool (`dotnet tool install -g Rask.Cli`) — a thin, dependency-free wrapper over the SDK. `rask new <name> [--template server|wasm|wasm-hosted|native] [--auth] [--pwa] [--cqrs] [--docker] [--output]` resolves the friendly template to its `dotnet new` short name, forwards only the flags that template supports (fails fast otherwise), and installs `Rask.Templates` on demand; `rask generate <page|component|feature> <Name>` (aliases `rask g`, `g f`/`g c`/`g p`) scaffolds a routed page (`Features/<Name>/<Name>Page.cs`), a component (`Components/<Name>.cs`), or a full **CQRS + EF Core CRUD `feature`** under `Features/<Plural>/`: an encapsulated entity (private setters + static `Create`/`Update`; Guid id by default, `--id int|long`), a `DbContext` (or `--context` existing), create/update/delete commands + list/get queries each with a handler that owns the EF access (create/update carry a request object the form binds to), and list/create/edit pages that dispatch via `IDispatcher` with type-safe `Routes.*()` nav. `--fields "n:type,…"` types string/int/long/decimal/double/bool/DateTime/Guid(+aliases), optional with trailing `?`, string max-length via `(N)` (default 200), Id auto-added; `--plural`/`--output`/`--force`/`--dry-run`; prints `AddRaskCqrs()`+`AddDbContextFactory`+`dotnet ef` next-steps. Finds the owning .csproj, derives the folder-based namespace, won't overwrite without `--force`, output compiles as-is; `rask dev [--project] [--no-hot-reload] [-- app args]` runs `dotnet watch run`; `rask info` reports CLI/SDK/template/OS; `rask --version`. Roadmap: `rask db` (migrations), `rask deploy`.
 - [Live playground](docs/playground.md): write Rask component C# in the browser with a real IDE and see it compile + render live — Roslyn + the Rask source generator run entirely in WebAssembly (no server), the emitted component is Assembly.Load-ed and mounted as a child of the playground's own tree so its handlers/state run through the shared live session. The editor has Roslyn `CompletionService` IntelliSense and as-you-type diagnostics (CS + RASK) as inline Monaco squiggles, driven by a workspace-backed analysis path that never Emits/loads (so typing can't leak assemblies — only Run does); a left-hand gallery offers Counter / Form+validation / Todo starters (Ctrl/Cmd+Enter runs). The `samples/Rask.Example.Playground` app, published to GitHub Pages at `/rask/playground/` next to the showcase; ships untrimmed (Roslyn reads the `_framework/*.dll` back as metadata references, so WasmEnableWebcil=false; Microsoft.CodeAnalysis.CSharp.Features adds CompletionService), user code always runs interpreted, entry point is a `Playground : Component` in a namespace.

--- a/src/Rask.Cli/NUGET.md
+++ b/src/Rask.Cli/NUGET.md
@@ -47,4 +47,4 @@ Run `rask <command> --help` for command-specific usage, or `rask --version` for 
 ## Notes
 
 - **No external dependencies** — pure BCL over the `dotnet` SDK you already have.
-- More commands (`db`, `deploy`) are on the roadmap as Rask grows into a complete one-person framework.
+- More commands (`db`, `deploy`) are on the roadmap — the CLI is the front door to Rask, the .NET One Person Framework.

--- a/src/Rask.Templates/content/rask-native/AGENTS.md
+++ b/src/Rask.Templates/content/rask-native/AGENTS.md
@@ -1,6 +1,7 @@
 # AGENTS.md — building this app with an AI assistant
 
-This is a **Rask** native mobile app (iOS + Android) for .NET 10. It's a **WebView hybrid**: your C#
+This is a **Rask** native mobile app (iOS + Android) for .NET 10. Rask is the .NET One Person Framework —
+one C# codebase, one server, every UI surface. This app is a **WebView hybrid**: your C#
 runs natively on the device via `Rask.Native`, and the UI renders in a platform WebView driven by Rask's
 live diff pipeline. The **same component code** as any other Rask host works here. Full docs:
 https://github.com/pal-tamas/rask/tree/main/docs — native specifics: docs/native.md.

--- a/src/Rask.Templates/content/rask-server/AGENTS.md
+++ b/src/Rask.Templates/content/rask-server/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — building this app with an AI assistant
 
-This is a **Rask** app (a C# component framework for .NET 10). This file tells AI coding
+This is a **Rask** app. Rask is the .NET One Person Framework (a full-stack C# framework for .NET 10). This file tells AI coding
 assistants the conventions so generated code compiles and runs. Full docs:
 https://github.com/pal-tamas/rask/tree/main/docs
 

--- a/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm-hosted/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — building this app with an AI assistant
 
-This is a **Rask** app (a C# component framework for .NET 10). This file tells AI coding
+This is a **Rask** app. Rask is the .NET One Person Framework (a full-stack C# framework for .NET 10). This file tells AI coding
 assistants the conventions so generated code compiles and runs. Full docs:
 https://github.com/pal-tamas/rask/tree/main/docs
 

--- a/src/Rask.Templates/content/rask-wasm/AGENTS.md
+++ b/src/Rask.Templates/content/rask-wasm/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md — building this app with an AI assistant
 
-This is a **Rask** app (a C# component framework for .NET 10). This file tells AI coding
+This is a **Rask** app. Rask is the .NET One Person Framework (a full-stack C# framework for .NET 10). This file tells AI coding
 assistants the conventions so generated code compiles and runs. Full docs:
 https://github.com/pal-tamas/rask/tree/main/docs
 


### PR DESCRIPTION
Repositions Rask's top-of-funnel around **"the .NET One Person Framework"** — one developer builds, runs, and ships a whole product solo, in C#, on one server, with SQLite as the production database. The existing "one component → Server/WASM/Native, beats Blazor" story stays as *supporting proof*, not the headline.

## What changed
- **New `docs/one-person-framework.md`** — the doctrine (the problem it removes, one codebase/every surface, SQLite-first/one-server/no-PaaS, the batteries, DB-backed by default).
- **New `docs/roadmap.md`** — the pillars, shipped vs planned (DB-backed background jobs, transactional outbox, mail, cache, broadcast — all riding the app's SQLite DB).
- **README** — hero → the OPF tagline; `## Why Rask` rewritten around the solo-dev thesis with a one-command feature-scaffold snippet; the Blazor benchmark (real numbers, unchanged) folded under *"why it's serious"*.
- **getting-started** — intro leads with the OPF identity; *Next steps* reframed as scaffold → SQLite → ship.
- **llms.txt** self-description, **docs index** ("Start here"), template + native + root **AGENTS.md**, and the CLI **NUGET.md** all lead with the identity.

## Notes
- **No Ruby / Rails / DHH** in the new narrative (per request).
- Pre-existing SQLite/`IToaster` *feature* descriptions still cite Rails technically; scrubbing those + adding the sqlite.md "why one server, no PaaS" thesis + consolidating the `data-access`/`data`/`sqlite` docs come in the **follow-up PR**.
- Links to `Rask.Data`'s `data.md` point to `data-access.md` for now (data.md lands with #373).
- Real benchmark claims are unchanged — nothing fabricated.