### PR TITLE
feat(bootstrap): per-option OptionDisabled + Select-all header (select family PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`BsSelect` and `BsMultiSelect` gain per-option disabling, and `BsMultiSelect` gains a "Select all / Clear
+  all" header.** A new `OptionDisabled` predicate (`item => bool`) on both controls marks individual options
+  non-selectable: the option renders greyed with `aria-disabled`, takes no click, and the keyboard cursor
+  skips over it (in `Native` mode it becomes a disabled `<option>`). `BsMultiSelect` also accepts
+  `SelectAll: true`, which adds a header row that toggles every shown, enabled option in one click —
+  respecting an active `Filter` and never touching a disabled option, in both bound and controlled modes.
 - **`BsMultiSelect` is now fully keyboard-operable and reaches listbox accessibility parity with `BsSelect`.**
   The multiselect dropdown previously responded only to Escape; it now has a roving highlight driven by
   **Arrow Up/Down** (with **Home/End** to jump), opens from a closed box on Arrow/Enter/Space seeding the

--- a/docs/bootstrap-select.md
+++ b/docs/bootstrap-select.md
@@ -31,6 +31,12 @@ to pick more (inside the search field, Space types a literal space instead of to
 `BsSelect(() => model.PersonId, people, OptionValue: p => p.Id, OptionLabel: p => Text(p.Name))` binds
 the id but renders/searches the whole `Person`.
 
+Both controls accept an **`OptionDisabled` predicate** (`item => bool`) to mark individual options
+non-selectable: a disabled option renders greyed with `aria-disabled`, takes no click, and the keyboard
+cursor skips over it (in `Native` mode it becomes a disabled `<option>`). `BsMultiSelect` additionally
+takes **`SelectAll: true`**, which adds a "Select all / Clear all" header row that toggles every shown,
+enabled option in one click (respecting an active `Filter` and never touching a disabled option).
+
 ## `BsSelect<T>` variants
 
 The same control across every option: basic (binds the option), `Floating` label, searchable

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -29,10 +29,19 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
     public string? Placeholder { get; set; }
     public bool? Disabled { get; set; }
 
+    // Marks individual options non-selectable. A disabled option renders greyed (aria-disabled), takes no
+    // click, and the keyboard cursor skips over it; e.g. OptionDisabled: t => t.Retired.
+    public Func<TItem, bool>? OptionDisabled { get; set; }
+
     // The predicate that decides whether an option matches the text typed into the dropdown's search field.
     // Only when it is supplied does the dropdown show a search field and narrow the options; e.g.
     // Filter: (t, text) => t.Name.Contains(text, StringComparison.OrdinalIgnoreCase).
     public Func<TItem, string, bool>? Filter { get; set; }
+
+    // Opt in to a "Select all / Clear all" header row at the top of the dropdown. It toggles the currently
+    // shown (filtered), enabled options in one click — adds them all, or clears them when they are already
+    // all selected — never touching a disabled option. With a Filter active it applies to the visible subset.
+    public bool? SelectAll { get; set; }
 
     // Optional field label. Floating wraps the control + label in a .form-floating (the .form-select
     // control box makes Bootstrap float the label just like a native select); otherwise it sits above.
@@ -105,9 +114,9 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             : Options;
         var filteredList = filtered as IReadOnlyList<TItem> ?? filtered.ToList();
 
-        // No per-option disabling in this control yet — the cursor may land on any option. (PR wiring an
-        // OptionDisabled predicate replaces this so disabled options are skipped over.)
-        Func<int, bool> optDisabled = static _ => false;
+        // Per-option disable predicate over the filtered list; the keyboard cursor skips these indices and the
+        // option row takes no click.
+        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(filteredList[i]) == true;
 
         // The roving keyboard cursor lives in flat filtered-index space. Normalise it once against the current
         // list so a filter change (which may shrink the list) can't leave it dangling past the end, and seed
@@ -170,6 +179,31 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                     OnKeyDownAsync: e => OnKeyAsync(e, fromSearch: true))]);
         }
 
+        // Opt-in "Select all / Clear all" header: toggles every shown, ENABLED option in one click (never a
+        // disabled one). Shows "Clear all" once they are all selected. Not part of the roving-cursor option
+        // space (it is a bulk-action button, not a role="option"), so arrow keys skip it.
+        if (SelectAll is true && !disabled)
+        {
+            var enabledFiltered = new List<TItem>();
+            for (var i = 0; i < filteredList.Count; i++)
+            {
+                if (!optDisabled(i))
+                {
+                    enabledFiltered.Add(filteredList[i]);
+                }
+            }
+
+            if (enabledFiltered.Count > 0)
+            {
+                var allOn = enabledFiltered.All(o => selected is not null && selected.Contains(o, comparer));
+                rows.Add(Button(
+                    Type: "button",
+                    Class: "dropdown-item d-flex align-items-center gap-2 fw-semibold",
+                    OnClickAsync: () => SelectAllAsync(acc, ctx, fid, enabledFiltered, comparer, add: !allOn))[
+                    allOn ? "Clear all" : "Select all"]);
+            }
+        }
+
         if (searchable && filteredList.Count == 0)
         {
             rows.Add(Span(Class: BsClass.Join("dropdown-item", "disabled", Txt.Muted))["No matches"]);
@@ -181,10 +215,17 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             {
                 var captured = option;
                 var isChecked = selected is not null && selected.Contains(captured, comparer);
+                var optionDisabled = disabled || optDisabled(idx);
                 // aria-selected and the read-only checkbox both derive from isChecked (never from _cursor), so
                 // they can't drift; the cursor is surfaced only as the .active highlight. role="option" +
-                // aria-selected make this a proper listbox option for assistive tech.
+                // aria-selected make this a proper listbox option for assistive tech; a per-option-disabled row
+                // adds aria-disabled and drops its click handler.
                 var optAria = new Dictionary<string, string?> { ["selected"] = isChecked ? "true" : "false" };
+                if (optionDisabled)
+                {
+                    optAria["disabled"] = "true";
+                }
+
                 rows.Add(Button(
                     Type: "button",
                     Class: BsClass.Join("dropdown-item d-flex align-items-center gap-2",
@@ -192,8 +233,10 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                     Id: BsSelectNav.OptId(prefix, idx),
                     Role: "option",
                     Aria: optAria,
-                    Disabled: Disabled,
-                    OnClickAsync: disabled ? null : () => ToggleAsync(acc, ctx, fid, captured, comparer, add: !isChecked),
+                    Disabled: optionDisabled ? true : null,
+                    OnClickAsync: optionDisabled
+                        ? null
+                        : () => ToggleAsync(acc, ctx, fid, captured, comparer, add: !isChecked),
                     Key: idx)[
                     Input<string>(InputType.Checkbox, Class: "form-check-input m-0 pe-none", Checked: isChecked),
                     LabelOf(captured)
@@ -364,6 +407,39 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         {
             var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
             BindingHelpers.SetCollectionMembership(next, item, add, comparer);
+            await ((IFormControl<ICollection<TItem>>)this).InvokeOnChangeAsync(next).ConfigureAwait(false);
+        }
+    }
+
+    // Bulk add/remove for the "Select all / Clear all" header — applies membership to every item then notifies
+    // once (bound: mutate the model collection in place; controlled: emit a fresh list), mirroring ToggleAsync.
+    private async Task SelectAllAsync(
+        ExpressionAccessor.Accessor? acc, EditContext? ctx, FieldIdentifier fid,
+        IReadOnlyList<TItem> items, IEqualityComparer<TItem> comparer, bool add)
+    {
+        if (acc is not null)
+        {
+            if (acc.Getter() is not ICollection<TItem> collection)
+            {
+                return;
+            }
+
+            foreach (var item in items)
+            {
+                BindingHelpers.SetCollectionMembership(collection, item, add, comparer);
+            }
+
+            await BindingHelpers.NotifyAndValidateFieldAsync(ctx, fid).ConfigureAwait(false);
+            await ((IFormControl<ICollection<TItem>>)this).InvokeAfterBindAsync(collection).ConfigureAwait(false);
+        }
+        else
+        {
+            var next = Value is null ? new List<TItem>() : new List<TItem>(Value);
+            foreach (var item in items)
+            {
+                BindingHelpers.SetCollectionMembership(next, item, add, comparer);
+            }
+
             await ((IFormControl<ICollection<TItem>>)this).InvokeOnChangeAsync(next).ConfigureAwait(false);
         }
     }

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -24,6 +24,10 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
     // Filter: (p, text) => p.Name.Contains(text, StringComparison.OrdinalIgnoreCase).
     public Func<TItem, string, bool>? Filter { get; set; }
 
+    // Marks individual options non-selectable. A disabled option renders greyed (aria-disabled), takes no
+    // click, and the keyboard cursor skips over it; e.g. OptionDisabled: p => p.SoldOut.
+    public Func<TItem, bool>? OptionDisabled { get; set; }
+
     // Opt out of the custom popover and render the native <select> instead. Guarantees a working control
     // (and the OS picker on mobile) where the custom UI is unwanted.
     public bool? Native { get; set; }
@@ -38,8 +42,6 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
     private string? _filter;
 
     private static readonly IEqualityComparer<TValue> Comparer = EqualityComparer<TValue>.Default;
-    private static readonly IReadOnlyDictionary<string, string?> SelectedAria =
-        new Dictionary<string, string?> { ["selected"] = "true" };
 
     // A nullable value-type binding (int?/DateOnly?/…) can be cleared back to null; mirrors the pickers'
     // CanClear. Reference types can't be told from their non-nullable form at runtime, so — like the
@@ -83,7 +85,10 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
 
         for (var i = 0; i < opts.Count; i++)
         {
-            children.Add(Option(Value: BindingHelpers.FormatValue(ValueOf(opts[i])), Key: i)[LabelOf(opts[i])]);
+            children.Add(Option(
+                Value: BindingHelpers.FormatValue(ValueOf(opts[i])),
+                Disabled: OptionDisabled?.Invoke(opts[i]) == true ? true : null,
+                Key: i)[LabelOf(opts[i])]);
         }
 
         var control = Select<string>(
@@ -119,6 +124,16 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         var filtered = searchable && !string.IsNullOrEmpty(_filter)
             ? opts.Where(o => Filter!(o, _filter)).ToList()
             : opts;
+
+        // Per-option disable predicate over the filtered list; the keyboard cursor skips these indices.
+        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(filtered[i]) == true;
+
+        // Snap the roving cursor into the current filtered list and off any disabled option (a filter change
+        // sets _cursor loosely, and a selected-but-disabled seed must move to the nearest enabled option).
+        if (_open)
+        {
+            _cursor = BsSelectNav.Normalize(_cursor, filtered.Count, optDisabled);
+        }
 
         // The box shows the selected option's (rich) label, or the muted placeholder; blank while floating+empty.
         Component? content = selectedIdx >= 0
@@ -202,15 +217,33 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
                 var idx = i;
                 var item = filtered[i];
                 var isSelected = b.Current is not null && Comparer.Equals(ValueOf(item), b.Current);
+                var optionDisabled = optDisabled(idx);
+                // aria dict only when there's something to say (keeps the enabled/unselected option markup as
+                // it was): aria-selected first, then aria-disabled — a disabled option stays a role="option".
+                Dictionary<string, string?>? optAria = null;
+                if (isSelected || optionDisabled)
+                {
+                    optAria = new Dictionary<string, string?>();
+                    if (isSelected)
+                    {
+                        optAria["selected"] = "true";
+                    }
+
+                    if (optionDisabled)
+                    {
+                        optAria["disabled"] = "true";
+                    }
+                }
+
                 rows.Add(Button(
                     Type: "button",
                     Class: BsClass.Join("dropdown-item", isSelected || (_open && idx == _cursor) ? "active" : null),
                     Id: BsSelectNav.OptId(prefix, idx),
                     Role: "option",
-                    Aria: isSelected ? SelectedAria : null,
-                    Disabled: Disabled,
+                    Aria: optAria,
+                    Disabled: disabled || optionDisabled ? true : null,
                     Key: idx,
-                    OnClickAsync: disabled ? null : () => WriteAsync(b, ValueOf(item)))[LabelOf(item)]);
+                    OnClickAsync: disabled || optionDisabled ? null : () => WriteAsync(b, ValueOf(item)))[LabelOf(item)]);
             }
         }
 
@@ -276,7 +309,8 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         return Div(Class: BsClass.Join("dropdown", Class), Data: BsPopover.Wrapper)[children];
     }
 
-    // Clicking the display box toggles the popover; opening seeds the keyboard cursor to the selected option.
+    // Clicking the display box toggles the popover; opening seeds the keyboard cursor to the selected option
+    // (or the first enabled option when the selection is disabled/absent).
     private void Toggle(Bound b, IReadOnlyList<TItem> opts)
     {
         if (_open)
@@ -285,8 +319,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             return;
         }
 
-        var s = SelectedIndex(b, opts);
-        _cursor = s >= 0 ? s : 0;
+        _cursor = BsSelectNav.Seed(SelectedIndex(b, opts), opts.Count, i => OptionDisabled?.Invoke(opts[i]) == true);
         _open = true;
     }
 
@@ -316,16 +349,18 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         _filter = null;
     }
 
-    // Combobox keyboard over the FILTERED list: arrows move the cursor, Home/End jump, Enter picks the
-    // cursor, Escape closes. Space is left to type into the filter. Focus already opened the popover.
+    // Combobox keyboard over the FILTERED list: arrows move the cursor (skipping disabled options), Home/End
+    // jump to the first/last enabled option, Enter picks the cursor, Escape closes. Space is left to type into
+    // the filter. Focus already opened the popover.
     private async Task OnKeyAsync(Bound b, IReadOnlyList<TItem> filtered, KeyboardEventArgs e)
     {
+        var count = filtered.Count;
+        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(filtered[i]) == true;
         if (!_open)
         {
             if (e.Key is "ArrowDown" or "ArrowUp" or "Enter" or " ")
             {
-                var s = SelectedIndex(b, filtered);
-                _cursor = s >= 0 ? s : 0;
+                _cursor = BsSelectNav.Seed(SelectedIndex(b, filtered), count, optDisabled);
                 _open = true;
             }
 
@@ -338,19 +373,19 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
                 CloseAndReset();
                 break;
             case "ArrowDown":
-                _cursor = Math.Min(_cursor + 1, filtered.Count - 1);
+                _cursor = BsSelectNav.Step(_cursor, 1, count, optDisabled);
                 break;
             case "ArrowUp":
-                _cursor = Math.Max(_cursor - 1, 0);
+                _cursor = BsSelectNav.Step(_cursor, -1, count, optDisabled);
                 break;
             case "Home":
-                _cursor = 0;
+                _cursor = BsSelectNav.FirstEnabled(count, optDisabled);
                 break;
             case "End":
-                _cursor = filtered.Count - 1;
+                _cursor = BsSelectNav.LastEnabled(count, optDisabled);
                 break;
             case "Enter":
-                if (_cursor >= 0 && _cursor < filtered.Count)
+                if (_cursor >= 0 && _cursor < count && !optDisabled(_cursor))
                 {
                     await WriteAsync(b, ValueOf(filtered[_cursor])).ConfigureAwait(false);
                 }

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -108,6 +108,28 @@ public class BsMultiSelectTests
             "<div id=\"m-error\" class=\"invalid-feedback d-block\" role=\"alert\">pick a tag</div>", after);
     }
 
+    [Fact]
+    public void MultiSelect_OptionDisabled_RendersAriaDisabledOption() =>
+        // A per-option-disabled row keeps role="option" + aria-selected but adds aria-disabled and the disabled
+        // attribute; the enabled rows are unaffected.
+        Assert.Contains(
+            "<button id=\"m-opt-1\" class=\"dropdown-item d-flex align-items-center gap-2\" data-rask-key=\"1\" " +
+            "role=\"option\" aria-selected=\"false\" aria-disabled=\"true\" type=\"button\" disabled>",
+            BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string>(),
+                OptionDisabled: o => o == "b", Id: "m").ToHtml());
+
+    [Fact]
+    public void MultiSelect_SelectAll_RendersSelectAllHeader() =>
+        // Opt-in header row at the top of the menu; "Select all" while not everything is selected.
+        Assert.Contains("fw-semibold\" type=\"button\">Select all</button>",
+            BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string>(), SelectAll: true, Id: "m").ToHtml());
+
+    [Fact]
+    public void MultiSelect_SelectAll_ShowsClearAll_WhenAllEnabledSelected() =>
+        Assert.Contains(">Clear all</button>",
+            BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string> { "a", "b" }, SelectAll: true)
+                .ToHtml());
+
     private sealed class TagModel
     {
         public List<string> Tags { get; set; } = [];

--- a/tests/Rask.Bootstrap.Tests/BsSelectNavTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectNavTests.cs
@@ -1,0 +1,66 @@
+namespace Rask.Bootstrap.Tests;
+
+// Unit tests for the shared roving-cursor math that both BsSelect and BsMultiSelect drive (BsSelectNav).
+// The `disabled` predicate lets the cursor skip per-option-disabled indices; -1 means "nothing selectable".
+public class BsSelectNavTests
+{
+    private static Func<int, bool> Disabled(params int[] idx) => i => idx.Contains(i);
+    private static readonly Func<int, bool> None = _ => false;
+
+    [Fact]
+    public void OptId_Formats_PrefixOptIndex() =>
+        Assert.Equal("x-opt-3", BsSelectNav.OptId("x", 3));
+
+    [Fact]
+    public void FirstEnabled_SkipsLeadingDisabled()
+    {
+        Assert.Equal(0, BsSelectNav.FirstEnabled(3, None));
+        Assert.Equal(2, BsSelectNav.FirstEnabled(4, Disabled(0, 1)));
+        Assert.Equal(-1, BsSelectNav.FirstEnabled(2, Disabled(0, 1))); // all disabled
+        Assert.Equal(-1, BsSelectNav.FirstEnabled(0, None));           // empty
+    }
+
+    [Fact]
+    public void LastEnabled_SkipsTrailingDisabled()
+    {
+        Assert.Equal(2, BsSelectNav.LastEnabled(3, None));
+        Assert.Equal(1, BsSelectNav.LastEnabled(4, Disabled(2, 3)));
+        Assert.Equal(-1, BsSelectNav.LastEnabled(2, Disabled(0, 1)));
+    }
+
+    [Fact]
+    public void Step_MovesToNextEnabled_SkippingDisabled()
+    {
+        Assert.Equal(1, BsSelectNav.Step(0, 1, 3, None));
+        Assert.Equal(2, BsSelectNav.Step(0, 1, 3, Disabled(1)));   // skip the disabled 1
+        Assert.Equal(0, BsSelectNav.Step(1, -1, 3, None));
+    }
+
+    [Fact]
+    public void Step_StaysPut_WhenNoEnabledInThatDirection()
+    {
+        Assert.Equal(2, BsSelectNav.Step(2, 1, 3, None));            // already last → stay (no wrap)
+        Assert.Equal(0, BsSelectNav.Step(0, -1, 3, None));          // already first → stay
+        Assert.Equal(0, BsSelectNav.Step(0, 1, 3, Disabled(1, 2))); // nothing enabled ahead → stay
+    }
+
+    [Fact]
+    public void Seed_PrefersSelected_ElseFirstEnabled()
+    {
+        Assert.Equal(2, BsSelectNav.Seed(2, 4, None));             // selection in range + enabled
+        Assert.Equal(0, BsSelectNav.Seed(-1, 4, None));            // no selection → first enabled
+        Assert.Equal(1, BsSelectNav.Seed(0, 4, Disabled(0)));     // selection disabled → first enabled
+        Assert.Equal(-1, BsSelectNav.Seed(0, 2, Disabled(0, 1))); // everything disabled → -1
+    }
+
+    [Fact]
+    public void Normalize_ClampsAndSnapsOffDisabled()
+    {
+        Assert.Equal(2, BsSelectNav.Normalize(9, 3, None));         // past the end → last
+        Assert.Equal(0, BsSelectNav.Normalize(-4, 3, None));       // below 0 → first
+        Assert.Equal(1, BsSelectNav.Normalize(1, 3, None));        // in range + enabled → unchanged
+        Assert.Equal(-1, BsSelectNav.Normalize(0, 0, None));       // empty list → -1
+        Assert.Equal(2, BsSelectNav.Normalize(1, 4, Disabled(1))); // on a disabled option → next enabled
+        Assert.Equal(0, BsSelectNav.Normalize(2, 3, Disabled(1, 2))); // none ahead → nearest enabled behind
+    }
+}

--- a/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
@@ -139,4 +139,18 @@ public class BsSelectTests
             "<div class=\"position-relative\"><div id=\"s\" class=\"form-select bs-select-clearable\"", html);
         Assert.Contains("bs-select-clear", html);
     }
+
+    [Fact]
+    public void Select_OptionDisabled_Custom_RendersAriaDisabledOptionWithNoHandler() =>
+        // The "b" option is disabled: still a role="option", but greyed via aria-disabled and non-clickable.
+        Assert.Contains(
+            "<button id=\"s-opt-1\" class=\"dropdown-item\" data-rask-key=\"1\" role=\"option\" " +
+            "aria-disabled=\"true\" type=\"button\" disabled>b</button>",
+            BsSelect<string>(Options: ["a", "b"], Value: "a", OptionDisabled: o => o == "b", Id: "s").ToHtml());
+
+    [Fact]
+    public void Select_OptionDisabled_Native_RendersDisabledOption() =>
+        Assert.Contains("<option data-rask-key=\"1\" value=\"b\" disabled>b</option>",
+            BsSelect<string>(Options: ["a", "b"], Value: "a", Native: true, OptionDisabled: o => o == "b", Id: "t")
+                .ToHtml());
 }

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -362,6 +362,74 @@ public sealed class MultiSelectTests
             TestServices.Default()));
     }
 
+    [Fact]
+    public async Task OptionDisabled_NotToggleableByClick_AndSkippedByKeyboard()
+    {
+        var model = new Bag();
+        var page = RaskTest.Render(
+            () => Form(model)[BsMultiSelect<string>(() => model.Tags, Options, OptionDisabled: o => o == "b")],
+            TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open, cursor seeded to option 0 ("a")
+
+        var html = page.Render();
+        Assert.Contains("aria-disabled=\"true\"", html);       // "b" is disabled
+        // the disabled "b" has no click handler: box + opt-a + opt-c + backdrop = 4 (would be 5 if b enabled)
+        Assert.Equal(4, ClickIds(html).Count);
+
+        // ArrowDown from "a" (0) skips the disabled "b" (1) and lands on "c" (2)
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\"ArrowDown\"}");
+        Assert.Equal("Tags-opt-2", Markup.Attr(page.Render(), "aria-activedescendant")!);
+    }
+
+    [Fact]
+    public async Task SelectAll_AddsAllEnabled_ThenClearsAll()
+    {
+        var model = new Bag();
+        var page = RaskTest.Render(
+            () => Form(model)[BsMultiSelect<string>(() => model.Tags, Options, SelectAll: true)],
+            TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open
+
+        // Empty selection → no chips, so the header is the first click handler after the box.
+        await page.InvokeAsync(ClickIds(page.Render())[1]); // "Select all"
+        Assert.Equal(["a", "b", "c"], model.Tags);
+        Assert.Contains("Clear all", page.Render());
+
+        // Now chips render before the menu rows; the header sits after box + one remove-button per chip.
+        await page.InvokeAsync(ClickIds(page.Render())[1 + model.Tags.Count]); // "Clear all"
+        Assert.Empty(model.Tags);
+    }
+
+    [Fact]
+    public async Task SelectAll_ExcludesDisabledOptions()
+    {
+        var model = new Bag();
+        var page = RaskTest.Render(
+            () => Form(model)[BsMultiSelect<string>(
+                () => model.Tags, Options, SelectAll: true, OptionDisabled: o => o == "b")],
+            TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open
+
+        await page.InvokeAsync(ClickIds(page.Render())[1]); // "Select all" — adds only the enabled options
+        Assert.Equal(["a", "c"], model.Tags);               // "b" is disabled, never added
+    }
+
+    [Fact]
+    public async Task SelectAll_Controlled_EmitsFullSelection_WithoutMutatingValue()
+    {
+        var value = new List<string>();
+        ICollection<string>? emitted = null;
+        var page = RaskTest.Render(
+            () => BsMultiSelect<string>(Options, Value: value, SelectAll: true, OnChange: next => emitted = next),
+            TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open
+
+        await page.InvokeAsync(ClickIds(page.Render())[1]); // "Select all"
+
+        Assert.Equal(["a", "b", "c"], emitted!);
+        Assert.Empty(value); // controlled mode never mutates the parent's Value in place
+    }
+
     private static IReadOnlyList<string> ClickIds(string html) =>
         Markup.Attrs(html, "data-rask-on-click");
 


### PR DESCRIPTION
## Summary

**PR2 of the select-family completeness epic** (stacked on #432). Adds per-option disabling to both selects and a bulk Select-all to the multiselect.

- **`OptionDisabled` predicate** (`item => bool`) on `BsSelect` **and** `BsMultiSelect`: a disabled option renders greyed with `aria-disabled`, takes no click, and the roving keyboard cursor **skips over it**; in `Native` mode it becomes a disabled `<option>`.
- **`BsSelect` keyboard refactor:** the ad-hoc `Math.Min/Max` clamps and `s>=0?s:0` seed are replaced by the shared `BsSelectNav.Step`/`Seed`/`FirstEnabled`/`LastEnabled` primitives (from PR1) plus a render-top `Normalize`, so the disabled-skip logic is one implementation both controls share.
- **`SelectAll: true` on `BsMultiSelect`:** an opt-in "Select all / Clear all" header row that toggles every shown, **enabled** option in one click — respecting an active `Filter` and never touching a disabled option — in bound and controlled modes (`SelectAllAsync` mirrors `ToggleAsync`).

## Testing

- **`BsSelectNavTests`** (new) covers the cursor-skip math directly.
- Static markup: disabled option (custom + native, exact `aria-disabled` order) and the Select-all header.
- Live demo-suite: disabled option click-inert + keyboard-skipped; Select-all add/clear/exclude-disabled/controlled.
- Full local unit gate passed, `dotnet format` clean, `-warnaserror` analyzer-clean build, browser E2E gate passed (25/25; opt-in props off in current demos, so the journey is unchanged).

## Benchmarks

Not applicable — Bootstrap layer, no render hot-path touched.

## Changelog

`[Unreleased]` → Added entry.

## Notes

Demos + E2E for the new props land with PR4 (batched with the grouping demos, per the epic plan). Review surfaced one low, documented UX note: with a `Filter` active, "Clear all" clears the visible subset (standard filtered-select-all behavior).

> Stacked on #432 — its base is that PR's branch, so the diff shown here is PR2 only. Merge #432 first.