### PR TITLE
test(bootstrap): drive the BsDataGrid suites through Rask.Testing's public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **The `BsDataGrid` suites drive their clicks through `Rask.Testing`'s public API.** They were the proof that
+  the package's first-match-only helpers weren't enough: each of the four files carried its own copy of a
+  `Regex` that scraped handler ids out of the markup. They now use `grid.HandlerIds("click")[n]` (and
+  `Markup.Attrs` for markup held as a string), and the duplicated helper is gone. Test-only; no assertion in
+  the diff changed, and the suite still catches a deliberately broken sort.
 - **Rask's own test helpers build on `Rask.Testing` instead of duplicating it.** `Rask.TestSupport`'s
   `Markup.Attr` was a character-for-character copy of the package's scanner — two implementations of one
   algorithm, already at risk of drifting apart. The duplicate is deleted: `Markup.Attr`/`Attrs` now come from

--- a/tests/Rask.Bootstrap.Tests/BsDataGridControlledTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridControlledTests.cs
@@ -36,9 +36,6 @@ public class BsDataGridControlledTests
         new BsColumn<Row> { Title = "Qty", Value = r => r.Qty, Sortable = true, SortField = "qty" },
     ];
 
-    private static string[] ClickHandlers(string html) =>
-        Regex.Matches(html, "data-rask-on-click=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ToArray();
-
     private static string[] BodyCells(string html, int column)
     {
         var body = Regex.Match(html, "<tbody>(.*?)</tbody>", RegexOptions.Singleline).Groups[1].Value;
@@ -68,7 +65,7 @@ public class BsDataGridControlledTests
         var grid = RaskTest.Render(new Host(() => BsDataGrid<Row>(Data: All, Columns: Columns(), PageSize: 2,
             Page: 0, OnPageChange: p => asked.Add(p))));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[4]); // page 2
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[4]); // page 2
 
         Assert.Equal([1], asked);
         // Still page 1: the grid does not own the page, so nothing moves until the caller re-renders it.
@@ -94,11 +91,11 @@ public class BsDataGridControlledTests
             Sort: "name", SortDescending: false, OnSortChange: s => asked.Add(s))));
 
         // Clicking the already-sorted column asks for the opposite direction...
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        await grid.InvokeAsync(grid.HandlerIds("click")[0]);
         Assert.Equal(new DataGridSort("name", true), asked[^1]);
 
         // ...and a different column asks for ascending on that field.
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[1]);
+        await grid.InvokeAsync(grid.HandlerIds("click")[1]);
         Assert.Equal(new DataGridSort("qty", false), asked[^1]);
     }
 
@@ -108,7 +105,7 @@ public class BsDataGridControlledTests
         var grid = RaskTest.Render(new Host(() => BsDataGrid<Row>(Data: All, Columns: Columns(),
             Sort: null, OnSortChange: _ => { })));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]);
 
         // The caller owns the sort and has not changed it, so the order is untouched.
         Assert.Equal(["Banana", "Apple", "Cherry", "Date", "Elderberry"], BodyCells(html, 0));
@@ -126,11 +123,11 @@ public class BsDataGridControlledTests
         Assert.Contains("1-2 / 5", grid.Html); // the whole list, not the page
 
         // It sorts...
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]);
         Assert.Equal(["Apple", "Banana"], BodyCells(html, 0));
 
         // ...and pages, entirely on its own.
-        html = await grid.InvokeAsync(ClickHandlers(html)[4]);
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[4]);
         Assert.Equal(["Cherry", "Date"], BodyCells(html, 0));
         Assert.Contains("3-4 / 5", html);
     }
@@ -161,7 +158,7 @@ public class BsDataGridControlledTests
                 asked.Add(s);
             })));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        await grid.InvokeAsync(grid.HandlerIds("click")[0]);
 
         Assert.Equal(new DataGridSort("name", true), Assert.Single(asked));
     }
@@ -178,7 +175,7 @@ public class BsDataGridControlledTests
                 asked.Add(p);
             })));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[4]); // page 2
+        await grid.InvokeAsync(grid.HandlerIds("click")[4]); // page 2
 
         Assert.Equal([1], asked);
     }
@@ -195,7 +192,7 @@ public class BsDataGridControlledTests
                 return Task.CompletedTask;
             })));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]);
 
         Assert.Equal(new DataGridSort("name", false), Assert.Single(asked));
         // Controlled: it reported the click and left the order alone.
@@ -257,7 +254,7 @@ public class BsDataGridControlledTests
             Page: 1, OnPageChange: p => pages.Add(p),
             Sort: "qty", SortDescending: true, OnSortChange: s => asked.Add(s))));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[0]); // click Name
+        await grid.InvokeAsync(grid.HandlerIds("click")[0]); // click Name
         Assert.Equal(new DataGridSort("name", false), asked[^1]);
 
         // Nothing moved on its own: the caller re-renders the grid with the new query results.

--- a/tests/Rask.Bootstrap.Tests/BsDataGridInteractionTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridInteractionTests.cs
@@ -26,11 +26,6 @@ public class BsDataGridInteractionTests
         new BsColumn<Row> { Title = "Qty", Value = r => r.Qty, Sortable = true },
     ];
 
-    // Handler ids are reissued on every render and RenderedComponent's helpers target the *first* match, but a
-    // grid wires many buttons. Read them all in document order and index the one under test — re-reading after
-    // every render rather than reusing a captured id.
-    private static string[] ClickHandlers(string html) =>
-        Regex.Matches(html, "data-rask-on-click=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ToArray();
 
     private static string[] BodyCells(string html, int column)
     {
@@ -48,13 +43,13 @@ public class BsDataGridInteractionTests
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: Columns()));
         Assert.Equal(["Banana", "Apple", "Cherry"], BodyCells(grid.Html, 0));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]);
         Assert.Equal(["Apple", "Banana", "Cherry"], BodyCells(html, 0));
         Assert.Contains("aria-sort=\"ascending\"", html);
         Assert.Contains("bi-caret-up-fill", html);
 
         // A second click on the same header flips to descending, exactly reversed.
-        html = await grid.InvokeAsync(ClickHandlers(html)[0]);
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[0]);
         Assert.Equal(["Cherry", "Banana", "Apple"], BodyCells(html, 0));
         Assert.Contains("aria-sort=\"descending\"", html);
         Assert.Contains("bi-caret-down-fill", html);
@@ -65,8 +60,8 @@ public class BsDataGridInteractionTests
     {
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: Columns()));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);            // by Name
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[1]); // then by Qty
+        await grid.InvokeAsync(grid.HandlerIds("click")[0]);            // by Name
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[1]); // then by Qty
 
         Assert.Equal(["Cherry", "Banana", "Apple"], BodyCells(html, 0)); // 1, 3, 5
         // Only one column may claim a direction, and only it shows a caret.
@@ -82,7 +77,7 @@ public class BsDataGridInteractionTests
         Assert.Contains("1-2 / 3", grid.Html);
 
         // Handlers: [0] Name, [1] Qty, [2] prev, [3] page 1, [4] page 2, [5] next.
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[4]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[4]);
 
         var second = BodyCells(html, 0);
         Assert.Contains("3-3 / 3", html);
@@ -95,10 +90,10 @@ public class BsDataGridInteractionTests
     {
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: Columns(), PageSize: 2));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[5]); // next
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[5]); // next
         Assert.Equal(["Cherry"], BodyCells(html, 0));
 
-        html = await grid.InvokeAsync(ClickHandlers(html)[2]); // prev
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[2]); // prev
         Assert.Equal(["Banana", "Apple"], BodyCells(html, 0));
         Assert.Contains("1-2 / 3", html);
     }
@@ -110,7 +105,7 @@ public class BsDataGridInteractionTests
         // unguarded decrement went to page -1 and rendered "-1-0 / 3".
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: Columns(), PageSize: 2));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[2]); // prev, already on page 1
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[2]); // prev, already on page 1
 
         Assert.Contains("1-2 / 3", html);
         Assert.DoesNotContain("-1-0", html);
@@ -122,8 +117,8 @@ public class BsDataGridInteractionTests
     {
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: Columns(), PageSize: 2));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[5]);            // -> page 2 (last)
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[5]); // next again
+        await grid.InvokeAsync(grid.HandlerIds("click")[5]);            // -> page 2 (last)
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[5]); // next again
 
         Assert.Contains("3-3 / 3", html);
         Assert.Equal(["Cherry"], BodyCells(html, 0));
@@ -134,10 +129,10 @@ public class BsDataGridInteractionTests
     {
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: Columns(), PageSize: 2));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[4]); // page 2
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[4]); // page 2
         Assert.Contains("3-3 / 3", html);
 
-        html = await grid.InvokeAsync(ClickHandlers(html)[0]); // sort by Name
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[0]); // sort by Name
 
         Assert.Contains("1-2 / 3", html);
     }
@@ -154,7 +149,7 @@ public class BsDataGridInteractionTests
         var grid = RaskTest.Render(BsDataGrid<Row>(Data: Rows, Columns: columns, PageSize: 2));
         Assert.Contains("<tfoot><tr><td></td><td>9</td></tr></tfoot>", grid.Html);
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[3]); // page 2
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[3]); // page 2
 
         Assert.Equal(["Cherry"], BodyCells(html, 0));
         Assert.Contains("<tfoot><tr><td></td><td>9</td></tr></tfoot>", html);
@@ -167,7 +162,7 @@ public class BsDataGridInteractionTests
             RowKey: r => r.Name, ExpandedContent: r => Div()[$"detail-{r.Name}"]));
         Assert.DoesNotContain("<div>detail-Banana</div>", grid.Html);
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[2]); // first row's expander
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[2]); // first row's expander
         Assert.Contains("<div>detail-Banana</div>", html);
         // The detail id is derived from the row's position, not from RowKey: a RowKey like "Espresso Machine"
         // would put a space in the id, and aria-controls is a space-separated id list — one space silently
@@ -179,7 +174,7 @@ public class BsDataGridInteractionTests
         // The detail row spans the expander column plus both data columns.
         Assert.Contains("<td colspan=\"3\">", html);
 
-        html = await grid.InvokeAsync(ClickHandlers(html)[2]);
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[2]);
         Assert.DoesNotContain("<div>detail-Banana</div>", html);
         Assert.DoesNotContain("aria-expanded=\"true\"", html);
     }
@@ -195,7 +190,7 @@ public class BsDataGridInteractionTests
         var grid = RaskTest.Render(BsDataGrid<Row>(Id: "g", Data: rows, Columns: Columns(),
             RowKey: r => r.Name, ExpandedContent: _ => Div()["d"]));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[2]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[2]);
 
         var controls = Regex.Match(html, "aria-controls=\"([^\"]+)\"").Groups[1].Value;
         Assert.DoesNotContain(" ", controls);
@@ -210,13 +205,13 @@ public class BsDataGridInteractionTests
         var grid = RaskTest.Render(BsDataGrid<Row>(Id: "g", Data: Rows, Columns: Columns(),
             RowKey: r => r.Name, ExpandedContent: r => Div()[$"detail-{r.Name}"]));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[2]); // Banana
+        await grid.InvokeAsync(grid.HandlerIds("click")[2]); // Banana
         // Banana's detail row shifts the handler list, so Apple's expander is now at [3].
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[3]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[3]);
         Assert.Contains("<div>detail-Banana</div>", html);
         Assert.Contains("<div>detail-Apple</div>", html);
 
-        html = await grid.InvokeAsync(ClickHandlers(html)[2]); // close Banana
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[2]); // close Banana
         Assert.DoesNotContain("<div>detail-Banana</div>", html);
         Assert.Contains("<div>detail-Apple</div>", html);
     }
@@ -228,8 +223,8 @@ public class BsDataGridInteractionTests
         var grid = RaskTest.Render(BsDataGrid<Row>(Id: "g", Data: Rows, Columns: Columns(),
             RowKey: r => r.Name, ExpandedContent: r => Div()[$"detail-{r.Name}"]));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[2]);            // open Banana (first row)
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]); // sort -> Apple, Banana, Cherry
+        await grid.InvokeAsync(grid.HandlerIds("click")[2]);            // open Banana (first row)
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]); // sort -> Apple, Banana, Cherry
 
         Assert.Equal(["Apple", "Banana", "Cherry"], BodyCells(html, 1));
         Assert.Contains("<div>detail-Banana</div>", html);
@@ -245,14 +240,14 @@ public class BsDataGridInteractionTests
         var host = RaskTest.Render(new FilterHost());
 
         // Handlers: [0] the host's filter toggle, then the grid's sortable headers.
-        var html = await host.InvokeAsync(ClickHandlers(host.Html)[1]); // sort by Name
+        var html = await host.InvokeAsync(host.HandlerIds("click")[1]); // sort by Name
         Assert.Equal(["Apple", "Banana", "Cherry"], BodyCells(html, 0));
 
-        html = await host.InvokeAsync(ClickHandlers(html)[0]); // filter everything out
+        html = await host.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[0]); // filter everything out
         Assert.Contains("<div>none</div>", html);
         Assert.DoesNotContain("<table", html);
 
-        html = await host.InvokeAsync(ClickHandlers(html)[0]); // and back
+        html = await host.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[0]); // and back
         Assert.Equal(["Apple", "Banana", "Cherry"], BodyCells(html, 0));
     }
 

--- a/tests/Rask.Bootstrap.Tests/BsDataGridMatrixTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridMatrixTests.cs
@@ -42,9 +42,6 @@ public class BsDataGridMatrixTests
         },
     ];
 
-    private static string[] ClickHandlers(string html) =>
-        Regex.Matches(html, "data-rask-on-click=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ToArray();
-
     private static string[] BodyCells(string html, int column)
     {
         var body = Regex.Match(html, "<tbody>(.*?)</tbody>", RegexOptions.Singleline).Groups[1].Value;
@@ -78,7 +75,7 @@ public class BsDataGridMatrixTests
             Data: All.AsQueryable(), Columns: Columns(), PageSize: 5,
             Sort: null, OnSortChange: s => asked.Add(s))));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]);
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]);
 
         Assert.Equal(new DataGridSort("name", false), Assert.Single(asked));
         // The caller owns the sort and hasn't changed it, so the query's own order stands.
@@ -126,7 +123,7 @@ public class BsDataGridMatrixTests
             Id: "g", Data: All.AsQueryable(), Columns: Columns(), PageSize: 2,
             RowKey: r => r.Id, ExpandedContent: r => Div()[$"detail-{r.Name}"])));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[2]); // first row's expander
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[2]); // first row's expander
 
         Assert.Contains("<div>detail-Banana</div>", html);
         Assert.Contains("aria-expanded=\"true\"", html);
@@ -164,7 +161,7 @@ public class BsDataGridMatrixTests
         var host = RaskTest.Render(new QueryFilterHost());
         Assert.Equal(5, BodyCells(host.Html, 0).Length);
 
-        var html = await host.InvokeAsync(ClickHandlers(host.Html)[0]); // flip the filter
+        var html = await host.InvokeAsync(host.HandlerIds("click")[0]); // flip the filter
 
         Assert.Equal(["Date", "Elderberry"], BodyCells(html, 0)); // 9, 7
     }
@@ -282,8 +279,8 @@ public class BsDataGridMatrixTests
         var grid = RaskTest.Render(new Host(() => BsDataGrid<Row>(
             Id: "g", Data: All, Columns: Columns(), ExpandedContent: r => Div()[$"detail-{r.Name}"])));
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[2]);            // open row 0 (Banana)
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]); // sort by Name -> Apple is row 0
+        await grid.InvokeAsync(grid.HandlerIds("click")[2]);            // open row 0 (Banana)
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]); // sort by Name -> Apple is row 0
 
         Assert.Contains("<div>detail-Apple</div>", html);   // the position stayed open...
         Assert.DoesNotContain("<div>detail-Banana</div>", html); // ...not the row

--- a/tests/Rask.Bootstrap.Tests/BsDataGridQueryTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridQueryTests.cs
@@ -56,9 +56,6 @@ public class BsDataGridQueryTests
         },
     ];
 
-    private static string[] ClickHandlers(string html) =>
-        Regex.Matches(html, "data-rask-on-click=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ToArray();
-
     private static string[] BodyCells(string html, int column)
     {
         var body = Regex.Match(html, "<tbody>(.*?)</tbody>", RegexOptions.Singleline).Groups[1].Value;
@@ -87,11 +84,11 @@ public class BsDataGridQueryTests
         var grid = RaskTest.Render(new Host(() => BsDataGrid<Row>(
             Data: All.AsQueryable(), Columns: Columns(), PageSize: 2)));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[0]); // by Name
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[0]); // by Name
         Assert.Equal(["Apple", "Banana"], BodyCells(html, 0));
         Assert.Contains("aria-sort=\"ascending\"", html);
 
-        html = await grid.InvokeAsync(ClickHandlers(html)[0]); // descending
+        html = await grid.InvokeAsync(Markup.Attrs(html, "data-rask-on-click")[0]); // descending
         Assert.Equal(["Elderberry", "Date"], BodyCells(html, 0));
         Assert.Contains("aria-sort=\"descending\"", html);
     }
@@ -103,7 +100,7 @@ public class BsDataGridQueryTests
         var grid = RaskTest.Render(new Host(() => BsDataGrid<Row>(
             Data: All.AsQueryable(), Columns: Columns(), PageSize: 5)));
 
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[1]); // by Qty
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[1]); // by Qty
 
         Assert.Equal(["Cherry", "Banana", "Apple", "Elderberry", "Date"], BodyCells(html, 0)); // 1,3,5,7,9
     }
@@ -115,7 +112,7 @@ public class BsDataGridQueryTests
             Data: All.AsQueryable(), Columns: Columns(), PageSize: 2)));
 
         // [0] Name, [1] Qty, [2] prev, [3] p1, [4] p2, [5] p3, [6] next.
-        var html = await grid.InvokeAsync(ClickHandlers(grid.Html)[5]); // page 3
+        var html = await grid.InvokeAsync(grid.HandlerIds("click")[5]); // page 3
 
         Assert.Equal(["Elderberry"], BodyCells(html, 0));
         Assert.Contains("5-5 / 5", html);
@@ -175,7 +172,7 @@ public class BsDataGridQueryTests
             Data: query, Columns: Columns(), PageSize: 2)));
         var afterFirst = source.Executions;
 
-        await grid.InvokeAsync(ClickHandlers(grid.Html)[0]); // sort
+        await grid.InvokeAsync(grid.HandlerIds("click")[0]); // sort
 
         Assert.True(source.Executions > afterFirst, "a new sort must re-run the query");
     }


### PR DESCRIPTION
Stacked on #405. **The proof PR** for the whole stack: if the API from #402 doesn't kill the regex cleanly, it's wrong, and we learn it at four files instead of forty.

## What it deletes

Each of the four `BsDataGrid` files carried its own copy of this, with a comment spelling out the gap it worked around:

```csharp
// Handler ids are reissued on every render and RenderedComponent's helpers target the *first* match, but a
// grid wires many buttons. Read them all in document order and index the one under test [...]
private static string[] ClickHandlers(string html) =>
    Regex.Matches(html, "data-rask-on-click=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ToArray();
```

That is a gap in the shipped API found by dogfooding and never closed. Now closed:

- a handle's own markup → `grid.HandlerIds("click")[n]`
- the 9 sites indexing a returned `html` string → `Markup.Attrs(html, "data-rask-on-click")`

The helper is gone from all four files, and `using System.Text.RegularExpressions` with it wherever nothing else needed it. (`BodyCells` keeps its regex — it parses *table structure*, which the attribute scanner deliberately can't and shouldn't.)

## Behaviour-preserving, and checked as such

- **No `Assert` line in the diff** — mechanically verified.
- **248 tests before and after.**
- **The suite still bites:** stubbing `BsDataGrid`'s sort to a no-op turns exactly the 3 sort tests red, so they observe post-invoke state, not a stale pre-invoke frame. This is the check that catches the migration's real failure mode.
- `dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed.

## Bug filed, not fixed

The reason these buttons can only be indexed positionally is a real product defect: the pager's prev/next controls are icon-only with **no accessible name** (#406). That's also why a CSS-selector API would've been useless here — `#id`/`.class`/`[attr]` can't target them, only `:has()` + text could. The honest fix is an accessible name, which is out of scope for a behaviour-preserving test migration — so it's an issue, not a change here.

## Changelog

`[Unreleased] → Changed`.