### PR TITLE
feat(bootstrap): hide grouped columns in BsDataGrid by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ them until tagged releases begin.
   `select sqlite_version()` through the real graph reports `3.50.4`.
 
 ### Changed
+- **Breaking: `BsDataGrid` now hides a grouped column by default.** A grouped column holds the same value for
+  every row in its band, and the band header already names it (`Region: EMEA (4)`), so repeating it in-row was a
+  column of duplicates. While a column is grouped its header, cells, subtotal and footer are now dropped and the
+  band-header/detail-row colspans shrink to match; its ungroup control lives on the panel chip. Set the new
+  `ShowGroupedColumns: true` to restore the previous behaviour (the value in the band header **and** repeated
+  down every row). Grouping still orders, bands and subtotals exactly as before. Documented in
+  `docs/data-grid.md`; the grouping demo gains a "Show grouped column" toggle.
 - **The showcase page, layout and guide suites render through `Rask.Testing`.** They called the internal
   `RenderAsLiveRoot(services)` straight on a page component; they now use
   `RaskTest.Render(new SomePage(), services).Html`, which is the same thing a consumer writes. Test-only;

--- a/docs/data-grid.md
+++ b/docs/data-grid.md
@@ -163,6 +163,23 @@ page, and paging cuts wherever it cuts.
 `Grouped` is URL input, so unknown or non-`Groupable` field names are ignored rather than thrown — a stale
 `?group=deleteMe` renders an ungrouped grid.
 
+### Grouped columns fold away
+
+A grouped column holds the **same value for every row in its band**, and the band header already names it
+(`Region: EMEA (4)`). Rendering the column too would be a run of duplicates under a header that says nothing new —
+so by default a grouped column is **dropped from the table** while it is grouped: its header, cells, subtotal
+and footer go, and the band-header and detail-row colspans shrink to match. Its group control moves to the panel
+chip, which is where you ungroup it.
+
+Set `ShowGroupedColumns: true` to keep it — the value then shows in the band header **and** repeated down every
+row (the behaviour before this default). Nothing else changes; grouping still orders, bands and subtotals the
+same way.
+
+```csharp
+BsDataGrid(Data: deals, Grouped: ["region"], OnGroupedChange: g => _grouped = [.. g],
+    ShowGroupedColumns: true, Columns: [...]) // keep the Region column visible while grouped
+```
+
 ### Collapsing and subtotals
 
 `GroupCollapsible` makes each band header a toggle. Collapse state is keyed by the band's **value path**, so it
@@ -189,16 +206,22 @@ header carries group-by. So the whole feature works from the keyboard alone, and
 That ordering is deliberate: a feature whose primary action is drag-only cannot be reached by keyboard at all,
 which would fail WCAG 2.1.1 for the thing the panel exists to do.
 
-The edge buttons are `disabled` at the ends rather than being no-ops that look live, and the group control
-carries `aria-pressed` so its state is announced.
+The edge buttons are `disabled` at the ends rather than being no-ops that look live, and a groupable header's
+group control carries `aria-pressed` so its state is announced. Once a column is grouped its header folds away
+(see [Grouped columns fold away](#grouped-columns-fold-away)), so the panel chip is what then carries its
+ungroup control — unless `ShowGroupedColumns: true` keeps the header, and its pressed control, in place.
 
 ### What it costs
 
-Grouping re-orders the set and boxes one key per row per level to find the runs: about **+5% render
-allocation** for one level over 100 rows, **+19%** for two (`BsDataGridBenchmarks`).
+Grouping re-orders the set and boxes one key per row per level to find the runs — but by default it also
+**removes the grouped column's cells**, and a folded-away column of 100 cells outweighs the ordering. Net, a
+grouped grid allocates **less** than a plain one over 100 rows: about **−8%** for one level, **−7%** for two
+(`BsDataGridBenchmarks`). Keep the column with `ShowGroupedColumns: true` and the ordering shows as a cost
+instead — **+5%** for one level, **+19%** for two.
 
 **Don't group by a near-unique column.** Grouping 100 rows by a unique SKU is 100 bands — one header per row —
-and measured **+87%**. Group by the low-cardinality things (region, status, month); that is what a band is for.
+and a band header spans the whole table whether or not the column folds away, so it stays expensive. Group by
+the low-cardinality things (region, status, month); that is what a band is for.
 
 ## Selection
 
@@ -557,6 +580,7 @@ renders only the visible window instead.
 | `GroupCollapsible` | `null` | Band headers become toggles. |
 | `GroupSubtotals` | `null` | A subtotal row per innermost band, reusing each column's `Footer`. Page-scoped. |
 | `GroupPanel` | `null` | Chips + per-header group controls. Drag or keyboard — every gesture has a button. |
+| `ShowGroupedColumns` | `null` | `true` keeps a grouped column in the table. Default folds it away — its value already names the band header. |
 | `Selectable` | `null` | Adds the leading checkbox column. Implied by `SelectedKeys`/`OnSelectionChange`. Set `RowKey` with it. |
 | `SelectedKeys` | `null` | Controlled selection (`RowKey` values). Null = the grid owns it. |
 | `OnSelectionChange` / `OnSelectionChangeAsync` | `null` | The full set of selected keys after a click; the async form is awaited. |

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsDataGridGroupDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsDataGridGroupDemo.cs
@@ -14,6 +14,10 @@ namespace Rask.Example.Shared.Features;
 // GroupPanel adds the chips and the per-header group control. Drag a header into the panel, drag the chips to
 // renest, drag one out to ungroup — and every one of those is also a real button, so the whole thing works
 // from the keyboard alone. Tab to a header's group control and press Enter.
+//
+// A grouped column folds away by default: its value is the same for every row in its band and already names
+// the band header, so the column would be a run of duplicates. "Show grouped column" flips ShowGroupedColumns
+// to keep it — the value then appears in the band header AND repeated down every row.
 public sealed class BsDataGridGroupDemo : Component
 {
     private sealed record Deal(string Account, string Region, string Rep, decimal Amount);
@@ -32,6 +36,7 @@ public sealed class BsDataGridGroupDemo : Component
     ];
 
     private List<string> _grouped = ["region"];
+    private bool _showGrouped;
 
     protected override Component? Render() =>
         Div(Id: "grid-group-demo")[
@@ -42,7 +47,9 @@ public sealed class BsDataGridGroupDemo : Component
                 BsButton(Id: "group-nested", Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
                     Active: Is("region", "rep"), OnClick: () => _grouped = ["region", "rep"])["Region ▸ rep"],
                 BsButton(Id: "group-none", Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
-                    Active: _grouped.Count == 0, OnClick: () => _grouped = [])["Ungrouped"]
+                    Active: _grouped.Count == 0, OnClick: () => _grouped = [])["Ungrouped"],
+                BsButton(Id: "group-show-col", Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
+                    Active: _showGrouped, OnClick: () => _showGrouped = !_showGrouped)["Show grouped column"]
             ],
             BsDataGrid(
                 Id: "bs-grid-group",
@@ -53,6 +60,7 @@ public sealed class BsDataGridGroupDemo : Component
                 GroupPanel: true,
                 GroupCollapsible: true,
                 GroupSubtotals: true,
+                ShowGroupedColumns: _showGrouped,
                 Columns:
                 [
                     new BsColumn<Deal> { Title = "Account", Value = d => d.Account, Field = d => d.Account, Sortable = true },

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -314,7 +314,9 @@ public static class DemoRegistry
                        + "band is a run of CONSECUTIVE rows, so the grid orders by the group keys first and "
                        + "the user's sort applies inside each band. Click Amount and watch the rows re-sort "
                        + "within the bands rather than scattering them. Subtotals reuse each column's Footer "
-                       + "delegate over the band's rows, and see only the rows on this page.",
+                       + "delegate over the band's rows, and see only the rows on this page. A grouped column "
+                       + "folds away by default — its value already names the band header — so 'Show grouped "
+                       + "column' flips ShowGroupedColumns to keep it in the table too.",
                 Result: BsDataGridGroupDemo()),
             ["data-grid-selection"] = () => CodeSample(
                 ["BsDataGridSelectionDemo.cs"],

--- a/src/Rask.Bootstrap/BsDataGrid.cs
+++ b/src/Rask.Bootstrap/BsDataGrid.cs
@@ -494,6 +494,14 @@ public sealed class BsDataGrid<T> : BsBlock
     /// </remarks>
     public bool? GroupPanel { get; set; }
 
+    /// <summary>
+    ///     Whether a grouped column stays in the table. A grouped column's value is the same for every row in
+    ///     its band and already names the band header, so by default (null/false) the column is folded away
+    ///     while it is grouped — its header, cells, subtotal and footer are dropped and the colspans shrink to
+    ///     match. Set true to keep it, so the value shows both in the band header and repeated down every row.
+    /// </summary>
+    public bool? ShowGroupedColumns { get; set; }
+
     private bool Expandable => ExpandedContent is not null;
 
     // Same three-way opt-in Sort uses, and for the same reason: Grouped = null legitimately means "ungrouped"
@@ -706,6 +714,43 @@ public sealed class BsDataGrid<T> : BsBlock
         return result;
     }
 
+    // A grouped column is folded out of the table body: its value is identical for every row in its band and
+    // already names the band header, so repeating it as a column would be a run of duplicates under a header
+    // the band header already carries. Mirrors GroupColumns' match (Groupable + FieldName == token) so the two
+    // never disagree about which columns are grouped. ShowGroupedColumns keeps the column instead.
+    private bool IsGroupedAway(BsColumn<T> column) =>
+        ShowGroupedColumns is not true
+        && column.Groupable
+        && column.FieldName is { } f
+        && CurrentGrouped.Contains(f);
+
+    // The columns that render, computed once per render (Render threads the result down). Returns `columns`
+    // itself — same reference, no allocation — whenever nothing is hidden, which is every ungrouped grid and
+    // every grid that opts out, so the feature stays free when unused. Only a grid that actually folds a column
+    // away pays for the copy, and only once.
+    private IReadOnlyList<BsColumn<T>> VisibleColumns(IReadOnlyList<BsColumn<T>> columns)
+    {
+        if (ShowGroupedColumns is true || CurrentGrouped.Count == 0)
+        {
+            return columns;
+        }
+
+        List<BsColumn<T>>? visible = null;
+        for (var i = 0; i < columns.Count; i++)
+        {
+            if (IsGroupedAway(columns[i]))
+            {
+                visible ??= [.. columns.Take(i)]; // first hidden column: seed with the visible ones before it
+            }
+            else
+            {
+                visible?.Add(columns[i]);
+            }
+        }
+
+        return visible ?? columns;
+    }
+
     private Task SetGroupedAsync(IReadOnlyList<string> next)
     {
         if (!GroupControlled)
@@ -916,7 +961,12 @@ public sealed class BsDataGrid<T> : BsBlock
             return Wrap(GroupPanel is true ? GroupPanelRow(columns) : null, Empty, null);
         }
 
-        var hasFooter = columns.Any(c => c.HasFooter);
+        // The columns that actually render, folded once per render and threaded down like `selected`/`pageKeys`
+        // below — so the per-cell path never re-derives it. A grouped-away column takes its footer with it, so
+        // `visible` is also what decides whether there is a <tfoot> at all. HeaderCells keeps the FULL list: its
+        // sort index is a position in `columns`, which the visible subset would renumber.
+        var visible = VisibleColumns(columns);
+        var hasFooter = visible.Any(c => c.HasFooter);
 
         // Built once per render and threaded down, rather than rebuilt per row. The page's keys come with it:
         // the select-all box needs them, and computing a key is a user delegate call per row.
@@ -927,8 +977,8 @@ public sealed class BsDataGrid<T> : BsBlock
             StickyHeader: StickyHeader, MaxHeight: MaxHeight, Class: Class,
             Aria: Busy ? BsGridAria.Busy : null)[
             Thead()[Tr()[HeaderCells(columns, selected, pageKeys)]],
-            Tbody()[BodyRows(columns, pageRows, selected)],
-            hasFooter ? Tfoot()[Tr()[FooterCells(columns, footerRows)]] : null
+            Tbody()[BodyRows(visible, columns, pageRows, selected)],
+            hasFooter ? Tfoot()[Tr()[FooterCells(visible, footerRows)]] : null
         ];
 
         return Wrap(GroupPanel is true ? GroupPanelRow(columns) : null, table,
@@ -1112,7 +1162,7 @@ public sealed class BsDataGrid<T> : BsBlock
     // controls is a run of sibling <tr>s with no wrapper element to point at, and aria-controls takes an id
     // LIST — so honouring it would mean minting and emitting an id for every row in every band. aria-expanded
     // alone is a valid disclosure pattern; this is the price of banding inside one <tbody>.
-    private Component BandHeaderRow(IReadOnlyList<BsColumn<T>> columns, BsColumn<T> column, object? key,
+    private Component BandHeaderRow(IReadOnlyList<BsColumn<T>> visible, BsColumn<T> column, object? key,
         IReadOnlyList<T> band, int level, string path, bool collapsed)
     {
         Component content = column.GroupHeader is { } header
@@ -1137,7 +1187,7 @@ public sealed class BsDataGrid<T> : BsBlock
 
         // Nested bands indent so the hierarchy is visible; level 0 sits flush.
         return Tr(Key: $"band:{path}", Class: "table-group-divider")[
-            Td(Colspan: columns.Count + LeadingCells,
+            Td(Colspan: Math.Max(1, visible.Count + LeadingCells),
                 Class: level > 0 ? Padding.Start(level * 3 + 2) : null)[label, content]
         ];
     }
@@ -1145,11 +1195,11 @@ public sealed class BsDataGrid<T> : BsBlock
     // Reuses each column's Footer/FooterTemplate over the band's rows: those delegates already take an
     // IReadOnlyList<T>, so a subtotal is the same delegate over a narrower set — one shape to learn, and a
     // column that totals in the footer totals per band for free.
-    private Component SubtotalRow(IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> band, int level,
+    private Component SubtotalRow(IReadOnlyList<BsColumn<T>> visible, IReadOnlyList<T> band, int level,
         string path) =>
-        Tr(Key: $"sub:{path}", Class: "table-light")[SubtotalCells(columns, band, level)];
+        Tr(Key: $"sub:{path}", Class: "table-light")[SubtotalCells(visible, band, level)];
 
-    private IEnumerable<Component> SubtotalCells(IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> band,
+    private IEnumerable<Component> SubtotalCells(IReadOnlyList<BsColumn<T>> visible, IReadOnlyList<T> band,
         int level)
     {
         for (var i = 0; i < LeadingCells; i++)
@@ -1157,9 +1207,11 @@ public sealed class BsDataGrid<T> : BsBlock
             yield return Td()[""];
         }
 
-        for (var c = 0; c < columns.Count; c++)
+        // `visible` has the grouped-away columns already folded out, so the "Subtotal" caption on the first cell
+        // with no footer of its own lands on the first column the user actually sees.
+        for (var c = 0; c < visible.Count; c++)
         {
-            var column = columns[c];
+            var column = visible[c];
             yield return Td(Class: Bs.Join(column.Class, Font.Semibold))[
                 c == 0 && !column.HasFooter ? "Subtotal" : column.FooterCell(band)];
         }
@@ -1203,6 +1255,13 @@ public sealed class BsDataGrid<T> : BsBlock
         for (var i = 0; i < columns.Count; i++)
         {
             var column = columns[i];
+
+            // A grouped column is folded away — its header goes with its cells. `i` is NOT renumbered: it stays
+            // the index into the full column list, which is what CurrentSortColumn and ToggleSortAsync speak.
+            if (IsGroupedAway(column))
+            {
+                continue;
+            }
 
             // The panel's other half: the keyboard route to grouping. Dragging the header does the same thing
             // for a mouse, so the header is a drag SOURCE too — the field rides the grid's own drag state.
@@ -1268,13 +1327,16 @@ public sealed class BsDataGrid<T> : BsBlock
             OnClickAsync: () => GroupByAsync(field))[BsIcon(Name: BsIconName.Diagram3)];
     }
 
-    private IEnumerable<Component> BodyRows(IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> pageRows,
-        HashSet<object>? selected)
+    // `visible` is the columns that render (grouped-away ones already folded out); `columns` is the full list,
+    // needed only to resolve the grouping columns for banding — a band's key comes from a column that has itself
+    // been folded away.
+    private IEnumerable<Component> BodyRows(IReadOnlyList<BsColumn<T>> visible,
+        IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> pageRows, HashSet<object>? selected)
     {
         var groups = GroupColumns(columns);
         return groups.Count == 0
-            ? PlainRows(columns, pageRows, selected, 0, pageRows.Count)
-            : BandRows(columns, pageRows, selected, groups, 0, 0, pageRows.Count);
+            ? PlainRows(visible, pageRows, selected, 0, pageRows.Count)
+            : BandRows(visible, pageRows, selected, groups, 0, 0, pageRows.Count);
     }
 
     // Bands one level of the page, then recurses. A band is a RUN of consecutive rows sharing the key at this
@@ -1283,7 +1345,7 @@ public sealed class BsDataGrid<T> : BsBlock
     //
     // Nesting falls out of the recursion: each band at level N re-bands its own slice by level N+1, and the
     // deepest level renders the rows themselves.
-    private IEnumerable<Component> BandRows(IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> pageRows,
+    private IEnumerable<Component> BandRows(IReadOnlyList<BsColumn<T>> visible, IReadOnlyList<T> pageRows,
         HashSet<object>? selected, List<BsColumn<T>> groups, int level, int start, int end)
     {
         var column = groups[level];
@@ -1304,13 +1366,13 @@ public sealed class BsDataGrid<T> : BsBlock
             var band = Slice(pageRows, i, runEnd);
             var collapsed = _collapsed.Contains(path);
 
-            yield return BandHeaderRow(columns, column, key, band, level, path, collapsed);
+            yield return BandHeaderRow(visible, column, key, band, level, path, collapsed);
 
             if (!collapsed)
             {
                 var inner = level + 1 < groups.Count
-                    ? BandRows(columns, pageRows, selected, groups, level + 1, i, runEnd)
-                    : PlainRows(columns, pageRows, selected, i, runEnd);
+                    ? BandRows(visible, pageRows, selected, groups, level + 1, i, runEnd)
+                    : PlainRows(visible, pageRows, selected, i, runEnd);
 
                 foreach (var row in inner)
                 {
@@ -1319,9 +1381,9 @@ public sealed class BsDataGrid<T> : BsBlock
 
                 // Subtotals sit at the END of the band, where a running total belongs, and only at the deepest
                 // level: one per innermost band rather than a cascade of identical rows at every level.
-                if (GroupSubtotals is true && level + 1 == groups.Count && columns.Any(c => c.HasFooter))
+                if (GroupSubtotals is true && level + 1 == groups.Count && visible.Any(c => c.HasFooter))
                 {
-                    yield return SubtotalRow(columns, band, level, path);
+                    yield return SubtotalRow(visible, band, level, path);
                 }
             }
 
@@ -1353,7 +1415,7 @@ public sealed class BsDataGrid<T> : BsBlock
         return BandPath(keys, level);
     }
 
-    private IEnumerable<Component> PlainRows(IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> pageRows,
+    private IEnumerable<Component> PlainRows(IReadOnlyList<BsColumn<T>> visible, IReadOnlyList<T> pageRows,
         HashSet<object>? selected, int start, int end)
     {
         for (var r = start; r < end; r++)
@@ -1365,7 +1427,7 @@ public sealed class BsDataGrid<T> : BsBlock
             // table-active is joined with the caller's RowClass rather than replacing it, so a row can be both
             // overdue and selected.
             yield return Tr(Key: key, Class: BsClass.Join(RowClass?.Invoke(row), isSelected ? "table-active" : null))[
-                Cells(columns, row, key, r, selected, isSelected)];
+                Cells(visible, row, key, r, selected, isSelected)];
 
             if (!Expandable || !_expanded.Contains(key))
             {
@@ -1376,13 +1438,13 @@ public sealed class BsDataGrid<T> : BsBlock
             if (detail is not null)
             {
                 yield return Tr(Key: $"{key}:detail", Id: DetailId(r))[
-                    Td(Colspan: columns.Count + LeadingCells)[detail]
+                    Td(Colspan: Math.Max(1, visible.Count + LeadingCells))[detail]
                 ];
             }
         }
     }
 
-    private IEnumerable<Component> Cells(IReadOnlyList<BsColumn<T>> columns, T row, object key, int index,
+    private IEnumerable<Component> Cells(IReadOnlyList<BsColumn<T>> visible, T row, object key, int index,
         HashSet<object>? selected, bool isSelected)
     {
         if (selected is not null)
@@ -1391,7 +1453,7 @@ public sealed class BsDataGrid<T> : BsBlock
             // (via the first Value column where there is one), because twenty identical "Select row"s in a
             // list read as one control repeated rather than twenty distinct ones.
             yield return Td(Class: "bs-grid-check")[
-                SelectBox(isSelected, SelectRowAria(columns, row), Busy,
+                SelectBox(isSelected, SelectRowAria(visible, row), Busy,
                     raw => SetSelectedAsync(selected, key, raw == "true"))
             ];
         }
@@ -1406,9 +1468,10 @@ public sealed class BsDataGrid<T> : BsBlock
         // the handler *id* is still per element, which is why OnRowClick scales rows × columns.
         var click = RowClickHandler(row);
 
-        for (var c = 0; c < columns.Count; c++)
+        // `visible` already excludes grouped-away columns, so the row loop stays a straight walk — no per-cell
+        // hidden check on the hottest path.
+        foreach (var column in visible)
         {
-            var column = columns[c];
             var clickable = click is not null && column.IsRowClickable;
 
             yield return Td(
@@ -1487,7 +1550,7 @@ public sealed class BsDataGrid<T> : BsBlock
         return BsGridAria.SelectRow;
     }
 
-    private IEnumerable<Component> FooterCells(IReadOnlyList<BsColumn<T>> columns, IReadOnlyList<T> data)
+    private IEnumerable<Component> FooterCells(IReadOnlyList<BsColumn<T>> visible, IReadOnlyList<T> data)
     {
         // The easy miss: the footer needs a leading cell for EVERY leading column, or every <tfoot> cell is
         // off by one and the totals sit under the wrong headers.
@@ -1501,7 +1564,9 @@ public sealed class BsDataGrid<T> : BsBlock
             yield return Td()[""];
         }
 
-        foreach (var column in columns)
+        // `visible` has grouped-away columns already folded out, so each remaining column lines up with its
+        // header.
+        foreach (var column in visible)
         {
             yield return Td(Class: column.Class)[column.FooterCell(data)];
         }

--- a/tests/Rask.Bootstrap.Tests/BsDataGridApiCompatTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridApiCompatTests.cs
@@ -139,8 +139,8 @@ public class BsDataGridApiCompatTests
                 "OnGroupedChange",
                 "OnGroupedChangeAsync", "OnPageChange", "OnPageChangeAsync", "OnRowClick", "OnRowClickAsync",
                 "OnSelectionChange", "OnSelectionChangeAsync", "OnSortChange", "OnSortChangeAsync", "Page",
-                "PageSize", "Responsive", "RowClass", "RowKey", "Selectable", "SelectedKeys", "Small", "Sort",
-                "SortDescending", "StickyHeader", "Striped", "TotalCount",
+                "PageSize", "Responsive", "RowClass", "RowKey", "Selectable", "SelectedKeys", "ShowGroupedColumns",
+                "Small", "Sort", "SortDescending", "StickyHeader", "Striped", "TotalCount",
             ],
             actual);
     }

--- a/tests/Rask.Bootstrap.Tests/BsDataGridGroupPanelTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridGroupPanelTests.cs
@@ -75,10 +75,12 @@ public class BsDataGridGroupPanelTests
 
         Assert.Contains("Grouped by", html, StringComparison.Ordinal);
         Assert.Equal(3, Regex.Matches(html, "table-group-divider").Count); // AMER, APAC, EMEA
-        Assert.Contains("aria-pressed=\"true\"", html, StringComparison.Ordinal);
+        // Region's header (and with it the aria-pressed group-by toggle) folds away once it's grouped — its
+        // value lives in the band header now, so the panel chip is what carries the grouped state and ungroup.
+        Assert.DoesNotContain("aria-label=\"Group by Region\"", html, StringComparison.Ordinal);
         Assert.Contains("aria-label=\"Stop grouping by Region\"", html, StringComparison.Ordinal);
 
-        // The same button ungroups. Read it by label, not index: once grouped, the panel's chip buttons
+        // The chip ungroups. Read it by label, not index: once grouped, the panel's chip buttons
         // precede the headers in document order and every index shifts.
         html = await grid.InvokeAsync(ClickFor(html, "Stop grouping by Region"));
         Assert.DoesNotContain("table-group-divider", html, StringComparison.Ordinal);

--- a/tests/Rask.Bootstrap.Tests/BsDataGridGroupServerTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridGroupServerTests.cs
@@ -88,6 +88,15 @@ public class BsDataGridGroupServerTests
             .ToArray();
     }
 
+    // The header titles, markup stripped.
+    private static string[] HeaderTitles(string html)
+    {
+        var head = Regex.Match(html, "<thead>(.*?)</thead>", RegexOptions.Singleline).Groups[1].Value;
+        return Regex.Matches(head, "<th[^>]*>(.*?)</th>", RegexOptions.Singleline)
+            .Select(m => Regex.Replace(Regex.Replace(m.Groups[1].Value, "<[^>]+>", " "), @"\s+", " ").Trim())
+            .ToArray();
+    }
+
     // --- IQueryable: the store orders --------------------------------------------------------------------
     //
     // These go through RaskTest.Render (a real render engine), not ToHtml(): an IQueryable Data throws under
@@ -141,6 +150,19 @@ public class BsDataGridGroupServerTests
     }
 
     [Fact]
+    public void Query_GroupedColumn_IsHiddenByDefault()
+    {
+        // Column hiding is orthogonal to where the data comes from: the grouped column folds away over an
+        // IQueryable exactly as over a list, while the store still leads the ORDER BY with it.
+        var grid = RaskTest.Render(new Host(() => BsDataGrid(
+            Data: Interleaved.AsQueryable(), Columns: Columns(), RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { })));
+
+        Assert.Equal(["Name", "Supplier", "Qty"], HeaderTitles(grid.Html));
+        Assert.Contains("Category: Fruit", grid.Html, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void Query_Grouping_DoesNotDefeatTheQueryCache()
     {
         // The cache key folds in the grouping (string.Join(',', CurrentGrouped)), so a grouped grid still
@@ -184,6 +206,23 @@ public class BsDataGridGroupServerTests
 
         Assert.Equal(["Category: Fruit (3)", "Category: Veg (2)"], BandTitles(html));
         Assert.Equal(["Apple", "Banana", "Cherry", "Carrot", "Leek"], FirstCells(html));
+    }
+
+    [Fact]
+    public void TotalCount_GroupedColumn_IsHiddenByDefault()
+    {
+        var slice = new List<Row>
+        {
+            new("Apple", "Fruit", "Acme", 5),
+            new("Banana", "Fruit", "Bolt", 3),
+            new("Carrot", "Veg", "Acme", 9),
+        };
+
+        var html = BsDataGrid(Data: slice, Columns: Columns(), RowKey: r => r.Name, TotalCount: slice.Count,
+            PageSize: 10, Grouped: ["category"], OnGroupedChange: _ => { }).ToHtml();
+
+        Assert.Equal(["Name", "Supplier", "Qty"], HeaderTitles(html));
+        Assert.Contains("Category: Fruit", html, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Bootstrap.Tests/BsDataGridGroupTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridGroupTests.cs
@@ -53,6 +53,15 @@ public class BsDataGridGroupTests
             .ToArray();
     }
 
+    // The header titles, markup stripped — a sortable header wraps its title in a button, so tags come out.
+    private static string[] HeaderTitles(string html)
+    {
+        var head = Regex.Match(html, "<thead>(.*?)</thead>", RegexOptions.Singleline).Groups[1].Value;
+        return Regex.Matches(head, "<th[^>]*>(.*?)</th>", RegexOptions.Singleline)
+            .Select(m => Regex.Replace(Regex.Replace(m.Groups[1].Value, "<[^>]+>", " "), @"\s+", " ").Trim())
+            .ToArray();
+    }
+
     [Fact]
     public void Field_NamesTheColumn_FromTheMember()
     {
@@ -123,13 +132,117 @@ public class BsDataGridGroupTests
     }
 
     [Fact]
-    public void TheBandHeader_SpansEveryColumn_IncludingTheLeadingOnes()
+    public void TheBandHeader_SpansEveryVisibleColumn_IncludingTheLeadingOnes()
     {
         var html = BsDataGrid(Data: Rows, Columns: Columns(), RowKey: r => r.Name, Selectable: true,
             Grouped: ["category"], OnGroupedChange: _ => { }).ToHtml();
 
-        // 4 data columns + the checkbox column.
-        Assert.Contains("<td colspan=\"5\">", html, StringComparison.Ordinal);
+        // 4 data columns, Category grouped away (3 visible), + the checkbox column = 4.
+        Assert.Contains("<td colspan=\"4\">", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GroupedColumn_IsHiddenByDefault_AndItsValueSurvivesInTheBandHeader()
+    {
+        // A grouped column repeats one value down its whole band under a header the band header already carries,
+        // so by default it folds away — the value lives only in the band header.
+        var html = BsDataGrid(Data: Rows, Columns: Columns(), RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { }).ToHtml();
+
+        Assert.Equal(["Name", "Supplier", "Qty"], HeaderTitles(html)); // Category's <th> is gone
+        Assert.Contains("Category: Fruit", html, StringComparison.Ordinal); // but the band header keeps it
+        // The Category cell "Fruit"/"Veg" no longer appears as a row cell; only Name leads each row.
+        Assert.Equal(["Apple", "Banana", "Cherry", "Carrot", "Leek"], FirstCells(html));
+    }
+
+    [Fact]
+    public void ShowGroupedColumns_KeepsTheGroupedColumn_InHeaderAndCells()
+    {
+        var html = BsDataGrid(Data: Rows, Columns: Columns(), RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { }, ShowGroupedColumns: true).ToHtml();
+
+        Assert.Equal(["Name", "Category", "Supplier", "Qty"], HeaderTitles(html)); // all four stay
+        // The value shows both in the band header AND repeated in every row (the pre-hide behaviour).
+        var fruitBand = Regex.Match(html, "Category: Fruit.*?(?=Category: Veg)", RegexOptions.Singleline).Value;
+        Assert.Contains(">Fruit<", fruitBand, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void MultiLevelGrouping_HidesEveryGroupedColumn()
+    {
+        var html = BsDataGrid(Data: Rows, Columns: Columns(), RowKey: r => r.Name,
+            Grouped: ["category", "supplier"], OnGroupedChange: _ => { }).ToHtml();
+
+        // Both grouped columns fold away; only the ungrouped Name and Qty remain.
+        Assert.Equal(["Name", "Qty"], HeaderTitles(html));
+    }
+
+    [Fact]
+    public void SubtotalLabel_LandsOnTheFirstVisibleColumn_WhenColumnZeroIsGroupedAway()
+    {
+        // Column 0 is the grouped-away one, so "Subtotal" must move to the first column that actually renders.
+        BsColumn<Row>[] columns =
+        [
+            new BsColumn<Row>
+            {
+                Title = "Category", Value = r => r.Category, Field = r => r.Category, Groupable = true,
+            },
+            new BsColumn<Row> { Title = "Name", Value = r => r.Name, Field = r => r.Name },
+            new BsColumn<Row> { Title = "Qty", Value = r => r.Qty, Footer = rs => rs.Sum(x => x.Qty) },
+        ];
+
+        var html = BsDataGrid(Data: Rows, Columns: columns, RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { }, GroupSubtotals: true).ToHtml();
+
+        var firstSubtotal = Regex.Match(html, "<tr class=\"table-light\"[^>]*>(.*?)</tr>", RegexOptions.Singleline)
+            .Groups[1].Value;
+        // First rendered cell (Name's slot) carries the caption; the Category cell it used to sit under is gone.
+        Assert.Contains(">Subtotal<", firstSubtotal, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AGroupedColumnsFooter_DoesNotForceATfoot()
+    {
+        // The only footer belongs to the column being grouped; folding the column away takes its footer with it,
+        // so there is nothing left to put a <tfoot> on the table.
+        BsColumn<Row>[] columns =
+        [
+            new BsColumn<Row> { Title = "Name", Value = r => r.Name, Field = r => r.Name },
+            new BsColumn<Row>
+            {
+                Title = "Category", Value = r => r.Category, Field = r => r.Category, Groupable = true,
+                Footer = rs => rs.Count,
+            },
+        ];
+
+        var grouped = BsDataGrid(Data: Rows, Columns: columns, RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { }).ToHtml();
+        Assert.DoesNotContain("<tfoot>", grouped, StringComparison.Ordinal);
+
+        // Kept (opt-out) or ungrouped, the footer is back.
+        var shown = BsDataGrid(Data: Rows, Columns: columns, RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { }, ShowGroupedColumns: true).ToHtml();
+        Assert.Contains("<tfoot>", shown, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void GroupingEveryColumn_NeverEmitsAZeroColspanBandHeader()
+    {
+        // The degenerate case: the one and only column is grouped away, so the band header spans no data
+        // columns. colspan must clamp to 1 rather than emit the invalid colspan="0".
+        BsColumn<Row>[] columns =
+        [
+            new BsColumn<Row>
+            {
+                Title = "Category", Value = r => r.Category, Field = r => r.Category, Groupable = true,
+            },
+        ];
+
+        var html = BsDataGrid(Data: Rows, Columns: columns, RowKey: r => r.Name,
+            Grouped: ["category"], OnGroupedChange: _ => { }).ToHtml();
+
+        Assert.DoesNotContain("colspan=\"0\"", html, StringComparison.Ordinal);
+        Assert.Contains("<td colspan=\"1\">", html, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -289,8 +402,10 @@ public class BsDataGridGroupTests
             },
         ];
 
+        // ShowGroupedColumns keeps the sole column visible — the point here is that the CELL shows the whole
+        // name while the BAND is keyed by the initial, which is only observable with the column rendered.
         var html = BsDataGrid(Data: Rows, Columns: columns, RowKey: r => r.Name,
-            Grouped: ["name"], OnGroupedChange: _ => { }).ToHtml();
+            Grouped: ["name"], OnGroupedChange: _ => { }, ShowGroupedColumns: true).ToHtml();
 
         Assert.Equal(["Initial: A (1)", "Initial: B (1)", "Initial: C (2)", "Initial: L (1)"], BandTitles(html));
         Assert.Equal(["Apple", "Banana", "Carrot", "Cherry", "Leek"], FirstCells(html));

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -663,6 +663,17 @@ public abstract partial class SharedSmokeTests
         await Expect(bands).ToHaveCountAsync(3); // AMER, APAC, EMEA
         await Expect(bands.First).ToContainTextAsync("Region: AMER");
 
+        // === Grouped columns fold away (default). Region is grouped, so its own <th> is gone — the value lives
+        //     only in the band header. "Show grouped column" flips ShowGroupedColumns to bring the column back;
+        //     toggle it off again so the rest of the walk runs against the default. ===
+        await Expect(grid.Locator("thead th:has-text('Region')")).ToHaveCountAsync(0);
+        await demo.Locator("#group-show-col").ClickAsync();
+        await Expect(grid.Locator("thead th:has-text('Region')")).ToHaveCountAsync(1,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
+        await demo.Locator("#group-show-col").ClickAsync();
+        await Expect(grid.Locator("thead th:has-text('Region')")).ToHaveCountAsync(0,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
+
         // === The user's sort applies WITHIN a band, never across it. Sorting by Account keeps three bands. ===
         await grid.Locator("th:has-text('Account') button").ClickAsync();
         await Expect(grid.Locator("th:has-text('Account')")).ToHaveAttributeAsync("aria-sort", "ascending",


### PR DESCRIPTION
## Summary

A grouped `BsDataGrid` column holds the **same value for every row in its band**, and the band header already names it (`Region: EMEA (4)`) — so rendering the column too was a run of duplicates under a header that says nothing new. The grid now folds a grouped column out of the table body: its header, cells, subtotal and footer are dropped and the band-header/detail-row colspans shrink to match. Its ungroup control lives on the panel chip (or the header, if kept). This matches AG-Grid/Telerik/DevExpress defaults.

The new **`ShowGroupedColumns: true`** restores the previous behaviour (value in the band header *and* repeated down every row).

### ⚠️ Breaking
Grouped grids re-render with fewer columns unless `ShowGroupedColumns` is set. Grouping still orders, bands and subtotals exactly as before — only the column set changes.

## How
- `VisibleColumns(columns)` folds out grouped columns **once per render** and is threaded down like `selected`/`pageKeys`; the per-cell path never re-derives it. Returns the column list unchanged (zero allocation) for any ungrouped grid or `ShowGroupedColumns: true`, so the feature stays free when unused.
- `HeaderCells` keeps the **full** list (its sort index is a position in `columns`, which the visible subset would renumber) and skips hidden headers via `IsGroupedAway`.
- Colspans clamp to `Math.Max(1, …)` for the all-columns-grouped edge (never `colspan="0"`).

## Testing
- **Unit** (`BsDataGridGroupTests` / `BsDataGridGroupServerTests`): default-hide (header + cells gone, value in band header), `ShowGroupedColumns` opt-out, multi-level hide, subtotal label on first visible column, footer no longer forces `<tfoot>`, all-columns-grouped `colspan` clamp, and both server modes (`IQueryable` + `TotalCount`). 181 BsDataGrid tests green; full local unit gate green.
- **E2E** (`SharedSmokeTests.Journey`): asserts the Region header folds away while grouped and the new "Show grouped column" toggle brings it back. 25/25 across Server WS + WASM.
- **ApiCompat**: `ShowGroupedColumns` added to the frozen public-surface list (appended, optional).

## Benchmarks (`BsDataGridBenchmarks`, 100 rows)
Hiding removes a whole column of cells+handlers, so a grouped grid now allocates **less** than a plain one:

| Case | Before (column shown) | After (hidden, default) |
|---|---|---|
| `Grid100_Grouped` | 605 KB (+5% vs plain) | **536 KB (−8%)** |
| `Grid100_GroupedNested` | 687 KB (+19%) | **542 KB (−7%)** |

CPU also improves (per-cell scans removed): Grouped 164µs (was 172µs), Nested 174µs (was 189µs).

## Changelog / docs / sample
- `CHANGELOG.md` `[Unreleased]` — breaking "Changed" entry.
- `docs/data-grid.md` — "Grouped columns fold away" section, updated cost note, Reference-table row.
- `BsDataGridGroupDemo` — a "Show grouped column" toggle demonstrating the opt-out.