### PR TITLE
test(cli): make the build gates fail visibly instead of passing unrun

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,23 +1,39 @@
 #!/usr/bin/env bash
-# Pre-push gate: run the local browser-journey E2E suite before anything leaves the machine.
+# Pre-push gate: run the local browser-journey E2E and the CLI build gate before anything leaves the machine.
 #
 # The E2E suites (browser + on-device native) were moved OUT of CI — they run locally instead, and this
 # hook enforces the browser gate on push. Enable it once with:  git config core.hooksPath .githooks
 #
-# Bypass for docs-only or emergency pushes:  git push --no-verify   (or set RASK_SKIP_E2E=1)
+# The CLI build gate is here too because it is the only thing proving the code `rask new` / `rask generate`
+# writes actually COMPILES — every other CLI test asserts on generated strings. It is too slow for
+# pre-commit (it packs 15 packages and runs full builds), so push is the right boundary.
+#
+# Bypass for docs-only or emergency pushes:  git push --no-verify
+# Per-gate bypass: RASK_SKIP_E2E=1 (browser) · RASK_SKIP_CLI_BUILD_E2E=1 (CLI build)
 set -euo pipefail
-
-if [ "${RASK_SKIP_E2E:-}" = "1" ]; then
-  echo "pre-push: RASK_SKIP_E2E=1 set — skipping the local E2E gate."
-  exit 0
-fi
 
 root="$(git rev-parse --show-toplevel)"
 
-echo "pre-push: running the local E2E gate (browser journeys)."
-echo "          bypass with 'git push --no-verify' or RASK_SKIP_E2E=1 (e.g. docs-only pushes)."
+if [ "${RASK_SKIP_E2E:-}" = "1" ]; then
+  echo "pre-push: RASK_SKIP_E2E=1 set — skipping the local browser E2E gate."
+else
+  echo "pre-push: running the local E2E gate (browser journeys)."
+  echo "          bypass with 'git push --no-verify' or RASK_SKIP_E2E=1 (e.g. docs-only pushes)."
 
-if ! "$root/scripts/run-e2e-local.sh"; then
-  echo "pre-push: E2E gate FAILED — push aborted. Fix the failing journey, or bypass with --no-verify." >&2
-  exit 1
+  if ! "$root/scripts/run-e2e-local.sh"; then
+    echo "pre-push: E2E gate FAILED — push aborted. Fix the failing journey, or bypass with --no-verify." >&2
+    exit 1
+  fi
+fi
+
+if [ "${RASK_SKIP_CLI_BUILD_E2E:-}" = "1" ]; then
+  echo "pre-push: RASK_SKIP_CLI_BUILD_E2E=1 set — skipping the CLI build gate."
+else
+  echo "pre-push: running the CLI build gate (scaffold output + tutorial must compile)."
+  echo "          bypass with 'git push --no-verify' or RASK_SKIP_CLI_BUILD_E2E=1."
+
+  if ! "$root/scripts/run-cli-build-e2e.sh"; then
+    echo "pre-push: CLI build gate FAILED — push aborted. The code the CLI writes doesn't compile." >&2
+    exit 1
+  fi
 fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **The CLI build gates no longer pass without running.** The tests that prove the code `rask new` and
+  `rask generate` write actually *compiles* are opted into with `RASK_CLI_BUILD_E2E=1` — but that variable was
+  set nowhere in the repo, and each case returned early when it was absent, so all 20 reported **passed**
+  while never executing. Every other CLI test asserts on generated strings, so in practice nothing was
+  checking that a scaffolded project builds. The gates now use `Skip.IfNot` (the `Xunit.SkippableFact`
+  pattern the Appium suite already uses) and report **SKIPPED** with the reason, and a new
+  `scripts/run-cli-build-e2e.sh` runs them for real — wired into `.githooks/pre-push`, so a scaffolding
+  break is caught before it leaves the machine instead of in a beginner's terminal. Bypass with
+  `RASK_SKIP_CLI_BUILD_E2E=1`.
+
 ### Added
 - **The `docs/tutorial/` walk-through is now a compile gate.** A new opt-in end-to-end test
   (`TutorialWalkthroughE2ETests`, `RASK_CLI_BUILD_E2E=1`) reproduces the tutorial's chapters 1–8 exactly as a

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -65,6 +65,15 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   with `git config core.hooksPath .githooks`; bypass with `git push --no-verify` or `RASK_SKIP_E2E=1`).
   The on-device native suite needs an emulator/simulator + Appium — run it manually (see
   [native.md](native.md)).
+- **The CLI build gate runs locally, enforced before push.** `scripts/run-cli-build-e2e.sh` is the only
+  thing proving the code the CLI *writes* actually compiles — every other CLI test asserts on generated
+  strings. It packs this commit's Rask packages to a local feed, scaffolds every `rask new` flag
+  combination plus a multi-entity `rask generate feature` and the whole [tutorial](tutorial/00-overview.md)
+  walk-through, then builds each one with `-warnaserror`. Because it packs 15 packages and runs several
+  full builds it is too slow for the pre-commit loop, so the `.githooks/pre-push` hook runs it instead
+  (bypass with `git push --no-verify` or `RASK_SKIP_CLI_BUILD_E2E=1`). The gates are opted into by
+  `RASK_CLI_BUILD_E2E=1`, which the script exports; without it every case reports **SKIPPED** rather than
+  passing silently, so an un-run gate is always visible in the test output.
 - `commitlint.yml` — Conventional Commits check on PRs.
 - `nightly.yml` — prerelease publish on `main`.
 - `release.yml` — tag-triggered stable publish.

--- a/scripts/run-cli-build-e2e.sh
+++ b/scripts/run-cli-build-e2e.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Local CLI build gate — does the code the CLI writes actually compile?
+#
+# Every other CLI test asserts on generated *strings*. These are the only tests that pack this commit's
+# Rask packages to a local feed, drop a generated project on disk, restore it against that feed, and run
+# a real `dotnet build -warnaserror` over the result. They cover every `rask new` flag combination, a
+# multi-entity `rask generate feature`, and the whole docs/tutorial walk-through (chapters 1-8).
+#
+# They are opt-in because they pack 15 packages and run several full builds — far too slow for the
+# pre-commit inner loop. The pre-push hook (.githooks/pre-push) runs them, so a scaffolding break is
+# caught before it leaves the machine rather than in a beginner's terminal.
+#
+# Usage:  scripts/run-cli-build-e2e.sh
+# Skip:   RASK_SKIP_CLI_BUILD_E2E=1 (also honoured by the pre-push hook)
+set -euo pipefail
+
+if [ "${RASK_SKIP_CLI_BUILD_E2E:-}" = "1" ]; then
+  echo "run-cli-build-e2e: RASK_SKIP_CLI_BUILD_E2E=1 — skipping."
+  exit 0
+fi
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+# The gates read this to decide whether to run; without it every case reports SKIPPED.
+export RASK_CLI_BUILD_E2E=1
+
+echo "==> Build the CLI test project (Release)"
+# MinVerSkip is deliberately NOT set: the gate packs the Rask packages and reads the packed version off
+# the nupkg filename, so MinVer must stamp a real version here.
+dotnet build tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release -m:1
+
+echo "==> CLI build gates (scaffold output + tutorial walk-through must compile)"
+# Serial (-m:1 above, and one pack at a time inside the fixture): the gates share a single packed feed,
+# built lazily on first use.
+dotnet test tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release --no-build \
+  --filter "FullyQualifiedName~BuildE2ETests|FullyQualifiedName~TutorialWalkthroughE2ETests" \
+  --logger "console;verbosity=normal"
+
+echo
+echo "==> CLI build gate passed."

--- a/tests/Rask.Cli.Tests/CliBuildE2E.cs
+++ b/tests/Rask.Cli.Tests/CliBuildE2E.cs
@@ -47,6 +47,15 @@ internal static class CliBuildE2E
     // Packed once and shared across every case (packing the projects is the expensive part of these gates).
     internal static readonly Lazy<Task<(string Feed, string Version)>> LocalFeed = new(PackLocalFeedAsync);
 
+    /// <summary>
+    /// Why a build gate didn't run. Reported through <c>Skip.IfNot</c> so an un-run gate shows up as SKIPPED in
+    /// the test output instead of passing silently — these are the only tests that prove the CLI emits code that
+    /// actually compiles, so "green" must never be able to mean "never ran".
+    /// </summary>
+    internal const string SkipReason =
+        "CLI build gate: set RASK_CLI_BUILD_E2E=1 to run it (it packs this commit's Rask packages, restores, " +
+        "and builds the generated projects, so it needs the SDK and network). See scripts/run-cli-build-e2e.sh.";
+
     /// <summary>True when the build-the-output gates are opted into (they restore + build, needing the SDK and network).</summary>
     internal static bool Enabled => Environment.GetEnvironmentVariable("RASK_CLI_BUILD_E2E") == "1";
 

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -23,14 +23,11 @@ public sealed class ProjectGeneratorBuildE2ETests
         }
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(BuildAffectingCombinations))]
     public async Task Generated_server_project_builds(bool auth, bool pwa, bool cqrs)
     {
-        if (!CliBuildE2E.Enabled)
-        {
-            return; // opt-in: this restores + builds, needing the SDK and network.
-        }
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
         var name = $"E2E{(auth ? "A" : "")}{(pwa ? "P" : "")}{(cqrs ? "Q" : "")}";
         if (name == "E2E")
@@ -70,15 +67,12 @@ public sealed class ProjectGeneratorBuildE2ETests
     /// Program.cs (the config-driven connection string, the ISaveChangesInterceptor injection) and the
     /// AppDbContext resolve — both alone and composed with <c>--auth</c> (which shares the same Program.cs).
     /// </summary>
-    [Theory]
+    [SkippableTheory]
     [InlineData(false)]
     [InlineData(true)]
     public async Task Generated_data_server_project_builds(bool auth)
     {
-        if (!CliBuildE2E.Enabled)
-        {
-            return; // opt-in: this restores + builds, needing the SDK and network.
-        }
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
         var name = $"DE2E{(auth ? "A" : "")}";
         var (feed, version) = await CliBuildE2E.LocalFeed.Value;
@@ -116,14 +110,11 @@ public sealed class ProjectGeneratorBuildE2ETests
         }
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(WasmBuildAffectingCombinations))]
     public async Task Generated_wasm_project_builds(bool auth, bool pwa)
     {
-        if (!CliBuildE2E.Enabled)
-        {
-            return; // opt-in: this restores + builds, needing the SDK and network.
-        }
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
         var name = $"WE2E{(auth ? "A" : "")}{(pwa ? "P" : "")}";
         if (name == "WE2E")
@@ -157,14 +148,11 @@ public sealed class ProjectGeneratorBuildE2ETests
         }
     }
 
-    [Theory]
+    [SkippableTheory]
     [MemberData(nameof(WasmBuildAffectingCombinations))]
     public async Task Generated_wasm_hosted_solution_builds(bool auth, bool pwa)
     {
-        if (!CliBuildE2E.Enabled)
-        {
-            return; // opt-in: this packs the repo + restores + builds the WASM solution.
-        }
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
         var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 
@@ -205,13 +193,10 @@ public sealed class ProjectGeneratorBuildE2ETests
     /// name a DbContext declared in the root's namespace, and the DbContext names types in each target's.
     /// Only a real compile proves those resolve.
     /// </summary>
-    [Fact]
+    [SkippableFact]
     public async Task Generated_multi_entity_feature_builds()
     {
-        if (!CliBuildE2E.Enabled)
-        {
-            return; // opt-in: this packs the repo + restores + builds.
-        }
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
         var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 

--- a/tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj
+++ b/tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj
@@ -14,6 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk"/>
     <PackageReference Include="xunit"/>
+    <PackageReference Include="Xunit.SkippableFact"/>
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Rask.Cli.Tests/TutorialWalkthroughE2ETests.cs
+++ b/tests/Rask.Cli.Tests/TutorialWalkthroughE2ETests.cs
@@ -41,13 +41,10 @@ namespace Rask.Cli.Tests;
 /// </remarks>
 public sealed class TutorialWalkthroughE2ETests
 {
-    [Fact]
+    [SkippableFact]
     public async Task Tutorial_shop_walkthrough_builds()
     {
-        if (!CliBuildE2E.Enabled)
-        {
-            return; // opt-in: this packs the repo + restores + builds. Set RASK_CLI_BUILD_E2E=1.
-        }
+        Skip.IfNot(CliBuildE2E.Enabled, CliBuildE2E.SkipReason);
 
         var (feed, version) = await CliBuildE2E.LocalFeed.Value;
 


### PR DESCRIPTION
## Summary

The tests that prove the code `rask new` and `rask generate` write actually **compiles** are opted into
with `RASK_CLI_BUILD_E2E=1`. That variable is set **nowhere in the repo** — not in `scripts/`, not in any
workflow — and each case `return`ed early when it was absent. So all 20 reported **passed while never
executing**.

Every other CLI test asserts on generated *strings*. These gates are the only thing that compiles the
output, so in practice nothing was checking that a scaffolded project builds at all.

## What changed

- **The gates report `SKIPPED`, not passed.** They now use `Skip.IfNot` — the `Xunit.SkippableFact`
  pattern `tests/Rask.Native.Appium.Tests` already uses — with a reason pointing at the runner script.
  "Green" can no longer mean "never ran".
- **`scripts/run-cli-build-e2e.sh`** runs them for real (exports the variable, builds, filters to the two
  gate classes).
- **Wired into `.githooks/pre-push`.** It packs 15 packages and runs full builds (~1.5 min), which is too
  slow for the pre-commit inner loop, so push is the right boundary. The hook now runs the browser E2E and
  the CLI gate independently, each with its own bypass: `RASK_SKIP_E2E=1` / `RASK_SKIP_CLI_BUILD_E2E=1`.
- Documented in `docs/development-workflow.md`.

No production code is touched — this is test plumbing, a script, a hook, and docs.

## Testing

- **Ran the gate for the first time: 20/20 pass in ~1.6 min.** The scaffolding was fine; it simply was
  never being verified.
- Without the variable: 20/20 now report `SKIPPED` with the reason (previously: 20 silent passes).
- `scripts/run-unit-local.sh` (build + `dotnet format whitespace --verify-no-changes` + full unit suite): green.
- The push of this branch exercised the new pre-push hook end to end — it ran the gate and passed.

## Changelog

`[Unreleased] → Fixed`.