### PR TITLE
fix(sqlite): harden and diagnose the raw immediate-transaction path against pooled-handle reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,16 @@ them until tagged releases begin.
   `Markup` in scope together make every unqualified use ambiguous. Test-only; no shipped behaviour changes.
 
 ### Fixed
+- **`Rask.SQLite`'s raw immediate-transaction path is hardened against pooled-handle reuse, and its
+  failures are now diagnosable.** `ExecuteInImmediateTransactionAsync` drives `BEGIN`/`COMMIT`/`ROLLBACK`
+  through the pooled native `sqlite3` handle, outside Microsoft.Data.Sqlite's transaction bookkeeping. It
+  now clears a leaked transaction before `BEGIN IMMEDIATE` (a handle that arrived mid-transaction would
+  otherwise hit a non-retryable `SQLITE_ERROR`) and, via a `finally`, never returns a mid-transaction
+  handle to the pool. When a statement genuinely fails, the thrown `SqliteException` now carries the
+  extended result code and the autocommit state (e.g. `SQLite Error 1 (errcode 1, extended 1, autocommit
+  1): '…'`) instead of the opaque `SQLite Error 1: 'not an error'` a bare exec code plus `errmsg` produced
+  when a pooled handle's returned code and error slot disagreed. The retry classifier now compares the
+  primary result code so an extended `BUSY`/`LOCKED` variant is still waited out rather than misread as fatal.
 - **`BsDataGrid`'s pager prev/next buttons had no accessible name.** They render an icon-only child (a
   decorative, `aria-hidden` `BsIcon` chevron), so a screen reader announced two unlabelled buttons on every
   grid with `PageSize > 0` — the numbered items were fine (their text names them), which made it easy to miss

--- a/benchmarks/Rask.Benchmarks.Sqlite/Baselines/README.md
+++ b/benchmarks/Rask.Benchmarks.Sqlite/Baselines/README.md
@@ -106,4 +106,8 @@ The open question is narrow: **what does `SqliteConnection.Deactivate()` execute
 and under what condition?** Answer that and the fix follows.
 
 - The harness also once logged a burst of non-busy errors on `raw-nonblocking` mid-sweep that no later run
-  reproduced. It predates the current error reporting, so its exception was never captured.
+  reproduced. It predates the current error reporting, so its exception was never captured. The raw
+  immediate-transaction path is now hardened for a recurrence: it clears a leaked transaction before
+  `BEGIN IMMEDIATE`, never returns a mid-transaction handle to the pool, and throws a `SqliteException`
+  carrying the extended result code and autocommit state — so a repeat would be attributable rather than
+  an opaque `SQLite Error 1: 'not an error'`.

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -495,6 +495,13 @@ Assert.Equal("wal", cmd.ExecuteScalar());
 See `tests/Rask.SQLite.Tests` for the unit + integration coverage, and
 `tests/Rask.Examples.E2E.Tests/SqliteExampleTests.cs` for the end-to-end concurrent-writes check.
 
+> **Careful with `SqliteConnection.ClearAllPools()`.** It is process-global and disposes the underlying
+> `sqlite3` handle of connections that are *currently leased and in use*, not just idle ones — so calling
+> it while writes are in flight can throw `ObjectDisposedException` from a live connection on another
+> thread. In tests, keep pool-clearing teardown from running in parallel with connection-using tests (the
+> SQLite test assemblies set `[assembly: CollectionBehavior(DisableTestParallelization = true)]` for this);
+> in app code, do not call it on a reset/health-check path that overlaps request handling.
+
 For load rather than correctness, `benchmarks/Rask.Benchmarks.Sqlite` drives sustained concurrent traffic and
 reports throughput, tail latency and error counts (the numbers in
 [Load-test numbers](#load-test-numbers) above). Its `check` mode is a regression gate over invariants and

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -126,6 +126,12 @@ For a transaction you drive yourself, `connection.BeginImmediate()` gives you a 
 that took the write lock up front (its wait, though, blocks the thread inside Microsoft.Data.Sqlite —
 use `ExecuteInImmediateTransactionAsync` when you want the non-blocking retry).
 
+Because the lock is taken through the pooled native handle, the path is defensive about connection
+reuse: it clears a leaked transaction before `BEGIN IMMEDIATE`, and never hands a mid-transaction handle
+back to the pool. If a statement genuinely fails it throws a `SqliteException` carrying the extended
+result code and the autocommit state, so a rare failure is attributable rather than an opaque
+`SQLite Error 1: 'not an error'`.
+
 ### Entity Framework Core — opt-in retry strategy
 
 Pass `configureRetry` (even empty) to register a fair-interval execution strategy so `SaveChanges`

--- a/src/Rask.SQLite/Rask.SQLite.csproj
+++ b/src/Rask.SQLite/Rask.SQLite.csproj
@@ -34,9 +34,11 @@
     <PackageReference Include="SQLitePCLRaw.core"/>
   </ItemGroup>
 
-  <!-- The EF Core companion shares SqlitePragmaOptions.Validate() (internal). -->
+  <!-- The EF Core companion shares SqlitePragmaOptions.Validate() (internal); the test project drives
+       the internal SqliteBusyRetry retry/diagnostics loop directly. -->
   <ItemGroup>
     <InternalsVisibleTo Include="Rask.SQLite.EntityFrameworkCore"/>
+    <InternalsVisibleTo Include="Rask.SQLite.Tests"/>
   </ItemGroup>
 
 </Project>

--- a/src/Rask.SQLite/SqliteBusyRetry.cs
+++ b/src/Rask.SQLite/SqliteBusyRetry.cs
@@ -31,8 +31,11 @@ internal static class SqliteBusyRetry
                 return;
             }
 
-            // Only a contended lock is retryable; every other result code is a real error.
-            if (rc != raw.SQLITE_BUSY && rc != raw.SQLITE_LOCKED)
+            // Only a contended lock is retryable; every other result code is a real error. Compare the
+            // primary result code (low byte) so an extended BUSY/LOCKED variant is still treated as a
+            // contended lock rather than misclassified as fatal.
+            var primary = rc & 0xFF;
+            if (primary != raw.SQLITE_BUSY && primary != raw.SQLITE_LOCKED)
             {
                 throw Failure(handle, rc);
             }
@@ -49,7 +52,20 @@ internal static class SqliteBusyRetry
 
     private static SqliteException Failure(sqlite3 handle, int rc)
     {
+        // Capture the full diagnosis straight off the handle. The bare exec return code plus errmsg can
+        // read as the meaningless "SQLite Error 1: 'not an error'" when a pooled handle's error slot and
+        // the returned rc disagree (e.g. a BEGIN issued on a handle already inside a transaction); the
+        // extended errcode and the autocommit flag make that state attributable instead of a dead end.
+        var errcode = raw.sqlite3_errcode(handle);
+        var extended = raw.sqlite3_extended_errcode(handle);
+        var autocommit = raw.sqlite3_get_autocommit(handle);
         var message = raw.sqlite3_errmsg(handle).utf8_to_string();
-        return new SqliteException($"SQLite Error {rc}: '{message}'.", rc);
+
+        // Keep the primary result code (the exec return's low byte) as SqliteErrorCode — the same value
+        // callers see today — and carry the extended code through SqliteExtendedErrorCode.
+        return new SqliteException(
+            $"SQLite Error {rc} (errcode {errcode}, extended {extended}, autocommit {autocommit}): '{message}'.",
+            rc & 0xFF,
+            extended);
     }
 }

--- a/src/Rask.SQLite/SqliteConnectionExtensions.cs
+++ b/src/Rask.SQLite/SqliteConnectionExtensions.cs
@@ -67,6 +67,16 @@ public static class SqliteConnectionExtensions
         // Thread.Sleep retry (governed by CommandTimeout) never runs either.
         raw.sqlite3_busy_timeout(handle, 0);
 
+        // BEGIN/COMMIT/ROLLBACK run through the raw handle, bypassing Microsoft.Data.Sqlite's
+        // SqliteTransaction bookkeeping, and the underlying sqlite3 handle is pooled and reused. If an
+        // earlier lease left a transaction open on it, BEGIN IMMEDIATE here would hit "cannot start a
+        // transaction within a transaction" (SQLITE_ERROR) — a non-retryable fast failure. Clear any
+        // leaked transaction first so BEGIN always starts from autocommit (Rails' transaction_active? guard).
+        if (raw.sqlite3_get_autocommit(handle) == 0)
+        {
+            raw.sqlite3_exec(handle, "ROLLBACK;");
+        }
+
         await SqliteBusyRetry.ExecAsync(handle, "BEGIN IMMEDIATE;", retry, time, cancellationToken).ConfigureAwait(false);
         try
         {
@@ -74,11 +84,16 @@ public static class SqliteConnectionExtensions
             await SqliteBusyRetry.ExecAsync(handle, "COMMIT;", retry, time, cancellationToken).ConfigureAwait(false);
             return result;
         }
-        catch
+        finally
         {
-            // Best-effort rollback; ignore the result code — the transaction may already be gone.
-            raw.sqlite3_exec(handle, "ROLLBACK;");
-            throw;
+            // Never hand a mid-transaction handle back to the pool. On the happy path COMMIT already
+            // restored autocommit and this is a no-op; on any failure (a throwing work, or a COMMIT that
+            // never completed) this rolls the open transaction back. Best-effort: ignore the result code —
+            // the transaction may already be gone.
+            if (raw.sqlite3_get_autocommit(handle) == 0)
+            {
+                raw.sqlite3_exec(handle, "ROLLBACK;");
+            }
         }
     }
 

--- a/tests/Rask.SQLite.EntityFrameworkCore.Tests/AssemblyInfo.cs
+++ b/tests/Rask.SQLite.EntityFrameworkCore.Tests/AssemblyInfo.cs
@@ -1,0 +1,8 @@
+// SQLite connection pooling and SqliteConnection.ClearAllPools() are process-global: clearing the pool
+// disposes the underlying sqlite3 handle of connections that are currently leased and in use, not just
+// idle ones. These classes open pooled connections (RaskSqliteOpenUnderLockTests deliberately holds a
+// write lock) and call ClearAllPools() in Dispose, so running them in parallel lets one class's teardown
+// clear the pool out from under another's live connection — a flaky ObjectDisposedException('SQLitePCL.sqlite3').
+// Serialise the assembly so no teardown races another class's live connections. See the sibling note in
+// Rask.SQLite.Tests/AssemblyInfo.cs.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Rask.SQLite.Tests/AssemblyInfo.cs
+++ b/tests/Rask.SQLite.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+// SQLite connection pooling is process-global, and so is SqliteConnection.ClearAllPools(): calling it
+// disposes the underlying sqlite3 handle of connections that are *currently leased and in use*, not just
+// idle ones (verified against plain Microsoft.Data.Sqlite — Pooling=False immunises it). Several classes
+// here open pooled connections and call ClearAllPools() in Dispose to release the temp-file handle. Run in
+// parallel, one class's teardown can clear the pool out from under another class's in-flight writers — the
+// concurrency stress test especially — surfacing a flaky ObjectDisposedException('SQLitePCL.sqlite3').
+// Serialise the assembly so no teardown races another class's live connections. (The SQLite load harness
+// serialises its arms for the same reason — see benchmarks/Rask.Benchmarks.Sqlite/Program.cs.)
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Rask.SQLite.Tests/SqliteBusyRetryDiagnosticsTests.cs
+++ b/tests/Rask.SQLite.Tests/SqliteBusyRetryDiagnosticsTests.cs
@@ -1,0 +1,64 @@
+using Microsoft.Data.Sqlite;
+using SQLitePCL;
+
+namespace Rask.SQLite.Tests;
+
+// The retry loop classifies a non-BUSY/LOCKED result code as a real error and throws. This proves the
+// thrown SqliteException is diagnosable: it carries the extended result code and the actual SQLite error
+// text, rather than the meaningless "SQLite Error 1: 'not an error'" the bare exec code + errmsg produced
+// when a pooled handle's error slot and the returned code disagreed.
+public sealed class SqliteBusyRetryDiagnosticsTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-sqlite-diag-{Guid.NewGuid():N}.db");
+
+    [Fact]
+    public async Task A_genuine_error_throws_a_diagnosable_exception()
+    {
+        await using var connection = new SqliteConnection($"Data Source={_dbPath}");
+        await connection.OpenAsync();
+
+        var exception = await Assert.ThrowsAsync<SqliteException>(() =>
+            SqliteBusyRetry.ExecAsync(
+                connection.Handle!,
+                "THIS IS NOT VALID SQL;",
+                new SqliteBusyRetryOptions(),
+                TimeProvider.System,
+                CancellationToken.None));
+
+        // SQLITE_ERROR(1), surfaced with the real parser message and the extended code — not "not an error".
+        Assert.Equal(1, exception.SqliteErrorCode);
+        Assert.DoesNotContain("not an error", exception.Message);
+        Assert.Contains("extended", exception.Message);
+        Assert.Contains("errcode", exception.Message);
+        Assert.Contains("syntax error", exception.Message);
+    }
+
+    [Fact]
+    public async Task Ok_statements_do_not_throw()
+    {
+        await using var connection = new SqliteConnection($"Data Source={_dbPath}");
+        await connection.OpenAsync();
+
+        // A well-formed statement returns SQLITE_OK and completes without a diagnosis.
+        await SqliteBusyRetry.ExecAsync(
+            connection.Handle!,
+            "CREATE TABLE IF NOT EXISTS ok(id INTEGER PRIMARY KEY);",
+            new SqliteBusyRetryOptions(),
+            TimeProvider.System,
+            CancellationToken.None);
+
+        Assert.Equal(1, raw.sqlite3_get_autocommit(connection.Handle!));
+    }
+
+    public void Dispose()
+    {
+        SqliteConnection.ClearAllPools();
+        foreach (var path in new[] { _dbPath, $"{_dbPath}-shm", $"{_dbPath}-wal" })
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+    }
+}

--- a/tests/Rask.SQLite.Tests/SqliteImmediateTransactionTests.cs
+++ b/tests/Rask.SQLite.Tests/SqliteImmediateTransactionTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using Microsoft.Data.Sqlite;
+using SQLitePCL;
 
 namespace Rask.SQLite.Tests;
 
@@ -111,6 +112,53 @@ public sealed class SqliteImmediateTransactionTests : IDisposable
         // The wait ended near the 150 ms timeout — not the driver's multi-second synchronous block.
         Assert.True(stopwatch.Elapsed < TimeSpan.FromSeconds(2), $"took {stopwatch.ElapsedMilliseconds} ms");
         Assert.Equal(0, Count());
+    }
+
+    [Fact]
+    public async Task Recovers_when_the_handle_arrives_with_a_leaked_transaction()
+    {
+        // The raw path drives BEGIN/COMMIT through the native handle, invisible to ADO's transaction
+        // bookkeeping, and the handle is pooled. Simulate an earlier lease that left a transaction open:
+        // once autocommit is off, a plain BEGIN IMMEDIATE would fail non-retryably ("cannot start a
+        // transaction within a transaction"). The entry guard must clear it and still commit the work.
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        Exec(connection, "BEGIN IMMEDIATE;"); // leak a write transaction onto the raw handle
+        Assert.Equal(0, raw.sqlite3_get_autocommit(connection.Handle!)); // precondition: mid-transaction
+
+        await connection.ExecuteInImmediateTransactionAsync(
+            new SqliteBusyRetryOptions(),
+            async (c, ct) =>
+            {
+                await using var cmd = c.CreateCommand();
+                cmd.CommandText = "INSERT INTO t(v) VALUES('recovered');";
+                await cmd.ExecuteNonQueryAsync(ct);
+            });
+
+        Assert.Equal(1, Count());
+        Assert.Equal(1, raw.sqlite3_get_autocommit(connection.Handle!)); // handle left clean
+    }
+
+    [Fact]
+    public async Task Leaves_the_handle_in_autocommit_after_work_throws()
+    {
+        // The finally guard must never return a mid-transaction handle to the pool, even when work throws.
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            connection.ExecuteInImmediateTransactionAsync(
+                new SqliteBusyRetryOptions(),
+                async (c, ct) =>
+                {
+                    await using var cmd = c.CreateCommand();
+                    cmd.CommandText = "INSERT INTO t(v) VALUES('doomed');";
+                    await cmd.ExecuteNonQueryAsync(ct);
+                    throw new InvalidOperationException("boom");
+                }));
+
+        Assert.Equal(0, Count());
+        Assert.Equal(1, raw.sqlite3_get_autocommit(connection.Handle!)); // rolled back, pool not poisoned
     }
 
     private static void Insert(SqliteConnection connection, SqliteTransaction transaction, string value)


### PR DESCRIPTION
## Summary

`Rask.SQLite`'s `ExecuteInImmediateTransactionAsync` drives `BEGIN`/`COMMIT`/`ROLLBACK` through the **pooled native `sqlite3` handle**, outside Microsoft.Data.Sqlite's transaction bookkeeping. This PR does two related things.

### 1. Harden + diagnose the raw immediate-transaction path
Two weaknesses combined into a rare, non-retryable, uninformative failure under write contention (`SQLite Error 1: 'not an error'`, thrown in ~57 ms — not a timeout):

- **Diagnostically blind classifier.** `SqliteBusyRetry.Failure` read only `sqlite3_errmsg` + the exec return code. It now also reads `sqlite3_errcode` / `sqlite3_extended_errcode` / `sqlite3_get_autocommit` and throws `SqliteException(msg, rc & 0xFF, extended)` via the 3-arg ctor — **primary code preserved** as `SqliteErrorCode`, extended code carried through `SqliteExtendedErrorCode`. The retry check masks to the primary result code so an extended `BUSY`/`LOCKED` variant is still waited out.
- **No transaction-state guard.** A pooled handle left mid-transaction by an earlier lease would hit `cannot start a transaction within a transaction`. It now clears a leaked transaction **before** `BEGIN IMMEDIATE`, and a `finally` (folding in the old best-effort catch-rollback) guarantees a mid-transaction handle is **never** returned to the pool.

### 2. Fix the flaky stress test (root-caused)
While verifying, a separate `ObjectDisposedException('SQLitePCL.sqlite3')` surfaced in `SqliteConcurrencyStressTests`. Investigated with a standalone repro (Rask-factory and **plain Microsoft.Data.Sqlite** modes):

- **200,000 pooled writes with no `ClearAllPools()` → zero failures** (no intrinsic burst trigger; forced gen2 GC alone does nothing either).
- A **concurrent `SqliteConnection.ClearAllPools()`** racing in-flight writers reproduces in ~9–33 iterations — **in plain Microsoft.Data.Sqlite too**. `Pooling=False` fully immunises it.

`ClearAllPools()` is process-global and disposes the `sqlite3` handle of connections **currently leased and in use**, not just idle ones. Five classes in `Rask.SQLite.Tests` call it in `Dispose`, and xUnit runs classes in parallel — so a sibling's teardown clears the pool out from under the stress test's ~200 ms burst. (The load harness serialises its arms for the same reason: `Rask.Benchmarks.Sqlite/Program.cs`.) **Not a production defect** — nothing calls `ClearAllPools()` concurrently with live work.

Fix: `[assembly: CollectionBehavior(DisableTestParallelization = true)]` on `Rask.SQLite.Tests` and `Rask.SQLite.EntityFrameworkCore.Tests` (the latter has 4 pool-clearing classes incl. a lock-holding one).

## Testing
- `dotnet format` clean; full solution `-warnaserror` build clean (0 warnings).
- `Rask.SQLite.Tests` green (40/40, +4 new/extended tests: diagnosable exception, leaked-tx recovery, handle-left-clean); EF-Core (11) and Limitations (5) green — `SqliteErrorCode` semantics for EF consumers unchanged.
- Serialised suites stay green; `Rask.SQLite.Tests` 235 ms → 441 ms (sub-second).
- Benchmark (`SqliteWriteContentionBenchmarks.NonBlockingRetry`, short job): alloc-neutral — the change adds only two `int`-returning native calls on the success path.

## Changelog
`[Unreleased] → Fixed` for the raw-path hardening/diagnostics. `docs/sqlite.md` and the benchmark baselines README updated. The test-parallelization change is test-only (no CHANGELOG).