### PR TITLE
feat(cli): add shell completion, .rask/generate.json defaults, and rask new --dry-run

### DIFF
--- a/.claude/skills/run-rask-cli/smoke.sh
+++ b/.claude/skills/run-rask-cli/smoke.sh
@@ -59,6 +59,26 @@ echo "==> Environment"
 check "info"            0 "Rask CLI"          -- info
 check "--version"       0 "[0-9]+\.[0-9]+"    -- --version
 
+echo "==> Help is discoverable (options table + examples; hidden feature flags surfaced)"
+check "generate --help shows feature flags" 0 "Feature options" -- generate --help
+check "generate --help shows examples"      0 "Examples:"       -- generate --help
+# --outbox/--tests were previously undocumented — help must now list them.
+helpout="$( rask generate --help 2>&1 )"
+if echo "$helpout" | grep -q -- "--outbox" && echo "$helpout" | grep -q -- "--tests"; then
+  echo "  PASS  generate --help lists --outbox/--tests"; PASS=$((PASS+1))
+else
+  echo "  FAIL  generate --help missing hidden flags"; echo "$helpout" | sed 's/^/        | /' | head -6; FAIL=$((FAIL+1))
+fi
+
+echo "==> Shell completion (generated from the live command + option set)"
+check "completion bash"  0 "complete -F _rask_complete rask" -- completion bash
+check "completion fish"  0 "complete -c rask"                 -- completion fish
+check "completion bad shell" 1 "Specify a shell"              -- completion tcsh
+
+echo "==> new --dry-run previews without writing"
+check "new --dry-run"    0 "would write"      -- new Ghost --template server --output "$WORK/Ghost" --dry-run
+[ -e "$WORK/Ghost" ] && { echo "  FAIL  new --dry-run wrote files"; FAIL=$((FAIL+1)); } || { echo "  PASS  new --dry-run wrote nothing"; PASS=$((PASS+1)); }
+
 echo "==> Scaffold a new server project"
 check "new Shop"        0 "Created Shop"      -- new Shop --template server --output "$WORK/Shop"
 have "$WORK/Shop/Shop.csproj"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,37 @@ them until tagged releases begin.
   existing custom app without a `/health` endpoint should deploy with `--no-health-check` (or point
   `--health-path` at its readiness route); the failure message says so. Documented in `docs/deployment.md`
   and `docs/cli.md`.
+- **`rask completion <bash|zsh|fish>` prints a shell completion script.** Generated from the live command
+  list and each command's option schema, so it always matches the CLI — new commands and flags are completed
+  without a separate list to maintain. Install e.g. `rask completion fish > ~/.config/fish/completions/rask.fish`.
+- **`rask generate feature` reads team defaults from `.rask/generate.json`.** Persist a project's preferred
+  `--bs` / `--validation` / `--id` / `--tests` (etc.) once and every `generate feature` inherits them;
+  explicit flags on the command line always win. `--save-defaults` writes the current run's feature flags
+  back to the file. Booleans are opt-in (absent = off), and the file is trim-safe (source-generated JSON).
+- **`rask new --dry-run` previews the project plan without writing anything.** Prints the files it would
+  create (and skips `dotnet restore`), matching `rask generate --dry-run`.
+- **`rask new` with no name starts an interactive wizard.** On a terminal, running `rask new` (no project
+  name) now prompts for the name, a numbered template picker, and a yes/no for each feature flag the chosen
+  template supports — then scaffolds exactly as if you'd typed the flags. The answers flow back through the
+  same validation and generation path, so nothing new can drift. **Non-interactive is unchanged**: when
+  stdin is piped/redirected (scripts, CI), a missing name is still the same hard error, so automation is
+  unaffected. Backed by a new dependency-free `Prompt` helper (Ask/Confirm/Select), EOF-safe so a command
+  can never hang.
+- **The `rask` CLI now speaks in color, with consistent output and progress feedback.** Written files
+  are reported with one shared green `+ <path>` marker across `rask new` and `rask generate` (previously
+  `  + path` vs `Created path`); action headings are bold, warnings are yellow, deploy failures are red,
+  and "Deployed. The app is live at …" is green. Otherwise-silent long operations — the `rask deploy`
+  readiness poll (up to ~20s) — now animate a spinner. All of it is **terminal-aware**: color and the
+  spinner switch off automatically when output is piped/redirected or `NO_COLOR` is set, so scripts, CI
+  logs, and captured output are byte-for-byte unchanged. Pure BCL — no new dependencies.
+- **`rask <command> --help` now teaches — an aligned options table, arguments, and examples.** Every command's
+  help was three lines (summary + one usage string); it now renders a described **Options** table straight from
+  the same schema that parses the arguments (so it can never drift), a **Arguments** section, and copy-pasteable
+  **Examples**. This surfaces `rask generate`'s previously **undiscoverable** feature flags — `--bs`, `--modal`,
+  `--soft-delete`, `--concurrency`, `--events`, `--outbox`, `--tests`, `--validation`, `--no-restore` — grouped
+  under "Feature options". Output is colorized when writing to a terminal and stays plain when piped or when
+  `NO_COLOR` is set (so `rask info | cat` and CI logs are unaffected). Parse errors now point at
+  `rask <command> --help`. No new dependencies — the styling and help layers are pure BCL.
 - **Live demos for `BsTable` and `BsPagination`, plus unit tests for `BsBadge`.** The "Cards, lists &
   tables" guide gains a `BsTable` demo (typed style toggles over core `Thead`/`Tbody` markup) and an
   interactive `BsPagination` demo (click a page — the `.active` marker and readout follow, zero-JS). Both

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -16,15 +16,37 @@ That puts a `rask` command on your `PATH`. Update it later with `dotnet tool upd
 > `rask generate`), and shells out to `dotnet` for the rest — `rask dev` wraps `dotnet watch`, `rask db`
 > wraps `dotnet ef`.
 
+## Getting help
+
+`rask` on its own lists the commands. `rask <command> --help` (or `-h`) prints that command's full
+reference — its arguments, an aligned table of every option with a one-line description, and
+copy-pasteable examples:
+
+```bash
+rask                       # list all commands
+rask new --help            # arguments, options, and examples for `new`
+rask generate feature --help
+```
+
+Help (and other output) is colorized when `rask` is writing to a terminal, and falls back to plain
+text when the output is piped or when the [`NO_COLOR`](https://no-color.org) environment variable is
+set — so `rask info | cat` and CI logs stay clean.
+
 ## `rask new` — scaffold a project
 
 ```bash
+rask new                             # interactive: prompts for name, template, and features
 rask new MyApp                       # a server-rendered app (the default template)
 rask new MyApp --auth --docker       # + cookie auth + a production Dockerfile
 rask new Spa --template wasm --pwa   # an installable browser-WASM PWA
 rask new Shop --template wasm-hosted # a WASM SPA with an ASP.NET host
 rask new Field --template native     # a native iOS + Android app
 ```
+
+Run `rask new` on its own (no name) and — on a terminal — it walks you through a short wizard: the
+project name, a numbered template picker, and a yes/no for each feature the template supports. It then
+scaffolds exactly as if you'd passed the flags. Piped or in a script (no terminal), a missing name is a
+plain error instead, so automation stays predictable.
 
 The CLI writes the project's files itself, pins the `Rask.*` package references, and runs `dotnet
 restore` so the output builds immediately. `wasm-hosted` emits a three-project solution — `MyApp.Client`
@@ -54,6 +76,7 @@ page, styled with Bootstrap. Add pages and components to taste — `rask generat
 | `--docker` | Emit a production `Dockerfile` + `.dockerignore` (web templates). |
 | `--host` | `local` (default) or `server` — which native mode to scaffold (the `native` template only). |
 | `--output`, `-o` | Target directory (defaults to a folder named after the project). |
+| `--dry-run` | Print the files that would be created and write nothing (skips `dotnet restore`). |
 
 The flags wire a feature up; they don't scaffold sample pages for you to delete.
 
@@ -108,6 +131,14 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 | `--output`, `-o` | Write into this folder instead of the default (the namespace follows the folder). |
 | `--force` | Overwrite existing file(s). |
 | `--dry-run` | Print the file(s) that would be written, and write nothing. |
+| `--save-defaults` | `feature` only: remember this run's feature flags in `.rask/generate.json` (see below). |
+
+**Team defaults (`.rask/generate.json`).** So a project doesn't retype the same feature flags every
+time, `rask generate feature` reads defaults from `.rask/generate.json` at the project root — e.g.
+`{ "bs": true, "validation": "fluent", "tests": true }`. Explicit flags on the command line always win.
+Write the file by hand, or let the CLI record your choices: `rask generate feature Order Total:decimal
+--bs --tests --save-defaults` scaffolds *and* remembers `--bs`/`--tests` for next time. Booleans are
+opt-in (an absent key means off).
 
 The generated code compiles as-is in any project scaffolded by `rask new` — the factory methods and the
 `Component` base come from Rask's implicit usings, and pages navigate with the type-safe generated
@@ -226,6 +257,18 @@ rask info
 
 A quick check when diagnosing a machine: the tool version, the .NET SDK version, and the OS.
 `rask --version` prints just the tool version.
+
+## `rask completion` — shell completion
+
+```bash
+rask completion bash >> ~/.bashrc
+rask completion zsh  > "${fpath[1]}/_rask"
+rask completion fish > ~/.config/fish/completions/rask.fish
+```
+
+Prints a completion script for `bash`, `zsh`, or `fish`. It's generated from the live command list and
+each command's option schema, so it always matches the installed CLI — completing command names and
+their `--options`. Re-run it after upgrading `rask` to pick up new commands and flags.
 
 ## Roadmap
 

--- a/src/Rask.Cli/ArgumentSchema.cs
+++ b/src/Rask.Cli/ArgumentSchema.cs
@@ -36,11 +36,26 @@ internal sealed class ParsedArguments(
 }
 
 /// <summary>
+/// A declared flag or option: its names, whether it takes a value (and a hint for it), a one-line
+/// description, and an optional <see cref="Group"/> label so help can bucket, say, <c>generate</c>'s
+/// feature-only flags apart from the common ones. This is the single source of truth that both parses
+/// arguments and documents them — <c>--help</c> renders straight from this list, so it can never drift.
+/// </summary>
+internal sealed record OptionInfo(
+    string LongName,
+    char? ShortName,
+    bool IsFlag,
+    string? ValueHint,
+    string? Description,
+    string? Group);
+
+/// <summary>
 /// A tiny, dependency-free argument parser. Each command declares its boolean <see cref="Flag"/>s and
 /// valued <see cref="Option"/>s (with optional single-char aliases); <see cref="Parse"/> then turns a
 /// raw token list into a <see cref="ParsedArguments"/>. Supports <c>--name value</c>, <c>--name=value</c>,
 /// <c>-n value</c>, and a <c>--</c> separator after which everything is passthrough. Unknown options and
-/// options missing a value are reported as errors rather than guessed at.
+/// options missing a value are reported as errors rather than guessed at. Every declaration also records
+/// an <see cref="OptionInfo"/> (see <see cref="Declared"/>) so command help documents exactly what parses.
 /// </summary>
 internal sealed class ArgumentSchema
 {
@@ -48,18 +63,24 @@ internal sealed class ArgumentSchema
     private readonly HashSet<string> _flags = new(StringComparer.Ordinal);
     private readonly HashSet<string> _options = new(StringComparer.Ordinal);
     private readonly HashSet<string> _multiOptions = new(StringComparer.Ordinal);
+    private readonly List<OptionInfo> _declared = [];
 
-    public ArgumentSchema Flag(string longName, char? shortName = null)
+    /// <summary>Every flag/option declared on this schema, in declaration order — the source for <c>--help</c>.</summary>
+    public IReadOnlyList<OptionInfo> Declared => _declared;
+
+    public ArgumentSchema Flag(string longName, char? shortName = null, string? description = null, string? group = null)
     {
         _flags.Add(longName);
         Register(longName, shortName);
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: true, ValueHint: null, description, group));
         return this;
     }
 
-    public ArgumentSchema Option(string longName, char? shortName = null)
+    public ArgumentSchema Option(string longName, char? shortName = null, string? valueHint = null, string? description = null, string? group = null)
     {
         _options.Add(longName);
         Register(longName, shortName);
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group));
         return this;
     }
 
@@ -67,11 +88,12 @@ internal sealed class ArgumentSchema
     /// A valued option that may be supplied more than once (e.g. <c>--env A=1 --env B=2</c>); every value is
     /// collected in order and read via <see cref="ParsedArguments.MultiOption"/> rather than overwriting.
     /// </summary>
-    public ArgumentSchema MultiOption(string longName, char? shortName = null)
+    public ArgumentSchema MultiOption(string longName, char? shortName = null, string? valueHint = null, string? description = null, string? group = null)
     {
         _options.Add(longName);
         _multiOptions.Add(longName);
         Register(longName, shortName);
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group));
         return this;
     }
 

--- a/src/Rask.Cli/CliApplication.cs
+++ b/src/Rask.Cli/CliApplication.cs
@@ -20,22 +20,29 @@ internal sealed class CliApplication
     }
 
     /// <summary>Wire the real command set with production collaborators.</summary>
-    public static CliApplication CreateDefault(IConsole console, IProcessRunner process, IFileSystem fileSystem) =>
-        new(console,
-        [
+    public static CliApplication CreateDefault(IConsole console, IProcessRunner process, IFileSystem fileSystem)
+    {
+        var commands = new List<CliCommand>
+        {
             new NewCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new DevCommand(console, process),
             new GenerateCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new DbCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new DeployCommand(console, fileSystem, process, Environment.CurrentDirectory),
             new InfoCommand(console, process),
-        ]);
+        };
+
+        // Completion reflects the live command set (names + option schemas), so it is added last with a
+        // reference to the same list it will introspect.
+        commands.Add(new CompletionCommand(console, commands));
+        return new(console, commands);
+    }
 
     public async Task<int> RunAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
         {
-            PrintUsage(_console.Out);
+            CommandHelp.RenderTopLevel(_console, _commands, toError: false);
             return 0;
         }
 
@@ -45,11 +52,11 @@ internal sealed class CliApplication
         {
             if (args.Count > 1 && TryGetCommand(args[1], out var helpTarget))
             {
-                PrintCommandHelp(_console.Out, helpTarget);
+                CommandHelp.RenderCommand(_console, helpTarget);
             }
             else
             {
-                PrintUsage(_console.Out);
+                CommandHelp.RenderTopLevel(_console, _commands, toError: false);
             }
 
             return 0;
@@ -63,15 +70,15 @@ internal sealed class CliApplication
 
         if (!TryGetCommand(first, out var command))
         {
-            _console.Error.WriteLine($"Unknown command '{first}'.");
-            PrintUsage(_console.Error);
+            _console.WriteErrorLine($"Unknown command '{first}'.", ConsoleStyle.Error);
+            CommandHelp.RenderTopLevel(_console, _commands, toError: true);
             return 1;
         }
 
         var rest = args.Skip(1).ToArray();
         if (RequestsHelp(rest))
         {
-            PrintCommandHelp(_console.Out, command);
+            CommandHelp.RenderCommand(_console, command);
             return 0;
         }
 
@@ -113,31 +120,5 @@ internal sealed class CliApplication
 
         command = null!;
         return false;
-    }
-
-    private void PrintUsage(TextWriter writer)
-    {
-        writer.WriteLine("rask — the Rask framework command-line tool");
-        writer.WriteLine();
-        writer.WriteLine("Usage: rask <command> [options]");
-        writer.WriteLine();
-        writer.WriteLine("Commands:");
-
-        var width = _commands.Count == 0 ? 0 : _commands.Max(c => c.Name.Length);
-        foreach (var command in _commands)
-        {
-            writer.WriteLine($"  {command.Name.PadRight(width)}   {command.Summary}");
-        }
-
-        writer.WriteLine();
-        writer.WriteLine("Run 'rask <command> --help' for command-specific usage.");
-        writer.WriteLine("  --version    Show the tool version.");
-    }
-
-    private static void PrintCommandHelp(TextWriter writer, CliCommand command)
-    {
-        writer.WriteLine(command.Summary);
-        writer.WriteLine();
-        writer.WriteLine($"Usage: {command.Usage}");
     }
 }

--- a/src/Rask.Cli/CliCommand.cs
+++ b/src/Rask.Cli/CliCommand.cs
@@ -22,18 +22,40 @@ internal abstract class CliCommand(IConsole console)
     /// <summary>A one-line usage string shown in the command's own help and on errors.</summary>
     public abstract string Usage { get; }
 
+    /// <summary>Positional arguments (name + description) documented in <c>--help</c>. Empty by default.</summary>
+    public virtual IReadOnlyList<(string Name, string Description)> Arguments => [];
+
+    /// <summary>Copy-pasteable example invocations shown in <c>--help</c>. Empty by default.</summary>
+    public virtual IReadOnlyList<string> Examples => [];
+
+    /// <summary>
+    /// The command's flag/option schema, used by <c>--help</c> to render the options table. Commands that
+    /// take options override this to return the same schema they parse with, so help never drifts.
+    /// </summary>
+    public virtual ArgumentSchema? OptionSchema => null;
+
     /// <summary>Run the command with the arguments that follow its name. Returns a process exit code.</summary>
     public abstract Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken);
+
+    /// <summary>Report a written file with the shared green <c>+ path</c> marker (used by <c>new</c> and <c>generate</c>).</summary>
+    protected void WriteCreated(string relativePath) => Console.WriteLine($"  + {relativePath}", ConsoleStyle.Success);
+
+    /// <summary>Print a bold section/action heading to stdout.</summary>
+    protected void WriteHeading(string message) => Console.WriteLine(message, ConsoleStyle.Heading);
+
+    /// <summary>Print a non-fatal caution (yellow) to stderr — the tool carries on.</summary>
+    protected void WriteWarning(string message) => Console.WriteErrorLine(message, ConsoleStyle.Warning);
 
     /// <summary>Report parse errors to stderr and return the conventional usage exit code.</summary>
     protected int Fail(IReadOnlyList<string> errors)
     {
         foreach (var error in errors)
         {
-            Console.Error.WriteLine(error);
+            Console.WriteErrorLine(error, ConsoleStyle.Error);
         }
 
         Console.Error.WriteLine($"Usage: {Usage}");
+        Console.Error.WriteLine($"Run 'rask {Name} --help' for details.");
         return 1;
     }
 }

--- a/src/Rask.Cli/CommandHelp.cs
+++ b/src/Rask.Cli/CommandHelp.cs
@@ -1,0 +1,130 @@
+using System.Text;
+
+namespace Rask.Cli;
+
+/// <summary>
+/// Renders the CLI's help pages — the top-level command list and a per-command page (summary, usage,
+/// arguments, an aligned options table, and examples). Options come straight from each command's
+/// <see cref="ArgumentSchema.Declared"/> list, so help documents exactly what parses. Color is applied
+/// only when the target stream is a terminal; everything is written through plain <see cref="TextWriter"/>s
+/// with a resolved <c>color</c> flag so both stdout (help) and stderr (usage-on-error) render correctly.
+/// </summary>
+internal static class CommandHelp
+{
+    /// <summary>The top-level <c>rask</c> usage: tagline, command list, and footer hints.</summary>
+    public static void RenderTopLevel(IConsole console, IReadOnlyList<CliCommand> commands, bool toError)
+    {
+        var writer = toError ? console.Error : console.Out;
+        var color = ConsoleStyling.ColorEnabled(toError ? console.IsErrorRedirected : console.IsOutputRedirected);
+
+        writer.WriteLine(Paint("rask", ConsoleStyle.Heading, color) + " — the Rask framework command-line tool");
+        writer.WriteLine();
+        writer.WriteLine($"Usage: {Paint("rask <command> [options]", ConsoleStyle.Code, color)}");
+        writer.WriteLine();
+        writer.WriteLine(Paint("Commands:", ConsoleStyle.Heading, color));
+
+        var width = commands.Count == 0 ? 0 : commands.Max(c => c.Name.Length);
+        foreach (var command in commands)
+        {
+            writer.WriteLine($"  {Paint(command.Name.PadRight(width), ConsoleStyle.Code, color)}   {command.Summary}");
+        }
+
+        writer.WriteLine();
+        writer.WriteLine($"Run '{Paint("rask <command> --help", ConsoleStyle.Code, color)}' for command-specific usage.");
+        writer.WriteLine();
+        writer.WriteLine(Paint("Options:", ConsoleStyle.Heading, color));
+        writer.WriteLine("  --version    Show the tool version.");
+        writer.WriteLine("  --help       Show help for a command.");
+    }
+
+    /// <summary>A single command's help page: summary, usage, arguments, options, examples.</summary>
+    public static void RenderCommand(IConsole console, CliCommand command)
+    {
+        var writer = console.Out;
+        var color = ConsoleStyling.ColorEnabled(console.IsOutputRedirected);
+
+        writer.WriteLine(command.Summary);
+        writer.WriteLine();
+        writer.WriteLine($"Usage: {Paint(command.Usage, ConsoleStyle.Code, color)}");
+
+        if (command.Arguments.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine(Paint("Arguments:", ConsoleStyle.Heading, color));
+            var argWidth = command.Arguments.Max(a => a.Name.Length);
+            foreach (var (name, description) in command.Arguments)
+            {
+                writer.WriteLine($"  {Paint(name.PadRight(argWidth), ConsoleStyle.Code, color)}   {description}");
+            }
+        }
+
+        RenderOptions(writer, command.OptionSchema, color);
+
+        if (command.Examples.Count > 0)
+        {
+            writer.WriteLine();
+            writer.WriteLine(Paint("Examples:", ConsoleStyle.Heading, color));
+            foreach (var example in command.Examples)
+            {
+                writer.WriteLine($"  {Paint(example, ConsoleStyle.Code, color)}");
+            }
+        }
+    }
+
+    private static void RenderOptions(TextWriter writer, ArgumentSchema? schema, bool color)
+    {
+        if (schema is null || schema.Declared.Count == 0)
+        {
+            return;
+        }
+
+        // One column width across every group keeps the descriptions aligned down the whole page.
+        var width = schema.Declared.Max(o => Label(o).Length);
+
+        var ungrouped = schema.Declared.Where(o => o.Group is null).ToArray();
+        var groups = schema.Declared
+            .Where(o => o.Group is not null)
+            .GroupBy(o => o.Group!, StringComparer.Ordinal);
+
+        writer.WriteLine();
+        writer.WriteLine(Paint("Options:", ConsoleStyle.Heading, color));
+        foreach (var option in ungrouped)
+        {
+            WriteOption(writer, option, width, color);
+        }
+
+        foreach (var group in groups)
+        {
+            writer.WriteLine();
+            writer.WriteLine($"  {Paint(group.Key + ":", ConsoleStyle.Heading, color)}");
+            foreach (var option in group)
+            {
+                WriteOption(writer, option, width, color);
+            }
+        }
+    }
+
+    private static void WriteOption(TextWriter writer, OptionInfo option, int width, bool color)
+    {
+        var label = Label(option);
+        var painted = Paint(label.PadRight(width), ConsoleStyle.Code, color);
+        writer.WriteLine(option.Description is { Length: > 0 } d ? $"  {painted}   {d}" : $"  {painted}");
+    }
+
+    /// <summary>The left-column label, e.g. <c>-t, --template &lt;value&gt;</c> or <c>    --auth</c>.</summary>
+    private static string Label(OptionInfo option)
+    {
+        var builder = new StringBuilder();
+        builder.Append(option.ShortName is char c ? $"-{c}, " : "    ");
+        builder.Append("--").Append(option.LongName);
+        if (!option.IsFlag)
+        {
+            builder.Append(" <").Append(option.ValueHint ?? "value").Append('>');
+        }
+
+        return builder.ToString();
+    }
+
+    private static string Paint(string text, ConsoleStyle style, bool color) =>
+        color ? ConsoleStyling.Paint(text, style) : text;
+}

--- a/src/Rask.Cli/Commands/CompletionCommand.cs
+++ b/src/Rask.Cli/Commands/CompletionCommand.cs
@@ -1,0 +1,140 @@
+using System.Text;
+
+namespace Rask.Cli.Commands;
+
+/// <summary>
+/// <c>rask completion &lt;bash|zsh|fish&gt;</c> — print a shell completion script. The script is generated
+/// from the live command list and each command's option schema, so it always matches the CLI: add a
+/// command or an option and completion follows without a separate list to maintain.
+/// </summary>
+internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliCommand> commands) : CliCommand(console)
+{
+    private static readonly string[] Shells = ["bash", "zsh", "fish"];
+
+    public override string Name => "completion";
+
+    public override string Summary => "Print a shell completion script (bash, zsh, or fish).";
+
+    public override string Usage => "rask completion <bash|zsh|fish>";
+
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+        [("<bash|zsh|fish>", "The shell to generate a completion script for.")];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask completion bash >> ~/.bashrc",
+        "rask completion zsh > \"${fpath[1]}/_rask\"",
+        "rask completion fish > ~/.config/fish/completions/rask.fish",
+    ];
+
+    public override Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
+    {
+        var shell = args.Count > 0 ? args[0] : null;
+        if (shell is null || !Shells.Contains(shell))
+        {
+            Console.Error.WriteLine($"Specify a shell: {string.Join(", ", Shells)}.");
+            Console.Error.WriteLine($"Usage: {Usage}");
+            return Task.FromResult(1);
+        }
+
+        // Exclude self from the completed command list — but keep it a valid word so `rask compl<tab>` works.
+        var named = commands.Select(c => c.Name).ToArray();
+        var script = shell switch
+        {
+            "bash" => Bash(named),
+            "zsh" => Zsh(named),
+            _ => Fish(),
+        };
+
+        Console.Out.Write(script);
+        return Task.FromResult(0);
+    }
+
+    private IReadOnlyList<string> OptionsFor(string commandName)
+    {
+        var command = commands.FirstOrDefault(c => c.Name.Equals(commandName, StringComparison.Ordinal));
+        return command?.OptionSchema?.Declared.Select(o => "--" + o.LongName).ToArray() ?? [];
+    }
+
+    private string Bash(IReadOnlyList<string> commandNames)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# rask bash completion — source this file (e.g. add to ~/.bashrc).");
+        builder.AppendLine("_rask_complete() {");
+        builder.AppendLine("  local cur prev words cword");
+        builder.AppendLine("  _get_comp_words_by_ref -n : cur prev words cword 2>/dev/null || { cur=\"${COMP_WORDS[COMP_CWORD]}\"; words=(\"${COMP_WORDS[@]}\"); cword=$COMP_CWORD; }");
+        builder.AppendLine($"  local commands=\"{string.Join(' ', commandNames)}\"");
+        builder.AppendLine("  if [ \"$cword\" -le 1 ]; then");
+        builder.AppendLine("    COMPREPLY=( $(compgen -W \"$commands\" -- \"$cur\") ); return 0");
+        builder.AppendLine("  fi");
+        builder.AppendLine("  case \"${words[1]}\" in");
+        foreach (var command in commandNames)
+        {
+            var options = OptionsFor(command);
+            if (options.Count > 0)
+            {
+                builder.AppendLine($"    {command}) COMPREPLY=( $(compgen -W \"{string.Join(' ', options)}\" -- \"$cur\") );;");
+            }
+        }
+
+        builder.AppendLine("    *) COMPREPLY=( $(compgen -f -- \"$cur\") );;");
+        builder.AppendLine("  esac");
+        builder.AppendLine("}");
+        builder.AppendLine("complete -F _rask_complete rask");
+        return builder.ToString();
+    }
+
+    private string Zsh(IReadOnlyList<string> commandNames)
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("#compdef rask");
+        builder.AppendLine("# rask zsh completion — place on your $fpath as _rask.");
+        builder.AppendLine("_rask() {");
+        builder.AppendLine("  local -a commands");
+        builder.AppendLine($"  commands=({string.Join(' ', commandNames)})");
+        builder.AppendLine("  if (( CURRENT <= 2 )); then");
+        builder.AppendLine("    compadd -- $commands; return");
+        builder.AppendLine("  fi");
+        builder.AppendLine("  case \"${words[2]}\" in");
+        foreach (var command in commandNames)
+        {
+            var options = OptionsFor(command);
+            if (options.Count > 0)
+            {
+                builder.AppendLine($"    {command}) compadd -- {string.Join(' ', options)} ;;");
+            }
+        }
+
+        builder.AppendLine("    *) _files ;;");
+        builder.AppendLine("  esac");
+        builder.AppendLine("}");
+        builder.AppendLine("_rask \"$@\"");
+        return builder.ToString();
+    }
+
+    private string Fish()
+    {
+        var builder = new StringBuilder();
+        builder.AppendLine("# rask fish completion — save as ~/.config/fish/completions/rask.fish.");
+        builder.AppendLine("function __rask_no_subcommand");
+        builder.AppendLine("  set -l cmd (commandline -opc)");
+        builder.AppendLine("  test (count $cmd) -eq 1");
+        builder.AppendLine("end");
+        foreach (var command in commands)
+        {
+            var description = command.Summary.Replace("'", "", StringComparison.Ordinal);
+            builder.AppendLine($"complete -c rask -f -n __rask_no_subcommand -a {command.Name} -d '{description}'");
+        }
+
+        foreach (var command in commands)
+        {
+            foreach (var option in command.OptionSchema?.Declared ?? [])
+            {
+                var description = (option.Description ?? string.Empty).Replace("'", "", StringComparison.Ordinal);
+                builder.AppendLine($"complete -c rask -n '__fish_seen_subcommand_from {command.Name}' -l {option.LongName} -d '{description}'");
+            }
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/Rask.Cli/Commands/DbCommand.cs
+++ b/src/Rask.Cli/Commands/DbCommand.cs
@@ -25,6 +25,30 @@ internal sealed class DbCommand(IConsole console, IFileSystem fileSystem, IProce
     public override string Usage =>
         "rask db <add|remove|list|update|drop> [<name>] [--project <path>] [--startup-project <path>] [--context <Name>] [--output <dir>] [--force] [-- <ef args>]";
 
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+    [
+        ("<add|remove|list|update|drop>", "The migration action to run."),
+        ("[<name>]", "Migration name — required for 'add', e.g. InitialCreate."),
+    ];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask db add InitialCreate",
+        "rask db update",
+        "rask db list",
+        "rask db drop --force",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("project", 'p', "path", "Project containing the DbContext (default: found from the current directory).")
+            .Option("startup-project", 's', "path", "Startup project (default: same as --project).")
+            .Option("context", 'c', "Name", "DbContext to use when the project defines more than one.")
+            .Option("output", 'o', "dir", "Directory for the migration files (add only).")
+            .Flag("force", 'f', "Skip the confirmation prompt (drop only).");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
@@ -41,12 +65,7 @@ internal sealed class DbCommand(IConsole console, IFileSystem fileSystem, IProce
             return 1;
         }
 
-        var schema = new ArgumentSchema()
-            .Option("project", 'p')
-            .Option("startup-project", 's')
-            .Option("context", 'c')
-            .Option("output", 'o')
-            .Flag("force", 'f');
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -56,20 +56,33 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         "[--name <slug>] [--dockerfile <path>] [--env KEY=VALUE ...] [--env-file <path>] " +
         "[--health-path <path>] [--no-health-check] [--dry-run]";
 
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask deploy --host deploy@box.example.com --domain app.example.com",
+        "rask deploy --host deploy@box.example.com --port 8080",
+        "rask deploy --env ConnectionStrings__Db=... --env-file .env.production",
+        "rask deploy --dry-run",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("host", 'h', "user@box", "SSH target to build and run on (remembered in .rask/deploy.json).")
+            .Option("domain", 'd', "host", "Public domain to serve over HTTPS via Caddy (implies ports 80/443).")
+            .Option("port", valueHint: "n", description: "Published port when not using --domain (default: 8080).")
+            .Option("project", 'p', "path", "Project to deploy (default: found from the current directory).")
+            .Option("name", 'n', "slug", "Container/app name (default: derived from the project).")
+            .Option("dockerfile", valueHint: "path", description: "Dockerfile to build (default: ./Dockerfile).")
+            .Option("env-file", valueHint: "path", description: "File of KEY=VALUE lines to pass to the container.")
+            .MultiOption("env", 'e', "KEY=VALUE", "Environment variable to pass (repeatable).")
+            .Option("health-path", valueHint: "path", description: "HTTP path probed for readiness before the blue-green swap (default: /).")
+            .Flag("no-health-check", description: "Skip the post-deploy HTTP health check.")
+            .Flag("dry-run", description: "Print the docker commands that would run without changing anything.");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        var schema = new ArgumentSchema()
-            .Option("host", 'h')
-            .Option("domain", 'd')
-            .Option("port")
-            .Option("project", 'p')
-            .Option("name", 'n')
-            .Option("dockerfile")
-            .Option("env-file")
-            .MultiOption("env", 'e')
-            .Option("health-path")
-            .Flag("no-health-check")
-            .Flag("dry-run");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args);
         if (parsed.HasErrors)
@@ -162,10 +175,10 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             return 1;
         }
 
-        Console.Out.WriteLine($"Building {slug}:latest on {host}…");
+        WriteHeading($"Building {slug}:latest on {host}…");
         if (await Run(BuildBuildArguments(host, slug, dockerfile, contextDir), cancellationToken).ConfigureAwait(false) != 0)
         {
-            Console.Error.WriteLine("Docker build failed.");
+            Console.WriteErrorLine("Docker build failed.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -181,7 +194,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         Console.Out.WriteLine($"Starting {slug} on port {port}…");
         if (await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env), cancellationToken).ConfigureAwait(false) != 0)
         {
-            Console.Error.WriteLine("Failed to start the container.");
+            Console.WriteErrorLine("Failed to start the container.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -196,12 +209,12 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         if (healthEnabled && !await WaitUntilHealthyAsync(host, slug, healthPath, cancellationToken).ConfigureAwait(false))
         {
             await DumpLogsAsync(host, slug, cancellationToken).ConfigureAwait(false);
-            Console.Error.WriteLine(HealthFailureMessage(healthPath, rolledBack: false));
+            Console.WriteErrorLine(HealthFailureMessage(healthPath, rolledBack: false), ConsoleStyle.Error);
             return 1;
         }
 
         PersistConfig(host, domain: null, port, slug, project, envFile, healthEnabled, healthPath);
-        Console.Out.WriteLine($"Deployed. The app is live at http://{HostName(host)}:{port}");
+        Console.WriteLine($"Deployed. The app is live at http://{HostName(host)}:{port}", ConsoleStyle.Success);
         return 0;
     }
 
@@ -226,7 +239,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         // In domain mode the app is reached internally on ContainerPort; no host port is published.
         if (await Run(BuildRunArguments(host, slug, domain, newColor, ContainerPort, env), cancellationToken).ConfigureAwait(false) != 0)
         {
-            Console.Error.WriteLine("Failed to start the new container.");
+            Console.WriteErrorLine("Failed to start the new container.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -236,7 +249,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         {
             await DumpLogsAsync(host, newContainer, cancellationToken).ConfigureAwait(false);
             await Run(BuildRemoveArguments(host, newContainer), cancellationToken).ConfigureAwait(false);
-            Console.Error.WriteLine("The new container exited before it was ready — left the previous version serving.");
+            Console.WriteErrorLine("The new container exited before it was ready — left the previous version serving.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -267,7 +280,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         // need a moment before `caddy reload` succeeds.
         if (await RunWithRetryAsync(BuildCaddyReloadArguments(host), cancellationToken).ConfigureAwait(false) != 0)
         {
-            Console.Error.WriteLine("Caddy reload failed — the new container is running but not yet routed. Check `docker -H ssh://" + host + " logs rask-caddy`.");
+            Console.WriteErrorLine("Caddy reload failed — the new container is running but not yet routed. Check `docker -H ssh://" + host + " logs rask-caddy`.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -278,8 +291,8 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         }
 
         PersistConfig(host, domain, port: null, slug, project, envFile, healthEnabled, healthPath);
-        Console.Out.WriteLine($"Deployed. The app is live at https://{domain}");
-        Console.Out.WriteLine($"  (make sure {domain}'s DNS A/AAAA record points at {HostName(host)})");
+        Console.WriteLine($"Deployed. The app is live at https://{domain}", ConsoleStyle.Success);
+        Console.WriteLine($"  (make sure {domain}'s DNS A/AAAA record points at {HostName(host)})", ConsoleStyle.Dim);
         return 0;
     }
 
@@ -299,6 +312,9 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
     private async Task<bool> WaitUntilRunningAsync(string host, string container, CancellationToken cancellationToken)
     {
+        // The poll is otherwise silent for up to ReadinessAttempts × ReadinessDelay — spin so an
+        // interactive user sees it's working (a no-op when stdout is redirected/piped).
+        await using var spinner = Spinner.Start(Console, $"Waiting for {container} to become healthy…");
         for (var attempt = 0; attempt < ReadinessAttempts; attempt++)
         {
             // Inspect first, then wait only between retries — a container that's already up returns immediately.

--- a/src/Rask.Cli/Commands/DevCommand.cs
+++ b/src/Rask.Cli/Commands/DevCommand.cs
@@ -15,11 +15,23 @@ internal sealed class DevCommand(IConsole console, IProcessRunner process) : Cli
 
     public override string Usage => "rask dev [--project <path>] [--no-hot-reload] [-- <args passed to the app>]";
 
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask dev",
+        "rask dev --project src/App",
+        "rask dev -- --urls http://localhost:5000",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("project", 'p', "path", "Project to run (default: the project in the current directory).")
+            .Flag("no-hot-reload", description: "Use a plain 'dotnet run' instead of 'dotnet watch' (no hot reload).");
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        var schema = new ArgumentSchema()
-            .Option("project", 'p')
-            .Flag("no-hot-reload");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args);
         if (parsed.HasErrors)

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -35,6 +35,48 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
     public override string Usage =>
         "rask generate <page|component|feature|job|email> <Name> [<field:type> ...] [--id guid|int|long] [--route <path>] [--context <Name>] [--plural <Name>] [--output <dir>] [--force] [--dry-run]";
 
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+    [
+        ("<page|component|feature|job|email>", "What to scaffold (aliases: p, c, f, j, e)."),
+        ("<Name>", "The type name, e.g. Product or Dashboard."),
+        ("[<field:type> ...]", "Fields for a feature, e.g. Name:string Price:decimal."),
+    ];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask generate page Dashboard --route /dashboard",
+        "rask generate component UserCard",
+        "rask generate feature Product Name:string Price:decimal",
+        "rask generate feature Order Total:decimal --bs --modal --tests",
+        "rask g j SendWelcomeEmail",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private const string FeatureGroup = "Feature options (rask generate feature)";
+
+    /// <summary>The flag/option schema — shared by <see cref="ExecuteAsync"/> and <c>--help</c> so they can't drift.</summary>
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("output", 'o', "dir", "Directory to write into (default: derived from the artifact).")
+            .Flag("force", description: "Overwrite existing files instead of refusing.")
+            .Flag("dry-run", description: "Print what would be written without touching disk.")
+            .Option("route", 'r', "path", "URL route for the page.", group: "Page options")
+            .Option("fields", 'f', "list", "Fields as Name:type,... (or pass them positionally).", FeatureGroup)
+            .Option("context", 'c', "Name", "Reuse an existing DbContext instead of generating one.", FeatureGroup)
+            .Option("plural", 'p', "Name", "Plural name for the feature folder/route (default: auto-pluralized).", FeatureGroup)
+            .Option("id", valueHint: "guid|int|long", description: "Primary-key type (default: guid).", group: FeatureGroup)
+            .Option("validation", valueHint: "mode", description: "Validation style: valueobjects (default), dataannotations, or fluent.", group: FeatureGroup)
+            .Flag("bs", description: "Render pages with Rask.Bootstrap (Bs*) components.", group: FeatureGroup)
+            .Flag("modal", description: "Fold create/edit into a modal on the list page (implies --bs).", group: FeatureGroup)
+            .Flag("soft-delete", description: "Soft-delete rows and add a Restore command.", group: FeatureGroup)
+            .Flag("concurrency", description: "Add optimistic-concurrency (row version) handling.", group: FeatureGroup)
+            .Flag("events", description: "Raise domain events on create/update/delete.", group: FeatureGroup)
+            .Flag("outbox", description: "Persist domain events via the transactional outbox (implies --events).", group: FeatureGroup)
+            .Flag("tests", description: "Generate a sibling <Project>.Tests project with domain + persistence tests.", group: FeatureGroup)
+            .Flag("no-restore", description: "Write files without adding packages or restoring.", group: FeatureGroup)
+            .Flag("save-defaults", description: "Remember this run's feature flags in .rask/generate.json for next time.", group: FeatureGroup);
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
@@ -51,24 +93,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             return 1;
         }
 
-        var schema = new ArgumentSchema()
-            .Option("route", 'r')
-            .Option("output", 'o')
-            .Option("fields", 'f')
-            .Option("context", 'c')
-            .Option("plural", 'p')
-            .Option("id")
-            .Option("validation")
-            .Flag("bs")
-            .Flag("modal")
-            .Flag("soft-delete")
-            .Flag("concurrency")
-            .Flag("events")
-            .Flag("outbox")
-            .Flag("tests")
-            .Flag("no-restore")
-            .Flag("force")
-            .Flag("dry-run");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)
@@ -109,9 +134,10 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             && (parsed.Option("fields") is not null || parsed.Option("context") is not null
                 || parsed.Option("plural") is not null || parsed.Option("id") is not null
                 || parsed.Option("validation") is not null || parsed.HasFlag("bs") || parsed.HasFlag("modal")
-                || parsed.HasFlag("soft-delete") || parsed.HasFlag("concurrency") || parsed.HasFlag("events") || parsed.HasFlag("outbox") || parsed.HasFlag("tests")))
+                || parsed.HasFlag("soft-delete") || parsed.HasFlag("concurrency") || parsed.HasFlag("events")
+                || parsed.HasFlag("outbox") || parsed.HasFlag("tests") || parsed.HasFlag("save-defaults")))
         {
-            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, --modal, --soft-delete, --concurrency, --events, --outbox, and --tests only apply to 'generate feature'.");
+            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, --modal, --soft-delete, --concurrency, --events, --outbox, --tests, and --save-defaults only apply to 'generate feature'.");
             return 1;
         }
 
@@ -147,9 +173,17 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
         var dryRun = parsed.HasFlag("dry-run");
         var written = Write(result, parsed.HasFlag("force"), dryRun);
-        if (written == 0 && !dryRun && result.Packages.Count > 0)
+        if (written == 0 && !dryRun)
         {
-            await AddPackagesAsync(project.ProjectDirectory, result.Packages, parsed.HasFlag("no-restore"), cancellationToken).ConfigureAwait(false);
+            if (parsed.HasFlag("save-defaults"))
+            {
+                SaveDefaults(project.ProjectDirectory, parsed);
+            }
+
+            if (result.Packages.Count > 0)
+            {
+                await AddPackagesAsync(project.ProjectDirectory, result.Packages, parsed.HasFlag("no-restore"), cancellationToken).ConfigureAwait(false);
+            }
         }
 
         return written;
@@ -162,17 +196,17 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
     {
         if (noRestore)
         {
-            Console.Out.WriteLine($"Skipped adding packages (--no-restore): {string.Join(", ", packages)}");
+            Console.WriteLine($"Skipped adding packages (--no-restore): {string.Join(", ", packages)}", ConsoleStyle.Dim);
             return;
         }
 
-        Console.Out.WriteLine($"Adding {packages.Count} package(s) to the project…");
+        Console.WriteLine($"Adding {packages.Count} package(s) to the project…", ConsoleStyle.Dim);
         foreach (var package in packages)
         {
             var exit = await _process.RunAsync("dotnet", ["add", "package", package], projectDirectory, cancellationToken).ConfigureAwait(false);
             if (exit != 0)
             {
-                Console.Error.WriteLine($"  Couldn't add {package} automatically — add it manually: dotnet add package {package}");
+                WriteWarning($"  Couldn't add {package} automatically — add it manually: dotnet add package {package}");
             }
         }
     }
@@ -235,7 +269,10 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                     return false;
                 }
 
-                var idType = parsed.Option("id")?.ToLowerInvariant() switch
+                // Team defaults from .rask/generate.json fill in what wasn't passed; explicit flags always win.
+                var config = GenerateConfig.Load(_fileSystem, project.ProjectDirectory);
+
+                var idType = (parsed.Option("id") ?? config.Id)?.ToLowerInvariant() switch
                 {
                     null or "guid" => "Guid",
                     "int" => "int",
@@ -250,7 +287,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                     return false;
                 }
 
-                var validation = parsed.Option("validation")?.ToLowerInvariant() ?? "valueobjects";
+                var validation = (parsed.Option("validation") ?? config.Validation)?.ToLowerInvariant() ?? "valueobjects";
                 if (validation is not ("valueobjects" or "dataannotations" or "fluent"))
                 {
                     result = null!;
@@ -259,10 +296,15 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                 }
 
                 // --modal puts create/update in a BsModal on the list page, so it implies --bs.
-                var useModal = parsed.HasFlag("modal");
-                var useBs = useModal || parsed.HasFlag("bs");
+                var useModal = parsed.HasFlag("modal") || (config.Modal ?? false);
+                var useBs = useModal || parsed.HasFlag("bs") || (config.Bs ?? false);
+                var softDelete = parsed.HasFlag("soft-delete") || (config.SoftDelete ?? false);
+                var concurrency = parsed.HasFlag("concurrency") || (config.Concurrency ?? false);
+                var events = parsed.HasFlag("events") || (config.Events ?? false);
+                var outbox = parsed.HasFlag("outbox") || (config.Outbox ?? false);
+                var tests = parsed.HasFlag("tests") || (config.Tests ?? false);
 
-                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, parsed.HasFlag("soft-delete"), parsed.HasFlag("concurrency"), parsed.HasFlag("events"), parsed.HasFlag("outbox"), parsed.HasFlag("tests"), parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
+                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, softDelete, concurrency, events, outbox, tests, parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
                 return true;
         }
     }
@@ -305,11 +347,66 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             }
 
             _fileSystem.WriteAllText(file.Path, file.Content);
-            Console.Out.WriteLine($"Created {Display(file.Path)}");
+            WriteCreated(Display(file.Path));
         }
 
         WriteNotes(result.Notes);
         return 0;
+    }
+
+    // Overlay this run's explicit feature flags/options onto any existing .rask/generate.json and save it —
+    // so the next `rask generate feature` inherits them. Only sets values the user actually passed (booleans
+    // are never written false), keeping the file to the team's deliberate choices.
+    private void SaveDefaults(string projectDirectory, ParsedArguments parsed)
+    {
+        var config = GenerateConfig.Load(_fileSystem, projectDirectory);
+        if (parsed.HasFlag("bs"))
+        {
+            config.Bs = true;
+        }
+
+        if (parsed.HasFlag("modal"))
+        {
+            config.Modal = true;
+        }
+
+        if (parsed.HasFlag("soft-delete"))
+        {
+            config.SoftDelete = true;
+        }
+
+        if (parsed.HasFlag("concurrency"))
+        {
+            config.Concurrency = true;
+        }
+
+        if (parsed.HasFlag("events"))
+        {
+            config.Events = true;
+        }
+
+        if (parsed.HasFlag("outbox"))
+        {
+            config.Outbox = true;
+        }
+
+        if (parsed.HasFlag("tests"))
+        {
+            config.Tests = true;
+        }
+
+        if (parsed.Option("validation") is { } validation)
+        {
+            config.Validation = validation;
+        }
+
+        if (parsed.Option("id") is { } id)
+        {
+            config.Id = id;
+        }
+
+        config.Save(_fileSystem, projectDirectory);
+        Console.WriteLine($"Saved generate defaults to {Display(GenerateConfig.PathFor(projectDirectory))}.", ConsoleStyle.Success);
     }
 
     private void WriteNotes(string? notes)

--- a/src/Rask.Cli/Commands/InfoCommand.cs
+++ b/src/Rask.Cli/Commands/InfoCommand.cs
@@ -16,6 +16,8 @@ internal sealed class InfoCommand(IConsole console, IProcessRunner process) : Cl
 
     public override string Usage => "rask info";
 
+    public override IReadOnlyList<string> Examples => ["rask info"];
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         var sdkVersion = await CaptureSingleLineAsync(["--version"], cancellationToken).ConfigureAwait(false);

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -31,17 +31,38 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     public override string Usage =>
         "rask new <name> [--template server|wasm|wasm-hosted|native] [--auth] [--pwa] [--cqrs] [--docker] [--host local|server] [--output <dir>]";
 
-    public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+        [("<name>", "Name of the project to create (scaffolds ./<name>/).")];
+
+    public override IReadOnlyList<string> Examples =>
+    [
+        "rask new Shop",
+        "rask new Shop --template wasm --pwa",
+        "rask new Api --template server --auth --docker",
+        "rask new MyApp --template native --host server",
+    ];
+
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    /// <summary>The flag/option schema — shared by <see cref="ExecuteAsync"/> and <c>--help</c> so they can't drift.</summary>
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Option("template", 't', "name", "Template to scaffold: server (default), wasm, wasm-hosted, or native.")
+            .Option("output", 'o', "dir", "Directory to create the project in (default: ./<name>).")
+            .Option("name", 'n', "name", "Project name, if not given positionally.")
+            .Option("host", valueHint: "local|server", description: "Native host mode: local (default) or server. Native template only.")
+            .Flag("auth", description: "Add cookie authentication (login + members pages).")
+            .Flag("pwa", description: "Add a PWA manifest, icon, and offline page.")
+            .Flag("cqrs", description: "Wire up Rask.Cqrs (server template only).")
+            .Flag("docker", description: "Add a Dockerfile and .dockerignore for container deploys.")
+            .Flag("dry-run", description: "Print the files that would be written without touching disk.");
+
+    public override Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken) =>
+        ExecuteAsync(args, allowWizard: true, cancellationToken);
+
+    private async Task<int> ExecuteAsync(IReadOnlyList<string> args, bool allowWizard, CancellationToken cancellationToken)
     {
-        var schema = new ArgumentSchema()
-            .Option("template", 't')
-            .Option("output", 'o')
-            .Option("name", 'n')
-            .Option("host")
-            .Flag("auth")
-            .Flag("pwa")
-            .Flag("cqrs")
-            .Flag("docker");
+        var schema = CreateSchema();
 
         var parsed = schema.Parse(args);
         if (parsed.HasErrors)
@@ -52,6 +73,14 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         var name = parsed.Option("name") ?? parsed.Positionals.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(name))
         {
+            // No name given. On a terminal, walk an interactive wizard and re-run with the answers
+            // (allowWizard:false bounds this to one hop); piped/scripted, keep the hard-error contract.
+            var prompt = new Prompt(Console);
+            if (allowWizard && prompt.Interactive)
+            {
+                return await ExecuteAsync(RunWizard(prompt), allowWizard: false, cancellationToken).ConfigureAwait(false);
+            }
+
             Console.Error.WriteLine("A project name is required.");
             Console.Error.WriteLine($"Usage: {Usage}");
             return 1;
@@ -98,7 +127,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             }
 
             return await GenerateDirectAsync(
-                template, name, parsed.Option("output"),
+                template, name, parsed.Option("output"), parsed.HasFlag("dry-run"),
                 (dir, version) => ProjectGenerator.GenerateNative(dir, name, host, version),
                 cancellationToken).ConfigureAwait(false);
         }
@@ -106,7 +135,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         // Every web template is generated directly by the CLI (server, wasm, wasm-hosted). native is handled
         // above with its own shape; the key here is one of those three (validated by TemplateCatalog.TryGet).
         return await GenerateDirectAsync(
-            template, name, parsed.Option("output"),
+            template, name, parsed.Option("output"), parsed.HasFlag("dry-run"),
             (dir, version) =>
             {
                 bool auth = requestedFlags.Contains("auth"), pwa = requestedFlags.Contains("pwa"),
@@ -121,8 +150,43 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             cancellationToken).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Walk the interactive first-run flow (name → template → applicable feature flags) and return the
+    /// equivalent argument list, so the answers flow back through the exact same validation and generation
+    /// path as a fully-typed command line. Only reached on a terminal.
+    /// </summary>
+    private static IReadOnlyList<string> RunWizard(Prompt prompt)
+    {
+        var name = prompt.Ask("Project name");
+        var templateKey = prompt.Select(
+            "Template",
+            [.. TemplateCatalog.All.Select(t => (t.Key, $"{t.Key} — {t.DisplayName}"))],
+            TemplateCatalog.Default.Key);
+
+        var args = new List<string> { name, "--template", templateKey };
+        _ = TemplateCatalog.TryGet(templateKey, out var template);
+
+        if (templateKey == "native")
+        {
+            var host = prompt.Select("Host", [("local", "local — self-hosted app"), ("server", "server — thin client of a Rask server")], "local");
+            args.Add("--host");
+            args.Add(host);
+            return args;
+        }
+
+        foreach (var flag in FeatureFlags.Where(template.SupportedFlags.Contains))
+        {
+            if (prompt.Confirm($"Add --{flag}?", @default: false))
+            {
+                args.Add("--" + flag);
+            }
+        }
+
+        return args;
+    }
+
     private async Task<int> GenerateDirectAsync(
-        TemplateInfo template, string name, string? output,
+        TemplateInfo template, string name, string? output, bool dryRun,
         Func<string, string, ScaffoldResult> build, CancellationToken cancellationToken)
     {
         // rask new MyApp → ./MyApp/ ; --output overrides the destination directory.
@@ -134,6 +198,18 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         var version = ResolvePackageVersion(CliMetadata.Version);
         var result = build(targetDirectory, version);
 
+        // --dry-run previews the plan without touching disk or restoring — same spirit as `rask generate --dry-run`.
+        if (dryRun)
+        {
+            WriteHeading($"Would create {template.DisplayName} '{name}':");
+            foreach (var file in result.Files)
+            {
+                Console.Out.WriteLine($"  [dry-run] would write {Path.GetRelativePath(_workingDirectory, file.Path)}");
+            }
+
+            return 0;
+        }
+
         var restoreTarget = result.RestoreTarget is { } relative
             ? Path.Combine(targetDirectory, relative)
             : Path.Combine(targetDirectory, name + ".csproj");
@@ -144,7 +220,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             return 1;
         }
 
-        Console.Out.WriteLine($"Creating {template.DisplayName} '{name}'…");
+        WriteHeading($"Creating {template.DisplayName} '{name}'…");
         foreach (var file in result.Files)
         {
             var directory = Path.GetDirectoryName(file.Path);
@@ -154,15 +230,16 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             }
 
             _fileSystem.WriteAllText(file.Path, file.Content);
-            Console.Out.WriteLine($"  + {Path.GetRelativePath(_workingDirectory, file.Path)}");
+            WriteCreated(Path.GetRelativePath(_workingDirectory, file.Path));
         }
 
         // Package refs are already baked into the csproj(s) at the pinned version; restore pulls them so the
         // project builds immediately. A restore failure is a warning — the files are written and correct.
+        Console.WriteLine("Restoring packages…", ConsoleStyle.Dim);
         var restore = await _process.RunAsync("dotnet", ["restore", restoreTarget], targetDirectory, cancellationToken).ConfigureAwait(false);
         if (restore != 0)
         {
-            Console.Error.WriteLine("  Couldn't restore automatically — run 'dotnet restore' in the project directory.");
+            WriteWarning("  Couldn't restore automatically — run 'dotnet restore' in the project directory.");
         }
 
         if (!string.IsNullOrEmpty(result.Notes))

--- a/src/Rask.Cli/ConsoleStyling.cs
+++ b/src/Rask.Cli/ConsoleStyling.cs
@@ -1,0 +1,71 @@
+namespace Rask.Cli;
+
+/// <summary>The semantic roles the CLI colors — mapped to ANSI SGR codes by <see cref="ConsoleStyling"/>.</summary>
+internal enum ConsoleStyle
+{
+    /// <summary>A completed action (green).</summary>
+    Success,
+
+    /// <summary>A failure (red).</summary>
+    Error,
+
+    /// <summary>A non-fatal caution (yellow).</summary>
+    Warning,
+
+    /// <summary>A section title (bold).</summary>
+    Heading,
+
+    /// <summary>Secondary/hint text (dim).</summary>
+    Dim,
+
+    /// <summary>An inline command or path the user can copy (cyan).</summary>
+    Code,
+}
+
+/// <summary>
+/// A tiny, dependency-free ANSI styling layer. Color is emitted only when the target stream is a real
+/// terminal (not piped) and <c>NO_COLOR</c> is unset — so <c>rask info | cat</c>, CI logs, and captured
+/// test output stay plain. Everything routes through <see cref="IConsole"/> so tests (which report both
+/// streams as redirected) see uncolored text and their substring assertions keep holding.
+/// </summary>
+internal static class ConsoleStyling
+{
+    private const string Reset = "\x1b[0m";
+
+    /// <summary>The SGR parameter for a style, e.g. <c>32</c> (green) for <see cref="ConsoleStyle.Success"/>.</summary>
+    private static string Sgr(ConsoleStyle style) => style switch
+    {
+        ConsoleStyle.Success => "32",
+        ConsoleStyle.Error => "31",
+        ConsoleStyle.Warning => "33",
+        ConsoleStyle.Heading => "1",
+        ConsoleStyle.Dim => "2",
+        ConsoleStyle.Code => "36",
+        _ => "0",
+    };
+
+    /// <summary>Wrap <paramref name="text"/> in the style's escape codes. Pure — unit-tested directly.</summary>
+    public static string Paint(string text, ConsoleStyle style) => $"\x1b[{Sgr(style)}m{text}{Reset}";
+
+    /// <summary>
+    /// True when styling should be applied to a stream with the given redirection state: a real terminal
+    /// (<paramref name="redirected"/> is false) and no <c>NO_COLOR</c> override.
+    /// </summary>
+    public static bool ColorEnabled(bool redirected) =>
+        !redirected && string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NO_COLOR"));
+
+    /// <summary>Style <paramref name="text"/> for stdout, or return it unchanged when color is off.</summary>
+    public static string Style(this IConsole console, string text, ConsoleStyle style) =>
+        ColorEnabled(console.IsOutputRedirected) ? Paint(text, style) : text;
+
+    /// <summary>Write a styled line to stdout (plain when color is off).</summary>
+    public static void WriteLine(this IConsole console, string text, ConsoleStyle style) =>
+        console.Out.WriteLine(console.Style(text, style));
+
+    /// <summary>Write a styled line to stderr (plain when color is off), honoring stderr's own redirection.</summary>
+    public static void WriteErrorLine(this IConsole console, string text, ConsoleStyle style)
+    {
+        var painted = ColorEnabled(console.IsErrorRedirected) ? Paint(text, style) : text;
+        console.Error.WriteLine(painted);
+    }
+}

--- a/src/Rask.Cli/IConsole.cs
+++ b/src/Rask.Cli/IConsole.cs
@@ -1,14 +1,28 @@
 namespace Rask.Cli;
 
 /// <summary>
-/// The tool's console output seam. Abstracting <see cref="System.Console"/> keeps every command
-/// unit-testable — tests substitute an in-memory writer and assert on the captured text.
+/// The tool's console seam. Abstracting <see cref="System.Console"/> keeps every command
+/// unit-testable — tests substitute in-memory readers/writers and assert on the captured text. The
+/// redirection flags let output honor <c>NO_COLOR</c> / piping (see <see cref="ConsoleStyling"/>) and
+/// let interactive prompts fall back to their defaults when there is no terminal.
 /// </summary>
 internal interface IConsole
 {
     TextWriter Out { get; }
 
     TextWriter Error { get; }
+
+    /// <summary>The input stream, read by interactive prompts.</summary>
+    TextReader In { get; }
+
+    /// <summary>True when stdout is piped/redirected — color escapes are suppressed.</summary>
+    bool IsOutputRedirected { get; }
+
+    /// <summary>True when stderr is piped/redirected — color escapes are suppressed.</summary>
+    bool IsErrorRedirected { get; }
+
+    /// <summary>True when stdin is piped/redirected — prompts skip and use their default answer.</summary>
+    bool IsInputRedirected { get; }
 }
 
 /// <summary>The real console, wired in <c>Program.cs</c>.</summary>
@@ -19,4 +33,12 @@ internal sealed class SystemConsole : IConsole
     public TextWriter Out => Console.Out;
 
     public TextWriter Error => Console.Error;
+
+    public TextReader In => Console.In;
+
+    public bool IsOutputRedirected => Console.IsOutputRedirected;
+
+    public bool IsErrorRedirected => Console.IsErrorRedirected;
+
+    public bool IsInputRedirected => Console.IsInputRedirected;
 }

--- a/src/Rask.Cli/NUGET.md
+++ b/src/Rask.Cli/NUGET.md
@@ -51,8 +51,11 @@ rask info
 | `rask deploy` | Build and run the app on a single host over SSH (`docker -H ssh://…`). `--domain` fronts it with auto-HTTPS Caddy; deploys are zero-downtime and multiple apps share one box. |
 | `rask dev` | Run the app with C# Hot Reload (`dotnet watch run`); `--no-hot-reload` for a plain run. Args after `--` reach the app. |
 | `rask info` | Report the CLI version, .NET SDK version, and OS. |
+| `rask completion <bash\|zsh\|fish>` | Print a shell completion script, generated from the live command + option set. |
 
-Run `rask <command> --help` for command-specific usage, or `rask --version` for the tool version.
+Run `rask <command> --help` for a full reference — arguments, a described options table, and examples
+— or `rask --version` for the tool version. Output is colorized on a terminal and plain when piped or
+under `NO_COLOR`.
 
 ## Notes
 

--- a/src/Rask.Cli/Prompt.cs
+++ b/src/Rask.Cli/Prompt.cs
@@ -1,0 +1,122 @@
+namespace Rask.Cli;
+
+/// <summary>
+/// A tiny, dependency-free interactive prompt over <see cref="IConsole"/>. It reads from the console's
+/// input stream and is only meant to run when <see cref="Interactive"/> is true (a real terminal); when
+/// stdin is redirected/piped, callers should skip prompting and keep their non-interactive behavior. All
+/// reads are EOF-safe — a closed stream returns the default rather than looping — so a command can never
+/// hang. In tests, <c>StringConsole.InputLines</c> scripts the answers and flips the console to interactive.
+/// </summary>
+internal sealed class Prompt(IConsole console)
+{
+    /// <summary>True when stdin is a terminal — the only time a command should prompt.</summary>
+    public bool Interactive => !console.IsInputRedirected;
+
+    /// <summary>
+    /// Ask for a line of text. With a <paramref name="default"/>, an empty answer accepts it; without one
+    /// the question repeats until non-empty (or the input ends, which yields empty and lets the caller fail).
+    /// </summary>
+    public string Ask(string label, string? @default = null)
+    {
+        while (true)
+        {
+            console.Out.Write(@default is null ? $"{label}: " : $"{label} [{@default}]: ");
+            console.Out.Flush();
+
+            var line = console.In.ReadLine();
+            if (line is null)
+            {
+                return @default ?? string.Empty; // EOF — don't loop forever.
+            }
+
+            line = line.Trim();
+            if (line.Length > 0)
+            {
+                return line;
+            }
+
+            if (@default is not null)
+            {
+                return @default;
+            }
+        }
+    }
+
+    /// <summary>Ask a yes/no question. An empty answer accepts <paramref name="default"/>; EOF returns it.</summary>
+    public bool Confirm(string label, bool @default)
+    {
+        var hint = @default ? "[Y/n]" : "[y/N]";
+        while (true)
+        {
+            console.Out.Write($"{label} {hint} ");
+            console.Out.Flush();
+
+            var line = console.In.ReadLine();
+            if (line is null)
+            {
+                return @default;
+            }
+
+            line = line.Trim();
+            if (line.Length == 0)
+            {
+                return @default;
+            }
+
+            if (line.Equals("y", StringComparison.OrdinalIgnoreCase) || line.Equals("yes", StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+
+            if (line.Equals("n", StringComparison.OrdinalIgnoreCase) || line.Equals("no", StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Choose one of <paramref name="options"/> (value + label) by number or by typing the value. An empty
+    /// answer or EOF accepts <paramref name="default"/>.
+    /// </summary>
+    public string Select(string label, IReadOnlyList<(string Value, string Label)> options, string @default)
+    {
+        console.Out.WriteLine($"{label}:");
+        for (var i = 0; i < options.Count; i++)
+        {
+            var marker = options[i].Value.Equals(@default, StringComparison.Ordinal) ? " (default)" : string.Empty;
+            console.Out.WriteLine($"  {i + 1}) {options[i].Label}{marker}");
+        }
+
+        while (true)
+        {
+            console.Out.Write($"Choose [1-{options.Count}]: ");
+            console.Out.Flush();
+
+            var line = console.In.ReadLine();
+            if (line is null)
+            {
+                return @default;
+            }
+
+            line = line.Trim();
+            if (line.Length == 0)
+            {
+                return @default;
+            }
+
+            if (int.TryParse(line, out var index) && index >= 1 && index <= options.Count)
+            {
+                return options[index - 1].Value;
+            }
+
+            foreach (var option in options)
+            {
+                if (option.Value.Equals(line, StringComparison.OrdinalIgnoreCase))
+                {
+                    return option.Value;
+                }
+            }
+        }
+    }
+}

--- a/src/Rask.Cli/Scaffolding/GenerateConfig.cs
+++ b/src/Rask.Cli/Scaffolding/GenerateConfig.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Rask.Cli.Scaffolding;
+
+/// <summary>
+/// Team defaults for <c>rask generate feature</c>, persisted at <c>.rask/generate.json</c> in the project
+/// so everyone scaffolds the same shape without re-typing flags. Explicit command-line flags always win;
+/// these only fill in what you didn't pass. Booleans are opt-in (a <c>null</c>/absent value means "off"),
+/// and <c>--save-defaults</c> writes the feature flags from the current invocation back here.
+/// </summary>
+internal sealed class GenerateConfig
+{
+    public bool? Bs { get; set; }
+
+    public bool? Modal { get; set; }
+
+    public bool? SoftDelete { get; set; }
+
+    public bool? Concurrency { get; set; }
+
+    public bool? Events { get; set; }
+
+    public bool? Outbox { get; set; }
+
+    public bool? Tests { get; set; }
+
+    public string? Validation { get; set; }
+
+    public string? Id { get; set; }
+
+    /// <summary>The <c>.rask/generate.json</c> path under <paramref name="projectDirectory"/>.</summary>
+    public static string PathFor(string projectDirectory) =>
+        Path.Combine(projectDirectory, ".rask", "generate.json");
+
+    /// <summary>Load the persisted defaults, or an empty set when the file is absent or unreadable.</summary>
+    public static GenerateConfig Load(IFileSystem fileSystem, string projectDirectory)
+    {
+        var path = PathFor(projectDirectory);
+        if (!fileSystem.FileExists(path))
+        {
+            return new GenerateConfig();
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize(fileSystem.ReadAllText(path), GenerateConfigJsonContext.Default.GenerateConfig)
+                ?? new GenerateConfig();
+        }
+        catch (JsonException)
+        {
+            // A hand-edited or corrupt file shouldn't wedge a scaffold — fall back to flags/built-in defaults.
+            return new GenerateConfig();
+        }
+    }
+
+    /// <summary>Write the defaults to <c>.rask/generate.json</c> (creating the <c>.rask</c> directory).</summary>
+    public void Save(IFileSystem fileSystem, string projectDirectory)
+    {
+        var path = PathFor(projectDirectory);
+        fileSystem.CreateDirectory(Path.GetDirectoryName(path)!);
+        fileSystem.WriteAllText(path, JsonSerializer.Serialize(this, GenerateConfigJsonContext.Default.GenerateConfig));
+    }
+}
+
+/// <summary>Source-generated (reflection-free) serialization for <see cref="GenerateConfig"/>.</summary>
+[JsonSourceGenerationOptions(
+    WriteIndented = true,
+    PropertyNamingPolicy = JsonKnownNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull)]
+[JsonSerializable(typeof(GenerateConfig))]
+internal sealed partial class GenerateConfigJsonContext : JsonSerializerContext;

--- a/src/Rask.Cli/Spinner.cs
+++ b/src/Rask.Cli/Spinner.cs
@@ -1,0 +1,78 @@
+namespace Rask.Cli;
+
+/// <summary>
+/// A tiny, dependency-free progress spinner for otherwise-silent long operations (e.g. polling a
+/// remote container until it's healthy). It animates a single line in place while the work runs and
+/// clears it on dispose. It is a **no-op when stdout is redirected** — piped output and captured test
+/// output stay byte-for-byte unchanged, and CI logs don't fill with carriage returns. Use it with
+/// <c>await using</c> so the line is always cleared, even on an exception.
+/// </summary>
+internal sealed class Spinner : IAsyncDisposable
+{
+    private static readonly string[] Frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+    private readonly TextWriter _out;
+    private readonly string _message;
+    private readonly bool _enabled;
+    private readonly CancellationTokenSource _cts = new();
+    private readonly Task? _loop;
+
+    private Spinner(IConsole console, string message)
+    {
+        _out = console.Out;
+        _message = message;
+        _enabled = !console.IsOutputRedirected;
+        if (_enabled)
+        {
+            _loop = RunAsync();
+        }
+    }
+
+    /// <summary>Begin spinning with <paramref name="message"/>. Returns immediately; dispose to stop and clear.</summary>
+    public static Spinner Start(IConsole console, string message) => new(console, message);
+
+    private async Task RunAsync()
+    {
+        var frame = 0;
+        try
+        {
+            while (!_cts.IsCancellationRequested)
+            {
+                _out.Write($"\r{Frames[frame++ % Frames.Length]} {_message}");
+                _out.Flush();
+                await Task.Delay(80, _cts.Token).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Disposed — fall through and let DisposeAsync clear the line.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (!_enabled)
+        {
+            _cts.Dispose();
+            return;
+        }
+
+        await _cts.CancelAsync().ConfigureAwait(false);
+        if (_loop is not null)
+        {
+            try
+            {
+                await _loop.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected on cancellation.
+            }
+        }
+
+        // Erase the spinner line so the next write starts clean.
+        _out.Write('\r' + new string(' ', _message.Length + 2) + '\r');
+        _out.Flush();
+        _cts.Dispose();
+    }
+}

--- a/tests/Rask.Cli.Tests/ArgumentSchemaTests.cs
+++ b/tests/Rask.Cli.Tests/ArgumentSchemaTests.cs
@@ -109,4 +109,22 @@ public sealed class ArgumentSchemaTests
         Assert.Equal("-5", parsed.Option("output"));
         Assert.False(parsed.HasErrors);
     }
+
+    [Fact]
+    public void Declared_records_each_option_for_help()
+    {
+        var schema = new ArgumentSchema()
+            .Option("template", 't', "name", "Which template.")
+            .Flag("auth", description: "Add auth.", group: "Extras");
+
+        var template = schema.Declared.Single(o => o.LongName == "template");
+        Assert.Equal('t', template.ShortName);
+        Assert.False(template.IsFlag);
+        Assert.Equal("name", template.ValueHint);
+        Assert.Equal("Which template.", template.Description);
+
+        var auth = schema.Declared.Single(o => o.LongName == "auth");
+        Assert.True(auth.IsFlag);
+        Assert.Equal("Extras", auth.Group);
+    }
 }

--- a/tests/Rask.Cli.Tests/CommandHelpTests.cs
+++ b/tests/Rask.Cli.Tests/CommandHelpTests.cs
@@ -1,0 +1,91 @@
+namespace Rask.Cli.Tests;
+
+public sealed class CommandHelpTests
+{
+    private static (StringConsole Console, CliApplication App) Build()
+    {
+        var console = new StringConsole();
+        return (console, CliApplication.CreateDefault(console, new FakeProcessRunner(), new FakeFileSystem()));
+    }
+
+    [Fact]
+    public async Task Command_help_lists_options_with_descriptions()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["new", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Options:", text, StringComparison.Ordinal);
+        Assert.Contains("-t, --template <name>", text, StringComparison.Ordinal);
+        Assert.Contains("Template to scaffold", text, StringComparison.Ordinal);
+        Assert.Contains("--auth", text, StringComparison.Ordinal);
+        Assert.Contains("Add cookie authentication", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Command_help_shows_arguments_and_examples()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["new", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Arguments:", text, StringComparison.Ordinal);
+        Assert.Contains("Examples:", text, StringComparison.Ordinal);
+        Assert.Contains("rask new Shop", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Generate_help_surfaces_the_feature_only_flags()
+    {
+        var (console, app) = Build();
+
+        // These flags were previously undiscoverable — not in usage, not in help.
+        await app.RunAsync(["generate", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Feature options (rask generate feature)", text, StringComparison.Ordinal);
+        foreach (var flag in new[] { "--bs", "--modal", "--soft-delete", "--concurrency", "--events", "--outbox", "--tests", "--no-restore" })
+        {
+            Assert.Contains(flag, text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task Help_output_is_uncolored_when_stdout_is_redirected()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["generate", "--help"], CancellationToken.None);
+
+        Assert.DoesNotContain('\x1b', console.OutText);
+    }
+
+    [Fact]
+    public async Task Top_level_usage_lists_every_command()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync([], CancellationToken.None);
+
+        var text = console.OutText;
+        foreach (var name in new[] { "new", "dev", "generate", "db", "deploy", "info" })
+        {
+            Assert.Contains(name, text, StringComparison.Ordinal);
+        }
+
+        Assert.Contains("--version", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Parse_error_points_at_command_help()
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync(["new", "--nope"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Run 'rask new --help' for details.", console.ErrorText, StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Cli.Tests/CompletionCommandTests.cs
+++ b/tests/Rask.Cli.Tests/CompletionCommandTests.cs
@@ -1,0 +1,60 @@
+namespace Rask.Cli.Tests;
+
+public sealed class CompletionCommandTests
+{
+    private static (StringConsole Console, CliApplication App) Build()
+    {
+        var console = new StringConsole();
+        return (console, CliApplication.CreateDefault(console, new FakeProcessRunner(), new FakeFileSystem()));
+    }
+
+    [Theory]
+    [InlineData("bash")]
+    [InlineData("zsh")]
+    [InlineData("fish")]
+    public async Task Emits_a_script_that_mentions_commands_and_options(string shell)
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync(["completion", shell], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        var script = console.OutText;
+        Assert.Contains("generate", script, StringComparison.Ordinal); // a command name
+        // Option names appear as `--template` (bash/zsh) or `-l template` (fish) — match the bare name.
+        Assert.Contains("template", script, StringComparison.Ordinal); // an option from `new`'s schema
+        Assert.Contains("outbox", script, StringComparison.Ordinal);   // a feature-only option
+    }
+
+    [Fact]
+    public async Task Missing_shell_is_an_error()
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync(["completion"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Specify a shell", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Unknown_shell_is_an_error()
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync(["completion", "powershell"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Specify a shell", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Completion_appears_in_the_top_level_command_list()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync([], CancellationToken.None);
+
+        Assert.Contains("completion", console.OutText, StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Cli.Tests/ConsoleStylingTests.cs
+++ b/tests/Rask.Cli.Tests/ConsoleStylingTests.cs
@@ -1,0 +1,47 @@
+namespace Rask.Cli.Tests;
+
+public sealed class ConsoleStylingTests
+{
+    [Fact]
+    public void Paint_wraps_text_in_the_style_and_reset_codes()
+    {
+        var painted = ConsoleStyling.Paint("done", ConsoleStyle.Success);
+
+        Assert.Equal("\x1b[32mdone\x1b[0m", painted);
+    }
+
+    [Fact]
+    public void Color_is_disabled_when_the_stream_is_redirected()
+    {
+        Assert.False(ConsoleStyling.ColorEnabled(redirected: true));
+    }
+
+    [Fact]
+    public void Styled_writes_stay_plain_when_output_is_redirected()
+    {
+        // StringConsole reports both streams as redirected, so nothing should be colored.
+        var console = new StringConsole();
+
+        console.WriteLine("hello", ConsoleStyle.Success);
+        console.WriteErrorLine("boom", ConsoleStyle.Error);
+
+        Assert.Equal("hello" + Environment.NewLine, console.OutText);
+        Assert.Equal("boom" + Environment.NewLine, console.ErrorText);
+        Assert.DoesNotContain('\x1b', console.OutText);
+        Assert.DoesNotContain('\x1b', console.ErrorText);
+    }
+
+    [Fact]
+    public async Task Spinner_writes_nothing_when_output_is_redirected()
+    {
+        // Redirected (piped/CI/tests) → the spinner must be a silent no-op: no frames, no carriage returns.
+        var console = new StringConsole();
+
+        var spinner = Spinner.Start(console, "Working…");
+        await Task.Delay(50);
+        await spinner.DisposeAsync();
+
+        Assert.Equal(string.Empty, console.OutText);
+        Assert.DoesNotContain('\r', console.OutText);
+    }
+}

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -17,7 +17,8 @@ public sealed class GenerateCommandTests
         var path = Path.GetFullPath("/proj/Features/Products/ProductsPage.cs");
         Assert.True(fs.Files.ContainsKey(path));
         Assert.Contains("namespace MyApp.Features.Products;", fs.Files[path], StringComparison.Ordinal);
-        Assert.Contains("Created", console.OutText, StringComparison.Ordinal);
+        // Written files are reported with the shared "  + <path>" marker (unified with `rask new`).
+        Assert.Contains("+ Features/Products/ProductsPage.cs", console.OutText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -437,6 +438,48 @@ public sealed class GenerateCommandTests
 
         Assert.Equal(1, exit);
         Assert.Contains("Couldn't find a single .csproj", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Feature_inherits_defaults_from_dot_rask_generate_json()
+    {
+        var (console, fs, command) = Build();
+        // A team default of --bs, with no --bs on the command line.
+        fs.Seed("/proj/.rask/generate.json", "{ \"bs\": true }");
+
+        var exit = await command.ExecuteAsync(["feature", "Product", "Name:string", "--dry-run"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        // The Bootstrap create page renders a BsAlert — proof the config default was applied.
+        Assert.Contains("BsAlert", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Save_defaults_writes_the_run_flags_to_the_config_file()
+    {
+        var (console, fs, command) = Build();
+
+        var exit = await command.ExecuteAsync(
+            ["feature", "Product", "Name:string", "--bs", "--tests", "--no-restore", "--save-defaults"],
+            CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        var configPath = Path.GetFullPath("/proj/.rask/generate.json");
+        Assert.True(fs.Files.ContainsKey(configPath));
+        Assert.Contains("\"bs\": true", fs.Files[configPath], StringComparison.Ordinal);
+        Assert.Contains("\"tests\": true", fs.Files[configPath], StringComparison.Ordinal);
+        Assert.Contains("Saved generate defaults", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Save_defaults_only_applies_to_feature()
+    {
+        var (console, _, command) = Build();
+
+        var exit = await command.ExecuteAsync(["page", "Dashboard", "--save-defaults"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("only apply to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
     }
 
     private static (StringConsole Console, FakeFileSystem Fs, GenerateCommand Command) Build()

--- a/tests/Rask.Cli.Tests/GenerateConfigTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateConfigTests.cs
@@ -1,0 +1,41 @@
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+public sealed class GenerateConfigTests
+{
+    [Fact]
+    public void Round_trips_through_the_filesystem()
+    {
+        var fs = new FakeFileSystem();
+        new GenerateConfig { Bs = true, Tests = true, Validation = "fluent", Id = "int" }.Save(fs, "/proj");
+
+        var loaded = GenerateConfig.Load(fs, "/proj");
+
+        Assert.True(loaded.Bs);
+        Assert.True(loaded.Tests);
+        Assert.Equal("fluent", loaded.Validation);
+        Assert.Equal("int", loaded.Id);
+        Assert.Null(loaded.Modal); // absent stays null (off), not false
+    }
+
+    [Fact]
+    public void Absent_file_loads_an_empty_config()
+    {
+        var loaded = GenerateConfig.Load(new FakeFileSystem(), "/proj");
+
+        Assert.Null(loaded.Bs);
+        Assert.Null(loaded.Validation);
+    }
+
+    [Fact]
+    public void Corrupt_file_falls_back_to_empty_rather_than_throwing()
+    {
+        var fs = new FakeFileSystem();
+        fs.Seed(GenerateConfig.PathFor("/proj"), "{ not valid json");
+
+        var loaded = GenerateConfig.Load(fs, "/proj");
+
+        Assert.Null(loaded.Bs);
+    }
+}

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -202,6 +202,51 @@ public sealed class NewCommandTests
         Assert.Contains("--frobnicate", console.ErrorText, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task No_name_on_a_terminal_walks_the_wizard_and_scaffolds()
+    {
+        var (console, fs, runner, command) = Build();
+        // Simulate a terminal (InputLines flips the console to interactive) and script the answers:
+        // name → template select (2 = wasm) → --auth? no → --pwa? yes → --docker? no.
+        console.InputLines = ["Spa", "2", "n", "y", "n"];
+
+        var exit = await command.ExecuteAsync([], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.True(fs.FileExists("/proj/Spa/Spa.csproj"));
+        Assert.True(fs.FileExists("/proj/Spa/wwwroot/index.html")); // wasm template
+        Assert.True(fs.FileExists("/proj/Spa/wwwroot/icon.svg"));   // --pwa answered yes
+        Assert.False(fs.FileExists("/proj/Spa/Auth/CredentialStore.cs")); // --auth answered no
+        Assert.Contains(runner.Invocations, i => i.Arguments.Contains("restore"));
+    }
+
+    [Fact]
+    public async Task Dry_run_prints_the_plan_and_writes_nothing()
+    {
+        var (console, fs, runner, command) = Build();
+
+        var exit = await command.ExecuteAsync(["MyApp", "--template", "server", "--auth", "--dry-run"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("would write", console.OutText, StringComparison.Ordinal);
+        Assert.Contains("MyApp.csproj", console.OutText, StringComparison.Ordinal);
+        // Nothing is written and nothing is restored.
+        Assert.False(fs.FileExists("/proj/MyApp/MyApp.csproj"));
+        Assert.Empty(runner.Invocations);
+    }
+
+    [Fact]
+    public async Task No_name_without_a_terminal_still_hard_errors()
+    {
+        var (console, _, runner, command) = Build();
+        // StringConsole defaults to redirected stdin (non-interactive) — the wizard must not run.
+        var exit = await command.ExecuteAsync([], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("name is required", console.ErrorText, StringComparison.Ordinal);
+        Assert.Empty(runner.Invocations);
+    }
+
     private static (StringConsole Console, FakeFileSystem Fs, FakeProcessRunner Runner, NewCommand Command) Build()
     {
         var console = new StringConsole();

--- a/tests/Rask.Cli.Tests/PromptTests.cs
+++ b/tests/Rask.Cli.Tests/PromptTests.cs
@@ -1,0 +1,92 @@
+namespace Rask.Cli.Tests;
+
+public sealed class PromptTests
+{
+    [Fact]
+    public void Interactive_reflects_stdin_redirection()
+    {
+        var console = new StringConsole();
+        Assert.False(new Prompt(console).Interactive); // default: redirected
+
+        console.InputLines = ["x"]; // flips to a terminal
+        Assert.True(new Prompt(console).Interactive);
+    }
+
+    [Fact]
+    public void Ask_returns_the_typed_answer()
+    {
+        var console = new StringConsole { InputLines = ["Shop"] };
+
+        Assert.Equal("Shop", new Prompt(console).Ask("Project name"));
+    }
+
+    [Fact]
+    public void Ask_accepts_the_default_on_an_empty_answer()
+    {
+        var console = new StringConsole { InputLines = [""] };
+
+        Assert.Equal("server", new Prompt(console).Ask("Template", "server"));
+    }
+
+    [Fact]
+    public void Ask_reasks_until_non_empty_when_required()
+    {
+        var console = new StringConsole { InputLines = ["", "  ", "Shop"] };
+
+        Assert.Equal("Shop", new Prompt(console).Ask("Project name"));
+    }
+
+    [Fact]
+    public void Ask_returns_empty_on_end_of_input_rather_than_looping()
+    {
+        var console = new StringConsole { InputLines = [] };
+
+        Assert.Equal(string.Empty, new Prompt(console).Ask("Project name"));
+    }
+
+    [Theory]
+    [InlineData("y", true)]
+    [InlineData("yes", true)]
+    [InlineData("n", false)]
+    [InlineData("no", false)]
+    public void Confirm_parses_yes_and_no(string answer, bool expected)
+    {
+        var console = new StringConsole { InputLines = [answer] };
+
+        Assert.Equal(expected, new Prompt(console).Confirm("Add auth?", @default: false));
+    }
+
+    [Fact]
+    public void Confirm_uses_the_default_on_empty_or_eof()
+    {
+        Assert.True(new Prompt(new StringConsole { InputLines = [""] }).Confirm("Add auth?", @default: true));
+        Assert.False(new Prompt(new StringConsole { InputLines = [] }).Confirm("Add auth?", @default: false));
+    }
+
+    [Fact]
+    public void Select_accepts_a_number()
+    {
+        var console = new StringConsole { InputLines = ["2"] };
+        var options = new[] { ("server", "Server"), ("wasm", "WASM") };
+
+        Assert.Equal("wasm", new Prompt(console).Select("Template", options, "server"));
+    }
+
+    [Fact]
+    public void Select_accepts_the_value_by_name()
+    {
+        var console = new StringConsole { InputLines = ["wasm"] };
+        var options = new[] { ("server", "Server"), ("wasm", "WASM") };
+
+        Assert.Equal("wasm", new Prompt(console).Select("Template", options, "server"));
+    }
+
+    [Fact]
+    public void Select_falls_back_to_the_default_on_empty()
+    {
+        var console = new StringConsole { InputLines = [""] };
+        var options = new[] { ("server", "Server"), ("wasm", "WASM") };
+
+        Assert.Equal("server", new Prompt(console).Select("Template", options, "server"));
+    }
+}

--- a/tests/Rask.Cli.Tests/TestDoubles.cs
+++ b/tests/Rask.Cli.Tests/TestDoubles.cs
@@ -3,19 +3,43 @@ using Rask.Cli.Scaffolding;
 
 namespace Rask.Cli.Tests;
 
-/// <summary>An <see cref="IConsole"/> that captures everything written, for assertions.</summary>
+/// <summary>
+/// An <see cref="IConsole"/> that captures everything written, for assertions. Both output streams
+/// report as redirected so styling stays off and captured text is plain — substring assertions hold
+/// regardless of the styling layer. Seed <see cref="InputLines"/> to script interactive prompts.
+/// </summary>
 internal sealed class StringConsole : IConsole
 {
     private readonly StringWriter _out = new();
     private readonly StringWriter _error = new();
+    private TextReader _in = new StringReader(string.Empty);
 
     public TextWriter Out => _out;
 
     public TextWriter Error => _error;
 
+    public TextReader In => _in;
+
+    /// <summary>When false, the console behaves like a terminal (styling on, prompts read input).</summary>
+    public bool IsOutputRedirected { get; set; } = true;
+
+    public bool IsErrorRedirected { get; set; } = true;
+
+    public bool IsInputRedirected { get; set; } = true;
+
     public string OutText => _out.ToString();
 
     public string ErrorText => _error.ToString();
+
+    /// <summary>Script the answers an interactive prompt will read, one per line, and treat stdin as a terminal.</summary>
+    public IReadOnlyList<string> InputLines
+    {
+        set
+        {
+            _in = new StringReader(string.Join(Environment.NewLine, value) + Environment.NewLine);
+            IsInputRedirected = false;
+        }
+    }
 }
 
 /// <summary>A recorded invocation of the process runner.</summary>


### PR DESCRIPTION
## Summary
PR 4 (final) of the CLI-DX series (**stacked on #460**). Three convenience features that round out the CLI:
- **`rask completion <bash|zsh|fish>`** — prints a shell completion script generated from the live command list and each command's option schema, so it always matches the installed CLI (new commands/flags are completed with no separate list to maintain). Registered as a real command (shows in help + completes itself).
- **`.rask/generate.json` team defaults** — `rask generate feature` now reads a project's preferred `--bs` / `--validation` / `--id` / `--tests` (etc.) from `.rask/generate.json`; explicit flags always win. `--save-defaults` records the current run's feature flags. Booleans are opt-in; the file is trim-safe source-generated JSON (mirrors the existing `DeployConfig`).
- **`rask new --dry-run`** — previews the files a template would create (and skips `dotnet restore`), matching `rask generate --dry-run`.

Pure BCL, no new dependencies.

## Testing
- Unit: `dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"` — **all pass** (full local gate green). CLI suite **364 pass, 0 fail** (new `CompletionCommandTests`, `GenerateConfigTests`, plus config-application / `--save-defaults` / `new --dry-run` tests).
- CLI smoke: `.claude/skills/run-rask-cli/smoke.sh` — **20/20** (added completion, bad-shell, and `new --dry-run`-writes-nothing checks).
- Manual: `rask completion bash|zsh|fish` emit valid scripts; `rask new Demo --dry-run` writes nothing; a seeded `.rask/generate.json` applies and is overridden by explicit flags.
- E2E: n/a — CLI-only change.

## Benchmarks
n/a — the CLI is not on the render hot path.

## CHANGELOG
- [Unreleased] entries added: `rask completion`, `.rask/generate.json` defaults + `--save-defaults`, and `rask new --dry-run`.

## Series note
This completes the 4-PR CLI-DX chain: #458 (rich help + foundation) ← #459 (color/consistent output) ← #460 (interactive wizard) ← this. Merge in order, or squash #458 to `main` and rebase the rest.