### PR TITLE
feat(cli): generate feature --fields supports date / time / datetime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`rask generate feature --fields` supports `date`, `time`, and `datetime`.** `date` maps to `DateOnly`,
+  `time` to `TimeOnly`, and `datetime` to `DateTime` (the bound form inputs auto-render as `type="date"` /
+  `type="time"`, and EF Core maps them to SQLite). Previously `date` was an alias for `DateTime`.
+
 ## [0.17.0] - 2026-07-15
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -68,7 +68,7 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 
 | Option | Meaning |
 |--------|---------|
-| `--fields`, `-f` | `feature` only: the entity's fields as `Name:type,…`. Types: `string`, `int`, `long`, `decimal`, `double`, `bool`, `DateTime`, `Guid` (aliases like `text`/`number`/`money`/`date` too). A field is optional with a trailing `?` (`Note:string?`); strings get a default max length, overridable with `Name:string(100)`. An `Id` is added automatically. |
+| `--fields`, `-f` | `feature` only: the entity's fields as `Name:type,…`. Types: `string`, `int`, `long`, `decimal`, `double`, `bool`, `date` (→ `DateOnly`), `time` (→ `TimeOnly`), `datetime` (→ `DateTime`), `Guid` (aliases like `text`/`number`/`money` too). A field is optional with a trailing `?` (`Note:string?`); strings get a default max length, overridable with `Name:string(100)`. An `Id` is added automatically. |
 | `--id` | `feature` only: the entity's key type — `guid` (default), `int`, or `long`. |
 | `--modal` | `feature` only (implies `--bs`): create + update happen in a `BsModal` on the list page, instead of separate create/edit pages. |
 | `--bs` | `feature` only: render the pages with Rask.Bootstrap `Bs*` components (`BsCard`/`BsTable`/`BsButton`/`BsInput`/`BsCheck`/`BsIcon`) + `Bs.Join(...)` utility classes instead of raw core + Bootstrap class strings. |

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -548,6 +548,8 @@ internal static class FeatureGenerator
         "double" => second ? "2.5d" : "1.5d",
         "bool" => second ? "false" : "true",
         "DateTime" => second ? "new DateTime(2025, 6, 15)" : "new DateTime(2024, 1, 1)",
+        "DateOnly" => second ? "new DateOnly(2025, 6, 15)" : "new DateOnly(2024, 1, 1)",
+        "TimeOnly" => second ? "new TimeOnly(14, 45)" : "new TimeOnly(9, 30)",
         "Guid" => second ? "Guid.Parse(\"22222222-2222-2222-2222-222222222222\")" : "Guid.Parse(\"11111111-1111-1111-1111-111111111111\")",
         _ => "default",
     };

--- a/src/Rask.Cli/Scaffolding/FieldSpec.cs
+++ b/src/Rask.Cli/Scaffolding/FieldSpec.cs
@@ -42,7 +42,8 @@ internal static class FieldSpecParser
         ["bool"] = "bool",
         ["boolean"] = "bool",
         ["datetime"] = "DateTime",
-        ["date"] = "DateTime",
+        ["date"] = "DateOnly",
+        ["time"] = "TimeOnly",
         ["guid"] = "Guid",
     };
 

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -33,7 +33,9 @@ public sealed class FieldSpecParserTests
     [InlineData("text", "string")]
     [InlineData("number", "int")]
     [InlineData("money", "decimal")]
-    [InlineData("date", "DateTime")]
+    [InlineData("date", "DateOnly")]
+    [InlineData("time", "TimeOnly")]
+    [InlineData("datetime", "DateTime")]
     [InlineData("guid", "Guid")]
     public void Maps_type_aliases(string alias, string csType)
     {


### PR DESCRIPTION
Adds distinct `date`, `time`, and `datetime` field types to `rask generate feature --fields`:

- `date` → **`DateOnly`**, `time` → **`TimeOnly`**, `datetime` → **`DateTime`** (previously `date` aliased `DateTime`).
- The Rask form binder already parses `DateOnly`/`TimeOnly` and `Input` auto-derives `type="date"`/`type="time"`; EF Core maps them to SQLite. So no framework changes were needed — just the field-type mapping + sample values for the generated `--tests`.

## Verified
- A `Booking(Day:date, StartsAt:time, CreatedOn:datetime)` slice compiles `-warnaserror` in the EfCore sample, and its generated `--tests` pass (incl. the SQLite round-trip of `DateOnly`/`TimeOnly`/`DateTime`).
- **175 CLI unit tests** (added `time`/`datetime` alias cases; updated `date`→`DateOnly`).
- `docs/cli.md` + CHANGELOG updated.