### PR TITLE
test(example): drive the lifecycle demo suites through Rask.Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **The lifecycle demo suites drive mount/unmount through `Rask.Testing`.** The five suites that assert on
+  lifecycle hooks (`LiveTicker`, `LifecycleProbe`, `CancellationProbe`, `DisposableTimerProbe`, `MetricsView`)
+  now render with `RaskTest.Render`, and unmount by having their factory return `null` instead of flipping a
+  flag on a test-only host wrapper. This confirms in a real suite what the package documents: a `null` factory
+  result drives a generated-factory child through its full unmount path — `OnUnmount`, `OnUnmountAsync`,
+  subscription teardown and cancellation all fire. Test-only; 22 tests before and after, and the suites still
+  catch a component that forgets to unsubscribe on unmount.
+  `LiveTickerTests` loses a self-referencing `LiveHost? host = null; host = new LiveHost(… host!.Log.Add …)`
+  knot that existed only because its lifecycle log lived on the host wrapper — the test owns the log now.
 - **The showcase demo suites drop their copy-pasted markup helpers for `Rask.Testing`.** Five files each kept
   their own `Empty()` / `Json()` / `ClickIds()` / `HandlerIds()` — the same helpers, written five times, over
   the same markup. `InvokeAsync`'s `"{}"` payload default deletes every `Empty()` outright, and

--- a/tests/Rask.Example.Shared.Tests/Demos/CancellationProbeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/CancellationProbeTests.cs
@@ -10,16 +10,15 @@ public sealed class CancellationProbeTests
     public async Task OnMountAsync_LogsCancelledOnUnmount_ThroughRegisterCallback()
     {
         var log = new LifecycleLog();
-        var host = new LiveHost(
-            () => CancellationProbe(log.Add, 1),
+        var mounted = true;
+        var page = RaskTest.Render(
+            () => mounted ? CancellationProbe(log.Add, 1) : null,
             TestServices.Default());
-
-        host.RenderAsLiveRoot();
         // Wait until the probe is in the "running" state (its post-StateHasChanged render).
-        await WaitFor.True(() => host.RenderAsLiveRoot().Contains("running"), TimeSpan.FromSeconds(2));
+        await WaitFor.True(() => page.Render().Contains("running"), TimeSpan.FromSeconds(2));
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
 
         await WaitFor.True(() => log.Contains("cancelled"), TimeSpan.FromSeconds(2));
         Assert.Contains(log.Snapshot(), e => e.Contains("#1 cancelled"));
@@ -29,15 +28,14 @@ public sealed class CancellationProbeTests
     public async Task OnMountAsync_DoubleObservation_LogsOnceViaInterlocked()
     {
         var log = new LifecycleLog();
-        var host = new LiveHost(
-            () => CancellationProbe(log.Add, 9),
+        var mounted = true;
+        var page = RaskTest.Render(
+            () => mounted ? CancellationProbe(log.Add, 9) : null,
             TestServices.Default());
+        await WaitFor.True(() => page.Render().Contains("running"), TimeSpan.FromSeconds(2));
 
-        host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.RenderAsLiveRoot().Contains("running"), TimeSpan.FromSeconds(2));
-
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         await WaitFor.True(() => log.Contains("cancelled"), TimeSpan.FromSeconds(2));
 
         // Even if both the Register callback and the polling loop observe cancellation,

--- a/tests/Rask.Example.Shared.Tests/Demos/DisposableTimerProbeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/DisposableTimerProbeTests.cs
@@ -10,15 +10,14 @@ public sealed class DisposableTimerProbeTests
     public async Task DisposableTimerProbe_DisposeFires_OnUnmount()
     {
         var log = new LifecycleLog();
-        var host = new LiveHost(
-            () => DisposableTimerProbe(log.Add, 1),
+        var mounted = true;
+        var page = RaskTest.Render(
+            () => mounted ? DisposableTimerProbe(log.Add, 1) : null,
             TestServices.Default());
-
-        host.RenderAsLiveRoot();
         Assert.Contains(log.Snapshot(), e => e == "#1 mounted");
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         await WaitFor.True(() => log.Contains("disposed"), TimeSpan.FromSeconds(2));
 
         Assert.Contains(log.Snapshot(), e => e.StartsWith("#1 disposed"));
@@ -28,15 +27,14 @@ public sealed class DisposableTimerProbeTests
     public async Task UnmountTimerProbe_TimerStoppedOnUnmount_NoFurtherTicks()
     {
         var log = new LifecycleLog();
-        var host = new LiveHost(
-            () => UnmountTimerProbe(log.Add, 2),
+        var mounted = true;
+        var page = RaskTest.Render(
+            () => mounted ? UnmountTimerProbe(log.Add, 2) : null,
             TestServices.Default());
-
-        host.RenderAsLiveRoot();
         Assert.Contains(log.Snapshot(), e => e == "#2 ticker started");
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         await WaitFor.True(() => log.Contains("ticker stopped"), TimeSpan.FromSeconds(2));
 
         Assert.Contains(log.Snapshot(), e => e.StartsWith("#2 ticker stopped after"));
@@ -46,15 +44,14 @@ public sealed class DisposableTimerProbeTests
     public async Task DisposableAsyncProbe_DisposeAsyncFires_OnUnmount()
     {
         var log = new LifecycleLog();
-        var host = new LiveHost(
-            () => DisposableAsyncProbe(log.Add, 3),
+        var mounted = true;
+        var page = RaskTest.Render(
+            () => mounted ? DisposableAsyncProbe(log.Add, 3) : null,
             TestServices.Default());
-
-        host.RenderAsLiveRoot();
         Assert.Contains(log.Snapshot(), e => e == "#3 async-mounted");
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         await WaitFor.True(() => log.Contains("async-disposed"), TimeSpan.FromSeconds(2));
 
         Assert.Contains(log.Snapshot(), e => e.StartsWith("#3 async-disposed"));

--- a/tests/Rask.Example.Shared.Tests/Demos/LifecycleProbeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/LifecycleProbeTests.cs
@@ -16,28 +16,26 @@ public sealed class LifecycleProbeTests
     [Fact]
     public async Task TriggerReRender_ThroughBsButton_RunsHandlerAndRepaintsProbe()
     {
-        var host = new LiveHost(() => LifecycleProbe(), TestServices.Default());
+        var page = RaskTest.Render(() => LifecycleProbe(), TestServices.Default());
 
         // The probe's only click handler is the trigger button; that an id exists proves BsButton forwarded
         // the OnClick to the native button.
-        var clickId = ClickIds(host.RenderAsLiveRoot())[0];
-        await host.TryInvokeHandlerAsync(clickId, Empty());
+        var clickId = Markup.Attrs(page.Render(), "data-rask-on-click")[0];
+        await page.InvokeAsync(clickId);
 
-        Assert.Contains("Trigger re-render (button click)", host.RenderAsLiveRoot());
+        Assert.Contains("Trigger re-render (button click)", page.Render());
     }
 
 
     [Fact]
     public async Task LifecycleProbe_FiresMountThroughRenderedHooks_InOrder()
     {
-        var host = new LiveHost(() => LifecycleProbe(), TestServices.Default());
-
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => LifecycleProbe(), TestServices.Default());
         // OnMountAsync awaits 450ms; allow time for the full sequence.
-        await WaitFor.True(() => RenderedHtml(host).Contains("OnMountAsync (after 450ms await)"),
+        await WaitFor.True(() => page.Render().Contains("OnMountAsync (after 450ms await)"),
             TimeSpan.FromSeconds(2));
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("OnMount", html);
         Assert.Contains("OnMountAsync (start)", html);
         Assert.Contains("OnMountAsync (after 450ms await)", html);
@@ -50,11 +48,9 @@ public sealed class LifecycleProbeTests
     {
         var log = new LifecycleLog();
         var instanceId = 7;
-        var host = new LiveHost(
+        var page = RaskTest.Render(
             () => LifecycleCycleProbe(log.Add, instanceId),
             TestServices.Default());
-
-        host.RenderAsLiveRoot();
 
         Assert.Contains(log.Snapshot(), e => e == "#7 OnMount");
         Assert.Contains(log.Snapshot(), e => e.StartsWith("#7 OnMountAsync (start)"));
@@ -64,44 +60,17 @@ public sealed class LifecycleProbeTests
     public async Task LifecycleCycleProbe_OnUnmount_FiresWhenRemovedFromTree()
     {
         var log = new LifecycleLog();
-        var host = new LiveHost(
-            () => LifecycleCycleProbe(log.Add, 1),
+        var mounted = true;
+        var page = RaskTest.Render(
+            () => mounted ? LifecycleCycleProbe(log.Add, 1) : null,
             TestServices.Default());
-
-        host.RenderAsLiveRoot();
         await WaitFor.True(() => log.Contains("#1 OnMountAsync (after 150ms await)"), TimeSpan.FromSeconds(2));
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         await WaitFor.True(() => log.Contains("#1 OnUnmountAsync"), TimeSpan.FromSeconds(2));
 
         Assert.Contains(log.Snapshot(), e => e == "#1 OnUnmount");
         Assert.Contains(log.Snapshot(), e => e == "#1 OnUnmountAsync");
-    }
-
-    // Helper: the LifecycleProbe captures its log internally and re-renders, so we
-    // peek at the rendered HTML to inspect the log contents.
-    private static string RenderedHtml(LiveHost host) => host.RenderAsLiveRoot();
-
-    private static JsonElement Empty()
-    {
-        using var doc = JsonDocument.Parse("{}");
-        return doc.RootElement.Clone();
-    }
-
-    private static List<string> ClickIds(string html)
-    {
-        var ids = new List<string>();
-        const string marker = "data-rask-on-click=\"";
-        var i = 0;
-        while ((i = html.IndexOf(marker, i, StringComparison.Ordinal)) >= 0)
-        {
-            i += marker.Length;
-            var end = html.IndexOf('"', i);
-            ids.Add(html[i..end]);
-            i = end;
-        }
-
-        return ids;
     }
 }

--- a/tests/Rask.Example.Shared.Tests/Demos/LiveTickerTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/LiveTickerTests.cs
@@ -6,7 +6,7 @@ using static Rask.Example.Shared.Generated;
 
 namespace Rask.Example.Shared.Tests.Demos;
 
-// Each test drives the component through its parent wrapper (LiveHost), so the
+// Each test drives the component through RaskTest.Render's forwarding root, so the
 // real framework — render-walk, lifecycle dispatch, prop diff, unmount — is what
 // fires the hooks. LiveTicker uses no JavaScript: the price feed is fully synthetic
 // (see LiveTicker.PollOnceAsync) and the chart is a server-rendered SVG (Sparkline)
@@ -32,16 +32,14 @@ public sealed class LiveTickerTests
     public async Task OnMountAsync_PopulatesHistoryFromSyntheticFeed()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, 30);
-
-        host.RenderAsLiveRoot();
+        var (page, log, mounted) = BuildHost(symbol, 30);
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1,
+            () => PointCount(page.Render()) >= 1,
             Settle,
             "the synthetic feed never populated the history");
 
-        Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnMount:"));
-        var html = host.RenderAsLiveRoot();
+        Assert.Contains(log.Snapshot(), l => l.Contains("OnMount:"));
+        var html = page.Render();
         Assert.True(PointCount(html) >= 1);
         // The chart is a server-rendered SVG, drawn straight from the rolling buffer.
         Assert.Contains("<svg", html);
@@ -51,34 +49,30 @@ public sealed class LiveTickerTests
     public async Task OnPropsChanged_LogsSymbolSwitch()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, 30);
-
-        host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnPropsChangedAsync"), Settle);
+        var (page, log, mounted) = BuildHost(symbol, 30);
+        await WaitFor.True(() => log.Contains("OnPropsChangedAsync"), Settle);
 
         symbol.Value = "ETH";
-        host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("Symbol BTC → ETH"), Settle);
+        page.Render();
+        await WaitFor.True(() => log.Contains("Symbol BTC → ETH"), Settle);
 
-        Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnPropsChanged: Symbol BTC → ETH"));
-        Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnPropsChangedAsync: switched to ETH"));
+        Assert.Contains(log.Snapshot(), l => l.Contains("OnPropsChanged: Symbol BTC → ETH"));
+        Assert.Contains(log.Snapshot(), l => l.Contains("OnPropsChangedAsync: switched to ETH"));
     }
 
     [Fact]
     public async Task OnUnmount_FiresOnRemovalFromTree()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, 30);
+        var (page, log, mounted) = BuildHost(symbol, 30);
+        await WaitFor.True(() => log.Contains("OnMountAsync"), Settle);
 
-        host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnMountAsync"), Settle);
+        mounted.Value = false;
+        page.Render();
+        await WaitFor.True(() => log.Contains("OnUnmountAsync: flushed"), Settle);
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnUnmountAsync: flushed"), Settle);
-
-        Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnUnmount: stopping"));
-        Assert.Contains(host.Log.Snapshot(), l => l.Contains("OnUnmountAsync: flushed"));
+        Assert.Contains(log.Snapshot(), l => l.Contains("OnUnmount: stopping"));
+        Assert.Contains(log.Snapshot(), l => l.Contains("OnUnmountAsync: flushed"));
     }
 
     // The poll loop is linked to the lifetime CancellationToken, so unmount cancels it.
@@ -88,18 +82,16 @@ public sealed class LiveTickerTests
     public async Task PollLoop_StopsAfterUnmount()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(symbol, 30);
-
-        host.RenderAsLiveRoot();
+        var (page, log, mounted) = BuildHost(symbol, 30);
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1, Settle,
+            () => PointCount(page.Render()) >= 1, Settle,
             "the poll loop never produced a tick");
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
-        await WaitFor.True(() => host.Log.Contains("OnUnmountAsync: flushed"), Settle);
+        mounted.Value = false;
+        page.Render();
+        await WaitFor.True(() => log.Contains("OnUnmountAsync: flushed"), Settle);
         await WaitFor.True(
-            () => host.Log.Contains("poll loop cancelled"), Settle,
+            () => log.Contains("poll loop cancelled"), Settle,
             "the poll loop did not stop after unmount");
     }
 
@@ -113,23 +105,21 @@ public sealed class LiveTickerTests
     {
         var symbol = new Box<string>("BTC");
         var counter = 0;
-        var host = BuildHost(symbol, 1, _ => 10_000m + counter++);
-
-        host.RenderAsLiveRoot();
+        var (page, log, mounted) = BuildHost(symbol, 1, _ => 10_000m + counter++);
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 60, FillToCapacity,
+            () => PointCount(page.Render()) >= 60, FillToCapacity,
             "the history never filled to capacity");
 
-        Assert.Equal(60, PointCount(host.RenderAsLiveRoot()));
+        Assert.Equal(60, PointCount(page.Render()));
 
         // Prove the loop keeps ticking past capacity (the current/last price climbs with
         // the increasing feed) yet the count stays pinned at 60 — the oldest rolled off.
-        var price = PriceFromHtml(host.RenderAsLiveRoot());
+        var price = PriceFromHtml(page.Render());
         await WaitFor.True(
-            () => PriceFromHtml(host.RenderAsLiveRoot()) > price + 5m, Settle,
+            () => PriceFromHtml(page.Render()) > price + 5m, Settle,
             "the poll loop stopped ticking after reaching capacity");
 
-        Assert.Equal(60, PointCount(host.RenderAsLiveRoot()));
+        Assert.Equal(60, PointCount(page.Render()));
     }
 
     // PollOnceAsync captures the symbol before its simulated latency and drops the
@@ -143,21 +133,19 @@ public sealed class LiveTickerTests
         // Large interval ⇒ steady-state polling is gated; the symbol switch is what
         // drives the next poll (via the wake). The first BTC poll parks in the 50 ms
         // simulated-latency Task.Delay while we flip the symbol underneath it.
-        var host = BuildHost(symbol, 5000);
-
-        host.RenderAsLiveRoot();
+        var (page, log, mounted) = BuildHost(symbol, 5000);
         // The flip lands within microseconds — well inside the 50 ms in-flight window,
         // which is the determinism margin for this race.
         symbol.Value = "ETH";
-        host.RenderAsLiveRoot();
+        page.Render();
 
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1, Settle,
+            () => PointCount(page.Render()) >= 1, Settle,
             "the symbol switch did not wake the poll loop");
 
         // The only price that landed is ETH-magnitude (seed ≈2 500); a stale
         // BTC-magnitude price (≈70 000) would prove the mid-flight result leaked through.
-        var price = PriceFromHtml(host.RenderAsLiveRoot());
+        var price = PriceFromHtml(page.Render());
         Assert.True(price < 10_000m, $"a stale BTC-magnitude price ({price}) leaked into ETH's history");
     }
 
@@ -169,21 +157,19 @@ public sealed class LiveTickerTests
         var symbol = new Box<string>("BTC");
         // Large interval: without the wake the next poll wouldn't run for 5 s. The
         // assertion is that switching symbols polls the new asset well inside that.
-        var host = BuildHost(symbol, 5000);
-
-        host.RenderAsLiveRoot();
+        var (page, log, mounted) = BuildHost(symbol, 5000);
         await WaitFor.True(
-            () => PointCount(host.RenderAsLiveRoot()) >= 1, Settle,
+            () => PointCount(page.Render()) >= 1, Settle,
             "first poll never ran");
 
         symbol.Value = "ETH";
-        host.RenderAsLiveRoot();
+        page.Render();
 
         // An ETH-magnitude price lands far sooner than the 5 s interval would allow.
         await WaitFor.True(
             () =>
             {
-                var html = host.RenderAsLiveRoot();
+                var html = page.Render();
                 return PointCount(html) >= 1 && PriceFromHtml(html) < 10_000m;
             },
             Settle,
@@ -196,17 +182,16 @@ public sealed class LiveTickerTests
     public async Task PollLoop_FeedFailure_SurfacesErrorAlert()
     {
         var symbol = new Box<string>("BTC");
-        var host = BuildHost(
+        var (page, _, _) = BuildHost(
             symbol, 30,
             _ => throw new InvalidOperationException("feed offline"));
 
-        host.RenderAsLiveRoot();
         await WaitFor.True(
-            () => host.RenderAsLiveRoot().Contains("Feed error: feed offline"),
+            () => page.Render().Contains("Feed error: feed offline"),
             Settle,
             "a throwing price source never surfaced the #ticker-error alert");
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
         Assert.Contains("ticker-error", html);
         Assert.Contains("Feed error: feed offline", html);
     }
@@ -227,15 +212,17 @@ public sealed class LiveTickerTests
         Assert.Equal(2, Regex.Matches(html, "ticker-chart-container").Count);
     }
 
-    private static LiveHost BuildHost(
+    private static (RenderedComponent Page, LifecycleLog Log, Box<bool> Mounted) BuildHost(
         Box<string> symbol, int interval, Func<string, decimal>? priceSource = null)
     {
-        LiveHost? host = null;
-        host = new LiveHost(
-            () => LiveTicker(
-                symbol.Value, interval, host!.Log.Add, priceSource),
+        var log = new LifecycleLog();
+        var mounted = new Box<bool>(true);
+        var page = RaskTest.Render(
+            () => mounted.Value
+                ? LiveTicker(symbol.Value, interval, log.Add, priceSource)
+                : null,
             LiveHost.Services());
-        return host;
+        return (page, log, mounted);
     }
 
     // "<n>/60 pts" in the header reflects _history.Count.

--- a/tests/Rask.Example.Shared.Tests/Demos/MetricsViewTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MetricsViewTests.cs
@@ -6,7 +6,7 @@ using static Rask.Example.Shared.Generated;
 
 namespace Rask.Example.Shared.Tests.Demos;
 
-// MetricsGauge / MetricsChart are driven through LiveHost so the real framework fires
+// MetricsGauge / MetricsChart are driven through RaskTest.Render so the real framework fires
 // their lifecycle hooks. A FakeMetricsFeed stands in for the producer so the test pushes
 // updates by hand (Publish) — fully deterministic, no background timer.
 public sealed class MetricsViewTests
@@ -15,9 +15,9 @@ public sealed class MetricsViewTests
     public void Gauge_RendersInitialSnapshot()
     {
         var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
-        var host = new LiveHost(() => MetricsGauge(), Services(feed));
+        var page = RaskTest.Render(() => MetricsGauge(), Services(feed));
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Html;
 
         Assert.Contains("tick 0", html);
         Assert.Contains("50.0%", html);
@@ -27,11 +27,10 @@ public sealed class MetricsViewTests
     public void Gauge_RepaintsWhenFeedPublishes()
     {
         var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
-        var host = new LiveHost(() => MetricsGauge(), Services(feed));
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => MetricsGauge(), Services(feed));
 
         feed.Publish(Snapshot(tick: 7, cpu: 73.5, jobs: 9));
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.Contains("tick 7", html);
         Assert.Contains("73.5%", html);
@@ -42,13 +41,12 @@ public sealed class MetricsViewTests
     public void Gauge_SubscribesOnMount_AndUnsubscribesOnUnmount()
     {
         var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
-        var host = new LiveHost(() => MetricsGauge(), Services(feed));
-
-        host.RenderAsLiveRoot();
+        var mounted = true;
+        var page = RaskTest.Render(() => mounted ? MetricsGauge() : null, Services(feed));
         Assert.Equal(1, feed.SubscriberCount);
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         Assert.Equal(0, feed.SubscriberCount);
 
         // A tick after unmount must not throw (no live handler) and produces no value change.
@@ -60,17 +58,18 @@ public sealed class MetricsViewTests
     public void Chart_SubscribesAndRendersSvgFromHistory()
     {
         var feed = new FakeMetricsFeed(Snapshot(tick: 0, cpu: 50, jobs: 4));
-        var host = new LiveHost(() => MetricsChart(), Services(feed));
+        var mounted = true;
+        var page = RaskTest.Render(() => mounted ? MetricsChart() : null, Services(feed));
 
-        var html = host.RenderAsLiveRoot();
+        var html = page.Html;
         Assert.Equal(1, feed.SubscriberCount);
         Assert.Contains("<svg", html);
         // Percentage-formatted axis labels (ValueFormat "0.0'%'"), not the default money.
         Assert.Contains("50.0%", html);
         Assert.DoesNotContain("$", html);
 
-        host.Mounted = false;
-        host.RenderAsLiveRoot();
+        mounted = false;
+        page.Render();
         Assert.Equal(0, feed.SubscriberCount);
     }
 


### PR DESCRIPTION
Stacked on #415. The five suites deliberately held back from that pass.

## Why they were held back

They **count renders**, and `RaskTest.Render` renders once itself where `new LiveHost(...)` did not. Every explicit first render had to be dropped *per test* rather than bulk-replaced — the same off-by-one that already bit once in #413. Bulk-rewriting tests that count renders is how you get a suite that passes and proves nothing.

## They settle a claim rather than restate one

Back in #401 I documented that a `null` factory result unmounts a child *"for a child built by its generated factory"* — but I couldn't verify it there: `Rask.Testing.Tests` is consumer-shaped and has **no generator**, so `OnUnmount` never fired for its raw-constructed components. I corrected the doc to claim only what I'd tested and moved on.

These suites have the generator. **They confirm it:** `OnUnmount`, `OnUnmountAsync`, subscription teardown and cancellation all fire when the factory returns `null`:

```csharp
var mounted = true;
var page = RaskTest.Render(() => mounted ? MetricsGauge() : null, Services(feed));
Assert.Equal(1, feed.SubscriberCount);

mounted = false;
page.Render();
Assert.Equal(0, feed.SubscriberCount);   // OnUnmount ran
```

And it isn't passing by accident: mutating `MetricsGauge` to skip its `OnUnmount` unsubscribe turns that test red. The test observes the path rather than merely surviving it.

## Unmount is now a flag the factory reads

That's what a consumer has — no test-only host wrapper to flip. `LiveTickerTests` also loses a knot that only existed because the lifecycle log lived on that wrapper:

```csharp
// before: the factory needed the host that the factory was being passed to
LiveHost? host = null;
host = new LiveHost(() => LiveTicker(symbol.Value, interval, host!.Log.Add, …), LiveHost.Services());

// after: the test owns the log
var log = new LifecycleLog();
var page = RaskTest.Render(() => mounted ? LiveTicker(symbol.Value, interval, log.Add, …) : null, …);
```

I also kept the `mounted` flag **only** in tests that actually unmount — a first pass added it everywhere, which is pointless indirection.

## Testing

- **22 tests before and after** (verified per-file against the pre-migration sources).
- **The suites still bite:** stubbing `MetricsGauge`'s unmount unsubscribe turns `Gauge_SubscribesOnMount_AndUnsubscribesOnUnmount` red.
- Assert changes are two equivalent substitutions: `host.Log` → `log`, and `host.RenderAsLiveRoot()` → `page.Render()` inside an assertion.
- Touches `tests/` + CHANGELOG only — no `samples/`, so the E2E surface is untouched.
- `dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` passed.

## What this leaves

`LiveHost` now has no users in `Demos/` at all — only the static `LiveHost.Services(...)` DI helper survives there. Its remaining component users are `Pages`/`Layout`/`Guides` (#10) and the `RecordingHandle` render-count tests, which are the genuine internals case.

## Changelog

`[Unreleased] → Changed`.