### PR TITLE
chore(site): rename live showcase deploy /demo/ → /docs/, drop external Docs link

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,7 +37,7 @@ jobs:
           restore-keys: nuget-${{ runner.os }}-
 
       # The Pages site is three Rask WASM apps: the marketing landing page (Rask.Example.Site) at the
-      # root /<repo>/, the live feature showcase (Rask.Example.Wasm) at /<repo>/demo/, and the live
+      # root /<repo>/, the live feature showcase (Rask.Example.Wasm) at /<repo>/docs/, and the live
       # playground at /<repo>/playground/. Each is published with /p:RaskPathBase so the framework's
       # _RaskRewriteBaseHref target rewrites its <base href> to the sub-path; every other asset URL +
       # the SRI-pinned import map stays document-relative, so the corrected base resolves them all
@@ -46,11 +46,11 @@ jobs:
       - name: Publish the landing site (Rask.Example.Site → /)
         run: dotnet publish samples/Rask.Example.Site -c Release /p:RaskPathBase=/${{ github.event.repository.name }}
 
-      - name: Publish the live demo (Rask.Example.Wasm → /demo/)
-        run: dotnet publish samples/Rask.Example.Wasm -c Release /p:RaskPathBase=/${{ github.event.repository.name }}/demo
+      - name: Publish the live showcase / docs (Rask.Example.Wasm → /docs/)
+        run: dotnet publish samples/Rask.Example.Wasm -c Release /p:RaskPathBase=/${{ github.event.repository.name }}/docs
 
       # The playground is untrimmed (Roslyn needs full assembly metadata as references), so it is kept
-      # out of the size-tuned demo bundle and published to its own output dir.
+      # out of the size-tuned docs bundle and published to its own output dir.
       - name: Publish the playground (→ /playground/)
         run: dotnet publish samples/Rask.Example.Playground -c Release /p:RaskPathBase=/${{ github.event.repository.name }}/playground -o playground-publish
 
@@ -61,13 +61,13 @@ jobs:
       # post-publish: the runtime JS is SRI-pinned in the import map (see #63), so changing its bytes
       # breaks the integrity check. Shipping the 270 KB map to silence a DevTools-only 404 isn't worth
       # it on a size-tuned bundle (we already drop ICU).
-      - name: Assemble the Pages bundle (landing at root, demo + playground nested)
+      - name: Assemble the Pages bundle (landing at root, docs + playground nested)
         id: bundle
         run: |
           LANDING=samples/Rask.Example.Site/bin/Release/net10.0-browser/publish/wwwroot
-          DEMO=samples/Rask.Example.Wasm/bin/Release/net10.0-browser/publish/wwwroot
+          DOCS=samples/Rask.Example.Wasm/bin/Release/net10.0-browser/publish/wwwroot
           PLAYGROUND=playground-publish/wwwroot
-          for d in "$LANDING" "$DEMO" "$PLAYGROUND"; do
+          for d in "$LANDING" "$DOCS" "$PLAYGROUND"; do
             if [ ! -d "$d" ]; then
               echo "Could not locate published wwwroot: $d" >&2
               find . -maxdepth 6 -type d -name wwwroot
@@ -77,14 +77,14 @@ jobs:
           SITE="$RUNNER_TEMP/site"
           mkdir -p "$SITE"
           cp -r "$LANDING"/. "$SITE"/                 # marketing landing app at the root
-          cp -r "$DEMO" "$SITE/demo"
+          cp -r "$DOCS" "$SITE/docs"
           cp -r "$PLAYGROUND" "$SITE/playground"
-          # GitHub Pages serves /404.html for any unknown path; boot the demo SPA (its <base href> is
-          # /<repo>/demo/, so it client-routes correctly) as the deep-link fallback — the landing page
+          # GitHub Pages serves /404.html for any unknown path; boot the docs SPA (its <base href> is
+          # /<repo>/docs/, so it client-routes correctly) as the deep-link fallback — the landing page
           # itself is a single route, so it needs none.
-          cp "$SITE/demo/index.html" "$SITE/404.html"
+          cp "$SITE/docs/index.html" "$SITE/404.html"
           echo "--- landing <base> ---";      grep -i "<base"   "$SITE/index.html" || true
-          echo "--- demo <base> ---";         grep -i "<base"   "$SITE/demo/index.html" || true
+          echo "--- docs <base> ---";         grep -i "<base"   "$SITE/docs/index.html" || true
           echo "--- playground <base> ---";   grep -i "<base"   "$SITE/playground/index.html" || true
           echo "dir=$SITE" >> "$GITHUB_OUTPUT"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -174,6 +174,15 @@ them until tagged releases begin.
   Core-tier wrapper, so it works on **both transports** (no user gesture needed). Showcased on the Browser APIs
   page and documented in [`docs/apis/web-locks.md`](docs/apis/web-locks.md).
 
+### Changed
+- **The live showcase moved from `/demo/` to `/docs/` on the GitHub Pages site, and the landing page now
+  leads with it as "Docs".** The showcase (`Rask.Example.Wasm`) is guides-first — the repo's `docs/*.md`
+  rendered on-site with the interactive demos embedded inline — so it *is* the documentation. The marketing
+  landing page's "Demo" nav entry is renamed "Docs" and points at that showcase; the redundant external
+  "Docs → GitHub markdown folder" links were removed. The Pages workflow now publishes the showcase to
+  `/<repo>/docs/` (and boots it as the 404 deep-link fallback), and every `live demo` link across the
+  README, `NUGET.md`, and the guides now targets `/docs/`.
+
 ### Fixed
 - **`Rask.Outbox` now delivers nested `IOutboxEvent` types.** The source generator registers each event by
   its dot-separated display name, but `OutboxSerializerRegistry.Serialize` stored `Type.FullName` — which

--- a/NUGET.md
+++ b/NUGET.md
@@ -74,7 +74,7 @@ the page). It's a craft project built in the open, deep on Roslyn source generat
   [Configuration](https://github.com/pal-tamas/rask/blob/main/docs/configuration.md) ·
   [Observability](https://github.com/pal-tamas/rask/blob/main/docs/observability.md) ·
   [Accessibility](https://github.com/pal-tamas/rask/blob/main/docs/accessibility.md)
-- 🚀 **[Live demo](https://pal-tamas.github.io/rask/demo/)**
+- 🚀 **[Live demo](https://pal-tamas.github.io/rask/docs/)**
 - 💻 **[Source & README](https://github.com/pal-tamas/rask)**
 - 🤖 **[AI assistant guide](https://github.com/pal-tamas/rask/blob/main/llms.txt)**
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4)
 
-# ▶ **[Try the live demo ↗](https://pal-tamas.github.io/rask/demo/)** &nbsp;·&nbsp; 🛝 **[Playground ↗](https://pal-tamas.github.io/rask/playground/)** &nbsp;·&nbsp; 📖 **[Read the docs ↗](docs/)** &nbsp;·&nbsp; 🧪 **[Browse the examples ↗](samples/)**
+# ▶ **[Try the live demo ↗](https://pal-tamas.github.io/rask/docs/)** &nbsp;·&nbsp; 🛝 **[Playground ↗](https://pal-tamas.github.io/rask/playground/)** &nbsp;·&nbsp; 📖 **[Read the docs ↗](docs/)** &nbsp;·&nbsp; 🧪 **[Browse the examples ↗](samples/)**
 
 </div>
 
@@ -46,7 +46,7 @@ public sealed class Counter : Component
 ```
 
 <sub>☝️ A complete, live, interactive component — routing, state, and event handling in a single C# class.
-**[See it running, and dozens more, in the live demo ↗](https://pal-tamas.github.io/rask/demo/)**</sub>
+**[See it running, and dozens more, in the live demo ↗](https://pal-tamas.github.io/rask/docs/)**</sub>
 
 **Ship a whole feature in one command:**
 
@@ -75,7 +75,7 @@ device — **vibration, share sheet, geolocation, clipboard, orientation** — t
 rask new MyApp --template wasm --pwa     # → an installable, offline PWA, ready to deploy
 ```
 
-**[📖 Build mobile apps with Rask →](docs/pwa.md)**  ·  **[Try the installable demo ↗](https://pal-tamas.github.io/rask/demo/)**
+**[📖 Build mobile apps with Rask →](docs/pwa.md)**  ·  **[Try the installable demo ↗](https://pal-tamas.github.io/rask/docs/)**
 
 Going further than a PWA? **`Rask.Native`** *(preview)* ships the *same* component code as a real
 **native iOS/Android app** for App Store / Play Store distribution — a WebView hybrid where your C#
@@ -138,7 +138,7 @@ xychart-beta
 The full byte-for-byte table — including where and why each scenario lands — is in the
 **[Rask vs Blazor baselines ↗](benchmarks/Rask.Benchmarks.VsBlazor/Baselines/vs-blazor.md)**.
 
-*Rask* is the Norwegian/Danish/Swedish word for **fast**. **The [docs ↗](docs/) and the [live demo ↗](https://pal-tamas.github.io/rask/demo/)
+*Rask* is the Norwegian/Danish/Swedish word for **fast**. **The [docs ↗](docs/) and the [live demo ↗](https://pal-tamas.github.io/rask/docs/)
 are the real tour — this README is just the front door.**
 
 ## 📦 Install
@@ -205,7 +205,7 @@ host trade-offs, and sub-path hosting are covered in **[getting started](docs/ge
 
 **The fastest way to understand Rask is to click through a real app and read its source.**
 
-- **[Live demo ↗](https://pal-tamas.github.io/rask/demo/)** — `Rask.Example.Wasm` is published to GitHub Pages on every push
+- **[Live demo ↗](https://pal-tamas.github.io/rask/docs/)** — `Rask.Example.Wasm` is published to GitHub Pages on every push
   to `main`; click through a full multi-page Rask app in the browser before cloning anything.
 - **[Playground ↗](https://pal-tamas.github.io/rask/playground/)** — write Rask component C# in the browser with a real
   IDE: Roslyn-powered IntelliSense, as-you-type diagnostics, and a gallery of ready-to-run examples — then see it
@@ -257,7 +257,7 @@ Rask is released under the [MIT License](LICENSE).
 
 ⚡ **Rask** — *Norwegian/Danish/Swedish for "fast".*
 
-**[Live demo ↗](https://pal-tamas.github.io/rask/demo/)** · **[Docs ↗](docs/)** · **[Examples ↗](samples/)** · **[NuGet ↗](https://www.nuget.org/packages/Rask.Server)**
+**[Live demo ↗](https://pal-tamas.github.io/rask/docs/)** · **[Docs ↗](docs/)** · **[Examples ↗](samples/)** · **[NuGet ↗](https://www.nuget.org/packages/Rask.Server)**
 
 Built with .NET 10. Issues and PRs welcome.
 

--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -12,7 +12,7 @@ This page is the **map of the whole surface**. For an at-a-glance view of *where
 under [`docs/apis/`](apis/). For the deeper "why" — user activation, the transport seam, element
 refs — see [JS interop → Typed browser APIs](js-interop.md#typed-browser-apis); for the mobile/PWA
 angle see the [Mobile & PWA guide](pwa.md). Every wrapper has a runnable demo in the **Browser APIs**
-section of the [showcase](https://pal-tamas.github.io/rask/demo/).
+section of the [showcase](https://pal-tamas.github.io/rask/docs/).
 
 ## Three homes, one rule
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ Rask-specific ideas, not the language.
 
 > **Coming from Blazor?** Skim [migrating from Blazor](migration-from-blazor.md) for the concept
 > mapping (`@page` → `[Route]`, `[Parameter]` → a property, `EventCallback` → a plain delegate). **Just
-> want to look first?** Click through the [live demo](https://pal-tamas.github.io/rask/demo/) — a full
+> want to look first?** Click through the [live demo](https://pal-tamas.github.io/rask/docs/) — a full
 > multi-page Rask app, no install needed.
 
 ## Before you start

--- a/docs/playground.md
+++ b/docs/playground.md
@@ -6,7 +6,7 @@ squiggles included, before you ever press Run), and a **gallery of ready-to-run 
 live — nothing is sent to a server, the C# is compiled entirely in WebAssembly.
 
 The playground is the `samples/Rask.Example.Playground` app, published to GitHub Pages next to the
-[feature showcase](https://pal-tamas.github.io/rask/demo/) (the showcase's navbar links to it).
+[feature showcase](https://pal-tamas.github.io/rask/docs/) (the showcase's navbar links to it).
 
 ## How it works
 

--- a/docs/pwa.md
+++ b/docs/pwa.md
@@ -372,4 +372,4 @@ dotnet publish -c Release /p:RaskPathBase=/my-repo
 The manifest's relative `start_url`/`scope` and the `<base href>`-relative SW registration handle the
 prefix automatically — the published app is installable and offline at `https://you.github.io/my-repo/`.
 The Rask showcase itself is a deployed WASM PWA — install it from
-[the live demo](https://pal-tamas.github.io/rask/demo/).
+[the live demo](https://pal-tamas.github.io/rask/docs/).

--- a/samples/Rask.Example.Site/App.cs
+++ b/samples/Rask.Example.Site/App.cs
@@ -64,9 +64,8 @@ public class App : Component
             Div(Class: "wrap")[
                 Span(Class: "brand")[Raw(BrandSvg), " Rask"],
                 Nav()[
-                    A(Class: "hide-sm", Href: "demo/", Target: "_blank", Rel: "noopener")["Demo"],
+                    A(Class: "hide-sm", Href: "docs/", Target: "_blank", Rel: "noopener")["Docs"],
                     A(Class: "hide-sm", Href: "playground/", Target: "_blank", Rel: "noopener")["Playground"],
-                    A(Class: "hide-sm", Href: "https://github.com/pal-tamas/rask/tree/main/docs", Target: "_blank", Rel: "noopener")["Docs"],
                     A(Href: "https://github.com/pal-tamas/rask", Target: "_blank", Rel: "noopener")["GitHub ↗"],
                     Button(Id: "themeToggle", Type: "button", Aria: Attr("label", "Toggle color theme"))["◐ theme"]
                 ]
@@ -84,7 +83,7 @@ public class App : Component
                         P(Class: "lede")["One component model for the browser and the phone — no ", Code()[".razor"], ", no XAML, no JSX, no JavaScript, no Swift or Kotlin."],
                         P(Class: "sub")["The same component runs server-rendered over a WebSocket, fully client-side on WebAssembly, or as a native iOS/Android app. One codebase; pick the host per project."],
                         Div(Class: "cta-row")[
-                            A(Class: "btn btn-primary", Href: "demo/", Target: "_blank", Rel: "noopener")["▶ Try the live demo"],
+                            A(Class: "btn btn-primary", Href: "docs/", Target: "_blank", Rel: "noopener")["▶ Try the live demo"],
                             A(Class: "btn btn-ghost", Href: "playground/", Target: "_blank", Rel: "noopener")["🛝 Playground"]
                         ],
                         Div(Class: "badges")[
@@ -258,16 +257,15 @@ public class App : Component
         Footer()[
             Div(Class: "wrap")[
                 Div(Class: "foot-cta reveal")[
-                    H2()["The docs and the live demo are the real tour."],
+                    H2()["The live docs and the playground are the real tour."],
                     P()["This is just the front door. Click through a full multi-page Rask app in the browser, or write a component live in the playground."],
                     Div(Class: "cta-row", Style: "justify-content:center;")[
-                        A(Class: "btn btn-primary", Href: "demo/", Target: "_blank", Rel: "noopener")["▶ Open the live demo"],
+                        A(Class: "btn btn-primary", Href: "docs/", Target: "_blank", Rel: "noopener")["▶ Open the live demo"],
                         A(Class: "btn btn-ghost", Href: "https://github.com/pal-tamas/rask", Target: "_blank", Rel: "noopener")["★ Star on GitHub"]
                     ],
                     Div(Class: "foot-links")[
-                        A(Href: "demo/", Target: "_blank", Rel: "noopener")["Live demo"],
+                        A(Href: "docs/", Target: "_blank", Rel: "noopener")["Docs"],
                         A(Href: "playground/", Target: "_blank", Rel: "noopener")["Playground"],
-                        A(Href: "https://github.com/pal-tamas/rask/tree/main/docs", Target: "_blank", Rel: "noopener")["Docs"],
                         A(Href: "https://www.nuget.org/packages/Rask.Server", Target: "_blank", Rel: "noopener")["NuGet"],
                         A(Href: "https://github.com/pal-tamas/rask", Target: "_blank", Rel: "noopener")["GitHub"]
                     ],

--- a/tests/Rask.Examples.E2E.Tests/SiteExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SiteExampleTests.cs
@@ -9,7 +9,7 @@ namespace Rask.Examples.E2E.Tests;
 ///     host (<see cref="SiteWasmAppFixture" />) — the GitHub Pages front door. The whole page is rendered
 ///     by a Rask WASM app, so the journey proves the framework renders a full document shell, that the
 ///     live counter and install tabs are genuine stateful Rask components (click → diff → re-render), and
-///     that the demo/playground links point at the nested sub-apps.
+///     that the docs/playground links point at the nested sub-apps.
 /// </summary>
 [Collection(SiteExampleCollection.Name)]
 public sealed class SiteExampleTests
@@ -52,8 +52,14 @@ public sealed class SiteExampleTests
             await page.GetByRole(AriaRole.Tab, new PageGetByRoleOptions { Name = "Native" }).ClickAsync();
             await Expect(page.Locator(".term")).ToContainTextAsync("net10.0-android");
 
-            // The front door links into the nested demo + playground sub-apps.
-            await Expect(page.Locator("a.btn-primary").First).ToHaveAttributeAsync("href", "demo/");
+            // The front door links into the nested docs + playground sub-apps.
+            await Expect(page.Locator("a.btn-primary").First).ToHaveAttributeAsync("href", "docs/");
+
+            // The nav "Docs" entry points at the on-site showcase (/docs/), and the old external
+            // GitHub-docs link is gone — no nav link targets the repo's markdown folder anymore.
+            await Expect(page.Locator("nav a", new PageLocatorOptions { HasTextString = "Docs" }).First)
+                .ToHaveAttributeAsync("href", "docs/");
+            await Expect(page.Locator("a[href*='tree/main/docs']")).ToHaveCountAsync(0);
         }
         finally
         {


### PR DESCRIPTION
## Summary

The live feature showcase (`Rask.Example.Wasm`) is **guides-first** — the repo's `docs/*.md` rendered on-site with the interactive demos embedded inline — so it already *is* the documentation experience. This presents it as such on the marketing landing page and gives it a matching URL.

- **Landing page** (`samples/Rask.Example.Site/App.cs`) — rename the "Demo" nav entry to **"Docs"**, point every `demo/` link at `docs/`, and remove the two redundant external **"Docs → GitHub markdown folder"** links (topbar + footer). Tidied the footer heading that would otherwise name "docs" twice.
- **Pages workflow** (`.github/workflows/pages.yml`) — publish the showcase to `/<repo>/docs/` (`RaskPathBase`), assemble it under `$SITE/docs`, and boot it as the 404 deep-link fallback.
- **External links** — every absolute `github.io/rask/demo/` → `/docs/` across `README.md` (×6), `NUGET.md`, and the guides (`docs/browser-apis.md`, `docs/getting-started.md`, `docs/playground.md`, `docs/pwa.md`). Relative `](docs/)` repo-folder links and NUGET's "Documentation" link are unchanged — they aren't the deploy path.

## Testing

- `dotnet build` (site + E2E project) clean under `-warnaserror`; `dotnet format --verify-no-changes` clean.
- **E2E `SiteExampleTests` passes** — updated to assert the CTA and "Docs" nav resolve to `docs/`, and that no nav link targets `tree/main/docs` anymore.
- Pre-commit gate: format + 250 unit tests green. Pre-push gate: full browser E2E suite.

## Changelog

`[Unreleased] → Changed` entry added.

## Notes

An old bookmark to `/rask/demo/…` now hits the 404 fallback (which boots the docs SPA at `/docs/`) rather than a dedicated redirect — the `/demo/` path is only three days old (0.16.0), so a redirect stub seemed like unwarranted complexity. Easy to add if wanted.
