### PR TITLE
test(example): render the page, layout and guide suites through Rask.Testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **The showcase page, layout and guide suites render through `Rask.Testing`.** They called the internal
+  `RenderAsLiveRoot(services)` straight on a page component; they now use
+  `RaskTest.Render(new SomePage(), services).Html`, which is the same thing a consumer writes. Test-only;
+  84 tests before and after, and the suites still catch a layout that drops its `navbar-brand`.
 - **The lifecycle demo suites drive mount/unmount through `Rask.Testing`.** The five suites that assert on
   lifecycle hooks (`LiveTicker`, `LifecycleProbe`, `CancellationProbe`, `DisposableTimerProbe`, `MetricsView`)
   now render with `RaskTest.Render`, and unmount by having their factory return `null` instead of flipping a

--- a/tests/Rask.Example.Shared.Tests/Guides/GuideChromeTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Guides/GuideChromeTests.cs
@@ -94,7 +94,7 @@ public sealed class GuideChromeTests
         var sp = TestServices.Default();
         var js = sp.GetRequiredService<IJSRuntime>();
 
-        var html = new GuideChrome(js) { Slug = "routing" }.RenderAsLiveRoot(sp);
+        var html = RaskTest.Render(new GuideChrome(js) { Slug = "routing" }, sp).Html;
 
         // Chrome scaffolding.
         Assert.Contains("guide-chapters", html);
@@ -120,7 +120,7 @@ public sealed class GuideChromeTests
         var sp = TestServices.Default();
         var js = sp.GetRequiredService<IJSRuntime>();
 
-        var html = new GuideChrome(js) { Slug = "forms" }.RenderAsLiveRoot(sp);
+        var html = RaskTest.Render(new GuideChrome(js) { Slug = "forms" }, sp).Html;
 
         // Every marker resolved and mounted — no leftover comment, no unknown-demo warning.
         Assert.DoesNotContain("<!-- demo:", html);
@@ -139,7 +139,7 @@ public sealed class GuideChromeTests
         var sp = TestServices.Default();
         var js = sp.GetRequiredService<IJSRuntime>();
 
-        var html = new GuideChrome(js) { Slug = "no-such-guide" }.RenderAsLiveRoot(sp);
+        var html = RaskTest.Render(new GuideChrome(js) { Slug = "no-such-guide" }, sp).Html;
 
         Assert.Contains("No guide found", html);
     }

--- a/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
@@ -15,8 +15,7 @@ public sealed class ShowcaseLayoutTests
     public void RenderThroughApp_EmitsNavbarOffcanvasAndBrand()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         // The 5.3 dark navbar uses bg-dark + data-bs-theme (not the deprecated .navbar-dark).
         Assert.Contains("navbar", html);
@@ -32,8 +31,7 @@ public sealed class ShowcaseLayoutTests
     public void RenderThroughApp_GroupsLinks_UnderGroupToggles()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         // Each group renders a collapsible toggle whose label is the group name. Guides-first, so the
         // guide category groups lead (Overview + Core + Bootstrap + …); the surviving Examples group is Apps.
@@ -55,8 +53,7 @@ public sealed class ShowcaseLayoutTests
         // visible on landing, while the demoted Examples groups stay collapsed so the ~90-item list isn't
         // dumped at once. The five guide groups (Overview + the four categories) are open.
         var routeState = new RouteState { Path = "/" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         var open = Regex.Matches(html, "class=\"collapse show\"").Count;
         var closed = Regex.Matches(html, "class=\"collapse\"").Count;
@@ -70,8 +67,7 @@ public sealed class ShowcaseLayoutTests
     public void RenderThroughApp_RootPath_MarksAtLeastOneNavLinkActive()
     {
         var routeState = new RouteState { Path = "/" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         Assert.Contains("side-nav-link active", html);
     }
@@ -147,17 +143,18 @@ public sealed class ShowcaseLayoutTests
         // same RouteState. The layout's active-link computation must reflect the new
         // path — which requires its Render() to re-execute after the path change.
         var routeState = new RouteState { Path = "/" };
-        var app = new Shared.App();
         var services = TestServices.Default(routeState: routeState);
+        // One handle across both frames: the same App instance has to re-render after the path change.
+        var page = RaskTest.Render(new Shared.App(), services);
 
-        var htmlAtRoot = app.RenderAsLiveRoot(services);
+        var htmlAtRoot = page.Html;
         // The "All guides" link to "/" (the site root now the Welcome page is gone) is the active one
         // when the path is "/" — it carries the bi-book icon.
         Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-book",
             CollapseWhitespace(htmlAtRoot));
 
         routeState.Path = "/todos";
-        var htmlAtTodos = app.RenderAsLiveRoot(services);
+        var htmlAtTodos = page.Render();
         // After nav, the active link should be the Todos one (bi-check2-square icon).
         Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-check2-square",
             CollapseWhitespace(htmlAtTodos));

--- a/tests/Rask.Example.Shared.Tests/Pages/BoomPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/BoomPageTests.cs
@@ -15,9 +15,9 @@ public sealed class BoomPageTests
     {
         var sp = TestServices.Default();
 
-        Assert.Contains("boom-handler-host", new BoomHandlerDemo().RenderAsLiveRoot(sp));
-        Assert.Contains("boom-render-host", new BoomRenderDemo().RenderAsLiveRoot(sp));
-        Assert.Contains("boom-nested-host", new BoomNestedDemo().RenderAsLiveRoot(sp));
+        Assert.Contains("boom-handler-host", RaskTest.Render(new BoomHandlerDemo(), sp).Html);
+        Assert.Contains("boom-render-host", RaskTest.Render(new BoomRenderDemo(), sp).Html);
+        Assert.Contains("boom-nested-host", RaskTest.Render(new BoomNestedDemo(), sp).Html);
     }
 
     [Fact]

--- a/tests/Rask.Example.Shared.Tests/Pages/DownloadPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/DownloadPageTests.cs
@@ -14,7 +14,7 @@ public sealed class DownloadPageTests
         // Render DownloadDemo directly — its standalone /download page was folded into
         // docs/http-and-files.md, where the demo is embedded as a live sample.
         var nav = new Navigator(new RouteState { Path = "/" }, new CapturingDownloadSink());
-        var html = new DownloadDemo(nav).RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new DownloadDemo(nav), TestServices.Default()).Html;
 
         Assert.Contains("download-report", html);
         Assert.Contains("Generated 0 time(s)", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/GuidesTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/GuidesTests.cs
@@ -73,7 +73,7 @@ public sealed class GuidesTests
     public void GuidePage_KnownSlug_RendersGuideChromeWithMarkdownBody()
     {
         // GuidePage delegates to GuideChrome (a DI-ctor component), so it renders through a live context.
-        var html = new GuidePage { Slug = "routing" }.RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new GuidePage { Slug = "routing" }, TestServices.Default()).Html;
         Assert.Contains("markdown-body", html);
         Assert.Contains("All guides", html); // the back link
         Assert.Contains("guide-chapters", html); // the Rails-style Chapters TOC
@@ -82,7 +82,7 @@ public sealed class GuidesTests
     [Fact]
     public void GuidePage_UnknownSlug_RendersNotFound()
     {
-        var html = new GuidePage { Slug = "nope" }.RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new GuidePage { Slug = "nope" }, TestServices.Default()).Html;
         Assert.Contains("No guide found", html);
         Assert.DoesNotContain("markdown-body", html);
     }

--- a/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/HttpPageTests.cs
@@ -18,11 +18,10 @@ public sealed class HttpPageTests
         // Drive HttpFetchDemo directly through LiveHost — its standalone /http page was folded into
         // docs/http-and-files.md. Re-rendering the SAME host preserves the demo instance so the
         // awaited fetch's continuation result is observed.
-        var host = new LiveHost(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
         await WaitFor.True(() => fakeHttp.RequestCount >= 1, TimeSpan.FromSeconds(2));
         await Task.Delay(50);
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.True(fakeHttp.RequestCount >= 1);
         // Verify the fetch went to the expected relative path, and the post rendered.
@@ -38,11 +37,10 @@ public sealed class HttpPageTests
         var (http, _) = FakeHttp.Throwing(
             new HttpRequestException("boom", null, HttpStatusCode.InternalServerError));
 
-        var host = new LiveHost(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
         // Loading shows initially; after the fetch faults the error banner should appear on next render.
         await Task.Delay(120);
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.Contains("alert-danger", html);
     }
@@ -73,11 +71,10 @@ public sealed class HttpPageTests
         // page's source-code pane (which now contains "alert-danger"/"spinner-border" as literal
         // text). Re-rendering the SAME host preserves the demo instance, so the retried fetch's
         // continuation result is observed.
-        var host = new LiveHost(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
         await WaitFor.True(() => handler.RequestCount >= 2, TimeSpan.FromSeconds(2));
         await Task.Delay(50);
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.DoesNotContain("alert-danger", html);
         Assert.Contains("the body text", html);
@@ -95,11 +92,10 @@ public sealed class HttpPageTests
         // Re-rendering the SAME host preserves the demo instance so the retry loop's terminal
         // error (set on a continuation) is observed; the loop makes MaxTransientRetries + 1
         // attempts then stops.
-        var host = new LiveHost(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
         await WaitFor.True(() => handler.RequestCount > 3, TimeSpan.FromSeconds(3));
         await Task.Delay(50);
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.Contains("alert-danger", html);
         // The spinner is gone — the demo no longer hangs on the loading state. Asserting on the
@@ -114,10 +110,9 @@ public sealed class HttpPageTests
         // never throws out of the lifecycle — the page/guide stays alive around it.
         var (http, _) = FakeHttp.WithStatus(HttpStatusCode.NotFound);
 
-        var host = new LiveHost(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
-        host.RenderAsLiveRoot();
+        var page = RaskTest.Render(() => HttpFetchDemo(), LiveHost.Services((typeof(HttpClient), (object)http)));
         await Task.Delay(120);
-        var html = host.RenderAsLiveRoot();
+        var html = page.Render();
 
         Assert.Contains("alert-danger", html);
     }

--- a/tests/Rask.Example.Shared.Tests/Pages/KeyedListsPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/KeyedListsPageTests.cs
@@ -14,7 +14,7 @@ public sealed class KeyedListsPageTests
     [Fact]
     public void Demo_RendersSeededRows_KeyedByDefault()
     {
-        var html = new KeyedListsReorderDemo().RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new KeyedListsReorderDemo(), TestServices.Default()).Html;
 
         Assert.Contains("Apple", html);
         Assert.Contains("Elderberry", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/LiveTickerDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/LiveTickerDemoTests.cs
@@ -13,7 +13,7 @@ public sealed class LiveTickerDemoTests
     [Fact]
     public void Render_EmitsAllThreeSwitchButtons_AndTheTickerDefaultsToBtc()
     {
-        var html = new LiveTickerDemo().RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new LiveTickerDemo(), TestServices.Default()).Html;
 
         Assert.Contains("ticker-symbol-switcher", html);
         Assert.Contains("ticker-switch-BTC", html);
@@ -26,7 +26,7 @@ public sealed class LiveTickerDemoTests
     [Fact]
     public void Render_HookActivityCard_Present()
     {
-        var html = new LiveTickerDemo().RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new LiveTickerDemo(), TestServices.Default()).Html;
 
         Assert.Contains("Hook activity", html);
         Assert.Contains("ticker-clear-log", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/MasterDetailDemoTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/MasterDetailDemoTests.cs
@@ -33,5 +33,5 @@ public sealed class MasterDetailDemoTests
     }
 
     private static string Render() =>
-        new MasterDetailDemo().RenderAsLiveRoot(TestServices.Default());
+        RaskTest.Render(new MasterDetailDemo(), TestServices.Default()).Html;
 }

--- a/tests/Rask.Example.Shared.Tests/Pages/NotFoundPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/NotFoundPageTests.cs
@@ -12,8 +12,7 @@ public sealed class NotFoundPageTests
     public void Render_ShowsRouteInBody()
     {
         var routeState = new RouteState { Path = "/__unknown" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         Assert.Contains("Page not found", html);
         Assert.Contains("/__unknown", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/PageBaselineTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/PageBaselineTests.cs
@@ -16,8 +16,7 @@ public sealed class PageBaselineTests
     public void Page_RenderedAtRegisteredPath_EmitsTitleAndPageMarker(Type pageType, string path, string marker)
     {
         var routeState = new RouteState { Path = path };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         Assert.NotNull(pageType);
         // <title> now carries data-rask-key="tag:title" so the morph reconciles it by
@@ -47,8 +46,7 @@ public sealed class PageBaselineTests
     public void UnmatchedRoute_RendersNotFoundPage()
     {
         var routeState = new RouteState { Path = "/__no_such_route" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
         Assert.Contains("Page not found", html);
     }
 }

--- a/tests/Rask.Example.Shared.Tests/Pages/TodosPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/TodosPageTests.cs
@@ -12,8 +12,7 @@ public sealed class TodosPageTests
     public void Route_TodosList_RendersSeededItems()
     {
         var routeState = new RouteState { Path = "/todos" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         Assert.Contains("Read the Rask README", html);
         Assert.Contains("Wire up a feature toggle", html);
@@ -24,8 +23,7 @@ public sealed class TodosPageTests
     public void Route_TodosNew_OpensDialogInAddMode()
     {
         var routeState = new RouteState { Path = "/todos/new" };
-        var html = new Shared.App()
-            .RenderAsLiveRoot(TestServices.Default(routeState: routeState));
+        var html = RaskTest.Render(new Shared.App(), TestServices.Default(routeState: routeState)).Html;
 
         Assert.Contains(">Add todo<", html);
         Assert.Contains("todo-title", html);

--- a/tests/Rask.Example.Shared.Tests/Pages/UploadPageTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/UploadPageTests.cs
@@ -12,7 +12,7 @@ public sealed class UploadPageTests
     {
         // Render UploadDemo directly — its standalone /upload page was folded into
         // docs/http-and-files.md, where the demo is embedded as a live sample.
-        var html = new UploadDemo().RenderAsLiveRoot(TestServices.Default());
+        var html = RaskTest.Render(new UploadDemo(), TestServices.Default()).Html;
 
         Assert.Contains("upload-input", html);
         Assert.Contains("No file selected yet.", html);


### PR DESCRIPTION
Stacked on #418.

## What

These called the internal `RenderAsLiveRoot(services)` **straight on a page component** — a thing no consumer can do:

```csharp
// before
var html = new GuidePage { Slug = "routing" }.RenderAsLiveRoot(TestServices.Default());
// after
var html = RaskTest.Render(new GuidePage { Slug = "routing" }, TestServices.Default()).Html;
```

`ShowcaseLayoutTests`' two-frame nav test needed a real handle rather than a repeated call — one `RaskTest.Render`, then `page.Render()` after the route changes — which reads better than rendering the same `App` twice by hand.

**84 tests before and after.**

## The deliberate exception

`Layout/PathDisplayTests` stays on the internal path: it drives a `RecordingHandle` to assert render counts, and a render handle is a live-session mechanism below the seam the package covers. Same call as the two `AsyncValidator` post-handler tests in #413.

## A blind test, found by checking this migration bites

The mutation I first reached for — deleting `ShowcaseLayout`'s `route.Changed` subscription — **is caught by neither the migrated test nor the original one**. `OnMount_SubscribesToRouteChanged_ActiveLinkRefreshesOnNav` doesn't actually pin its subscription: two full root renders re-execute the layout regardless, so the subscription only matters for cache invalidation during a *diff*.

I verified this is **not a migration regression** by re-running the same mutation against the pre-migration file — identical result. This PR preserves the behaviour exactly; it just made the hole visible, which is what mutation-checking a migration is for.

Filed as #420 rather than fixed here: a behaviour-preserving migration is the wrong place to change what a test covers.

The suites *do* bite on what they actually assert — renaming `navbar-brand` turns the brand test red.

## Testing

- 84 tests before and after; full `Example.Shared.Tests` suite green (286).
- Touches `tests/Rask.Example.Shared.Tests/` + CHANGELOG only — no `samples/`, so the E2E surface is untouched.
- `dotnet format` clean · `-warnaserror` → 0 warnings · `scripts/run-unit-local.sh` green apart from one unrelated pre-existing flake (`SqliteConcurrencyStressTests(writers: 500)`, an `ObjectDisposedException` under load that passes in isolation).

## What's left in this project

~10 `Demos/` files plus `App/AppTests` and `RadioCheckboxGroupTests` still use internals — they're the remaining work before the `InternalsVisibleTo` ratchet can land.

## Changelog

`[Unreleased] → Changed`.