### PR TITLE
docs(sqlite): document SQLite's limitations, backed by tests

### DIFF
--- a/Rask.slnx
+++ b/Rask.slnx
@@ -70,6 +70,7 @@
         <Project Path="tests/Rask.Server.Tests/Rask.Server.Tests.csproj"/>
         <Project Path="tests/Rask.SQLite.Tests/Rask.SQLite.Tests.csproj"/>
         <Project Path="tests/Rask.SQLite.EntityFrameworkCore.Tests/Rask.SQLite.EntityFrameworkCore.Tests.csproj"/>
+        <Project Path="tests/Rask.SQLite.Limitations.Tests/Rask.SQLite.Limitations.Tests.csproj"/>
         <Project Path="tests/Rask.SQLite.Litestream.Tests/Rask.SQLite.Litestream.Tests.csproj"/>
         <Project Path="tests/Rask.SQLite.Snapshots.Tests/Rask.SQLite.Snapshots.Tests.csproj"/>
         <Project Path="tests/Rask.TestSupport/Rask.TestSupport.csproj"/>

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -334,6 +334,47 @@ already wraps:
 Keep SQLite behind the server (or on device with `Rask.Native`), and let the WASM client talk to it
 through an API or the browser storage APIs above.
 
+## Limitations & when to outgrow SQLite
+
+SQLite is a genuine production database for a single-server app — but it isn't a client-server database,
+and being honest about the boundaries is part of the pitch. Each of these is demonstrated by a test in
+[`tests/Rask.SQLite.Limitations.Tests`](../tests/Rask.SQLite.Limitations.Tests) so the behavior is pinned,
+not just asserted in prose.
+
+- **One writer at a time.** A write transaction holds the database's single write lock; WAL lets readers
+  keep reading *during* a write, but writes serialize. That's plenty for the vast majority of apps — but a
+  very write-heavy or highly-concurrent-write workload eventually hits this ceiling. A second
+  `BEGIN IMMEDIATE` while another is open gets `SQLITE_BUSY` (which the [transaction helpers](#transactions-begin-immediate--a-non-blocking-fair-interval-retry)
+  above wait out); there is no `SELECT … FOR UPDATE SKIP LOCKED`.
+- **One machine.** The database is a local file — you cannot scale *writes* across servers. Litestream is
+  continuous backup / disaster-recovery + read-replica restore, **not** multi-primary replication. Needing
+  several app servers that all write, or managed HA failover, is the boundary.
+- **Local disk only.** Never put the database on a network filesystem (NFS/CIFS/SMB) — SQLite's file
+  locking is unreliable there and can corrupt the file, and WAL needs real shared memory. Use local disk or
+  a single-attach block/named volume, one writer process.
+- **Dynamic typing.** SQLite uses *type affinity*, not strict types: it will happily store the text
+  `"lots"` in an `INTEGER` column. EF Core's model gives you type safety in C#, but the store itself won't
+  enforce it if something writes to it directly.
+- **No native `decimal` or `DateTimeOffset`.** Storage classes are `INTEGER`/`REAL`/`TEXT`/`BLOB`/`NULL`
+  only. To preserve precision, **EF Core stores a `decimal` as `TEXT`** (not `REAL`, which would round —
+  `0.1 + 0.2 ≠ 0.3`). The value round-trips exactly, but a TEXT column doesn't sort or aggregate
+  *numerically* in SQL, so server-side `ORDER BY` / `Sum` / `Average` on a decimal is unreliable (EF Core
+  warns). For money, store integer minor units instead (the EF Core sample's `Money` value object stores
+  cents) — it sorts and sums correctly. EF Core likewise maps `DateTime`/`DateOnly`/`TimeOnly`/`Guid` to
+  `TEXT` — mind text-sort ordering.
+- **Limited `ALTER TABLE`.** SQLite can add/rename/drop columns but not, say, change a column's type or
+  constraints in place — EF Core migrations rebuild the table (create → copy → drop → rename) for those,
+  which is slower and briefly locks the table.
+- **No server-side surface.** It's an in-process library, not a server: no network endpoint, no
+  users/roles/`GRANT`, no stored procedures, no `LISTEN/NOTIFY`. Access control and connection management
+  are the app's job.
+
+**Outgrowing it is cheap.** Because Rask's data layer is EF Core, moving to a client-server database
+(e.g. PostgreSQL) when you genuinely need multi-writer scale-out or managed HA is largely a provider +
+connection-string change — the [`Rask.Data`](data.md) aggregates, [`Rask.Cqrs`](cqrs.md) handlers, and the
+generated slices are provider-agnostic. SQLite gets you far enough that most single-person products never
+make the switch.
+
 ## Testing
 
 The pragmas are easy to assert against a real database file — open a connection through the factory

--- a/tests/Rask.SQLite.Limitations.Tests/Rask.SQLite.Limitations.Tests.csproj
+++ b/tests/Rask.SQLite.Limitations.Tests/Rask.SQLite.Limitations.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Rask.SQLite.Limitations.Tests/SqliteLimitationsTests.cs
+++ b/tests/Rask.SQLite.Limitations.Tests/SqliteLimitationsTests.cs
@@ -1,0 +1,132 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.SQLite.Limitations.Tests;
+
+public sealed class Price
+{
+    public int Id { get; set; }
+    public decimal Amount { get; set; }
+}
+
+public sealed class PriceContext(string dbPath) : DbContext
+{
+    public DbSet<Price> Prices => Set<Price>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder options) =>
+        options.UseSqlite($"Data Source={dbPath}");
+}
+
+// These tests PIN the SQLite limitations documented in docs/sqlite.md — they demonstrate the real
+// behavior (not Rask code), so the "when to outgrow SQLite" guidance stays honest and can't silently drift.
+public sealed class SqliteLimitationsTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-sqlite-limits-{Guid.NewGuid():N}.db");
+
+    private SqliteConnection Open()
+    {
+        var connection = new SqliteConnection($"Data Source={_dbPath}");
+        connection.Open();
+        return connection;
+    }
+
+    private static object? Scalar(SqliteConnection connection, string sql)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        return cmd.ExecuteScalar();
+    }
+
+    private static void Exec(SqliteConnection connection, string sql)
+    {
+        using var cmd = connection.CreateCommand();
+        cmd.CommandText = sql;
+        cmd.ExecuteNonQuery();
+    }
+
+    [Fact]
+    public void Dynamic_typing_a_text_value_fits_an_integer_column()
+    {
+        using var db = Open();
+        Exec(db, "CREATE TABLE n (x INTEGER);");
+        Exec(db, "INSERT INTO n (x) VALUES ('lots');"); // not enforced — affinity can't coerce it
+
+        Assert.Equal("lots", Scalar(db, "SELECT x FROM n"));
+        Assert.Equal("text", Scalar(db, "SELECT typeof(x) FROM n")); // stored as TEXT, no error
+    }
+
+    [Fact]
+    public void No_native_decimal_real_arithmetic_is_inexact()
+    {
+        using var db = Open();
+        // REAL money loses precision — the classic 0.1 + 0.2 != 0.3. (This is why EF Core avoids REAL.)
+        Assert.Equal(0L, Scalar(db, "SELECT (0.1 + 0.2 = 0.3)")); // false
+        Assert.NotEqual(0.3, Convert.ToDouble(Scalar(db, "SELECT 0.1 + 0.2")));
+    }
+
+    [Fact]
+    public void EF_Core_stores_decimal_as_text_to_keep_precision()
+    {
+        using (var ctx = new PriceContext(_dbPath))
+        {
+            ctx.Database.EnsureCreated();
+            ctx.Prices.Add(new Price { Amount = 19.95m });
+            ctx.SaveChanges();
+        }
+
+        // EF Core stores decimal as TEXT (not REAL), so the value round-trips exactly...
+        using var read = new PriceContext(_dbPath);
+        Assert.Equal(19.95m, read.Prices.Single().Amount);
+
+        // ...but the raw column is TEXT — numeric ORDER BY / SUM don't translate on it.
+        using var raw = Open();
+        Assert.Equal("text", Scalar(raw, "SELECT typeof(Amount) FROM Prices"));
+    }
+
+    [Fact]
+    public void DateTime_and_Guid_are_stored_as_text()
+    {
+        using var db = Open();
+        Exec(db, "CREATE TABLE e (d, g);");
+        using (var insert = db.CreateCommand())
+        {
+            insert.CommandText = "INSERT INTO e (d, g) VALUES ($d, $g)";
+            insert.Parameters.AddWithValue("$d", DateTime.UtcNow);
+            insert.Parameters.AddWithValue("$g", Guid.NewGuid());
+            insert.ExecuteNonQuery();
+        }
+
+        Assert.Equal("text", Scalar(db, "SELECT typeof(d) FROM e"));
+        Assert.Equal("text", Scalar(db, "SELECT typeof(g) FROM e"));
+    }
+
+    [Fact]
+    public void Single_writer_a_second_immediate_transaction_is_busy()
+    {
+        using var writer = Open();
+        Exec(writer, "PRAGMA busy_timeout = 0;");
+        Exec(writer, "CREATE TABLE t (x);");
+        Exec(writer, "BEGIN IMMEDIATE;"); // takes the write lock and holds it (no commit)
+
+        using var second = Open();
+        Exec(second, "PRAGMA busy_timeout = 0;");
+
+        using var begin = second.CreateCommand();
+        begin.CommandText = "BEGIN IMMEDIATE;";
+        begin.CommandTimeout = 1; // cap the driver's SQLITE_BUSY retry (0 would mean retry forever)
+
+        var ex = Assert.Throws<SqliteException>(() => begin.ExecuteNonQuery());
+        Assert.Equal(5, ex.SqliteErrorCode); // SQLITE_BUSY — writes serialize to one writer
+
+        Exec(writer, "ROLLBACK;");
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        if (File.Exists(_dbPath))
+        {
+            File.Delete(_dbPath);
+        }
+    }
+}


### PR DESCRIPTION
Adds an honest **"Limitations & when to outgrow SQLite"** section to `docs/sqlite.md` — important credibility for the SQLite-first, One-Person-Framework positioning — and **pins every claim with a test** so the guidance can't silently drift.

## Documented limitations
One writer at a time · one machine (Litestream is backup/DR, not multi-primary) · local-disk-only (no NFS/CIFS) · dynamic typing (type affinity) · **no native `decimal`/`DateTimeOffset`** (EF Core stores `decimal` + `DateTime`/`DateOnly`/`TimeOnly`/`Guid` as `TEXT` — exact round-trip, but no numeric `ORDER BY`/`SUM` in SQL, so integer minor units stay the money recommendation) · limited `ALTER TABLE` · no server-side surface (no users/roles/procs) · and the **cheap EF-Core exit** to a client-server DB.

## Tests — `tests/Rask.SQLite.Limitations.Tests` (5, green)
Raw `Microsoft.Data.Sqlite` + a tiny EF Core context:
- dynamic typing — text stored in an `INTEGER` column (`typeof = text`);
- `REAL` arithmetic is inexact (`0.1 + 0.2 != 0.3`);
- `DateTime`/`Guid` stored as `TEXT`;
- **EF Core stores `decimal` as `TEXT`** — round-trips `19.95` exactly, raw column `typeof = text`;
- a second `BEGIN IMMEDIATE` gets `SQLITE_BUSY` — writes serialize to one writer.