### PR TITLE
test(cli): compile-gate the docs tutorial walk-through end to end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The `docs/tutorial/` walk-through is now a compile gate.** A new opt-in end-to-end test
+  (`TutorialWalkthroughE2ETests`, `RASK_CLI_BUILD_E2E=1`) reproduces the tutorial's chapters 1–8 exactly as a
+  reader would — the real `rask new`/`generate feature`/`generate job`/`generate email` generators, the real
+  `Program.cs`/`DbContext` splices, and the hand-written code the prose tells the reader to type (the job body,
+  the `IMailQueue` send, the `ICache.GetOrCreateAsync` read-through, the `IOutboxEvent` + handler, the
+  `Entity.Raise`, the Litestream wiring) — and builds the fully-wired `Shop` under `-warnaserror`. If a Rask
+  package changes a signature the tutorial uses, the tutorial now breaks a test in the same commit rather than
+  in a beginner's terminal. The shared pack/build plumbing was lifted into `CliBuildE2E`, shared with the
+  existing scaffold gate so the local feed is packed once per session.
 - **`rask generate` gains a `--feature <Name>` flag.** `component`, `job`, and `email` now default to the
   cross-cutting `Features/Shared/` bucket; `--feature <Name>` (`-F`) co-locates the file into that feature's
   slice (`Features/<Name>/`) instead — for a job or email that belongs to one feature. The namespace follows
@@ -21,6 +30,23 @@ them until tagged releases begin.
   first `rask generate feature <Name> --context AppDbContext` is immediately runnable with `rask db add` /
   `rask db update` — no manual DI. Verified end to end: the generated project (alone and with `--auth`)
   builds under `-warnaserror`. (Closes #478.)
+
+### Fixed
+- **`rask generate` no longer corrupts `Program.cs` when wiring a registration after a multi-line one.** The
+  Program.cs splice anchored on the line that *starts* a `builder.Services.` statement, so a second wiring pass
+  (e.g. `rask generate email`'s `AddRaskMail<…>` running after `rask generate feature` had left the multi-line
+  `AddDbContextFactory<…>((sp, o) => o …)` — the tutorial's exact chapter 2 → chapter 5 flow) inserted the new
+  registration *inside* that statement, producing a `Program.cs` that no longer compiled. The splice now
+  advances to the end of the statement (its terminating `;`) before inserting.
+
+### Docs
+- **Tutorial (chapter 5): email bodies carry data on public properties and are built through their generated
+  factory.** The email-body example used `new OrderReceipt(orderId, total)` with constructor parameters, which
+  doesn't compile — `RASK014` forbids constructing a component with `new`, and the generated factory passes
+  data via public properties, not constructor arguments. It now declares `public Guid OrderId { get; set; }` /
+  `public decimal Total { get; set; }` and sends with `Body(OrderReceipt(OrderId: …, Total: …))`.
+- **Tutorial (chapter 2): the field-type list notes the `text` → `string` and `money` → `decimal` aliases**,
+  which chapter 3's relationship example (`Body:text`) relies on.
 
 ### Changed
 - **Everything the CLI generates now lives under `Features/` — one consistent vertical-slice layout.**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,11 +40,12 @@ them until tagged releases begin.
   advances to the end of the statement (its terminating `;`) before inserting.
 
 ### Docs
-- **Tutorial (chapter 5): email bodies carry data on public properties and are built through their generated
-  factory.** The email-body example used `new OrderReceipt(orderId, total)` with constructor parameters, which
-  doesn't compile — `RASK014` forbids constructing a component with `new`, and the generated factory passes
-  data via public properties, not constructor arguments. It now declares `public Guid OrderId { get; set; }` /
-  `public decimal Total { get; set; }` and sends with `Body(OrderReceipt(OrderId: …, Total: …))`.
+- **Email bodies carry data on public properties and are built through their generated factory.** The
+  tutorial (chapter 5), `mail.md`, `Rask.Mail/NUGET.md`, and the `rask generate email` scaffold comment all
+  showed `new EmailComponent(ctorParams)`, which doesn't compile — `RASK014` forbids constructing a component
+  with `new`, and the generated factory passes data via public properties, not constructor arguments. They now
+  declare a public property (e.g. `public decimal Total { get; set; }`) and send through the factory
+  (`Body(OrderReceipt(OrderId: …, Total: …))` / `Body(WelcomeEmail(Name: …))`). (Closes #500.)
 - **Tutorial (chapter 2): the field-type list notes the `text` → `string` and `money` → `decimal` aliases**,
   which chapter 3's relationship example (`Body:text`) relies on.
 

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -25,10 +25,12 @@ you already use for pages — no separate templating language.
 ## Use
 
 ```csharp
-public sealed class WelcomeEmail(string name) : Component
+public sealed class WelcomeEmail : Component
 {
+    public string Name { get; set; } = "";
+
     protected override Component? Render() =>
-        Div()[H1()[$"Welcome, {name}!"], P()["Thanks for signing up."]];
+        Div()[H1()[$"Welcome, {Name}!"], P()["Thanks for signing up."]];
 }
 
 // Program.cs
@@ -62,7 +64,7 @@ Add a migration for the new table before running — `rask db add AddMail && ras
 await mail.SendAsync(Email
     .To(user.Email, user.Name)
     .Subject("Welcome")
-    .Body(new WelcomeEmail(user.Name)));                       // send asap
+    .Body(WelcomeEmail(Name: user.Name)));                     // the generated factory, not new (RASK014)
 
 await mail.ScheduleAsync(reminder, delay: TimeSpan.FromHours(24));  // send later
 ```

--- a/docs/tutorial/02-first-feature.md
+++ b/docs/tutorial/02-first-feature.md
@@ -21,8 +21,9 @@ rask generate feature Product Name:string Price:decimal InStock:bool --validatio
 ```
 
 Read the field list as `name:type`. Rask understands `string`, `int`, `long`, `decimal`, `double`, `bool`,
-`datetime`, `date`, `time`, and `guid`. A trailing `?` makes a field optional (`Description:string?`), and
-`string(100)` caps a string's length. `Id` is added for you — don't list it.
+`datetime`, `date`, `time`, and `guid` — plus a few aliases (`text` → `string`, `money` → `decimal`). A
+trailing `?` makes a field optional (`Description:string?`), and `string(100)` caps a string's length. `Id` is
+added for you — don't list it.
 
 > **`--validation` is optional; we pass `dataannotations`** here to keep the form validation familiar:
 > `[Required]`, `[MaxLength]`, and a `DataAnnotationsValidator()` on the form. Drop the flag and you get

--- a/docs/tutorial/05-email.md
+++ b/docs/tutorial/05-email.md
@@ -25,15 +25,19 @@ public sealed class OrderReceipt : Component
 }
 ```
 
-Give it the order data and build a real body:
+Give it the order data and build a real body. A component carries data on **public properties** (that's what
+the generated factory fills in), so add an `OrderId` and a `Total` and render them:
 
 ```csharp
-public sealed class OrderReceipt(Guid orderId, decimal total) : Component
+public sealed class OrderReceipt : Component
 {
+    public Guid OrderId { get; set; }
+    public decimal Total { get; set; }
+
     protected override Component? Render() =>
         Div()[
             H1()["Thanks for your order!"],
-            P()[$"Order {orderId} — total ", Strong()[$"{total:C}"], "."],
+            P()[$"Order {OrderId} — total ", Strong()[$"{Total:C}"], "."],
             P()["We'll email again when it ships."]
         ];
 }
@@ -93,16 +97,18 @@ public sealed class SendOrderReceiptHandler(
         await mail.SendAsync(
             Email.To("customer@example.com")
                  .Subject($"Your order {order.Id}")
-                 .Body(new OrderReceipt(order.Id, order.Total)),
+                 .Body(OrderReceipt(OrderId: order.Id, Total: order.Total)),
             ct);
     }
 }
 ```
 
 `Email.To(...)` is a fluent builder — chain `Subject(...)`, `Cc/Bcc`, `Attach(...)`, and `Body(component)`,
-which renders your component to HTML right there. `SendAsync` just queues the row; the background sender
-delivers it. You now have the full chain: **place order → enqueue job → job sends email**, none of it on the
-customer's request.
+which renders your component to HTML right there. Note `Body(OrderReceipt(OrderId: …, Total: …))` calls the
+**generated `OrderReceipt` factory**, not `new OrderReceipt(...)` — every Rask component is built through its
+factory (the framework enforces this), and the factory takes one named argument per public property. `SendAsync`
+just queues the row; the background sender delivers it. You now have the full chain: **place order → enqueue job
+→ job sends email**, none of it on the customer's request.
 
 ## Verify
 

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -321,6 +321,18 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
                 anchor = lines.FindLastIndex(l => l.Contains("WebApplication.CreateBuilder", StringComparison.Ordinal));
             }
 
+            // A registration can span multiple lines (e.g. `AddDbContextFactory<T>((sp, o) => o` with a fluent
+            // body on the lines below); the match above finds where that statement *starts*. Advance to the line
+            // that ends it (terminating in ';') so the new registration lands after the whole statement, not
+            // spliced into the middle of it — which would produce invalid C#.
+            if (anchor >= 0)
+            {
+                while (anchor < lines.Count - 1 && !lines[anchor].TrimEnd().EndsWith(';'))
+                {
+                    anchor++;
+                }
+            }
+
             lines.InsertRange(anchor + 1, registration.Split('\n'));
             added.Add(firstLine);
         }
@@ -423,13 +435,53 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         }
 
         var text = _fileSystem.ReadAllText(result.ContextFilePath);
+        var (updated, addedSets, addedModel, unplacedModelLines) =
+            SpliceContext(text, result.ContextUsings, result.ContextDbSets, result.ContextModelLines);
+
+        // A custom context with no ApplyRaskConventions anchor: we can't place the OnModelCreating lines
+        // safely, so print them for the user rather than guessing a location.
+        foreach (var line in unplacedModelLines)
+        {
+            Console.WriteLine($"Add to your DbContext's OnModelCreating: {line.Trim()}", ConsoleStyle.Dim);
+        }
+
+        if (ReferenceEquals(updated, text))
+        {
+            return; // everything was already present (or only unplaced lines, surfaced above)
+        }
+
+        _fileSystem.WriteAllText(result.ContextFilePath, updated);
+        if (addedSets > 0)
+        {
+            Console.WriteLine($"Added {addedSets} DbSet(s) to {Display(result.ContextFilePath)}.", ConsoleStyle.Success);
+        }
+
+        if (addedModel > 0)
+        {
+            Console.WriteLine($"Mapped {addedModel} table(s) in {Display(result.ContextFilePath)} (OnModelCreating).", ConsoleStyle.Success);
+        }
+    }
+
+    /// <summary>
+    /// Pure splice for a DbContext file: insert any missing <paramref name="usings"/> (after the last using),
+    /// <paramref name="dbSets"/> (after the last <c>public DbSet&lt;</c>, else after the class-body brace), and
+    /// <paramref name="modelLines"/> (inside <c>OnModelCreating</c>, after the <c>ApplyRaskConventions</c> call) —
+    /// all idempotently, a member already present is left alone. Returns the rewritten text (the original
+    /// instance when nothing changed), the counts added, and any model lines that had no anchor to attach to (a
+    /// custom context without <c>ApplyRaskConventions</c>) so the caller can surface them. Extracted from
+    /// <see cref="EditContext"/> — mirroring <see cref="SpliceProgramCs"/> — so the exact splice can be
+    /// unit-tested and compile-gated.
+    /// </summary>
+    internal static (string Text, int AddedSets, int AddedModel, IReadOnlyList<string> UnplacedModelLines) SpliceContext(
+        string text, IReadOnlyList<string> usings, IReadOnlyList<string> dbSets, IReadOnlyList<string> modelLines)
+    {
         var newline = text.Contains("\r\n", StringComparison.Ordinal) ? "\r\n" : "\n";
         var lines = text.Replace("\r\n", "\n", StringComparison.Ordinal).Split('\n').ToList();
 
         var addedUsings = 0;
         var lastUsing = lines.FindLastIndex(l => l.TrimStart().StartsWith("using ", StringComparison.Ordinal) && l.TrimEnd().EndsWith(';'));
         var usingAt = lastUsing >= 0 ? lastUsing + 1 : 0;
-        foreach (var ns in result.ContextUsings)
+        foreach (var ns in usings)
         {
             var directive = $"using {ns};";
             if (!lines.Any(l => l.Trim() == directive))
@@ -440,7 +492,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         }
 
         var addedSets = 0;
-        foreach (var set in result.ContextDbSets)
+        foreach (var set in dbSets)
         {
             if (lines.Any(l => l.Trim() == set.Trim()))
             {
@@ -465,7 +517,8 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         }
 
         var addedModel = 0;
-        foreach (var line in result.ContextModelLines)
+        var unplaced = new List<string>();
+        foreach (var line in modelLines)
         {
             if (lines.Any(l => l.Trim() == line.Trim()))
             {
@@ -473,11 +526,11 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             }
 
             // Inside OnModelCreating, after the Rask conventions call the generated contexts always make. If a
-            // custom context has no such call we can't place it safely — print it for the user instead.
+            // custom context has no such call we can't place it safely — hand it back for the caller to surface.
             var anchor = lines.FindLastIndex(l => l.Contains("ApplyRaskConventions", StringComparison.Ordinal));
             if (anchor < 0)
             {
-                Console.WriteLine($"Add to your DbContext's OnModelCreating: {line.Trim()}", ConsoleStyle.Dim);
+                unplaced.Add(line);
                 continue;
             }
 
@@ -485,21 +538,9 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             addedModel++;
         }
 
-        if (addedSets == 0 && addedUsings == 0 && addedModel == 0)
-        {
-            return;
-        }
-
-        _fileSystem.WriteAllText(result.ContextFilePath, string.Join(newline, lines));
-        if (addedSets > 0)
-        {
-            Console.WriteLine($"Added {addedSets} DbSet(s) to {Display(result.ContextFilePath)}.", ConsoleStyle.Success);
-        }
-
-        if (addedModel > 0)
-        {
-            Console.WriteLine($"Mapped {addedModel} table(s) in {Display(result.ContextFilePath)} (OnModelCreating).", ConsoleStyle.Success);
-        }
+        return addedSets == 0 && addedUsings == 0 && addedModel == 0
+            ? (text, 0, 0, unplaced)
+            : (string.Join(newline, lines), addedSets, addedModel, unplaced);
     }
 
     // A short display name for a registration line, e.g. "builder.Services.AddRaskCqrs();" -> "AddRaskCqrs".

--- a/src/Rask.Cli/Scaffolding/EmailGenerator.cs
+++ b/src/Rask.Cli/Scaffolding/EmailGenerator.cs
@@ -49,7 +49,7 @@ internal static class EmailGenerator
         }
 
         // Send it anywhere IMailQueue is injected:
-        //   await mail.SendAsync(Email.To("jane@example.com").Subject("Welcome").Body(new {{name}}()));
+        //   await mail.SendAsync(Email.To("jane@example.com").Subject("Welcome").Body({{name}}()));
 
         """;
 
@@ -65,7 +65,7 @@ internal static class EmailGenerator
           3. Create the schema:
                rask db add AddMail && rask db update
           4. Send it anywhere IMailQueue is injected:
-               await mail.SendAsync(Email.To("jane@example.com").Subject("Welcome").Body(new {{name}}()));
+               await mail.SendAsync(Email.To("jane@example.com").Subject("Welcome").Body({{name}}()));
         """;
 
     /// <summary>Next-steps when the wiring was applied automatically — only the migration + a send example remain.</summary>
@@ -74,6 +74,6 @@ internal static class EmailGenerator
         Wired Rask.Mail into {{context}} (AddRaskMail + the mail table). Create the schema:
           rask db add AddMail && rask db update
         Then send it anywhere IMailQueue is injected:
-          await mail.SendAsync(Email.To("jane@example.com").Subject("Welcome").Body(new {{name}}()));
+          await mail.SendAsync(Email.To("jane@example.com").Subject("Welcome").Body({{name}}()));
         """;
 }

--- a/src/Rask.Mail/NUGET.md
+++ b/src/Rask.Mail/NUGET.md
@@ -15,10 +15,12 @@ request thread, with no broker or Redis.
 ## Use
 
 ```csharp
-public sealed class WelcomeEmail(string name) : Element
+public sealed class WelcomeEmail : Component
 {
-    protected override Component Render() =>
-        Div()[H1()[$"Welcome, {name}!"], P()["Thanks for signing up."]];
+    public string Name { get; set; } = "";
+
+    protected override Component? Render() =>
+        Div()[H1()[$"Welcome, {Name}!"], P()["Thanks for signing up."]];
 }
 
 // Program.cs
@@ -39,7 +41,7 @@ builder.Services.AddDbContextFactory<AppDbContext>(o => o.UseSqlite("Data Source
 await mail.SendAsync(Email
     .To(user.Email, user.Name)
     .Subject("Welcome")
-    .Body(new WelcomeEmail(user.Name)));
+    .Body(WelcomeEmail(Name: user.Name)));   // the generated factory, not new (RASK014)
 
 await mail.ScheduleAsync(reminder, delay: TimeSpan.FromHours(24));
 ```

--- a/tests/Rask.Cli.Tests/CliBuildE2E.cs
+++ b/tests/Rask.Cli.Tests/CliBuildE2E.cs
@@ -1,0 +1,195 @@
+using System.Diagnostics;
+using System.Text.RegularExpressions;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// The shared machinery behind the CLI build-the-output gates: pack <b>this commit's</b> Rask packages to a
+/// local feed once, drop a generated project's files on disk, point it at that feed, and run the real
+/// <c>dotnet build</c>. Both <see cref="ProjectGeneratorBuildE2ETests"/> (every scaffold flag combination) and
+/// <see cref="TutorialWalkthroughE2ETests"/> (the docs walk-through) consume it, so the nine-project pack runs
+/// once per test session rather than once per file.
+/// </summary>
+/// <remarks>
+/// Every case builds against the local feed rather than the latest published stable. That's the faithful
+/// contract — the CLI and the packages are released together under one tag, so a generated project pins the
+/// version of the CLI that made it — and it's what lets a gate catch a break in the same commit that
+/// introduces it instead of one release later.
+/// </remarks>
+internal static class CliBuildE2E
+{
+    /// <summary>
+    /// Every packable Rask package a generated project, feature, job, email, or later-chapter pillar can
+    /// reference, packed once into a shared feed. <c>Rask.Core</c> is deliberately absent — it is
+    /// <c>IsPackable=false</c> and ships bundled inside <c>Rask.Server</c>/<c>Rask.Wasm</c>'s <c>lib/</c>, so
+    /// packing it would produce nothing to restore.
+    /// </summary>
+    internal static readonly string[] FeedPackages =
+    [
+        "Rask.Server",                      // server template
+        "Rask.Wasm",                        // wasm + wasm-hosted templates
+        "Rask.Wasm.Hosting",                // wasm-hosted template
+        "Rask.Bootstrap",                   // every template, and `generate feature --bs`
+        "Rask.Cqrs",                        // server template --cqrs, and every generated feature
+        "Rask.Data",                        // every generated feature
+        "Rask.SQLite",                      // --data + every generated feature (via Rask.SQLite.EntityFrameworkCore)
+        "Rask.SQLite.EntityFrameworkCore",  // server template --data and generated features that own a context (UseRaskSqlite)
+        "Rask.SQLite.Litestream",           // tutorial ch8 — AddRaskSqliteLitestream / RestoreSqliteFromLitestreamAsync
+        "Rask.Outbox",                      // generate feature --outbox, and tutorial ch7
+        "Rask.Jobs",                        // generate job, and tutorial ch4
+        "Rask.Mail",                        // generate email, and tutorial ch5
+        "Rask.Cache",                       // tutorial ch6 — AddRaskCache / ICache.GetOrCreateAsync
+        "Rask.Validation.DataAnnotations",  // generate feature --validation dataannotations
+        "Rask.Validation.FluentValidation", // generate feature --validation fluent
+    ];
+
+    // Packed once and shared across every case (packing the projects is the expensive part of these gates).
+    internal static readonly Lazy<Task<(string Feed, string Version)>> LocalFeed = new(PackLocalFeedAsync);
+
+    /// <summary>True when the build-the-output gates are opted into (they restore + build, needing the SDK and network).</summary>
+    internal static bool Enabled => Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") == "1";
+
+    /// <summary>Packs <see cref="FeedPackages"/> to a temp feed; returns its directory and the packed version.</summary>
+    private static async Task<(string Feed, string Version)> PackLocalFeedAsync()
+    {
+        var repoRoot = FindRepoRoot();
+        var feed = Path.Combine(Path.GetTempPath(), "rask-cli-e2e-feed", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(feed);
+
+        foreach (var project in FeedPackages)
+        {
+            var csproj = Path.Combine(repoRoot, "src", project, project + ".csproj");
+            var (exit, output) = await RunDotnet($"pack \"{csproj}\" -c Release -o \"{feed}\" -m:1");
+            Assert.True(exit == 0, $"failed to pack {project} for the build gate.{Diagnostics(output)}");
+        }
+
+        // Read the packed version off a nupkg filename (MinVer stamps a prerelease off the current commit).
+        // Every project packs at the same version, so any one of them answers for the set — Rask.Server is
+        // used because no other package's id starts with it (Rask.Wasm.* would match two).
+        var nupkg = Directory.GetFiles(feed, "Rask.Server.*.nupkg").Single();
+        var version = Path.GetFileNameWithoutExtension(nupkg)["Rask.Server.".Length..];
+        return (feed, version);
+    }
+
+    // The packages a generated project needs, written straight into the csproj. Rask.* come from the local
+    // feed at the packed version; everything else takes the version this repo pins, so the gate can't drift
+    // from the rest of the build.
+    internal static void InjectPackages(SystemFileSystem fs, string csproj, IReadOnlyList<string> packages, string raskVersion)
+    {
+        var pins = RepoPackagePins();
+        var refs = string.Join(
+            "\n",
+            packages.Select(p => $"""    <PackageReference Include="{p}" Version="{VersionFor(p, pins, raskVersion)}"/>"""));
+
+        var content = fs.ReadAllText(csproj);
+        fs.WriteAllText(csproj, content.Replace("</Project>", $"  <ItemGroup>\n{refs}\n  </ItemGroup>\n\n</Project>", StringComparison.Ordinal));
+    }
+
+    private static string VersionFor(string package, IReadOnlyDictionary<string, string> pins, string raskVersion)
+    {
+        if (package.StartsWith("Rask.", StringComparison.Ordinal))
+        {
+            return raskVersion;
+        }
+
+        if (pins.TryGetValue(package, out var pinned))
+        {
+            return pinned;
+        }
+
+        // EF's Design package isn't referenced by this repo, so it has no pin of its own — but it ships in
+        // lockstep with EF Core, so borrow that version rather than inventing one.
+        if (package.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal))
+        {
+            return pins["Microsoft.EntityFrameworkCore"];
+        }
+
+        throw new InvalidOperationException($"No version known for '{package}'. Pin it in Directory.Packages.props.");
+    }
+
+    private static Dictionary<string, string> RepoPackagePins()
+    {
+        var props = File.ReadAllText(Path.Combine(FindRepoRoot(), "Directory.Packages.props"));
+        return Regex.Matches(props, """<PackageVersion\s+Include="([^"]+)"\s+Version="([^"]+)"\s*/>""")
+            .ToDictionary(m => m.Groups[1].Value, m => m.Groups[2].Value, StringComparer.Ordinal);
+    }
+
+    // Local feed first (this commit's packages), nuget.org for the framework/Microsoft.* deps.
+    internal static void WriteNuGetConfig(SystemFileSystem fs, string projectDir, string feed) =>
+        fs.WriteAllText(
+            Path.Combine(projectDir, "nuget.config"),
+            $"""
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <clear/>
+                <add key="local" value="{feed}"/>
+                <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
+              </packageSources>
+            </configuration>
+            """);
+
+    internal static string FindRepoRoot()
+    {
+        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return dir;
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
+    }
+
+    internal static async Task<(int Exit, string Output)> RunDotnet(string arguments)
+    {
+        var psi = new ProcessStartInfo("dotnet", arguments)
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.Environment["CI"] = "true";
+
+        using var process = Process.Start(psi)!;
+        var stdout = await process.StandardOutput.ReadToEndAsync();
+        var stderr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return (process.ExitCode, stdout + stderr);
+    }
+
+    /// <summary>
+    /// The child process's diagnostics, folded into the assertion message. xUnit reports the message but not
+    /// the child's console, so without this a failure says only *that* the build broke — never why.
+    /// </summary>
+    internal static string Diagnostics(string output)
+    {
+        var errors = output
+            .Split('\n')
+            .Select(l => l.TrimEnd('\r'))
+            .Where(l => l.Contains(": error ", StringComparison.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .Take(15)
+            .ToArray();
+
+        return "\n" + string.Join("\n", errors.Length > 0 ? errors : output.Split('\n').TakeLast(20));
+    }
+
+    internal static void TryDeleteDirectory(string path)
+    {
+        try
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, recursive: true);
+            }
+        }
+        catch (IOException)
+        {
+            // best-effort temp cleanup
+        }
+    }
+}

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -361,6 +361,36 @@ public sealed class GenerateCommandTests
     }
 
     [Fact]
+    public void SpliceProgramCs_inserts_after_a_multiline_registration_not_inside_it()
+    {
+        // `generate feature` leaves a multi-line AddDbContextFactory in Program.cs; a later splice (e.g.
+        // `generate email`'s AddRaskMail — the tutorial's ch5 step) must land *after* its closing `;`, not
+        // between the `(sp, o) => o` line and its fluent body, which would be invalid C#.
+        const string WithFactory =
+            "using MyApp;\n" +
+            "var builder = WebApplication.CreateBuilder(args);\n" +
+            "builder.Services.AddRask();\n" +
+            "builder.Services.AddDbContextFactory<AppDbContext>((sp, o) => o\n" +
+            "    .UseRaskSqlite(\"Data Source=app.db\")\n" +
+            "    .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));\n" +
+            "var app = builder.Build();\n" +
+            "app.Run();\n";
+
+        var (text, added) = GenerateCommand.SpliceProgramCs(
+            WithFactory, ["Rask.Mail"], ["builder.Services.AddRaskMail<AppDbContext>(o => o.From = \"x\");"]);
+
+        Assert.Single(added);
+        // The factory statement is intact and unbroken: its three lines stay contiguous, in order.
+        var factory = text.IndexOf("AddDbContextFactory<AppDbContext>((sp, o) => o", StringComparison.Ordinal);
+        var pragma = text.IndexOf(".UseRaskSqlite(\"Data Source=app.db\")", StringComparison.Ordinal);
+        var interceptors = text.IndexOf(".AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));", StringComparison.Ordinal);
+        var mail = text.IndexOf("AddRaskMail<AppDbContext>", StringComparison.Ordinal);
+        Assert.True(factory < pragma && pragma < interceptors, "the multi-line factory was split apart");
+        Assert.True(interceptors < mail, "the new registration landed inside the factory, not after it");
+        Assert.True(mail < text.IndexOf("builder.Build();", StringComparison.Ordinal), "registration must precede Build()");
+    }
+
+    [Fact]
     public void SpliceProgramCs_is_idempotent_and_signals_no_change()
     {
         var once = GenerateCommand.SpliceProgramCs(ProgramCs, ["Rask.Cqrs"], ["builder.Services.AddRaskCqrs();"]).Text;

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -98,7 +98,7 @@ public sealed class GenerateCommandTests
         Assert.True(fs.Files.ContainsKey(path));
         Assert.Contains("namespace MyApp.Features.Shared;", fs.Files[path], StringComparison.Ordinal);
         Assert.Contains("class WelcomeEmail : Component", fs.Files[path], StringComparison.Ordinal);
-        Assert.Contains("Body(new WelcomeEmail())", fs.Files[path], StringComparison.Ordinal);
+        Assert.Contains("Body(WelcomeEmail())", fs.Files[path], StringComparison.Ordinal);   // the factory, not new (RASK014)
         Assert.Contains(process.Invocations, i => i.Arguments is ["add", "package", "Rask.Mail", "--version", _]);
         Assert.Contains("AddRaskMail", console.OutText, StringComparison.Ordinal);
     }

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -1,5 +1,3 @@
-using System.Diagnostics;
-using System.Text.RegularExpressions;
 using Rask.Cli.Commands;
 using Rask.Cli.Scaffolding;
 
@@ -10,38 +8,11 @@ namespace Rask.Cli.Tests;
 /// against <b>this commit's</b> Rask packages, packed to a local feed. This packs the repo, restores, and runs
 /// the full C# build, so it's opt-in — set <c>RASK_CLI_BUILD_E2E=1</c> to run it (matches the repo's "tests run
 /// locally, not in CI" model). The exhaustive file/shape assertions live in <see cref="ProjectGeneratorTests"/>
-/// and always run.
+/// and always run. The pack + build plumbing lives in <see cref="CliBuildE2E"/>, shared with
+/// <see cref="TutorialWalkthroughE2ETests"/> so the feed is packed once per session.
 /// </summary>
-/// <remarks>
-/// Every case builds against the local feed rather than the latest published stable. That's the faithful
-/// contract — the CLI and the packages are released together under one tag, so a generated project pins the
-/// version of the CLI that made it — and it's what lets the gate catch a break in the same commit that
-/// introduces it instead of one release later.
-/// </remarks>
 public sealed class ProjectGeneratorBuildE2ETests
 {
-    /// <summary>
-    /// Every packable Rask package a generated project or feature can reference, packed once into a shared
-    /// feed. <c>Rask.Core</c> is deliberately absent — it is <c>IsPackable=false</c> and ships bundled inside
-    /// <c>Rask.Server</c>/<c>Rask.Wasm</c>'s <c>lib/</c>, so packing it would produce nothing to restore.
-    /// </summary>
-    private static readonly string[] FeedPackages =
-    [
-        "Rask.Server",                      // server template
-        "Rask.Wasm",                        // wasm + wasm-hosted templates
-        "Rask.Wasm.Hosting",                // wasm-hosted template
-        "Rask.Bootstrap",                   // every template, and `generate feature --bs`
-        "Rask.Cqrs",                        // server template --cqrs, and every generated feature
-        "Rask.Data",                        // every generated feature
-        "Rask.SQLite",                      // --data + every generated feature (via Rask.SQLite.EntityFrameworkCore)
-        "Rask.SQLite.EntityFrameworkCore",  // server template --data and generated features that own a context (UseRaskSqlite)
-        "Rask.Outbox",                      // generate feature --outbox
-        "Rask.Validation.DataAnnotations",  // generate feature --validation dataannotations
-        "Rask.Validation.FluentValidation", // generate feature --validation fluent
-    ];
-
-    // Packed once and shared across every case (packing nine projects is the expensive part of this gate).
-    private static readonly Lazy<Task<(string Feed, string Version)>> LocalFeed = new(PackLocalFeedAsync);
     // docker doesn't affect the build (just adds Dockerfile/.dockerignore), so the 3 build-relevant flags
     // give 2³ = 8 combinations — every scenario, per the "test every scenario" directive.
     public static IEnumerable<object[]> BuildAffectingCombinations()
@@ -56,7 +27,7 @@ public sealed class ProjectGeneratorBuildE2ETests
     [MemberData(nameof(BuildAffectingCombinations))]
     public async Task Generated_server_project_builds(bool auth, bool pwa, bool cqrs)
     {
-        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        if (!CliBuildE2E.Enabled)
         {
             return; // opt-in: this restores + builds, needing the SDK and network.
         }
@@ -67,7 +38,7 @@ public sealed class ProjectGeneratorBuildE2ETests
             name = "E2ENone";
         }
 
-        var (feed, version) = await LocalFeed.Value;
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 
         var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(temp, name);
@@ -82,14 +53,14 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            WriteNuGetConfig(fs, projectDir, feed);
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[auth={auth},pwa={pwa},cqrs={cqrs}] generated project failed to build.{Diagnostics(output)}");
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa},cqrs={cqrs}] generated project failed to build.{CliBuildE2E.Diagnostics(output)}");
         }
         finally
         {
-            TryDeleteDirectory(temp);
+            CliBuildE2E.TryDeleteDirectory(temp);
         }
     }
 
@@ -104,13 +75,13 @@ public sealed class ProjectGeneratorBuildE2ETests
     [InlineData(true)]
     public async Task Generated_data_server_project_builds(bool auth)
     {
-        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        if (!CliBuildE2E.Enabled)
         {
             return; // opt-in: this restores + builds, needing the SDK and network.
         }
 
         var name = $"DE2E{(auth ? "A" : "")}";
-        var (feed, version) = await LocalFeed.Value;
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 
         var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(temp, name);
@@ -125,14 +96,14 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            WriteNuGetConfig(fs, projectDir, feed);
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[data,auth={auth}] generated project failed to build.{Diagnostics(output)}");
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[data,auth={auth}] generated project failed to build.{CliBuildE2E.Diagnostics(output)}");
         }
         finally
         {
-            TryDeleteDirectory(temp);
+            CliBuildE2E.TryDeleteDirectory(temp);
         }
     }
 
@@ -149,7 +120,7 @@ public sealed class ProjectGeneratorBuildE2ETests
     [MemberData(nameof(WasmBuildAffectingCombinations))]
     public async Task Generated_wasm_project_builds(bool auth, bool pwa)
     {
-        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        if (!CliBuildE2E.Enabled)
         {
             return; // opt-in: this restores + builds, needing the SDK and network.
         }
@@ -160,7 +131,7 @@ public sealed class ProjectGeneratorBuildE2ETests
             name = "WE2ENone";
         }
 
-        var (feed, version) = await LocalFeed.Value;
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 
         var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
         var projectDir = Path.Combine(temp, name);
@@ -175,14 +146,14 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            WriteNuGetConfig(fs, projectDir, feed);
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm project failed to build.{Diagnostics(output)}");
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm project failed to build.{CliBuildE2E.Diagnostics(output)}");
         }
         finally
         {
-            TryDeleteDirectory(temp);
+            CliBuildE2E.TryDeleteDirectory(temp);
         }
     }
 
@@ -190,12 +161,12 @@ public sealed class ProjectGeneratorBuildE2ETests
     [MemberData(nameof(WasmBuildAffectingCombinations))]
     public async Task Generated_wasm_hosted_solution_builds(bool auth, bool pwa)
     {
-        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        if (!CliBuildE2E.Enabled)
         {
             return; // opt-in: this packs the repo + restores + builds the WASM solution.
         }
 
-        var (feed, version) = await LocalFeed.Value;
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 
         var name = $"HE2E{(auth ? "A" : "")}{(pwa ? "P" : "")}";
         if (name == "HE2E")
@@ -216,14 +187,14 @@ public sealed class ProjectGeneratorBuildE2ETests
                 fs.WriteAllText(file.Path, file.Content);
             }
 
-            WriteNuGetConfig(fs, projectDir, feed);
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, name + ".sln")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm-hosted solution failed to build.{Diagnostics(output)}");
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, name + ".sln")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm-hosted solution failed to build.{CliBuildE2E.Diagnostics(output)}");
         }
         finally
         {
-            TryDeleteDirectory(temp);
+            CliBuildE2E.TryDeleteDirectory(temp);
         }
     }
 
@@ -237,12 +208,12 @@ public sealed class ProjectGeneratorBuildE2ETests
     [Fact]
     public async Task Generated_multi_entity_feature_builds()
     {
-        if (Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") != "1")
+        if (!CliBuildE2E.Enabled)
         {
             return; // opt-in: this packs the repo + restores + builds.
         }
 
-        var (feed, version) = await LocalFeed.Value;
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 
         const string Name = "FE2E";
         var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
@@ -284,158 +255,15 @@ public sealed class ProjectGeneratorBuildE2ETests
 
             // `dotnet add package` is GenerateCommand's job, not the generator's — so add what the generator
             // says it needs. Driving off result.Packages keeps this from drifting from what the CLI does.
-            InjectPackages(fs, Path.Combine(projectDir, Name + ".csproj"), feature.Packages, version);
-            WriteNuGetConfig(fs, projectDir, feed);
+            CliBuildE2E.InjectPackages(fs, Path.Combine(projectDir, Name + ".csproj"), feature.Packages, version);
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var (exit, output) = await RunDotnet($"build \"{Path.Combine(projectDir, Name + ".csproj")}\" -warnaserror -m:1");
-            Assert.True(exit == 0, $"generated multi-entity feature failed to build.{Diagnostics(output)}");
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, Name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"generated multi-entity feature failed to build.{CliBuildE2E.Diagnostics(output)}");
         }
         finally
         {
-            TryDeleteDirectory(temp);
-        }
-    }
-
-    // The packages a generated feature needs, written straight into the csproj. Rask.* come from the local
-    // feed at the packed version; everything else takes the version this repo pins, so the gate can't drift
-    // from the rest of the build.
-    private static void InjectPackages(SystemFileSystem fs, string csproj, IReadOnlyList<string> packages, string raskVersion)
-    {
-        var pins = RepoPackagePins();
-        var refs = string.Join(
-            "\n",
-            packages.Select(p => $"""    <PackageReference Include="{p}" Version="{VersionFor(p, pins, raskVersion)}"/>"""));
-
-        var content = fs.ReadAllText(csproj);
-        fs.WriteAllText(csproj, content.Replace("</Project>", $"  <ItemGroup>\n{refs}\n  </ItemGroup>\n\n</Project>", StringComparison.Ordinal));
-    }
-
-    private static string VersionFor(string package, IReadOnlyDictionary<string, string> pins, string raskVersion)
-    {
-        if (package.StartsWith("Rask.", StringComparison.Ordinal))
-        {
-            return raskVersion;
-        }
-
-        if (pins.TryGetValue(package, out var pinned))
-        {
-            return pinned;
-        }
-
-        // EF's Design package isn't referenced by this repo, so it has no pin of its own — but it ships in
-        // lockstep with EF Core, so borrow that version rather than inventing one.
-        if (package.StartsWith("Microsoft.EntityFrameworkCore", StringComparison.Ordinal))
-        {
-            return pins["Microsoft.EntityFrameworkCore"];
-        }
-
-        throw new InvalidOperationException($"No version known for '{package}'. Pin it in Directory.Packages.props.");
-    }
-
-    private static Dictionary<string, string> RepoPackagePins()
-    {
-        var props = File.ReadAllText(Path.Combine(FindRepoRoot(), "Directory.Packages.props"));
-        return Regex.Matches(props, """<PackageVersion\s+Include="([^"]+)"\s+Version="([^"]+)"\s*/>""")
-            .ToDictionary(m => m.Groups[1].Value, m => m.Groups[2].Value, StringComparer.Ordinal);
-    }
-
-    /// <summary>Packs <see cref="FeedPackages"/> to a temp feed; returns its directory and the packed version.</summary>
-    private static async Task<(string Feed, string Version)> PackLocalFeedAsync()
-    {
-        var repoRoot = FindRepoRoot();
-        var feed = Path.Combine(Path.GetTempPath(), "rask-cli-e2e-feed", Guid.NewGuid().ToString("N"));
-        Directory.CreateDirectory(feed);
-
-        foreach (var project in FeedPackages)
-        {
-            var csproj = Path.Combine(repoRoot, "src", project, project + ".csproj");
-            var (exit, output) = await RunDotnet($"pack \"{csproj}\" -c Release -o \"{feed}\" -m:1");
-            Assert.True(exit == 0, $"failed to pack {project} for the build gate.{Diagnostics(output)}");
-        }
-
-        // Read the packed version off a nupkg filename (MinVer stamps a prerelease off the current commit).
-        // Every project packs at the same version, so any one of them answers for the set — Rask.Server is
-        // used because no other package's id starts with it (Rask.Wasm.* would match two).
-        var nupkg = Directory.GetFiles(feed, "Rask.Server.*.nupkg").Single();
-        var version = Path.GetFileNameWithoutExtension(nupkg)["Rask.Server.".Length..];
-        return (feed, version);
-    }
-
-    // Local feed first (this commit's packages), nuget.org for the framework/Microsoft.* deps.
-    private static void WriteNuGetConfig(SystemFileSystem fs, string projectDir, string feed) =>
-        fs.WriteAllText(
-            Path.Combine(projectDir, "nuget.config"),
-            $"""
-            <?xml version="1.0" encoding="utf-8"?>
-            <configuration>
-              <packageSources>
-                <clear/>
-                <add key="local" value="{feed}"/>
-                <add key="nuget.org" value="https://api.nuget.org/v3/index.json"/>
-              </packageSources>
-            </configuration>
-            """);
-
-    private static string FindRepoRoot()
-    {
-        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
-        {
-            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
-            {
-                return dir;
-            }
-        }
-
-        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
-    }
-
-    private static async Task<(int Exit, string Output)> RunDotnet(string arguments)
-    {
-        var psi = new ProcessStartInfo("dotnet", arguments)
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        psi.Environment["CI"] = "true";
-
-        using var process = Process.Start(psi)!;
-        var stdout = await process.StandardOutput.ReadToEndAsync();
-        var stderr = await process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
-
-        return (process.ExitCode, stdout + stderr);
-    }
-
-    /// <summary>
-    /// The child process's diagnostics, folded into the assertion message. xUnit reports the message but not
-    /// the child's console, so without this a failure says only *that* the build broke — never why.
-    /// </summary>
-    private static string Diagnostics(string output)
-    {
-        var errors = output
-            .Split('\n')
-            .Select(l => l.TrimEnd('\r'))
-            .Where(l => l.Contains(": error ", StringComparison.Ordinal))
-            .Distinct(StringComparer.Ordinal)
-            .Take(15)
-            .ToArray();
-
-        return "\n" + string.Join("\n", errors.Length > 0 ? errors : output.Split('\n').TakeLast(20));
-    }
-
-    private static void TryDeleteDirectory(string path)
-    {
-        try
-        {
-            if (Directory.Exists(path))
-            {
-                Directory.Delete(path, recursive: true);
-            }
-        }
-        catch (IOException)
-        {
-            // best-effort temp cleanup
+            CliBuildE2E.TryDeleteDirectory(temp);
         }
     }
 }

--- a/tests/Rask.Cli.Tests/TutorialWalkthroughE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TutorialWalkthroughE2ETests.cs
@@ -1,0 +1,392 @@
+using Rask.Cli.Commands;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// The docs walk-through, compiled. <c>docs/tutorial/</c> takes a reader from <c>rask new Shop</c> to a
+/// deployed, database-backed product across nine chapters — and it's the framework's flagship proof, so its
+/// code must never rot. This gate reproduces chapters 1-8 exactly as a reader would: it runs the real
+/// generators the CLI runs (<see cref="ProjectGenerator.GenerateServer"/>, <see cref="FeatureGenerator"/>,
+/// <see cref="JobGenerator"/>, <see cref="EmailGenerator"/>), applies the CLI's real Program.cs / DbContext
+/// splices (<see cref="GenerateCommand.SpliceProgramCs"/>, <see cref="GenerateCommand.SpliceContext"/>), and
+/// then applies the <b>hand-written code the prose tells the reader to type</b> — the job body, the
+/// <c>IMailQueue</c> send, the <c>ICache.GetOrCreateAsync</c> read-through, the <c>IOutboxEvent</c> +
+/// <c>INotificationHandler</c>, the <c>Entity.Raise</c>, the Litestream wiring — and builds the whole thing
+/// with <c>-warnaserror</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The point is to catch tutorial drift the moment it happens: if a Rask package changes a signature the
+/// tutorial uses (<c>Email.To(...).Body(component)</c>, <c>ICache.GetOrCreateAsync</c>, <c>Entity.Raise</c>,
+/// <c>AddRaskJobs&lt;T&gt;</c>'s options, <c>AddRaskSqliteLitestream</c>), this build breaks in the same commit
+/// rather than in a beginner's terminal one release later. <see cref="CliBuildE2E.Diagnostics"/> folds the C#
+/// errors into the failure so each maps back to the chapter whose snippet stopped compiling.
+/// </para>
+/// <para>
+/// <b>Boundaries.</b> This is a compile gate, not a run: it does <b>not</b> run <c>rask db add</c>/<c>update</c>
+/// (real <c>dotnet-ef</c> + a database — a network + state side effect the suite deliberately avoids), nor
+/// chapter 9's <c>rask deploy</c> (SSH/Docker, covered by <c>DeployCommandTests</c>/<c>HostBootstrapTests</c>).
+/// Building the fully-wired app proves every <c>AddRask*</c> registration, every <c>modelBuilder.AddRask*</c>
+/// map, and every prose API resolves against this commit's packages — the tutorial's compile contract.
+/// </para>
+/// <para>
+/// Where the prose edits generated <i>handlers</i> in place (chapter 4's enqueue, chapter 6's cache rewrite),
+/// this test compiles the exact prose bodies against the real generated <c>ProductsDbContext</c>/<c>Product</c>
+/// types in dedicated companion files rather than string-surgering the generated templates — same API
+/// coverage, without a false failure every time an unrelated template detail is reformatted. Edits that have a
+/// single stable anchor (the wiring splices, <c>Order.Create</c>'s one-liner, the wholly hand-authored job/
+/// email files) are applied faithfully in place and assert their anchor, so a genuine drift still fails loudly.
+/// </para>
+/// </remarks>
+public sealed class TutorialWalkthroughE2ETests
+{
+    [Fact]
+    public async Task Tutorial_shop_walkthrough_builds()
+    {
+        if (!CliBuildE2E.Enabled)
+        {
+            return; // opt-in: this packs the repo + restores + builds. Set RASK_CLI_BUILD_E2E=1.
+        }
+
+        var (feed, version) = await CliBuildE2E.LocalFeed.Value;
+
+        const string Name = "Shop";
+        var temp = Path.Combine(Path.GetTempPath(), "rask-cli-e2e", Guid.NewGuid().ToString("N"));
+        var projectDir = Path.Combine(temp, Name);
+        try
+        {
+            var fs = new SystemFileSystem();
+            var project = new ProjectContext(projectDir, Name);
+            var packages = new HashSet<string>(StringComparer.Ordinal);
+
+            var productsDir = Path.Combine(projectDir, "Features", "Products");
+            var ordersDir = Path.Combine(projectDir, "Features", "Orders");
+            var sharedDir = Path.Combine(projectDir, "Features", "Shared");
+            var productsCtx = Path.Combine(productsDir, "ProductsDbContext.cs");
+            var programPath = Path.Combine(projectDir, "Program.cs");
+            var productsNs = project.NamespaceFor(productsDir);   // Shop.Features.Products
+
+            // --- local helpers (mirror what GenerateCommand does after each command) ---
+            // Writes a scaffold's files and records the NuGet packages it needs (`dotnet add package` is the
+            // command's job, not the generator's). The server template's own refs (Rask.Server/Rask.Bootstrap)
+            // are already baked into its csproj, so its ScaffoldResult carries none to add here.
+            void WriteFiles(ScaffoldResult r)
+            {
+                foreach (var file in r.Files)
+                {
+                    fs.CreateDirectory(Path.GetDirectoryName(file.Path)!);
+                    fs.WriteAllText(file.Path, file.Content);
+                }
+
+                packages.UnionWith(r.Packages);
+            }
+
+            // The real Program.cs splice (idempotent, exactly as WireProgramCs runs it).
+            void Program(IReadOnlyList<string> usings, IReadOnlyList<string> registrations)
+            {
+                var (updated, _) = GenerateCommand.SpliceProgramCs(fs.ReadAllText(programPath), usings, registrations);
+                fs.WriteAllText(programPath, updated);
+            }
+
+            // The real DbContext splice (DbSets + OnModelCreating maps), exactly as EditContext runs it.
+            void Context(IReadOnlyList<string> usings, IReadOnlyList<string> dbSets, IReadOnlyList<string> modelLines)
+            {
+                var (updated, _, _, _) = GenerateCommand.SpliceContext(fs.ReadAllText(productsCtx), usings, dbSets, modelLines);
+                fs.WriteAllText(productsCtx, updated);
+            }
+
+            // A targeted in-place edit for the few prose changes that replace a generated line. Asserts the
+            // anchor is present so a genuine template drift fails loudly instead of silently no-op'ing.
+            void Replace(string path, string anchor, string replacement)
+            {
+                var text = fs.ReadAllText(path);
+                Assert.True(text.Contains(anchor, StringComparison.Ordinal),
+                    $"tutorial edit anchor not found in {Path.GetFileName(path)}: {anchor}");
+                fs.WriteAllText(path, text.Replace(anchor, replacement, StringComparison.Ordinal));
+            }
+
+            // ===== Chapter 1 — rask new Shop --auth --docker =====
+            // The server template's own package refs (Rask.Server/Rask.Bootstrap) are already in its csproj, so
+            // the CLI never `dotnet add`s them — subtract them before injecting so restore sees no duplicates.
+            var host = ProjectGenerator.GenerateServer(projectDir, Name, auth: true, pwa: false, cqrs: false, data: false, docker: true, version);
+            WriteFiles(host);
+
+            // ===== Chapter 2 — rask generate feature Product ... --validation dataannotations =====
+            var product = new EntitySpec("Product", "Products",
+            [
+                new FieldSpec("Name", "string", IsNullable: false, MaxLength: 200),
+                new FieldSpec("Price", "decimal", IsNullable: false, MaxLength: null),
+                new FieldSpec("InStock", "bool", IsNullable: false, MaxLength: null),
+            ]);
+            var f2 = FeatureGenerator.Generate(project, projectDir, new FeatureSpec(product, []),
+                new FeatureOptions { IdType = "Guid", Validation = "dataannotations" });
+            WriteFiles(f2);
+            Program(f2.ProgramUsings, f2.ProgramRegistrations);
+
+            // ===== Chapter 3 — rask generate feature Order ... --context ProductsDbContext =====
+            var order = new EntitySpec("Order", "Orders",
+            [
+                new FieldSpec("Total", "decimal", IsNullable: false, MaxLength: null),
+                new FieldSpec("ProductId", "Guid", IsNullable: false, MaxLength: null),
+                new FieldSpec("Placed", "DateTime", IsNullable: false, MaxLength: null),
+            ]);
+            // GenerateCommand resolves ContextNamespace/ContextFilePath by scanning the project; here we know them
+            // (the context we just wrote), so supply them the way TryBuild does — ContextFilePath lands on the result.
+            var f3 = FeatureGenerator.Generate(project, projectDir, new FeatureSpec(order, []),
+                new FeatureOptions
+                {
+                    IdType = "Guid",
+                    Validation = "dataannotations",
+                    ContextOverride = "ProductsDbContext",
+                    ContextNamespace = productsNs,
+                }) with
+            { ContextFilePath = productsCtx };
+            WriteFiles(f3);
+            Program(f3.ProgramUsings, f3.ProgramRegistrations);
+            Context(f3.ContextUsings, f3.ContextDbSets, f3.ContextModelLines);   // adds DbSet<Order> to ProductsDbContext
+
+            // ===== Chapter 4 — rask generate job SendOrderReceipt =====
+            var f4 = JobGenerator.Generate(project, projectDir, "SendOrderReceipt", feature: null, outputOverride: null);
+            WriteFiles(f4);
+            // Wire jobs (manual, as the prose shows): registration + the jobs table.
+            Program(["Rask.Jobs", productsNs],
+            [
+                """
+                builder.Services.AddRaskJobs<ProductsDbContext>(o =>
+                {
+                    o.PollInterval = TimeSpan.FromSeconds(5);
+                    o.MaxAttempts = 25;
+                });
+                """,
+            ]);
+            Context(["Rask.Jobs"], [], ["        modelBuilder.AddRaskJobs();"]);
+            // The prose enqueues from CreateOrderCommandHandler; compiled here so IJobQueue.EnqueueAsync is gated.
+            fs.WriteAllText(Path.Combine(sharedDir, "OrderEnqueuer.cs"), OrderEnqueuerProse);
+
+            // ===== Chapter 5 — rask generate email OrderReceipt (auto-wires) =====
+            var f5 = EmailGenerator.Generate(project, projectDir, "OrderReceipt", feature: null, outputOverride: null,
+                context: ("ProductsDbContext", productsNs, productsCtx));
+            WriteFiles(f5);
+            Program(f5.ProgramUsings, f5.ProgramRegistrations);         // AddRaskMail<ProductsDbContext>
+            Context([], [], f5.ContextModelLines);                      // modelBuilder.AddRaskMail()
+
+            // The prose fills in the generated stubs: the OrderReceipt body (ch5) and the job handler that reads
+            // the order and sends the receipt (ch4 + ch5). These files are hand-authored in the tutorial, so we
+            // write the finished versions verbatim.
+            fs.WriteAllText(Path.Combine(sharedDir, "OrderReceipt.cs"), OrderReceiptComponent);
+            fs.WriteAllText(Path.Combine(sharedDir, "SendOrderReceipt.cs"), SendOrderReceiptJob);
+
+            // ===== Chapter 6 — caching the catalog =====
+            Program(["Rask.Cache", productsNs], ["builder.Services.AddRaskCache<ProductsDbContext>();"]);
+            Context(["Rask.Cache"], [], ["        modelBuilder.AddRaskCache();"]);
+            packages.Add("Rask.Cache");
+            fs.WriteAllText(Path.Combine(sharedDir, "CatalogCache.cs"), CatalogCacheProse);
+
+            // ===== Chapter 7 — domain events + the outbox =====
+            fs.WriteAllText(Path.Combine(ordersDir, "OrderEvents.cs"), OrderEvents);
+            fs.WriteAllText(Path.Combine(ordersDir, "OrderPlacedHandler.cs"), OrderPlacedHandler);
+            // Raise the event from Order.Create (the generated one-liner becomes a body that raises).
+            Replace(Path.Combine(ordersDir, "Order.cs"),
+                "public static Order Create(decimal total, Guid productId, DateTime placed) => new(total, productId, placed);",
+                """
+                public static Order Create(decimal total, Guid productId, DateTime placed)
+                    {
+                        var order = new Order(total, productId, placed);
+                        order.Raise(new OrderPlaced(order.Id));
+                        return order;
+                    }
+                """);
+            // Hand domain events to the outbox (post-commit) instead of dispatching them in-process.
+            Replace(programPath,
+                "builder.Services.AddRaskData();",
+                "builder.Services.AddRaskData(o => o.DispatchDomainEventsInProcess = false);");
+            Program(["Rask.Outbox", productsNs],
+            [
+                """
+                builder.Services.AddRaskOutbox<ProductsDbContext>(o =>
+                {
+                    o.PollInterval = TimeSpan.FromSeconds(5);
+                    o.MaxAttempts = 10;
+                });
+                """,
+            ]);
+            Context(["Rask.Outbox"], [], ["        modelBuilder.AddRaskOutbox();"]);
+            packages.Add("Rask.Outbox");
+
+            // ===== Chapter 8 — production SQLite + Litestream =====
+            // (Ch8 step 1's UseRaskSqlite swap is already what the generator emits — no edit needed.)
+            Program(["Rask.SQLite.Litestream"],
+            [
+                """
+                builder.Services.AddRaskSqliteLitestream(o =>
+                {
+                    o.DatabasePath = "app.db";
+                    o.ReplicaUrl = "s3://my-bucket/shop";
+                });
+                """,
+            ]);
+            Replace(programPath, "app.Run();",
+                """
+                await app.Services.RestoreSqliteFromLitestreamAsync();
+
+                app.Run();
+                """);
+            packages.Add("Rask.SQLite.Litestream");
+
+            // ===== Build the fully-wired Shop =====
+            packages.ExceptWith(host.Packages);   // already baked into the template csproj
+            CliBuildE2E.InjectPackages(fs, Path.Combine(projectDir, Name + ".csproj"), packages.ToList(), version);
+            CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
+
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, Name + ".csproj")}\" -warnaserror -m:1");
+            Assert.True(exit == 0, $"tutorial Shop walk-through failed to build.{CliBuildE2E.Diagnostics(output)}");
+        }
+        finally
+        {
+            CliBuildE2E.TryDeleteDirectory(temp);
+        }
+    }
+
+    // ---- Verbatim prose from the tutorial chapters, compiled against the generated Shop types ----
+
+    // docs/tutorial/05-email.md — the finished email body. Data rides public init properties (so the generated
+    // factory can pass it); Component + the HTML factories are global usings.
+    private const string OrderReceiptComponent =
+        """
+        namespace Shop.Features.Shared;
+
+        public sealed class OrderReceipt : Component
+        {
+            public Guid OrderId { get; set; }
+            public decimal Total { get; set; }
+
+            protected override Component? Render() =>
+                Div()[
+                    H1()["Thanks for your order!"],
+                    P()[$"Order {OrderId} — total ", Strong()[$"{Total:C}"], "."],
+                    P()["We'll email again when it ships."]
+                ];
+        }
+        """;
+
+    // docs/tutorial/04-background-jobs.md + 05-email.md — the finished job handler: read the order, send the receipt.
+    private const string SendOrderReceiptJob =
+        """
+        using Microsoft.EntityFrameworkCore;
+        using Rask.Cqrs;
+        using Rask.Jobs;
+        using Rask.Mail;
+        using Shop.Features.Orders;
+        using Shop.Features.Products;
+
+        namespace Shop.Features.Shared;
+
+        public sealed record SendOrderReceipt(Guid OrderId) : IJob;
+
+        public sealed class SendOrderReceiptHandler(
+            IDbContextFactory<ProductsDbContext> dbFactory,
+            IMailQueue mail) : ICommandHandler<SendOrderReceipt>
+        {
+            public async Task HandleAsync(SendOrderReceipt job, CancellationToken ct)
+            {
+                await using var db = await dbFactory.CreateDbContextAsync(ct);
+                var order = await db.Orders.FindAsync([job.OrderId], ct);
+                if (order is null)
+                {
+                    return;
+                }
+
+                await mail.SendAsync(
+                    Email.To("customer@example.com")
+                         .Subject($"Your order {order.Id}")
+                         .Body(OrderReceipt(OrderId: order.Id, Total: order.Total)),   // the generated factory, not new
+                    ct);
+            }
+        }
+        """;
+
+    // docs/tutorial/04-background-jobs.md — enqueue the job right after the order is saved (IJobQueue.EnqueueAsync).
+    private const string OrderEnqueuerProse =
+        """
+        using Rask.Jobs;
+
+        namespace Shop.Features.Shared;
+
+        public sealed class OrderEnqueuer(IJobQueue jobs)
+        {
+            public Task EnqueueAsync(Guid orderId, CancellationToken cancellationToken) =>
+                jobs.EnqueueAsync(new SendOrderReceipt(orderId), cancellationToken);
+        }
+        """;
+
+    // docs/tutorial/06-cache.md — the ProductListItem projection + GetOrCreateAsync read-through + RemoveAsync
+    // invalidation, compiled against the real ProductsDbContext/Product. Named distinctly from the generated
+    // ListProductsQuery it mirrors so both coexist in the one assembly.
+    private const string CatalogCacheProse =
+        """
+        using Microsoft.EntityFrameworkCore;
+        using Microsoft.Extensions.Caching.Distributed;
+        using Rask.Cache;
+        using Rask.Cqrs;
+        using Shop.Features.Products;
+
+        namespace Shop.Features.Shared;
+
+        public sealed record ProductListItem(Guid Id, string Name, decimal Price, bool InStock);
+
+        public sealed record CatalogQuery : IQuery<IReadOnlyList<ProductListItem>>;
+
+        public sealed class CatalogQueryHandler(
+            IDbContextFactory<ProductsDbContext> dbContextFactory,
+            ICache cache) : IQueryHandler<CatalogQuery, IReadOnlyList<ProductListItem>>
+        {
+            public Task<IReadOnlyList<ProductListItem>> HandleAsync(CatalogQuery query, CancellationToken ct) =>
+                cache.GetOrCreateAsync(
+                    "catalog:all",
+                    async token =>
+                    {
+                        await using var db = await dbContextFactory.CreateDbContextAsync(token);
+                        return (IReadOnlyList<ProductListItem>)await db.Products
+                            .AsNoTracking()
+                            .OrderBy(p => p.Id)
+                            .Select(p => new ProductListItem(p.Id, p.Name, p.Price, p.InStock))
+                            .ToListAsync(token);
+                    },
+                    new DistributedCacheEntryOptions { SlidingExpiration = TimeSpan.FromMinutes(5) });
+        }
+
+        public sealed class CatalogInvalidator(ICache cache)
+        {
+            public Task ClearAsync(CancellationToken ct) => cache.RemoveAsync("catalog:all", ct);
+        }
+        """;
+
+    // docs/tutorial/07-outbox-events.md — the domain event and its handler.
+    private const string OrderEvents =
+        """
+        using Rask.Outbox;
+
+        namespace Shop.Features.Orders;
+
+        public sealed record OrderPlaced(Guid Id) : IOutboxEvent;
+        """;
+
+    private const string OrderPlacedHandler =
+        """
+        using Microsoft.Extensions.Logging;
+        using Rask.Cqrs;
+
+        namespace Shop.Features.Orders;
+
+        public sealed class OrderPlacedHandler(ILogger<OrderPlacedHandler> logger)
+            : INotificationHandler<OrderPlaced>
+        {
+            public Task HandleAsync(OrderPlaced notification, CancellationToken cancellationToken)
+            {
+                logger.LogInformation("Order {Id} placed — updating stock / analytics…", notification.Id);
+                return Task.CompletedTask;
+            }
+        }
+        """;
+}


### PR DESCRIPTION
## Summary

`docs/tutorial/` is the framework's flagship proof — nine chapters from `rask new Shop` to a deployed, database-backed product — yet nothing tested it, and (more importantly) nothing compiled the hand-written code the prose tells a reader to type. This adds a compile gate that does, and fixes two real bugs it surfaced.

**New gate — `TutorialWalkthroughE2ETests`** (opt-in, `RASK_CLI_BUILD_E2E=1`): reproduces the tutorial's chapters 1–8 exactly as a reader would:
- the real generators (`rask new --auth --docker` → `generate feature Product` → `generate feature Order --context` → `generate job` → `generate email`),
- the real `Program.cs` / `DbContext` splices, and
- the reader's own code (job body, `IMailQueue` send + `Email.To(...).Body(factory)`, `ICache.GetOrCreateAsync` read-through + `RemoveAsync`, `IOutboxEvent` + `INotificationHandler`, `Entity.Raise`, `AddRaskSqliteLitestream` + restore),

then builds the fully-wired `Shop` under `-warnaserror`. A tutorial-breaking package change now fails a test in the same commit instead of in a beginner's terminal.

Shared pack/build plumbing was lifted into `CliBuildE2E` (feed packed once per session, shared with the existing scaffold gate), and `GenerateCommand.SpliceContext` was extracted (pure, mirroring `SpliceProgramCs`) so the `--context` DbSet + `OnModelCreating` edits are reused faithfully rather than re-derived.

## Bugs the gate caught

1. **`Program.cs` splice corruption (user-facing).** `SpliceProgramCs` anchored on the line that *starts* a `builder.Services.` statement, so wiring a registration after a multi-line one — `generate email`'s `AddRaskMail<…>` running after `generate feature`'s multi-line `AddDbContextFactory<…>((sp, o) => o …)`, i.e. the tutorial's exact chapter 2 → chapter 5 flow — inserted it *inside* that statement and broke the build. Fixed to advance to the statement's terminating `;`. New unit test `SpliceProgramCs_inserts_after_a_multiline_registration_not_inside_it`.
2. **Email bodies built with `new` didn't compile.** The tutorial ch5, `mail.md`, `Rask.Mail/NUGET.md`, and the `generate email` scaffold comment all used `new EmailComponent(ctorParams)` — but `RASK014` forbids `new` on a component, and the generated factory passes data via public properties, not constructor args. All now declare a public property and send through the generated factory (`Body(OrderReceipt(OrderId: …, Total: …))` / `Body(WelcomeEmail(Name: …))`). **Closes #500.**

Also: ch2's field-type note now lists the `text` → `string` / `money` → `decimal` aliases that ch3's relationship example relies on.

## Testing

- `dotnet test` Rask.Cli.Tests (no env): **652 passed** — the `SpliceContext` extraction and the email-scaffold-comment change are behavior-preserving.
- `RASK_CLI_BUILD_E2E=1` `TutorialWalkthroughE2ETests`: **passes** — the fully-wired ch1–8 Shop compiles under `-warnaserror`.
- `RASK_CLI_BUILD_E2E=1` `Generated_multi_entity_feature_builds`: **passes** — confirms the `CliBuildE2E` extraction is behavior-preserving through the real gate.
- `dotnet format --verify-no-changes` clean; pre-commit gate (build + format + unit) passed on each commit.

## Changelog

`[Unreleased]` updated: **Added** (the tutorial compile gate), **Fixed** (the Program.cs splice corruption), **Docs** (the email-body sweep + the ch2 alias note).