### PR TITLE
fix(packaging): three packages declared a dependency on unpublishable Rask.Core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@ them until tagged releases begin.
   assertion now checks `StartsWith` (matching the `WasmJwtAuthExampleTests` sibling, which had it right).
   Test-only; the property it guards is unchanged, and it still fails — naming the leaked token — when the
   sample is mutated to store the raw JWT.
+- **`Rask.Wasm.Hosting`, `Rask.Validation.DataAnnotations` and `Rask.Validation.FluentValidation` could not be
+  restored at all.** Each referenced `Rask.Core` without `PrivateAssets="all"`, and because Core is
+  `IsPackable=false` their nuspecs declared a dependency on a `Rask.Core` package that exists on no feed — at
+  version `1.0.0`, which MinVer never stamps. Every `dotnet restore` that touched one died with `NU1101: Unable
+  to find package Rask.Core`, so the wasm-hosted template and both validation add-ons were unusable from
+  nuget.org. The references are now private, matching `Rask.Server`/`Rask.Wasm`, which is what lets consumers
+  pick up `Rask.Core.dll` from the host package's `lib/` instead. Nothing about the shipped assemblies changes.
+  The in-repo projects that had been inheriting Core through those references now name it directly, as
+  `Rask.Example.Server` already did, and a new repo-wide test fails if any packable project ever again depends
+  on an unpublishable one.
 - **The `Rask.Wasm` package never declared its `Microsoft.JSInterop` dependency.** The runtime uses JSInterop
   directly (`WasmJSRuntime`, `WasmLiveSession`, the typed `Browser/*` wrappers), but it only ever arrived
   transitively through the `PrivateAssets="all"` `Rask.Core` reference — which deliberately keeps Core out of the

--- a/samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/Rask.Example.Auth.WasmCookie.Host.csproj
@@ -16,6 +16,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Rask.Wasm.Hosting keeps its Rask.Core reference private (Core is IsPackable=false), so name it
+         directly rather than inheriting it — the same reason Rask.Example.Server references Core itself. -->
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Wasm.Hosting\Rask.Wasm.Hosting.csproj"/>
     <ProjectReference Include="..\Rask.Example.Auth.WasmCookie\Rask.Example.Auth.WasmCookie.csproj"
                       ReferenceOutputAssembly="false"

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Rask.Example.Auth.WasmJwt.Host.csproj
@@ -20,6 +20,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Rask.Wasm.Hosting keeps its Rask.Core reference private (Core is IsPackable=false), so name it
+         directly rather than inheriting it — the same reason Rask.Example.Server references Core itself. -->
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Wasm.Hosting\Rask.Wasm.Hosting.csproj"/>
     <ProjectReference Include="..\Rask.Example.Auth.WasmJwt\Rask.Example.Auth.WasmJwt.csproj"
                       ReferenceOutputAssembly="false"

--- a/src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj
+++ b/src/Rask.Validation.DataAnnotations/Rask.Validation.DataAnnotations.csproj
@@ -14,7 +14,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj"/>
+    <!-- PrivateAssets="all" — Rask.Core is IsPackable=false; without it the nuspec declares a dependency on
+         a nonexistent "Rask.Core" package and every restore fails with NU1101. Core.dll reaches consumers
+         from the Rask.Server / Rask.Wasm package this add-on sits alongside, which bundle it into lib/. -->
+    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
     <ProjectReference Include="..\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>

--- a/src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj
+++ b/src/Rask.Validation.FluentValidation/Rask.Validation.FluentValidation.csproj
@@ -18,7 +18,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj"/>
+    <!-- PrivateAssets="all" — Rask.Core is IsPackable=false; without it the nuspec declares a dependency on
+         a nonexistent "Rask.Core" package and every restore fails with NU1101. Core.dll reaches consumers
+         from the Rask.Server / Rask.Wasm package this add-on sits alongside, which bundle it into lib/. -->
+    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
     <ProjectReference Include="..\Rask.Generators\Rask.Generators.csproj"
                       OutputItemType="Analyzer"
                       ReferenceOutputAssembly="false"/>

--- a/src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj
+++ b/src/Rask.Wasm.Hosting/Rask.Wasm.Hosting.csproj
@@ -17,7 +17,15 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Rask.Wasm\Rask.Wasm.csproj"/>
-    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj"/>
+    <!--
+      PrivateAssets="all" — Rask.Core is IsPackable=false, so without it the nuspec lists a dependency on
+      a "Rask.Core" package that exists on no feed (at a bogus 1.0.0, since Core carries no MinVer
+      version) and every restore of this package fails with NU1101. Consumers get Core.dll from
+      Rask.Wasm above, which bundles it into its own lib/ — the same arrangement Rask.Server and
+      Rask.Wasm use for their own Core references, so nothing is packed here. In-repo consumers do not
+      inherit Core through this reference and must reference it themselves, as the samples already do.
+    -->
+    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Rask.Generators.Tests/PackageDependencyTests.cs
+++ b/tests/Rask.Generators.Tests/PackageDependencyTests.cs
@@ -1,0 +1,90 @@
+using System.Xml.Linq;
+
+namespace Rask.Generators.Tests;
+
+// Guards a packaging invariant across the whole repo: a shipped package must never declare a NuGet
+// dependency on a project that is never published.
+//
+// The regression: Rask.Wasm.Hosting referenced Rask.Core (IsPackable=false) without PrivateAssets="all",
+// so its nuspec listed `<dependency id="Rask.Core" version="1.0.0" />` — an id that exists on no feed, at
+// a version MinVer never stamped. Every restore of the published package died with NU1101, which made the
+// wasm-hosted template unusable from NuGet. Nothing caught it: the in-repo build resolves Rask.Core through
+// the ProjectReference, so only a restore of the *published* package ever failed.
+//
+// Unpackable projects reach consumers by being bundled into a host package's lib/ folder (see
+// _RaskAddCoreToLib in Rask.Wasm/Rask.Server), which is exactly what PrivateAssets="all" pairs with. This
+// test reads the csproj XML rather than packing, so it's instant and covers every package at once.
+public class PackageDependencyTests
+{
+    [Fact]
+    public void No_packable_project_depends_on_an_unpackable_one()
+    {
+        var projects = Directory
+            .GetFiles(Path.Combine(RepoRoot(), "src"), "*.csproj", SearchOption.AllDirectories)
+            .ToDictionary(p => Path.GetFileNameWithoutExtension(p), p => p, StringComparer.OrdinalIgnoreCase);
+
+        var offenders = new List<string>();
+
+        foreach (var (name, path) in projects.Where(p => IsPackable(p.Value)))
+        {
+            var doc = XDocument.Load(path);
+            foreach (var reference in doc.Descendants("ProjectReference"))
+            {
+                var include = reference.Attribute("Include")?.Value;
+                if (include is null)
+                {
+                    continue;
+                }
+
+                var target = Path.GetFileNameWithoutExtension(include.Replace('\\', '/'));
+                // Only a reference to an unpackable project can name a nonexistent package.
+                if (!projects.TryGetValue(target, out var targetPath) || IsPackable(targetPath))
+                {
+                    continue;
+                }
+
+                // ReferenceOutputAssembly="false" already keeps the reference out of the nuspec — it's how the
+                // analyzer/generator projects are consumed (OutputItemType="Analyzer"), and those pack fine.
+                if (string.Equals(reference.Attribute("ReferenceOutputAssembly")?.Value, "false", StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // PrivateAssets="all" is what keeps it out of the nuspec's dependency list.
+                var privateAssets = reference.Attribute("PrivateAssets")?.Value
+                    ?? reference.Element(reference.Name.Namespace + "PrivateAssets")?.Value;
+
+                if (!string.Equals(privateAssets, "all", StringComparison.OrdinalIgnoreCase))
+                {
+                    offenders.Add($"{name} -> {target} (PrivateAssets=\"{privateAssets ?? "<unset>"}\")");
+                }
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "These packable projects reference an IsPackable=false project without PrivateAssets=\"all\", so their "
+            + "nuspec will declare a dependency on a package that does not exist and every restore of them fails "
+            + "with NU1101:\n  " + string.Join("\n  ", offenders));
+    }
+
+    // Mirrors how the repo declares it: an explicit <IsPackable>false</IsPackable>. Everything else in src/
+    // ships (the SDK default is true), so absence means packable.
+    private static bool IsPackable(string csprojPath) =>
+        !XDocument.Load(csprojPath)
+            .Descendants("IsPackable")
+            .Any(e => string.Equals(e.Value.Trim(), "false", StringComparison.OrdinalIgnoreCase));
+
+    // Walks up from the test assembly to the repo root (the directory holding Rask.slnx).
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName ?? throw new DirectoryNotFoundException(
+            "Could not locate repo root (Rask.slnx) from " + AppContext.BaseDirectory);
+    }
+}

--- a/tests/Rask.Wasm.Hosting.Tests/Rask.Wasm.Hosting.Tests.csproj
+++ b/tests/Rask.Wasm.Hosting.Tests/Rask.Wasm.Hosting.Tests.csproj
@@ -30,6 +30,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- Rask.Wasm.Hosting keeps its Rask.Core reference private (Core is IsPackable=false), so name it
+         directly rather than inheriting it — the same reason Rask.Example.Server references Core itself. -->
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
     <ProjectReference Include="..\..\src\Rask.Wasm.Hosting\Rask.Wasm.Hosting.csproj"/>
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Three shipped packages could not be restored at all:

- `Rask.Wasm.Hosting`
- `Rask.Validation.DataAnnotations`
- `Rask.Validation.FluentValidation`

Each referenced `Rask.Core` without `PrivateAssets="all"`. Core is `IsPackable=false`, so their nuspecs
declared a dependency on a `Rask.Core` package that exists on no feed — at version `1.0.0`, which MinVer
never stamps:

```xml
<dependency id="Rask.Core" version="1.0.0" exclude="Build,Analyzers" />
```

Every `dotnet restore` that touched one died with `NU1101: Unable to find package Rask.Core`, which means
the **wasm-hosted template and both validation add-ons have never worked from nuget.org**.

Found while porting the `wasm-hosted` template into `rask new`: the generated solution wouldn't restore.

## Why nothing caught it

The in-repo build resolves `Rask.Core` through the `ProjectReference`, so only a restore of the *published*
package can fail — and nothing restores a published Rask package. `Rask.Server` and `Rask.Wasm` already got
this right (`PrivateAssets="all"` + bundling `Rask.Core.dll` into their own `lib/`); these three were the
ones that missed it.

## The fix

Mark the references private, matching `Rask.Server`/`Rask.Wasm`. Consumers pick up `Rask.Core.dll` from the
host package's `lib/` folder, which is exactly what that arrangement exists for. **The shipped assemblies are
unchanged — only the nuspec dependency lists are.**

The three in-repo projects that had been inheriting Core through `Rask.Wasm.Hosting` now reference it
directly, as `Rask.Example.Server` already did.

## Testing

- New `PackageDependencyTests` guards the whole class of bug: no packable project may reference an
  `IsPackable=false` project without `PrivateAssets="all"`. Analyzer references
  (`ReferenceOutputAssembly="false"`) are exempt — verified against real nuspecs that they produce no
  dependency. Confirmed it fails on the unfixed tree and passes on the fixed one.
- Packed all three and diffed the nuspecs: the `Rask.Core 1.0.0` entry is gone; `Rask.Wasm.Hosting` keeps only
  `Rask.Wasm`, `Rask.Validation.FluentValidation` keeps only `FluentValidation`, `Rask.Validation.DataAnnotations`
  has none.
- Full solution builds clean under `-warnaserror`; unit gate green (250 tests).
- Browser E2E green (25/25) on this tree.

## Follow-up

Unblocks the `wasm-hosted` port of `rask new` (stacked, held), which needs a release carrying this fix before
its generated projects can restore.