### PR TITLE
fix(cli): pin the wasm auth scaffold's framework version; gate it on a local feed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,15 @@ them until tagged releases begin.
   nothing. The check now derives from the schema's own grouping, which closes the drift for good. The message
   also names only the options you actually passed (`--no-restore only applies to 'generate feature'.`) rather
   than reciting all thirteen.
+- **`rask new --template wasm --auth` scaffolded a project that couldn't build.** The wasm auth scaffold pins
+  `Microsoft.JSInterop` / `Microsoft.AspNetCore.Authorization` itself (a browser-wasm app has no
+  `Microsoft.AspNetCore.App` framework reference to supply them), but the pinned version had drifted to `10.0.9`
+  while `Rask.Wasm` — which references the same two packages — moved to `10.0.10`. That put the generated project
+  *below* its own dependency, so NuGet reported a package downgrade (`NU1605`): a warning on a plain build, and a
+  hard error under `-warnaserror`. The scaffold now pins the same version the repo does, and a test holds the two
+  in sync so they can't drift apart again. The build gate missed this because it compiled generated projects
+  against the latest *published* packages (whose deps were still `10.0.9`) rather than the ones in the same
+  commit — it now uses a local feed packed from the repo, so a break surfaces in the commit that causes it.
 - **`Rask.Outbox` now delivers nested `IOutboxEvent` types.** The source generator registers each event by
   its dot-separated display name, but `OutboxSerializerRegistry.Serialize` stored `Type.FullName` — which
   uses `+` between a nesting type and a nested type — so a nested event (a record declared inside a class)

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
@@ -48,7 +48,12 @@ internal static partial class ProjectGenerator
     // The JWT auth scaffold uses IJSRuntime (localStorage) + [AllowAnonymous]. On a browser-wasm app there's
     // no Microsoft.AspNetCore.App framework reference to supply them and the transitive compile assets from
     // Rask.Core don't flow through the published package chain, so the --auth scaffold references them directly.
-    private const string AspNetCoreFrameworkVersion = "10.0.9";
+    //
+    // This MUST match what Directory.Packages.props pins, because Rask.Wasm references the same two packages
+    // and its nuspec therefore demands `>= <that pin>`. Scaffolding a lower version puts the generated project
+    // *below* its own dependency and NuGet reports a downgrade (NU1605) — an error under -warnaserror.
+    // ProjectGeneratorTests.Wasm_auth_framework_version_matches_the_repo_pin holds the two in sync.
+    internal const string AspNetCoreFrameworkVersion = "10.0.10";
 
     // The WebAssembly SDK <PropertyGroup> — byte-identical for the standalone `wasm` template and the
     // `wasm-hosted` client project. Shared here so the two csproj builders (WasmCsproj and

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -1,17 +1,43 @@
 using System.Diagnostics;
-using Rask.Cli.Commands;
 using Rask.Cli.Scaffolding;
 
 namespace Rask.Cli.Tests;
 
 /// <summary>
 /// The build-the-output gate: generate every build-affecting flag combination and prove it actually compiles
-/// against the published Rask packages. This restores from NuGet and runs the full C# build, so it's opt-in —
-/// set <c>RASK_CLI_BUILD_E2E=1</c> to run it (matches the repo's "tests run locally, not in CI" model). The
-/// exhaustive file/shape assertions live in <see cref="ProjectGeneratorTests"/> and always run.
+/// against <b>this commit's</b> Rask packages, packed to a local feed. This packs the repo, restores, and runs
+/// the full C# build, so it's opt-in — set <c>RASK_CLI_BUILD_E2E=1</c> to run it (matches the repo's "tests run
+/// locally, not in CI" model). The exhaustive file/shape assertions live in <see cref="ProjectGeneratorTests"/>
+/// and always run.
 /// </summary>
+/// <remarks>
+/// Every case builds against the local feed rather than the latest published stable. That's the faithful
+/// contract — the CLI and the packages are released together under one tag, so a generated project pins the
+/// version of the CLI that made it — and it's what lets the gate catch a break in the same commit that
+/// introduces it instead of one release later.
+/// </remarks>
 public sealed class ProjectGeneratorBuildE2ETests
 {
+    /// <summary>
+    /// Every packable Rask package a generated project or feature can reference, packed once into a shared
+    /// feed. <c>Rask.Core</c> is deliberately absent — it is <c>IsPackable=false</c> and ships bundled inside
+    /// <c>Rask.Server</c>/<c>Rask.Wasm</c>'s <c>lib/</c>, so packing it would produce nothing to restore.
+    /// </summary>
+    private static readonly string[] FeedPackages =
+    [
+        "Rask.Server",                      // server template
+        "Rask.Wasm",                        // wasm + wasm-hosted templates
+        "Rask.Wasm.Hosting",                // wasm-hosted template
+        "Rask.Bootstrap",                   // every template, and `generate feature --bs`
+        "Rask.Cqrs",                        // server template --cqrs, and every generated feature
+        "Rask.Data",                        // every generated feature
+        "Rask.Outbox",                      // generate feature --outbox
+        "Rask.Validation.DataAnnotations",  // generate feature --validation dataannotations
+        "Rask.Validation.FluentValidation", // generate feature --validation fluent
+    ];
+
+    // Packed once and shared across every case (packing nine projects is the expensive part of this gate).
+    private static readonly Lazy<Task<(string Feed, string Version)>> LocalFeed = new(PackLocalFeedAsync);
     // docker doesn't affect the build (just adds Dockerfile/.dockerignore), so the 3 build-relevant flags
     // give 2³ = 8 combinations — every scenario, per the "test every scenario" directive.
     public static IEnumerable<object[]> BuildAffectingCombinations()
@@ -37,12 +63,12 @@ public sealed class ProjectGeneratorBuildE2ETests
             name = "E2ENone";
         }
 
+        var (feed, version) = await LocalFeed.Value;
+
         var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(temp, name);
         try
         {
-            // Pin the latest published stable so restore resolves (the running test build is a prerelease).
-            var version = NewCommand.ResolvePackageVersion(cliVersion: "0.0.0");
             var result = ProjectGenerator.GenerateServer(projectDir, name, auth, pwa, cqrs, docker: false, version);
 
             var fs = new SystemFileSystem();
@@ -52,8 +78,10 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            var exit = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[auth={auth},pwa={pwa},cqrs={cqrs}] generated project failed to build.");
+            WriteNuGetConfig(fs, projectDir, feed);
+
+            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa},cqrs={cqrs}] generated project failed to build.{Diagnostics(output)}");
         }
         finally
         {
@@ -85,11 +113,12 @@ public sealed class ProjectGeneratorBuildE2ETests
             name = "WE2ENone";
         }
 
+        var (feed, version) = await LocalFeed.Value;
+
         var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(temp, name);
         try
         {
-            var version = NewCommand.ResolvePackageVersion(cliVersion: "0.0.0");
             var result = ProjectGenerator.GenerateWasm(projectDir, name, auth, pwa, docker: false, version);
 
             var fs = new SystemFileSystem();
@@ -99,20 +128,16 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            var exit = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm project failed to build.");
+            WriteNuGetConfig(fs, projectDir, feed);
+
+            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm project failed to build.{Diagnostics(output)}");
         }
         finally
         {
             TryDeleteDirectory(temp);
         }
     }
-
-    // wasm-hosted is a three-project solution referencing Rask.Wasm.Hosting, whose fix for the unpublishable
-    // Rask.Core nuspec dep isn't in a published stable yet — so, unlike server/wasm, it can't restore from
-    // NuGet. Build it against a local feed packed from THIS repo instead (also a stronger test: it exercises
-    // the current package output, not a stale published one). The feed is packed once and shared across cases.
-    private static readonly Lazy<Task<(string Feed, string Version)>> LocalFeed = new(PackLocalFeedAsync);
 
     [Theory]
     [MemberData(nameof(WasmBuildAffectingCombinations))]
@@ -135,7 +160,6 @@ public sealed class ProjectGeneratorBuildE2ETests
         var projectDir = Path.Combine(temp, name);
         try
         {
-            // Pin the locally-packed version so restore resolves against the feed (with the fix in it).
             var result = ProjectGenerator.GenerateWasmHosted(projectDir, name, auth, pwa, docker: false, version);
 
             var fs = new SystemFileSystem();
@@ -145,21 +169,10 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            // Local feed first (has the fixed packages), NuGet for the framework/Microsoft.* deps.
-            fs.WriteAllText(Path.Combine(projectDir, "nuget.config"),
-                $"""
-                <?xml version="1.0" encoding="utf-8"?>
-                <configuration>
-                  <packageSources>
-                    <clear/>
-                    <add key="local" value="{feed}"/>
-                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
-                  </packageSources>
-                </configuration>
-                """);
+            WriteNuGetConfig(fs, projectDir, feed);
 
-            var exit = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".sln")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm-hosted solution failed to build.");
+            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".sln")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm-hosted solution failed to build.{Diagnostics(output)}");
         }
         finally
         {
@@ -167,25 +180,42 @@ public sealed class ProjectGeneratorBuildE2ETests
         }
     }
 
-    // Pack the three Rask packages wasm-hosted references to a temp feed and return (feedDir, packedVersion).
+    /// <summary>Packs <see cref="FeedPackages"/> to a temp feed; returns its directory and the packed version.</summary>
     private static async Task<(string Feed, string Version)> PackLocalFeedAsync()
     {
         var repoRoot = FindRepoRoot();
         var feed = Path.Combine(Path.GetTempPath(), "rask-cli-e2e-feed", Guid.NewGuid().ToString("N"));
         Directory.CreateDirectory(feed);
 
-        foreach (var project in new[] { "Rask.Wasm", "Rask.Bootstrap", "Rask.Wasm.Hosting" })
+        foreach (var project in FeedPackages)
         {
             var csproj = Path.Combine(repoRoot, "src", project, project + ".csproj");
-            var exit = await RunDotnet($"pack \"{csproj}\" -c Release -o \"{feed}\" -m:1");
-            Assert.True(exit == 0, $"failed to pack {project} for the wasm-hosted build gate.");
+            var (exit, output) = await RunDotnet($"pack \"{csproj}\" -c Release -o \"{feed}\" -m:1");
+            Assert.True(exit == 0, $"failed to pack {project} for the build gate.{Diagnostics(output)}");
         }
 
-        // Read the packed version off the nupkg filename (MinVer stamps a prerelease off the current commit).
-        var nupkg = Directory.GetFiles(feed, "Rask.Wasm.Hosting.*.nupkg").Single();
-        var version = Path.GetFileNameWithoutExtension(nupkg)["Rask.Wasm.Hosting.".Length..];
+        // Read the packed version off a nupkg filename (MinVer stamps a prerelease off the current commit).
+        // Every project packs at the same version, so any one of them answers for the set — Rask.Server is
+        // used because no other package's id starts with it (Rask.Wasm.* would match two).
+        var nupkg = Directory.GetFiles(feed, "Rask.Server.*.nupkg").Single();
+        var version = Path.GetFileNameWithoutExtension(nupkg)["Rask.Server.".Length..];
         return (feed, version);
     }
+
+    // Local feed first (this commit's packages), nuget.org for the framework/Microsoft.* deps.
+    private static void WriteNuGetConfig(SystemFileSystem fs, string projectDir, string feed) =>
+        fs.WriteAllText(
+            Path.Combine(projectDir, "nuget.config"),
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear/>
+                <add key="local" value="{feed}"/>
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
+              </packageSources>
+            </configuration>
+            """);
 
     private static string FindRepoRoot()
     {
@@ -200,7 +230,7 @@ public sealed class ProjectGeneratorBuildE2ETests
         throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
     }
 
-    private static async Task<int> RunDotnet(string arguments)
+    private static async Task<(int Exit, string Output)> RunDotnet(string arguments)
     {
         var psi = new ProcessStartInfo("dotnet", arguments)
         {
@@ -215,13 +245,24 @@ public sealed class ProjectGeneratorBuildE2ETests
         var stderr = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
 
-        if (process.ExitCode != 0)
-        {
-            Console.Error.WriteLine(stdout);
-            Console.Error.WriteLine(stderr);
-        }
+        return (process.ExitCode, stdout + stderr);
+    }
 
-        return process.ExitCode;
+    /// <summary>
+    /// The child process's diagnostics, folded into the assertion message. xUnit reports the message but not
+    /// the child's console, so without this a failure says only *that* the build broke — never why.
+    /// </summary>
+    private static string Diagnostics(string output)
+    {
+        var errors = output
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r'))
+            .Where(l => l.Contains(": error ", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .Take(15)
+            .ToArray();
+
+        return "\n" + string.Join("\n", errors.Length > 0 ? errors : output.Split('\n').TakeLast(20));
     }
 
     private static void TryDeleteDirectory(string path)

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Rask.Cli.Scaffolding;
 
 namespace Rask.Cli.Tests;
@@ -598,5 +599,37 @@ public sealed class ProjectGeneratorTests
             Assert.DoesNotContain("Company.RaskServer", content, StringComparison.Ordinal);
             Assert.DoesNotContain("Company.RaskServer", path, StringComparison.Ordinal);
         }
+    }
+
+    /// <summary>
+    /// The wasm <c>--auth</c> scaffold pins Microsoft.JSInterop / Microsoft.AspNetCore.Authorization itself.
+    /// Rask.Wasm references the same two packages, so its nuspec demands <c>&gt;=</c> whatever
+    /// Directory.Packages.props pins — scaffolding anything lower puts the generated project below its own
+    /// dependency, which NuGet reports as a downgrade (NU1605) and <c>-warnaserror</c> turns into a failed
+    /// build. The two drifted apart once already (10.0.9 vs 10.0.10); this keeps them married.
+    /// </summary>
+    [Theory]
+    [InlineData("Microsoft.JSInterop")]
+    [InlineData("Microsoft.AspNetCore.Authorization")]
+    public void Wasm_auth_framework_version_matches_the_repo_pin(string package)
+    {
+        var props = File.ReadAllText(Path.Combine(FindRepoRoot(), "Directory.Packages.props"));
+        var match = Regex.Match(props, $"""<PackageVersion\s+Include="{Regex.Escape(package)}"\s+Version="([^"]+)"\s*/>""");
+
+        Assert.True(match.Success, $"{package} is not pinned in Directory.Packages.props.");
+        Assert.Equal(ProjectGenerator.AspNetCoreFrameworkVersion, match.Groups[1].Value);
+    }
+
+    private static string FindRepoRoot()
+    {
+        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return dir;
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
     }
 }


### PR DESCRIPTION
> **Stacked on #468** (which is stacked on #465). Review those first; this PR targets #468's branch, so the diff here is only the gate + the bug it found. Retarget as the stack merges.

## The bug

**`rask new --template wasm --auth` scaffolds a project that doesn't build.**

The wasm auth scaffold pins `Microsoft.JSInterop` / `Microsoft.AspNetCore.Authorization` itself — a browser-wasm app has no `Microsoft.AspNetCore.App` framework reference to supply them. That pin had drifted to `10.0.9` while `Directory.Packages.props` moved to `10.0.10`, and `Rask.Wasm` references the same two packages, so its nuspec demands `>= 10.0.10`.

The generated project therefore pins itself **below its own dependency**:

```
error NU1605: Detected package downgrade: Microsoft.AspNetCore.Authorization from 10.0.10 to 10.0.9
  WE2EA -> Rask.Wasm 0.18.1-alpha.0.27 -> Microsoft.AspNetCore.Authorization (>= 10.0.10)
  WE2EA -> Microsoft.AspNetCore.Authorization (>= 10.0.9)
```

A warning on a plain `dotnet build`; a **hard error** under `-warnaserror`, which this repo's own conventions encourage.

**Fix:** the constant now matches the repo's pin, and a test parses `Directory.Packages.props` and asserts they agree — so they can't drift apart silently again. The build gate is opt-in, so it can't be the guard; this test always runs.

## Why the gate was blind to it

`Generated_server_project_builds` and `Generated_wasm_project_builds` pinned `NewCommand.ResolvePackageVersion("0.0.0")` — the latest **published** stable. So they compiled *current* generator output against a *stale released* package, whose deps were still `10.0.9`. No downgrade existed there. **Any break between the generator and the packages of the same commit was invisible by construction.**

All three cases now build against a local feed packed from this repo. That's also the faithful contract: the CLI and the packages ship together under one tag, so a generated project pins the version of the CLI that made it. Only the wasm-hosted case did this before — and its own comment already conceded it was *"a stronger test: it exercises the current package output, not a stale published one."*

The feed generalises to every packable Rask package a generated project or feature can reference (nine, each annotated with the flag that pulls it in) — which is also the infrastructure the relationship-emission gate will need.

`Rask.Core` is **deliberately absent**: it's `IsPackable=false` and ships bundled inside `Rask.Server`/`Rask.Wasm`'s `lib/net10.0/` via `PrivateAssets="all"`, so packing it would produce nothing to restore.

## The gate couldn't say why it failed

`RunDotnet` wrote the compiler's output to `Console.Error`, which xUnit never surfaces — so a failure reported only *that* the build broke, never what broke. The diagnostics now fold into the assertion message. That's the only reason the `NU1605` above was visible at all; a build gate that can't name the error is barely a gate.

## Testing

- **Build gate: 16/16** (`RASK_CLI_BUILD_E2E=1`) — was **13/16**; the three `auth: True` failures were exactly this bug, and they pass with the fix.
- 429 always-on CLI tests green (+2: the new drift guard, one per package).
- `dotnet format whitespace --verify-no-changes` — clean (the gate `.githooks/pre-commit` enforces).
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors.
- `scripts/run-unit-local.sh` — passed (also re-run by the pre-commit hook).
- `scripts/run-e2e-local.sh` — passed via the pre-push hook.

## Benchmarks

Not applicable — no render-hotpath or runtime code is touched.

## Changelog

`[Unreleased] → Fixed`, covering both the scaffold pin and why the gate missed it.