### PR TITLE
test(cli): prove rask deploy against a real container host

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -37,3 +37,24 @@ else
     exit 1
   fi
 fi
+
+# The deploy gate boots a privileged container, so it runs only when this push actually touches the
+# deploy path — the alternative (always, or never) is either a tax on every unrelated push or a gate
+# that quietly never runs. Changing how a production box is deployed to is exactly when it must run.
+deploy_paths='^(src/Rask\.Cli/(Commands/DeployCommand|Host(Probe|Setup|Bootstrap)|SshTarget|DockerProbe)\.cs|src/Rask\.Cli/Scaffolding/(DeployConfig|GitHubActionsWorkflow)\.cs|tests/Rask\.Cli\.Tests/Deploy)'
+
+if [ "${RASK_SKIP_DEPLOY_E2E:-}" = "1" ]; then
+  echo "pre-push: RASK_SKIP_DEPLOY_E2E=1 set — skipping the deploy gate."
+elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "pre-push: no origin/main to diff against — skipping the deploy gate."
+elif ! git diff --name-only origin/main...HEAD | grep -qE "$deploy_paths"; then
+  : # nothing in this push touches the deploy path
+else
+  echo "pre-push: this push changes the deploy path — running the deploy gate against a container host."
+  echo "          bypass with 'git push --no-verify' or RASK_SKIP_DEPLOY_E2E=1."
+
+  if ! "$root/scripts/run-deploy-e2e-local.sh"; then
+    echo "pre-push: deploy gate FAILED — push aborted. Fix it, or bypass with RASK_SKIP_DEPLOY_E2E=1." >&2
+    exit 1
+  fi
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`rask deploy` is now verified against a real host.** Every deploy test in the repo was mocked — a fake
+  process runner recorded the argv and returned a scripted exit code — so the suite proved the command line
+  Rask *builds* and nothing about whether deploying *works*. A new opt-in gate
+  (`DeployHostE2ETests`, `RASK_DEPLOY_E2E=1`, `scripts/run-deploy-e2e-local.sh`) points the real
+  `rask deploy` at a throwaway container standing in for a bare VPS — sshd plus its own Docker daemon —
+  and asserts on what happened *on the host*: the image built over SSH, the container answers its health
+  check, a redeploy keeps the named volume's contents (the database-survives-redeploy contract), the
+  blue-green swap moves the domain from blue to green and retires the old colour, a real Caddy accepts the
+  generated Caddyfile, and a container that starts but never answers is removed with the previous version
+  left serving. It needs a `docker` CLI and a daemon that can run a privileged container; it installs
+  nothing and never reads or writes your `~/.ssh`. The `pre-push` hook runs it only when the push touches
+  the deploy path. Real DNS + Let's Encrypt issuance remain uncovered — the gate uses a `.test` domain.
+
 ### Fixed
 - **The CLI build gates no longer pass without running.** The tests that prove the code `rask new` and
   `rask generate` write actually *compiles* are opted into with `RASK_CLI_BUILD_E2E=1` — but that variable was

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -74,6 +74,17 @@ Every change passes this gate before a PR (the `rask-ship` skill):
   (bypass with `git push --no-verify` or `RASK_SKIP_CLI_BUILD_E2E=1`). The gates are opted into by
   `RASK_CLI_BUILD_E2E=1`, which the script exports; without it every case reports **SKIPPED** rather than
   passing silently, so an un-run gate is always visible in the test output.
+- **The deploy gate runs locally, on pushes that touch the deploy path.**
+  `scripts/run-deploy-e2e-local.sh` points the real `rask deploy` at a throwaway container standing in for
+  a bare VPS — sshd plus its own Docker daemon (`docker:dind`, privileged) — and asserts on what happened
+  *on the host*: an image that built over SSH, a container that answers its health check, a blue-green
+  swap that retired the old colour, a Caddyfile a real Caddy accepted, and a named volume whose contents
+  outlived the container. Every other deploy test is mocked, so this is the only coverage that the deploy
+  actually deploys. It needs a `docker` CLI and a daemon that can run a privileged container; it installs
+  nothing and never reads or writes your `~/.ssh`. The `.githooks/pre-push` hook runs it only when the
+  push changes `DeployCommand`/`Host*`/`SshTarget`/`DockerProbe`/`DeployConfig` or the deploy tests
+  (bypass with `RASK_SKIP_DEPLOY_E2E=1`). **Not covered:** real DNS and Let's Encrypt issuance — the gate
+  uses a `.test` domain, so ACME never runs.
 - `commitlint.yml` — Conventional Commits check on PRs.
 - `nightly.yml` — prerelease publish on `main`.
 - `release.yml` — tag-triggered stable publish.

--- a/scripts/run-deploy-e2e-local.sh
+++ b/scripts/run-deploy-e2e-local.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Local deploy gate — does `rask deploy` actually deploy?
+#
+# Every other deploy test in the repo is mocked: a fake process runner records the argv and returns a
+# scripted exit code, so they prove the command line Rask *builds* and nothing about whether it *works*.
+# This gate points the real `rask deploy` at a throwaway container standing in for a bare VPS (sshd + its
+# own Docker daemon, privileged) and asserts on what happened ON THE HOST: an image that built, a
+# container that answers HTTP, a Caddyfile a real Caddy accepted, a volume that outlived its container.
+#
+# Requirements: a `docker` CLI and a daemon that can run a privileged container (Docker Desktop, Colima,
+# or podman). Nothing is installed on your machine and your ~/.ssh is never read or written — the gate
+# generates a throwaway key and reaches the container through its own ssh config.
+#
+# Usage:  scripts/run-deploy-e2e-local.sh
+# Skip:   RASK_SKIP_DEPLOY_E2E=1 (also honoured by the pre-push hook)
+set -euo pipefail
+
+if [ "${RASK_SKIP_DEPLOY_E2E:-}" = "1" ]; then
+  echo "run-deploy-e2e-local: RASK_SKIP_DEPLOY_E2E=1 — skipping."
+  exit 0
+fi
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "run-deploy-e2e-local: no \`docker\` CLI on PATH — the deploy gate needs one to boot its fake VPS." >&2
+  echo "                      Install a Docker client, or set RASK_SKIP_DEPLOY_E2E=1 to bypass." >&2
+  exit 1
+fi
+
+# Opted into by the tests themselves; when unset every case reports SKIPPED rather than passing silently.
+export RASK_DEPLOY_E2E=1
+
+echo "==> Build the CLI test project (Release)"
+dotnet build tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release -m:1
+
+echo "==> Deploy gate (real rask deploy against a container host)"
+dotnet test tests/Rask.Cli.Tests/Rask.Cli.Tests.csproj -c Release --no-build \
+  --filter "FullyQualifiedName~DeployHostE2ETests" \
+  --logger "console;verbosity=normal"
+
+echo
+echo "==> Deploy gate passed."
+echo "    Not covered: real DNS + Let's Encrypt issuance. The gate uses a .test domain, so Caddy's"
+echo "    Caddyfile is validated but ACME never runs — verify that once against a throwaway VPS."

--- a/tests/Rask.Cli.Tests/DeployE2E.cs
+++ b/tests/Rask.Cli.Tests/DeployE2E.cs
@@ -1,0 +1,134 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// Shared plumbing for the deploy gate: a throwaway <b>container acting as a bare VPS</b> that the real
+/// <c>rask deploy</c> is pointed at, over real SSH, driving a real Docker daemon.
+///
+/// <para>Every other deploy test in this assembly is mocked — <see cref="FakeProcessRunner"/> records the
+/// argv and hands back a scripted exit code, so they prove the command line Rask <em>builds</em> and
+/// nothing about whether it <em>works</em>. That left the whole deploy path (a Dockerfile that has to
+/// build, a container that has to answer, a Caddyfile a real Caddy has to accept, a volume that has to
+/// survive) unverified. These tests close that gap without a cloud account: the "host" is a privileged
+/// <c>docker:dind</c> container running its own dockerd and an sshd.</para>
+/// </summary>
+internal static class DeployE2E
+{
+    /// <summary>The dind image the fake VPS is built on. Pinned: 27-dind's alpine index no longer resolves openssh-server.</summary>
+    internal const string DindImage = "docker.io/library/docker:28-dind";
+
+    internal const string SkipReason =
+        "Deploy host gate: set RASK_DEPLOY_E2E=1 to run it. It needs a local `docker` CLI and a daemon that " +
+        "can run a privileged container (Docker Desktop, Colima, or podman). See scripts/run-deploy-e2e-local.sh.";
+
+    /// <summary>True when the deploy-host gate is opted into (it builds images and boots a privileged container).</summary>
+    internal static bool Enabled => Environment.GetEnvironmentVariable("RASK_DEPLOY_E2E") == "1";
+
+    /// <summary>Run a process to completion, capturing both streams. Used for the harness's own docker/ssh calls.</summary>
+    internal static async Task<(int Exit, string Output)> RunAsync(
+        string fileName,
+        IReadOnlyList<string> arguments,
+        IReadOnlyDictionary<string, string>? environment = null,
+        CancellationToken cancellationToken = default)
+    {
+        var info = new ProcessStartInfo(fileName)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+
+        if (environment is not null)
+        {
+            foreach (var (key, value) in environment)
+            {
+                info.Environment[key] = value;
+            }
+        }
+
+        using var process = Process.Start(info)!;
+        var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        return (process.ExitCode, await stdout.ConfigureAwait(false) + await stderr.ConfigureAwait(false));
+    }
+
+    /// <summary>A TCP port nothing is listening on, for the fake VPS's published sshd.</summary>
+    internal static int FreePort()
+    {
+        using var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        var port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+}
+
+/// <summary>
+/// The real <see cref="ProcessRunner"/> behaviour with extra environment variables layered on — the seam
+/// that lets the gate run the genuine <c>rask deploy</c> code path while keeping its SSH identity, config,
+/// and known-hosts entirely inside the test's temp directory.
+///
+/// <para>Why this instead of pointing <c>HOME</c> at a temp dir: on macOS OpenSSH resolves <c>~/.ssh</c>
+/// through <c>getpwuid()</c>, <b>not</b> <c>$HOME</c>, so a redirected HOME is silently ignored and ssh
+/// reads the developer's real config. The fixture therefore puts an <c>ssh</c> shim first on <c>PATH</c>
+/// (it re-execs the real ssh with <c>-F &lt;temp config&gt;</c>), which both Rask's own
+/// <c>ssh</c> calls and Docker's <c>ssh://</c> transport pick up — neither ever learns it isn't the real
+/// binary, and the developer's <c>~/.ssh</c> is never read or written.</para>
+/// </summary>
+internal sealed class EnvScopedProcessRunner(
+    IReadOnlyDictionary<string, string> environment,
+    IReadOnlyDictionary<string, string> executables) : IProcessRunner
+{
+    public async Task<int> RunAsync(string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
+    {
+        var (exit, _) = await CaptureCoreAsync(fileName, arguments, workingDirectory, cancellationToken).ConfigureAwait(false);
+        return exit;
+    }
+
+    public async Task<ProcessResult> CaptureAsync(string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
+    {
+        var (exit, output) = await CaptureCoreAsync(fileName, arguments, workingDirectory, cancellationToken).ConfigureAwait(false);
+        return new ProcessResult(exit, output.StandardOutput, output.StandardError);
+    }
+
+    private async Task<(int Exit, (string StandardOutput, string StandardError) Streams)> CaptureCoreAsync(
+        string fileName, IReadOnlyList<string> arguments, string? workingDirectory, CancellationToken cancellationToken)
+    {
+        // A bare "ssh" would be resolved against the PARENT process's PATH — .NET does the executable
+        // lookup itself, before the child's environment applies — so prefixing PATH is not enough to
+        // redirect Rask's own ssh calls. Substituting the absolute path of the shim is. (Docker's
+        // ssh:// transport looks ssh up in its own environment, which the PATH entry below does cover.)
+        var info = new ProcessStartInfo(executables.TryGetValue(fileName, out var resolved) ? resolved : fileName)
+        {
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            WorkingDirectory = workingDirectory ?? Environment.CurrentDirectory,
+        };
+
+        foreach (var argument in arguments)
+        {
+            info.ArgumentList.Add(argument);
+        }
+
+        foreach (var (key, value) in environment)
+        {
+            info.Environment[key] = value;
+        }
+
+        using var process = Process.Start(info)!;
+        var stdout = process.StandardOutput.ReadToEndAsync(cancellationToken);
+        var stderr = process.StandardError.ReadToEndAsync(cancellationToken);
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+        return (process.ExitCode, (await stdout.ConfigureAwait(false), await stderr.ConfigureAwait(false)));
+    }
+}

--- a/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
+++ b/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
@@ -1,0 +1,172 @@
+using Rask.Cli.Commands;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// The deploy gate: run the real <c>rask deploy</c> against a container standing in for a bare VPS and
+/// assert on what actually happened <b>on the host</b> — an image that built, a container that answers
+/// HTTP, a Caddyfile a real Caddy accepted, a volume whose contents outlived the container.
+///
+/// <para>These are the assertions the mocked suite structurally cannot make. <see cref="DeployCommandTests"/>
+/// proves <c>docker run</c> is spelled correctly; this proves the thing it spells actually serves.</para>
+/// </summary>
+public sealed class DeployHostE2ETests(DeployHostFixture host) : IClassFixture<DeployHostFixture>
+{
+    /// <summary>
+    /// The app under deployment. Deliberately tiny (busybox httpd, no .NET) so the gate measures the deploy
+    /// path rather than a SDK image pull: the mechanics being tested — build on the box, health-gate, swap,
+    /// mount the volume — are identical whatever the image contains. Each boot appends to a file under
+    /// <c>/data</c>, which is how volume persistence is observed across container replacement.
+    /// </summary>
+    private const string AppDockerfile = """
+        FROM docker.io/library/nginx:alpine
+        RUN mkdir -p /data \
+         && printf 'server { listen 8080; location /health { return 200 "ok"; } }\n' > /etc/nginx/conf.d/default.conf
+        EXPOSE 8080
+        CMD ["/bin/sh","-c","echo boot >> /data/boots.txt; exec nginx -g 'daemon off;'"]
+        """;
+
+    [SkippableFact]
+    public async Task Deploy_to_a_port_builds_runs_and_answers_its_health_check()
+    {
+        var project = Start(out var console, out var command);
+
+        var exit = await command.ExecuteAsync(["--host", host.Host, "--port", "8080", "--name", "portapp"], CancellationToken.None);
+
+        Assert.True(exit == 0, $"deploy failed.\n{console.OutText}\n{console.ErrorText}");
+        Assert.Contains("Deployed.", console.OutText, StringComparison.Ordinal);
+
+        // The container is genuinely up on the host, and the app answers on the published port.
+        var (_, running) = await host.DockerAsync("ps", "--filter", "name=portapp", "--format", "{{.Names}} {{.Status}}");
+        Assert.Contains("portapp", running, StringComparison.Ordinal);
+        Assert.Contains("Up", running, StringComparison.Ordinal);
+
+        var (probeExit, body) = await host.OnHostAsync("wget -qO- http://127.0.0.1:8080/health");
+        Assert.True(probeExit == 0, $"the deployed app didn't answer on the published port: {body}");
+        Assert.Contains("ok", body, StringComparison.Ordinal);
+
+        // The host is the source of truth for the next deploy, so the config it remembers must be real.
+        Assert.True(File.Exists(Path.Combine(project, ".rask", "deploy.json")), "deploy.json wasn't persisted.");
+    }
+
+    /// <summary>
+    /// The database-survives-redeploy contract. Every deploy runs a <em>fresh container</em>, so the SQLite
+    /// file only survives because <c>rask deploy</c> mounts a per-app named volume at <c>/data</c> — the
+    /// single most destructive thing to get wrong, and previously asserted only against a mock.
+    /// </summary>
+    [SkippableFact]
+    public async Task Redeploy_keeps_the_data_volume()
+    {
+        var project = Start(out var console, out var command);
+        string[] args = ["--host", host.Host, "--port", "8081", "--name", "dataapp"];
+
+        Assert.True(await command.ExecuteAsync(args, CancellationToken.None) == 0, $"first deploy failed.\n{console.ErrorText}");
+        var (_, first) = await host.DockerAsync("exec", "dataapp", "cat", "/data/boots.txt");
+        Assert.Equal(1, CountBoots(first));
+
+        // A second deploy replaces the container entirely — same volume, so the file must accumulate.
+        Assert.True(await command.ExecuteAsync(args, CancellationToken.None) == 0, $"redeploy failed.\n{console.ErrorText}");
+        var (_, second) = await host.DockerAsync("exec", "dataapp", "cat", "/data/boots.txt");
+        Assert.Equal(2, CountBoots(second));
+
+        Assert.True(File.Exists(Path.Combine(project, ".rask", "deploy.json")));
+    }
+
+    /// <summary>
+    /// The zero-downtime path: a blue-green swap behind the shared Caddy proxy. This is the one that needs a
+    /// real host most — the Caddyfile is generated as text and only a running Caddy can say whether it is
+    /// valid, and the colour bookkeeping is read back from live container labels.
+    /// </summary>
+    [SkippableFact]
+    public async Task Domain_deploy_swaps_colour_behind_a_real_caddy()
+    {
+        Start(out var console, out var command);
+        string[] args = ["--host", host.Host, "--domain", "rask-e2e.test", "--name", "webapp"];
+
+        Assert.True(await command.ExecuteAsync(args, CancellationToken.None) == 0, $"first domain deploy failed.\n{console.OutText}\n{console.ErrorText}");
+
+        var (_, afterFirst) = await host.DockerAsync("ps", "--format", "{{.Names}}");
+        Assert.Contains("webapp-blue", afterFirst, StringComparison.Ordinal);
+        Assert.Contains("rask-caddy", afterFirst, StringComparison.Ordinal);
+
+        // A real Caddy accepted the generated Caddyfile — `caddy reload` validates before applying, so the
+        // deploy returning 0 already means it parsed. Assert the route landed in the running config too.
+        var (_, caddyfile) = await host.DockerAsync("exec", "rask-caddy", "cat", "/etc/caddy/Caddyfile");
+        Assert.Contains("rask-e2e.test", caddyfile, StringComparison.Ordinal);
+        Assert.Contains("webapp-blue:8080", caddyfile, StringComparison.Ordinal);
+
+        Assert.True(await command.ExecuteAsync(args, CancellationToken.None) == 0, $"second domain deploy failed.\n{console.ErrorText}");
+
+        // Green took over and blue was retired — the swap, observed on the host rather than in argv.
+        var (_, afterSecond) = await host.DockerAsync("ps", "--format", "{{.Names}}");
+        Assert.Contains("webapp-green", afterSecond, StringComparison.Ordinal);
+        Assert.DoesNotContain("webapp-blue", afterSecond, StringComparison.Ordinal);
+
+        var (_, reloaded) = await host.DockerAsync("exec", "rask-caddy", "cat", "/etc/caddy/Caddyfile");
+        Assert.Contains("webapp-green:8080", reloaded, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A container that starts but never answers must not take the domain. The old version keeps serving and
+    /// the failed colour is removed — the rollback that only exists at deploy time, proven end to end.
+    /// </summary>
+    [SkippableFact]
+    public async Task A_failing_health_check_leaves_the_previous_version_serving()
+    {
+        var project = Start(out var console, out var command);
+        string[] good = ["--host", host.Host, "--domain", "rask-health.test", "--name", "healthapp"];
+        Assert.True(await command.ExecuteAsync(good, CancellationToken.None) == 0, $"baseline deploy failed.\n{console.ErrorText}");
+
+        // Replace the app with one that runs but serves nothing, then redeploy: the probe must fail.
+        File.WriteAllText(
+            Path.Combine(project, "Dockerfile"),
+            """
+            FROM docker.io/library/alpine:3.20
+            EXPOSE 8080
+            CMD ["sleep", "600"]
+            """);
+
+        var exit = await command.ExecuteAsync(good, CancellationToken.None);
+
+        Assert.True(exit != 0, "a deploy whose health probe never passes must fail.");
+        var (_, containers) = await host.DockerAsync("ps", "--format", "{{.Names}}");
+        Assert.Contains("healthapp-blue", containers, StringComparison.Ordinal);   // the good one still serves
+        Assert.DoesNotContain("healthapp-green", containers, StringComparison.Ordinal); // the bad one was removed
+
+        var (_, caddyfile) = await host.DockerAsync("exec", "rask-caddy", "cat", "/etc/caddy/Caddyfile");
+        Assert.Contains("healthapp-blue:8080", caddyfile, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Set up a project directory holding the app's Dockerfile and a <see cref="DeployCommand"/> wired to the
+    /// real filesystem and a process runner scoped to the fixture's ssh identity. Skips when the gate is off
+    /// or the fake VPS couldn't start, so a machine without Docker reports SKIPPED rather than failing.
+    /// </summary>
+    private string Start(out StringConsole console, out DeployCommand command)
+    {
+        Skip.IfNot(DeployE2E.Enabled, DeployE2E.SkipReason);
+
+        // Deliberately a FAILURE, not another skip: the gate was explicitly asked for with
+        // RASK_DEPLOY_E2E=1, so "the harness couldn't start" is a result the runner must see. Skipping
+        // here would recreate exactly the fail-open hole the CLI build gates just had — a suite that
+        // reports fine while verifying nothing.
+        Assert.True(host.Unavailable is null, $"the deploy host gate was requested but its host is unusable — {host.Unavailable}");
+
+        var project = Path.Combine(Path.GetTempPath(), "rask-deploy-e2e", "proj-" + Guid.NewGuid().ToString("N")[..8]);
+        Directory.CreateDirectory(project);
+        File.WriteAllText(Path.Combine(project, "Dockerfile"), AppDockerfile.ReplaceLineEndings("\n"));
+
+        console = new StringConsole();
+        command = new DeployCommand(console, new SystemFileSystem(), new EnvScopedProcessRunner(host.Environment, host.Executables), project)
+        {
+            // The app answers immediately; a real box's 2s×10 budget only slows the gate down.
+            ReadinessDelay = TimeSpan.FromMilliseconds(500),
+            ReadinessAttempts = 30,
+        };
+        return project;
+    }
+
+    private static int CountBoots(string output) =>
+        output.Split('\n').Count(l => l.Trim() == "boot");
+}

--- a/tests/Rask.Cli.Tests/DeployHostFixture.cs
+++ b/tests/Rask.Cli.Tests/DeployHostFixture.cs
@@ -1,0 +1,242 @@
+using System.Globalization;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// Boots a throwaway container that stands in for a bare VPS: sshd on a published port, its own Docker
+/// daemon inside (<c>docker:dind</c>, privileged), and a key-only <c>root</c> login whose identity lives
+/// in this fixture's temp directory. <c>rask deploy</c> is then pointed at it exactly as it would be at a
+/// real box — <c>docker -H ssh://&lt;host&gt;</c> for every step, no special-casing anywhere in the CLI.
+///
+/// <para>The host presents as <b>already Docker-ready</b>, so <see cref="HostSetup"/> returns the target
+/// untouched (<c>facts.DockerReady &amp;&amp; mode != Forced</c>) and these tests exercise the deploy path
+/// rather than the bootstrap path. Bootstrapping a bare box is a separate concern: it installs Docker and
+/// rewrites sshd config, which needs a systemd host rather than a dind container.</para>
+/// </summary>
+public sealed class DeployHostFixture : IAsyncLifetime
+{
+    private readonly string _id = Guid.NewGuid().ToString("N")[..8];
+    private string _root = string.Empty;
+    private string _image = string.Empty;
+    private bool _started;
+
+    /// <summary>The `--host` value: an ssh-config alias, resolved through this fixture's own config.</summary>
+    public string Host => $"rask-e2e-{_id}";
+
+    /// <summary>The fake VPS's container name on the developer's local daemon.</summary>
+    public string Container => $"rask-e2e-vps-{_id}";
+
+    /// <summary>Environment for <see cref="EnvScopedProcessRunner"/>: puts the ssh shim first on PATH.</summary>
+    public Dictionary<string, string> Environment { get; private set; } = [];
+
+    /// <summary>Executable substitutions for <see cref="EnvScopedProcessRunner"/>: <c>ssh</c> → the shim.</summary>
+    public Dictionary<string, string> Executables { get; private set; } = [];
+
+    /// <summary>
+    /// Why the fixture couldn't start, when it couldn't. Set only once the gate has been asked for, and
+    /// the tests turn it into a <b>failure</b> — being unable to prepare a host the run explicitly
+    /// requested is a result, not a reason to report success.
+    /// </summary>
+    public string? Unavailable { get; private set; }
+
+    public async Task InitializeAsync()
+    {
+        if (!DeployE2E.Enabled)
+        {
+            return;
+        }
+
+        // The identity is scoped through a POSIX `ssh` shim on PATH (see EnvScopedProcessRunner for why a
+        // redirected HOME can't work), so the gate is Unix-only by construction.
+        if (OperatingSystem.IsWindows())
+        {
+            Unavailable = "the deploy host gate needs a Unix host (its ssh shim is a shell script).";
+            return;
+        }
+
+        var (dockerExit, dockerOut) = await DeployE2E.RunAsync("docker", ["version", "--format", "{{.Server.Version}}"]).ConfigureAwait(false);
+        if (dockerExit != 0)
+        {
+            Unavailable = $"no usable local Docker daemon: {dockerOut.Trim()}";
+            return;
+        }
+
+        _root = Path.Combine(Path.GetTempPath(), "rask-deploy-e2e", _id);
+        Directory.CreateDirectory(_root);
+
+        var key = Path.Combine(_root, "id_e2e");
+        var (keyExit, keyOut) = await DeployE2E.RunAsync("ssh-keygen", ["-t", "ed25519", "-N", string.Empty, "-f", key, "-C", "rask-deploy-e2e", "-q"]).ConfigureAwait(false);
+        if (keyExit != 0)
+        {
+            Unavailable = $"ssh-keygen failed: {keyOut.Trim()}";
+            return;
+        }
+
+        WriteImageContext(key + ".pub");
+
+        _image = $"rask-e2e-vps:{_id}";
+        var (buildExit, buildOut) = await DeployE2E.RunAsync("docker", ["build", "-t", _image, _root]).ConfigureAwait(false);
+        if (buildExit != 0)
+        {
+            Unavailable = $"couldn't build the fake-VPS image: {Tail(buildOut)}";
+            return;
+        }
+
+        var sshPort = DeployE2E.FreePort();
+        var (runExit, runOut) = await DeployE2E.RunAsync(
+            "docker",
+            [
+                "run", "-d", "--name", Container, "--privileged",
+                // dind serves plain TCP internally; we only ever reach it over ssh, so TLS bootstrap is noise.
+                "-e", "DOCKER_TLS_CERTDIR=",
+                "-p", $"127.0.0.1:{sshPort.ToString(CultureInfo.InvariantCulture)}:22",
+                _image,
+            ]).ConfigureAwait(false);
+        if (runExit != 0)
+        {
+            Unavailable = $"couldn't start the fake VPS (privileged containers may be unavailable): {Tail(runOut)}";
+            return;
+        }
+
+        _started = true;
+        WriteSshConfig(key, sshPort);
+
+        // PATH covers the ssh that *docker* spawns for its ssh:// transport; the substitution covers the
+        // ssh that Rask spawns directly (see EnvScopedProcessRunner).
+        Environment = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["PATH"] = Path.Combine(_root, "shim") + Path.PathSeparator + System.Environment.GetEnvironmentVariable("PATH"),
+        };
+        Executables = new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["ssh"] = Path.Combine(_root, "shim", "ssh"),
+        };
+
+        if (await WaitForHostAsync().ConfigureAwait(false) is { } reason)
+        {
+            Unavailable = reason;
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_started)
+        {
+            // The container, then the per-run image it was built from — otherwise every run of the gate
+            // silently leaves another ~500 MB fake-VPS image behind on the developer's daemon.
+            await DeployE2E.RunAsync("docker", ["rm", "-f", Container]).ConfigureAwait(false);
+            await DeployE2E.RunAsync("docker", ["image", "rm", "-f", _image]).ConfigureAwait(false);
+        }
+
+        if (_root.Length > 0)
+        {
+            CliBuildE2E.TryDeleteDirectory(_root);
+        }
+    }
+
+    /// <summary>Run a command on the fake VPS over the same ssh path the CLI uses.</summary>
+    public Task<(int Exit, string Output)> OnHostAsync(string command) =>
+        DeployE2E.RunAsync(Path.Combine(_root, "shim", "ssh"), ["-o", "BatchMode=yes", "--", Host, command], Environment);
+
+    /// <summary>Run a docker command against the fake VPS's own daemon.</summary>
+    public Task<(int Exit, string Output)> DockerAsync(params string[] arguments) =>
+        DeployE2E.RunAsync("docker", [.. new[] { "-H", $"ssh://{Host}" }.Concat(arguments)], Environment);
+
+    // The fake VPS: dind (its own dockerd) + sshd, with only our throwaway key trusted.
+    private void WriteImageContext(string publicKeyPath)
+    {
+        File.Copy(publicKeyPath, Path.Combine(_root, "authorized_keys"), overwrite: true);
+
+        // sshd must be running before dockerd takes over PID 1, so it starts first and the dind
+        // entrypoint is exec'd (keeping dockerd as the container's main process).
+        File.WriteAllText(
+            Path.Combine(_root, "entrypoint.sh"),
+            """
+            #!/bin/sh
+            set -e
+            [ -f /etc/ssh/ssh_host_ed25519_key ] || ssh-keygen -A
+            /usr/sbin/sshd
+            exec dockerd-entrypoint.sh "$@"
+
+            """.ReplaceLineEndings("\n"));
+
+        File.WriteAllText(
+            Path.Combine(_root, "Dockerfile"),
+            $"""
+            FROM {DeployE2E.DindImage}
+            RUN apk add --no-cache openssh-server
+            RUN mkdir -p /root/.ssh && chmod 700 /root/.ssh
+            COPY authorized_keys /root/.ssh/authorized_keys
+            RUN chmod 600 /root/.ssh/authorized_keys \
+             && printf 'PermitRootLogin prohibit-password\nPasswordAuthentication no\n' > /etc/ssh/sshd_config.d/rask-e2e.conf
+            COPY entrypoint.sh /usr/local/bin/rask-vps-entrypoint.sh
+            RUN chmod +x /usr/local/bin/rask-vps-entrypoint.sh
+            ENTRYPOINT ["/usr/local/bin/rask-vps-entrypoint.sh"]
+
+            """.ReplaceLineEndings("\n"));
+    }
+
+    /// <summary>
+    /// The ssh config that makes <see cref="Host"/> resolve, plus the shim that makes ssh read it.
+    /// <c>UserKnownHostsFile=/dev/null</c> keeps a per-run container host key out of the developer's
+    /// known_hosts — the fixture's whole point is to leave no trace outside its temp directory.
+    /// </summary>
+    private void WriteSshConfig(string keyPath, int sshPort)
+    {
+        var sshDir = Path.Combine(_root, "ssh");
+        Directory.CreateDirectory(sshDir);
+        var configPath = Path.Combine(sshDir, "config");
+        File.WriteAllText(
+            configPath,
+            $"""
+            Host {Host}
+              HostName 127.0.0.1
+              Port {sshPort.ToString(CultureInfo.InvariantCulture)}
+              User root
+              IdentityFile {keyPath}
+              IdentitiesOnly yes
+              StrictHostKeyChecking no
+              UserKnownHostsFile /dev/null
+              LogLevel ERROR
+
+            """.ReplaceLineEndings("\n"));
+
+        var shimDir = Path.Combine(_root, "shim");
+        Directory.CreateDirectory(shimDir);
+        var shim = Path.Combine(shimDir, "ssh");
+        File.WriteAllText(
+            shim,
+            $"""
+            #!/bin/sh
+            exec /usr/bin/ssh -F "{configPath}" "$@"
+
+            """.ReplaceLineEndings("\n"));
+
+        if (!OperatingSystem.IsWindows())
+        {
+            File.SetUnixFileMode(shim, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
+    }
+
+    /// <summary>Wait until sshd answers and dockerd inside the container is up. Returns null once ready.</summary>
+    private async Task<string?> WaitForHostAsync()
+    {
+        string last = "never answered";
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            var (exit, output) = await OnHostAsync("docker info >/dev/null 2>&1 && echo rask-vps-ready").ConfigureAwait(false);
+            if (exit == 0 && output.Contains("rask-vps-ready", StringComparison.Ordinal))
+            {
+                return null;
+            }
+
+            last = output.Trim();
+            await Task.Delay(TimeSpan.FromSeconds(1)).ConfigureAwait(false);
+        }
+
+        return $"the fake VPS never became ready (sshd + dockerd): {Tail(last)}";
+    }
+
+    private static string Tail(string output) =>
+        string.Join('\n', output.Split('\n').Where(l => l.Trim().Length > 0).TakeLast(6));
+}


### PR DESCRIPTION
> Stacked on #502 — review that first; this PR's own diff is the four `Deploy*` files, the script, the hook clause, and the docs/changelog entries.

## Summary

`rask deploy` had **120 tests and none of them deployed anything.** `FakeProcessRunner` records the argv
and returns a scripted exit code, so the suite proves the command line Rask *builds* — not that the
Dockerfile builds, the container answers, the Caddyfile parses, or the volume survives.

This gate points the real `rask deploy` at a throwaway container standing in for a bare VPS — sshd plus
its own Docker daemon (`docker:dind`, privileged) — and asserts on what happened **on the host**:

| Test | What it proves that a mock cannot |
|------|-----------------------------------|
| `Deploy_to_a_port_builds_runs_and_answers_its_health_check` | The image builds over SSH, the container runs, the app answers `/health`, `.rask/deploy.json` is persisted |
| `Redeploy_keeps_the_data_volume` | The database-survives-redeploy contract — a fresh container, same named volume, contents accumulate |
| `Domain_deploy_swaps_colour_behind_a_real_caddy` | Blue→green swap, blue retired, and **a real Caddy accepted the generated Caddyfile** with the right upstream |
| `A_failing_health_check_leaves_the_previous_version_serving` | A container that starts but never answers is removed and the previous version keeps the domain |

## Design notes

- **SSH identity is scoped through a shim on `PATH`, not a redirected `HOME`.** macOS OpenSSH resolves
  `~/.ssh` through `getpwuid()` and ignores `$HOME`, so a redirected HOME is silently ignored and ssh reads
  the developer's real config. The shim re-execs the real ssh with `-F <temp config>`; your `~/.ssh` is
  never read or written and nothing is installed.
- **A requested-but-unstartable host FAILS, it does not skip.** Skipping would recreate exactly the
  fail-open hole #502 fixes. Unset `RASK_DEPLOY_E2E` → clean `SKIPPED`; set it and the host won't come up →
  a real failure.
- **The pre-push hook runs it only when the push touches the deploy path** (`DeployCommand`, `Host*`,
  `SshTarget`, `DockerProbe`, `DeployConfig`, or the deploy tests). Always-on would tax every unrelated
  push; never-on is a gate that quietly never runs.
- The fixture removes its container **and its image** on dispose — otherwise each run leaves a ~500 MB
  image behind.

## Testing

- **4/4 pass against a real container host** (~80 s), repeatedly, with no leaked containers or images.
- Verified the gate genuinely bites: an app that started but served nothing was caught by the health probe
  and the deploy correctly failed (that's now the fourth test).
- `RASK_DEPLOY_E2E` unset → 4/4 `SKIPPED` with a reason.
- `scripts/run-unit-local.sh`: green.
- Pushing this branch exercised the hook end to end — it detected the deploy-path change and ran the gate.

## Not covered

Real DNS and Let's Encrypt issuance. The gate uses a `.test` domain, so the Caddyfile is validated but
ACME never runs — worth one throwaway-VPS run before a 1.0 that advertises auto-HTTPS.

## Unrelated flake seen

`Rask.SQLite.Tests.SqliteConcurrencyStressTests.All_concurrent_immediate_writers_commit(writers: 500)`
failed once in a full-solution run with `cannot start a transaction within a transaction`, then passed 3/3
in isolation and on a full re-run. Cross-assembly pooling interference, untouched by this branch — filed
separately.

## Changelog

`[Unreleased] → Added`.