### PR TITLE
feat(cli): rich per-command --help with options table, examples, and color

### DIFF
--- a/.claude/skills/run-rask-cli/smoke.sh
+++ b/.claude/skills/run-rask-cli/smoke.sh
@@ -59,6 +59,17 @@ echo "==> Environment"
 check "info"            0 "Rask CLI"          -- info
 check "--version"       0 "[0-9]+\.[0-9]+"    -- --version
 
+echo "==> Help is discoverable (options table + examples; hidden feature flags surfaced)"
+check "generate --help shows feature flags" 0 "Feature options" -- generate --help
+check "generate --help shows examples"      0 "Examples:"       -- generate --help
+# --outbox/--tests were previously undocumented — help must now list them.
+helpout="$( rask generate --help 2>&1 )"
+if echo "$helpout" | grep -q -- "--outbox" && echo "$helpout" | grep -q -- "--tests"; then
+  echo "  PASS  generate --help lists --outbox/--tests"; PASS=$((PASS+1))
+else
+  echo "  FAIL  generate --help missing hidden flags"; echo "$helpout" | sed 's/^/        | /' | head -6; FAIL=$((FAIL+1))
+fi
+
 echo "==> Scaffold a new server project"
 check "new Shop"        0 "Created Shop"      -- new Shop --template server --output "$WORK/Shop"
 have "$WORK/Shop/Shop.csproj"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,14 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
-- **Live demos for `BsTable` and `BsPagination`, plus unit tests for `BsBadge`.** The "Cards, lists &
+- **`rask <command> --help` now teaches — an aligned options table, arguments, and examples.** Every command's
+  help was three lines (summary + one usage string); it now renders a described **Options** table straight from
+  the same schema that parses the arguments (so it can never drift), a **Arguments** section, and copy-pasteable
+  **Examples**. This surfaces `rask generate`'s previously **undiscoverable** feature flags — `--bs`, `--modal`,
+  `--soft-delete`, `--concurrency`, `--events`, `--outbox`, `--tests`, `--validation`, `--no-restore` — grouped
+  under "Feature options". Output is colorized when writing to a terminal and stays plain when piped or when
+  `NO_COLOR` is set (so `rask info | cat` and CI logs are unaffected). Parse errors now point at
+  `rask <command> --help`. No new dependencies — the styling and help layers are pure BCL. The "Cards, lists &
   tables" guide gains a `BsTable` demo (typed style toggles over core `Thead`/`Tbody` markup) and an
   interactive `BsPagination` demo (click a page — the `.active` marker and readout follow, zero-JS). Both
   components were already unit-tested; `BsBadge` (already shown on the buttons demo) now gets a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,6 +16,22 @@ That puts a `rask` command on your `PATH`. Update it later with `dotnet tool upd
 > `rask generate`), and shells out to `dotnet` for the rest — `rask dev` wraps `dotnet watch`, `rask db`
 > wraps `dotnet ef`.
 
+## Getting help
+
+`rask` on its own lists the commands. `rask <command> --help` (or `-h`) prints that command's full
+reference — its arguments, an aligned table of every option with a one-line description, and
+copy-pasteable examples:
+
+```bash
+rask                       # list all commands
+rask new --help            # arguments, options, and examples for `new`
+rask generate feature --help
+```
+
+Help (and other output) is colorized when `rask` is writing to a terminal, and falls back to plain
+text when the output is piped or when the [`NO_COLOR`](https://no-color.org) environment variable is
+set — so `rask info | cat` and CI logs stay clean.
+
 ## `rask new` — scaffold a project
 
 ```bash

--- a/src/Rask.Cli/ArgumentSchema.cs
+++ b/src/Rask.Cli/ArgumentSchema.cs
@@ -36,11 +36,26 @@ internal sealed class ParsedArguments(
 }
 
 /// <summary>
+/// A declared flag or option: its names, whether it takes a value (and a hint for it), a one-line
+/// description, and an optional <see cref="Group"/> label so help can bucket, say, <c>generate</c>'s
+/// feature-only flags apart from the common ones. This is the single source of truth that both parses
+/// arguments and documents them — <c>--help</c> renders straight from this list, so it can never drift.
+/// </summary>
+internal sealed record OptionInfo(
+    string LongName,
+    char? ShortName,
+    bool IsFlag,
+    string? ValueHint,
+    string? Description,
+    string? Group);
+
+/// <summary>
 /// A tiny, dependency-free argument parser. Each command declares its boolean <see cref="Flag"/>s and
 /// valued <see cref="Option"/>s (with optional single-char aliases); <see cref="Parse"/> then turns a
 /// raw token list into a <see cref="ParsedArguments"/>. Supports <c>--name value</c>, <c>--name=value</c>,
 /// <c>-n value</c>, and a <c>--</c> separator after which everything is passthrough. Unknown options and
-/// options missing a value are reported as errors rather than guessed at.
+/// options missing a value are reported as errors rather than guessed at. Every declaration also records
+/// an <see cref="OptionInfo"/> (see <see cref="Declared"/>) so command help documents exactly what parses.
 /// </summary>
 internal sealed class ArgumentSchema
 {
@@ -48,18 +63,24 @@ internal sealed class ArgumentSchema
     private readonly HashSet<string> _flags = new(StringComparer.Ordinal);
     private readonly HashSet<string> _options = new(StringComparer.Ordinal);
     private readonly HashSet<string> _multiOptions = new(StringComparer.Ordinal);
+    private readonly List<OptionInfo> _declared = [];
 
-    public ArgumentSchema Flag(string longName, char? shortName = null)
+    /// <summary>Every flag/option declared on this schema, in declaration order — the source for <c>--help</c>.</summary>
+    public IReadOnlyList<OptionInfo> Declared => _declared;
+
+    public ArgumentSchema Flag(string longName, char? shortName = null, string? description = null, string? group = null)
     {
         _flags.Add(longName);
         Register(longName, shortName);
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: true, ValueHint: null, description, group));
         return this;
     }
 
-    public ArgumentSchema Option(string longName, char? shortName = null)
+    public ArgumentSchema Option(string longName, char? shortName = null, string? valueHint = null, string? description = null, string? group = null)
     {
         _options.Add(longName);
         Register(longName, shortName);
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group));
         return this;
     }
 
@@ -67,11 +88,12 @@ internal sealed class ArgumentSchema
     /// A valued option that may be supplied more than once (e.g. <c>--env A=1 --env B=2</c>); every value is
     /// collected in order and read via <see cref="ParsedArguments.MultiOption"/> rather than overwriting.
     /// </summary>
-    public ArgumentSchema MultiOption(string longName, char? shortName = null)
+    public ArgumentSchema MultiOption(string longName, char? shortName = null, string? valueHint = null, string? description = null, string? group = null)
     {
         _options.Add(longName);
         _multiOptions.Add(longName);
         Register(longName, shortName);
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group));
         return this;
     }
 

--- a/src/Rask.Cli/CliApplication.cs
+++ b/src/Rask.Cli/CliApplication.cs
@@ -35,7 +35,7 @@ internal sealed class CliApplication
     {
         if (args.Count == 0)
         {
-            PrintUsage(_console.Out);
+            CommandHelp.RenderTopLevel(_console, _commands, toError: false);
             return 0;
         }
 
@@ -45,11 +45,11 @@ internal sealed class CliApplication
         {
             if (args.Count > 1 && TryGetCommand(args[1], out var helpTarget))
             {
-                PrintCommandHelp(_console.Out, helpTarget);
+                CommandHelp.RenderCommand(_console, helpTarget);
             }
             else
             {
-                PrintUsage(_console.Out);
+                CommandHelp.RenderTopLevel(_console, _commands, toError: false);
             }
 
             return 0;
@@ -63,15 +63,15 @@ internal sealed class CliApplication
 
         if (!TryGetCommand(first, out var command))
         {
-            _console.Error.WriteLine($"Unknown command '{first}'.");
-            PrintUsage(_console.Error);
+            _console.WriteErrorLine($"Unknown command '{first}'.", ConsoleStyle.Error);
+            CommandHelp.RenderTopLevel(_console, _commands, toError: true);
             return 1;
         }
 
         var rest = args.Skip(1).ToArray();
         if (RequestsHelp(rest))
         {
-            PrintCommandHelp(_console.Out, command);
+            CommandHelp.RenderCommand(_console, command);
             return 0;
         }
 
@@ -113,31 +113,5 @@ internal sealed class CliApplication
 
         command = null!;
         return false;
-    }
-
-    private void PrintUsage(TextWriter writer)
-    {
-        writer.WriteLine("rask — the Rask framework command-line tool");
-        writer.WriteLine();
-        writer.WriteLine("Usage: rask <command> [options]");
-        writer.WriteLine();
-        writer.WriteLine("Commands:");
-
-        var width = _commands.Count == 0 ? 0 : _commands.Max(c => c.Name.Length);
-        foreach (var command in _commands)
-        {
-            writer.WriteLine($"  {command.Name.PadRight(width)}   {command.Summary}");
-        }
-
-        writer.WriteLine();
-        writer.WriteLine("Run 'rask <command> --help' for command-specific usage.");
-        writer.WriteLine("  --version    Show the tool version.");
-    }
-
-    private static void PrintCommandHelp(TextWriter writer, CliCommand command)
-    {
-        writer.WriteLine(command.Summary);
-        writer.WriteLine();
-        writer.WriteLine($"Usage: {command.Usage}");
     }
 }

--- a/src/Rask.Cli/CliCommand.cs
+++ b/src/Rask.Cli/CliCommand.cs
@@ -22,6 +22,18 @@ internal abstract class CliCommand(IConsole console)
     /// <summary>A one-line usage string shown in the command's own help and on errors.</summary>
     public abstract string Usage { get; }
 
+    /// <summary>Positional arguments (name + description) documented in <c>--help</c>. Empty by default.</summary>
+    public virtual IReadOnlyList<(string Name, string Description)> Arguments => [];
+
+    /// <summary>Copy-pasteable example invocations shown in <c>--help</c>. Empty by default.</summary>
+    public virtual IReadOnlyList<string> Examples => [];
+
+    /// <summary>
+    /// The command's flag/option schema, used by <c>--help</c> to render the options table. Commands that
+    /// take options override this to return the same schema they parse with, so help never drifts.
+    /// </summary>
+    public virtual ArgumentSchema? OptionSchema => null;
+
     /// <summary>Run the command with the arguments that follow its name. Returns a process exit code.</summary>
     public abstract Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken);
 
@@ -30,10 +42,11 @@ internal abstract class CliCommand(IConsole console)
     {
         foreach (var error in errors)
         {
-            Console.Error.WriteLine(error);
+            Console.WriteErrorLine(error, ConsoleStyle.Error);
         }
 
         Console.Error.WriteLine($"Usage: {Usage}");
+        Console.Error.WriteLine($"Run 'rask {Name} --help' for details.");
         return 1;
     }
 }

--- a/src/Rask.Cli/CommandHelp.cs
+++ b/src/Rask.Cli/CommandHelp.cs
@@ -1,0 +1,130 @@
+using System.Text;
+
+namespace Rask.Cli;
+
+/// <summary>
+/// Renders the CLI's help pages — the top-level command list and a per-command page (summary, usage,
+/// arguments, an aligned options table, and examples). Options come straight from each command's
+/// <see cref="ArgumentSchema.Declared"/> list, so help documents exactly what parses. Color is applied
+/// only when the target stream is a terminal; everything is written through plain <see cref="TextWriter"/>s
+/// with a resolved <c>color</c> flag so both stdout (help) and stderr (usage-on-error) render correctly.
+/// </summary>
+internal static class CommandHelp
+{
+    /// <summary>The top-level <c>rask</c> usage: tagline, command list, and footer hints.</summary>
+    public static void RenderTopLevel(IConsole console, IReadOnlyList<CliCommand> commands, bool toError)
+    {
+        var writer = toError ? console.Error : console.Out;
+        var color = ConsoleStyling.ColorEnabled(toError ? console.IsErrorRedirected : console.IsOutputRedirected);
+
+        writer.WriteLine(Paint("rask", ConsoleStyle.Heading, color) + " — the Rask framework command-line tool");
+        writer.WriteLine();
+        writer.WriteLine($"Usage: {Paint("rask <command> [options]", ConsoleStyle.Code, color)}");
+        writer.WriteLine();
+        writer.WriteLine(Paint("Commands:", ConsoleStyle.Heading, color));
+
+        var width = commands.Count == 0 ? 0 : commands.Max(c => c.Name.Length);
+        foreach (var command in commands)
+        {
+            writer.WriteLine($"  {Paint(command.Name.PadRight(width), ConsoleStyle.Code, color)}   {command.Summary}");
+        }
+
+        writer.WriteLine();
+        writer.WriteLine($"Run '{Paint("rask <command> --help", ConsoleStyle.Code, color)}' for command-specific usage.");
+        writer.WriteLine();
+        writer.WriteLine(Paint("Options:", ConsoleStyle.Heading, color));
+        writer.WriteLine("  --version    Show the tool version.");
+        writer.WriteLine("  --help       Show help for a command.");
+    }
+
+    /// <summary>A single command's help page: summary, usage, arguments, options, examples.</summary>
+    public static void RenderCommand(IConsole console, CliCommand command)
+    {
+        var writer = console.Out;
+        var color = ConsoleStyling.ColorEnabled(console.IsOutputRedirected);
+
+        writer.WriteLine(command.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"Usage: {Paint(command.Usage, ConsoleStyle.Code, color)}");
+
+        if (command.Arguments.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine(Paint("Arguments:", ConsoleStyle.Heading, color));
+            var argWidth = command.Arguments.Max(a => a.Name.Length);
+            foreach (var (name, description) in command.Arguments)
+            {
+                writer.WriteLine($"  {Paint(name.PadRight(argWidth), ConsoleStyle.Code, color)}   {description}");
+            }
+        }
+
+        RenderOptions(writer, command.OptionSchema, color);
+
+        if (command.Examples.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine(Paint("Examples:", ConsoleStyle.Heading, color));
+            foreach (var example in command.Examples)
+            {
+                writer.WriteLine($"  {Paint(example, ConsoleStyle.Code, color)}");
+            }
+        }
+    }
+
+    private static void RenderOptions(TextWriter writer, ArgumentSchema? schema, bool color)
+    {
+        if (schema is null || schema.Declared.Count == 0)
+        {
+            return;
+        }
+
+        // One column width across every group keeps the descriptions aligned down the whole page.
+        var width = schema.Declared.Max(o => Label(o).Length);
+
+        var ungrouped = schema.Declared.Where(o => o.Group is null).ToArray();
+        var groups = schema.Declared
+            .Where(o => o.Group is not null)
+            .GroupBy(o => o.Group!, StringComparer.Ordinal);
+
+        writer.WriteLine();
+        writer.WriteLine(Paint("Options:", ConsoleStyle.Heading, color));
+        foreach (var option in ungrouped)
+        {
+            WriteOption(writer, option, width, color);
+        }
+
+        foreach (var group in groups)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"  {Paint(group.Key + ":", ConsoleStyle.Heading, color)}");
+            foreach (var option in group)
+            {
+                WriteOption(writer, option, width, color);
+            }
+        }
+    }
+
+    private static void WriteOption(TextWriter writer, OptionInfo option, int width, bool color)
+    {
+        var label = Label(option);
+        var painted = Paint(label.PadRight(width), ConsoleStyle.Code, color);
+        writer.WriteLine(option.Description is { Length: > 0 } d ? $"  {painted}   {d}" : $"  {painted}");
+    }
+
+    /// <summary>The left-column label, e.g. <c>-t, --template &lt;value&gt;</c> or <c>    --auth</c>.</summary>
+    private static string Label(OptionInfo option)
+    {
+        var builder = new StringBuilder();
+        builder.Append(option.ShortName is char c ? $"-{c}, " : "    ");
+        builder.Append("--").Append(option.LongName);
+        if (!option.IsFlag)
+        {
+            builder.Append(" <").Append(option.ValueHint ?? "value").Append('>');
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Paint(string text, ConsoleStyle style, bool color) =>
+        color ? ConsoleStyling.Paint(text, style) : text;
+}

--- a/src/Rask.Cli/Commands/DbCommand.cs
+++ b/src/Rask.Cli/Commands/DbCommand.cs
@@ -25,6 +25,30 @@ internal sealed class DbCommand(IConsole console, IFileSystem fileSystem, IProce
     public override string Usage =>
         "rask db <add|remove|list|update|drop> [<name>] [--project <path>] [--startup-project <path>] [--context <Name>] [--output <dir>] [--force] [-- <ef args>]";
 
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+    [
+        ("<add|remove|list|update|drop>", "The migration action to run."),
+        ("[<name>]", "Migration name — required for 'add', e.g. InitialCreate."),
+    ];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask db add InitialCreate",
+        "rask db update",
+        "rask db list",
+        "rask db drop --force",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("project", 'p', "path", "Project containing the DbContext (default: found from the current directory).")
+            .Option("startup-project", 's', "path", "Startup project (default: same as --project).")
+            .Option("context", 'c', "Name", "DbContext to use when the project defines more than one.")
+            .Option("output", 'o', "dir", "Directory for the migration files (add only).")
+            .Flag("force", 'f', "Skip the confirmation prompt (drop only).");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
@@ -41,12 +65,7 @@ internal sealed class DbCommand(IConsole console, IFileSystem fileSystem, IProce
             return 1;
         }
 
-        var schema = new ArgumentSchema()
-            .Option("project", 'p')
-            .Option("startup-project", 's')
-            .Option("context", 'c')
-            .Option("output", 'o')
-            .Flag("force", 'f');
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -47,18 +47,31 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         "rask deploy [--host user@box] [--domain app.example.com] [--port <n>] [--project <path>] " +
         "[--name <slug>] [--dockerfile <path>] [--env KEY=VALUE ...] [--env-file <path>] [--dry-run]";
 
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask deploy --host deploy@box.example.com --domain app.example.com",
+        "rask deploy --host deploy@box.example.com --port 8080",
+        "rask deploy --env ConnectionStrings__Db=... --env-file .env.production",
+        "rask deploy --dry-run",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("host", 'h', "user@box", "SSH target to build and run on (remembered in .rask/deploy.json).")
+            .Option("domain", 'd', "host", "Public domain to serve over HTTPS via Caddy (implies ports 80/443).")
+            .Option("port", valueHint: "n", description: "Published port when not using --domain (default: 8080).")
+            .Option("project", 'p', "path", "Project to deploy (default: found from the current directory).")
+            .Option("name", 'n', "slug", "Container/app name (default: derived from the project).")
+            .Option("dockerfile", valueHint: "path", description: "Dockerfile to build (default: ./Dockerfile).")
+            .Option("env-file", valueHint: "path", description: "File of KEY=VALUE lines to pass to the container.")
+            .MultiOption("env", 'e', "KEY=VALUE", "Environment variable to pass (repeatable).")
+            .Flag("dry-run", description: "Print the docker commands that would run without changing anything.");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        var schema = new ArgumentSchema()
-            .Option("host", 'h')
-            .Option("domain", 'd')
-            .Option("port")
-            .Option("project", 'p')
-            .Option("name", 'n')
-            .Option("dockerfile")
-            .Option("env-file")
-            .MultiOption("env", 'e')
-            .Flag("dry-run");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args);
         if (parsed.HasErrors)

--- a/src/Rask.Cli/Commands/DevCommand.cs
+++ b/src/Rask.Cli/Commands/DevCommand.cs
@@ -15,11 +15,23 @@ internal sealed class DevCommand(IConsole console, IProcessRunner process) : Cli
 
     public override string Usage => "rask dev [--project <path>] [--no-hot-reload] [-- <args passed to the app>]";
 
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask dev",
+        "rask dev --project src/App",
+        "rask dev -- --urls http://localhost:5000",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("project", 'p', "path", "Project to run (default: the project in the current directory).")
+            .Flag("no-hot-reload", description: "Use a plain 'dotnet run' instead of 'dotnet watch' (no hot reload).");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        var schema = new ArgumentSchema()
-            .Option("project", 'p')
-            .Flag("no-hot-reload");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args);
         if (parsed.HasErrors)

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -35,6 +35,47 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
     public override string Usage =>
         "rask generate <page|component|feature|job|email> <Name> [<field:type> ...] [--id guid|int|long] [--route <path>] [--context <Name>] [--plural <Name>] [--output <dir>] [--force] [--dry-run]";
 
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+    [
+        ("<page|component|feature|job|email>", "What to scaffold (aliases: p, c, f, j, e)."),
+        ("<Name>", "The type name, e.g. Product or Dashboard."),
+        ("[<field:type> ...]", "Fields for a feature, e.g. Name:string Price:decimal."),
+    ];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask generate page Dashboard --route /dashboard",
+        "rask generate component UserCard",
+        "rask generate feature Product Name:string Price:decimal",
+        "rask generate feature Order Total:decimal --bs --modal --tests",
+        "rask g j SendWelcomeEmail",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private const string FeatureGroup = "Feature options (rask generate feature)";
+
+    /// <summary>The flag/option schema — shared by <see cref="ExecuteAsync"/> and <c>--help</c> so they can't drift.</summary>
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("output", 'o', "dir", "Directory to write into (default: derived from the artifact).")
+            .Flag("force", description: "Overwrite existing files instead of refusing.")
+            .Flag("dry-run", description: "Print what would be written without touching disk.")
+            .Option("route", 'r', "path", "URL route for the page.", group: "Page options")
+            .Option("fields", 'f', "list", "Fields as Name:type,... (or pass them positionally).", FeatureGroup)
+            .Option("context", 'c', "Name", "Reuse an existing DbContext instead of generating one.", FeatureGroup)
+            .Option("plural", 'p', "Name", "Plural name for the feature folder/route (default: auto-pluralized).", FeatureGroup)
+            .Option("id", valueHint: "guid|int|long", description: "Primary-key type (default: guid).", group: FeatureGroup)
+            .Option("validation", valueHint: "mode", description: "Validation style: valueobjects (default), dataannotations, or fluent.", group: FeatureGroup)
+            .Flag("bs", description: "Render pages with Rask.Bootstrap (Bs*) components.", group: FeatureGroup)
+            .Flag("modal", description: "Fold create/edit into a modal on the list page (implies --bs).", group: FeatureGroup)
+            .Flag("soft-delete", description: "Soft-delete rows and add a Restore command.", group: FeatureGroup)
+            .Flag("concurrency", description: "Add optimistic-concurrency (row version) handling.", group: FeatureGroup)
+            .Flag("events", description: "Raise domain events on create/update/delete.", group: FeatureGroup)
+            .Flag("outbox", description: "Persist domain events via the transactional outbox (implies --events).", group: FeatureGroup)
+            .Flag("tests", description: "Generate a sibling <Project>.Tests project with domain + persistence tests.", group: FeatureGroup)
+            .Flag("no-restore", description: "Write files without adding packages or restoring.", group: FeatureGroup);
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
@@ -51,24 +92,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             return 1;
         }
 
-        var schema = new ArgumentSchema()
-            .Option("route", 'r')
-            .Option("output", 'o')
-            .Option("fields", 'f')
-            .Option("context", 'c')
-            .Option("plural", 'p')
-            .Option("id")
-            .Option("validation")
-            .Flag("bs")
-            .Flag("modal")
-            .Flag("soft-delete")
-            .Flag("concurrency")
-            .Flag("events")
-            .Flag("outbox")
-            .Flag("tests")
-            .Flag("no-restore")
-            .Flag("force")
-            .Flag("dry-run");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)

--- a/src/Rask.Cli/Commands/InfoCommand.cs
+++ b/src/Rask.Cli/Commands/InfoCommand.cs
@@ -16,6 +16,8 @@ internal sealed class InfoCommand(IConsole console, IProcessRunner process) : Cl
 
     public override string Usage => "rask info";
 
+    public override IReadOnlyList<string> Examples => ["rask info"];
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         var sdkVersion = await CaptureSingleLineAsync(["--version"], cancellationToken).ConfigureAwait(false);

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -31,17 +31,34 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     public override string Usage =>
         "rask new <name> [--template server|wasm|wasm-hosted|native] [--auth] [--pwa] [--cqrs] [--docker] [--host local|server] [--output <dir>]";
 
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+        [("<name>", "Name of the project to create (scaffolds ./<name>/).")];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask new Shop",
+        "rask new Shop --template wasm --pwa",
+        "rask new Api --template server --auth --docker",
+        "rask new MyApp --template native --host server",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    /// <summary>The flag/option schema — shared by <see cref="ExecuteAsync"/> and <c>--help</c> so they can't drift.</summary>
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("template", 't', "name", "Template to scaffold: server (default), wasm, wasm-hosted, or native.")
+            .Option("output", 'o', "dir", "Directory to create the project in (default: ./<name>).")
+            .Option("name", 'n', "name", "Project name, if not given positionally.")
+            .Option("host", valueHint: "local|server", description: "Native host mode: local (default) or server. Native template only.")
+            .Flag("auth", description: "Add cookie authentication (login + members pages).")
+            .Flag("pwa", description: "Add a PWA manifest, icon, and offline page.")
+            .Flag("cqrs", description: "Wire up Rask.Cqrs (server template only).")
+            .Flag("docker", description: "Add a Dockerfile and .dockerignore for container deploys.");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        var schema = new ArgumentSchema()
-            .Option("template", 't')
-            .Option("output", 'o')
-            .Option("name", 'n')
-            .Option("host")
-            .Flag("auth")
-            .Flag("pwa")
-            .Flag("cqrs")
-            .Flag("docker");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args);
         if (parsed.HasErrors)

--- a/src/Rask.Cli/ConsoleStyling.cs
+++ b/src/Rask.Cli/ConsoleStyling.cs
@@ -1,0 +1,71 @@
+namespace Rask.Cli;
+
+/// <summary>The semantic roles the CLI colors — mapped to ANSI SGR codes by <see cref="ConsoleStyling"/>.</summary>
+internal enum ConsoleStyle
+{
+    /// <summary>A completed action (green).</summary>
+    Success,
+
+    /// <summary>A failure (red).</summary>
+    Error,
+
+    /// <summary>A non-fatal caution (yellow).</summary>
+    Warning,
+
+    /// <summary>A section title (bold).</summary>
+    Heading,
+
+    /// <summary>Secondary/hint text (dim).</summary>
+    Dim,
+
+    /// <summary>An inline command or path the user can copy (cyan).</summary>
+    Code,
+}
+
+/// <summary>
+/// A tiny, dependency-free ANSI styling layer. Color is emitted only when the target stream is a real
+/// terminal (not piped) and <c>NO_COLOR</c> is unset — so <c>rask info | cat</c>, CI logs, and captured
+/// test output stay plain. Everything routes through <see cref="IConsole"/> so tests (which report both
+/// streams as redirected) see uncolored text and their substring assertions keep holding.
+/// </summary>
+internal static class ConsoleStyling
+{
+    private const string Reset = "\x1b[0m";
+
+    /// <summary>The SGR parameter for a style, e.g. <c>32</c> (green) for <see cref="ConsoleStyle.Success"/>.</summary>
+    private static string Sgr(ConsoleStyle style) => style switch
+    {
+        ConsoleStyle.Success => "32",
+        ConsoleStyle.Error => "31",
+        ConsoleStyle.Warning => "33",
+        ConsoleStyle.Heading => "1",
+        ConsoleStyle.Dim => "2",
+        ConsoleStyle.Code => "36",
+        _ => "0",
+    };
+
+    /// <summary>Wrap <paramref name="text"/> in the style's escape codes. Pure — unit-tested directly.</summary>
+    public static string Paint(string text, ConsoleStyle style) => $"\x1b[{Sgr(style)}m{text}{Reset}";
+
+    /// <summary>
+    /// True when styling should be applied to a stream with the given redirection state: a real terminal
+    /// (<paramref name="redirected"/> is false) and no <c>NO_COLOR</c> override.
+    /// </summary>
+    public static bool ColorEnabled(bool redirected) =>
+        !redirected && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"));
+
+    /// <summary>Style <paramref name="text"/> for stdout, or return it unchanged when color is off.</summary>
+    public static string Style(this IConsole console, string text, ConsoleStyle style) =>
+        ColorEnabled(console.IsOutputRedirected) ? Paint(text, style) : text;
+
+    /// <summary>Write a styled line to stdout (plain when color is off).</summary>
+    public static void WriteLine(this IConsole console, string text, ConsoleStyle style) =>
+        console.Out.WriteLine(console.Style(text, style));
+
+    /// <summary>Write a styled line to stderr (plain when color is off), honoring stderr's own redirection.</summary>
+    public static void WriteErrorLine(this IConsole console, string text, ConsoleStyle style)
+    {
+        var painted = ColorEnabled(console.IsErrorRedirected) ? Paint(text, style) : text;
+        console.Error.WriteLine(painted);
+    }
+}

--- a/src/Rask.Cli/IConsole.cs
+++ b/src/Rask.Cli/IConsole.cs
@@ -1,14 +1,28 @@
 namespace Rask.Cli;
 
 /// <summary>
-/// The tool's console output seam. Abstracting <see cref="System.Console"/> keeps every command
-/// unit-testable — tests substitute an in-memory writer and assert on the captured text.
+/// The tool's console seam. Abstracting <see cref="System.Console"/> keeps every command
+/// unit-testable — tests substitute in-memory readers/writers and assert on the captured text. The
+/// redirection flags let output honor <c>NO_COLOR</c> / piping (see <see cref="ConsoleStyling"/>) and
+/// let interactive prompts fall back to their defaults when there is no terminal.
 /// </summary>
 internal interface IConsole
 {
     TextWriter Out { get; }
 
     TextWriter Error { get; }
+
+    /// <summary>The input stream, read by interactive prompts.</summary>
+    TextReader In { get; }
+
+    /// <summary>True when stdout is piped/redirected — color escapes are suppressed.</summary>
+    bool IsOutputRedirected { get; }
+
+    /// <summary>True when stderr is piped/redirected — color escapes are suppressed.</summary>
+    bool IsErrorRedirected { get; }
+
+    /// <summary>True when stdin is piped/redirected — prompts skip and use their default answer.</summary>
+    bool IsInputRedirected { get; }
 }
 
 /// <summary>The real console, wired in <c>Program.cs</c>.</summary>
@@ -19,4 +33,12 @@ internal sealed class SystemConsole : IConsole
     public TextWriter Out => Console.Out;
 
     public TextWriter Error => Console.Error;
+
+    public TextReader In => Console.In;
+
+    public bool IsOutputRedirected => Console.IsOutputRedirected;
+
+    public bool IsErrorRedirected => Console.IsErrorRedirected;
+
+    public bool IsInputRedirected => Console.IsInputRedirected;
 }

--- a/src/Rask.Cli/NUGET.md
+++ b/src/Rask.Cli/NUGET.md
@@ -52,7 +52,9 @@ rask info
 | `rask dev` | Run the app with C# Hot Reload (`dotnet watch run`); `--no-hot-reload` for a plain run. Args after `--` reach the app. |
 | `rask info` | Report the CLI version, .NET SDK version, and OS. |
 
-Run `rask <command> --help` for command-specific usage, or `rask --version` for the tool version.
+Run `rask <command> --help` for a full reference — arguments, a described options table, and examples
+— or `rask --version` for the tool version. Output is colorized on a terminal and plain when piped or
+under `NO_COLOR`.
 
 ## Notes
 

--- a/tests/Rask.Cli.Tests/ArgumentSchemaTests.cs
+++ b/tests/Rask.Cli.Tests/ArgumentSchemaTests.cs
@@ -109,4 +109,22 @@ public sealed class ArgumentSchemaTests
         Assert.Equal("-5", parsed.Option("output"));
         Assert.False(parsed.HasErrors);
     }
+
+    [Fact]
+    public void Declared_records_each_option_for_help()
+    {
+        var schema = new ArgumentSchema()
+            .Option("template", 't', "name", "Which template.")
+            .Flag("auth", description: "Add auth.", group: "Extras");
+
+        var template = schema.Declared.Single(o => o.LongName == "template");
+        Assert.Equal('t', template.ShortName);
+        Assert.False(template.IsFlag);
+        Assert.Equal("name", template.ValueHint);
+        Assert.Equal("Which template.", template.Description);
+
+        var auth = schema.Declared.Single(o => o.LongName == "auth");
+        Assert.True(auth.IsFlag);
+        Assert.Equal("Extras", auth.Group);
+    }
 }

--- a/tests/Rask.Cli.Tests/CommandHelpTests.cs
+++ b/tests/Rask.Cli.Tests/CommandHelpTests.cs
@@ -1,0 +1,91 @@
+namespace Rask.Cli.Tests;
+
+public sealed class CommandHelpTests
+{
+    private static (StringConsole Console, CliApplication App) Build()
+    {
+        var console = new StringConsole();
+        return (console, CliApplication.CreateDefault(console, new FakeProcessRunner(), new FakeFileSystem()));
+    }
+
+    [Fact]
+    public async Task Command_help_lists_options_with_descriptions()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["new", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Options:", text, StringComparison.Ordinal);
+        Assert.Contains("-t, --template <name>", text, StringComparison.Ordinal);
+        Assert.Contains("Template to scaffold", text, StringComparison.Ordinal);
+        Assert.Contains("--auth", text, StringComparison.Ordinal);
+        Assert.Contains("Add cookie authentication", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Command_help_shows_arguments_and_examples()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["new", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Arguments:", text, StringComparison.Ordinal);
+        Assert.Contains("Examples:", text, StringComparison.Ordinal);
+        Assert.Contains("rask new Shop", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Generate_help_surfaces_the_feature_only_flags()
+    {
+        var (console, app) = Build();
+
+        // These flags were previously undiscoverable — not in usage, not in help.
+        await app.RunAsync(["generate", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Feature options (rask generate feature)", text, StringComparison.Ordinal);
+        foreach (var flag in new[] { "--bs", "--modal", "--soft-delete", "--concurrency", "--events", "--outbox", "--tests", "--no-restore" })
+        {
+            Assert.Contains(flag, text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task Help_output_is_uncolored_when_stdout_is_redirected()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["generate", "--help"], CancellationToken.None);
+
+        Assert.DoesNotContain('\x1b', console.OutText);
+    }
+
+    [Fact]
+    public async Task Top_level_usage_lists_every_command()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync([], CancellationToken.None);
+
+        var text = console.OutText;
+        foreach (var name in new[] { "new", "dev", "generate", "db", "deploy", "info" })
+        {
+            Assert.Contains(name, text, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("--version", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Parse_error_points_at_command_help()
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync(["new", "--nope"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Run 'rask new --help' for details.", console.ErrorText, StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Cli.Tests/ConsoleStylingTests.cs
+++ b/tests/Rask.Cli.Tests/ConsoleStylingTests.cs
@@ -1,0 +1,33 @@
+namespace Rask.Cli.Tests;
+
+public sealed class ConsoleStylingTests
+{
+    [Fact]
+    public void Paint_wraps_text_in_the_style_and_reset_codes()
+    {
+        var painted = ConsoleStyling.Paint("done", ConsoleStyle.Success);
+
+        Assert.Equal("\x1b[32mdone\x1b[0m", painted);
+    }
+
+    [Fact]
+    public void Color_is_disabled_when_the_stream_is_redirected()
+    {
+        Assert.False(ConsoleStyling.ColorEnabled(redirected: true));
+    }
+
+    [Fact]
+    public void Styled_writes_stay_plain_when_output_is_redirected()
+    {
+        // StringConsole reports both streams as redirected, so nothing should be colored.
+        var console = new StringConsole();
+
+        console.WriteLine("hello", ConsoleStyle.Success);
+        console.WriteErrorLine("boom", ConsoleStyle.Error);
+
+        Assert.Equal("hello" + Environment.NewLine, console.OutText);
+        Assert.Equal("boom" + Environment.NewLine, console.ErrorText);
+        Assert.DoesNotContain('\x1b', console.OutText);
+        Assert.DoesNotContain('\x1b', console.ErrorText);
+    }
+}

--- a/tests/Rask.Cli.Tests/TestDoubles.cs
+++ b/tests/Rask.Cli.Tests/TestDoubles.cs
@@ -3,19 +3,43 @@ using Rask.Cli.Scaffolding;
 
 namespace Rask.Cli.Tests;
 
-/// <summary>An <see cref="IConsole"/> that captures everything written, for assertions.</summary>
+/// <summary>
+/// An <see cref="IConsole"/> that captures everything written, for assertions. Both output streams
+/// report as redirected so styling stays off and captured text is plain — substring assertions hold
+/// regardless of the styling layer. Seed <see cref="InputLines"/> to script interactive prompts.
+/// </summary>
 internal sealed class StringConsole : IConsole
 {
     private readonly StringWriter _out = new();
     private readonly StringWriter _error = new();
+    private TextReader _in = new StringReader(string.Empty);
 
     public TextWriter Out => _out;
 
     public TextWriter Error => _error;
 
+    public TextReader In => _in;
+
+    /// <summary>When false, the console behaves like a terminal (styling on, prompts read input).</summary>
+    public bool IsOutputRedirected { get; set; } = true;
+
+    public bool IsErrorRedirected { get; set; } = true;
+
+    public bool IsInputRedirected { get; set; } = true;
+
     public string OutText => _out.ToString();
 
     public string ErrorText => _error.ToString();
+
+    /// <summary>Script the answers an interactive prompt will read, one per line, and treat stdin as a terminal.</summary>
+    public IReadOnlyList<string> InputLines
+    {
+        set
+        {
+            _in = new StringReader(string.Join(Environment.NewLine, value) + Environment.NewLine);
+            IsInputRedirected = false;
+        }
+    }
 }
 
 /// <summary>A recorded invocation of the process runner.</summary>


### PR DESCRIPTION
## Summary
`rask <command> --help` was three lines (summary + one usage string). It now renders a described **Options** table straight from the same `ArgumentSchema` that parses the arguments (so help can't drift), an **Arguments** section, and copy-pasteable **Examples**. This surfaces `rask generate`'s previously *undiscoverable* feature flags — `--bs`, `--modal`, `--soft-delete`, `--concurrency`, `--events`, `--outbox`, `--tests`, `--validation`, `--no-restore` — grouped under "Feature options". Output is colorized on a terminal and stays plain when piped or under `NO_COLOR` (so `rask info | cat` and CI logs are unaffected); parse errors now point at `rask <command> --help`. Pure BCL — no new dependencies.

This is the first of four sequenced CLI-DX PRs (rich help → colored/consistent output → interactive prompts/wizard → completion + config defaults). It lands the shared foundation: the styling/redirection seam on `IConsole` and the self-documenting `ArgumentSchema`.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **250+335 pass, 0 fail** (full local gate green: whole-solution Release build, whitespace format check, all non-E2E tests). 10 new CLI tests (`CommandHelpTests`, `ConsoleStylingTests`, `ArgumentSchema.Declared`).
- CLI smoke: `.claude/skills/run-rask-cli/smoke.sh` — **15/15 pass**, incl. new checks that `generate --help` surfaces `--outbox`/`--tests` and an examples section.
- E2E: n/a — CLI-only change, no `samples/` or render-path code touched (pre-push E2E gate skipped per its documented bypass for non-UI pushes).

## Benchmarks
n/a — the CLI is not on the render hot path.

## CHANGELOG
- [Unreleased] entry added: `rask <command> --help` now teaches — aligned options table, arguments, examples, color, and the surfaced generate feature flags.