### PR TITLE
docs(bootstrap): live demos for BsTable & BsPagination, unit tests for BsBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **Live demos for `BsTable` and `BsPagination`, plus unit tests for `BsBadge`.** The "Cards, lists &
+  tables" guide gains a `BsTable` demo (typed style toggles over core `Thead`/`Tbody` markup) and an
+  interactive `BsPagination` demo (click a page — the `.active` marker and readout follow, zero-JS). Both
+  components were already unit-tested; `BsBadge` (already shown on the buttons demo) now gets a
+  rendered-markup unit test too. The shared browser E2E journey asserts the table rows, drives the
+  pagination page-click, and checks a badge renders — closing the last `Bs*` demo/test-coverage gaps.
 - **Live demos and unit tests for `BsOffcanvas` and `BsConfirmDialog`.** The two interactive overlay
   components — previously documented in prose only — now each have a showcase demo (code-above /
   live-result-below) on the "Modals, offcanvas & dropdowns" guide: an offcanvas drawer that slides in

--- a/docs/bootstrap-cards.md
+++ b/docs/bootstrap-cards.md
@@ -84,3 +84,29 @@ BsPlaceholder(Col: 7, Animation: BsPlaceholderAnimation.Glow)
 ```
 
 <!-- demo:bootstrap-placeholder -->
+
+## Tables
+
+`BsTable` wraps a core `<table>` with the typed style toggles — `Striped`, `Hover`, `Bordered`,
+`Small`, `Responsive`, and more — over the usual `Thead`/`Tbody`/`Tr`/`Th`/`Td` markup. For typed
+columns, click-to-sort and paging, reach for [`BsDataGrid<T>`](data-grid.md) instead.
+
+```csharp
+BsTable(Striped: true, Hover: true)[ Thead()[Tr()[Th()["Name"]]], Tbody()[Tr()[Td()["Ada"]]] ]
+```
+
+<!-- demo:bootstrap-table -->
+
+## Pagination
+
+`BsPagination`(+`BsPageItem`) renders `<nav><ul class="pagination">…`. Each item is a real `<button>`
+(or an `<a>` with `Href`); wire `OnClick` to drive paging from C#, mark the current page `Active`, and
+`Disabled` greys the ends — all zero-JS through the live runtime.
+
+```csharp
+BsPagination()[
+    BsPageItem(Disabled: true)["Previous"], BsPageItem(Active: true)["1"], BsPageItem()["2"]
+]
+```
+
+<!-- demo:bootstrap-pagination -->

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsPaginationDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsPaginationDemo.cs
@@ -1,0 +1,27 @@
+namespace Rask.Example.Shared.Features;
+
+// A Bootstrap pagination control driven by Rask's live runtime — no bootstrap.js. Each BsPageItem is a
+// real <button>; its OnClick flips _page and the live diff re-renders, moving the .active marker and
+// disabling Previous/Next at the ends. The readout below tracks the current page.
+public sealed class BsPaginationDemo : Component
+{
+    private const int TotalPages = 5;
+    private int _page = 1;
+
+    protected override Component? Render()
+    {
+        IEnumerable<Component?> items =
+        [
+            BsPageItem(Key: "prev", Disabled: _page == 1, OnClick: () => { if (_page > 1) _page--; })["Previous"],
+            .. Enumerable.Range(1, TotalPages)
+                .Select(p => BsPageItem(Key: p.ToString(), Active: p == _page, OnClick: () => _page = p)[p.ToString()]),
+            BsPageItem(Key: "next", Disabled: _page == TotalPages, OnClick: () => { if (_page < TotalPages) _page++; })["Next"],
+        ];
+
+        return
+        [
+            BsPagination(Label: "Demo pages")[items],
+            P(Id: "bs-pagination-status", Class: "mt-2 mb-0 text-body-secondary")[$"Page {_page} of {TotalPages}"]
+        ];
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsTableDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsTableDemo.cs
@@ -1,0 +1,19 @@
+namespace Rask.Example.Shared.Features;
+
+// A Bootstrap table — the typed style toggles (Striped/Hover/Bordered/…) map to the .table-* classes.
+// Children are the usual core Thead/Tbody/Tr/Th/Td markup. For typed columns, sorting and paging, reach
+// for BsDataGrid<T> instead (see the data-grid guide).
+public sealed class BsTableDemo : Component
+{
+    protected override Component? Render() =>
+        BsTable(Striped: true, Hover: true, Bordered: true)[
+            Thead()[
+                Tr()[Th()["#"], Th()["Name"], Th()["Role"]]
+            ],
+            Tbody()[
+                Tr()[Td()["1"], Td()["Ada Lovelace"], Td()["Engineer"]],
+                Tr()[Td()["2"], Td()["Grace Hopper"], Td()["Admiral"]],
+                Tr()[Td()["3"], Td()["Alan Turing"], Td()["Codebreaker"]]
+            ]
+        ];
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -285,6 +285,8 @@ public static class DemoRegistry
             ["bootstrap-icons"] = () => CodeSample(["BsIconsDemo.cs"], Result: BsIconsDemo()),
             ["bootstrap-modal"] = () => CodeSample(["BsModalDemo.cs"], Result: BsModalDemo()),
             ["bootstrap-tabs"] = () => CodeSample(["BsTabsDemo.cs"], Result: BsTabsDemo()),
+            ["bootstrap-table"] = () => CodeSample(["BsTableDemo.cs"], Result: BsTableDemo()),
+            ["bootstrap-pagination"] = () => CodeSample(["BsPaginationDemo.cs"], Result: BsPaginationDemo()),
             ["bootstrap-offcanvas"] = () => CodeSample(["BsOffcanvasDemo.cs"], Result: BsOffcanvasDemo()),
             ["bootstrap-confirm"] = () => CodeSample(["BsConfirmDialogDemo.cs"], Result: BsConfirmDialogDemo()),
             ["bootstrap-collapse"] = () => CodeSample(["BsCollapseDemo.cs"], Result: BsCollapseDemo()),

--- a/tests/Rask.Bootstrap.Tests/BsBadgeTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsBadgeTests.cs
@@ -1,0 +1,31 @@
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for BsBadge — the .badge span, Bootstrap 5.3's contrast-aware text-bg-*
+// colour helper, the pill modifier, and user class/style merging.
+public class BsBadgeTests
+{
+    [Fact]
+    public void Badge_NoColor_IsPlainBadgeSpan() =>
+        Assert.Equal(
+            "<span class=\"badge\">New</span>",
+            BsBadge()["New"].ToHtml());
+
+    [Fact]
+    public void Badge_Color_UsesContrastAwareTextBg() =>
+        Assert.Equal(
+            "<span class=\"badge text-bg-success\">New</span>",
+            BsBadge(Color: BsColor.Success)["New"].ToHtml());
+
+    [Fact]
+    // Modifier order: base, colour, pill, then the caller's own class.
+    public void Badge_PillWithColor_AddsRoundedPill() =>
+        Assert.Equal(
+            "<span class=\"badge text-bg-primary rounded-pill\">4</span>",
+            BsBadge(Color: BsColor.Primary, Pill: true)["4"].ToHtml());
+
+    [Fact]
+    public void Badge_MergesUserClassAndStyle() =>
+        Assert.Equal(
+            "<span class=\"badge ms-1\" style=\"font-size:1rem\">7</span>",
+            BsBadge(Class: "ms-1", Style: "font-size:1rem")["7"].ToHtml());
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -270,6 +270,9 @@ public abstract partial class SharedSmokeTests
         // Gate on it so the page has hydrated before we assert.
         await Expect(Page.Locator(".guide-demo .sample-result-body button.btn.btn-primary").First)
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 45_000 });
+        // Badges render on the same demo (the .badge span; exact markup is unit-tested).
+        await Expect(Page.Locator(".guide-demo .sample-result-body .badge").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
 
         // === Tabs, accordion & collapse — the disclosure components, all controlled and zero-JS. The
         //     accordion is embedded in the tabs demo; BsCollapse has its own demo whose toggle flips Open. ===
@@ -393,6 +396,17 @@ public abstract partial class SharedSmokeTests
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
         await Expect(Page.Locator(".guide-demo .sample-result-body .placeholder").First)
             .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        // BsTable renders its rows (static — structural proof; exact markup is unit-tested).
+        await Expect(Page.Locator(".guide-demo .sample-result-body table.table tbody tr").First)
+            .ToBeVisibleAsync(new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        // BsPagination — clicking a page button flips _page through the live runtime: the .active marker
+        // moves to that page and the readout updates. Each item is a real <button>, no bootstrap.js.
+        await Page.Locator(".guide-demo .sample-result-body .pagination .page-link")
+            .Filter(new LocatorFilterOptions { HasText = "3" }).First.ClickAsync();
+        await Expect(Page.Locator(".guide-demo .sample-result-body .pagination .page-item.active .page-link"))
+            .ToHaveTextAsync("3", new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });
+        await Expect(Page.Locator("#bs-pagination-status")).ToContainTextAsync("Page 3",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
 
         // === Form controls — the IFormControl<T>-bound demo, incl. the in-form single-select (BsSelect). ===
         await SideAsync("Form controls", "form controls", "main .markdown-body h1");


### PR DESCRIPTION
## Summary

Final PR of the `Bs*` demo-coverage series (after #446, #450, #451) — closes the remaining gaps on the *Cards, lists & tables* and *Buttons & badges* guides:

- **`BsTable`** → `BsTableDemo` — the typed style toggles (`Striped`/`Hover`/`Bordered`) over core `Thead`/`Tbody`/`Tr`/`Th`/`Td` markup.
- **`BsPagination`** → `BsPaginationDemo` — interactive: each `BsPageItem` is a real `<button>` whose `OnClick` flips the page through the live runtime; the `.active` marker moves and a readout tracks the current page (keyed items, RASK022-clean).
- **`BsBadge`** — already shown on the buttons demo, so it needed only the missing rendered-markup unit test.

## Changes

- New demos: `BsTableDemo.cs`, `BsPaginationDemo.cs` (+ registry keys `bootstrap-table` / `bootstrap-pagination`, new *Tables* and *Pagination* sections with markers in `docs/bootstrap-cards.md`).
- New unit tests: `BsBadgeTests` — 4 exact rendered-HTML facts (plain, contrast-aware `text-bg-*`, pill, class/style merge). `BsTable` and `BsPagination` already had unit tests.
- E2E: `WalkBootstrapGuideAsync` now asserts a badge renders (buttons page), the table rows render, and drives the pagination page-click (asserting the active marker + status readout) on the cards page.

## Testing

- `dotnet format` clean; `dotnet build -warnaserror` analyzer-clean.
- Unit: full `Rask.Bootstrap.Tests` + `Rask.Example.Shared.Tests` (incl. guide marker↔registry integrity) green.
- E2E: full `scripts/run-e2e-local.sh` gate green — 26/26.
- Code review: no findings. No benchmarks (sample/docs/test only).

## Changelog

`[Unreleased]` updated under Added.