### PR TITLE
test(example): drive the showcase demo suites through Rask.Testing's public API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **The showcase demo suites drop their copy-pasted markup helpers for `Rask.Testing`.** Five files each kept
+  their own `Empty()` / `Json()` / `ClickIds()` / `HandlerIds()` — the same helpers, written five times, over
+  the same markup. `InvokeAsync`'s `"{}"` payload default deletes every `Empty()` outright, and
+  `Markup.Attrs` / `page.HandlerIds(evt)` replace the hand-rolled scanners. Test-only; 44 tests before and
+  after, and the suite still catches a toast that won't dismiss.
+  One helper deliberately survives: `FormControlsDemoTests.ClickIds(html, cssClass)` filters handlers by the
+  CSS class on their element, which is *structural*. `Markup` reads attributes, not structure, and that line
+  is the same one that made a CSS-selector API the wrong shape for this package — so the honest outcome is to
+  leave the structural helper where it is rather than grow the package toward a DOM.
 - **`Rask.Core`'s Forms suite drives its handlers through `Rask.Testing`'s public API.** All eight files that
   rendered and dispatched — the canonical `StubComponent` + `RenderAsLiveRoot` + `Markup.Attr` +
   `JsonDocument.Parse` + `TryInvokeHandlerAsync` shape — now read as `RaskTest.Render(() => Form(m)[…])` +

--- a/tests/Rask.Example.Shared.Tests/Demos/ComponentTiersDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/ComponentTiersDemoTests.cs
@@ -14,8 +14,8 @@ public sealed class ComponentTiersDemoTests
     [Fact]
     public void Render_ShowsAllThreeTiers()
     {
-        var host = new LiveHost(() => ComponentTiersDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => ComponentTiersDemo(), TestServices.Default());
+        var html = page.Render();
 
         // Tier 0 — the static helper's inlined badges.
         Assert.Contains("inlined", html);
@@ -30,21 +30,15 @@ public sealed class ComponentTiersDemoTests
     [Fact]
     public async Task StatefulCounter_Click_Increments_WithoutStateHasChanged()
     {
-        var host = new LiveHost(() => ComponentTiersDemo(), TestServices.Default());
-        var clickId = ClickHandler(host.RenderAsLiveRoot());
+        var page = RaskTest.Render(() => ComponentTiersDemo(), TestServices.Default());
+        var clickId = ClickHandler(page.Render());
 
-        await host.TryInvokeHandlerAsync(clickId, Empty());
-        await host.TryInvokeHandlerAsync(clickId, Empty());
+        await page.InvokeAsync(clickId);
+        await page.InvokeAsync(clickId);
 
-        var final = host.RenderAsLiveRoot();
+        var final = page.Render();
         Assert.Contains("Clicked 2 times", final);
         Assert.DoesNotContain("Clicked 0 times", final);
-    }
-
-    private static JsonElement Empty()
-    {
-        using var doc = JsonDocument.Parse("{}");
-        return doc.RootElement.Clone();
     }
 
     // The counter's OnClick is the only wired event in the demo, so its id is the first (and only)

--- a/tests/Rask.Example.Shared.Tests/Demos/FloatingLabelsDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/FloatingLabelsDemoTests.cs
@@ -14,40 +14,33 @@ public sealed class FloatingLabelsDemoTests
     [Fact]
     public async Task ValidSubmit_ShowsSuccessAlert()
     {
-        var host = new LiveHost(() => FloatingLabelsDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FloatingLabelsDemo(), TestServices.Default());
+        var html = page.Render();
 
         // Populate the model through the live field handlers (the submit bridge validates/invokes
         // against the live-bound model, not the event payload).
-        await Fill(host, html, "ff-FullName", "Ada Lovelace");
-        await Fill(host, html, "ff-Email", "ada@example.com");
-        await Fill(host, html, "ff-Age", "30");
-        await Fill(host, html, "ff-Plan", "pro");
+        await Fill(page, html, "ff-FullName", "Ada Lovelace");
+        await Fill(page, html, "ff-Email", "ada@example.com");
+        await Fill(page, html, "ff-Age", "30");
+        await Fill(page, html, "ff-Plan", "pro");
 
-        await host.TryInvokeHandlerAsync(SubmitHandler(host.RenderAsLiveRoot()), Empty());
+        await page.InvokeAsync(SubmitHandler(page.Render()));
 
-        var final = host.RenderAsLiveRoot();
+        var final = page.Render();
         Assert.Contains("Created account for Ada Lovelace", final);
         Assert.Contains("alert-success", final);
     }
 
-    private static async Task Fill(LiveHost host, string html, string id, string value)
+    private static async Task Fill(RenderedComponent page, string html, string id, string value)
     {
         foreach (var attr in new[] { "data-rask-on-input", "data-rask-on-change" })
         {
             var hid = TryAttrOnTagWith(html, $"id=\"{id}\"", attr);
             if (hid is not null)
             {
-                using var v = JsonDocument.Parse($"{{\"value\":\"{value}\"}}");
-                await host.TryInvokeHandlerAsync(hid, v.RootElement);
+                await page.InvokeAsync(hid, $"{{\"value\":\"{value}\"}}");
             }
         }
-    }
-
-    private static JsonElement Empty()
-    {
-        using var doc = JsonDocument.Parse("{}");
-        return doc.RootElement.Clone();
     }
 
     private static string SubmitHandler(string html)
@@ -79,7 +72,7 @@ public sealed class FloatingLabelsDemoTests
     [Fact]
     public void FloatingLabelsDemo_Render_EmitsFloatingFieldsAndLinkedLabels()
     {
-        var html = new LiveHost(() => FloatingLabelsDemo(), TestServices.Default()).RenderAsLiveRoot();
+        var html = RaskTest.Render(() => FloatingLabelsDemo(), TestServices.Default()).Html;
 
         // Bootstrap floating-label markup across all three controls.
         Assert.Contains("form-floating", html);

--- a/tests/Rask.Example.Shared.Tests/Demos/FormControlsDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/FormControlsDemoTests.cs
@@ -16,26 +16,26 @@ public sealed class FormControlsDemoTests
     [Fact]
     public async Task Select_Controlled_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsSelectDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsSelectDemo(), TestServices.Default());
+        var html = page.Render();
         Assert.Contains("Picked: <strong>Rask</strong>", html);
 
         var id = HandlerIn(html, "id=\"fc-select-controlled\"", "data-rask-on-change");
-        await host.TryInvokeHandlerAsync(id, Value("Blazor"));
+        await page.InvokeAsync(id, Value("Blazor"));
 
-        Assert.Contains("Picked: <strong>Blazor</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Picked: <strong>Blazor</strong>", page.Render());
     }
 
     [Fact]
     public async Task Select_Bound_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsSelectDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsSelectDemo(), TestServices.Default());
+        var html = page.Render();
 
         var id = HandlerIn(html, "id=\"fc-select-bound\"", "data-rask-on-change");
-        await host.TryInvokeHandlerAsync(id, Value("htmx"));
+        await page.InvokeAsync(id, Value("htmx"));
 
-        var html2 = host.RenderAsLiveRoot();
+        var html2 = page.Render();
         Assert.Contains("fc-select-bound-out", html2);
         Assert.Contains("Picked: <strong>htmx</strong>", html2);
     }
@@ -45,27 +45,27 @@ public sealed class FormControlsDemoTests
     [Fact]
     public async Task Input_Controlled_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsInputDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsInputDemo(), TestServices.Default());
+        var html = page.Render();
         Assert.Contains("Echo: <strong>(empty)</strong>", html);
 
         var id = HandlerIn(html, "id=\"fc-input-controlled\"", "data-rask-on-change");
-        await host.TryInvokeHandlerAsync(id, Value("hello"));
+        await page.InvokeAsync(id, Value("hello"));
 
-        Assert.Contains("Echo: <strong>hello</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Echo: <strong>hello</strong>", page.Render());
     }
 
     [Fact]
     public async Task Input_Bound_OnInput_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsInputDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsInputDemo(), TestServices.Default());
+        var html = page.Render();
 
         // A bound text Input streams via data-rask-on-input (per keystroke); the change handler only touches.
         var id = HandlerIn(html, "id=\"fc-input-bound\"", "data-rask-on-input");
-        await host.TryInvokeHandlerAsync(id, Value("world"));
+        await page.InvokeAsync(id, Value("world"));
 
-        Assert.Contains("Echo: <strong>world</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Echo: <strong>world</strong>", page.Render());
     }
 
     // ---- Textarea ----
@@ -73,26 +73,26 @@ public sealed class FormControlsDemoTests
     [Fact]
     public async Task Textarea_Controlled_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsTextareaDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsTextareaDemo(), TestServices.Default());
+        var html = page.Render();
         Assert.Contains("Length: <strong>0</strong>", html);
 
         var id = HandlerIn(html, "id=\"fc-textarea-controlled\"", "data-rask-on-change");
-        await host.TryInvokeHandlerAsync(id, Value("abcd"));
+        await page.InvokeAsync(id, Value("abcd"));
 
-        Assert.Contains("Length: <strong>4</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Length: <strong>4</strong>", page.Render());
     }
 
     [Fact]
     public async Task Textarea_Bound_OnInput_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsTextareaDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsTextareaDemo(), TestServices.Default());
+        var html = page.Render();
 
         var id = HandlerIn(html, "id=\"fc-textarea-bound\"", "data-rask-on-input");
-        await host.TryInvokeHandlerAsync(id, Value("abc"));
+        await page.InvokeAsync(id, Value("abc"));
 
-        var html2 = host.RenderAsLiveRoot();
+        var html2 = page.Render();
         Assert.Contains("fc-textarea-bound-out", html2);
         Assert.Contains("Length: <strong>3</strong>", html2);
     }
@@ -102,28 +102,28 @@ public sealed class FormControlsDemoTests
     [Fact]
     public async Task Radio_Controlled_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsRadioDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsRadioDemo(), TestServices.Default());
+        var html = page.Render();
         Assert.Contains("Plan: <strong>Free</strong>", html);
 
         // Controlled group renders first → first occurrence of value="Pro".
         var id = HandlerIn(html, "value=\"Pro\"", "data-rask-on-change");
-        await host.TryInvokeHandlerAsync(id, Value("true"));
+        await page.InvokeAsync(id, Value("true"));
 
-        Assert.Contains("Plan: <strong>Pro</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Plan: <strong>Pro</strong>", page.Render());
     }
 
     [Fact]
     public async Task Radio_Bound_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsRadioDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsRadioDemo(), TestServices.Default());
+        var html = page.Render();
 
         // Bound group renders second → second occurrence of value="Team".
         var id = HandlerIn(html, "value=\"Team\"", "data-rask-on-change", skip: 1);
-        await host.TryInvokeHandlerAsync(id, Value("true"));
+        await page.InvokeAsync(id, Value("true"));
 
-        var html2 = host.RenderAsLiveRoot();
+        var html2 = page.Render();
         Assert.Contains("fc-radio-bound-out", html2);
         Assert.Contains("Plan: <strong>Team</strong>", html2);
     }
@@ -133,26 +133,26 @@ public sealed class FormControlsDemoTests
     [Fact]
     public async Task Checkbox_Controlled_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsCheckboxDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsCheckboxDemo(), TestServices.Default());
+        var html = page.Render();
         Assert.Contains("Interests: <strong>none</strong>", html);
 
         var id = HandlerIn(html, "value=\"AI\"", "data-rask-on-change");
-        await host.TryInvokeHandlerAsync(id, Value("true"));
+        await page.InvokeAsync(id, Value("true"));
 
-        Assert.Contains("Interests: <strong>AI</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Interests: <strong>AI</strong>", page.Render());
     }
 
     [Fact]
     public async Task Checkbox_Bound_OnChange_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsCheckboxDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsCheckboxDemo(), TestServices.Default());
+        var html = page.Render();
 
         var id = HandlerIn(html, "value=\"Mobile\"", "data-rask-on-change", skip: 1);
-        await host.TryInvokeHandlerAsync(id, Value("true"));
+        await page.InvokeAsync(id, Value("true"));
 
-        var html2 = host.RenderAsLiveRoot();
+        var html2 = page.Render();
         Assert.Contains("fc-checkbox-bound-out", html2);
         Assert.Contains("Interests: <strong>Mobile</strong>", html2);
     }
@@ -162,38 +162,35 @@ public sealed class FormControlsDemoTests
     [Fact]
     public async Task MultiSelect_Controlled_Select_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsMultiSelectDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsMultiSelectDemo(), TestServices.Default());
+        var html = page.Render();
         Assert.Contains("Selected: <strong>none</strong>", html);
 
         // Option buttons in order (News, Sports, Tech, …); controlled group first → Tech is index 2.
         var clicks = ClickIds(html, "dropdown-item");
-        await host.TryInvokeHandlerAsync(clicks[2], Empty());
+        await page.InvokeAsync(clicks[2]);
 
-        Assert.Contains("Selected: <strong>Tech</strong>", host.RenderAsLiveRoot());
+        Assert.Contains("Selected: <strong>Tech</strong>", page.Render());
     }
 
     [Fact]
     public async Task MultiSelect_Bound_Select_UpdatesReadout()
     {
-        var host = new LiveHost(() => FormControlsMultiSelectDemo(), TestServices.Default());
-        var html = host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => FormControlsMultiSelectDemo(), TestServices.Default());
+        var html = page.Render();
 
         // 5 controlled option buttons, then 5 bound → bound Tech is index 7.
         var clicks = ClickIds(html, "dropdown-item");
-        await host.TryInvokeHandlerAsync(clicks[7], Empty());
+        await page.InvokeAsync(clicks[7]);
 
-        var html2 = host.RenderAsLiveRoot();
+        var html2 = page.Render();
         Assert.Contains("fc-multiselect-bound-out", html2);
         Assert.Contains("Selected: <strong>Tech</strong>", html2);
     }
 
     // ---- helpers ----
 
-    private static JsonElement Value(string v) =>
-        JsonDocument.Parse($"{{\"value\":\"{v}\"}}").RootElement;
-
-    private static JsonElement Empty() => JsonDocument.Parse("{}").RootElement;
+    private static string Value(string v) => $"{{\"value\":\"{v}\"}}";
 
     // Returns the value of `attr` on the (skip-th) element tag that also contains `anchor`. Splitting on
     // '<' yields one element's attribute text per piece, so a match is scoped to a single tag.

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -14,20 +14,20 @@ public sealed class MultiSelectTests
 {
     private static readonly string[] Options = ["a", "b", "c"];
 
-    private static (LiveHost Host, Bag Model) MountBound()
+    private static (RenderedComponent Page, Bag Model) MountBound()
     {
         var model = new Bag();
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => Form(model)[BsMultiSelect<string>(() => model.Tags, Options)],
             TestServices.Default());
-        return (host, model);
+        return (page, model);
     }
 
     [Fact]
     public void Render_Closed_ShowsPlaceholderAndAllOptions()
     {
-        var (host, _) = MountBound();
-        var html = host.RenderAsLiveRoot();
+        var (page, _) = MountBound();
+        var html = page.Render();
 
         Assert.Contains("Select&#x2026;", html);           // default placeholder, HTML-encoded ellipsis
         Assert.DoesNotContain("dropdown-menu show", html);  // closed by default
@@ -38,12 +38,12 @@ public sealed class MultiSelectTests
     [Fact]
     public async Task Toggle_OpensMenu_AndRendersBackdrop()
     {
-        var (host, _) = MountBound();
-        var ids = ClickIds(host.RenderAsLiveRoot());
+        var (page, _) = MountBound();
+        var ids = ClickIds(page.Render());
 
-        await host.TryInvokeHandlerAsync(ids[0], Empty()); // box toggle is the first click handler
+        await page.InvokeAsync(ids[0]); // box toggle is the first click handler
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("dropdown-menu show", html);
         Assert.Contains("position-fixed", html);            // click-outside backdrop only when open
     }
@@ -51,49 +51,49 @@ public sealed class MultiSelectTests
     [Fact]
     public async Task ClickOutside_ClosesMenu()
     {
-        var (host, _) = MountBound();
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // open
+        var (page, _) = MountBound();
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open
 
-        var openIds = ClickIds(host.RenderAsLiveRoot()); // [box, opt-a, opt-b, opt-c, backdrop]
-        await host.TryInvokeHandlerAsync(openIds[^1], Empty()); // backdrop is the last click handler
+        var openIds = ClickIds(page.Render()); // [box, opt-a, opt-b, opt-c, backdrop]
+        await page.InvokeAsync(openIds[^1]); // backdrop is the last click handler
 
-        Assert.DoesNotContain("dropdown-menu show", host.RenderAsLiveRoot());
+        Assert.DoesNotContain("dropdown-menu show", page.Render());
     }
 
     [Fact]
     public async Task Escape_ClosesMenu()
     {
-        var (host, _) = MountBound();
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // open
+        var (page, _) = MountBound();
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open
 
-        var keyId = HandlerIds(host.RenderAsLiveRoot(), "data-rask-on-keydown")[0];
-        await host.TryInvokeHandlerAsync(keyId, Json("{\"key\":\"Escape\"}"));
+        var keyId = page.HandlerIds("keydown")[0];
+        await page.InvokeAsync(keyId, "{\"key\":\"Escape\"}");
 
-        Assert.DoesNotContain("dropdown-menu show", host.RenderAsLiveRoot());
+        Assert.DoesNotContain("dropdown-menu show", page.Render());
     }
 
     [Fact]
     public async Task Escape_OtherKey_DoesNotClose()
     {
-        var (host, _) = MountBound();
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // open
+        var (page, _) = MountBound();
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open
 
-        var keyId = HandlerIds(host.RenderAsLiveRoot(), "data-rask-on-keydown")[0];
-        await host.TryInvokeHandlerAsync(keyId, Json("{\"key\":\"ArrowDown\"}"));
+        var keyId = page.HandlerIds("keydown")[0];
+        await page.InvokeAsync(keyId, "{\"key\":\"ArrowDown\"}");
 
-        Assert.Contains("dropdown-menu show", host.RenderAsLiveRoot());
+        Assert.Contains("dropdown-menu show", page.Render());
     }
 
     [Fact]
     public async Task SelectOption_AddsToCollection_RendersChipAndCheck()
     {
-        var (host, model) = MountBound();
-        var ids = ClickIds(host.RenderAsLiveRoot()); // [toggle, opt-a, opt-b, opt-c]
+        var (page, model) = MountBound();
+        var ids = ClickIds(page.Render()); // [toggle, opt-a, opt-b, opt-c]
 
-        await host.TryInvokeHandlerAsync(ids[2], Empty()); // select "b"
+        await page.InvokeAsync(ids[2]); // select "b"
 
         Assert.Equal(["b"], model.Tags);
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("badge", html);                      // chip rendered for the selection
         Assert.Equal(1, CountOccurrences(html, " checked")); // exactly one option checked
     }
@@ -101,12 +101,12 @@ public sealed class MultiSelectTests
     [Fact]
     public async Task RemoveChip_RemovesFromCollection()
     {
-        var (host, model) = MountBound();
+        var (page, model) = MountBound();
         model.Tags.Add("a");
         // Layout order: box toggle, then chip-remove buttons (inside the box), then option rows.
-        var ids = ClickIds(host.RenderAsLiveRoot()); // [toggle, chip-remove-a, opt-a, opt-b, opt-c]
+        var ids = ClickIds(page.Render()); // [toggle, chip-remove-a, opt-a, opt-b, opt-c]
 
-        await host.TryInvokeHandlerAsync(ids[1], Empty()); // remove the "a" chip
+        await page.InvokeAsync(ids[1]); // remove the "a" chip
 
         Assert.Empty(model.Tags);
     }
@@ -119,16 +119,16 @@ public sealed class MultiSelectTests
         // path used to resolve no owner (DelegateOwner skipped the generic display class holding `this`),
         // so the control never re-rendered and the badge lingered until an unrelated render (reopening the
         // dropdown). A cache-aware second render must now drop the removed chip on its own.
-        var (host, model) = MountBound();
+        var (page, model) = MountBound();
         model.Tags.Add("a");
         model.Tags.Add("b");
-        var ids = ClickIds(host.RenderAsLiveRoot()); // [toggle, chip-remove-a, chip-remove-b, opt-a, opt-b, opt-c]
+        var ids = ClickIds(page.Render()); // [toggle, chip-remove-a, chip-remove-b, opt-a, opt-b, opt-c]
 
-        await host.TryInvokeHandlerAsync(ids[1], Empty()); // remove the "a" chip
+        await page.InvokeAsync(ids[1]); // remove the "a" chip
         Assert.Equal(["b"], model.Tags);
 
         // The cache-aware re-render must reflect the removal without any extra interaction.
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Equal(1, CountOccurrences(html, "badge"));     // only the surviving "b" chip
         Assert.Equal(1, CountOccurrences(html, " checked")); // exactly one option still ticked
     }
@@ -136,14 +136,14 @@ public sealed class MultiSelectTests
     [Fact]
     public async Task SelectingTwice_TogglesOff()
     {
-        var (host, model) = MountBound();
-        var ids = ClickIds(host.RenderAsLiveRoot());
+        var (page, model) = MountBound();
+        var ids = ClickIds(page.Render());
 
-        await host.TryInvokeHandlerAsync(ids[1], Empty()); // select "a"
+        await page.InvokeAsync(ids[1]); // select "a"
         Assert.Equal(["a"], model.Tags);
 
-        var ids2 = ClickIds(host.RenderAsLiveRoot()); // now [toggle, chip-remove-a, opt-a, opt-b, opt-c]
-        await host.TryInvokeHandlerAsync(ids2[2], Empty()); // click the "a" option row again
+        var ids2 = ClickIds(page.Render()); // now [toggle, chip-remove-a, opt-a, opt-b, opt-c]
+        await page.InvokeAsync(ids2[2]); // click the "a" option row again
         Assert.Empty(model.Tags);
     }
 
@@ -151,7 +151,7 @@ public sealed class MultiSelectTests
     public async Task Validate_ShowsMessage_BelowMinimum_AndClearsWhenSatisfied()
     {
         var model = new Bag();
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => Form(model)[
                 BsMultiSelect<string>(
                     () => model.Tags,
@@ -159,13 +159,13 @@ public sealed class MultiSelectTests
                     Validate: tags => tags.Count >= 2 ? Array.Empty<string>() : ["Pick at least two."])],
             TestServices.Default());
 
-        var ids = ClickIds(host.RenderAsLiveRoot());
-        await host.TryInvokeHandlerAsync(ids[1], Empty()); // select "a" (count 1 < 2)
-        Assert.Contains("Pick at least two.", host.RenderAsLiveRoot());
+        var ids = ClickIds(page.Render());
+        await page.InvokeAsync(ids[1]); // select "a" (count 1 < 2)
+        Assert.Contains("Pick at least two.", page.Render());
 
-        var ids2 = ClickIds(host.RenderAsLiveRoot());
-        await host.TryInvokeHandlerAsync(ids2[3], Empty()); // select "b" (count 2)
-        Assert.DoesNotContain("Pick at least two.", host.RenderAsLiveRoot());
+        var ids2 = ClickIds(page.Render());
+        await page.InvokeAsync(ids2[3]); // select "b" (count 2)
+        Assert.DoesNotContain("Pick at least two.", page.Render());
     }
 
     [Fact]
@@ -173,12 +173,12 @@ public sealed class MultiSelectTests
     {
         var model = new Bag();
         ICollection<string>? seen = null;
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => Form(model)[BsMultiSelect<string>(() => model.Tags, Options, AfterBind: c => seen = c)],
             TestServices.Default());
 
-        var ids = ClickIds(host.RenderAsLiveRoot());
-        await host.TryInvokeHandlerAsync(ids[2], Empty()); // select "b"
+        var ids = ClickIds(page.Render());
+        await page.InvokeAsync(ids[2]); // select "b"
 
         Assert.NotNull(seen);
         Assert.Equal(["b"], seen!);
@@ -190,7 +190,7 @@ public sealed class MultiSelectTests
     {
         var model = new Bag();
         var fired = false;
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => Form(model)[BsMultiSelect<string>(
                 () => model.Tags, Options, AfterBindAsync: _ =>
                 {
@@ -199,7 +199,7 @@ public sealed class MultiSelectTests
                 })],
             TestServices.Default());
 
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[1], Empty());
+        await page.InvokeAsync(ClickIds(page.Render())[1]);
 
         Assert.True(fired);
     }
@@ -209,12 +209,12 @@ public sealed class MultiSelectTests
     {
         var value = new List<string> { "a" };
         ICollection<string>? emitted = null;
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => BsMultiSelect<string>(Options, Value: value, OnChange: next => emitted = next),
             TestServices.Default());
 
-        var ids = ClickIds(host.RenderAsLiveRoot()); // [box, chip-remove-a, opt-a, opt-b, opt-c]
-        await host.TryInvokeHandlerAsync(ids[3], Empty()); // select "b"
+        var ids = ClickIds(page.Render()); // [box, chip-remove-a, opt-a, opt-b, opt-c]
+        await page.InvokeAsync(ids[3]); // select "b"
 
         Assert.NotNull(emitted);
         Assert.Equal(["a", "b"], emitted!);
@@ -226,7 +226,7 @@ public sealed class MultiSelectTests
     {
         var value = new List<string>();
         ICollection<string>? emitted = null;
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => BsMultiSelect<string>(Options, Value: value, OnChangeAsync: next =>
             {
                 emitted = next;
@@ -234,7 +234,7 @@ public sealed class MultiSelectTests
             }),
             TestServices.Default());
 
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[1], Empty()); // select "a"
+        await page.InvokeAsync(ClickIds(page.Render())[1]); // select "a"
 
         Assert.Equal(["a"], emitted!);
     }
@@ -242,11 +242,11 @@ public sealed class MultiSelectTests
     [Fact]
     public void Controlled_NoValidationMessage_NoEditContext()
     {
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => BsMultiSelect<string>(Options, Value: new List<string>(), OnChange: _ => { }),
             TestServices.Default());
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("dropdown-item", html);
         Assert.DoesNotContain("invalid-feedback", html); // no bound field → no ValidationMessage
     }
@@ -255,11 +255,11 @@ public sealed class MultiSelectTests
     public void Disabled_ToggleBoxHasNoClickHandler()
     {
         var model = new Bag();
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => Form(model)[BsMultiSelect<string>(() => model.Tags, Options, Disabled: true)],
             TestServices.Default());
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.Contains("form-select", html);
         Assert.Contains("disabled", html);
@@ -270,48 +270,22 @@ public sealed class MultiSelectTests
     public void NullOptions_ThrowsArgumentNullException()
     {
         var model = new Bag();
-        var host = new LiveHost(
+        // Render() renders as it is called, so the render-time throw surfaces from the call itself.
+        Assert.Throws<ArgumentNullException>(() => RaskTest.Render(
             () => Form(model)[BsMultiSelect<string>(() => model.Tags, null!)],
-            TestServices.Default());
-
-        Assert.Throws<ArgumentNullException>(() => host.RenderAsLiveRoot());
+            TestServices.Default()));
     }
 
     [Fact]
     public void NeitherBindNorValue_Throws()
     {
-        var host = new LiveHost(
+        Assert.Throws<InvalidOperationException>(() => RaskTest.Render(
             () => BsMultiSelect<string>(Options),
-            TestServices.Default());
-
-        Assert.Throws<InvalidOperationException>(() => host.RenderAsLiveRoot());
+            TestServices.Default()));
     }
 
-    private static JsonElement Empty() => Json("{}");
-
-    private static JsonElement Json(string json)
-    {
-        using var doc = JsonDocument.Parse(json);
-        return doc.RootElement.Clone();
-    }
-
-    private static List<string> ClickIds(string html) => HandlerIds(html, "data-rask-on-click");
-
-    private static List<string> HandlerIds(string html, string attr)
-    {
-        var ids = new List<string>();
-        var marker = attr + "=\"";
-        var i = 0;
-        while ((i = html.IndexOf(marker, i, StringComparison.Ordinal)) >= 0)
-        {
-            i += marker.Length;
-            var end = html.IndexOf('"', i);
-            ids.Add(html[i..end]);
-            i = end;
-        }
-
-        return ids;
-    }
+    private static IReadOnlyList<string> ClickIds(string html) =>
+        Markup.Attrs(html, "data-rask-on-click");
 
     private static int CountOccurrences(string haystack, string needle)
     {

--- a/tests/Rask.Example.Shared.Tests/Demos/ToastDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/ToastDemoTests.cs
@@ -13,7 +13,7 @@ public sealed class ToastDemoTests
     [Fact]
     public void Render_Initial_NoToasts_ShowsTriggerAndEmptyState()
     {
-        var html = new LiveHost(() => ToastDemo(), TestServices.Default()).RenderAsLiveRoot();
+        var html = RaskTest.Render(() => ToastDemo(), TestServices.Default()).Html;
 
         Assert.DoesNotContain("toast show", html);
         Assert.Contains("Show toast", html);
@@ -23,11 +23,11 @@ public sealed class ToastDemoTests
     [Fact]
     public async Task ShowToast_AddsVisibleToast()
     {
-        var host = new LiveHost(() => ToastDemo(), TestServices.Default());
+        var page = RaskTest.Render(() => ToastDemo(), TestServices.Default());
 
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // "Show toast"
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // "Show toast"
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("toast show", html);
         Assert.Contains("Hello, world! This is a toast message.", html);
         Assert.DoesNotContain("No toasts", html);
@@ -36,35 +36,35 @@ public sealed class ToastDemoTests
     [Fact]
     public async Task ShowToast_Twice_StacksTwoToasts()
     {
-        var host = new LiveHost(() => ToastDemo(), TestServices.Default());
+        var page = RaskTest.Render(() => ToastDemo(), TestServices.Default());
 
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty());
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty());
+        await page.InvokeAsync(ClickIds(page.Render())[0]);
+        await page.InvokeAsync(ClickIds(page.Render())[0]);
 
-        Assert.Equal(2, CountOccurrences(host.RenderAsLiveRoot(), "toast show"));
+        Assert.Equal(2, CountOccurrences(page.Render(), "toast show"));
     }
 
     [Fact]
     public async Task Dismiss_RemovesToast()
     {
-        var host = new LiveHost(() => ToastDemo(), TestServices.Default());
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[0], Empty()); // show
+        var page = RaskTest.Render(() => ToastDemo(), TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // show
 
         // The toast's × is the last click handler, appended after the trigger/option controls.
-        var ids = ClickIds(host.RenderAsLiveRoot());
-        await host.TryInvokeHandlerAsync(ids[^1], Empty()); // close
+        var ids = ClickIds(page.Render());
+        await page.InvokeAsync(ids[^1]); // close
 
-        Assert.DoesNotContain("toast show", host.RenderAsLiveRoot());
+        Assert.DoesNotContain("toast show", page.Render());
     }
 
     [Fact]
     public async Task SuccessButton_RendersColouredToast_WithWhiteClose()
     {
-        var host = new LiveHost(() => ToastDemo(), TestServices.Default());
+        var page = RaskTest.Render(() => ToastDemo(), TestServices.Default());
 
-        await host.TryInvokeHandlerAsync(ClickIds(host.RenderAsLiveRoot())[1], Empty()); // "Success"
+        await page.InvokeAsync(ClickIds(page.Render())[1]); // "Success"
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("text-bg-success", html);
         Assert.Contains("btn-close-white", html);
         Assert.Contains("Your changes were saved.", html);
@@ -73,9 +73,9 @@ public sealed class ToastDemoTests
     [Fact]
     public void Toast_Render_EmitsBootstrapMarkup()
     {
-        var html = new LiveHost(
+        var html = RaskTest.Render(
             () => BsToast(Id: 1, Title: "Heads up", Message: "A message", Timestamp: "just now", Icon: BsIconName.Bell),
-            TestServices.Default()).RenderAsLiveRoot();
+            TestServices.Default()).Html;
 
         Assert.Contains("toast show", html);
         Assert.Contains("toast-header", html);
@@ -91,9 +91,9 @@ public sealed class ToastDemoTests
     [Fact]
     public void Toast_ColouredVariant_UsesHeaderlessFlexLayout()
     {
-        var html = new LiveHost(
+        var html = RaskTest.Render(
             () => BsToast(Id: 1, Title: "Saved", Message: "Done", Color: BsColor.Success),
-            TestServices.Default()).RenderAsLiveRoot();
+            TestServices.Default()).Html;
 
         Assert.Contains("toast show align-items-center text-bg-success border-0", html);
         Assert.Contains("<div class=\"d-flex\">", html);
@@ -104,18 +104,12 @@ public sealed class ToastDemoTests
     [Fact]
     public void Toast_Default_NoVariant_NoWhiteClose()
     {
-        var html = new LiveHost(
+        var html = RaskTest.Render(
             () => BsToast(Id: 1, Title: "T", Message: "M"),
-            TestServices.Default()).RenderAsLiveRoot();
+            TestServices.Default()).Html;
 
         Assert.DoesNotContain("text-bg", html);
         Assert.DoesNotContain("btn-close-white", html);
-    }
-
-    private static JsonElement Empty()
-    {
-        using var doc = JsonDocument.Parse("{}");
-        return doc.RootElement.Clone();
     }
 
     private static List<string> ClickIds(string html)

--- a/tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj
+++ b/tests/Rask.Example.Shared.Tests/Rask.Example.Shared.Tests.csproj
@@ -24,10 +24,14 @@
 
   <ItemGroup>
     <Using Include="Xunit"/>
+    <Using Include="Rask.Testing"/>
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <!-- The shipped testing package: this suite tests a sample app, so it drives it the way an
+         app author would. -->
+    <ProjectReference Include="..\..\src\Rask.Testing\Rask.Testing.csproj"/>
     <ProjectReference Include="..\..\samples\Rask.Example.Shared\Rask.Example.Shared.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"


### PR DESCRIPTION
Stacked on #413.

## The graveyard

Five demo files each carried their **own** `Empty()` / `Json()` / `ClickIds()` / `HandlerIds()` — the same helpers, written five times, against the same markup. They existed because the package gave them nothing to use. That's precisely the duplication dogfooding is meant to surface, so it goes:

- `InvokeAsync`'s `"{}"` payload default deletes every `Empty()` outright.
- `Markup.Attrs` / `page.HandlerIds(evt)` replace the hand-rolled scanners (including MultiSelect's own private `HandlerIds`, and its keydown lookup → `page.HandlerIds("keydown")`).

`Example.Shared.Tests` now references `Rask.Testing` directly — the setup a real app author has.

## One helper deliberately survives, and it's the interesting one

`FormControlsDemoTests.ClickIds(html, cssClass)` filters handler ids by the **CSS class on their element** — structural, not attribute lookup. `Markup` reads attributes and has no notion of elements or nesting, which is exactly the line that made a CSS-selector API the wrong shape for this package (#402).

Leaving the structural helper in the one test that needs it is the honest outcome. Growing the package toward a DOM to absorb it would not be.

## The eager render surfaced a real semantic

`RaskTest.Render` renders **in the call**, so a render-time throw escapes from `Render` itself rather than from a later deferred call:

```csharp
// was: construct, then assert the deferred render throws
Assert.Throws<ArgumentNullException>(() => host.RenderAsLiveRoot());
// now: the render *is* the call under test
Assert.Throws<ArgumentNullException>(() => RaskTest.Render(() => …, TestServices.Default()));
```

Which is how a consumer would express it anyway.

## Testing

- **44 tests before and after** (verified per-file against the pre-migration sources).
- **The suite still bites:** stubbing `ToastDemo`'s dismiss to a no-op turns `Dismiss_RemovesToast` red.
- **16 `Assert` lines changed**, all equivalent substitutions: `host.RenderAsLiveRoot()` → `page.Render()` *inside* the assertion (both render and return the HTML), plus the two throw sites above. Listed rather than buried, per this stack's standing rule.
- Touches `tests/` + CHANGELOG only — no `samples/`, so the E2E surface is untouched.
- `dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed.

Net **−44 lines** with five helper copies deleted.

## Scope

Deliberately the graveyard files. The five lifecycle/render-counting demos (`LiveTicker`, `LifecycleProbe`, `CancellationProbe`, `DisposableTimerProbe`, `MetricsView`) need per-test care about render counts — `RaskTest.Render` renders once itself, which already caused one off-by-one bug in #413 — so they get their own pass rather than a bulk rewrite.

## Changelog

`[Unreleased] → Changed`.