### PR TITLE
fix(native): honor Continuous in the iOS speech-recognition backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ them until tagged releases begin.
   `SFSpeechRecognizer` + `AVAudioEngine` and Android `SpeechRecognizer` (needs mic permission: iOS
   `NSMicrophoneUsageDescription` + `NSSpeechRecognitionUsageDescription`, Android `RECORD_AUDIO`). Showcased on
   the Browser APIs page and documented in [`docs/apis/speech-recognition.md`](docs/apis/speech-recognition.md).
+  The iOS backend honours `Continuous`: without it the session stops after the first final utterance, matching
+  the browser and Android contract (`AVAudioEngine` otherwise streams until disposed).
 - **`BsDataGrid` column chooser and reordering.** `ColumnChooser: true` renders a "Columns" menu above the
   grid — a checkbox to show or hide each column, and move earlier/later buttons to reorder it — and makes each
   header a drag source so a column can also be dragged onto another to reorder it. Both axes are controlled or

--- a/src/Rask.Native/Platforms/iOS/NativeSpeechRecognition.cs
+++ b/src/Rask.Native/Platforms/iOS/NativeSpeechRecognition.cs
@@ -46,14 +46,17 @@ internal sealed class NativeSpeechRecognition : ISpeechRecognition
         private readonly SFSpeechRecognizer _recognizer;
         private readonly Func<RecognitionResult, Task> _onResult;
         private readonly bool _interim;
+        private readonly bool _continuous;
         private SFSpeechAudioBufferRecognitionRequest? _request;
         private SFSpeechRecognitionTask? _task;
+        private bool _stopped;
         private bool _disposed;
 
         public Session(Func<RecognitionResult, Task> onResult, SpeechRecognitionOptions? options)
         {
             _onResult = onResult;
             _interim = options?.InterimResults ?? false;
+            _continuous = options?.Continuous ?? false;
             _recognizer = options?.Lang is { } lang
                 ? new SFSpeechRecognizer(NSLocale.FromLocaleIdentifier(lang))
                 : new SFSpeechRecognizer();
@@ -73,6 +76,13 @@ internal sealed class NativeSpeechRecognition : ISpeechRecognition
                 if (result is not null)
                 {
                     _ = _onResult(new RecognitionResult(result.BestTranscription.FormattedString, result.Final, 0));
+
+                    // Match the browser/Android contract: without Continuous, stop after the first final
+                    // utterance rather than streaming until DisposeAsync (AVAudioEngine has no built-in stop).
+                    if (result.Final && !_continuous)
+                    {
+                        StopListening();
+                    }
                 }
             });
 
@@ -87,6 +97,20 @@ internal sealed class NativeSpeechRecognition : ISpeechRecognition
             _engine.StartAndReturnError(out _);
         }
 
+        private void StopListening()
+        {
+            if (_stopped)
+            {
+                return;
+            }
+
+            _stopped = true;
+            _engine.InputNode.RemoveTapOnBus(0);
+            _engine.Stop();
+            _request?.EndAudio();
+            _task?.Cancel();
+        }
+
         public ValueTask DisposeAsync()
         {
             if (_disposed)
@@ -95,10 +119,7 @@ internal sealed class NativeSpeechRecognition : ISpeechRecognition
             }
 
             _disposed = true;
-            _engine.InputNode.RemoveTapOnBus(0);
-            _engine.Stop();
-            _request?.EndAudio();
-            _task?.Cancel();
+            StopListening();
             return default;
         }
     }


### PR DESCRIPTION
## Summary

Small follow-up to **#447** (which added `ISpeechRecognition`).

The iOS `SFSpeechRecognizer` / `AVAudioEngine` backend streamed until the session was disposed
regardless of `SpeechRecognitionOptions.Continuous`, diverging from the browser and Android backends
where `Continuous=false` stops after the first final utterance. This extracts the teardown into an
idempotent `StopListening()` and calls it from the recognition callback when a final result arrives and
`Continuous` is off; `DisposeAsync` reuses the same path, so behaviour now matches across all three
transports. The CHANGELOG note on the still-unreleased `ISpeechRecognition` entry records the parity.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean.
- `scripts/run-unit-local.sh` (build `-warnaserror` + full unit suite) — 250/250.
- No new unit test: the change is in a native-platform backend (`Rask.Native/Platforms/iOS`), which no
  local gate compiles (workloads absent) and which the existing suite doesn't cover — consistent with the
  rest of the native backends. It's verified only by CI's `native` job; please confirm that check is green
  before merge.
- No E2E / benchmarks — no `samples/` or render/runtime hot-path change.

## Changelog

Amends the unreleased `ISpeechRecognition` `Added` entry with the iOS `Continuous` parity note.
