### PR TITLE
refactor(cli): share the WASM SDK PropertyGroup across the two csproj builders

### DIFF
--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
@@ -50,18 +50,11 @@ internal static partial class ProjectGenerator
     // Rask.Core don't flow through the published package chain, so the --auth scaffold references them directly.
     private const string AspNetCoreFrameworkVersion = "10.0.9";
 
-    private static string WasmCsproj(bool auth, string version)
-    {
-        var authRefs = auth
-            ? $"""
-
-                    <PackageReference Include="Microsoft.JSInterop" Version="{AspNetCoreFrameworkVersion}"/>
-                    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="{AspNetCoreFrameworkVersion}"/>
-                """.TrimEnd()
-            : "";
-        return $"""
-        <Project Sdk="Microsoft.NET.Sdk.WebAssembly">
-
+    // The WebAssembly SDK <PropertyGroup> — byte-identical for the standalone `wasm` template and the
+    // `wasm-hosted` client project. Shared here so the two csproj builders (WasmCsproj and
+    // WasmHostedClientCsproj) can never drift.
+    internal const string WasmSdkPropertyGroup =
+        """
           <PropertyGroup>
             <TargetFramework>net10.0-browser</TargetFramework>
             <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
@@ -95,6 +88,21 @@ internal static partial class ProjectGenerator
                  [DynamicDependency] on them (standard Blazor WASM mitigation) instead of suppressing. -->
             <NoWarn>$(NoWarn);IL2104</NoWarn>
           </PropertyGroup>
+        """;
+
+    private static string WasmCsproj(bool auth, string version)
+    {
+        var authRefs = auth
+            ? $"""
+
+                    <PackageReference Include="Microsoft.JSInterop" Version="{AspNetCoreFrameworkVersion}"/>
+                    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="{AspNetCoreFrameworkVersion}"/>
+                """.TrimEnd()
+            : "";
+        return $"""
+        <Project Sdk="Microsoft.NET.Sdk.WebAssembly">
+
+        {WasmSdkPropertyGroup}
 
           <ItemGroup>
             <PackageReference Include="Rask.Wasm" Version="{version}"/>

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
@@ -317,46 +317,14 @@ internal static partial class ProjectGenerator
 
         """;
 
-    // NOTE: the property block mirrors the standalone `wasm` template's WasmCsproj (ProjectGenerator.Wasm.cs) —
-    // keep the two in sync. The hosted client differs only in referencing the Shared project (and never the
-    // --auth JSInterop/Authorization refs — hosted auth is cookie-based, so it needs neither).
+    // Shares the WebAssembly SDK property block with the standalone `wasm` template (WasmSdkPropertyGroup in
+    // ProjectGenerator.Wasm.cs) so the two can't drift. The hosted client differs only in referencing the
+    // Shared project (and never the --auth JSInterop/Authorization refs — hosted auth is cookie-based).
     private static string WasmHostedClientCsproj(string version) =>
         $"""
         <Project Sdk="Microsoft.NET.Sdk.WebAssembly">
 
-          <PropertyGroup>
-            <TargetFramework>net10.0-browser</TargetFramework>
-            <RuntimeIdentifier>browser-wasm</RuntimeIdentifier>
-            <OutputType>Exe</OutputType>
-            <UseAppHost>false</UseAppHost>
-            <ImplicitUsings>enable</ImplicitUsings>
-            <Nullable>enable</Nullable>
-            <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-            <!-- Rask WASM marker (gates the framework's wwwroot staging + scoped-asset bake). -->
-            <RaskWasm>true</RaskWasm>
-            <!-- Fingerprint framework assets + fill the index.html import map / preload placeholders on
-                 publish so static-host (GitHub Pages) redeploys stay subresource-integrity-safe. -->
-            <OverrideHtmlAssetPlaceholders>true</OverrideHtmlAssetPlaceholders>
-            <!-- Full WASM AOT is opt-in: publish with -p:RaskWasmAot=true (needs the wasm-tools workload)
-                 to AOT-compile IL->WASM; the default keeps the Mono interpreter. Both are gated off the fast
-                 no-native build: the SDK's runtime-pack default for this property is empty, so even 'false'
-                 is a relink trigger conflicting with -p:WasmBuildNative=false. -->
-            <RunAOTCompilation Condition=" '$(RaskWasmAot)' == 'true' ">true</RunAOTCompilation>
-            <RunAOTCompilation Condition=" '$(RaskWasmAot)' != 'true' and '$(WasmBuildNative)' != 'false' ">false</RunAOTCompilation>
-            <!-- Trimming is trim-safe: page types reach the runtime via the route registry's generated
-                 module initialiser, which emits a [DynamicDependency] per registered page. -->
-            <PublishTrimmed>true</PublishTrimmed>
-            <TrimMode>full</TrimMode>
-            <!-- Drops the ~2.6 MB of ICU data under _framework/icudt*.dat. Remove this if your app
-                 formats culture-sensitive values (dates, numbers, currency). Gated off the fast
-                 no-native build (-p:WasmBuildNative=false): the SDK forces a native relink when
-                 InvariantGlobalization=true, so the two conflict, and it's irrelevant with no runtime. -->
-            <InvariantGlobalization Condition=" '$(WasmBuildNative)' != 'false' ">true</InvariantGlobalization>
-            <!-- IL2104 comes from Microsoft.JSInterop's reflection-driven [JSInvokable] scanner; apps
-                 that only INVOKE JS never hit it. If you mark methods [JSInvokable], add a
-                 [DynamicDependency] on them (standard Blazor WASM mitigation) instead of suppressing. -->
-            <NoWarn>$(NoWarn);IL2104</NoWarn>
-          </PropertyGroup>
+        {WasmSdkPropertyGroup}
 
           <ItemGroup>
             <PackageReference Include="Rask.Wasm" Version="{version}"/>


### PR DESCRIPTION
## Summary
Pure refactor. `WasmCsproj` (the `wasm` template) and `WasmHostedClientCsproj` (the `wasm-hosted` client) each inlined the same ~35-line WebAssembly SDK `<PropertyGroup>`. Extract it into a single `WasmSdkPropertyGroup` const so the two csproj builders can't drift. No behavior change — the generated csproj output is byte-identical.

## Testing
- Unit: `scripts/run-unit-local.sh` (pre-commit gate) — **pass** (280 CLI tests + format-verify clean).
- E2E (pre-push gate): full browser suite — **pass** (no `samples/` change; verifies no regression).
- Verified byte-identity: generated `wasm` and `wasm-hosted`-client csproj `<PropertyGroup>` blocks `diff` clean, and both projects still build under `-warnaserror`.

## Benchmarks
n/a — CLI/scaffolding only, no render or live-runtime hot path.

## CHANGELOG
n/a — internal refactor with no user-facing change (generated output is byte-identical).
