### PR TITLE
feat(cli): interactive rask new wizard when no name is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`rask new` with no name starts an interactive wizard.** On a terminal, running `rask new` (no project
+  name) now prompts for the name, a numbered template picker, and a yes/no for each feature flag the chosen
+  template supports — then scaffolds exactly as if you'd typed the flags. The answers flow back through the
+  same validation and generation path, so nothing new can drift. **Non-interactive is unchanged**: when
+  stdin is piped/redirected (scripts, CI), a missing name is still the same hard error, so automation is
+  unaffected. Backed by a new dependency-free `Prompt` helper (Ask/Confirm/Select), EOF-safe so a command
+  can never hang.
 - **The `rask` CLI now speaks in color, with consistent output and progress feedback.** Written files
   are reported with one shared green `+ <path>` marker across `rask new` and `rask generate` (previously
   `  + path` vs `Created path`); action headings are bold, warnings are yellow, deploy failures are red,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,12 +35,18 @@ set — so `rask info | cat` and CI logs stay clean.
 ## `rask new` — scaffold a project
 
 ```bash
+rask new                             # interactive: prompts for name, template, and features
 rask new MyApp                       # a server-rendered app (the default template)
 rask new MyApp --auth --docker       # + cookie auth + a production Dockerfile
 rask new Spa --template wasm --pwa   # an installable browser-WASM PWA
 rask new Shop --template wasm-hosted # a WASM SPA with an ASP.NET host
 rask new Field --template native     # a native iOS + Android app
 ```
+
+Run `rask new` on its own (no name) and — on a terminal — it walks you through a short wizard: the
+project name, a numbered template picker, and a yes/no for each feature the template supports. It then
+scaffolds exactly as if you'd passed the flags. Piped or in a script (no terminal), a missing name is a
+plain error instead, so automation stays predictable.
 
 The CLI writes the project's files itself, pins the `Rask.*` package references, and runs `dotnet
 restore` so the output builds immediately. `wasm-hosted` emits a three-project solution — `MyApp.Client`

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -56,7 +56,10 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             .Flag("cqrs", description: "Wire up Rask.Cqrs (server template only).")
             .Flag("docker", description: "Add a Dockerfile and .dockerignore for container deploys.");
 
-    public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
+    public override Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken) =>
+        ExecuteAsync(args, allowWizard: true, cancellationToken);
+
+    private async Task<int> ExecuteAsync(IReadOnlyList<string> args, bool allowWizard, CancellationToken cancellationToken)
     {
         var schema = CreateSchema();
 
@@ -69,6 +72,14 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         var name = parsed.Option("name") ?? parsed.Positionals.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(name))
         {
+            // No name given. On a terminal, walk an interactive wizard and re-run with the answers
+            // (allowWizard:false bounds this to one hop); piped/scripted, keep the hard-error contract.
+            var prompt = new Prompt(Console);
+            if (allowWizard && prompt.Interactive)
+            {
+                return await ExecuteAsync(RunWizard(prompt), allowWizard: false, cancellationToken).ConfigureAwait(false);
+            }
+
             Console.Error.WriteLine("A project name is required.");
             Console.Error.WriteLine($"Usage: {Usage}");
             return 1;
@@ -136,6 +147,41 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
                 };
             },
             cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Walk the interactive first-run flow (name → template → applicable feature flags) and return the
+    /// equivalent argument list, so the answers flow back through the exact same validation and generation
+    /// path as a fully-typed command line. Only reached on a terminal.
+    /// </summary>
+    private static IReadOnlyList<string> RunWizard(Prompt prompt)
+    {
+        var name = prompt.Ask("Project name");
+        var templateKey = prompt.Select(
+            "Template",
+            [.. TemplateCatalog.All.Select(t => (t.Key, $"{t.Key} — {t.DisplayName}"))],
+            TemplateCatalog.Default.Key);
+
+        var args = new List<string> { name, "--template", templateKey };
+        _ = TemplateCatalog.TryGet(templateKey, out var template);
+
+        if (templateKey == "native")
+        {
+            var host = prompt.Select("Host", [("local", "local — self-hosted app"), ("server", "server — thin client of a Rask server")], "local");
+            args.Add("--host");
+            args.Add(host);
+            return args;
+        }
+
+        foreach (var flag in FeatureFlags.Where(template.SupportedFlags.Contains))
+        {
+            if (prompt.Confirm($"Add --{flag}?", @default: false))
+            {
+                args.Add("--" + flag);
+            }
+        }
+
+        return args;
     }
 
     private async Task<int> GenerateDirectAsync(

--- a/src/Rask.Cli/Prompt.cs
+++ b/src/Rask.Cli/Prompt.cs
@@ -1,0 +1,122 @@
+namespace Rask.Cli;
+
+/// <summary>
+/// A tiny, dependency-free interactive prompt over <see cref="IConsole"/>. It reads from the console's
+/// input stream and is only meant to run when <see cref="Interactive"/> is true (a real terminal); when
+/// stdin is redirected/piped, callers should skip prompting and keep their non-interactive behavior. All
+/// reads are EOF-safe — a closed stream returns the default rather than looping — so a command can never
+/// hang. In tests, <c>StringConsole.InputLines</c> scripts the answers and flips the console to interactive.
+/// </summary>
+internal sealed class Prompt(IConsole console)
+{
+    /// <summary>True when stdin is a terminal — the only time a command should prompt.</summary>
+    public bool Interactive => !console.IsInputRedirected;
+
+    /// <summary>
+    /// Ask for a line of text. With a <paramref name="default"/>, an empty answer accepts it; without one
+    /// the question repeats until non-empty (or the input ends, which yields empty and lets the caller fail).
+    /// </summary>
+    public string Ask(string label, string? @default = null)
+    {
+        while (true)
+        {
+            console.Out.Write(@default is null ? $"{label}: " : $"{label} [{@default}]: ");
+            console.Out.Flush();
+
+            var line = console.In.ReadLine();
+            if (line is null)
+            {
+                return @default ?? string.Empty; // EOF — don't loop forever.
+            }
+
+            line = line.Trim();
+            if (line.Length > 0)
+            {
+                return line;
+            }
+
+            if (@default is not null)
+            {
+                return @default;
+            }
+        }
+    }
+
+    /// <summary>Ask a yes/no question. An empty answer accepts <paramref name="default"/>; EOF returns it.</summary>
+    public bool Confirm(string label, bool @default)
+    {
+        var hint = @default ? "[Y/n]" : "[y/N]";
+        while (true)
+        {
+            console.Out.Write($"{label} {hint} ");
+            console.Out.Flush();
+
+            var line = console.In.ReadLine();
+            if (line is null)
+            {
+                return @default;
+            }
+
+            line = line.Trim();
+            if (line.Length == 0)
+            {
+                return @default;
+            }
+
+            if (line.Equals("y", StringComparison.OrdinalIgnoreCase) || line.Equals("yes", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (line.Equals("n", StringComparison.OrdinalIgnoreCase) || line.Equals("no", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Choose one of <paramref name="options"/> (value + label) by number or by typing the value. An empty
+    /// answer or EOF accepts <paramref name="default"/>.
+    /// </summary>
+    public string Select(string label, IReadOnlyList<(string Value, string Label)> options, string @default)
+    {
+        console.Out.WriteLine($"{label}:");
+        for (var i = 0; i < options.Count; i++)
+        {
+            var marker = options[i].Value.Equals(@default, StringComparison.Ordinal) ? " (default)" : string.Empty;
+            console.Out.WriteLine($"  {i + 1}) {options[i].Label}{marker}");
+        }
+
+        while (true)
+        {
+            console.Out.Write($"Choose [1-{options.Count}]: ");
+            console.Out.Flush();
+
+            var line = console.In.ReadLine();
+            if (line is null)
+            {
+                return @default;
+            }
+
+            line = line.Trim();
+            if (line.Length == 0)
+            {
+                return @default;
+            }
+
+            if (int.TryParse(line, out var index) && index >= 1 && index <= options.Count)
+            {
+                return options[index - 1].Value;
+            }
+
+            foreach (var option in options)
+            {
+                if (option.Value.Equals(line, StringComparison.OrdinalIgnoreCase))
+                {
+                    return option.Value;
+                }
+            }
+        }
+    }
+}

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -202,6 +202,36 @@ public sealed class NewCommandTests
         Assert.Contains("--frobnicate", console.ErrorText, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task No_name_on_a_terminal_walks_the_wizard_and_scaffolds()
+    {
+        var (console, fs, runner, command) = Build();
+        // Simulate a terminal (InputLines flips the console to interactive) and script the answers:
+        // name → template select (2 = wasm) → --auth? no → --pwa? yes → --docker? no.
+        console.InputLines = ["Spa", "2", "n", "y", "n"];
+
+        var exit = await command.ExecuteAsync([], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.True(fs.FileExists("/proj/Spa/Spa.csproj"));
+        Assert.True(fs.FileExists("/proj/Spa/wwwroot/index.html")); // wasm template
+        Assert.True(fs.FileExists("/proj/Spa/wwwroot/icon.svg"));   // --pwa answered yes
+        Assert.False(fs.FileExists("/proj/Spa/Auth/CredentialStore.cs")); // --auth answered no
+        Assert.Contains(runner.Invocations, i => i.Arguments.Contains("restore"));
+    }
+
+    [Fact]
+    public async Task No_name_without_a_terminal_still_hard_errors()
+    {
+        var (console, _, runner, command) = Build();
+        // StringConsole defaults to redirected stdin (non-interactive) — the wizard must not run.
+        var exit = await command.ExecuteAsync([], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("name is required", console.ErrorText, StringComparison.Ordinal);
+        Assert.Empty(runner.Invocations);
+    }
+
     private static (StringConsole Console, FakeFileSystem Fs, FakeProcessRunner Runner, NewCommand Command) Build()
     {
         var console = new StringConsole();

--- a/tests/Rask.Cli.Tests/PromptTests.cs
+++ b/tests/Rask.Cli.Tests/PromptTests.cs
@@ -1,0 +1,92 @@
+namespace Rask.Cli.Tests;
+
+public sealed class PromptTests
+{
+    [Fact]
+    public void Interactive_reflects_stdin_redirection()
+    {
+        var console = new StringConsole();
+        Assert.False(new Prompt(console).Interactive); // default: redirected
+
+        console.InputLines = ["x"]; // flips to a terminal
+        Assert.True(new Prompt(console).Interactive);
+    }
+
+    [Fact]
+    public void Ask_returns_the_typed_answer()
+    {
+        var console = new StringConsole { InputLines = ["Shop"] };
+
+        Assert.Equal("Shop", new Prompt(console).Ask("Project name"));
+    }
+
+    [Fact]
+    public void Ask_accepts_the_default_on_an_empty_answer()
+    {
+        var console = new StringConsole { InputLines = [""] };
+
+        Assert.Equal("server", new Prompt(console).Ask("Template", "server"));
+    }
+
+    [Fact]
+    public void Ask_reasks_until_non_empty_when_required()
+    {
+        var console = new StringConsole { InputLines = ["", "  ", "Shop"] };
+
+        Assert.Equal("Shop", new Prompt(console).Ask("Project name"));
+    }
+
+    [Fact]
+    public void Ask_returns_empty_on_end_of_input_rather_than_looping()
+    {
+        var console = new StringConsole { InputLines = [] };
+
+        Assert.Equal(string.Empty, new Prompt(console).Ask("Project name"));
+    }
+
+    [Theory]
+    [InlineData("y", true)]
+    [InlineData("yes", true)]
+    [InlineData("n", false)]
+    [InlineData("no", false)]
+    public void Confirm_parses_yes_and_no(string answer, bool expected)
+    {
+        var console = new StringConsole { InputLines = [answer] };
+
+        Assert.Equal(expected, new Prompt(console).Confirm("Add auth?", @default: false));
+    }
+
+    [Fact]
+    public void Confirm_uses_the_default_on_empty_or_eof()
+    {
+        Assert.True(new Prompt(new StringConsole { InputLines = [""] }).Confirm("Add auth?", @default: true));
+        Assert.False(new Prompt(new StringConsole { InputLines = [] }).Confirm("Add auth?", @default: false));
+    }
+
+    [Fact]
+    public void Select_accepts_a_number()
+    {
+        var console = new StringConsole { InputLines = ["2"] };
+        var options = new[] { ("server", "Server"), ("wasm", "WASM") };
+
+        Assert.Equal("wasm", new Prompt(console).Select("Template", options, "server"));
+    }
+
+    [Fact]
+    public void Select_accepts_the_value_by_name()
+    {
+        var console = new StringConsole { InputLines = ["wasm"] };
+        var options = new[] { ("server", "Server"), ("wasm", "WASM") };
+
+        Assert.Equal("wasm", new Prompt(console).Select("Template", options, "server"));
+    }
+
+    [Fact]
+    public void Select_falls_back_to_the_default_on_empty()
+    {
+        var console = new StringConsole { InputLines = [""] };
+        var options = new[] { ("server", "Server"), ("wasm", "WASM") };
+
+        Assert.Equal("server", new Prompt(console).Select("Template", options, "server"));
+    }
+}


### PR DESCRIPTION
## Summary
PR 3 of the CLI-DX series (**stacked on #459**). Adds first-run interactivity:
- **`rask new` wizard** — running `rask new` with no project name, on a terminal, now prompts for the name, a numbered template picker, and a yes/no for each feature flag the chosen template supports. The answers are turned into the equivalent argument list and re-run through the **same validation and generation path**, so nothing new can drift.
- **New `Prompt` helper** (`Ask`/`Confirm`/`Select`) — dependency-free, reads `IConsole.In`, gated on `Interactive = !IsInputRedirected`, and **EOF-safe** (a closed stream returns the default rather than looping — a command can never hang).
- **Non-interactive is byte-for-byte unchanged** — when stdin is piped/redirected (scripts, CI, the smoke test), a missing name is still the same hard error.

Scope note vs. the original plan: `rask db drop` already delegates its confirmation to `dotnet ef database drop` (which prompts unless `--force`), so no duplicate prompt was added; and the global `dotnet-ef` install keeps its existing deliberate no-confirmation behavior (documented in `EfToolProbe`).

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all pass** (full local gate green). CLI suite **351 pass, 0 fail** (new `PromptTests`; a wizard integration test drives scripted answers → asserts the scaffolded files; a test proving the non-interactive path still hard-errors).
- Manual: `printf '' | rask new` → still errors with "A project name is required" (exit 1), no hang.
- CLI smoke: `.claude/skills/run-rask-cli/smoke.sh` — 15/15 (unaffected; smoke drives non-interactively).
- E2E: n/a — CLI-only change.

## Benchmarks
n/a — the CLI is not on the render hot path.

## CHANGELOG
- [Unreleased] entry added: `rask new` with no name starts an interactive wizard; non-interactive unchanged.