### PR TITLE
perf(core): live-session capacity benchmarks, right-sized buffers, and full clean-subtree caching

### DIFF
--- a/.claude/skills/run-benchmarks/SKILL.md
+++ b/.claude/skills/run-benchmarks/SKILL.md
@@ -32,4 +32,6 @@ dotnet run -c Release --project benchmarks/Rask.Benchmarks/Rask.Benchmarks.cspro
 Read the `Allocated` (and `Mean`) columns from the two
 `BenchmarkDotNet.Artifacts/results/*-report-github.md` runs. Trust `Allocated` even on
 `InvocationCount=1` benches. Quote the **delta** (e.g. "Allocated 1.84 KB → 0.91 KB, −51%") in
-the PR body. Custom byte reports: append `bundle-size` or `payload-bytes` instead of `--filter`.
+the PR body. Custom reports: append `bundle-size`, `payload-bytes`, `session-footprint` (per-live-session retained
+memory + sessions-per-GiB across a page-size sweep) or `session-churn` (soak + create/dispose churn)
+instead of `--filter`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,66 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **Live sessions now size their buffers to the page instead of pre-renting a fixed block — a small-page
+  session costs ~4.6x less memory.** A session used to rent ~33 KB of `char` buffers, ~20 KB of frame
+  buffers and ~8 KB of payload buffers up front, before knowing whether its page was 300 bytes or
+  300 KB — most of what an idle session cost. All of them now rent on first use, at the size the page
+  actually needs. Pages large enough to outgrow the old defaults re-rented anyway, so they are
+  unaffected; small pages get several times denser. Measured with `session-footprint`: an empty-shell
+  session drops **74 KB → 16 KB** (~14,500 → ~65,000 sessions/GiB) and a small page **98 KB → 51 KB**
+  (~10,900 → ~20,600); a 200-row grid is unchanged. The wire format is byte-identical (the
+  `payload-bytes` gate passes unchanged), diff-path allocation is byte-identical across every
+  `FrameDifferBenchmarks` row, and session create→dispose allocation is marginally *lower*.
+  The one public-API detail: `FrameWriter`'s default `initialCapacity` is now `16` rather than `256` —
+  pass an explicit capacity when you build a short-lived writer whose frame count you already know.
+- **Keyed subtrees are now eligible for the clean-subtree cache, making updates to keyed lists ~15%
+  faster.** A component carrying a `Key` was excluded from the cache outright, because a `Key` is a
+  reconciliation identity rather than a reactive prop — it can change without dirtying the component,
+  and replaying a snapshot would then emit a stale `data-rask-key`. The snapshot now records the
+  identity it was captured under and declines to replay under a different one, so keyed subtrees cache
+  like any other. On a 1,000-row keyed list this is **−13% allocation and −15% time per update** (the
+  element path re-walks the graph and re-stringifies every key on every render; a replay does neither).
+  It costs ~4% more retained memory on such a page — a per-row snapshot runs slightly larger than the
+  small element graph it releases — which is a deliberate trade: the ceiling moves a little, every
+  interaction gets cheaper.
+- **Handler-bearing subtrees are now cached too, making updates to interactive grids ~24% cheaper.** The
+  last exclusion from the clean-subtree cache was any subtree containing an event handler — which is the
+  shape most real data grids take (a keyed row with a button), so the pages with the most elements to
+  release were releasing none. Handler ids are positional and reissued from zero every root render, so a
+  replay used to be unsound twice over: it never re-registered its handlers (leaving the id absent from
+  the freshly-cleared map — a dead button) and never advanced the counter (shifting every later sibling's
+  ids into collisions). The snapshot now records the handler run and the counter value it was captured
+  at; a replay re-registers the run and advances the counter, reproducing exactly what the walk did, and
+  declines when the counter no longer lines up. On a 1,000-row interactive grid: **−23.6% allocation and
+  −28% time per update** (200-row: −18.7% / −30.4%), for ~2.7% more retained memory.
+  As part of this the cache's `LiveState` fields collapse into a single reference to a side object, so
+  only components that actually cache pay for the state — an empty-shell session gets *smaller*
+  (16,370 → 16,090 B) despite the added handler bookkeeping.
+
+### Fixed
+- **A clean child could replay a stale forwarded `data-rask-key`.** A keyless component's first element
+  adopts a keyed ancestor's forwarded key and bakes it into its cached frame snapshot. Nothing dirties
+  that child when the ancestor's key changes, so it would re-emit the old identity and the diff would
+  reconcile the subtree against the wrong sibling — moving the wrong DOM. The snapshot now records the
+  forwarded key it was captured under and falls back to a walk when it no longer matches.
+
 ### Added
 - **`rask generate feature --fields` supports `date`, `time`, and `datetime`.** `date` maps to `DateOnly`,
   `time` to `TimeOnly`, and `datetime` to `DateTime` (the bound form inputs auto-render as `type="date"` /
   `type="time"`, and EF Core maps them to SQLite). Previously `date` was an alias for `DateTime`.
+- **Live-session capacity benchmarks — "how many sessions fit in 1 GB?"** Two new reports in
+  `benchmarks/Rask.Benchmarks`. `session-footprint` measures what one live session retains, sweeping
+  page size and separating a GET-minted session whose socket never arrived from a connected one whose
+  buffers have reached their high-water mark. `session-churn` soaks sessions under sustained updates
+  and churns create→dispose cycles to prove the footprint converges and that nothing survives teardown
+  (it doesn't: 500 cycles leave a constant 16 KB residue, and 100 sessions over 200 updates each hold
+  flat to the byte). [`docs/configuration.md`](docs/configuration.md#sizing-maxsessions-for-a-memory-budget)
+  turns the numbers into guidance for sizing `MaxSessions`, which defaults to uncapped and previously
+  had no way to size it. Headline: session cost is driven by **page size, not user count** — ~65,000
+  sessions/GiB on a trivial page vs ~150 on a 1,000-row grid. `session-churn` also reports the
+  per-interaction cost (allocation + time per update), so a change that trades retained memory against
+  update cost can be read against both.
 
 ## [0.17.0] - 2026-07-15
 

--- a/benchmarks/Rask.Benchmarks/Infrastructure/FootprintApp.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/FootprintApp.cs
@@ -1,0 +1,81 @@
+using Rask.Core;
+using B = Rask.Benchmarks.Infrastructure.Generated;
+using C = Rask.Core.Components.Generated;
+
+namespace Rask.Benchmarks.Infrastructure;
+
+/// <summary>
+///     The page under measurement for the session capacity reports — a data-table page: a shell, a header
+///     carrying a mutable counter, and <see cref="RowCount" /> keyed rows that each own an event handler.
+///     <para>
+///         One component shape swept by row count, rather than several hand-written pages, so that
+///         <b>page size is the only independent variable</b> across the sweep. If the sizes differed in
+///         shape too, a change in bytes-per-session couldn't be attributed to page size.
+///     </para>
+///     <para>
+///         The rows are keyed and interactive on purpose: that is what a real data grid looks like, and it
+///         is the shape the clean-subtree cache cannot help with. A component is only eligible for that
+///         cache — which snapshots its subtree as a compact ~24 B/node <c>LeanFrame</c> span and releases
+///         the Element object graph — when it has no nested user component, no handler, and no
+///         <c>Key</c> (<c>Component.TryCacheCleanSubtree</c>). Since RASK022 pushes every list item toward
+///         a <c>Key</c>, the pages where retained memory matters most are exactly the pages that keep their
+///         Element graph for the session's lifetime. Measuring a keyless, handler-free table instead would
+///         report a best case that few real pages hit.
+///     </para>
+/// </summary>
+public sealed class FootprintApp : Component
+{
+    /// <summary>Counter rendered into the header. Bumped to make a render differ from the last one.</summary>
+    public int Counter;
+
+    // Non-nullable, no initializer → a required factory parameter (RASK001). Public so the generator
+    // emits it; the reports build the page via B.FootprintApp(RowCount: n).
+    public int RowCount { get; set; }
+
+    protected override Component? Head => C.Title()["rask session footprint"];
+
+    /// <summary>
+    ///     Change the rendered HTML so the next render survives the session's dedup.
+    ///     <c>LiveSession.RenderAndSendAsync</c> early-returns before building a payload when the
+    ///     rendered HTML matches the baseline, so a session driven without this would never allocate
+    ///     its payload buffers and would report a footprint that no real session has.
+    /// </summary>
+    public void Bump() => Counter++;
+
+    protected override Component? Render()
+    {
+        var rows = new List<Component>(RowCount);
+        for (var i = 0; i < RowCount; i++)
+        {
+            rows.Add(B.FootprintRow(Index: i, Key: i));
+        }
+
+        return
+        [
+            C.Doctype(),
+            C.Html()[
+                C.Head(),
+                C.Body()[
+                    C.Div(Class: "container", Id: "root")[
+                        C.Div(Class: "header")[C.Span()[$"rows={RowCount} counter={Counter}"]],
+                        C.Table(Class: "table")[C.Tbody()[rows]]
+                    ]
+                ]
+            ]
+        ];
+    }
+}
+
+/// <summary>One table row: a few text cells and a select button.</summary>
+public sealed class FootprintRow : Component
+{
+    public int Index { get; set; }
+
+    protected override Component? Render() =>
+        C.Tr(Class: "row")[
+            C.Td()[$"#{Index}"],
+            C.Td()[$"Item {Index}"],
+            C.Td()[$"{Index * 37 % 1000} units"],
+            C.Td()[C.Button(OnClick: () => { })["select"]]
+        ];
+}

--- a/benchmarks/Rask.Benchmarks/Infrastructure/NullWebSocket.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/NullWebSocket.cs
@@ -1,0 +1,74 @@
+using System.Net.WebSockets;
+
+namespace Rask.Benchmarks.Infrastructure;
+
+/// <summary>
+///     A WebSocket that reports itself Open and drops every frame it is handed, counting the bytes.
+///     <para>
+///         The capacity reports need a session in its <b>connected steady state</b>: every buffer pair
+///         (<c>RenderedHtmlBuffers</c>, the <c>SessionRenderCache</c> frame writers, and
+///         <c>_writeBuffer</c>/<c>_lastSentBuffer</c>) grown to its high-water mark. Those only fill on
+///         the render→send path, and <c>LiveSession.RenderAndSendAsync</c> early-returns unless a socket
+///         is attached and <see cref="WebSocketState.Open" />. A real socket would work but would fold
+///         Kestrel's own per-connection buffers (32 KB of receive buffer alone) into a number that is
+///         supposed to measure the <i>session</i> — so the transport is stubbed out instead.
+///     </para>
+///     <para>
+///         Only the send path is implemented: the reports drive renders directly and never run the
+///         inbound socket loop, so <see cref="ReceiveAsync" /> would signal a bug in the harness rather
+///         than a case worth faking. <see cref="BytesSent" /> is the harness's proof that frames really
+///         flowed — a session whose count is still zero never reached steady state and its footprint
+///         would be silently under-measured.
+///     </para>
+/// </summary>
+internal sealed class NullWebSocket : WebSocket
+{
+    private WebSocketState _state = WebSocketState.Open;
+
+    /// <summary>Total payload bytes this socket was handed. Zero means no frame ever reached the wire.</summary>
+    public long BytesSent { get; private set; }
+
+    public override WebSocketCloseStatus? CloseStatus => null;
+    public override string? CloseStatusDescription => null;
+    public override WebSocketState State => _state;
+    public override string? SubProtocol => null;
+
+    public override void Abort() => _state = WebSocketState.Aborted;
+
+    public override void Dispose() => _state = WebSocketState.Closed;
+
+    public override Task CloseAsync(WebSocketCloseStatus closeStatus, string? statusDescription,
+        CancellationToken cancellationToken)
+    {
+        _state = WebSocketState.Closed;
+        return Task.CompletedTask;
+    }
+
+    public override Task CloseOutputAsync(WebSocketCloseStatus closeStatus, string? statusDescription,
+        CancellationToken cancellationToken)
+    {
+        _state = WebSocketState.CloseSent;
+        return Task.CompletedTask;
+    }
+
+    public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer,
+        CancellationToken cancellationToken) =>
+        throw new NotSupportedException("The capacity reports drive renders directly and never receive.");
+
+    public override Task SendAsync(ArraySegment<byte> buffer, WebSocketMessageType messageType,
+        bool endOfMessage, CancellationToken cancellationToken)
+    {
+        BytesSent += buffer.Count;
+        return Task.CompletedTask;
+    }
+
+    // LiveSession sends via the ReadOnlyMemory overload. The base implementation would unwrap it to the
+    // ArraySegment one above, but only after a MemoryMarshal.TryGetArray round-trip — overriding here
+    // keeps the stub's own cost out of the churn pass's allocation counter.
+    public override ValueTask SendAsync(ReadOnlyMemory<byte> buffer, WebSocketMessageType messageType,
+        bool endOfMessage, CancellationToken cancellationToken)
+    {
+        BytesSent += buffer.Length;
+        return ValueTask.CompletedTask;
+    }
+}

--- a/benchmarks/Rask.Benchmarks/Infrastructure/SessionHarness.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/SessionHarness.cs
@@ -1,0 +1,199 @@
+using System.Globalization;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core.Live;
+using Rask.Server;
+using B = Rask.Benchmarks.Infrastructure.Generated;
+
+namespace Rask.Benchmarks.Infrastructure;
+
+/// <summary>
+///     Shared plumbing for the <c>session-footprint</c> and <c>session-churn</c> reports: builds a
+///     production-shaped host, mints live sessions against it, and drives them to a steady state —
+///     all in-process, with no HTTP and no real socket.
+/// </summary>
+internal static class SessionHarness
+{
+    /// <summary>
+    ///     Updates driven to reach steady state. Two sends is the minimum for BOTH payload buffers to
+    ///     reach their high-water mark: the first send swaps the page-sized <c>_writeBuffer</c> into
+    ///     <c>_lastSentBuffer</c> and installs a fresh 4 KB one, which only grows on the send after it.
+    ///     A third leaves margin.
+    /// </summary>
+    public const int UpdatesToSteadyState = 3;
+
+    /// <summary>
+    ///     A host container built exactly as production builds it — <c>AddRask</c> registers the
+    ///     <see cref="LiveSessionStore" /> singleton, the ~15 scoped services a session's DI scope
+    ///     carries, and <c>DiffMode.Auto</c> (so the diff codec, and therefore the
+    ///     <c>SessionRenderCache</c> buffers, are part of the measured cost). An empty
+    ///     <c>ServiceCollection</c> would under-count the scoped tail.
+    /// </summary>
+    public static ServiceProvider NewHost() => new ServiceCollection().AddRask().BuildServiceProvider();
+
+    /// <summary>
+    ///     Creates one session the way the GET endpoint does (<c>store.Create</c> wraps the app in a
+    ///     <c>RootErrorBoundary</c> and wires the id/scope/accessor), renders the initial root, and — when
+    ///     <paramref name="connected" /> — attaches a stub socket and drives it to steady state.
+    ///     The store retains the session; the returned handle is for measurement and teardown.
+    /// </summary>
+    public static SessionHandle Create(LiveSessionStore store, int rows, bool connected)
+    {
+        FootprintApp? app = null;
+        var session = store.Create(_ =>
+        {
+            app = B.FootprintApp(RowCount: rows);
+            // Mirrors the GET endpoint, which wraps the user's App in this same implicit boundary
+            // (RaskEndpointExtensions). RootErrorBoundary is framework-internal and has no public
+            // factory, so this is the only way to reproduce production's real tree shape — and the
+            // wrapper is part of what every session retains.
+#pragma warning disable RASK014
+            return new RootErrorBoundary(app);
+#pragma warning restore RASK014
+        });
+
+        // The GET render: seeds the dedup baseline and, with the diff codec on, the frame baseline.
+        var html = session.RenderInitialRoot();
+        var pageHtmlBytes = Encoding.UTF8.GetByteCount(html);
+        if (!connected)
+        {
+            return new SessionHandle(session, app!, pageHtmlBytes, 0);
+        }
+
+        var socket = new NullWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+        Drive(session, app!, UpdatesToSteadyState);
+
+        return new SessionHandle(session, app!, pageHtmlBytes, socket.BytesSent);
+    }
+
+    /// <summary>
+    ///     Tears a session down through the store's own removal funnel — the same path the socket-close
+    ///     grace period takes in production, which detaches it from the store and disposes the component
+    ///     tree and DI scope.
+    /// </summary>
+    public static void Remove(LiveSessionStore store, SessionHandle handle) =>
+        store.RemoveAsync(handle.Session.Id).GetAwaiter().GetResult();
+
+    /// <summary>
+    ///     Drives <paramref name="updates" /> render→send cycles. Each bumps the counter first:
+    ///     <c>LiveSession.RenderAndSendAsync</c> early-returns before building a payload when the render
+    ///     matches the baseline, so a session driven without a real state change would never allocate its
+    ///     payload buffers and would report a footprint no real session has.
+    /// </summary>
+    public static void Drive(LiveSession session, FootprintApp app, int updates)
+    {
+        for (var i = 0; i < updates; i++)
+        {
+            app.Bump();
+            session.RequestRenderAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
+    ///     Three forced blocking gen-2 collections, then the live bytes.
+    ///     <para>
+    ///         Deliberately NOT the same technique as the vs-Blazor <c>mem-footprint</c> report, which
+    ///         reads <c>GC.GetTotalMemory(true)</c> — see the note below on why that over-reports.
+    ///         Numbers from the two reports are therefore not directly comparable in absolute terms;
+    ///         that report's retained-heap figures lead with a Rask-vs-Blazor <i>ratio</i>, which the
+    ///         inflation cancels out of.
+    ///     </para>
+    /// </summary>
+    public static long StableHeap()
+    {
+        for (var i = 0; i < 3; i++)
+        {
+            GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, true, true);
+            GC.WaitForPendingFinalizers();
+        }
+
+        // Sum the LIVE bytes per generation rather than calling GC.GetTotalMemory.
+        //
+        // GetTotalMemory reports the heap's committed size, which still includes the empty ephemeral
+        // space left behind by the allocations that got us here — and that space scales with how much
+        // was allocated. The effect is not subtle: measured against known-size controls it reports
+        // EXACTLY 2x for every small-object allocation (a byte[16384] whose true cost is 16,408 comes
+        // back as 32,815) while reporting large-object allocations exactly right, because those bypass
+        // gen0. A per-session footprint built on it would be ~2x too pessimistic.
+        //
+        // GenerationInfo's SizeAfterBytes is the live data per generation after the collection above,
+        // with no committed-but-free space in it, and it reproduces the controls to within a rounding
+        // error.
+        var info = GC.GetGCMemoryInfo();
+        long live = 0;
+        foreach (var gen in info.GenerationInfo)
+        {
+            live += gen.SizeAfterBytes;
+        }
+
+        return live;
+    }
+
+    /// <summary>
+    ///     Verifies <see cref="StableHeap" /> against a known-size allocation before any real number is
+    ///     reported, and throws if it is off by more than 5%.
+    ///     <para>
+    ///         This is not paranoia. The obvious implementation of <see cref="StableHeap" /> —
+    ///         <c>GC.GetTotalMemory(true)</c> after a forced collection — over-reports every small-object
+    ///         allocation by <b>exactly 2x</b>, because the heap's committed size still includes the empty
+    ///         ephemeral space the allocations left behind. It reports large-object allocations correctly,
+    ///         which is what makes the error so easy to miss: spot-check it with a big array and it looks
+    ///         perfect. Every figure this harness produces is a small-object measurement, so a regression
+    ///         here would silently double the whole report. Fail loudly instead.
+    ///     </para>
+    /// </summary>
+    public static void VerifySelfMeasurement()
+    {
+        const int count = 200;
+        const int arrayBytes = 16 * 1024;
+        // byte[16384]: 16,384 payload + 24 bytes of array header, and small enough to live on the
+        // small-object heap — the same heap every buffer in a live session lives on.
+        const long expectedEach = arrayBytes + 24;
+
+        var sink = new List<byte[]>(count);
+        sink.Add(new byte[arrayBytes]); // warm up before the baseline
+        var before = StableHeap();
+        for (var i = 0; i < count; i++)
+        {
+            sink.Add(new byte[arrayBytes]);
+        }
+
+        var measured = (StableHeap() - before) / count;
+        GC.KeepAlive(sink);
+
+        var driftPercent = Math.Abs(measured - expectedEach) * 100.0 / expectedEach;
+        if (driftPercent > 5.0)
+        {
+            throw new InvalidOperationException(string.Format(CultureInfo.InvariantCulture,
+                "Heap measurement is unsound: a byte[{0}] should retain ~{1} bytes but measured {2} " +
+                "({3:0.0}% off). Every number this report prints would be wrong by about that factor. " +
+                "If StableHeap was changed to GC.GetTotalMemory, that is the cause — it counts committed " +
+                "ephemeral space and doubles small-object measurements.",
+                arrayBytes, expectedEach, measured, driftPercent));
+        }
+    }
+
+    /// <summary>
+    ///     Guards against the failure mode that would silently invalidate every number here: a session
+    ///     that never reached steady state because no frame ever went out.
+    /// </summary>
+    public static void EnsureReachedSteadyState(SessionHandle handle)
+    {
+        if (handle.BytesSent == 0)
+        {
+            throw new InvalidOperationException(
+                "Connected session sent no frames — it never reached steady state, so its footprint " +
+                "would be under-measured. Check that the socket attached and that Bump() actually " +
+                "changed the rendered HTML (RenderAndSendAsync dedups identical renders).");
+        }
+    }
+
+    /// <summary>
+    ///     A created session plus what the reports need from it: the app instance (to mutate state so a
+    ///     render survives the dedup), the page's rendered size, and the bytes its socket actually
+    ///     received (zero proves it never reached steady state).
+    /// </summary>
+    internal readonly record struct SessionHandle(
+        LiveSession Session, FootprintApp App, int PageHtmlBytes, long BytesSent);
+}

--- a/benchmarks/Rask.Benchmarks/Program.cs
+++ b/benchmarks/Rask.Benchmarks/Program.cs
@@ -15,5 +15,17 @@ if (args.Length >= 1 && args[0] == "payload-bytes")
     return PayloadBytesReport.Run(args);
 }
 
+// `session-footprint` answers "how many live sessions fit in 1 GB" across a page-size sweep;
+// `session-churn` soaks and churns sessions to prove that number holds under sustained load.
+if (args.Length >= 1 && args[0] == "session-footprint")
+{
+    return SessionFootprintReport.Run(args);
+}
+
+if (args.Length >= 1 && args[0] == "session-churn")
+{
+    return SessionChurnReport.Run(args);
+}
+
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 return 0;

--- a/benchmarks/Rask.Benchmarks/SessionChurnReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionChurnReport.cs
@@ -1,0 +1,203 @@
+using System.Diagnostics;
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Benchmarks.Infrastructure;
+using Rask.Server;
+
+namespace Rask.Benchmarks;
+
+/// <summary>
+///     The stress counterpart to <see cref="SessionFootprintReport" />. That report measures a session's
+///     footprint at one instant; this one asks whether that footprint <i>holds</i> — because a capacity
+///     number is only meaningful if per-session cost converges rather than creeping upward with traffic.
+///     A one-shot report (NOT a BenchmarkDotNet benchmark).
+///     <para>
+///         <b>Soak pass.</b> Holds a fixed set of sessions open and drives update rounds through them,
+///         reporting retained bytes-per-session after each round. The framework's buffers are all
+///         grow-to-high-water-and-reuse, so the curve <b>should go flat</b> once the buffers have sized
+///         themselves to the page. A curve that keeps climbing means something accumulates per update —
+///         the root's handler map, the alive-sets, or the keyed-diff scratch retaining capacity — and the
+///         capacity number would then be a function of uptime rather than of page size.
+///     </para>
+///     <para>
+///         <b>Churn pass.</b> Creates, renders and disposes sessions in a loop. Read
+///         <c>RetainedTotal</c>, not the per-cycle column: a leak makes the TOTAL climb with the cycle
+///         count, whereas a constant total (with the per-cycle figure decaying toward zero as it is
+///         divided by more cycles) means nothing survives teardown.
+///     </para>
+///     <para>
+///         <c>AllocBytesPerCycle</c> is the turnover cost — what the server allocates to stand a session
+///         up and tear it down. Worth watching because <c>LiveSession.Dispose</c> never disposes
+///         <c>_htmlBuffers</c> or the <c>SessionRenderCache</c>, both of which have a <c>Dispose</c> that
+///         would return their pooled <c>char[]</c>/<c>RenderFrame[]</c> rentals to the
+///         <c>ArrayPool</c>. Nothing leaks — unreturned arrays are simply collected — but the pool never
+///         gets them back, so each new session re-allocates buffers a departing one could have handed
+///         over. That is a churn cost, not a retention cost, which is exactly why it surfaces here and
+///         not in the footprint report.
+///     </para>
+///     <para>
+///         <b>Update-cost pass.</b> Allocation and wall time for one state change on a steady-state
+///         session. The footprint report's retained bytes set the capacity ceiling; this is what a user
+///         pays per interaction. A change that trades retained memory for update cost (or the reverse)
+///         has to be read against both.
+///     </para>
+///     <para>
+///         Invoke: <c>dotnet run -c Release --project benchmarks/Rask.Benchmarks -- session-churn</c>
+///     </para>
+/// </summary>
+internal static class SessionChurnReport
+{
+    private const int SoakSessions = 100;
+    private const int SoakRounds = 8;
+    private const int UpdatesPerRound = 25;
+    private const int ChurnCycles = 500;
+    private const int ChurnBatch = 50;
+    private const int UpdateWarmup = 200;
+    private const int UpdateSamples = 2000;
+
+    private static readonly int[] UpdateCostRows = [200, 1000];
+
+    // The medium page from the footprint sweep — big enough that the page-scaled buffers dominate,
+    // small enough to soak quickly.
+    private const int Rows = 200;
+
+    public static int Run(string[] args)
+    {
+        _ = args;
+        SessionHarness.VerifySelfMeasurement();
+        Soak();
+        Console.WriteLine();
+        UpdateCost();
+        Console.WriteLine();
+        Churn();
+        return 0;
+    }
+
+    // ---- Soak: does per-session cost converge? ---------------------------------------
+
+    private static void Soak()
+    {
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "# Soak — {0} sessions held open, {1} updates each per round ({2}-row page).",
+            SoakSessions, UpdatesPerRound, Rows));
+        Console.WriteLine("# BytesPerSession should FLATTEN: the buffers grow to the page's high-water mark");
+        Console.WriteLine("# and are then reused. A rising curve means per-update accumulation.");
+        Console.WriteLine("Round,CumulativeUpdatesPerSession,BytesPerSession,DeltaVsPreviousRound");
+
+        var services = SessionHarness.NewHost();
+        var store = services.GetRequiredService<LiveSessionStore>();
+
+        var baseline = SessionHarness.StableHeap();
+        var sessions = new List<SessionHarness.SessionHandle>(SoakSessions);
+        BuildSoakSet(store, sessions);
+        SessionHarness.EnsureReachedSteadyState(sessions[0]);
+
+        long previous = 0;
+        for (var round = 1; round <= SoakRounds; round++)
+        {
+            foreach (var handle in sessions)
+            {
+                SessionHarness.Drive(handle.Session, handle.App, UpdatesPerRound);
+            }
+
+            var perSession = (SessionHarness.StableHeap() - baseline) / SoakSessions;
+            var delta = round == 1 ? 0 : perSession - previous;
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0},{1},{2},{3}",
+                round, SessionHarness.UpdatesToSteadyState + (round * UpdatesPerRound), perSession,
+                round == 1 ? "-" : delta.ToString("+#;-#;0", CultureInfo.InvariantCulture)));
+            previous = perSession;
+        }
+
+        GC.KeepAlive(sessions);
+        GC.KeepAlive(store);
+        GC.KeepAlive(services);
+    }
+
+    // Separate method so the per-session transients fall out of scope before the rounds are measured.
+    private static void BuildSoakSet(LiveSessionStore store, List<SessionHarness.SessionHandle> sessions)
+    {
+        for (var i = 0; i < SoakSessions; i++)
+        {
+            sessions.Add(SessionHarness.Create(store, Rows, connected: true));
+        }
+    }
+
+    // ---- Update cost: what one interaction costs -------------------------------------
+
+    // The footprint report answers what a session RETAINS; this answers what it costs to USE. Retained
+    // bytes set the capacity ceiling, but allocation per update is what turns into GC pressure while a
+    // user is clicking, so a change that trades one for the other has to show both.
+    private static void UpdateCost()
+    {
+        Console.WriteLine("# Update cost — allocation and wall time for ONE state change on a live session,");
+        Console.WriteLine("# measured after warmup on a steady-state session. This is the per-interaction cost");
+        Console.WriteLine("# (GC pressure), as opposed to the retained ceiling session-footprint reports.");
+        Console.WriteLine("Rows,AllocBytesPerUpdate,MicrosecondsPerUpdate");
+
+        foreach (var rows in UpdateCostRows)
+        {
+            var services = SessionHarness.NewHost();
+            var store = services.GetRequiredService<LiveSessionStore>();
+            var handle = SessionHarness.Create(store, rows, connected: true);
+            SessionHarness.EnsureReachedSteadyState(handle);
+            SessionHarness.Drive(handle.Session, handle.App, UpdateWarmup);
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            var sw = Stopwatch.StartNew();
+            SessionHarness.Drive(handle.Session, handle.App, UpdateSamples);
+            sw.Stop();
+
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0},{1},{2:0.0}",
+                rows, (GC.GetAllocatedBytesForCurrentThread() - before) / UpdateSamples,
+                sw.Elapsed.TotalMicroseconds / UpdateSamples));
+            GC.KeepAlive(store);
+            GC.KeepAlive(services);
+        }
+    }
+
+    // ---- Churn: does a session survive its own disposal? ------------------------------
+
+    private static void Churn()
+    {
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "# Churn — {0} create→render→dispose cycles ({1}-row page), reported every {2}.",
+            ChurnCycles, Rows, ChurnBatch));
+        Console.WriteLine("# RetainedTotal is the number to read: FLAT across cycle counts = nothing survives");
+        Console.WriteLine("# teardown. (PerCycle is RetainedTotal/Cycles, so it decays toward 0 when total is");
+        Console.WriteLine("# flat — a real leak would hold PerCycle steady and grow the total instead.)");
+        Console.WriteLine("Cycles,RetainedTotal,RetainedPerCycle,AllocBytesPerCycle");
+
+        var services = SessionHarness.NewHost();
+        var store = services.GetRequiredService<LiveSessionStore>();
+
+        // Warm up so JIT/statics/pool are settled before the baseline.
+        RunChurnBatch(store, ChurnBatch);
+
+        var baseline = SessionHarness.StableHeap();
+        var allocBefore = GC.GetAllocatedBytesForCurrentThread();
+        var done = 0;
+        while (done < ChurnCycles)
+        {
+            RunChurnBatch(store, ChurnBatch);
+            done += ChurnBatch;
+
+            var retainedTotal = SessionHarness.StableHeap() - baseline;
+            var allocPerCycle = (GC.GetAllocatedBytesForCurrentThread() - allocBefore) / done;
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0},{1},{2},{3}",
+                done, retainedTotal, retainedTotal / done, allocPerCycle));
+        }
+
+        GC.KeepAlive(store);
+        GC.KeepAlive(services);
+    }
+
+    // Each cycle mints a session, drives it to steady state, then disposes it — which also removes it
+    // from the store, so a leak here is the session itself outliving its own teardown.
+    private static void RunChurnBatch(LiveSessionStore store, int cycles)
+    {
+        for (var i = 0; i < cycles; i++)
+        {
+            SessionHarness.Remove(store, SessionHarness.Create(store, Rows, connected: true));
+        }
+    }
+}

--- a/benchmarks/Rask.Benchmarks/SessionFootprintReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionFootprintReport.cs
@@ -1,0 +1,146 @@
+using System.Globalization;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Benchmarks.Infrastructure;
+using Rask.Server;
+
+namespace Rask.Benchmarks;
+
+/// <summary>
+///     Answers "how many concurrent live sessions fit in 1 GB" — a one-shot report (NOT a
+///     BenchmarkDotNet benchmark), measured from the GC's per-generation live-bytes counters.
+///     <para>
+///         <b>Why a sweep and not one number.</b> A session's retained cost is dominated by things that
+///         scale with the <i>page</i>, not with the update: two <c>RenderedHtmlBuffers</c> char arrays
+///         (UTF-16 — 4 bytes of RAM per page character across the pair), the <c>SessionRenderCache</c>'s
+///         two <c>FrameWriter</c>s (~40 B per node), <c>_writeBuffer</c>/<c>_lastSentBuffer</c>, and —
+///         usually the largest term — the retained Element graph. All of them grow to a high-water mark
+///         and never shrink. The answer therefore swings by two orders of magnitude across realistic
+///         pages, and a single headline figure would be wrong for almost everyone.
+///     </para>
+///     <para>
+///         <b>Two axes.</b> <c>Rows</c> sweeps page size with the page's shape held constant, so the delta
+///         is attributable to size alone; <c>Empty_0Rows</c> isolates the fixed per-session floor that no
+///         page can go below. <c>State</c> separates a session created by a bare GET whose socket never
+///         arrived — it still holds a <c>MaxSessions</c> slot for the 10 s
+///         <c>UnconnectedSessionGracePeriod</c>, which makes it the cheapest session an attacker can mint —
+///         from one with an attached socket and updates behind it, where every buffer pair sits at its
+///         high-water mark.
+///     </para>
+///     <para>
+///         <b>On the page shape.</b> Rows are keyed and each owns a handler, i.e. a real data grid. That is
+///         deliberately the shape the clean-subtree cache cannot help: <c>TryCacheCleanSubtree</c> rejects
+///         any component carrying a <c>Key</c>, and RASK022 pushes every list item toward one — so the
+///         pages where retained memory actually matters are exactly the pages that keep their Element
+///         graph. A keyless, handler-free variant was measured during development and did not come out
+///         materially cheaper per byte of page, so the sweep reports the realistic shape only rather than
+///         an axis whose arms differ in page size as well as in shape.
+///     </para>
+///     <para>
+///         <b>What this excludes.</b> The transport (a real socket plus Kestrel's ~32 KB of per-connection
+///         buffers) and the application's own scoped services. A per-session DbContext dwarfs everything
+///         measured here. This is the framework's floor, not a budget for a real app.
+///     </para>
+///     <para>
+///         Invoke: <c>dotnet run -c Release --project benchmarks/Rask.Benchmarks -- session-footprint</c>
+///         (optionally <c>--sessions=400</c> to confirm the number is stable in N).
+///     </para>
+/// </summary>
+internal static class SessionFootprintReport
+{
+    private const int DefaultSessions = 200;
+    private const long BytesPerGib = 1024L * 1024 * 1024;
+
+    private static readonly (string Name, int Rows)[] Pages =
+    [
+        ("Empty_0Rows", 0),
+        ("Small_5Rows", 5),
+        ("Medium_200Rows", 200),
+        ("Large_1000Rows", 1000)
+    ];
+
+    public static int Run(string[] args)
+    {
+        var sessions = ParseSessions(args);
+        SessionHarness.VerifySelfMeasurement();
+
+        Console.WriteLine("# Live-session retained footprint. Framework floor only — excludes the transport");
+        Console.WriteLine("# (real socket + Kestrel per-connection buffers) and the app's own scoped services.");
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
+            "# {0} sessions retained per row; SessionsPer1GiB = 1GiB / BytesPerSession.", sessions));
+        Console.WriteLine("# Page shape: a keyed data-table row owning one event handler — a real data grid,");
+        Console.WriteLine("# and the shape the clean-subtree cache cannot help (a Key alone disqualifies it).");
+        Console.WriteLine("# State: Unconnected = GET'd, socket never attached (still holds a MaxSessions slot);");
+        Console.WriteLine("#        Connected = socket attached + updates driven (buffers at high-water).");
+        Console.WriteLine("Page,PageHtmlBytes,State,BytesPerSession,SessionsPer1GiB");
+
+        foreach (var (name, rows) in Pages)
+        {
+            // A zero-row page has no rows to make interactive, so the shape axis is meaningless there —
+            // emitting it twice would imply a comparison that isn't being made.
+            Emit(name, rows, connected: false, sessions);
+            Emit(name, rows, connected: true, sessions);
+        }
+
+        return 0;
+    }
+
+    private static void Emit(string name, int rows, bool connected, int sessions)
+    {
+        var (bytesPerSession, pageHtmlBytes) = Measure(rows, connected, sessions);
+        var density = bytesPerSession <= 0
+            ? "n/a"
+            : (BytesPerGib / bytesPerSession).ToString(CultureInfo.InvariantCulture);
+        Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0},{1},{2},{3},{4}",
+            name, pageHtmlBytes, connected ? "Connected" : "Unconnected", bytesPerSession, density));
+    }
+
+    private static (long BytesPerSession, int PageHtmlBytes) Measure(int rows, bool connected, int sessions)
+    {
+        var services = SessionHarness.NewHost();
+        var store = services.GetRequiredService<LiveSessionStore>();
+
+        // Warm up on the same store: settles JIT, first-use statics, and the ArrayPool bucket cache
+        // before the baseline is taken. The warm-up session stays in the store, so it lands inside
+        // `before` and doesn't skew the delta.
+        var warmup = SessionHarness.Create(store, rows, connected);
+        if (connected)
+        {
+            SessionHarness.EnsureReachedSteadyState(warmup);
+        }
+
+        var before = SessionHarness.StableHeap();
+        // Built in a separate method so its transient locals (per-session HTML strings, factory closures)
+        // are out of scope and reclaimable before `after` is read — only what the store and the sessions
+        // genuinely retain counts toward the delta.
+        BuildSessionsInto(store, rows, connected, sessions);
+        var after = SessionHarness.StableHeap();
+        GC.KeepAlive(store);
+        GC.KeepAlive(services);
+
+        return ((after - before) / sessions, warmup.PageHtmlBytes);
+    }
+
+    private static void BuildSessionsInto(LiveSessionStore store, int rows, bool connected, int sessions)
+    {
+        for (var i = 0; i < sessions; i++)
+        {
+            SessionHarness.Create(store, rows, connected);
+        }
+    }
+
+    private static int ParseSessions(string[] args)
+    {
+        foreach (var arg in args)
+        {
+            if (arg.StartsWith("--sessions=", StringComparison.Ordinal)
+                && int.TryParse(arg.AsSpan("--sessions=".Length), NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var n)
+                && n > 0)
+            {
+                return n;
+            }
+        }
+
+        return DefaultSessions;
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,7 +46,7 @@ Applied to both the Server and WASM runtimes.
 | --- | --- | --- |
 | `DiffMode` | `Auto` | Wire payload shape — `Auto` ships a diff when smaller, `DisabledFull` always full HTML, `Forced` always a diff. |
 | `PathBase` | `""` | URL prefix so two Rask apps share one origin (e.g. `/appA`). |
-| `MaxSessions` | `0` (uncapped) | Hard cap on concurrent live sessions; a GET past the cap gets `503` + `Retry-After`. Pairs with the [health check](observability.md#health-checks). |
+| `MaxSessions` | `0` (uncapped) | Hard cap on concurrent live sessions; a GET past the cap gets `503` + `Retry-After`. Pairs with the [health check](observability.md#health-checks). See [sizing it for a memory budget](#sizing-maxsessions-for-a-memory-budget). |
 | `MinifyScopedAssets` | `null` (auto) | Minify the scoped-CSS bundle (strip comments + insignificant whitespace) before it's hashed and served. `null` = **auto**: on outside `Development`, off in `Development` (so hot-reloaded CSS stays readable) — resolved by `UseRask` from `IHostEnvironment`. Set `true`/`false` to force it. Minifying before hashing keeps the digest, immutable URL, and brotli/gzip caches all keyed off the minified bytes. Conservative: only the CSS bundle is minified (JS is served as-is), and only whitespace around `{ } ; ,` is stripped, so combinators and `calc()` are untouched. |
 
 ## Server-host-only options — `RaskServerOptions` (`configureServer`)
@@ -100,6 +100,63 @@ overlay handles the user-facing side automatically — nothing to configure:
 ```csharp
 builder.Services.Configure<RaskUploadOptions>(o => o.MaxFileSize = 10 * 1024 * 1024);
 ```
+
+## Sizing `MaxSessions` for a memory budget
+
+`MaxSessions` defaults to `0` (uncapped), which is only safe when something else bounds who can reach
+the app. Every session pins a component tree, a DI scope, and several buffers, so an uncapped host
+facing untrusted traffic can be pushed into memory exhaustion. To set the cap you need to know what a
+session costs — measure it with the capacity report:
+
+```bash
+dotnet run -c Release --project benchmarks/Rask.Benchmarks -- session-footprint
+```
+
+Measured on the framework's own data-table page (Apple M4, .NET 10, Server GC, 200 sessions per row):
+
+| Page | Page HTML | Unconnected | Connected | Sessions per GiB |
+| --- | ---: | ---: | ---: | ---: |
+| Empty shell | 292 B | 11 KB | 16 KB | ~66,000 |
+| 5-row table | 1 KB | 35 KB | 52 KB | ~20,300 |
+| 200-row grid | 29 KB | 1.01 MB | 1.39 MB | ~735 |
+| 1,000-row grid | 147 KB | 5.3 MB | 7.0 MB | ~146 |
+
+**Page size, not user count, is what moves this** — the same host holds ~66,000 sessions of a trivial
+page or ~146 of a big grid, a ~450× swing. Sessions are cheap until the page isn't. A session retains
+roughly:
+
+- **two rendered-HTML buffers** — the current render plus the last-applied baseline, used for
+  dedup and the head-compare. They're `char` arrays, so a page costs ~**4 bytes of RAM per HTML
+  character** across the pair, and they're rented from a pool that rounds up to a power of two.
+- **two frame buffers** (~40 B per node, when the diff codec is on — it is by default) and **two
+  payload buffers**.
+- **the component tree.** Usually the largest term on a big page. A subtree is compacted — its element
+  graph released in favour of a frame snapshot — unless it contains a nested component, so most rows
+  hold a compact snapshot rather than a graph of objects.
+
+Every one of these is rented at the size the page turns out to need, then grows to a high-water mark
+and is reused, so per-session cost converges. Cost is a function of your largest page, not of uptime.
+
+These are steady-state figures, and steady state is what a session settles into: a soak of 100 sessions
+over 200 updates each holds flat to the byte, and 500 create-and-dispose cycles leave under 100 bytes
+behind.
+
+To pick a number: take the RAM you'll give the process, subtract the app's own baseline, and divide by
+the connected cost of your **largest** page — then leave headroom, because `MaxSessions` also counts
+sessions created by a bare `GET` whose WebSocket never arrived (they hold a slot for
+`UnconnectedSessionGracePeriod`, 10 s), and because a rejected user gets a `503`.
+
+```csharp
+// ~2 GiB of session budget for an app whose heaviest page measures ~1.34 MB connected.
+builder.Services.AddRask(live => live.MaxSessions = 1200);
+```
+
+Two caveats before you trust the table. These are **framework floors** — they exclude the WebSocket
+transport (Kestrel adds ~32 KB of per-connection buffers) and, more importantly, your own scoped
+services: one `DbContext` per session can dwarf everything above. And they're measured on one page
+shape. Run the report against your own budget rather than quoting these numbers, and pair the cap with
+the [live-session health check](observability.md#health-checks) so an orchestrator sheds load before
+the host starts refusing sessions.
 
 ## A note on limits and reverse proxies
 

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -851,9 +851,9 @@ public abstract class Component
     // The clean test mirrors RenderForLive's short-circuit: no prop/state change, no cache bypass, and
     // no ambient-state read. A dirty component falls through so its fresh Render() runs; if it stays
     // eligible afterwards it re-caches, otherwise it reverts to the element path transparently.
-    internal bool TryReplayCleanSubtree(StringBuilder sb, FrameWriter frames)
+    internal bool TryReplayCleanSubtree(StringBuilder sb, FrameWriter frames, LiveRenderContext? liveCtx)
     {
-        var cached = _live?.CachedFrames;
+        var cached = _live?.Cached;
         if (cached is null
             || Live.PropsDirty || Live.StateDirty
             || BypassRenderCache || _readsAmbientState)
@@ -861,10 +861,54 @@ public abstract class Component
             return false;
         }
 
+        // Handler ids are positional and reissued from zero on every root render, so the ids baked into
+        // this span are only the ids a walk would issue now if the counter has arrived back at exactly
+        // the value it held when we captured. It hasn't when anything upstream changed how many handlers
+        // it registers, and replaying then would emit ids that collide with a sibling's. Fall through to
+        // a walk, which reissues correct ids and re-captures under them.
+        //
+        // A miss is not free — we released the Element graph at capture, so the walk re-runs Render() —
+        // but it is exactly what every render costs today, and it only happens when an upstream handler
+        // count actually moves.
+        if (cached.Handlers is { } handlers)
+        {
+            if (liveCtx is null || liveCtx.PeekNextHandlerId != cached.HandlerStartId)
+            {
+                return false;
+            }
+
+            liveCtx.ReplayHandlerRun(cached.HandlerStartId, handlers);
+        }
+
+        // The captured frames carry a baked-in data-rask-key: this component's own Key forwarded onto
+        // its first element, or a keyed ancestor's that our first element adopted. Neither dirties us
+        // when it changes — Key is a reconciliation identity, excluded from the propsChanged fold (see
+        // ComponentFactoryGenerator), and an ancestor's key was never our prop at all — so a clean
+        // component can be sitting on a snapshot whose identity has since gone stale. Replaying it would
+        // emit the wrong key and the diff would match this subtree against the wrong sibling, moving the
+        // wrong DOM. Fall through to a walk instead: it re-emits under the current key and re-caches.
+        //
+        // The expression is the identity a walk would emit right now — our own Key when we have one (the
+        // serializer arms it, overwriting whatever an ancestor forwarded), else the ancestor's key still
+        // pending in the slot. Compared by object rather than by the stringified key: KeyString
+        // allocates for a value key (int, Guid) and this runs per keyed node per render, which is
+        // exactly the per-update allocation this cache exists to avoid. Object equality is conservative
+        // — a Key that changes identity but stringifies the same merely costs a walk — which is the safe
+        // direction to be wrong in.
+        if (!Equals(Key ?? (object?)KeyForwardScope.Peek(), cached.KeyIdentity))
+        {
+            return false;
+        }
+
         // Re-emit the HTML and re-write the full frame stream (with fresh offsets) into the active
         // writer in one pass — the replayed frames are identical to a fresh walk's, so the diff sees
         // no change, and no Element object graph is touched.
-        HtmlSerializer.ReplayLeanFrames(cached.AsSpan(0, Live.CachedFrameCount), sb, frames);
+        HtmlSerializer.ReplayLeanFrames(cached.Frames.AsSpan(0, cached.FrameCount), sb, frames);
+
+        // Leave the forward slot exactly as a walk would have: empty. A walk either armed our own key
+        // and cleared it in its finally, or let our first element consume an ancestor's. Replaying skips
+        // both, so an ancestor's key would otherwise stay armed and leak onto the next sibling element.
+        KeyForwardScope.Clear();
         return true;
     }
 
@@ -877,22 +921,51 @@ public abstract class Component
     //     parent's frames would skip its re-render and show stale content — <paramref name="hadNested" />),
     //   * no event handlers (Rask reissues handler ids positionally each render, so a baked-in id in a
     //     replayed span could collide with a sibling's — deferred to a stable-id follow-up),
-    //   * no Key (reconciliation identity can change without a re-render), no indexer Children, no Head
-    //     contribution (would be dropped on replay), not collecting native chrome, and cache-eligible
-    //     (no bypass / ambient-state read) — everything that would make a frame replay diverge from a walk.
+    //   * no indexer Children, no Head contribution (would be dropped on replay), not collecting native
+    //     chrome, and cache-eligible (no bypass / ambient-state read) — everything that would make a
+    //     frame replay diverge from a walk.
+    //
+    // A Key does NOT disqualify, though it used to. The key baked into the span (this component's own,
+    // or an ancestor's forwarded onto our first element) can change while we stay clean — Key is a
+    // reconciliation identity, excluded from the propsChanged fold (see ComponentFactoryGenerator) — so
+    // rather than refusing to cache keyed subtrees at all, the snapshot records the identity it was
+    // captured under and TryReplayCleanSubtree refuses a replay when it no longer matches.
+    //
+    // The trade is deliberate and measured, and it is NOT a memory win: caching keyed rows costs ~4%
+    // MORE retained memory (a per-row snapshot runs bigger than the small Element graph it releases,
+    // ~+266 B/row at 1,000 rows — this cache pays off in bytes when one component snapshots many nodes,
+    // not when many components each snapshot a few). It buys a cheaper UPDATE, which is what a user
+    // actually feels: the element path re-walks the graph and re-stringifies every Key on every render
+    // (a value key allocates — see Component.KeyString), while a replay does neither. On a 1,000-row
+    // keyed list that is ~13% less allocation and ~15% less time PER UPDATE, i.e. less GC pressure on
+    // every interaction, for a one-off 4% on the retained ceiling. Numbers from the `session-churn`
+    // update-cost pass and `session-footprint` (benchmarks/Rask.Benchmarks).
+    //
+    // <paramref name="forwardedKeyAtCapture" /> is the ambient forwarded key read BEFORE the walk (only
+    // meaningful when this component has no Key of its own; ours would overwrite the slot). A KEYLESS
+    // component's first element adopts an ancestor's forwarded key, baking someone else's identity into
+    // our span — not covered by our own-Key check, and stale-replaying it was a live bug.
+    //
+    // Event handlers no longer disqualify either. They used to, because ids are positional and reissued
+    // from zero every root render (RenderAsLiveRootCore clears the map): a replay skips the walk, so it
+    // would neither re-register its handlers — leaving the id absent from the freshly-cleared map, i.e.
+    // a dead button — nor advance the counter, shifting every later sibling's ids into collisions. So
+    // the snapshot records the handler run instead (<paramref name="handlerStartId" /> is the counter
+    // read BEFORE the walk), and a replay re-registers it and advances the counter by its length,
+    // reproducing exactly what the walk did. TryReplayCleanSubtree refuses when the counter no longer
+    // lines up.
     internal void TryCacheCleanSubtree(
-        FrameWriter frames, int frameStart, bool hadNested, bool collectsNativeChrome)
+        FrameWriter frames, int frameStart, bool hadNested, bool collectsNativeChrome,
+        string? forwardedKeyAtCapture, int handlerStartId, LiveRenderContext? liveCtx)
     {
         var count = frames.Count - frameStart;
         if (hadNested
-            || Key is not null
             || Children is not null
             || BypassRenderCache
             || _readsAmbientState
             || HeadInternal is not null
             || collectsNativeChrome
-            || count <= 0
-            || SpanHasHandler(frames.WrittenSpan.Slice(frameStart, count)))
+            || count <= 0)
         {
             // This component just walked (first render or a dirty re-render) into something we won't
             // cache — a nested component, a handler, nothing, etc. Any PRIOR snapshot (e.g. this
@@ -902,8 +975,7 @@ public abstract class Component
             // RenderForLive this walk) stays intact.
             if (_live is not null)
             {
-                _live.CachedFrames = null;
-                _live.CachedFrameCount = 0;
+                _live.Cached = null;
             }
 
             return;
@@ -914,8 +986,9 @@ public abstract class Component
         // Reuse the existing snapshot array when it still fits, so a component that re-renders every
         // frame (e.g. a stateful counter page) re-captures with ZERO allocation — only a fresh or grown
         // subtree allocates. Without this the per-update allocation win regresses by the snapshot size.
-        var snapshot = _live!.CachedFrames;
-        if (snapshot is null || snapshot.Length < count)
+        var cached = _live!.Cached ??= new CachedSubtree();
+        var snapshot = cached.Frames;
+        if (snapshot.Length < count)
         {
             snapshot = new LeanFrame[count];
         }
@@ -935,30 +1008,21 @@ public abstract class Component
             };
         }
 
-        Live.CachedFrames = snapshot;
-        Live.CachedFrameCount = count;
+        cached.Frames = snapshot;
+        cached.FrameCount = count;
+        // Record the identity this span was captured under so a later replay can prove it is still the
+        // right one.
+        // Same expression as the replay check, but against the forwarded key as it was BEFORE the walk:
+        // by now our first element has consumed it, so the live slot no longer holds it.
+        cached.KeyIdentity = Key ?? (object?)forwardedKeyAtCapture;
+        // Snapshot the handler run this walk registered (empty run → null, so a handler-free subtree
+        // pays nothing and its replay skips the counter check entirely).
+        cached.HandlerStartId = handlerStartId;
+        cached.Handlers = liveCtx?.CaptureHandlerRun(handlerStartId);
         // Drop the Element object graph: a clean re-render now replays the frame span above.
         Live.CachedRenderResult = null;
     }
 
-    // A subtree carries an event handler when any attribute frame is a data-rask-on-* hook. Handler ids
-    // are reissued positionally each render, so a replayed span's baked-in id could collide with a
-    // sibling's — such a subtree keeps the element-walk path rather than being frame-cached.
-    private static bool SpanHasHandler(ReadOnlySpan<RenderFrame> span)
-    {
-        for (var i = 0; i < span.Length; i++)
-        {
-            ref readonly var f = ref span[i];
-            if (f.Kind == RenderFrameKind.Attribute
-                && f.Name is { } n
-                && n.StartsWith("data-rask-on-", StringComparison.Ordinal))
-            {
-                return true;
-            }
-        }
-
-        return false;
-    }
 
     internal T GetOrCreateChild<T>(
         Func<IServiceProvider, T> factory,
@@ -1096,7 +1160,7 @@ public abstract class Component
     // Test hooks for the Phase B clean-subtree frame cache: whether this component's rendered
     // subtree was cached as frames, and whether it still retains its Element object graph. A cached
     // component has the first true and the second false (the graph was released).
-    internal bool IsCleanSubtreeCachedForTest => _live?.CachedFrames is not null;
+    internal bool IsCleanSubtreeCachedForTest => _live?.Cached is not null;
     internal bool RetainsElementGraphForTest => _live?.CachedRenderResult is not null;
 
     public Task StateHasChangedAsync()
@@ -1128,8 +1192,7 @@ public abstract class Component
         }
 
         Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
-        var n = Live.NextHandlerId++;
-        var id = n < _smallHandlerIds.Length ? _smallHandlerIds[n] : CreateLargeHandlerId(n);
+        var id = HandlerId(Live.NextHandlerId++);
         Live.Handlers[id] = (owner, handler);
         return id;
     }
@@ -1157,6 +1220,63 @@ public abstract class Component
             ? new string(buf[..(1 + written)])
             : "h" + n;
     }
+
+    // ---- Clean-subtree handler round-trip (root-scoped; see CachedSubtree.Handlers) ----------------
+    //
+    // These exist so a replayed subtree can reproduce the walk's effect on handler state. They are only
+    // ever called on the live-render ROOT (LiveRenderContext holds it), which is where the id counter
+    // and the map live.
+
+    /// <summary>The next handler id this render will issue — the replay's staleness check.</summary>
+    internal int NextHandlerIdInternal => Live.NextHandlerId;
+
+    /// <summary>
+    ///     The (owner, delegate) pairs registered from <paramref name="startId" /> to the current
+    ///     counter, in id order, or <c>null</c> for an empty run. The ids of one subtree's walk are
+    ///     contiguous — a cached subtree contains no nested user component, so nothing interleaves its
+    ///     own registrations — which is what lets the run be described by a start and a length.
+    /// </summary>
+    internal (Component Owner, Delegate Handler)[]? CaptureHandlerRun(int startId)
+    {
+        var count = Live.NextHandlerId - startId;
+        if (count <= 0 || Live.Handlers is not { } map)
+        {
+            return null;
+        }
+
+        var run = new (Component, Delegate)[count];
+        for (var i = 0; i < count; i++)
+        {
+            if (!map.TryGetValue(HandlerId(startId + i), out var entry))
+            {
+                // The run isn't what we assumed it was; caching it would risk a dead handler on replay.
+                return null;
+            }
+
+            run[i] = entry;
+        }
+
+        return run;
+    }
+
+    /// <summary>
+    ///     Re-register a captured run under the ids it was captured with and advance the counter past it,
+    ///     leaving the root's handler state exactly as the skipped walk would have.
+    /// </summary>
+    internal void ReplayHandlerRun(int startId, (Component Owner, Delegate Handler)[] run)
+    {
+        var map = Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
+        for (var i = 0; i < run.Length; i++)
+        {
+            map[HandlerId(startId + i)] = run[i];
+        }
+
+        Live.NextHandlerId = startId + run.Length;
+    }
+
+    // The id for counter value n. Shared by issue / capture / replay so all three agree by construction.
+    private static string HandlerId(int n) =>
+        n < _smallHandlerIds.Length ? _smallHandlerIds[n] : CreateLargeHandlerId(n);
 
     internal ValueTask<bool> TryInvokeHandlerAsync(string id, JsonElement payload)
         => TryInvokeHandlerAsync(id, payload, null);
@@ -1847,6 +1967,56 @@ public abstract class Component
         FileListReader.ResolveBackend()?.Release(files);
     }
 
+    /// <summary>
+    ///     Everything a clean-subtree snapshot needs, hung off <see cref="LiveState.Cached" /> so only
+    ///     the components that actually cache pay for it — see the note on that field.
+    ///     <para>
+    ///         Held instead of the Element object graph: on capture the subtree's frames are leaned down
+    ///         into <see cref="Frames" /> and <c>CachedRenderResult</c> is released, so a clean re-render
+    ///         replays from here and never touches an element again. Everything else on this object exists
+    ///         to prove the snapshot is still valid to replay — identity and handler wiring that a walk
+    ///         would have re-established and a replay must reproduce exactly.
+    ///     </para>
+    /// </summary>
+    private sealed class CachedSubtree
+    {
+        /// <summary>
+        ///     The leaned-down frame span. <c>Frames.Length</c> may exceed <see cref="FrameCount" /> — the
+        ///     array is reused across captures so a component that re-renders every frame re-captures with
+        ///     zero allocation. <c>LeanFrame</c> (~24 B) rather than <c>RenderFrame</c> (~40 B): a held
+        ///     snapshot never needs the per-render HTML offsets or the diff-only component ref, both of
+        ///     which replay regenerates.
+        /// </summary>
+        public LeanFrame[] Frames = [];
+
+        public int FrameCount;
+
+        /// <summary>
+        ///     The <c>data-rask-key</c> identity baked into <see cref="Frames" />: the component's own
+        ///     Key, or — when it has none — the ancestor-forwarded key its first element adopted. One
+        ///     slot, because only one can ever reach our elements (an own Key overwrites the forwarded
+        ///     one). Either can change without dirtying the component, so the replay re-checks it.
+        /// </summary>
+        public object? KeyIdentity;
+
+        /// <summary>
+        ///     The subtree's event handlers in the order the walk registered them, or <c>null</c> when it
+        ///     has none. Ids are NOT stored: the walk issues them from a contiguous counter run starting
+        ///     at <see cref="HandlerStartId" />, so id <c>i</c> is recomputable — one less reference per
+        ///     entry. Retaining the delegates is not new retention: the released Element graph held these
+        ///     very instances.
+        /// </summary>
+        public (Component Owner, Delegate Handler)[]? Handlers;
+
+        /// <summary>
+        ///     The root's handler counter as it stood when <see cref="Frames" /> were captured, i.e. the
+        ///     first id this subtree baked in. Handler ids are positional and reissued from zero every
+        ///     root render, so a replay is only sound when the counter has arrived back at this exact
+        ///     value — otherwise the baked ids are not the ones a walk would now issue.
+        /// </summary>
+        public int HandlerStartId;
+    }
+
     // The hoisted state — class so it stays out-of-band from each Component instance.
     // Field grouping mirrors the prior layout for readability of the diff.
     private sealed class LiveState
@@ -1860,15 +2030,12 @@ public abstract class Component
         public CancellationTokenSource? LifetimeCts;
         public Component? CachedRenderResult;
 
-        // Phase B clean-subtree frame cache. When a user component's rendered subtree is pure
-        // elements/text (no nested user components, no event handlers), we retain its RenderFrame
-        // span here and RELEASE CachedRenderResult, so the (large) Element object graph is collectible
-        // — a clean re-render replays these frames (+ EmitFromFrames) instead of re-walking elements.
-        // CachedFrames.Length may exceed CachedFrameCount (the array is a reused snapshot). It holds
-        // LeanFrames (~24 B) rather than full RenderFrames (~40 B) — a held snapshot never needs the
-        // per-render HTML offsets or the diff-only component ref, which replay regenerates.
-        public LeanFrame[]? CachedFrames;
-        public int CachedFrameCount;
+        // Phase B clean-subtree frame cache — see CachedSubtree. ONE reference, not the handful of
+        // fields the snapshot actually needs: LiveState is allocated per node on a mounted page, so
+        // every field here costs ~8 B on every node of every live session (measured: ~56 KB per field
+        // on a 1,000-row page). Hanging the state off a side object moves that cost onto the
+        // components that actually cache, and leaves the rest paying a single null reference.
+        public CachedSubtree? Cached;
         public int ChildPositions;
         public Dictionary<(Type, int), Component>? Children;
         public Dictionary<LiveRenderContext.ObjectKey, EditContext>? EditContextsPool;

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -449,7 +449,7 @@ internal static class HtmlSerializer
                 // ineligible component returns false here and falls through to the walk below, which
                 // re-renders it and may re-cache. A replayed component is itself a nested user component
                 // for its parent, so flag that.
-                if (frames is not null && component.TryReplayCleanSubtree(sb, frames))
+                if (frames is not null && component.TryReplayCleanSubtree(sb, frames, liveCtx))
                 {
                     _sawNestedComponent = true;
                     break;
@@ -467,6 +467,16 @@ internal static class HtmlSerializer
                 // re-asserted to true after the walk so an ENCLOSING component still sees us as nested.
                 _sawNestedComponent = false;
                 var frameStart = frames?.Count ?? -1;
+
+                // Read the ambient forwarded key BEFORE the walk: if this component has no Key of its
+                // own, its first element will Consume() an ancestor's pending key and bake it into the
+                // frames we are about to capture. Reading it afterwards is too late — it has been
+                // consumed — and the snapshot needs to know which identity it was captured under.
+                var forwardedKeyAtCapture = KeyForwardScope.Peek();
+
+                // Likewise the handler-id counter: the walk about to run issues this subtree's ids
+                // starting here, and the snapshot has to know where its run began to replay it.
+                var handlerStartId = liveCtx?.PeekNextHandlerId ?? 0;
 
                 using (LiveRenderContext.PushScopeOrNone(liveCtx, component))
                 using (LiveRenderContext.EnterParentScopeOrNone(liveCtx, component))
@@ -500,7 +510,8 @@ internal static class HtmlSerializer
                 if (frames is not null && frameStart >= 0)
                 {
                     component.TryCacheCleanSubtree(
-                        frames, frameStart, hadNested, liveCtx?.CollectsNativeChrome ?? false);
+                        frames, frameStart, hadNested, liveCtx?.CollectsNativeChrome ?? false,
+                        forwardedKeyAtCapture, handlerStartId, liveCtx);
                 }
 
                 // Mark that our parent's subtree now contains a user component (us).

--- a/src/Rask.Core/Live/KeyForwardScope.cs
+++ b/src/Rask.Core/Live/KeyForwardScope.cs
@@ -32,6 +32,18 @@ public static class KeyForwardScope
     public static void Clear() => _pending = null;
 
     /// <summary>
+    ///     Read the pending forwarded key WITHOUT consuming it.
+    ///     <para>
+    ///         The clean-subtree frame cache needs this. A cached subtree's frames have whatever key its
+    ///         first element consumed baked into them — which may be an ancestor's forwarded key, not its
+    ///         own — so the snapshot has to record what was in effect when it was captured and refuse to
+    ///         replay under a different one. <see cref="Consume" /> can't answer that question because
+    ///         asking would steal the key from the element that should adopt it.
+    ///     </para>
+    /// </summary>
+    internal static string? Peek() => _pending;
+
+    /// <summary>
     ///     Return the pending forwarded key (or <c>null</c>) and clear the slot, so exactly one
     ///     element adopts it. Called by every element's attribute-writing path.
     /// </summary>

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -212,6 +212,21 @@ public sealed class LiveRenderContext : IDisposable
         // owner association is what lets the post-handler dirty-mark land on the right node.
         _root.RegisterHandler(handler, CurrentParent);
 
+    // Handler ids and their map live on the root; the clean-subtree frame cache needs to read the
+    // counter and re-establish a skipped walk's registrations, and only this context knows the root.
+    // See Component.CachedSubtree.Handlers.
+
+    /// <summary>The next handler id this render will issue.</summary>
+    internal int PeekNextHandlerId => _root.NextHandlerIdInternal;
+
+    /// <summary>Snapshot the handler run registered since <paramref name="startId" /> (null if empty).</summary>
+    internal (Component Owner, Delegate Handler)[]? CaptureHandlerRun(int startId) =>
+        _root.CaptureHandlerRun(startId);
+
+    /// <summary>Re-register a captured run and advance the counter past it, as the skipped walk would.</summary>
+    internal void ReplayHandlerRun(int startId, (Component Owner, Delegate Handler)[] run) =>
+        _root.ReplayHandlerRun(startId, run);
+
     public T GetOrCreate<T>(Func<IServiceProvider, T> factory) where T : Component
     {
         var parent = CurrentParent;

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -16,7 +16,11 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 {
     // Pooled across the session lifetime; ResetWrittenCount between frames keeps the rented backing
     // array hot. Non-readonly: TryEmitFrameAsync swaps it with the previous-frame buffer for zero-copy dedup.
-    protected ArrayBufferWriter<byte> _writeBuffer = new(4096);
+    //
+    // Sized on demand rather than pre-sized: this is retained per session, and the first payload grows it
+    // to the page's real size regardless, so a fixed pre-size only ever mattered for pages small enough
+    // not to need it — while costing every concurrent session, including the ones that never send a frame.
+    protected ArrayBufferWriter<byte> _writeBuffer = new();
 
     // The buffer holding the last frame we sent — the double-buffer dedup baseline. TryEmitFrameAsync
     // swaps it with _writeBuffer after each send, so neither the baseline nor the emit copies a byte[].
@@ -202,7 +206,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
 
         await SendFrameAsync(_writeBuffer.WrittenMemory).ConfigureAwait(false);
 
-        (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>(4096));
+        (_lastSentBuffer, _writeBuffer) = (_writeBuffer, _lastSentBuffer ?? new ArrayBufferWriter<byte>());
         return true;
     }
 

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -138,7 +138,19 @@ public sealed class FrameWriter
 {
     private RenderFrame[] _buffer;
 
-    public FrameWriter(int initialCapacity = 256) =>
+    /// <summary>
+    ///     The default starts small and lets <c>Reserve</c>'s doubling find the page's real size.
+    ///     <para>
+    ///         A live session retains two of these for its whole life (the diff baseline and the render in
+    ///         flight), so the initial capacity is not scratch space — it is paid per concurrent user. The
+    ///         old 256-frame default rented ~10 KB per writer, ~20 KB per session, before knowing whether
+    ///         the page had ten nodes or ten thousand. Growth is amortized doubling, and the buffer is
+    ///         reused across renders once it reaches the high-water mark, so a large page pays a handful of
+    ///         grow-and-copy steps on its first render only and nothing thereafter. Pass an explicit
+    ///         capacity when the frame count is known up front and the writer is short-lived.
+    ///     </para>
+    /// </summary>
+    public FrameWriter(int initialCapacity = 16) =>
         _buffer = ArrayPool<RenderFrame>.Shared.Rent(Math.Max(16, initialCapacity));
 
     /// <summary>Total frames emitted so far.</summary>

--- a/src/Rask.Core/Live/RenderedHtmlBuffers.cs
+++ b/src/Rask.Core/Live/RenderedHtmlBuffers.cs
@@ -28,10 +28,23 @@ internal sealed class RenderedHtmlBuffers : IDisposable
     private int _curLen;
     private int _prevLen;
 
-    public RenderedHtmlBuffers(int initialCapacity = 8 * 1024)
+    /// <summary>
+    ///     Starts with no buffers at all: the first <see cref="CopyFrom" /> / <see cref="SeedPrevious" />
+    ///     rents each one at the size the page actually needs.
+    ///     <para>
+    ///         These are per-session and live as long as the session does, so pre-renting a fixed size is
+    ///         not free the way a scratch buffer would be — it is paid once per concurrent user. The
+    ///         previous 8 KB-char default rented ~33 KB per session before knowing anything about the page,
+    ///         which was most of the ~56 KB an idle session cost even when its page was 292 bytes. Pages
+    ///         over 8 K chars re-rented anyway, so the pre-rent only ever helped pages small enough not to
+    ///         need it. Renting on first use costs one extra rent for a small page — once, at session
+    ///         start — and nothing at all for a large one.
+    ///     </para>
+    /// </summary>
+    public RenderedHtmlBuffers()
     {
-        _cur = ArrayPool<char>.Shared.Rent(initialCapacity);
-        _prev = ArrayPool<char>.Shared.Rent(initialCapacity);
+        _cur = Array.Empty<char>();
+        _prev = Array.Empty<char>();
     }
 
     /// <summary>True once at least one render has been committed as the baseline.</summary>
@@ -87,8 +100,18 @@ internal sealed class RenderedHtmlBuffers : IDisposable
 
     public void Dispose()
     {
-        ArrayPool<char>.Shared.Return(_cur);
-        ArrayPool<char>.Shared.Return(_prev);
+        // A session disposed before its first render still holds the zero-length sentinels, which must
+        // not be handed to the pool.
+        if (_cur.Length > 0)
+        {
+            ArrayPool<char>.Shared.Return(_cur);
+        }
+
+        if (_prev.Length > 0)
+        {
+            ArrayPool<char>.Shared.Return(_prev);
+        }
+
         _cur = _prev = Array.Empty<char>();
         _curLen = _prevLen = 0;
     }
@@ -100,7 +123,13 @@ internal sealed class RenderedHtmlBuffers : IDisposable
             return;
         }
 
-        ArrayPool<char>.Shared.Return(buffer);
+        // Skip the return on the first grow: the buffer is still the zero-length sentinel the ctor
+        // installed, which never came from the pool.
+        if (buffer.Length > 0)
+        {
+            ArrayPool<char>.Shared.Return(buffer);
+        }
+
         buffer = ArrayPool<char>.Shared.Rent(needed);
     }
 }

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -30,6 +30,13 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Rask.Core.Tests"/>
     <InternalsVisibleTo Include="Rask.Server.Tests"/>
+    <!--
+      The session-footprint / session-churn capacity reports construct real LiveSessions to measure
+      per-session retained memory. LiveSession, LiveSessionStore.Create and RenderInitialRoot are all
+      internal, and measuring through the public HTTP/WebSocket surface would fold Kestrel's own
+      per-connection buffers into the per-session number.
+    -->
+    <InternalsVisibleTo Include="Rask.Benchmarks"/>
   </ItemGroup>
 
   <!--

--- a/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
+++ b/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using System.Text.Json;
 using Rask.Core.Live;
 using Rask.TestSupport;
 
@@ -133,26 +134,261 @@ public class CleanSubtreeReplayTests
         Assert.Empty(ops); // nothing changed between render 2 and 3
     }
 
-    [Fact]
-    public void HandlerBearingComponent_IsNotCached()
-    {
-        // A LiveRenderContext is needed for event handlers to register + emit their data-rask-on-*
-        // hooks. Handler ids are reissued positionally each root render, so a replayed span with a
-        // baked-in id could collide with a sibling's — such a subtree must keep the element-walk path.
-        var page = new StubComponent(() => Div(Class: "btn", OnClick: () => { })["click me"]);
-        var cache = new SessionRenderCache();
-        var ops = new List<EditOp>();
-        var sb = new StringBuilder();
+    // ---- Handler-bearing subtrees ----------------------------------------------------------
+    //
+    // Handler ids are positional and reissued from zero on every ROOT render, so these go through
+    // RenderAsLiveRoot rather than HtmlSerializer.Serialize: only the real root path clears the map and
+    // resets the counter, which is exactly the state a replay has to reproduce. The component under test
+    // is a nested child (the root itself is never cacheable — it contains a user component).
 
-        using (LiveRenderContext.Begin(page))
+    private static JsonElement EmptyPayload => JsonDocument.Parse("{}").RootElement;
+
+    private static string RenderRoot(SessionRenderCache cache, Component root, List<EditOp> ops)
+    {
+        string html;
         using (FrameSinkScope.Push(cache.PrepareCurrentBuffer()))
         {
-            HtmlSerializer.Serialize(page, sb);
+            html = root.RenderAsLiveRoot();
         }
 
-        Assert.Contains("data-rask-on-click", sb.ToString());
-        Assert.False(page.IsCleanSubtreeCachedForTest, "handler-bearing subtree must not be frame-cached");
-        Assert.True(page.RetainsElementGraphForTest);
+        cache.TryComputeDiff(ops);
+        return html;
+    }
+
+    // Pulls the id out of the first data-rask-on-*="hN" in the emitted HTML — what the browser would
+    // send back.
+    private static string HandlerIdIn(string html, int occurrence = 0)
+    {
+        var idx = -1;
+        for (var i = 0; i <= occurrence; i++)
+        {
+            idx = html.IndexOf("data-rask-on-", idx + 1, StringComparison.Ordinal);
+            Assert.True(idx >= 0, $"expected at least {occurrence + 1} handler hook(s) in: {html}");
+        }
+
+        var open = html.IndexOf('"', idx) + 1;
+        return html[open..html.IndexOf('"', open)];
+    }
+
+    [Fact]
+    public void HandlerBearingComponent_IsCachedAndReleasesElementGraph()
+    {
+        // A button per row is what a real data grid looks like, so this shape has to cache like any
+        // other pure-element subtree — the handler wiring is reproduced on replay rather than banned.
+        var row = new StubComponent(() => Div(Class: "btn", OnClick: () => { })["click me"]);
+        var root = new StubComponent(() => Div(Class: "page")[row]);
+        var cache = new SessionRenderCache();
+
+        var html = RenderRoot(cache, root, new List<EditOp>());
+
+        Assert.Contains("data-rask-on-click", html);
+        Assert.True(row.IsCleanSubtreeCachedForTest, "handler-bearing subtree should be frame-cached");
+        Assert.False(row.RetainsElementGraphForTest, "the Element graph should be released after caching");
+    }
+
+    [Fact]
+    public async Task ReplayedHandler_StillFires()
+    {
+        // The failure this guards is a silently dead button: a replay skips the walk, so unless it
+        // re-registers the run, the id the browser sends back is absent from the freshly-cleared map.
+        var clicks = 0;
+        var row = new StubComponent(() => Div(Class: "btn", OnClick: () => clicks++)["click me"]);
+        var root = new StubComponent(() => Div(Class: "page")[row]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = RenderRoot(cache, root, ops);
+        Assert.True(row.IsCleanSubtreeCachedForTest);
+
+        var second = RenderRoot(cache, root, ops);
+        Assert.Equal(first, second);   // replayed, byte-identical
+        Assert.Empty(ops);
+
+        var id = HandlerIdIn(second);
+        Assert.True(await root.TryInvokeHandlerAsync(id, EmptyPayload), "the replayed id must still resolve");
+        Assert.Equal(1, clicks);
+    }
+
+    [Fact]
+    public async Task ReplayedHandlerOwnedByItsComponent_DirtyMarksThatComponent()
+    {
+        // The map stores (owner, delegate); the owner is what gets dirty-marked after a dispatch. A
+        // replay must carry the resolved owner through, not just the delegate — otherwise the click
+        // fires but the UI never updates.
+        var counter = new CounterRow();
+        var root = new StubComponent(() => Div(Class: "page")[counter]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = RenderRoot(cache, root, ops);
+        Assert.Contains(">0<", first);
+        Assert.True(counter.IsCleanSubtreeCachedForTest);
+
+        RenderRoot(cache, root, ops);   // replay
+        await root.TryInvokeHandlerAsync(HandlerIdIn(first), EmptyPayload);
+
+        // The dispatch dirtied the owner, so the next render must re-walk it and show the new value.
+        var third = RenderRoot(cache, root, ops);
+        Assert.Contains(">1<", third);
+    }
+
+    [Fact]
+    public async Task ReplayedSubtree_AdvancesTheHandlerCounter()
+    {
+        // A replay that didn't advance the counter would hand the SECOND row the first row's id.
+        var a = new StubComponent(() => Div(Class: "a", OnClick: () => { })["a"]);
+        var b = new StubComponent(() => Div(Class: "b", OnClick: () => { })["b"]);
+        var root = new StubComponent(() => Div(Class: "page")[a, b]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = RenderRoot(cache, root, ops);
+        var second = RenderRoot(cache, root, ops);
+
+        Assert.Equal(first, second);
+        Assert.NotEqual(HandlerIdIn(second, 0), HandlerIdIn(second, 1));
+        // Both ids still resolve, so neither row's registration was lost or overwritten.
+        Assert.True(await root.TryInvokeHandlerAsync(HandlerIdIn(second, 0), EmptyPayload));
+        Assert.True(await root.TryInvokeHandlerAsync(HandlerIdIn(second, 1), EmptyPayload));
+    }
+
+    [Fact]
+    public async Task HandlerIdsShiftUpstream_FallsBackToWalk()
+    {
+        // A handler appearing BEFORE a cached sibling shifts every later id by one. The sibling's baked
+        // ids are then not what a walk would issue, so it must re-walk under the corrected ids rather
+        // than replay a colliding span.
+        var headerHandler = false;
+        var rowClicks = 0;
+        var row = new StubComponent(() => Div(Class: "row", OnClick: () => rowClicks++)["row"]);
+        var root = new StubComponent(() => Div(Class: "page")[
+            headerHandler ? Div(Class: "hdr", OnClick: () => { })["hdr"] : Div(Class: "hdr")["hdr"],
+            row
+        ]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = RenderRoot(cache, root, ops);
+        var rowIdBefore = HandlerIdIn(first);
+        Assert.True(row.IsCleanSubtreeCachedForTest);
+
+        // The header grows a handler and takes the row's old id.
+        headerHandler = true;
+        var second = RenderRoot(cache, root, ops);
+        var headerId = HandlerIdIn(second, 0);
+        var rowIdAfter = HandlerIdIn(second, 1);
+
+        Assert.Equal(rowIdBefore, headerId);       // the header claimed the id the row used to hold
+        Assert.NotEqual(rowIdAfter, headerId);     // the row moved rather than colliding
+        Assert.True(await root.TryInvokeHandlerAsync(rowIdAfter, EmptyPayload));
+        Assert.Equal(1, rowClicks);                // and it is still the ROW's handler behind it
+    }
+
+    // ---- Keyed subtrees ------------------------------------------------------------------
+    //
+    // A Key is forwarded onto the component's first rendered element and baked into its captured
+    // frames as data-rask-key. Key is deliberately NOT part of the propsChanged diff (it is a
+    // reconciliation identity, not a reactive prop — see ComponentFactoryGenerator), so a keyed
+    // component can have its Key reassigned while staying clean. That is why the snapshot records the
+    // Key it was captured under and refuses to replay against a different one; without that check a
+    // key-only change would replay a stale data-rask-key and the diff would match the wrong sibling.
+
+    [Fact]
+    public void KeyedPureElementComponent_IsCachedAndReleasesElementGraph()
+    {
+        // A keyed list row is the shape where retained memory matters most (RASK022 wants a Key on
+        // every list item), so it has to be cacheable like any other pure-element subtree.
+        var page = new StubComponent(() => Div(Class: "row")[Span()["r1"]]) { Key = "k1" };
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        Render(cache, page, ops);
+
+        Assert.True(page.IsCleanSubtreeCachedForTest, "a keyed pure-element subtree should be frame-cached");
+        Assert.False(page.RetainsElementGraphForTest, "the Element graph should be released after caching");
+    }
+
+    [Fact]
+    public void KeyedComponent_CleanReRender_ReplaysTheKeyIntoTheHtml()
+    {
+        var built = 0;
+        var page = new StubComponent(() =>
+        {
+            built++;
+            return Div(Class: "row")[Span()["r1"]];
+        })
+        { Key = "k1" };
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, page, ops);
+        var second = Render(cache, page, ops);
+
+        Assert.Contains("data-rask-key=\"k1\"", first);
+        Assert.Equal(first, second);   // the forwarded key survives the replay byte-for-byte
+        Assert.Empty(ops);
+        Assert.Equal(1, built);        // replayed from frames, Render NOT re-run
+    }
+
+    [Fact]
+    public void KeyedComponent_KeyChangedWhileClean_DoesNotStaleReplay()
+    {
+        // The hazard the snapshot's key check exists for: reassigning Key does not dirty the component
+        // (Key is excluded from the propsChanged fold), so a replay here would emit the OLD key and the
+        // diff would reconcile this row against the wrong sibling.
+        var page = new StubComponent(() => Div(Class: "row")[Span()["r1"]]) { Key = "k1" };
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, page, ops);
+        Assert.Contains("data-rask-key=\"k1\"", first);
+
+        // Key changes, nothing else — the component is NOT marked dirty.
+        page.Key = "k2";
+        var second = Render(cache, page, ops);
+
+        Assert.Contains("data-rask-key=\"k2\"", second);
+        Assert.DoesNotContain("data-rask-key=\"k1\"", second);
+        // Re-walked under the new key, so it re-caches and releases the graph again.
+        Assert.True(page.IsCleanSubtreeCachedForTest);
+        Assert.False(page.RetainsElementGraphForTest);
+    }
+
+    [Fact]
+    public void KeyedComponent_KeyRemoved_DoesNotStaleReplay()
+    {
+        // Same hazard in the null direction: dropping the Key must drop the attribute, not replay it.
+        var page = new StubComponent(() => Div(Class: "row")[Span()["r1"]]) { Key = "k1" };
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        Render(cache, page, ops);
+        page.Key = null;
+        var second = Render(cache, page, ops);
+
+        Assert.DoesNotContain("data-rask-key", second);
+    }
+
+    [Fact]
+    public void ForwardedKeyChangedWhileChildClean_DoesNotStaleReplay()
+    {
+        // Regression: a keyed OUTER whose body is a keyless nested component. Outer arms its key and
+        // inner's first element consumes it, so OUTER's key is baked into INNER's cached frames — and
+        // inner is clean and cacheable in its own right. When outer's key changes, nothing dirties
+        // inner, so it would replay a snapshot carrying the old identity and the diff would match this
+        // subtree against the wrong sibling. The snapshot records the forwarded key it was captured
+        // under precisely so this falls back to a walk.
+        var inner = new StubComponent(() => Div(Class: "row")[Span()["x"]]);
+        var outer = new StubComponent(() => inner) { Key = "k1" };
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, outer, ops);
+        Assert.Contains("data-rask-key=\"k1\"", first);
+
+        outer.Key = "k2";
+        var second = Render(cache, outer, ops);
+        Assert.Contains("data-rask-key=\"k2\"", second);
     }
 
     [Fact]
@@ -176,4 +412,15 @@ public class CleanSubtreeReplayTests
         var op = Assert.Single(ops);
         Assert.Equal("2", op.Value);
     }
+}
+
+// A component that owns its handler (the closure captures `this`), so DelegateOwner resolves the owner
+// to this instance and a dispatch dirty-marks it — the wiring ReplayedHandlerOwnedByItsComponent_* checks
+// survives a frame replay.
+internal sealed class CounterRow : Component
+{
+    private int _count;
+
+    protected override Component? Render() =>
+        Div(Class: "counter", OnClick: () => _count++)[_count.ToString()];
 }

--- a/tests/Rask.Core.Tests/Live/RenderedHtmlBuffersTests.cs
+++ b/tests/Rask.Core.Tests/Live/RenderedHtmlBuffersTests.cs
@@ -7,7 +7,7 @@ public class RenderedHtmlBuffersTests
 {
     private static RenderedHtmlBuffers WithCurrent(string html)
     {
-        var b = new RenderedHtmlBuffers(16);
+        var b = new RenderedHtmlBuffers();
         b.CopyFrom(new StringBuilder(html));
         return b;
     }
@@ -15,7 +15,7 @@ public class RenderedHtmlBuffersTests
     [Fact]
     public void FreshBuffers_HaveNoPrevious()
     {
-        using var b = new RenderedHtmlBuffers(16);
+        using var b = new RenderedHtmlBuffers();
         Assert.False(b.HasPrevious);
         // With no baseline a render can never dedup as a no-op — it must always be treated as changed.
         b.CopyFrom(new StringBuilder("<p>x</p>"));
@@ -87,7 +87,7 @@ public class RenderedHtmlBuffersTests
     [Fact]
     public void SeedPrevious_SetsBaselineFromAString_ForTheGetRenderHandoff()
     {
-        using var b = new RenderedHtmlBuffers(16);
+        using var b = new RenderedHtmlBuffers();
         b.SeedPrevious("<html><head></head><body>x</body></html>");
         Assert.True(b.HasPrevious);
         // The first live update after the GET must dedup a byte-identical re-render against the seed.
@@ -96,9 +96,9 @@ public class RenderedHtmlBuffersTests
     }
 
     [Fact]
-    public void GrowsBeyondInitialCapacity_WithoutTruncating()
+    public void GrowsFromNothing_WithoutTruncating()
     {
-        using var b = new RenderedHtmlBuffers(8);
+        using var b = new RenderedHtmlBuffers();
         var big = new string('a', 5000);
         b.CopyFrom(new StringBuilder(big));
         Assert.Equal(5000, b.CurrentSpan.Length);
@@ -109,5 +109,44 @@ public class RenderedHtmlBuffersTests
         b.CopyFrom(new StringBuilder(bigger));
         Assert.Equal(bigger, b.CurrentSpan.ToString());
         Assert.Equal(big, b.PreviousSpan.ToString());
+    }
+
+    [Fact]
+    public void FreshBuffers_AreEmpty_BecauseNothingIsRentedUntilFirstUse()
+    {
+        // The buffers are per-session and outlive every render, so they rent at the page's real size on
+        // first use rather than pre-renting a fixed block for a page they haven't seen yet.
+        using var b = new RenderedHtmlBuffers();
+        Assert.Equal(0, b.CurrentSpan.Length);
+        Assert.Equal(0, b.PreviousSpan.Length);
+    }
+
+    [Fact]
+    public void Dispose_BeforeAnyRender_DoesNotThrow()
+    {
+        // A session can be torn down before it ever renders (an abandoned GET). Both buffers are still
+        // the zero-length sentinel at that point, and handing those to the ArrayPool is not valid.
+        var b = new RenderedHtmlBuffers();
+        b.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_AfterSeedingOnlyTheBaseline_DoesNotThrow()
+    {
+        // The GET path seeds `previous` and may never render into `current`, so disposal has to cope with
+        // one real rented buffer and one sentinel.
+        var b = new RenderedHtmlBuffers();
+        b.SeedPrevious("<html></html>");
+        b.Dispose();
+    }
+
+    [Fact]
+    public void Dispose_IsIdempotent()
+    {
+        var b = new RenderedHtmlBuffers();
+        b.CopyFrom(new StringBuilder("<p>x</p>"));
+        b.Dispose();
+        // Returning the same array to the pool twice would let two sessions rent the same buffer.
+        b.Dispose();
     }
 }


### PR DESCRIPTION
## Summary

Started as **"how many open live sessions fit in 1 GB?"**. Answering it required building the measurement, and the measurement then found three things worth fixing — so sessions are now cheaper to *hold* and materially cheaper to *use*.

Nothing measured per-session memory before this, yet `RaskLiveOptions.MaxSessions` defaults to **uncapped** while its own doc calls unbounded sessions *"a memory-exhaustion (DoS) surface"*. There was no load/soak test for live sessions either.

## The answer

Session cost is driven by **page size, not user count** — a ~450× swing:

| Page | Page HTML | Unconnected | Connected | Sessions per GiB |
| --- | ---: | ---: | ---: | ---: |
| Empty shell | 292 B | 11 KB | 16 KB | ~66,000 |
| 5-row table | 1 KB | 35 KB | 52 KB | ~20,300 |
| 200-row grid | 29 KB | 1.01 MB | 1.39 MB | ~735 |
| 1,000-row grid | 147 KB | 5.3 MB | 7.0 MB | ~146 |

`Unconnected` = minted by a bare `GET` whose socket never arrived; it still holds a `MaxSessions` slot for the 10 s grace, making it the cheapest session an attacker can mint. [`docs/configuration.md`](docs/configuration.md#sizing-maxsessions-for-a-memory-budget) turns this into `MaxSessions` sizing guidance.

## 1 — Buffers sized to the page (retained memory)

A session used to rent **~33 KB of char buffers, ~20 KB of frame buffers and ~8 KB of payload buffers up front**, before knowing whether its page was 300 bytes or 300 KB. All now rent on first use. Pages that outgrew the old defaults re-rented anyway, so they're unaffected; small pages get several times denser.

- empty shell **74 KB → 16 KB** (~14,500 → ~66,000 sessions/GiB)
- 5-row table **98 KB → 52 KB**

## 2 & 3 — Both clean-subtree-cache bans lifted (update cost)

The cache releases a subtree's Element graph and replays it from a compact frame snapshot. Two exclusions kept the pages that need it most from ever using it: **`Key`** (RASK022 wants one on every list item) and **event handlers** (every real data-grid row has one). Both bans were sound — each identity can change *while the component stays clean*, so a replay would emit a stale `data-rask-key`, or a dead button plus colliding handler ids.

Both are now fixed the same way: **the snapshot records what it was captured under and declines to replay when reality has moved** (falling back to a walk, which reissues correct values and re-caches).

**These are not memory wins, and that's the point** — measured, same build, ban toggled:

| 1,000-row keyed list | ban | cached | delta |
| --- | ---: | ---: | ---: |
| alloc/update | 427,856 B | 371,412 B | **−13.2%** |
| time/update | 1,002 µs | 854 µs | **−14.7%** |

| 1,000-row interactive grid | ban | cached | delta |
| --- | ---: | ---: | ---: |
| alloc/update | 570,102 B | 435,704 B | **−23.6%** |
| time/update | 1,172 µs | 844 µs | **−28.0%** |

A per-row snapshot runs slightly larger than the small element graph it releases, so retained cost rises ~4% and ~2.7% respectively: **the ceiling moves a little, every interaction gets cheaper.** Per-update garbage is GC pressure while a user is clicking; retained bytes are a ceiling you hit once. The element path re-walks the graph and re-stringifies every `Key` on every render — a replay does neither.

`session-churn` grew an **update-cost pass** so this trade can never again be judged on one axis. Cache state also collapsed from three `LiveState` fields to one reference (that struct is per-node: ~56 KB per field on a 1,000-row page), which is what pays for the handler bookkeeping — an empty-shell session gets *smaller* despite it.

## 🐛 Fixed: a stale forwarded key (bug on `main` today)

Independent of the above. A **keyless** component's first element adopts a keyed ancestor's forwarded key and bakes it into its snapshot. Nothing dirties that child when the ancestor's key changes, so it replays the old identity and the diff reconciles against the wrong sibling — moving the wrong DOM. `ForwardedKeyChangedWhileChildClean_DoesNotStaleReplay` **fails on main**.

## A measurement bug worth knowing about

`GC.GetTotalMemory(true)` after a forced collect **over-reports every small-object allocation by exactly 2×** (committed ephemeral space scales with what was allocated), while reporting large-object allocations correctly — so a big-array spot-check looks perfect and hides it.

| Control | True | `GetTotalMemory` | `GenerationInfo` |
| --- | ---: | ---: | ---: |
| `byte[16384]` (SOH) | 16,408 | 32,815 (2.00×) | 16,407 |
| `byte[100000]` (LOH) | 100,024 | 100,023 (1.00×) | 100,055 |

Every figure here is a small-object measurement, so my first numbers were 2× too pessimistic. Summing `GCMemoryInfo.GenerationInfo.SizeAfterBytes` reproduces the controls to within a byte, and **both reports self-check against a control before printing**.

⚠️ **Follow-up (not here):** the existing `VsBlazorMemFootprintReport` uses `GetTotalMemory`, so its retained figures in `Baselines/vs-blazor.md` are ~2× inflated. Both sides inflate equally so the **1.41× ratio it leads with is unaffected**; the absolutes should be re-baselined.

## Evidence it's safe

- **Wire format byte-identical** — `payload-bytes --check` unchanged on all 5 scenarios.
- **Diff hot path byte-identical** — `Allocated` matches to the byte on all 27 `FrameDifferBenchmarks` rows.
- **Soak**: 100 sessions × 200 updates → flat to the byte. **Churn**: 500 create→dispose cycles → 96 B residue.
- Full unit suite green (Core 1938, Server 250, Wasm 194, Native 82, Bootstrap 168, Generators 246); **browser E2E 25/25**.

Handler tests drive **real dispatches**, not cache flags — the failure mode is a silently dead button: a replayed handler still fires, its owner is still dirty-marked, sibling ids stay distinct, and an upstream id shift falls back to a walk.

## Notes

- `FrameWriter`'s default `initialCapacity` is now `16` rather than `256` (public API — pass an explicit capacity for a short-lived writer whose frame count you know).
- `Rask.Server` grants internals to `Rask.Benchmarks`: `LiveSession`/`LiveSessionStore.Create`/`RenderInitialRoot` are internal, and measuring through the public HTTP/WS surface would fold Kestrel's per-connection buffers into a per-session number. A stub `WebSocket` stands in for the transport for the same reason.
- Reports are **not CI-gated** — GC numbers are noisy; `ci.yml` gates only deterministic byte counts. They belong in the nightly informational lane next to `mem-footprint`.
- The capacity table is a **framework floor**, not a promise: it excludes the transport and your own scoped services (a per-session `DbContext` dwarfs all of it). The docs say so.
- Remaining cache exclusion: a subtree containing a **nested user component** — that one is load-bearing (the nested component can go dirty on its own).