### PR TITLE
fix(outbox): deliver nested IOutboxEvent types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ them until tagged releases begin.
   `ArrowDown` nudges the second by `SecondStep` (plain arrows stay on the minute, `PageUp`/`PageDown` on the
   hour). Every nudge still clamps to `[Min, Max]`. Documented in `docs/bootstrap-pickers.md`.
 
+### Fixed
+- **`Rask.Outbox` now delivers nested `IOutboxEvent` types.** The source generator registers each event by
+  its dot-separated display name, but `OutboxSerializerRegistry.Serialize` stored `Type.FullName` — which
+  uses `+` between a nesting type and a nested type — so a nested event (a record declared inside a class)
+  was stored under a name the registry never had: it deserialized to `null` and was silently left unpublished
+  until it exhausted its attempts. `Serialize` now normalizes the name to match the generator. (Top-level
+  events were unaffected.)
+
 ## [0.18.0] - 2026-07-16
 
 ### Changed

--- a/src/Rask.Outbox/OutboxSerializerRegistry.cs
+++ b/src/Rask.Outbox/OutboxSerializerRegistry.cs
@@ -28,8 +28,13 @@ public static class OutboxSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(domainEvent);
         var type = domainEvent.GetType();
-        return (type.FullName ?? type.Name, JsonSerializer.Serialize(domainEvent, type, Json));
+        return (TypeName(type), JsonSerializer.Serialize(domainEvent, type, Json));
     }
+
+    // Match the name the source generator registers (Roslyn's ToDisplayString is dot-separated even for a
+    // nested type) — Type.FullName uses '+' between a nesting type and its nested type, so normalize it,
+    // otherwise a nested IOutboxEvent would be stored under a name the registry never has and never publish.
+    internal static string TypeName(Type type) => (type.FullName ?? type.Name).Replace('+', '.');
 
     /// <summary>Rehydrates a stored event, or <c>null</c> if its type isn't registered.</summary>
     public static INotification? Deserialize(string typeName, string payload)

--- a/tests/Rask.Outbox.Tests/OutboxTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxTests.cs
@@ -164,3 +164,23 @@ public sealed class OutboxTests : IDisposable
         }
     }
 }
+
+// A nested outbox event: its Type.FullName uses '+', which must still match the generator's dotted registration.
+public sealed class OuterScope
+{
+    public sealed record NestedEvent(int N) : IOutboxEvent;
+}
+
+public sealed class OutboxSerializerRegistryTests
+{
+    [Fact]
+    public void A_nested_event_type_round_trips()
+    {
+        // The Rask.Outbox source generator registered this assembly's IOutboxEvent types at module load.
+        var (type, payload) = OutboxSerializerRegistry.Serialize(new OuterScope.NestedEvent(7));
+
+        Assert.DoesNotContain('+', type); // stored dotted, matching the generator's registration
+        var back = OutboxSerializerRegistry.Deserialize(type, payload);
+        Assert.Equal(7, Assert.IsType<OuterScope.NestedEvent>(back).N);
+    }
+}


### PR DESCRIPTION
## Summary

Fixes a latent bug in `Rask.Outbox`: a **nested** `IOutboxEvent` (a record declared inside a class) was **silently never published**.

The source generator registers each event type by its dot-separated display name (`Ns.Outer.Inner`), but `OutboxSerializerRegistry.Serialize` stored `Type.FullName` — which uses `+` between a nesting type and its nested type (`Ns.Outer+Inner`). So a nested event was stored under a name the registry never had: `Deserialize` returned `null`, and the `OutboxProcessor` treated it as an unregistered type, leaving it unpublished until it exhausted `MaxAttempts` — with no error surfaced. Top-level events were unaffected.

`Serialize` now normalizes the stored name (`FullName.Replace('+', '.')`) to match the generator's key.

This is the same defect found and fixed in the new `Rask.Jobs` package (#443); this applies the fix to its sibling.

## Testing
- New `A_nested_event_type_round_trips` test: `Serialize` a nested `IOutboxEvent`, assert the stored name is dot-separated, and `Deserialize` back to the concrete type. Fails before the fix, passes after.
- `Rask.Outbox.Tests` green (3); full local unit + format gate green; warnings-as-errors build clean.

No `samples/` change (no browser E2E surface).

## Changelog
Fixed: **`Rask.Outbox` now delivers nested `IOutboxEvent` types.**