### PR TITLE
fix(cli)!: validate --domain, and make every template deployable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Security
+- **`rask deploy --domain` is now validated before it reaches the shared proxy.** The domain was written
+  verbatim into the Caddyfile that fronts *every* app on the box, so a value containing `{`, `}` or a
+  newline could close the generated site block and inject arbitrary Caddy directives — a global options
+  block, a `file_server` over `/`, an open admin endpoint — and an embedded tab or newline could forge a
+  row in the tab-separated `docker ps` label listing the routing is rebuilt from. Because the domain is
+  remembered in the **committed** `.rask/deploy.json` and read by CI, a hostile value could arrive by pull
+  request and reconfigure the proxy of every host the repo deploys to. This is the same threat model that
+  motivated the existing SSH-host check, and it now has the same kind of boundary: `--domain` must be an
+  RFC-1123 host name (optionally with a leading `*.`), validated wherever the value comes from.
+- **A failed deploy no longer prints the values you passed it.** The container's last log lines are dumped
+  to stderr on failure — which, in the workflow `--github-actions` writes, is a CI job log — so any
+  `--env` / `--env-file` value appearing in them is now masked first. Likewise an unparseable `--env-file`
+  line is reported by **line number** instead of by echoing the line, which was a credential.
+
+### Fixed
+- **The standalone `wasm` template can be deployed.** Its nginx image listened on port 80 while
+  `rask deploy` had the container port hardcoded to 8080, so the proxy and the readiness probe both aimed
+  at a closed port and the deploy could never succeed. The generated `nginx.conf` now listens on `8080`
+  and serves `/health`, matching the server and wasm-hosted templates, and a new `--container-port` flag
+  (remembered, and recorded as a label on the container) covers any hand-written Dockerfile that listens
+  elsewhere. Because the port is stored per container, a host running several apps that don't agree on one
+  keeps each app's routing correct.
+- **The `wasm-hosted` Dockerfile prepares `/data` like the server template does.** `rask deploy` mounts a
+  named volume at `/data` and points the app at `/data/app.db` for *every* template, but this image never
+  created the directory or gave it to the non-root runtime user — so the mount landed root-owned and the
+  app couldn't create its database.
+- **A port-mode deploy is visible to the host inventory.** Its container carries `rask.*` labels (without a
+  domain, so it is never proxied), which means moving an app to `--domain` later retires the old container
+  instead of leaving it running and unaccounted for.
+- **The generated Caddyfile is removed from the temp directory** once it has been copied to the host,
+  rather than left behind under a predictable name.
+
 ### Added
 - **`rask deploy` is now verified against a real host.** Every deploy test in the repo was mocked — a fake
   process runner recorded the argv and returned a scripted exit code — so the suite proved the command line

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -259,6 +259,7 @@ writable `/data`; a custom Dockerfile needs `RUN mkdir -p /data && chown $APP_UI
 | `--host user@box` | SSH target. Required on the first deploy, then remembered in `.rask/deploy.json`. |
 | `--domain <host>` | Front the app with auto-HTTPS Caddy. Omit to publish `--port` directly. |
 | `--port <n>` | Host port when there's no domain (default `8080`). |
+| `--container-port <n>` | The port your app listens on **inside** the container — what the proxy is pointed at and what the readiness probe hits (default `8080`, which every `rask new --docker` Dockerfile uses). Only needed for a hand-written Dockerfile that exposes something else. Remembered in `.rask/deploy.json`, and recorded on the container so a host running apps on different ports keeps each one's routing correct. |
 | `--name <slug>` | Image/container name (default: the project name). |
 | `--project <path>` · `--dockerfile <path>` | The build context / Dockerfile, if not the current project. |
 | `--env KEY=VALUE` · `--env-file <path>` | Runtime environment for the app container (repeat `--env`). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -176,12 +176,15 @@ copies it into a tiny `nginx:alpine` image with a bundled `nginx.conf`:
 
 ```bash
 docker build -t myapp .
-docker run --rm -p 8080:80 myapp     # nginx listens on 80 inside the container
+docker run --rm -p 8080:8080 myapp
 # open http://localhost:8080
 ```
 
-The `nginx.conf` does three things that matter for a Rask WASM bundle:
+The `nginx.conf` does four things that matter for a Rask WASM bundle:
 
+- **Listens on `8080`, and serves `/health`** — the same container port and readiness endpoint as the
+  server and wasm-hosted templates, so [`rask deploy`](cli.md#rask-deploy--ship-to-a-single-host-over-ssh)
+  can health-gate and proxy a static bundle exactly like any other Rask app.
 - **SPA fallback** — `try_files $uri $uri/ /index.html;` so client-side routes resolve.
 - **`application/wasm` MIME** — the browser refuses to streaming-compile the Mono runtime `.wasm`
   under any other type.

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -29,8 +29,12 @@ namespace Rask.Cli.Commands;
 internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
     : CliCommand(console)
 {
-    /// <summary>The container port the scaffolded server/wasm-hosted Dockerfiles listen on (<c>EXPOSE 8080</c>).</summary>
-    internal const int ContainerPort = 8080;
+    /// <summary>
+    /// The port an app listens on <em>inside</em> its container, unless <c>--container-port</c> says otherwise.
+    /// Every Dockerfile <c>rask new --docker</c> emits listens here, so the default is right for scaffolded
+    /// apps; a hand-written Dockerfile that exposes something else needs the flag (it is then remembered).
+    /// </summary>
+    internal const int DefaultContainerPort = 8080;
 
     /// <summary>The shared docker network app containers and the Caddy proxy join in domain mode.</summary>
     internal const string Network = "rask";
@@ -62,8 +66,8 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     public override string Summary => "Build and deploy the app to a single host over SSH (auto-HTTPS with --domain).";
 
     public override string Usage =>
-        "rask deploy [--host user@box] [--domain app.example.com] [--port <n>] [--project <path>] " +
-        "[--name <slug>] [--dockerfile <path>] [--env KEY=VALUE ...] [--env-file <path>] " +
+        "rask deploy [--host user@box] [--domain app.example.com] [--port <n>] [--container-port <n>] " +
+        "[--project <path>] [--name <slug>] [--dockerfile <path>] [--env KEY=VALUE ...] [--env-file <path>] " +
         "[--health-path <path>] [--no-health-check] [--setup-host] [--github-actions] [--dry-run]";
 
     public override IReadOnlyList<string> Examples =>
@@ -85,6 +89,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             .Option("host", 'h', "user@box", "SSH target to build and run on (remembered in .rask/deploy.json).")
             .Option("domain", 'd', "host", "Public domain to serve over HTTPS via Caddy (implies ports 80/443).")
             .Option("port", valueHint: "n", description: "Published port when not using --domain (default: 8080).")
+            .Option("container-port", valueHint: "n", description: "Port the app listens on inside the container (default: 8080; remembered).")
             .Option("project", 'p', "path", "Project to deploy (default: found from the current directory).")
             .Option("name", 'n', "slug", "Container/app name (default: derived from the project).")
             .Option("dockerfile", valueHint: "path", description: "Dockerfile to build (default: ./Dockerfile).")
@@ -128,6 +133,26 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         {
             Console.Error.WriteLine(portError);
             return 1;
+        }
+
+        if (!TryResolveContainerPort(parsed.Option("container-port"), config.ContainerPort, out var containerPort, out var containerPortError))
+        {
+            Console.Error.WriteLine(containerPortError);
+            return 1;
+        }
+
+        // Validated at the boundary for the same reason as the SSH host below: the domain is written
+        // verbatim into the Caddyfile that fronts every app on the box, and it may come from the
+        // *committed* .rask/deploy.json rather than from this user's keyboard.
+        if (domain is not null)
+        {
+            if (!DomainName.TryParse(domain, out var parsedDomain, out var domainError))
+            {
+                Console.WriteErrorLine(domainError!, ConsoleStyle.Error);
+                return 1;
+            }
+
+            domain = parsedDomain;
         }
 
         // --port and --domain are two different modes: with a domain the app is reached internally on the
@@ -206,7 +231,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             // thing you do in a repo, rather than emitting a workflow that can't resolve a host.
             if (!dryRun)
             {
-                PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath);
+                PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath, containerPort);
             }
 
             return WriteGitHubActionsWorkflow(sshTarget, host, dryRun);
@@ -214,7 +239,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
         if (dryRun)
         {
-            PrintPlan(host, slug, domain, port, dockerfile, contextDir, env, healthEnabled, healthPath);
+            PrintPlan(host, slug, domain, port, containerPort, dockerfile, contextDir, env, healthEnabled, healthPath);
             return 0;
         }
 
@@ -247,7 +272,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         if (!string.Equals(newHost, host, StringComparison.Ordinal))
         {
             host = newHost;
-            PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath);
+            PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath, containerPort);
             Console.WriteLine($"  Remembered {host} in {Path.Combine(".rask", "deploy.json")} — deploy as that from now on.", ConsoleStyle.Dim);
         }
 
@@ -259,19 +284,19 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         }
 
         return domain is null
-            ? await DeployPortAsync(host, slug, port, env, projectSetting, envFile, healthEnabled, healthPath, cancellationToken).ConfigureAwait(false)
-            : await DeployWithProxyAsync(host, slug, domain, env, projectSetting, envFile, healthEnabled, healthPath, cancellationToken).ConfigureAwait(false);
+            ? await DeployPortAsync(host, slug, port, containerPort, env, projectSetting, envFile, healthEnabled, healthPath, cancellationToken).ConfigureAwait(false)
+            : await DeployWithProxyAsync(host, slug, domain, containerPort, env, projectSetting, envFile, healthEnabled, healthPath, cancellationToken).ConfigureAwait(false);
     }
 
     // ── The bare port path: stop-old-start-new (brief downtime — no proxy to swap behind). ──────────────
-    private async Task<int> DeployPortAsync(string host, string slug, int port, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
+    private async Task<int> DeployPortAsync(string host, string slug, int port, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
     {
         // Retire the old container gracefully (SIGTERM → Litestream flush + WAL checkpoint) before removing it,
         // so the last writes reach the replica; both no-op on the first deploy (no container yet).
         await Run(BuildStopArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         await Run(BuildRemoveArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         Console.Out.WriteLine($"Starting {slug} on port {port}…");
-        if (await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env), cancellationToken).ConfigureAwait(false) != 0)
+        if (await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env, containerPort), cancellationToken).ConfigureAwait(false) != 0)
         {
             Console.WriteErrorLine("Failed to start the container.", ConsoleStyle.Error);
             return 1;
@@ -279,27 +304,27 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
         if (!await WaitUntilRunningAsync(host, slug, cancellationToken).ConfigureAwait(false))
         {
-            await DumpLogsAsync(host, slug, cancellationToken).ConfigureAwait(false);
+            await DumpLogsAsync(host, slug, env, cancellationToken).ConfigureAwait(false);
             return 1;
         }
 
         // No blue-green here (the old container is already gone), so a failed probe can't roll back — it
         // surfaces the broken deploy with logs rather than leaving it to fail silently under traffic.
-        if (healthEnabled && !await WaitUntilHealthyAsync(host, slug, healthPath, cancellationToken).ConfigureAwait(false))
+        if (healthEnabled && !await WaitUntilHealthyAsync(host, slug, healthPath, containerPort, cancellationToken).ConfigureAwait(false))
         {
-            await DumpLogsAsync(host, slug, cancellationToken).ConfigureAwait(false);
+            await DumpLogsAsync(host, slug, env, cancellationToken).ConfigureAwait(false);
             Console.WriteErrorLine(HealthFailureMessage(healthPath, rolledBack: false), ConsoleStyle.Error);
             return 1;
         }
 
-        PersistConfig(host, domain: null, port, slug, project, envFile, healthEnabled, healthPath);
+        PersistConfig(host, domain: null, port, slug, project, envFile, healthEnabled, healthPath, containerPort);
         Console.WriteLine($"Deployed. The app is live at http://{HostName(host)}:{port}", ConsoleStyle.Success);
         return 0;
     }
 
     // ── The domain path: blue-green swap behind a shared, multi-app Caddy proxy (zero downtime). ────────
     private async Task<int> DeployWithProxyAsync(
-        string host, string slug, string domain, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
+        string host, string slug, string domain, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
     {
         // The live containers are the source of truth. Read them once: the current color of this app (to
         // pick the next), plus every other app's route (to regenerate the full Caddyfile).
@@ -315,8 +340,8 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         await Run(BuildRemoveArguments(host, newContainer), cancellationToken).ConfigureAwait(false); // ignore-absent
 
         Console.Out.WriteLine($"Starting {newContainer} ({domain})…");
-        // In domain mode the app is reached internally on ContainerPort; no host port is published.
-        if (await Run(BuildRunArguments(host, slug, domain, newColor, ContainerPort, env), cancellationToken).ConfigureAwait(false) != 0)
+        // In domain mode the app is reached internally on its container port; no host port is published.
+        if (await Run(BuildRunArguments(host, slug, domain, newColor, containerPort, env, containerPort), cancellationToken).ConfigureAwait(false) != 0)
         {
             Console.WriteErrorLine("Failed to start the new container.", ConsoleStyle.Error);
             return 1;
@@ -326,7 +351,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         // old one keeps serving (safe rollback — this deploy simply didn't happen).
         if (!await WaitUntilRunningAsync(host, newContainer, cancellationToken).ConfigureAwait(false))
         {
-            await DumpLogsAsync(host, newContainer, cancellationToken).ConfigureAwait(false);
+            await DumpLogsAsync(host, newContainer, env, cancellationToken).ConfigureAwait(false);
             await Run(BuildRemoveArguments(host, newContainer), cancellationToken).ConfigureAwait(false);
             Console.WriteErrorLine("The new container exited before it was ready — left the previous version serving.", ConsoleStyle.Error);
             return 1;
@@ -335,9 +360,9 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         // Second gate: the container is up, but is the app actually answering? Probe over HTTP before
         // touching the proxy, so a container that starts but 500s (bad config, failed migration) never
         // takes the domain — remove it and leave the old color serving (safe rollback).
-        if (healthEnabled && !await WaitUntilHealthyAsync(host, newContainer, healthPath, cancellationToken).ConfigureAwait(false))
+        if (healthEnabled && !await WaitUntilHealthyAsync(host, newContainer, healthPath, containerPort, cancellationToken).ConfigureAwait(false))
         {
-            await DumpLogsAsync(host, newContainer, cancellationToken).ConfigureAwait(false);
+            await DumpLogsAsync(host, newContainer, env, cancellationToken).ConfigureAwait(false);
             await Run(BuildRemoveArguments(host, newContainer), cancellationToken).ConfigureAwait(false);
             Console.Error.WriteLine(HealthFailureMessage(healthPath, rolledBack: true));
             return 1;
@@ -349,11 +374,15 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
         // Regenerate the whole Caddyfile from the live routes, forcing this app to its NEW container, then
         // hot-reload — Caddy drains in-flight requests to the old color.
-        var routes = BuildRoutingMap(apps, slug, domain, newContainer);
+        var routes = BuildRoutingMap(apps, slug, domain, new RouteTarget(newContainer, containerPort));
         var caddyfilePath = Path.Combine(Path.GetTempPath(), $"rask-{slug}.Caddyfile");
         _fileSystem.WriteAllText(caddyfilePath, BuildCaddyfile(routes));
         Console.Out.WriteLine($"Routing {domain} → {newContainer} (auto-HTTPS via Caddy)…");
         await Run(BuildCaddyCopyArguments(host, caddyfilePath), cancellationToken).ConfigureAwait(false);
+
+        // The file has been copied to the box; leaving a predictably-named copy in the shared temp dir
+        // serves no purpose and is a symlink-clobber target on a multi-user machine.
+        _fileSystem.TryDelete(caddyfilePath);
 
         // Retry the reload: on a fresh host the proxy was just started detached, so its admin endpoint may
         // need a moment before `caddy reload` succeeds.
@@ -372,7 +401,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             await Run(BuildRemoveArguments(host, stale.Container), cancellationToken).ConfigureAwait(false);
         }
 
-        PersistConfig(host, domain, port: null, slug, project, envFile, healthEnabled, healthPath);
+        PersistConfig(host, domain, port: null, slug, project, envFile, healthEnabled, healthPath, containerPort);
         Console.WriteLine($"Deployed. The app is live at https://{domain}", ConsoleStyle.Success);
         Console.WriteLine($"  (make sure {domain}'s DNS A/AAAA record points at {HostName(host)})", ConsoleStyle.Dim);
         return 0;
@@ -425,7 +454,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         return 0;
     }
 
-    private void PersistConfig(string host, string? domain, int? port, string slug, string? project, string? envFile, bool healthEnabled, string healthPath) =>
+    private void PersistConfig(string host, string? domain, int? port, string slug, string? project, string? envFile, bool healthEnabled, string healthPath, int containerPort) =>
         new DeployConfig
         {
             Host = host,
@@ -437,6 +466,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             // Only persist non-defaults so a fresh deploy.json stays clean (default path, health on).
             HealthPath = healthPath == DefaultHealthPath ? null : healthPath,
             HealthCheckDisabled = healthEnabled ? null : true,
+            ContainerPort = containerPort == DefaultContainerPort ? null : containerPort,
         }.Save(_fileSystem, _workingDirectory);
 
     private async Task<bool> WaitUntilRunningAsync(string host, string container, CancellationToken cancellationToken)
@@ -465,7 +495,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     // Probe the app over HTTP from an ephemeral curl container sharing the target's network namespace, so
     // it works whether or not a host port is published (domain mode publishes none) and needs no HTTP client
     // in the app image. Retried across the readiness window — the app may warm up after the container is up.
-    private async Task<bool> WaitUntilHealthyAsync(string host, string container, string healthPath, CancellationToken cancellationToken)
+    private async Task<bool> WaitUntilHealthyAsync(string host, string container, string healthPath, int containerPort, CancellationToken cancellationToken)
     {
         for (var attempt = 0; attempt < ReadinessAttempts; attempt++)
         {
@@ -475,7 +505,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
                 await Task.Delay(ReadinessDelay, cancellationToken).ConfigureAwait(false);
             }
 
-            if (await Run(BuildHealthCheckArguments(host, container, healthPath), cancellationToken).ConfigureAwait(false) == 0)
+            if (await Run(BuildHealthCheckArguments(host, container, healthPath, containerPort), cancellationToken).ConfigureAwait(false) == 0)
             {
                 return true;
             }
@@ -506,18 +536,47 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         return exit;
     }
 
-    private async Task DumpLogsAsync(string host, string container, CancellationToken cancellationToken)
+    /// <summary>
+    /// Show the failing container's last log lines, with any value we passed in via <c>--env</c> /
+    /// <c>--env-file</c> masked out first. An app that logs its own configuration on a failed start is
+    /// ordinary, and this output goes to stderr — which, in the workflow <c>--github-actions</c> writes,
+    /// is a CI job log. We can't know what else is a secret, but we do know exactly what we handed it.
+    /// </summary>
+    private async Task DumpLogsAsync(string host, string container, IReadOnlyList<string> env, CancellationToken cancellationToken)
     {
         var logs = await Capture(BuildLogsArguments(host, container), cancellationToken).ConfigureAwait(false);
         if (!string.IsNullOrWhiteSpace(logs.StandardOutput))
         {
-            Console.Error.WriteLine(logs.StandardOutput.TrimEnd());
+            Console.Error.WriteLine(MaskSecrets(logs.StandardOutput.TrimEnd(), env));
         }
 
         if (!string.IsNullOrWhiteSpace(logs.StandardError))
         {
-            Console.Error.WriteLine(logs.StandardError.TrimEnd());
+            Console.Error.WriteLine(MaskSecrets(logs.StandardError.TrimEnd(), env));
         }
+    }
+
+    /// <summary>Replace every non-trivial <c>--env</c> value found in <paramref name="text"/> with an ellipsis.</summary>
+    internal static string MaskSecrets(string text, IReadOnlyList<string> env)
+    {
+        foreach (var entry in env)
+        {
+            var eq = entry.IndexOf('=', StringComparison.Ordinal);
+            if (eq < 0)
+            {
+                continue;
+            }
+
+            // Very short values ("1", "true", a port) are not secrets and masking them would shred the
+            // log into ellipses, destroying the diagnostics this dump exists to provide.
+            var value = entry[(eq + 1)..];
+            if (value.Length >= 6)
+            {
+                text = text.Replace(value, "…", StringComparison.Ordinal);
+            }
+        }
+
+        return text;
     }
 
     private Task<int> Run(IReadOnlyList<string> args, CancellationToken cancellationToken) =>
@@ -526,7 +585,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     private Task<ProcessResult> Capture(IReadOnlyList<string> args, CancellationToken cancellationToken) =>
         _process.CaptureAsync("docker", args, _workingDirectory, cancellationToken);
 
-    private void PrintPlan(string host, string slug, string? domain, int port, string dockerfile, string contextDir, IReadOnlyList<string> env, bool healthEnabled, string healthPath)
+    private void PrintPlan(string host, string slug, string? domain, int port, int containerPort, string dockerfile, string contextDir, IReadOnlyList<string> env, bool healthEnabled, string healthPath)
     {
         var writer = Console.Out;
         writer.WriteLine("Dry run — the following docker commands would run (no changes made):");
@@ -540,11 +599,11 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         if (domain is null)
         {
             Line(BuildRemoveArguments(host, slug));
-            Line(BuildRunArguments(host, slug, domain: null, color: null, port, redacted));
+            Line(BuildRunArguments(host, slug, domain: null, color: null, port, redacted, containerPort));
             Line(BuildInspectRunningArguments(host, slug));
             if (healthEnabled)
             {
-                Line(BuildHealthCheckArguments(host, slug, healthPath));
+                Line(BuildHealthCheckArguments(host, slug, healthPath, containerPort));
             }
         }
         else
@@ -553,11 +612,11 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             var container = $"{slug}-{color}";
             Line(BuildListArguments(host));
             Line(BuildNetworkCreateArguments(host, Network));
-            Line(BuildRunArguments(host, slug, domain, color, port, redacted));
+            Line(BuildRunArguments(host, slug, domain, color, containerPort, redacted, containerPort));
             Line(BuildInspectRunningArguments(host, container));
             if (healthEnabled)
             {
-                Line(BuildHealthCheckArguments(host, container, healthPath));
+                Line(BuildHealthCheckArguments(host, container, healthPath, containerPort));
             }
 
             Line(BuildCaddyRunArguments(host, Network));
@@ -580,17 +639,23 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     internal static IReadOnlyList<string> BuildNetworkCreateArguments(string host, string network) =>
         [.. Prefix(host), "network", "create", network];
 
-    internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env)
+    internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env, int containerPort = DefaultContainerPort)
     {
         var args = new List<string>(Prefix(host)) { "run", "-d" };
         if (domain is null)
         {
-            args.AddRange(["--name", slug, "--restart", "unless-stopped", "-p", $"{port}:{ContainerPort}"]);
+            args.AddRange(["--name", slug, "--restart", "unless-stopped", "-p", $"{port}:{containerPort}"]);
+
+            // Labelled like a domain-mode container (minus a domain, so BuildRoutingMap skips it): without
+            // this a port-mode deploy is invisible to the host inventory, so switching an app to --domain
+            // would strand its old container running forever.
+            args.AddRange(["--label", "rask.managed=true", "--label", $"rask.app={slug}", "--label", $"rask.port={containerPort.ToString(CultureInfo.InvariantCulture)}"]);
         }
         else
         {
             args.AddRange(["--name", $"{slug}-{color}", "--restart", "unless-stopped", "--network", Network]);
             args.AddRange(["--label", "rask.managed=true", "--label", $"rask.app={slug}", "--label", $"rask.domain={domain}", "--label", $"rask.color={color}"]);
+            args.AddRange(["--label", $"rask.port={containerPort.ToString(CultureInfo.InvariantCulture)}"]);
         }
 
         // Persist the SQLite database on a per-app named volume so it survives container replacement — every
@@ -626,7 +691,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     internal static IReadOnlyList<string> BuildListArguments(string host) =>
     [
         .. Prefix(host), "ps", "--filter", "label=rask.managed=true",
-        "--format", "{{.Names}}\t{{.Label \"rask.app\"}}\t{{.Label \"rask.domain\"}}\t{{.Label \"rask.color\"}}",
+        "--format", "{{.Names}}\t{{.Label \"rask.app\"}}\t{{.Label \"rask.domain\"}}\t{{.Label \"rask.color\"}}\t{{.Label \"rask.port\"}}",
     ];
 
     internal static IReadOnlyList<string> BuildInspectRunningArguments(string host, string container) =>
@@ -637,10 +702,10 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     /// the app on <c>localhost:8080</c>. <c>--rm</c> cleans it up; <c>-f</c> makes a <c>&gt;= 400</c> response a
     /// non-zero exit; <c>-m 5</c> bounds a hung connect. Exit 0 ⇒ the app answered a success status.
     /// </summary>
-    internal static IReadOnlyList<string> BuildHealthCheckArguments(string host, string container, string healthPath) =>
+    internal static IReadOnlyList<string> BuildHealthCheckArguments(string host, string container, string healthPath, int containerPort = DefaultContainerPort) =>
     [
         .. Prefix(host), "run", "--rm", "--network", $"container:{container}", CurlImage,
-        "-fsS", "-m", "5", $"http://localhost:{ContainerPort}{healthPath}",
+        "-fsS", "-m", "5", $"http://localhost:{containerPort}{healthPath}",
     ];
 
     internal static IReadOnlyList<string> BuildLogsArguments(string host, string container) =>
@@ -673,7 +738,13 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
                 continue;
             }
 
-            apps.Add(new DeployedApp(parts[0], Label(parts[1]), Label(parts[2]), Label(parts[3])));
+            // A container deployed before rask.port existed reports no label; it can only have been
+            // listening on the then-hardcoded default, so that is the correct reading of its absence.
+            var port = parts.Length > 4 && int.TryParse(Label(parts[4]), NumberStyles.None, CultureInfo.InvariantCulture, out var labelled)
+                ? labelled
+                : DeployCommand.DefaultContainerPort;
+
+            apps.Add(new DeployedApp(parts[0], Label(parts[1]), Label(parts[2]), Label(parts[3]), port));
         }
 
         return apps;
@@ -686,10 +757,10 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     /// The <c>domain → container</c> routing for the shared proxy: every other app keeps its live
     /// container; the app being deployed is forced to its new container. Sorted for a deterministic file.
     /// </summary>
-    internal static IReadOnlyDictionary<string, string> BuildRoutingMap(
-        IReadOnlyList<DeployedApp> apps, string deployingApp, string deployingDomain, string newContainer)
+    internal static IReadOnlyDictionary<string, RouteTarget> BuildRoutingMap(
+        IReadOnlyList<DeployedApp> apps, string deployingApp, string deployingDomain, RouteTarget newTarget)
     {
-        var map = new SortedDictionary<string, string>(StringComparer.Ordinal);
+        var map = new SortedDictionary<string, RouteTarget>(StringComparer.Ordinal);
         foreach (var app in apps)
         {
             if (app.Domain.Length == 0 || app.App == deployingApp)
@@ -697,26 +768,28 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
                 continue; // port-mode apps aren't proxied; the deploying app is set explicitly below
             }
 
-            map[app.Domain] = app.Container;
+            // Each app keeps ITS OWN container port: one box can host apps that don't agree on one.
+            map[app.Domain] = new RouteTarget(app.Container, app.Port);
         }
 
-        map[deployingDomain] = newContainer;
+        map[deployingDomain] = newTarget;
         return map;
     }
 
     /// <summary>Render the multi-site Caddyfile from a <c>domain → container</c> map (uses <c>\n</c> for determinism).</summary>
-    internal static string BuildCaddyfile(IReadOnlyDictionary<string, string> routes)
+    internal static string BuildCaddyfile(IReadOnlyDictionary<string, RouteTarget> routes)
     {
         var builder = new StringBuilder();
-        foreach (var (domain, container) in routes)
+        foreach (var (domain, target) in routes)
         {
             if (builder.Length > 0)
             {
                 builder.Append('\n');
             }
 
+            // `domain` reached here through DomainName.TryParse, so it cannot close this block early.
             builder.Append(domain).Append(" {\n");
-            builder.Append("\treverse_proxy ").Append(container).Append(':').Append(ContainerPort).Append('\n');
+            builder.Append("\treverse_proxy ").Append(target.Container).Append(':').Append(target.Port).Append('\n');
             builder.Append("}\n");
         }
 
@@ -833,7 +906,30 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             return true;
         }
 
-        port = fromConfig ?? ContainerPort;
+        port = fromConfig ?? DefaultContainerPort;
+        return true;
+    }
+
+    /// <summary>
+    /// The port the app listens on inside its container. Unlike <c>--port</c> this isn't a host-side
+    /// publish: it's what the proxy is pointed at and what the readiness probe hits, so getting it wrong
+    /// means a deploy that builds and starts and then never answers.
+    /// </summary>
+    private static bool TryResolveContainerPort(string? fromFlag, int? fromConfig, out int containerPort, out string? error)
+    {
+        error = null;
+        if (fromFlag is not null)
+        {
+            if (!int.TryParse(fromFlag, NumberStyles.Integer, CultureInfo.InvariantCulture, out containerPort) || containerPort is < 1 or > 65535)
+            {
+                error = $"--container-port must be a number between 1 and 65535, not '{fromFlag}'.";
+                return false;
+            }
+
+            return true;
+        }
+
+        containerPort = fromConfig ?? DefaultContainerPort;
         return true;
     }
 
@@ -851,8 +947,10 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
                 return false;
             }
 
+            var lineNumber = 0;
             foreach (var raw in _fileSystem.ReadAllText(envFile).Split('\n'))
             {
+                lineNumber++;
                 var line = raw.Trim();
                 if (line.Length == 0 || line.StartsWith('#'))
                 {
@@ -862,7 +960,11 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
                 if (!line.Contains('=', StringComparison.Ordinal))
                 {
                     env = [];
-                    error = $"--env-file line isn't KEY=VALUE: '{line}'.";
+
+                    // The LINE NUMBER, never the line: an env file holds secrets, and the offending line
+                    // is the one we've decided we can't parse — echoing it would print a credential to
+                    // stderr (and into a CI log) precisely when something has gone wrong.
+                    error = $"--env-file '{envFile}' line {lineNumber.ToString(CultureInfo.InvariantCulture)} isn't KEY=VALUE.";
                     return false;
                 }
 
@@ -901,4 +1003,12 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 }
 
 /// <summary>A rask-managed app container discovered from its <c>rask.*</c> labels via <c>docker ps</c>.</summary>
-internal readonly record struct DeployedApp(string Container, string App, string Domain, string Color);
+/// <summary>
+/// A live Rask-managed container, as read back from its own labels. <see cref="Port"/> is what the app
+/// listens on inside the container — carried as a label so the proxy config can be regenerated for a
+/// host running several apps that don't all listen on the same port.
+/// </summary>
+internal readonly record struct DeployedApp(string Container, string App, string Domain, string Color, int Port);
+
+/// <summary>Where the shared proxy sends one domain: a container and the port it listens on.</summary>
+internal readonly record struct RouteTarget(string Container, int Port);

--- a/src/Rask.Cli/DomainName.cs
+++ b/src/Rask.Cli/DomainName.cs
@@ -1,0 +1,92 @@
+namespace Rask.Cli;
+
+/// <summary>
+/// The public host name an app is served on (<c>--domain</c>), validated before it reaches the shared
+/// reverse proxy.
+///
+/// <para><strong>This is a security boundary, not tidiness</strong> — the same one
+/// <see cref="SshTarget.TryParse"/> draws, for the same reason. The value is written verbatim into the
+/// Caddyfile that fronts <em>every</em> app on the box:</para>
+///
+/// <code>
+/// &lt;domain&gt; {
+///     reverse_proxy &lt;container&gt;:&lt;port&gt;
+/// }
+/// </code>
+///
+/// <para>A value containing <c>{</c>, <c>}</c> or a newline closes that block and opens another, so a
+/// hostile domain injects arbitrary directives into a host-wide proxy config — a global options block, a
+/// <c>file_server</c> over <c>/</c>, an open <c>admin</c> endpoint. It also becomes a
+/// <c>--label rask.domain=</c> value that is later parsed back out of tab-separated <c>docker ps</c>
+/// output, where an embedded newline or tab forges rows.</para>
+///
+/// <para>And, exactly as with the SSH host, the domain is remembered in <c>.rask/deploy.json</c> — a
+/// <em>committed</em> file, read by CI — so a hostile value there would otherwise reconfigure the proxy of
+/// every box the repo deploys to.</para>
+/// </summary>
+internal static class DomainName
+{
+    /// <summary>Longest legal DNS name, and longest legal label within one (RFC 1035).</summary>
+    private const int MaxLength = 253;
+
+    private const int MaxLabelLength = 63;
+
+    /// <summary>
+    /// Validate a <c>--domain</c> value. A whitelist, not a blocklist: an RFC-1123 host name, optionally
+    /// with a leading <c>*.</c> wildcard label (Caddy accepts one, and it can't widen the character set).
+    /// </summary>
+    public static bool TryParse(string value, out string domain, out string? error)
+    {
+        domain = value.Trim();
+        error = null;
+
+        if (domain.Length == 0)
+        {
+            error = "A domain can't be empty.";
+            return false;
+        }
+
+        if (domain.Length > MaxLength)
+        {
+            error = $"'{Describe(value)}' isn't a valid domain — it's longer than {MaxLength} characters.";
+            return false;
+        }
+
+        var labels = domain.Split('.');
+        for (var i = 0; i < labels.Length; i++)
+        {
+            // "*.example.com" — a wildcard is only meaningful as the whole first label.
+            if (i == 0 && labels[i] == "*" && labels.Length > 1)
+            {
+                continue;
+            }
+
+            if (!IsLabel(labels[i]))
+            {
+                error = $"'{Describe(value)}' isn't a valid domain — it must be a host name like 'app.example.com' "
+                    + "(letters, digits and '-', in dot-separated labels, optionally led by '*.').";
+                return false;
+            }
+        }
+
+        return true;
+
+        static bool IsLabel(string label) =>
+            label.Length is > 0 and <= MaxLabelLength
+            && !label.StartsWith('-')
+            && !label.EndsWith('-')
+            && label.All(c => char.IsAsciiLetterOrDigit(c) || c == '-');
+    }
+
+    /// <summary>
+    /// The offending value, made safe to print. The rejected input can itself contain newlines or control
+    /// characters, and this message is written to a terminal and to CI logs — echoing it raw would let a
+    /// hostile value forge log lines on its way out of the very check that caught it.
+    /// </summary>
+    private static string Describe(string value)
+    {
+        var trimmed = value.Trim();
+        var sanitized = string.Concat(trimmed.Select(c => char.IsControl(c) ? '?' : c));
+        return sanitized.Length > 60 ? sanitized[..60] + "…" : sanitized;
+    }
+}

--- a/src/Rask.Cli/Scaffolding/DeployConfig.cs
+++ b/src/Rask.Cli/Scaffolding/DeployConfig.cs
@@ -29,6 +29,13 @@ internal sealed class DeployConfig
     /// <summary>When <c>true</c>, skip the HTTP health probe and gate only on the container running.</summary>
     public bool? HealthCheckDisabled { get; set; }
 
+    /// <summary>
+    /// The port the app listens on <em>inside</em> its container — what the proxy is pointed at and what the
+    /// health probe hits (default <c>8080</c>, which every Dockerfile <c>rask new --docker</c> emits uses).
+    /// Only needed for a hand-written Dockerfile that listens elsewhere.
+    /// </summary>
+    public int? ContainerPort { get; set; }
+
     /// <summary>The <c>.rask/deploy.json</c> path under <paramref name="workingDirectory"/>.</summary>
     public static string PathFor(string workingDirectory) =>
         Path.Combine(workingDirectory, ".rask", "deploy.json");

--- a/src/Rask.Cli/Scaffolding/IFileSystem.cs
+++ b/src/Rask.Cli/Scaffolding/IFileSystem.cs
@@ -19,6 +19,13 @@ internal interface IFileSystem
     void CreateDirectory(string path);
 
     void WriteAllText(string path, string content);
+
+    /// <summary>
+    /// Delete <paramref name="path"/> if it's there, swallowing an I/O or permission failure. For temp
+    /// files whose removal is hygiene rather than correctness — failing to tidy up must never fail the
+    /// operation that already succeeded.
+    /// </summary>
+    void TryDelete(string path);
 }
 
 /// <summary>The real filesystem, backed by <see cref="File"/> / <see cref="Directory"/>.</summary>
@@ -41,4 +48,20 @@ internal sealed class SystemFileSystem : IFileSystem
     public void CreateDirectory(string path) => Directory.CreateDirectory(path);
 
     public void WriteAllText(string path, string content) => File.WriteAllText(path, content);
+
+    public void TryDelete(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+        catch (UnauthorizedAccessException)
+        {
+            // best-effort cleanup
+        }
+    }
 }

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Wasm.cs
@@ -334,9 +334,20 @@ internal static partial class ProjectGenerator
     private const string WasmNginxConf =
         """
         server {
-            listen 80;
+            # 8080, not 80, so this image matches the server and wasm-hosted templates — `rask deploy`
+            # points the proxy and its readiness probe at one container port for every template.
+            listen 8080;
             root /usr/share/nginx/html;
             index index.html;
+
+            # A readiness endpoint, so a deployed bundle can be health-gated like any other Rask app.
+            # A static bundle has nothing to report but "nginx is serving", which is exactly the
+            # question the deploy's blue-green swap asks before switching traffic.
+            location = /health {
+                access_log off;
+                add_header Content-Type text/plain;
+                return 200 'ok';
+            }
 
             # Serve the *.gz siblings the publish step baked next to each asset. (Rask also bakes
             # *.br, but the stock nginx:alpine image has no brotli module; gzip is universally
@@ -376,7 +387,7 @@ internal static partial class ProjectGenerator
         FROM nginx:alpine
         COPY --from=build /app/wwwroot /usr/share/nginx/html
         COPY nginx.conf /etc/nginx/conf.d/default.conf
-        EXPOSE 80
+        EXPOSE 8080
 
         """;
 

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
@@ -619,6 +619,15 @@ internal static partial class ProjectGenerator
         FROM mcr.microsoft.com/dotnet/aspnet:10.0
         WORKDIR /app
         COPY --from=build /app .
+
+        # A writable data directory for the SQLite database, owned by the image's non-root runtime user
+        # ($APP_UID) — the same preparation the server template's Dockerfile does, and for the same reason:
+        # `rask deploy` mounts a named volume at /data and points the app at /data/app.db unconditionally.
+        # Without this the mount lands root-owned and a non-root app can't create the database in it.
+        USER root
+        RUN mkdir -p /data && chown $APP_UID:$APP_UID /data
+        USER $APP_UID
+
         EXPOSE 8080
         # The Server calls UseHttpsRedirection(); inside the container no HTTPS port is configured,
         # so it no-ops. Terminate TLS at your reverse proxy / ingress and forward plain HTTP to 8080.

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -28,6 +28,7 @@ public sealed class DeployCommandTests
             "-H", "ssh://deploy@box", "run", "-d", "--name", "shop-green", "--restart", "unless-stopped",
             "--network", "rask", "--label", "rask.managed=true", "--label", "rask.app=shop",
             "--label", "rask.domain=shop.example.com", "--label", "rask.color=green",
+            "--label", "rask.port=8080",
             // The persistent DB volume + connection string come before the user env, so --env A=1 still wins.
             "-v", "shop-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db",
             "-e", "A=1", "shop:latest",
@@ -43,6 +44,8 @@ public sealed class DeployCommandTests
         [
             "-H", "ssh://deploy@box", "run", "-d", "--name", "shop", "--restart", "unless-stopped",
             "-p", "9000:8080",
+            // Labelled but with no rask.domain, so the host inventory sees it and the proxy doesn't.
+            "--label", "rask.managed=true", "--label", "rask.app=shop", "--label", "rask.port=8080",
             "-v", "shop-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db",
             "shop:latest",
         ], args);
@@ -64,11 +67,11 @@ public sealed class DeployCommandTests
     [Fact]
     public void ParseDeployedApps_reads_the_label_listing_and_normalizes_no_value()
     {
-        var apps = DeployCommand.ParseDeployedApps("shop-blue\tshop\tshop.example.com\tblue\napi\tapi\t<no value>\t<no value>\n");
+        var apps = DeployCommand.ParseDeployedApps("shop-blue\tshop\tshop.example.com\tblue\t8080\napi\tapi\t<no value>\t<no value>\t9000\n");
 
         Assert.Equal(2, apps.Count);
-        Assert.Equal(new DeployedApp("shop-blue", "shop", "shop.example.com", "blue"), apps[0]);
-        Assert.Equal(new DeployedApp("api", "api", string.Empty, string.Empty), apps[1]);
+        Assert.Equal(new DeployedApp("shop-blue", "shop", "shop.example.com", "blue", 8080), apps[0]);
+        Assert.Equal(new DeployedApp("api", "api", string.Empty, string.Empty, 9000), apps[1]);
     }
 
     [Fact]
@@ -76,22 +79,22 @@ public sealed class DeployCommandTests
     {
         IReadOnlyList<DeployedApp> apps =
         [
-            new("shop-blue", "shop", "shop.example.com", "blue"),
-            new("demo-blue", "demo", "demo.example.com", "blue"),
+            new("shop-blue", "shop", "shop.example.com", "blue", 8080),
+            new("demo-blue", "demo", "demo.example.com", "blue", 8080),
         ];
 
-        var map = DeployCommand.BuildRoutingMap(apps, "demo", "demo.example.com", "demo-green");
+        var map = DeployCommand.BuildRoutingMap(apps, "demo", "demo.example.com", new RouteTarget("demo-green", 8080));
 
-        Assert.Equal("demo-green", map["demo.example.com"]); // deploying app → new container
-        Assert.Equal("shop-blue", map["shop.example.com"]);  // other app kept
+        Assert.Equal(new RouteTarget("demo-green", 8080), map["demo.example.com"]); // deploying app → new container
+        Assert.Equal(new RouteTarget("shop-blue", 8080), map["shop.example.com"]);  // other app kept
     }
 
     [Fact]
     public void BuildRoutingMap_skips_port_mode_apps_without_a_domain()
     {
-        IReadOnlyList<DeployedApp> apps = [new("api", "api", string.Empty, string.Empty)];
+        IReadOnlyList<DeployedApp> apps = [new("api", "api", string.Empty, string.Empty, 8080)];
 
-        var map = DeployCommand.BuildRoutingMap(apps, "demo", "demo.example.com", "demo-blue");
+        var map = DeployCommand.BuildRoutingMap(apps, "demo", "demo.example.com", new RouteTarget("demo-blue", 8080));
 
         Assert.Single(map);
         Assert.False(map.ContainsKey(string.Empty));
@@ -100,10 +103,10 @@ public sealed class DeployCommandTests
     [Fact]
     public void BuildCaddyfile_emits_a_block_per_route()
     {
-        var caddyfile = DeployCommand.BuildCaddyfile(new SortedDictionary<string, string>(StringComparer.Ordinal)
+        var caddyfile = DeployCommand.BuildCaddyfile(new SortedDictionary<string, RouteTarget>(StringComparer.Ordinal)
         {
-            ["demo.example.com"] = "demo-green",
-            ["shop.example.com"] = "shop-blue",
+            ["demo.example.com"] = new RouteTarget("demo-green", 8080),
+            ["shop.example.com"] = new RouteTarget("shop-blue", 8080),
         });
 
         Assert.Equal(
@@ -351,7 +354,7 @@ public sealed class DeployCommandTests
         var exit = await command.ExecuteAsync(["--host", "deploy@box", "--domain", "demo.example.com", "--name", "demo"], CancellationToken.None);
 
         Assert.Equal(0, exit);
-        var caddyfile = fs.Files.First(f => f.Key.EndsWith("rask-demo.Caddyfile", StringComparison.Ordinal)).Value;
+        var caddyfile = fs.Written.First(f => f.Key.EndsWith("rask-demo.Caddyfile", StringComparison.Ordinal)).Value;
         Assert.Contains("demo.example.com {", caddyfile);       // the new app
         Assert.Contains("reverse_proxy demo-blue:8080", caddyfile);
         Assert.Contains("shop.example.com {", caddyfile);       // the existing app is preserved
@@ -668,6 +671,136 @@ public sealed class DeployCommandTests
         Assert.Contains("would be read as an ssh option", console.ErrorText, StringComparison.Ordinal);
         Assert.Empty(runner.Invocations); // nothing was launched at all
     }
+
+    [Fact]
+    public async Task A_domain_that_would_inject_caddy_directives_is_refused()
+    {
+        // The same threat model as the ssh host above, one field over: the domain is written verbatim
+        // into the Caddyfile that fronts EVERY app on the box, and it too comes from the committed
+        // .rask/deploy.json. A value that closes the site block reconfigures the whole host's proxy.
+        var fs = new FakeFileSystem();
+        fs.Seed(
+            "/proj/.rask/deploy.json",
+            """{"host":"deploy@box","name":"shop","domain":"app.example.com {\n}\n:80 {\n\trespond \"pwned\"\n}"}""");
+        var runner = new FakeProcessRunner();
+        var console = new StringConsole();
+        var command = Create(fs, runner, console);
+
+        var exit = await command.ExecuteAsync([], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("isn't a valid domain", console.ErrorText, StringComparison.Ordinal);
+        Assert.Empty(runner.Invocations); // refused before anything was launched
+    }
+
+    [Fact]
+    public async Task Container_port_flows_into_the_run_the_probe_and_the_proxy()
+    {
+        // The standalone wasm template used to be undeployable for exactly this reason: its nginx image
+        // listened on a port nothing else knew about, so the proxy and the readiness probe both aimed at
+        // a closed port. --container-port is the escape hatch for any Dockerfile that isn't on 8080.
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var console = new StringConsole();
+        var command = Create(fs, runner, console);
+
+        var exit = await command.ExecuteAsync(
+            ["--host", "deploy@box", "--name", "shop", "--domain", "shop.example.com", "--container-port", "3000"],
+            CancellationToken.None);
+
+        Assert.Equal(0, exit);
+
+        // The app's own `run` — the shared Caddy proxy is started with `run --name` too.
+        var run = runner.Invocations.Single(i => i.Arguments.Contains("rask.app=shop"));
+        Assert.Contains("rask.port=3000", run.Arguments);
+
+        var probe = runner.Invocations.Single(i => i.Arguments.Contains(DeployCommand.CurlImage));
+        Assert.Contains("http://localhost:3000/health", probe.Arguments);
+
+        // ...and the proxy is pointed at the same port, not the default.
+        Assert.Contains("shop-blue:3000", TheCaddyfile(fs));
+    }
+
+    [Fact]
+    public async Task Container_port_is_remembered_only_when_it_is_not_the_default()
+    {
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var command = Create(fs, runner, new StringConsole());
+
+        await command.ExecuteAsync(["--host", "deploy@box", "--name", "shop", "--port", "9000", "--container-port", "3000"], CancellationToken.None);
+        Assert.Contains("\"containerPort\": 3000", fs.Files[Path.GetFullPath("/proj/.rask/deploy.json")], StringComparison.Ordinal);
+
+        await command.ExecuteAsync(["--host", "deploy@box", "--name", "shop", "--port", "9000", "--container-port", "8080"], CancellationToken.None);
+        Assert.DoesNotContain("containerPort", fs.Files[Path.GetFullPath("/proj/.rask/deploy.json")], StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("70000")]
+    [InlineData("http")]
+    public async Task An_invalid_container_port_is_rejected(string value)
+    {
+        var console = new StringConsole();
+        var runner = new FakeProcessRunner();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        var exit = await command.ExecuteAsync(["--host", "deploy@box", "--container-port", value], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--container-port must be a number", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_port_mode_container_is_labelled_so_the_host_inventory_can_see_it()
+    {
+        // Without labels a port-mode deploy is invisible to `docker ps --filter label=rask.managed`, so
+        // moving the app to --domain later would leave the old container running and unaccounted for.
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var command = Create(new FakeFileSystem(), runner, new StringConsole());
+
+        await command.ExecuteAsync(["--host", "deploy@box", "--name", "shop", "--port", "9000"], CancellationToken.None);
+
+        var run = runner.Invocations.Single(i => i.Arguments.Contains("rask.app=shop"));
+        Assert.Contains("rask.managed=true", run.Arguments);
+        Assert.Contains("rask.app=shop", run.Arguments);
+        Assert.DoesNotContain("rask.domain=", run.Arguments); // ...but no domain, so it is never proxied
+    }
+
+    [Fact]
+    public async Task An_env_file_parse_error_reports_the_line_number_not_the_line()
+    {
+        // The offending line lives in a file of secrets, and this message goes to stderr — and, in the
+        // workflow --github-actions writes, into a CI log.
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/.env.production", "GOOD=1\nAWS_SECRET_ACCESS_KEY-wJalrXUtnFEMI\n");
+        var console = new StringConsole();
+        var command = Create(fs, new FakeProcessRunner(), console);
+
+        var exit = await command.ExecuteAsync(["--host", "deploy@box", "--env-file", "/proj/.env.production"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("line 2", console.ErrorText, StringComparison.Ordinal);
+        Assert.DoesNotContain("wJalrXUtnFEMI", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Dumped_logs_mask_the_values_we_passed_in()
+    {
+        // An app that echoes its configuration on a failed start is ordinary; the dump exists to show
+        // why it failed, so short values stay readable and only real secrets are masked.
+        var masked = DeployCommand.MaskSecrets(
+            "starting with ConnectionStrings__App=Data Source=/data/app.db and key s3cr3t-value-here on port 8080",
+            ["API_KEY=s3cr3t-value-here", "PORT=8080"]);
+
+        Assert.DoesNotContain("s3cr3t-value-here", masked, StringComparison.Ordinal);
+        Assert.Contains("port 8080", masked, StringComparison.Ordinal); // short value left alone
+    }
+
+    /// <summary>The Caddyfile the deploy generated — read from the write history, since it is deleted
+    /// once it has been copied to the host.</summary>
+    private static string TheCaddyfile(FakeFileSystem fs) =>
+        fs.Written.First(f => f.Key.EndsWith(".Caddyfile", StringComparison.Ordinal)).Value;
 
     [Fact]
     public async Task The_live_url_names_the_machine_not_the_ssh_port()

--- a/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
+++ b/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
@@ -139,6 +139,39 @@ public sealed class DeployHostE2ETests(DeployHostFixture host) : IClassFixture<D
     }
 
     /// <summary>
+    /// An app that listens somewhere other than 8080 — the shape the standalone <c>wasm</c> template had
+    /// (an nginx image on port 80) and which was undeployable, because the readiness probe and the proxy
+    /// both aimed at a hardcoded 8080. Proven here against a real host: the probe has to actually connect.
+    /// </summary>
+    [SkippableFact]
+    public async Task An_app_on_a_non_default_container_port_deploys()
+    {
+        var project = Start(out var console, out var command);
+        File.WriteAllText(
+            Path.Combine(project, "Dockerfile"),
+            """
+            FROM docker.io/library/nginx:alpine
+            RUN printf 'server { listen 3000; location /health { return 200 "ok"; } }\n' > /etc/nginx/conf.d/default.conf
+            EXPOSE 3000
+            CMD ["nginx", "-g", "daemon off;"]
+            """.ReplaceLineEndings("\n"));
+
+        var exit = await command.ExecuteAsync(
+            ["--host", host.Host, "--domain", "rask-port.test", "--name", "portapp3000", "--container-port", "3000"],
+            CancellationToken.None);
+
+        Assert.True(exit == 0, $"deploy on a non-default container port failed.\n{console.OutText}\n{console.ErrorText}");
+
+        // The proxy points at 3000, and the port was remembered as a label on the container itself so a
+        // later deploy of a *different* app can regenerate the shared Caddyfile without losing it.
+        var (_, caddyfile) = await host.DockerAsync("exec", "rask-caddy", "cat", "/etc/caddy/Caddyfile");
+        Assert.Contains("portapp3000-blue:3000", caddyfile, StringComparison.Ordinal);
+
+        var (_, label) = await host.DockerAsync("inspect", "--format", "{{index .Config.Labels \"rask.port\"}}", "portapp3000-blue");
+        Assert.Equal("3000", label.Trim());
+    }
+
+    /// <summary>
     /// Set up a project directory holding the app's Dockerfile and a <see cref="DeployCommand"/> wired to the
     /// real filesystem and a process runner scoped to the fixture's ssh identity. Skips when the gate is off
     /// or the fake VPS couldn't start, so a machine without Docker reports SKIPPED rather than failing.

--- a/tests/Rask.Cli.Tests/DomainNameTests.cs
+++ b/tests/Rask.Cli.Tests/DomainNameTests.cs
@@ -1,0 +1,87 @@
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// <see cref="DomainName"/> is a security boundary, so these read like <see cref="SshTargetTests"/>: a
+/// handful of shapes that must be accepted, and a catalogue of the injections that must not be.
+/// </summary>
+public sealed class DomainNameTests
+{
+    [Theory]
+    [InlineData("example.com")]
+    [InlineData("app.example.com")]
+    [InlineData("a.b.c.d.example.co.uk")]
+    [InlineData("my-app.example.com")]
+    [InlineData("xn--bcher-kva.example.com")] // punycode — already ASCII by the time it reaches us
+    [InlineData("localhost")]
+    [InlineData("app1.example2.com")]
+    [InlineData("*.example.com")]             // Caddy accepts one wildcard label
+    public void Accepts_host_names(string value)
+    {
+        Assert.True(DomainName.TryParse(value, out var domain, out var error), error);
+        Assert.Equal(value, domain);
+    }
+
+    [Fact]
+    public void Trims_surrounding_whitespace()
+    {
+        Assert.True(DomainName.TryParse("  app.example.com \n", out var domain, out _));
+        Assert.Equal("app.example.com", domain);
+    }
+
+    /// <summary>
+    /// The reason this type exists. Each of these would otherwise be written verbatim into the Caddyfile
+    /// that fronts every app on the box — closing the generated site block and opening attacker-chosen
+    /// directives — or forge a row in the tab-separated <c>docker ps</c> label listing.
+    /// </summary>
+    [Theory]
+    [InlineData("app.example.com {\n}\n:80 {\n\trespond \"pwned\"", "closes the site block and opens another")]
+    [InlineData("app.example.com {\n\tfile_server browse\n}\n#", "injects a directive into the app's own block")]
+    [InlineData("example.com\n{\n\tadmin 0.0.0.0:2019\n}", "opens Caddy's admin API to the world")]
+    [InlineData("evil\tapp\tother.example.com\tblue", "forges a row in the docker ps label listing")]
+    [InlineData("app.example.com\rmalicious.example.com", "smuggles a second name past a line-oriented reader")]
+    [InlineData("app.example.com respond \"x\"", "a space starts a second Caddy token")]
+    [InlineData("$(id).example.com", "command substitution, if the value is ever pasted into a shell")]
+    [InlineData("`id`.example.com", "backtick command substitution")]
+    [InlineData("app.example.com;rm -rf /", "shell metacharacters")]
+    public void Rejects_injection(string value, string why)
+    {
+        Assert.False(DomainName.TryParse(value, out _, out var error), why);
+        Assert.NotNull(error);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("-leading-dash.example.com")]
+    [InlineData("trailing-dash-.example.com")]
+    [InlineData("double..dot.example.com")]
+    [InlineData("under_score.example.com")]  // legal in DNS records, not in a host name
+    [InlineData("*")]                        // a wildcard with nothing to qualify it
+    [InlineData("app.*.example.com")]        // a wildcard that isn't the first label
+    public void Rejects_malformed_names(string value) =>
+        Assert.False(DomainName.TryParse(value, out _, out _));
+
+    [Fact]
+    public void Rejects_an_over_long_name()
+    {
+        var tooLong = string.Join('.', Enumerable.Repeat("abcdefghij", 26)); // 26 * 11 - 1 = 285 chars
+        Assert.False(DomainName.TryParse(tooLong, out _, out var error));
+        Assert.Contains("253", error, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Rejects_an_over_long_label() =>
+        Assert.False(DomainName.TryParse(new string('a', 64) + ".example.com", out _, out _));
+
+    /// <summary>
+    /// The error text is printed to a terminal and into CI logs, so the rejected value must not be able to
+    /// smuggle control characters through the very message that reports it.
+    /// </summary>
+    [Fact]
+    public void Error_message_does_not_echo_control_characters()
+    {
+        Assert.False(DomainName.TryParse("evil\n\tFAKE LOG LINE.example.com", out _, out var error));
+        Assert.DoesNotContain('\n', error!);
+        Assert.DoesNotContain('\t', error!);
+    }
+}

--- a/tests/Rask.Cli.Tests/TestDoubles.cs
+++ b/tests/Rask.Cli.Tests/TestDoubles.cs
@@ -88,15 +88,23 @@ internal sealed class FakeProcessRunner : IProcessRunner
 internal sealed class FakeFileSystem : IFileSystem
 {
     private readonly Dictionary<string, string> _files = new(StringComparer.Ordinal);
+    private readonly Dictionary<string, string> _written = new(StringComparer.Ordinal);
     private readonly HashSet<string> _directories = new(StringComparer.Ordinal);
 
-    /// <summary>Files written (via WriteAllText), keyed by normalized absolute path.</summary>
+    /// <summary>Files that exist now, keyed by normalized absolute path.</summary>
     public IReadOnlyDictionary<string, string> Files => _files;
+
+    /// <summary>
+    /// Everything ever written, including files since deleted. Lets a test assert on the content of a
+    /// deliberately short-lived file — the generated Caddyfile is copied to the host and then removed.
+    /// </summary>
+    public IReadOnlyDictionary<string, string> Written => _written;
 
     public void Seed(string path, string content = "")
     {
         var full = Normalize(path);
         _files[full] = content;
+        _written[full] = content;
         _directories.Add(Normalize(Path.GetDirectoryName(path)!));
     }
 
@@ -129,8 +137,11 @@ internal sealed class FakeFileSystem : IFileSystem
     public void WriteAllText(string path, string content)
     {
         _files[Normalize(path)] = content;
+        _written[Normalize(path)] = content;
         _directories.Add(Normalize(Path.GetDirectoryName(path)!));
     }
+
+    public void TryDelete(string path) => _files.Remove(Normalize(path));
 
     private static string Normalize(string path) => Path.GetFullPath(path);
 }


### PR DESCRIPTION
> Stacked on #503 (which is stacked on #502). Review those first; this PR's own diff is `DomainName.cs`, `DeployCommand.cs`, the two Dockerfile templates, and their tests.

## The security fix

`--domain` was written **verbatim** into the Caddyfile that fronts *every* app on the box:

```
<domain> {
    reverse_proxy <container>:<port>
}
```

A value containing `{`, `}` or a newline closes that block and opens attacker-chosen ones — a global
options block, a `file_server` over `/`, an open `admin` endpoint. An embedded tab or newline also forges
a row in the tab-separated `docker ps` label listing the routing map is rebuilt from.

The domain is remembered in the **committed** `.rask/deploy.json` and read by CI, so a hostile value could
arrive by pull request and reconfigure the proxy of every host the repo deploys to. **This is the exact
threat model that motivated `SshTarget.TryParse`**, one field over, and it now has the same kind of
boundary: an RFC-1123 host name (optionally `*.`-prefixed), validated wherever the value came from.

The rejection message also can't be used to forge log lines — control characters in the offending value
are scrubbed before it's echoed back.

## Three ways a deploy simply could not work

| Bug | Effect |
|-----|--------|
| The standalone `wasm` template's nginx listened on **80** while the container port was hardcoded to **8080** | `rask new --template wasm --docker && rask deploy` could **never** succeed — proxy and probe both aimed at a closed port, and a static bundle had no `/health` at all |
| The `wasm-hosted` Dockerfile never created `/data` or gave it to `$APP_UID` | deploy mounts a volume there and sets `ConnectionStrings__App` for *every* template, so the mount landed root-owned and a non-root app couldn't create its database |
| Port-mode containers carried no `rask.*` labels | invisible to the host inventory, so moving an app to `--domain` later stranded the old container running forever |

The wasm template now listens on `8080` and serves `/health` like the others, and `--container-port` is
the escape hatch for any hand-written Dockerfile. The port is stored **as a label on each container**, so
a host running several apps that don't agree on one port keeps each app's routing correct — previously
`BuildCaddyfile` applied one global constant to every route.

## Secret hygiene

- A failed deploy dumps the container's last 50 log lines to stderr — which, in the workflow
  `--github-actions` writes, is a **CI job log**. Values passed via `--env`/`--env-file` are now masked
  first. Short values (a port, `true`) are left alone so the dump stays diagnostic.
- An unparseable `--env-file` line was reported by **echoing the line** — from a file of secrets. It now
  reports the line *number*.
- The generated Caddyfile is deleted from the temp dir once copied, instead of being left under a
  predictable name.

## Testing

- **Deploy gate: 5/5 against a real container host**, including a new case that deploys an app listening on
  **3000** and asserts the proxy and the `rask.port` label both follow it — the bug class that made the
  wasm template undeployable, now proven fixed on a live host rather than in argv.
- 670 CLI unit tests green, including a new `DomainNameTests` (9 injection payloads, each with the reason
  it matters) and command-level tests that the boundary is enforced on the value read from `deploy.json`.
- Scaffold build gate 20/20 (both Dockerfile templates changed).
- `scripts/run-unit-local.sh` green.

## Breaking change

The standalone `wasm` template's container now listens on **8080**, not 80. Run it with
`docker run -p 8080:8080`; update any proxy or compose file pointing at port 80. Documented in
`deployment.md`. Existing deployed containers are unaffected — they keep serving on whatever port they
were built with, and `ParseDeployedApps` reads a missing `rask.port` label as the old hardcoded default.

## Changelog

`[Unreleased] → Security` and `→ Fixed`.