### PR TITLE
fix: resolve three reported bugs (pager a11y, playground host leak, layout test)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,28 @@ them until tagged releases begin.
   `Markup` in scope together make every unqualified use ambiguous. Test-only; no shipped behaviour changes.
 
 ### Fixed
+- **`BsDataGrid`'s pager prev/next buttons had no accessible name.** They render an icon-only child (a
+  decorative, `aria-hidden` `BsIcon` chevron), so a screen reader announced two unlabelled buttons on every
+  grid with `PageSize > 0` — the numbered items were fine (their text names them), which made it easy to miss
+  until you tabbed to the arrows. `BsPageItem` now takes an `Aria` bag (matching `BsButton`/`BsTable`), and the
+  grid's arrows carry `aria-label="Previous page"` / `"Next page"`. A disabled arrow keeps both its name and its
+  `aria-disabled` state.
+- **The playground accumulated an empty `.pg-code-host` per full-HTML frame.** `PlaygroundView` put
+  `data-rask-managed` on the editor host div it *also renders* — inverting the marker's contract (it flags
+  nodes that are live but absent from the render payload). The live-diff `morph` filtered the marked host out
+  of the existing DOM but not the incoming tree, so it appended a fresh empty host every full-HTML frame,
+  unbounded for the tab's life. The marker now goes on Monaco's own library-created child nodes (where it
+  belongs — the same placement the Gantt wrapper uses), and `rask-morph.js` is hardened to ignore
+  `data-rask-managed` on a node that *is* in the incoming tree (always a misuse), so the mistake now fails safe
+  instead of duplicating silently. The playground holds a single host again.
+- **`ShowcaseLayoutTests.OnMount_SubscribesToRouteChanged_ActiveLinkRefreshesOnNav` didn't pin the
+  subscription it was named for** — it passed with `route.Changed += OnRouteChanged` deleted. It drove two full
+  root renders and asserted the active link refreshed, but that class is owned by `NavLink`, which subscribes
+  to `RouteState.Changed` itself; the layout's subscription actually drives the mobile drawer-close and the
+  active-group accordion auto-expand. The test now asserts those effects (and goes red when the subscription is
+  removed), and a new `Rask.Core.Tests` case pins the underlying framework invariant: a clean subtree that
+  depends on untracked external state is served stale from the render cache unless a `Changed` subscription
+  marks it dirty.
 - **`PackageDependencyTests` crashed instead of running, once `Rask.Templates` had been packed.** The guard
   added alongside the `PrivateAssets="all"` packaging fix scanned `src/` for `*.csproj` with
   `SearchOption.AllDirectories` — which also reaches `src/Rask.Templates/obj/`, where packing copies the

--- a/docs/data-grid.md
+++ b/docs/data-grid.md
@@ -348,6 +348,9 @@ Handled for you, and worth knowing about:
   — so sorting is keyboard-operable (Tab, then Enter or Space) with no extra work.
 - The expander toggle has an accessible name and `aria-expanded`, plus `aria-controls` pointing at its detail
   row while open.
+- The pager's prev/next arrows are icon-only, so they carry an explicit `aria-label` (*"Previous page"* /
+  *"Next page"*); the numbered items are named by their own text. (`BsPageItem` takes an `Aria` bag if you
+  build your own pager and need to name an icon-only control.)
 - A selection checkbox has no visible label, so it is named from its row's first `Value` column ("Select
   Espresso Machine") rather than twenty identical "Select row"s, which read as one control repeated. The
   header's says *"select all rows on this page"* — see [selection](#select-all-covers-the-page).

--- a/samples/Rask.Example.Playground/PlaygroundView.cs
+++ b/samples/Rask.Example.Playground/PlaygroundView.cs
@@ -151,10 +151,12 @@ public sealed class PlaygroundView : Component
                     ]
                 ],
                 Section(Class: "pg-editor")[
-                    // Monaco mounts into this host in OnRenderedAsync(firstRender). data-rask-managed keeps
-                    // the live-diff morph from touching the editor's own DOM after mount.
-                    Div(Ref: _editorHost, Class: "pg-code-host",
-                        Data: new Dictionary<string, string?> { ["rask-managed"] = "" })
+                    // Monaco mounts into this host in OnRenderedAsync(firstRender). The host renders childless,
+                    // so the positional diff never addresses inside it — but a *morph* (every full-HTML frame)
+                    // compares live children against the rendered ones and would strip Monaco's DOM. mountEditor
+                    // tags the nodes Monaco creates with data-rask-managed, which takes them out of the live-side
+                    // comparison; the marker belongs on those library-created children, never on this host.
+                    Div(Ref: _editorHost, Class: "pg-code-host")
                 ],
                 Section(Class: "pg-output")[
                     Div(Class: "pg-preview-head")["Preview"],

--- a/samples/Rask.Example.Playground/PlaygroundView.js
+++ b/samples/Rask.Example.Playground/PlaygroundView.js
@@ -52,6 +52,15 @@ function loadMonaco() {
     return loadPromise;
 }
 
+// Tag the nodes a library mounts into `host` with data-rask-managed. The .NET side renders the host
+// childless, so the live-diff morph would otherwise compare the editor's DOM against zero rendered
+// children and strip it on the next full-HTML frame. The marker takes these children out of the live-side
+// comparison — it belongs on the library-created nodes, never on the host the .NET side renders (marking
+// the host instead makes morph append a duplicate empty host every frame).
+function markManaged(host) {
+    for (const child of host.children) child.setAttribute("data-rask-managed", "");
+}
+
 export async function mountEditor(host, code) {
     if (!host || editor || host.__fallback) return;
     try {
@@ -71,6 +80,7 @@ export async function mountEditor(host, code) {
             renderLineHighlight: "line",
             fixedOverflowWidgets: true
         });
+        markManaged(host);
     } catch {
         // Monaco unavailable — degrade to a textarea so the playground still compiles and runs code.
         const ta = document.createElement("textarea");
@@ -79,6 +89,7 @@ export async function mountEditor(host, code) {
         ta.value = code;
         host.appendChild(ta);
         host.__fallback = ta;
+        markManaged(host);
     }
 }
 

--- a/src/Rask.Bootstrap/BsDataGrid.cs
+++ b/src/Rask.Bootstrap/BsDataGrid.cs
@@ -1524,7 +1524,10 @@ public sealed class BsDataGrid<T> : BsBlock
     {
         // While loading every item is disabled, not just the edges: the pager is what the user just clicked,
         // so it is where a "wait" has to be visible. BsPageItem renders aria-disabled from this.
+        // The arrows' only child is a decorative (aria-hidden) BsIcon, so they need an explicit
+        // accessible name — without it a screen reader announces an unlabelled button.
         yield return BsPageItem(Key: "prev", Disabled: Busy || CurrentPage == 0,
+            Aria: new Dictionary<string, string?> { ["label"] = "Previous page" },
             OnClickAsync: () => GoToPageAsync(CurrentPage - 1, pageCount))[BsIcon(Name: BsIconName.ChevronLeft)];
 
         // A small sliding window around the current page keeps the pager compact for many pages.
@@ -1540,6 +1543,7 @@ public sealed class BsDataGrid<T> : BsBlock
         }
 
         yield return BsPageItem(Key: "next", Disabled: Busy || CurrentPage == pageCount - 1,
+            Aria: new Dictionary<string, string?> { ["label"] = "Next page" },
             OnClickAsync: () => GoToPageAsync(CurrentPage + 1, pageCount))[BsIcon(Name: BsIconName.ChevronRight)];
     }
 

--- a/src/Rask.Bootstrap/BsPagination.cs
+++ b/src/Rask.Bootstrap/BsPagination.cs
@@ -32,6 +32,11 @@ public sealed class BsPageItem : BsBlock
     public Callback? OnClick { get; set; }
     public CallbackAsync? OnClickAsync { get; set; }
 
+    // Extra ARIA attributes for the page link itself — pass aria-label to name an icon-only control
+    // (a prev/next arrow whose only child is a decorative BsIcon has no accessible name otherwise).
+    // Merged under the component's own aria-disabled, so a disabled labelled item keeps both.
+    public IReadOnlyDictionary<string, string?>? Aria { get; set; }
+
     protected override Component? Render()
     {
         var liCls = BsClass.Join(
@@ -51,9 +56,11 @@ public sealed class BsPageItem : BsBlock
         // Deliberately aria-disabled rather than the disabled attribute: disabled would drop focus to <body>
         // the moment a page click starts a fetch, throwing away the user's keyboard position. Callers still
         // guard their handlers — see BsDataGrid.GoToPageAsync.
+        // Caller aria first (e.g. aria-label naming an arrow), then aria-disabled layered on top so a
+        // disabled arrow keeps its name — WithAria copies rather than mutating the caller's dictionary.
         var linkAria = Disabled is true
-            ? new Dictionary<string, string?> { ["disabled"] = "true" }
-            : null;
+            ? BsClass.WithAria(Aria, "disabled", "true")
+            : Aria;
 
         Component link = Href is not null
             ? A(Class: "page-link", Href: Href, Aria: linkAria)[Items]

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -264,12 +264,21 @@ function morph(from, to) {
     // the Server overlay (reconnect spinner sibling of <html>) and the WASM
     // scoped-css / scoped-js bundle tags (head children that don't appear in
     // the .NET-rendered HTML payload).
+    //
+    // The filter is symmetric: an incoming (to-side) child carrying the marker is
+    // always a misuse — a .NET-rendered node is by definition part of the payload,
+    // so the marker contradicts itself. Skipping it makes that mistake a harmless
+    // no-op; without this, the from-side node is filtered out but the to-side one
+    // isn't, so every morph appends a fresh unpaired copy (unbounded DOM growth).
     const fc = [], tc = [];
     for (let n = from.firstChild; n; n = n.nextSibling) {
         if (n.nodeType === 1 && n.hasAttribute("data-rask-managed")) continue;
         fc.push(n);
     }
-    for (let m = to.firstChild; m; m = m.nextSibling) tc.push(m);
+    for (let m = to.firstChild; m; m = m.nextSibling) {
+        if (m.nodeType === 1 && m.hasAttribute("data-rask-managed")) continue;
+        tc.push(m);
+    }
 
     // Keyed reconciliation: if any incoming child carries data-rask-key, match
     // by key instead of by position so reordered list items keep their DOM

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -2209,12 +2209,21 @@ function morph(from, to) {
     // the Server overlay (reconnect spinner sibling of <html>) and the WASM
     // scoped-css / scoped-js bundle tags (head children that don't appear in
     // the .NET-rendered HTML payload).
+    //
+    // The filter is symmetric: an incoming (to-side) child carrying the marker is
+    // always a misuse — a .NET-rendered node is by definition part of the payload,
+    // so the marker contradicts itself. Skipping it makes that mistake a harmless
+    // no-op; without this, the from-side node is filtered out but the to-side one
+    // isn't, so every morph appends a fresh unpaired copy (unbounded DOM growth).
     const fc = [], tc = [];
     for (let n = from.firstChild; n; n = n.nextSibling) {
         if (n.nodeType === 1 && n.hasAttribute("data-rask-managed")) continue;
         fc.push(n);
     }
-    for (let m = to.firstChild; m; m = m.nextSibling) tc.push(m);
+    for (let m = to.firstChild; m; m = m.nextSibling) {
+        if (m.nodeType === 1 && m.hasAttribute("data-rask-managed")) continue;
+        tc.push(m);
+    }
 
     // Keyed reconciliation: if any incoming child carries data-rask-key, match
     // by key instead of by position so reordered list items keep their DOM

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2615,12 +2615,21 @@ function morph(from, to) {
     // the Server overlay (reconnect spinner sibling of <html>) and the WASM
     // scoped-css / scoped-js bundle tags (head children that don't appear in
     // the .NET-rendered HTML payload).
+    //
+    // The filter is symmetric: an incoming (to-side) child carrying the marker is
+    // always a misuse — a .NET-rendered node is by definition part of the payload,
+    // so the marker contradicts itself. Skipping it makes that mistake a harmless
+    // no-op; without this, the from-side node is filtered out but the to-side one
+    // isn't, so every morph appends a fresh unpaired copy (unbounded DOM growth).
     const fc = [], tc = [];
     for (let n = from.firstChild; n; n = n.nextSibling) {
         if (n.nodeType === 1 && n.hasAttribute("data-rask-managed")) continue;
         fc.push(n);
     }
-    for (let m = to.firstChild; m; m = m.nextSibling) tc.push(m);
+    for (let m = to.firstChild; m; m = m.nextSibling) {
+        if (m.nodeType === 1 && m.hasAttribute("data-rask-managed")) continue;
+        tc.push(m);
+    }
 
     // Keyed reconciliation: if any incoming child carries data-rask-key, match
     // by key instead of by position so reordered list items keep their DOM

--- a/tests/Rask.Bootstrap.Tests/BsDataGridTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridTests.cs
@@ -73,6 +73,18 @@ public class BsDataGridTests
     }
 
     [Fact]
+    public void Paging_PrevNextArrows_CarryAnAccessibleName()
+    {
+        // The prev/next pager buttons are icon-only (a decorative chevron), so they need an explicit
+        // aria-label or a screen reader announces two unlabelled buttons. The numbered items are named
+        // by their text.
+        var html = BsDataGrid<Row>(Data: Rows, Columns: Columns(), PageSize: 2).ToHtml();
+
+        Assert.Contains("aria-label=\"Previous page\"", html);
+        Assert.Contains("aria-label=\"Next page\"", html);
+    }
+
+    [Fact]
     public void Footer_RendersTfootWithColumnTotals_OverAllRows()
     {
         BsColumn<Row>[] columns =

--- a/tests/Rask.Bootstrap.Tests/BsPaginationTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsPaginationTests.cs
@@ -41,6 +41,26 @@ public class BsPaginationTests
         Assert.DoesNotContain("aria-disabled", BsPageItem()["4"].ToHtml(), StringComparison.Ordinal);
 
     [Fact]
+    // An icon-only arrow (its only child is a decorative BsIcon) has no accessible name, so Aria lets the
+    // caller name the link itself — the aria-label lands on the <button>, not the wrapping <li>.
+    public void PageItem_Aria_NamesTheLink() =>
+        Assert.Equal(
+            "<li class=\"page-item\">" +
+            "<button class=\"page-link\" aria-label=\"Previous page\" type=\"button\"></button></li>",
+            BsPageItem(Aria: new Dictionary<string, string?> { ["label"] = "Previous page" }).ToHtml());
+
+    [Fact]
+    // A disabled arrow keeps both its name and its state: the caller's aria-label serialises first (it seeds
+    // the bag), then the component layers aria-disabled on top — so a screen reader still announces the name.
+    public void PageItem_Aria_CoexistsWithDisabled_LabelBeforeState() =>
+        Assert.Equal(
+            "<li class=\"page-item disabled\">" +
+            "<button class=\"page-link\" aria-label=\"Previous page\" aria-disabled=\"true\" type=\"button\">" +
+            "</button></li>",
+            BsPageItem(Disabled: true, Aria: new Dictionary<string, string?> { ["label"] = "Previous page" })
+                .ToHtml());
+
+    [Fact]
     public void Pagination_Size_MapsToPaginationModifier() =>
         Assert.Equal(
             "<nav aria-label=\"Page navigation\"><ul class=\"pagination pagination-lg\"></ul></nav>",

--- a/tests/Rask.Core.Tests/Live/ExternalStateInvalidationTests.cs
+++ b/tests/Rask.Core.Tests/Live/ExternalStateInvalidationTests.cs
@@ -1,0 +1,82 @@
+using System.Text;
+using Rask.Core.Live;
+using Rask.TestSupport;
+
+#pragma warning disable RASK014 // test-defined component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+// The framework invariant behind ShowcaseLayout's route.Changed subscription (issue #420).
+//
+// A component that derives its UI from external state it does NOT own — a constructor-injected service read
+// directly, like ShowcaseLayout reading RouteState.Path — is invisible to the render cache. Only *ambient*
+// reads (Context.Get / EditContext) set _readsAmbientState and opt a component out of the cache; a plain
+// service read does not. So such a component stays fully cache-eligible, and a clean re-render REPLAYS its
+// stale subtree without re-executing Render(). The only thing that refreshes it is a dirty mark — which is
+// exactly what StateHasChanged produces during a diff. That is *why* the component must subscribe to the
+// source's Changed event (`route.Changed += StateHasChanged`): without it, an external change that nothing
+// else touches is served stale from the cache. This test pins both halves.
+public class ExternalStateInvalidationTests
+{
+    // Stand-in for RouteState: state the component reads but the cache doesn't track.
+    private sealed class ExternalSource
+    {
+        public string Value = "a";
+    }
+
+    private static string Render(SessionRenderCache cache, Component tree, List<EditOp> ops)
+    {
+        var sb = new StringBuilder();
+        using (FrameSinkScope.Push(cache.PrepareCurrentBuffer()))
+        {
+            HtmlSerializer.Serialize(tree, sb);
+        }
+
+        cache.TryComputeDiff(ops, rotate: true);
+        return sb.ToString();
+    }
+
+    [Fact]
+    public void UntrackedStateChange_WithoutInvalidation_ReplaysStale_WithInvalidation_ReWalks()
+    {
+        var source = new ExternalSource();
+        var built = 0;
+        // Pure-element subtree deriving its text from the untracked external source (the shape of a nav
+        // link's active class computed from RouteState.Path).
+        var view = new StubComponent(() =>
+        {
+            built++;
+            return Div(Class: "nav")[Span(Class: "active")[source.Value]];
+        });
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = Render(cache, view, ops);
+        Assert.Contains(">a<", first);
+        Assert.Equal(1, built);
+        // Reading external, non-ambient state leaves the subtree cache-eligible — the crux of the hazard.
+        Assert.True(view.IsCleanSubtreeCachedForTest,
+            "reading a ctor-injected service is not ambient state, so the subtree stays cacheable");
+
+        // Hazard: the source changed, but nothing marked the component dirty → the clean subtree REPLAYS
+        // the stale frame. Render() is not re-run, so the new value never reaches the DOM. This is the stale
+        // active link / un-expanded group that a missing route.Changed subscription would leave behind.
+        source.Value = "b";
+        var stale = Render(cache, view, ops);
+        Assert.Contains(">a<", stale);
+        Assert.DoesNotContain(">b<", stale);
+        Assert.Equal(1, built);   // replayed from frames, Render NOT re-executed
+        Assert.Empty(ops);        // the cache believed nothing changed
+
+        // Fix: mark the component dirty — the cache-level effect of StateHasChanged, which the subscription
+        // fires on every Changed. Now the subtree re-walks and the new value ships as a single text edit.
+        source.Value = "c";
+        view.MarkDirtyForFrame();
+        var fresh = Render(cache, view, ops);
+        Assert.Contains(">c<", fresh);
+        Assert.Equal(2, built);   // re-walked
+        var op = Assert.Single(ops);
+        Assert.Equal(EditOpKind.UpdateText, op.Kind);
+        Assert.Equal("c", op.Value);
+    }
+}

--- a/tests/Rask.Core.Tests/Live/MorphManagedGuardFixture.mjs
+++ b/tests/Rask.Core.Tests/Live/MorphManagedGuardFixture.mjs
@@ -1,0 +1,115 @@
+// Node-driven fixture for rask-morph.js's data-rask-managed handling (both sides of the
+// child-reconciliation filter).
+//
+// data-rask-managed marks nodes that are live but ABSENT from the .NET render payload (a
+// library's injected DOM, the reconnect overlay, the WASM bundle tags). morph filters them
+// out of BOTH the existing (from) and incoming (to) child lists:
+//   * from-side (always correct): a marked node the .NET tree doesn't know about is preserved,
+//     not paired against an incoming child and trimmed/replaced.
+//   * to-side (the guard): a marked node that IS in the incoming payload is a contradiction —
+//     a rendered node is by definition part of the payload. Before the guard, the from copy was
+//     filtered out but the to copy wasn't, so every morph appended a fresh unpaired duplicate
+//     (the playground's unbounded empty .pg-code-host growth, issue #419). The guard skips it,
+//     turning the misuse into a harmless no-op.
+//
+// The C# test (MorphManagedGuardTests) runs this in a node subprocess and asserts the JSON line.
+import {readFileSync} from "node:fs";
+
+const morphPath = process.argv[2];
+if (!morphPath) {
+    console.error("usage: node MorphManagedGuardFixture.mjs <rask-morph.js path>");
+    process.exit(2);
+}
+
+// ----- Minimal DOM stub (child list with sibling relinking) -----------------------
+function makeEl(nodeName, attrs) {
+    const a = new Map(Object.entries(attrs || {}));
+    const kids = [];
+
+    function relink() {
+        for (let i = 0; i < kids.length; i++) {
+            kids[i].nextSibling = kids[i + 1] || null;
+            kids[i].previousSibling = kids[i - 1] || null;
+        }
+    }
+
+    const el = {
+        nodeType: 1, nodeName, tagName: nodeName, parentNode: null,
+        nextSibling: null, previousSibling: null, textContent: "",
+        get firstChild() { return kids[0] || null; },
+        get childNodes() { return kids; },
+        get attributes() { return [...a.entries()].map(([name, value]) => ({name, value})); },
+        hasAttribute: (n) => a.has(n),
+        getAttribute: (n) => (a.has(n) ? a.get(n) : null),
+        setAttribute: (n, v) => a.set(n, String(v)),
+        removeAttribute: (n) => a.delete(n),
+        insertBefore(node, ref) {
+            if (node.parentNode) node.parentNode.removeChild(node);
+            const idx = ref === null ? kids.length : kids.indexOf(ref);
+            kids.splice(idx < 0 ? kids.length : idx, 0, node);
+            node.parentNode = el;
+            relink();
+            return node;
+        },
+        appendChild(node) { return el.insertBefore(node, null); },
+        removeChild(node) {
+            kids.splice(kids.indexOf(node), 1);
+            node.parentNode = null;
+            relink();
+            return node;
+        },
+        replaceChild(newNode, oldNode) {
+            el.insertBefore(newNode, oldNode);
+            el.removeChild(oldNode);
+            return oldNode;
+        },
+        _kids: kids
+    };
+    return el;
+}
+
+function child(parent, node) { parent.appendChild(node); return node; }
+
+globalThis.window = globalThis;
+globalThis.document = {activeElement: null, head: makeEl("HEAD"), createElement: (n) => makeEl(String(n).toUpperCase())};
+
+// ----- Load the production morph (all helpers it needs live in rask-morph.js) -----
+const {morph} = new Function(readFileSync(morphPath, "utf8") + "\n;return { morph };")();
+
+// ---- Scenario A: the MISUSE (marker on the host the .NET side renders) fails safe ----
+// from: <section.pg-editor> → <div.pg-code-host data-rask-managed> → <canvas> (Monaco stand-in)
+// to:   <section.pg-editor> → <div.pg-code-host data-rask-managed> (childless, freshly rendered)
+// Before the to-side guard this appended a second empty host every morph; now it's a no-op.
+const editorFrom = makeEl("SECTION", {class: "pg-editor"});
+const hostFrom = child(editorFrom, makeEl("DIV", {class: "pg-code-host", "data-rask-managed": ""}));
+child(hostFrom, makeEl("CANVAS", {}));               // Monaco's DOM
+const editorTo = makeEl("SECTION", {class: "pg-editor"});
+child(editorTo, makeEl("DIV", {class: "pg-code-host", "data-rask-managed": ""}));
+
+morph(editorFrom, editorTo);
+morph(editorFrom, editorTo);                          // a second frame must not duplicate either
+const misuseHostCount = editorFrom._kids.filter((k) => k.getAttribute("class") === "pg-code-host").length;
+const misuseMonacoKept = hostFrom.parentNode === editorFrom
+    && hostFrom._kids.some((k) => k.nodeName === "CANVAS");
+
+// ---- Scenario B: the CORRECT placement (marker on the library-created child) survives ----
+// from: <section.pg-editor> → <div.pg-code-host> (unmarked host) → <canvas data-rask-managed>
+// to:   <section.pg-editor> → <div.pg-code-host> (unmarked, childless — what the .NET side renders)
+// The host pairs and recurses; the marked child is filtered out of the host's from-side, so a
+// childless incoming host does NOT strip Monaco.
+const editorFrom2 = makeEl("SECTION", {class: "pg-editor"});
+const hostFrom2 = child(editorFrom2, makeEl("DIV", {class: "pg-code-host"}));
+child(hostFrom2, makeEl("CANVAS", {"data-rask-managed": ""}));
+const editorTo2 = makeEl("SECTION", {class: "pg-editor"});
+child(editorTo2, makeEl("DIV", {class: "pg-code-host"}));
+
+morph(editorFrom2, editorTo2);
+const correctHostCount = editorFrom2._kids.filter((k) => k.getAttribute("class") === "pg-code-host").length;
+const correctMonacoKept = hostFrom2._kids.some((k) => k.nodeName === "CANVAS");
+
+process.stdout.write(JSON.stringify({
+    misuseHostCount,     // 1 — no duplicate empty host appended (was 3 after two frames pre-guard)
+    misuseMonacoKept,    // true — the original host and its Monaco DOM untouched
+    correctHostCount,    // 1 — single host
+    correctMonacoKept    // true — marked child survives a childless incoming host
+}) + "\n");

--- a/tests/Rask.Core.Tests/Live/MorphManagedGuardTests.cs
+++ b/tests/Rask.Core.Tests/Live/MorphManagedGuardTests.cs
@@ -1,0 +1,110 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Rask.Core.Tests.Live;
+
+// Regression guard for issue #419: the playground accumulated an empty .pg-code-host per
+// full-HTML frame because data-rask-managed sat on a node the .NET side ALSO rendered.
+//
+// morph filters data-rask-managed nodes out of the existing (from) child list but, before the
+// fix, not the incoming (to) list — so a marked node present in the payload had its from copy
+// filtered out and its to copy left unpaired, appended fresh every morph (unbounded growth). The
+// guard makes the to-side filter symmetric: a marked node in the incoming tree is always a misuse
+// (a rendered node is part of the payload), so skipping it turns the mistake into a no-op.
+//
+// This exercises the production rask-morph.js in a Node subprocess with a stub DOM. The
+// user-observable side is covered by PlaygroundExampleTests (.pg-code-host count after a run).
+public sealed class MorphManagedGuardTests
+{
+    [Fact]
+    public void ManagedNodeInIncomingTree_IsNotDuplicated_AndCorrectlyPlacedMarkerSurvives()
+    {
+        var node = ResolveNode();
+        if (node is null)
+        {
+            // No node on PATH — the JS-driven reproduction can't run. Don't hard-fail; the
+            // playground E2E covers the user-observable side.
+            return;
+        }
+
+        var repoRoot = LocateRepoRoot();
+        var fixtureScript = Path.Combine(repoRoot, "tests", "Rask.Core.Tests", "Live", "MorphManagedGuardFixture.mjs");
+        var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
+        Assert.True(File.Exists(fixtureScript), $"Fixture script missing: {fixtureScript}");
+        Assert.True(File.Exists(morphPath), $"Morph source missing: {morphPath}");
+
+        var psi = new ProcessStartInfo(node, $"\"{fixtureScript}\" \"{morphPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        Assert.True(proc.ExitCode == 0,
+            $"Fixture exited with code {proc.ExitCode}. stderr:\n{stderr}\nstdout:\n{stdout}");
+
+        var jsonLine = stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(s => s.StartsWith('{') && s.EndsWith('}'));
+        Assert.False(jsonLine is null,
+            $"Fixture didn't emit a JSON line. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(jsonLine!);
+        var root = doc.RootElement;
+
+        bool GetBool(string name) => root.GetProperty(name).GetBoolean();
+        int GetInt(string name) => root.GetProperty(name).GetInt32();
+
+        // The misuse (marker on the rendered host) is a no-op: after two morph frames the host is
+        // still single, not duplicated, and the original Monaco DOM is untouched.
+        Assert.Equal(1, GetInt("misuseHostCount"));
+        Assert.True(GetBool("misuseMonacoKept"), "the original host / Monaco DOM was disturbed by the guard");
+
+        // The correct placement (marker on Monaco's own child) survives a childless incoming host.
+        Assert.Equal(1, GetInt("correctHostCount"));
+        Assert.True(GetBool("correctMonacoKept"), "a correctly-marked library child was stripped by morph");
+    }
+
+    private static string? ResolveNode()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "node.exe", "node.cmd" } : new[] { "node" };
+        foreach (var dir in path.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in exeNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Layout/ShowcaseLayoutTests.cs
@@ -137,27 +137,37 @@ public sealed class ShowcaseLayoutTests
     }
 
     [Fact]
-    public void OnMount_SubscribesToRouteChanged_ActiveLinkRefreshesOnNav()
+    public async Task OnRouteChanged_ExpandsActiveGroupAndClosesDrawer()
     {
-        // Behavioural test: navigate from "/" to "/todos", then re-render App with the
-        // same RouteState. The layout's active-link computation must reflect the new
-        // path — which requires its Render() to re-execute after the path change.
+        // ShowcaseLayout subscribes to RouteState.Changed in OnMount so that on every nav it closes the
+        // mobile drawer and expands the accordion group holding the newly-active route (OnRouteChanged →
+        // _drawerOpen = false + OpenActiveGroup + StateHasChanged). Those two effects are the subscription's
+        // real job — NOT the sidebar's active CSS class, which each NavLink owns and refreshes off its own
+        // RouteState.Changed subscription. This test asserts the two effects, so deleting the layout's
+        // subscription (which leaves the drawer open and the group collapsed) turns it red.
         var routeState = new RouteState { Path = "/" };
         var services = TestServices.Default(routeState: routeState);
-        // One handle across both frames: the same App instance has to re-render after the path change.
+        // One handle across frames: the same App/layout instance re-renders after the path change.
         var page = RaskTest.Render(new Shared.App(), services);
 
-        var htmlAtRoot = page.Html;
-        // The "All guides" link to "/" (the site root now the Welcome page is gone) is the active one
-        // when the path is "/" — it carries the bi-book icon.
-        Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-book",
-            CollapseWhitespace(htmlAtRoot));
+        // The "Apps" accordion (Examples section, holding Todos) is collapsed at "/" — only the guide
+        // groups auto-open (OpenGuideGroups). Its toggle carries the "open" class only when expanded.
+        var appsExpanded = new Regex("nav-group-toggle open\"[\\s\\S]{0,200}nav-group-label\">Apps<");
+        Assert.DoesNotMatch(appsExpanded, CollapseWhitespace(page.Html));
 
-        routeState.Path = "/todos";
-        var htmlAtTodos = page.Render();
-        // After nav, the active link should be the Todos one (bi-check2-square icon).
-        Assert.Matches("side-nav-link active[^>]*>[^<]*<i class=\"bi bi-check2-square",
-            CollapseWhitespace(htmlAtTodos));
+        // Open the mobile drawer via the hamburger (it toggles _drawerOpen); the backdrop marks it open.
+        var hamburgerId = Regex.Match(page.Html, "hamburger-btn[^\"]*\"[^>]*data-rask-on-click=\"([^\"]+)\"")
+            .Groups[1].Value;
+        Assert.NotEqual("", hamburgerId);
+        Assert.Contains("offcanvas-backdrop", await page.InvokeAsync(hamburgerId));
+
+        // Navigate to /todos → RouteState.Changed fires → OnRouteChanged closes the drawer and expands the
+        // group holding /todos. Without the subscription neither happens (the drawer stays open, Apps stays
+        // collapsed) even though the layout still re-renders.
+        routeState.Path = Rask.Example.Shared.Features.Routes.TodosPage();
+        var atTodos = CollapseWhitespace(page.Render());
+        Assert.Matches(appsExpanded, atTodos);                 // active group auto-expanded
+        Assert.DoesNotContain("offcanvas-backdrop", atTodos);  // drawer closed
     }
 
     private static string CollapseWhitespace(string s) =>

--- a/tests/Rask.Examples.E2E.Tests/PlaygroundExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/PlaygroundExampleTests.cs
@@ -80,6 +80,17 @@ public sealed class PlaygroundExampleTests
             await Expect(page.Locator(".pg-preview"))
                 .ToContainTextAsync("Try the Rask playground",
                     new LocatorAssertionsToContainTextOptions { Timeout = 60_000 });
+
+            // Regression guard for #419: the editor host must stay singular. data-rask-managed used to sit on
+            // the .pg-code-host div the .NET side renders, so every full-HTML frame (the first frame after
+            // each interaction ships full HTML) appended a second empty host — unbounded for the tab's life.
+            // After the Run + click + gallery interactions above there must be exactly one host and none empty.
+            var hostCount = await page.EvaluateAsync<int>(
+                "() => document.querySelectorAll('.pg-code-host').length");
+            var emptyHostCount = await page.EvaluateAsync<int>(
+                "() => [...document.querySelectorAll('.pg-code-host')].filter(h => h.children.length === 0).length");
+            Assert.Equal(1, hostCount);
+            Assert.Equal(0, emptyHostCount);
         }
         finally
         {


### PR DESCRIPTION
## Summary

Fixes three open `bug` issues. Each was latent (nothing visibly broken today) but a real defect with a test that failed to catch it — and two of the three turned out to have the wrong mechanism in their own fix sketch, so the fix here is grounded in what the code actually does.

### #406 — BsDataGrid pager prev/next buttons have no accessible name
The pager arrows render an icon-only child (a decorative, `aria-hidden` `BsIcon` chevron), so a screen reader announced two unlabelled buttons on every grid with `PageSize > 0`. The numbered items were fine (their text names them), which made it easy to miss.

- `BsPageItem` gains an `Aria` passthrough (the same pattern as `BsButton`/`BsTable`), merged under its own `aria-disabled` so a disabled arrow keeps both its name and its state.
- `BsDataGrid` labels the arrows `aria-label="Previous page"` / `"Next page"`.

### #419 — playground accumulates an empty `.pg-code-host` per full-HTML frame
`PlaygroundView` put `data-rask-managed` on the `.pg-code-host` div it **also renders**, inverting the marker's contract (it flags nodes that are live but *absent* from the render payload). `morph` filtered the marked host out of the existing DOM but not the incoming tree, so it appended a fresh empty host every full-HTML frame — unbounded for the tab's life. Removing the marker outright would delete Monaco (the host renders childless).

- The marker moves onto Monaco's own library-created child nodes (`PlaygroundView.js`, both the editor and textarea-fallback mount paths) — the correct placement, matching the Gantt wrapper.
- `rask-morph.js` is hardened to ignore `data-rask-managed` on a node that **is** in the incoming tree (always a misuse), so the mistake now fails safe instead of duplicating silently. The change is spliced into both the Server and WASM clients.

### #420 — ShowcaseLayout's route-subscription test didn't pin the subscription
`OnMount_SubscribesToRouteChanged_ActiveLinkRefreshesOnNav` passed with `route.Changed += OnRouteChanged` deleted. It drove two full root renders and asserted the active link refreshed — but that class is owned by **`NavLink`**, which subscribes to `RouteState.Changed` itself and refreshes independently. The layout's subscription actually drives the mobile **drawer-close** and the **active-group accordion auto-expand**.

- The test is rewritten to assert those two effects (and goes red when the subscription is removed — verified by mutation).
- A new `Rask.Core.Tests` case pins the underlying framework invariant: a clean subtree that derives UI from untracked external state (a ctor-injected service, not ambient `Context.Get`) is served **stale** from the render cache unless a `Changed` subscription marks it dirty.

## Testing

- `dotnet format` clean; `dotnet build Rask.slnx -warnaserror` clean (0 warnings).
- Full local unit suite green (`scripts/run-unit-local.sh`), including the splice-integrity tests for the regenerated `rask.wasm.js` / `rask.native.js` bundles.
- New coverage: `BsPaginationTests` (Aria passthrough + label/disabled order), `BsDataGridTests` (pager labels), `MorphManagedGuardTests` (jsdom, both marker sides), `ExternalStateInvalidationTests` (render-cache invalidation), rewritten `ShowcaseLayoutTests`.
- **Mutation-checked** each new/rewritten test by reverting its target fix and confirming it goes red (the morph guard → host count 2; the layout subscription → active group stays collapsed).
- Browser E2E green (`scripts/run-e2e-local.sh`); `PlaygroundExampleTests` now asserts exactly one `.pg-code-host` (0 empty) after the run/gallery interactions, verified against a clean Release publish.

## Benchmarks

Not applicable — the C# render hot-path is untouched. The morph guard adds one `hasAttribute` per incoming child, identical in cost to the existing from-side filter, and runs client-side (no BenchmarkDotNet surface). The jsdom fixture is the evidence.

## Changelog

`CHANGELOG.md` `[Unreleased] → Fixed` gains one entry per issue.
