### PR TITLE
chore(skills): add run-rask skill to launch and drive the Server showcase

### DIFF
--- a/.claude/skills/run-rask/.gitignore
+++ b/.claude/skills/run-rask/.gitignore
@@ -1,0 +1,3 @@
+screenshots/
+obj/
+bin/

--- a/.claude/skills/run-rask/SKILL.md
+++ b/.claude/skills/run-rask/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: run-rask
+description: Build, launch, and drive the Rask Server showcase app (samples/Rask.Example.Server) — the server-rendered, live-over-WebSocket demo of the framework. Use to run/start/launch the app, take a screenshot, or confirm a UI change works in the real running app (not just tests). Drives it headlessly with a committed C# Playwright driver — pure .NET, no Node.
+---
+
+# Run the Rask showcase
+
+`samples/Rask.Example.Server` is the framework's showcase: plain-C# components, **server-rendered
+and live-updated over a WebSocket** (the browser posts `data-rask-on-*` events, the server
+re-renders and streams back a DOM diff). It's the app to launch when you want to *see* a change.
+
+**`curl` can only see the first server-rendered HTML — it can never observe the live loop.** To
+prove interactivity you need a real browser. The committed driver `.claude/skills/run-rask/driver.cs`
+does that with the repo's existing **Microsoft.Playwright** (.NET) dependency — the same version the
+E2E suite uses, browsers already in the `ms-playwright` cache. It's a .NET 10 *file-based app*: **no
+Node, no npm, no csproj** — just `dotnet run driver.cs`.
+
+All paths below are relative to the repo root (the unit). Run everything from there unless told
+otherwise.
+
+## Prerequisites
+
+- **.NET 10 SDK** — `dotnet --version` → `10.0.302` here. That's the whole toolchain; the driver
+  pulls `Microsoft.Playwright` via NuGet (version comes from `Directory.Packages.props`, so the
+  `#:package` directive is intentionally unversioned — Central Package Management supplies it).
+- **Playwright browsers** — already present in `~/Library/Caches/ms-playwright` (installed for the
+  E2E suite). If missing, the driver errors with a "browser not found" message; install with
+  `dotnet run --project tests/Rask.Examples.E2E.Tests -- ...` build once then run the generated
+  `playwright.ps1 install chromium`, or see `scripts/run-e2e-local.sh`.
+
+## Build
+
+```bash
+dotnet build samples/Rask.Example.Server -c Debug -m:1
+```
+
+~3–8s. Pulls in Rask.Core, Rask.Server, Rask.Bootstrap, the generators, and the shared sample
+assembly. Clean build = 0 warnings.
+
+## Run (agent path)
+
+1. **Launch the server in the background** (override the port explicitly; check it's free first):
+
+   ```bash
+   lsof -ti :5099 && echo "BUSY — see Gotchas" || echo "free"
+   ASPNETCORE_ENVIRONMENT=Development \
+     dotnet run --project samples/Rask.Example.Server -c Debug --no-build \
+     --urls http://localhost:5099 > /tmp/rask-server.log 2>&1 &
+   ```
+
+2. **Wait for it, smoke it with curl** (initial HTML only):
+
+   ```bash
+   for i in $(seq 1 30); do curl -sf http://localhost:5099/ -o /dev/null && { echo "UP (${i}s)"; break; }; sleep 1; done
+   curl -s http://localhost:5099/ | grep -o '<title>[^<]*</title>'   # → <title>Rask</title>
+   ```
+
+3. **Drive it with the C# Playwright driver** — screenshots + the live WebSocket round-trip. Run it
+   **from the skill directory** so screenshots land in `./screenshots/`:
+
+   ```bash
+   cd .claude/skills/run-rask
+   dotnet run driver.cs all          # screenshots home/todos/table/routing + toggles a todo over WS
+   ```
+
+   Expected output (this is what it printed here):
+
+   ```
+   Driving http://localhost:5099  (all)
+     OK /                      200  "Guides — Rask"  -> home.png
+     OK /todos                 200  "Todos — Rask"  -> todos.png
+     OK /table                 200  "Data table — Rask"  -> table.png
+     OK /routing-demo/about    200  "Rask — feature showcase"  -> routing-about.png
+     OK /todos checkbox toggled over WS: False -> True  -> todos-toggled.png
+   done.
+   ```
+
+   Screenshots land in `.claude/skills/run-rask/screenshots/`. **Open one** (e.g. `todos-toggled.png`
+   shows the flipped checkbox) to confirm the render is real.
+
+   Driver commands: `shots` (screenshots only, the default), `todos` (interactive WS proof only),
+   `all`. Point it at another port with a second arg: `dotnet run driver.cs all http://localhost:5199`.
+
+4. **Stop the server** when done:
+
+   ```bash
+   lsof -ti :5099 | xargs kill
+   ```
+
+## Run (human path)
+
+```bash
+dotnet run --project samples/Rask.Example.Server
+```
+
+Serves on http://localhost:5099 (from `Properties/launchSettings.json`); open it in a browser.
+Useless for automation — it blocks the terminal and opens nothing headlessly. Ctrl-C to stop.
+
+## Gotchas
+
+- **`curl` sees a dead page.** The showcase only becomes interactive once the browser opens the
+  WebSocket. Any "does clicking work?" question must go through `driver.cs`, not curl.
+- **`/counter` from the README is NOT a live route.** It's a doc snippet. The showcase's real routes
+  come from the sidebar: `/` (guides), `/todos`, `/table`, `/routing-demo/about`, `/server-pwa`, and
+  the device-API demos (`/serial`, `/usb`, `/bluetooth`, `/wake-lock`, …). Hitting a bogus path
+  returns a styled 200 "Page not found" — don't mistake it for a working page.
+- **Port 5099 is shared and hardcoded.** It's the same port the E2E gate (`scripts/run-e2e-local.sh`)
+  and every other worktree use. If `lsof -ti :5099` shows it busy, a *different* build is answering
+  your requests and your driver will silently test the wrong app. Launch on another port
+  (`--urls http://localhost:5199`) and pass `dotnet run driver.cs all http://localhost:5199`. The
+  pre-push hook also runs E2E on 5099, so a server you left running there will block a push.
+- **The driver is a file-based app, so two `#:property` lines are load-bearing.** `#:package
+  Microsoft.Playwright` is deliberately **unversioned** — the repo enforces Central Package
+  Management, which *forbids* a version on the reference and supplies 1.61.0 itself; adding `@1.61.0`
+  fails with NU1008. And `JsonSerializerIsReflectionEnabledByDefault=true` is required because
+  file-based apps disable reflection-based System.Text.Json by default, which Playwright's transport
+  needs (without it: `Reflection-based serialization has been disabled`).
+- **Native samples don't build here.** `Rask.Example.Native{,.Server}` multi-target
+  `net10.0-ios;net10.0-android` and are excluded from `Rask.slnx`; without the mobile workloads they
+  won't restore. This skill is the *web* showcase only.
+
+## Troubleshooting
+
+- `error NU1008: … cannot define a value for Version: Microsoft.Playwright` → you added a version to
+  the `#:package` directive; remove it (CPM owns the version — see Gotchas).
+- `Reflection-based serialization has been disabled` on `Playwright.CreateAsync()` → the
+  `#:property JsonSerializerIsReflectionEnabledByDefault=true` line is missing from `driver.cs`.
+- Driver hangs on `WaitForFunctionAsync` / times out → the server isn't up on the base URL's port, or
+  another worktree grabbed 5099. Re-check step 1's `lsof` and `curl`.
+- `dotnet run --project …` exits immediately with an address-in-use bind error → 5099 is taken; pick
+  another port (see Gotchas) or kill the holder with `lsof -ti :5099 | xargs kill`.

--- a/.claude/skills/run-rask/driver.cs
+++ b/.claude/skills/run-rask/driver.cs
@@ -1,0 +1,92 @@
+#:package Microsoft.Playwright
+#:property JsonSerializerIsReflectionEnabledByDefault=true
+// Driver for the Rask Server showcase (samples/Rask.Example.Server).
+//
+// The showcase is a server-rendered app whose components live-update over a WebSocket: the browser
+// sends `data-rask-on-*` events, the server re-renders and streams back a DOM diff. `curl` sees only
+// the first server-rendered HTML — it can NEVER observe the live loop. This driver uses the repo's
+// existing Microsoft.Playwright dependency (same version the E2E suite uses; browsers already in the
+// ms-playwright cache) to load pages, screenshot them, and exercise the WS round-trip.
+//
+// It's a .NET 10 *file-based app* — no csproj, no Node, no npm. Run it with `dotnet run driver.cs`.
+// The reflection-enabled property is required: file-based apps disable reflection-based System.Text.
+// Json by default, which Playwright's transport needs.
+//
+// Prereq: the server must already be running (see SKILL.md "Run" — launch it, then run this).
+//
+// Usage (run from THIS directory so screenshots land in ./screenshots/):
+//   dotnet run driver.cs                       # shots (default): screenshot home + a few pages
+//   dotnet run driver.cs todos                 # interactive: toggle a todo checkbox, assert the diff
+//   dotnet run driver.cs all                   # shots + todos
+//   dotnet run driver.cs all http://localhost:5199   # override the base URL
+
+using Microsoft.Playwright;
+
+string cmd = args.Length > 0 ? args[0] : "shots";
+string baseUrl = args.Length > 1 ? args[1] : "http://localhost:5099";
+string shotDir = Path.Combine(Directory.GetCurrentDirectory(), "screenshots");
+Directory.CreateDirectory(shotDir);
+
+// Home plus a spread of the showcase's pages.
+(string path, string name)[] pages =
+[
+    ("/", "home"),
+    ("/todos", "todos"),
+    ("/table", "table"),
+    ("/routing-demo/about", "routing-about"),
+];
+
+using var pw = await Playwright.CreateAsync();
+// Headless Chromium from the already-installed ms-playwright cache — no download.
+await using var browser = await pw.Chromium.LaunchAsync(new() { Headless = true });
+var page = await browser.NewPageAsync(new() { ViewportSize = new() { Width = 1280, Height = 900 } });
+
+Console.WriteLine($"Driving {baseUrl}  ({cmd})");
+
+if (cmd is "shots" or "all")
+{
+    foreach (var (path, name) in pages)
+    {
+        var res = await page.GotoAsync(baseUrl + path, new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 20000 });
+        await WaitLiveAsync(page);
+        var file = Path.Combine(shotDir, name + ".png");
+        await page.ScreenshotAsync(new() { Path = file });
+        Console.WriteLine($"  OK {path,-22} {res!.Status}  \"{await page.TitleAsync()}\"  -> {name}.png");
+    }
+}
+
+if (cmd is "todos" or "all")
+{
+    await page.GotoAsync(baseUrl + "/todos", new() { WaitUntil = WaitUntilState.NetworkIdle, Timeout = 20000 });
+    await WaitLiveAsync(page);
+    var boxes = page.Locator("input.form-check-input[type=checkbox]");
+    if (await boxes.CountAsync() == 0)
+        throw new Exception("no todo checkboxes found — page shape changed?");
+
+    var before = await boxes.First.IsCheckedAsync();
+    await boxes.First.ClickAsync();
+    // The re-render arrives over the WS; wait for the checkbox to reflect the flipped state.
+    await page.WaitForFunctionAsync(
+        "was => { const el = document.querySelector('input.form-check-input[type=checkbox]'); return el && el.checked !== was; }",
+        before, new() { Timeout = 10000 });
+    var after = await page.Locator("input.form-check-input[type=checkbox]").First.IsCheckedAsync();
+    await page.ScreenshotAsync(new() { Path = Path.Combine(shotDir, "todos-toggled.png") });
+    if (after == before)
+        throw new Exception($"toggle did NOT round-trip (still {after})");
+    Console.WriteLine($"  OK /todos checkbox toggled over WS: {before} -> {after}  -> todos-toggled.png");
+}
+
+Console.WriteLine("done.");
+
+// The live client swaps `data-rask-connecting` off <html> once the WebSocket is open. Waiting for it
+// guarantees the interactive loop is live before we click anything (already gone? fine — we move on).
+static async Task WaitLiveAsync(IPage page)
+{
+    try
+    {
+        await page.WaitForFunctionAsync(
+            "() => !document.documentElement.hasAttribute('data-rask-connecting')",
+            null, new() { Timeout = 15000 });
+    }
+    catch (TimeoutException) { }
+}


### PR DESCRIPTION
## Summary

Adds a committed **run playbook** at `.claude/skills/run-rask/` so a future agent (or human) can
build, launch, and *drive* the `Rask.Example.Server` showcase from a clean machine — not just run its
tests. The showcase is server-rendered and live-updated over a WebSocket, so `curl` can only ever see
the first HTML; proving interactivity needs a real browser.

- **`driver.cs`** — a .NET 10 *file-based app* (`dotnet run driver.cs`): **no Node, no npm, no
  csproj**. It reuses the repo's existing `Microsoft.Playwright` dependency and the already-installed
  browsers to screenshot the showcase pages and exercise the live WebSocket round-trip (toggles a
  todo checkbox and asserts the diff comes back). Two `#:property` lines are load-bearing and
  documented inline: the `#:package` is intentionally unversioned (CPM owns the version), and
  reflection-based `System.Text.Json` is re-enabled for Playwright's transport.
- **`SKILL.md`** — the agent path (launch → curl smoke → driver), the human path, and the real
  gotchas (the README's `/counter` is not a live route; port 5099 is shared with the E2E gate and
  every worktree; native samples don't build here).

Tooling only — no framework, `src/`, or `samples/` code changes.

## Testing
- Unit: n/a — no product code changed (skill lives under `.claude/skills/`).
- E2E: not applicable to the change, but the pre-push browser-journey gate
  (`scripts/run-e2e-local.sh`, Server host on :5099) was run on push and passed.
- The skill itself was verified end-to-end from a clean slate: build → background-launch → `dotnet
  run driver.cs all` produced 5 real screenshots and confirmed the WS toggle (`False -> True`).

## Benchmarks
n/a — no render/runtime hotpath change.

## CHANGELOG
- n/a — internal agent tooling under `.claude/skills/`, not a user-facing framework change.
