### PR TITLE
feat(testing): ship TestJSRuntime and EditContextProbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,6 +161,16 @@ them until tagged releases begin.
   (16,370 → 16,090 B) despite the added handler bookkeeping.
 
 ### Added
+- **`Rask.Testing`: ships `TestJSRuntime` and `RaskTest.EditContextProbe`.** A component that injects
+  `IJSRuntime` was untestable without hand-writing a fake — so everyone wrote the same one (Rask itself had
+  four near-identical copies). `TestJSRuntime` records every call (`Calls` in invocation order, `ArgsFor(id)`,
+  `CallCount(id)`) and returns what you configure (`SetResponse`/`SetException`); an unconfigured call returns
+  `default`, matching a real absent value. It records and replays — nothing more. Adds a `Microsoft.JSInterop`
+  dependency, which every consumer already has transitively via `Rask.Core`.
+  `RaskTest.EditContextProbe(capture)`, placed inside a `Form`'s children, hands a test the form's
+  `EditContext` — the only way to assert validation state (`GetValidationMessages`, `IsModified`,
+  `IsValidating`), which never reaches the markup. It's a factory method rather than a constructible type
+  because RASK014 makes `new` on a component an error, including on types Rask ships.
 - **`Rask.Testing`: `RenderedComponent<T>.Instance` and a non-throwing `TryInvokeAsync`.**
   `RaskTest.Render(component)` now returns a `RenderedComponent<T>` whose `Instance` is the object you passed
   in, so a test can assert the component's own state instead of parsing it back out of the markup. The

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -77,6 +77,44 @@ public async Task Clicking_increments()
 - **`Markup.Attr(html, name)`** / **`Markup.Attrs(html, name)`** — the same lookups over any HTML string you
   hold, rather than over a `RenderedComponent` (e.g. markup lifted out of a live payload).
 
+### Components that call JavaScript
+
+`TestJSRuntime` is an `IJSRuntime` that records every call and returns what you configure — register it and
+assert on the identifier and arguments your component shipped:
+
+```csharp
+var js = new TestJSRuntime();
+js.SetResponse("raskApi.clipboard.read", "hello");
+var services = new ServiceCollection().AddSingleton<IJSRuntime>(js).BuildServiceProvider();
+
+var page = RaskTest.Render(new Copier(), services);
+await page.ClickAsync();
+
+Assert.Equal(["hello"], js.ArgsFor("raskApi.clipboard.write"));
+```
+
+`.Calls` lists every call in order; `.ArgsFor(id)` is the single-call shorthand, `.CallCount(id)` counts, and
+`.SetException(id, ex)` faults one. An unconfigured call returns `default` — the same as a real absent value.
+
+### Forms: asserting validation state
+
+Validation state (messages, `IsModified`, `IsValidating`) never reaches the markup, so reach the form's
+`EditContext` with a probe placed **inside** the form's children:
+
+```csharp
+EditContext? ctx = null;
+var page = RaskTest.Render(() => Form(model)[
+    Input(() => model.Name),
+    RaskTest.EditContextProbe(c => ctx = c)
+]);
+
+await page.InputAsync("{\"value\":\"Ada\"}");
+Assert.True(ctx!.IsModified(new FieldIdentifier(model, nameof(model.Name))));
+```
+
+The probe renders no markup of its own. Outside a form it captures nothing — the context is ambient only
+within the form's subtree.
+
 `Rask.Core` comes transitively from the app under test (via its `Rask.Server` / `Rask.Wasm` reference),
 so a test project only references `Rask.Testing` and the app.
 

--- a/src/Rask.Testing/EditContextProbe.cs
+++ b/src/Rask.Testing/EditContextProbe.cs
@@ -1,0 +1,27 @@
+using Rask.Core;
+using Rask.Core.Forms;
+
+namespace Rask.Testing;
+
+// Renders nothing and hands the test the EditContext a surrounding form pushed onto EditContextScope.
+//
+// Deliberately internal, reached through RaskTest.EditContextProbe: a public component type would force
+// consumers to write `new EditContextProbe(...)`, and RASK014 ("components must be created via factory
+// methods") is an *error* that fires on any `new` of a Component outside Rask.Core — including on types we
+// ship. A factory method is what that rule asks for, so this is the shape that composes with our own
+// analyzer instead of fighting it.
+//
+// It captures during Render, not at construction, because the context is ambient only while the form's
+// subtree is rendering — which is also why it must sit INSIDE the form's children to see anything.
+internal sealed class EditContextProbe(Action<EditContext> capture) : Component
+{
+    protected override Component? Render()
+    {
+        if (EditContextScope.Current is { } context)
+        {
+            capture(context);
+        }
+
+        return null;
+    }
+}

--- a/src/Rask.Testing/NUGET.md
+++ b/src/Rask.Testing/NUGET.md
@@ -44,6 +44,12 @@ public async Task Clicking_increments()
   than throwing, so you can assert a handler is gone.
 - **`.Instance`** — the component object you passed in, for asserting its state directly.
 - **`.Render()`** — re-render after mutating external state the component reads.
+- **`TestJSRuntime`** — an `IJSRuntime` that records calls and returns canned values, for components that
+  inject `IJSRuntime`. Register it in the provider, then assert with `.ArgsFor(id)` / `.Calls` /
+  `.CallCount(id)`; configure with `.SetResponse(id, value)` / `.SetException(id, ex)`.
+- **`RaskTest.EditContextProbe(capture)`** — placed inside a `Form`'s children, hands you the form's
+  `EditContext` so you can assert validation state (`GetValidationMessages`, `IsModified`, `IsValidating`)
+  that never appears in the markup.
 
 ## Install
 

--- a/src/Rask.Testing/Rask.Testing.csproj
+++ b/src/Rask.Testing/Rask.Testing.csproj
@@ -20,6 +20,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- TestJSRuntime implements IJSRuntime. A real dependency rather than bloat: Rask.Core already
+         references Microsoft.JSInterop (so components can ctor-inject IJSRuntime), which puts this
+         abstractions-only package in every consumer's graph transitively already. -->
+    <PackageReference Include="Microsoft.JSInterop"/>
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- PrivateAssets="all" keeps the (unpublished, IsPackable=false) Rask.Core "package" out of the
          nuspec: Rask.Testing is consumed alongside a host that already bundles Rask.Core.dll, so it
          resolves transitively — same pattern as Rask.Bootstrap. Core still resolves at compile time

--- a/src/Rask.Testing/RaskTest.cs
+++ b/src/Rask.Testing/RaskTest.cs
@@ -1,4 +1,5 @@
 using Rask.Core;
+using Rask.Core.Forms;
 
 namespace Rask.Testing;
 
@@ -48,6 +49,27 @@ public static class RaskTest
     {
         ArgumentNullException.ThrowIfNull(factory);
         return new RenderedComponent(new TestRoot(factory), services ?? EmptyServices);
+    }
+
+    /// <summary>
+    ///     A zero-markup component that hands <paramref name="capture" /> the <see cref="EditContext" /> the
+    ///     surrounding form is using, so a test can assert validation state (<c>GetValidationMessages</c>,
+    ///     <c>IsValidating</c>, <c>IsModified</c>) that never reaches the markup. Place it <b>inside</b> the
+    ///     form's children — the context is ambient only within that subtree:
+    ///     <code>
+    ///     EditContext? ctx = null;
+    ///     var page = RaskTest.Render(() => Form(model)[
+    ///         Input(() => model.Name),
+    ///         RaskTest.EditContextProbe(c => ctx = c)
+    ///     ]);
+    ///     </code>
+    ///     The callback runs on every render, so <paramref name="capture" /> sees the current context.
+    /// </summary>
+    /// <param name="capture">Receives the ambient context during each render.</param>
+    public static Component EditContextProbe(Action<EditContext> capture)
+    {
+        ArgumentNullException.ThrowIfNull(capture);
+        return new EditContextProbe(capture);
     }
 
     private static readonly IServiceProvider EmptyServices = new EmptyServiceProvider();

--- a/src/Rask.Testing/TestJSRuntime.cs
+++ b/src/Rask.Testing/TestJSRuntime.cs
@@ -1,0 +1,113 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Testing;
+
+/// <summary>One recorded JS interop call: the dotted <paramref name="Identifier" /> and its arguments.</summary>
+/// <param name="Identifier">The identifier the component invoked, e.g. <c>"raskApi.clipboard.write"</c>.</param>
+/// <param name="Args">The arguments passed, or <c>null</c> if none.</param>
+public readonly record struct JSCall(string Identifier, object?[]? Args);
+
+/// <summary>
+///     An <see cref="IJSRuntime" /> for tests: it records every call and returns whatever you configure,
+///     so a component that injects <c>IJSRuntime</c> can be unit-tested without a browser. Register it in
+///     the provider you pass to <see cref="RaskTest.Render{T}(T, IServiceProvider)" />, drive the component,
+///     then assert on the calls it made.
+/// </summary>
+/// <remarks>
+///     Records and replays — nothing more. An unconfigured call returns <c>default</c> for its return type,
+///     which matches a real absent value (a missing storage key reads back as <c>null</c>) and a void call.
+///     Safe to call from multiple threads; <see cref="Calls" /> keeps invocation order.
+/// </remarks>
+public sealed class TestJSRuntime : IJSRuntime
+{
+    private readonly List<JSCall> _calls = [];
+    private readonly Dictionary<string, Exception> _exceptions = [];
+    private readonly Lock _gate = new();
+    private readonly Dictionary<string, object?> _responses = [];
+
+    /// <summary>Every call made so far, in invocation order.</summary>
+    public IReadOnlyList<JSCall> Calls
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _calls.ToArray();
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public ValueTask<TValue> InvokeAsync<TValue>(string identifier, object?[]? args)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+
+        Exception? failure;
+        object? canned;
+        bool hasCanned;
+        lock (_gate)
+        {
+            _calls.Add(new JSCall(identifier, args));
+            _exceptions.TryGetValue(identifier, out failure);
+            hasCanned = _responses.TryGetValue(identifier, out canned);
+        }
+
+        if (failure is not null)
+        {
+            return ValueTask.FromException<TValue>(failure);
+        }
+
+        return hasCanned && canned is TValue typed
+            ? ValueTask.FromResult(typed)
+            : ValueTask.FromResult<TValue>(default!);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<TValue> InvokeAsync<TValue>(
+        string identifier, CancellationToken cancellationToken, object?[]? args) =>
+        InvokeAsync<TValue>(identifier, args);
+
+    /// <summary>Makes every call to <paramref name="identifier" /> return <paramref name="response" />.</summary>
+    public void SetResponse(string identifier, object? response)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+        lock (_gate)
+        {
+            _responses[identifier] = response;
+        }
+    }
+
+    /// <summary>Makes every call to <paramref name="identifier" /> fault with <paramref name="ex" />.</summary>
+    public void SetException(string identifier, Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+        ArgumentNullException.ThrowIfNull(ex);
+        lock (_gate)
+        {
+            _exceptions[identifier] = ex;
+        }
+    }
+
+    /// <summary>
+    ///     The arguments of the one call to <paramref name="identifier" />. Throws if it was not called
+    ///     exactly once — when several calls are expected, read <see cref="Calls" /> instead.
+    /// </summary>
+    public object?[]? ArgsFor(string identifier)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+
+        var matches = Calls.Where(c => c.Identifier == identifier).ToArray();
+        return matches.Length == 1
+            ? matches[0].Args
+            : throw new InvalidOperationException(
+                $"Expected exactly one call to '{identifier}', but there were {matches.Length}. "
+                + "Read Calls to assert against several.");
+    }
+
+    /// <summary>How many times <paramref name="identifier" /> was called.</summary>
+    public int CallCount(string identifier)
+    {
+        ArgumentNullException.ThrowIfNull(identifier);
+        return Calls.Count(c => c.Identifier == identifier);
+    }
+}

--- a/tests/Rask.Testing.Tests/EditContextProbeTests.cs
+++ b/tests/Rask.Testing.Tests/EditContextProbeTests.cs
@@ -1,0 +1,74 @@
+using Rask.Core.Forms;
+
+namespace Rask.Testing.Tests;
+
+// Validation state (messages, IsModified, IsValidating) never reaches the markup, so without a way to reach
+// the form's EditContext a consumer simply cannot assert it. These pin that the probe does.
+public class EditContextProbeTests
+{
+    private sealed class Model
+    {
+        public string Name { get; set; } = "";
+    }
+
+    [Fact]
+    public void Probe_InsideAForm_CapturesTheAmbientContext()
+    {
+        EditContext? captured = null;
+        var model = new Model();
+
+        RaskTest.Render(() => Form(model)[
+            Input(() => model.Name),
+            RaskTest.EditContextProbe(c => captured = c)
+        ]);
+
+        Assert.NotNull(captured);
+    }
+
+    [Fact]
+    public void Probe_RendersNoMarkupOfItsOwn()
+    {
+        var model = new Model();
+
+        var page = RaskTest.Render(() => Form(model)[RaskTest.EditContextProbe(_ => { })]);
+        var withoutProbe = RaskTest.Render(() => Form(model));
+
+        Assert.Equal(withoutProbe.Html, page.Html);
+    }
+
+    [Fact]
+    public async Task Probe_SeesStateTheMarkupNeverShows()
+    {
+        EditContext? captured = null;
+        var model = new Model();
+
+        var page = RaskTest.Render(() => Form(model)[
+            Input(() => model.Name),
+            RaskTest.EditContextProbe(c => captured = c)
+        ]);
+
+        var name = new FieldIdentifier(model, nameof(Model.Name));
+        Assert.False(captured!.IsModified(name));
+
+        await page.InputAsync("{\"value\":\"Ada\"}");
+
+        // The point of the probe: this is a fact about the form that reading Html could never tell you.
+        Assert.True(captured!.IsModified(name));
+    }
+
+    [Fact]
+    public void Probe_OutsideAForm_CapturesNothing()
+    {
+        var captured = false;
+
+        RaskTest.Render(() => Div()[RaskTest.EditContextProbe(_ => captured = true)]);
+
+        // There is no ambient context to hand over — placing the probe outside the form is a test bug, and
+        // it stays silent rather than inventing a context.
+        Assert.False(captured);
+    }
+
+    [Fact]
+    public void Probe_NullCapture_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => RaskTest.EditContextProbe(null!));
+}

--- a/tests/Rask.Testing.Tests/Rask.Testing.Tests.csproj
+++ b/tests/Rask.Testing.Tests/Rask.Testing.Tests.csproj
@@ -11,6 +11,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- A consumer registering a service for the component under test has DI available (their app pulls it
+         in); this project needs it explicitly to exercise the Render(component, services) overload.
+         Microsoft.JSInterop is NOT listed: it flows transitively from Rask.Testing, which is exactly how a
+         consumer gets it — so TestJSRuntime is being used here over the same surface they'd have. -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Rask.Testing.Tests/TestJSRuntimeTests.cs
+++ b/tests/Rask.Testing.Tests/TestJSRuntimeTests.cs
@@ -1,0 +1,110 @@
+#pragma warning disable RASK014 // test-defined components constructed directly
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.JSInterop;
+
+namespace Rask.Testing.Tests;
+
+// A component that injects IJSRuntime is untestable without a fake, so the package ships one. These pin
+// the record-and-replay contract a consumer relies on.
+public class TestJSRuntimeTests
+{
+    private sealed class Copier(IJSRuntime js) : Component
+    {
+        public string? Read { get; private set; }
+
+        protected override Component? Render() =>
+            Button(Type: "button", OnClick: async () =>
+            {
+                await js.InvokeVoidAsync("raskApi.clipboard.write", "hello");
+                Read = await js.InvokeAsync<string>("raskApi.clipboard.read");
+            })["copy"];
+    }
+
+    private static (RenderedComponent<Copier> Page, TestJSRuntime Js) RenderCopier()
+    {
+        var js = new TestJSRuntime();
+        var services = new ServiceCollection().AddSingleton<IJSRuntime>(js).BuildServiceProvider();
+        return (RaskTest.Render(new Copier(js), services), js);
+    }
+
+    [Fact]
+    public async Task RecordsTheIdentifierAndArgumentsAComponentInvoked()
+    {
+        var (page, js) = RenderCopier();
+
+        await page.ClickAsync();
+
+        Assert.Equal(["hello"], js.ArgsFor("raskApi.clipboard.write"));
+        Assert.Equal(1, js.CallCount("raskApi.clipboard.write"));
+    }
+
+    [Fact]
+    public async Task SetResponse_IsHandedBackToTheComponent()
+    {
+        var (page, js) = RenderCopier();
+        js.SetResponse("raskApi.clipboard.read", "from-the-clipboard");
+
+        await page.ClickAsync();
+
+        Assert.Equal("from-the-clipboard", page.Instance.Read);
+    }
+
+    [Fact]
+    public async Task UnconfiguredCall_ReturnsDefault_RatherThanThrowing()
+    {
+        var (page, js) = RenderCopier();
+
+        await page.ClickAsync();
+
+        // An absent value reads back as null, the same as a real empty clipboard/storage slot.
+        Assert.Null(page.Instance.Read);
+        Assert.Equal(1, js.CallCount("raskApi.clipboard.read"));
+    }
+
+    [Fact]
+    public async Task SetException_FaultsTheCall()
+    {
+        var js = new TestJSRuntime();
+        js.SetException("boom", new InvalidOperationException("no"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await js.InvokeAsync<string>("boom", []));
+    }
+
+    [Fact]
+    public async Task Calls_AreRecordedInInvocationOrder()
+    {
+        var (page, js) = RenderCopier();
+
+        await page.ClickAsync();
+
+        // Order is the contract: the write must be observable as having happened before the read.
+        Assert.Equal(
+            ["raskApi.clipboard.write", "raskApi.clipboard.read"],
+            js.Calls.Select(c => c.Identifier));
+    }
+
+    [Fact]
+    public async Task ArgsFor_WhenCalledMoreThanOnce_SaysSoInsteadOfThrowingAnOpaqueSequenceError()
+    {
+        var (page, js) = RenderCopier();
+        await page.ClickAsync();
+        await page.ClickAsync();
+
+        var ex = Assert.Throws<InvalidOperationException>(() => js.ArgsFor("raskApi.clipboard.write"));
+        Assert.Contains("exactly one call", ex.Message);
+        Assert.Contains("there were 2", ex.Message);
+    }
+
+    [Fact]
+    public void NullArguments_Throw()
+    {
+        var js = new TestJSRuntime();
+
+        Assert.Throws<ArgumentNullException>(() => js.SetResponse(null!, "x"));
+        Assert.Throws<ArgumentNullException>(() => js.SetException("id", null!));
+        Assert.Throws<ArgumentNullException>(() => js.ArgsFor(null!));
+        Assert.Throws<ArgumentNullException>(() => js.CallCount(null!));
+    }
+}


### PR DESCRIPTION
Stacked on #403. Last of the API-growth wave; the migrations follow.

## Why

Two things a consumer cannot test with the shipped API, both already worked around in-repo.

**A component that ctor-injects `IJSRuntime` needs a fake to be testable at all** — so everyone writes the same one. Rask has four near-identical copies (`Core.Tests/Interop`, `Wasm.Tests/Browser`, `Client.Tests`, `Example.Shared.Tests/Infrastructure`). That convergence *is* the API design; ship it.

**Validation state (messages, `IsModified`, `IsValidating`) never reaches the markup**, so it's unassertable without the form's `EditContext`.

## What

- `TestJSRuntime` (+ `JSCall`) — records calls and replays canned values. Nothing more; `SetSequence`/argument matchers are Moq's job. Adds `Microsoft.JSInterop`: honest rather than bloat, since `Rask.Core` already references it and it's in every consumer's graph transitively.
- `RaskTest.EditContextProbe(capture)` — captures the ambient context during render, which is why it must sit inside the form's children: that's where the context exists.

## Two shapes chosen against the obvious ones

**The probe is a factory method, not a public component type.** RASK014 ("components must be created via factory methods") is an **error** that fires on `new` of any `Component` outside `Rask.Core` — including on types we ship — so a public type would hand consumers an error on our own API. I verified the analyzer reaches consumers via `analyzers/dotnet/cs/` in the host packages. A factory method is exactly what that rule asks for.

**No `page.EditContext` / `page.ValidationMessages(field)`.** The context is pushed by `Form.EnterChildrenScope` *inside* the form's subtree, and `TestRoot` sits above it — at root-render time there is none. And `EditContext` already has a public assertion surface worth not duplicating.

**Backed by `lock` + `List`, not `ConcurrentBag`** (which `Example.Shared.Tests` used): a bag is *unordered*, and `Calls` promising invocation order is worth more than the bag was buying.

## Surface trimmed against real usage

`ArgsFor` (133 call sites) and `SetResponse` (138) carry the suites. `Calls`/`GetCalls` have **zero** call sites across all four copies — so rather than porting both, they collapse into one ordered `Calls` list. `ArgsFor` explains itself when a call happened twice, instead of throwing `Single()`'s opaque sequence error.

## Testing

12 new facts (39 total), including proof the probe sees `IsModified` flip — a fact about the form that reading `Html` could never tell you — and that it renders no markup of its own.

`dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed (one unrelated pre-existing flake, `ValidatingIndicator_...StaysRenderedForStickyWindow`, a wall-clock sticky-window test that passes in isolation; this stack touches no Core code).

## Changelog

`[Unreleased] → Added`.