### PR TITLE
test(core): drive the Forms suite through Rask.Testing's public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **`Rask.Core`'s Forms suite drives its handlers through `Rask.Testing`'s public API.** All eight files that
+  rendered and dispatched — the canonical `StubComponent` + `RenderAsLiveRoot` + `Markup.Attr` +
+  `JsonDocument.Parse` + `TryInvokeHandlerAsync` shape — now read as `RaskTest.Render(() => Form(m)[…])` +
+  `await page.ChangeAsync("{\"value\":\"…\"}")`, 232 lines shorter. `NestedBindingValidationTests`' hand-rolled
+  `ExtractAttrAfter` (which existed only to find the *second* input's handler) is deleted in favour of
+  `HandlerIds("input")[1]`. Test-only; 258 tests before and after, and the suite still catches an `EditContext`
+  that stops marking fields modified.
+  Two tests keep the internal entry points, deliberately and with the reason in the code: they install a render
+  handle so the dispatcher's mid-await render produces a real cached subtree, and that cache is what they exist
+  to pin. A render handle is a live-session mechanism, below the HTML + dispatch seam the package covers, so
+  it is not something `Rask.Testing` should grow.
 - **The validation suites are the first to run on nothing but the shipped package.**
   `Rask.Validation.{DataAnnotations,FluentValidation}.Tests` now use `RaskTest.Render` + `EditContextProbe`
   instead of `StubComponent`/`RenderAsLiveRoot`/`ContextCapture`, and they no longer need `Rask.TestSupport`

--- a/tests/Rask.Core.Tests/Forms/AfterBindTests.cs
+++ b/tests/Rask.Core.Tests/Forms/AfterBindTests.cs
@@ -19,16 +19,11 @@ public class AfterBindTests
         var m = new TextModel { Name = "" };
         var observed = new List<string>();
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Name, v => observed.Add(v))
         ]);
-        var html = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(html, "data-rask-on-input")!;
-
-        using var k1 = JsonDocument.Parse("{\"value\":\"A\"}");
-        await view.TryInvokeHandlerAsync(inputId, k1.RootElement);
-        using var k2 = JsonDocument.Parse("{\"value\":\"Ad\"}");
-        await view.TryInvokeHandlerAsync(inputId, k2.RootElement);
+        await page.InputAsync("{\"value\":\"A\"}");
+        await page.InputAsync("{\"value\":\"Ad\"}");
 
         Assert.Equal(new[] { "A", "Ad" }, observed);
         Assert.Equal("Ad", m.Name);
@@ -40,14 +35,10 @@ public class AfterBindTests
         var m = new NumberModel();
         int? captured = null;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Age, v => captured = v)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-
-        using var change = JsonDocument.Parse("{\"value\":\"42\"}");
-        await view.TryInvokeHandlerAsync(changeId, change.RootElement);
+        await page.ChangeAsync("{\"value\":\"42\"}");
 
         Assert.Equal(42, captured);
         Assert.Equal(42, m.Age);
@@ -59,14 +50,10 @@ public class AfterBindTests
         var m = new NumberModel { Age = 7 };
         var fired = false;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Age, _ => fired = true)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-
-        using var change = JsonDocument.Parse("{\"value\":\"not-a-number\"}");
-        await view.TryInvokeHandlerAsync(changeId, change.RootElement);
+        await page.ChangeAsync("{\"value\":\"not-a-number\"}");
 
         Assert.False(fired);
         Assert.Equal(7, m.Age); // unchanged — TrySetTyped rejected it
@@ -81,7 +68,7 @@ public class AfterBindTests
         var gate = new TaskCompletionSource();
         var order = new List<string>();
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Age,
                 _ =>
                 {
@@ -95,11 +82,10 @@ public class AfterBindTests
                     order.Add("afterBindAsync:end");
                 })
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
+        var changeId = page.HandlerId("change");
 
-        using var change = JsonDocument.Parse("{\"value\":\"42\"}");
-        var pending = view.TryInvokeHandlerAsync(changeId, change.RootElement);
+        // Held un-awaited: the gate below keeps the async handler mid-flight.
+        var pending = page.InvokeAsync(changeId!, "{\"value\":\"42\"}");
 
         // Spin until the async handler reaches the gate. The dispatcher does an extra
         // Task.Yield inside InvokeWithRenderingAsync, so a single Task.Yield here may not
@@ -124,7 +110,7 @@ public class AfterBindTests
         var order = new List<string>();
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Age,
                 _ =>
                 {
@@ -137,13 +123,9 @@ public class AfterBindTests
                     // The field must already be marked modified at this point.
                     Assert.True(captured!.IsModified(new FieldIdentifier(m, nameof(NumberModel.Age))));
                 }),
-            new ContextCapture(c => captured = c)
+            RaskTest.EditContextProbe(c => captured = c)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-
-        using var change = JsonDocument.Parse("{\"value\":\"9\"}");
-        await view.TryInvokeHandlerAsync(changeId, change.RootElement);
+        await page.ChangeAsync("{\"value\":\"9\"}");
 
         Assert.Equal(new[] { "afterBind", "validate" }, order);
     }
@@ -154,7 +136,7 @@ public class AfterBindTests
         var m = new TextModel { Name = "" };
         var order = new List<string>();
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Name,
                 _ => order.Add("sync"),
                 async _ =>
@@ -163,11 +145,7 @@ public class AfterBindTests
                     order.Add("async");
                 })
         ]);
-        var html = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(html, "data-rask-on-input")!;
-
-        using var k = JsonDocument.Parse("{\"value\":\"x\"}");
-        await view.TryInvokeHandlerAsync(inputId, k.RootElement);
+        await page.InputAsync("{\"value\":\"x\"}");
 
         Assert.Equal(new[] { "sync", "async" }, order);
     }
@@ -178,17 +156,13 @@ public class AfterBindTests
         var m = new ColorModel { Favorite = Color.Red };
         Color? captured = null;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Select(() => m.Favorite, v => captured = v)[
                 Option(nameof(Color.Red))["Red"],
                 Option(nameof(Color.Blue))["Blue"]
             ]
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-
-        using var change = JsonDocument.Parse("{\"value\":\"Blue\"}");
-        await view.TryInvokeHandlerAsync(changeId, change.RootElement);
+        await page.ChangeAsync("{\"value\":\"Blue\"}");
 
         Assert.Equal(Color.Blue, captured);
         Assert.Equal(Color.Blue, m.Favorite);
@@ -201,7 +175,7 @@ public class AfterBindTests
         var m = new RegionModel();
         List<string>? cities = null;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Select(() => m.Country, AfterBindAsync: async c =>
             {
                 await Task.Yield();
@@ -211,11 +185,7 @@ public class AfterBindTests
                 Option("DE")["DE"]
             ]
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-
-        using var pick = JsonDocument.Parse("{\"value\":\"US\"}");
-        await view.TryInvokeHandlerAsync(changeId, pick.RootElement);
+        await page.ChangeAsync("{\"value\":\"US\"}");
 
         Assert.NotNull(cities);
         Assert.Equal(new[] { "NYC", "LA" }, cities!);
@@ -228,14 +198,10 @@ public class AfterBindTests
         var m = new TextModel { Name = "" };
         string? captured = null;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Textarea(() => m.Name, v => captured = v)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(html, "data-rask-on-input")!;
-
-        using var k = JsonDocument.Parse("{\"value\":\"hello\"}");
-        await view.TryInvokeHandlerAsync(inputId, k.RootElement);
+        await page.InputAsync("{\"value\":\"hello\"}");
 
         Assert.Equal("hello", captured);
         Assert.Equal("hello", m.Name);
@@ -247,16 +213,14 @@ public class AfterBindTests
         var m = new FlagModel { Enabled = false };
         bool? captured = null;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Enabled, v => captured = v)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
+        var changeId = page.HandlerId("change");
 
         // Checking the box: the client reports the post-toggle checked state ("true").
         // BoolSetHandler sets the model to it and AfterBind sees the new value.
-        using var click = JsonDocument.Parse("{\"value\":\"true\"}");
-        await view.TryInvokeHandlerAsync(changeId, click.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"true\"}");
 
         Assert.True(captured);
         Assert.True(m.Enabled);
@@ -272,15 +236,11 @@ public class AfterBindTests
         var m = new TextModel { Name = "x" };
         var fires = 0;
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Name, _ => fires++)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(html, "data-rask-on-input")!;
-
-        using var same = JsonDocument.Parse("{\"value\":\"x\"}");
-        await view.TryInvokeHandlerAsync(inputId, same.RootElement);
-        await view.TryInvokeHandlerAsync(inputId, same.RootElement);
+        await page.InputAsync("{\"value\":\"x\"}");
+        await page.InputAsync("{\"value\":\"x\"}");
 
         Assert.Equal(2, fires);
     }

--- a/tests/Rask.Core.Tests/Forms/AsyncFormBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/AsyncFormBindingTests.cs
@@ -22,16 +22,14 @@ public class AsyncFormBindingTests
         var ctx = new EditContext(model);
         ctx.AddValidator(new TaggingAsyncValidator("Username", "no good"));
 
-        var view = new StubComponent(() => Form<SignupModel>(model, Context: ctx)[
+        var page = RaskTest.Render(() => Form<SignupModel>(model, Context: ctx)[
             Input(() => model.Username)
         ]);
 
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"new\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"new\"}");
 
         var fid = new FieldIdentifier(model, "Username");
         Assert.Equal(new[] { "no good" }, ctx.GetValidationMessages(fid));
@@ -45,14 +43,14 @@ public class AsyncFormBindingTests
         var validator = new GatedAsyncValidator();
         ctx.AddValidator(validator);
 
-        var view = new StubComponent(() => Form<SignupModel>(model, Context: ctx)[
+        var page = RaskTest.Render(() => Form<SignupModel>(model, Context: ctx)[
             Input(() => model.Username)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
 
-        using var doc = JsonDocument.Parse("{\"value\":\"taken\"}");
-        var dispatchTask = view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        // Held un-awaited on purpose: the gate keeps the validator mid-flight so the state below is
+        // observable. InvokeAsync returning a Task is what makes that expressible through the public API.
+        var dispatchTask = page.InvokeAsync(changeId!, "{\"value\":\"taken\"}");
 
         await validator.Started.Task;
         var fid = new FieldIdentifier(model, "Username");
@@ -72,18 +70,13 @@ public class AsyncFormBindingTests
         var ctx = new EditContext(model);
         ctx.AddValidator(new RejectIfEqualsValidator("admin", "Already taken."));
 
-        var view = new StubComponent(() => Form<SignupModel>(model, Context: ctx)[
+        var page = RaskTest.Render(() => Form<SignupModel>(model, Context: ctx)[
             Input(() => model.Username)
         ]);
-        var html = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(html, "data-rask-on-input");
-        var changeId = Markup.Attr(html, "data-rask-on-change");
 
         // Mirror the browser: OnInput sets the value, OnChange (blur) touches and validates.
-        using var inputDoc = JsonDocument.Parse("{\"value\":\"admin\"}");
-        await view.TryInvokeHandlerAsync(inputId!, inputDoc.RootElement);
-        using var changeDoc = JsonDocument.Parse("{\"value\":\"admin\"}");
-        await view.TryInvokeHandlerAsync(changeId!, changeDoc.RootElement);
+        await page.InputAsync("{\"value\":\"admin\"}");
+        await page.ChangeAsync("{\"value\":\"admin\"}");
 
         var fid = new FieldIdentifier(model, "Username");
         Assert.Equal("admin", model.Username);
@@ -91,6 +84,12 @@ public class AsyncFormBindingTests
         Assert.False(ctx.IsValidating(fid));
     }
 
+    // The two PostHandlerRender tests below stay on the internal render entry points, deliberately.
+    // They install a RenderingHandle so the dispatcher's mid-await render produces a real cached
+    // subtree — that cache is the thing under test, and RaskTest has no RenderHandle to install
+    // (nor should it: a render handle is a live-session mechanism, below the HTML + dispatch seam
+    // the package covers). They pass without the handle too, which is exactly the trap: the
+    // assertions survive while the cached-subtree path they exist to cover quietly stops running.
     [Fact]
     public async Task AsyncValidator_PostHandlerRender_ShowsMessage_AndNoIndicator()
     {
@@ -182,11 +181,10 @@ public class AsyncFormBindingTests
         _ = ctx.ValidateFieldAsync(fid);
         Assert.True(ctx.IsValidating(fid));
 
-        var view = new StubComponent(() => Form<SignupModel>(model, Context: ctx)[
+        var html = RaskTest.Render(() => Form<SignupModel>(model, Context: ctx)[
             ValidatingIndicator(() => model.Username, () => Span(Class: "spinner")["Checking..."])
-        ]);
+        ]).Html;
 
-        var html = view.RenderAsLiveRoot();
         Assert.Contains("<span class=\"spinner\">", html);
         Assert.Contains("Checking...", html);
     }
@@ -197,11 +195,10 @@ public class AsyncFormBindingTests
         var model = new SignupModel { Username = "ada" };
         var ctx = new EditContext(model);
 
-        var view = new StubComponent(() => Form<SignupModel>(model, Context: ctx)[
+        var html = RaskTest.Render(() => Form<SignupModel>(model, Context: ctx)[
             ValidatingIndicator(() => model.Username, () => Span(Class: "spinner")["Checking..."])
-        ]);
+        ]).Html;
 
-        var html = view.RenderAsLiveRoot();
         Assert.DoesNotContain("Checking...", html);
         Assert.DoesNotContain("spinner", html);
     }

--- a/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
+++ b/tests/Rask.Core.Tests/Forms/EditContextDisposalTests.cs
@@ -17,15 +17,14 @@ public class EditContextDisposalTests
         var ctx = new EditContext(model);
         var show = true;
 
-        var view = new StubComponent(() => show
+        var page = RaskTest.Render(() => show
             ? Form<Model>(model, Context: ctx)[Input(() => model.Name)]
             : Div()[Text("gone")]);
 
-        view.RenderAsLiveRoot();
         Assert.False(ctx.IsDisposed);
 
         show = false;
-        view.RenderAsLiveRoot(); // form unmounted → ctx not re-resolved this frame
+        page.Render(); // form unmounted → ctx not re-resolved this frame
         Assert.True(ctx.IsDisposed);
     }
 
@@ -34,10 +33,9 @@ public class EditContextDisposalTests
     {
         var model = new Model { Name = "ada" };
         var ctx = new EditContext(model);
-        var view = new StubComponent(() => Form<Model>(model, Context: ctx)[Input(() => model.Name)]);
+        var page = RaskTest.Render(() => Form<Model>(model, Context: ctx)[Input(() => model.Name)]);
 
-        view.RenderAsLiveRoot();
-        view.RenderAsLiveRoot();
+        page.Render();
 
         Assert.False(ctx.IsDisposed);
     }

--- a/tests/Rask.Core.Tests/Forms/FormBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/FormBindingTests.cs
@@ -12,13 +12,13 @@ public class FormBindingTests
     public void BoundInput_RendersValueFromGetter_AndAutoNamesField()
     {
         var p = new Person { Name = "Ada", Age = 30 };
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Name),
             Input(() => p.Age),
             Input(() => p.Subscribed)
         ]);
 
-        var html = view.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("name=\"Name\"", html);
         Assert.Contains("value=\"Ada\"", html);
@@ -32,16 +32,14 @@ public class FormBindingTests
     public async Task OnInput_UpdatesBoundStringField_DuringInputEvent()
     {
         var p = new Person { Name = "Ada", Age = 30 };
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Name)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var inputId = Markup.Attr(html, "data-rask-on-input");
+        var inputId = page.HandlerId("input");
         Assert.NotNull(inputId);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"Bea\"}");
-        var ok = await view.TryInvokeHandlerAsync(inputId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(inputId!, "{\"value\":\"Bea\"}");
 
         Assert.True(ok);
         Assert.Equal("Bea", p.Name);
@@ -51,16 +49,14 @@ public class FormBindingTests
     public async Task OnChange_UpdatesNumericBoundField_AndMarksTouched()
     {
         var p = new Person { Name = "Ada", Age = 30 };
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Age)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"42\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(changeId!, "{\"value\":\"42\"}");
 
         Assert.True(ok);
         Assert.Equal(42, p.Age);
@@ -73,7 +69,7 @@ public class FormBindingTests
         var validCalled = 0;
         var invalidCalled = 0;
 
-        var view = new StubComponent(() => Form<Person>(
+        var page = RaskTest.Render(() => Form<Person>(
             p,
             OnValidSubmit: _ => validCalled++,
             OnInvalidSubmit: _ => invalidCalled++,
@@ -81,11 +77,8 @@ public class FormBindingTests
                 string.IsNullOrEmpty(m.Name) ? new[] { "Name required" } : Array.Empty<string>())[
             Input(() => p.Name), Input(() => p.Age)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var submitId = Markup.Attr(html, "data-rask-on-submit");
-        using var doc = JsonDocument.Parse("{\"form\":{\"Name\":\"\",\"Age\":\"0\"}}");
-        await view.TryInvokeHandlerAsync(submitId!, doc.RootElement);
+        await page.SubmitAsync("{\"form\":{\"Name\":\"\",\"Age\":\"0\"}}");
 
         Assert.Equal(0, validCalled);
         Assert.Equal(1, invalidCalled);
@@ -101,7 +94,7 @@ public class FormBindingTests
         var p = new Person { Name = "Ada", Age = 30 };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form<Person>(
+        var page = RaskTest.Render(() => Form<Person>(
             p,
             async (m, ct) =>
             {
@@ -112,9 +105,8 @@ public class FormBindingTests
                     : Array.Empty<string>();
             })[
             Input(() => p.Name),
-            new ContextCapture(c => captured = c)
+            RaskTest.EditContextProbe(c => captured = c)
         ]);
-        var html = view.RenderAsLiveRoot();
         Assert.NotNull(captured);
 
         // Force the name to be blank so the async rule produces a message.
@@ -131,14 +123,11 @@ public class FormBindingTests
         var p = new Person { Name = "Ada", Age = 30 };
         Person? captured = null;
 
-        var view = new StubComponent(() => Form(
+        var page = RaskTest.Render(() => Form(
             p,
             (Callback<Person>)(m => captured = m))[Input(() => p.Name), Input(() => p.Age)]);
-        var html = view.RenderAsLiveRoot();
 
-        var submitId = Markup.Attr(html, "data-rask-on-submit");
-        using var doc = JsonDocument.Parse("{\"form\":{\"Name\":\"Ada\",\"Age\":\"30\"}}");
-        await view.TryInvokeHandlerAsync(submitId!, doc.RootElement);
+        await page.SubmitAsync("{\"form\":{\"Name\":\"Ada\",\"Age\":\"30\"}}");
 
         Assert.Same(p, captured);
         Assert.Equal("Ada", captured!.Name);
@@ -150,11 +139,11 @@ public class FormBindingTests
         var p = new Person { Name = "", Age = 30 };
         var captures = new List<EditContext>();
 
-        var view = new StubComponent(() => Form(p)[
-            new ContextCapture(captures.Add)
+        // Render() renders once itself, so one more call is the second frame.
+        var page = RaskTest.Render(() => Form(p)[
+            RaskTest.EditContextProbe(captures.Add)
         ]);
-        view.RenderAsLiveRoot();
-        view.RenderAsLiveRoot();
+        page.Render();
 
         Assert.Equal(2, captures.Count);
         Assert.Same(captures[0], captures[1]);
@@ -164,9 +153,9 @@ public class FormBindingTests
     public void BoundInput_NullableInt_RendersEmptyValue_WhenNull()
     {
         var p = new Person { Name = "Ada", Age = 30, OptionalAge = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.OptionalAge)]);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.OptionalAge)]);
 
-        var html = view.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("name=\"OptionalAge\"", html);
         Assert.Contains("type=\"number\"", html);
@@ -177,9 +166,9 @@ public class FormBindingTests
     public void BoundInput_NullableInt_RendersFormattedValue_WhenSet()
     {
         var p = new Person { Name = "Ada", Age = 30, OptionalAge = 7 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.OptionalAge)]);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.OptionalAge)]);
 
-        var html = view.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("value=\"7\"", html);
     }
@@ -188,9 +177,9 @@ public class FormBindingTests
     public void BoundInput_NullableDecimal_FormatsInvariantCulture()
     {
         var p = new Person { Name = "Ada", Age = 30, Price = 19.95m };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Price)]);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Price)]);
 
-        var html = view.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("type=\"number\"", html);
         Assert.Contains("value=\"19.95\"", html);
@@ -200,9 +189,9 @@ public class FormBindingTests
     public void BoundInput_NullableDateTime_RendersIsoFormat_WhenSet()
     {
         var p = new Person { Name = "Ada", Age = 30, StartedAt = new DateTime(2025, 5, 14, 9, 30, 0) };
-        var view = new StubComponent(() => Form(p)[Input(() => p.StartedAt)]);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.StartedAt)]);
 
-        var html = view.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("type=\"datetime-local\"", html);
         Assert.Contains("value=\"2025-05-14T09:30\"", html);
@@ -212,9 +201,9 @@ public class FormBindingTests
     public void BoundInput_NullableDateOnly_RendersIsoDate_WhenSet()
     {
         var p = new Person { Name = "Ada", Age = 30, Birthday = new DateOnly(1990, 1, 2) };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Birthday)]);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Birthday)]);
 
-        var html = view.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("type=\"date\"", html);
         Assert.Contains("value=\"1990-01-02\"", html);
@@ -224,14 +213,12 @@ public class FormBindingTests
     public async Task OnChange_NullableInt_EmptyString_SetsPropertyToNull()
     {
         var p = new Person { Name = "Ada", Age = 30, OptionalAge = 7 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.OptionalAge)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.OptionalAge)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(changeId!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Null(p.OptionalAge);
@@ -241,12 +228,9 @@ public class FormBindingTests
     public async Task OnChange_NullableInt_ValidValue_SetsTypedValue()
     {
         var p = new Person { Name = "Ada", Age = 30, OptionalAge = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.OptionalAge)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.OptionalAge)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"42\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"42\"}");
 
         Assert.True(ok);
         Assert.Equal(42, p.OptionalAge);
@@ -256,12 +240,9 @@ public class FormBindingTests
     public async Task OnChange_NullableInt_InvalidValue_LeavesPropertyUnchanged()
     {
         var p = new Person { Name = "Ada", Age = 30, OptionalAge = 7 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.OptionalAge)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.OptionalAge)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"not-a-number\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"not-a-number\"}");
 
         // Handler still completes (TouchAndValidateHandler always runs validation after the
         // optional set), but the property retains its prior value because TrySetTyped failed.
@@ -273,12 +254,9 @@ public class FormBindingTests
     public async Task OnChange_NullableDecimal_EmptyString_SetsPropertyToNull()
     {
         var p = new Person { Name = "Ada", Age = 30, Price = 19.95m };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Price)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Price)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Null(p.Price);
@@ -288,12 +266,9 @@ public class FormBindingTests
     public async Task OnChange_NullableDateTime_EmptyString_SetsPropertyToNull()
     {
         var p = new Person { Name = "Ada", Age = 30, StartedAt = new DateTime(2025, 5, 14, 9, 30, 0) };
-        var view = new StubComponent(() => Form(p)[Input(() => p.StartedAt)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.StartedAt)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Null(p.StartedAt);
@@ -303,12 +278,9 @@ public class FormBindingTests
     public async Task OnChange_NullableDateOnly_EmptyString_SetsPropertyToNull()
     {
         var p = new Person { Name = "Ada", Age = 30, Birthday = new DateOnly(1990, 1, 2) };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Birthday)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Birthday)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Null(p.Birthday);
@@ -318,12 +290,9 @@ public class FormBindingTests
     public async Task OnChange_NullableDecimal_ValidValue_SetsTypedValue()
     {
         var p = new Person { Name = "Ada", Age = 30, Price = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Price)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Price)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"12.5\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"12.5\"}");
 
         Assert.True(ok);
         Assert.Equal(12.5m, p.Price);
@@ -333,12 +302,9 @@ public class FormBindingTests
     public async Task OnChange_NullableDateTime_ValidIso_SetsTypedValue()
     {
         var p = new Person { Name = "Ada", Age = 30, StartedAt = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.StartedAt)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.StartedAt)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"2025-05-14T09:30\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"2025-05-14T09:30\"}");
 
         Assert.True(ok);
         Assert.Equal(new DateTime(2025, 5, 14, 9, 30, 0), p.StartedAt);
@@ -348,12 +314,9 @@ public class FormBindingTests
     public async Task OnChange_NullableDateOnly_ValidIso_SetsTypedValue()
     {
         var p = new Person { Name = "Ada", Age = 30, Birthday = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Birthday)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Birthday)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"1990-01-02\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"1990-01-02\"}");
 
         Assert.True(ok);
         Assert.Equal(new DateOnly(1990, 1, 2), p.Birthday);
@@ -363,12 +326,9 @@ public class FormBindingTests
     public async Task OnChange_NullableEnum_ValidValue_ParsesEnum()
     {
         var p = new Person { Name = "Ada", Age = 30, Status = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Status)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Status)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"Active\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"Active\"}");
 
         Assert.True(ok);
         Assert.Equal(PersonStatus.Active, p.Status);
@@ -378,12 +338,9 @@ public class FormBindingTests
     public async Task OnChange_NullableEnum_EmptyString_SetsPropertyToNull()
     {
         var p = new Person { Name = "Ada", Age = 30, Status = PersonStatus.Active };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Status)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Status)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Null(p.Status);
@@ -396,12 +353,9 @@ public class FormBindingTests
         // so the user can clear a number/date/enum input. The sibling nullable test above
         // (OnChange_NullableInt_EmptyString_SetsPropertyToNull) pins the null path for `int?`.
         var p = new Person { Name = "Ada", Age = 30 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Age)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Age)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Equal(0, p.Age);
@@ -411,12 +365,9 @@ public class FormBindingTests
     public async Task OnChange_NonNullableDecimal_EmptyString_SetsDefault()
     {
         var p = new Person { Name = "Ada", Age = 30, Salary = 5000m };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Salary)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Salary)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Equal(0m, p.Salary);
@@ -426,12 +377,9 @@ public class FormBindingTests
     public async Task OnChange_NonNullableDateOnly_EmptyString_SetsDefault()
     {
         var p = new Person { Name = "Ada", Age = 30, HireDate = new DateOnly(2020, 6, 1) };
-        var view = new StubComponent(() => Form(p)[Input(() => p.HireDate)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.HireDate)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Equal(default, p.HireDate);
@@ -441,12 +389,9 @@ public class FormBindingTests
     public async Task OnChange_NonNullableEnum_EmptyString_SetsDefault()
     {
         var p = new Person { Name = "Ada", Age = 30, CurrentStatus = PersonStatus.Inactive };
-        var view = new StubComponent(() => Form(p)[Input(() => p.CurrentStatus)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.CurrentStatus)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Equal(default, p.CurrentStatus);
@@ -459,14 +404,12 @@ public class FormBindingTests
         // PropertyInfo via NullabilityInfoContext and treats empty input as null. The
         // sibling test below pins the inverse for non-nullable `string`.
         var p = new Person { Name = "Ada", Age = 30, Nickname = "Bea" };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Nickname)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Nickname)]);
 
-        var inputId = Markup.Attr(html, "data-rask-on-input");
+        var inputId = page.HandlerId("input");
         Assert.NotNull(inputId);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(inputId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(inputId!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Null(p.Nickname);
@@ -480,14 +423,12 @@ public class FormBindingTests
         // for the annotation, so the empty→null shortcut is skipped and the value flows
         // through RouteValueParser, which returns "" verbatim.
         var p = new Person { Name = "Ada", Age = 30 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Name)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Name)]);
 
-        var inputId = Markup.Attr(html, "data-rask-on-input");
+        var inputId = page.HandlerId("input");
         Assert.NotNull(inputId);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        var ok = await view.TryInvokeHandlerAsync(inputId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(inputId!, "{\"value\":\"\"}");
 
         Assert.True(ok);
         Assert.Equal("", p.Name);
@@ -504,18 +445,17 @@ public class FormBindingTests
         // recover — once drifted it kept inverting, which is the "checkbox sticks after a
         // few clicks" bug once clicks ship diffs (no checked re-base) instead of full HTML.
         var p = new Person { Name = "Ada", Age = 30, AcceptedTerms = null };
-        var view = new StubComponent(() => Form(p)[Input(() => p.AcceptedTerms)]);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.AcceptedTerms)]);
 
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var html = page.Html;
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
 
         async Task SendAsync(string value)
         {
-            html = view.RenderAsLiveRoot();
+            html = page.Render();
             changeId = Markup.Attr(html, "data-rask-on-change");
-            using var doc = JsonDocument.Parse($"{{\"value\":\"{value}\"}}");
-            await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+            await page.InvokeAsync(changeId!, $"{{\"value\":\"{value}\"}}");
         }
 
         await SendAsync("true");

--- a/tests/Rask.Core.Tests/Forms/InputDelegateValidateTests.cs
+++ b/tests/Rask.Core.Tests/Forms/InputDelegateValidateTests.cs
@@ -13,18 +13,16 @@ public class InputDelegateValidateTests
         var p = new Person { Name = "" };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Name,
                 v =>
                     v.Length < 3 ? new[] { "too short" } : Array.Empty<string>()),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
-        using var blur = JsonDocument.Parse("{\"value\":\"ab\"}");
-        await view.TryInvokeHandlerAsync(changeId!, blur.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"ab\"}");
 
         Assert.NotNull(captured);
         Assert.Contains("too short",
@@ -42,19 +40,16 @@ public class InputDelegateValidateTests
         var invalidCalled = 0;
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form<Person>(
+        var page = RaskTest.Render(() => Form<Person>(
             p,
             _ => validCalled++,
             _ => invalidCalled++)[
             Input(() => p.Name,
                 _ => new[] { "always-fail" }),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var submitId = Markup.Attr(html, "data-rask-on-submit")!;
-        using var payload = JsonDocument.Parse("{\"form\":{\"Name\":\"\"}}");
-        await view.TryInvokeHandlerAsync(submitId, payload.RootElement);
+        await page.SubmitAsync("{\"form\":{\"Name\":\"\"}}");
 
         Assert.NotNull(captured);
         Assert.Contains("always-fail",
@@ -70,19 +65,16 @@ public class InputDelegateValidateTests
         var includeValidator = true;
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             includeValidator
                 ? Input(() => p.Name,
                     v =>
                         v.Length < 3 ? new[] { "too short" } : Array.Empty<string>())
                 : Input(() => p.Name),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
 
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"ab\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.ChangeAsync("{\"value\":\"ab\"}");
 
         Assert.NotEmpty(captured!.GetValidationMessages(new FieldIdentifier(p, nameof(Person.Name))));
 
@@ -90,10 +82,8 @@ public class InputDelegateValidateTests
         // Validate=null, which clears the prior registration. Then fire another change
         // event — no rule, no messages.
         includeValidator = false;
-        var html2 = view.RenderAsLiveRoot();
-        var changeId2 = Markup.Attr(html2, "data-rask-on-change")!;
-        using var blur2 = JsonDocument.Parse("{\"value\":\"ab\"}");
-        await view.TryInvokeHandlerAsync(changeId2, blur2.RootElement);
+        page.Render();
+        await page.ChangeAsync("{\"value\":\"ab\"}");
 
         Assert.Empty(captured.GetValidationMessages(new FieldIdentifier(p, nameof(Person.Name))));
     }
@@ -108,7 +98,7 @@ public class InputDelegateValidateTests
         var p = new Person { Name = "" };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Name,
                 async (v, ct) =>
                 {
@@ -116,9 +106,9 @@ public class InputDelegateValidateTests
                     ct.ThrowIfCancellationRequested();
                     return v.Length < 3 ? new[] { "async-too-short" } : Array.Empty<string>();
                 }),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
+
         Assert.NotNull(captured);
 
         await captured!.ValidateFieldAsync(new FieldIdentifier(p, nameof(Person.Name)));
@@ -136,7 +126,7 @@ public class InputDelegateValidateTests
         var p = new Person { Name = "abc" };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Name,
                 async (v, ct) =>
                 {
@@ -144,9 +134,9 @@ public class InputDelegateValidateTests
                     ct.ThrowIfCancellationRequested();
                     return Array.Empty<string>();
                 }),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        view.RenderAsLiveRoot();
+
         Assert.NotNull(captured);
 
         using var cts = new CancellationTokenSource();

--- a/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
+++ b/tests/Rask.Core.Tests/Forms/NestedBindingValidationTests.cs
@@ -25,18 +25,16 @@ public class NestedBindingValidationTests
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Street,
                 v =>
                     string.IsNullOrEmpty(v) ? new[] { "street required" } : Array.Empty<string>()),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
+        var changeId = page.HandlerId("change");
         Assert.NotNull(changeId);
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId!, blur.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"\"}");
 
         Assert.NotNull(captured);
         Assert.Contains("street required",
@@ -52,25 +50,20 @@ public class NestedBindingValidationTests
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Street,
                 v =>
                     v.Length < 3 ? new[] { "too short" } : Array.Empty<string>()),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
         var fid = new FieldIdentifier(p.Address, nameof(Address.Street));
 
         // Blur with empty — touches and produces the message.
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.ChangeAsync("{\"value\":\"\"}");
         Assert.Contains("too short", captured!.GetValidationMessages(fid));
 
         // Keystroke with a longer value — re-validates because the field is touched.
-        var inputId = Markup.Attr(html, "data-rask-on-input")!;
-        using var keystroke = JsonDocument.Parse("{\"value\":\"Oak\"}");
-        await view.TryInvokeHandlerAsync(inputId, keystroke.RootElement);
+        await page.InputAsync("{\"value\":\"Oak\"}");
         Assert.Empty(captured.GetValidationMessages(fid));
         Assert.Equal("Oak", p.Address.Street);
     }
@@ -85,16 +78,13 @@ public class NestedBindingValidationTests
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Street,
                 _ => new[] { "always-fail" }),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"x\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.ChangeAsync("{\"value\":\"x\"}");
 
         // The form's captured EditContext.Model is the root, not the sub-object.
         Assert.NotNull(captured);
@@ -116,19 +106,18 @@ public class NestedBindingValidationTests
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
         var ctx = new EditContext(p);
 
-        var view = new StubComponent(() => Form<Person>(p, Context: ctx)[
+        var page = RaskTest.Render(() => Form<Person>(p, Context: ctx)[
             Input(() => p.Address.Street,
                 _ => new[] { "model-plus-context" }),
             ValidationMessage(() => p.Address.Street,
                 msgs => [.. msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
-        var initial = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(initial, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"x\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        var initial = page.Render();
+        var changeId = page.HandlerId("change");
+        await page.InvokeAsync(changeId!, "{\"value\":\"x\"}");
 
-        var afterBlur = view.RenderAsLiveRoot();
+        var afterBlur = page.Render();
         Assert.Contains("model-plus-context", afterBlur);
         Assert.Contains("model-plus-context",
             ctx.GetValidationMessages(new FieldIdentifier(p.Address, nameof(Address.Street))));
@@ -143,16 +132,13 @@ public class NestedBindingValidationTests
         var ctx = new EditContext(p);
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(Context: ctx)[
+        var page = RaskTest.Render(() => Form(Context: ctx)[
             Input(() => p.Address.Street,
                 _ => new[] { "nested-explicit-ctx" }),
-            new ContextCapture(c => captured = c)
+            RaskTest.EditContextProbe(c => captured = c)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"x\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.ChangeAsync("{\"value\":\"x\"}");
 
         Assert.Same(ctx, captured);
         Assert.Contains("nested-explicit-ctx",
@@ -168,21 +154,18 @@ public class NestedBindingValidationTests
         var p = new Person { Name = "Ada", Address = new Address { Street = "old" } };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Street,
                 v =>
                     string.IsNullOrEmpty(v) ? new[] { "street required" } : Array.Empty<string>()),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        view.RenderAsLiveRoot();
 
         // Swap to a fresh Address and re-render.
         p.Address = new Address { Street = "" };
-        var html = view.RenderAsLiveRoot();
+        page.Render();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.ChangeAsync("{\"value\":\"\"}");
 
         Assert.NotNull(captured);
         Assert.Contains("street required",
@@ -201,7 +184,7 @@ public class NestedBindingValidationTests
         // the failure is render-pipeline or Server-WS-pipeline.
         var m = new StorefrontModel { Address = new StorefrontAddress { PostalCode = "" } };
 
-        var view = new StubComponent(() => Form<StorefrontModel>(m)[
+        var page = RaskTest.Render(() => Form<StorefrontModel>(m)[
             Input(() => m.Address.PostalCode,
                 async (v, ct) =>
                 {
@@ -222,25 +205,23 @@ public class NestedBindingValidationTests
                 msgs => [.. msgs.Select((s, i) => Div(Class: "err", Key: i)[s])])
         ]);
 
-        var initial = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(initial, "data-rask-on-input")!;
-        var changeId = Markup.Attr(initial, "data-rask-on-change")!;
+        var initial = page.Render();
+        var inputId = page.HandlerId("input");
+        var changeId = page.HandlerId("change");
 
         // Simulate typing "99999" one character at a time via OnInput. None of these should
         // produce validation messages — the field isn't touched yet.
         foreach (var partial in new[] { "9", "99", "999", "9999", "99999" })
         {
-            using var doc = JsonDocument.Parse($"{{\"value\":\"{partial}\"}}");
-            await view.TryInvokeHandlerAsync(inputId, doc.RootElement);
+            await page.InvokeAsync(inputId!, $"{{\"value\":\"{partial}\"}}");
         }
 
-        Assert.DoesNotContain("don't ship", view.RenderAsLiveRoot());
+        Assert.DoesNotContain("don't ship", page.Render());
 
         // Blur with the final value — OnChange handler touches + runs async validator.
-        using var blur = JsonDocument.Parse("{\"value\":\"99999\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"99999\"}");
 
-        var afterBlur = view.RenderAsLiveRoot();
+        var afterBlur = page.Render();
         Assert.Contains("ship to this area", afterBlur);
     }
 
@@ -253,7 +234,7 @@ public class NestedBindingValidationTests
         // see error clear after async settles".
         var m = new StorefrontModel { Address = new StorefrontAddress { PostalCode = "" } };
 
-        var view = new StubComponent(() => Form(m)[
+        var page = RaskTest.Render(() => Form(m)[
             Input(() => m.Address.PostalCode,
                 async (v, ct) =>
                 {
@@ -274,31 +255,22 @@ public class NestedBindingValidationTests
                 msgs => [.. msgs.Select((s, i) => Div(Class: "err", Key: i)[s])])
         ]);
 
-        var initial = view.RenderAsLiveRoot();
-        var inputId = Markup.Attr(initial, "data-rask-on-input")!;
-        var changeId = Markup.Attr(initial, "data-rask-on-change")!;
+        var initial = page.Render();
+        var inputId = page.HandlerId("input");
+        var changeId = page.HandlerId("change");
 
         // Step 1: blur with "99999" → undeliverable message lands.
-        using (var d = JsonDocument.Parse("{\"value\":\"99999\"}"))
-        {
-            await view.TryInvokeHandlerAsync(inputId, d.RootElement);
-        }
+        await page.InvokeAsync(inputId!, "{\"value\":\"99999\"}");
 
-        using (var d = JsonDocument.Parse("{\"value\":\"99999\"}"))
-        {
-            await view.TryInvokeHandlerAsync(changeId, d.RootElement);
-        }
+        await page.InvokeAsync(changeId!, "{\"value\":\"99999\"}");
 
-        Assert.Contains("ship to this area", view.RenderAsLiveRoot());
+        Assert.Contains("ship to this area", page.Render());
 
         // Step 2: now-touched field, type a valid value via OnInput. Async validator runs and
         // returns success; the message must clear.
-        using (var d = JsonDocument.Parse("{\"value\":\"12345\"}"))
-        {
-            await view.TryInvokeHandlerAsync(inputId, d.RootElement);
-        }
+        await page.InvokeAsync(inputId!, "{\"value\":\"12345\"}");
 
-        Assert.DoesNotContain("ship to this area", view.RenderAsLiveRoot());
+        Assert.DoesNotContain("ship to this area", page.Render());
     }
 
     [Fact]
@@ -311,7 +283,7 @@ public class NestedBindingValidationTests
         var m = new StorefrontModel { CustomerName = "", Address = new StorefrontAddress { PostalCode = "" } };
         string? submitted = null;
 
-        var view = new StubComponent(() => Form(
+        var page = RaskTest.Render(() => Form(
             m,
             mm => submitted = $"Charged to {mm.CustomerName}")[
             Input(() => m.CustomerName,
@@ -329,26 +301,18 @@ public class NestedBindingValidationTests
                 })
         ]);
 
-        var initial = view.RenderAsLiveRoot();
-        // Two inputs → two on-input handlers. Filter by attribute order.
-        var nameInputId = Markup.Attr(initial, "data-rask-on-input")!;
-        // To get the postal input id we look past the first occurrence.
-        var postalInputId = ExtractAttrAfter(initial, "data-rask-on-input", nameInputId);
+        // Two inputs → two on-input handlers, in document order.
+        var inputIds = page.HandlerIds("input");
+        var nameInputId = inputIds[0];
+        var postalInputId = inputIds[1];
         Assert.NotNull(postalInputId);
 
-        using (var d = JsonDocument.Parse("{\"value\":\"Ada\"}"))
-        {
-            await view.TryInvokeHandlerAsync(nameInputId, d.RootElement);
-        }
+        await page.InvokeAsync(nameInputId!, "{\"value\":\"Ada\"}");
 
-        using (var d = JsonDocument.Parse("{\"value\":\"12345\"}"))
-        {
-            await view.TryInvokeHandlerAsync(postalInputId!, d.RootElement);
-        }
+        await page.InvokeAsync(postalInputId!, "{\"value\":\"12345\"}");
 
-        var submitId = Markup.Attr(initial, "data-rask-on-submit")!;
-        using var submit = JsonDocument.Parse("{}");
-        await view.TryInvokeHandlerAsync(submitId, submit.RootElement);
+        var submitId = page.HandlerId("submit");
+        await page.InvokeAsync(submitId!, "{}");
 
         Assert.Equal("Charged to Ada", submitted);
     }
@@ -363,7 +327,7 @@ public class NestedBindingValidationTests
         // to during the re-render that follows the event dispatch.
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Street,
                 v =>
                     string.IsNullOrEmpty(v) ? new[] { "street required" } : Array.Empty<string>()),
@@ -371,14 +335,13 @@ public class NestedBindingValidationTests
                 msgs => [.. msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
-        var initial = view.RenderAsLiveRoot();
+        var initial = page.Render();
         Assert.DoesNotContain("street required", initial);
 
-        var changeId = Markup.Attr(initial, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        var changeId = page.HandlerId("change");
+        await page.InvokeAsync(changeId!, "{\"value\":\"\"}");
 
-        var afterBlur = view.RenderAsLiveRoot();
+        var afterBlur = page.Render();
         Assert.Contains("street required", afterBlur);
     }
 
@@ -389,7 +352,7 @@ public class NestedBindingValidationTests
         // makes the value valid must clear the message in the next render's HTML.
         var p = new Person { Name = "Ada", Address = new Address { Street = "" } };
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Street,
                 v =>
                     v.Length < 3 ? new[] { "too short" } : Array.Empty<string>()),
@@ -397,17 +360,15 @@ public class NestedBindingValidationTests
                 msgs => [.. msgs.Select((m, i) => Div(Class: "err", Key: i)[m])])
         ]);
 
-        var initial = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(initial, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
-        Assert.Contains("too short", view.RenderAsLiveRoot());
+        var initial = page.Render();
+        var changeId = page.HandlerId("change");
+        await page.InvokeAsync(changeId!, "{\"value\":\"\"}");
+        Assert.Contains("too short", page.Render());
 
-        var inputId = Markup.Attr(initial, "data-rask-on-input")!;
-        using var keystroke = JsonDocument.Parse("{\"value\":\"Oak\"}");
-        await view.TryInvokeHandlerAsync(inputId, keystroke.RootElement);
+        var inputId = page.HandlerId("input");
+        await page.InvokeAsync(inputId!, "{\"value\":\"Oak\"}");
 
-        var afterKeystroke = view.RenderAsLiveRoot();
+        var afterKeystroke = page.Render();
         Assert.DoesNotContain("too short", afterKeystroke);
     }
 
@@ -422,50 +383,18 @@ public class NestedBindingValidationTests
         };
         EditContext? captured = null;
 
-        var view = new StubComponent(() => Form(p)[
+        var page = RaskTest.Render(() => Form(p)[
             Input(() => p.Address.Postal.Code,
                 v =>
                     string.IsNullOrEmpty(v) ? new[] { "postal required" } : Array.Empty<string>()),
-            new ContextCapture(ctx => captured = ctx)
+            RaskTest.EditContextProbe(ctx => captured = ctx)
         ]);
-        var html = view.RenderAsLiveRoot();
 
-        var changeId = Markup.Attr(html, "data-rask-on-change")!;
-        using var blur = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId, blur.RootElement);
+        await page.ChangeAsync("{\"value\":\"\"}");
 
         Assert.NotNull(captured);
         Assert.Contains("postal required",
             captured!.GetValidationMessages(new FieldIdentifier(p.Address.Postal!, nameof(PostalInfo.Code))));
-    }
-
-    private static string? ExtractAttrAfter(string html, string attr, string skipValue)
-    {
-        var marker = attr + "=\"";
-        var cursor = 0;
-        while (true)
-        {
-            var i = html.IndexOf(marker, cursor, StringComparison.Ordinal);
-            if (i < 0)
-            {
-                return null;
-            }
-
-            var start = i + marker.Length;
-            var end = html.IndexOf('"', start);
-            if (end < 0)
-            {
-                return null;
-            }
-
-            var value = html.Substring(start, end - start);
-            if (value != skipValue)
-            {
-                return value;
-            }
-
-            cursor = end + 1;
-        }
     }
 
     private sealed class StorefrontModel

--- a/tests/Rask.Core.Tests/Forms/PrimitiveBindingTests.cs
+++ b/tests/Rask.Core.Tests/Forms/PrimitiveBindingTests.cs
@@ -70,15 +70,13 @@ public class PrimitiveBindingTests
         // comma-decimal locale ("3,14") and a period-decimal raw value ("3.14"), only the
         // invariant parser produces 3.14f. Asserting the round-trip pins both sides.
         var p = new NumericHolder { F = 1.5f };
-        var view = new StubComponent(() => Form(p)[Input(() => p.F)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.F)]);
+        var html = page.Html;
 
         Assert.Contains("type=\"number\"", html);
         Assert.Contains("value=\"1.5\"", html);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"3.14\"}");
-        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var ok = await page.TryInvokeAsync(page.HandlerId("change")!, "{\"value\":\"3.14\"}");
 
         Assert.True(ok);
         Assert.Equal(3.14f, p.F, 0.0001f);
@@ -88,12 +86,9 @@ public class PrimitiveBindingTests
     public async Task DoubleProperty_OnChange_ParsesScientificNotation()
     {
         var p = new NumericHolder { D = 0d };
-        var view = new StubComponent(() => Form(p)[Input(() => p.D)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.D)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"6.022e23\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.ChangeAsync("{\"value\":\"6.022e23\"}");
 
         Assert.Equal(6.022e23, p.D, 1e20);
     }
@@ -102,12 +97,9 @@ public class PrimitiveBindingTests
     public async Task DecimalProperty_OnChange_PreservesPrecision()
     {
         var p = new NumericHolder { M = 0m };
-        var view = new StubComponent(() => Form(p)[Input(() => p.M)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.M)]);
 
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-        using var doc = JsonDocument.Parse("{\"value\":\"12345.6789\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.ChangeAsync("{\"value\":\"12345.6789\"}");
 
         Assert.Equal(12345.6789m, p.M);
     }
@@ -119,12 +111,11 @@ public class PrimitiveBindingTests
     public async Task ByteProperty_OnChange_RoundTrips(string raw, byte expected)
     {
         var p = new NumericHolder { B = 1 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.B)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.B)]);
+        var html = page.Html;
         var changeId = Markup.Attr(html, "data-rask-on-change");
 
-        using var doc = JsonDocument.Parse($"{{\"value\":\"{raw}\"}}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.InvokeAsync(changeId!, $"{{\"value\":\"{raw}\"}}");
 
         Assert.Equal(expected, p.B);
     }
@@ -135,12 +126,8 @@ public class PrimitiveBindingTests
         // Specific to ulong: long.MaxValue + 1 must round-trip. If we accidentally routed
         // through long.TryParse this would fail.
         var p = new NumericHolder { Ul = 0ul };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Ul)]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-
-        using var doc = JsonDocument.Parse("{\"value\":\"9223372036854775808\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Ul)]);
+        await page.ChangeAsync("{\"value\":\"9223372036854775808\"}");
 
         Assert.Equal(9223372036854775808ul, p.Ul);
     }
@@ -149,12 +136,8 @@ public class PrimitiveBindingTests
     public async Task HalfProperty_OnChange_RoundTrips()
     {
         var p = new NumericHolder { H = (Half)0 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.H)]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-
-        using var doc = JsonDocument.Parse("{\"value\":\"2.5\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.H)]);
+        await page.ChangeAsync("{\"value\":\"2.5\"}");
 
         Assert.Equal((Half)2.5, p.H);
     }
@@ -163,13 +146,12 @@ public class PrimitiveBindingTests
     public async Task GuidProperty_OnChange_RoundTrips()
     {
         var p = new IdentityHolder { Token = Guid.Empty };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Token)]);
-        var html = view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Token)]);
+        var html = page.Html;
         var changeId = Markup.Attr(html, "data-rask-on-change");
 
         var fresh = Guid.NewGuid();
-        using var doc = JsonDocument.Parse($"{{\"value\":\"{fresh}\"}}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.InvokeAsync(changeId!, $"{{\"value\":\"{fresh}\"}}");
 
         Assert.Equal(fresh, p.Token);
     }
@@ -178,12 +160,8 @@ public class PrimitiveBindingTests
     public async Task CharProperty_OnChange_AcceptsSingleCharacter()
     {
         var p = new IdentityHolder { Letter = 'a' };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Letter)]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-
-        using var doc = JsonDocument.Parse("{\"value\":\"Z\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Letter)]);
+        await page.ChangeAsync("{\"value\":\"Z\"}");
 
         Assert.Equal('Z', p.Letter);
     }
@@ -193,11 +171,9 @@ public class PrimitiveBindingTests
     {
         var known = Guid.NewGuid();
         var p = new IdentityHolder { Token = known };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Token)]);
-        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Token)]);
 
-        using var doc = JsonDocument.Parse("{\"value\":\"not-a-guid\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.ChangeAsync("{\"value\":\"not-a-guid\"}");
 
         // Unparseable Guid text must NOT zero the field — TrySetTyped returns false, setter never runs.
         Assert.Equal(known, p.Token);
@@ -207,12 +183,11 @@ public class PrimitiveBindingTests
     public async Task CharProperty_MultiCharInput_LeavesPriorValue()
     {
         var p = new IdentityHolder { Letter = 'a' };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Letter)]);
-        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Letter)]);
+        var changeId = page.HandlerId("change");
 
         // char.TryParse only accepts a single character — a two-char string fails to parse.
-        using var doc = JsonDocument.Parse("{\"value\":\"ab\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"ab\"}");
 
         Assert.Equal('a', p.Letter);
     }
@@ -221,12 +196,11 @@ public class PrimitiveBindingTests
     public async Task EnumProperty_OnChange_RoundTripsCaseInsensitively()
     {
         var p = new IdentityHolder { Level = Priority.Low };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Level)]);
-        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Level)]);
+        var changeId = page.HandlerId("change");
 
         // Enum binding goes through Enum.TryParse(ignoreCase: true), so a lower-cased member name binds.
-        using var doc = JsonDocument.Parse("{\"value\":\"high\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"high\"}");
 
         Assert.Equal(Priority.High, p.Level);
     }
@@ -235,12 +209,11 @@ public class PrimitiveBindingTests
     public async Task EnumProperty_InvalidInput_LeavesPriorValue()
     {
         var p = new IdentityHolder { Level = Priority.High };
-        var view = new StubComponent(() => Form(p)[Input(() => p.Level)]);
-        var changeId = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change");
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.Level)]);
+        var changeId = page.HandlerId("change");
 
         // A string that is not a member name leaves the model untouched.
-        using var doc = JsonDocument.Parse("{\"value\":\"medium\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        await page.InvokeAsync(changeId!, "{\"value\":\"medium\"}");
 
         Assert.Equal(Priority.High, p.Level);
     }
@@ -249,12 +222,8 @@ public class PrimitiveBindingTests
     public async Task NullableNumericProperty_EmptyInput_SetsNull()
     {
         var p = new NumericHolder { OptionalDouble = 9.9 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.OptionalDouble)]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.OptionalDouble)]);
+        await page.ChangeAsync("{\"value\":\"\"}");
 
         Assert.Null(p.OptionalDouble);
     }
@@ -263,12 +232,8 @@ public class PrimitiveBindingTests
     public async Task NumericProperty_InvalidInput_LeavesPriorValue()
     {
         var p = new NumericHolder { D = 1.5 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.D)]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-
-        using var doc = JsonDocument.Parse("{\"value\":\"not-a-number\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.D)]);
+        await page.ChangeAsync("{\"value\":\"not-a-number\"}");
 
         // Invalid input (non-empty, unparseable) must NOT silently zero the field — TrySetTyped
         // returns false and the setter is never called. The empty-input case is a separate
@@ -280,12 +245,8 @@ public class PrimitiveBindingTests
     public async Task NumericProperty_EmptyInput_SetsDefault()
     {
         var p = new NumericHolder { D = 1.5 };
-        var view = new StubComponent(() => Form(p)[Input(() => p.D)]);
-        var html = view.RenderAsLiveRoot();
-        var changeId = Markup.Attr(html, "data-rask-on-change");
-
-        using var doc = JsonDocument.Parse("{\"value\":\"\"}");
-        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+        var page = RaskTest.Render(() => Form(p)[Input(() => p.D)]);
+        await page.ChangeAsync("{\"value\":\"\"}");
 
         // Empty input on a non-nullable value type clears to default(T) so the user can
         // actually empty the field. Without this, the next render snaps the input back to

--- a/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
+++ b/tests/Rask.Core.Tests/Forms/RaskFileDispatchTests.cs
@@ -19,17 +19,14 @@ public class RaskFileDispatchTests
         IReadOnlyList<RaskFile>? received = null;
         Callback<IReadOnlyList<RaskFile>> handler = files => received = files;
 
-        var view = new StubComponent(() => Input<string>(OnFiles: handler));
-        view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Input<string>(OnFiles: handler), services);
 
-        var payload = JsonDocument.Parse("""
-                                         { "id": "h0", "type": "files", "files": [
-                                             { "token": "t1", "name": "a.txt", "size": 5, "type": "text/plain", "lastModified": 1 },
-                                             { "token": "t2", "name": "b.txt", "size": 3, "type": "text/plain", "lastModified": 2 }
-                                         ]}
-                                         """).RootElement;
-
-        var ok = await view.TryInvokeHandlerAsync("h0", payload, services);
+        var ok = await page.TryInvokeAsync("h0", """
+                                                 { "id": "h0", "type": "files", "files": [
+                                                     { "token": "t1", "name": "a.txt", "size": 5, "type": "text/plain", "lastModified": 1 },
+                                                     { "token": "t2", "name": "b.txt", "size": 3, "type": "text/plain", "lastModified": 2 }
+                                                 ]}
+                                                 """);
 
         Assert.True(ok);
         Assert.NotNull(received);
@@ -54,16 +51,13 @@ public class RaskFileDispatchTests
             return Task.CompletedTask;
         };
 
-        var view = new StubComponent(() => Input<string>(OnFilesAsync: handler));
-        view.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => Input<string>(OnFilesAsync: handler), services);
 
-        var payload = JsonDocument.Parse("""
-                                         { "id": "h0", "type": "files", "files": [
-                                             { "token": "x", "name": "x.txt", "size": 1, "type": "text/plain", "lastModified": 0 }
-                                         ]}
-                                         """).RootElement;
-
-        await view.TryInvokeHandlerAsync("h0", payload, services);
+        await page.InvokeAsync("h0", """
+                                     { "id": "h0", "type": "files", "files": [
+                                         { "token": "x", "name": "x.txt", "size": 1, "type": "text/plain", "lastModified": 0 }
+                                     ]}
+                                     """);
 
         Assert.Equal(1, seen);
         Assert.Single(backend.Released);
@@ -73,8 +67,7 @@ public class RaskFileDispatchTests
     public void Input_Emits_DataRaskOnFiles_Attribute_When_OnFiles_Set()
     {
         Callback<IReadOnlyList<RaskFile>> handler = _ => { };
-        var view = new StubComponent(() => Input<string>(InputType.File, OnFiles: handler));
-        var html = view.RenderAsLiveRoot();
+        var html = RaskTest.Render(() => Input<string>(InputType.File, OnFiles: handler)).Html;
         Assert.Contains("data-rask-on-files=", html);
         Assert.Contains("type=\"file\"", html);
     }


### PR DESCRIPTION
Stacked on #409. The biggest migration so far: 8 files, **−232 lines**, same 258 tests.

## The shape

```csharp
// before
var view = new StubComponent(() => Form(m)[ Input(() => m.Name, v => observed.Add(v)) ]);
var html = view.RenderAsLiveRoot();
var inputId = Markup.Attr(html, "data-rask-on-input")!;
using var k1 = JsonDocument.Parse("{\"value\":\"A\"}");
await view.TryInvokeHandlerAsync(inputId, k1.RootElement);

// after
var page = RaskTest.Render(() => Form(m)[ Input(() => m.Name, v => observed.Add(v)) ]);
await page.InputAsync("{\"value\":\"A\"}");
```

## Two things the migration found rather than assumed

**The flagged risk wasn't one.** The plan expected the gated async pattern (hold the dispatch un-awaited, assert `IsValidating` mid-flight, release, await) to be the danger. It isn't — `InvokeAsync` returns `Task<string>`, so the test holds it exactly as before. I verified that on one case before touching the other seven. The plan's proposed exclusions (`AsyncFormBindingTests`, `NestedBindingValidationTests`) were also wrong: they came from grepping **comments** mentioning `LiveRenderContext`, not code.

**`HandlerIds` earned itself again.** `NestedBindingValidationTests` hand-rolled an `ExtractAttrAfter` helper whose entire job was finding the *second* input's handler id. That's what #402 added; the helper is deleted.

## Where the seam actually falls

Two tests **keep** the internal entry points, deliberately, with the reason written in the code. They install a render handle so the dispatcher's mid-await render produces a real cached subtree — and that cache is precisely what they exist to pin.

They pass *without* the handle, which is exactly the trap: the assertions survive while the path they cover quietly stops running. A render handle is a live-session mechanism, below the HTML + dispatch seam the package covers, so `RaskTest` should not grow one. This is the plan's bail-out working as intended — finding where the public API legitimately stops is a result, not a failure.

## Scripting bit twice — both caught, both worth knowing

1. **`RaskTest.Render` renders once itself**, so replacing two explicit renders with two more gives *three* frames. A capture-count assertion caught it.
2. **`var html = view.RenderAsLiveRoot()` is a RENDER, not a read.** Turning it into `page.Html` silently skips work a test relied on — `NestedField_SubObjectReplacedBetweenRenders` re-renders *after* swapping the sub-object. It failed loudly here, but this is the shape that passes silently.

So I audited **every** remaining `page.Html` to confirm it reads the frame the `Render` call directly above it produced. All 44 genuinely-dead `html` locals the script left behind are removed.

## Testing

- **258 tests before and after.**
- **The suite still bites:** stubbing `EditContext` to stop marking fields modified turns 3 of these tests red.
- **4 `Assert` lines changed** — all the same equivalent substitution: `view.RenderAsLiveRoot()` → `page.Render()` *inside* the assertion, where both render and return the HTML. Listed here rather than buried, since the standing rule for this stack is that migrations don't touch assertions:

```
-        Assert.Contains("ship to this area", view.RenderAsLiveRoot());
+        Assert.Contains("ship to this area", page.Render());
```

- `dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed.

## Changelog

`[Unreleased] → Changed`.