### PR TITLE
feat(cli): rask new generates the server template directly (no dotnet new)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **`rask new` generates the `server` template itself — no `dotnet new` / Rask.Templates.** The CLI is now the
+  scaffolding authority: `rask new <name>` writes the project's files directly, bakes the `Rask.*` package
+  references at the CLI's own version (falling back to the latest published stable for local/dev CLI builds),
+  and runs `dotnet restore` so the output builds immediately. Every feature-flag combination (`--auth`,
+  `--pwa`, `--cqrs`, `--docker`) is covered by a build-the-output test. The other templates (`wasm`,
+  `wasm-hosted`, `native`) still go through `dotnet new` until their generators land in follow-ups.
 - **`rask generate feature` takes its fields positionally.** Write
   `rask generate feature Product Name:string Price:decimal` instead of
   `--fields "Name:string,Price:decimal"`. The legacy `--fields` form still works (you just can't combine the

--- a/src/Rask.Cli/CliApplication.cs
+++ b/src/Rask.Cli/CliApplication.cs
@@ -23,7 +23,7 @@ internal sealed class CliApplication
     public static CliApplication CreateDefault(IConsole console, IProcessRunner process, IFileSystem fileSystem) =>
         new(console,
         [
-            new NewCommand(console, process),
+            new NewCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new DevCommand(console, process),
             new GenerateCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new InfoCommand(console, process),

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -1,18 +1,28 @@
+using Rask.Cli.Scaffolding;
 using Rask.Cli.Templates;
 
 namespace Rask.Cli.Commands;
 
 /// <summary>
-/// <c>rask new</c> — scaffold a Rask project. Resolves a friendly template name to its <c>dotnet new</c>
-/// short name, validates the requested feature flags against that template, ensures the Rask.Templates
-/// package is installed, then delegates to <c>dotnet new</c>.
+/// <c>rask new</c> — scaffold a Rask project. The CLI is the scaffolding authority: the <c>server</c> template
+/// is generated directly (files written + package refs baked at the CLI's own version + <c>dotnet restore</c>),
+/// with no <c>dotnet new</c> / Rask.Templates dependency. Templates not yet ported (<c>wasm</c>/<c>wasm-hosted</c>/
+/// <c>native</c>) still delegate to <c>dotnet new</c> until their generators land.
 /// </summary>
-internal sealed class NewCommand(IConsole console, IProcessRunner process) : CliCommand(console)
+internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
+    : CliCommand(console)
 {
+    private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IProcessRunner _process = process;
+    private readonly string _workingDirectory = workingDirectory;
 
     /// <summary>The opt-in feature flags <c>rask new</c> forwards to a template (as <c>--flag</c>).</summary>
     internal static readonly string[] FeatureFlags = ["auth", "pwa", "cqrs", "docker"];
+
+    // Latest published stable used when the running CLI's own version isn't a resolvable package (a dev/CI
+    // build stamps a prerelease like "0.17.1-alpha.0.5+sha" that isn't on NuGet). PR5's INuGetClient will
+    // resolve this live; until then a known-good stable keeps generated projects restorable.
+    private const string LatestStableFallback = "0.17.0";
 
     public override string Name => "new";
 
@@ -66,7 +76,70 @@ internal sealed class NewCommand(IConsole console, IProcessRunner process) : Cli
             return 1;
         }
 
-        var dotnetArgs = BuildDotnetNewArguments(template, name, parsed.Option("output"), requestedFlags);
+        // The server template is generated directly by the CLI. Other templates are ported incrementally;
+        // until then they still go through dotnet new + Rask.Templates.
+        if (template.Key == "server")
+        {
+            return await GenerateServerAsync(name, parsed.Option("output"), requestedFlags, cancellationToken).ConfigureAwait(false);
+        }
+
+        return await DelegateToDotnetNewAsync(template, name, parsed.Option("output"), requestedFlags, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task<int> GenerateServerAsync(string name, string? output, IReadOnlyList<string> flags, CancellationToken cancellationToken)
+    {
+        // rask new MyApp → ./MyApp/ ; --output overrides the destination directory.
+        var targetDirectory = Scaffold.TargetDirectory(_workingDirectory, output, name);
+        var csprojPath = Path.Combine(targetDirectory, name + ".csproj");
+        if (_fileSystem.FileExists(csprojPath))
+        {
+            Console.Error.WriteLine($"A project already exists at '{targetDirectory}' ({name}.csproj). Choose another name or --output.");
+            return 1;
+        }
+
+        var version = ResolvePackageVersion(CliMetadata.Version);
+        var result = ProjectGenerator.GenerateServer(
+            targetDirectory, name,
+            auth: flags.Contains("auth"),
+            pwa: flags.Contains("pwa"),
+            cqrs: flags.Contains("cqrs"),
+            docker: flags.Contains("docker"),
+            version);
+
+        Console.Out.WriteLine($"Creating Rask server app '{name}'…");
+        foreach (var file in result.Files)
+        {
+            var directory = Path.GetDirectoryName(file.Path);
+            if (!string.IsNullOrEmpty(directory))
+            {
+                _fileSystem.CreateDirectory(directory);
+            }
+
+            _fileSystem.WriteAllText(file.Path, file.Content);
+            Console.Out.WriteLine($"  + {Path.GetRelativePath(_workingDirectory, file.Path)}");
+        }
+
+        // Package refs are already baked into the csproj at the pinned version; restore pulls them so the
+        // project builds immediately. A restore failure is a warning — the files are written and correct.
+        var restore = await _process.RunAsync("dotnet", ["restore", csprojPath], targetDirectory, cancellationToken).ConfigureAwait(false);
+        if (restore != 0)
+        {
+            Console.Error.WriteLine("  Couldn't restore automatically — run 'dotnet restore' in the project directory.");
+        }
+
+        if (!string.IsNullOrEmpty(result.Notes))
+        {
+            Console.Out.WriteLine();
+            Console.Out.WriteLine(result.Notes);
+        }
+
+        return 0;
+    }
+
+    private async Task<int> DelegateToDotnetNewAsync(
+        TemplateInfo template, string name, string? output, IReadOnlyList<string> flags, CancellationToken cancellationToken)
+    {
+        var dotnetArgs = BuildDotnetNewArguments(template, name, output, flags);
 
         if (!await TemplateProbe.AreInstalledAsync(_process, cancellationToken).ConfigureAwait(false))
         {
@@ -82,6 +155,17 @@ internal sealed class NewCommand(IConsole console, IProcessRunner process) : Cli
         Console.Out.WriteLine($"Creating {template.DisplayName} '{name}'…");
         return await _process.RunAsync("dotnet", dotnetArgs, null, cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Resolve the package version to pin in a generated project: the CLI's own version when it's a published
+    /// stable, else the latest-stable fallback (a dev/CI prerelease isn't on NuGet). Pure — unit-tested directly.
+    /// </summary>
+    internal static string ResolvePackageVersion(string cliVersion) =>
+        !string.IsNullOrEmpty(cliVersion)
+        && !cliVersion.Contains('-', StringComparison.Ordinal)
+        && cliVersion != "0.0.0"
+            ? cliVersion
+            : LatestStableFallback;
 
     /// <summary>Build the <c>dotnet new</c> argument list. Pure and deterministic, so it is unit-tested directly.</summary>
     internal static IReadOnlyList<string> BuildDotnetNewArguments(

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.cs
@@ -1,0 +1,802 @@
+using System.Text;
+
+namespace Rask.Cli.Scaffolding;
+
+/// <summary>
+/// Generates a whole project directly (the CLI is the scaffolding authority — no <c>dotnet new</c> /
+/// Rask.Templates). Each template is hand-ported here: files are emitted with the placeholder namespace
+/// <c>Company.RaskServer</c> and a final pass rewrites it (and the csproj filename) to the app name, so the
+/// content reads exactly like the source template. Flag conditionals (<c>--auth</c>/<c>--pwa</c>/<c>--cqrs</c>/
+/// <c>--docker</c>) are generation logic, not <c>#if</c> markers. Package references are pinned to
+/// <paramref name="version"/> (the CLI's own version).
+/// </summary>
+internal static class ProjectGenerator
+{
+    private const string NameToken = "Company.RaskServer";
+
+    /// <summary>Generates the <c>server</c> template into <paramref name="targetDirectory"/>.</summary>
+    public static ScaffoldResult GenerateServer(string targetDirectory, string name, bool auth, bool pwa, bool cqrs, bool docker, string version)
+    {
+        var files = new List<(string Path, string Content)>
+        {
+            ($"{NameToken}.csproj", ServerCsproj(cqrs, version)),
+            ("Program.cs", ServerProgram(auth, pwa, cqrs)),
+            ("App.cs", ServerApp(cqrs)),
+            ("HomePage.cs", HomePage),
+            ("HomePage.css", HomePageCss),
+            ("Counter.cs", CounterCs),
+            ("Weather.cs", WeatherCs),
+            ("WeatherForecast.cs", WeatherForecastCs),
+            ("LocalWeatherForecastService.cs", LocalWeatherServiceCs),
+            ("Properties/launchSettings.json", LaunchSettings),
+            ("README.md", ServerReadme),
+            ("AGENTS.md", ServerAgents),
+        };
+
+        if (auth)
+        {
+            files.Add(("Auth/CredentialStore.cs", AuthCredentialStore));
+            files.Add(("Auth/LoginPage.cs", AuthLoginPage));
+            files.Add(("Auth/MembersPage.cs", AuthMembersPage));
+        }
+
+        if (cqrs)
+        {
+            files.Add(("Cqrs/GreetingQuery.cs", CqrsGreetingQuery));
+            files.Add(("Cqrs/GreetingPage.cs", CqrsGreetingPage));
+        }
+
+        if (pwa)
+        {
+            files.Add(("wwwroot/icon.svg", IconSvg));
+            files.Add(("wwwroot/offline.html", OfflineHtml));
+        }
+
+        if (docker)
+        {
+            files.Add(("Dockerfile", Dockerfile));
+            files.Add((".dockerignore", DockerIgnore));
+        }
+
+        // One replacement pass: the placeholder namespace + the csproj filename become the app name.
+        var scaffoldFiles = files.Select(f => new ScaffoldFile(
+            System.IO.Path.Combine(targetDirectory, f.Path.Replace(NameToken, name, StringComparison.Ordinal)),
+            f.Content.Replace(NameToken, name, StringComparison.Ordinal))).ToList();
+
+        var packages = new List<string> { "Rask.Server", "Rask.Bootstrap" };
+        if (cqrs)
+        {
+            packages.Add("Rask.Cqrs");
+        }
+
+        return new ScaffoldResult(scaffoldFiles, ServerNextSteps(name, docker)) { Packages = packages };
+    }
+
+    private static string ServerCsproj(bool cqrs, string version)
+    {
+        var cqrsRef = cqrs ? $"\n    <PackageReference Include=\"Rask.Cqrs\" Version=\"{version}\"/>" : "";
+        return $"""
+        <Project Sdk="Microsoft.NET.Sdk.Web">
+
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <ImplicitUsings>enable</ImplicitUsings>
+            <Nullable>enable</Nullable>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <PackageReference Include="Rask.Server" Version="{version}"/>
+            <PackageReference Include="Rask.Bootstrap" Version="{version}"/>{cqrsRef}
+          </ItemGroup>
+
+        </Project>
+
+        """;
+    }
+
+    private static string ServerProgram(bool auth, bool pwa, bool cqrs)
+    {
+        var sb = new StringBuilder();
+        sb.Append("using Company.RaskServer;\nusing Rask.Server;\n");
+        if (auth)
+        {
+            sb.Append("using Microsoft.AspNetCore.Authentication.Cookies;\n");
+        }
+
+        if (pwa)
+        {
+            sb.Append("using Rask.Core.Browser;\n");
+        }
+
+        if (cqrs)
+        {
+            sb.Append("using Rask.Cqrs;\n");
+        }
+
+        sb.Append("\nvar builder = WebApplication.CreateBuilder(args);\n\n");
+        sb.Append("builder.Services.AddRask();\n");
+        sb.Append("builder.Services.AddScoped<IWeatherForecastService, LocalWeatherForecastService>();\n");
+
+        if (cqrs)
+        {
+            sb.Append("""
+
+                // CQRS mediator: one call registers every IQueryHandler/ICommandHandler/INotificationHandler in
+                // this assembly (source-generated, reflection-free — trim/AOT-safe). Inject IDispatcher to send
+                // messages; add pipeline behaviors with o.AddOpenBehavior(...). See docs/cqrs.md.
+                builder.Services.AddRaskCqrs();
+
+                """.TrimStart('\n'));
+        }
+
+        if (pwa)
+        {
+            sb.Append("""
+
+                // Installable PWA: AddRaskPwa serves the manifest + service worker and emits the manifest link +
+                // SW registration into the server-rendered <head>. The app is installable and push-capable, but NOT
+                // an offline app (a Server app renders over a live WebSocket) — offline navigations show wwwroot/
+                // offline.html. To send Web Push from this app, add Rask.WebPush; see docs/pwa.md.
+                builder.Services.AddRaskPwa(new WebAppManifest
+                {
+                    Name = "Rask App",
+                    ShortName = "Rask App",
+                    ThemeColor = "#512BD4",
+                    BackgroundColor = "#faf9fe",
+                    Display = DisplayMode.Standalone,
+                    Icons = [new ManifestIcon("icon.svg", "any", "image/svg+xml", "any maskable")]
+                });
+
+                """.TrimStart('\n'));
+        }
+
+        if (auth)
+        {
+            sb.Append("""
+
+                // Cookie auth — Rask reads HttpContext.User; the sign-in handshake sets this cookie on redeem.
+                builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                    .AddCookie(o =>
+                    {
+                        o.Cookie.Name = "rask.auth";
+                        // Secure-by-default: never send the auth cookie over plain HTTP, and use SameSite=Lax so it
+                        // doesn't ride cross-site POSTs (CSRF). The dev launch profile runs on HTTPS so the cookie
+                        // is set in development too; if you must serve over plain HTTP, relax SecurePolicy.
+                        o.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                        // Fully qualified: the --pwa `using Rask.Core.Browser` also defines a SameSiteMode.
+                        o.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax;
+                        o.LoginPath = "/login";
+                        o.AccessDeniedPath = "/forbidden";
+                    });
+                builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
+
+                """.TrimStart('\n'));
+        }
+
+        sb.Append("""
+
+            var app = builder.Build();
+
+            // Transport security (applies whether or not auth is enabled): redirect HTTP→HTTPS, and in
+            // non-Development emit HSTS so browsers refuse plain-HTTP for the configured max-age.
+            if (!app.Environment.IsDevelopment())
+            {
+                app.UseHsts();
+            }
+
+            app.UseHttpsRedirection();
+
+            app.MapStaticAssets();
+
+            """.TrimStart('\n'));
+
+        if (auth)
+        {
+            sb.Append("// Must precede UseRask so HttpContext.User is populated on the GET and the WS upgrade.\n");
+            sb.Append("app.UseAuthentication();\n");
+            sb.Append("app.UseAuthorization();\n\n");
+        }
+
+        sb.Append("""
+            // To host this app under a sub-path (e.g. behind a reverse proxy mapping
+            // /myapp/* → this server), pass pathBase. Every framework endpoint and
+            // emitted URL is scoped under the prefix; user-space routes stay unprefixed.
+            //   app.UseRask<App>(pathBase: "/myapp");
+            app.UseRask<App>();
+
+            app.Run();
+
+            """.TrimStart('\n'));
+
+        return sb.ToString();
+    }
+
+    private static string ServerApp(bool cqrs)
+    {
+        var greetingNav = cqrs
+            ? """
+
+                            ,
+                            " | ",
+                            NavLink(GreetingPage())["Greeting"]
+                """.TrimEnd() + "\n"
+            : "";
+
+        return $$"""
+        using static Company.RaskServer.Routes;
+
+        namespace Company.RaskServer;
+
+        public sealed class App : Component
+        {
+            // App-level head contributions splice into the framework-managed <head>
+            // via the Component? Head override. Title is singleton — any page that
+            // overrides Head with its own Title supersedes this fallback for the tab.
+            protected override Component? Head => [
+                Title()["Company.RaskServer"],
+                Meta("utf-8"),
+                Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+                // Bootstrap 5.3 + Icons via Rask.Bootstrap (served from _content/Rask.Bootstrap).
+                BootstrapStyles()
+            ];
+
+            protected override Component? Render() =>
+                [
+                    Doctype(),
+                    Html("en")[
+                        Head(),
+                        Body()[
+                            Nav()[
+                                NavLink(HomePage())["Home"],
+                                " | ",
+                                NavLink(Counter())["Counter"],
+                                " | ",
+                                NavLink(Weather())["Weather"]{{greetingNav}}
+                            ],
+                            Hr(),
+                            Router()
+                        ]
+                    ]
+                ];
+        }
+
+        """;
+    }
+
+    private static string ServerNextSteps(string name, bool docker)
+    {
+        var steps = new StringBuilder();
+        steps.Append("Created ").Append(name).Append(" (Rask server app).\n\nNext steps:\n");
+        steps.Append("  cd ").Append(name).Append('\n');
+        steps.Append("  rask dev            # run with hot reload (or: dotnet run)\n");
+        if (docker)
+        {
+            steps.Append("  docker build -t ").Append(name.ToLowerInvariant()).Append(" .   # then: docker run -p 8080:8080 …\n");
+        }
+
+        return steps.ToString();
+    }
+
+    // ---- verbatim template files (namespace token Company.RaskServer replaced centrally) ----
+
+    private const string HomePage =
+        """
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        [Route("/")]
+        public sealed class HomePage : Component
+        {
+            protected override Component? Render() =>
+                Div(Class: "welcome-card")[
+                    H1(Class: "welcome-title")["Hello, Rask!"],
+                    P(Class: "welcome-lead")["Welcome to your new app."],
+                    P(Class: "welcome-hint")[
+                        "This card is styled by a sibling ",
+                        Code()["HomePage.css"],
+                        " file — selectors are auto-scoped to this component."
+                    ]
+                ];
+        }
+
+        """;
+
+    private const string HomePageCss =
+        """
+        .welcome-card {
+            max-width: 540px;
+            margin: 3rem auto;
+            padding: 1.75rem 2rem;
+            border: 1px solid #e1e4e8;
+            border-radius: 10px;
+            background: linear-gradient(180deg, #ffffff 0%, #f9fafb 100%);
+            box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04), 0 6px 18px rgba(0, 0, 0, 0.06);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+
+        .welcome-title {
+            margin: 0 0 0.5rem;
+            font-size: 1.75rem;
+            color: #1f2937;
+        }
+
+        .welcome-lead {
+            margin: 0 0 1rem;
+            font-size: 1.05rem;
+            color: #374151;
+        }
+
+        .welcome-hint {
+            margin: 0;
+            font-size: 0.9rem;
+            color: #6b7280;
+        }
+
+        .welcome-hint code {
+            background: #f3f4f6;
+            padding: 0.1rem 0.35rem;
+            border-radius: 4px;
+            font-size: 0.85em;
+            color: #1f2937;
+        }
+
+        """;
+
+    private const string CounterCs =
+        """
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        [Route("/counter")]
+        public sealed class Counter : Component
+        {
+            private int _count;
+
+            protected override Component? Render() =>
+                [
+                    H1()["Counter"],
+                    P()[$"Current count: {_count}"],
+                    BsButton(Color: BsColor.Primary,
+                        OnClick: () => _count++)["Click me"]
+                ];
+        }
+
+        """;
+
+    private const string WeatherCs =
+        """
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        [Route("/weather")]
+        public sealed class Weather(IWeatherForecastService service) : Component
+        {
+            private WeatherForecast[]? _forecasts;
+
+            protected override async Task OnMountAsync() =>
+                _forecasts = await service.GetForecastsAsync(CancellationToken);
+
+            protected override Component? Render() =>
+                [
+                    H1()["Weather"],
+                    P()["This component demonstrates showing async data."],
+                    _forecasts is null
+                        ? P()[Em()["Loading..."]]
+                        : Table()[
+                            Thead()[
+                                Tr()[
+                                    Th()["Date"],
+                                    Th()["Temp. (C)"],
+                                    Th()["Temp. (F)"],
+                                    Th()["Summary"]
+                                ]
+                            ],
+                            Tbody()[_forecasts.Select(f => Tr(Key: f.Date)[
+                                Td()[f.Date.ToString("yyyy-MM-dd")],
+                                Td()[f.TemperatureC],
+                                Td()[f.TemperatureF],
+                                Td()[f.Summary ?? ""]
+                            ]).ToArray()]
+                        ]
+                ];
+        }
+
+        """;
+
+    private const string WeatherForecastCs =
+        """
+        namespace Company.RaskServer;
+
+        public sealed record WeatherForecast(DateOnly Date, int TemperatureC, string? Summary)
+        {
+            public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+        }
+
+        public interface IWeatherForecastService
+        {
+            Task<WeatherForecast[]> GetForecastsAsync(CancellationToken cancellationToken = default);
+        }
+
+        """;
+
+    private const string LocalWeatherServiceCs =
+        """
+        namespace Company.RaskServer;
+
+        public sealed class LocalWeatherForecastService : IWeatherForecastService
+        {
+            private static readonly string[] Summaries =
+                ["Freezing", "Bracing", "Chilly", "Cool", "Mild", "Warm", "Balmy", "Hot", "Sweltering", "Scorching"];
+
+            public async Task<WeatherForecast[]> GetForecastsAsync(CancellationToken cancellationToken = default)
+            {
+                await Task.Delay(500, cancellationToken);
+                var startDate = DateOnly.FromDateTime(DateTime.Now);
+                var rng = Random.Shared;
+                return Enumerable.Range(1, 5).Select(i => new WeatherForecast(
+                    startDate.AddDays(i),
+                    rng.Next(-20, 55),
+                    Summaries[rng.Next(Summaries.Length)]
+                )).ToArray();
+            }
+        }
+
+        """;
+
+    private const string LaunchSettings =
+        """
+        {
+          "profiles": {
+            "Company.RaskServer": {
+              "commandName": "Project",
+              "launchBrowser": true,
+              "applicationUrl": "https://localhost:5001;http://localhost:5000",
+              "environmentVariables": {
+                "ASPNETCORE_ENVIRONMENT": "Development"
+              }
+            }
+          }
+        }
+
+        """;
+
+    private const string AuthCredentialStore =
+        """
+        using System.Security.Claims;
+
+        namespace Company.RaskServer;
+
+        // Demo credential store — replace with your real user store (ASP.NET Identity, a database, etc.).
+        public interface ICredentialStore
+        {
+            IReadOnlyList<Claim>? Validate(string username, string password);
+        }
+
+        public sealed class DemoCredentialStore : ICredentialStore
+        {
+            public IReadOnlyList<Claim>? Validate(string username, string password) =>
+                (username, password) switch
+                {
+                    ("alice", "password") => [new Claim(ClaimTypes.Name, "alice"), new Claim(ClaimTypes.Role, "user")],
+                    ("root", "password") => [new Claim(ClaimTypes.Name, "root"), new Claim(ClaimTypes.Role, "admin")],
+                    _ => null
+                };
+        }
+
+        public sealed class LoginModel
+        {
+            public string Username { get; set; } = "";
+            public string Password { get; set; } = "";
+        }
+
+        """;
+
+    private const string AuthLoginPage =
+        """
+        using System.Security.Claims;
+        using Microsoft.AspNetCore.Authentication.Cookies;
+        using Microsoft.AspNetCore.Authorization;
+        using Rask.Core.Authentication;
+        using Rask.Core.Components;
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        [Route("login")]
+        [AllowAnonymous]
+        public sealed class LoginPage(IAuthSignIn auth, ICredentialStore creds) : Component
+        {
+            private readonly LoginModel _model = new();
+            private string? _error;
+
+            [QueryParam] public string? ReturnUrl { get; set; }
+
+            protected override Component? Render() =>
+                Div(Class: "welcome-card")[
+                    H1()["Sign in"],
+                    _error is null ? null : Div(Style: "color:#b00020")[_error],
+                    // Async submit uses the generated OnValidSubmitAsync sibling (like Button's OnClickAsync).
+                    Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                        Div()[Label("username")["Username"], Input(() => _model.Username, Id: "username")],
+                        Div()[Label("password")["Password"], Input(() => _model.Password, Id: "password", Type: InputType.Password)],
+                        Button("submit")["Sign in"]
+                    ],
+                    P()["Try alice / password (user) or root / password (admin)."]
+                ];
+
+            private async Task SubmitAsync(LoginModel m)
+            {
+                var claims = creds.Validate(m.Username, m.Password);
+                if (claims is null)
+                {
+                    _error = "Invalid username or password.";
+                    return;
+                }
+
+                var identity = new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme);
+                await auth.SignInAsync(new ClaimsPrincipal(identity), returnUrl: ReturnUrl ?? "/members");
+            }
+        }
+
+        """;
+
+    private const string AuthMembersPage =
+        """
+        using Microsoft.AspNetCore.Authorization;
+        using Rask.Core.Authentication;
+        using Rask.Core.Components;
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        // [Authorize] blocks anonymous deep-links (full GET → 302 to /login). The Authorize component gates the
+        // content and re-renders when the post-sign-in reconnect re-seeds the principal; the signed-in view lives
+        // in its own component that injects IUserProvider, so it reads the freshly-authenticated principal — no
+        // manual Changed subscription.
+        [Route("members")]
+        [Authorize]
+        public sealed class MembersPage : Component
+        {
+            protected override Component? Render() =>
+                Div(Class: "welcome-card")[
+                    Authorize(
+                        NotAuthorized: P()["Please ", NavLink(Href: Routes.LoginPage())["sign in"], "."])[MemberContent()]
+                ];
+        }
+
+        public sealed class MemberContent(IAuthSignIn auth, IUserProvider userProvider) : Component
+        {
+            protected override Component? Render() =>
+                [
+                    H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
+                    Authorize(Roles: ["admin"])[
+                        Div(Style: "color:#7a5c00")["🔑 You have admin access."]],
+                    Button(OnClickAsync: () => auth.SignOutAsync(returnUrl: "/login"))["Sign out"]
+                ];
+        }
+
+        """;
+
+    private const string CqrsGreetingQuery =
+        """
+        using Rask.Cqrs;
+
+        namespace Company.RaskServer;
+
+        // A CQRS query and its handler. Rask.Cqrs discovers the handler at build time (source-generated,
+        // reflection-free) so a single AddRaskCqrs() in Program.cs registers it — no manual wiring here.
+        // Dispatch it with IDispatcher.DispatchAsync(new GreetingQuery(...)); the result type is inferred
+        // from IQuery<string>. Add more IQuery<T>/ICommand/ICommand<T> messages the same way. See docs/cqrs.md.
+        public sealed record GreetingQuery(string Name) : IQuery<string>;
+
+        public sealed class GreetingQueryHandler : IQueryHandler<GreetingQuery, string>
+        {
+            public Task<string> HandleAsync(GreetingQuery query, CancellationToken cancellationToken)
+            {
+                var name = string.IsNullOrWhiteSpace(query.Name) ? "world" : query.Name.Trim();
+                return Task.FromResult($"Hello, {name}!");
+            }
+        }
+
+        """;
+
+    private const string CqrsGreetingPage =
+        """
+        using Rask.Cqrs;
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        // Injects the umbrella IDispatcher and dispatches GreetingQuery — on mount, and again on each button
+        // click. The awaited dispatch re-renders this component automatically, so there's no StateHasChanged()
+        // by hand. This is the whole CQRS round-trip: a page sends a message, a handler (in
+        // Cqrs/GreetingQuery.cs) answers it, decoupled from the UI. See docs/cqrs.md.
+        [Route("/greeting")]
+        public sealed class GreetingPage(IDispatcher dispatcher) : Component
+        {
+            private static readonly string[] Names = ["world", "Ada", "Grace", "Linus"];
+            private int _index;
+            private string _greeting = "";
+
+            protected override async Task OnMountAsync() =>
+                _greeting = await dispatcher.DispatchAsync(new GreetingQuery(Names[_index]), CancellationToken);
+
+            private async Task GreetNextAsync()
+            {
+                _index = (_index + 1) % Names.Length;
+                _greeting = await dispatcher.DispatchAsync(new GreetingQuery(Names[_index]), CancellationToken);
+            }
+
+            protected override Component? Render() =>
+                [
+                    H1()["CQRS greeting"],
+                    P()["Each click dispatches a GreetingQuery through the mediator; a handler answers it."],
+                    P(Id: "greeting", Class: "fs-4 fw-semibold")[_greeting],
+                    BsButton(Color: BsColor.Primary, OnClickAsync: GreetNextAsync)["Greet the next name"]
+                ];
+        }
+
+        """;
+
+    private const string Dockerfile =
+        """
+        # Multi-stage build: compile on the .NET SDK image, run on the smaller aspnet runtime.
+        # The aspnet:10.0 image already runs as a non-root user and listens on port 8080
+        # (ASPNETCORE_HTTP_PORTS=8080) — no extra hardening needed for a basic deploy.
+        FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+        WORKDIR /src
+
+        # Restore first (cached layer): only the csproj invalidates it, so code edits reuse the cache.
+        COPY ["Company.RaskServer.csproj", "./"]
+        RUN dotnet restore
+        COPY . .
+        RUN dotnet publish "Company.RaskServer.csproj" -c Release -o /app --no-restore
+
+        FROM mcr.microsoft.com/dotnet/aspnet:10.0
+        WORKDIR /app
+        COPY --from=build /app .
+        EXPOSE 8080
+        # The app calls UseHttpsRedirection(); inside the container no HTTPS port is configured,
+        # so it no-ops. Terminate TLS at your reverse proxy / ingress and forward plain HTTP to 8080.
+        ENTRYPOINT ["dotnet", "Company.RaskServer.dll"]
+
+        """;
+
+    private const string DockerIgnore =
+        """
+        # Keep the build context small and reproducible — the image restores/publishes from source.
+        bin/
+        obj/
+        .git/
+        .gitignore
+        .vs/
+        .vscode/
+        .idea/
+        *.user
+        **/.DS_Store
+        Dockerfile
+        .dockerignore
+
+        """;
+
+    private const string IconSvg =
+        """
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+          <defs>
+            <linearGradient id="g" x1="0" y1="0" x2="1" y2="1">
+              <stop offset="0" stop-color="#7C3AED"/>
+              <stop offset="1" stop-color="#512BD4"/>
+            </linearGradient>
+          </defs>
+          <!-- Maskable safe zone: keep the glyph within the central 80%. Full-bleed background. -->
+          <rect width="512" height="512" fill="#faf9fe"/>
+          <rect x="56" y="56" width="400" height="400" rx="88" fill="url(#g)"/>
+          <path d="M300 120 L196 248 L256 248 L240 392 L356 236 L292 236 Z" fill="#ffffff"/>
+        </svg>
+
+        """;
+
+    private const string OfflineHtml =
+        """
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1">
+            <title>Offline</title>
+            <style>
+                :root { color-scheme: light dark; }
+                body {
+                    margin: 0; min-height: 100vh; display: grid; place-items: center;
+                    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+                    background: #faf9fe; color: #1c1c28; text-align: center; padding: 1.5rem;
+                }
+                @media (prefers-color-scheme: dark) { body { background: #14131c; color: #e8e7f0; } }
+                h1 { font-size: 1.5rem; margin: 0 0 .5rem; }
+                p { color: #6c6a7d; line-height: 1.5; margin: 0 0 1.25rem; max-width: 28rem; }
+                button { font: inherit; padding: .5rem 1.25rem; border: 0; border-radius: .5rem; background: #512BD4; color: #fff; cursor: pointer; }
+            </style>
+        </head>
+        <body>
+            <div>
+                <h1>You're offline</h1>
+                <p>This is a Rask Server app — its live UI runs over a WebSocket, so it needs a connection. Reconnect and you'll pick up where you left off.</p>
+                <button onclick="location.reload()">Try again</button>
+            </div>
+        </body>
+        </html>
+
+        """;
+
+    private const string ServerReadme =
+        """
+        # Company.RaskServer
+
+        A server-side [Rask](https://github.com/pal-tamas/rask) app. The browser holds a thin
+        client; renders and events flow over a WebSocket and Rask ships a minimal diff per update.
+
+        > Scaffolded with `rask new` — Rask is the .NET One Person Framework.
+        > For a client-side WebAssembly app instead, use `rask new --template wasm` (or `wasm-hosted`).
+
+        ## Run
+
+        ```bash
+        rask dev        # hot reload (or: dotnet run)
+        ```
+
+        Then open the printed URL.
+
+        ## Layout
+
+        - `Program.cs` — host wiring: `AddRask()` + `UseRask<App>()`.
+        - `App.cs` — the root component; renders the full page shell (`Doctype`/`Html`/`Head`/`Body`).
+        - `HomePage.cs` (+ `HomePage.css`) — a routed page with co-located scoped styles.
+        - `Counter.cs` — an interactive component.
+        - `Weather.cs` / `LocalWeatherForecastService.cs` — data via DI.
+
+        Add a full CRUD feature in one command: `rask generate feature Product --fields "Name:string,Price:decimal"`.
+
+        Next steps: the [Rask docs](https://github.com/pal-tamas/rask/tree/main/docs).
+
+        """;
+
+    private const string ServerAgents =
+        """
+        # AGENTS.md — building this app with an AI assistant
+
+        This is a **Rask** app. Rask is the .NET One Person Framework (a full-stack C# framework for .NET 10). This
+        file tells AI coding assistants the conventions so generated code compiles and runs. Full docs:
+        https://github.com/pal-tamas/rask/tree/main/docs
+
+        ## Mental model
+        - Components are **plain C# classes** deriving from `Component`. Override `Component? Render()`
+          and return a tree of HTML built with **generated factory methods** — no `.razor`, no JSX.
+        - The **same component code** runs server-rendered (live diff over WebSockets) or on WASM.
+
+        ## The rules that matter
+        - **Use factories, never `new`** for components: `Div(...)`, `Button(OnClick: ...)`. `new` outside the
+          framework is a compile error (RASK014).
+        - **Children go through the indexer**, not a constructor arg: `Div()[Span()["hi"], "text"]`. A bare
+          `string` becomes a text node; pass a list directly for collections: `Ul()[items]`. `..` spread does not work.
+        - **Props are factory parameters.** A nullable prop is optional; a non-nullable prop with no initializer is
+          **required**. Inject services through the **constructor**, not settable properties.
+        - **A page/root component renders the full shell**: `[Doctype(), Html(...)[Head(...), Body(...)]]` (RASK021).
+          The framework injects its runtime `<script>` automatically.
+        - **Text vs raw:** a bare string / `Text("..")` HTML-encodes; `Raw("..")` is verbatim (XSS risk).
+        - Route with `[Route("/users/{id:int}")]` + `[RouteParam]`/`[QueryParam]`. Lifecycle: `OnMount*`,
+          `OnPropsChanged*`, `OnRendered`, `OnUnmount*`. Navigate from event handlers via injected `Navigator`.
+
+        ## Scaffolding — use the `rask` CLI
+        - `rask generate page <Name>` / `rask generate component <Name>` scaffold a routed page / a component.
+        - `rask generate feature <Name> --fields "..."` emits a full CQRS + EF Core CRUD vertical slice (entity,
+          value objects, validation, list/create/edit pages, tests). Flags: `--bs`, `--modal`, `--soft-delete`,
+          `--concurrency`, `--events`, `--outbox`, `--tests`. See docs/cli.md.
+        - `rask dev` runs the app with hot reload; `rask new` scaffolds a project.
+
+        If you hit a `RASKxxx` compile error, see https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md
+
+        """;
+}

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -5,7 +5,7 @@ namespace Rask.Cli.Tests;
 
 public sealed class NewCommandTests
 {
-    private const string Installed = "These templates matched: rask-server, rask-wasm…";
+    private const string WorkingDirectory = "/proj";
 
     [Fact]
     public void BuildDotnetNewArguments_composes_name_output_and_flags()
@@ -29,39 +29,78 @@ public sealed class NewCommandTests
         Assert.Equal(["new", "rask-wasm", "--name", "Spa"], args);
     }
 
+    [Theory]
+    [InlineData("0.17.0", "0.17.0")]      // a published stable pins exactly
+    [InlineData("1.2.3", "1.2.3")]
+    [InlineData("0.18.0-alpha.0.5", "0.17.0")] // a dev/CI prerelease isn't on NuGet → fall back
+    [InlineData("0.0.0", "0.17.0")]       // the no-version sentinel → fall back
+    [InlineData("", "0.17.0")]
+    public void ResolvePackageVersion_falls_back_for_unpublishable_versions(string cliVersion, string expected) =>
+        Assert.Equal(expected, NewCommand.ResolvePackageVersion(cliVersion));
+
     [Fact]
-    public async Task Runs_dotnet_new_with_the_resolved_template_when_templates_installed()
+    public async Task Server_template_is_generated_directly_without_dotnet_new()
     {
-        var (console, runner, command) = Build();
-        runner.CaptureResult = new ProcessResult(0, Installed, string.Empty);
+        var (console, fs, runner, command) = Build();
 
         var exit = await command.ExecuteAsync(["MyApp", "--template", "server", "--auth"], CancellationToken.None);
 
         Assert.Equal(0, exit);
-        // No install step: only the create ran.
+        Assert.Empty(console.ErrorText);
+        // Files are written directly under ./MyApp.
+        Assert.True(fs.FileExists("/proj/MyApp/MyApp.csproj"));
+        Assert.True(fs.FileExists("/proj/MyApp/Program.cs"));
+        Assert.True(fs.FileExists("/proj/MyApp/Auth/CredentialStore.cs")); // --auth
+        // It restores, and never shells to `dotnet new` / installs Rask.Templates.
+        Assert.Contains(runner.Invocations, i => i.Arguments.Contains("restore"));
+        Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("new"));
+    }
+
+    [Fact]
+    public async Task Server_generation_refuses_to_overwrite_an_existing_project()
+    {
+        var (console, fs, runner, command) = Build();
+        fs.Seed("/proj/MyApp/MyApp.csproj", "<Project/>");
+
+        var exit = await command.ExecuteAsync(["MyApp"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("already exists", console.ErrorText, StringComparison.Ordinal);
+        Assert.Empty(runner.Invocations);
+    }
+
+    [Fact]
+    public async Task Non_ported_template_still_delegates_to_dotnet_new_when_installed()
+    {
+        var (console, _, runner, command) = Build();
+        runner.CaptureResult = new ProcessResult(0, "These templates matched: rask-server, rask-wasm…", string.Empty);
+
+        var exit = await command.ExecuteAsync(["Spa", "--template", "wasm"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
         Assert.DoesNotContain(runner.Invocations, i => !i.Captured && i.Arguments.Contains("install"));
-        Assert.Equal(["new", "rask-server", "--name", "MyApp", "--auth"], runner.LastRun!.Arguments);
+        Assert.Equal(["new", "rask-wasm", "--name", "Spa"], runner.LastRun!.Arguments);
         Assert.Empty(console.ErrorText);
     }
 
     [Fact]
-    public async Task Installs_templates_first_when_missing()
+    public async Task Non_ported_template_installs_templates_first_when_missing()
     {
-        var (_, runner, command) = Build();
+        var (_, _, runner, command) = Build();
         runner.CaptureResult = new ProcessResult(0, "No templates installed.", string.Empty);
 
-        var exit = await command.ExecuteAsync(["MyApp"], CancellationToken.None);
+        var exit = await command.ExecuteAsync(["Spa", "--template", "wasm"], CancellationToken.None);
 
         Assert.Equal(0, exit);
         var runs = runner.Invocations.Where(i => !i.Captured).ToArray();
         Assert.Equal(["new", "install", "Rask.Templates"], runs[0].Arguments);
-        Assert.Equal(["new", "rask-server", "--name", "MyApp"], runs[1].Arguments);
+        Assert.Equal(["new", "rask-wasm", "--name", "Spa"], runs[1].Arguments);
     }
 
     [Fact]
     public async Task Missing_name_fails_without_running_dotnet()
     {
-        var (console, runner, command) = Build();
+        var (console, _, runner, command) = Build();
 
         var exit = await command.ExecuteAsync([], CancellationToken.None);
 
@@ -73,7 +112,7 @@ public sealed class NewCommandTests
     [Fact]
     public async Task Unknown_template_fails()
     {
-        var (console, runner, command) = Build();
+        var (console, _, runner, command) = Build();
 
         var exit = await command.ExecuteAsync(["MyApp", "--template", "svelte"], CancellationToken.None);
 
@@ -85,7 +124,7 @@ public sealed class NewCommandTests
     [Fact]
     public async Task Unsupported_flag_for_template_fails_with_guidance()
     {
-        var (console, runner, command) = Build();
+        var (console, _, runner, command) = Build();
 
         var exit = await command.ExecuteAsync(["MyApp", "--template", "wasm", "--cqrs"], CancellationToken.None);
 
@@ -97,7 +136,7 @@ public sealed class NewCommandTests
     [Fact]
     public async Task Unknown_option_fails()
     {
-        var (console, runner, command) = Build();
+        var (console, _, runner, command) = Build();
 
         var exit = await command.ExecuteAsync(["MyApp", "--frobnicate"], CancellationToken.None);
 
@@ -106,10 +145,11 @@ public sealed class NewCommandTests
         Assert.Contains("--frobnicate", console.ErrorText, StringComparison.Ordinal);
     }
 
-    private static (StringConsole Console, FakeProcessRunner Runner, NewCommand Command) Build()
+    private static (StringConsole Console, FakeFileSystem Fs, FakeProcessRunner Runner, NewCommand Command) Build()
     {
         var console = new StringConsole();
+        var fs = new FakeFileSystem();
         var runner = new FakeProcessRunner();
-        return (console, runner, new NewCommand(console, runner));
+        return (console, fs, runner, new NewCommand(console, fs, runner, WorkingDirectory));
     }
 }

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -1,0 +1,102 @@
+using System.Diagnostics;
+using Rask.Cli.Commands;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// The build-the-output gate: generate every build-affecting flag combination and prove it actually compiles
+/// against the published Rask packages. This restores from NuGet and runs the full C# build, so it's opt-in —
+/// set <c>RASK_CLI_BUILD_E2E=1</c> to run it (matches the repo's "tests run locally, not in CI" model). The
+/// exhaustive file/shape assertions live in <see cref="ProjectGeneratorTests"/> and always run.
+/// </summary>
+public sealed class ProjectGeneratorBuildE2ETests
+{
+    // docker doesn't affect the build (just adds Dockerfile/.dockerignore), so the 3 build-relevant flags
+    // give 2³ = 8 combinations — every scenario, per the "test every scenario" directive.
+    public static IEnumerable<object[]> BuildAffectingCombinations()
+    {
+        for (var mask = 0; mask < 8; mask++)
+        {
+            yield return [(mask & 1) != 0, (mask & 2) != 0, (mask & 4) != 0];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BuildAffectingCombinations))]
+    public async Task Generated_server_project_builds(bool auth, bool pwa, bool cqrs)
+    {
+        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        {
+            return; // opt-in: this restores + builds, needing the SDK and network.
+        }
+
+        var name = $"E2E{(auth ? "A" : "")}{(pwa ? "P" : "")}{(cqrs ? "Q" : "")}";
+        if (name == "E2E")
+        {
+            name = "E2ENone";
+        }
+
+        var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(temp, name);
+        try
+        {
+            // Pin the latest published stable so restore resolves (the running test build is a prerelease).
+            var version = NewCommand.ResolvePackageVersion(cliVersion: "0.0.0");
+            var result = ProjectGenerator.GenerateServer(projectDir, name, auth, pwa, cqrs, docker: false, version);
+
+            var fs = new SystemFileSystem();
+            foreach (var file in result.Files)
+            {
+                fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                fs.WriteAllText(file.Path, file.Content);
+            }
+
+            var exit = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa},cqrs={cqrs}] generated project failed to build.");
+        }
+        finally
+        {
+            TryDeleteDirectory(temp);
+        }
+    }
+
+    private static async Task<int> RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["CI"] = "true";
+
+        using var process = Process.Start(psi)!;
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        if (process.ExitCode != 0)
+        {
+            Console.Error.WriteLine(stdout);
+            Console.Error.WriteLine(stderr);
+        }
+
+        return process.ExitCode;
+    }
+
+    private static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort temp cleanup
+        }
+    }
+}

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -1,0 +1,169 @@
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+public sealed class ProjectGeneratorTests
+{
+    private const string Root = "/proj/App";
+    private const string Version = "9.9.9";
+
+    // Files the server template always emits, whatever the flags.
+    private static readonly string[] AlwaysPresent =
+    [
+        "App.csproj", "Program.cs", "App.cs", "HomePage.cs", "HomePage.css", "Counter.cs",
+        "Weather.cs", "WeatherForecast.cs", "LocalWeatherForecastService.cs",
+        "Properties/launchSettings.json", "README.md", "AGENTS.md",
+    ];
+
+    [Fact]
+    public void Base_project_emits_the_core_files_and_packages_with_no_flags()
+    {
+        var (files, result) = Generate();
+
+        foreach (var expected in AlwaysPresent)
+        {
+            Assert.True(files.ContainsKey(expected), $"expected {expected} to be generated");
+        }
+
+        Assert.Equal(["Rask.Server", "Rask.Bootstrap"], result.Packages);
+        // No opt-in artifacts leak in.
+        Assert.DoesNotContain("Auth/CredentialStore.cs", files.Keys);
+        Assert.DoesNotContain("Cqrs/GreetingQuery.cs", files.Keys);
+        Assert.DoesNotContain("Dockerfile", files.Keys);
+        Assert.DoesNotContain("wwwroot/icon.svg", files.Keys);
+    }
+
+    [Fact]
+    public void Project_name_replaces_the_placeholder_namespace_everywhere()
+    {
+        var (files, _) = Generate(auth: true, pwa: true, cqrs: true, docker: true);
+
+        // The csproj is renamed to the project, and nothing retains the placeholder.
+        Assert.True(files.ContainsKey("App.csproj"));
+        foreach (var (path, content) in files)
+        {
+            Assert.DoesNotContain("Company.RaskServer", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("Company.RaskServer", path, StringComparison.Ordinal);
+        }
+
+        // Program.cs uses top-level statements (no namespace) but references the app namespace.
+        Assert.Contains("using App;", files["Program.cs"], StringComparison.Ordinal);
+        Assert.Contains("namespace App;", files["HomePage.cs"], StringComparison.Ordinal);
+        Assert.Contains("namespace App;", files["App.cs"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Csproj_pins_every_package_to_the_supplied_version()
+    {
+        var (files, _) = Generate(cqrs: true);
+        var csproj = files["App.csproj"];
+
+        Assert.Contains("<PackageReference Include=\"Rask.Server\" Version=\"9.9.9\"/>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"Rask.Bootstrap\" Version=\"9.9.9\"/>", csproj, StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"Rask.Cqrs\" Version=\"9.9.9\"/>", csproj, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Auth_flag_toggles_the_auth_files_and_wiring()
+    {
+        var (on, _) = Generate(auth: true);
+        Assert.True(on.ContainsKey("Auth/CredentialStore.cs"));
+        Assert.True(on.ContainsKey("Auth/LoginPage.cs"));
+        Assert.True(on.ContainsKey("Auth/MembersPage.cs"));
+        Assert.Contains("AddAuthentication", on["Program.cs"], StringComparison.Ordinal);
+
+        var (off, _) = Generate(auth: false);
+        Assert.DoesNotContain("Auth/CredentialStore.cs", off.Keys);
+        Assert.DoesNotContain("AddAuthentication", off["Program.cs"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Pwa_flag_toggles_the_manifest_assets_and_wiring()
+    {
+        var (on, _) = Generate(pwa: true);
+        Assert.True(on.ContainsKey("wwwroot/icon.svg"));
+        Assert.True(on.ContainsKey("wwwroot/offline.html"));
+        Assert.Contains("AddRaskPwa", on["Program.cs"], StringComparison.Ordinal);
+
+        var (off, _) = Generate(pwa: false);
+        Assert.DoesNotContain("wwwroot/icon.svg", off.Keys);
+        Assert.DoesNotContain("AddRaskPwa", off["Program.cs"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Cqrs_flag_toggles_files_wiring_package_and_nav()
+    {
+        var (on, onResult) = Generate(cqrs: true);
+        Assert.True(on.ContainsKey("Cqrs/GreetingQuery.cs"));
+        Assert.True(on.ContainsKey("Cqrs/GreetingPage.cs"));
+        Assert.Contains("AddRaskCqrs", on["Program.cs"], StringComparison.Ordinal);
+        Assert.Contains("Rask.Cqrs", onResult.Packages);
+        Assert.Contains("GreetingPage()", on["App.cs"], StringComparison.Ordinal); // nav link
+
+        var (off, offResult) = Generate(cqrs: false);
+        Assert.DoesNotContain("Cqrs/GreetingQuery.cs", off.Keys);
+        Assert.DoesNotContain("AddRaskCqrs", off["Program.cs"], StringComparison.Ordinal);
+        Assert.DoesNotContain("Rask.Cqrs", offResult.Packages);
+        Assert.DoesNotContain("GreetingPage()", off["App.cs"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Docker_flag_toggles_only_the_container_files()
+    {
+        var (on, _) = Generate(docker: true);
+        Assert.True(on.ContainsKey("Dockerfile"));
+        Assert.True(on.ContainsKey(".dockerignore"));
+        Assert.Contains("App.dll", on["Dockerfile"], StringComparison.Ordinal); // name substituted
+
+        var (off, _) = Generate(docker: false);
+        Assert.DoesNotContain("Dockerfile", off.Keys);
+        Assert.DoesNotContain(".dockerignore", off.Keys);
+    }
+
+    // "test every scenario" — all 16 flag combinations keep the invariants: core files always present,
+    // no placeholder leakage, packages always include the framework, opt-in files exactly track their flag.
+    [Theory]
+    [MemberData(nameof(AllFlagCombinations))]
+    public void Every_flag_combination_holds_the_invariants(bool auth, bool pwa, bool cqrs, bool docker)
+    {
+        var (files, result) = Generate(auth, pwa, cqrs, docker);
+
+        foreach (var expected in AlwaysPresent)
+        {
+            Assert.True(files.ContainsKey(expected), $"[{auth},{pwa},{cqrs},{docker}] missing {expected}");
+        }
+
+        Assert.Contains("Rask.Server", result.Packages);
+        Assert.Contains("Rask.Bootstrap", result.Packages);
+        Assert.Equal(cqrs, result.Packages.Contains("Rask.Cqrs"));
+
+        Assert.Equal(auth, files.ContainsKey("Auth/CredentialStore.cs"));
+        Assert.Equal(pwa, files.ContainsKey("wwwroot/icon.svg"));
+        Assert.Equal(cqrs, files.ContainsKey("Cqrs/GreetingQuery.cs"));
+        Assert.Equal(docker, files.ContainsKey("Dockerfile"));
+
+        foreach (var content in files.Values)
+        {
+            Assert.DoesNotContain("Company.RaskServer", content, StringComparison.Ordinal);
+        }
+    }
+
+    public static IEnumerable<object[]> AllFlagCombinations()
+    {
+        for (var mask = 0; mask < 16; mask++)
+        {
+            yield return [(mask & 1) != 0, (mask & 2) != 0, (mask & 4) != 0, (mask & 8) != 0];
+        }
+    }
+
+    private static (Dictionary<string, string> Files, ScaffoldResult Result) Generate(
+        bool auth = false, bool pwa = false, bool cqrs = false, bool docker = false)
+    {
+        var result = ProjectGenerator.GenerateServer(Root, "App", auth, pwa, cqrs, docker, Version);
+        var files = result.Files.ToDictionary(
+            f => Path.GetRelativePath(Root, f.Path).Replace('\\', '/'),
+            f => f.Content,
+            StringComparer.Ordinal);
+        return (files, result);
+    }
+}


### PR DESCRIPTION
First PR of the **CLI-owns-scaffolding** stack ("the CLI is the alpha and the omega"). Makes the `rask` CLI the scaffolding authority for the **server** template — no `dotnet new`, no on-demand Rask.Templates install.

## What
- **`ProjectGenerator.GenerateServer`** — hand-ported server template: emits all ~19 files, with `--auth`/`--pwa`/`--cqrs`/`--docker` expressed as **generation logic** (not `#if` markers). `Company.RaskServer` → app name via one central replace; `Rask.*` package refs pinned to the CLI's own version, with a **latest-stable fallback** for local/dev CLI builds (whose prerelease version isn't on NuGet).
- **`NewCommand` rewired** (+`IFileSystem`, +working dir): the `server` template writes files directly then `dotnet restore`s, so the output builds immediately. `wasm`/`wasm-hosted`/`native` still delegate to `dotnet new` until their generators land in follow-up PRs. Rask.Templates stays published until the last PR of the stack.

## Tests
- **`ProjectGeneratorTests`** — exhaustive over **all 16 flag combinations**: core files always present, opt-in files/packages exactly track their flag, no placeholder leakage, version pinned.
- **`ProjectGeneratorBuildE2ETests`** — opt-in (`RASK_CLI_BUILD_E2E=1`) build-the-output gate: generates and **compiles all 8 build-affecting combos under `-warnaserror`** (verified green, ~8s).
- 205 CLI unit tests + the pre-commit 250-test gate pass; both touched projects warnaserror-clean.

## Incidental fixes
Two latent bugs in the old template's never-tested `--auth --pwa` combo: ambiguous `SameSiteMode` (pwa's `Rask.Core.Browser` vs `Microsoft.AspNetCore.Http`) and a RASK033 string route in `MembersPage`.