### PR TITLE
chore(release): v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-07-16
+
 ### Changed
 - **The `rask` CLI now owns all scaffolding — `rask new --template wasm-hosted` is generated directly, and the
   `Rask.Templates` package is discontinued.** `wasm-hosted` was the last template still shelling out to


### PR DESCRIPTION
Promotes the accumulated `[Unreleased]` changelog entries to a dated release section, **`## [0.18.0] - 2026-07-16`**, leaving an empty `[Unreleased]` at the top (Keep a Changelog).

**Why 0.18.0** (minor bump from 0.17.0, pre-1.0): the set includes new features (`rask db`, `rask deploy`) alongside breaking changes (the `Rask.Templates` package removal and the `BsDataGrid` grouped-column default) — a minor bump in a 0.x line.

Changelog only, no code changes. Tagging `v0.18.0` (which MinVer reads and `release.yml` acts on to pack + publish to NuGet) is the separate next step, not part of this PR.