### PR TITLE
feat(cli): generated features use UseRaskSqlite, pin Rask packages, validate the project name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,26 @@ them until tagged releases begin.
   builds under `-warnaserror`. (Closes #478.)
 
 ### Changed
+- **Generated features use `UseRaskSqlite` (production pragmas) instead of raw `UseSqlite`.** A `rask generate
+  feature` run that owns its `DbContext` now registers it with `UseRaskSqlite` — the WAL + `busy_timeout` +
+  `foreign_keys` pragma set — so a generated app survives concurrent writers (jobs, email, outbox) instead of
+  hitting `database is locked`. The connection string honours a `ConnectionStrings:App` override (defaulting to
+  a local `app.db`), so a deploy can point it at a persistent volume. Adds `Rask.SQLite.EntityFrameworkCore` to
+  the project.
+- **`rask generate feature` pins the `Rask.*` packages it adds to the CLI's version.** Previously it floated
+  them to the latest on nuget.org (`dotnet add package` with no version), which could pair a template's
+  `Rask.Server` with a newer `Rask.Data`/`Rask.Cqrs`. Non-Rask packages (EF Core, SQLitePCLRaw) still float.
 - **OPF docs & landing-site polish.** The landing site now advertises **46** typed browser APIs (was a stale
   "43", matching `docs/apis/` and the docs index); the roadmap's CRUD-scaffolder entry now credits the
   `rask generate job`/`email` scaffolders alongside `feature`; the tutorial's Chapter 2 `--validation` note
   leads with the flag being optional and the `valueobjects` default; and the One Person Framework manifesto no
   longer implies a blob-store pillar Rask doesn't ship.
+
+### Fixed
+- **`rask new` rejects an invalid project name up front.** The name becomes the root namespace and csproj
+  filename, so a value like `my-app` or `9Lives` (a dash, a leading digit, a keyword, an empty dotted segment)
+  used to scaffold a project that never compiled. It's now validated before any files are written, with a clear
+  message; dotted names like `Contoso.Shop` are still accepted.
 
 ## [0.19.0] - 2026-07-20
 

--- a/docs/tutorial/02-first-feature.md
+++ b/docs/tutorial/02-first-feature.md
@@ -65,7 +65,7 @@ so `Program.cs` now has these lines (and the `using`s they need) added next to y
 builder.Services.AddRaskCqrs();
 builder.Services.AddRaskData();
 builder.Services.AddDbContextFactory<ProductsDbContext>((sp, o) => o
-    .UseSqlite("Data Source=app.db")
+    .UseRaskSqlite(builder.Configuration.GetConnectionString("App") ?? "Data Source=app.db")
     .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));
 ```
 
@@ -73,7 +73,11 @@ builder.Services.AddDbContextFactory<ProductsDbContext>((sp, o) => o
 - `AddRaskData()` registers the interceptors (auditing, and later soft-delete/concurrency/events).
 - `AddDbContextFactory<ProductsDbContext>(…)` registers the context **as a factory** — Rask pages are
   long-lived and may render concurrently, so each unit of work creates its own short-lived context rather
-  than sharing one scoped instance. `Data Source=app.db` is a SQLite file created next to the app.
+  than sharing one scoped instance. `UseRaskSqlite` is a drop-in for `UseSqlite` that also applies the
+  production pragmas (WAL, `busy_timeout`, `foreign_keys`) — so the app handles concurrent writers (the jobs,
+  email, and outbox you add in later chapters) without hitting `database is locked`. It defaults to a local
+  `app.db` file next to the app but honours a `ConnectionStrings:App` override, which is how a deploy points
+  it at a persistent volume.
 
 The insert is idempotent, so generating a second feature only adds what's new. (If the CLI can't find or
 safely edit your `Program.cs`, it prints the block instead for you to paste — same result.)

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -426,13 +426,24 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             return;
         }
 
+        // Pin the Rask.* packages to the CLI's own version so a generated feature can't float them past the
+        // Rask.Server the template baked (a locally/CI-built CLI would otherwise mix e.g. Rask.Server 0.17.0
+        // with a newer Rask.Data pulled from nuget.org). Non-Rask packages (EF Core, SQLitePCLRaw) keep
+        // floating — they version independently of Rask and resolve to the latest compatible.
+        var raskVersion = NewCommand.ResolvePackageVersion(CliMetadata.Version);
+
         Console.WriteLine($"Adding {packages.Count} package(s) to the project…", ConsoleStyle.Dim);
         foreach (var package in packages)
         {
-            var exit = await _process.RunAsync("dotnet", ["add", "package", package], projectDirectory, cancellationToken).ConfigureAwait(false);
+            var isRask = package.StartsWith("Rask.", StringComparison.Ordinal);
+            string[] args = isRask
+                ? ["add", "package", package, "--version", raskVersion]
+                : ["add", "package", package];
+            var exit = await _process.RunAsync("dotnet", args, projectDirectory, cancellationToken).ConfigureAwait(false);
             if (exit != 0)
             {
-                WriteWarning($"  Couldn't add {package} automatically — add it manually: dotnet add package {package}");
+                var manual = isRask ? $"dotnet add package {package} --version {raskVersion}" : $"dotnet add package {package}";
+                WriteWarning($"  Couldn't add {package} automatically — add it manually: {manual}");
             }
         }
     }

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -88,6 +88,17 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             return 1;
         }
 
+        // The name becomes the root namespace and the csproj filename, so an invalid one (a dash, a leading
+        // digit, a keyword) would scaffold a project that never compiles. Reject it up front with guidance
+        // rather than writing files the user then has to throw away.
+        if (!Identifiers.IsValidNamespaceName(name))
+        {
+            Console.Error.WriteLine(
+                $"'{name}' isn't a valid project name — it becomes the root namespace, so each dot-separated part must "
+                + "start with a letter or underscore and contain only letters, digits, or underscores (e.g. Shop or Contoso.Shop).");
+            return 1;
+        }
+
         var templateKey = parsed.Option("template") ?? TemplateCatalog.Default.Key;
         if (!TemplateCatalog.TryGet(templateKey, out var template))
         {

--- a/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/FeatureGenerator.cs
@@ -99,7 +99,7 @@ internal static class FeatureGenerator
             files,
             RenderNextSteps(context, root.Name, root.Plural, Identifiers.ToRoutePath(root.Plural), generateContext, options.Validation, options.UseBs, options.UseTests))
         {
-            Packages = FeaturePackages(options.Validation, options.UseBs, options.UseOutbox),
+            Packages = FeaturePackages(options.Validation, options.UseBs, options.UseOutbox, generateContext),
             ProgramUsings = programUsings,
             ProgramRegistrations = programRegistrations,
             ContextDbSets = contextDbSets,
@@ -167,10 +167,15 @@ internal static class FeatureGenerator
         {
             usings.Add("Microsoft.EntityFrameworkCore");
             usings.Add("Microsoft.EntityFrameworkCore.Diagnostics");
+            usings.Add("Rask.SQLite");
             usings.Add(contextNs);
+            // UseRaskSqlite is a drop-in for UseSqlite that also applies the production pragma set (WAL,
+            // busy_timeout, foreign_keys), so the app survives concurrent writers (jobs/mail/outbox) instead of
+            // hitting "database is locked". The connection string falls back to a local file but honours a
+            // ConnectionStrings:App override, so `rask deploy` can point it at a mounted volume that survives redeploys.
             registrations.Add(
                 $"builder.Services.AddDbContextFactory<{context}>((sp, o) => o\n"
-                + "    .UseSqlite(\"Data Source=app.db\")\n"
+                + "    .UseRaskSqlite(builder.Configuration.GetConnectionString(\"App\") ?? \"Data Source=app.db\")\n"
                 + "    .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));");
         }
 
@@ -925,7 +930,7 @@ internal static class FeatureGenerator
     }
 
     // The NuGet packages the generated slice references — the command adds these to the project.
-    private static IReadOnlyList<string> FeaturePackages(string validation, bool useBs, bool useOutbox)
+    private static IReadOnlyList<string> FeaturePackages(string validation, bool useBs, bool useOutbox, bool generateContext)
     {
         var packages = new List<string>
         {
@@ -942,6 +947,13 @@ internal static class FeatureGenerator
             "Rask.Cqrs",
             "Rask.Data", // the Entity<TId> base + interceptors every generated entity inherits
         };
+
+        // When the run owns the DbContext it registers UseRaskSqlite (production pragmas); with --context the
+        // existing context's project already carries this reference.
+        if (generateContext)
+        {
+            packages.Add("Rask.SQLite.EntityFrameworkCore");
+        }
 
         if (useOutbox)
         {

--- a/src/Rask.Cli/Scaffolding/Identifiers.cs
+++ b/src/Rask.Cli/Scaffolding/Identifiers.cs
@@ -22,6 +22,15 @@ internal static class Identifiers
         "void", "volatile", "while",
     };
 
+    /// <summary>
+    /// True if <paramref name="value"/> is usable as a namespace: every dot-separated segment is a valid,
+    /// non-keyword C# identifier. A generated project's name becomes its root namespace (and csproj name), so
+    /// this gates <c>rask new</c> — <c>Shop</c> and <c>Contoso.Shop</c> pass; <c>my-app</c>, <c>9Lives</c>,
+    /// and a trailing dot don't (they'd emit <c>namespace my-app;</c> and never compile).
+    /// </summary>
+    public static bool IsValidNamespaceName(string value) =>
+        !string.IsNullOrEmpty(value) && value.Split('.').All(IsValidTypeName);
+
     /// <summary>True if <paramref name="value"/> is a valid, non-keyword C# identifier (a usable type name).</summary>
     public static bool IsValidTypeName(string value)
     {

--- a/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
+++ b/tests/Rask.Cli.Tests/FeatureScaffoldingTests.cs
@@ -452,6 +452,30 @@ public sealed class FeatureGeneratorTests
     }
 
     [Fact]
+    public void Owned_context_registers_UseRaskSqlite_and_adds_the_package()
+    {
+        var result = Generate();
+
+        // The generated DbContext factory uses UseRaskSqlite (production pragmas), honouring a
+        // ConnectionStrings:App override so a deploy volume works — not the pragma-less raw UseSqlite.
+        Assert.Contains(result.ProgramRegistrations, r => r.Contains(".UseRaskSqlite(", StringComparison.Ordinal));
+        Assert.Contains(result.ProgramRegistrations, r => r.Contains("builder.Configuration.GetConnectionString(\"App\")", StringComparison.Ordinal));
+        Assert.DoesNotContain(result.ProgramRegistrations, r => r.Contains(".UseSqlite(\"Data Source", StringComparison.Ordinal));
+        Assert.Contains("Rask.SQLite", result.ProgramUsings);
+        Assert.Contains("Rask.SQLite.EntityFrameworkCore", result.Packages);
+    }
+
+    [Fact]
+    public void Explicit_context_does_not_register_a_factory_or_the_sqlite_package()
+    {
+        // With --context the existing context owns the registration + the Rask.SQLite.EntityFrameworkCore ref.
+        var result = Generate(context: "AppDbContext");
+
+        Assert.DoesNotContain(result.ProgramRegistrations, r => r.Contains("AddDbContextFactory", StringComparison.Ordinal));
+        Assert.DoesNotContain("Rask.SQLite.EntityFrameworkCore", result.Packages);
+    }
+
+    [Fact]
     public void Mutation_pages_handle_errors_gracefully_with_an_inline_alert()
     {
         var create = File(Generate(), "CreateProduct.cs");
@@ -592,7 +616,7 @@ public sealed class FeatureGeneratorTests
         // and only a direct reference lifts it. Don't drop it from this list without reading
         // Directory.Packages.props.
         Assert.Equal(
-            ["Microsoft.EntityFrameworkCore.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data"],
+            ["Microsoft.EntityFrameworkCore.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data", "Rask.SQLite.EntityFrameworkCore"],
             result.Packages);
     }
 

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -45,8 +45,9 @@ public sealed class GenerateCommandTests
         Assert.Contains("namespace MyApp.Jobs;", fs.Files[path], StringComparison.Ordinal);
         Assert.Contains("record SendWelcomeEmail : IJob", fs.Files[path], StringComparison.Ordinal);
         Assert.Contains("ICommandHandler<SendWelcomeEmail>", fs.Files[path], StringComparison.Ordinal);
-        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Jobs"]);
-        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Cqrs"]);
+        // Rask.* packages are pinned to the CLI version (see the dedicated pinning test); assert the shape here.
+        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Jobs", "--version", _]);
+        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Cqrs", "--version", _]);
         Assert.Contains("AddRaskJobs", console.OutText, StringComparison.Ordinal);
     }
 
@@ -74,8 +75,26 @@ public sealed class GenerateCommandTests
         Assert.Contains("namespace MyApp.Emails;", fs.Files[path], StringComparison.Ordinal);
         Assert.Contains("class WelcomeEmail : Component", fs.Files[path], StringComparison.Ordinal);
         Assert.Contains("Body(new WelcomeEmail())", fs.Files[path], StringComparison.Ordinal);
-        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Mail"]);
+        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Mail", "--version", _]);
         Assert.Contains("AddRaskMail", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Feature_pins_rask_packages_to_the_cli_version_but_floats_others()
+    {
+        var (_, _, process, command) = BuildWithProcess();
+
+        var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        var version = NewCommand.ResolvePackageVersion(CliMetadata.Version);
+        // Rask.* are pinned to the CLI version so a generated feature can't float them past the Rask.Server the
+        // template baked (a locally/CI-built CLI would otherwise mix versions from nuget.org).
+        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Data", "--version", var v] && v == version);
+        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.SQLite.EntityFrameworkCore", "--version", var v2] && v2 == version);
+        // EF Core / SQLitePCLRaw version independently of Rask — added without a pin so NuGet resolves the latest compatible.
+        Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Microsoft.EntityFrameworkCore.Sqlite"]);
+        Assert.DoesNotContain(process.Invocations, i => i.Arguments is ["add", "package", "Microsoft.EntityFrameworkCore.Sqlite", "--version", _]);
     }
 
     [Fact]
@@ -187,10 +206,14 @@ public sealed class GenerateCommandTests
         Assert.Contains("builder.Services.AddRaskCqrs();", program, StringComparison.Ordinal);
         Assert.Contains("builder.Services.AddRaskData();", program, StringComparison.Ordinal);
         Assert.Contains("builder.Services.AddDbContextFactory<ProductsDbContext>((sp, o) => o", program, StringComparison.Ordinal);
+        // UseRaskSqlite (production pragmas), honouring a ConnectionStrings:App override so a deploy volume works.
+        Assert.Contains(".UseRaskSqlite(", program, StringComparison.Ordinal);
+        Assert.Contains("builder.Configuration.GetConnectionString(\"App\")", program, StringComparison.Ordinal);
         Assert.Contains(".AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));", program, StringComparison.Ordinal);
         // The usings the registrations need are added too.
         Assert.Contains("using Rask.Cqrs;", program, StringComparison.Ordinal);
         Assert.Contains("using Rask.Data;", program, StringComparison.Ordinal);
+        Assert.Contains("using Rask.SQLite;", program, StringComparison.Ordinal);
         Assert.Contains("using MyApp.Features.Products;", program, StringComparison.Ordinal);
         Assert.Contains("using Microsoft.EntityFrameworkCore.Diagnostics;", program, StringComparison.Ordinal);
         Assert.Contains("Registered", console.OutText, StringComparison.Ordinal);
@@ -206,7 +229,7 @@ public sealed class GenerateCommandTests
             "builder.Services.AddRaskCqrs();\n" +
             "builder.Services.AddRaskData();\n" +
             "builder.Services.AddDbContextFactory<ProductsDbContext>((sp, o) => o\n" +
-            "    .UseSqlite(\"Data Source=app.db\")\n" +
+            "    .UseRaskSqlite(builder.Configuration.GetConnectionString(\"App\") ?? \"Data Source=app.db\")\n" +
             "    .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));\n");
 
         var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string", "--force"], CancellationToken.None);
@@ -331,14 +354,15 @@ public sealed class GenerateCommandTests
         var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string,Price:decimal", "--bs"], CancellationToken.None);
 
         Assert.Equal(0, exit);
+        // Match both shapes: non-Rask float (`add package X`) and Rask.* pinned (`add package X --version V`).
         var adds = process.Invocations
-            .Where(i => i.Arguments is ["add", "package", _])
+            .Where(i => i.Arguments.Count >= 3 && i.Arguments[0] == "add" && i.Arguments[1] == "package")
             .Select(i => i.Arguments[2])
             .ToArray();
         // SQLitePCLRaw is really added to the project, not merely printed — it's the direct reference that
         // lifts EF Core Sqlite's vulnerable 2.1.11 pin (CVE-2025-6965), and nothing else does.
         Assert.Equal(
-            ["Microsoft.EntityFrameworkCore.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data", "Rask.Bootstrap"],
+            ["Microsoft.EntityFrameworkCore.Sqlite", "SQLitePCLRaw.bundle_e_sqlite3", "Microsoft.EntityFrameworkCore.Design", "Rask.Cqrs", "Rask.Data", "Rask.SQLite.EntityFrameworkCore", "Rask.Bootstrap"],
             adds);
     }
 

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -76,6 +76,38 @@ public sealed class NewCommandTests
         Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("new"));
     }
 
+    [Theory]
+    [InlineData("my-app")]    // a dash isn't valid in a namespace
+    [InlineData("9Lives")]    // can't start with a digit
+    [InlineData("class")]     // a reserved keyword
+    [InlineData("Foo.")]      // trailing dot → empty segment
+    [InlineData("Foo..Bar")]  // empty middle segment
+    public async Task Invalid_project_name_is_rejected_before_writing_anything(string name)
+    {
+        var (console, fs, runner, command) = Build();
+
+        var exit = await command.ExecuteAsync([name], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Empty(runner.Invocations); // never even restored
+        Assert.Contains("isn't a valid project name", console.ErrorText, StringComparison.Ordinal);
+        Assert.False(fs.FileExists($"/proj/{name}/{name}.csproj"));
+    }
+
+    [Theory]
+    [InlineData("Shop")]
+    [InlineData("Contoso.Shop")] // a dotted name is a valid multi-part namespace
+    public async Task Valid_project_name_including_dotted_is_accepted(string name)
+    {
+        var (console, fs, _, command) = Build();
+
+        var exit = await command.ExecuteAsync([name], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(console.ErrorText);
+        Assert.True(fs.FileExists($"/proj/{name}/{name}.csproj"));
+    }
+
     [Fact]
     public async Task Server_generation_refuses_to_overwrite_an_existing_project()
     {

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -32,8 +32,8 @@ public sealed class ProjectGeneratorBuildE2ETests
         "Rask.Bootstrap",                   // every template, and `generate feature --bs`
         "Rask.Cqrs",                        // server template --cqrs, and every generated feature
         "Rask.Data",                        // every generated feature
-        "Rask.SQLite",                      // --data (dependency of Rask.SQLite.EntityFrameworkCore)
-        "Rask.SQLite.EntityFrameworkCore",  // server template --data (UseRaskSqlite)
+        "Rask.SQLite",                      // --data + every generated feature (via Rask.SQLite.EntityFrameworkCore)
+        "Rask.SQLite.EntityFrameworkCore",  // server template --data and generated features that own a context (UseRaskSqlite)
         "Rask.Outbox",                      // generate feature --outbox
         "Rask.Validation.DataAnnotations",  // generate feature --validation dataannotations
         "Rask.Validation.FluentValidation", // generate feature --validation fluent


### PR DESCRIPTION
## Summary
Second PR of the **"harden the flagship One Person Framework demo"** effort — three scaffold-polish fixes, each a rough edge the audits surfaced.

### 1. Generated features use `UseRaskSqlite` (not raw `UseSqlite`)
A `rask generate feature` run that owns its `DbContext` now registers it with `UseRaskSqlite` — the WAL + `busy_timeout` + `foreign_keys` production pragma set. Without this, a generated app hits `database is locked` the moment you add the concurrent writers the later tutorial chapters do (jobs, email, outbox). The connection string honours a **`ConnectionStrings:App`** override (default `Data Source=app.db`), so a deploy can point it at a persistent volume. Pulls in `Rask.SQLite.EntityFrameworkCore` — only when the run owns the context (a `--context` run's owner already carries the reference).

### 2. `rask generate feature` pins the `Rask.*` packages it adds
Previously it floated them via bare `dotnet add package` (latest on nuget.org), so a locally/CI-built CLI could pair a template's `Rask.Server 0.17.0` with a newer `Rask.Data`/`Rask.Cqrs`. Now Rask.* are pinned to the CLI's own resolved version (shared with `rask new`); non-Rask packages (EF Core, SQLitePCLRaw) still float.

### 3. `rask new` validates the project name
The name becomes the root namespace + csproj filename, so `my-app`, `9Lives`, a keyword, or an empty dotted segment used to scaffold a project that never compiled. It's now validated (`Identifiers.IsValidNamespaceName` — each dot segment a valid identifier) before any files are written, with a clear message. Dotted names like `Contoso.Shop` still pass.

## Testing
- `dotnet test tests/Rask.Cli.Tests` — **632 passed**. New/updated coverage: the `UseRaskSqlite` + `ConnectionStrings:App` registration and the `Rask.SQLite.EntityFrameworkCore` package (owned-context) with a `--context` negative; the Rask-pinned-vs-floated package split; project-name rejection/acceptance theories.
- **E2E compile gate** (`RASK_CLI_BUILD_E2E=1`): the multi-entity feature builds under `-warnaserror` (the local feed now packs `Rask.SQLite` + `Rask.SQLite.EntityFrameworkCore`).
- Browser E2E N/A (CLI-only).

> The Program.cs splice itself is build-gated in the follow-up test/docs PR; the identical `UseRaskSqlite(GetConnectionString("App") ?? …)` idiom is already proven to compile by the `rask new --data` E2E in #493.

## Notes
- Stacks conceptually on **#493** (`rask new --data`) but is independent of it; both standardise on the same `ConnectionStrings:App` override so `rask deploy` has one mechanism.
- **Email auto-wiring** (the `generate email` asymmetry) is split into its own next PR — it needs a new "insert into `OnModelCreating`" context-edit mechanism and deserves focused review.

## Changelog
Added under `[Unreleased]`.