### PR TITLE
chore(release): v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-15
+
 ### Added
 - **`BsDataGrid<T>` gained server-side paging/sorting and URL-owned state.** `Page`/`OnPageChange` and
   `Sort`+`SortDescending`/`OnSortChange` let the **caller** own the page and sort: the grid renders what it is


### PR DESCRIPTION
Promotes `[Unreleased]` to `## [0.17.0] - 2026-07-15` and opens a fresh empty `[Unreleased]`. No code changes — the tag is the version (MinVer).

## What ships in 0.17.0

Ten PRs since [v0.16.0](https://github.com/pal-tamas/rask/releases/tag/v0.16.0):

- **Two new packages** — `Rask.Data` (#373: `AggregateRoot` + EF Core interceptors) and `Rask.Outbox` (#378: package + generator + `generate feature --outbox`).
- **The CQRS/EF vertical-slice scaffolder** — `rask generate feature` reworked (#367) and grown: value objects + EF config + `--validation` modes (#368), plain-HTML default/`--bs`/`--modal` (#370), `--tests` + automatic package add (#371), base entity + `--soft-delete` (#375), `--concurrency` (#376), `--events` (#377).
- **`BsDataGrid<T>`** (#381) — server-side paging/sorting (an `IQueryable` as `Data`, or a fetched page + `TotalCount`), URL-owned `Page`/`Sort`, accessibility (`aria-sort`, `scope`, `aria-expanded`/`aria-controls`), a docs page with live demos, and four bug fixes. Closes #372.
- **Docs** — Rask positioned as "the .NET One Person Framework" (#374).

Minor bump: new features and packages, no breaking changes.

## Pre-flight

`dotnet format --verify-no-changes` clean · `dotnet build -warnaserror` **0 warnings** · full unit suite green across 28 projects.

Two pre-existing flakes surfaced while running all 28 projects in parallel on one machine — `Rask.SQLite`'s 500-writer concurrency stress test and `Rask.Outbox`'s processor-drain test. Each passes repeatedly in isolation and they failed on alternate runs, so they're load-sensitive, not regressions, and unrelated to this release's content. Worth a follow-up; if either flakes in `release.yml`, re-run the workflow.

## After merge

Tag `v0.17.0` on the squashed commit → `release.yml` runs the unit gate + sharded E2E, packs the eight NuGets and creates the GitHub release.