### PR TITLE
feat(bootstrap): BsMultiSelect keyboard nav + listbox a11y parity with BsSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`BsMultiSelect` is now fully keyboard-operable and reaches listbox accessibility parity with `BsSelect`.**
+  The multiselect dropdown previously responded only to Escape; it now has a roving highlight driven by
+  **Arrow Up/Down** (with **Home/End** to jump), opens from a closed box on Arrow/Enter/Space seeding the
+  highlight to the current selection, and **Enter/Space toggle** the highlighted option's membership while
+  leaving the dropdown open (Space still types a literal space in the search field). The listbox is marked
+  `aria-multiselectable`, each option is a proper `role="option"` carrying `aria-selected`, and the box
+  advertises the highlight through `aria-activedescendant` — matching `BsSelect`'s existing combobox wiring.
+  The shared cursor/id logic lives in a new internal `BsSelectNav` helper both controls consume.
 - **`BsTimePicker` keyboard parity — `Home`/`End` and a seconds nudge.** Rounding out the picker keyboard
   story: `Home`/`End` jump the clock to the earliest/latest selectable time (the `Min`/`Max` bound, or the
   day edge — `00:00`, and `23:59`/`23:59:59` with seconds), and when `Seconds` is on, `Shift`+`ArrowUp`/

--- a/docs/bootstrap-select.md
+++ b/docs/bootstrap-select.md
@@ -17,6 +17,15 @@ multi-value, with the chosen items shown as chips (and the same opt-in `Filter`)
 live-diff, keyboard-navigable, ARIA `combobox`/`listbox`: opening a searchable select focuses the
 filter so you can type at once, and the navigation/commit keys stay inside the open dropdown —
 **Enter picks the highlighted option without submitting the surrounding form**, Escape closes.
+
+Both controls share one keyboard model over the (filtered) options: a closed box opens on
+Arrow/Enter/Space and seeds the roving highlight to the current selection; while open, **Arrow Up/Down**
+move the highlight, **Home/End** jump to the first/last option, and **Escape** closes. The highlighted
+option is the listbox's `aria-activedescendant` and carries `.active`. `BsSelect` commits with **Enter**
+(picks and closes). `BsMultiSelect` is an `aria-multiselectable` listbox whose options each expose
+`aria-selected`; **Enter/Space toggle** the highlighted option's membership and leave the dropdown open
+to pick more (inside the search field, Space types a literal space instead of toggling).
+
 `Native: true` drops `BsSelect` back to the plain OS `<select>` (handy on mobile). To bind a
 **projected field** while the options are objects, add an `OptionValue` selector —
 `BsSelect(() => model.PersonId, people, OptionValue: p => p.Id, OptionLabel: p => Text(p.Name))` binds

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -40,9 +40,11 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
     public bool? Floating { get; set; }
 
     // View state only — the selection lives in the bound model / parent Value. Toggling re-renders. _filter
-    // is the text typed into the inline search field (null when not searching).
+    // is the text typed into the inline search field (null when not searching); _cursor is the roving
+    // keyboard highlight (a flat index into the filtered option list), surfaced as aria-activedescendant.
     private bool _open;
     private string? _filter;
+    private int _cursor;
 
     // A per-instance suffix so two id-less multiselects still emit unique list/label ids for the
     // combobox aria-controls / aria-labelledby wiring. Uses the shared non-generic counter so two
@@ -103,6 +105,28 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             : Options;
         var filteredList = filtered as IReadOnlyList<TItem> ?? filtered.ToList();
 
+        // No per-option disabling in this control yet — the cursor may land on any option. (PR wiring an
+        // OptionDisabled predicate replaces this so disabled options are skipped over.)
+        Func<int, bool> optDisabled = static _ => false;
+
+        // The roving keyboard cursor lives in flat filtered-index space. Normalise it once against the current
+        // list so a filter change (which may shrink the list) can't leave it dangling past the end, and seed
+        // it to the first selected option so opening lands the highlight where the eye already is.
+        if (_open)
+        {
+            _cursor = BsSelectNav.Normalize(_cursor, filteredList.Count, optDisabled);
+        }
+
+        var firstSelected = -1;
+        for (var i = 0; i < filteredList.Count; i++)
+        {
+            if (selected is not null && selected.Contains(filteredList[i], comparer))
+            {
+                firstSelected = i;
+                break;
+            }
+        }
+
         var hasChips = selected is not null && selected.Count > 0;
         var floating = Floating is true && Label is not null;
 
@@ -142,8 +166,8 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                     Autocomplete: "off",
                     Autofocus: true,
                     Aria: new Dictionary<string, string?> { ["label"] = "Search" },
-                    OnInput: raw => _filter = raw,
-                    OnKeyDown: OnBoxKeyDown)]);
+                    OnInput: raw => { _filter = raw; _cursor = 0; },
+                    OnKeyDownAsync: e => OnKeyAsync(e, fromSearch: true))]);
         }
 
         if (searchable && filteredList.Count == 0)
@@ -157,8 +181,18 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             {
                 var captured = option;
                 var isChecked = selected is not null && selected.Contains(captured, comparer);
+                // aria-selected and the read-only checkbox both derive from isChecked (never from _cursor), so
+                // they can't drift; the cursor is surfaced only as the .active highlight. role="option" +
+                // aria-selected make this a proper listbox option for assistive tech.
+                var optAria = new Dictionary<string, string?> { ["selected"] = isChecked ? "true" : "false" };
                 rows.Add(Button(
-                    Type: "button", Class: "dropdown-item d-flex align-items-center gap-2", Disabled: Disabled,
+                    Type: "button",
+                    Class: BsClass.Join("dropdown-item d-flex align-items-center gap-2",
+                        _open && idx == _cursor ? "active" : null),
+                    Id: BsSelectNav.OptId(prefix, idx),
+                    Role: "option",
+                    Aria: optAria,
+                    Disabled: Disabled,
                     OnClickAsync: disabled ? null : () => ToggleAsync(acc, ctx, fid, captured, comparer, add: !isChecked),
                     Key: idx)[
                     Input<string>(InputType.Checkbox, Class: "form-check-input m-0 pe-none", Checked: isChecked),
@@ -179,6 +213,11 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             boxAria["labelledby"] = labelId;
         }
 
+        if (_open && _cursor >= 0 && _cursor < filteredList.Count)
+        {
+            boxAria["activedescendant"] = BsSelectNav.OptId(prefix, _cursor);
+        }
+
         // Merge the shared aria-invalid/aria-describedby contract (the same builder BsSelect/BsFormControl
         // use) so the four controls stay in lockstep if it ever grows.
         if (BsClass.FieldAria(invalid, errorId) is { } fa)
@@ -197,8 +236,20 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             Role: "combobox",
             TabIndex: disabled ? null : 0,
             Aria: boxAria,
-            OnClick: disabled ? null : () => { _open = !_open; if (!_open) { _filter = null; } },
-            OnKeyDown: disabled ? null : OnBoxKeyDown)[box];
+            OnClick: disabled ? null : () =>
+            {
+                if (_open)
+                {
+                    _open = false;
+                    _filter = null;
+                }
+                else
+                {
+                    _cursor = BsSelectNav.Seed(firstSelected, filteredList.Count, optDisabled);
+                    _open = true;
+                }
+            },
+            OnKeyDownAsync: disabled ? null : e => OnKeyAsync(e, fromSearch: false))[box];
 
         var labelNode = Label is null
             ? null
@@ -217,9 +268,11 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             ? Div(Class: BsClass.Join("form-floating bs-floating", hasChips ? "bs-floating-filled" : null,
                 Position.Relative))[boxDiv, labelNode]
             : boxDiv);
-        children.Add(Div(Id: listId, Role: "listbox", Class: _open
-            ? BsClass.Join("dropdown-menu show", Display.Block(), Sizing.W(100))
-            : "dropdown-menu")[rows]);
+        children.Add(Div(Id: listId, Role: "listbox",
+            Aria: new Dictionary<string, string?> { ["multiselectable"] = "true" },
+            Class: _open
+                ? BsClass.Join("dropdown-menu show", Display.Block(), Sizing.W(100))
+                : "dropdown-menu")[rows]);
 
         if (_open && !disabled)
         {
@@ -240,14 +293,55 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         }
 
         return Div(Class: BsClass.Join("dropdown", Class), Id: Id, Data: BsPopover.Wrapper)[children];
-    }
 
-    private void OnBoxKeyDown(KeyboardEventArgs e)
-    {
-        if (e.Key == "Escape")
+        // Combobox keyboard over the FILTERED list, mirroring BsSelect's OnKeyAsync: arrows move the roving
+        // cursor (skipping disabled options), Home/End jump, Enter/Space toggle the cursor option's membership,
+        // Escape closes. A local function so it captures this render's binding state (acc/ctx/fid/selected/…),
+        // exactly as the chip-remove and option-click handlers do. `fromSearch` is true when the event comes
+        // from the in-dropdown search field, where Space must type a literal space instead of toggling.
+        async Task OnKeyAsync(KeyboardEventArgs e, bool fromSearch)
         {
-            _open = false;
-            _filter = null;
+            var count = filteredList.Count;
+            if (!_open)
+            {
+                if (e.Key is "ArrowDown" or "ArrowUp" or "Enter" or " ")
+                {
+                    _cursor = BsSelectNav.Seed(firstSelected, count, optDisabled);
+                    _open = true;
+                }
+
+                return;
+            }
+
+            switch (e.Key)
+            {
+                case "Escape":
+                    _open = false;
+                    _filter = null;
+                    break;
+                case "ArrowDown":
+                    _cursor = BsSelectNav.Step(_cursor, 1, count, optDisabled);
+                    break;
+                case "ArrowUp":
+                    _cursor = BsSelectNav.Step(_cursor, -1, count, optDisabled);
+                    break;
+                case "Home":
+                    _cursor = BsSelectNav.FirstEnabled(count, optDisabled);
+                    break;
+                case "End":
+                    _cursor = BsSelectNav.LastEnabled(count, optDisabled);
+                    break;
+                case "Enter":
+                case " " when !fromSearch:
+                    if (_cursor >= 0 && _cursor < count && !optDisabled(_cursor))
+                    {
+                        var item = filteredList[_cursor];
+                        var isChecked = selected is not null && selected.Contains(item, comparer);
+                        await ToggleAsync(acc, ctx, fid, item, comparer, add: !isChecked).ConfigureAwait(false);
+                    }
+
+                    break;
+            }
         }
     }
 

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -138,7 +138,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
 
         if (_open && _cursor >= 0 && _cursor < filtered.Count)
         {
-            aria["activedescendant"] = OptId(prefix, _cursor);
+            aria["activedescendant"] = BsSelectNav.OptId(prefix, _cursor);
         }
 
         if (FieldAria(b, controlId) is { } fa)
@@ -205,7 +205,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
                 rows.Add(Button(
                     Type: "button",
                     Class: BsClass.Join("dropdown-item", isSelected || (_open && idx == _cursor) ? "active" : null),
-                    Id: OptId(prefix, idx),
+                    Id: BsSelectNav.OptId(prefix, idx),
                     Role: "option",
                     Aria: isSelected ? SelectedAria : null,
                     Disabled: Disabled,
@@ -289,9 +289,6 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         _cursor = s >= 0 ? s : 0;
         _open = true;
     }
-
-    private static string OptId(string prefix, int idx) =>
-        prefix + "-opt-" + idx.ToString(CultureInfo.InvariantCulture);
 
     // Index of the option whose projected value equals the bound value, or -1.
     private int SelectedIndex(in Bound b, IReadOnlyList<TItem> opts)

--- a/src/Rask.Bootstrap/BsSelectNav.cs
+++ b/src/Rask.Bootstrap/BsSelectNav.cs
@@ -1,0 +1,99 @@
+using System.Globalization;
+
+namespace Rask.Bootstrap;
+
+// Shared keyboard/id helpers for the Bs select family (BsSelect + BsMultiSelect). The two controls cannot
+// share a base class (BsSelectBase<TValue,TItem> : BsFormControl<TValue> vs BsMultiSelect<TItem> : BsBlock),
+// so the option-id scheme (for aria-activedescendant) and the roving-cursor math over the flat option list
+// live here as a static helper both consume. The cursor is a flat index; every mover takes a `disabled`
+// predicate so a per-option-disabled option is skipped over rather than landed on.
+internal static class BsSelectNav
+{
+    // The stable per-option id an aria-activedescendant points at: "{prefix}-opt-{flatIndex}".
+    internal static string OptId(string prefix, int idx) =>
+        prefix + "-opt-" + idx.ToString(CultureInfo.InvariantCulture);
+
+    // First/last option index the keyboard cursor may land on, skipping disabled options; -1 if all disabled.
+    internal static int FirstEnabled(int count, Func<int, bool> disabled)
+    {
+        for (var i = 0; i < count; i++)
+        {
+            if (!disabled(i))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    internal static int LastEnabled(int count, Func<int, bool> disabled)
+    {
+        for (var i = count - 1; i >= 0; i--)
+        {
+            if (!disabled(i))
+            {
+                return i;
+            }
+        }
+
+        return -1;
+    }
+
+    // Moves the cursor one enabled option in `dir` (±1), skipping disabled ones; stays put when there is no
+    // enabled option that way (so ArrowDown at the last enabled option is a no-op, not a wrap-around).
+    internal static int Step(int cursor, int dir, int count, Func<int, bool> disabled)
+    {
+        for (var i = cursor + dir; i >= 0 && i < count; i += dir)
+        {
+            if (!disabled(i))
+            {
+                return i;
+            }
+        }
+
+        return cursor;
+    }
+
+    // The cursor to seed when the popover opens: the selected option if it is in range and enabled, else the
+    // first enabled option (-1 when every option is disabled/there are none).
+    internal static int Seed(int selected, int count, Func<int, bool> disabled) =>
+        selected >= 0 && selected < count && !disabled(selected)
+            ? selected
+            : FirstEnabled(count, disabled);
+
+    // Clamps a possibly-stale cursor back into the current (filtered) list and off any disabled option, so
+    // mutation points can set _cursor loosely (e.g. 0 on a filter change) and let render snap it once. Prefers
+    // the nearest enabled option forward, then backward; -1 when nothing is selectable.
+    internal static int Normalize(int cursor, int count, Func<int, bool> disabled)
+    {
+        if (count == 0)
+        {
+            return -1;
+        }
+
+        if (cursor < 0)
+        {
+            return FirstEnabled(count, disabled);
+        }
+
+        if (cursor >= count)
+        {
+            return LastEnabled(count, disabled);
+        }
+
+        if (!disabled(cursor))
+        {
+            return cursor;
+        }
+
+        var forward = Step(cursor, 1, count, disabled);
+        if (forward != cursor)
+        {
+            return forward;
+        }
+
+        var backward = Step(cursor, -1, count, disabled);
+        return backward != cursor ? backward : -1;
+    }
+}

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -20,9 +20,12 @@ public class BsMultiSelectTests
             "<div class=\"form-select h-auto d-flex flex-wrap align-items-center gap-1\" data-rask-anchor=\"\" " +
             "role=\"combobox\" tabindex=\"0\" aria-haspopup=\"listbox\" aria-expanded=\"false\" " +
             "aria-controls=\"m-list\"><span class=\"text-secondary\">Select&#x2026;</span></div>", html);
-        Assert.Contains("<div id=\"m-list\" class=\"dropdown-menu\" role=\"listbox\">", html);
         Assert.Contains(
-            "<button class=\"dropdown-item d-flex align-items-center gap-2\" data-rask-key=\"0\" type=\"button\">" +
+            "<div id=\"m-list\" class=\"dropdown-menu\" role=\"listbox\" aria-multiselectable=\"true\">", html);
+        // Each row is a proper listbox option: id (for aria-activedescendant), role="option", aria-selected.
+        Assert.Contains(
+            "<button id=\"m-opt-0\" class=\"dropdown-item d-flex align-items-center gap-2\" data-rask-key=\"0\" " +
+            "role=\"option\" aria-selected=\"false\" type=\"button\">" +
             "<input class=\"form-check-input m-0 pe-none\" type=\"checkbox\" />a</button>", html);
     }
 

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -85,6 +85,84 @@ public sealed class MultiSelectTests
     }
 
     [Fact]
+    public async Task ArrowDown_WhenClosed_OpensAndSeedsCursorToFirstOption()
+    {
+        var (page, _) = MountBound();
+        var keyId = page.HandlerIds("keydown")[0]; // closed → the box is the only keydown handler
+
+        await page.InvokeAsync(keyId, "{\"key\":\"ArrowDown\"}");
+
+        var html = page.Render();
+        Assert.Contains("dropdown-menu show", html);                              // opened
+        Assert.Equal("Tags-opt-0", Markup.Attr(html, "aria-activedescendant")!);  // seeded to the first option
+    }
+
+    [Fact]
+    public async Task ArrowKeys_HomeEnd_MoveRovingCursor_TrackingActiveDescendant()
+    {
+        var (page, _) = MountBound();
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open (cursor seeded to option 0)
+
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\"ArrowDown\"}"); // 0 -> 1
+        var html = page.Render();
+        Assert.Equal("Tags-opt-1", Markup.Attr(html, "aria-activedescendant")!);
+        // the highlighted (not selected) option carries .active
+        Assert.Contains(
+            "<button id=\"Tags-opt-1\" class=\"dropdown-item d-flex align-items-center gap-2 active\"", html);
+
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\"End\"}"); // -> last
+        Assert.Equal("Tags-opt-2", Markup.Attr(page.Render(), "aria-activedescendant")!);
+
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\"Home\"}"); // -> first
+        Assert.Equal("Tags-opt-0", Markup.Attr(page.Render(), "aria-activedescendant")!);
+    }
+
+    [Fact]
+    public async Task Enter_TogglesCursorOptionMembership()
+    {
+        var (page, model) = MountBound();
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open, cursor seeded to option 0 ("a")
+
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\"Enter\"}");
+
+        Assert.Equal(["a"], model.Tags);
+        var html = page.Render();
+        Assert.Contains("badge", html);                        // chip rendered
+        Assert.Contains("aria-selected=\"true\"", html);       // the option reflects selection
+    }
+
+    [Fact]
+    public async Task Space_FromBox_TogglesCursorOption()
+    {
+        var (page, model) = MountBound();
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open, cursor at option 0
+
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\" \"}");
+
+        Assert.Equal(["a"], model.Tags);
+    }
+
+    [Fact]
+    public async Task Space_InSearchField_TypesSpace_DoesNotToggle()
+    {
+        // With a Filter, the open dropdown grows a search field. Space there must type a literal space (fall
+        // through), never toggle the cursor option — the box handler owns Space-to-toggle, the search doesn't.
+        var model = new Bag();
+        var page = RaskTest.Render(
+            () => Form(model)[BsMultiSelect<string>(
+                () => model.Tags, Options,
+                Filter: (o, t) => o.Contains(t, StringComparison.OrdinalIgnoreCase))],
+            TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open → search field appears
+
+        var keydownIds = page.HandlerIds("keydown"); // [box, search field]
+        await page.InvokeAsync(keydownIds[1], "{\"key\":\" \"}"); // Space in the search field
+
+        Assert.Empty(model.Tags);                              // no membership toggled
+        Assert.Contains("dropdown-menu show", page.Render());  // still open
+    }
+
+    [Fact]
     public async Task SelectOption_AddsToCollection_RendersChipAndCheck()
     {
         var (page, model) = MountBound();


### PR DESCRIPTION
## Summary

`BsMultiSelect<T>` responded only to **Escape** and rendered plain `<button>` option rows — a real WCAG combobox/listbox gap next to `BsSelect`, which already had full keyboard nav and `role="option"`/`aria-selected`/`aria-activedescendant`. This is **PR1 of a select-family completeness epic** and brings `BsMultiSelect` to keyboard + a11y parity.

- **Roving keyboard cursor:** Arrow Up/Down move the highlight, Home/End jump, a closed box opens on Arrow/Enter/Space seeding the highlight to the current selection, and **Enter/Space toggle** the highlighted option's membership while leaving the dropdown open (Space still types a literal space inside the search field).
- **Listbox semantics:** the menu is `aria-multiselectable`; each row is a `role="option"` carrying `aria-selected`; the box advertises the highlight via `aria-activedescendant`.
- **No drift:** `aria-selected` and the read-only checkbox both derive from the same `isChecked` local (never from the cursor); the cursor shows only as the `.active` highlight.
- **Shared helper:** the cursor/id logic (`OptId` + `FirstEnabled`/`LastEnabled`/`Step`/`Seed`/`Normalize`) moves into a new internal `BsSelectNav` both controls consume (the two can't share a base class). `BsSelect`'s private `OptId` is rewired to it — output-identical. The cursor movers already take a `disabled` predicate so the next PRs (per-option disable, option groups) wire in with minimal churn.

The Escape-only `OnBoxKeyDown` is replaced by an in-`Render` async local (`OnKeyAsync`) that captures this render's binding state, exactly as the chip-remove/option-click handlers do.

## Testing

- **Unit (green):** static `role=option`/`aria-selected`/`aria-multiselectable` assertions in `BsMultiSelectTests`; behavioural open-on-key, Arrow/Home/End cursor tracking (`aria-activedescendant`), Enter/Space toggle, and Space-in-search in the `MultiSelect` demo suite (5 new).
- Full local unit gate passed (all projects), `dotnet format` clean, `-warnaserror` analyzer-clean build.
- Browser E2E gate (pre-push) passed — the existing multiselect journey still holds against the new markup.

## Benchmarks

Not applicable — Bootstrap layer, no render hot-path touched.

## Changelog

`[Unreleased]` → Added entry.