### PR TITLE
test(browser): pin every registered browser-API wrapper against its registrar

### DIFF
--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -60,7 +60,7 @@ Native column marks an API with a native C# backend (the rest run through the We
 
 ## Notes
 
-- **Web / Server** is the ASP.NET host (per-session, over WebSocket). The 31 transport-agnostic
+- **Web / Server** is the ASP.NET host (per-session, over WebSocket). The 34 transport-agnostic
   wrappers register there; the activation-gated ones (🟡) can't be injected but are reachable through
   declarative **gesture components** that run the call inside the click gesture. All six ship:
   [`FullscreenTrigger`](apis/fullscreen.md), [`ScreenOrientationTrigger`](apis/screen-orientation.md),

--- a/tests/Rask.Client.Tests/RaskClientBrowserApisTests.cs
+++ b/tests/Rask.Client.Tests/RaskClientBrowserApisTests.cs
@@ -20,6 +20,19 @@ public class RaskClientBrowserApisTests
         Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
     }
 
+    // IShare is the whole tier. The test above would still pass if a second wrapper were added and left
+    // unpinned, so pin the size too — the Core tier's list had silently fallen three behind its registrar.
+    [Fact]
+    public void AddClientBrowserApis_RegistersNothingBeyondShare()
+    {
+        var services = new ServiceCollection();
+
+        services.AddClientBrowserApis(ServiceLifetime.Singleton);
+
+        var registered = Assert.Single(services);
+        Assert.Equal(typeof(IShare), registered.ServiceType);
+    }
+
     [Fact]
     public void AddClientBrowserApis_IsFallbackOnly_ANativeShareRegisteredFirstWins()
     {

--- a/tests/Rask.Core.Tests/Browser/RaskBrowserApisTests.cs
+++ b/tests/Rask.Core.Tests/Browser/RaskBrowserApisTests.cs
@@ -9,7 +9,8 @@ namespace Rask.Core.Tests.Browser;
 // native platform or the app) wins and the JS-backed wrapper is only the fallback.
 public class RaskBrowserApisTests
 {
-    // The 31 transport-agnostic wrappers AddCoreBrowserApis must register — service type → default impl.
+    // The 34 transport-agnostic wrappers AddCoreBrowserApis must register — service type → default impl.
+    // Keep in sync with the registrar; AddCoreBrowserApis_RegistersNothingBeyondThePinnedSet enforces it.
     private static readonly (Type Service, Type Impl)[] CoreApis =
     [
         (typeof(IBrowserStorage), typeof(BrowserStorage)),
@@ -19,6 +20,7 @@ public class RaskBrowserApisTests
         (typeof(INetworkInfo), typeof(NetworkInfo)),
         (typeof(IMediaQuery), typeof(MediaQuery)),
         (typeof(ISpeechSynthesis), typeof(SpeechSynthesis)),
+        (typeof(ISpeechRecognition), typeof(SpeechRecognition)),
         (typeof(IScreenInfo), typeof(ScreenInfoReader)),
         (typeof(IStorageEstimator), typeof(StorageEstimator)),
         (typeof(IVisualViewport), typeof(VisualViewportReader)),
@@ -39,6 +41,8 @@ public class RaskBrowserApisTests
         (typeof(IPermissions), typeof(Permissions)),
         (typeof(IVibration), typeof(Vibration)),
         (typeof(IPageVisibility), typeof(PageVisibilityInfo)),
+        (typeof(IWebLocks), typeof(WebLocks)),
+        (typeof(IBattery), typeof(Battery)),
         (typeof(IWebPush), typeof(WebPush)),
         (typeof(INotifications), typeof(Notifications)),
         (typeof(IBadge), typeof(Badge)),
@@ -57,6 +61,24 @@ public class RaskBrowserApisTests
             var descriptor = Assert.Single(services, d => d.ServiceType == service);
             Assert.Equal(impl, descriptor.ImplementationType);
         }
+    }
+
+    // The other tests here only iterate CoreApis, so a wrapper missing from the list is simply never
+    // checked — the list had silently fallen three behind the registrar (ISpeechRecognition, IWebLocks,
+    // IBattery shipped unverified). Compare against what AddCoreBrowserApis actually registered, so
+    // adding a wrapper without pinning it fails here instead of going unnoticed.
+    [Fact]
+    public void AddCoreBrowserApis_RegistersNothingBeyondThePinnedSet()
+    {
+        var services = new ServiceCollection();
+
+        services.AddCoreBrowserApis(ServiceLifetime.Scoped);
+
+        var registered = services.Select(d => d.ServiceType).ToHashSet();
+        var pinned = CoreApis.Select(a => a.Service).ToHashSet();
+
+        Assert.Empty(registered.Except(pinned));   // registered but unpinned → add it to CoreApis
+        Assert.Empty(pinned.Except(registered));   // pinned but unregistered → stale entry
     }
 
     [Theory]

--- a/tests/Rask.Wasm.Tests/Browser/RaskWasmBrowserApisTests.cs
+++ b/tests/Rask.Wasm.Tests/Browser/RaskWasmBrowserApisTests.cs
@@ -4,7 +4,7 @@ using Rask.Wasm.Browser;
 namespace Rask.Wasm.Tests.Browser;
 
 // Covers the WASM-only device/handle set (Rask.Wasm). Together with the Core tier (Rask.Core.Tests) and the
-// in-process IShare tier (Rask.Client.Tests) this pins the full 43-wrapper surface and its Singleton lifetime
+// in-process IShare tier (Rask.Client.Tests) this pins the full 46-wrapper surface and its Singleton lifetime
 // on the WASM host.
 public class RaskWasmBrowserApisTests
 {
@@ -36,5 +36,22 @@ public class RaskWasmBrowserApisTests
             Assert.Equal(impl, descriptor.ImplementationType);
             Assert.Equal(ServiceLifetime.Singleton, descriptor.Lifetime);
         }
+    }
+
+    // The test above only iterates WasmOnlyApis, so a wrapper missing from the list would never be checked
+    // — the Core tier's equivalent list had silently fallen three behind its registrar. Compare against what
+    // AddWasmBrowserApis actually registered, so adding a wrapper without pinning it fails here.
+    [Fact]
+    public void AddWasmBrowserApis_RegistersNothingBeyondThePinnedSet()
+    {
+        var services = new ServiceCollection();
+
+        services.AddWasmBrowserApis(ServiceLifetime.Singleton);
+
+        var registered = services.Select(d => d.ServiceType).ToHashSet();
+        var pinned = WasmOnlyApis.Select(a => a.Service).ToHashSet();
+
+        Assert.Empty(registered.Except(pinned));   // registered but unpinned → add it to WasmOnlyApis
+        Assert.Empty(pinned.Except(registered));   // pinned but unregistered → stale entry
     }
 }


### PR DESCRIPTION
## Summary

`RaskBrowserApisTests.CoreApis` listed **31** wrappers while `AddCoreBrowserApis` registers **34**. Both tests only *iterate* the pin list:

```csharp
foreach (var (service, impl) in CoreApis)   // ← a wrapper missing from the list is simply never checked
```

So `ISpeechRecognition`, `IWebLocks` and `IBattery` — the three most recently added — shipped with their registration, lifetime, and native-override behaviour **never verified**. Nothing compared the list against the registrar, which makes the drift structural rather than an oversight: it would have recurred on the next wrapper added.

## The fix

Each tier now asserts the registered service types are **exactly** the pinned set, in both directions:

```csharp
Assert.Empty(registered.Except(pinned));   // registered but unpinned → the case that shipped
Assert.Empty(pinned.Except(registered));   // pinned but unregistered → stale entry
```

The three missing pins are just the backlog this exposed — the guard is the actual change.

The **Client** (`IShare`) and **WASM** tiers had the same shape, so they get the same guard. The 34 + 1 + 11 = **46**-wrapper surface is now *enforced* rather than asserted in a comment.

## Testing

- `dotnet format` + `dotnet build -warnaserror` clean; `scripts/run-unit-local.sh` and `scripts/run-e2e-local.sh` pass.
- **Verified the guard actually bites**, rather than passing vacuously: removing the `IBattery` pin fails `AddCoreBrowserApis_RegistersNothingBeyondThePinnedSet` while the other six tests still pass — which is exactly the gap that let this ship.

```
[FAIL] RaskBrowserApisTests.AddCoreBrowserApis_RegistersNothingBeyondThePinnedSet
Failed! - Failed: 1, Passed: 6
```

## Notes

- Also corrects the counts those comments carried (31 → 34, 43 → 46), including `docs/browser-capabilities.md`. Those comments are the count-of-record, so a stale one is how the next reader mis-learns the surface.
- **No CHANGELOG entry**: no user-visible behaviour changes. The three unpinned wrappers were registered correctly all along — they were merely unverified, so there's nothing for a user to have observed. Happy to add one if you'd rather track it.

## Benchmarks

N/A — test-only, plus one docs word. No render hot-path or runtime code touched.