### PR TITLE
feat(bootstrap): option groups (optgroup / dropdown-header) for the select family (PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`BsSelect` and `BsMultiSelect` gain option groups.** A new `OptionGroup` selector (`item => string`) groups
+  the options by the returned key in first-seen order — rendered as `<optgroup label>` in `Native` mode and as
+  non-interactive `.dropdown-header` rows in the custom dropdown. Grouping reorders the options into group order
+  while keeping keyboard navigation walking that flat visual order (headers are skipped), and composes with
+  `Filter` and `OptionDisabled`. The shared group/flatten/cursor logic lives in `BsSelectNav`.
 - **`BsSelect` and `BsMultiSelect` gain per-option disabling, and `BsMultiSelect` gains a "Select all / Clear
   all" header.** A new `OptionDisabled` predicate (`item => bool`) on both controls marks individual options
   non-selectable: the option renders greyed with `aria-disabled`, takes no click, and the keyboard cursor

--- a/docs/bootstrap-select.md
+++ b/docs/bootstrap-select.md
@@ -37,6 +37,12 @@ cursor skips over it (in `Native` mode it becomes a disabled `<option>`). `BsMul
 takes **`SelectAll: true`**, which adds a "Select all / Clear all" header row that toggles every shown,
 enabled option in one click (respecting an active `Filter` and never touching a disabled option).
 
+Pass an **`OptionGroup` selector** (`item => string`) to both controls to group the options by the
+returned key in first-seen order — `<optgroup label>` in `Native` mode, non-interactive
+`.dropdown-header` rows in the custom dropdown. Grouping only reorders the options into group order;
+keyboard navigation still walks that flat visual order (headers are skipped) and composes with `Filter`
+and `OptionDisabled`.
+
 ## `BsSelect<T>` variants
 
 The same control across every option: basic (binds the option), `Floating` label, searchable

--- a/src/Rask.Bootstrap/BsMultiSelect.cs
+++ b/src/Rask.Bootstrap/BsMultiSelect.cs
@@ -43,6 +43,10 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
     // all selected — never touching a disabled option. With a Filter active it applies to the visible subset.
     public bool? SelectAll { get; set; }
 
+    // Groups the options under non-interactive .dropdown-header rows, keyed by the returned string in first-seen
+    // order; e.g. OptionGroup: t => t.Category. The roving cursor still walks the flat option order.
+    public Func<TItem, string>? OptionGroup { get; set; }
+
     // Optional field label. Floating wraps the control + label in a .form-floating (the .form-select
     // control box makes Bootstrap float the label just like a native select); otherwise it sits above.
     public string? Label { get; set; }
@@ -114,22 +118,27 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             : Options;
         var filteredList = filtered as IReadOnlyList<TItem> ?? filtered.ToList();
 
-        // Per-option disable predicate over the filtered list; the keyboard cursor skips these indices and the
-        // option row takes no click.
-        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(filteredList[i]) == true;
+        // Group (optional) and flatten: `flat` is the option order the roving cursor indexes — grouping only
+        // reorders it into first-seen group order, so flat index still equals the rendered option position.
+        var layout = BsSelectNav.Build(filteredList, OptionGroup);
+        var flat = layout.Flat;
 
-        // The roving keyboard cursor lives in flat filtered-index space. Normalise it once against the current
+        // Per-option disable predicate over the flat list; the keyboard cursor skips these indices and the
+        // option row takes no click.
+        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(flat[i]) == true;
+
+        // The roving keyboard cursor lives in flat option-index space. Normalise it once against the current
         // list so a filter change (which may shrink the list) can't leave it dangling past the end, and seed
         // it to the first selected option so opening lands the highlight where the eye already is.
         if (_open)
         {
-            _cursor = BsSelectNav.Normalize(_cursor, filteredList.Count, optDisabled);
+            _cursor = BsSelectNav.Normalize(_cursor, flat.Count, optDisabled);
         }
 
         var firstSelected = -1;
-        for (var i = 0; i < filteredList.Count; i++)
+        for (var i = 0; i < flat.Count; i++)
         {
-            if (selected is not null && selected.Contains(filteredList[i], comparer))
+            if (selected is not null && selected.Contains(flat[i], comparer))
             {
                 firstSelected = i;
                 break;
@@ -185,11 +194,11 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         if (SelectAll is true && !disabled)
         {
             var enabledFiltered = new List<TItem>();
-            for (var i = 0; i < filteredList.Count; i++)
+            for (var i = 0; i < flat.Count; i++)
             {
                 if (!optDisabled(i))
                 {
-                    enabledFiltered.Add(filteredList[i]);
+                    enabledFiltered.Add(flat[i]);
                 }
             }
 
@@ -204,44 +213,53 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             }
         }
 
-        if (searchable && filteredList.Count == 0)
+        if (searchable && flat.Count == 0)
         {
             rows.Add(Span(Class: BsClass.Join("dropdown-item", "disabled", Txt.Muted))["No matches"]);
         }
         else
         {
-            var idx = 0;
-            foreach (var option in filteredList)
+            // Walk the groups: a non-interactive .dropdown-header per group (skipped by the cursor), then that
+            // group's option rows keyed by their FLAT index so ids/active/aria-activedescendant stay in step.
+            foreach (var g in layout.Groups)
             {
-                var captured = option;
-                var isChecked = selected is not null && selected.Contains(captured, comparer);
-                var optionDisabled = disabled || optDisabled(idx);
-                // aria-selected and the read-only checkbox both derive from isChecked (never from _cursor), so
-                // they can't drift; the cursor is surfaced only as the .active highlight. role="option" +
-                // aria-selected make this a proper listbox option for assistive tech; a per-option-disabled row
-                // adds aria-disabled and drops its click handler.
-                var optAria = new Dictionary<string, string?> { ["selected"] = isChecked ? "true" : "false" };
-                if (optionDisabled)
+                if (g.Header is not null)
                 {
-                    optAria["disabled"] = "true";
+                    rows.Add(Div(Class: "dropdown-header", Key: "hdr-" + g.Header)[g.Header]);
                 }
 
-                rows.Add(Button(
-                    Type: "button",
-                    Class: BsClass.Join("dropdown-item d-flex align-items-center gap-2",
-                        _open && idx == _cursor ? "active" : null),
-                    Id: BsSelectNav.OptId(prefix, idx),
-                    Role: "option",
-                    Aria: optAria,
-                    Disabled: optionDisabled ? true : null,
-                    OnClickAsync: optionDisabled
-                        ? null
-                        : () => ToggleAsync(acc, ctx, fid, captured, comparer, add: !isChecked),
-                    Key: idx)[
-                    Input<string>(InputType.Checkbox, Class: "form-check-input m-0 pe-none", Checked: isChecked),
-                    LabelOf(captured)
-                ]);
-                idx++;
+                foreach (var row in g.Rows)
+                {
+                    var idx = row.FlatIndex;
+                    var captured = row.Item;
+                    var isChecked = selected is not null && selected.Contains(captured, comparer);
+                    var optionDisabled = disabled || optDisabled(idx);
+                    // aria-selected and the read-only checkbox both derive from isChecked (never from _cursor),
+                    // so they can't drift; the cursor is surfaced only as the .active highlight. role="option" +
+                    // aria-selected make this a proper listbox option for assistive tech; a per-option-disabled
+                    // row adds aria-disabled and drops its click handler.
+                    var optAria = new Dictionary<string, string?> { ["selected"] = isChecked ? "true" : "false" };
+                    if (optionDisabled)
+                    {
+                        optAria["disabled"] = "true";
+                    }
+
+                    rows.Add(Button(
+                        Type: "button",
+                        Class: BsClass.Join("dropdown-item d-flex align-items-center gap-2",
+                            _open && idx == _cursor ? "active" : null),
+                        Id: BsSelectNav.OptId(prefix, idx),
+                        Role: "option",
+                        Aria: optAria,
+                        Disabled: optionDisabled ? true : null,
+                        OnClickAsync: optionDisabled
+                            ? null
+                            : () => ToggleAsync(acc, ctx, fid, captured, comparer, add: !isChecked),
+                        Key: idx)[
+                        Input<string>(InputType.Checkbox, Class: "form-check-input m-0 pe-none", Checked: isChecked),
+                        LabelOf(captured)
+                    ]);
+                }
             }
         }
 
@@ -256,7 +274,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
             boxAria["labelledby"] = labelId;
         }
 
-        if (_open && _cursor >= 0 && _cursor < filteredList.Count)
+        if (_open && _cursor >= 0 && _cursor < flat.Count)
         {
             boxAria["activedescendant"] = BsSelectNav.OptId(prefix, _cursor);
         }
@@ -288,7 +306,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                 }
                 else
                 {
-                    _cursor = BsSelectNav.Seed(firstSelected, filteredList.Count, optDisabled);
+                    _cursor = BsSelectNav.Seed(firstSelected, flat.Count, optDisabled);
                     _open = true;
                 }
             },
@@ -344,7 +362,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
         // from the in-dropdown search field, where Space must type a literal space instead of toggling.
         async Task OnKeyAsync(KeyboardEventArgs e, bool fromSearch)
         {
-            var count = filteredList.Count;
+            var count = flat.Count;
             if (!_open)
             {
                 if (e.Key is "ArrowDown" or "ArrowUp" or "Enter" or " ")
@@ -378,7 +396,7 @@ public sealed class BsMultiSelect<TItem> : BsBlock, IFormControl<ICollection<TIt
                 case " " when !fromSearch:
                     if (_cursor >= 0 && _cursor < count && !optDisabled(_cursor))
                     {
-                        var item = filteredList[_cursor];
+                        var item = flat[_cursor];
                         var isChecked = selected is not null && selected.Contains(item, comparer);
                         await ToggleAsync(acc, ctx, fid, item, comparer, add: !isChecked).ConfigureAwait(false);
                     }

--- a/src/Rask.Bootstrap/BsSelect.cs
+++ b/src/Rask.Bootstrap/BsSelect.cs
@@ -28,6 +28,10 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
     // click, and the keyboard cursor skips over it; e.g. OptionDisabled: p => p.SoldOut.
     public Func<TItem, bool>? OptionDisabled { get; set; }
 
+    // Groups the options, keyed by the returned string in first-seen order — <optgroup label> in Native mode,
+    // non-interactive .dropdown-header rows in the custom dropdown; e.g. OptionGroup: p => p.Category.
+    public Func<TItem, string>? OptionGroup { get; set; }
+
     // Opt out of the custom popover and render the native <select> instead. Guarantees a working control
     // (and the OS picker on mobile) where the custom UI is unwanted.
     public bool? Native { get; set; }
@@ -76,19 +80,44 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
 
         var children = new List<Component?>();
         // A leading empty option: a non-selectable prompt for a required select, or a selectable "none"
-        // entry when the binding is nullable (empty value → null via the shared StringChangeHandler).
+        // entry when the binding is nullable (empty value → null via the shared StringChangeHandler). It stays
+        // outside any <optgroup>.
         if (Placeholder is not null || CanClear)
         {
             children.Add(Option(Value: "", Disabled: CanClear ? null : true, Key: "placeholder")[
                 Placeholder ?? "None"]);
         }
 
-        for (var i = 0; i < opts.Count; i++)
+        // Group (optional) into <optgroup>s. Each option keeps its GLOBAL flat index as the reconciliation key
+        // so keys stay unique across the whole <select> once options nest under groups; each group gets its own
+        // ordinal key. With no OptionGroup this is one headerless group → options emitted flat, exactly as before.
+        var layout = BsSelectNav.Build(opts, OptionGroup);
+        Component OptionFor(BsSelectNav.FlatRow<TItem> fr) => Option(
+            Value: BindingHelpers.FormatValue(ValueOf(fr.Item)),
+            Disabled: OptionDisabled?.Invoke(fr.Item) == true ? true : null,
+            Key: fr.FlatIndex)[LabelOf(fr.Item)];
+
+        for (var g = 0; g < layout.Groups.Count; g++)
         {
-            children.Add(Option(
-                Value: BindingHelpers.FormatValue(ValueOf(opts[i])),
-                Disabled: OptionDisabled?.Invoke(opts[i]) == true ? true : null,
-                Key: i)[LabelOf(opts[i])]);
+            var group = layout.Groups[g];
+            if (group.Header is null)
+            {
+                foreach (var fr in group.Rows)
+                {
+                    children.Add(OptionFor(fr));
+                }
+            }
+            else
+            {
+                var groupOpts = new List<Component?>();
+                foreach (var fr in group.Rows)
+                {
+                    groupOpts.Add(OptionFor(fr));
+                }
+
+                children.Add(Optgroup(Label: group.Header, Key: "grp-" + g.ToString(CultureInfo.InvariantCulture))[
+                    groupOpts]);
+            }
         }
 
         var control = Select<string>(
@@ -125,14 +154,19 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             ? opts.Where(o => Filter!(o, _filter)).ToList()
             : opts;
 
-        // Per-option disable predicate over the filtered list; the keyboard cursor skips these indices.
-        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(filtered[i]) == true;
+        // Group (optional) and flatten: `flat` is the option order the roving cursor indexes — grouping only
+        // reorders it into first-seen group order, so the flat index still equals the rendered option position.
+        var layout = BsSelectNav.Build(filtered, OptionGroup);
+        var flat = layout.Flat;
 
-        // Snap the roving cursor into the current filtered list and off any disabled option (a filter change
+        // Per-option disable predicate over the flat list; the keyboard cursor skips these indices.
+        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(flat[i]) == true;
+
+        // Snap the roving cursor into the current flat list and off any disabled option (a filter change
         // sets _cursor loosely, and a selected-but-disabled seed must move to the nearest enabled option).
         if (_open)
         {
-            _cursor = BsSelectNav.Normalize(_cursor, filtered.Count, optDisabled);
+            _cursor = BsSelectNav.Normalize(_cursor, flat.Count, optDisabled);
         }
 
         // The box shows the selected option's (rich) label, or the muted placeholder; blank while floating+empty.
@@ -151,7 +185,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             aria["labelledby"] = labelId;
         }
 
-        if (_open && _cursor >= 0 && _cursor < filtered.Count)
+        if (_open && _cursor >= 0 && _cursor < flat.Count)
         {
             aria["activedescendant"] = BsSelectNav.OptId(prefix, _cursor);
         }
@@ -176,8 +210,8 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             Role: "combobox",
             TabIndex: disabled ? null : 0,
             Aria: aria,
-            OnClick: disabled ? null : () => Toggle(b, opts),
-            OnKeyDownAsync: disabled ? null : e => OnKeyAsync(b, filtered, e))[content];
+            OnClick: disabled ? null : () => Toggle(b, flat),
+            OnKeyDownAsync: disabled ? null : e => OnKeyAsync(b, flat, e))[content];
 
         var clear = showClear
             ? BsCloseButton(
@@ -203,47 +237,60 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
                     Autofocus: true,
                     Aria: new Dictionary<string, string?> { ["label"] = "Search" },
                     OnInput: raw => { _filter = raw; _cursor = 0; },
-                    OnKeyDownAsync: e => OnKeyAsync(b, filtered, e))]);
+                    OnKeyDownAsync: e => OnKeyAsync(b, flat, e))]);
         }
 
-        if (searchable && filtered.Count == 0)
+        if (searchable && flat.Count == 0)
         {
             rows.Add(Span(Class: BsClass.Join("dropdown-item", "disabled", Txt.Muted))["No matches"]);
         }
         else
         {
-            for (var i = 0; i < filtered.Count; i++)
+            // Walk the groups: a non-interactive .dropdown-header per group (skipped by the cursor), then that
+            // group's option rows keyed by their FLAT index so ids/active/aria-activedescendant stay in step.
+            foreach (var g in layout.Groups)
             {
-                var idx = i;
-                var item = filtered[i];
-                var isSelected = b.Current is not null && Comparer.Equals(ValueOf(item), b.Current);
-                var optionDisabled = optDisabled(idx);
-                // aria dict only when there's something to say (keeps the enabled/unselected option markup as
-                // it was): aria-selected first, then aria-disabled — a disabled option stays a role="option".
-                Dictionary<string, string?>? optAria = null;
-                if (isSelected || optionDisabled)
+                if (g.Header is not null)
                 {
-                    optAria = new Dictionary<string, string?>();
-                    if (isSelected)
-                    {
-                        optAria["selected"] = "true";
-                    }
-
-                    if (optionDisabled)
-                    {
-                        optAria["disabled"] = "true";
-                    }
+                    rows.Add(Div(Class: "dropdown-header", Key: "hdr-" + g.Header)[g.Header]);
                 }
 
-                rows.Add(Button(
-                    Type: "button",
-                    Class: BsClass.Join("dropdown-item", isSelected || (_open && idx == _cursor) ? "active" : null),
-                    Id: BsSelectNav.OptId(prefix, idx),
-                    Role: "option",
-                    Aria: optAria,
-                    Disabled: disabled || optionDisabled ? true : null,
-                    Key: idx,
-                    OnClickAsync: disabled || optionDisabled ? null : () => WriteAsync(b, ValueOf(item)))[LabelOf(item)]);
+                foreach (var fr in g.Rows)
+                {
+                    var idx = fr.FlatIndex;
+                    var item = fr.Item;
+                    var isSelected = b.Current is not null && Comparer.Equals(ValueOf(item), b.Current);
+                    var optionDisabled = optDisabled(idx);
+                    // aria dict only when there's something to say (keeps the enabled/unselected option markup
+                    // as it was): aria-selected first, then aria-disabled — a disabled option stays role="option".
+                    Dictionary<string, string?>? optAria = null;
+                    if (isSelected || optionDisabled)
+                    {
+                        optAria = new Dictionary<string, string?>();
+                        if (isSelected)
+                        {
+                            optAria["selected"] = "true";
+                        }
+
+                        if (optionDisabled)
+                        {
+                            optAria["disabled"] = "true";
+                        }
+                    }
+
+                    rows.Add(Button(
+                        Type: "button",
+                        Class: BsClass.Join("dropdown-item",
+                            isSelected || (_open && idx == _cursor) ? "active" : null),
+                        Id: BsSelectNav.OptId(prefix, idx),
+                        Role: "option",
+                        Aria: optAria,
+                        Disabled: disabled || optionDisabled ? true : null,
+                        Key: idx,
+                        OnClickAsync: disabled || optionDisabled
+                            ? null
+                            : () => WriteAsync(b, ValueOf(item)))[LabelOf(item)]);
+                }
             }
         }
 
@@ -310,8 +357,8 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
     }
 
     // Clicking the display box toggles the popover; opening seeds the keyboard cursor to the selected option
-    // (or the first enabled option when the selection is disabled/absent).
-    private void Toggle(Bound b, IReadOnlyList<TItem> opts)
+    // (or the first enabled option when the selection is disabled/absent). `flat` is the grouped option order.
+    private void Toggle(Bound b, IReadOnlyList<TItem> flat)
     {
         if (_open)
         {
@@ -319,7 +366,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             return;
         }
 
-        _cursor = BsSelectNav.Seed(SelectedIndex(b, opts), opts.Count, i => OptionDisabled?.Invoke(opts[i]) == true);
+        _cursor = BsSelectNav.Seed(SelectedIndex(b, flat), flat.Count, i => OptionDisabled?.Invoke(flat[i]) == true);
         _open = true;
     }
 
@@ -349,18 +396,18 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
         _filter = null;
     }
 
-    // Combobox keyboard over the FILTERED list: arrows move the cursor (skipping disabled options), Home/End
-    // jump to the first/last enabled option, Enter picks the cursor, Escape closes. Space is left to type into
-    // the filter. Focus already opened the popover.
-    private async Task OnKeyAsync(Bound b, IReadOnlyList<TItem> filtered, KeyboardEventArgs e)
+    // Combobox keyboard over the flat (filtered + grouped) option list: arrows move the cursor (skipping
+    // disabled options), Home/End jump to the first/last enabled option, Enter picks the cursor, Escape closes.
+    // Space is left to type into the filter. Focus already opened the popover.
+    private async Task OnKeyAsync(Bound b, IReadOnlyList<TItem> flat, KeyboardEventArgs e)
     {
-        var count = filtered.Count;
-        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(filtered[i]) == true;
+        var count = flat.Count;
+        Func<int, bool> optDisabled = i => OptionDisabled?.Invoke(flat[i]) == true;
         if (!_open)
         {
             if (e.Key is "ArrowDown" or "ArrowUp" or "Enter" or " ")
             {
-                _cursor = BsSelectNav.Seed(SelectedIndex(b, filtered), count, optDisabled);
+                _cursor = BsSelectNav.Seed(SelectedIndex(b, flat), count, optDisabled);
                 _open = true;
             }
 
@@ -387,7 +434,7 @@ public abstract class BsSelectBase<TValue, TItem> : BsFormControl<TValue>
             case "Enter":
                 if (_cursor >= 0 && _cursor < count && !optDisabled(_cursor))
                 {
-                    await WriteAsync(b, ValueOf(filtered[_cursor])).ConfigureAwait(false);
+                    await WriteAsync(b, ValueOf(flat[_cursor])).ConfigureAwait(false);
                 }
 
                 break;

--- a/src/Rask.Bootstrap/BsSelectNav.cs
+++ b/src/Rask.Bootstrap/BsSelectNav.cs
@@ -9,6 +9,71 @@ namespace Rask.Bootstrap;
 // predicate so a per-option-disabled option is skipped over rather than landed on.
 internal static class BsSelectNav
 {
+    // One rendered option and its position in the FLAT cursor space (== render order after grouping).
+    internal readonly record struct FlatRow<TItem>(TItem Item, int FlatIndex);
+
+    // A group of options under an optional header (null header == the ungrouped single group).
+    internal readonly record struct OptGroup<TItem>(string? Header, IReadOnlyList<FlatRow<TItem>> Rows);
+
+    // The rendered layout: groups (render order: header then Rows) plus the flat option list the roving cursor
+    // indexes. Flat[i] is the i-th rendered option, so the flat index doubles as the aria-activedescendant id.
+    internal readonly record struct Layout<TItem>(
+        IReadOnlyList<OptGroup<TItem>> Groups,
+        IReadOnlyList<TItem> Flat);
+
+    // Groups the already-filtered options for rendering while preserving a flat option list for cursor math.
+    // group == null → one headerless group and Flat == filtered. Otherwise options are bucketed by the group
+    // key in first-seen order; each option is assigned the next flat index so the flat list tracks final render
+    // order (headers are not in it). Empty groups can't arise — a key is created only on its first member.
+    internal static Layout<TItem> Build<TItem>(IReadOnlyList<TItem> filtered, Func<TItem, string>? group)
+    {
+        if (group is null)
+        {
+            var rows = new FlatRow<TItem>[filtered.Count];
+            for (var i = 0; i < filtered.Count; i++)
+            {
+                rows[i] = new FlatRow<TItem>(filtered[i], i);
+            }
+
+            return new Layout<TItem>([new OptGroup<TItem>(null, rows)], filtered);
+        }
+
+        // First pass: bucket items by group key in first-seen order (buckets hold the items, not yet indexed).
+        var order = new List<string>();
+        var buckets = new Dictionary<string, List<TItem>>();
+        foreach (var item in filtered)
+        {
+            var key = group(item);
+            if (!buckets.TryGetValue(key, out var bucket))
+            {
+                bucket = [];
+                buckets[key] = bucket;
+                order.Add(key);
+            }
+
+            bucket.Add(item);
+        }
+
+        // Second pass: lay the groups out in first-seen order and assign each option its flat index IN THAT
+        // RENDER ORDER, so the cursor's flat index equals the option's rendered position (arrows follow the eye).
+        var flat = new List<TItem>(filtered.Count);
+        var groups = new OptGroup<TItem>[order.Count];
+        for (var g = 0; g < order.Count; g++)
+        {
+            var items = buckets[order[g]];
+            var rows = new FlatRow<TItem>[items.Count];
+            for (var j = 0; j < items.Count; j++)
+            {
+                rows[j] = new FlatRow<TItem>(items[j], flat.Count);
+                flat.Add(items[j]);
+            }
+
+            groups[g] = new OptGroup<TItem>(order[g], rows);
+        }
+
+        return new Layout<TItem>(groups, flat);
+    }
+
     // The stable per-option id an aria-activedescendant points at: "{prefix}-opt-{flatIndex}".
     internal static string OptId(string prefix, int idx) =>
         prefix + "-opt-" + idx.ToString(CultureInfo.InvariantCulture);

--- a/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsMultiSelectTests.cs
@@ -130,6 +130,15 @@ public class BsMultiSelectTests
             BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string> { "a", "b" }, SelectAll: true)
                 .ToHtml());
 
+    [Fact]
+    public void MultiSelect_OptionGroup_RendersDropdownHeadersInFirstSeenOrder()
+    {
+        var html = BsMultiSelect<string>(Options: ["a", "b"], Value: new List<string>(),
+            OptionGroup: o => o == "a" ? "G1" : "G2", Id: "m").ToHtml();
+        Assert.Contains("<div class=\"dropdown-header\" data-rask-key=\"hdr-G1\">G1</div>", html);
+        Assert.Contains("<div class=\"dropdown-header\" data-rask-key=\"hdr-G2\">G2</div>", html);
+    }
+
     private sealed class TagModel
     {
         public List<string> Tags { get; set; } = [];

--- a/tests/Rask.Bootstrap.Tests/BsSelectNavTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectNavTests.cs
@@ -54,6 +54,38 @@ public class BsSelectNavTests
     }
 
     [Fact]
+    public void Build_NoGroup_OneHeaderlessGroup_FlatEqualsInput()
+    {
+        var layout = BsSelectNav.Build(new[] { "a", "b", "c" }, null);
+        Assert.Single(layout.Groups);
+        Assert.Null(layout.Groups[0].Header);
+        Assert.Equal(["a", "b", "c"], layout.Flat);
+        Assert.Equal([0, 1, 2], layout.Groups[0].Rows.Select(r => r.FlatIndex));
+    }
+
+    [Fact]
+    public void Build_Groups_InFirstSeenOrder_FlatIndexTracksRenderPosition()
+    {
+        // Items interleave groups; Build reorders into first-seen group order and the flat index equals the
+        // final rendered position (group X's rows first, then group Y's).
+        var items = new[] { ("X", "a"), ("Y", "b"), ("X", "c"), ("Y", "d") };
+        var layout = BsSelectNav.Build(items, i => i.Item1);
+
+        Assert.Equal(["X", "Y"], layout.Groups.Select(g => g.Header));
+        Assert.Equal(["a", "c", "b", "d"], layout.Flat.Select(i => i.Item2)); // X rows, then Y rows
+        Assert.Equal([0, 1], layout.Groups[0].Rows.Select(r => r.FlatIndex));
+        Assert.Equal([2, 3], layout.Groups[1].Rows.Select(r => r.FlatIndex));
+    }
+
+    [Fact]
+    public void Build_EmptyInput_ProducesNoGroups()
+    {
+        var layout = BsSelectNav.Build(Array.Empty<string>(), i => i);
+        Assert.Empty(layout.Groups); // a key is created only on its first member → no empty groups
+        Assert.Empty(layout.Flat);
+    }
+
+    [Fact]
     public void Normalize_ClampsAndSnapsOffDisabled()
     {
         Assert.Equal(2, BsSelectNav.Normalize(9, 3, None));         // past the end → last

--- a/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsSelectTests.cs
@@ -153,4 +153,25 @@ public class BsSelectTests
         Assert.Contains("<option data-rask-key=\"1\" value=\"b\" disabled>b</option>",
             BsSelect<string>(Options: ["a", "b"], Value: "a", Native: true, OptionDisabled: o => o == "b", Id: "t")
                 .ToHtml());
+
+    [Fact]
+    public void Select_OptionGroup_Custom_RendersDropdownHeadersInFirstSeenOrder()
+    {
+        var html = BsSelect<string>(Options: ["a", "b"], Value: "a",
+            OptionGroup: o => o == "a" ? "First" : "Second", Id: "s").ToHtml();
+        Assert.Contains("<div class=\"dropdown-header\" data-rask-key=\"hdr-First\">First</div>", html);
+        Assert.Contains("<div class=\"dropdown-header\" data-rask-key=\"hdr-Second\">Second</div>", html);
+    }
+
+    [Fact]
+    public void Select_OptionGroup_Native_WrapsOptionsInOptgroups()
+    {
+        var html = BsSelect<string>(Options: ["a", "b"], Value: "a", Native: true,
+            OptionGroup: o => o == "a" ? "First" : "Second", Id: "s").ToHtml();
+        // Each group is an <optgroup label> (own ordinal key); options keep their global flat key + value.
+        Assert.Contains("<optgroup data-rask-key=\"grp-0\" label=\"First\">" +
+            "<option data-rask-key=\"0\" value=\"a\" selected>a</option></optgroup>", html);
+        Assert.Contains("<optgroup data-rask-key=\"grp-1\" label=\"Second\">" +
+            "<option data-rask-key=\"1\" value=\"b\">b</option></optgroup>", html);
+    }
 }

--- a/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Demos/MultiSelectTests.cs
@@ -430,6 +430,29 @@ public sealed class MultiSelectTests
         Assert.Empty(value); // controlled mode never mutates the parent's Value in place
     }
 
+    [Fact]
+    public async Task Grouped_ArrowNavigation_WalksFlatOrder_SkippingHeadersAndDisabled()
+    {
+        // Options a,b,c,d grouped a,c -> "Odd", b,d -> "Even" (first-seen: Odd then Even), so the flat cursor
+        // order is a(0), c(1), b(2), d(3). Disable "c" (flat 1).
+        var model = new Bag();
+        var page = RaskTest.Render(
+            () => Form(model)[BsMultiSelect<string>(
+                () => model.Tags, ["a", "b", "c", "d"],
+                OptionGroup: o => o is "a" or "c" ? "Odd" : "Even",
+                OptionDisabled: o => o == "c")],
+            TestServices.Default());
+        await page.InvokeAsync(ClickIds(page.Render())[0]); // open, cursor seeds to flat 0 ("a")
+
+        var html = page.Render();
+        Assert.Contains("dropdown-header", html);                                  // grouped headers render
+        Assert.Equal("Tags-opt-0", Markup.Attr(html, "aria-activedescendant")!);   // a (flat 0)
+
+        // ArrowDown from a(0): the next flat option c(1) is disabled → skip it and the headers, land on b(2).
+        await page.InvokeAsync(page.HandlerIds("keydown")[0], "{\"key\":\"ArrowDown\"}");
+        Assert.Equal("Tags-opt-2", Markup.Attr(page.Render(), "aria-activedescendant")!);
+    }
+
     private static IReadOnlyList<string> ClickIds(string html) =>
         Markup.Attrs(html, "data-rask-on-click");
 


### PR DESCRIPTION
## Summary

**PR3 of the select-family completeness epic** (stacked on #438). Adds option grouping to both selects.

- **`OptionGroup` selector** (`item => string`) on `BsSelect` **and** `BsMultiSelect`: groups options by the returned key in first-seen order — `<optgroup label>` in `Native` mode, non-interactive `.dropdown-header` rows in the custom dropdown.
- **Composes cleanly:** grouping reorders the options into group order, but the roving keyboard cursor keeps walking that flat *visual* order (headers are skipped), and it composes with `Filter` (filter first, then group — empty groups never render) and `OptionDisabled` (still skipped).
- **Shared core:** the group/flatten logic lands in `BsSelectNav.Build` (`FlatRow`/`OptGroup`/`Layout` records). The key invariant — **flat index == rendered position** — makes the flat index double as the `aria-activedescendant` id; native options keep their global flat index as the reconciliation key so keys stay unique once nested under optgroups.

## Testing

- **`BsSelectNav.Build`** unit tests: first-seen group order, flat-index-tracks-render-position, empty input → no groups. (These caught a real cursor-ordering bug during development — the initial Build assigned flat indices in input order, not render order.)
- Static markup: `.dropdown-header` rows (both controls) and native `<optgroup label>` with unique keys.
- Live composition test: arrow-navigation walks the flat grouped order while skipping headers **and** disabled options; `aria-activedescendant` lands on the right flat id.
- Full local unit gate passed, `dotnet format` clean, `-warnaserror` build clean, browser E2E gate passed (grouping off in current demos → journey unchanged; the grouped demos + their E2E land in PR4).

## Benchmarks

Not applicable — Bootstrap layer, no render hot-path touched.

## Changelog

`[Unreleased]` → Added entry.

> Stacked on #438 → #432. Merge those first; this PR's diff is PR3 only.