### PR TITLE
test(e2e): assert the stored JWT blob by StartsWith, not DoesNotContain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Fixed
+- **Flaky E2E: `JwtServerAuthExampleTests.Journey_JwtLogin_AdminRoundTrip_ThenNonAdmin`.** It asserted the JWT
+  isn't JS-readable with `DoesNotContain("eyJ", stored)`, but `stored` is a Data Protection ciphertext — so
+  `eyJ` turning up *somewhere* inside its base64url bytes is pure chance (~1 run in 900), and it duly failed on
+  a blob that was never a JWT. A raw JWT is identified by *starting* with the base64url `eyJ` header, so the
+  assertion now checks `StartsWith` (matching the `WasmJwtAuthExampleTests` sibling, which had it right).
+  Test-only; the property it guards is unchanged, and it still fails — naming the leaked token — when the
+  sample is mutated to store the raw JWT.
 - **The `Rask.Wasm` package never declared its `Microsoft.JSInterop` dependency.** The runtime uses JSInterop
   directly (`WasmJSRuntime`, `WasmLiveSession`, the typed `Browser/*` wrappers), but it only ever arrived
   transitively through the `PrivateAssets="all"` `Rask.Core` reference — which deliberately keeps Core out of the

--- a/tests/Rask.Examples.E2E.Tests/JwtServerAuthExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/JwtServerAuthExampleTests.cs
@@ -56,9 +56,15 @@ public sealed class JwtServerAuthExampleTests : IAsyncLifetime
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
 
         // 4. The raw JWT must NOT be readable in JS — sessionStorage holds only the encrypted blob.
+        //    A raw JWT *starts with* the base64url "eyJ" header, so that's what we check. Don't reach for
+        //    DoesNotContain here: the value is a Data Protection ciphertext, and "eyJ" turning up somewhere
+        //    inside base64url random bytes is pure chance (~1 run in 900) — that assertion failed exactly
+        //    that way, on ciphertext that was never a JWT.
         var stored = await _page.EvaluateAsync<string?>("() => sessionStorage.getItem('rask.jwt')");
         Assert.False(string.IsNullOrEmpty(stored));
-        Assert.DoesNotContain("eyJ", stored); // not a raw JWT (which starts with the base64 "eyJ" header)
+        Assert.False(
+            stored!.StartsWith("eyJ", StringComparison.Ordinal),
+            $"sessionStorage must hold the encrypted blob, not a raw JWT — got: {stored}");
 
         // 5. Sign out → back to /login.
         await _page.Locator("#logout").ClickAsync();


### PR DESCRIPTION
Fixes a flaky browser-E2E assertion that fails on a chance string collision.

## The bug

`JwtServerAuthExampleTests.Journey_JwtLogin_AdminRoundTrip_ThenNonAdmin` guards a real security property — the raw JWT must not be readable from JS — but checked it with:

```csharp
Assert.DoesNotContain("eyJ", stored);
```

`Rask.Example.Auth.Jwt` stores the token through `ProtectedSessionStorage`, so `stored` is an ASP.NET Data Protection ciphertext: base64url random bytes. `eyJ` appearing *somewhere* inside it is pure chance (~1 run in 900 for a blob this size), and it duly failed on a value that had never been a JWT:

```
Assert.DoesNotContain() Failure: Sub-string found
                             ↓ (pos 216)
String: ···"aQ7bp4gfcabDqq5dV968eyJ5W01YriBU0do2RCos-"···
Found:  "eyJ"
```

Note `pos 216` — mid-blob, not at the start. A **raw JWT is identified by *starting* with** the base64url `eyJ` header (the encoding of `{"`), so `DoesNotContain` was a weak proxy for `DoesNotStartWith`. Since the pre-push hook enforces E2E, this randomly blocks pushes.

## The fix

Assert `StartsWith` instead — which is exactly what the `WasmJwtAuthExampleTests` sibling already does for the positive case (`Assert.StartsWith("eyJ", stored)`), so the two now agree.

## The assertion still catches the real thing

Tightening an assertion risks making it vacuous, so that was verified rather than assumed. With the sample **mutated** to write the raw JWT to plain `sessionStorage` instead of `ProtectedSessionStorage`, the fixed test fails and names the leaked token:

```
sessionStorage must hold the encrypted blob, not a raw JWT — got:
eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJuYW1lIjoicm9vdCIsInJvbGUiOiJhZG1pbiIsImV4cCI6...
```

(that payload decodes to `"name":"root","role":"admin"`). The mutation was then reverted — only the test file changes here.

## Testing

- The fixed test passes 3/3 consecutive runs against the real (protected) sample.
- Full E2E gate: **25 passed / 0 failed**.
- Unit gate: **3836 passed / 0 failed**; `-warnaserror` build clean.

Test-only: the guarded property and the sample are unchanged. No benchmarks — no runtime code touched.