### PR TITLE
feat(cli): generate feature base entity + --soft-delete + graceful errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`rask generate feature` entities inherit `Rask.Data`'s `AggregateRoot<TId>`, and `--soft-delete` is
+  new.** Every generated entity now inherits the base (Id + audit stamps + a domain-events buffer), the
+  generated `DbContext` calls `modelBuilder.ApplyRaskConventions()`, and the delete handler always
+  loads + `Remove`s (so it flows through the interceptors) instead of a set-based `ExecuteDelete`.
+  `--soft-delete` makes the entity `ISoftDeletable` (a `DeletedAt` stamp): deletes become soft deletes,
+  deleted rows drop out of the list behind a global query filter, and the list page gains a "Show deleted"
+  toggle + a generated `Restore<Entity>` command/button for deleted rows. Auto-NuGet + the next-steps add
+  `Rask.Data` + `AddRaskData()`. Every generated Create/Edit/modal page also now **handles errors
+  gracefully** — the submit try/catches and shows a friendly inline alert (`BsAlert` / `role="alert"`),
+  navigating only on success.
 - **Rask is now positioned as "the .NET One Person Framework".** A new [doctrine doc](docs/one-person-framework.md)
   and [roadmap](docs/roadmap.md) frame Rask as a full-stack, solo-developer framework — one C# codebase, one
   server, SQLite as the production database — with the UI reach (Server/WASM/native) and the lean runtime as

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -73,6 +73,7 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 | `--modal` | `feature` only (implies `--bs`): create + update happen in a `BsModal` on the list page, instead of separate create/edit pages. |
 | `--bs` | `feature` only: render the pages with Rask.Bootstrap `Bs*` components (`BsCard`/`BsTable`/`BsButton`/`BsInput`/`BsCheck`/`BsIcon`) + `Bs.Join(...)` utility classes instead of raw core + Bootstrap class strings. |
 | `--validation` | `feature` only: `valueobjects` (default — required strings become value objects with built-in, dependency-free validation), `dataannotations` (POCO + `[Required]`/`[MaxLength]` + `DataAnnotationsValidator`), or `fluent` (POCO + a generated `AbstractValidator` + `FluentValidationValidator`). |
+| `--soft-delete` | `feature` only: the entity implements `ISoftDeletable` (a `DeletedAt` stamp) so `Delete` becomes a soft delete (via `Rask.Data`'s interceptor + a global query filter), and the list page gains a "Show deleted" toggle + a `Restore` action for deleted rows. |
 | `--tests` | `feature` only: also emit xunit tests in a sibling `<Project>.Tests` project — a domain test (`Create`/`Update` + value-object validation) and, when the `DbContext` is generated, a SQLite round-trip persistence test. |
 | `--no-restore` | `feature` only: don't add the NuGet packages automatically (just print them). |
 | `--context`, `-c` | `feature` only: reference an existing `DbContext` by name instead of generating a feature-local one (then add a `DbSet` to it). |
@@ -84,11 +85,13 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 
 The generated code compiles as-is in any `dotnet new rask-*` project — the factory methods and the
 `Component` base come from Rask's implicit usings, and pages navigate with the type-safe generated
-`Routes.*()` URLs. A generated `feature` needs **EF Core + `Rask.Cqrs`** referenced, so `rask generate`
-**adds those packages to the project for you** (`dotnet add package` for EF Core + SQLite, `Rask.Cqrs`,
-and — with `--bs`/`--validation` — `Rask.Bootstrap` / the validation library; pass `--no-restore` to
-skip). It then prints the DI registration (`AddRaskCqrs()` + `AddDbContextFactory`) and the `dotnet ef`
-migration to run before it works.
+`Routes.*()` URLs. Every generated entity inherits [`Rask.Data`](data.md)'s `AggregateRoot<TId>` (Id +
+audit stamps + a domain-events buffer), so a generated `feature` needs **EF Core + `Rask.Cqrs` +
+`Rask.Data`** referenced — `rask generate` **adds those packages to the project for you**
+(`dotnet add package` for EF Core + SQLite, `Rask.Cqrs`, `Rask.Data`, and — with `--bs`/`--validation` —
+`Rask.Bootstrap` / the validation library; pass `--no-restore` to skip). It then prints the DI
+registration (`AddRaskCqrs()` + `AddRaskData()` + `AddDbContextFactory` with the interceptors) and the
+`dotnet ef` migration to run before it works.
 
 Every command has short aliases: `rask g` = `rask generate`, and `g f` / `g c` / `g p` scaffold a
 feature / component / page.

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -59,6 +59,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             .Option("validation")
             .Flag("bs")
             .Flag("modal")
+            .Flag("soft-delete")
             .Flag("tests")
             .Flag("no-restore")
             .Flag("force")
@@ -103,9 +104,9 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             && (parsed.Option("fields") is not null || parsed.Option("context") is not null
                 || parsed.Option("plural") is not null || parsed.Option("id") is not null
                 || parsed.Option("validation") is not null || parsed.HasFlag("bs") || parsed.HasFlag("modal")
-                || parsed.HasFlag("tests")))
+                || parsed.HasFlag("soft-delete") || parsed.HasFlag("tests")))
         {
-            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, --modal, and --tests only apply to 'generate feature'.");
+            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, --modal, --soft-delete, and --tests only apply to 'generate feature'.");
             return 1;
         }
 
@@ -228,7 +229,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                 var useModal = parsed.HasFlag("modal");
                 var useBs = useModal || parsed.HasFlag("bs");
 
-                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, parsed.HasFlag("tests"), parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
+                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, parsed.HasFlag("soft-delete"), parsed.HasFlag("tests"), parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
                 return true;
         }
     }

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -22,6 +22,7 @@ internal static class FeatureGenerator
         string validation,
         bool useBs,
         bool useModal,
+        bool useSoftDelete,
         bool useTests,
         string? contextOverride,
         string? pluralOverride,
@@ -46,12 +47,20 @@ internal static class FeatureGenerator
             ("__FORMFIELDS__", FormFields(entityName, fields, useValueObjects, useBs)), ("__COPYTOFORM__", CopyToForm(fields, useValueObjects)),
             ("__CONFIGPROPS__", ConfigProperties(entityName, fields, useValueObjects)),
             ("__VALIDATOR__", FormValidator(entityName, validation)),
+            ("__DELETEBODY__", DeleteHandlerBody(plural)),
+            ("__ERRORALERT__", ErrorAlert(useBs)),
+            ("__LISTQUERY__", ListQuery(plural, entityName, context, useSoftDelete)),
+            ("__LISTLOADARG__", useSoftDelete ? "_showDeleted" : ""),
+            ("__LISTSTATE__", ListState(useSoftDelete)),
+            ("__LISTMETHODS__", ListToggleMethod(useSoftDelete)),
+            ("__TOGGLEBUTTON__", ToggleButton(useBs, useSoftDelete)),
+            ("__ROWACTIONS__", RowActions(entityName, useBs, useModal, useSoftDelete)),
         };
 
         var listTemplate = useModal ? BsModalListTemplate : useBs ? BsListPageTemplate : ListPageTemplate;
         var files = new List<ScaffoldFile>
         {
-            new(Path.Combine(targetDirectory, entityName + ".cs"), RenderEntity(ns, entityName, fields, idType, useValueObjects)),
+            new(Path.Combine(targetDirectory, entityName + ".cs"), RenderEntity(ns, entityName, fields, idType, useValueObjects, useSoftDelete)),
             new(Path.Combine(targetDirectory, entityName + "Request.cs"), RenderRequest(ns, entityName, fields, validation)),
             new(Path.Combine(targetDirectory, entityName + "Configuration.cs"), Apply(ConfigurationTemplate, tokens)),
             new(Path.Combine(targetDirectory, plural + "Page.cs"), Apply(listTemplate, tokens)),
@@ -63,6 +72,12 @@ internal static class FeatureGenerator
         {
             files.Add(new ScaffoldFile(Path.Combine(targetDirectory, "Create" + entityName + ".cs"), Apply(useBs ? BsCreateTemplate : CreateTemplate, tokens)));
             files.Add(new ScaffoldFile(Path.Combine(targetDirectory, "Update" + entityName + ".cs"), Apply(useBs ? BsUpdateTemplate : UpdateTemplate, tokens)));
+        }
+
+        // --soft-delete adds a reusable Restore button + command (the list shows it on soft-deleted rows).
+        if (useSoftDelete)
+        {
+            files.Add(new ScaffoldFile(Path.Combine(targetDirectory, "Restore" + entityName + ".cs"), Apply(useBs ? BsRestoreTemplate : RestoreTemplate, tokens)));
         }
 
         // valueobjects mode: one value object per required-string field, each owning its validation.
@@ -122,6 +137,105 @@ internal static class FeatureGenerator
         _ => "",
     };
 
+    // The inline error banner rendered above a mutation form (as a conditional child; null when there's no
+    // error). Bootstrap gets a BsAlert; plain HTML gets a semantic role="alert" div.
+    private static string ErrorAlert(bool useBs) => useBs
+        ? "_error is null ? null : BsAlert(Color: BsColor.Danger)[_error],"
+        : "_error is null ? null : Div(Role: \"alert\")[_error],";
+
+    // The delete command handler body. Always load + Remove + SaveChanges (never set-based ExecuteDelete),
+    // so every delete flows through Rask.Data's interceptors: a --soft-delete entity is rewritten to a
+    // DeletedAt stamp, audit/version columns update, and domain events fire — all of which ExecuteDelete
+    // would bypass.
+    private static string DeleteHandlerBody(string plural) =>
+        $"        var entity = await db.{plural}.FirstOrDefaultAsync(x => x.Id == command.Id, cancellationToken);\n"
+            + "        if (entity is null)\n"
+            + "        {\n"
+            + "            return;\n"
+            + "        }\n\n"
+            + $"        db.{plural}.Remove(entity);\n"
+            + "        await db.SaveChangesAsync(cancellationToken);";
+
+    // The List query record + handler. With --soft-delete it takes an IncludeDeleted flag that lifts the
+    // global "DeletedAt == null" query filter (IgnoreQueryFilters) so the list can show deleted rows.
+    private static string ListQuery(string plural, string entity, string context, bool useSoftDelete) => useSoftDelete
+        ? $$"""
+        public sealed record List{{plural}}Query(bool IncludeDeleted = false) : IQuery<IReadOnlyList<{{entity}}>>;
+
+        public sealed class List{{plural}}QueryHandler(IDbContextFactory<{{context}}> dbContextFactory)
+            : IQueryHandler<List{{plural}}Query, IReadOnlyList<{{entity}}>>
+        {
+            public async Task<IReadOnlyList<{{entity}}>> HandleAsync(List{{plural}}Query query, CancellationToken cancellationToken)
+            {
+                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+                var items = db.{{plural}}.AsNoTracking();
+                if (query.IncludeDeleted)
+                {
+                    items = items.IgnoreQueryFilters();
+                }
+
+                return await items.OrderBy(x => x.Id).ToListAsync(cancellationToken);
+            }
+        }
+        """
+        : $$"""
+        public sealed record List{{plural}}Query : IQuery<IReadOnlyList<{{entity}}>>;
+
+        public sealed class List{{plural}}QueryHandler(IDbContextFactory<{{context}}> dbContextFactory)
+            : IQueryHandler<List{{plural}}Query, IReadOnlyList<{{entity}}>>
+        {
+            public async Task<IReadOnlyList<{{entity}}>> HandleAsync(List{{plural}}Query query, CancellationToken cancellationToken)
+            {
+                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+                return await db.{{plural}}.AsNoTracking().OrderBy(x => x.Id).ToListAsync(cancellationToken);
+            }
+        }
+        """;
+
+    // The per-row action cell contents on the list page. With --soft-delete each live row shows edit + delete;
+    // a soft-deleted row (DeletedAt set) shows Restore instead (null children drop out).
+    private static string RowActions(string entity, bool useBs, bool useModal, bool useSoftDelete)
+    {
+        var edit = useModal
+            ? $"BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClickAsync: () => OpenEditAsync(x.Id))[BsIcon(Name: BsIconName.Pencil)]"
+            : useBs
+                ? $"BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClick: () => navigator.NavigateTo(Routes.Update{entity}(x.Id)))[BsIcon(Name: BsIconName.Pencil)]"
+                : $"NavLink(Routes.Update{entity}(x.Id))[\"Edit\"]";
+        var delete = $"Delete{entity}(Id: x.Id, OnDeleted: LoadAsync)";
+
+        // The continuation indent below matches the generated Td()[ … ] cell (32 spaces).
+        if (!useSoftDelete)
+        {
+            return $"{edit},\n                                {delete}";
+        }
+
+        var restore = $"Restore{entity}(Id: x.Id, OnRestored: LoadAsync)";
+        return $"x.DeletedAt is null ? {edit} : null,\n"
+            + $"                                x.DeletedAt is null ? (Component){delete} : {restore}";
+    }
+
+    // The "Show deleted" toggle rendered in the list header (only with --soft-delete). ToggleDeletedAsync flips
+    // the flag and reloads; the button label reflects the current state.
+    private static string ToggleButton(bool useBs, bool useSoftDelete)
+    {
+        if (!useSoftDelete)
+        {
+            return "";
+        }
+
+        return useBs
+            ? "BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClickAsync: ToggleDeletedAsync)[_showDeleted ? \"Hide deleted\" : \"Show deleted\"],"
+            : "Button(\"button\", OnClickAsync: ToggleDeletedAsync)[_showDeleted ? \"Hide deleted\" : \"Show deleted\"],";
+    }
+
+    // The _showDeleted field + ToggleDeletedAsync method injected into the list component (only --soft-delete),
+    // at generated indentation (fields 4 spaces, method body 8).
+    private static string ListState(bool useSoftDelete) => useSoftDelete ? "\n    private bool _showDeleted;" : "";
+
+    private static string ListToggleMethod(bool useSoftDelete) => useSoftDelete
+        ? "\n    private async Task ToggleDeletedAsync()\n    {\n        _showDeleted = !_showDeleted;\n        await LoadAsync();\n    }\n"
+        : "";
+
     // FluentValidation RuleFor lines for the string fields (NotEmpty for required, MaximumLength for all).
     private static string FluentRules(IReadOnlyList<FieldSpec> fields) =>
         string.Join("\n", fields.Where(f => f.IsString).Select(f =>
@@ -142,19 +256,38 @@ internal static class FeatureGenerator
     private static string EntityPropertyType(string entity, FieldSpec f, bool useValueObjects) =>
         IsValueObject(f, useValueObjects) ? ValueObjectName(entity, f) : f.PropertyType;
 
-    internal static string RenderEntity(string ns, string entity, IReadOnlyList<FieldSpec> fields, string idType, bool useValueObjects)
+    internal static string RenderEntity(string ns, string entity, IReadOnlyList<FieldSpec> fields, string idType, bool useValueObjects, bool useSoftDelete)
     {
         var sb = new StringBuilder();
         sb.Append("namespace ").Append(ns).Append(";\n\n");
-        sb.Append("public sealed class ").Append(entity).Append("\n{\n");
+
+        // Every aggregate inherits AggregateRoot<TId> (Id + CreatedAt/UpdatedAt audit stamps + a
+        // domain-events buffer, from Rask.Data). --soft-delete opts into ISoftDeletable (adds DeletedAt).
+        var bases = "AggregateRoot<" + idType + ">";
+        if (useSoftDelete)
+        {
+            bases += ", ISoftDeletable";
+        }
+
+        sb.Append("public sealed class ").Append(entity).Append(" : ").Append(bases).Append("\n{\n");
         sb.Append("    private ").Append(entity).Append("() { } // EF Core materialization\n\n");
 
         // The ctor takes the value-object types; Create/Update take primitives and wrap them via Create.
         var ctorParams = string.Join(", ", fields.Select(f => $"{EntityPropertyType(entity, f, useValueObjects)} {Identifiers.ToCamelCase(f.Name)}"));
         sb.Append("    private ").Append(entity).Append('(').Append(ctorParams).Append(")\n    {\n");
-        sb.Append(Assignments(fields, "        ")).Append("\n    }\n\n");
-        sb.Append("    public ").Append(idType).Append(" Id { get; private set; }");
-        sb.Append(idType == "Guid" ? " = Guid.NewGuid();\n" : "\n");
+        if (idType == "Guid")
+        {
+            // int/long ids are database-generated; a Guid id is assigned up front (Id is on the base).
+            sb.Append("        Id = Guid.NewGuid();\n");
+        }
+
+        sb.Append(Assignments(fields, "        ")).Append("\n    }\n");
+
+        if (useSoftDelete)
+        {
+            sb.Append("\n    public DateTime? DeletedAt { get; private set; }\n");
+            sb.Append("\n    public void Restore() => DeletedAt = null;\n");
+        }
 
         foreach (var field in fields)
         {
@@ -429,6 +562,7 @@ internal static class FeatureGenerator
             "Microsoft.EntityFrameworkCore.Sqlite",
             "Microsoft.EntityFrameworkCore.Design",
             "Rask.Cqrs",
+            "Rask.Data", // the AggregateRoot<TId> base + interceptors every generated entity inherits
         };
 
         if (useBs)
@@ -467,7 +601,7 @@ internal static class FeatureGenerator
             steps.Append(", Rask.Validation.FluentValidation");
         }
 
-        steps.Append(").\n");
+        steps.Append(", Rask.Data").Append(").\n");
         if (useBs)
         {
             steps.Append("     Link BootstrapStyles() in your Head.\n");
@@ -475,14 +609,18 @@ internal static class FeatureGenerator
 
         steps.Append("  2. Register services in Program.cs:\n");
         steps.Append("       builder.Services.AddRaskCqrs();\n");
+        steps.Append("       builder.Services.AddRaskData();\n");
         if (generatedContext)
         {
-            steps.Append("       builder.Services.AddDbContextFactory<").Append(context).Append(">(o => o.UseSqlite(\"Data Source=app.db\"));\n");
+            steps.Append("       builder.Services.AddDbContextFactory<").Append(context).Append(">((sp, o) => o\n");
+            steps.Append("           .UseSqlite(\"Data Source=app.db\")\n");
+            steps.Append("           .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));\n");
         }
         else
         {
-            steps.Append("       // in your ").Append(context).Append(": add `public DbSet<").Append(entity).Append("> ").Append(plural).Append(" => Set<").Append(entity).Append(">();`\n");
-            steps.Append("       // and apply the config: modelBuilder.ApplyConfigurationsFromAssembly(typeof(").Append(entity).Append("Configuration).Assembly);\n");
+            steps.Append("       // in your ").Append(context).Append(": add `public DbSet<").Append(entity).Append("> ").Append(plural).Append(" => Set<").Append(entity).Append(">();`,\n");
+            steps.Append("       // call modelBuilder.ApplyConfigurationsFromAssembly(...) + modelBuilder.ApplyRaskConventions() in OnModelCreating,\n");
+            steps.Append("       // and add .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()) where you register it.\n");
         }
 
         steps.Append("  3. Create the schema (EF Core migrations):\n");
@@ -525,8 +663,11 @@ internal static class FeatureGenerator
         {
             public DbSet<__ENTITY__> __PLURAL__ => Set<__ENTITY__>();
 
-            protected override void OnModelCreating(ModelBuilder modelBuilder) =>
+            protected override void OnModelCreating(ModelBuilder modelBuilder)
+            {
                 modelBuilder.ApplyConfigurationsFromAssembly(typeof(__CONTEXT__).Assembly);
+                modelBuilder.ApplyRaskConventions();
+            }
         }
 
         """;
@@ -615,23 +756,13 @@ internal static class FeatureGenerator
 
         namespace __NS__;
 
-        public sealed record List__PLURAL__Query : IQuery<IReadOnlyList<__ENTITY__>>;
-
-        public sealed class List__PLURAL__QueryHandler(IDbContextFactory<__CONTEXT__> dbContextFactory)
-            : IQueryHandler<List__PLURAL__Query, IReadOnlyList<__ENTITY__>>
-        {
-            public async Task<IReadOnlyList<__ENTITY__>> HandleAsync(List__PLURAL__Query query, CancellationToken cancellationToken)
-            {
-                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                return await db.__PLURAL__.AsNoTracking().OrderBy(x => x.Id).ToListAsync(cancellationToken);
-            }
-        }
+        __LISTQUERY__
 
         [Route("__ROUTE__")]
         public sealed class __PLURAL__Page(IDispatcher dispatcher) : Component
         {
             private IReadOnlyList<__ENTITY__> _items = [];
-            private bool _loaded;
+            private bool _loaded;__LISTSTATE__
 
             protected override Component? Head => Title()["__PLURAL__"];
 
@@ -639,14 +770,15 @@ internal static class FeatureGenerator
 
             private async Task LoadAsync()
             {
-                _items = await dispatcher.DispatchAsync(new List__PLURAL__Query(), CancellationToken);
+                _items = await dispatcher.DispatchAsync(new List__PLURAL__Query(__LISTLOADARG__), CancellationToken);
                 _loaded = true;
-            }
+            }__LISTMETHODS__
 
             protected override Component? Render() =>
             [
                 Div()[
                     H1()["__PLURAL__"],
+                    __TOGGLEBUTTON__
                     NavLink(Routes.Create__ENTITY__())["New __ENTITY__"]
                 ],
                 !_loaded
@@ -666,8 +798,7 @@ internal static class FeatureGenerator
                                     Td()[$"{x.Id}"],
         __CELLS__
                                     Td()[
-                                        NavLink(Routes.Update__ENTITY__(x.Id))["Edit"],
-                                        Delete__ENTITY__(Id: x.Id, OnDeleted: LoadAsync)
+                                        __ROWACTIONS__
                                     ]
                                 ])
                             ]
@@ -691,7 +822,7 @@ internal static class FeatureGenerator
             public async Task HandleAsync(Delete__ENTITY__Command command, CancellationToken cancellationToken)
             {
                 await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                await db.__PLURAL__.Where(x => x.Id == command.Id).ExecuteDeleteAsync(cancellationToken);
+        __DELETEBODY__
             }
         }
 
@@ -714,6 +845,102 @@ internal static class FeatureGenerator
 
             protected override Component? Render() =>
                 Button("button", OnClickAsync: DeleteAsync)["Delete"];
+        }
+
+        """;
+
+    // --soft-delete: restore a soft-deleted row. Loads with IgnoreQueryFilters (the row is hidden by the
+    // global filter), clears DeletedAt via the entity's Restore(), and saves.
+    private const string RestoreTemplate =
+        """
+        using Microsoft.EntityFrameworkCore;
+
+        namespace __NS__;
+
+        public sealed record Restore__ENTITY__Command(__IDTYPE__ Id) : ICommand;
+
+        public sealed class Restore__ENTITY__CommandHandler(IDbContextFactory<__CONTEXT__> dbContextFactory)
+            : ICommandHandler<Restore__ENTITY__Command>
+        {
+            public async Task HandleAsync(Restore__ENTITY__Command command, CancellationToken cancellationToken)
+            {
+                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+                var entity = await db.__PLURAL__.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == command.Id, cancellationToken);
+                if (entity is null)
+                {
+                    return;
+                }
+
+                entity.Restore();
+                await db.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        // A reusable restore button: dispatches the restore command, then invokes OnRestored so the caller
+        // (the list page) can refresh.
+        public sealed class Restore__ENTITY__(IDispatcher dispatcher) : Component
+        {
+            public __IDTYPE__ Id { get; set; }
+
+            public Func<Task>? OnRestored { get; set; }
+
+            private async Task RestoreAsync()
+            {
+                await dispatcher.DispatchAsync(new Restore__ENTITY__Command(Id), CancellationToken);
+                if (OnRestored is not null)
+                {
+                    await OnRestored();
+                }
+            }
+
+            protected override Component? Render() =>
+                Button("button", OnClickAsync: RestoreAsync)["Restore"];
+        }
+
+        """;
+
+    private const string BsRestoreTemplate =
+        """
+        using Microsoft.EntityFrameworkCore;
+
+        namespace __NS__;
+
+        public sealed record Restore__ENTITY__Command(__IDTYPE__ Id) : ICommand;
+
+        public sealed class Restore__ENTITY__CommandHandler(IDbContextFactory<__CONTEXT__> dbContextFactory)
+            : ICommandHandler<Restore__ENTITY__Command>
+        {
+            public async Task HandleAsync(Restore__ENTITY__Command command, CancellationToken cancellationToken)
+            {
+                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
+                var entity = await db.__PLURAL__.IgnoreQueryFilters().FirstOrDefaultAsync(x => x.Id == command.Id, cancellationToken);
+                if (entity is null)
+                {
+                    return;
+                }
+
+                entity.Restore();
+                await db.SaveChangesAsync(cancellationToken);
+            }
+        }
+
+        public sealed class Restore__ENTITY__(IDispatcher dispatcher) : Component
+        {
+            public __IDTYPE__ Id { get; set; }
+
+            public Func<Task>? OnRestored { get; set; }
+
+            private async Task RestoreAsync()
+            {
+                await dispatcher.DispatchAsync(new Restore__ENTITY__Command(Id), CancellationToken);
+                if (OnRestored is not null)
+                {
+                    await OnRestored();
+                }
+            }
+
+            protected override Component? Render() =>
+                BsButton(Color: BsColor.Success, Outline: true, Size: BsSize.Sm, OnClickAsync: RestoreAsync)[BsIcon(Name: BsIconName.ArrowCounterclockwise)];
         }
 
         """;
@@ -744,19 +971,28 @@ internal static class FeatureGenerator
         public sealed class Create__ENTITY__(IDispatcher dispatcher, Navigator navigator) : Component
         {
             private readonly __ENTITY__Request _form = new();
+            private string? _error;
 
             protected override Component? Head => Title()["New __ENTITY__"];
 
             private async Task SubmitAsync(__ENTITY__Request form)
             {
-                await dispatcher.DispatchAsync(new Create__ENTITY__Command(form), CancellationToken);
-                navigator.NavigateTo(Routes.__PLURAL__Page());
+                try
+                {
+                    await dispatcher.DispatchAsync(new Create__ENTITY__Command(form), CancellationToken);
+                    navigator.NavigateTo(Routes.__PLURAL__Page());
+                }
+                catch (Exception)
+                {
+                    _error = "Something went wrong — please try again.";
+                }
             }
 
             protected override Component? Render() =>
                 Div()[
                     Div()[
                         H1()["New __ENTITY__"],
+                        __ERRORALERT__
                         Form(_form, OnValidSubmitAsync: SubmitAsync)[
         __VALIDATOR____FORMFIELDS__
                             Div()[
@@ -814,6 +1050,7 @@ internal static class FeatureGenerator
             private readonly __ENTITY__Request _form = new();
             private bool _loaded;
             private bool _found;
+            private string? _error;
 
             [RouteParam] public __IDTYPE__ Id { get; set; }
 
@@ -834,8 +1071,15 @@ internal static class FeatureGenerator
 
             private async Task SubmitAsync(__ENTITY__Request form)
             {
-                await dispatcher.DispatchAsync(new Update__ENTITY__Command(Id, form), CancellationToken);
-                navigator.NavigateTo(Routes.__PLURAL__Page());
+                try
+                {
+                    await dispatcher.DispatchAsync(new Update__ENTITY__Command(Id, form), CancellationToken);
+                    navigator.NavigateTo(Routes.__PLURAL__Page());
+                }
+                catch (Exception)
+                {
+                    _error = "Something went wrong — please try again.";
+                }
             }
 
             protected override Component? Render()
@@ -853,6 +1097,7 @@ internal static class FeatureGenerator
                 return Div()[
                     Div()[
                         H1()["Edit __ENTITY__"],
+                        __ERRORALERT__
                         Form(_form, OnValidSubmitAsync: SubmitAsync)[
         __VALIDATOR____FORMFIELDS__
                             Div()[
@@ -876,23 +1121,13 @@ internal static class FeatureGenerator
 
         namespace __NS__;
 
-        public sealed record List__PLURAL__Query : IQuery<IReadOnlyList<__ENTITY__>>;
-
-        public sealed class List__PLURAL__QueryHandler(IDbContextFactory<__CONTEXT__> dbContextFactory)
-            : IQueryHandler<List__PLURAL__Query, IReadOnlyList<__ENTITY__>>
-        {
-            public async Task<IReadOnlyList<__ENTITY__>> HandleAsync(List__PLURAL__Query query, CancellationToken cancellationToken)
-            {
-                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                return await db.__PLURAL__.AsNoTracking().OrderBy(x => x.Id).ToListAsync(cancellationToken);
-            }
-        }
+        __LISTQUERY__
 
         [Route("__ROUTE__")]
         public sealed class __PLURAL__Page(IDispatcher dispatcher, Navigator navigator) : Component
         {
             private IReadOnlyList<__ENTITY__> _items = [];
-            private bool _loaded;
+            private bool _loaded;__LISTSTATE__
 
             protected override Component? Head => Title()["__PLURAL__"];
 
@@ -900,16 +1135,19 @@ internal static class FeatureGenerator
 
             private async Task LoadAsync()
             {
-                _items = await dispatcher.DispatchAsync(new List__PLURAL__Query(), CancellationToken);
+                _items = await dispatcher.DispatchAsync(new List__PLURAL__Query(__LISTLOADARG__), CancellationToken);
                 _loaded = true;
-            }
+            }__LISTMETHODS__
 
             protected override Component? Render() =>
             [
                 Div(Class: Bs.Join(Display.Flex(), Flex.Justify(BsJustify.Between), Flex.Align(BsAlign.Center), Margin.Bottom(3)))[
                     H1(Class: "h3 mb-0")["__PLURAL__"],
-                    BsButton(Color: BsColor.Primary, OnClick: () => navigator.NavigateTo(Routes.Create__ENTITY__()))[
-                        BsIcon(Name: BsIconName.PlusLg, Class: Margin.End(1)), "New __ENTITY__"
+                    Div(Class: Bs.Join(Display.Flex(), Flex.Gap(2)))[
+                        __TOGGLEBUTTON__
+                        BsButton(Color: BsColor.Primary, OnClick: () => navigator.NavigateTo(Routes.Create__ENTITY__()))[
+                            BsIcon(Name: BsIconName.PlusLg, Class: Margin.End(1)), "New __ENTITY__"
+                        ]
                     ]
                 ],
                 !_loaded
@@ -929,8 +1167,7 @@ internal static class FeatureGenerator
                                     Td()[$"{x.Id}"],
         __CELLS__
                                     Td(Class: Bs.Join(Txt.End(), Txt.Nowrap))[
-                                        BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClick: () => navigator.NavigateTo(Routes.Update__ENTITY__(x.Id)))[BsIcon(Name: BsIconName.Pencil)],
-                                        Delete__ENTITY__(Id: x.Id, OnDeleted: LoadAsync)
+                                        __ROWACTIONS__
                                     ]
                                 ])
                             ]
@@ -954,7 +1191,7 @@ internal static class FeatureGenerator
             public async Task HandleAsync(Delete__ENTITY__Command command, CancellationToken cancellationToken)
             {
                 await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                await db.__PLURAL__.Where(x => x.Id == command.Id).ExecuteDeleteAsync(cancellationToken);
+        __DELETEBODY__
             }
         }
 
@@ -1005,19 +1242,28 @@ internal static class FeatureGenerator
         public sealed class Create__ENTITY__(IDispatcher dispatcher, Navigator navigator) : Component
         {
             private readonly __ENTITY__Request _form = new();
+            private string? _error;
 
             protected override Component? Head => Title()["New __ENTITY__"];
 
             private async Task SubmitAsync(__ENTITY__Request form)
             {
-                await dispatcher.DispatchAsync(new Create__ENTITY__Command(form), CancellationToken);
-                navigator.NavigateTo(Routes.__PLURAL__Page());
+                try
+                {
+                    await dispatcher.DispatchAsync(new Create__ENTITY__Command(form), CancellationToken);
+                    navigator.NavigateTo(Routes.__PLURAL__Page());
+                }
+                catch (Exception)
+                {
+                    _error = "Something went wrong — please try again.";
+                }
             }
 
             protected override Component? Render() =>
                 BsCard(Class: Bs.Join(Shadow.Sm, Border.None, "mx-auto"))[
                     BsCardBody()[
                         H1(Class: "h4 mb-3")["New __ENTITY__"],
+                        __ERRORALERT__
                         Form(_form, OnValidSubmitAsync: SubmitAsync, Class: Bs.Join(Display.Flex(), Flex.Column(), Flex.Gap(3)))[
         __VALIDATOR____FORMFIELDS__
                             Div(Class: Bs.Join(Display.Flex(), Flex.Justify(BsJustify.End), Flex.Gap(2)))[
@@ -1075,6 +1321,7 @@ internal static class FeatureGenerator
             private readonly __ENTITY__Request _form = new();
             private bool _loaded;
             private bool _found;
+            private string? _error;
 
             [RouteParam] public __IDTYPE__ Id { get; set; }
 
@@ -1095,8 +1342,15 @@ internal static class FeatureGenerator
 
             private async Task SubmitAsync(__ENTITY__Request form)
             {
-                await dispatcher.DispatchAsync(new Update__ENTITY__Command(Id, form), CancellationToken);
-                navigator.NavigateTo(Routes.__PLURAL__Page());
+                try
+                {
+                    await dispatcher.DispatchAsync(new Update__ENTITY__Command(Id, form), CancellationToken);
+                    navigator.NavigateTo(Routes.__PLURAL__Page());
+                }
+                catch (Exception)
+                {
+                    _error = "Something went wrong — please try again.";
+                }
             }
 
             protected override Component? Render()
@@ -1114,6 +1368,7 @@ internal static class FeatureGenerator
                 return BsCard(Class: Bs.Join(Shadow.Sm, Border.None, "mx-auto"))[
                     BsCardBody()[
                         H1(Class: "h4 mb-3")["Edit __ENTITY__"],
+                        __ERRORALERT__
                         Form(_form, OnValidSubmitAsync: SubmitAsync, Class: Bs.Join(Display.Flex(), Flex.Column(), Flex.Gap(3)))[
         __VALIDATOR____FORMFIELDS__
                             Div(Class: Bs.Join(Display.Flex(), Flex.Justify(BsJustify.End), Flex.Gap(2)))[
@@ -1136,17 +1391,7 @@ internal static class FeatureGenerator
 
         namespace __NS__;
 
-        public sealed record List__PLURAL__Query : IQuery<IReadOnlyList<__ENTITY__>>;
-
-        public sealed class List__PLURAL__QueryHandler(IDbContextFactory<__CONTEXT__> dbContextFactory)
-            : IQueryHandler<List__PLURAL__Query, IReadOnlyList<__ENTITY__>>
-        {
-            public async Task<IReadOnlyList<__ENTITY__>> HandleAsync(List__PLURAL__Query query, CancellationToken cancellationToken)
-            {
-                await using var db = await dbContextFactory.CreateDbContextAsync(cancellationToken);
-                return await db.__PLURAL__.AsNoTracking().OrderBy(x => x.Id).ToListAsync(cancellationToken);
-            }
-        }
+        __LISTQUERY__
 
         public sealed record Get__ENTITY__Query(__IDTYPE__ Id) : IQuery<__ENTITY__?>;
 
@@ -1198,10 +1443,11 @@ internal static class FeatureGenerator
         public sealed class __PLURAL__Page(IDispatcher dispatcher) : Component
         {
             private IReadOnlyList<__ENTITY__> _items = [];
-            private bool _loaded;
+            private bool _loaded;__LISTSTATE__
             private __ENTITY__Request _form = new();
             private bool _modalOpen;
             private __IDTYPE__? _editingId;
+            private string? _error;
 
             protected override Component? Head => Title()["__PLURAL__"];
 
@@ -1209,14 +1455,15 @@ internal static class FeatureGenerator
 
             private async Task LoadAsync()
             {
-                _items = await dispatcher.DispatchAsync(new List__PLURAL__Query(), CancellationToken);
+                _items = await dispatcher.DispatchAsync(new List__PLURAL__Query(__LISTLOADARG__), CancellationToken);
                 _loaded = true;
-            }
+            }__LISTMETHODS__
 
             private void OpenCreate()
             {
                 _form = new __ENTITY__Request();
                 _editingId = null;
+                _error = null;
                 _modalOpen = true;
             }
 
@@ -1231,6 +1478,7 @@ internal static class FeatureGenerator
                 _form = new __ENTITY__Request();
         __COPYTOFORM__
                 _editingId = id;
+                _error = null;
                 _modalOpen = true;
             }
 
@@ -1238,25 +1486,35 @@ internal static class FeatureGenerator
 
             private async Task SaveAsync(__ENTITY__Request form)
             {
-                if (_editingId is null)
+                try
                 {
-                    await dispatcher.DispatchAsync(new Create__ENTITY__Command(form), CancellationToken);
-                }
-                else
-                {
-                    await dispatcher.DispatchAsync(new Update__ENTITY__Command(_editingId.Value, form), CancellationToken);
-                }
+                    if (_editingId is null)
+                    {
+                        await dispatcher.DispatchAsync(new Create__ENTITY__Command(form), CancellationToken);
+                    }
+                    else
+                    {
+                        await dispatcher.DispatchAsync(new Update__ENTITY__Command(_editingId.Value, form), CancellationToken);
+                    }
 
-                _modalOpen = false;
-                await LoadAsync();
+                    _modalOpen = false;
+                    await LoadAsync();
+                }
+                catch (Exception)
+                {
+                    _error = "Something went wrong — please try again.";
+                }
             }
 
             protected override Component? Render() =>
             [
                 Div(Class: Bs.Join(Display.Flex(), Flex.Justify(BsJustify.Between), Flex.Align(BsAlign.Center), Margin.Bottom(3)))[
                     H1(Class: "h3 mb-0")["__PLURAL__"],
-                    BsButton(Color: BsColor.Primary, OnClick: OpenCreate)[
-                        BsIcon(Name: BsIconName.PlusLg, Class: Margin.End(1)), "New __ENTITY__"
+                    Div(Class: Bs.Join(Display.Flex(), Flex.Gap(2)))[
+                        __TOGGLEBUTTON__
+                        BsButton(Color: BsColor.Primary, OnClick: OpenCreate)[
+                            BsIcon(Name: BsIconName.PlusLg, Class: Margin.End(1)), "New __ENTITY__"
+                        ]
                     ]
                 ],
                 !_loaded
@@ -1276,13 +1534,13 @@ internal static class FeatureGenerator
                                     Td()[$"{x.Id}"],
         __CELLS__
                                     Td(Class: Bs.Join(Txt.End(), Txt.Nowrap))[
-                                        BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClickAsync: () => OpenEditAsync(x.Id))[BsIcon(Name: BsIconName.Pencil)],
-                                        Delete__ENTITY__(Id: x.Id, OnDeleted: LoadAsync)
+                                        __ROWACTIONS__
                                     ]
                                 ])
                             ]
                         ],
                 BsModal(Open: _modalOpen, Title: _editingId is null ? "New __ENTITY__" : "Edit __ENTITY__", Centered: true, OnClose: CloseModal)[
+                    __ERRORALERT__
                     Form(_form, OnValidSubmitAsync: SaveAsync, Class: Bs.Join(Display.Flex(), Flex.Column(), Flex.Gap(3)))[
         __VALIDATOR____FORMFIELDS__
                         Div(Class: Bs.Join(Display.Flex(), Flex.Justify(BsJustify.End), Flex.Gap(2)))[

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -117,8 +117,8 @@ public sealed class FeatureGeneratorTests
         new("Price", "decimal", IsNullable: false, MaxLength: null),
     ];
 
-    private static ScaffoldResult Generate(string idType = "Guid", string validation = "valueobjects", bool useBs = false, bool useModal = false, bool useTests = false, string? context = null, string? plural = null) =>
-        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, validation, useBs, useModal, useTests, context, plural, outputOverride: null);
+    private static ScaffoldResult Generate(string idType = "Guid", string validation = "valueobjects", bool useBs = false, bool useModal = false, bool useSoftDelete = false, bool useTests = false, string? context = null, string? plural = null) =>
+        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, validation, useBs, useModal, useSoftDelete, useTests, context, plural, outputOverride: null);
 
     private static string File(ScaffoldResult result, string fileName) =>
         result.Files.Single(f => Path.GetFileName(f.Path) == fileName).Content;
@@ -150,7 +150,9 @@ public sealed class FeatureGeneratorTests
     {
         var entity = File(Generate(), "Product.cs");
 
-        Assert.Contains("public Guid Id { get; private set; } = Guid.NewGuid();", entity, StringComparison.Ordinal);
+        // Id (and the audit stamps + domain-events buffer) come from the Rask.Data base; a Guid is assigned up front.
+        Assert.Contains("public sealed class Product : AggregateRoot<Guid>", entity, StringComparison.Ordinal);
+        Assert.Contains("Id = Guid.NewGuid();", entity, StringComparison.Ordinal);
         // Create/Update take primitives; the required string becomes a value object, wrapped via Create.
         Assert.Contains("public static Product Create(string name, decimal price) => new(ProductName.Create(name), price);", entity, StringComparison.Ordinal);
         Assert.Contains("public ProductName Name { get; private set; }", entity, StringComparison.Ordinal);
@@ -189,20 +191,21 @@ public sealed class FeatureGeneratorTests
     public void Assignments_are_this_qualified_so_a_lowercase_field_does_not_self_assign()
     {
         var entity = FeatureGenerator.RenderEntity("MyApp.Features.Notes", "Note",
-            [new FieldSpec("title", "string", false, 200)], "Guid", useValueObjects: false);
+            [new FieldSpec("title", "string", false, 200)], "Guid", useValueObjects: false, useSoftDelete: false);
 
         Assert.Contains("this.title = title;", entity, StringComparison.Ordinal);
         Assert.DoesNotContain("\n        title = title;", entity, StringComparison.Ordinal); // not a self-assignment
     }
 
     [Theory]
-    [InlineData("int", "public int Id { get; private set; }", "{id:int}")]
-    [InlineData("long", "public long Id { get; private set; }", "{id:long}")]
-    public void Id_type_is_configurable(string idType, string idProp, string routeConstraint)
+    [InlineData("int", "AggregateRoot<int>", "{id:int}")]
+    [InlineData("long", "AggregateRoot<long>", "{id:long}")]
+    public void Id_type_is_configurable(string idType, string baseType, string routeConstraint)
     {
         var result = Generate(idType);
 
-        Assert.Contains(idProp, File(result, "Product.cs"), StringComparison.Ordinal);
+        // Id lives on the base; an int/long id is database-generated (no Guid.NewGuid()).
+        Assert.Contains("public sealed class Product : " + baseType, File(result, "Product.cs"), StringComparison.Ordinal);
         Assert.DoesNotContain("Guid.NewGuid()", File(result, "Product.cs"), StringComparison.Ordinal);
         Assert.Contains(routeConstraint, File(result, "UpdateProduct.cs"), StringComparison.Ordinal);
     }
@@ -289,6 +292,74 @@ public sealed class FeatureGeneratorTests
     }
 
     [Fact]
+    public void Every_generated_entity_inherits_the_rask_data_base()
+    {
+        var entity = File(Generate(), "Product.cs");
+        Assert.Contains("public sealed class Product : AggregateRoot<Guid>", entity, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Delete_always_loads_and_removes_so_interceptors_fire()
+    {
+        // ExecuteDelete would bypass SaveChanges + the soft-delete/audit/event interceptors.
+        var delete = File(Generate(), "DeleteProduct.cs");
+        Assert.Contains("db.Products.Remove(entity);", delete, StringComparison.Ordinal);
+        Assert.DoesNotContain("ExecuteDeleteAsync", delete, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Soft_delete_makes_the_entity_ISoftDeletable_and_generates_restore_plus_toggle()
+    {
+        var result = Generate(useSoftDelete: true);
+
+        var entity = File(result, "Product.cs");
+        Assert.Contains("public sealed class Product : AggregateRoot<Guid>, ISoftDeletable", entity, StringComparison.Ordinal);
+        Assert.Contains("public DateTime? DeletedAt { get; private set; }", entity, StringComparison.Ordinal);
+        Assert.Contains("public void Restore() => DeletedAt = null;", entity, StringComparison.Ordinal);
+
+        // A reusable Restore button + command, mirroring Delete.
+        var restore = File(result, "RestoreProduct.cs");
+        Assert.Contains("public sealed record RestoreProductCommand(Guid Id) : ICommand;", restore, StringComparison.Ordinal);
+        Assert.Contains("IgnoreQueryFilters()", restore, StringComparison.Ordinal);
+        Assert.Contains("entity.Restore();", restore, StringComparison.Ordinal);
+
+        // The list page can show + restore deleted rows via a toggle.
+        var list = File(result, "ProductsPage.cs");
+        Assert.Contains("public sealed record ListProductsQuery(bool IncludeDeleted = false)", list, StringComparison.Ordinal);
+        Assert.Contains("items = items.IgnoreQueryFilters();", list, StringComparison.Ordinal);
+        Assert.Contains("private async Task ToggleDeletedAsync()", list, StringComparison.Ordinal);
+        Assert.Contains("_showDeleted ? \"Hide deleted\" : \"Show deleted\"", list, StringComparison.Ordinal);
+        Assert.Contains("x.DeletedAt is null ? (Component)DeleteProduct(Id: x.Id, OnDeleted: LoadAsync) : RestoreProduct(Id: x.Id, OnRestored: LoadAsync)", list, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Without_soft_delete_there_is_no_restore_file_or_deletedat()
+    {
+        var result = Generate();
+        Assert.DoesNotContain(result.Files, f => Path.GetFileName(f.Path) == "RestoreProduct.cs");
+        Assert.DoesNotContain("DeletedAt", File(result, "Product.cs"), StringComparison.Ordinal);
+        Assert.DoesNotContain("_showDeleted", File(result, "ProductsPage.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_generated_dbcontext_applies_rask_conventions()
+    {
+        Assert.Contains("modelBuilder.ApplyRaskConventions();", File(Generate(), "ProductsDbContext.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Mutation_pages_handle_errors_gracefully_with_an_inline_alert()
+    {
+        var create = File(Generate(), "CreateProduct.cs");
+        Assert.Contains("private string? _error;", create, StringComparison.Ordinal);
+        Assert.Contains("catch (Exception)", create, StringComparison.Ordinal);
+        Assert.Contains("_error = \"Something went wrong", create, StringComparison.Ordinal);
+        // Plain HTML uses a semantic role="alert"; --bs uses BsAlert.
+        Assert.Contains("_error is null ? null : Div(Role: \"alert\")[_error]", create, StringComparison.Ordinal);
+        Assert.Contains("_error is null ? null : BsAlert(Color: BsColor.Danger)[_error]", File(Generate(useBs: true), "CreateProduct.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Tests_flag_emits_domain_and_persistence_tests_in_a_sibling_test_project()
     {
         var result = Generate(useTests: true);
@@ -332,7 +403,7 @@ public sealed class FeatureGeneratorTests
     public void Plural_override_drives_names_and_route()
     {
         var result = FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Person",
-            Fields, "Guid", "valueobjects", useBs: false, useModal: false, useTests: false, contextOverride: null, pluralOverride: "People", outputOverride: null);
+            Fields, "Guid", "valueobjects", useBs: false, useModal: false, useSoftDelete: false, useTests: false, contextOverride: null, pluralOverride: "People", outputOverride: null);
 
         Assert.Contains(result.Files, f => f.Path.EndsWith("PeoplePage.cs", StringComparison.Ordinal));
         Assert.Contains("[Route(\"/people\")]", File(result, "PeoplePage.cs"), StringComparison.Ordinal);
@@ -389,7 +460,7 @@ public sealed class FeatureGeneratorTests
         Assert.Contains("dotnet ef migrations add AddProduct", notes, StringComparison.Ordinal);
         // The packages are added to the project automatically (not just printed).
         Assert.Equal(
-            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs"],
+            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data"],
             result.Packages);
     }
 

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -110,7 +110,7 @@ public sealed class GenerateCommandTests
             .Select(i => i.Arguments[2])
             .ToArray();
         Assert.Equal(
-            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Bootstrap"],
+            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data", "Rask.Bootstrap"],
             adds);
     }
 
@@ -248,7 +248,7 @@ public sealed class GenerateCommandTests
 
         Assert.Equal(0, exit);
         var entity = fs.Files.Single(f => Path.GetFileName(f.Key) == "Product.cs").Value;
-        Assert.Contains("public int Id { get; private set; }", entity, StringComparison.Ordinal);
+        Assert.Contains("public sealed class Product : AggregateRoot<int>", entity, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Increment B of the soft-delete/concurrency/events/outbox plan — wires `Rask.Data` (#373) into the `rask generate feature` scaffolder.

## Base entity (always on)
Every generated entity now inherits **`AggregateRoot<TId>`** (Id + `CreatedAt`/`UpdatedAt` audit stamps + a domain-events buffer). The generated `DbContext` calls `modelBuilder.ApplyRaskConventions()`, and the **delete handler always `load → db.Remove → SaveChanges`** (never set-based `ExecuteDelete`) so every delete flows through the interceptors. Auto-NuGet + next-steps add `Rask.Data` + `AddRaskData()` + `.AddInterceptors(...)`.

## `--soft-delete`
- Entity implements `ISoftDeletable` (`DeletedAt`); the `SoftDeleteInterceptor` turns `db.Remove` into a `DeletedAt` stamp; a global query filter hides deleted rows.
- The list page gains a **"Show deleted" toggle** (`List<Plural>Query(bool IncludeDeleted)` + `IgnoreQueryFilters()`) and a generated **`Restore<Entity>`** command/button; per-row actions swap Edit/Delete → Restore on deleted rows.
- Works across the **plain, `--bs`, and `--modal`** list variants.

## Graceful error handling (all mutation pages)
Every Create/Edit/modal submit now try/catches the dispatch and re-renders a friendly inline alert (`BsAlert` for `--bs`, a plain `role="alert"` div otherwise), navigating only on success.

## Verified
- core + `--bs` + `--modal` `--soft-delete` slices compile `-warnaserror` in the EfCore sample; the plain path stays free of `DeletedAt`/`_showDeleted`.
- **167 CLI unit tests** (soft-delete + graceful-error coverage added).
- `docs/cli.md` + CHANGELOG updated.

Next: increment C (`--concurrency`), D (`--events`), E (`Rask.Outbox` + `--outbox`).