### PR TITLE
refactor(example): migrate the showcase onto BsRow/BsCol/BsStack

### DIFF
--- a/samples/Rask.Example.Shared/Features/AssetLoading/JsOnlyDemo.cs
+++ b/samples/Rask.Example.Shared/Features/AssetLoading/JsOnlyDemo.cs
@@ -13,7 +13,7 @@ public sealed class JsOnlyDemo(IJSRuntime js) : Component
     private string _clicks = "0";
 
     protected override Component? Render() =>
-        Div(Class: "d-flex align-items-center gap-3")[
+        BsStack(Gap: 3, Align: BsAlign.Center)[
             BsButton(Color: BsColor.Primary, Outline: true, Class: "js-only-btn", OnClickAsync: HandleClickAsync)[
                 "Click to bump (via scoped JS)"],
             Span(Class: "text-secondary")["Bumped ", Strong()[_clicks], " times"]

--- a/samples/Rask.Example.Shared/Features/BackgroundService/BackgroundMetricsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/BackgroundService/BackgroundMetricsDemo.cs
@@ -6,11 +6,11 @@ namespace Rask.Example.Shared.Features;
 public sealed class BackgroundMetricsDemo : Component
 {
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-lg-5")[
+        BsRow(Gutter: 4)[
+            BsCol(Lg: 5)[
                 MetricsGauge()
             ],
-            Div(Class: "col-lg-7")[
+            BsCol(Lg: 7)[
                 MetricsChart()
             ]
         ];

--- a/samples/Rask.Example.Shared/Features/BackgroundService/MetricsGauge.cs
+++ b/samples/Rask.Example.Shared/Features/BackgroundService/MetricsGauge.cs
@@ -29,12 +29,12 @@ public sealed class MetricsGauge(IMetricsFeed feed) : Component
         var s = feed.State.Current;
         return BsCard(Class: Bs.Join(Shadow.Sm, Border.None, Sizing.H(100)))[
             BsCardBody()[
-                Div(Class: "d-flex align-items-baseline justify-content-between mb-3")[
+                BsStack(Justify: BsJustify.Between, Align: BsAlign.Baseline, Class: Margin.Bottom(3))[
                     H3(Class: "h6 text-secondary text-uppercase small mb-0")["System metrics"],
                     BsBadge(Color: BsColor.Secondary, Pill: true, Id: "metrics-tick")[
                         $"tick {s.Tick.ToString(Inv)}"]
                 ],
-                Div(Class: "row text-center g-3")[
+                BsRow(Gutter: 3, Class: Txt.Center())[
                     Stat("CPU", $"{s.CpuPercent.ToString("0.0", Inv)}%", "metrics-cpu"),
                     Stat("Active jobs", s.ActiveJobs.ToString(Inv), "metrics-jobs")
                 ],
@@ -46,7 +46,7 @@ public sealed class MetricsGauge(IMetricsFeed feed) : Component
     }
 
     private static Component Stat(string label, string value, string id) =>
-        Div(Class: "col-6")[
+        BsCol(Span: 6)[
             Div(Class: "fs-3 fw-bold", Id: id)[value],
             Div(Class: "text-secondary small")[label]
         ];

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsBreadcrumbDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsBreadcrumbDemo.cs
@@ -6,7 +6,7 @@ namespace Rask.Example.Shared.Features;
 public sealed class BsBreadcrumbDemo : Component
 {
     protected override Component? Render() =>
-        Div(Class: "d-flex flex-column gap-3")[
+        BsStack(Vertical: true, Gap: 3)[
             BsBreadcrumb()[
                 BsBreadcrumbItem(Href: "#")["Home"],
                 BsBreadcrumbItem(Href: "#")["Library"],

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsCardsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsCardsDemo.cs
@@ -5,8 +5,8 @@ namespace Rask.Example.Shared.Features;
 public sealed class BsCardsDemo : Component
 {
     protected override Component? Render() =>
-        Div(Class: "row g-3")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 3)[
+            BsCol(Md: 6)[
                 BsCard()[
                     BsCardBody()[
                         BsCardTitle()["Card title"],
@@ -16,7 +16,7 @@ public sealed class BsCardsDemo : Component
                     ]
                 ]
             ],
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 BsCard(Color: BsColor.Dark)[
                     BsCardHeader()["Featured"],
                     BsCardBody()[

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsListGroupDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsListGroupDemo.cs
@@ -6,8 +6,8 @@ namespace Rask.Example.Shared.Features;
 public sealed class BsListGroupDemo : Component
 {
     protected override Component? Render() =>
-        Div(Class: "row g-3")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 3)[
+            BsCol(Md: 6)[
                 BsListGroup()[
                     BsListGroupItem(Active: true)["Active item"],
                     BsListGroupItem()["A second item"],
@@ -16,7 +16,7 @@ public sealed class BsListGroupDemo : Component
                     BsListGroupItem(Href: "#")["A linked action item"]
                 ]
             ],
-            Div(Class: "col-md-6 d-flex flex-column gap-3")[
+            BsCol(Md: 6, Class: Bs.Join(Display.Flex(), Flex.Column(), Flex.Gap(3)))[
                 BsListGroup(Numbered: true)[
                     BsListGroupItem()["First"],
                     BsListGroupItem()["Second"],

--- a/samples/Rask.Example.Shared/Features/Bootstrap/BsPlaceholderDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Bootstrap/BsPlaceholderDemo.cs
@@ -6,8 +6,8 @@ namespace Rask.Example.Shared.Features;
 public sealed class BsPlaceholderDemo : Component
 {
     protected override Component? Render() =>
-        Div(Class: "row g-3")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 3)[
+            BsCol(Md: 6)[
                 BsCard()[
                     BsCardBody()[
                         BsCardTitle()[BsPlaceholder(Col: 6, Animation: BsPlaceholderAnimation.Glow)],
@@ -21,7 +21,7 @@ public sealed class BsPlaceholderDemo : Component
                     ]
                 ]
             ],
-            Div(Class: "col-md-6 d-flex flex-column gap-2")[
+            BsCol(Md: 6, Class: Bs.Join(Display.Flex(), Flex.Column(), Flex.Gap(2)))[
                 BsPlaceholder(Col: 12, Color: BsColor.Primary, Animation: BsPlaceholderAnimation.Wave),
                 BsPlaceholder(Col: 8, Color: BsColor.Success, Size: BsSize.Lg, Animation: BsPlaceholderAnimation.Wave),
                 BsPlaceholder(Col: 6, Color: BsColor.Danger, Size: BsSize.Sm, Animation: BsPlaceholderAnimation.Wave)

--- a/samples/Rask.Example.Shared/Features/Browser/BatteryDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/BatteryDemo.cs
@@ -43,7 +43,7 @@ public sealed class BatteryDemo(IBattery battery) : Component, IAsyncDisposable
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "battery-read", OnClickAsync: Read)[
                         "Read now"]
                 ],

--- a/samples/Rask.Example.Shared/Features/Browser/CryptoDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/CryptoDemo.cs
@@ -14,7 +14,7 @@ public sealed class CryptoDemo(ICrypto crypto) : Component
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     Button(Class: "btn btn-outline-primary btn-sm", Id: "crypto-uuid", OnClickAsync: Uuid)["Random UUID"],
                     Button(Class: "btn btn-outline-primary btn-sm", Id: "crypto-bytes", OnClickAsync: Bytes)[
                         "Random bytes"]

--- a/samples/Rask.Example.Shared/Features/Browser/DeviceSensorsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/DeviceSensorsDemo.cs
@@ -71,15 +71,15 @@ public sealed class DeviceSensorsDemo(IDeviceOrientation orientation, IDeviceMot
             Div(Class: "card-body")[
                 Button(Class: "btn btn-sm btn-primary mb-3", Id: "sensor-start", OnClickAsync: Start)["Start"],
                 Div(Class: "small text-secondary mb-2")["Status: ", Code(Id: "sensor-status")[_status]],
-                Div(Class: "row g-3")[
-                    Div(Class: "col-sm-6")[
+                BsRow(Gutter: 3)[
+                    BsCol(Sm: 6)[
                         Div(Class: "fw-semibold small mb-1")["Orientation (°)"],
                         Div(Class: "small text-secondary")[
                             "α ", Code(Id: "sensor-alpha")[Fmt(_tilt?.Alpha)],
                             " · β ", Code(Id: "sensor-beta")[Fmt(_tilt?.Beta)],
                             " · γ ", Code(Id: "sensor-gamma")[Fmt(_tilt?.Gamma)]]
                     ],
-                    Div(Class: "col-sm-6")[
+                    BsCol(Sm: 6)[
                         Div(Class: "fw-semibold small mb-1")["Acceleration (m/s²)"],
                         Div(Class: "small text-secondary")[
                             "x ", Code(Id: "sensor-ax")[Fmt(_accel?.AccelerationX)],

--- a/samples/Rask.Example.Shared/Features/Browser/FileSystemAccessDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/FileSystemAccessDemo.cs
@@ -16,7 +16,7 @@ public sealed class FileSystemAccessDemo(IFileSystemAccess files) : Component, I
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     Button(Class: "btn btn-primary btn-sm", Id: "fs-open", OnClickAsync: Open)[
                         I(Class: "bi bi-folder2-open me-1"), "Open file"],
                     Button(Class: "btn btn-outline-primary btn-sm", Id: "fs-save", Disabled: _handle is null,

--- a/samples/Rask.Example.Shared/Features/Browser/GeolocationWatchDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/GeolocationWatchDemo.cs
@@ -19,7 +19,7 @@ public sealed class GeolocationWatchDemo(IGeolocation geolocation) : Component, 
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     _watch is null
                         ? Button(Class: "btn btn-primary btn-sm", Id: "geowatch-start", OnClickAsync: Start)[
                             "Start watching"]

--- a/samples/Rask.Example.Shared/Features/Browser/GestureBridgeDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/GestureBridgeDemo.cs
@@ -21,7 +21,7 @@ public sealed class GestureBridgeDemo : Component
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap align-items-center mb-3")[
+                BsStack(Gap: 2, Align: BsAlign.Center, WrapItems: true, Class: Margin.Bottom(3))[
                     // Headless: we render our own buttons; the triggers just supply the gesture attribute.
                     FullscreenTrigger(g =>
                         Button(Type: "button", Class: "btn btn-primary btn-sm", Id: "fullscreen-btn", Data: g)[
@@ -44,7 +44,7 @@ public sealed class GestureBridgeDemo : Component
                         ? Span(Class: "small text-secondary")["not prompted"]
                         : Span(Class: "small")["install: ", Code(Id: "install-outcome")[_install]]
                 ],
-                Div(Class: "d-flex gap-2 flex-wrap align-items-center mb-2")[
+                BsStack(Gap: 2, Align: BsAlign.Center, WrapItems: true, Class: Margin.Bottom(2))[
                     EyeDropperTrigger(
                         OnColor: hex =>
                         {
@@ -65,7 +65,7 @@ public sealed class GestureBridgeDemo : Component
                 ],
                 // MediaCaptureTrigger fills this <video> from the camera; PictureInPictureTrigger then pops
                 // that same element out — both resolve the element from its ElementRef.
-                Div(Class: "d-flex gap-2 flex-wrap align-items-center")[
+                BsStack(Gap: 2, Align: BsAlign.Center, WrapItems: true)[
                     MediaCaptureTrigger(For: _preview, Video: true, FacingMode: "user",
                         Template: g =>
                             Button(Type: "button", Class: "btn btn-outline-secondary btn-sm", Id: "camera-btn",

--- a/samples/Rask.Example.Shared/Features/Browser/IndexedDbDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/IndexedDbDemo.cs
@@ -20,14 +20,14 @@ public sealed class IndexedDbDemo(IIndexedDb indexedDb) : Component
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "row g-2 mb-2")[
-                    Div(Class: "col-sm-4")[
+                BsRow(Gutter: 2, Class: Margin.Bottom(2))[
+                    BsCol(Sm: 4)[
                         Input(Id: "idb-key", Class: "form-control form-control-sm", Value: _key, OnInput: v => _key = v)],
-                    Div(Class: "col-sm-8")[
+                    BsCol(Sm: 8)[
                         Input(Id: "idb-value", Class: "form-control form-control-sm", Value: _value,
                             OnInput: v => _value = v)]
                 ],
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     Button(Class: "btn btn-primary btn-sm", Id: "idb-set", OnClickAsync: Set)["Set"],
                     Button(Class: "btn btn-outline-primary btn-sm", Id: "idb-get", OnClickAsync: Get)["Get"],
                     Button(Class: "btn btn-outline-secondary btn-sm", Id: "idb-keys", OnClickAsync: Keys)["List keys"],

--- a/samples/Rask.Example.Shared/Features/Browser/IntersectionObserverDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/IntersectionObserverDemo.cs
@@ -34,7 +34,7 @@ public sealed class IntersectionObserverDemo(IIntersectionObserver observer) : C
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex align-items-center gap-2 mb-2")[
+                BsStack(Gap: 2, Align: BsAlign.Center, Class: Margin.Bottom(2))[
                     Span(Class: _visible ? "badge text-bg-success" : "badge text-bg-secondary", Id: "io-status")[
                         _visible ? "in view" : "out of view"],
                     Span(Class: "small text-secondary", Id: "io-changes")[$"{_changes} change(s)"]

--- a/samples/Rask.Example.Shared/Features/Browser/MediaSessionDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/MediaSessionDemo.cs
@@ -56,7 +56,7 @@ public sealed class MediaSessionDemo(IMediaSession media) : Component, IAsyncDis
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex flex-wrap gap-2 mb-3")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(3))[
                     Button(Class: "btn btn-sm btn-primary", Id: "ms-publish", OnClickAsync: Publish)["Publish metadata"],
                     Button(Class: "btn btn-sm btn-outline-primary", Id: "ms-playing",
                         OnClickAsync: () => SetState(PlaybackState.Playing, "playing"))["Mark playing"],

--- a/samples/Rask.Example.Shared/Features/Browser/MutationObserverDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/MutationObserverDemo.cs
@@ -48,7 +48,7 @@ public sealed class MutationObserverDemo(IMutationObserver observer) : Component
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex flex-wrap gap-2 mb-3")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(3))[
                     Button(Class: "btn btn-sm btn-primary", Id: "mo-add", OnClick: () => _items++)["Add item"],
                     Button(Class: "btn btn-sm btn-outline-primary", Id: "mo-remove",
                         OnClick: () => { if (_items > 0) _items--; })["Remove item"],

--- a/samples/Rask.Example.Shared/Features/Browser/NotificationsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/NotificationsDemo.cs
@@ -14,7 +14,7 @@ public sealed class NotificationsDemo(INotifications notifications, IBadge badge
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "notif-permission",
                         OnClickAsync: RequestPermission)["Request permission"],
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "notif-show",

--- a/samples/Rask.Example.Shared/Features/Browser/PermissionsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/PermissionsDemo.cs
@@ -15,7 +15,7 @@ public sealed class PermissionsDemo(IPermissions permissions) : Component
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "perm-geo", OnClickAsync: QueryGeo)[
                         "Query geolocation"],
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "perm-clip", OnClickAsync: QueryClipboard)[

--- a/samples/Rask.Example.Shared/Features/Browser/ShareDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/ShareDemo.cs
@@ -14,7 +14,7 @@ public sealed class ShareDemo : Component
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     // Headless: we render our own button; Shareable just supplies the share attribute.
                     Shareable(
                         new ShareData

--- a/samples/Rask.Example.Shared/Features/Browser/SpeechDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/SpeechDemo.cs
@@ -16,7 +16,7 @@ public sealed class SpeechDemo(ISpeechSynthesis speech) : Component
                     Class: "form-control form-control-sm mb-2",
                     Value: _text,
                     OnInput: v => _text = v),
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "speech-speak", OnClickAsync: Speak)["Speak"],
                     BsButton(Color: BsColor.Danger, Outline: true, Size: BsSize.Sm, Id: "speech-cancel", OnClickAsync: Cancel)["Stop"]
                 ],

--- a/samples/Rask.Example.Shared/Features/Browser/SpeechRecognitionDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/SpeechRecognitionDemo.cs
@@ -21,7 +21,7 @@ public sealed class SpeechRecognitionDemo(ISpeechRecognition recognition) : Comp
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "speech-recognize-start",
                         Disabled: Listening, OnClickAsync: Start)["Start listening"],
                     BsButton(Color: BsColor.Danger, Outline: true, Size: BsSize.Sm, Id: "speech-recognize-stop",

--- a/samples/Rask.Example.Shared/Features/Browser/VibrationDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/VibrationDemo.cs
@@ -10,7 +10,7 @@ public sealed class VibrationDemo(IVibration vibration) : Component
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "vibrate-buzz", OnClickAsync: Buzz)["Buzz"],
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "vibrate-pattern", OnClickAsync: Pattern)[
                         "Pattern"],

--- a/samples/Rask.Example.Shared/Features/Browser/WebAuthnDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/WebAuthnDemo.cs
@@ -49,7 +49,7 @@ public sealed class WebAuthnDemo(IWebAuthn webAuthn) : Component
     protected override Component? Render() =>
         Div(Class: "card shadow-sm border-0")[
             Div(Class: "card-body")[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     Button(Class: "btn btn-primary btn-sm", Id: "webauthn-create", OnClickAsync: Create)[
                         I(Class: "bi bi-fingerprint me-1"), "Create passkey"],
                     Button(Class: "btn btn-outline-primary btn-sm", Id: "webauthn-auth",

--- a/samples/Rask.Example.Shared/Features/Browser/WebLocksDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/WebLocksDemo.cs
@@ -18,7 +18,7 @@ public sealed class WebLocksDemo(IWebLocks locks) : Component
     protected override Component? Render() =>
         BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex gap-2 flex-wrap mb-2")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(2))[
                     BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "locks-hold", OnClickAsync: Hold)[
                         "Hold exclusive for 2s"],
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "locks-try", OnClickAsync: TryHold)[

--- a/samples/Rask.Example.Shared/Features/Cancellation/CancellationDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Cancellation/CancellationDemo.cs
@@ -11,7 +11,7 @@ public sealed class CancellationDemo : Component
 
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "cancel-mount", Disabled: _mounted, OnClick: Mount)[BsIcon(Name: BsIconName.PlayCircle, Class: "me-1"), "Mount probe"],
                 BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "cancel-unmount", Disabled: !_mounted, OnClick: Unmount)[BsIcon(Name: BsIconName.StopCircle, Class: "me-1"), "Unmount probe"]
             ],

--- a/samples/Rask.Example.Shared/Features/Cancellation/CancellationProbe.cs
+++ b/samples/Rask.Example.Shared/Features/Cancellation/CancellationProbe.cs
@@ -82,7 +82,7 @@ public sealed class CancellationProbe : Component
             _ => "badge text-bg-secondary"
         };
 
-        return Div(Class: "d-flex align-items-center gap-2")[
+        return BsStack(Gap: 2, Align: BsAlign.Center)[
             Span(Class: $"{pillClass} cancel-probe-pill")[$"#{InstanceId} {_status}"],
             Span(Class: "text-secondary small")[
                 _status == "running"

--- a/samples/Rask.Example.Shared/Features/ComponentTiers/ComponentTiersDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ComponentTiers/ComponentTiersDemo.cs
@@ -9,7 +9,7 @@ namespace Rask.Example.Shared.Features;
 public sealed class ComponentTiersDemo : Component
 {
     protected override Component? Render() =>
-        Div(Id: "component-tiers", Class: "row g-3")[
+        BsRow(Id: "component-tiers", Gutter: 3)[
             Tier("Tier 0 — static method", "Inlined markup. No instance, no state, no lifecycle.",
                 TierStaticHelperDemo()),
             Tier("Tier 1 — stateless component", "Props in → markup out. Identity + lifecycle, no fields.",
@@ -20,7 +20,7 @@ public sealed class ComponentTiersDemo : Component
 
     // A Tier-0 static helper itself — the pattern the first card describes — reused for each column.
     private static Component Tier(string title, string blurb, Component body) =>
-        Div(Class: "col-md-4")[
+        BsCol(Md: 4)[
             BsCard(Class: "h-100")[
                 BsCardBody()[
                     H6(Class: "fw-semibold mb-1")[title],

--- a/samples/Rask.Example.Shared/Features/ComponentTiers/TierStaticHelperDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ComponentTiers/TierStaticHelperDemo.cs
@@ -16,7 +16,7 @@ internal static class TierStaticHelper
 public sealed class TierStaticHelperDemo : Component
 {
     protected override Component? Render() =>
-        Div(Class: "d-flex gap-2")[
+        BsStack(Gap: 2)[
             TierStaticHelper.Badge("inlined"),
             TierStaticHelper.Badge("no state"),
             TierStaticHelper.Badge("no lifecycle")

--- a/samples/Rask.Example.Shared/Features/Context/ThemeCard.cs
+++ b/samples/Rask.Example.Shared/Features/Context/ThemeCard.cs
@@ -7,7 +7,7 @@ namespace Rask.Example.Shared.Features;
 public sealed class ThemeCard : Component
 {
     protected override Component? Render() =>
-        Div(Class: "d-flex align-items-center gap-2")[
+        BsStack(Gap: 2, Align: BsAlign.Center)[
             Span(Class: "small text-secondary")["Deeply nested, no theme prop passed in:"],
             ThemeBadge()
         ];

--- a/samples/Rask.Example.Shared/Features/Cqrs/CqrsCounterDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Cqrs/CqrsCounterDemo.cs
@@ -21,7 +21,7 @@ public sealed class CqrsCounterDemo(IDispatcher dispatcher) : Component
 
     protected override Component? Render() =>
         Div(Id: "cqrs-counter", Class: "vstack gap-3")[
-            Div(Class: "d-flex align-items-center gap-3")[
+            BsStack(Gap: 3, Align: BsAlign.Center)[
                 Span(Id: "cqrs-count", Class: "display-6 fw-semibold")[$"{_view.Count}"],
                 BsButton(Color: BsColor.Primary, Id: "cqrs-increment", OnClickAsync: IncrementAsync)["Increment"]
             ],

--- a/samples/Rask.Example.Shared/Features/Disposal/DisposableAsyncProbe.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/DisposableAsyncProbe.cs
@@ -20,7 +20,7 @@ public sealed class DisposableAsyncProbe : Component, IAsyncDisposable
     }
 
     protected override Component? Render() =>
-        Div(Class: "d-flex align-items-center gap-2")[
+        BsStack(Gap: 2, Align: BsAlign.Center)[
             BsBadge(Color: BsColor.Info, Class: "dispose-async-pill")[$"#{InstanceId} alive"],
             Span(Class: "text-secondary small")[
                 $"Mounted at {_mountedAt:HH:mm:ss.fff}. Unmount me to fire DisposeAsync()."]

--- a/samples/Rask.Example.Shared/Features/Disposal/DisposableTimerProbe.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/DisposableTimerProbe.cs
@@ -17,7 +17,7 @@ public sealed class DisposableTimerProbe : Component, IDisposable
     }
 
     protected override Component? Render() =>
-        Div(Class: "d-flex align-items-center gap-2")[
+        BsStack(Gap: 2, Align: BsAlign.Center)[
             BsBadge(Color: BsColor.Warning, Class: "dispose-probe-pill")[$"#{InstanceId} alive"],
             Span(Class: "text-secondary small")[$"Mounted at {_mountedAt:HH:mm:ss.fff}. Unmount me to fire Dispose()."]
         ];

--- a/samples/Rask.Example.Shared/Features/Disposal/DisposalAsyncDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/DisposalAsyncDemo.cs
@@ -10,7 +10,7 @@ public sealed class DisposalAsyncDemo : Component
 
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "dispose-async-mount", Disabled: _asyncMounted, OnClick: MountAsync)[BsIcon(Name: BsIconName.PlayCircle, Class: "me-1"), "Mount async probe"],
                 BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "dispose-async-unmount", Disabled: !_asyncMounted, OnClick: UnmountAsync)[BsIcon(Name: BsIconName.StopCircle, Class: "me-1"), "Unmount async probe"]
             ],

--- a/samples/Rask.Example.Shared/Features/Disposal/DisposalSyncDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/DisposalSyncDemo.cs
@@ -10,7 +10,7 @@ public sealed class DisposalSyncDemo : Component
 
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "dispose-sync-mount", Disabled: _syncMounted, OnClick: MountSync)[BsIcon(Name: BsIconName.PlayCircle, Class: "me-1"), "Mount sync probe"],
                 BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "dispose-sync-unmount", Disabled: !_syncMounted, OnClick: UnmountSync)[BsIcon(Name: BsIconName.StopCircle, Class: "me-1"), "Unmount sync probe"]
             ],

--- a/samples/Rask.Example.Shared/Features/Disposal/DisposalUnmountDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/DisposalUnmountDemo.cs
@@ -10,7 +10,7 @@ public sealed class DisposalUnmountDemo : Component
 
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "unmount-hook-mount", Disabled: _hookMounted, OnClick: MountHook)[BsIcon(Name: BsIconName.PlayCircle, Class: "me-1"), "Start ticker"],
                 BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "unmount-hook-unmount", Disabled: !_hookMounted, OnClick: UnmountHook)[BsIcon(Name: BsIconName.StopCircle, Class: "me-1"), "Stop ticker"]
             ],

--- a/samples/Rask.Example.Shared/Features/Disposal/UnmountTimerProbe.cs
+++ b/samples/Rask.Example.Shared/Features/Disposal/UnmountTimerProbe.cs
@@ -28,7 +28,7 @@ public sealed class UnmountTimerProbe : Component
     }
 
     protected override Component? Render() =>
-        Div(Class: "d-flex align-items-center gap-2")[
+        BsStack(Gap: 2, Align: BsAlign.Center)[
             BsBadge(Color: BsColor.Warning)[$"#{InstanceId} tick {_ticks}"],
             Span(Class: "text-secondary small")["Stop me to fire OnUnmount and dispose the Timer."]
         ];

--- a/samples/Rask.Example.Shared/Features/DragDrop/DragDropKanbanDemo.cs
+++ b/samples/Rask.Example.Shared/Features/DragDrop/DragDropKanbanDemo.cs
@@ -88,7 +88,7 @@ public sealed class DragDropKanbanDemo : Component
             ]);
         }
 
-        return Div(Class: "row g-3 dd-board")[cols];
+        return BsRow(Gutter: 3, Class: "dd-board")[cols];
     }
 
     private void MoveCard(DragDropMove move)

--- a/samples/Rask.Example.Shared/Features/ElementRef/ElementRefDemo.cs
+++ b/samples/Rask.Example.Shared/Features/ElementRef/ElementRefDemo.cs
@@ -21,7 +21,7 @@ public sealed class ElementRefDemo : Component
                 Class: "form-control mb-2",
                 Placeholder: "Focus me from C#",
                 Ref: _input),
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, OnClickAsync: FocusInput)["Focus the input"],
                 BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClickAsync: MeasureBox)["Measure the box"]
             ],

--- a/samples/Rask.Example.Shared/Features/Elements/ElementsFormsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Elements/ElementsFormsDemo.cs
@@ -25,16 +25,16 @@ public sealed class ElementsFormsDemo : Component
                 Textarea<string>(Id: "bio", Class: "form-control form-control-sm", Placeholder: "About you…")
             ]
         ],
-        Div(Class: "row align-items-center g-3")[
-            Div(Class: "col-auto")[
+        BsRow(Gutter: 3, Class: Flex.Align(BsAlign.Center))[
+            BsCol(Auto: true)[
                 Label(Class: "form-label small mb-1")["Progress"], Br(),
                 Progress(Value: 0.6, Max: 1.0)
             ],
-            Div(Class: "col-auto")[
+            BsCol(Auto: true)[
                 Label(Class: "form-label small mb-1")["Meter"], Br(),
                 Meter(Value: 0.8, Min: 0, Max: 1, Low: 0.2, High: 0.9, Optimum: 1)
             ],
-            Div(Class: "col-auto")[
+            BsCol(Auto: true)[
                 Label(Class: "form-label small mb-1")["Output"], Br(),
                 Output(For: "fruit")["Pear"]
             ]

--- a/samples/Rask.Example.Shared/Features/Elements/ElementsGroupingDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Elements/ElementsGroupingDemo.cs
@@ -9,18 +9,18 @@ public sealed class ElementsGroupingDemo : Component
         Blockquote(Class: "blockquote fs-6 border-start ps-3", Cite: "https://example.com")[
             "A small DSL, an honest day's HTML."],
         Hr(),
-        Div(Class: "row")[
-            Div(Class: "col")[
+        BsRow()[
+            BsCol()[
                 P(Class: "fw-semibold mb-1")["Ordered (start=2, reversed)"],
                 Ol(Class: "mb-0", Start: 2, Reversed: true)[
                     Li(Value: 2)["Second"], Li()["First-ish"], Li()["Zeroth-ish"]
                 ]
             ],
-            Div(Class: "col")[
+            BsCol()[
                 P(Class: "fw-semibold mb-1")["Unordered"],
                 Ul(Class: "mb-0")[Li()["Alpha"], Li()["Beta"], Li()["Gamma"]]
             ],
-            Div(Class: "col")[
+            BsCol()[
                 P(Class: "fw-semibold mb-1")["Description"],
                 Dl(Class: "mb-0")[
                     Dt()["Rask"], Dd(Class: "mb-1")["A C# UI framework."],

--- a/samples/Rask.Example.Shared/Features/Elements/ElementsMediaDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Elements/ElementsMediaDemo.cs
@@ -9,7 +9,7 @@ public sealed class ElementsMediaDemo : Component
     private static string Asset(string name) => LiveOptions.PathBase + "/img/" + name;
 
     protected override Component? Render() => Div(Class: "vstack gap-3")[
-        Div(Class: "d-flex flex-wrap gap-3 align-items-start")[
+        BsStack(Gap: 3, Align: BsAlign.Start, WrapItems: true)[
             Figure(Class: "figure m-0")[
                 // <picture> picks a <source> by media query, else falls back to <img>.
                 Picture()[
@@ -29,7 +29,7 @@ public sealed class ElementsMediaDemo : Component
                 Figcaption(Class: "figure-caption")["iframe (srcdoc)"]
             ]
         ],
-        Div(Class: "d-flex flex-wrap gap-3 align-items-start")[
+        BsStack(Gap: 3, Align: BsAlign.Start, WrapItems: true)[
             Figure(Class: "figure m-0")[
                 Embed(Src: Asset("rask-placeholder.svg"), Type: "image/svg+xml", Width: 96, Height: 96),
                 Figcaption(Class: "figure-caption")["embed"]
@@ -45,12 +45,12 @@ public sealed class ElementsMediaDemo : Component
                 Figcaption(Class: "figure-caption")["img usemap / map / area"]
             ]
         ],
-        Div(Class: "row g-3")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 3)[
+            BsCol(Md: 6)[
                 P(Class: "small mb-1 text-secondary")["audio (controls)"],
                 Audio(Controls: true, Preload: "none", Class: "w-100")
             ],
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 P(Class: "small mb-1 text-secondary")["video (poster + track)"],
                 Video(Controls: true, Width: 240, Poster: Asset("rask-placeholder.svg"), Preload: "none",
                     Class: "border rounded")[

--- a/samples/Rask.Example.Shared/Features/Elements/ElementsSectionsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Elements/ElementsSectionsDemo.cs
@@ -17,7 +17,7 @@ public sealed class ElementsSectionsDemo : Component
         Search(Class: "my-2")[
             Input<string>(InputType.Search, Class: "form-control form-control-sm", Placeholder: "Search…")
         ],
-        Div(Class: "row")[
+        BsRow()[
             Main(Class: "col-8")[
                 Section(Id: "a")[H2(Class: "h6")["Section heading levels"],
                     P(Class: "mb-1")["Headings ", Code()["H1"], "–", Code()["H6"], ":"],

--- a/samples/Rask.Example.Shared/Features/Events/EventsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Events/EventsDemo.cs
@@ -20,9 +20,9 @@ public sealed class EventsDemo : Component
     private static string Fmt(double d) => d.ToString("0", CultureInfo.InvariantCulture);
 
     protected override Component? Render() =>
-        Div(Class: "row g-3")[
+        BsRow(Gutter: 3)[
             // Pointer tracking pad: mousemove + enter/leave + wheel, all typed.
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Div(Class: "border rounded p-4 text-center user-select-none",
                     Style: _hovering ? "background:#eef6ff" : null,
                     OnMouseMove: e => { _x = e.OffsetX; _y = e.OffsetY; },
@@ -35,7 +35,7 @@ public sealed class EventsDemo : Component
                 ]
             ],
             // Double-click + context menu (preventDefault'd client-side so the native menu is suppressed).
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Button(Class: "btn btn-outline-primary w-100 py-4", OnDoubleClick: _ => _doubleClicks++,
                     OnContextMenu: _ => _contextMenu = !_contextMenu)[
                     "Double-click or right-click me"],
@@ -43,7 +43,7 @@ public sealed class EventsDemo : Component
                     $"double-clicks: {_doubleClicks} · context-menu toggled: {_contextMenu}"]
             ],
             // Focus / blur + keyboard on a focusable div.
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Div(Class: "border rounded p-4",
                     TabIndex: 0,
                     Style: _focused ? "outline:2px solid #0d6efd" : null,
@@ -56,7 +56,7 @@ public sealed class EventsDemo : Component
                 ]
             ],
             // Clipboard: paste into the box and read the text server-side.
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Div(Class: "border rounded p-4",
                     OnPaste: e => _pasted = e.Text)[
                     Strong()["Paste text here"],

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsCheckboxDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsCheckboxDemo.cs
@@ -12,8 +12,8 @@ public sealed class FormControlsCheckboxDemo : Component
     private readonly Model _model = new();
 
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6", Id: "fc-checkbox-controlled")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6, Id: "fc-checkbox-controlled")[
                 Label(Class: "form-label fw-semibold d-block")["Controlled (Value + OnChange)"],
                 BsCheckboxGroup<string>(
                     AllInterests,
@@ -25,7 +25,7 @@ public sealed class FormControlsCheckboxDemo : Component
                     "Interests: ", Strong()[_controlled.Count == 0 ? "none" : string.Join(", ", _controlled)]
                 ]
             ],
-            Div(Class: "col-md-6", Id: "fc-checkbox-bound")[
+            BsCol(Md: 6, Id: "fc-checkbox-bound")[
                 Label(Class: "form-label fw-semibold d-block")["Bound (two-way)"],
                 Form(_model)[
                     // Label: names the group — the options render inside a <fieldset>/<legend> for the

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsInputDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsInputDemo.cs
@@ -10,8 +10,8 @@ public sealed class FormControlsInputDemo : Component
     private readonly Model _model = new();
 
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold")["Controlled (Value + OnChange)"],
                 Input<string>(
                     Value: _controlled,
@@ -23,7 +23,7 @@ public sealed class FormControlsInputDemo : Component
                     "Echo: ", Strong()[_controlled.Length == 0 ? "(empty)" : _controlled]
                 ]
             ],
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold")["Bound (two-way)"],
                 Form(_model)[
                     Input(() => _model.Text, Class: "form-control mb-2", Placeholder: "Type…",

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsMultiSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsMultiSelectDemo.cs
@@ -12,8 +12,8 @@ public sealed class FormControlsMultiSelectDemo : Component
     private readonly Model _model = new();
 
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold d-block")["Controlled (Value + OnChange)"],
                 BsMultiSelect<string>(
                     AllTopics,
@@ -25,7 +25,7 @@ public sealed class FormControlsMultiSelectDemo : Component
                     "Selected: ", Strong()[_controlled.Count == 0 ? "none" : string.Join(", ", _controlled)]
                 ]
             ],
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold d-block")["Bound (two-way)"],
                 Form(_model)[
                     BsMultiSelect(() => _model.Topics, AllTopics, Id: "fc-multiselect-bound",

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsRadioDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsRadioDemo.cs
@@ -12,8 +12,8 @@ public sealed class FormControlsRadioDemo : Component
     private readonly Model _model = new();
 
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6", Id: "fc-radio-controlled")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6, Id: "fc-radio-controlled")[
                 Label(Class: "form-label fw-semibold d-block")["Controlled (Value + OnChange)"],
                 BsRadioGroup(
                     AllPlans,
@@ -25,7 +25,7 @@ public sealed class FormControlsRadioDemo : Component
                     "Plan: ", Strong()[_controlled.ToString()]
                 ]
             ],
-            Div(Class: "col-md-6", Id: "fc-radio-bound")[
+            BsCol(Md: 6, Id: "fc-radio-bound")[
                 Label(Class: "form-label fw-semibold d-block")["Bound (two-way)"],
                 Form(_model)[
                     // Label: names the group — the options render inside a <fieldset>/<legend> for the

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsSelectDemo.cs
@@ -11,8 +11,8 @@ public sealed class FormControlsSelectDemo : Component
     private readonly Model _model = new();
 
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold")["Controlled (Value + OnChange)"],
                 Select<string>(
                     Value: _controlled,
@@ -25,7 +25,7 @@ public sealed class FormControlsSelectDemo : Component
                     "Picked: ", Strong()[_controlled]
                 ]
             ],
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold")["Bound (two-way)"],
                 Form(_model)[
                     Select(() => _model.Framework, Class: "form-select mb-2", Id: "fc-select-bound")[

--- a/samples/Rask.Example.Shared/Features/FormControls/FormControlsTextareaDemo.cs
+++ b/samples/Rask.Example.Shared/Features/FormControls/FormControlsTextareaDemo.cs
@@ -10,8 +10,8 @@ public sealed class FormControlsTextareaDemo : Component
     private readonly Model _model = new();
 
     protected override Component? Render() =>
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold")["Controlled (Value + OnChange)"],
                 Textarea<string>(
                     Value: _controlled,
@@ -24,7 +24,7 @@ public sealed class FormControlsTextareaDemo : Component
                     "Length: ", Strong()[_controlled.Length.ToString()]
                 ]
             ],
-            Div(Class: "col-md-6")[
+            BsCol(Md: 6)[
                 Label(Class: "form-label fw-semibold")["Bound (two-way)"],
                 Form(_model)[
                     Textarea(() => _model.Bio, Class: "form-control mb-2", Rows: 3, Placeholder: "Type…",

--- a/samples/Rask.Example.Shared/Features/Gantt/GanttDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Gantt/GanttDemo.cs
@@ -34,7 +34,7 @@ public sealed class GanttDemo : Component
 
     protected override Component? Render() =>
         Div(Class: "vstack gap-3")[
-            Div(Class: "d-flex flex-wrap gap-2 align-items-center")[
+            BsStack(Gap: 2, Align: BsAlign.Center, WrapItems: true)[
                 BsButtonGroup(Size: BsSize.Sm)[
                     Enum.GetValues<GanttViewMode>().Select(mode =>
                         BsButton(

--- a/samples/Rask.Example.Shared/Features/JsRuntime/JsRuntimeDemo.cs
+++ b/samples/Rask.Example.Shared/Features/JsRuntime/JsRuntimeDemo.cs
@@ -43,7 +43,7 @@ public sealed class JsRuntimeDemo(IJSRuntime js) : Component
                         Value: _input,
                         OnInput: v => _input = v)
                 ],
-                Div(Class: "d-flex gap-2 flex-wrap mb-3")[
+                BsStack(Gap: 2, WrapItems: true, Class: Margin.Bottom(3))[
                     BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "demo-set", OnClickAsync: SetAsync)[
                         BsIcon(Name: BsIconName.Save, Class: "me-1"), "Set"],
                     BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "demo-read", OnClickAsync: ReadAsync)[

--- a/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsReorderDemo.cs
+++ b/samples/Rask.Example.Shared/Features/KeyedLists/KeyedListsReorderDemo.cs
@@ -21,7 +21,7 @@ public sealed class KeyedListsReorderDemo : Component
 
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex flex-wrap align-items-center gap-2 mb-3")[
+            BsStack(Gap: 2, Align: BsAlign.Center, WrapItems: true, Class: Margin.Bottom(3))[
                 Button(
                     Class: _useKeys ? "btn btn-success btn-sm" : "btn btn-outline-secondary btn-sm",
                     Id: "kl-toggle-keys",

--- a/samples/Rask.Example.Shared/Features/Lifecycle/LifecycleCycleDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Lifecycle/LifecycleCycleDemo.cs
@@ -11,7 +11,7 @@ public sealed class LifecycleCycleDemo : Component
 
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, Id: "lifecycle-cycle-mount", Disabled: _cycleMounted, OnClick: MountCycle)[BsIcon(Name: BsIconName.PlayCircle, Class: "me-1"), "Mount probe"],
                 BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "lifecycle-cycle-unmount", Disabled: !_cycleMounted, OnClick: UnmountCycle)[BsIcon(Name: BsIconName.StopCircle, Class: "me-1"), "Unmount probe"]
             ],

--- a/samples/Rask.Example.Shared/Features/Lifecycle/LifecycleCycleProbe.cs
+++ b/samples/Rask.Example.Shared/Features/Lifecycle/LifecycleCycleProbe.cs
@@ -25,7 +25,7 @@ public sealed class LifecycleCycleProbe : Component
     }
 
     protected override Component? Render() =>
-        Div(Class: "d-flex align-items-center gap-2")[
+        BsStack(Gap: 2, Align: BsAlign.Center)[
             BsBadge(Color: BsColor.Success)[$"#{InstanceId} alive"],
             Span(Class: "text-secondary small")["Unmount me to fire OnUnmount / OnUnmountAsync."]
         ];

--- a/samples/Rask.Example.Shared/Features/Lifecycle/LifecycleProbe.cs
+++ b/samples/Rask.Example.Shared/Features/Lifecycle/LifecycleProbe.cs
@@ -27,7 +27,7 @@ public sealed class LifecycleProbe : Component
 
     protected override Component? Render() =>
         [
-            Div(Class: "d-flex align-items-center gap-3 mb-3")[
+            BsStack(Gap: 3, Align: BsAlign.Center, Class: Margin.Bottom(3))[
                 BsBadge(Color: BsColor.Primary, Class: "fs-6")[$"Render #{++_renderCount}"],
                 // The handler just records the click; Rask re-renders the component that owns the
                 // callback (this probe — the lambda closes over its state) right after it runs, so the

--- a/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
+++ b/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
@@ -198,12 +198,12 @@ public sealed class LiveTicker : Component
 
         return BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
             BsCardBody()[
-                Div(Class: "d-flex align-items-baseline justify-content-between mb-3")[
+                BsStack(Justify: BsJustify.Between, Align: BsAlign.Baseline, Class: Margin.Bottom(3))[
                     H3(Class: "h4 mb-0 fw-semibold", Id: "ticker-symbol")[Symbol],
                     Span(Class: "text-secondary small")[
                         $"poll {IntervalMs} ms · {_history.Count}/{HistoryCapacity} pts"]
                 ],
-                Div(Class: "d-flex align-items-baseline gap-3 mb-3")[
+                BsStack(Gap: 3, Align: BsAlign.Baseline, Class: Margin.Bottom(3))[
                     _history.Count == 0
                         ? Span(Class: "fs-3 text-secondary", Id: "ticker-price")["Waiting for first tick…"]
                         : Span(Class: "fs-2 fw-bold", Id: "ticker-price")[

--- a/samples/Rask.Example.Shared/Features/LiveTicker/LiveTickerDemo.cs
+++ b/samples/Rask.Example.Shared/Features/LiveTicker/LiveTickerDemo.cs
@@ -18,14 +18,14 @@ public sealed class LiveTickerDemo : Component
             SwitchButton("ETH"),
             SwitchButton("SOL")
         ],
-        Div(Class: "row g-4")[
-            Div(Class: "col-lg-7")[
+        BsRow(Gutter: 4)[
+            BsCol(Lg: 7)[
                 LiveTicker(_symbol, Log: AppendLog)
             ],
-            Div(Class: "col-lg-5")[
+            BsCol(Lg: 5)[
                 BsCard(Class: "border-0 bg-light h-100")[
                     BsCardBody()[
-                        Div(Class: "d-flex justify-content-between align-items-baseline mb-3")[
+                        BsStack(Justify: BsJustify.Between, Align: BsAlign.Baseline, Class: Margin.Bottom(3))[
                             H3(Class: "h6 text-secondary text-uppercase small mb-0")["Hook activity"],
                             BsButton(Size: BsSize.Sm, Class: "btn-link p-0 text-decoration-none",
                                 Id: "ticker-clear-log", OnClick: ClearLog)["clear"]

--- a/samples/Rask.Example.Shared/Features/Navigator/NavigatorDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Navigator/NavigatorDemo.cs
@@ -7,7 +7,7 @@ namespace Rask.Example.Shared.Features;
 public sealed class NavigatorDemo(Navigator nav) : Component
 {
     protected override Component? Render() =>
-        Div(Class: "d-flex flex-column gap-2")[
+        BsStack(Vertical: true, Gap: 2)[
             Button(
                 OnClick: () => nav.NavigateTo("/dashboard"))["Open dashboard"],
 

--- a/samples/Rask.Example.Shared/Features/Navigator/NavigatorQueryDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Navigator/NavigatorQueryDemo.cs
@@ -12,12 +12,12 @@ public sealed class NavigatorQueryDemo(Navigator nav, RouteState route) : Compon
         Div()[
             BsCard(Class: Bs.Join(Shadow.Sm, Border.None, Margin.Bottom(3)))[
                 BsCardBody()[
-                    Div(Class: "row g-3")[
-                        Div(Class: "col-md-6")[
+                    BsRow(Gutter: 3)[
+                        BsCol(Md: 6)[
                             Span(Class: "text-secondary small text-uppercase")["Path"],
                             Div()[Code(Class: "fs-6", Id: "nav-path")[route.Path]]
                         ],
-                        Div(Class: "col-md-6")[
+                        BsCol(Md: 6)[
                             Span(Class: "text-secondary small text-uppercase")["Query"],
                             Div()[
                                 Code(Class: "fs-6", Id: "nav-query")[

--- a/samples/Rask.Example.Shared/Features/NestedForms/NestedFluentValidationDemo.cs
+++ b/samples/Rask.Example.Shared/Features/NestedForms/NestedFluentValidationDemo.cs
@@ -66,7 +66,7 @@ public sealed class NestedFluentValidationDemo : Component
                     Thead()[Tr()[Th()["SKU"], Th()["Qty"], Th()]],
                     Tbody()[rows]
                 ],
-                Div(Class: "d-flex gap-2")[
+                BsStack(Gap: 2)[
                     BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "nf-fv-add", OnClick: () => _model.Lines.Add(new NestedOrderLine { Sku = $"BOX-{_seq++}", Quantity = 1 }))[
                         BsIcon(Name: BsIconName.PlusLg, Class: "me-1"), "Add line"],
                     BsButton(Type: "submit", Color: BsColor.Primary, Size: BsSize.Sm, Id: "nf-fv-submit")[

--- a/samples/Rask.Example.Shared/Features/NestedForms/NestedListForeachDemo.cs
+++ b/samples/Rask.Example.Shared/Features/NestedForms/NestedListForeachDemo.cs
@@ -47,7 +47,7 @@ public sealed class NestedListForeachDemo : Component
                     Thead()[Tr()[Th()["Description"], Th()["Quantity"], Th()]],
                     Tbody()[rows]
                 ],
-                Div(Class: "d-flex gap-2")[
+                BsStack(Gap: 2)[
                     BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "nf-list-add", OnClick: () =>
                             _model.Items.Add(new LineItem { Description = $"New item #{_seq++}", Quantity = 1 }))[
                         BsIcon(Name: BsIconName.PlusLg, Class: "me-1"), "Add row"],

--- a/samples/Rask.Example.Shared/Features/NestedForms/NestedListIndexerDemo.cs
+++ b/samples/Rask.Example.Shared/Features/NestedForms/NestedListIndexerDemo.cs
@@ -52,7 +52,7 @@ public sealed class NestedListIndexerDemo : Component
                     Thead()[Tr()[Th(Style: "width: 3rem;")["#"], Th()["SKU"], Th()["Price"], Th()]],
                     Tbody()[rows]
                 ],
-                Div(Class: "d-flex gap-2")[
+                BsStack(Gap: 2)[
                     BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "nf-idx-add", OnClick: () => _model.Skus.Add(new SkuRow { Code = $"WIDGET-{_seq++}", Price = 1.00m }))[
                         BsIcon(Name: BsIconName.PlusLg, Class: "me-1"), "Add row"],
                     BsButton(Type: "submit", Color: BsColor.Primary, Size: BsSize.Sm, Id: "nf-idx-submit")[

--- a/samples/Rask.Example.Shared/Features/NotFound/NotFoundPage.cs
+++ b/samples/Rask.Example.Shared/Features/NotFound/NotFoundPage.cs
@@ -13,7 +13,7 @@ public sealed class NotFoundPage(Navigator nav, RouteState route) : Component
         PageHeader.Render(
             "Page not found",
             $"No route is registered for {route.Path}. Pick a section from the sidebar — every showcase page is reachable from there."),
-        Div(Class: "d-flex gap-2 mt-3")[
+        BsStack(Gap: 2, Class: Margin.Top(3))[
             BsButton(Color: BsColor.Primary, OnClick: () => nav.NavigateTo(Routes.GuidesIndexPage()))[
                 BsIcon(Name: BsIconName.House, Class: "me-2"), "Back to guides"]
         ]

--- a/samples/Rask.Example.Shared/Features/Table/TablePage.cs
+++ b/samples/Rask.Example.Shared/Features/Table/TablePage.cs
@@ -94,7 +94,7 @@ public sealed class TablePage(Navigator nav) : Component
                                 KeyValuePair.Create<string, string?>("filter", v ?? string.Empty),
                                 KeyValuePair.Create<string, string?>("page", "1")))
                     ],
-                    Div(Class: "d-flex align-items-center gap-2")[
+                    BsStack(Gap: 2, Align: BsAlign.Center)[
                         Label(Class: "small text-secondary mb-0")["Rows per page"],
                         Select<string>(
                             Class: "form-select form-select-sm",

--- a/samples/Rask.Example.Shared/Features/Toast/ToastDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Toast/ToastDemo.cs
@@ -67,7 +67,7 @@ public sealed class ToastDemo : Component
         var toasts = Snapshot();
         return Div()[
             // Trigger buttons — each pushes a toast onto the stack.
-            Div(Class: "d-flex flex-wrap gap-2")[
+            BsStack(Gap: 2, WrapItems: true)[
                 BsButton(Color: BsColor.Primary, OnClick: () =>
                     Add("Rask", "Hello, world! This is a toast message.", null, null))[
                     BsIcon(Name: BsIconName.Bell, Class: "me-1"), "Show toast"],
@@ -83,7 +83,7 @@ public sealed class ToastDemo : Component
             ],
 
             // Options — auto-hide toggle + placement picker.
-            Div(Class: "d-flex flex-wrap align-items-center gap-3 mt-3")[
+            BsStack(Gap: 3, Align: BsAlign.Center, WrapItems: true, Class: Margin.Top(3))[
                 Button(
                     Class: _autoHide ? "btn btn-sm btn-success" : "btn btn-sm btn-outline-secondary",
                     OnClick: () => _autoHide = !_autoHide)[

--- a/samples/Rask.Example.Shared/Features/Toaster/ToasterDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Toaster/ToasterDemo.cs
@@ -11,7 +11,7 @@ public sealed class ToasterDemo(IToaster toast) : Component
 {
     protected override Component? Render() =>
         Div()[
-            Div(Class: "d-flex flex-wrap gap-2")[
+            BsStack(Gap: 2, WrapItems: true)[
                 BsButton(Color: BsColor.Info, OnClick: () => toast.Info("Just so you know.", "Info"))["Info"],
                 BsButton(Color: BsColor.Success,
                     OnClick: () => toast.Success("Your changes were saved.", "Saved"))["Success"],

--- a/samples/Rask.Example.Shared/Features/Users/AuthorizeDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Users/AuthorizeDemo.cs
@@ -14,7 +14,7 @@ public sealed class AuthorizeDemo : Component
 
     protected override Component? Render() =>
         Div(Id: "authorize-demo")[
-            Div(Class: "d-flex gap-2 mb-3")[
+            BsStack(Gap: 2, Class: Margin.Bottom(3))[
                 BsButton(Color: BsColor.Primary, Size: BsSize.Sm, OnClick: () => _auth.SignIn("alice", "user"))[
                     "Sign in as user"],
                 BsButton(Color: BsColor.Warning, Size: BsSize.Sm, OnClick: () => _auth.SignIn("rootadmin", "admin"))[

--- a/samples/Rask.Example.Shared/Features/Users/UserGateDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Users/UserGateDemo.cs
@@ -25,7 +25,7 @@ public sealed class UserGateDemo : Component
                     BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClick: _auth.SignOut)["Sign out"]]
                 : [
                     P(Class: "text-secondary")["You are signed out."],
-                    Div(Class: "d-flex gap-2")[
+                    BsStack(Gap: 2)[
                         BsButton(Color: BsColor.Primary, Size: BsSize.Sm, OnClick: () => _auth.SignIn("alice", "user"))[
                             "Sign in as user"],
                         BsButton(Color: BsColor.Warning, Size: BsSize.Sm, OnClick: () => _auth.SignIn("rootadmin", "admin"))[

--- a/samples/Rask.Example.Shared/Features/Validation/NestedAsyncWithLiveTotalsDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Validation/NestedAsyncWithLiveTotalsDemo.cs
@@ -103,30 +103,30 @@ public sealed class NestedAsyncWithLiveTotalsDemo : Component
                 ],
                 Div(Class: "border rounded p-3")[
                     Div(Class: "fw-semibold small mb-2")["Items"],
-                    Div(Class: "row g-2 mb-2 align-items-center")[
-                        Div(Class: "col-6")[
+                    BsRow(Gutter: 2, Class: Bs.Join(Margin.Bottom(2), Flex.Align(BsAlign.Center)))[
+                        BsCol(Span: 6)[
                             Input(() => _model.Items[0].Name,
                                 Id: "v-nlive-item0-name", Class: "form-control form-control-sm")
                         ],
-                        Div(Class: "col-3")[
+                        BsCol(Span: 3)[
                             Input(() => _model.Items[0].Quantity,
                                 Id: "v-nlive-item0-qty", Class: "form-control form-control-sm", Min: "0")
                         ],
-                        Div(Class: "col-3")[
+                        BsCol(Span: 3)[
                             Input(() => _model.Items[0].UnitPrice,
                                 Id: "v-nlive-item0-price", Class: "form-control form-control-sm", Step: "0.01")
                         ]
                     ],
-                    Div(Class: "row g-2 align-items-center")[
-                        Div(Class: "col-6")[
+                    BsRow(Gutter: 2, Class: Flex.Align(BsAlign.Center))[
+                        BsCol(Span: 6)[
                             Input(() => _model.Items[1].Name,
                                 Id: "v-nlive-item1-name", Class: "form-control form-control-sm")
                         ],
-                        Div(Class: "col-3")[
+                        BsCol(Span: 3)[
                             Input(() => _model.Items[1].Quantity,
                                 Id: "v-nlive-item1-qty", Class: "form-control form-control-sm", Min: "0")
                         ],
-                        Div(Class: "col-3")[
+                        BsCol(Span: 3)[
                             Input(() => _model.Items[1].UnitPrice,
                                 Id: "v-nlive-item1-price", Class: "form-control form-control-sm", Step: "0.01")
                         ]
@@ -139,22 +139,22 @@ public sealed class NestedAsyncWithLiveTotalsDemo : Component
                     Input(() => _model.DiscountCode, Id: "v-nlive-promo", Class: "form-control")
                 ],
                 Div(Id: "v-nlive-totals", Class: "bg-light rounded p-3 small")[
-                    Div(Class: "d-flex justify-content-between")[
+                    BsStack(Justify: BsJustify.Between)[
                         Span()["Subtotal"],
                         Span("v-nlive-subtotal")[$"${subtotal.ToString("F2", CultureInfo.InvariantCulture)}"]
                     ],
-                    Div(Class: "d-flex justify-content-between")[
+                    BsStack(Justify: BsJustify.Between)[
                         Span()[discountPct > 0m
                             ? $"Discount ({(int)(discountPct * 100)}%)"
                             : "Discount"],
                         Span("v-nlive-discount")[$"-${discount.ToString("F2", CultureInfo.InvariantCulture)}"]
                     ],
-                    Div(Class: "d-flex justify-content-between")[
+                    BsStack(Justify: BsJustify.Between)[
                         Span()["Tax (8%)"],
                         Span("v-nlive-tax")[$"${tax.ToString("F2", CultureInfo.InvariantCulture)}"]
                     ],
                     Hr(Class: "my-2"),
-                    Div(Class: "d-flex justify-content-between fw-bold")[
+                    BsStack(Justify: BsJustify.Between, Class: Font.Bold)[
                         Span()["Total"],
                         Span("v-nlive-total")[$"${total.ToString("F2", CultureInfo.InvariantCulture)}"]
                     ]

--- a/samples/Rask.Example.Shared/Features/Validation/ProgrammaticValidateDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Validation/ProgrammaticValidateDemo.cs
@@ -38,7 +38,7 @@ public sealed class ProgrammaticValidateDemo : Component
                 ValidatingIndicator(() => _model.Title, Checking),
                 ValidationMessage(() => _model.Title, FieldError)
             ],
-            Div(Class: "d-flex gap-2")[
+            BsStack(Gap: 2)[
                 BsButton(Color: BsColor.Secondary, Outline: true, Id: "v6-validate-now", OnClickAsync: ValidateNowAsync)[
                     BsIcon(Name: BsIconName.Search, Class: "me-1"), "Validate now"
                 ],

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -242,7 +242,7 @@ public static class DemoRegistry
                 ["ElementRefDemo.cs", "ElementRefDemo.js"], Result: ElementRefDemo()),
             ["js-interop-scoped-css"] = () => CodeSample(
                 ["ScopedRed.cs", "ScopedBlue.cs", "ScopedRed.css", "ScopedBlue.css"],
-                Result: Div(Class: "d-flex flex-column gap-2")[ScopedRed(), ScopedBlue()]),
+                Result: BsStack(Vertical: true, Gap: 2)[ScopedRed(), ScopedBlue()]),
             ["js-interop-jsruntime"] = () => CodeSample(["JsRuntimeDemo.cs"], Result: JsRuntimeDemo()),
             ["js-interop-thirdparty"] = () => CodeSample(
                 ["GanttDemo.cs", "Gantt.cs", "Gantt.js"],
@@ -269,7 +269,7 @@ public static class DemoRegistry
                 ["BasicScopedCss.cs", "BasicScopedCss.css"], Result: BasicScopedCss()),
             ["asset-js-only"] = () => CodeSample(["JsOnlyDemo.cs", "JsOnlyDemo.js"], Result: JsOnlyDemo()),
             ["asset-twin-bundle"] = () => CodeSample(
-                ["TwinA.cs", "TwinA.css"], Result: Div(Class: "d-flex gap-2 flex-wrap")[TwinA(), TwinB()]),
+                ["TwinA.cs", "TwinA.css"], Result: BsStack(Gap: 2, WrapItems: true)[TwinA(), TwinB()]),
             ["asset-lazy-mount"] = () => CodeSample(
                 ["LazyMount.cs", "LazyChild.cs", "LazyChild.css"], Result: LazyMount()),
 

--- a/samples/Rask.Example.Shared/Shared/GuideCards.cs
+++ b/samples/Rask.Example.Shared/Shared/GuideCards.cs
@@ -22,12 +22,12 @@ public static class GuideCards
 
             yield return H2(Class: Bs.Join(Font.Bold, Txt.Uppercase, Txt.Color(BsColor.Secondary),
                 Margin.Top(4), Margin.Bottom(3), "h6", "feature-section"))[group];
-            yield return Div(Class: "row g-3")[cards.Select(c => (Component)Card(c))];
+            yield return BsRow(Gutter: 3)[cards.Select(c => (Component)Card(c))];
         }
     }
 
     private static Component Card(GuideEntry g) =>
-        Div(Class: "col-md-6 col-lg-4", Key: g.Slug)[
+        BsCol(Md: 6, Lg: 4, Key: g.Slug)[
             NavLink(Href: Features.Routes.GuidePage(g.Slug), ActiveClass: "", Class: "text-decoration-none")[
                 BsCard(Class: Bs.Join(Sizing.H(100), Border.None, Shadow.Sm, "feature-card"))[
                     BsCardBody(Class: "p-4")[


### PR DESCRIPTION
Third and last of the layout series. **Base is `worktree-bs-layout-primitives` (#469), not `main`** — it needs the primitives. Retarget to `main` once #469 lands and the diff stays exactly what you see here.

The demos are the teaching surface — `CodeSample` embeds their real source into the guides — so every hand-written layout string was actively teaching the raw-class idiom the primitives exist to replace. This migrates **all 137 `Div`-form layout sites across 73 files** in `Rask.Example.Shared`.

## The migration is proven token-neutral, not asserted to be

The demo markup golden (#464) is **byte-for-byte unchanged** across all 178 demos after the migration. That is the whole review gate: I borrowed the golden into this branch purely to run it, then dropped it, so the diff here stays a clean migration.

Most sites are byte-identical — `BsRow(Gutter: 4)` *is* `"row g-4"`, `BsCol(Md: 6)` *is* `"col-md-6"`, `BsStack(Gap: 2)` *is* `"d-flex gap-2"`. The rest only reorder tokens within the class attribute, which has no effect on CSS whatsoever; the golden sorts class tokens precisely so that a reorder is correctly a non-diff while an added or removed token is not.

```diff
-        Div(Class: "row g-4")[
-            Div(Class: "col-md-6")[
+        BsRow(Gutter: 4)[
+            BsCol(Md: 6)[
```

## Deliberately NOT migrated

These are the interesting part of the diff — the boundary, not the bulk:

- **The 44 `vstack` / 5 `hstack` sites.** Those shorthands are not what `BsStack` emits: `.vstack` also sets `flex:1 1 auto`, `.hstack` also sets `align-items:center`, and both add `align-self:stretch`. Migrating them is a real CSS delta, not a rename — the golden would (correctly) flag it. They stay until each is judged individually.
- **`Dl`/`Dt`/`Dd`/`Aside`/`Main` sites carrying grid classes.** That is a Bootstrap description-list grid; the `Bs` primitives always render a `<div>`, so migrating them would silently drop the semantic tag. This is why the migration is scoped to `Div(...)` forms only.
- **`col-md-6 d-flex flex-column gap-N` composites** stay one element (`BsCol` with a flex `Class`). Splitting them into `BsCol[BsStack[...]]` would add a DOM node and change the layout.
- **The container shells in the Auth/Sqlite samples.** Five of those six projects do not reference `Rask.Bootstrap` at all — adding a package dependency to a sample to replace one string is a worse trade than leaving it. (`Rask.Example.EfCore` is the only one that could, and one string is not worth a lone inconsistency.)

## Testing

- **Golden unchanged** across 178 demos — the gate.
- `dotnet format` clean · `dotnet build Rask.slnx -warnaserror` clean · **33 unit assemblies, 0 failures**.
- **E2E green on all three hosts** (Server + Wasm + StandaloneWasm, 13/13).

## Stack

#464 (golden) → #469 (primitives) → this. Independent of #464 in content, but #464 is what makes this reviewable.