### PR TITLE
fix(test): PackageDependencyTests scanned obj/, so it crashed instead of guarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Fixed
+- **`PackageDependencyTests` crashed instead of running, once `Rask.Templates` had been packed.** The guard
+  added alongside the `PrivateAssets="all"` packaging fix scanned `src/` for `*.csproj` with
+  `SearchOption.AllDirectories` — which also reaches `src/Rask.Templates/obj/`, where packing copies the
+  `dotnet new` content. Every template project was therefore found twice and the name lookup threw
+  `An item with the same key has already been added. Key: Company.RaskWasm` before a single reference was
+  checked, so the invariant it guards was silently unenforced on any machine that had packed. The scan now
+  skips `bin`/`obj` segments: build output is never the thing under test. The guard itself is unchanged and
+  still names the offender when `PrivateAssets="all"` is removed from `Rask.Wasm.Hosting`.
 - **Flaky E2E: `JwtServerAuthExampleTests.Journey_JwtLogin_AdminRoundTrip_ThenNonAdmin`.** It asserted the JWT
   isn't JS-readable with `DoesNotContain("eyJ", stored)`, but `stored` is a Data Protection ciphertext — so
   `eyJ` turning up *somewhere* inside its base64url bytes is pure chance (~1 run in 900), and it duly failed on

--- a/tests/Rask.Generators.Tests/PackageDependencyTests.cs
+++ b/tests/Rask.Generators.Tests/PackageDependencyTests.cs
@@ -21,6 +21,7 @@ public class PackageDependencyTests
     {
         var projects = Directory
             .GetFiles(Path.Combine(RepoRoot(), "src"), "*.csproj", SearchOption.AllDirectories)
+            .Where(IsSource)
             .ToDictionary(p => Path.GetFileNameWithoutExtension(p), p => p, StringComparer.OrdinalIgnoreCase);
 
         var offenders = new List<string>();
@@ -67,6 +68,15 @@ public class PackageDependencyTests
             + "nuspec will declare a dependency on a package that does not exist and every restore of them fails "
             + "with NU1101:\n  " + string.Join("\n  ", offenders));
     }
+
+    // Only real sources. Rask.Templates copies its `dotnet new` content — Company.RaskWasm.csproj and friends —
+    // into obj/ at build time, so an all-directories scan sees every template project twice and the lookup below
+    // throws on the duplicate name rather than reporting anything. Build output is never the thing under test.
+    private static bool IsSource(string csprojPath) =>
+        !csprojPath.Split(Path.DirectorySeparatorChar, StringSplitOptions.RemoveEmptyEntries)
+            .Any(segment =>
+                segment.Equals("bin", StringComparison.OrdinalIgnoreCase)
+                || segment.Equals("obj", StringComparison.OrdinalIgnoreCase));
 
     // Mirrors how the repo declares it: an explicit <IsPackable>false</IsPackable>. Everything else in src/
     // ships (the SDK default is true), so absence means packable.


### PR DESCRIPTION
Follow-up to #423, which added `PackageDependencyTests` — the guard that a shipped package never declares a
NuGet dependency on an `IsPackable=false` project.

## The bug

The scan is `Directory.GetFiles(src, "*.csproj", SearchOption.AllDirectories)`, which also reaches
`src/Rask.Templates/obj/`. Packing `Rask.Templates` copies its `dotnet new` content there, so every template
project exists twice on disk:

```
src/Rask.Templates/content/rask-wasm/Company.RaskWasm.csproj
src/Rask.Templates/obj/Release/netstandard2.0/templates/rask-wasm/Company.RaskWasm.csproj
```

The `ToDictionary` on file-name-without-extension then throws before a single reference is checked:

```
System.ArgumentException : An item with the same key has already been added. Key: Company.RaskWasm
```

Five template projects collide this way (`Company.RaskNative`, `Company.RaskServer`, `Company.RaskWasm`,
`Company.RaskWasmHosted.Host`, `Company.RaskWasmHosted.Wasm`).

**This is worse than a red test.** It is state-dependent: it passes on a clean checkout and starts throwing
the moment anyone runs `dotnet pack` — and a crash means the packaging invariant it exists to enforce was not
being checked at all. `main` is red right now for exactly this reason.

## The fix

Skip `bin`/`obj` path segments. Build output is never the thing under test.

## Testing

- **Reproduced first**: `dotnet pack src/Rask.Templates -c Release` materialises the obj copies → 5 duplicate
  basenames → the test throws. With the fix, it passes with those same copies on disk.
- **The guard still guards** — removing `PrivateAssets="all"` from the `Rask.Core` reference in
  `Rask.Wasm.Hosting` still fails it, naming the offender:
  `Rask.Wasm.Hosting -> Rask.Core (PrivateAssets="<unset>")`.
- `scripts/run-unit-local.sh` green (exit 0, 0 failures), `dotnet format` clean.
- Test-only; no `src/` change, so no benchmark and no browser journey is reachable.

## Changelog

`[Unreleased] → Fixed`.