### PR TITLE
docs: fold the duplicate [Unreleased] "Fixed" heading back into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ them until tagged releases begin.
   assertion raced that write and lost whenever the disk was busy. It now waits on `ProcessedAt` itself (which
   implies the publish already happened). Test-only: the processor's ordering is the documented
   at-least-once behaviour and is unchanged.
+- **A clean child could replay a stale forwarded `data-rask-key`.** A keyless component's first element
+  adopts a keyed ancestor's forwarded key and bakes it into its cached frame snapshot. Nothing dirties
+  that child when the ancestor's key changes, so it would re-emit the old identity and the diff would
+  reconcile the subtree against the wrong sibling — moving the wrong DOM. The snapshot now records the
+  forwarded key it was captured under and falls back to a walk when it no longer matches.
 
 ### Changed
 - **`rask new` generates the `server`, `wasm` and `native` templates itself — no `dotnet new` / Rask.Templates.**
@@ -70,13 +75,6 @@ them until tagged releases begin.
   As part of this the cache's `LiveState` fields collapse into a single reference to a side object, so
   only components that actually cache pay for the state — an empty-shell session gets *smaller*
   (16,370 → 16,090 B) despite the added handler bookkeeping.
-
-### Fixed
-- **A clean child could replay a stale forwarded `data-rask-key`.** A keyless component's first element
-  adopts a keyed ancestor's forwarded key and bakes it into its cached frame snapshot. Nothing dirties
-  that child when the ancestor's key changes, so it would re-emit the old identity and the diff would
-  reconcile the subtree against the wrong sibling — moving the wrong DOM. The snapshot now records the
-  forwarded key it was captured under and falls back to a walk when it no longer matches.
 
 ### Added
 - **`rask generate feature --fields` supports `date`, `time`, and `datetime`.** `date` maps to `DateOnly`,


### PR DESCRIPTION
## Summary

`[Unreleased]` currently has **two `### Fixed` headings**. `main` had exactly one of each section type before, and every other section still does — Keep a Changelog wants one per type per version.

## How it got there

#388's entry *was* consolidated on its branch. But #386 merged in between that rebase and #388's merge, so GitHub three-way-merged #388 into a `main` that had moved. The result was **conflict-free and still wrong** — which is the point worth noting: nothing about this is a textual conflict, so neither the rebase nor GitHub could catch it. Hand-consolidating a shared append-point file races any PR that lands in the window.

## The change

A pure move: the outbox entry joins the existing `### Fixed`, and the duplicate heading plus its blank line go away.

- The set of `- **…**` bullets is **byte-identical** before and after (verified by diffing the sorted bullet sets) — nothing added, nothing lost.
- Net −2 lines: the redundant heading and one blank.

Docs only; no code touched.
