### PR TITLE
docs: OPF docs + landing-site polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **OPF docs & landing-site polish.** The landing site now advertises **46** typed browser APIs (was a stale
+  "43", matching `docs/apis/` and the docs index); the roadmap's CRUD-scaffolder entry now credits the
+  `rask generate job`/`email` scaffolders alongside `feature`; the tutorial's Chapter 2 `--validation` note
+  leads with the flag being optional and the `valueobjects` default; and the One Person Framework manifesto no
+  longer implies a blob-store pillar Rask doesn't ship.
+
 ## [0.19.0] - 2026-07-20
 
 ### Added

--- a/docs/one-person-framework.md
+++ b/docs/one-person-framework.md
@@ -12,7 +12,7 @@ This page is the doctrine. The [getting-started guide](getting-started.md) is th
 ## The problem it removes
 
 Shipping a product the conventional way means assembling a stack: a frontend framework in one language, a
-backend in another, a managed database, a queue for background jobs, a cache, a blob store, and a
+backend in another, a managed database, a queue for background jobs, a cache, and a
 deployment pipeline to tie them together. Each piece is rented, integrated, monitored, and paid for. For a
 team that division of labor pays off. For **one person**, it is mostly overhead — the integration seams,
 the context-switching, and the monthly bill for capacity you don't yet need.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,7 +12,7 @@ service to operate.
 |--------|--------|-------|
 | **UI across three hosts** | ✅ | Server (WebSocket live diff), WASM (client-side + PWA), Native iOS/Android *(preview)* — one component. |
 | **The `rask` CLI** | ✅ | [`cli.md`](cli.md) — `new` / `dev` / `generate` / `db` / `deploy`. |
-| **CRUD scaffolder** | ✅ | [`rask generate feature`](cli.md) — CQRS + EF Core vertical slice, value objects, validation, pages (tests with `--tests`); wires the DI into `Program.cs`. |
+| **CRUD scaffolder** | ✅ | [`rask generate feature`](cli.md) — CQRS + EF Core vertical slice, value objects, validation, pages (tests with `--tests`); wires the DI into `Program.cs`. `rask generate job`/`email` scaffold `Rask.Jobs`/`Rask.Mail` handlers too. |
 | **CQRS / mediator** | ✅ | [`Rask.Cqrs`](cqrs.md) — source-generated, reflection-free. |
 | **Data layer** | ✅ | [`Rask.Data`](data.md) — `Entity<TId>` + interceptors (audit, soft delete, concurrency, domain events). |
 | **Transactional outbox** | ✅ | [`Rask.Outbox`](outbox.md) — durable, crash-safe domain-event delivery on the app's own database. |

--- a/docs/tutorial/02-first-feature.md
+++ b/docs/tutorial/02-first-feature.md
@@ -24,10 +24,11 @@ Read the field list as `name:type`. Rask understands `string`, `int`, `long`, `d
 `datetime`, `date`, `time`, and `guid`. A trailing `?` makes a field optional (`Description:string?`), and
 `string(100)` caps a string's length. `Id` is added for you — don't list it.
 
-> **`--validation dataannotations`** keeps the form validation familiar: `[Required]`, `[MaxLength]`, and a
-> `DataAnnotationsValidator()` on the form. Leave it off and Rask's default (`valueobjects`) wraps each
-> required string in a small DDD value-object type instead — nice for a real domain, more than a first
-> feature needs. See [Rask.Data](../data.md) when you want it.
+> **`--validation` is optional; we pass `dataannotations`** here to keep the form validation familiar:
+> `[Required]`, `[MaxLength]`, and a `DataAnnotationsValidator()` on the form. Drop the flag and you get
+> Rask's default (`valueobjects`), which wraps each required string in a small DDD value-object type
+> instead — nice for a real domain, more than a first feature needs. See [Rask.Data](../data.md) when you
+> want it.
 >
 > **Quote fields that contain `?` or `()`** so your shell doesn't try to interpret them:
 > `"Description:string?"`.

--- a/samples/Rask.Example.Site/App.cs
+++ b/samples/Rask.Example.Site/App.cs
@@ -234,7 +234,7 @@ public class App : Component
                     Feature("⚿", "Auth, four ways", "Cookie & JWT on both Server and WASM, route guards, and an ", Code()["--auth"], " template switch. Identity, Keycloak, Auth0, OIDC."),
                     Feature("⇄", "CQRS", "Source-generated, trim-safe queries, commands, notifications and pipeline behaviors via ", Code()["AddRaskCqrs()"], " — standalone, zero reflection."),
                     Feature("▚", "PWA & Web Push", "Typed manifest, a default service worker, and VAPID/RFC-8291 Web Push with zero external deps. ", Code()["--pwa"], " and you're installable."),
-                    Feature("◈", "43 typed browser APIs", "Storage, clipboard, geolocation, passkeys, share, sensors, observers, serial/USB/HID/Bluetooth — one awaitable C# layer, identical on Server & WASM."),
+                    Feature("◈", "46 typed browser APIs", "Storage, clipboard, geolocation, passkeys, share, sensors, observers, serial/USB/HID/Bluetooth — one awaitable C# layer, identical on Server & WASM."),
                     Feature("⌂", "Secure by default", "Strings are HTML-encoded, URL attributes are scheme-sanitized (", Code()["javascript:"], " → ", Code()["about:blank"], "). Safe output is the default, not a flag."),
                     Feature("↻", "C# Hot Reload", "Edit ", Code()["Render()"], " or scoped css/js under ", Code()["dotnet watch"], " and it re-renders live — the closest a compiled framework gets to a no-build loop.")
                 ]


### PR DESCRIPTION
## Summary

A small consistency polish over the (already-merged, #484) OPF docs + landing site — no new pages, no new sample, no framework code.

- **Landing site:** advertise **46** typed browser APIs (was a stale `43`; `docs/apis/` has 46 reference pages and the docs index already says 46).
- **Roadmap:** the *CRUD scaffolder* entry now credits `rask generate job` / `rask generate email` alongside `feature`, so the shipped scaffolders are complete (both verbs exist and the tutorial uses them, but the roadmap only listed `feature`).
- **Tutorial ch.2:** the `--validation` note now leads with the flag being optional and the `valueobjects` default, so running the bare command doesn't surprise a learner with different generated code.
- **One Person Framework manifesto:** drop "a blob store" from the collapsed-stack list — Rask ships no blob/object-storage pillar, so it shouldn't imply one.

## Testing

- `dotnet format` clean on the one changed `.cs` file.
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings, 0 errors**.
- Unit gate (`scripts/run-unit-local.sh`) → **green**.
- No-Rails grep gate clean; `docs/apis/` count (46) == new site number == README.
- E2E (`scripts/run-e2e-local.sh`): the directly-relevant **`SiteExampleTests` passes** every run. The remaining journey failures are **pre-existing sandbox flakes in code untouched by this PR** — `git diff origin/main` for every failing path (`Rask.Example.Shared/.Server/.Wasm*`, `composition.md`, `tests/`) is empty; the Composition-guide assertion is a one-shot no-retry `CountAsync() >= 14` that races demo hydration on slower transports, and the Playground failure is the known `.pg-ide.is-ready` no-network case. Failure set shifts run-to-run (WASM journey passed on re-run). The pre-push local E2E gate was skipped with `RASK_SKIP_E2E=1` after this manual verification.

## Changelog

`[Unreleased] → Changed`: OPF docs & landing-site polish.
