### PR TITLE
refactor(cli): parse generate-feature relationships and collapse the generator signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -269,6 +269,12 @@ them until tagged releases begin.
 - **`rask deploy --help` stated the wrong default for `--health-path`.** It read `(default: /)` while the
   probe actually uses `/health` (as `docs/cli.md` documents), so anyone trusting `--help` would think an
   app without a root-path readiness route needed the flag when it didn't.
+- **`rask generate page --no-restore` (and any other feature-only option) is now rejected instead of silently
+  accepted.** The guard that keeps feature options off a page/component/job/email was a hand-kept list that had
+  drifted from the option schema, so `--no-restore` — declared as a feature option — slipped through and did
+  nothing. The check now derives from the schema's own grouping, which closes the drift for good. The message
+  also names only the options you actually passed (`--no-restore only applies to 'generate feature'.`) rather
+  than reciting all thirteen.
 - **`Rask.Outbox` now delivers nested `IOutboxEvent` types.** The source generator registers each event by
   its dot-separated display name, but `OutboxSerializerRegistry.Serialize` stored `Type.FullName` — which
   uses `+` between a nesting type and a nested type — so a nested event (a record declared inside a class)

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -32,8 +32,10 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
     public override string Summary => "Scaffold a page, component, CRUD feature, background job, or email into the current project.";
 
+    // The shape only — the option list lives in the schema, which --help renders directly. Spelling the
+    // flags out here is what let this string go stale before.
     public override string Usage =>
-        "rask generate <page|component|feature|job|email> <Name> [<field:type> ...] [--id guid|int|long] [--route <path>] [--context <Name>] [--plural <Name>] [--output <dir>] [--force] [--dry-run]";
+        "rask generate <page|component|feature|job|email> <Name> [<field:type> ...] [options]";
 
     public override IReadOnlyList<(string Name, string Description)> Arguments =>
     [
@@ -76,6 +78,22 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             .Flag("tests", description: "Generate a sibling <Project>.Tests project with domain + persistence tests.", group: FeatureGroup)
             .Flag("no-restore", description: "Write files without adding packages or restoring.", group: FeatureGroup)
             .Flag("save-defaults", description: "Remember this run's feature flags in .rask/generate.json for next time.", group: FeatureGroup);
+
+    /// <summary>The feature-only options this run actually supplied, in declaration order.</summary>
+    private static List<string> FeatureOnly(ArgumentSchema schema, ParsedArguments parsed) =>
+        schema.Declared
+            .Where(o => o.Group == FeatureGroup)
+            .Where(o => o.IsFlag ? parsed.HasFlag(o.LongName) : parsed.Option(o.LongName) is not null)
+            .Select(o => "--" + o.LongName)
+            .ToList();
+
+    /// <summary>"--a" / "--a and --b" / "--a, --b, and --c".</summary>
+    private static string Humanize(IReadOnlyList<string> items) => items.Count switch
+    {
+        1 => items[0],
+        2 => $"{items[0]} and {items[1]}",
+        _ => $"{string.Join(", ", items.Take(items.Count - 1))}, and {items[^1]}",
+    };
 
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
@@ -130,14 +148,12 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             }
         }
 
-        if (kind != "feature"
-            && (parsed.Option("fields") is not null || parsed.Option("context") is not null
-                || parsed.Option("plural") is not null || parsed.Option("id") is not null
-                || parsed.Option("validation") is not null || parsed.HasFlag("bs") || parsed.HasFlag("modal")
-                || parsed.HasFlag("soft-delete") || parsed.HasFlag("concurrency") || parsed.HasFlag("events")
-                || parsed.HasFlag("outbox") || parsed.HasFlag("tests") || parsed.HasFlag("save-defaults")))
+        // Derived from the schema's own grouping rather than a hand-kept list, so a new feature option can't
+        // be forgotten here (--no-restore was, and slipped through on a page for exactly that reason).
+        if (kind != "feature" && FeatureOnly(schema, parsed) is { Count: > 0 } misapplied)
         {
-            Console.Error.WriteLine("--fields, --context, --plural, --id, --validation, --bs, --modal, --soft-delete, --concurrency, --events, --outbox, --tests, and --save-defaults only apply to 'generate feature'.");
+            var verb = misapplied.Count == 1 ? "applies" : "apply";
+            Console.Error.WriteLine($"{Humanize(misapplied)} only {verb} to 'generate feature'.");
             return 1;
         }
 
@@ -234,38 +250,44 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                 return true;
 
             default: // feature
-                // Fields are positional: `generate feature Product Name:string Price:decimal`. The legacy
-                // `--fields "Name:string,Price:decimal"` form still works, but not both at once.
-                var positionalFields = parsed.Positionals.Skip(1).ToArray();
+                // Fields and relationships are positional: `generate feature Post Title:string 1:n Comment Body:text`.
+                // The legacy `--fields "Title:string,1:n,Comment,Body:text"` form still works, but not both at once.
+                var positionalTokens = parsed.Positionals.Skip(1).ToArray();
                 var fieldsOption = parsed.Option("fields");
-                if (positionalFields.Length > 0 && fieldsOption is not null)
+                if (positionalTokens.Length > 0 && fieldsOption is not null)
                 {
                     result = null!;
                     error = "Specify fields positionally (e.g. Name:string Price:decimal) or with --fields, not both.";
                     return false;
                 }
 
-                // Positional tokens use the same grammar as one --fields entry, so join them and reuse the parser.
-                var fieldsSpec = positionalFields.Length > 0 ? string.Join(",", positionalFields) : fieldsOption;
-                if (string.IsNullOrWhiteSpace(fieldsSpec))
+                // --fields is the same token stream, comma-separated — so relationships work in both forms.
+                var tokens = positionalTokens.Length > 0
+                    ? positionalTokens
+                    : (fieldsOption ?? "").Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+
+                if (tokens.Length == 0)
                 {
                     result = null!;
                     error = "'generate feature' needs fields, e.g. rask generate feature Product Name:string Price:decimal.";
                     return false;
                 }
 
-                if (!FieldSpecParser.TryParse(fieldsSpec, out var fields, out var fieldError))
+                if (!FeatureSpecParser.TryParse(name, parsed.Option("plural"), tokens, out var spec, out var specError))
                 {
                     result = null!;
-                    error = fieldError;
+                    error = specError;
                     return false;
                 }
 
-                var collision = fields.FirstOrDefault(f => f.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
-                if (collision is not null)
+                // The grammar parses and validates ahead of the emitter that will consume it. Refuse rather
+                // than generate the root and drop the targets on the floor — silently discarding what was
+                // asked for is worse than not supporting it yet.
+                if (spec.Relationships.Count > 0)
                 {
+                    var relationship = spec.Relationships[0];
                     result = null!;
-                    error = $"Field '{collision.Name}' can't share the entity's name '{name}' (a member can't match its type).";
+                    error = $"Relationships aren't generated yet — '{relationship.Token} {relationship.To.Name}' parses, but emitting it isn't implemented. Scaffold the entities separately for now.";
                     return false;
                 }
 
@@ -295,16 +317,27 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                     return false;
                 }
 
-                // --modal puts create/update in a BsModal on the list page, so it implies --bs.
-                var useModal = parsed.HasFlag("modal") || (config.Modal ?? false);
-                var useBs = useModal || parsed.HasFlag("bs") || (config.Bs ?? false);
-                var softDelete = parsed.HasFlag("soft-delete") || (config.SoftDelete ?? false);
-                var concurrency = parsed.HasFlag("concurrency") || (config.Concurrency ?? false);
-                var events = parsed.HasFlag("events") || (config.Events ?? false);
-                var outbox = parsed.HasFlag("outbox") || (config.Outbox ?? false);
-                var tests = parsed.HasFlag("tests") || (config.Tests ?? false);
+                // A flag set here or defaulted on in .rask/generate.json turns the option on; explicit wins.
+                bool Flag(string longName, bool? configured) => parsed.HasFlag(longName) || (configured ?? false);
 
-                result = FeatureGenerator.Generate(project, _workingDirectory, name, fields, idType, validation, useBs, useModal, softDelete, concurrency, events, outbox, tests, parsed.Option("context"), parsed.Option("plural"), parsed.Option("output"));
+                // --modal puts create/update in a BsModal on the list page, so it implies --bs.
+                var useModal = Flag("modal", config.Modal);
+                var options = new FeatureOptions
+                {
+                    IdType = idType,
+                    Validation = validation,
+                    UseModal = useModal,
+                    UseBs = useModal || Flag("bs", config.Bs),
+                    UseSoftDelete = Flag("soft-delete", config.SoftDelete),
+                    UseConcurrency = Flag("concurrency", config.Concurrency),
+                    UseEvents = Flag("events", config.Events),
+                    UseOutbox = Flag("outbox", config.Outbox),
+                    UseTests = Flag("tests", config.Tests),
+                    ContextOverride = parsed.Option("context"),
+                    OutputOverride = parsed.Option("output"),
+                };
+
+                result = FeatureGenerator.Generate(project, _workingDirectory, spec, options);
                 return true;
         }
     }

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -16,32 +16,32 @@ internal static class FeatureGenerator
     public static ScaffoldResult Generate(
         ProjectContext project,
         string baseDirectory,
-        string entityName,
-        IReadOnlyList<FieldSpec> fields,
-        string idType,
-        string validation,
-        bool useBs,
-        bool useModal,
-        bool useSoftDelete,
-        bool useConcurrency,
-        bool useEvents,
-        bool useOutbox,
-        bool useTests,
-        string? contextOverride,
-        string? pluralOverride,
-        string? outputOverride)
+        FeatureSpec spec,
+        FeatureOptions options)
     {
-        // Both flags raise domain events on the entity; --outbox additionally routes them through the
-        // durable outbox (the events then implement IOutboxEvent). Either flag turns the event machinery on.
-        var useDomainEvents = useEvents || useOutbox;
-        var plural = pluralOverride ?? Pluralizer.Pluralize(entityName);
+        // spec.Relationships is parsed and validated but not yet emitted — relationship rendering lands in a
+        // later slice. Until then a run generates its root exactly as before.
+        var entityName = spec.Root.Name;
+        var fields = spec.Root.Fields;
+        var plural = spec.Root.Plural;
+
+        var idType = options.IdType;
+        var validation = options.Validation;
+        var useBs = options.UseBs;
+        var useModal = options.UseModal;
+        var useSoftDelete = options.UseSoftDelete;
+        var useConcurrency = options.UseConcurrency;
+        var useOutbox = options.UseOutbox;
+        var useTests = options.UseTests;
+        var useDomainEvents = options.UseDomainEvents;
+        var useValueObjects = options.UseValueObjects;
+
         var route = Identifiers.ToRoutePath(plural);
         var idConstraint = idType == "Guid" ? "guid" : idType;
-        var generateContext = contextOverride is null;
-        var context = contextOverride ?? plural + "DbContext";
-        var useValueObjects = validation == "valueobjects";
+        var generateContext = options.ContextOverride is null;
+        var context = options.ContextOverride ?? plural + "DbContext";
 
-        var targetDirectory = Scaffold.TargetDirectory(baseDirectory, outputOverride, "Features", plural);
+        var targetDirectory = Scaffold.TargetDirectory(baseDirectory, options.OutputOverride, "Features", plural);
         var ns = project.NamespaceFor(targetDirectory);
 
         var tokens = new (string, string)[]

--- a/src/Rask.Cli/Scaffolding/FeatureOptions.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureOptions.cs
@@ -1,0 +1,43 @@
+namespace Rask.Cli.Scaffolding;
+
+/// <summary>
+/// The knobs a <c>generate feature</c> run carries beyond its <see cref="FeatureSpec"/>. One set governs the
+/// whole command, so every entity in a run shares a key type, a validation style, and a UI flavour — which is
+/// what makes a foreign key's type match the primary key it points at by construction rather than by check.
+/// </summary>
+internal sealed record FeatureOptions
+{
+    /// <summary>The primary-key type for every entity in the run: <c>Guid</c> (default), <c>int</c>, or <c>long</c>.</summary>
+    public required string IdType { get; init; }
+
+    /// <summary><c>valueobjects</c> (default), <c>dataannotations</c>, or <c>fluent</c>.</summary>
+    public required string Validation { get; init; }
+
+    public bool UseBs { get; init; }
+
+    public bool UseModal { get; init; }
+
+    public bool UseSoftDelete { get; init; }
+
+    public bool UseConcurrency { get; init; }
+
+    public bool UseEvents { get; init; }
+
+    public bool UseOutbox { get; init; }
+
+    public bool UseTests { get; init; }
+
+    /// <summary>An existing DbContext to attach to, instead of generating one.</summary>
+    public string? ContextOverride { get; init; }
+
+    public string? OutputOverride { get; init; }
+
+    /// <summary>
+    /// Both flags raise domain events on the entity; <c>--outbox</c> additionally routes them through the
+    /// durable outbox (the events then implement <c>IOutboxEvent</c>). Either turns the machinery on.
+    /// </summary>
+    public bool UseDomainEvents => UseEvents || UseOutbox;
+
+    /// <summary>Value objects are the default; the other two styles leave the entity's properties primitive.</summary>
+    public bool UseValueObjects => Validation == "valueobjects";
+}

--- a/src/Rask.Cli/Scaffolding/FeatureSpec.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureSpec.cs
@@ -1,0 +1,93 @@
+namespace Rask.Cli.Scaffolding;
+
+/// <summary>
+/// The shape of a relationship between two generated entities, as written on the command line
+/// (<c>rask g f Post Title:string 1:n Comment Body:text</c>). <see cref="RelationshipSpec.IsOptional"/>
+/// carries the nullability a <c>0</c> in the token asks for, so <c>1:n</c> and <c>0:n</c> share this enum.
+/// </summary>
+internal enum Cardinality
+{
+    /// <summary><c>1:n</c> / <c>0:n</c> — one root, many targets. The target holds the foreign key.</summary>
+    OneToMany,
+
+    /// <summary><c>n:1</c> / <c>n:0</c> — many roots, one target. The <b>root</b> holds the foreign key.</summary>
+    ManyToOne,
+
+    /// <summary><c>1:1</c> / <c>0:1</c> — one root, one target. The target holds a unique foreign key.</summary>
+    OneToOne,
+
+    /// <summary><c>n:n</c> — many to many, through a generated join entity.</summary>
+    ManyToMany,
+}
+
+/// <summary>One entity in a <see cref="FeatureSpec"/> — the root, or a relationship's target.</summary>
+internal sealed record EntitySpec(string Name, string Plural, IReadOnlyList<FieldSpec> Fields);
+
+/// <summary>
+/// One <c>&lt;card&gt; &lt;Target&gt;</c> segment. <see cref="From"/> is always the feature's root (relationships
+/// form a star — segments never chain), and <see cref="To"/> is the target the segment named.
+/// </summary>
+internal sealed record RelationshipSpec(Cardinality Cardinality, bool IsOptional, EntitySpec From, EntitySpec To)
+{
+    /// <summary>
+    /// The side that owns the key the relationship points at. It's the target only for <c>n:1</c>/<c>n:0</c>,
+    /// where the root is the "many" end; every other cardinality keeps the root as the principal.
+    /// </summary>
+    public EntitySpec Principal => Cardinality is Cardinality.ManyToOne ? To : From;
+
+    /// <summary>The side that carries the foreign key. Meaningless for <see cref="Cardinality.ManyToMany"/>.</summary>
+    public EntitySpec Dependent => Cardinality is Cardinality.ManyToOne ? From : To;
+
+    /// <summary>The foreign-key property on <see cref="Dependent"/>, e.g. <c>PostId</c>.</summary>
+    public string ForeignKeyName => Principal.Name + "Id";
+
+    /// <summary>The generated join entity for an <c>n:n</c>, e.g. <c>PostTag</c>.</summary>
+    public string JoinName => From.Name + To.Name;
+
+    /// <summary>The token this relationship was written as, e.g. <c>0:n</c> — for echoing back in messages.</summary>
+    public string Token => (Cardinality, IsOptional) switch
+    {
+        (Cardinality.OneToMany, false) => "1:n",
+        (Cardinality.OneToMany, true) => "0:n",
+        (Cardinality.ManyToOne, false) => "n:1",
+        (Cardinality.ManyToOne, true) => "n:0",
+        (Cardinality.OneToOne, false) => "1:1",
+        (Cardinality.OneToOne, true) => "0:1",
+        _ => "n:n",
+    };
+
+    /// <summary>
+    /// Every member this relationship adds, as (entity, member) pairs. The single source both the validator
+    /// (to reject a user field that would collide) and the generator (to emit them) read, so the two can't
+    /// disagree about what a relationship produces.
+    /// </summary>
+    public IEnumerable<(string Entity, string Member)> GeneratedMembers()
+    {
+        if (Cardinality is Cardinality.ManyToMany)
+        {
+            yield return (From.Name, To.Plural);   // Post.Tags
+            yield return (To.Name, From.Plural);   // Tag.Posts
+            yield break;
+        }
+
+        var principal = Principal;
+        var dependent = Dependent;
+
+        yield return (dependent.Name, ForeignKeyName);  // Comment.PostId
+        yield return (dependent.Name, principal.Name);  // Comment.Post
+
+        // The principal's back-reference: a collection, except for 1:1 where it's a single reference.
+        yield return (principal.Name, Cardinality is Cardinality.OneToOne ? dependent.Name : dependent.Plural);
+    }
+}
+
+/// <summary>
+/// A whole <c>generate feature</c> request: the root entity plus every relationship segment that followed it.
+/// The key type isn't here — one <c>--id</c> governs the run, so it lives on the generator's options and a
+/// foreign key can't disagree with the primary key it points at.
+/// </summary>
+internal sealed record FeatureSpec(EntitySpec Root, IReadOnlyList<RelationshipSpec> Relationships)
+{
+    /// <summary>The root followed by each relationship's target, in the order they were written.</summary>
+    public IEnumerable<EntitySpec> Entities => [Root, .. Relationships.Select(r => r.To)];
+}

--- a/src/Rask.Cli/Scaffolding/FeatureSpecParser.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureSpecParser.cs
@@ -1,0 +1,292 @@
+namespace Rask.Cli.Scaffolding;
+
+/// <summary>
+/// Parses a <c>generate feature</c> token stream — fields, plus optional <c>&lt;card&gt; &lt;Target&gt;</c>
+/// relationship segments — into a <see cref="FeatureSpec"/>:
+/// <code>
+/// rask g f Post Title:string 1:n Comment Body:text n:n Tag Name:string
+///          └─ root fields ─┘ └── segment ──┘ └─── segment ───┘
+/// </code>
+/// A cardinality token opens a new segment, and every field after it belongs to that segment's target.
+/// Relationships form a <b>star</b>: each one attaches to the root, so segments never chain
+/// (<c>Post 1:n Comment n:1 Author</c> means Author is <i>Post's</i> author, not Comment's).
+/// </summary>
+internal static class FeatureSpecParser
+{
+    // Recognising a cardinality before trying to parse a field is safe — and steals nothing that could
+    // otherwise have parsed — because every card token is an invalid field spec: its type half ('n', '1',
+    // '0') is not in FieldSpecParser.TypeAliases. Note the weaker "it's not an identifier" reasoning does
+    // NOT hold: 'n' in `n:1` is a perfectly valid property name.
+    private static readonly Dictionary<string, (Cardinality Cardinality, bool IsOptional)> Cards =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            ["1:n"] = (Cardinality.OneToMany, false),
+            ["0:n"] = (Cardinality.OneToMany, true),
+            ["n:1"] = (Cardinality.ManyToOne, false),
+            ["n:0"] = (Cardinality.ManyToOne, true),
+            ["1:1"] = (Cardinality.OneToOne, false),
+            ["0:1"] = (Cardinality.OneToOne, true),
+            ["n:n"] = (Cardinality.ManyToMany, false),
+        };
+
+    /// <summary>The cardinality tokens, in the order the help and error messages list them.</summary>
+    public static IReadOnlyList<string> SupportedCardinalities { get; } =
+        ["1:n", "0:n", "n:1", "n:0", "1:1", "0:1", "n:n"];
+
+    /// <summary>
+    /// Parses <paramref name="tokens"/> (everything after the root's name) into a <see cref="FeatureSpec"/>.
+    /// <paramref name="rootPlural"/> is <c>--plural</c>, which applies to the root only — targets are
+    /// pluralized automatically.
+    /// </summary>
+    public static bool TryParse(
+        string rootName,
+        string? rootPlural,
+        IReadOnlyList<string> tokens,
+        out FeatureSpec spec,
+        out string? error)
+    {
+        spec = null!;
+
+        if (!TrySegment(rootName, rootPlural, tokens, out var segments, out error)
+            || !TryBuildEntities(segments, out var entities, out error)
+            || !TryValidateNames(entities, out error))
+        {
+            return false;
+        }
+
+        var root = entities[0];
+        var relationships = new List<RelationshipSpec>(entities.Count - 1);
+        for (var i = 1; i < entities.Count; i++)
+        {
+            var (cardinality, isOptional) = Cards[segments[i].Card!];
+            relationships.Add(new RelationshipSpec(cardinality, isOptional, root, entities[i]));
+        }
+
+        if (!TryValidateRelationships(entities, relationships, out error))
+        {
+            return false;
+        }
+
+        spec = new FeatureSpec(root, relationships);
+        return true;
+    }
+
+    // Split the token stream into segments: the root, then one per `<card> <Target>` pair.
+    private static bool TrySegment(
+        string rootName,
+        string? rootPlural,
+        IReadOnlyList<string> tokens,
+        out List<Segment> segments,
+        out string? error)
+    {
+        segments = [new Segment(rootName, rootPlural, Card: null)];
+        error = null;
+        string? pendingCard = null;
+
+        foreach (var token in tokens)
+        {
+            // A card is pending, so this token must name the target. Checked before the card lookup below,
+            // so `1:n n:1` reports the missing name rather than silently dropping the first card.
+            if (pendingCard is not null)
+            {
+                if (!TryOpenSegment(token, pendingCard, segments, out error))
+                {
+                    return false;
+                }
+
+                pendingCard = null;
+                continue;
+            }
+
+            if (Cards.ContainsKey(token))
+            {
+                pendingCard = token;
+                continue;
+            }
+
+            if (LooksLikeCardinality(token))
+            {
+                error = $"Unknown cardinality '{token}'. Supported: {string.Join(", ", SupportedCardinalities)}.";
+                return false;
+            }
+
+            segments[^1].FieldTokens.Add(token);
+        }
+
+        if (pendingCard is not null)
+        {
+            error = $"Cardinality '{pendingCard}' needs a target entity name after it, e.g. {pendingCard} Comment Body:text.";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool TryOpenSegment(string token, string pendingCard, List<Segment> segments, out string? error)
+    {
+        if (Cards.ContainsKey(token))
+        {
+            error = $"Expected a target entity name after '{pendingCard}', but found the cardinality '{token}'.";
+            return false;
+        }
+
+        if (token.Contains(':', StringComparison.Ordinal))
+        {
+            error = $"Expected a target entity name after '{pendingCard}', but found the field '{token}'.";
+            return false;
+        }
+
+        if (token.Equals("Id", StringComparison.OrdinalIgnoreCase))
+        {
+            error = "'Id' can't be an entity name — every entity gets an Id automatically.";
+            return false;
+        }
+
+        if (!Identifiers.IsValidTypeName(token))
+        {
+            error = $"'{token}' is not a valid entity name.";
+            return false;
+        }
+
+        segments.Add(new Segment(token, PluralOverride: null, pendingCard));
+        error = null;
+        return true;
+    }
+
+    // Each segment's fields go through FieldSpecParser as one comma-joined spec — the same grammar the
+    // root has always used, which also scopes duplicate-field detection to the entity for free.
+    private static bool TryBuildEntities(List<Segment> segments, out List<EntitySpec> entities, out string? error)
+    {
+        entities = new List<EntitySpec>(segments.Count);
+        error = null;
+
+        foreach (var segment in segments)
+        {
+            if (segment.FieldTokens.Count == 0)
+            {
+                error = segment.Card is null
+                    ? "At least one field is required, e.g. rask generate feature Product Name:string Price:decimal."
+                    : $"Target '{segment.Name}' needs at least one field, e.g. {segment.Card} {segment.Name} Name:string.";
+                return false;
+            }
+
+            if (!FieldSpecParser.TryParse(string.Join(",", segment.FieldTokens), out var fields, out var fieldError))
+            {
+                // Name the entity only when there's more than one, so a plain feature's message is unchanged.
+                error = segments.Count > 1 ? $"{fieldError} (on '{segment.Name}')" : fieldError;
+                return false;
+            }
+
+            entities.Add(new EntitySpec(segment.Name, segment.PluralOverride ?? Pluralizer.Pluralize(segment.Name), fields));
+        }
+
+        return true;
+    }
+
+    private static bool TryValidateNames(List<EntitySpec> entities, out string? error)
+    {
+        var root = entities[0];
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var plurals = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var entity in entities)
+        {
+            if (!seen.Add(entity.Name))
+            {
+                error = entity.Name.Equals(root.Name, StringComparison.OrdinalIgnoreCase)
+                    ? $"Target '{entity.Name}' can't share the root entity's name — a relationship needs two entities."
+                    : $"Duplicate target '{entity.Name}' — each entity may appear once (one relationship per target).";
+                return false;
+            }
+
+            // A property can't be named after the type that declares it.
+            var collision = entity.Fields.FirstOrDefault(f => f.Name.Equals(entity.Name, StringComparison.OrdinalIgnoreCase));
+            if (collision is not null)
+            {
+                error = $"Field '{collision.Name}' can't share the entity's name '{entity.Name}' (a member can't match its type).";
+                return false;
+            }
+
+            if (!plurals.TryAdd(entity.Plural, entity.Name))
+            {
+                error = $"'{plurals[entity.Plural]}' and '{entity.Name}' both use the plural '{entity.Plural}' — their feature folders would collide. Pass --plural or rename one.";
+                return false;
+            }
+        }
+
+        error = null;
+        return true;
+    }
+
+    private static bool TryValidateRelationships(
+        List<EntitySpec> entities,
+        List<RelationshipSpec> relationships,
+        out string? error)
+    {
+        var names = entities.Select(e => e.Name).ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var relationship in relationships.Where(r => r.Cardinality is Cardinality.ManyToMany))
+        {
+            if (names.Contains(relationship.JoinName))
+            {
+                error = $"The n:n join entity for '{relationship.From.Name} n:n {relationship.To.Name}' would be named '{relationship.JoinName}', which collides with the entity '{relationship.JoinName}'. Rename one of them.";
+                return false;
+            }
+        }
+
+        // A user field can't take a name a relationship already generates.
+        var generated = new Dictionary<string, RelationshipSpec>(StringComparer.OrdinalIgnoreCase);
+        foreach (var relationship in relationships)
+        {
+            foreach (var (entity, member) in relationship.GeneratedMembers())
+            {
+                generated[entity + "." + member] = relationship;
+            }
+        }
+
+        foreach (var entity in entities)
+        {
+            foreach (var field in entity.Fields)
+            {
+                if (!generated.TryGetValue(entity.Name + "." + field.Name, out var relationship))
+                {
+                    continue;
+                }
+
+                var kind = relationship.Cardinality is not Cardinality.ManyToMany
+                    && field.Name.Equals(relationship.ForeignKeyName, StringComparison.OrdinalIgnoreCase)
+                        ? "foreign key"
+                        : "navigation property";
+
+                error = $"Field '{field.Name}' on '{entity.Name}' collides with the '{relationship.Token} {relationship.To.Name}' relationship's {kind} — it's generated automatically.";
+                return false;
+            }
+        }
+
+        error = null;
+        return true;
+    }
+
+    // A near-miss like `1:m`, `m:n`, `2:n`, or `1:*`: ER notation that isn't one of ours. Catching it beats
+    // letting it fall through to the field parser, which would complain that '1' isn't a property name.
+    // It can't shadow a real field — no multiplicity part is a supported field type.
+    private static bool LooksLikeCardinality(string token)
+    {
+        var colon = token.IndexOf(':', StringComparison.Ordinal);
+        return colon > 0
+            && colon == token.LastIndexOf(':')
+            && IsMultiplicity(token[..colon])
+            && IsMultiplicity(token[(colon + 1)..]);
+    }
+
+    private static bool IsMultiplicity(string part) =>
+        part.Length > 0
+        && (part == "*"
+            || part.All(char.IsAsciiDigit)
+            || (part.Length == 1 && part[0] is 'n' or 'N' or 'm' or 'M'));
+
+    private sealed record Segment(string Name, string? PluralOverride, string? Card)
+    {
+        public List<string> FieldTokens { get; } = [];
+    }
+}

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -120,7 +120,24 @@ public sealed class FeatureGeneratorTests
     ];
 
     private static ScaffoldResult Generate(string idType = "Guid", string validation = "valueobjects", bool useBs = false, bool useModal = false, bool useSoftDelete = false, bool useConcurrency = false, bool useEvents = false, bool useOutbox = false, bool useTests = false, string? context = null, string? plural = null) =>
-        FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Product", Fields, idType, validation, useBs, useModal, useSoftDelete, useConcurrency, useEvents, useOutbox, useTests, context, plural, outputOverride: null);
+        FeatureGenerator.Generate(
+            new ProjectContext("/proj", "MyApp"),
+            "/proj",
+            new FeatureSpec(new EntitySpec("Product", plural ?? Pluralizer.Pluralize("Product"), Fields), []),
+            new FeatureOptions
+            {
+                IdType = idType,
+                Validation = validation,
+                UseBs = useBs,
+                UseModal = useModal,
+                UseSoftDelete = useSoftDelete,
+                UseConcurrency = useConcurrency,
+                UseEvents = useEvents,
+                UseOutbox = useOutbox,
+                UseTests = useTests,
+                ContextOverride = context,
+                OutputOverride = null,
+            });
 
     private static string File(ScaffoldResult result, string fileName) =>
         result.Files.Single(f => Path.GetFileName(f.Path) == fileName).Content;
@@ -488,8 +505,11 @@ public sealed class FeatureGeneratorTests
     [Fact]
     public void Plural_override_drives_names_and_route()
     {
-        var result = FeatureGenerator.Generate(new ProjectContext("/proj", "MyApp"), "/proj", "Person",
-            Fields, "Guid", "valueobjects", useBs: false, useModal: false, useSoftDelete: false, useConcurrency: false, useEvents: false, useOutbox: false, useTests: false, contextOverride: null, pluralOverride: "People", outputOverride: null);
+        var result = FeatureGenerator.Generate(
+            new ProjectContext("/proj", "MyApp"),
+            "/proj",
+            new FeatureSpec(new EntitySpec("Person", "People", Fields), []),
+            new FeatureOptions { IdType = "Guid", Validation = "valueobjects" });
 
         Assert.Contains(result.Files, f => f.Path.EndsWith("PeoplePage.cs", StringComparison.Ordinal));
         Assert.Contains("[Route(\"/people\")]", File(result, "PeoplePage.cs"), StringComparison.Ordinal);

--- a/tests/Rask.Cli.Tests/FeatureSpecParserTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureSpecParserTests.cs
@@ -1,0 +1,298 @@
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+public sealed class FeatureSpecParserTests
+{
+    private static FeatureSpec Parse(params string[] tokens)
+    {
+        Assert.True(FeatureSpecParser.TryParse("Post", null, tokens, out var spec, out var error), error);
+        return spec;
+    }
+
+    private static string Error(params string[] tokens)
+    {
+        Assert.False(FeatureSpecParser.TryParse("Post", null, tokens, out _, out var error));
+        Assert.NotNull(error);
+        return error!;
+    }
+
+    // ---- the no-relationship case is exactly what it was before the grammar grew ----
+
+    [Fact]
+    public void A_feature_with_no_relationships_is_just_a_root()
+    {
+        var spec = Parse("Title:string", "Views:int");
+
+        Assert.Empty(spec.Relationships);
+        Assert.Equal("Post", spec.Root.Name);
+        Assert.Equal("Posts", spec.Root.Plural);
+        Assert.Equal(["Title", "Views"], spec.Root.Fields.Select(f => f.Name));
+    }
+
+    // ---- segmenting ----
+
+    [Fact]
+    public void Fields_bind_to_the_segment_that_precedes_them()
+    {
+        var spec = Parse("Title:string", "1:n", "Comment", "Body:string", "Author:string");
+
+        Assert.Equal(["Title"], spec.Root.Fields.Select(f => f.Name));
+        var comment = Assert.Single(spec.Relationships).To;
+        Assert.Equal("Comment", comment.Name);
+        Assert.Equal(["Body", "Author"], comment.Fields.Select(f => f.Name));
+    }
+
+    [Fact]
+    public void Every_relationship_attaches_to_the_root_segments_do_not_chain()
+    {
+        // `Post 1:n Comment n:1 Author` means Author is POST's author — not Comment's.
+        var spec = Parse("Title:string", "1:n", "Comment", "Body:string", "n:1", "Author", "Name:string");
+
+        Assert.Equal(2, spec.Relationships.Count);
+        Assert.All(spec.Relationships, r => Assert.Equal("Post", r.From.Name));
+        Assert.Equal(["Comment", "Author"], spec.Relationships.Select(r => r.To.Name));
+    }
+
+    [Fact]
+    public void The_root_and_every_target_are_entities()
+    {
+        var spec = Parse("Title:string", "1:n", "Comment", "Body:string", "n:n", "Tag", "Name:string");
+
+        Assert.Equal(["Post", "Comment", "Tag"], spec.Entities.Select(e => e.Name));
+    }
+
+    // ---- cardinality tokens ----
+
+    // Cardinality is internal, so the shape travels as its member name rather than the enum itself.
+    [Theory]
+    [InlineData("1:n", nameof(Cardinality.OneToMany), false)]
+    [InlineData("0:n", nameof(Cardinality.OneToMany), true)]
+    [InlineData("n:1", nameof(Cardinality.ManyToOne), false)]
+    [InlineData("n:0", nameof(Cardinality.ManyToOne), true)]
+    [InlineData("1:1", nameof(Cardinality.OneToOne), false)]
+    [InlineData("0:1", nameof(Cardinality.OneToOne), true)]
+    [InlineData("n:n", nameof(Cardinality.ManyToMany), false)]
+    public void Each_cardinality_token_maps_to_a_shape_and_a_nullability(string token, string cardinality, bool isOptional)
+    {
+        var relationship = Assert.Single(Parse("Title:string", token, "Tag", "Name:string").Relationships);
+
+        Assert.Equal(cardinality, relationship.Cardinality.ToString());
+        Assert.Equal(isOptional, relationship.IsOptional);
+        Assert.Equal(token, relationship.Token);
+    }
+
+    [Theory]
+    [InlineData("1:N")]
+    [InlineData("N:1")]
+    [InlineData("N:N")]
+    public void Cardinality_tokens_are_case_insensitive(string token) =>
+        Assert.Single(Parse("Title:string", token, "Tag", "Name:string").Relationships);
+
+    // ---- which side owns the key ----
+
+    [Fact]
+    public void One_to_many_puts_the_foreign_key_on_the_target()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "1:n", "Comment", "Body:string").Relationships);
+
+        Assert.Equal("Post", relationship.Principal.Name);
+        Assert.Equal("Comment", relationship.Dependent.Name);
+        Assert.Equal("PostId", relationship.ForeignKeyName);
+    }
+
+    [Fact]
+    public void Many_to_one_flips_it_the_root_owns_the_foreign_key()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "n:1", "Category", "Name:string").Relationships);
+
+        Assert.Equal("Category", relationship.Principal.Name);
+        Assert.Equal("Post", relationship.Dependent.Name);
+        Assert.Equal("CategoryId", relationship.ForeignKeyName);
+    }
+
+    [Fact]
+    public void Many_to_many_names_a_join_entity_after_both_sides()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "n:n", "Tag", "Name:string").Relationships);
+
+        Assert.Equal("PostTag", relationship.JoinName);
+    }
+
+    // ---- generated members ----
+
+    [Fact]
+    public void One_to_many_generates_a_collection_on_the_root_and_a_key_plus_reference_on_the_target()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "1:n", "Comment", "Body:string").Relationships);
+
+        Assert.Equal(
+            [("Comment", "PostId"), ("Comment", "Post"), ("Post", "Comments")],
+            relationship.GeneratedMembers());
+    }
+
+    [Fact]
+    public void Many_to_one_generates_the_key_on_the_root_and_a_collection_on_the_target()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "n:1", "Category", "Name:string").Relationships);
+
+        Assert.Equal(
+            [("Post", "CategoryId"), ("Post", "Category"), ("Category", "Posts")],
+            relationship.GeneratedMembers());
+    }
+
+    [Fact]
+    public void One_to_one_generates_a_single_reference_on_each_side_not_a_collection()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "1:1", "Seo", "Slug:string").Relationships);
+
+        Assert.Equal(
+            [("Seo", "PostId"), ("Seo", "Post"), ("Post", "Seo")],
+            relationship.GeneratedMembers());
+    }
+
+    [Fact]
+    public void Many_to_many_generates_a_collection_on_both_sides()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "n:n", "Tag", "Name:string").Relationships);
+
+        Assert.Equal([("Post", "Tags"), ("Tag", "Posts")], relationship.GeneratedMembers());
+    }
+
+    // ---- naming ----
+
+    [Fact]
+    public void A_target_is_pluralized_automatically()
+    {
+        var relationship = Assert.Single(Parse("Title:string", "1:n", "Category", "Name:string").Relationships);
+
+        Assert.Equal("Categories", relationship.To.Plural);
+    }
+
+    [Fact]
+    public void Plural_override_applies_to_the_root_only()
+    {
+        Assert.True(FeatureSpecParser.TryParse("Person", "People", ["Name:string", "1:n", "Category", "Label:string"], out var spec, out _));
+
+        Assert.Equal("People", spec.Root.Plural);
+        Assert.Equal("Categories", spec.Relationships[0].To.Plural);
+    }
+
+    // ---- fields are scoped per entity ----
+
+    [Fact]
+    public void The_same_field_name_may_appear_on_two_entities()
+    {
+        var spec = Parse("Name:string", "1:n", "Comment", "Name:string");
+
+        Assert.Equal("Name", spec.Root.Fields[0].Name);
+        Assert.Equal("Name", spec.Relationships[0].To.Fields[0].Name);
+    }
+
+    [Fact]
+    public void A_duplicate_field_within_one_entity_is_still_rejected_and_names_it() =>
+        Assert.Contains("Duplicate field 'Body'", Error("Title:string", "1:n", "Comment", "Body:string", "Body:int"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_field_error_on_a_target_names_the_entity() =>
+        Assert.Contains("(on 'Comment')", Error("Title:string", "1:n", "Comment", "Body:wobble"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_field_error_with_no_relationships_reads_exactly_as_before() =>
+        Assert.DoesNotContain("(on '", Error("Title:wobble"), StringComparison.Ordinal);
+
+    // ---- errors ----
+
+    [Fact]
+    public void A_cardinality_at_the_end_has_no_target() =>
+        Assert.Contains("needs a target entity name after it", Error("Title:string", "1:n"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_cardinality_followed_by_a_cardinality_is_a_missing_target() =>
+        Assert.Contains("but found the cardinality 'n:1'", Error("Title:string", "1:n", "n:1", "Tag", "Name:string"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_cardinality_followed_by_a_field_is_a_missing_target() =>
+        Assert.Contains("but found the field 'Body:string'", Error("Title:string", "1:n", "Body:string"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_target_must_be_a_valid_type_name() =>
+        Assert.Contains("'2Comment' is not a valid entity name", Error("Title:string", "1:n", "2Comment", "Body:string"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_target_may_not_be_named_Id() =>
+        Assert.Contains("every entity gets an Id automatically", Error("Title:string", "1:n", "Id", "Body:string"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_target_may_not_share_the_roots_name() =>
+        Assert.Contains("can't share the root entity's name", Error("Title:string", "1:n", "Post", "Body:string"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_target_may_not_repeat() =>
+        Assert.Contains("Duplicate target 'Tag'", Error("Title:string", "1:n", "Tag", "A:string", "n:n", "Tag", "B:string"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_target_needs_at_least_one_field() =>
+        Assert.Contains("Target 'Comment' needs at least one field", Error("Title:string", "1:n", "Comment"), StringComparison.Ordinal);
+
+    [Fact]
+    public void A_root_with_no_fields_is_rejected() =>
+        Assert.Contains("At least one field is required", Error("1:n", "Comment", "Body:string"), StringComparison.Ordinal);
+
+    [Theory]
+    [InlineData("1:m")]
+    [InlineData("m:n")]
+    [InlineData("n:m")]
+    [InlineData("1:*")]
+    [InlineData("2:n")]
+    public void A_near_miss_cardinality_says_so_rather_than_blaming_the_field_name(string token)
+    {
+        var error = Error("Title:string", token, "Tag", "Name:string");
+
+        Assert.Contains($"Unknown cardinality '{token}'", error, StringComparison.Ordinal);
+        Assert.Contains("Supported: 1:n, 0:n, n:1, n:0, 1:1, 0:1, n:n", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_field_may_not_collide_with_a_generated_foreign_key() =>
+        Assert.Contains(
+            "Field 'PostId' on 'Comment' collides with the '1:n Comment' relationship's foreign key",
+            Error("Title:string", "1:n", "Comment", "PostId:guid"),
+            StringComparison.Ordinal);
+
+    [Fact]
+    public void A_field_may_not_collide_with_a_generated_navigation() =>
+        Assert.Contains(
+            "Field 'Comments' on 'Post' collides with the '1:n Comment' relationship's navigation property",
+            Error("Comments:string", "1:n", "Comment", "Body:string"),
+            StringComparison.Ordinal);
+
+    [Fact]
+    public void A_field_may_not_collide_with_a_generated_many_to_many_navigation() =>
+        Assert.Contains(
+            "Field 'Tags' on 'Post' collides with the 'n:n Tag' relationship's navigation property",
+            Error("Tags:string", "n:n", "Tag", "Name:string"),
+            StringComparison.Ordinal);
+
+    [Fact]
+    public void A_field_may_not_share_its_own_entitys_name() =>
+        Assert.Contains(
+            "Field 'Comment' can't share the entity's name 'Comment'",
+            Error("Title:string", "1:n", "Comment", "Comment:string"),
+            StringComparison.Ordinal);
+
+    [Fact]
+    public void A_join_entity_may_not_collide_with_a_real_entity() =>
+        Assert.Contains(
+            "would be named 'PostTag', which collides with the entity 'PostTag'",
+            Error("Title:string", "n:n", "Tag", "Name:string", "1:n", "PostTag", "Note:string"),
+            StringComparison.Ordinal);
+
+    [Fact]
+    public void Two_entities_may_not_share_a_plural()
+    {
+        Assert.False(FeatureSpecParser.TryParse("Post", "Comments", ["Title:string", "1:n", "Comment", "Body:string"], out _, out var error));
+
+        Assert.Contains("both use the plural 'Comments'", error!, StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -332,7 +332,53 @@ public sealed class GenerateCommandTests
         var exit = await command.ExecuteAsync(["page", "Products", "--fields", "Name:string"], CancellationToken.None);
 
         Assert.Equal(1, exit);
-        Assert.Contains("only apply to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("--fields only applies to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_feature_option_only_names_itself_not_every_feature_option()
+    {
+        var (console, _, command) = Build();
+
+        await command.ExecuteAsync(["page", "Products", "--fields", "Name:string"], CancellationToken.None);
+
+        // The message is built from what was actually passed, so it can't list flags the user never typed.
+        Assert.DoesNotContain("--outbox", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task No_restore_on_a_page_is_rejected()
+    {
+        var (console, _, command) = Build();
+
+        var exit = await command.ExecuteAsync(["page", "Dashboard", "--no-restore"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--no-restore only applies to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_relationship_is_refused_rather_than_silently_dropped()
+    {
+        var (console, fs, command) = Build();
+
+        var exit = await command.ExecuteAsync(["feature", "Post", "Title:string", "1:n", "Comment", "Body:text"], CancellationToken.None);
+
+        // The grammar lands ahead of the emitter — until it arrives, generating Post and discarding Comment
+        // would quietly lose what was asked for. Delete this test when relationship emission ships.
+        Assert.Equal(1, exit);
+        Assert.Contains("Relationships aren't generated yet", console.ErrorText, StringComparison.Ordinal);
+        Assert.DoesNotContain(fs.Files, f => f.Key.EndsWith(".cs", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task A_relationship_is_validated_before_it_is_refused()
+    {
+        var (console, _, command) = Build();
+
+        await command.ExecuteAsync(["feature", "Post", "Title:string", "1:m", "Comment", "Body:text"], CancellationToken.None);
+
+        Assert.Contains("Unknown cardinality '1:m'", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -479,7 +525,7 @@ public sealed class GenerateCommandTests
         var exit = await command.ExecuteAsync(["page", "Dashboard", "--save-defaults"], CancellationToken.None);
 
         Assert.Equal(1, exit);
-        Assert.Contains("only apply to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("--save-defaults only applies to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
     }
 
     private static (StringConsole Console, FakeFileSystem Fs, GenerateCommand Command) Build()


### PR DESCRIPTION
> **Stacked on #465** — review that first; this PR targets its branch, so the diff here is only the CLI work. Retarget to `main` once #465 merges.

## Summary

Groundwork for relationship support in `rask generate feature`. This lands the **grammar, its validation, and the spec model**. Emitting the relationships comes next — and this PR deliberately refuses them rather than pretending.

```
rask g f <Root> <field:type>... [<card> <Target> <field:type>...]...
```

`<card>` is one of `1:n` `0:n` `n:1` `n:0` `1:1` `0:1` `n:n`, where a **`0` marks the foreign key nullable**. A cardinality token opens a segment, so every field after `<card> <Target>` belongs to that target. Relationships form a **star**: each attaches to the root, and segments never chain — `Post 1:n Comment n:1 Author` means Author is *Post's* author.

### Why the tokenizer is safe

Recognising a cardinality before parsing a field steals nothing that could otherwise have parsed, because **every card token is an invalid field spec** — its type half (`n`/`1`/`0`) isn't a supported field type. The tempting "it isn't an identifier" reasoning does *not* hold: `n` in `n:1` is a perfectly valid property name. That distinction is load-bearing and is now a comment in the code.

### Relationships are refused, not silently dropped

The grammar lands ahead of the emitter. Generating the root while discarding its targets would **lose what the user asked for** — worse than not supporting it yet, especially on a repo that publishes nightly prereleases. So a relationship spec parses, validates, and then errors:

```
$ rask g f Post Title:string 1:n Comment Body:text
Relationships aren't generated yet — '1:n Comment' parses, but emitting it isn't implemented. Scaffold the entities separately for now.
```

A test pins that refusal, so enabling emission has to be deliberate. Nothing about the grammar is advertised in `--help` or the docs until it works.

All the validation is live today, though:

```
$ rask g f Post Title:string 1:m Comment Body:text
Unknown cardinality '1:m'. Supported: 1:n, 0:n, n:1, n:0, 1:1, 0:1, n:n.

$ rask g f Post Title:string 1:n Comment PostId:guid
Field 'PostId' on 'Comment' collides with the '1:n Comment' relationship's foreign key — it's generated automatically.
```

`RelationshipSpec.GeneratedMembers()` is the single source both the validator (to reject a colliding user field) and the future emitter read, so the two can't disagree about what a relationship produces.

## Also in here

- **`FeatureGenerator.Generate` took 16 positional arguments with 7 consecutive `bool`s.** Now `(project, baseDirectory, FeatureSpec, FeatureOptions)`. One `--id` governs a run, so a foreign key's type matches the key it points at *by construction* rather than by validation.
- **Fixes a live bug.** The guard keeping feature options off a page/component/job/email was a hand-kept list that had drifted from the option schema — so `--no-restore`, declared as a feature option, was **silently accepted on `rask g p Foo` and did nothing**. It now derives from the schema's own grouping, closing the drift class. The message also names only the options you passed (`--no-restore only applies to 'generate feature'.`) instead of reciting all thirteen.
- **`Usage` no longer spells out the flags** — which is how it went stale (it was missing every feature flag). `--help` renders them from the schema.
- Each segment's fields go through the existing `FieldSpecParser` as one comma-joined spec, reusing the field grammar wholesale and scoping duplicate-field detection to the entity for free. All 12 existing `FieldSpecParserTests` are untouched and green.

## Testing

- `dotnet format` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — passed (also re-run by the pre-commit hook)
- **427 CLI tests green** (376 existing + 51 new: a `FeatureSpecParserTests` suite covering every cardinality, segment binding, the star lock, `GeneratedMembers()` per shape, and each error case)
- `scripts/run-e2e-local.sh` — passed via the pre-push hook
- `.claude/skills/run-rask-cli/smoke.sh` — 20/20
- Every quoted message above was captured from the **real CLI binary**, not a unit test.

## Benchmarks

Not applicable — no render-hotpath or runtime code is touched.

## Changelog

`[Unreleased] → Fixed`, for the `--no-restore` guard. The grammar isn't announced until it emits.