### PR TITLE
build(deps): bump the .NET platform stack to 10.0.10 + Test.Sdk 18.8.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,14 +16,26 @@ updates:
       # analyzer that references a newer Roslyn than the running csc fails with CS9057, and it
       # would raise the compiler floor for every downstream Rask consumer. Keep these pinned to
       # the SDK's Roslyn version; bump them by hand alongside a global.json / SDK-band update.
+      #
+      # .Features is listed for the same reason even though no generator references it (only the
+      # Playground sample and its tests do): it depends on .CSharp of the same version, and central
+      # package management allows one version per package — so a Features bump drags .CSharp with
+      # it. Leaving it off the list is how PR #396 got opened despite .CSharp being ignored;
+      # dependabot updates must-move-together packages as a pair.
       - dependency-name: "Microsoft.CodeAnalysis.CSharp"
+      - dependency-name: "Microsoft.CodeAnalysis.CSharp.Features"
       - dependency-name: "Microsoft.CodeAnalysis.CSharp.Workspaces"
     groups:
+      # The .NET platform stack ships as one versioned family (10.0.x) and lands in a single
+      # Directory.Packages.props — group it so a patch wave is one PR. Ungrouped members each open
+      # their own PR against that one file, and those PRs then conflict pairwise.
       microsoft-extensions:
         patterns:
           - "Microsoft.Extensions.*"
           - "Microsoft.AspNetCore.*"
           - "Microsoft.JSInterop"
+          - "Microsoft.EntityFrameworkCore*"
+          - "Microsoft.Data.Sqlite"
       test-tooling:
         patterns:
           - "xunit*"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -137,7 +137,7 @@ jobs:
           dotnet pack src/Rask.Cli/Rask.Cli.csproj -c Release -o ./artifacts
 
       - name: Download Rask.Native package (macOS-built, with heads)
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: native-nupkgs
           path: ./artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       # Rask.Native is packed WITH its iOS/Android platform heads on macOS (the pack-native job) — this
       # Ubuntu runner has no ios/android workloads. Pull that .nupkg/.snupkg into ./artifacts.
       - name: Download Rask.Native package (macOS-built, with heads)
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           name: native-nupkgs
           path: ./artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Fixed
+- **The `Rask.Wasm` package never declared its `Microsoft.JSInterop` dependency.** The runtime uses JSInterop
+  directly (`WasmJSRuntime`, `WasmLiveSession`, the typed `Browser/*` wrappers), but it only ever arrived
+  transitively through the `PrivateAssets="all"` `Rask.Core` reference — which deliberately keeps Core out of the
+  nuspec — and the WASM track has no `Microsoft.AspNetCore.App` framework reference to supply it instead. It is now
+  surfaced at the package boundary like `Microsoft.AspNetCore.Authorization` already was, so consumers restore it.
 - **The `rask` CLI and the `Rask.Data` / `Rask.Outbox` / `Rask.Testing` packages are now published.** All four
   were packable but missing from the release + nightly pack lists, so `dotnet tool install -g Rask.Cli` failed
   ("Rask.Cli is not found in NuGet feeds") and the packages that `rask generate feature --events`/`--outbox` and

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,27 +12,27 @@
     <PackageVersion Include="coverlet.collector" Version="10.0.1" />
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authorization" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Build.Utilities.Core" Version="18.7.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.3.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
-    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.9" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.ObjectPool" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Primitives" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.JSInterop" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
     <PackageVersion Include="SQLitePCLRaw.core" Version="2.1.11" />

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -47,6 +47,13 @@
       surface this dep at the package boundary so consumers can restore it.
     -->
     <PackageReference Include="Microsoft.AspNetCore.Authorization"/>
+    <!--
+      Same reasoning: this project uses Microsoft.JSInterop directly (JSInterop/WasmJSRuntime,
+      WasmLiveSession, the Browser/* wrappers), but it only ever arrived transitively through the
+      PrivateAssets="all" Rask.Core reference — which deliberately keeps Core out of the nuspec, so
+      the dep was never declared for consumers to restore.
+    -->
+    <PackageReference Include="Microsoft.JSInterop"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Lands the safe half of the eight open dependabot PRs as one verified commit, and fixes the config that made them conflict.

All seven NuGet PRs edit `Directory.Packages.props`, so they conflict pairwise — only the first could merge cleanly and the rest need a rebase round-trip each. Since CI runs no tests and main has no required checks, their green checks prove nothing; the only meaningful verification is one local run over the combined state. Hence one branch.

## Taken

| PR | Bump |
|----|------|
| #390, #397, #398, #399 | `Microsoft.AspNetCore.*` / `Microsoft.Extensions.*` / `Microsoft.JSInterop` / `Microsoft.Data.Sqlite` / `Microsoft.EntityFrameworkCore*` 10.0.9 → **10.0.10** |
| #395 | `Microsoft.NET.Test.Sdk` 18.7.0 → **18.8.1** |
| #389 | `actions/download-artifact` v7 → **v8** |

The 10.0.10 wave is the package half of the .NET **10.0.10 security release (17 CVEs)**. The local SDK was still on 10.0.201 / runtime 10.0.5 and has been updated to **10.0.302 / runtime 10.0.10**, which is what CI (`dotnet-version: 10.0.x`) already floats to — worth noting because local is where the tests actually run.

`download-artifact` v8 is safe alongside `upload-artifact` v7: the two shipped as a matched pair on 2026-02-26 and there is no upload v8. Its breaking changes (ESM, hash-mismatch now erroring by default) do not affect these call sites. Landing it deliberately matters because `release.yml` only runs on a tag — CI never exercises that path.

## Packaging fix (user-facing)

`Rask.Wasm` never declared its `Microsoft.JSInterop` dependency. The runtime uses it directly (`WasmJSRuntime`, `WasmLiveSession`, the typed `Browser/*` wrappers), but it only ever arrived transitively through the `PrivateAssets="all"` `Rask.Core` reference — which deliberately keeps Core out of the nuspec — and the WASM track has no `Microsoft.AspNetCore.App` framework reference to supply it. Now surfaced at the package boundary exactly like `Microsoft.AspNetCore.Authorization` already was. Verified by packing and reading the nuspec.

Dependabot also wanted to add `Microsoft.Extensions.DependencyInjection` to `Rask.SQLite.EntityFrameworkCore`; dropped, as that project uses no DI type anywhere — it would only add a spurious nuspec dependency.

## Not taken

**#396 (Roslyn 5.3.0 → 5.6.0)** — `dependabot.yml` already ignores `Microsoft.CodeAnalysis.CSharp` on purpose: an analyzer referencing a newer Roslyn than the running `csc` fails CS9057, and it raises the compiler floor for every downstream Rask consumer. The SDK ships Roslyn 5.300 (= 5.3.0). It only got opened because `.Features` was missing from the ignore list and dependabot moves must-update-together packages as a pair; it would also have left `.Workspaces` skewed at 5.3.0. A generator targets the *oldest* Roslyn it supports, so this stays at 5.3.0 even after the SDK update. `.Features` added to the ignore list.

**#400 (SQLitePCLRaw.core 2.1.11 → 3.0.3)** — CVE-2025-6965 / GHSA-2m69-gcr7-jv3q is against `lib.e_sqlite3`, **not** `core`, so this bump fixes nothing. Meanwhile `Microsoft.Data.Sqlite` 10.0.10 still declares `SQLitePCLRaw.core 2.1.11`, and with `CentralPackageTransitivePinning` off only Rask.SQLite (the sole direct reference) would move — splitting the graph and risking a `sqlite3` type-identity mismatch across a major on `SqliteConnection.Handle`, which `SqliteBusyRetry` / `SqliteConnectionExtensions` call `raw.*` through.

## Root cause

`Microsoft.EntityFrameworkCore*` / `Microsoft.Data.Sqlite` were in no dependabot group, so each opened its own PR against the one shared file — that is what turned a single patch wave into five conflicting PRs. Now grouped.

## Follow-up (not this PR)

The SQLite CVE is real and still suppressed. The family now ships **2.1.12**, which exits the advisory’s `<= 2.1.11` range — the exact exit condition the `NuGetAuditSuppress` comment names — and stays on the major `Microsoft.Data.Sqlite` expects. Doing it right needs verifying the SQLite version actually embedded in `lib.e_sqlite3` 2.1.12 genuinely patches CVE-2025-6965 (GitHub still records `first_patched_version: null`, so exiting the range is not by itself proof), deciding on `CentralPackageTransitivePinning` to move the transitive package, removing the suppression, and re-checking the `Rask.Example.Native` iOS/Android `e_sqlite3` asset path. That is a security investigation, not a version bump.

## Testing

- `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings, 0 errors**
- Baselined the SDK update on unchanged packages first (also 0/0), so the bumps are attributable
- Unit: **3836 passed / 0 failed** across 29 projects (`scripts/run-unit-local.sh`)
- E2E: **25 passed** (`scripts/run-e2e-local.sh`)
- `dotnet pack` + nuspec inspection confirms `Rask.Wasm` → `Microsoft.JSInterop 10.0.10` present, `Rask.SQLite.EntityFrameworkCore` → no DI dep

No benchmarks: versions only, no render/runtime code touched.