### PR TITLE
feat(bootstrap): BsTimePicker Home/End and Shift-arrow seconds keyboard nudge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`BsTimePicker` keyboard parity — `Home`/`End` and a seconds nudge.** Rounding out the picker keyboard
+  story: `Home`/`End` jump the clock to the earliest/latest selectable time (the `Min`/`Max` bound, or the
+  day edge — `00:00`, and `23:59`/`23:59:59` with seconds), and when `Seconds` is on, `Shift`+`ArrowUp`/
+  `ArrowDown` nudges the second by `SecondStep` (plain arrows stay on the minute, `PageUp`/`PageDown` on the
+  hour). Every nudge still clamps to `[Min, Max]`. Documented in `docs/bootstrap-pickers.md`.
+
 ## [0.18.0] - 2026-07-16
 
 ### Changed

--- a/docs/bootstrap-pickers.md
+++ b/docs/bootstrap-pickers.md
@@ -40,9 +40,9 @@ focus and `aria-activedescendant` tracks a virtual cursor). A first navigation k
 | Key | Date / date-time grid | Time columns |
 | --- | --- | --- |
 | `←` / `→` | previous / next day | — |
-| `↑` / `↓` | previous / next week | nudge the minute by `MinuteStep` |
+| `↑` / `↓` | previous / next week | nudge the minute by `MinuteStep` (`Shift`: the second) |
 | `PageUp` / `PageDown` | previous / next month (`Shift` → year) | nudge the hour |
-| `Home` / `End` | start / end of the week | — |
+| `Home` / `End` | start / end of the week | earliest / latest time (`Min`/`Max` or day edge) |
 | `Enter` | select the navigated day | commit / close |
 | `Escape` | close | close |
 

--- a/src/Rask.Bootstrap/BsTimePicker.cs
+++ b/src/Rask.Bootstrap/BsTimePicker.cs
@@ -7,7 +7,8 @@ namespace Rask.Bootstrap;
 // minute lists (plus seconds when Seconds:true), bound to a TimeOnly (or TimeOnly?). Open/close and
 // selection are pure live-diff view state — no bootstrap.js. Minutes step by MinuteStep (default 5),
 // seconds by SecondStep (default 5). Min/Max grey out-of-range items and clamp every write. Keyboard: a
-// first nav key opens; ArrowUp/Down nudge the minute by a step, PageUp/Down nudge the hour, Enter/Escape
+// first nav key opens; ArrowUp/Down nudge the minute by a step (Shift+ArrowUp/Down the second when Seconds
+// is on), PageUp/Down nudge the hour, Home/End jump to the earliest/latest selectable time, Enter/Escape
 // close; typing into the box also commits live. Labels localizes the column/clear aria-labels. Native:true
 // falls back to <input type=time>.
 //   Bound:      BsTimePicker(() => model.Alarm, Label: "Alarm", MinuteStep: 15)
@@ -20,8 +21,9 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
     public bool? Seconds { get; set; }
     public int? SecondStep { get; set; }
 
-    // The effective minute step (default 5), shared by the render and the keyboard nudge.
+    // The effective minute/second steps (default 5), shared by the render and the keyboard nudge.
     private int Step => MinuteStep is { } s && s > 0 ? s : 5;
+    private int SecStep => SecondStep is { } ss && ss > 0 ? ss : 5;
 
     protected override Component? Render()
     {
@@ -35,7 +37,7 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
         var gridId = (controlId ?? FallbackPrefix("bstp")) + "-time";
         var selected = ReadTime(b);
         var step = Step;
-        var secStep = SecondStep is { } ss && ss > 0 ? ss : 5;
+        var secStep = SecStep;
         var showSeconds = Seconds is true;
 
         var acc = b.Accessor;
@@ -68,7 +70,8 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
     private static TimeOnly? ReadTime(in Bound b) =>
         (object?)b.Current is TimeOnly t ? t : null;
 
-    // A first nav key opens; then ArrowUp/Down nudge the minute by a step, PageUp/Down nudge the hour,
+    // A first nav key opens; then ArrowUp/Down nudge the minute by a step (Shift+ArrowUp/Down the second when
+    // Seconds is on), PageUp/Down nudge the hour, Home/End jump to the earliest/latest selectable time, and
     // Enter/Escape close. Nudges wrap within the day and clamp to [Min,Max]; typing commits live separately.
     private async Task OnKeyAsync(
         ExpressionAccessor.Accessor? acc, EditContext? ctx, FieldIdentifier fid,
@@ -78,7 +81,7 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
         {
             // Enter and Space are excluded: Enter is the form's submit key (and the client only contains it
             // while the popover is already open), and Space is a literal text character in the editable box.
-            if (e.Key is "ArrowDown" or "ArrowUp" or "PageDown" or "PageUp")
+            if (e.Key is "ArrowDown" or "ArrowUp" or "PageDown" or "PageUp" or "Home" or "End")
             {
                 Open = true;
             }
@@ -87,6 +90,7 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
         }
 
         var step = Step;
+        var seconds = Seconds is true;
         var cur = selected ?? new TimeOnly(0, 0);
         switch (e.Key)
         {
@@ -96,10 +100,14 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
                 Text = null;
                 break;
             case "ArrowDown":
-                await NudgeAsync(acc, ctx, fid, cur.AddMinutes(step)).ConfigureAwait(false);
+                await NudgeAsync(acc, ctx, fid,
+                    seconds && e.Shift ? cur.Add(TimeSpan.FromSeconds(SecStep)) : cur.AddMinutes(step))
+                    .ConfigureAwait(false);
                 break;
             case "ArrowUp":
-                await NudgeAsync(acc, ctx, fid, cur.AddMinutes(-step)).ConfigureAwait(false);
+                await NudgeAsync(acc, ctx, fid,
+                    seconds && e.Shift ? cur.Add(TimeSpan.FromSeconds(-SecStep)) : cur.AddMinutes(-step))
+                    .ConfigureAwait(false);
                 break;
             case "PageDown":
                 await NudgeAsync(acc, ctx, fid, cur.AddHours(1)).ConfigureAwait(false);
@@ -107,8 +115,20 @@ public sealed class BsTimePicker<T> : BsPickerBase<T>
             case "PageUp":
                 await NudgeAsync(acc, ctx, fid, cur.AddHours(-1)).ConfigureAwait(false);
                 break;
+            case "Home":
+                await NudgeAsync(acc, ctx, fid, Earliest()).ConfigureAwait(false);
+                break;
+            case "End":
+                await NudgeAsync(acc, ctx, fid, Latest()).ConfigureAwait(false);
+                break;
         }
     }
+
+    // The earliest/latest selectable time for Home/End: the Min/Max bound, or the day edge (00:00, and 23:59
+    // or 23:59:59 with seconds). NudgeAsync clamps + normalizes, so these are exact whatever the precision.
+    private TimeOnly Earliest() => Min ?? new TimeOnly(0, 0, 0);
+
+    private TimeOnly Latest() => Max ?? (Seconds is true ? new TimeOnly(23, 59, 59) : new TimeOnly(23, 59));
 
     // Live per-keystroke parse of the typed text in the current culture; empty clears a nullable picker.
     // An out-of-[Min,Max] value is ignored (keep typing) rather than committed.

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -557,6 +557,13 @@ public abstract partial class SharedSmokeTests
         await kbTime.PressAsync("ArrowDown");
         await Expect(Page.Locator("#pick-readout")).ToContainTextAsync("09:15",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        // Home/End jump to the day edge (this picker has no Min/Max): End → 23:59, Home → 00:00.
+        await kbTime.PressAsync("End");
+        await Expect(Page.Locator("#pick-readout")).ToContainTextAsync("23:59",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+        await kbTime.PressAsync("Home");
+        await Expect(Page.Locator("#pick-readout")).ToContainTextAsync("00:00",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
         await Page.Locator(".dropdown:has(#pick-time) .position-fixed").DispatchEventAsync("click");
 
         // Nullable picker × clears to null: set a deadline, then click the × — the readout's last segment


### PR DESCRIPTION
## Summary
Completes the date/time picker keyboard story shipped in #433. `BsTimePicker` gains `Home`/`End` (jump the
clock to the earliest/latest selectable time — the `Min`/`Max` bound, or the day edge `00:00` / `23:59` /
`23:59:59` with seconds) and, when `Seconds` is on, `Shift`+`ArrowUp`/`ArrowDown` to nudge the second by
`SecondStep` (plain arrows stay on the minute, `PageUp`/`PageDown` on the hour). Every nudge still clamps to
`[Min, Max]` through the existing `NudgeAsync` path — no new write/clamp logic.

The new keys are already in `rask-dom.js`'s open-popover containment set (`Home`/`End`/`ArrowUp`/`ArrowDown`),
so no client-side change is needed and the text caret isn't hijacked while the popover is open.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **pass** (250; the 25 `BsPickerTests` render-markup cases unchanged, since this is handler-only)
- E2E (journey changed): hosts **Server + WASM** — **pass**; the shared time-picker keyboard step now also drives `End` → `23:59` and `Home` → `00:00` on `#pick-time` and asserts the bound readout
- `dotnet format` + `dotnet build -warnaserror` clean

## Benchmarks
n/a — `Rask.Bootstrap` component code, not a render hot path.

## CHANGELOG
- [Unreleased] entry added: `BsTimePicker` keyboard parity — `Home`/`End` and a `Shift`+arrow seconds nudge.
