### PR TITLE
fix(e2e): build WASM samples no-native in the local gate to stop the 96% stuck boot

### DIFF
--- a/scripts/run-e2e-local.sh
+++ b/scripts/run-e2e-local.sh
@@ -21,8 +21,16 @@ fi
 root="$(git rev-parse --show-toplevel)"
 cd "$root"
 
-echo "==> Build the E2E graph once (Release, serial: the nested WASM publish double-builds Rask.Core.dll)"
-dotnet build Rask.slnx -c Release -m:1
+# WasmBuildNative=false: build every WASM sample against the prebuilt .NET-WASM runtime, the same mode
+# the fixtures serve (Site/Playground/Standalone all publish with it below) and the CI unit gate uses.
+# Without it, the slnx build compiles Rask.Example.Wasm with the native relink (unset WasmBuildNative →
+# InvariantGlobalization forces it) while the other WASM builds stay no-native — two modes writing the
+# same obj/, so the fingerprinted _framework assets can drift out of sync with the SRI hashes the boot
+# import map pins. The browser then blocks the mismatched asset and the runtime hangs at "Loading… 96%"
+# (WasmExampleAppFixture boots this build with `dotnet run --no-build`). One consistent mode = no drift,
+# and it skips the slow, flaky relink. Serial (-m:1): the nested WASM publish double-builds Rask.Core.dll.
+echo "==> Build the E2E graph once (Release, serial, prebuilt WASM runtime)"
+dotnet build Rask.slnx -c Release -m:1 -p:WasmBuildNative=false
 
 echo "==> Publish the samples the E2E fixtures boot"
 # Server shard boots the *published* host; the WASM static-host shards need their published wwwroot bundle.


### PR DESCRIPTION
## Summary

Fixes an intermittent **"Loading… 96%" stuck-boot** that fails the WASM-showcase E2E journeys (`WasmExampleTests`, `SharedSmokeTests`) — the app never mounts, so every test times out waiting for `.side-nav a.side-nav-link.active`.

### Root cause

- `src/Rask.Wasm/Browser/main.js` renders **resource-count** boot progress. `Loading… 96%` = one boot resource never finished loading, so `runMain()` never resolves.
- The bundle pins every `_framework/*` asset with **subresource-integrity** hashes (the `index.html` import map, filled by the SDK's `OverrideHtmlAssetPlaceholders`). If an asset's on-disk bytes don't match its pinned SRI hash, the browser **blocks** it — it never counts as loaded, and the bar sticks.
- `scripts/run-e2e-local.sh` built the whole slnx **without** `-p:WasmBuildNative=false`, so `Rask.Example.Wasm` compiled with the **native WASM relink** (unset `WasmBuildNative` → `InvariantGlobalization` forces it; the codebase documents this relink as *"flaky in some build environments"*). Every *other* WASM build in the gate uses `WasmBuildNative=false`. `WasmExampleAppFixture` then serves that native build via `dotnet run --no-build`.
- Two build modes writing the same `obj/`, plus incremental staleness, let the fingerprinted `_framework` assets drift out of sync with the import map's SRI hashes → one asset is rejected → **stuck at 96%**.

### Fix

Add `-p:WasmBuildNative=false` to the slnx build in `scripts/run-e2e-local.sh` so `Rask.Example.Wasm` builds against the **prebuilt .NET-WASM runtime** — the same single mode the fixtures serve everywhere else. One consistent mode ⇒ no fingerprint/SRI drift, no flaky native relink, and a **faster** gate.

## Testing

- Reproduced deterministically: the WASM journeys hung at `Loading… 96%` with a stale/native `obj/`; `rm -rf samples/Rask.Example.Wasm/{obj,bin}` + rerun made all 27 pass — confirming an inconsistent-build boot, not a code defect.
- With this fix, `scripts/run-e2e-local.sh` runs green (all 27 E2E tests), including the native→no-native `obj/` transition a developer hits on first pull.

## Changelog

Not applicable — this is a local test-gate script; nothing ships to consumers.
