### PR TITLE
ci: publish Rask.Cli + Rask.Data/Outbox/Testing (were packable but never pushed)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -131,6 +131,10 @@ jobs:
           dotnet pack src/Rask.SQLite.EntityFrameworkCore/Rask.SQLite.EntityFrameworkCore.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.SQLite.Litestream/Rask.SQLite.Litestream.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.SQLite.Snapshots/Rask.SQLite.Snapshots.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Data/Rask.Data.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Outbox/Rask.Outbox.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Testing/Rask.Testing.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Cli/Rask.Cli.csproj -c Release -o ./artifacts
 
       - name: Download Rask.Native package (macOS-built, with heads)
         uses: actions/download-artifact@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,18 @@ jobs:
       - name: Pack Rask.SQLite.Snapshots
         run: dotnet pack src/Rask.SQLite.Snapshots/Rask.SQLite.Snapshots.csproj -c Release --no-build -o ./artifacts
 
+      - name: Pack Rask.Data
+        run: dotnet pack src/Rask.Data/Rask.Data.csproj -c Release --no-build -o ./artifacts
+
+      - name: Pack Rask.Outbox
+        run: dotnet pack src/Rask.Outbox/Rask.Outbox.csproj -c Release --no-build -o ./artifacts
+
+      - name: Pack Rask.Testing
+        run: dotnet pack src/Rask.Testing/Rask.Testing.csproj -c Release --no-build -o ./artifacts
+
+      - name: Pack Rask.Cli (the `rask` dotnet tool)
+        run: dotnet pack src/Rask.Cli/Rask.Cli.csproj -c Release --no-build -o ./artifacts
+
       - name: Upload packages
         uses: actions/upload-artifact@v7
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **The `rask` CLI and the `Rask.Data` / `Rask.Outbox` / `Rask.Testing` packages are now published.** All four
+  were packable but missing from the release + nightly pack lists, so `dotnet tool install -g Rask.Cli` failed
+  ("Rask.Cli is not found in NuGet feeds") and the packages that `rask generate feature --events`/`--outbox` and
+  `--tests` add to a project couldn't be restored from nuget.org. They now pack and push alongside the rest.
 - **Flaky `Rask.Outbox` test: `The_processor_drains_the_outbox_and_publishes_events`.** It waited for the
   in-process handler to run and then asserted on the *persisted* `ProcessedAt`, but the drain publishes the
   whole batch first and only writes `ProcessedAt` in a single end-of-batch `SaveChangesAsync` — so the


### PR DESCRIPTION
Fixes **"Rask.Cli is not found in NuGet feeds https://api.nuget.org/v3/index.json"** — the `rask` CLI tool was never published.

The release + nightly pipelines packed 15 packages but omitted four that are `IsPackable`/`PackAsTool` and shipped:
- **`Rask.Cli`** — the `rask` dotnet tool (`dotnet tool install -g Rask.Cli` was failing).
- **`Rask.Data`** / **`Rask.Outbox`** — referenced by `rask generate feature --events` / `--outbox`, which `dotnet add package` them at generate time.
- **`Rask.Testing`** — the shipped test helper, added by `rask generate feature --tests`.

So the tool couldn't be installed and generated projects couldn't restore those packages from nuget.org. This adds all four to the pack lists in both `release.yml` and `nightly.yml`. Verified locally that each packs cleanly (`Rask.Cli` as a tool package).

To prevent recurrence: a new packable `src/` project must be added to both workflows' pack lists.