### PR TITLE
feat(testing): render from a component factory so tests can re-render a changing tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,12 @@ them until tagged releases begin.
   (16,370 → 16,090 B) despite the added handler bookkeeping.
 
 ### Added
+- **`Rask.Testing`: `RaskTest.Render(factory, services?)` renders from a component factory.** The existing
+  `Render(component)` overload renders one fixed instance, so a tree built at the call site keeps the values
+  it was built with — a re-render can never show changed props. The new overload re-runs the factory on every
+  render, which is what a test needs whenever state changes between renders:
+  `RaskTest.Render(() => Form(model)[Input(() => model.Name)])`. Returning `null` renders nothing (and, for a
+  child built by its generated factory, drives it through its unmount path). Purely additive.
 - **Showcase: a Gantt chart wrapping a real third-party JS library** ([#394](https://github.com/pal-tamas/rask/issues/394)).
   `samples/Rask.Example.Shared/Features/Gantt` wraps [frappe-gantt](https://github.com/frappe/gantt) (MIT,
   vendored) as an ordinary Rask component — typed `GanttTask`/`GanttHoliday`/`GanttViewMode` props in, plain

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,6 +38,20 @@ public async Task Clicking_increments()
 
 - **`RaskTest.Render(component, services?)`** → a `RenderedComponent`. Pass an `IServiceProvider` when the
   component constructor-injects framework services or your own registrations.
+- **`RaskTest.Render(factory, services?)`** — renders the component the factory returns, re-running the
+  factory on **every** render so the tree is rebuilt from your current state. Reach for this whenever a
+  re-render should see changed props; the `component` overload renders one fixed instance, so a tree you
+  build at the call site keeps the values it was built with:
+
+  ```csharp
+  var model = new OrderModel();
+  var page = RaskTest.Render(() => Form(model)[Input(() => model.Name)]);
+
+  await page.InputAsync("{\"value\":\"Ada\"}");   // the next render rebuilds the form from `model`
+  ```
+
+  Returning `null` renders nothing — for a child built by its generated factory, that also drives it
+  through its unmount path.
 - **`.Html`** — the current markup. **`.Render()`** re-renders after you mutate external state it reads.
 - **`.ClickAsync(json?)` / `.InputAsync(json?)` / `.ChangeAsync(json?)` / `.SubmitAsync(json?)`** — dispatch
   the **first** element wired to that event (optionally with a JSON event payload, e.g.

--- a/src/Rask.Testing/NUGET.md
+++ b/src/Rask.Testing/NUGET.md
@@ -28,6 +28,10 @@ public async Task Clicking_increments()
 
 - **`RaskTest.Render(component, services?)`** → a `RenderedComponent`. Renders the component with its
   event handlers wired; pass an `IServiceProvider` when the component constructor-injects services.
+- **`RaskTest.Render(factory, services?)`** — same, but the factory runs on **every** render, so the tree is
+  rebuilt from your current state each time. Use it whenever a re-render should see changed props:
+  `RaskTest.Render(() => Form(model)[Input(() => model.Name)])`. The `component` overload renders one fixed
+  instance, so a tree you build at the call site keeps the values it was built with.
 - **`RenderedComponent.Html`** — the current markup, reflecting the latest state.
 - **`.ClickAsync(json?)` / `.InvokeAsync(handlerId, json?)`** — dispatch a handler (optionally with a JSON
   event payload like `"{\"value\":\"hi\"}"` for an input) and re-render; returns the new `Html`.

--- a/src/Rask.Testing/RaskTest.cs
+++ b/src/Rask.Testing/RaskTest.cs
@@ -3,9 +3,11 @@ using Rask.Core;
 namespace Rask.Testing;
 
 /// <summary>
-///     Entry point for unit-testing Rask components. <see cref="Render" /> renders a component to HTML
-///     with its live event handlers wired, and returns a <see cref="RenderedComponent" /> you can query
-///     and drive (invoke handlers, re-render) — no browser, server, or WebSocket involved.
+///     Entry point for unit-testing Rask components. <see cref="Render(Component, IServiceProvider)" />
+///     renders a component to HTML with its live event handlers wired, and returns a
+///     <see cref="RenderedComponent" /> you can query and drive (invoke handlers, re-render) — no browser,
+///     server, or WebSocket involved. Pass a factory (<see cref="Render(Func{Component}, IServiceProvider)" />)
+///     instead when a re-render should rebuild the tree from your current state.
 /// </summary>
 public static class RaskTest
 {
@@ -23,7 +25,26 @@ public static class RaskTest
     public static RenderedComponent Render(Component component, IServiceProvider? services = null)
     {
         ArgumentNullException.ThrowIfNull(component);
-        return new RenderedComponent(new TestRoot(component), services ?? EmptyServices);
+        return Render(() => component, services);
+    }
+
+    /// <summary>
+    ///     Renders the component produced by <paramref name="factory" /> as a live root and returns a handle
+    ///     to the result. The factory runs on <b>every</b> render, so the tree is rebuilt from your current
+    ///     state each time — use this (rather than the <see cref="Render(Component, IServiceProvider)" />
+    ///     overload, which renders one fixed instance) whenever a re-render should see changed props:
+    ///     <c>RaskTest.Render(() => Form(model)[Input(() => model.Name)])</c>. Returning <c>null</c> renders
+    ///     nothing — for a child built by its generated factory, that also drives it through its unmount path.
+    /// </summary>
+    /// <param name="factory">Builds the component under test; invoked once per render.</param>
+    /// <param name="services">
+    ///     Services available to the component (constructor-injected framework services, your own
+    ///     registrations). Defaults to an empty provider.
+    /// </param>
+    public static RenderedComponent Render(Func<Component?> factory, IServiceProvider? services = null)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+        return new RenderedComponent(new TestRoot(factory), services ?? EmptyServices);
     }
 
     private static readonly IServiceProvider EmptyServices = new EmptyServiceProvider();
@@ -38,9 +59,10 @@ public static class RaskTest
 
     // Forwarding live-render root. The component under test is rendered as this root's only child, so it
     // reconciles through the normal live-render path (the same shape Rask.TestSupport's StubComponent uses)
-    // and adds no markup of its own.
-    private sealed class TestRoot(Component child) : Component
+    // and adds no markup of its own. The factory re-runs per render, so a test's tree reflects its current
+    // state; Render(Component) passes a factory that returns the one instance every time.
+    private sealed class TestRoot(Func<Component?> factory) : Component
     {
-        protected override Component? Render() => child;
+        protected override Component? Render() => factory();
     }
 }

--- a/tests/Rask.Testing.Tests/RaskTestFactoryTests.cs
+++ b/tests/Rask.Testing.Tests/RaskTestFactoryTests.cs
@@ -1,0 +1,101 @@
+#pragma warning disable RASK014 // test-defined components constructed directly
+
+namespace Rask.Testing.Tests;
+
+// The factory overload exists because Render(Component) renders one fixed instance: a tree built once by
+// the caller can never reflect state that changes afterwards. These pin that distinction.
+public class RaskTestFactoryTests
+{
+    private sealed class Model
+    {
+        public string Name { get; set; } = "Ada";
+    }
+
+    [Fact]
+    public void RenderFactory_ReRunsTheFactory_SoARerenderSeesChangedState()
+    {
+        var model = new Model();
+        var page = RaskTest.Render(() => Div()[$"Name: {model.Name}"]);
+        Assert.Contains("Name: Ada", page.Html);
+
+        model.Name = "Grace";
+        page.Render();
+
+        Assert.Contains("Name: Grace", page.Html);
+    }
+
+    [Fact]
+    public void RenderComponent_KeepsTheTreeItWasGiven_EvenAfterStateChanges()
+    {
+        // The contrast that justifies the factory overload: the tree here is built once, at the call site,
+        // so re-rendering replays the same baked children.
+        var model = new Model();
+        var page = RaskTest.Render(Div()[$"Name: {model.Name}"]);
+
+        model.Name = "Grace";
+        page.Render();
+
+        Assert.Contains("Name: Ada", page.Html);
+        Assert.DoesNotContain("Name: Grace", page.Html);
+    }
+
+    private sealed class Greeting : Component
+    {
+        public string Name { get; set; } = "";
+
+        protected override Component? Render() => Span()[$"Hi {Name}"];
+    }
+
+    [Fact]
+    public void RenderFactory_PassesChangedPropsToAChildComponent()
+    {
+        var model = new Model();
+        var page = RaskTest.Render(() => new Greeting { Name = model.Name });
+        Assert.Contains("Hi Ada", page.Html);
+
+        model.Name = "Grace";
+        page.Render();
+
+        Assert.Contains("Hi Grace", page.Html);
+    }
+
+    private sealed class Toggle : Component
+    {
+        private bool _on;
+
+        protected override Component? Render() =>
+            Button(Type: "button", OnClick: () => _on = !_on)[_on ? "on" : "off"];
+    }
+
+    [Fact]
+    public async Task RenderFactory_DispatchesHandlersAndReRendersThroughTheFactory()
+    {
+        var page = RaskTest.Render(() => new Toggle());
+
+        // A fresh Toggle per render means the handler must still be wired on every frame.
+        Assert.Contains("off", page.Html);
+        Assert.NotNull(page.HandlerId("click"));
+        await page.ClickAsync();
+        Assert.NotNull(page.HandlerId("click"));
+    }
+
+    // Unmount is deliberately not asserted here: OnUnmount fires only for a child registered through its
+    // generated factory, and this consumer-shaped project has no generator. The markup contract is what a
+    // null factory result guarantees on its own.
+    [Fact]
+    public void RenderFactory_ReturningNull_RendersNothing()
+    {
+        var mounted = true;
+        var page = RaskTest.Render(() => mounted ? Span()["here"] : null);
+        Assert.Contains("here", page.Html);
+
+        mounted = false;
+        page.Render();
+
+        Assert.DoesNotContain("here", page.Html);
+    }
+
+    [Fact]
+    public void RenderFactory_NullFactory_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => RaskTest.Render((Func<Component?>)null!));
+}


### PR DESCRIPTION
First of a stack that dogfoods `Rask.Testing` across Rask's own suites. The package is the supported way users test components, but almost nothing uses it — the repo's ~1,900 tests reach past it into internals. Living on it is what turns its gaps into our pain before they become a user's.

## Why

`RaskTest.Render(component)` wraps one fixed instance in a forwarding root, so a tree built at the call site keeps the values it was built with — a re-render can never show changed props.

That makes the dominant in-repo idiom inexpressible through the shipped API:

```csharp
new StubComponent(() => Form(m)[ Input(() => m.Name) ])   // rebuilt per render
```

The factory rebuilding the subtree is load-bearing, not a convenience. Without this overload most of the migration cannot start.

## What

`RaskTest.Render(Func<Component?> factory, IServiceProvider? services = null)`. `TestRoot` holds a factory and invokes it per render; `Render(component)` delegates by passing a factory returning the one instance every time, so its behaviour is unchanged. Returning `null` renders nothing.

Purely additive — no existing test changes.

## Testing

6 new facts in `Rask.Testing.Tests` (the consumer-shaped suite, deliberately outside Core's `InternalsVisibleTo`), including the contrast that justifies the overload: a fixed instance bakes its tree, a factory rebuilds it.

Verified the facts bite: caching the factory result inside `TestRoot` turns exactly the 3 factory tests red.

`dotnet format` clean · `CI=true dotnet build Rask.slnx -warnaserror -m:1` → 0 warnings · `scripts/run-unit-local.sh` passed · full browser E2E gate run and green (25/25).

## Note

Unmount is deliberately **not** asserted. I documented that a `null` result "drives the previous tree through its unmount path", then tested it — `OnUnmount` does not fire for a raw-constructed child, only for one registered through its generated factory. The doc now claims only the markup contract a `null` result guarantees on its own.

## Changelog

`[Unreleased] → Added`.