### PR TITLE
fix(docs): stop claiming IFileSystemAccess and IWebPush work on Native

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -184,6 +184,18 @@ them until tagged releases begin.
   README, `NUGET.md`, and the guides now targets `/docs/`.
 
 ### Fixed
+- **The capability matrix no longer claims `IFileSystemAccess` and `IWebPush` work on Native.**
+  `docs/browser-capabilities.md` marked both ✅ in the Native column, but neither API exists in the WebView:
+  `window.showOpenFilePicker` is `undefined` on WebKit (the File System Access API is effectively
+  Chromium-desktop-only), and `window.PushManager` is `undefined`, so there is nothing to subscribe with
+  (service workers do register — push specifically is missing). Both are now ⬜ with a note pointing at the
+  alternative (`<input type="file">`) and the tracked APNs/FCM follow-up. `INotifications` is unaffected — it
+  has a native backend, so local notifications work on device. No code changed: these APIs never worked on
+  Native, the matrix just said they did. The on-device Appium suite now asserts the app origin is a secure
+  context and prints what each WebView-only wrapper actually resolves to, so the Native column has evidence
+  behind it instead of assumption. `docs/native.md` also documents *why* both origins are secure contexts —
+  Android by its `https` scheme, iOS because WebKit treats a custom `WKURLSchemeHandler` scheme as
+  trustworthy whatever the host, which is easy to get wrong when writing a custom `INativeWebView`.
 - **`Rask.Outbox` now delivers nested `IOutboxEvent` types.** The source generator registers each event by
   its dot-separated display name, but `OutboxSerializerRegistry.Serialize` stored `Type.FullName` — which
   uses `+` between a nesting type and a nested type — so a nested event (a record declared inside a class)

--- a/docs/browser-apis.md
+++ b/docs/browser-apis.md
@@ -11,8 +11,11 @@ This page is the **map of the whole surface**. For an at-a-glance view of *where
 [**capability matrix**](browser-capabilities.md) — it links to a dedicated reference page per API
 under [`docs/apis/`](apis/). For the deeper "why" — user activation, the transport seam, element
 refs — see [JS interop → Typed browser APIs](js-interop.md#typed-browser-apis); for the mobile/PWA
-angle see the [Mobile & PWA guide](pwa.md). Every wrapper has a runnable demo in the **Browser APIs**
-section of the [showcase](https://pal-tamas.github.io/rask/docs/).
+angle see the [Mobile & PWA guide](pwa.md). Every wrapper has a runnable demo in the
+[showcase](https://pal-tamas.github.io/rask/docs/), under **Browser APIs** — except the WASM-only tier
+plus `IWakeLock` and `IWebPush`, which get their own pages under **PWA** because they need something the
+Server transport can't give them. (The six activation-gated ones appear in both: as gesture components
+under Browser APIs, and as injectable services under PWA.)
 
 ## Three homes, one rule
 

--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -33,7 +33,7 @@ Native column marks an API with a native C# backend (the rest run through the We
 | [`ICrypto`](apis/crypto.md) | ✅ | ✅ | ✅ | — |
 | [`IPerformance`](apis/performance.md) | ✅ | ✅ | ✅ | — |
 | [`IIndexedDb`](apis/indexeddb.md) | ✅ | ✅ | ✅ | — |
-| [`IFileSystemAccess`](apis/file-system-access.md) | ✅ | ✅ | ✅ | — |
+| [`IFileSystemAccess`](apis/file-system-access.md) | ✅ | ✅ | ⬜ | — |
 | [`IWebAuthn`](apis/webauthn.md) | ✅ | ✅ | ✅ | — |
 | [`IWebLocks`](apis/web-locks.md) | ✅ | ✅ | ✅ | — |
 | [`IBroadcastChannel`](apis/broadcast-channel.md) | ✅ | ✅ | ✅ | — |
@@ -41,7 +41,7 @@ Native column marks an API with a native C# backend (the rest run through the We
 | [`IResizeObserver`](apis/resize-observer.md) | ✅ | ✅ | ✅ | — |
 | [`IMutationObserver`](apis/mutation-observer.md) | ✅ | ✅ | ✅ | — |
 | [`IGamepad`](apis/gamepad.md) | ✅ | ✅ | ✅ | — |
-| [`IWebPush`](apis/web-push.md) | ✅ | ✅ | ✅ | — |
+| [`IWebPush`](apis/web-push.md) | ✅ | ✅ | ⬜ | — |
 | [`INotifications`](apis/notifications.md) | ✅ | ✅ | ✅&nbsp;★ | UNUserNotificationCenter / NotificationManager |
 | [`IBadge`](apis/badge.md) | ✅ | ✅ | ✅&nbsp;★ | SetBadgeCount / badge notification |
 | [`IWakeLock`](apis/wake-lock.md) | ✅ | ✅ | ✅&nbsp;★ | IdleTimerDisabled / FLAG_KEEP_SCREEN_ON |
@@ -69,6 +69,16 @@ Native column marks an API with a native C# backend (the rest run through the We
   (plus the generic `GestureTrigger`). The last two target a `<video>` via its `ElementRef`.
 - **PWA / WASM** is the in-browser WebAssembly host, which registers the full set.
 - **Native** is the `Rask.Native` host. Every ★ API has a first-class native backend wired by
-  `ApplePlatform` / `AndroidPlatform` (see [native.md](native.md)); the rest run through the WebView.
+  `ApplePlatform` / `AndroidPlatform` (see [native.md](native.md)); the rest run through the WebView, so
+  their Native cell is whatever the WebView's own JS engine exposes — which is *not* the same set a
+  desktop browser has. The ★ backends exist precisely where that gap bites, so the two ⬜ rows below are
+  the ones nothing covers yet:
+  - **`IFileSystemAccess` — ⬜ on Native.** `window.showOpenFilePicker` is `undefined` on WebKit; the File
+    System Access API is effectively Chromium-desktop-only. Use a plain `<input type="file">` instead.
+  - **`IWebPush` — ⬜ on Native.** `window.PushManager` is `undefined` in the WebView, so there is nothing
+    to subscribe with (service workers *do* register — it's push specifically that's missing). Native push
+    needs an APNs/FCM backend behind the same interface, which is a tracked follow-up
+    ([native.md](native.md#roadmap)). `INotifications` is unaffected: it has a ★ native backend, so
+    *local* notifications work on device.
 - Push subscription (`IWebPush`) and the PWA APIs (`INotifications`, `IBadge`, `IWakeLock`) work on
   Server too, but their JS helpers ship only under `AddRaskPwa` — see [pwa.md](pwa.md).

--- a/docs/native.md
+++ b/docs/native.md
@@ -214,6 +214,29 @@ serves a **real origin** (a `WKUrlSchemeHandler` on iOS, `WebViewClient.ShouldIn
 so secure-context device APIs (`localStorage`, `crypto.subtle`) work, and marshals `ApplyRenderAsync`/
 `EvaluateJavaScriptAsync` onto the UI thread.
 
+### Why both origins are secure contexts
+
+`crypto.subtle`, `navigator.credentials`, `navigator.locks` and `navigator.storage.estimate` only exist on a
+**potentially trustworthy** origin, and an origin that misses that bar doesn't fail loudly — those APIs are
+simply `undefined`. Each head clears it a different way, and only one of them is obvious:
+
+| Head | Origin | Secure context because |
+|------|--------|------------------------|
+| Android | `https://appassets.rask/` | the `https` scheme — the ordinary rule |
+| iOS | `raskapp://local/` | WebKit treats a **custom `WKURLSchemeHandler` scheme** as trustworthy |
+
+The iOS row surprises people (`raskapp://` is not `https`, and the host isn't `localhost`, so the
+[W3C algorithm][secure-contexts] alone would say no). WebKit goes further than the spec's baseline and
+grants scheme-handler origins a secure context regardless of host — verified directly against `WKWebView`:
+`raskapp://local/` reports `isSecureContext === true` and a live `crypto.subtle`. The Appium suite asserts
+this on device, so a future change to the scheme or origin can't quietly cost you the whole secure-context
+API tier.
+
+> If you write your own `INativeWebView`, this is the thing to preserve. Serving the app from `file://` or a
+> plain-`http` non-loopback origin would silently drop those APIs.
+
+[secure-contexts]: https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy
+
 ## Wiring a platform head
 
 The app head (a `net10.0-ios` / `net10.0-android` project) is just an entry point that composes the shipped

--- a/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
+++ b/tests/Rask.Native.Appium.Tests/NativeShowcaseAppiumTests.cs
@@ -2,6 +2,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Android;
 using OpenQA.Selenium.Appium.iOS;
+using Xunit.Abstractions;
 
 namespace Rask.Native.Appium.Tests;
 
@@ -12,7 +13,7 @@ namespace Rask.Native.Appium.Tests;
 // projected to REAL platform bars (iOS UINavigationBar/UITabBar, Android top/bottom bars), and tapping a
 // native tab drives the WebView's route over the bridge. This is the device-level replacement for the old
 // headless shim.
-public sealed class NativeShowcaseAppiumTests
+public sealed class NativeShowcaseAppiumTests(ITestOutputHelper output)
 {
     // Appium's synthetic context for the app's native view tree (vs. the WEBVIEW_*/CHROMIUM contexts).
     private const string NativeContext = "NATIVE_APP";
@@ -78,7 +79,7 @@ public sealed class NativeShowcaseAppiumTests
     // Switch into the app's WebView and assert the showcase rendered with its assets — the same evidence
     // the headless suite used to check, now against a real on-device WebView. Returns the WebView context
     // name so the native-chrome flow can hop back into it to read the route.
-    private static string AssertShowcaseRendered(AppiumDriver driver)
+    private string AssertShowcaseRendered(AppiumDriver driver)
     {
         var webContext = WaitForWebViewContext(driver);
         driver.Context = webContext;
@@ -113,7 +114,55 @@ public sealed class NativeShowcaseAppiumTests
         Assert.Contains("Rask", bodyText, StringComparison.OrdinalIgnoreCase);
         // Scoped CSS + Bootstrap were served through NativeOriginAssets → stylesheets are present.
         Assert.True(sheets > 0, "Scoped/Bootstrap stylesheets should have loaded via NativeOriginAssets." + diag);
+        AssertSecureContext(driver);
+        ProbeWebViewCapabilities(driver);
         return webContext;
+    }
+
+    // Both heads serve a secure-context origin, but for different reasons — Android by its https scheme,
+    // iOS because WebKit treats a custom WKURLSchemeHandler scheme as trustworthy whatever the host (see
+    // docs/native.md). Neither is obvious, and losing it costs the whole secure-context tier — crypto.subtle,
+    // navigator.credentials, storage.estimate, Web Locks — silently, as `undefined` rather than an error.
+    // Pin it on device so a change to the scheme or origin can't quietly take those APIs away.
+    private static void AssertSecureContext(AppiumDriver driver)
+    {
+        var isSecure = ExecuteScript(driver, "return String(window.isSecureContext)");
+        var subtle = ExecuteScript(driver, "return typeof (window.crypto && window.crypto.subtle)");
+        var origin = ExecuteScript(driver, "return document.location ? document.location.origin : '?'");
+        var diag = $" [origin={origin}; isSecureContext={isSecure}; typeof crypto.subtle={subtle}]";
+
+        Assert.True(
+            string.Equals(isSecure, "true", StringComparison.Ordinal),
+            "The app origin must be a secure context or the whole secure-context API tier is undefined "
+            + "on device." + diag);
+        Assert.Equal("object", subtle);
+    }
+
+    // Report what the WebView-only wrappers (the ones with no ★ native backend) actually resolve to on
+    // device. docs/browser-capabilities.md's Native column can only be as honest as what a real WebView
+    // reports — it claimed IFileSystemAccess/IWebPush worked here until this was checked. Print rather than
+    // assert: the point is to surface drift for a human to fold back into the matrix, not to freeze a
+    // vendor's support table into a red build.
+    private void ProbeWebViewCapabilities(AppiumDriver driver)
+    {
+        var probes = new (string Api, string Script)[]
+        {
+            ("IFileSystemAccess → showOpenFilePicker", "return typeof window.showOpenFilePicker"),
+            ("IWebPush → PushManager", "return typeof window.PushManager"),
+            ("IWebPush → serviceWorker", "return String('serviceWorker' in navigator)"),
+            ("IWebAuthn → navigator.credentials", "return typeof navigator.credentials"),
+            ("IWebLocks → navigator.locks", "return typeof navigator.locks"),
+            ("IStorageEstimator → storage.estimate", "return typeof (navigator.storage && navigator.storage.estimate)"),
+            ("IPermissions → navigator.permissions", "return typeof navigator.permissions"),
+            ("IMediaSession → navigator.mediaSession", "return typeof navigator.mediaSession"),
+            ("IGamepad → navigator.getGamepads", "return typeof navigator.getGamepads"),
+            ("IIndexedDb → indexedDB", "return typeof window.indexedDB")
+        };
+
+        foreach (var (api, script) in probes)
+        {
+            output.WriteLine($"[capability] {api} = {ExecuteScript(driver, script)}");
+        }
     }
 
     // Assert NativeShowcaseApp's native chrome projected to REAL platform bars, then prove a native tab tap


### PR DESCRIPTION
> **This PR was repurposed.** It originally "fixed" the iOS origin's secure context. That premise was refuted by a device check before merge — see [the comment below](#issuecomment-5001638876). There was no bug; the shipped code and docs were right. What survives is what the verification actually turned up.

## Summary

Three documentation claims about the browser-API surface didn't match reality. **No code changes** — nothing here was broken in code; the docs just described a surface we'd never checked.

### 1. `IFileSystemAccess` and `IWebPush` don't work on Native

Both marked ✅ in the Native column of `docs/browser-capabilities.md`. Neither API exists in the WebView — probed against the real native origin on `WKWebView`:

```
IFileSystemAccess → showOpenFilePicker = undefined     ← matrix said ✅
IWebPush          → PushManager        = undefined     ← matrix said ✅
IWebPush          → serviceWorker      = true          ← SWs register; push is what's missing
```

Both become ⬜, naming the alternative (`<input type="file">`) and the tracked APNs/FCM follow-up. **`INotifications` is unaffected** — it has a ★ native backend, so local notifications work on device.

### 2. Every wrapper's demo isn't in the section the docs point at

`docs/browser-apis.md` said every wrapper has a demo "in the **Browser APIs** section of the showcase". The *coverage* claim is true — all 46 have a runnable demo — but the **section** is wrong for 13 of them: the WASM-only tier plus `IWakeLock` and `IWebPush` have their own pages under the showcase's **PWA** group (verified: all 13 nav entries resolve to a real page). The six activation-gated ones appear in both — as gesture components under Browser APIs, as injectable services under PWA.

Pedantic-looking, but Browser APIs is where a reader is *told to look*, and a third of the surface isn't there.

### 3. Why the origins are secure contexts wasn't written down

`docs/native.md` now documents it, because only one of the two is obvious:

| Head | Origin | Secure context because |
|------|--------|------------------------|
| Android | `https://appassets.rask/` | the `https` scheme — the ordinary rule |
| iOS | `raskapp://local/` | WebKit treats a custom `WKURLSchemeHandler` scheme as trustworthy |

The iOS row goes further than the [W3C algorithm](https://w3c.github.io/webappsec-secure-contexts/#is-origin-trustworthy) alone would: `raskapp://` isn't `https` and the host isn't `localhost`, yet `isSecureContext === true`. Reading that origin as insecure and "fixing" the host is a real trap — I fell in it, which is what this PR originally was — and it matters to anyone writing a custom `INativeWebView`.

## What stops this recurring

The Native column was written from assumption. It now gets evidence: the Appium suite **prints what each WebView-only wrapper actually resolves to** on device, and **asserts the app origin is a secure context** — losing that would take `crypto.subtle`, `navigator.credentials`, `storage.estimate` and Web Locks away *silently*, as `undefined` rather than an error.

## Testing

- `dotnet format` + `dotnet build -warnaserror` clean; `scripts/run-unit-local.sh` (250/250) + `scripts/run-e2e-local.sh` pass.
- Corrections verified against `WKWebView` + `WKURLSchemeHandler` — the same shape `RaskWkWebView` uses. A negative control (`http://example.com/` → `isSecureContext=false`, `crypto.subtle=undefined`) confirms the probe discriminates rather than always reporting support.
- Verified on **macOS WebKit**, which shares WebCore with iOS. The Appium assertion + probe confirm it on a real device; the ios workload is orphaned by an SDK feature-band bump locally, so that run is still outstanding — and no longer blocking, since the probe answered the question directly.

## Follow-ups

- **`IWebAuthn` Native ✅ stands.** I expected to demote it; probing says otherwise — see [the comment below](#issuecomment-5003038659). `create()` from the native origin returns `NotAllowedError` (no focused document), **not** `SecurityError`, so origin/RP-ID validation *passes*. Still unproven: that a registration *completes* with a real authenticator on device.
- **Native push (APNs/FCM)** behind `IWebPush` — what the new ⬜ points at.

## Benchmarks

N/A — docs and an on-device test. No render hot-path or runtime code touched.