### PR TITLE
fix(outbox): wait on the persisted signal in the drain test, not the handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **Flaky `Rask.Outbox` test: `The_processor_drains_the_outbox_and_publishes_events`.** It waited for the
+  in-process handler to run and then asserted on the *persisted* `ProcessedAt`, but the drain publishes the
+  whole batch first and only writes `ProcessedAt` in a single end-of-batch `SaveChangesAsync` — so the
+  assertion raced that write and lost whenever the disk was busy. It now waits on `ProcessedAt` itself (which
+  implies the publish already happened). Test-only: the processor's ordering is the documented
+  at-least-once behaviour and is unchanged.
+
 ### Changed
 - **Live sessions now size their buffers to the page instead of pre-renting a fixed block — a small-page
   session costs ~4.6x less memory.** A session used to rent ~33 KB of `char` buffers, ~20 KB of frame

--- a/tests/Rask.Outbox.Tests/OutboxTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxTests.cs
@@ -115,7 +115,18 @@ public sealed class OutboxTests : IDisposable
         await processor.StartAsync(CancellationToken.None);
         try
         {
-            await WaitUntilAsync(() => _recorder.Events.Any(e => e.Id == id), TimeSpan.FromSeconds(10));
+            // Wait for the LAST thing the drain does, not the first. It publishes the whole batch (which is
+            // what fills the recorder) and only then persists ProcessedAt, in a single end-of-batch
+            // SaveChangesAsync — so waiting on the recorder and then asserting on ProcessedAt races that
+            // save, and loses whenever the write is slow. Waiting on ProcessedAt implies the publish already
+            // happened, so it covers both assertions below.
+            await WaitUntilAsync(
+                async () =>
+                {
+                    await using var poll = NewContext();
+                    return await poll.Set<OutboxMessage>().AnyAsync(m => m.ProcessedAt != null);
+                },
+                TimeSpan.FromSeconds(10));
         }
         finally
         {
@@ -128,10 +139,12 @@ public sealed class OutboxTests : IDisposable
         Assert.NotNull((await read.Set<OutboxMessage>().SingleAsync()).ProcessedAt); // marked processed
     }
 
-    private static async Task WaitUntilAsync(Func<bool> condition, TimeSpan timeout)
+    // The condition is async so it can poll the database — the only place the drain's completion is
+    // observable — rather than an in-process side effect that runs earlier.
+    private static async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan timeout)
     {
         var deadline = DateTime.UtcNow + timeout;
-        while (!condition())
+        while (!await condition())
         {
             if (DateTime.UtcNow > deadline)
             {


### PR DESCRIPTION
## Summary

`OutboxTests.The_processor_drains_the_outbox_and_publishes_events` fails intermittently with:

```
Assert.NotNull() Failure: Value of type 'Nullable<DateTime>' does not have a value
```

Since tests run in the **pre-commit hook**, not CI, a flaky test blocks commits for whoever hits it — worth fixing properly rather than re-running.

## Root cause: it waits on the wrong signal

The test waits for the in-process `Recorder` to see the published event, then asserts on the **persisted** `ProcessedAt`. Those are not the same moment. `OutboxProcessor.DrainAsync`:

1. `PublishAsync(...)` → invokes the handler → **fills the recorder** ← the test's wait ends here
2. `message.ProcessedAt = ...` — in memory only
3. …rest of the batch…
4. `await db.SaveChangesAsync()` — **persists `ProcessedAt`** ← the test's assertion reads this

So the wait releases on a signal that *strictly precedes* the one being asserted, separated by a database write. That's why it only failed on a loaded box (my SQLite load harness was hammering the same disk) and passed 3/3 in isolation.

## Proven, not assumed

- **The race exists**: holding the write lock so the drain's `SaveChangesAsync` cannot complete shows the recorder populated while `ProcessedAt` is still `null` — "the handler ran" does not imply "the message is marked processed".
- **The fix removes it**: running the test body against a save made *slow but still successful* (a 2s lock hold), under identical conditions:
  - old wait (recorder) → **FAILED**
  - new wait (persisted `ProcessedAt`) → **PASSED**

Both were scratch experiments, not committed — they'd be testing SQLite's locking, not the outbox contract.

## The fix

Wait on `ProcessedAt` itself. It's the last thing the drain does, so it implies the publish already happened and covers both assertions. `WaitUntilAsync` now takes an async predicate so it can poll the database — the only place the drain's completion is observable.

**Test-only.** The processor's publish-then-mark ordering is the documented at-least-once behaviour (a crash between the two republishes the message) and is deliberately unchanged.

## Testing

- `scripts/run-unit-local.sh` green (format + warnings-as-errors + all test projects).
- The fixed test run 5× consecutively: 5/5 green.
