### PR TITLE
docs(bootstrap): live demos + unit tests for BsOffcanvas and BsConfirmDialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Live demos and unit tests for `BsOffcanvas` and `BsConfirmDialog`.** The two interactive overlay
+  components — previously documented in prose only — now each have a showcase demo (code-above /
+  live-result-below) on the "Modals, offcanvas & dropdowns" guide: an offcanvas drawer that slides in
+  over a backdrop, and a `BsModal`-backed confirm/cancel prompt with a status readout. `BsOffcanvas`
+  gains a rendered-markup unit test, and the shared browser E2E journey now drives both (open the
+  drawer + backdrop-dismiss it, and confirm the destructive-delete dialog).
 - **`Rask.Mail` — durable transactional email on the app's own database.** The roadmap's next DB-backed
   pillar: compose an email with a fluent `Email` builder — its body is a **Rask component rendered to HTML**
   (`Body(new WelcomeEmail(name))`) — call `IMailQueue.SendAsync(email)`, and a hosted `MailProcessor` delivers

--- a/docs/bootstrap-overlays.md
+++ b/docs/bootstrap-overlays.md
@@ -21,6 +21,11 @@ static column above it.
 
 <!-- demo:bootstrap-modal -->
 
+An offcanvas drawer — it slides in over a backdrop and dismisses from the ×, the backdrop, or your
+own button, all through the live diff:
+
+<!-- demo:bootstrap-offcanvas -->
+
 ## Dropdowns
 
 `BsDropdown`(+`BsDropdownItem`) is a controlled, Popper-less menu: you own the `Open` state and wire
@@ -41,3 +46,10 @@ rule, not a Rask bug: an ancestor with a CSS
 
 The package also ships `BsPopover` (a hover/click text popover) and `BsConfirmDialog` (a modal-backed
 confirm prompt) for the common one-off cases.
+
+## Confirm dialog
+
+`BsConfirmDialog` layers a confirm/cancel prompt over `BsModal` for destructive actions — hold a
+`bool`, wire `Open` + `OnConfirm`/`OnCancel`, and the confirm button defaults to `Danger`:
+
+<!-- demo:bootstrap-confirm -->

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsConfirmDialogDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsConfirmDialogDemo.cs
@@ -1,0 +1,26 @@
+namespace Rask.Example.Shared.Features;
+
+// BsConfirmDialog — an "are you sure?" prompt layered on BsModal for destructive actions. Controlled
+// like a modal: _open holds visibility, OnConfirm/OnCancel run your action and close it. The confirm
+// button defaults to Danger. Zero-JS; dismissible via Cancel, the ×, or a backdrop click.
+public sealed class BsConfirmDialogDemo : Component
+{
+    private bool _open;
+    private string _status = "No action taken yet.";
+
+    protected override Component? Render() =>
+    [
+        Div(Class: "vstack gap-2 align-items-start")[
+            BsButton(Color: BsColor.Danger, OnClick: () => _open = true)["Delete item"],
+            P(Id: "bs-confirm-status", Class: "mb-0 text-body-secondary")[_status]
+        ],
+        BsConfirmDialog(
+            Open: _open,
+            Title: "Delete item?",
+            Message: "This can't be undone. Are you sure you want to delete it?",
+            ConfirmText: "Delete",
+            CancelText: "Keep it",
+            OnConfirm: () => { _status = "Item deleted."; _open = false; },
+            OnCancel: () => { _status = "Cancelled — nothing was deleted."; _open = false; })
+    ];
+}

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsOffcanvasDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsOffcanvasDemo.cs
@@ -1,0 +1,23 @@
+namespace Rask.Example.Shared.Features;
+
+// A Bootstrap offcanvas drawer driven entirely by Rask's live runtime — no bootstrap.js. _open is a
+// plain field; the trigger sets it true, and OnClose (the ×, the backdrop click, or the footer button)
+// sets it false. The panel stays in the DOM and slides in via the .show class the live diff toggles.
+public sealed class BsOffcanvasDemo : Component
+{
+    private bool _open;
+
+    protected override Component? Render() =>
+    [
+        BsButton(Color: BsColor.Primary, OnClick: () => _open = true)["Open settings"],
+        BsOffcanvas(
+            Open: _open,
+            Title: "Settings",
+            Placement: BsPlacement.End,
+            OnClose: () => _open = false)[
+            P()["This drawer slides in from the end over a dimming backdrop, all through the live diff. "
+                + "Click the backdrop or the × to dismiss it — no bootstrap.js."],
+            BsButton(Color: BsColor.Secondary, OnClick: () => _open = false)["Done"]
+        ]
+    ];
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -285,6 +285,8 @@ public static class DemoRegistry
             ["bootstrap-icons"] = () => CodeSample(["BsIconsDemo.cs"], Result: BsIconsDemo()),
             ["bootstrap-modal"] = () => CodeSample(["BsModalDemo.cs"], Result: BsModalDemo()),
             ["bootstrap-tabs"] = () => CodeSample(["BsTabsDemo.cs"], Result: BsTabsDemo()),
+            ["bootstrap-offcanvas"] = () => CodeSample(["BsOffcanvasDemo.cs"], Result: BsOffcanvasDemo()),
+            ["bootstrap-confirm"] = () => CodeSample(["BsConfirmDialogDemo.cs"], Result: BsConfirmDialogDemo()),
             ["bootstrap-collapse"] = () => CodeSample(["BsCollapseDemo.cs"], Result: BsCollapseDemo()),
             ["bootstrap-spinner"] = () => CodeSample(["BsSpinnerDemo.cs"], Result: BsSpinnerDemo()),
             ["bootstrap-progress"] = () => CodeSample(["BsProgressDemo.cs"], Result: BsProgressDemo()),

--- a/tests/Rask.Bootstrap.Tests/BsOffcanvasTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsOffcanvasTests.cs
@@ -1,0 +1,49 @@
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for BsOffcanvas. The panel always stays in the DOM (role="dialog",
+// tabindex=-1); Open adds .show and, unless suppressed, a dimming backdrop. ToHtml() renders static
+// markup — the click handlers are exercised live in the showcase E2E.
+public class BsOffcanvasTests
+{
+    [Fact]
+    public void Closed_RendersPanelWithHeaderAndBody_NoShowNoBackdrop() =>
+        Assert.Equal(
+            "<div class=\"offcanvas offcanvas-start\" role=\"dialog\" tabindex=\"-1\">" +
+            "<div class=\"offcanvas-header\"><h5 class=\"offcanvas-title\">Menu</h5>" +
+            "<button class=\"btn-close\" aria-label=\"Close\" type=\"button\"></button></div>" +
+            "<div class=\"offcanvas-body\">Body</div></div>",
+            BsOffcanvas(Title: "Menu")["Body"].ToHtml());
+
+    [Fact]
+    public void Open_AddsShowAndBackdrop() =>
+        Assert.Equal(
+            "<div class=\"offcanvas offcanvas-start show\" role=\"dialog\" tabindex=\"-1\">" +
+            "<div class=\"offcanvas-header\"><h5 class=\"offcanvas-title\">Menu</h5>" +
+            "<button class=\"btn-close\" aria-label=\"Close\" type=\"button\"></button></div>" +
+            "<div class=\"offcanvas-body\">Body</div></div>" +
+            "<div class=\"offcanvas-backdrop fade show\"></div>",
+            BsOffcanvas(Open: true, Title: "Menu")["Body"].ToHtml());
+
+    [Fact]
+    public void Placement_End_SwitchesSideClass() =>
+        Assert.Equal(
+            "<div class=\"offcanvas offcanvas-end\" role=\"dialog\" tabindex=\"-1\">" +
+            "<div class=\"offcanvas-body\">Body</div></div>",
+            BsOffcanvas(Placement: BsPlacement.End, HideClose: true)["Body"].ToHtml());
+
+    [Fact]
+    // With no Title and HideClose, the drawer carries no header chrome.
+    public void HideCloseWithoutTitle_OmitsHeader() =>
+        Assert.Equal(
+            "<div class=\"offcanvas offcanvas-start\" role=\"dialog\" tabindex=\"-1\">" +
+            "<div class=\"offcanvas-body\">Body</div></div>",
+            BsOffcanvas(HideClose: true)["Body"].ToHtml());
+
+    [Fact]
+    // Backdrop: false suppresses the dimming layer even when open.
+    public void OpenWithBackdropFalse_RendersNoBackdrop() =>
+        Assert.Equal(
+            "<div class=\"offcanvas offcanvas-start show\" role=\"dialog\" tabindex=\"-1\">" +
+            "<div class=\"offcanvas-body\">Body</div></div>",
+            BsOffcanvas(Open: true, Backdrop: false, HideClose: true)["Body"].ToHtml());
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -351,7 +351,11 @@ public abstract partial class SharedSmokeTests
         await Page.Locator(".guide-demo button:has-text('Open settings')").First.ClickAsync();
         var drawer = Page.Locator(".guide-demo .sample-result-body .offcanvas.show").First;
         await Expect(drawer).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
-        await Page.Locator(".guide-demo .sample-result-body .offcanvas-backdrop").First.ClickAsync();
+        // Dispatch the click rather than actuate it: the .offcanvas-backdrop is position:fixed far down a
+        // long guide page, where Playwright's actionability/scroll handling can fail to land a real click on
+        // a fixed Bs overlay. DispatchEventAsync fires the handler directly — the same idiom the sidebar
+        // drawer dismissal uses above.
+        await Page.Locator(".guide-demo .sample-result-body .offcanvas-backdrop").First.DispatchEventAsync("click");
         await Expect(Page.Locator(".guide-demo .sample-result-body .offcanvas.show")).ToHaveCountAsync(0,
             new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -346,6 +346,26 @@ public abstract partial class SharedSmokeTests
         await Expect(Page.Locator("#demo-dropdown-out")).ToContainTextAsync("Archive",
             new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
+        // Offcanvas — the panel stays in the DOM and slides in via .show; the trigger opens it, a
+        // backdrop click dismisses it, all through the live diff (no bootstrap.js).
+        await Page.Locator(".guide-demo button:has-text('Open settings')").First.ClickAsync();
+        var drawer = Page.Locator(".guide-demo .sample-result-body .offcanvas.show").First;
+        await Expect(drawer).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
+        await Page.Locator(".guide-demo .sample-result-body .offcanvas-backdrop").First.ClickAsync();
+        await Expect(Page.Locator(".guide-demo .sample-result-body .offcanvas.show")).ToHaveCountAsync(0,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
+
+        // Confirm dialog — a BsModal-backed prompt. Confirming runs the action (updates the readout) and
+        // closes it; the destructive confirm button is btn-danger.
+        await Page.Locator(".guide-demo button:has-text('Delete item')").First.ClickAsync();
+        var confirm = Page.Locator("div.modal.show").First;
+        await Expect(confirm).ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 15_000 });
+        await confirm.Locator("button.btn-danger:has-text('Delete')").First.ClickAsync();
+        await Expect(Page.Locator("div.modal.show")).ToHaveCountAsync(0,
+            new LocatorAssertionsToHaveCountOptions { Timeout = 15_000 });
+        await Expect(Page.Locator("#bs-confirm-status")).ToContainTextAsync("deleted",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
         // === Toasts — shown and dismissed entirely by live-diff state (no bootstrap.js, no data-bs-dismiss).
         //     Showing renders class="toast show"; the × removes it. ===
         await SideAsync("Toasts", "toasts", "main .markdown-body h1");


### PR DESCRIPTION
## Summary

Continues the `Bs*` demo-coverage series (after #446, #450) with the two interactive **overlay** components that were documented in prose only — no runnable demo, no browser coverage — on the *Modals, offcanvas & dropdowns* guide:

- **`BsOffcanvas`** → `BsOffcanvasDemo` — a drawer that slides in from the end over a dimming backdrop; dismisses via the ×, the backdrop, or a footer button, all through the live diff (no `bootstrap.js`).
- **`BsConfirmDialog`** → `BsConfirmDialogDemo` — a `BsModal`-backed confirm/cancel prompt for a destructive delete, with a status readout that updates on confirm/cancel.

Each demo shows its source via `CodeSample` (code above, live result below), wired through the usual demo component + `DemoRegistry` entry + `<!-- demo: -->` marker.

## Changes

- New demos: `BsOffcanvasDemo.cs`, `BsConfirmDialogDemo.cs` (+ registry keys `bootstrap-offcanvas` / `bootstrap-confirm`, markers in `docs/bootstrap-overlays.md`).
- New unit tests: `BsOffcanvasTests` — 5 exact rendered-HTML facts (closed panel, open + backdrop, placement, headerless, backdrop-suppressed). `BsConfirmDialog` already had unit tests.
- E2E: `WalkBootstrapGuideAsync` now drives both on the overlays page — open the drawer + backdrop-dismiss it (via `DispatchEventAsync` to avoid the fixed-overlay click flake), and confirm the destructive-delete dialog (asserting the status readout).

## Testing

- `dotnet format` clean; `dotnet build -warnaserror` analyzer-clean.
- Unit: full `Rask.Bootstrap.Tests` + `Rask.Example.Shared.Tests` (incl. guide marker↔registry integrity) green.
- E2E: full `scripts/run-e2e-local.sh` gate green — 26/26; the hardened offcanvas step re-verified on the slower WASM transport after a code-review flag.
- No benchmarks: sample/docs/test only.

## Changelog

`[Unreleased]` updated under Added.