### PR TITLE
test(validation): drive the DataAnnotations and FluentValidation suites through Rask.Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **The validation suites are the first to run on nothing but the shipped package.**
+  `Rask.Validation.{DataAnnotations,FluentValidation}.Tests` now use `RaskTest.Render` + `EditContextProbe`
+  instead of `StubComponent`/`RenderAsLiveRoot`/`ContextCapture`, and they no longer need `Rask.TestSupport`
+  **or** `Rask.Core`'s internals — both `InternalsVisibleTo` entries are removed. They reference the package
+  and the validator under test, exactly like an app author's test project would, which is the proof that a
+  Rask validation package is testable from outside.
+  Their `RegisterValidator` helper used to hand-push an `EditContextScope` — a mechanism that is `internal`,
+  that only `Form` ever pushes, and that therefore no consumer could reach. It now renders a real `Form`, so
+  the suites cover the actual registration path rather than an approximation of it. Test-only; no assertion
+  changed and the suites still catch a validator that drops its service snapshot.
 - **The `BsDataGrid` suites drive their clicks through `Rask.Testing`'s public API.** They were the proof that
   the package's first-match-only helpers weren't enough: each of the four files carried its own copy of a
   `Regex` that scraped handler ids out of the markup. They now use `grid.HandlerIds("click")[n]` (and

--- a/src/Rask.Core/Rask.Core.csproj
+++ b/src/Rask.Core/Rask.Core.csproj
@@ -40,8 +40,6 @@
     <InternalsVisibleTo Include="Rask.Wasm.Tests"/>
     <InternalsVisibleTo Include="Rask.Native"/>
     <InternalsVisibleTo Include="Rask.Native.Tests"/>
-    <InternalsVisibleTo Include="Rask.Validation.DataAnnotations.Tests"/>
-    <InternalsVisibleTo Include="Rask.Validation.FluentValidation.Tests"/>
     <InternalsVisibleTo Include="Rask.Benchmarks"/>
     <InternalsVisibleTo Include="Rask.Benchmarks.VsBlazor"/>
     <InternalsVisibleTo Include="Rask.Example.Shared.Tests"/>

--- a/tests/Rask.Validation.DataAnnotations.Tests/CustomAttributeTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/CustomAttributeTests.cs
@@ -1,10 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
-using Rask.Core;
 using Rask.Core.Forms;
-using Rask.Core.Live;
-
-#pragma warning disable RASK014 // test-only NoOpRoot subclass has no generated factory
 
 namespace Rask.Validation.DataAnnotations.Tests;
 
@@ -13,8 +9,8 @@ namespace Rask.Validation.DataAnnotations.Tests;
 //   • IsValid(object?) overrides fire and produce per-field messages.
 //   • GetValidationResult(object?, ValidationContext) overrides can read ObjectInstance
 //     (cross-field) and MemberName (per-field path).
-//   • ValidationContext.GetService<T>() resolves from the render-scoped LiveRenderContext.Services
-//     when one is active, and degrades to null otherwise (ASP.NET Core parity).
+//   • ValidationContext.GetService<T>() resolves from the services the render was given, and
+//     degrades to null when there are none (ASP.NET Core parity).
 public class CustomAttributeTests
 {
     [Fact]
@@ -80,18 +76,13 @@ public class CustomAttributeTests
     {
         // [Banned] resolves IBannedWords from ValidationContext.GetService — proves the
         // render-scoped IServiceProvider flows through ValidationContext construction. The
-        // validator snapshots LiveRenderContext.Current?.Services at registration time (which
-        // is the Render() pass), so the live context must be active around RegisterValidator,
-        // NOT around Validate (handler invocation doesn't re-enter LiveRenderContext, just
-        // like the production path).
+        // validator snapshots the render's services at registration time (which is the Render()
+        // pass), so they have to be supplied to the render — not around Validate, which doesn't
+        // re-enter a render context, just like the production path.
         var sp = new StubServices(new BannedWords("admin", "root"));
         var m = new Account { Username = "admin", Password = "Strong1Pass", ConfirmPassword = "Strong1Pass" };
 
-        EditContext ctx;
-        using (LiveRenderContext.Begin(new NoOpRoot(), sp))
-        {
-            ctx = RegisterValidator(m);
-        }
+        var ctx = RegisterValidator(m, sp);
 
         ctx.Validate();
 
@@ -112,11 +103,6 @@ public class CustomAttributeTests
         ctx.Validate();
 
         Assert.Empty(ctx.GetValidationMessages(new FieldIdentifier(m, nameof(Account.Username))));
-    }
-
-    private sealed class NoOpRoot : Component
-    {
-        protected override Component? Render() => null;
     }
 
     private sealed class StubServices : IServiceProvider

--- a/tests/Rask.Validation.DataAnnotations.Tests/DataAnnotationsValidatorTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/DataAnnotationsValidatorTests.cs
@@ -1,9 +1,7 @@
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json;
 using Rask.Core;
 using Rask.Core.Forms;
 
-#pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory
 
 namespace Rask.Validation.DataAnnotations.Tests;
 
@@ -22,7 +20,7 @@ public class DataAnnotationsValidatorTests
         //   4. Submit a valid payload via the new handler — must reach OnValidSubmit.
         var p = new Person { Name = "", Age = 0 };
         Person? captured = null;
-        var view = new StubComponent(() => Form<Person>(
+        var page = RaskTest.Render(() => Form<Person>(
             p,
             (Callback<Person>)(m => captured = m))[
             DataAnnotationsValidator(),
@@ -30,14 +28,10 @@ public class DataAnnotationsValidatorTests
             Input(() => p.Age)
         ]);
 
-        var html1 = view.RenderAsLiveRoot();
-        var submit1 = Markup.Attr(html1, "data-rask-on-submit");
+        var submit1 = page.HandlerId("submit");
         Assert.NotNull(submit1);
 
-        using (var doc = JsonDocument.Parse("{\"form\":{\"Name\":\"\",\"Age\":\"0\"}}"))
-        {
-            await view.TryInvokeHandlerAsync(submit1!, doc.RootElement);
-        }
+        await page.InvokeAsync(submit1!, "{\"form\":{\"Name\":\"\",\"Age\":\"0\"}}");
 
         Assert.Null(captured);
 
@@ -47,14 +41,11 @@ public class DataAnnotationsValidatorTests
         p.Name = "Ada";
         p.Age = 30;
 
-        var html2 = view.RenderAsLiveRoot();
-        var submit2 = Markup.Attr(html2, "data-rask-on-submit");
+        page.Render();
+        var submit2 = page.HandlerId("submit");
         Assert.NotNull(submit2);
 
-        using (var doc = JsonDocument.Parse("{\"form\":{\"Name\":\"Ada\",\"Age\":\"30\"}}"))
-        {
-            await view.TryInvokeHandlerAsync(submit2!, doc.RootElement);
-        }
+        await page.InvokeAsync(submit2!, "{\"form\":{\"Name\":\"Ada\",\"Age\":\"30\"}}");
 
         Assert.Same(p, captured);
     }
@@ -198,16 +189,17 @@ public class DataAnnotationsValidatorTests
     public void Component_Render_IsIdempotent_AcrossMultipleRenders()
     {
         var p = new Person { Name = "" };
-        var ctx = new EditContext(p);
+        EditContext? captured = null;
 
         // Two separate component instances each Render under the same context: AddValidator's
         // type-dedup should prevent double-registration. If duplicated, "Name is required"
         // would appear twice in the messages list.
-        using (EditContextScope.Push(ctx))
-        {
-            DataAnnotationsValidator().ToHtml();
-            DataAnnotationsValidator().ToHtml();
-        }
+        RaskTest.Render(() => Form(p)[
+            DataAnnotationsValidator(),
+            DataAnnotationsValidator(),
+            RaskTest.EditContextProbe(c => captured = c)
+        ]);
+        var ctx = captured!;
 
         ctx.Validate();
         Assert.Single(ctx.GetValidationMessages(new FieldIdentifier(p, "Name")));

--- a/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/NestedValidationTests.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json;
 using Rask.Core.Forms;
 
-#pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory
 
 namespace Rask.Validation.DataAnnotations.Tests;
 
@@ -244,17 +242,15 @@ public class NestedValidationTests
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             DataAnnotationsValidator(),
             Input(() => p.Address!.Street),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId!, blur.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"\"}");
 
         Assert.NotNull(captured);
         Assert.Same(p, captured!.Model);
@@ -271,21 +267,19 @@ public class NestedValidationTests
         // misses by reading the EditContext directly instead of going through the renderer.
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             DataAnnotationsValidator(),
             Input(() => p.Address!.Street),
             ValidationMessage(() => p.Address!.Street,
                 msgs => [.. msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
-        var initial = view.RenderAsLiveRoot();
+        var initial = page.Html;
         Assert.DoesNotContain("Street required", initial);
 
-        var changeId = Markup.Attr(initial, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        var changeId = page.HandlerId("change")!;
+        var afterBlur = await page.InvokeAsync(changeId, "{\"value\":\"\"}");
 
-        var afterBlur = view.RenderAsLiveRoot();
         Assert.Contains("Street required", afterBlur);
     }
 

--- a/tests/Rask.Validation.DataAnnotations.Tests/Rask.Validation.DataAnnotations.Tests.csproj
+++ b/tests/Rask.Validation.DataAnnotations.Tests/Rask.Validation.DataAnnotations.Tests.csproj
@@ -31,14 +31,15 @@
     <Using Include="Rask.Validation.DataAnnotations"/>
     <Using Include="Rask.Validation.DataAnnotations.Generated" Static="true"/>
     <Using Include="Rask.Testing"/>
-    <Using Include="Rask.TestSupport"/>
     <Using Include="Rask.Validation.DataAnnotations.Tests.ValidationTestSupport" Static="true"/>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <!-- The shipped testing package, referenced directly: this suite needs no in-repo helpers and no
+         access to Rask.Core internals — the same setup an app author has. -->
+    <ProjectReference Include="..\..\src\Rask.Testing\Rask.Testing.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Validation.DataAnnotations\Rask.Validation.DataAnnotations.csproj"/>
-    <ProjectReference Include="..\Rask.TestSupport\Rask.TestSupport.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>

--- a/tests/Rask.Validation.DataAnnotations.Tests/ValidationTestSupport.cs
+++ b/tests/Rask.Validation.DataAnnotations.Tests/ValidationTestSupport.cs
@@ -3,21 +3,35 @@ using Rask.Core.Forms;
 namespace Rask.Validation.DataAnnotations.Tests;
 
 /// <summary>
-///     Shared validator-registration helper for the DataAnnotations test suite. Pushes an
-///     <see cref="EditContext" /> scope, renders a <c>DataAnnotationsValidator</c> (which
-///     self-registers its <c>IFieldValidator</c> into the context), and hands the context back
+///     Shared validator-registration helper for the DataAnnotations test suite. Renders a real
+///     <c>Form</c> over <paramref name="model" /> with a <c>DataAnnotationsValidator</c> child (which
+///     self-registers its <c>IFieldValidator</c> into the form's context) and hands that context back
 ///     for assertions. Imported as a static using so call sites read <c>RegisterValidator(m)</c>.
 /// </summary>
+/// <remarks>
+///     This used to push an <c>EditContextScope</c> by hand. That scope is <c>internal</c> and only
+///     <c>Form</c> ever pushes it, so hand-pushing simulated a form rather than exercising one — and it
+///     was a path no consumer could reach. Going through <c>Form</c> is what an app author actually
+///     does, so it covers the real registration path instead of an approximation of it.
+/// </remarks>
 internal static class ValidationTestSupport
 {
-    public static EditContext RegisterValidator<T>(T model) where T : class
+    /// <param name="model">The model to validate.</param>
+    /// <param name="services">
+    ///     Services the validator should see. A validator snapshots the render's provider when it
+    ///     registers, so an attribute resolving a service through <c>ValidationContext.GetService</c> needs
+    ///     it supplied here — the render is where it is read. Omit it to render with no services, which is
+    ///     what an app without a configured provider looks like.
+    /// </param>
+    public static EditContext RegisterValidator<T>(T model, IServiceProvider? services = null)
+        where T : class
     {
-        var ctx = new EditContext(model);
-        using (EditContextScope.Push(ctx))
-        {
-            DataAnnotationsValidator().ToHtml();
-        }
+        EditContext? ctx = null;
+        RaskTest.Render(() => Form(model)[
+            DataAnnotationsValidator(),
+            RaskTest.EditContextProbe(c => ctx = c)
+        ], services);
 
-        return ctx;
+        return ctx!;
     }
 }

--- a/tests/Rask.Validation.FluentValidation.Tests/NestedValidationTests.cs
+++ b/tests/Rask.Validation.FluentValidation.Tests/NestedValidationTests.cs
@@ -1,9 +1,7 @@
-using System.Text.Json;
 using FluentValidation;
 using FluentValidation.Results;
 using Rask.Core.Forms;
 
-#pragma warning disable RASK014 // test-only StubComponent subclass has no generated factory
 
 namespace Rask.Validation.FluentValidation.Tests;
 
@@ -148,17 +146,15 @@ public class NestedValidationTests
         var p = new Person { Address = new Address { Street = "" } };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             FluentValidationValidator(new PersonValidator()),
             Input(() => p.Address!.Street),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId!, blur.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"\"}");
 
         Assert.NotNull(captured);
         Assert.Same(p, captured!.Model);

--- a/tests/Rask.Validation.FluentValidation.Tests/Rask.Validation.FluentValidation.Tests.csproj
+++ b/tests/Rask.Validation.FluentValidation.Tests/Rask.Validation.FluentValidation.Tests.csproj
@@ -32,14 +32,15 @@
     <Using Include="Rask.Validation.FluentValidation"/>
     <Using Include="Rask.Validation.FluentValidation.Generated" Static="true"/>
     <Using Include="Rask.Testing"/>
-    <Using Include="Rask.TestSupport"/>
     <Using Include="Rask.Validation.FluentValidation.Tests.ValidationTestSupport" Static="true"/>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <!-- The shipped testing package, referenced directly: this suite needs no in-repo helpers and no
+         access to Rask.Core internals — the same setup an app author has. -->
+    <ProjectReference Include="..\..\src\Rask.Testing\Rask.Testing.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Validation.FluentValidation\Rask.Validation.FluentValidation.csproj"/>
-    <ProjectReference Include="..\Rask.TestSupport\Rask.TestSupport.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>

--- a/tests/Rask.Validation.FluentValidation.Tests/ValidationTestSupport.cs
+++ b/tests/Rask.Validation.FluentValidation.Tests/ValidationTestSupport.cs
@@ -4,21 +4,27 @@ using Rask.Core.Forms;
 namespace Rask.Validation.FluentValidation.Tests;
 
 /// <summary>
-///     Shared validator-registration helper for the FluentValidation test suite. Pushes an
-///     <see cref="EditContext" /> scope, renders a <c>FluentValidationValidator</c> bound to the
-///     supplied <paramref name="validator" />, and returns the context for assertions. Imported
+///     Shared validator-registration helper for the FluentValidation test suite. Renders a real
+///     <c>Form</c> over <paramref name="model" /> with a <c>FluentValidationValidator</c> bound to the
+///     supplied <paramref name="validator" />, and returns the form's context for assertions. Imported
 ///     as a static using so call sites read <c>RegisterValidator(model, validator)</c>.
 /// </summary>
+/// <remarks>
+///     This used to push an <c>EditContextScope</c> by hand. That scope is <c>internal</c> and only
+///     <c>Form</c> ever pushes it, so hand-pushing simulated a form rather than exercising one — and it
+///     was a path no consumer could reach. Going through <c>Form</c> is what an app author actually
+///     does, so it covers the real registration path instead of an approximation of it.
+/// </remarks>
 internal static class ValidationTestSupport
 {
     public static EditContext RegisterValidator<T>(T model, IValidator validator) where T : class
     {
-        var ctx = new EditContext(model);
-        using (EditContextScope.Push(ctx))
-        {
-            FluentValidationValidator(validator).ToHtml();
-        }
+        EditContext? ctx = null;
+        RaskTest.Render(() => Form(model)[
+            FluentValidationValidator(validator),
+            RaskTest.EditContextProbe(c => ctx = c)
+        ]);
 
-        return ctx;
+        return ctx!;
     }
 }


### PR DESCRIPTION
Stacked on #407.

## Why these suites first

They test opt-in packages the way an app author uses them, so they're consumer-shaped by construction. That makes them the first place the dogfooding claim can be **settled** rather than asserted.

It settles well: **both suites now run on the shipped package alone**, and their `InternalsVisibleTo` entries are gone from `Rask.Core`. A test project referencing `Rask.Testing` and the validator under test is the whole setup — the proof that a Rask validation package is testable from outside.

This is the epic's ratchet, arriving early and at small scale. It's a one-line-per-project change that's impossible to regress silently: reaching for an internal is now a compile error.

## Two findings, both from trying it rather than reasoning about it

**1. `RegisterValidator` was testing a path no consumer could reach.** It hand-pushed an `EditContextScope`:

```csharp
var ctx = new EditContext(model);
using (EditContextScope.Push(ctx))          // Push is internal; only Form ever calls it
    DataAnnotationsValidator().ToHtml();
```

So it *simulated* a form rather than exercising one. It now renders a real `Form` and takes the context from an `EditContextProbe` — covering the actual registration path instead of an approximation. Same for the idempotency test: two validator children under one `Form` is the same invariant, expressed the way an app hits it.

**2. The service-resolving custom-attribute test then failed — and it was right to.** It wrapped the helper in `LiveRenderContext.Begin(root, sp)` so the validator would snapshot `sp`. But **`RaskTest.Render` always begins its own render context with the provider it's given — it does not inherit an ambient one.** The public API says this directly: pass the provider to `Render`. The hand-built context and its `NoOpRoot` are gone:

```csharp
var ctx = RegisterValidator(m, sp);   // was: using (LiveRenderContext.Begin(new NoOpRoot(), sp)) { ... }
```

That's a sharper test *and* a sharper API story: this is how a consumer tests a service-resolving validation attribute.

## Testing

- **No `Assert` line in the diff** — mechanically verified.
- **31 + 16 tests before and after.**
- **The suite still bites:** stubbing the validator's service snapshot to `null` turns exactly the service-resolving test red — now through the public `Render(component, services)` path.
- `dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed.

Net −12 lines, and two fewer projects with privileged access.

## Changelog

`[Unreleased] → Changed`.