### PR TITLE
feat(cli): emit every entity of a generate-feature run; fix the CVE its build gate exposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@ them until tagged releases begin.
   It's pure scaffolding: no host, no network, works before the box exists, honours `--dry-run`, and
   won't overwrite a workflow you've edited. The generated job deploys with `--no-setup-host` on purpose —
   a host that isn't ready should fail the build rather than be reconfigured from a runner.
+- **`rask generate feature` can emit several entities in one run.** Groundwork for relationship support: a run
+  now scaffolds every entity its spec names, each as an independent root in its own `Features/<Plural>/` folder
+  and namespace with a full CRUD slice (entity, request, configuration, pages, CQRS handlers), all sharing one
+  generated `DbContext` that holds a `DbSet` per entity. Because `ApplyConfigurationsFromAssembly` is
+  assembly-wide, every entity's configuration is picked up with no extra wiring — so a multi-entity run needs no
+  `--context`. Not yet reachable from the command line: `rask g f Post Title:string 1:n Comment Body:text` still
+  refuses, because generating the entities without the relationship between them would silently drop what was
+  asked for. A single-entity run is byte-for-byte unchanged.
 - **`rask deploy` gates the blue-green swap on an HTTP health check.** After the new container reports
   `Running`, deploy now probes it over HTTP (`GET /health` by default) and only reloads Caddy onto it
   once it answers `2xx` — a container that boots but fails its first request (bad connection string,
@@ -252,6 +260,15 @@ them until tagged releases begin.
   contain whitespace/control characters) are now rejected up front with a clear message, and the
   destination is additionally passed after `--` so ssh can't reinterpret it. Found while reviewing the
   new host-setup path; the same hardening covers the pre-existing `docker -H ssh://…` host.
+- **`rask generate feature` no longer scaffolds a project carrying a known high-severity vulnerability.** The
+  generated slice references `Microsoft.EntityFrameworkCore.Sqlite`, which pins the `SQLitePCLRaw` 2.1.11 family;
+  its `lib.e_sqlite3` bundles SQLite 3.49.1, vulnerable to
+  [CVE-2025-6965](https://github.com/advisories/GHSA-2m69-gcr7-jv3q) (memory corruption). `generate feature` now
+  also adds `SQLitePCLRaw.bundle_e_sqlite3`, whose 3.x family drops the vulnerable package entirely in favour of
+  `SourceGear.sqlite3` — a **direct** reference being the only lever that lifts a transitive pin. Every project in
+  this repo that touches EF Core Sqlite already carried that reference; the scaffolder was missed when the CVE was
+  closed, so the framework was clean while everything it generated was not. Existing scaffolded projects can add
+  the package themselves: `dotnet add package SQLitePCLRaw.bundle_e_sqlite3`.
 
 ### Fixed
 - **The capability matrix no longer claims `IFileSystemAccess` and `IWebPush` work on Native.**

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -19,11 +19,93 @@ internal static class FeatureGenerator
         FeatureSpec spec,
         FeatureOptions options)
     {
-        // spec.Relationships is parsed and validated but not yet emitted — relationship rendering lands in a
-        // later slice. Until then a run generates its root exactly as before.
-        var entityName = spec.Root.Name;
-        var fields = spec.Root.Fields;
-        var plural = spec.Root.Plural;
+        var generateContext = options.ContextOverride is null;
+        var context = options.ContextOverride ?? spec.Root.Plural + "DbContext";
+        var entities = spec.Entities.ToArray();
+
+        // Every entity gets its own Features/<Plural>/ folder and namespace — each one has its own route and
+        // pages, so nesting a target under the root's folder would put, say, /comments in ...Features.Posts.
+        // With --output they all share one folder instead, and the cross-namespace usings below collapse away.
+        var directories = entities.ToDictionary(
+            e => e.Name,
+            e => Scaffold.TargetDirectory(baseDirectory, options.OutputOverride, "Features", e.Plural),
+            StringComparer.Ordinal);
+
+        var namespaces = entities.ToDictionary(
+            e => e.Name,
+            e => project.NamespaceFor(directories[e.Name]),
+            StringComparer.Ordinal);
+
+        // The run's single DbContext lives with the root, so every other entity's handlers reach it by name.
+        var contextNs = namespaces[spec.Root.Name];
+
+        var files = new List<ScaffoldFile>();
+        foreach (var entity in entities)
+        {
+            files.AddRange(RenderSlice(
+                project, options, entity, context, generateContext,
+                directories[entity.Name], namespaces[entity.Name], contextNs));
+        }
+
+        // One DbContext for the whole run, holding a DbSet per entity. Its ApplyConfigurationsFromAssembly is
+        // assembly-wide, so every entity's generated configuration is picked up with no further wiring —
+        // which is why a multi-entity run needs no --context.
+        if (generateContext)
+        {
+            var dbSets = string.Join(
+                "\n",
+                entities.Select(e => $"    public DbSet<{e.Name}> {e.Plural} => Set<{e.Name}>();"));
+
+            files.Add(new ScaffoldFile(
+                Path.Combine(directories[spec.Root.Name], context + ".cs"),
+                Apply(DbContextTemplate,
+                [
+                    ("__NS__", contextNs),
+                    ("__CONTEXT__", context),
+                    ("__USINGS__", Usings(contextNs, entities.Select(e => namespaces[e.Name]))),
+                    ("__DBSETS__", dbSets),
+                    ("__OUTBOXMODEL__", options.UseOutbox ? "\n                modelBuilder.AddRaskOutbox();" : ""),
+                ])));
+        }
+
+        var root = spec.Root;
+        return new ScaffoldResult(
+            files,
+            RenderNextSteps(context, root.Name, root.Plural, Identifiers.ToRoutePath(root.Plural), generateContext, options.Validation, options.UseBs, options.UseTests, options.UseOutbox))
+        {
+            Packages = FeaturePackages(options.Validation, options.UseBs, options.UseOutbox),
+        };
+    }
+
+    /// <summary>
+    /// The <c>using</c> lines a file in <paramref name="fileNs"/> needs to see types from
+    /// <paramref name="referenced"/> — its own namespace excluded, so a single-folder run emits none.
+    /// </summary>
+    private static string Usings(string fileNs, IEnumerable<string> referenced) =>
+        string.Concat(referenced
+            .Where(n => !string.Equals(n, fileNs, StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .Select(n => "\nusing " + n + ";"));
+
+    /// <summary>
+    /// One entity's vertical slice. Every entity in a run gets the full set — entity, request, configuration,
+    /// pages, and CQRS handlers — because each is an independent root with its own CRUD. They share the run's
+    /// single DbContext, which is why a non-root entity's handlers need a using for <paramref name="contextNs"/>.
+    /// </summary>
+    private static List<ScaffoldFile> RenderSlice(
+        ProjectContext project,
+        FeatureOptions options,
+        EntitySpec entity,
+        string context,
+        bool generateContext,
+        string targetDirectory,
+        string ns,
+        string contextNs)
+    {
+        var entityName = entity.Name;
+        var fields = entity.Fields;
+        var plural = entity.Plural;
 
         var idType = options.IdType;
         var validation = options.Validation;
@@ -38,15 +120,14 @@ internal static class FeatureGenerator
 
         var route = Identifiers.ToRoutePath(plural);
         var idConstraint = idType == "Guid" ? "guid" : idType;
-        var generateContext = options.ContextOverride is null;
-        var context = options.ContextOverride ?? plural + "DbContext";
 
-        var targetDirectory = Scaffold.TargetDirectory(baseDirectory, options.OutputOverride, "Features", plural);
-        var ns = project.NamespaceFor(targetDirectory);
+        // The handlers name the DbContext, which lives with the root. An --context DbContext is the user's own
+        // and they wire it themselves (see the next-steps), so nothing is assumed about where it lives.
+        var usings = generateContext ? Usings(ns, [contextNs]) : "";
 
         var tokens = new (string, string)[]
         {
-            ("__NS__", ns), ("__ENTITY__", entityName), ("__PLURAL__", plural), ("__CONTEXT__", context),
+            ("__NS__", ns), ("__USINGS__", usings), ("__ENTITY__", entityName), ("__PLURAL__", plural), ("__CONTEXT__", context),
             ("__ROUTE__", route), ("__IDTYPE__", idType), ("__IDCONSTRAINT__", idConstraint),
             ("__CREATEARGS__", RequestArgs(fields, "command.Request")),
             ("__HEADERS__", TableHeaders(fields)), ("__CELLS__", TableCells(fields, useValueObjects)),
@@ -113,11 +194,6 @@ internal static class FeatureGenerator
                 Apply(FluentValidatorTemplate, tokens).Replace("__RULES__", FluentRules(fields), StringComparison.Ordinal)));
         }
 
-        if (generateContext)
-        {
-            files.Insert(2, new ScaffoldFile(Path.Combine(targetDirectory, context + ".cs"), Apply(DbContextTemplate, tokens)));
-        }
-
         // --tests: a sibling <Project>.Tests project gets a domain test (Create/Update + value-object
         // validation) and, when we own the DbContext, a SQLite round-trip persistence test.
         if (useTests)
@@ -135,14 +211,11 @@ internal static class FeatureGenerator
             {
                 files.Add(new ScaffoldFile(
                     Path.Combine(testDirectory, plural + "PersistenceTests.cs"),
-                    RenderPersistenceTests(testNamespace, ns, entityName, plural, context, idType, fields, useValueObjects)));
+                    RenderPersistenceTests(testNamespace, ns, contextNs, entityName, plural, context, idType, fields, useValueObjects)));
             }
         }
 
-        return new ScaffoldResult(files, RenderNextSteps(context, entityName, plural, route, generateContext, validation, useBs, useTests, useOutbox))
-        {
-            Packages = FeaturePackages(validation, useBs, useOutbox),
-        };
+        return files;
     }
 
     // The form-level validator component wired at the top of the create/edit forms (empty for the
@@ -483,11 +556,14 @@ internal static class FeatureGenerator
 
     // Persistence test: the entity round-trips through a real SQLite file, proving the configuration's
     // columns + value-object converters persist and rehydrate.
-    private static string RenderPersistenceTests(string testNs, string featureNs, string entity, string plural, string context, string idType, IReadOnlyList<FieldSpec> fields, bool useValueObjects)
+    private static string RenderPersistenceTests(string testNs, string featureNs, string contextNs, string entity, string plural, string context, string idType, IReadOnlyList<FieldSpec> fields, bool useValueObjects)
     {
         var sb = new StringBuilder();
-        sb.Append("using Microsoft.EntityFrameworkCore;\n");
-        sb.Append("using ").Append(featureNs).Append(";\n\n");
+        sb.Append("using Microsoft.EntityFrameworkCore;");
+
+        // The test names both the entity and the DbContext, which live in different namespaces when this
+        // entity isn't the run's root.
+        sb.Append(Usings(testNs, [featureNs, contextNs])).Append("\n\n");
         sb.Append("namespace ").Append(testNs).Append(";\n\n");
         sb.Append("public sealed class ").Append(plural).Append("PersistenceTests : IDisposable\n{\n");
         sb.Append("    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $\"rask-test-{Guid.NewGuid():N}.db\");\n\n");
@@ -662,6 +738,14 @@ internal static class FeatureGenerator
         var packages = new List<string>
         {
             "Microsoft.EntityFrameworkCore.Sqlite",
+
+            // Security: EF Core Sqlite pins the SQLitePCLRaw 2.1.11 family, whose lib.e_sqlite3 bundles
+            // SQLite 3.49.1 — vulnerable to CVE-2025-6965 (memory corruption). The 3.x bundle drops that
+            // package entirely for SourceGear.sqlite3 (SQLite 3.50.4+). A direct reference is the only lever
+            // that lifts it: transitive pinning does not move it. Every project in this repo that touches EF
+            // Core Sqlite carries the same reference — see Directory.Packages.props.
+            "SQLitePCLRaw.bundle_e_sqlite3",
+
             "Microsoft.EntityFrameworkCore.Design",
             "Rask.Cqrs",
             "Rask.Data", // the Entity<TId> base + interceptors every generated entity inherits
@@ -776,13 +860,13 @@ internal static class FeatureGenerator
 
     private const string DbContextTemplate =
         """
-        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore;__USINGS__
 
         namespace __NS__;
 
         public sealed class __CONTEXT__(DbContextOptions<__CONTEXT__> options) : DbContext(options)
         {
-            public DbSet<__ENTITY__> __PLURAL__ => Set<__ENTITY__>();
+        __DBSETS__
 
             protected override void OnModelCreating(ModelBuilder modelBuilder)
             {
@@ -837,7 +921,7 @@ internal static class FeatureGenerator
 
     private const string FluentValidatorTemplate =
         """
-        using FluentValidation;
+        using FluentValidation;__USINGS__
 
         namespace __NS__;
 
@@ -854,7 +938,7 @@ internal static class FeatureGenerator
     private const string ConfigurationTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Microsoft.EntityFrameworkCore.Metadata.Builders;
+        using Microsoft.EntityFrameworkCore.Metadata.Builders;__USINGS__
 
         namespace __NS__;
 
@@ -873,7 +957,7 @@ internal static class FeatureGenerator
     // --events: a sample notification handler so the extension point is obvious. Auto-registered by AddRaskCqrs().
     private const string EventHandlerTemplate =
         """
-        using Microsoft.Extensions.Logging;
+        using Microsoft.Extensions.Logging;__USINGS__
 
         namespace __NS__;
 
@@ -894,7 +978,7 @@ internal static class FeatureGenerator
     private const string ListPageTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 
@@ -952,7 +1036,7 @@ internal static class FeatureGenerator
 
     private const string DeleteTemplate =
         """
-        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore;__USINGS__
 
         namespace __NS__;
 
@@ -995,7 +1079,7 @@ internal static class FeatureGenerator
     // global filter), clears DeletedAt via the entity's Restore(), and saves.
     private const string RestoreTemplate =
         """
-        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore;__USINGS__
 
         namespace __NS__;
 
@@ -1043,7 +1127,7 @@ internal static class FeatureGenerator
 
     private const string BsRestoreTemplate =
         """
-        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore;__USINGS__
 
         namespace __NS__;
 
@@ -1090,7 +1174,7 @@ internal static class FeatureGenerator
     private const string CreateTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 
@@ -1151,7 +1235,7 @@ internal static class FeatureGenerator
     private const string UpdateTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 
@@ -1259,7 +1343,7 @@ internal static class FeatureGenerator
     private const string BsListPageTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 
@@ -1321,7 +1405,7 @@ internal static class FeatureGenerator
 
     private const string BsDeleteTemplate =
         """
-        using Microsoft.EntityFrameworkCore;
+        using Microsoft.EntityFrameworkCore;__USINGS__
 
         namespace __NS__;
 
@@ -1361,7 +1445,7 @@ internal static class FeatureGenerator
     private const string BsCreateTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 
@@ -1422,7 +1506,7 @@ internal static class FeatureGenerator
     private const string BsUpdateTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 
@@ -1529,7 +1613,7 @@ internal static class FeatureGenerator
     private const string BsModalListTemplate =
         """
         using Microsoft.EntityFrameworkCore;
-        using Rask.Core.Routing;
+        using Rask.Core.Routing;__USINGS__
 
         namespace __NS__;
 

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -564,9 +564,12 @@ public sealed class FeatureGeneratorTests
         Assert.Contains("AddRaskCqrs();", notes, StringComparison.Ordinal);
         Assert.Contains("AddDbContextFactory<ProductsDbContext>", notes, StringComparison.Ordinal);
         Assert.Contains("dotnet ef migrations add AddProduct", notes, StringComparison.Ordinal);
-        // The packages are added to the project automatically (not just printed).
+        // The packages are added to the project automatically (not just printed). SQLitePCLRaw is a security
+        // reference, not a convenience one: EF Core Sqlite pins the 2.1.11 family, which carries CVE-2025-6965,
+        // and only a direct reference lifts it. Don't drop it from this list without reading
+        // Directory.Packages.props.
         Assert.Equal(
-            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data"],
+            ["Microsoft.EntityFrameworkCore.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data"],
             result.Packages);
     }
 
@@ -586,5 +589,141 @@ public sealed class FeatureGeneratorTests
         Assert.DoesNotContain(result.Files, f => f.Path.EndsWith("DbContext.cs", StringComparison.Ordinal));
         Assert.Contains("IDbContextFactory<AppDbContext>", File(result, "ProductsPage.cs"), StringComparison.Ordinal);
         Assert.Contains("public DbSet<Product> Products => Set<Product>();", result.Notes!, StringComparison.Ordinal);
+    }
+}
+
+/// <summary>
+/// A run that names relationship targets generates <b>every</b> entity in it, each as an independent root
+/// with its own folder, namespace and full CRUD, all sharing one DbContext. The relationships themselves
+/// (foreign keys, navigations, EF mapping) are not emitted yet — these cover the multi-entity shape only.
+/// </summary>
+public sealed class FeatureGeneratorMultiEntityTests
+{
+    private static readonly EntitySpec Post = new("Post", "Posts", [new FieldSpec("Title", "string", IsNullable: false, MaxLength: 200)]);
+    private static readonly EntitySpec Comment = new("Comment", "Comments", [new FieldSpec("Body", "string", IsNullable: false, MaxLength: 200)]);
+
+    private static ScaffoldResult Generate(string? context = null, string? output = null) =>
+        FeatureGenerator.Generate(
+            new ProjectContext("/proj", "MyApp"),
+            "/proj",
+            new FeatureSpec(Post, [new RelationshipSpec(Cardinality.OneToMany, IsOptional: false, Post, Comment)]),
+            new FeatureOptions
+            {
+                IdType = "Guid",
+                Validation = "valueobjects",
+                ContextOverride = context,
+                OutputOverride = output,
+            });
+
+    private static string File(ScaffoldResult result, string fileName) =>
+        result.Files.Single(f => Path.GetFileName(f.Path) == fileName).Content;
+
+    private static string Directory(ScaffoldResult result, string fileName) =>
+        Path.GetFullPath(Path.GetDirectoryName(result.Files.Single(f => Path.GetFileName(f.Path) == fileName).Path)!);
+
+    [Fact]
+    public void Every_entity_gets_its_own_full_crud_slice()
+    {
+        var names = Generate().Files.Select(f => Path.GetFileName(f.Path)).OrderBy(n => n, StringComparer.Ordinal);
+
+        Assert.Equal(
+            [
+                "Comment.cs", "CommentBody.cs", "CommentConfiguration.cs", "CommentRequest.cs", "CommentsPage.cs",
+                "CreateComment.cs", "CreatePost.cs", "DeleteComment.cs", "DeletePost.cs",
+                "Post.cs", "PostConfiguration.cs", "PostRequest.cs", "PostTitle.cs", "PostsDbContext.cs",
+                "PostsPage.cs", "UpdateComment.cs", "UpdatePost.cs",
+            ],
+            names);
+    }
+
+    [Fact]
+    public void Each_entity_lands_in_its_own_feature_folder()
+    {
+        var result = Generate();
+
+        Assert.Equal(Path.GetFullPath("/proj/Features/Posts"), Directory(result, "Post.cs"));
+        Assert.Equal(Path.GetFullPath("/proj/Features/Comments"), Directory(result, "Comment.cs"));
+    }
+
+    [Fact]
+    public void Each_entity_gets_the_namespace_of_its_own_folder()
+    {
+        var result = Generate();
+
+        Assert.Contains("namespace MyApp.Features.Posts;", File(result, "Post.cs"), StringComparison.Ordinal);
+        Assert.Contains("namespace MyApp.Features.Comments;", File(result, "Comment.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_target_gets_its_own_route_not_one_under_the_root()
+    {
+        Assert.Contains("[Route(\"/comments\")]", File(Generate(), "CommentsPage.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void One_dbcontext_holds_a_dbset_for_every_entity()
+    {
+        var context = File(Generate(), "PostsDbContext.cs");
+
+        Assert.Contains("public DbSet<Post> Posts => Set<Post>();", context, StringComparison.Ordinal);
+        Assert.Contains("public DbSet<Comment> Comments => Set<Comment>();", context, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_dbcontext_lives_with_the_root_and_is_generated_once()
+    {
+        var result = Generate();
+
+        Assert.Single(result.Files, f => Path.GetFileName(f.Path).EndsWith("DbContext.cs", StringComparison.Ordinal));
+        Assert.Equal(Path.GetFullPath("/proj/Features/Posts"), Directory(result, "PostsDbContext.cs"));
+    }
+
+    [Fact]
+    public void The_dbcontext_usings_reach_every_entitys_namespace()
+    {
+        var context = File(Generate(), "PostsDbContext.cs");
+
+        // Its own namespace needs no using; the target's does.
+        Assert.Contains("using MyApp.Features.Comments;", context, StringComparison.Ordinal);
+        Assert.DoesNotContain("using MyApp.Features.Posts;", context, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_targets_handlers_can_see_the_shared_dbcontext()
+    {
+        var deleteComment = File(Generate(), "DeleteComment.cs");
+
+        // The context lives with the root, so a target's slice needs a using to name it.
+        Assert.Contains("using MyApp.Features.Posts;", deleteComment, StringComparison.Ordinal);
+        Assert.Contains("IDbContextFactory<PostsDbContext>", deleteComment, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_roots_own_slice_needs_no_using_for_a_context_beside_it()
+    {
+        var deletePost = File(Generate(), "DeletePost.cs");
+
+        Assert.DoesNotContain("using MyApp.Features.Posts;", deletePost, StringComparison.Ordinal);
+        Assert.Contains("IDbContextFactory<PostsDbContext>", deletePost, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void With_an_external_context_no_dbcontext_is_generated_and_nothing_is_assumed_about_where_it_lives()
+    {
+        var result = Generate(context: "AppDbContext");
+
+        Assert.DoesNotContain(result.Files, f => Path.GetFileName(f.Path).EndsWith("DbContext.cs", StringComparison.Ordinal));
+        Assert.Contains("IDbContextFactory<AppDbContext>", File(result, "DeleteComment.cs"), StringComparison.Ordinal);
+        Assert.DoesNotContain("using MyApp.Features.Posts;", File(result, "DeleteComment.cs"), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void With_an_output_override_every_entity_shares_one_folder_so_no_cross_usings_are_emitted()
+    {
+        var result = Generate(output: "Slice");
+
+        Assert.All(result.Files, f => Assert.Equal(Path.GetFullPath("/proj/Slice"), Path.GetFullPath(Path.GetDirectoryName(f.Path)!)));
+        Assert.DoesNotContain("using MyApp.Slice;", File(result, "DeleteComment.cs"), StringComparison.Ordinal);
+        Assert.DoesNotContain("using MyApp.Slice;", File(result, "PostsDbContext.cs"), StringComparison.Ordinal);
     }
 }

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -178,8 +178,10 @@ public sealed class GenerateCommandTests
             .Where(i => i.Arguments is ["add", "package", _])
             .Select(i => i.Arguments[2])
             .ToArray();
+        // SQLitePCLRaw is really added to the project, not merely printed — it's the direct reference that
+        // lifts EF Core Sqlite's vulnerable 2.1.11 pin (CVE-2025-6965), and nothing else does.
         Assert.Equal(
-            ["Microsoft.EntityFrameworkCore.Sqlite", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data", "Rask.Bootstrap"],
+            ["Microsoft.EntityFrameworkCore.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data", "Rask.Bootstrap"],
             adds);
     }
 

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 using Rask.Cli.Scaffolding;
 
 namespace Rask.Cli.Tests;
@@ -178,6 +179,108 @@ public sealed class ProjectGeneratorBuildE2ETests
         {
             TryDeleteDirectory(temp);
         }
+    }
+
+    /// <summary>
+    /// A feature run that names relationship targets emits several entities at once — each in its own folder
+    /// and namespace, all sharing one DbContext that lives with the root. That shape is the first generated
+    /// code to carry cross-namespace <c>using</c>s, which string assertions can't validate: a target's handlers
+    /// name a DbContext declared in the root's namespace, and the DbContext names types in each target's.
+    /// Only a real compile proves those resolve.
+    /// </summary>
+    [Fact]
+    public async Task Generated_multi_entity_feature_builds()
+    {
+        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        {
+            return; // opt-in: this packs the repo + restores + builds.
+        }
+
+        var (feed, version) = await LocalFeed.Value;
+
+        const string Name = "FE2E";
+        var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(temp, Name);
+        try
+        {
+            var fs = new SystemFileSystem();
+
+            var host = ProjectGenerator.GenerateServer(projectDir, Name, auth: false, pwa: false, cqrs: false, docker: false, version);
+            foreach (var file in host.Files)
+            {
+                fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                fs.WriteAllText(file.Path, file.Content);
+            }
+
+            var post = new EntitySpec("Post", "Posts", [new FieldSpec("Title", "string", IsNullable: false, MaxLength: 200)]);
+            var comment = new EntitySpec("Comment", "Comments", [new FieldSpec("Body", "string", IsNullable: false, MaxLength: 200)]);
+            var feature = FeatureGenerator.Generate(
+                new ProjectContext(projectDir, Name),
+                projectDir,
+                new FeatureSpec(post, [new RelationshipSpec(Cardinality.OneToMany, IsOptional: false, post, comment)]),
+                new FeatureOptions { IdType = "Guid", Validation = "valueobjects" });
+
+            foreach (var file in feature.Files)
+            {
+                fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                fs.WriteAllText(file.Path, file.Content);
+            }
+
+            // `dotnet add package` is GenerateCommand's job, not the generator's — so add what the generator
+            // says it needs. Driving off result.Packages keeps this from drifting from what the CLI does.
+            InjectPackages(fs, Path.Combine(projectDir, Name + ".csproj"), feature.Packages, version);
+            WriteNuGetConfig(fs, projectDir, feed);
+
+            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, Name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"generated multi-entity feature failed to build.{Diagnostics(output)}");
+        }
+        finally
+        {
+            TryDeleteDirectory(temp);
+        }
+    }
+
+    // The packages a generated feature needs, written straight into the csproj. Rask.* come from the local
+    // feed at the packed version; everything else takes the version this repo pins, so the gate can't drift
+    // from the rest of the build.
+    private static void InjectPackages(SystemFileSystem fs, string csproj, IReadOnlyList<string> packages, string raskVersion)
+    {
+        var pins = RepoPackagePins();
+        var refs = string.Join(
+            "\n",
+            packages.Select(p => $"""    <PackageReference Include="{p}" Version="{VersionFor(p, pins, raskVersion)}"/>"""));
+
+        var content = fs.ReadAllText(csproj);
+        fs.WriteAllText(csproj, content.Replace("</Project>", $"  <ItemGroup>\n{refs}\n  </ItemGroup>\n\n</Project>", StringComparison.Ordinal));
+    }
+
+    private static string VersionFor(string package, IReadOnlyDictionary<string, string> pins, string raskVersion)
+    {
+        if (package.StartsWith("Rask.", StringComparison.Ordinal))
+        {
+            return raskVersion;
+        }
+
+        if (pins.TryGetValue(package, out var pinned))
+        {
+            return pinned;
+        }
+
+        // EF's Design package isn't referenced by this repo, so it has no pin of its own — but it ships in
+        // lockstep with EF Core, so borrow that version rather than inventing one.
+        if (package.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal))
+        {
+            return pins["Microsoft.EntityFrameworkCore"];
+        }
+
+        throw new InvalidOperationException($"No version known for '{package}'. Pin it in Directory.Packages.props.");
+    }
+
+    private static Dictionary<string, string> RepoPackagePins()
+    {
+        var props = File.ReadAllText(Path.Combine(FindRepoRoot(), "Directory.Packages.props"));
+        return Regex.Matches(props, """<PackageVersion\s+Include="([^"]+)"\s+Version="([^"]+)"\s*/>""")
+            .ToDictionary(m => m.Groups[1].Value, m => m.Groups[2].Value, StringComparer.Ordinal);
     }
 
     /// <summary>Packs <see cref="FeedPackages"/> to a temp feed; returns its directory and the packed version.</summary>


### PR DESCRIPTION
> **Stacked on #471 → #468 → #465.** This PR targets #471's branch, so the diff here is only the multi-entity work. Retarget as the stack merges.

## ⚠️ Read this part first: a shipped high-severity CVE

**Every project `rask generate feature` has ever scaffolded carries [CVE-2025-6965](https://github.com/advisories/GHSA-2m69-gcr7-jv3q)** — high severity, memory corruption in SQLite 3.49.1.

The generated slice references `Microsoft.EntityFrameworkCore.Sqlite`, which pins the `SQLitePCLRaw` 2.1.11 family, whose `lib.e_sqlite3` bundles the vulnerable SQLite. `Directory.Packages.props` already documents both the problem and the cure:

> every project with a direct Microsoft.Data.Sqlite / EF Core Sqlite reference **also references `SQLitePCLRaw.bundle_e_sqlite3` explicitly**. A direct reference is the only lever that lifts these — CentralPackageTransitivePinning does NOT move them.

Every in-repo project follows that rule — **including the hand-written `samples/Rask.Example.EfCore`, the twin of what the scaffolder emits**. The scaffolder alone was missed when the CVE was closed, leaving the framework clean and everything it generates vulnerable.

It went unnoticed because **nothing had ever compiled a generated feature** — the build gate only covered `rask new`, so NuGet audit had never run on scaffolded output. It surfaced within minutes of the first gate that does (added below).

Fixed by adding `SQLitePCLRaw.bundle_e_sqlite3` to the feature's packages, covered by two tests: one that it's in the list, one that it's actually `dotnet add package`'d. Existing scaffolded projects can self-remedy: `dotnet add package SQLitePCLRaw.bundle_e_sqlite3`.

**This fix is independent of the rest of this PR.** It's here because the gate can't be green without it, and because the same file changed — and this repo squash-merges, so in-PR commit splits don't survive anyway. Happy to pull it into a standalone PR off `main` if you'd rather merge it ahead of the stack.

## Multi-entity emission

A `generate feature` run now scaffolds **every entity its spec names**, not just the root — the groundwork relationship emission needs.

Each entity is an independent root with its own route and pages, so each gets its own `Features/<Plural>/` folder, namespace, and full CRUD slice. They share **one** generated `DbContext`, living with the root, holding a `DbSet` per entity:

```csharp
// Features/Posts/PostsDbContext.cs
using Microsoft.EntityFrameworkCore;
using MyApp.Features.Comments;

namespace MyApp.Features.Posts;

public sealed class PostsDbContext(DbContextOptions<PostsDbContext> options) : DbContext(options)
{
    public DbSet<Post> Posts => Set<Post>();
    public DbSet<Comment> Comments => Set<Comment>();
```

Because `ApplyConfigurationsFromAssembly` is assembly-wide, every entity's configuration is picked up with no extra wiring — **so a multi-entity run needs no `--context`.**

### Cross-namespace usings

This is the first generated code to need them: a target's handlers name a DbContext declared in the root's namespace, and the DbContext names types in each target's. A new `__USINGS__` token carries them, computed per file:

```csharp
// Features/Comments/DeleteComment.cs  — needs the root's namespace to see the context
using MyApp.Features.Posts;
...
public sealed class DeleteCommentCommandHandler(IDbContextFactory<PostsDbContext> dbContextFactory)
```

It's empty when the namespaces coincide, so **a single-entity run is byte-for-byte unchanged** (every pre-existing exact-string test passes untouched), and `--output` — one folder for the whole run — emits none.

### Still not reachable from the CLI

`rask g f Post Title:string 1:n Comment Body:text` still refuses. Emitting the entities *without* the relationship between them would silently drop what was asked for — the same reason #468 added the guard. Lifting it is the next slice.

## Testing

String assertions cannot prove a cross-namespace `using` resolves — so this ships with a build-gate case that compiles a **real two-entity slice** against the local feed from #471. That case is what found the CVE.

- **Build gate: 17/17** (`RASK_CLI_BUILD_E2E=1`) — the 16 from #471 plus the new multi-entity case
- **441 unit tests** (+12: 11 multi-entity shape, 1 package-list)
- `dotnet format whitespace --verify-no-changes` — clean (what `.githooks/pre-commit` enforces)
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — passed (also re-run by the pre-commit hook)
- `scripts/run-e2e-local.sh` — passed via the pre-push hook

## Benchmarks

Not applicable — no render-hotpath or runtime code is touched.

## Changelog

`[Unreleased]` → a new **`### Security`** section for the CVE, and `### Added` for multi-entity emission.