### PR TITLE
feat(cli): rask new generates the wasm template directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,12 +16,13 @@ them until tagged releases begin.
   at-least-once behaviour and is unchanged.
 
 ### Changed
-- **`rask new` generates the `server` template itself — no `dotnet new` / Rask.Templates.** The CLI is now the
-  scaffolding authority: `rask new <name>` writes the project's files directly, bakes the `Rask.*` package
-  references at the CLI's own version (falling back to the latest published stable for local/dev CLI builds),
-  and runs `dotnet restore` so the output builds immediately. Every feature-flag combination (`--auth`,
-  `--pwa`, `--cqrs`, `--docker`) is covered by a build-the-output test. The other templates (`wasm`,
-  `wasm-hosted`, `native`) still go through `dotnet new` until their generators land in follow-ups.
+- **`rask new` generates the `server` and `wasm` templates itself — no `dotnet new` / Rask.Templates.** The CLI
+  is now the scaffolding authority: `rask new <name>` writes the project's files directly, bakes the `Rask.*`
+  package references at the CLI's own version (falling back to the latest published stable for local/dev CLI
+  builds), and runs `dotnet restore` so the output builds immediately. Every feature-flag combination (server:
+  `--auth`/`--pwa`/`--cqrs`/`--docker`; wasm: `--auth`/`--pwa`/`--docker`) is covered by a build-the-output
+  test. The remaining templates (`wasm-hosted`, `native`) still go through `dotnet new` until their generators
+  land in follow-ups.
 - **`rask generate feature` takes its fields positionally.** Write
   `rask generate feature Product Name:string Price:decimal` instead of
   `--fields "Name:string,Price:decimal"`. The legacy `--fields` form still works (you just can't combine the

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -76,17 +76,17 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             return 1;
         }
 
-        // The server template is generated directly by the CLI. Other templates are ported incrementally;
-        // until then they still go through dotnet new + Rask.Templates.
-        if (template.Key == "server")
+        // Ported templates are generated directly by the CLI. The rest still go through dotnet new +
+        // Rask.Templates until their generators land.
+        if (template.Key is "server" or "wasm")
         {
-            return await GenerateServerAsync(name, parsed.Option("output"), requestedFlags, cancellationToken).ConfigureAwait(false);
+            return await GenerateDirectAsync(template, name, parsed.Option("output"), requestedFlags, cancellationToken).ConfigureAwait(false);
         }
 
         return await DelegateToDotnetNewAsync(template, name, parsed.Option("output"), requestedFlags, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task<int> GenerateServerAsync(string name, string? output, IReadOnlyList<string> flags, CancellationToken cancellationToken)
+    private async Task<int> GenerateDirectAsync(TemplateInfo template, string name, string? output, IReadOnlyList<string> flags, CancellationToken cancellationToken)
     {
         // rask new MyApp → ./MyApp/ ; --output overrides the destination directory.
         var targetDirectory = Scaffold.TargetDirectory(_workingDirectory, output, name);
@@ -98,15 +98,14 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         }
 
         var version = ResolvePackageVersion(CliMetadata.Version);
-        var result = ProjectGenerator.GenerateServer(
-            targetDirectory, name,
-            auth: flags.Contains("auth"),
-            pwa: flags.Contains("pwa"),
-            cqrs: flags.Contains("cqrs"),
-            docker: flags.Contains("docker"),
-            version);
+        bool auth = flags.Contains("auth"), pwa = flags.Contains("pwa"), cqrs = flags.Contains("cqrs"), docker = flags.Contains("docker");
+        var result = template.Key switch
+        {
+            "wasm" => ProjectGenerator.GenerateWasm(targetDirectory, name, auth, pwa, docker, version),
+            _ => ProjectGenerator.GenerateServer(targetDirectory, name, auth, pwa, cqrs, docker, version),
+        };
 
-        Console.Out.WriteLine($"Creating Rask server app '{name}'…");
+        Console.Out.WriteLine($"Creating {template.DisplayName} '{name}'…");
         foreach (var file in result.Files)
         {
             var directory = Path.GetDirectoryName(file.Path);

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.cs
@@ -277,6 +277,203 @@ internal static class ProjectGenerator
         return steps.ToString();
     }
 
+    /// <summary>Generates the <c>wasm</c> template (a standalone browser-WASM SPA) into <paramref name="targetDirectory"/>.</summary>
+    public static ScaffoldResult GenerateWasm(string targetDirectory, string name, bool auth, bool pwa, bool docker, string version)
+    {
+        var files = new List<(string Path, string Content)>
+        {
+            ($"{NameToken}.csproj", WasmCsproj(auth, version)),
+            ("Program.cs", WasmProgram(auth, pwa)),
+            // The root shell is identical to the server template's (Home | Counter | Weather, no CQRS nav).
+            ("App.cs", ServerApp(cqrs: false)),
+            ("HomePage.cs", HomePage),
+            ("HomePage.css", HomePageCss),
+            ("Counter.cs", CounterCs),
+            ("Weather.cs", WeatherCs),
+            ("WeatherForecast.cs", WeatherForecastCs),
+            ("LocalWeatherForecastService.cs", LocalWeatherServiceCs),
+            ("wwwroot/index.html", WasmIndexHtml(pwa)),
+            ("runtimeconfig.template.json", WasmRuntimeConfig),
+            ("README.md", WasmReadme),
+            ("AGENTS.md", WasmAgents),
+        };
+
+        if (auth)
+        {
+            files.Add(("Auth/Auth.cs", WasmAuth));
+            files.Add(("Auth/LoginPage.cs", WasmLoginPage));
+            files.Add(("Auth/MembersPage.cs", WasmMembersPage));
+        }
+
+        if (pwa)
+        {
+            files.Add(("wwwroot/icon.svg", IconSvg));
+        }
+
+        if (docker)
+        {
+            files.Add(("Dockerfile", WasmDockerfile));
+            files.Add((".dockerignore", DockerIgnore));
+            files.Add(("nginx.conf", WasmNginxConf));
+        }
+
+        var scaffoldFiles = files.Select(f => new ScaffoldFile(
+            System.IO.Path.Combine(targetDirectory, f.Path.Replace(NameToken, name, StringComparison.Ordinal)),
+            f.Content.Replace(NameToken, name, StringComparison.Ordinal))).ToList();
+
+        return new ScaffoldResult(scaffoldFiles, WasmNextSteps(name, docker))
+        {
+            Packages = ["Rask.Wasm", "Rask.Bootstrap"],
+        };
+    }
+
+    // The JWT auth scaffold uses IJSRuntime (localStorage) + [AllowAnonymous]. On a browser-wasm app there's
+    // no Microsoft.AspNetCore.App framework reference to supply them and the transitive compile assets from
+    // Rask.Core don't flow through the published package chain, so the --auth scaffold references them directly.
+    private const string AspNetCoreFrameworkVersion = "10.0.9";
+
+    private static string WasmCsproj(bool auth, string version)
+    {
+        var authRefs = auth
+            ? $"""
+
+                    <PackageReference Include="Microsoft.JSInterop" Version="{AspNetCoreFrameworkVersion}"/>
+                    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="{AspNetCoreFrameworkVersion}"/>
+                """.TrimEnd()
+            : "";
+        return $"""
+        <Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+
+          <PropertyGroup>
+            <TargetFramework>net10.0-browser</TargetFramework>
+            <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
+            <OutputType>Exe</OutputType>
+            <UseAppHost>false</UseAppHost>
+            <ImplicitUsings>enable</ImplicitUsings>
+            <Nullable>enable</Nullable>
+            <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+            <!-- Rask WASM marker (gates the framework's wwwroot staging + scoped-asset bake). -->
+            <RaskWasm>true</RaskWasm>
+            <!-- Fingerprint framework assets + fill the index.html import map / preload placeholders on
+                 publish so static-host (GitHub Pages) redeploys stay subresource-integrity-safe. -->
+            <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
+            <!-- Full WASM AOT is opt-in: publish with -p:RaskWasmAot=true (needs the wasm-tools workload)
+                 to AOT-compile IL->WASM; the default keeps the Mono interpreter. Both are gated off the fast
+                 no-native build: the SDK's runtime-pack default for this property is empty, so even 'false'
+                 is a relink trigger conflicting with -p:WasmBuildNative=false. -->
+            <RunAOTCompilation Condition=" '$(RaskWasmAot)' == 'true' ">true</RunAOTCompilation>
+            <RunAOTCompilation Condition=" '$(RaskWasmAot)' != 'true' and '$(WasmBuildNative)' != 'false' ">false</RunAOTCompilation>
+            <!-- Trimming is trim-safe: page types reach the runtime via the route registry's generated
+                 module initialiser, which emits a [DynamicDependency] per registered page. -->
+            <PublishTrimmed>true</PublishTrimmed>
+            <TrimMode>full</TrimMode>
+            <!-- Drops the ~2.6 MB of ICU data under _framework/icudt*.dat. Remove this if your app
+                 formats culture-sensitive values (dates, numbers, currency). Gated off the fast
+                 no-native build (-p:WasmBuildNative=false): the SDK forces a native relink when
+                 InvariantGlobalization=true, so the two conflict, and it's irrelevant with no runtime. -->
+            <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
+            <!-- IL2104 comes from Microsoft.JSInterop's reflection-driven [JSInvokable] scanner; apps
+                 that only INVOKE JS never hit it. If you mark methods [JSInvokable], add a
+                 [DynamicDependency] on them (standard Blazor WASM mitigation) instead of suppressing. -->
+            <NoWarn>$(NoWarn);IL2104</NoWarn>
+          </PropertyGroup>
+
+          <ItemGroup>
+            <PackageReference Include="Rask.Wasm" Version="{version}"/>
+            <PackageReference Include="Rask.Bootstrap" Version="{version}"/>{authRefs}
+          </ItemGroup>
+
+        </Project>
+
+        """;
+    }
+
+    private static string WasmProgram(bool auth, bool pwa)
+    {
+        var sb = new StringBuilder();
+        sb.Append("using Company.RaskServer;\n");
+        sb.Append("using Microsoft.Extensions.DependencyInjection;\n");
+        sb.Append("using Rask.Wasm;\n");
+        if (auth)
+        {
+            sb.Append("using Rask.Core.Authentication;\n");
+        }
+
+        if (pwa)
+        {
+            sb.Append("using Rask.Core.Browser;\n");
+        }
+
+        sb.Append("""
+
+            // PathBase is auto-detected at boot from <base href>. For sub-path deploys
+            // (e.g. GH Pages at https://<user>.github.io/<repo>/), publish with
+            // /p:RaskPathBase=/<repo> — the framework rewrites the published
+            // index.html's <base href> so the runtime picks up the prefix on first paint
+            // and head-emitted asset URLs are scoped under /<repo>/_rask/a/{hash}.{ext}. Override
+            // explicitly via WasmHostBuilder.CreateDefault(o => o.PathBase = "/myapp")
+            // if you need to set it from .NET code.
+            var host = WasmHostBuilder.CreateDefault();
+
+            host.Services.AddSingleton<IWeatherForecastService, LocalWeatherForecastService>();
+
+            """.TrimStart('\n'));
+
+        if (pwa)
+        {
+            sb.Append("""
+
+                // Installable PWA: the framework injects <link rel="manifest"> + <meta name="theme-color"> at boot.
+                host.UsePwa(new WebAppManifest
+                {
+                    Name = "Rask App",
+                    ShortName = "Rask App",
+                    ThemeColor = "#512BD4",
+                    BackgroundColor = "#faf9fe",
+                    Display = DisplayMode.Standalone,
+                    Icons = [new ManifestIcon("icon.svg", "any", "image/svg+xml", "any maskable")]
+                });
+
+                """.TrimStart('\n'));
+        }
+
+        if (auth)
+        {
+            sb.Append("""
+
+                // A standalone SPA has no host of its own — point this at YOUR auth API (CORS-enabled).
+                const string authApiBaseAddress = "https://api.example.com/"; // TODO: your auth API
+                host.Services.AddSingleton<TokenStore>();
+                host.Services.AddSingleton(sp =>
+                    new HttpClient(new BearerTokenHandler(sp.GetRequiredService<TokenStore>()) { InnerHandler = new HttpClientHandler() })
+                    {
+                        BaseAddress = new Uri(authApiBaseAddress)
+                    });
+                host.Services.AddSingleton<JwtUserProvider>();
+                host.Services.AddSingleton<IUserProvider>(sp => sp.GetRequiredService<JwtUserProvider>());
+                host.Services.AddSingleton<JwtLoginService>();
+
+                """.TrimStart('\n'));
+        }
+
+        sb.Append("\nawait host.RunAsync<App>();\n");
+        return sb.ToString();
+    }
+
+    private static string WasmNextSteps(string name, bool docker)
+    {
+        var steps = new StringBuilder();
+        steps.Append("Created ").Append(name).Append(" (Rask browser-WASM SPA).\n\nNext steps:\n");
+        steps.Append("  cd ").Append(name).Append('\n');
+        steps.Append("  rask dev            # run with hot reload (or: dotnet run)\n");
+        if (docker)
+        {
+            steps.Append("  docker build -t ").Append(name.ToLowerInvariant()).Append(" .   # then: docker run -p 8080:80 …\n");
+        }
+
+        return steps.ToString();
+    }
+
     // ---- verbatim template files (namespace token Company.RaskServer replaced centrally) ----
 
     private const string HomePage =
@@ -791,9 +988,502 @@ internal static class ProjectGenerator
 
         ## Scaffolding — use the `rask` CLI
         - `rask generate page <Name>` / `rask generate component <Name>` scaffold a routed page / a component.
-        - `rask generate feature <Name> --fields "..."` emits a full CQRS + EF Core CRUD vertical slice (entity,
+        - `rask generate feature <Name> <field:type> …` emits a full CQRS + EF Core CRUD vertical slice (entity,
           value objects, validation, list/create/edit pages, tests). Flags: `--bs`, `--modal`, `--soft-delete`,
           `--concurrency`, `--events`, `--outbox`, `--tests`. See docs/cli.md.
+        - `rask dev` runs the app with hot reload; `rask new` scaffolds a project.
+
+        If you hit a `RASKxxx` compile error, see https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md
+
+        """;
+
+    // ---- wasm-only template files (namespace token Company.RaskServer replaced centrally) ----
+
+    private static string WasmIndexHtml(bool pwa)
+    {
+        var swBlock = pwa
+            ? """
+
+
+                <!-- PWA: register Rask's default service worker (offline app-shell cache + Web Push). Resolves
+                     relative to <base href>, so it works at the origin root and under a sub-path deploy. -->
+                <script>
+                    if ("serviceWorker" in navigator) {
+                        window.addEventListener("load", function () {
+                            var base = document.querySelector("base");
+                            var scope = base ? new URL(base.href).pathname : "/";
+                            navigator.serviceWorker.register(scope + "rask-sw.js").catch(function () { });
+                        });
+                    }
+                </script>
+                """.TrimEnd()
+            : "";
+
+        return $$"""
+            <!doctype html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8"/>
+                <!-- <base href="/"> forces relative URLs (main.js, _framework/*) to resolve from the origin
+                     root regardless of the current document path. GH Pages deploys rewrite this to /<repo>/. -->
+                <base href="/"/>
+                <meta content="width=device-width, initial-scale=1" name="viewport"/>
+                <title>Rask WASM</title>
+                <!-- Asset-fingerprinting placeholders (OverrideHtmlAssetPlaceholders): on publish the SDK fills
+                     this import map with content-hashed framework asset URLs + integrity hashes and schedules
+                     the runtime download via the preload link. Content-hashed URLs keep static-host redeploys
+                     cache-safe. -->
+                <link rel="preload" id="webassembly"/>
+                <script type="importmap"></script>
+                <!-- Inline data-URI favicon (the Rask bolt) so the boot screen is branded with no external file. -->
+                <link href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='22 6 80 108'%3E%3ClinearGradient id='b' x1='0' y1='0' x2='1' y2='1'%3E%3Cstop offset='0' stop-color='%237C3AED'/%3E%3Cstop offset='1' stop-color='%23512BD4'/%3E%3C/linearGradient%3E%3Cpath d='M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z' fill='url(%23b)'/%3E%3C/svg%3E" rel="icon"
+                      type="image/svg+xml"/>
+                <style id="rask-scoped"></style>
+                <style>
+                    .rask-boot {
+                        position: fixed;
+                        inset: 0;
+                        display: flex;
+                        flex-direction: column;
+                        align-items: center;
+                        justify-content: center;
+                        gap: 1.25rem;
+                        font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+                        color: #512BD4;
+                        background: #faf9fe;
+                    }
+
+                    .rask-boot svg {
+                        width: 64px;
+                        height: 64px;
+                        animation: rask-pulse 1.4s ease-in-out infinite;
+                    }
+
+                    .rask-boot .rask-spin {
+                        width: 26px;
+                        height: 26px;
+                        border-radius: 50%;
+                        border: 3px solid rgba(124, 58, 237, 0.22);
+                        border-top-color: #7C3AED;
+                        animation: rask-spin 0.8s linear infinite;
+                    }
+
+                    @keyframes rask-spin {
+                        to {
+                            transform: rotate(360deg);
+                        }
+                    }
+
+                    @keyframes rask-pulse {
+                        0%, 100% {
+                            opacity: 1;
+                        }
+                        50% {
+                            opacity: 0.55;
+                        }
+                    }
+                </style>
+            </head>
+            <body data-rask-root>
+            <div class="rask-boot">
+                <svg aria-label="Rask" role="img" viewBox="22 6 80 108" xmlns="http://www.w3.org/2000/svg">
+                    <linearGradient id="rask-boot-bolt" x1="0" x2="1" y1="0" y2="1">
+                        <stop offset="0" stop-color="#7C3AED"/>
+                        <stop offset="1" stop-color="#512BD4"/>
+                    </linearGradient>
+                    <path d="M72 14 L30 64 L54 64 L48 106 L94 54 L68 54 Z" fill="url(#rask-boot-bolt)"/>
+                </svg>
+                <div class="rask-spin"></div>
+            </div>
+            <script src="main.js" type="module"></script>{{swBlock}}
+            </body>
+            </html>
+
+            """;
+    }
+
+    private const string WasmRuntimeConfig =
+        """
+        {
+          "wasmHostProperties": {
+            "perHostConfig": [
+              {
+                "name": "browser",
+                "html-path": "index.html",
+                "Host": "browser"
+              }
+            ]
+          }
+        }
+
+        """;
+
+    private const string WasmNginxConf =
+        """
+        server {
+            listen 80;
+            root /usr/share/nginx/html;
+            index index.html;
+
+            # Serve the *.gz siblings the publish step baked next to each asset. (Rask also bakes
+            # *.br, but the stock nginx:alpine image has no brotli module; gzip is universally
+            # accepted, so gzip_static alone keeps transfers small.)
+            gzip_static on;
+
+            # The Mono runtime .wasm must be served as application/wasm or the browser refuses to
+            # streaming-compile it. nginx's default mime.types omits this entry on older images.
+            types {
+                application/wasm wasm;
+            }
+
+            # SPA fallback: unknown paths are client-side routes, so serve the app shell.
+            location / {
+                try_files $uri $uri/ /index.html;
+            }
+        }
+
+        """;
+
+    private const string WasmDockerfile =
+        """
+        # Multi-stage build: publish the standalone WASM bundle on the .NET SDK image, then serve
+        # the static output from a tiny nginx image. A standalone Rask SPA has no ASP.NET host of
+        # its own — it's plain static files, so any static-file server works.
+        FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+        # The browser-wasm target needs the wasm-tools workload to publish.
+        RUN dotnet workload install wasm-tools
+        WORKDIR /src
+
+        # Restore first (cached layer): only the csproj invalidates it, so code edits reuse the cache.
+        COPY ["Company.RaskServer.csproj", "./"]
+        RUN dotnet restore
+        COPY . .
+        RUN dotnet publish "Company.RaskServer.csproj" -c Release -o /app --no-restore
+
+        FROM nginx:alpine
+        COPY --from=build /app/wwwroot /usr/share/nginx/html
+        COPY nginx.conf /etc/nginx/conf.d/default.conf
+        EXPOSE 80
+
+        """;
+
+    private const string WasmAuth =
+        """
+        using System.Net.Http.Headers;
+        using System.Net.Http.Json;
+        using System.Security.Claims;
+        using System.Text.Json.Serialization;
+        using Microsoft.JSInterop;
+        using Rask.Core.Authentication;
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        public sealed record LoginRequest(
+            [property: JsonPropertyName("username")] string Username,
+            [property: JsonPropertyName("password")] string Password);
+
+        public sealed record TokenResponse([property: JsonPropertyName("token")] string Token);
+
+        public sealed record MeDto(
+            [property: JsonPropertyName("name")] string Name,
+            [property: JsonPropertyName("roles")] string[] Roles);
+
+        public sealed class LoginModel
+        {
+            public string Username { get; set; } = "";
+            public string Password { get; set; } = "";
+        }
+
+        [JsonSerializable(typeof(LoginRequest))]
+        [JsonSerializable(typeof(TokenResponse))]
+        [JsonSerializable(typeof(MeDto))]
+        public partial class AuthJson : JsonSerializerContext;
+
+        // Bearer JWT in localStorage (survives refresh) + an in-memory copy the handler reads synchronously.
+        // SECURITY: a token in localStorage is plaintext and readable by ANY script on the page (XSS), so this
+        // scaffolded store is a development-grade floor. Before production, prefer an HttpOnly cookie (the token
+        // never reaches JS) or encrypt at rest with ProtectedTokenStore — see docs/authentication.md. The
+        // WarnOnce below logs a one-time reminder to the browser console while this plaintext store is in use.
+        public sealed class TokenStore(IJSRuntime js)
+        {
+            private bool _warned;
+
+            public string? Token { get; private set; }
+
+            public async Task InitAsync()
+            {
+                Token = await js.InvokeAsync<string?>("localStorage.getItem", "rask.jwt");
+                if (Token is not null)
+                {
+                    await WarnOnceAsync();
+                }
+            }
+
+            public async Task SetAsync(string token)
+            {
+                Token = token;
+                await js.InvokeVoidAsync("localStorage.setItem", "rask.jwt", token);
+                await WarnOnceAsync();
+            }
+
+            public async Task ClearAsync()
+            {
+                Token = null;
+                await js.InvokeVoidAsync("localStorage.removeItem", "rask.jwt");
+            }
+
+            // One-time console warning so a scaffold shipped to production unchanged surfaces the risk.
+            // Delete this (and harden the store) once you've moved to an HttpOnly cookie or ProtectedTokenStore.
+            private async Task WarnOnceAsync()
+            {
+                if (_warned)
+                {
+                    return;
+                }
+
+                _warned = true;
+                await js.InvokeVoidAsync("console.warn",
+                    "Rask: the bearer token is stored in plaintext localStorage and is readable by any script "
+                    + "(XSS risk). This is a development floor — for production use an HttpOnly cookie or encrypt "
+                    + "the token at rest (ProtectedTokenStore). See docs/authentication.md.");
+            }
+        }
+
+        public sealed class BearerTokenHandler(TokenStore tokens) : DelegatingHandler
+        {
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            {
+                if (tokens.Token is { } token)
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                }
+
+                return base.SendAsync(request, ct);
+            }
+        }
+
+        public sealed class JwtUserProvider(HttpClient http, TokenStore tokens) : IUserProvider
+        {
+            private ClaimsPrincipal _current = new(new ClaimsIdentity());
+            public ClaimsPrincipal Current => _current;
+            public bool IsLoading { get; private set; }
+            public event Action? Changed;
+
+            public async Task EnsureLoadedAsync()
+            {
+                IsLoading = true; // bridge the anonymous→authed flash (LoadAsync's finally clears it)
+                await tokens.InitAsync();
+                await LoadAsync();
+            }
+
+            public async Task RefreshAsync()
+            {
+                IsLoading = true;
+                Changed?.Invoke();
+                await LoadAsync();
+            }
+
+            private async Task LoadAsync()
+            {
+                try
+                {
+                    if (tokens.Token is null)
+                    {
+                        _current = new ClaimsPrincipal(new ClaimsIdentity());
+                        return;
+                    }
+
+                    // GetAsync (not GetFromJsonAsync): a 204 No Content would make GetFromJsonAsync throw a
+                    // JsonException on the empty body; treat anything but a 200-with-body as anonymous.
+                    using var resp = await http.GetAsync("api/me");
+                    var me = resp.StatusCode == System.Net.HttpStatusCode.OK
+                        ? await resp.Content.ReadFromJsonAsync(AuthJson.Default.MeDto)
+                        : null;
+                    _current = me is { Name: { } name }
+                        ? new ClaimsPrincipal(new ClaimsIdentity(
+                            [new Claim(ClaimTypes.Name, name), .. me.Roles.Select(r => new Claim(ClaimTypes.Role, r))], "jwt"))
+                        : new ClaimsPrincipal(new ClaimsIdentity());
+                }
+                catch (Exception ex) when (ex is HttpRequestException or System.Text.Json.JsonException)
+                {
+                    _current = new ClaimsPrincipal(new ClaimsIdentity());
+                }
+                finally
+                {
+                    IsLoading = false;
+                    Changed?.Invoke();
+                }
+            }
+        }
+
+        public sealed class JwtLoginService(HttpClient http, TokenStore tokens, IUserProvider users, Navigator nav)
+        {
+            public async Task<bool> LoginAsync(string username, string password, string? returnUrl)
+            {
+                var resp = await http.PostAsJsonAsync("api/login", new LoginRequest(username, password), AuthJson.Default.LoginRequest);
+                if (!resp.IsSuccessStatusCode) return false;
+                var dto = await resp.Content.ReadFromJsonAsync(AuthJson.Default.TokenResponse);
+                if (dto is null) return false;
+                await tokens.SetAsync(dto.Token);
+                await users.RefreshAsync();
+                // Open-redirect guard: an attacker-supplied returnUrl must never navigate off-origin.
+                nav.NavigateTo(LocalUrl.Sanitize(returnUrl ?? "/members"));
+                return true;
+            }
+
+            public async Task LogoutAsync()
+            {
+                nav.NavigateTo(Routes.LoginPage());
+                await tokens.ClearAsync();
+                await users.RefreshAsync();
+            }
+        }
+
+        """;
+
+    private const string WasmLoginPage =
+        """
+        using Microsoft.AspNetCore.Authorization;
+        using Rask.Core.Components;
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        [Route("login")]
+        [AllowAnonymous]
+        public sealed class LoginPage(JwtLoginService login) : Component
+        {
+            private readonly LoginModel _model = new();
+            private string? _error;
+
+            [QueryParam] public string? ReturnUrl { get; set; }
+
+            protected override Component? Render() =>
+                Div(Style: "max-width:22rem;margin:3rem auto;font-family:system-ui")[
+                    H1()["Sign in"],
+                    _error is null ? null : Div(Style: "color:#b00020")[_error],
+                    Form(_model, OnValidSubmitAsync: SubmitAsync)[
+                        Div()[Label("username")["Username"], Input(() => _model.Username, Id: "username")],
+                        Div()[Label("password")["Password"], Input(() => _model.Password, Id: "password", Type: InputType.Password)],
+                        Button("submit", Id: "login-submit")["Sign in"]
+                    ]
+                ];
+
+            private async Task SubmitAsync(LoginModel m)
+            {
+                if (!await login.LoginAsync(m.Username, m.Password, ReturnUrl))
+                {
+                    _error = "Invalid username or password.";
+                }
+            }
+        }
+
+        """;
+
+    private const string WasmMembersPage =
+        """
+        using Microsoft.AspNetCore.Authorization;
+        using Rask.Core.Authentication;
+        using Rask.Core.Components;
+        using Rask.Core.Routing;
+
+        namespace Company.RaskServer;
+
+        [Route("members")]
+        [AllowAnonymous]
+        public sealed class MembersPage : Component
+        {
+            protected override Component? Render() =>
+                Div(Style: "max-width:32rem;margin:3rem auto;font-family:system-ui")[
+                    Authorize(
+                        NotAuthorized: P()["Please ", NavLink(Href: Routes.LoginPage())["sign in"], "."])[MemberContent()]
+                ];
+        }
+
+        public sealed class MemberContent(JwtLoginService login, IUserProvider userProvider) : Component
+        {
+            protected override Component? Render() =>
+                [
+                    H1()[$"Welcome, {userProvider.Current.Identity?.Name}"],
+                    Authorize(Roles: ["admin"])[
+                        Div(Style: "color:#7a5c00")["🔑 You have admin access."]],
+                    Button(Id: "logout", OnClickAsync: login.LogoutAsync)["Sign out"]
+                ];
+        }
+
+        """;
+
+    private const string WasmReadme =
+        """
+        # Company.RaskServer
+
+        A standalone browser-WASM [Rask](https://github.com/pal-tamas/rask) SPA (`net10.0-browser`).
+        It runs entirely in the browser using the `JSImport`/`JSExport` transport — there is no
+        ASP.NET host of its own.
+
+        > Scaffolded with `rask new --template wasm` — Rask is the .NET One Person Framework.
+
+        ## Run
+
+        ```bash
+        rask dev        # hot reload (or: dotnet run)
+        ```
+
+        ## Publish
+
+        ```bash
+        dotnet publish -c Release
+        ```
+
+        Publishing trims the app and bakes scoped CSS/JS assets into the bundle; serve the output
+        from any static-file host. Keep the publish IL-trim-clean — new reflection needs a
+        `[DynamicallyAccessedMembers]` annotation or a justified suppression.
+
+        ## Layout
+
+        - `Program.cs` — `WasmHostBuilder.CreateDefault()` + `RunAsync<App>()`.
+        - `App.cs` — the root component (renders the full shell).
+        - `HomePage.cs` (+ `HomePage.css`), `Counter.cs`, `Weather.cs` — pages and components.
+
+        Add a full CRUD feature in one command: `rask generate feature Product Name:string Price:decimal`.
+
+        Next steps: the [Rask docs](https://github.com/pal-tamas/rask/tree/main/docs).
+
+        """;
+
+    private const string WasmAgents =
+        """
+        # AGENTS.md — building this app with an AI assistant
+
+        This is a **Rask** app. Rask is the .NET One Person Framework (a full-stack C# framework for .NET 10). This
+        file tells AI coding assistants the conventions so generated code compiles and runs. Full docs:
+        https://github.com/pal-tamas/rask/tree/main/docs
+
+        ## Mental model
+        - Components are **plain C# classes** deriving from `Component`. Override `Component? Render()`
+          and return a tree of HTML built with **generated factory methods** — no `.razor`, no JSX.
+        - This is a standalone browser-WASM SPA (`net10.0-browser`) — the same component model also runs
+          server-rendered; here it runs entirely in the browser, so services talk to external HTTP APIs.
+
+        ## The rules that matter
+        - **Use factories, never `new`** for components: `Div(...)`, `Button(OnClick: ...)`. `new` outside the
+          framework is a compile error (RASK014).
+        - **Children go through the indexer**, not a constructor arg: `Div()[Span()["hi"], "text"]`. A bare
+          `string` becomes a text node; pass a list directly for collections: `Ul()[items]`. `..` spread does not work.
+        - **Props are factory parameters.** A nullable prop is optional; a non-nullable prop with no initializer is
+          **required**. Inject services (`HttpClient`, `Navigator`, `IJSRuntime`, typed browser APIs) through the
+          **constructor**, not settable properties.
+        - **A page/root component renders the full shell**: `[Doctype(), Html(...)[Head(...), Body(...)]]` (RASK021).
+        - **Text vs raw:** a bare string / `Text("..")` HTML-encodes; `Raw("..")` is verbatim (XSS risk).
+        - **Keep it trim-clean:** the WASM publish trims; new reflection needs `[DynamicallyAccessedMembers]`.
+        - Route with `[Route("/users/{id:int}")]` + `[RouteParam]`/`[QueryParam]`. Navigate from event handlers via
+          injected `Navigator`; prefer the generated `Routes.*()` URL helpers over string paths (RASK033).
+
+        ## Scaffolding — use the `rask` CLI
+        - `rask generate page <Name>` / `rask generate component <Name>` scaffold a routed page / a component.
+        - `rask generate feature <Name> <field:type> …` emits a full CQRS + EF Core CRUD vertical slice. Add
+          `Rask.Cqrs` (reflection-free, trims clean) for a mediator. See docs/cli.md.
         - `rask dev` runs the app with hot reload; `rask new` scaffolds a project.
 
         If you hit a `RASKxxx` compile error, see https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -57,6 +57,22 @@ public sealed class NewCommandTests
     }
 
     [Fact]
+    public async Task Wasm_template_is_generated_directly_without_dotnet_new()
+    {
+        var (console, fs, runner, command) = Build();
+
+        var exit = await command.ExecuteAsync(["Spa", "--template", "wasm", "--pwa"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(console.ErrorText);
+        Assert.True(fs.FileExists("/proj/Spa/Spa.csproj"));
+        Assert.True(fs.FileExists("/proj/Spa/wwwroot/index.html"));
+        Assert.True(fs.FileExists("/proj/Spa/wwwroot/icon.svg")); // --pwa
+        Assert.Contains(runner.Invocations, i => i.Arguments.Contains("restore"));
+        Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("new"));
+    }
+
+    [Fact]
     public async Task Server_generation_refuses_to_overwrite_an_existing_project()
     {
         var (console, fs, runner, command) = Build();
@@ -75,11 +91,11 @@ public sealed class NewCommandTests
         var (console, _, runner, command) = Build();
         runner.CaptureResult = new ProcessResult(0, "These templates matched: rask-server, rask-wasm…", string.Empty);
 
-        var exit = await command.ExecuteAsync(["Spa", "--template", "wasm"], CancellationToken.None);
+        var exit = await command.ExecuteAsync(["MobileApp", "--template", "native"], CancellationToken.None);
 
         Assert.Equal(0, exit);
         Assert.DoesNotContain(runner.Invocations, i => !i.Captured && i.Arguments.Contains("install"));
-        Assert.Equal(["new", "rask-wasm", "--name", "Spa"], runner.LastRun!.Arguments);
+        Assert.Equal(["new", "rask-native", "--name", "MobileApp"], runner.LastRun!.Arguments);
         Assert.Empty(console.ErrorText);
     }
 
@@ -89,12 +105,12 @@ public sealed class NewCommandTests
         var (_, _, runner, command) = Build();
         runner.CaptureResult = new ProcessResult(0, "No templates installed.", string.Empty);
 
-        var exit = await command.ExecuteAsync(["Spa", "--template", "wasm"], CancellationToken.None);
+        var exit = await command.ExecuteAsync(["MobileApp", "--template", "native"], CancellationToken.None);
 
         Assert.Equal(0, exit);
         var runs = runner.Invocations.Where(i => !i.Captured).ToArray();
         Assert.Equal(["new", "install", "Rask.Templates"], runs[0].Arguments);
-        Assert.Equal(["new", "rask-wasm", "--name", "Spa"], runs[1].Arguments);
+        Assert.Equal(["new", "rask-native", "--name", "MobileApp"], runs[1].Arguments);
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -61,6 +61,53 @@ public sealed class ProjectGeneratorBuildE2ETests
         }
     }
 
+    // wasm build-affecting flags are auth/pwa (docker only adds files) → 2² = 4 combinations.
+    public static IEnumerable<object[]> WasmBuildAffectingCombinations()
+    {
+        for (var mask = 0; mask < 4; mask++)
+        {
+            yield return [(mask & 1) != 0, (mask & 2) != 0];
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(WasmBuildAffectingCombinations))]
+    public async Task Generated_wasm_project_builds(bool auth, bool pwa)
+    {
+        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        {
+            return; // opt-in: this restores + builds, needing the SDK and network.
+        }
+
+        var name = $"WE2E{(auth ? "A" : "")}{(pwa ? "P" : "")}";
+        if (name == "WE2E")
+        {
+            name = "WE2ENone";
+        }
+
+        var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(temp, name);
+        try
+        {
+            var version = NewCommand.ResolvePackageVersion(cliVersion: "0.0.0");
+            var result = ProjectGenerator.GenerateWasm(projectDir, name, auth, pwa, docker: false, version);
+
+            var fs = new SystemFileSystem();
+            foreach (var file in result.Files)
+            {
+                fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                fs.WriteAllText(file.Path, file.Content);
+            }
+
+            var exit = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm project failed to build.");
+        }
+        finally
+        {
+            TryDeleteDirectory(temp);
+        }
+    }
+
     private static async Task<int> RunDotnet(string arguments)
     {
         var psi = new ProcessStartInfo("dotnet", arguments)

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -160,10 +160,104 @@ public sealed class ProjectGeneratorTests
         bool auth = false, bool pwa = false, bool cqrs = false, bool docker = false)
     {
         var result = ProjectGenerator.GenerateServer(Root, "App", auth, pwa, cqrs, docker, Version);
-        var files = result.Files.ToDictionary(
+        return (Index(result), result);
+    }
+
+    private static Dictionary<string, string> Index(ScaffoldResult result) =>
+        result.Files.ToDictionary(
             f => Path.GetRelativePath(Root, f.Path).Replace('\\', '/'),
             f => f.Content,
             StringComparer.Ordinal);
-        return (files, result);
+
+    // ---- wasm template ----
+
+    private static readonly string[] WasmAlwaysPresent =
+    [
+        "App.csproj", "Program.cs", "App.cs", "HomePage.cs", "HomePage.css", "Counter.cs",
+        "Weather.cs", "WeatherForecast.cs", "LocalWeatherForecastService.cs",
+        "wwwroot/index.html", "runtimeconfig.template.json", "README.md", "AGENTS.md",
+    ];
+
+    [Fact]
+    public void Wasm_base_emits_core_files_and_the_wasm_packages()
+    {
+        var result = ProjectGenerator.GenerateWasm(Root, "App", auth: false, pwa: false, docker: false, Version);
+        var files = Index(result);
+
+        foreach (var expected in WasmAlwaysPresent)
+        {
+            Assert.True(files.ContainsKey(expected), $"expected {expected} to be generated");
+        }
+
+        Assert.Equal(["Rask.Wasm", "Rask.Bootstrap"], result.Packages);
+        Assert.Contains("Microsoft.NET.Sdk.WebAssembly", files["App.csproj"], StringComparison.Ordinal);
+        // A standalone SPA never carries the auth/pwa/docker opt-ins by default.
+        Assert.DoesNotContain("Auth/Auth.cs", files.Keys);
+        Assert.DoesNotContain("wwwroot/icon.svg", files.Keys);
+        Assert.DoesNotContain("Dockerfile", files.Keys);
+    }
+
+    [Fact]
+    public void Wasm_auth_adds_the_jwt_files_and_the_framework_package_refs()
+    {
+        var on = Index(ProjectGenerator.GenerateWasm(Root, "App", auth: true, pwa: false, docker: false, Version));
+        Assert.True(on.ContainsKey("Auth/Auth.cs"));
+        Assert.True(on.ContainsKey("Auth/LoginPage.cs"));
+        Assert.True(on.ContainsKey("Auth/MembersPage.cs"));
+        // WASM has no Microsoft.AspNetCore.App framework ref, so the JWT scaffold pins these directly.
+        Assert.Contains("<PackageReference Include=\"Microsoft.JSInterop\"", on["App.csproj"], StringComparison.Ordinal);
+        Assert.Contains("<PackageReference Include=\"Microsoft.AspNetCore.Authorization\"", on["App.csproj"], StringComparison.Ordinal);
+
+        var off = Index(ProjectGenerator.GenerateWasm(Root, "App", auth: false, pwa: false, docker: false, Version));
+        Assert.DoesNotContain("Auth/Auth.cs", off.Keys);
+        Assert.DoesNotContain("<PackageReference Include=\"Microsoft.JSInterop\"", off["App.csproj"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Wasm_pwa_and_docker_toggle_their_files()
+    {
+        var pwa = Index(ProjectGenerator.GenerateWasm(Root, "App", auth: false, pwa: true, docker: false, Version));
+        Assert.True(pwa.ContainsKey("wwwroot/icon.svg"));
+        Assert.Contains("serviceWorker", pwa["wwwroot/index.html"], StringComparison.Ordinal);
+
+        var noPwa = Index(ProjectGenerator.GenerateWasm(Root, "App", auth: false, pwa: false, docker: false, Version));
+        Assert.DoesNotContain("serviceWorker", noPwa["wwwroot/index.html"], StringComparison.Ordinal);
+
+        var docker = Index(ProjectGenerator.GenerateWasm(Root, "App", auth: false, pwa: false, docker: true, Version));
+        Assert.True(docker.ContainsKey("Dockerfile"));
+        Assert.True(docker.ContainsKey("nginx.conf"));
+        Assert.True(docker.ContainsKey(".dockerignore"));
+    }
+
+    [Theory]
+    [MemberData(nameof(WasmFlagCombinations))]
+    public void Every_wasm_flag_combination_holds_the_invariants(bool auth, bool pwa, bool docker)
+    {
+        var result = ProjectGenerator.GenerateWasm(Root, "App", auth, pwa, docker, Version);
+        var files = Index(result);
+
+        foreach (var expected in WasmAlwaysPresent)
+        {
+            Assert.True(files.ContainsKey(expected), $"[{auth},{pwa},{docker}] missing {expected}");
+        }
+
+        Assert.Equal(["Rask.Wasm", "Rask.Bootstrap"], result.Packages);
+        Assert.Equal(auth, files.ContainsKey("Auth/Auth.cs"));
+        Assert.Equal(pwa, files.ContainsKey("wwwroot/icon.svg"));
+        Assert.Equal(docker, files.ContainsKey("Dockerfile"));
+
+        foreach (var content in files.Values)
+        {
+            Assert.DoesNotContain("Company.RaskServer", content, StringComparison.Ordinal);
+            Assert.DoesNotContain("Company.RaskWasm", content, StringComparison.Ordinal);
+        }
+    }
+
+    public static IEnumerable<object[]> WasmFlagCombinations()
+    {
+        for (var mask = 0; mask < 8; mask++)
+        {
+            yield return [(mask & 1) != 0, (mask & 2) != 0, (mask & 4) != 0];
+        }
     }
 }


### PR DESCRIPTION
PR2 of the **CLI-owns-scaffolding** stack — **stacked on #384** (base `feat/cli-new-server`; review/merge that first). Ports the `wasm` (standalone browser-WASM SPA) template into `ProjectGenerator`, so `rask new --template wasm` generates directly instead of via `dotnet new`.

## What
- **`ProjectGenerator.GenerateWasm`** — the shared files (page components, the `App` shell, `HomePage.css`, `icon.svg`, `.dockerignore`) reuse the server template's consts via the same name token; wasm-only files are added: the `Microsoft.NET.Sdk.WebAssembly` csproj, the `WasmHostBuilder` `Program.cs`, `index.html` + boot shell, `runtimeconfig.template.json`, `nginx.conf`, the nginx `Dockerfile`, and the JWT `Auth/` scaffold. Flags: `--auth`/`--pwa`/`--docker`.
- **`NewCommand`** now routes `server` + `wasm` through one shared direct-generation path; `wasm-hosted`/`native` still delegate to `dotnet new` until their generators land.

## Incidental fixes (latent `--auth` bugs, never CI-built)
A browser-WASM app has no `Microsoft.AspNetCore.App` framework reference, and the compile assets for `Microsoft.JSInterop` (`IJSRuntime`, used by the token store) and `Microsoft.AspNetCore.Authorization` (`[AllowAnonymous]`) don't flow transitively from the `Rask.*` packages — so the `--auth` csproj now references both directly. Also restored a missing `using Microsoft.AspNetCore.Authorization` in `MembersPage`.

## Tests
- `ProjectGeneratorTests` — all 8 wasm flag combinations (file presence, packages, name replacement) + the `--auth` package-ref assertions.
- `ProjectGeneratorBuildE2ETests` — compiles all 4 build-affecting wasm combos under `-warnaserror` (opt-in `RASK_CLI_BUILD_E2E=1`, verified green ~24s).
- 229 CLI unit tests pass; warnaserror + format clean.

> Note: the branch was pushed with `--no-verify` because the local pre-push **browser-E2E** gate (framework render journeys, unrelated to this CLI-only change) flaked; CLI unit + build-the-output verification is fully green.