### PR TITLE
fix(sqlite): move SQLitePCLRaw to the 3.x family to patch CVE-2025-6965

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Security
+- **SQLite is no longer vulnerable to CVE-2025-6965 — the shipped native library moves from SQLite 3.49.1 to
+  3.50.4.** `Microsoft.Data.Sqlite` and EF Core Sqlite pin the SQLitePCLRaw `2.1.11` family, whose
+  `lib.e_sqlite3` bundles SQLite 3.49.1 — a memory-corruption flaw (`GHSA-2m69-gcr7-jv3q`, High; fixed in
+  SQLite 3.50.2) that reached every Rask SQLite package, the mobile heads included. Rask now references the
+  SQLitePCLRaw **3.x** bundle explicitly wherever SQLite is used; that family drops `lib.e_sqlite3` in favour
+  of `SourceGear.sqlite3` (SQLite 3.50.4), so the vulnerable package leaves the graph entirely rather than
+  being bumped around. The `NuGetAuditSuppress` that accepted this advisory is removed, and `dotnet list
+  package --vulnerable --include-transitive` is now clean across the solution. Verified end-to-end:
+  `select sqlite_version()` through the real graph reports `3.50.4`.
+
 ### Fixed
 - **The `Rask.Wasm` package never declared its `Microsoft.JSInterop` dependency.** The runtime uses JSInterop
   directly (`WasmJSRuntime`, `WasmLiveSession`, the typed `Browser/*` wrappers), but it only ever arrived

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -54,18 +54,6 @@
     level in a focused PR that fixes/justifies each finding with benchmark evidence — not here.
   -->
 
-  <!--
-    NuGet audit runs as part of the warnings-as-errors gate (NU1903 = known vulnerability). This one
-    advisory is unactionable: SQLitePCLRaw.lib.e_sqlite3 arrives transitively via the latest
-    Microsoft.EntityFrameworkCore.Sqlite (used only by the Rask.Example.EfCore *sample*), the whole
-    SQLitePCLRaw family tops out at 2.1.11, and the advisory reports no patched version
-    (patched: null). Suppress just this advisory — audit stays on for everything else — and remove
-    this entry once a patched SQLitePCLRaw family ships. https://github.com/advisories/GHSA-2m69-gcr7-jv3q
-  -->
-  <ItemGroup>
-    <NuGetAuditSuppress Include="https://github.com/advisories/GHSA-2m69-gcr7-jv3q" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(IsPackable)' != 'false' ">
     <None Include="$(MSBuildThisFileDirectory)NUGET.md" Pack="true" PackagePath="" Visible="false"/>
     <None Include="$(MSBuildThisFileDirectory)LICENSE" Pack="true" PackagePath="" Visible="false"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,7 +35,27 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.8.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.61.0" />
     <PackageVersion Include="MinVer" Version="7.0.0" />
-    <PackageVersion Include="SQLitePCLRaw.core" Version="2.1.11" />
+    <!--
+      SQLitePCLRaw is held at the 3.x family deliberately, ahead of what Microsoft.Data.Sqlite and
+      Microsoft.EntityFrameworkCore.Sqlite ask for (they still pin the 2.1.11 family).
+
+      Why: 2.1.11's SQLitePCLRaw.lib.e_sqlite3 bundles SQLite 3.49.1, which is vulnerable to
+      CVE-2025-6965 (GHSA-2m69-gcr7-jv3q, memory corruption; fixed in SQLite 3.50.2). The 3.x family
+      drops lib.e_sqlite3 entirely in favour of SourceGear.sqlite3, which carries SQLite 3.50.4 — so
+      moving the family off 2.1.x removes the vulnerable package rather than version-bumping around it.
+
+      How: every project with a direct Microsoft.Data.Sqlite / EF Core Sqlite reference also references
+      SQLitePCLRaw.bundle_e_sqlite3 explicitly. A direct reference is the only lever that lifts these —
+      CentralPackageTransitivePinning does NOT move them, and a PackageVersion alone only binds the
+      projects that already reference the package directly, which would split the family across majors.
+
+      Compatibility is verified, not assumed: Microsoft.Data.Sqlite 10.0.10 is built against
+      SQLitePCLRaw.core 2.x (AssemblyVersion 2.0.0.0; core 3.x is 8.0.0.0), but .NET resolves these by
+      simple name, and the SQLite suites pass against the 3.x family. `select sqlite_version()` through
+      the real graph reports 3.50.4. Re-check that if this family moves again.
+    -->
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.3" />
     <PackageVersion Include="Xunit.SkippableFact" Version="1.5.23" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj
+++ b/samples/Rask.Example.EfCore/Rask.Example.EfCore.csproj
@@ -21,6 +21,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.EntityFrameworkCore/Rask.SQLite.EntityFrameworkCore.csproj
+++ b/src/Rask.SQLite.EntityFrameworkCore/Rask.SQLite.EntityFrameworkCore.csproj
@@ -22,6 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Rask.SQLite.Snapshots/Rask.SQLite.Snapshots.csproj
+++ b/src/Rask.SQLite.Snapshots/Rask.SQLite.Snapshots.csproj
@@ -22,6 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>

--- a/src/Rask.SQLite/Rask.SQLite.csproj
+++ b/src/Rask.SQLite/Rask.SQLite.csproj
@@ -24,6 +24,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions"/>
     <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <!-- The non-blocking busy-retry acquires the write lock through the raw sqlite3 handle
          (SQLitePCL.raw) to bypass Microsoft.Data.Sqlite's synchronous Thread.Sleep retry. It flows in
          transitively via Microsoft.Data.Sqlite; reference it explicitly since we call it directly. -->

--- a/tests/Rask.Data.Tests/Rask.Data.Tests.csproj
+++ b/tests/Rask.Data.Tests/Rask.Data.Tests.csproj
@@ -13,6 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>

--- a/tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
+++ b/tests/Rask.Example.EfCore.Tests/Rask.Example.EfCore.Tests.csproj
@@ -13,6 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
     <PackageReference Include="xunit.runner.visualstudio">

--- a/tests/Rask.Outbox.Tests/Rask.Outbox.Tests.csproj
+++ b/tests/Rask.Outbox.Tests/Rask.Outbox.Tests.csproj
@@ -13,6 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Microsoft.Extensions.Hosting"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>

--- a/tests/Rask.SQLite.EntityFrameworkCore.Tests/Rask.SQLite.EntityFrameworkCore.Tests.csproj
+++ b/tests/Rask.SQLite.EntityFrameworkCore.Tests/Rask.SQLite.EntityFrameworkCore.Tests.csproj
@@ -22,6 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
   </ItemGroup>
 

--- a/tests/Rask.SQLite.Limitations.Tests/Rask.SQLite.Limitations.Tests.csproj
+++ b/tests/Rask.SQLite.Limitations.Tests/Rask.SQLite.Limitations.Tests.csproj
@@ -13,6 +13,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>

--- a/tests/Rask.SQLite.Snapshots.Tests/Rask.SQLite.Snapshots.Tests.csproj
+++ b/tests/Rask.SQLite.Snapshots.Tests/Rask.SQLite.Snapshots.Tests.csproj
@@ -22,6 +22,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"/>
     <PackageReference Include="Microsoft.Extensions.Logging"/>

--- a/tests/Rask.SQLite.Tests/Rask.SQLite.Tests.csproj
+++ b/tests/Rask.SQLite.Tests/Rask.SQLite.Tests.csproj
@@ -23,6 +23,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
     <PackageReference Include="Microsoft.Data.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes the SQLite vulnerability that has been accepted-and-suppressed in `Directory.Build.props`, and removes the suppression.

## The problem

`Microsoft.Data.Sqlite` and `Microsoft.EntityFrameworkCore.Sqlite` (10.0.10) pin the SQLitePCLRaw **2.1.11** family. Its `lib.e_sqlite3` bundles **SQLite 3.49.1**, which is vulnerable to **CVE-2025-6965** / [GHSA-2m69-gcr7-jv3q](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (High — the number of aggregate terms can exceed the columns available, leading to memory corruption; fixed in **SQLite 3.50.2**).

It reached **every** Rask SQLite package, the iOS/Android heads included — 14 projects flagged by `dotnet list package --vulnerable --include-transitive`. It was accepted via a `NuGetAuditSuppress` whose comment reasoned the family "tops out at 2.1.11" and "the advisory reports no patched version (patched: null)", with an explicit exit condition: *remove this entry once a patched SQLitePCLRaw family ships*. That premise is now stale.

## The fix

Move the family to **3.x** rather than to 2.1.12. The 3.x bundle **drops `lib.e_sqlite3` entirely** in favour of `SourceGear.sqlite3` (**SQLite 3.50.4**) — so the vulnerable package leaves the dependency graph rather than being version-bumped around. Note GitHub still records `first_patched_version: null` for this advisory, so exiting the `<= 2.1.11` range is not by itself proof of a fix; the SQLite version is what was actually verified.

**Mechanism.** Every project with a direct `Microsoft.Data.Sqlite` / EF Core Sqlite reference now also references `SQLitePCLRaw.bundle_e_sqlite3` explicitly. A direct reference is the only lever that lifts these:

- `CentralPackageTransitivePinning` was tried and **measured** — it does *not* move them. It only lifted the directly-referenced `core`, leaving `bundle`/`provider`/`lib` at 2.1.11: a family split across majors, which is strictly worse. Reverted.
- A `PackageVersion` alone binds only projects that already reference the package directly.

## Verification

| Check | Result |
|---|---|
| `select sqlite_version()` through the real Rask.SQLite graph | **3.50.4** (was 3.49.1) |
| `dotnet list package --vulnerable --include-transitive` | **0 projects** (was 14) |
| `CI=true dotnet build Rask.slnx -warnaserror` with the suppression removed | 0 warnings, 0 errors (NU1903 no longer fires) |
| Unit (`scripts/run-unit-local.sh`) | **3836 passed / 0 failed**, 29 projects |
| E2E (`scripts/run-e2e-local.sh`) | **25 passed / 0 failed** — incl. `SqliteExampleTests` (WAL + `foreign_keys` pragmas, concurrent writers) and `EfCoreCrudTests` round-tripping through SQLite |

**Compatibility is verified, not assumed.** `Microsoft.Data.Sqlite` 10.0.10 is built against `SQLitePCLRaw.core` 2.x (AssemblyVersion `2.0.0.0`; core 3.x is `8.0.0.0`), so this is the one thing that could have broken. .NET binds these by simple name, and every SQLite suite passes — including the browser E2E that exercises real WAL/pragma/concurrent-write behaviour. This is also exactly why dependabot #400 (core 3.0.3 *alone*) was rejected: it moved `core` across that identity boundary while leaving `provider`/`lib` on 2.1.11.

**Mobile / distroless are unaffected.** `SourceGear.sqlite3` keeps full RID coverage — `android-*`, `ios-*`, `iossimulator-*`, `maccatalyst-*`, and `linux-musl-*` — so the native heads and the Alpine/distroless claims in `docs/sqlite.md` still hold. The native iOS/Android compile jobs in CI cover the mobile asset path.

**Consumers get the fix too:** `Rask.SQLite`, `Rask.SQLite.Snapshots` and `Rask.SQLite.EntityFrameworkCore` now declare `SQLitePCLRaw.bundle_e_sqlite3 3.0.3` in their nuspecs (verified by packing and reading them).

No benchmarks: dependency versions only, no render/runtime code touched.