### PR TITLE
feat(testing): expose the live instance and a non-throwing TryInvokeAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,13 @@ them until tagged releases begin.
   (16,370 → 16,090 B) despite the added handler bookkeeping.
 
 ### Added
+- **`Rask.Testing`: `RenderedComponent<T>.Instance` and a non-throwing `TryInvokeAsync`.**
+  `RaskTest.Render(component)` now returns a `RenderedComponent<T>` whose `Instance` is the object you passed
+  in, so a test can assert the component's own state instead of parsing it back out of the markup. The
+  forwarding test root renders that object directly rather than reconciling it, so `Instance` is guaranteed
+  to stay the same instance for the handle's lifetime. `TryInvokeAsync(id, json?)` dispatches only if the id
+  is still live and returns `false` otherwise — for asserting a handler is *gone*, where `InvokeAsync` throws.
+  Source-compatible: existing `Render(x)` calls bind to the generic overload and get a subtype.
 - **`Rask.Testing`: query every match — `HandlerIds(domEvent)`, `Attrs(name)`, and a public `Markup`.**
   `HandlerId`/`Attr` reach only the first match, which is useless for a component that wires many elements to
   one event; the workaround was to scrape the markup with a hand-rolled `Regex` (Rask's own `BsDataGrid`

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,6 +57,10 @@ public async Task Clicking_increments()
   the **first** element wired to that event (optionally with a JSON event payload, e.g.
   `"{\"value\":\"hi\"}"` for an input), then re-render; returns the new `Html`.
 - **`.InvokeAsync(handlerId, json?)`** — dispatch a specific handler by id.
+- **`.TryInvokeAsync(handlerId, json?)`** — dispatch only if the id is still live; returns `false` instead of
+  throwing. Use it to assert a handler is **gone** (a removed element, a disposed subtree).
+- **`.Instance`** — the component object you passed to `Render(component)`, so you can assert its own state
+  rather than parsing it back out of the markup. It stays the same object for the handle's lifetime.
 - **`.HandlerId(domEvent)`** / **`.Attr(name)`** — read a handler id / attribute off the current `Html`.
   Handler ids are reissued every render, so read one from the current `Html` right before invoking rather
   than reusing a captured id.

--- a/src/Rask.Testing/NUGET.md
+++ b/src/Rask.Testing/NUGET.md
@@ -40,6 +40,9 @@ public async Task Clicking_increments()
 - **`.HandlerIds(domEvent)`** / **`.Attrs(name)`** — every match, in document order. Index these to target
   one of several same-event elements: `await page.InvokeAsync(page.HandlerIds("click")[1])`.
 - **`Markup.Attr(html, name)`** / **`Markup.Attrs(html, name)`** — the same lookups over any HTML string.
+- **`.TryInvokeAsync(handlerId, json?)`** — dispatch only if the id is still live; returns `false` rather
+  than throwing, so you can assert a handler is gone.
+- **`.Instance`** — the component object you passed in, for asserting its state directly.
 - **`.Render()`** — re-render after mutating external state the component reads.
 
 ## Install

--- a/src/Rask.Testing/RaskTest.cs
+++ b/src/Rask.Testing/RaskTest.cs
@@ -3,7 +3,7 @@ using Rask.Core;
 namespace Rask.Testing;
 
 /// <summary>
-///     Entry point for unit-testing Rask components. <see cref="Render(Component, IServiceProvider)" />
+///     Entry point for unit-testing Rask components. <see cref="Render{T}(T, IServiceProvider)" />
 ///     renders a component to HTML with its live event handlers wired, and returns a
 ///     <see cref="RenderedComponent" /> you can query and drive (invoke handlers, re-render) — no browser,
 ///     server, or WebSocket involved. Pass a factory (<see cref="Render(Func{Component}, IServiceProvider)" />)
@@ -15,23 +15,26 @@ public static class RaskTest
     ///     Renders <paramref name="component" /> as a live root and returns a handle to the result. The
     ///     component is wrapped in a forwarding root (so any component — including one that can't be a
     ///     page root — works), its event handlers are registered, and <see cref="RenderedComponent.Html" />
-    ///     holds the initial markup.
+    ///     holds the initial markup. The handle's <see cref="RenderedComponent{T}.Instance" /> is this same
+    ///     object, so a test can assert against the component's own state as well as its markup.
     /// </summary>
+    /// <typeparam name="T">The component's type, inferred from <paramref name="component" />.</typeparam>
     /// <param name="component">The component under test.</param>
     /// <param name="services">
     ///     Services available to the component (constructor-injected framework services, your own
     ///     registrations). Defaults to an empty provider.
     /// </param>
-    public static RenderedComponent Render(Component component, IServiceProvider? services = null)
+    public static RenderedComponent<T> Render<T>(T component, IServiceProvider? services = null)
+        where T : Component
     {
         ArgumentNullException.ThrowIfNull(component);
-        return Render(() => component, services);
+        return new RenderedComponent<T>(new TestRoot(() => component), component, services ?? EmptyServices);
     }
 
     /// <summary>
     ///     Renders the component produced by <paramref name="factory" /> as a live root and returns a handle
     ///     to the result. The factory runs on <b>every</b> render, so the tree is rebuilt from your current
-    ///     state each time — use this (rather than the <see cref="Render(Component, IServiceProvider)" />
+    ///     state each time — use this (rather than the <see cref="Render{T}(T, IServiceProvider)" />
     ///     overload, which renders one fixed instance) whenever a re-render should see changed props:
     ///     <c>RaskTest.Render(() => Form(model)[Input(() => model.Name)])</c>. Returning <c>null</c> renders
     ///     nothing — for a child built by its generated factory, that also drives it through its unmount path.

--- a/src/Rask.Testing/RenderedComponent.cs
+++ b/src/Rask.Testing/RenderedComponent.cs
@@ -8,11 +8,13 @@ namespace Rask.Testing;
 ///     (<see cref="InvokeAsync" />, <see cref="ClickAsync" />) to simulate an event, which dispatches it
 ///     and re-renders, or call <see cref="Render" /> to re-render after mutating external state.
 /// </summary>
-public sealed class RenderedComponent
+public class RenderedComponent
 {
     private readonly Component _root;
     private readonly IServiceProvider _services;
 
+    // Not sealed so RenderedComponent<T> can add Instance; the ctor stays internal, so this type is still
+    // only constructible — and only derivable — inside the package.
     internal RenderedComponent(Component root, IServiceProvider services)
     {
         _root = root;
@@ -70,6 +72,42 @@ public sealed class RenderedComponent
     public async Task<string> InvokeAsync(string handlerId, string? jsonPayload = null)
     {
         ArgumentNullException.ThrowIfNull(handlerId);
+
+        if (!await DispatchAsync(handlerId, jsonPayload).ConfigureAwait(false))
+        {
+            throw new InvalidOperationException(
+                $"No handler with id '{handlerId}' is registered in the current render. Handler ids are "
+                + "reissued every render — read the id from the current Html (HandlerId(\"click\") / "
+                + "Attr(\"data-rask-on-...\")) immediately before invoking.");
+        }
+
+        return Render();
+    }
+
+    /// <summary>
+    ///     Dispatches <paramref name="handlerId" /> if it is live in the current render, re-rendering and
+    ///     returning <c>true</c>; returns <c>false</c> — without re-rendering — if no such handler is
+    ///     registered. Use this to assert that a handler is <b>gone</b> (a removed element, a disposed
+    ///     subtree); <see cref="InvokeAsync" /> is the ergonomic default when you expect it to be there.
+    /// </summary>
+    /// <exception cref="ArgumentException">The payload is not valid JSON.</exception>
+    public async Task<bool> TryInvokeAsync(string handlerId, string? jsonPayload = null)
+    {
+        ArgumentNullException.ThrowIfNull(handlerId);
+
+        var dispatched = await DispatchAsync(handlerId, jsonPayload).ConfigureAwait(false);
+        if (dispatched)
+        {
+            Render();
+        }
+
+        return dispatched;
+    }
+
+    // Parses the payload and hands it to the handler. Returns whether the id was live — the throw-vs-bool
+    // choice belongs to the callers above. An invalid payload is a caller bug either way, so it always throws.
+    private async Task<bool> DispatchAsync(string handlerId, string? jsonPayload)
+    {
         JsonDocument doc;
         try
         {
@@ -84,18 +122,9 @@ public sealed class RenderedComponent
 
         using (doc)
         {
-            var dispatched = await _root.TryInvokeHandlerAsync(handlerId, doc.RootElement, _services)
+            return await _root.TryInvokeHandlerAsync(handlerId, doc.RootElement, _services)
                 .ConfigureAwait(false);
-            if (!dispatched)
-            {
-                throw new InvalidOperationException(
-                    $"No handler with id '{handlerId}' is registered in the current render. Handler ids are "
-                    + "reissued every render — read the id from the current Html (HandlerId(\"click\") / "
-                    + "Attr(\"data-rask-on-...\")) immediately before invoking.");
-            }
         }
-
-        return Render();
     }
 
     /// <summary>Dispatches the <b>first</b> <c>click</c> handler in the current render (see <see cref="HandlerId" />).</summary>
@@ -118,4 +147,24 @@ public sealed class RenderedComponent
                      $"No {domEvent} handler (data-rask-on-{domEvent}) in the current render.");
         return InvokeAsync(id, jsonPayload);
     }
+}
+
+/// <summary>
+///     A rendered component under test whose <see cref="Instance" /> is the component object itself — for
+///     asserting against a component's own state, rather than only the markup it produced.
+/// </summary>
+/// <typeparam name="T">The component's type.</typeparam>
+public sealed class RenderedComponent<T> : RenderedComponent
+    where T : Component
+{
+    internal RenderedComponent(Component root, T instance, IServiceProvider services)
+        : base(root, services) => Instance = instance;
+
+    /// <summary>
+    ///     The component under test — the very object passed to
+    ///     <see cref="RaskTest.Render{T}(T, IServiceProvider)" />, for the lifetime of this handle. The
+    ///     forwarding test root renders it directly rather than reconciling it, so this never becomes a
+    ///     different instance behind your back.
+    /// </summary>
+    public T Instance { get; }
 }

--- a/tests/Rask.Testing.Tests/RenderedComponentInstanceTests.cs
+++ b/tests/Rask.Testing.Tests/RenderedComponentInstanceTests.cs
@@ -1,0 +1,106 @@
+#pragma warning disable RASK014 // test-defined components constructed directly
+
+namespace Rask.Testing.Tests;
+
+// Markup is not always the thing under test: a component's own state is often what a test wants to assert.
+// These pin Instance's identity guarantee and the non-throwing dispatch.
+public class RenderedComponentInstanceTests
+{
+    private sealed class Counter : Component
+    {
+        public int Count { get; private set; }
+
+        protected override Component? Render() =>
+            Button(Type: "button", OnClick: () => Count++)[$"Count: {Count}"];
+    }
+
+    [Fact]
+    public void Instance_IsTheObjectPassedIn()
+    {
+        var counter = new Counter();
+        var page = RaskTest.Render(counter);
+
+        Assert.Same(counter, page.Instance);
+    }
+
+    [Fact]
+    public async Task Instance_StaysTheSameObjectAcrossRenders_AndExposesState()
+    {
+        var counter = new Counter();
+        var page = RaskTest.Render(counter);
+
+        await page.ClickAsync();
+        await page.ClickAsync();
+        page.Render();
+
+        // The identity guarantee: the forwarding root renders the caller's object rather than reconciling
+        // it, so a test can hold on to Instance and assert state directly instead of parsing it back out.
+        Assert.Same(counter, page.Instance);
+        Assert.Equal(2, page.Instance.Count);
+    }
+
+    // A component that stops wiring its handler once clicked — the shape TryInvokeAsync exists for.
+    private sealed class OneShot : Component
+    {
+        private bool _done;
+
+        protected override Component? Render() =>
+            _done ? Span()["done"] : Button(Type: "button", OnClick: () => _done = true)["go"];
+    }
+
+    [Fact]
+    public async Task TryInvokeAsync_LiveHandler_DispatchesAndReports()
+    {
+        var page = RaskTest.Render(new OneShot());
+        var id = page.HandlerId("click")!;
+
+        Assert.True(await page.TryInvokeAsync(id));
+        Assert.Contains("done", page.Html);
+    }
+
+    [Fact]
+    public async Task TryInvokeAsync_HandlerThatIsGone_ReturnsFalseInsteadOfThrowing()
+    {
+        var page = RaskTest.Render(new OneShot());
+        var id = page.HandlerId("click")!;
+        await page.InvokeAsync(id);
+
+        // The button is gone, so its id is no longer live. InvokeAsync would throw here; the point of
+        // TryInvokeAsync is to let a test assert the handler is gone.
+        Assert.False(await page.TryInvokeAsync(id));
+        Assert.Empty(page.HandlerIds("click"));
+    }
+
+    private sealed class RenderCount : Component
+    {
+        public int Renders { get; private set; }
+
+        protected override Component? Render()
+        {
+            Renders++;
+            return Span()[$"{Renders}"];
+        }
+    }
+
+    [Fact]
+    public async Task TryInvokeAsync_DeadHandler_DoesNotReRender()
+    {
+        var page = RaskTest.Render(new RenderCount());
+        Assert.Equal(1, page.Instance.Renders);
+
+        Assert.False(await page.TryInvokeAsync("not-a-real-id"));
+
+        // Nothing was dispatched, so nothing can have changed — re-rendering would be pure noise.
+        Assert.Equal(1, page.Instance.Renders);
+    }
+
+    [Fact]
+    public async Task TryInvokeAsync_InvalidJson_StillThrows()
+    {
+        var page = RaskTest.Render(new Counter());
+        var id = page.HandlerId("click")!;
+
+        // A malformed payload is a bug in the test, not a "handler missing" condition, so it throws either way.
+        await Assert.ThrowsAsync<ArgumentException>(() => page.TryInvokeAsync(id, "value=hi"));
+    }
+}


### PR DESCRIPTION
Stacked on #402.

## Why

Two gaps the in-repo suites hit:

- `RenderHarness.Render<T>` hands lifecycle tests back the resolved component so they can assert its state. `RaskTest` gave back only HTML, so ~28 files had no public path.
- Core's `TryInvokeHandlerAsync` returns `bool`, and tests assert it directly (`Assert.False(ok)`) to prove a handler is gone. `RaskTest.InvokeAsync` only throws.

## What

- `Render(component)` now returns `RenderedComponent<T>` with `.Instance`.
- `TryInvokeAsync(id, json?)` → `bool`, skipping the re-render when nothing was dispatched (nothing dispatched ⇒ nothing can have changed). An invalid payload still throws in both: that's a bug in the test, not a missing-handler condition.

## The `Instance` guarantee is exact, not incidental

`TestRoot.Render()` returns the caller's object and never routes through `GetOrCreateChild` (which only fires for generated factory calls inside a `Render` body), so `Instance` cannot become a different object behind the test's back. That's worth relying on, so it's stated in the XML doc and pinned by a test.

## Compatibility

`RenderedComponent` is unsealed to host the generic subtype. Safe: its ctor is `internal`, so nothing outside the package could derive from it before or now.

The generic overload is source-compatible — existing `Render(x)` calls bind to it and get a subtype. The whole solution building clean with 0 warnings confirms it: `Rask.Bootstrap.Tests` already calls `Render` and needed no change.

## Testing

6 new facts (27 total), covering identity across renders, the handler-is-gone case, and that a dead id doesn't re-render.

`dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed.

## Changelog

`[Unreleased] → Added`.