### PR TITLE
chore(skills): add run-rask-cli skill to build and drive the rask CLI

### DIFF
--- a/.claude/skills/run-rask-cli/SKILL.md
+++ b/.claude/skills/run-rask-cli/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: run-rask-cli
+description: Build and drive the `rask` CLI (src/Rask.Cli) — the framework's scaffolding front door (rask new / generate / db / dev / deploy / info). Use to run, build, smoke-test, or exercise the CLI, or to confirm a change to `rask new` or `rask generate` actually scaffolds a real project on disk (not just that a unit test passes). Driven by a committed bash smoke script.
+---
+
+# Run / drive the `rask` CLI
+
+`src/Rask.Cli` is the `rask` command-line tool: `rask new` scaffolds a project, `rask generate`
+scaffolds pages/components/CRUD features/jobs/emails into it, and `rask info|db|dev|deploy` wrap the
+.NET SDK. It ships as a .NET tool (`ToolCommandName=rask`), but from this repo you drive it from
+source with `dotnet run --project src/Rask.Cli -- <args>`.
+
+The thing worth *driving* (vs. unit-testing) is the two commands that write artifacts end-to-end —
+`new` and `generate`. The committed driver **`.claude/skills/run-rask-cli/smoke.sh`** scaffolds a
+project into a temp dir, generates into it, and asserts both exit codes *and* the files/plans that
+appear. That's the CLI's equivalent of "take a screenshot": proof the assembled tool produces a real
+project, not just that an internal method returns the right string.
+
+All paths below are relative to the repo root (the unit).
+
+## Prerequisites
+
+- **.NET 10 SDK** — `dotnet --version` → `10.0.302` here. Nothing else for the smoke (it uses
+  `--dry-run` for the package-adding step, so it needs no network).
+- **Network** is required only for the *full* `rask generate feature` (no `--dry-run`) and for
+  `rask new`'s restore — they hit nuget.org. See Gotchas.
+
+## Build
+
+```bash
+dotnet build src/Rask.Cli -c Debug -m:1
+```
+
+Sub-second warm. Clean build = 0 warnings.
+
+## Run (agent path)
+
+Run the smoke driver — it builds the CLI, then drives `info`, `new`, `generate`, and the error paths,
+printing PASS/FAIL per check and exiting non-zero on any failure:
+
+```bash
+.claude/skills/run-rask-cli/smoke.sh
+# or skip the rebuild if you just built:
+RASK_CLI_NO_BUILD=1 .claude/skills/run-rask-cli/smoke.sh
+```
+
+Expected tail (this is what it printed here):
+
+```
+==> Scaffold a new server project
+  PASS  new Shop  (exit 0)
+  PASS  file: Shop/Shop.csproj
+  ...
+==> Generate a CRUD feature (dry-run: hermetic, shows the plan, no nuget)
+  PASS  generate feature --dry-run (CRUD plan)
+==> Error paths (must exit 1 with a helpful message)
+  PASS  generate outside a project  (exit 1)
+  PASS  unknown command  (exit 1)
+  PASS  bad field type  (exit 1)
+
+==> 12 passed, 0 failed.
+```
+
+The driver scaffolds into a `mktemp -d` dir and cleans up on exit — it leaves nothing in the repo.
+
+## Direct invocation (drive one command by hand)
+
+From source, everything after `--` is passed to `rask`:
+
+```bash
+dotnet run --project src/Rask.Cli --no-build -- info
+dotnet run --project src/Rask.Cli --no-build -- new Shop --template server --output /tmp/Shop
+# generate resolves the project by walking UP for a single .csproj, so run it INSIDE the project:
+( cd /tmp/Shop && dotnet run --project "$OLDPWD/src/Rask.Cli" --no-build -- \
+    generate feature Product Name:string Price:decimal --dry-run )
+```
+
+`--dry-run` prints each file it *would* write (and adds no packages, touches no network) — use it to
+inspect scaffolding output hermetically. Drop it to actually write the files.
+
+## Run (human path)
+
+Packaged as a global tool (`dotnet tool install -g Rask.Cli` → `rask new …`). Not exercised here — no
+published package in this container — so treat the `dotnet run --project … --` form above as the
+verified path.
+
+## Test
+
+```bash
+dotnet test tests/Rask.Cli.Tests -c Debug
+```
+
+325 tests, ~real-fast. This is the unit sanity check; the smoke driver is what proves the
+end-to-end scaffolding.
+
+## Gotchas
+
+- **`generate` resolves the target project by walking UP the directory tree for a *single* `.csproj`.**
+  Run it from inside the project dir. From a dir with no project it exits 1 (`Couldn't find a single
+  .csproj …`); worse, from a dir that happens to have a *stray* `.csproj` above it, it silently
+  scaffolds into that project's namespace — running `generate page Foo` from `/tmp` here produced a
+  `namespace Rask.Wasm.Hosting.Features.Foo` because it found a csproj up the tree. Always `cd` into
+  the project first.
+- **Validation order: project first, fields second.** `generate feature Bad Name:wobble` reports
+  `Couldn't find a single .csproj` (not the bad type) when run outside a project — the type error
+  (`Unknown field type 'wobble'. Supported: …`) only surfaces once a project is found. That's why the
+  smoke runs the bad-field check *inside* the scaffolded Shop project.
+- **The full `generate feature` mutates the `.csproj` and hits nuget.org** to add EF Core + SQLite,
+  Rask.Cqrs, Rask.Data. That's why the smoke uses `--dry-run` for it. A real run needs network and
+  will edit the project file — don't run it against a repo you don't want touched.
+- **Mind the `--`.** `dotnet run --project src/Rask.Cli -- <rask args>` — without the `--`, `dotnet`
+  tries to parse `new`/`generate`/flags as *its own* arguments.
+- **Version looks like `0.18.1-alpha.0.16`** — MinVer-derived from git height, not a hardcoded
+  string. `rask --version` and `rask info` both report it.
+
+## Troubleshooting
+
+- `Couldn't find a single .csproj at or above '<dir>'. Run this inside a Rask project.` → you ran
+  `generate` from outside a project; `cd` into the scaffolded app first.
+- `dotnet` errors with `Unrecognized command or argument 'new'` (or similar) → you dropped the `--`
+  separating dotnet's args from rask's.
+- The smoke's `generate feature --dry-run` check fails with a network/package error → you removed
+  `--dry-run`; the real feature generate needs nuget.org and writes to the `.csproj`.

--- a/.claude/skills/run-rask-cli/smoke.sh
+++ b/.claude/skills/run-rask-cli/smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Smoke driver for the `rask` CLI (src/Rask.Cli).
+#
+# The CLI is the framework's front door: `rask new` scaffolds a project, `rask generate` scaffolds
+# pages/components/CRUD features/jobs/emails into it, `rask info|db|dev|deploy` wrap the SDK. This
+# script drives the two that actually produce artifacts end-to-end (new + generate), asserting exit
+# codes AND that the expected files / output show up — the thing a unit test of an internal method
+# can't prove: that the assembled tool scaffolds a real project on disk.
+#
+# It stays HERMETIC: the full `generate feature` reaches out to nuget.org to add EF Core/Cqrs/Data
+# packages, so the feature step here uses --dry-run (prints the plan, writes nothing, no network).
+# The real-write proof is `generate page`, which writes one .cs file and touches no packages.
+#
+# Usage (from anywhere — paths resolve off this script's location):
+#   .claude/skills/run-rask-cli/smoke.sh              # build the CLI, then run the smoke
+#   RASK_CLI_NO_BUILD=1 .claude/skills/run-rask-cli/smoke.sh   # skip the build (already built)
+set -uo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CLI_PROJ="$REPO/src/Rask.Cli"
+WORK="$(mktemp -d)"
+PASS=0; FAIL=0
+
+cleanup() { rm -rf "$WORK"; }
+trap cleanup EXIT
+
+rask() { dotnet run --project "$CLI_PROJ" --no-build -- "$@"; }
+
+# check <name> <expected-exit> <grep-pattern|-> -- <rask args...>   (runs in the current dir)
+check() { checkin "." "$@"; }
+
+# checkin <dir> <name> <expected-exit> <grep-pattern|-> -- <rask args...>
+checkin() {
+  local dir="$1" name="$2" want="$3" pat="$4"; shift 4; [ "$1" = "--" ] && shift
+  local out code
+  out="$(cd "$dir" && rask "$@" 2>&1)"; code=$?
+  local ok=1
+  [ "$code" = "$want" ] || ok=0
+  if [ "$pat" != "-" ]; then echo "$out" | grep -qE "$pat" || ok=0; fi
+  if [ "$ok" = 1 ]; then
+    echo "  PASS  $name  (exit $code)"; PASS=$((PASS+1))
+  else
+    echo "  FAIL  $name  (exit $code, wanted $want${pat:+, /$pat/})"; echo "$out" | sed 's/^/        | /' | head -6; FAIL=$((FAIL+1))
+  fi
+}
+
+# assert a file exists
+have() {
+  if [ -f "$1" ]; then echo "  PASS  file: ${1#$WORK/}"; PASS=$((PASS+1));
+  else echo "  FAIL  file missing: ${1#$WORK/}"; FAIL=$((FAIL+1)); fi
+}
+
+if [ "${RASK_CLI_NO_BUILD:-}" != "1" ]; then
+  echo "==> Build the CLI (Debug)"
+  dotnet build "$CLI_PROJ" -c Debug -m:1 --nologo | tail -2
+fi
+
+echo "==> Environment"
+check "info"            0 "Rask CLI"          -- info
+check "--version"       0 "[0-9]+\.[0-9]+"    -- --version
+
+echo "==> Scaffold a new server project"
+check "new Shop"        0 "Created Shop"      -- new Shop --template server --output "$WORK/Shop"
+have "$WORK/Shop/Shop.csproj"
+have "$WORK/Shop/Program.cs"
+have "$WORK/Shop/App.cs"
+
+echo "==> Generate into it (real write: a page — no packages, no network)"
+( cd "$WORK/Shop" && rask generate page Dashboard --route /dashboard ) >/dev/null 2>&1 \
+  && { echo "  PASS  generate page (exit 0)"; PASS=$((PASS+1)); } \
+  || { echo "  FAIL  generate page"; FAIL=$((FAIL+1)); }
+have "$WORK/Shop/Features/Dashboard/DashboardPage.cs"
+
+echo "==> Generate a CRUD feature (dry-run: hermetic, shows the plan, no nuget)"
+featureout="$( cd "$WORK/Shop" && rask generate feature Product Name:string Price:decimal --dry-run 2>&1 )"
+if echo "$featureout" | grep -q "would write Features/Products/Product.cs" \
+   && echo "$featureout" | grep -q "AggregateRoot"; then
+  echo "  PASS  generate feature --dry-run (CRUD plan)"; PASS=$((PASS+1))
+else
+  echo "  FAIL  generate feature --dry-run"; echo "$featureout" | sed 's/^/        | /' | head -6; FAIL=$((FAIL+1))
+fi
+
+echo "==> Error paths (must exit 1 with a helpful message)"
+mkdir -p "$WORK/empty"
+# Project is resolved by walking UP for a single .csproj — so "no project" must run in an empty dir,
+# and field validation (which happens AFTER project resolution) must run INSIDE the Shop project.
+checkin "$WORK/empty" "generate outside a project" 1 "Couldn't find a single .csproj" -- generate page Nope --dry-run
+check                 "unknown command"            1 "Unknown command"                -- frobnicate
+checkin "$WORK/Shop"  "bad field type"             1 "Unknown field type"             -- generate feature Bad Name:wobble --dry-run
+
+echo
+echo "==> $PASS passed, $FAIL failed."
+[ "$FAIL" = 0 ]


### PR DESCRIPTION
## Summary

Adds a committed **run playbook** at `.claude/skills/run-rask-cli/` for `src/Rask.Cli` — the
framework's scaffolding front door (`rask new` / `generate` / `db` / `dev` / `deploy` / `info`).
Complements the existing `run-rask` skill (which covers the Server showcase); this one drives the
*CLI*, a different surface with a different driver shape.

- **`smoke.sh`** — a bash driver that builds the CLI, scaffolds a project into a temp dir
  (`rask new`), generates into it (a real `generate page` write + a `--dry-run` CRUD `generate
  feature`), and asserts **exit codes and the artifacts/plans produced** — plus three error paths
  that must exit 1. 12/12 checks, hermetic (`--dry-run` avoids the feature generate's nuget package
  adds), self-cleaning (`mktemp`, nothing left in the repo).
- **`SKILL.md`** — the agent path (the smoke driver), direct per-command invocation, the unit-test
  command, and the real gotchas: `generate` resolves the project by walking *up* for a single
  `.csproj` (wrong dir → wrong namespace, observed as `Rask.Wasm.Hosting.Features.*` from `/tmp`),
  project-before-field validation order, and the network + `.csproj` mutation the full feature
  generate performs.

Tooling only — no framework, `src/`, or `samples/` code changes.

## Testing
- Driver: `.claude/skills/run-rask-cli/smoke.sh` → `12 passed, 0 failed`.
- CLI unit tests: `dotnet test tests/Rask.Cli.Tests` → 325 passed.
- The pre-push browser-journey E2E gate (`scripts/run-e2e-local.sh`, Server host on :5099) ran on
  push and passed (unrelated to this change, but not skipped).

## Benchmarks
n/a — no render/runtime hotpath change.

## CHANGELOG
- n/a — internal agent tooling under `.claude/skills/`, not a user-facing framework change.
