### PR TITLE
docs: add a CLI cheat sheet and recipes cookbook, cross-link the pillar docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -278,6 +278,18 @@ them until tagged releases begin.
   Core-tier wrapper, so it works on **both transports** (no user gesture needed). Showcased on the Browser APIs
   page and documented in [`docs/apis/web-locks.md`](docs/apis/web-locks.md).
 
+### Documentation
+- **A cheat sheet and a recipes cookbook for faster day-to-day DX.** New [`docs/cheatsheet.md`](docs/cheatsheet.md)
+  puts every CLI command, feature field token, `AddRask…` wiring one-liner, and code idiom on one scannable
+  page; new [`docs/recipes.md`](docs/recipes.md) answers "how do I do X?" (add a feature to an existing
+  database, gate a page, run a job, cache a query, deploy an update, …) with the command, the wiring line, and
+  links to the reference + the tutorial chapter that teaches it. Both are linked from the docs index, and each
+  pillar reference (`jobs`/`mail`/`cache`/`outbox`/`data`/`sqlite`/`authentication`/`deployment`/`cli`) now
+  carries an "In practice" pointer back to its tutorial chapter and recipe, so every entry point leads to the
+  others. Also corrected two drifted lines: the Chapter 1 goal box (`rask new Shop --auth --docker`) and the
+  CLI reference (`rask generate` now **writes** the DI registration into `Program.cs`, printing only as a
+  fallback).
+
 ### Changed
 - **Renamed `Rask.Data`'s `AggregateRoot<TId>` to `Entity<TId>` (BREAKING, pre-1.0).** The base class every
   `rask generate feature` entity inherits is now `Entity<TId>`. The old name claimed an aggregate boundary

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,8 @@ whole product solo, in C#, on one server. **New to Rask?** Read
 interactive app. **Ready to build something real?** The [**Tutorial**](tutorial/00-overview.md) takes you
 from an empty folder to a deployed, database-backed product that uses every pillar. Want the philosophy
 first? Read **[The .NET One Person Framework](one-person-framework.md)**. Want the pitch and a quick demo?
-See the project [README](../README.md).
+See the project [README](../README.md). Already building? Keep the [**Cheat sheet**](cheatsheet.md) open
+and reach for the [**Recipes**](recipes.md) when you need "how do I do X?".
 
 ## Start here
 
@@ -14,6 +15,8 @@ See the project [README](../README.md).
 |-------|----------------|
 | [**The .NET One Person Framework**](one-person-framework.md) | The doctrine: one developer, a whole product, one C# codebase, one server, SQLite-first — and the batteries that make it real. |
 | [**Tutorial: zero to deploy**](tutorial/00-overview.md) | Build the "Shop" app end to end — scaffold → first DB-backed feature → auth → jobs → email → cache → events → production SQLite → deploy to one box. One chapter per pillar. |
+| [**Cheat sheet**](cheatsheet.md) | The one page to keep open — every CLI command, feature field token, wiring one-liner (`AddRask…`), and code idiom, dense and scannable. |
+| [**Recipes**](recipes.md) | Task-first "how do I do X?" — add a feature to an existing database, gate a page, run a job, cache a query, deploy an update — the command, the wiring line, and where to go deeper. |
 | [Roadmap](roadmap.md) | The One Person Framework pillars — what's shipped (DB-backed jobs, outbox, mail, cache) and what's next (broadcast). |
 
 ## Guides

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,5 +1,7 @@
 # Authentication in Rask
 
+> **In practice:** [Tutorial Ch 3](tutorial/03-orders-and-auth.md) · recipe [require login on a page](recipes.md#require-login-on-a-page) · [cheat sheet](cheatsheet.md).
+
 Rask ships the *plumbing* for authentication — a scoped current-user, a sign-in/out handshake, route
 guards, and a declarative gate — and lets you bring any backing store (a cookie, a JWT, ASP.NET Identity,
 Keycloak/OIDC, …). This guide shows the complete, copy-pasteable flow for each combination.

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -1,5 +1,7 @@
 # Rask.Cache — a developer-facing cache on your database
 
+> **In practice:** [Tutorial Ch 6](tutorial/06-cache.md) · recipe [cache an expensive query](recipes.md#cache-an-expensive-query) · [cheat sheet](cheatsheet.md).
+
 `Rask.Cache` caches computed values in the app's own database — no message broker, no Redis. It implements
 the standard **`IDistributedCache`** (so it drops straight into ASP.NET session state, output caching, and
 anything else built on the abstraction) and adds a typed **`ICache`** convenience layer with a read-through

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -1,0 +1,117 @@
+# Cheat sheet
+
+The one page to keep open. Every command, token, and wiring line you reach for while building — dense
+and scannable. For the prose reference see [the `rask` CLI](cli.md); to learn it in order, follow the
+[Tutorial](tutorial/00-overview.md). Looking for "how do I do X?" — that's the [Recipes](recipes.md).
+
+## The CLI in a screenful
+
+```bash
+# scaffold & run
+rask new Shop --auth --docker         # new app: cookie auth + a Dockerfile for deploy
+rask dev                              # dotnet watch run — hot reload
+rask info                             # what rask sees: project, packages, versions
+
+# a full CRUD vertical slice (entity + CQRS + EF + pages)
+rask generate feature Product Name:string Price:decimal InStock:bool
+rask g f Order Total:decimal --id long          # g = generate, f = feature; long key
+rask g f Order Total:decimal -c ProductsDbContext   # reuse an existing DbContext
+rask g f Post Title:string 1:n Comment Body:text    # a related entity in the same run
+
+# other artifacts
+rask g page Products                  # → Features/Products/ProductsPage.cs ([Route("/products")])
+rask g component PriceTag             # → Components/PriceTag.cs
+rask g job SendWelcomeEmail           # → Jobs/… (IJob + handler)  + Rask.Jobs
+rask g email WelcomeEmail             # → Emails/… (email-body component)  + Rask.Mail
+rask g p Orders --dry-run             # print what would be written, touch nothing
+
+# database (wraps dotnet-ef; installs it on first use)
+rask db add InitialCreate             # generate a migration from the current model
+rask db update                        # apply it — creates app.db
+
+# ship it
+rask deploy --host root@box --domain shop.example.com   # bare box → live HTTPS
+rask deploy                           # redeploy (host/domain remembered), zero-downtime
+rask deploy --github-actions          # write .github/workflows/deploy.yml
+```
+
+Short aliases everywhere: `rask g` = `rask generate`; `g f`/`g c`/`g p`/`g j`/`g e` =
+feature / component / page / job / email.
+
+## Feature field tokens
+
+`rask g f <Entity> <Name:type> …` — fields are **positional** after the name. `Id` is added for you.
+
+| Type token | C# type | | Modifier | Meaning |
+|---|---|---|---|---|
+| `string` / `text` | `string` | | `Name:string?` | trailing `?` → **optional** |
+| `int` / `number` | `int` | | `Name:string(100)` | `(n)` → max length |
+| `long` | `long` | | `'Note:string?(500)'` | quote specs with `?`/`(…)` so the shell won't expand them |
+| `decimal` / `money` | `decimal` | | | |
+| `double` | `double` | | **Relationship** | after the root's fields: |
+| `bool` | `bool` | | `1:n Comment Body:text` | one Post → many Comments (FK on Comment) |
+| `date` | `DateOnly` | | `n:1` · `1:1` · `n:n` | many-to-one · one-to-one · many-to-many |
+| `time` | `TimeOnly` | | `0:n` (leading `0`) | makes the foreign key **optional** |
+| `datetime` | `DateTime` | | | `n:n` uses EF's implicit join table |
+| `Guid` | `Guid` | | | |
+
+**Feature flags:** `--bs` (Bootstrap `Bs*` pages) · `--modal` (create/edit in a `BsModal`, implies
+`--bs`) · `--soft-delete` · `--concurrency` (row version) · `--events` · `--outbox` (implies
+`--events`) · `--tests` (sibling `<Project>.Tests`) · `--validation valueobjects|dataannotations|fluent`
+· `--id guid|int|long` · `--plural People` · `--context <Name>` · `--no-restore` · `--force` ·
+`--dry-run` · `--save-defaults` (remember these flags in `.rask/generate.json`).
+
+## Wiring one-liners
+
+`rask g f` **writes these three for you** into `Program.cs` (and adds the packages):
+
+```csharp
+builder.Services.AddRaskCqrs();                        // the mediator (IDispatcher)
+builder.Services.AddRaskData();                        // EF interceptors: audit/soft-delete/events
+builder.Services.AddDbContextFactory<ProductsDbContext>(o => o.UseSqlite("Data Source=app.db"));
+```
+
+The other pillars are **one registration + one `modelBuilder` line + a migration** you add by hand:
+
+```csharp
+builder.Services.AddRaskJobs<ProductsDbContext>(o => { /* … */ });   modelBuilder.AddRaskJobs();
+builder.Services.AddRaskMail<ProductsDbContext>(o => { /* … */ });   modelBuilder.AddRaskMail();
+builder.Services.AddRaskCache<ProductsDbContext>();                  modelBuilder.AddRaskCache();
+builder.Services.AddRaskOutbox<ProductsDbContext>(o => { /* … */ }); modelBuilder.AddRaskOutbox();
+// with the outbox, disable the in-process publisher:
+builder.Services.AddRaskData(o => o.DispatchDomainEventsInProcess = false);
+
+// production SQLite — a drop-in for .UseSqlite that installs the pragma interceptor:
+.UseRaskSqlite("Data Source=app.db")
+builder.Services.AddRaskSqliteLitestream(o => { /* off-box backup */ });
+```
+
+After any `modelBuilder.AddRask…` line: `rask db add <Name>` → `rask db update`.
+
+## Code idioms
+
+```csharp
+// Dispatch a query or command — one method, result type inferred from the message:
+var view = await dispatcher.DispatchAsync(new GetProducts(), CancellationToken);   // IDispatcher, ctor-injected
+
+// Type-safe URL for a routed page — never a string path:
+NavLink(Href: Routes.ProductsPage())["Catalog"];       // list page → <Plural>Page
+nav.NavigateTo(Routes.UpdateProduct(Id: id));          // edit page → Update<Entity>; Navigator, event-handler only
+
+// Gate on auth — route-level attribute, or a component that renders only when signed in:
+[Authorize]                                            // redirects anonymous deep-links to /login
+Authorize()[ NewProductButton() ]                      // shown only to signed-in users
+Authorize(Roles: ["admin"])[ DeleteProductButton(id) ]
+
+// Cache an expensive read; invalidate on write:
+var products = await cache.GetOrCreateAsync("products", async _ => await LoadAsync(), CancellationToken);
+await cache.RemoveAsync("products");
+
+// Enqueue work off the request thread — returns as soon as the row is written:
+await jobs.EnqueueAsync(new SendOrderReceipt(order.Id), CancellationToken);
+```
+
+---
+
+Full reference → [the `rask` CLI](cli.md) · Learn it in order → [Tutorial](tutorial/00-overview.md) ·
+How do I…? → [Recipes](recipes.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -4,6 +4,9 @@
 Rask a short, task-focused command line on top of the .NET SDK. It is dependency-free, it generates or
 shells out to `dotnet` for everything it does, and it never gets in the way of the tools you already use.
 
+> **In a hurry?** The [cheat sheet](cheatsheet.md) lists every command on one page, and the
+> [recipes](recipes.md) answer "how do I do X?" with the command and the wiring line.
+
 ## Install
 
 ```bash
@@ -147,9 +150,10 @@ The generated code compiles as-is in any project scaffolded by `rask new` — th
 audit stamps + a domain-events buffer), so a generated `feature` needs **EF Core + `Rask.Cqrs` +
 `Rask.Data`** referenced — `rask generate` **adds those packages to the project for you**
 (`dotnet add package` for EF Core + SQLite, `Rask.Cqrs`, `Rask.Data`, and — with `--bs`/`--validation` —
-`Rask.Bootstrap` / the validation library; pass `--no-restore` to skip). It then prints the DI
-registration (`AddRaskCqrs()` + `AddRaskData()` + `AddDbContextFactory` with the interceptors) and the
-migration to create and apply with [`rask db`](#rask-db--ef-core-migrations) before it works.
+`Rask.Bootstrap` / the validation library; pass `--no-restore` to skip). It then **writes the DI
+registration** (`AddRaskCqrs()` + `AddRaskData()` + `AddDbContextFactory` with the interceptors) into
+`Program.cs` for you — falling back to printing it if it can't find the file — and prints the migration
+to create and apply with [`rask db`](#rask-db--ef-core-migrations) before it works.
 
 Every command has short aliases: `rask g` = `rask generate`, and `g f` / `g c` / `g p` scaffold a
 feature / component / page.

--- a/docs/data.md
+++ b/docs/data.md
@@ -1,5 +1,7 @@
 # Rask.Data — base entity + EF Core interceptors
 
+> **In practice:** [Tutorial Ch 2](tutorial/02-first-feature.md) · recipe [add a feature to an existing database](recipes.md#add-a-feature-to-an-existing-database) · [cheat sheet](cheatsheet.md).
+
 `Rask.Data` is a tiny, provider-agnostic data layer for **Entity Framework Core** applications. It gives
 your entities a shared base with identity, audit stamps, and a domain-events buffer, and drives four
 production concerns — auditing, soft delete, optimistic concurrency, and domain-event publication —

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,7 @@
 # Deployment
 
+> **In practice:** [Tutorial Ch 9](tutorial/09-deploy.md) · recipe [deploy and redeploy](recipes.md#deploy-and-redeploy) · [cheat sheet](cheatsheet.md).
+
 Rask apps are ordinary .NET apps, so every standard .NET hosting path works — `dotnet publish`
 behind a reverse proxy, Azure App Service, a systemd unit, or a container. This guide covers
 **containers**, which the templates scaffold for you — and `rask deploy`, which ships one to a single

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -357,3 +357,6 @@ Read **[the doctrine](one-person-framework.md)** for the why. Reference guides f
 - **Test your components** → [testing](testing.md) — unit-testing components and rendered HTML.
 - **Write idiomatic Rask** → [best practices](best-practices.md) — patterns and pitfalls that keep an app correct, secure, and fast.
 - **Decode a build error** → [diagnostics](diagnostics.md) — every RASK0xx analyzer ID and its fix.
+
+**Keep handy while you build:** the [cheat sheet](cheatsheet.md) (every command + wiring line on one
+page) and the [recipes](recipes.md) (task-first "how do I do X?").

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,5 +1,7 @@
 # Rask.Jobs — durable background jobs on your database
 
+> **In practice:** [Tutorial Ch 4](tutorial/04-background-jobs.md) · recipe [run work off the request thread](recipes.md#run-work-off-the-request-thread) · [cheat sheet](cheatsheet.md).
+
 `Rask.Jobs` runs **background work off the request thread**, stored in the app's own database — no message
 broker, no Redis. Enqueue a job and a hosted worker runs it later, **at-least-once**, with exponential-backoff
 retries; it also runs **delayed** and durable **interval-recurring** jobs. Scaffold one with

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -1,5 +1,7 @@
 # Rask.Mail — durable transactional email on your database
 
+> **In practice:** [Tutorial Ch 5](tutorial/05-email.md) · recipe [send a transactional email](recipes.md#send-a-transactional-email) · [cheat sheet](cheatsheet.md).
+
 `Rask.Mail` sends **transactional email off the request thread**, queued in the app's own database — no message
 broker, no Redis. Compose an email whose body is a **Rask component rendered to HTML**, call
 `SendAsync`, and a hosted worker delivers it later over SMTP, **at-least-once**, with exponential-backoff

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -1,5 +1,7 @@
 # Rask.Outbox — a transactional outbox on your database
 
+> **In practice:** [Tutorial Ch 7](tutorial/07-outbox-events.md) · recipe [publish a domain event through the outbox](recipes.md#publish-a-domain-event-through-the-outbox) · [cheat sheet](cheatsheet.md).
+
 `Rask.Outbox` gives [`Rask.Data`](data.md) aggregates **durable, crash-safe domain-event delivery** on the
 app's own database — no message broker, no Redis. It's the durable counterpart to `Rask.Data`'s in-process
 publisher, and what `rask generate feature --outbox` wires up.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,185 @@
+# Recipes
+
+Task-first answers to "how do I do X in an app I already have?" Each recipe is the shortest path —
+the command, the one wiring line, and where to go deeper. The [Tutorial](tutorial/00-overview.md)
+teaches these in order on one app; this page is the lookup. Keep the [Cheat sheet](cheatsheet.md)
+open alongside.
+
+| I want to… | Jump to |
+|---|---|
+| add a CRUD feature to a database I already have | [↓](#add-a-feature-to-an-existing-database) |
+| relate two entities (one-to-many, many-to-many) | [↓](#add-a-related-entity) |
+| require a login to reach a page | [↓](#require-login-on-a-page) |
+| run work off the request thread | [↓](#run-work-off-the-request-thread) |
+| send a transactional email | [↓](#send-a-transactional-email) |
+| cache an expensive query | [↓](#cache-an-expensive-query) |
+| publish a domain event durably | [↓](#publish-a-domain-event-through-the-outbox) |
+| harden SQLite for production | [↓](#turn-on-production-sqlite) |
+| deploy, and redeploy | [↓](#deploy-and-redeploy) |
+| stop retyping the same feature flags | [↓](#save-team-defaults) |
+| get tests with a generated feature | [↓](#generate-tests-for-a-feature) |
+
+---
+
+## Add a feature to an existing database
+
+Point a new feature at a `DbContext` you already have instead of generating a fresh one — the CLI
+resolves the class, adds the `DbSet`, and wires the cross-namespace `using` so it compiles.
+
+```bash
+rask g f Order Total:decimal ProductId:guid Placed:datetime --context ProductsDbContext
+rask db add AddOrder && rask db update
+```
+
+→ Reference: [data access](data.md) · Learn it: [Tutorial Ch 3](tutorial/03-orders-and-auth.md)
+
+## Add a related entity
+
+Name a cardinality, a target entity, and its fields **after the root's fields** — both slices are
+generated in one run, with the foreign key, navigation properties, and EF mapping in place.
+
+```bash
+rask g f Post Title:string 1:n Comment Body:text     # Post → many Comments (Comment.PostId + Comment.Post, Post.Comments)
+```
+
+Cardinalities: `1:n` `n:1` `1:1` `n:n` — a leading `0` (`0:n`) makes the foreign key optional; `n:n`
+maps through EF Core's implicit join table (no join entity).
+
+→ Reference: [the `rask` CLI](cli.md) · Learn it: [Tutorial Ch 3](tutorial/03-orders-and-auth.md)
+
+## Require login on a page
+
+Two gates, use both: `[Authorize]` at the route (redirects anonymous deep-links to `/login`), and the
+`Authorize` component to hide UI that anonymous users shouldn't see.
+
+```csharp
+[Authorize]                                    // route-level; from Microsoft.AspNetCore.Authorization
+public sealed class CreateProduct : Component { … }
+
+Authorize()[ NewProductButton() ]              // rendered only for signed-in users
+Authorize(Roles: ["admin"])[ DeleteProductButton(product.Id) ]
+```
+
+Scaffold the login itself with `rask new … --auth`.
+
+→ Reference: [authentication](authentication.md) · Learn it: [Tutorial Ch 3](tutorial/03-orders-and-auth.md)
+
+## Run work off the request thread
+
+Generate a job, add one registration + its table, then enqueue. `EnqueueAsync` returns as soon as the
+row is written, so the request finishes immediately; a background processor runs it at-least-once.
+
+```bash
+rask g job SendOrderReceipt
+```
+```csharp
+builder.Services.AddRaskJobs<ProductsDbContext>(o => { /* … */ });   // needs AddRaskCqrs()
+modelBuilder.AddRaskJobs();                                          // then: rask db add AddJobs && rask db update
+await jobs.EnqueueAsync(new SendOrderReceipt(order.Id), CancellationToken);
+```
+
+→ Reference: [background jobs](jobs.md) · Learn it: [Tutorial Ch 4](tutorial/04-background-jobs.md)
+
+## Send a transactional email
+
+Generate an email whose body is a Rask component, add the mail queue, then send. Delivery happens off
+the request thread over SMTP with backoff.
+
+```bash
+rask g email OrderReceipt
+```
+```csharp
+builder.Services.AddRaskMail<ProductsDbContext>(o => { /* SMTP … */ });
+modelBuilder.AddRaskMail();                                          // then: rask db add AddMail && rask db update
+```
+
+→ Reference: [transactional email](mail.md) · Learn it: [Tutorial Ch 5](tutorial/05-email.md)
+
+## Cache an expensive query
+
+One registration + one table, then wrap the read in `GetOrCreateAsync` and invalidate on write.
+
+```csharp
+builder.Services.AddRaskCache<ProductsDbContext>();
+modelBuilder.AddRaskCache();                                         // then: rask db add AddCache && rask db update
+
+var products = await cache.GetOrCreateAsync("products", async _ => await LoadAsync(), CancellationToken);
+await cache.RemoveAsync("products");                                 // when the catalog changes
+```
+
+→ Reference: [cache](cache.md) · Learn it: [Tutorial Ch 6](tutorial/06-cache.md)
+
+## Publish a domain event through the outbox
+
+Events are written to an `OutboxMessage` row **in the same transaction** as your data, then delivered
+post-commit (crash-safe, at-least-once). The fastest path is to scaffold it with the feature:
+
+```bash
+rask g f Order Total:decimal --outbox        # emits the event records, the Raise calls, and a handler stub
+```
+
+For an existing feature, wire it by hand:
+
+```csharp
+builder.Services.AddRaskData(o => o.DispatchDomainEventsInProcess = false);   // was AddRaskData()
+builder.Services.AddRaskOutbox<ProductsDbContext>(o => { /* … */ });
+modelBuilder.AddRaskOutbox();                                        // then: rask db add AddOutbox && rask db update
+```
+
+→ Reference: [outbox](outbox.md) · Learn it: [Tutorial Ch 7](tutorial/07-outbox-events.md)
+
+## Turn on production SQLite
+
+`UseRaskSqlite` is a drop-in for `.UseSqlite` that installs the pragma interceptor (WAL, `foreign_keys`,
+`busy_timeout` on every open). Add Litestream for continuous off-box backup.
+
+```csharp
+.UseRaskSqlite("Data Source=app.db")                                // was .UseSqlite("Data Source=app.db")
+builder.Services.AddRaskSqliteLitestream(o => { /* S3/replica … */ });
+```
+
+→ Reference: [production SQLite](sqlite.md) · Learn it: [Tutorial Ch 8](tutorial/08-production-sqlite.md)
+
+## Deploy and redeploy
+
+`rask deploy` builds your Docker image on the server, runs it behind a shared Caddy proxy with
+automatic HTTPS, and does a health-gated zero-downtime swap. The first run on a bare box also sets it
+up (Docker, a non-root deploy user, firewall, SSH hardening).
+
+```bash
+rask deploy --host root@your-box.example.com --domain shop.example.com   # first time
+rask deploy                                                             # after: host/domain remembered
+rask deploy --github-actions                                            # write .github/workflows/deploy.yml
+```
+
+Needs a `Dockerfile` — `rask new … --docker` writes one.
+
+→ Reference: [deployment](deployment.md) · Learn it: [Tutorial Ch 9](tutorial/09-deploy.md)
+
+## Save team defaults
+
+So a project stops retyping the same feature flags, record them once in `.rask/generate.json`; explicit
+flags on the command line always win.
+
+```bash
+rask g f Order Total:decimal --bs --tests --save-defaults    # scaffolds and remembers --bs/--tests
+```
+
+→ Reference: [the `rask` CLI](cli.md#rask-generate--scaffold-code)
+
+## Generate tests for a feature
+
+`--tests` emits a sibling `<Project>.Tests` project (created and wired on first use) with a domain test
+and — when the `DbContext` is generated — a SQLite round-trip persistence test, so `dotnet test` runs
+as-is.
+
+```bash
+rask g f Product Name:string Price:decimal --tests
+```
+
+→ Reference: [testing](testing.md)
+
+---
+
+Command reference → [the `rask` CLI](cli.md) · One-page reference → [Cheat sheet](cheatsheet.md) ·
+Learn it in order → [Tutorial](tutorial/00-overview.md)

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -1,5 +1,7 @@
 # SQLite production pragmas (`Rask.SQLite`)
 
+> **In practice:** [Tutorial Ch 8](tutorial/08-production-sqlite.md) · recipe [turn on production SQLite](recipes.md#turn-on-production-sqlite) · [cheat sheet](cheatsheet.md).
+
 SQLite's stock configuration is tuned for a single embedded process, not a web app. Out of the box a
 connection uses the rollback journal (not WAL), does **not** enforce foreign keys, has **no**
 `busy_timeout`, and fsyncs on every commit — so the moment two requests write at once you get

--- a/docs/tutorial/01-scaffold.md
+++ b/docs/tutorial/01-scaffold.md
@@ -1,13 +1,14 @@
 # Chapter 1 — Scaffold the app
 
 > **Goal:** create the Shop project, run it, and understand what the template gave you.
-> **You'll run:** `rask new Shop --auth`
+> **You'll run:** `rask new Shop --auth --docker`
 
 ## Create the project
 
 The `rask` CLI scaffolds projects. We'll use the default **server** template (one ASP.NET project,
 components render on the server, live updates ship over a WebSocket) and add `--auth` up front, because
 Chapter 3 will lock the catalog behind a login and it's easiest to have that wiring from the start.
+`--docker` writes a production Dockerfile now so [Chapter 9](09-deploy.md)'s `rask deploy` has one ready.
 
 ```bash
 rask new Shop --auth --docker


### PR DESCRIPTION
## Summary
A docs-navigability / onboarding DX pass. Adds the lookup-oriented middle layer the docs were missing between the linear tutorial and the per-pillar reference: a one-page **cheat sheet** (`docs/cheatsheet.md`) with every CLI command, feature field token, `AddRask…` wiring one-liner, and code idiom; and a task-first **recipes** cookbook (`docs/recipes.md`) answering "how do I do X?" with the command, the wiring line, and links to the reference + the tutorial chapter that teaches it. Both are linked from the docs index, and each pillar reference now carries a reciprocal "In practice" pointer back to its tutorial chapter and recipe, so every entry point leads to the others. Also fixes two drifted lines (Chapter 1 goal box → `rask new Shop --auth --docker`; the CLI reference now says `rask generate` **writes** the DI into `Program.cs`, printing only as a fallback).

Docs-only — no CLI/framework code changes. Every command, flag, and wiring line was copied from verified reality (`GenerateCommand.CreateSchema()`, `FeatureGenerator`, and the shipped tutorial chapters), not paraphrased.

## Testing
- Unit: n/a — docs-only, no code changed (pre-commit correctly skipped the format + unit gate).
- E2E: n/a — no `samples/` change.
- Docs integrity: every relative file link and every `#anchor` target in the new/edited pages resolves; HARD-RULE scan (no Ruby/Rails/DHH) clean; code-fence balance verified.

## Benchmarks
n/a — no render/runtime change.

## CHANGELOG
- [Unreleased] entry added under **Documentation**: cheat sheet + recipes cookbook, reciprocal pillar-doc cross-links, and the two corrected lines.
