### PR TITLE
feat(cli): rask deploy status, logs and rollback

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -26,10 +26,21 @@ else
   fi
 fi
 
+# Like the deploy gate below, this one is scoped to the pushes it can actually say something about:
+# it packs 15 packages and runs several full builds, and only the CLI's generators, the packages a
+# generated project references, or the tutorial it reproduces can change its answer. Running it on
+# every push (a docs typo, a Bootstrap component) is minutes of tax for a foregone conclusion.
+generator_paths='^(src/Rask\.Cli/(Scaffolding|Templates)/|src/Rask\.[A-Za-z.]+/|docs/tutorial/|Directory\.Packages\.props|tests/Rask\.Cli\.Tests/(CliBuildE2E|ProjectGeneratorBuildE2ETests|TutorialWalkthroughE2ETests)\.cs)'
+
 if [ "${RASK_SKIP_CLI_BUILD_E2E:-}" = "1" ]; then
   echo "pre-push: RASK_SKIP_CLI_BUILD_E2E=1 set — skipping the CLI build gate."
+elif ! git rev-parse --verify --quiet origin/main >/dev/null; then
+  echo "pre-push: no origin/main to diff against — running the CLI build gate to be safe."
+  "$root/scripts/run-cli-build-e2e.sh" || { echo "pre-push: CLI build gate FAILED — push aborted." >&2; exit 1; }
+elif ! git diff --name-only origin/main...HEAD | grep -qE "$generator_paths"; then
+  : # nothing in this push can change what the generators emit
 else
-  echo "pre-push: running the CLI build gate (scaffold output + tutorial must compile)."
+  echo "pre-push: this push touches the generators or the packages they emit — running the CLI build gate."
   echo "          bypass with 'git push --no-verify' or RASK_SKIP_CLI_BUILD_E2E=1."
 
   if ! "$root/scripts/run-cli-build-e2e.sh"; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`rask deploy status` / `logs` / `rollback` — the CLI now covers operating the app, not just shipping
+  it.** Until now `rask deploy` took you to production and left you there: seeing what was running,
+  reading its logs, or undoing a bad release all meant hand-writing `docker -H ssh://…` commands, which is
+  precisely the SSH session the deploy story promises you never have to open. All three read the same
+  `rask.*` container labels a deploy writes, so they describe the box as it actually is rather than as
+  `.rask/deploy.json` remembers it, and they need no Dockerfile and no build.
+  - **`status`** lists every Rask-managed app sharing the host — URL or published port, blue/green colour,
+    uptime — and says whether a rollback is currently possible.
+  - **`logs`** tails the live container (`--tail <n|all>`, `--follow`).
+  - **`rollback`** exists for the failure the blue-green swap cannot catch. That swap protects you from a
+    release that *fails*; it can do nothing about one that starts, answers its health check, and is simply
+    wrong. Each deploy now moves the image it replaces to `<app>:previous` before building — previously the
+    build overwrote `:latest` and the old image was left untagged and unrecoverable — and `rollback` starts
+    it back up through the same gates a deploy uses (running → healthy → reload the proxy → retire the old
+    container). It then swaps the two tags, so running it again undoes the rollback rather than repeating
+    it. Images are now built as `<app>:current` (plus `:latest`, kept so `docker images` still reads the way
+    you'd expect).
+
+### Changed
+- **The pre-push CLI build gate now runs only when a push can change what the generators emit** — the CLI's
+  scaffolding, the `Rask.*` packages a generated project references, the tutorial, or the gate itself.
+  It packs 15 packages and runs several full builds, so running it on a docs typo was minutes of tax for a
+  foregone conclusion. Same conditional treatment the deploy gate already had.
+
 ### Security
 - **`rask deploy --domain` is now validated before it reaches the shared proxy.** The domain was written
   verbatim into the Caddyfile that fronts *every* app on the box, so a value containing `{`, `}` or a

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -268,6 +268,37 @@ writable `/data`; a custom Dockerfile needs `RUN mkdir -p /data && chown $APP_UI
 | `--github-actions` | Write `.github/workflows/deploy.yml` (deploy on push to main) and print the secrets to add. Touches no host. |
 | `--dry-run` | Print the exact docker commands without running them. |
 
+### After it's live — `status`, `logs`, `rollback`
+
+```bash
+rask deploy status            # what's running on the box (every app, not just this one)
+rask deploy logs             # the live container's last 100 lines
+rask deploy logs --follow    # ...and stream new ones
+rask deploy rollback         # put the previous image back, health-gated
+```
+
+These read the same `rask.*` container labels a deploy writes, so they describe the box **as it actually
+is** rather than as `.rask/deploy.json` remembers it. They need a host (from the config or `--host`) and
+nothing else — no Dockerfile, no build.
+
+`status` lists every Rask-managed app sharing the box, with its URL or published port, its blue/green
+colour, and how long it has been up — and tells you whether a rollback is currently possible.
+
+`rollback` exists for the failure the blue-green swap can't catch. That swap protects you from a release
+that *fails* — one that won't start, or won't answer its health check. It can do nothing about a release
+that starts, answers, and is simply **wrong**. Each deploy therefore moves the image it replaces to
+`<app>:previous` before building, and `rask deploy rollback` starts that image back up through the same
+gates a deploy uses (running → healthy → reload the proxy → retire the old container). It then swaps the
+two tags, so running it again undoes the rollback rather than repeating it.
+
+| Option | Applies to | Purpose |
+| --- | --- | --- |
+| `--tail <n\|all>` | `logs` | Lines to show (default `100`). |
+| `--follow`, `-f` | `logs` | Stream new lines until interrupted. |
+
+Options that describe *what to deploy* (`--domain`, `--container-port`, `--dockerfile`, `--dry-run`, …)
+are rejected on these verbs rather than silently ignored — they operate on what is already deployed.
+
 Host setup options — these only matter the first time you deploy to a box:
 
 | Option | Purpose |

--- a/src/Rask.Cli/Commands/DeployCommand.Ops.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.Ops.cs
@@ -1,0 +1,306 @@
+using System.Globalization;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Commands;
+
+/// <summary>
+/// The day-two half of <c>rask deploy</c>: what you need <em>after</em> the app is live.
+///
+/// <para>Shipping was already covered; operating wasn't. Seeing what's running, reading its logs, and
+/// undoing a bad release all meant hand-writing <c>docker -H ssh://…</c> commands — which is exactly the
+/// SSH session the deploy story promises you never have to open. These verbs read the same
+/// <c>rask.*</c> container labels the deploy writes, so they describe the box as it actually is rather
+/// than as <c>.rask/deploy.json</c> remembers it.</para>
+/// </summary>
+internal sealed partial class DeployCommand
+{
+    /// <summary>Default log lines to show — enough to see a startup failure, short enough to read.</summary>
+    private const int DefaultLogTail = 100;
+
+    /// <summary>
+    /// Reject options that belong to a different verb, rather than accepting and ignoring them. Silently
+    /// dropping <c>--follow</c> from a deploy, or <c>--domain</c> from a rollback, would leave the user
+    /// believing something happened that didn't.
+    /// </summary>
+    private static bool TryRejectMisplacedOptions(ParsedArguments parsed, string? action, out string? error)
+    {
+        error = null;
+
+        var logsOnly = parsed.Option("tail") is not null || parsed.HasFlag("follow");
+        if (logsOnly && action != "logs")
+        {
+            error = "--tail and --follow only apply to `rask deploy logs`.";
+            return false;
+        }
+
+        if (action is null)
+        {
+            return true;
+        }
+
+        // Everything below changes what would be deployed, which none of these verbs do.
+        foreach (var name in new[] { "domain", "port", "container-port", "dockerfile", "health-path" })
+        {
+            if (parsed.Option(name) is not null)
+            {
+                error = $"--{name} doesn't apply to `rask deploy {action}` — it operates on what's already deployed.";
+                return false;
+            }
+        }
+
+        foreach (var name in new[] { "github-actions", "dry-run", "setup-host" })
+        {
+            if (parsed.HasFlag(name))
+            {
+                error = $"--{name} doesn't apply to `rask deploy {action}`.";
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    // ── status ──────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// What is actually running on the box, read from the containers themselves. Lists every Rask-managed
+    /// app, not just this one: they share a host and a proxy, so "what else is here" is part of the
+    /// answer — and it's how you notice a second app you'd forgotten holding port 80.
+    /// </summary>
+    private async Task<int> StatusAsync(string host, string slug, CancellationToken cancellationToken)
+    {
+        var listing = await Capture(BuildStatusArguments(host), cancellationToken).ConfigureAwait(false);
+        var apps = ParseStatusRows(listing.StandardOutput);
+
+        if (apps.Count == 0)
+        {
+            Console.WriteLine($"Nothing deployed on {HostName(host)} yet.", ConsoleStyle.Dim);
+            Console.Out.WriteLine("Run `rask deploy` to ship this app.");
+            return 0;
+        }
+
+        WriteHeading($"Deployed on {HostName(host)}");
+
+        var rows = apps.Select(a => (
+            App: a.App.Length > 0 ? a.App : a.Container,
+            Where: a.Domain.Length > 0 ? $"https://{a.Domain}" : a.Ports.Length > 0 ? a.Ports : "(not published)",
+            Colour: a.Color.Length > 0 ? a.Color : "-",
+            State: a.Status)).ToArray();
+
+        var appWidth = Math.Max(3, rows.Max(r => r.App.Length));
+        var whereWidth = Math.Max(5, rows.Max(r => r.Where.Length));
+        var colourWidth = Math.Max(6, rows.Max(r => r.Colour.Length));
+
+        Console.WriteLine(
+            $"  {"APP".PadRight(appWidth)}  {"URL".PadRight(whereWidth)}  {"COLOUR".PadRight(colourWidth)}  STATE",
+            ConsoleStyle.Dim);
+
+        foreach (var row in rows)
+        {
+            var line = $"  {row.App.PadRight(appWidth)}  {row.Where.PadRight(whereWidth)}  {row.Colour.PadRight(colourWidth)}  {row.State}";
+
+            // This project's own app is highlighted; the others are context, and printing them plain
+            // keeps it obvious at a glance which row you came here about.
+            if (string.Equals(row.App, slug, StringComparison.Ordinal))
+            {
+                Console.WriteLine(line, ConsoleStyle.Success);
+            }
+            else
+            {
+                Console.Out.WriteLine(line);
+            }
+        }
+
+        // Whether a rollback is even possible is the other half of "what's the state of this app".
+        Console.Out.WriteLine();
+        var rollbackTo = await ResolveRollbackImageAsync(host, slug, cancellationToken).ConfigureAwait(false);
+        Console.WriteLine(
+            rollbackTo is null
+                ? $"  No previous image for '{slug}' — `rask deploy rollback` has nothing to go back to yet."
+                : $"  `rask deploy rollback` would restore {slug}:{PreviousTag} ({rollbackTo}).",
+            ConsoleStyle.Dim);
+
+        return 0;
+    }
+
+    // ── logs ────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Tail the live container's logs. Runs with the streams inherited rather than captured, so
+    /// <c>--follow</c> streams to the terminal and Ctrl-C ends it the way it would for plain docker.
+    /// </summary>
+    private async Task<int> LogsAsync(string host, string slug, ParsedArguments parsed, CancellationToken cancellationToken)
+    {
+        var container = await ResolveLiveContainerAsync(host, slug, cancellationToken).ConfigureAwait(false);
+        if (container is null)
+        {
+            Console.WriteErrorLine($"'{slug}' isn't running on {HostName(host)} — nothing to show logs for.", ConsoleStyle.Error);
+            Console.Error.WriteLine("Run `rask deploy status` to see what is deployed.");
+            return 1;
+        }
+
+        if (!TryResolveTail(parsed.Option("tail"), out var tail, out var tailError))
+        {
+            Console.Error.WriteLine(tailError);
+            return 1;
+        }
+
+        return await Run(BuildLogsArguments(host, container, tail, parsed.HasFlag("follow")), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary><c>--tail</c> is a line count or the literal <c>all</c>, matching <c>docker logs</c>.</summary>
+    private static bool TryResolveTail(string? value, out string tail, out string? error)
+    {
+        error = null;
+        if (value is null)
+        {
+            tail = DefaultLogTail.ToString(CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        if (string.Equals(value, "all", StringComparison.OrdinalIgnoreCase))
+        {
+            tail = "all";
+            return true;
+        }
+
+        if (int.TryParse(value, NumberStyles.None, CultureInfo.InvariantCulture, out var lines) && lines > 0)
+        {
+            tail = lines.ToString(CultureInfo.InvariantCulture);
+            return true;
+        }
+
+        tail = string.Empty;
+        error = $"--tail must be a positive number or 'all', not '{value}'.";
+        return false;
+    }
+
+    // ── rollback ────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Put the previous image back, through the same gates a deploy goes through.
+    ///
+    /// <para>The deploy-time rollback only covers a release that <em>fails</em> — a container that won't
+    /// start, or won't answer. It can't help with the worse case: a release that starts, answers, and is
+    /// simply wrong. That is what this is for, and it is deliberately the same code path as a deploy
+    /// (start alongside, gate on running + healthy, reload the proxy, retire the old one) so a rollback
+    /// can't take traffic on weaker evidence than the deploy it's undoing.</para>
+    /// </summary>
+    private async Task<int> RollbackAsync(
+        string host, string slug, string? domain, int port, int containerPort,
+        IReadOnlyList<string> env, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
+    {
+        var image = await ResolveRollbackImageAsync(host, slug, cancellationToken).ConfigureAwait(false);
+        if (image is null)
+        {
+            Console.WriteErrorLine($"No previous image for '{slug}' on {HostName(host)} — nothing to roll back to.", ConsoleStyle.Error);
+            Console.Error.WriteLine($"A rollback restores {slug}:{PreviousTag}, which is written by the deploy that replaces it. The first deploy of an app has no predecessor.");
+            return 1;
+        }
+
+        WriteHeading($"Rolling {slug} back to {slug}:{PreviousTag} ({image})…");
+
+        var result = domain is null
+            ? await DeployPortAsync(host, slug, port, containerPort, env, project: null, envFile: null, healthEnabled, healthPath, cancellationToken, tag: PreviousTag).ConfigureAwait(false)
+            : await DeployWithProxyAsync(host, slug, domain, containerPort, env, project: null, envFile: null, healthEnabled, healthPath, cancellationToken, tag: PreviousTag).ConfigureAwait(false);
+
+        if (result != 0)
+        {
+            return result;
+        }
+
+        // Swap the tags so :current still names what is serving. Without this a second `rask deploy
+        // rollback` would "roll back" to the image it just restored — and a later deploy would file the
+        // rolled-back image away as the previous version, losing the one that was actually replaced.
+        await SwapTagsAsync(host, slug, cancellationToken).ConfigureAwait(false);
+
+        Console.WriteLine("Rolled back. `rask deploy rollback` again to undo this.", ConsoleStyle.Dim);
+        return 0;
+    }
+
+    /// <summary>Exchange <c>:current</c> and <c>:previous</c> via a scratch tag, then drop the scratch.</summary>
+    private async Task SwapTagsAsync(string host, string slug, CancellationToken cancellationToken)
+    {
+        const string scratch = "rollback-swap";
+        await Run(BuildRetagArguments(host, slug, CurrentTag, scratch), cancellationToken).ConfigureAwait(false);
+        await Run(BuildRetagArguments(host, slug, PreviousTag, CurrentTag), cancellationToken).ConfigureAwait(false);
+        await Run(BuildRetagArguments(host, slug, scratch, PreviousTag), cancellationToken).ConfigureAwait(false);
+
+        // Removing a tag that shares an image with others only untags it — the image itself survives.
+        await Run(BuildUntagArguments(host, slug, scratch), cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>The image id behind <c>:previous</c>, or null when there isn't one.</summary>
+    private async Task<string?> ResolveRollbackImageAsync(string host, string slug, CancellationToken cancellationToken)
+    {
+        var result = await Capture(BuildImageExistsArguments(host, slug, PreviousTag), cancellationToken).ConfigureAwait(false);
+        if (result.ExitCode != 0)
+        {
+            return null;
+        }
+
+        var id = result.StandardOutput.Trim();
+        return id.Length == 0 ? null : Shorten(id);
+    }
+
+    /// <summary>The container currently serving this app, from its labels (blue/green, or port-mode).</summary>
+    private async Task<string?> ResolveLiveContainerAsync(string host, string slug, CancellationToken cancellationToken)
+    {
+        var listing = await Capture(BuildListArguments(host), cancellationToken).ConfigureAwait(false);
+        var apps = ParseDeployedApps(listing.StandardOutput);
+        return apps.FirstOrDefault(a => string.Equals(a.App, slug, StringComparison.Ordinal)).Container is { Length: > 0 } container
+            ? container
+            : null;
+    }
+
+    /// <summary>"sha256:8f1a…" → "8f1a…" — an image id is only ever shown to identify a version.</summary>
+    private static string Shorten(string imageId)
+    {
+        var bare = imageId.StartsWith("sha256:", StringComparison.Ordinal) ? imageId["sha256:".Length..] : imageId;
+        return bare.Length > 12 ? bare[..12] : bare;
+    }
+
+    // ── Pure builders/parsers for the ops verbs ─────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A richer listing than <see cref="BuildListArguments"/>: that one feeds the routing map and must stay
+    /// exactly the four fields it parses, so status asks its own question rather than widening it.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildStatusArguments(string host) =>
+    [
+        .. Prefix(host), "ps", "--filter", "label=rask.managed=true",
+        "--format", "{{.Names}}\t{{.Label \"rask.app\"}}\t{{.Label \"rask.domain\"}}\t{{.Label \"rask.color\"}}\t{{.Status}}\t{{.Ports}}",
+    ];
+
+    internal static IReadOnlyList<string> BuildUntagArguments(string host, string slug, string tag) =>
+        [.. Prefix(host), "image", "rm", $"{slug}:{tag}"];
+
+    /// <summary>Parse the status listing. Malformed rows are skipped, never guessed at.</summary>
+    internal static IReadOnlyList<StatusRow> ParseStatusRows(string psOutput)
+    {
+        var rows = new List<StatusRow>();
+        foreach (var raw in psOutput.Split('\n'))
+        {
+            var line = raw.TrimEnd('\r');
+            if (line.Length == 0)
+            {
+                continue;
+            }
+
+            var parts = line.Split('\t');
+            if (parts.Length < 6 || parts[0].Length == 0)
+            {
+                continue;
+            }
+
+            rows.Add(new StatusRow(parts[0], Label(parts[1]), Label(parts[2]), Label(parts[3]), Label(parts[4]), Label(parts[5])));
+        }
+
+        return rows;
+
+        static string Label(string value) => value == "<no value>" ? string.Empty : value.Trim();
+    }
+}
+
+/// <summary>One row of <c>rask deploy status</c>, as the host reported it.</summary>
+internal readonly record struct StatusRow(string Container, string App, string Domain, string Color, string Status, string Ports);

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -26,7 +26,7 @@ namespace Rask.Cli.Commands;
 /// (default <c>/health</c>, the endpoint <c>rask new</c> scaffolds); <c>--no-health-check</c> falls back to
 /// the container-running gate only.</para>
 /// </summary>
-internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
+internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
     : CliCommand(console)
 {
     /// <summary>
@@ -52,6 +52,22 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     /// app's Litestream flush + SQLite WAL checkpoint (Litestream's default shutdown grace is 10s).</summary>
     internal const int StopTimeoutSeconds = 20;
 
+    /// <summary>
+    /// The tag the running app is built to, and the one holding the version it replaced.
+    ///
+    /// <para>Deploys used to build straight to <c>:latest</c> every time, which left the previous image
+    /// untagged and therefore unrecoverable — so a bad deploy that <em>passed</em> its health check (it
+    /// starts and answers, it's just wrong) could only be undone by building again from fixed source.
+    /// Keeping the last image under its own tag is what makes <c>rask deploy rollback</c> possible at
+    /// all.</para>
+    /// </summary>
+    internal const string CurrentTag = "current";
+
+    internal const string PreviousTag = "previous";
+
+    /// <summary>Verbs that operate on an existing deployment. A bare <c>rask deploy</c> deploys.</summary>
+    private static readonly string[] Subcommands = ["status", "logs", "rollback"];
+
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IProcessRunner _process = process;
     private readonly string _workingDirectory = workingDirectory;
@@ -65,8 +81,13 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
     public override string Summary => "Build and deploy the app to a single host over SSH (auto-HTTPS with --domain).";
 
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+    [
+        ("[status|logs|rollback]", "Operate on what's already deployed instead of deploying (omit to deploy)."),
+    ];
+
     public override string Usage =>
-        "rask deploy [--host user@box] [--domain app.example.com] [--port <n>] [--container-port <n>] " +
+        "rask deploy [status|logs|rollback] [--host user@box] [--domain app.example.com] [--port <n>] [--container-port <n>] " +
         "[--project <path>] [--name <slug>] [--dockerfile <path>] [--env KEY=VALUE ...] [--env-file <path>] " +
         "[--health-path <path>] [--no-health-check] [--setup-host] [--github-actions] [--dry-run]";
 
@@ -77,6 +98,9 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         "rask deploy --env ConnectionStrings__Db=... --env-file .env.production",
         "rask deploy --github-actions",
         "rask deploy --dry-run",
+        "rask deploy status",
+        "rask deploy logs --follow",
+        "rask deploy rollback",
     ];
 
     /// <summary>Options that only matter the first time a box is deployed to — grouped so --help stays readable.</summary>
@@ -99,6 +123,8 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             .Flag("no-health-check", description: "Skip the post-deploy HTTP health check.")
             .Flag("github-actions", description: "Write a .github/workflows/deploy.yml that runs this deploy on push, and print the secrets to add.")
             .Flag("dry-run", description: "Print the docker commands that would run without changing anything.")
+            .Option("tail", valueHint: "n", description: "Log lines to show (logs only; default: 100, 'all' for everything).")
+            .Flag("follow", 'f', "Stream new log lines until interrupted (logs only).")
             .Flag("setup-host", group: SetupGroup, description: "Prepare the host without asking (installs Docker, creates the deploy user, firewall, SSH hardening).")
             .Flag("no-setup-host", group: SetupGroup, description: "Never change the host; fail with instructions if it isn't ready.")
             .Option("deploy-user", valueHint: "name", group: SetupGroup, description: "Non-root login to create and deploy as when given a root host (default: deploy).")
@@ -116,9 +142,24 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             return Fail(parsed.Errors);
         }
 
-        if (parsed.Positionals.Count > 0)
+        // A bare `rask deploy` deploys; a verb after it operates on what is already deployed.
+        if (parsed.Positionals.Count > 0 && !Subcommands.Contains(parsed.Positionals[0], StringComparer.Ordinal))
         {
-            Console.Error.WriteLine($"Unexpected argument '{parsed.Positionals[0]}'. Usage: {Usage}");
+            Console.Error.WriteLine($"Unknown deploy action '{parsed.Positionals[0]}' — expected one of: {string.Join(", ", Subcommands)}.");
+            Console.Error.WriteLine($"Usage: {Usage}");
+            return 1;
+        }
+
+        if (parsed.Positionals.Count > 1)
+        {
+            Console.Error.WriteLine($"Unexpected argument '{parsed.Positionals[1]}'. Usage: {Usage}");
+            return 1;
+        }
+
+        var action = parsed.Positionals.Count > 0 ? parsed.Positionals[0] : null;
+        if (!TryRejectMisplacedOptions(parsed, action, out var optionError))
+        {
+            Console.Error.WriteLine(optionError);
             return 1;
         }
 
@@ -190,7 +231,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         var contextDir = Path.GetDirectoryName(Path.GetFullPath(dockerfile)) ?? projectDir;
         var slug = ToContainerSlug(parsed.Option("name") ?? config.Name ?? located?.RootNamespace ?? new DirectoryInfo(projectDir).Name);
 
-        if (!_fileSystem.FileExists(dockerfile))
+        if (action is null && !_fileSystem.FileExists(dockerfile))
         {
             Console.Error.WriteLine($"No Dockerfile found at '{dockerfile}'.");
             Console.Error.WriteLine("Scaffold one with `rask new <name> --docker`, or point at yours with --dockerfile <path>.");
@@ -276,7 +317,21 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             Console.WriteLine($"  Remembered {host} in {Path.Combine(".rask", "deploy.json")} — deploy as that from now on.", ConsoleStyle.Dim);
         }
 
-        WriteHeading($"Building {slug}:latest on {host}…");
+        if (action is not null)
+        {
+            return action switch
+            {
+                "status" => await StatusAsync(host, slug, cancellationToken).ConfigureAwait(false),
+                "logs" => await LogsAsync(host, slug, parsed, cancellationToken).ConfigureAwait(false),
+                _ => await RollbackAsync(host, slug, domain, port, containerPort, env, healthEnabled, healthPath, cancellationToken).ConfigureAwait(false),
+            };
+        }
+
+        // Move the live image aside before the build takes its tag, so the version being replaced stays
+        // recoverable by `rask deploy rollback`. It fails harmlessly on a first deploy (no :current yet).
+        await Run(BuildRetagArguments(host, slug, CurrentTag, PreviousTag), cancellationToken).ConfigureAwait(false); // ignore-absent
+
+        WriteHeading($"Building {slug}:{CurrentTag} on {host}…");
         if (await Run(BuildBuildArguments(host, slug, dockerfile, contextDir), cancellationToken).ConfigureAwait(false) != 0)
         {
             Console.WriteErrorLine("Docker build failed.", ConsoleStyle.Error);
@@ -289,14 +344,14 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     }
 
     // ── The bare port path: stop-old-start-new (brief downtime — no proxy to swap behind). ──────────────
-    private async Task<int> DeployPortAsync(string host, string slug, int port, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
+    private async Task<int> DeployPortAsync(string host, string slug, int port, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag)
     {
         // Retire the old container gracefully (SIGTERM → Litestream flush + WAL checkpoint) before removing it,
         // so the last writes reach the replica; both no-op on the first deploy (no container yet).
         await Run(BuildStopArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         await Run(BuildRemoveArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         Console.Out.WriteLine($"Starting {slug} on port {port}…");
-        if (await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env, containerPort), cancellationToken).ConfigureAwait(false) != 0)
+        if (await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env, containerPort, tag), cancellationToken).ConfigureAwait(false) != 0)
         {
             Console.WriteErrorLine("Failed to start the container.", ConsoleStyle.Error);
             return 1;
@@ -324,7 +379,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
     // ── The domain path: blue-green swap behind a shared, multi-app Caddy proxy (zero downtime). ────────
     private async Task<int> DeployWithProxyAsync(
-        string host, string slug, string domain, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken)
+        string host, string slug, string domain, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag)
     {
         // The live containers are the source of truth. Read them once: the current color of this app (to
         // pick the next), plus every other app's route (to regenerate the full Caddyfile).
@@ -341,7 +396,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
 
         Console.Out.WriteLine($"Starting {newContainer} ({domain})…");
         // In domain mode the app is reached internally on its container port; no host port is published.
-        if (await Run(BuildRunArguments(host, slug, domain, newColor, containerPort, env, containerPort), cancellationToken).ConfigureAwait(false) != 0)
+        if (await Run(BuildRunArguments(host, slug, domain, newColor, containerPort, env, containerPort, tag), cancellationToken).ConfigureAwait(false) != 0)
         {
             Console.WriteErrorLine("Failed to start the new container.", ConsoleStyle.Error);
             return 1;
@@ -633,13 +688,26 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
     internal static string NextColor(string? current) =>
         string.Equals(current, "blue", StringComparison.Ordinal) ? "green" : "blue";
 
+    /// <summary>
+    /// Build the image. Tagged <c>:current</c> (what containers are started from, and what the next deploy
+    /// will move aside to <c>:previous</c>) and <c>:latest</c>, which is kept purely so the box still reads
+    /// the way a person expects when they run <c>docker images</c> themselves.
+    /// </summary>
     internal static IReadOnlyList<string> BuildBuildArguments(string host, string slug, string dockerfile, string contextDir) =>
-        [.. Prefix(host), "build", "-t", $"{slug}:latest", "-f", dockerfile, contextDir];
+        [.. Prefix(host), "build", "-t", $"{slug}:{CurrentTag}", "-t", $"{slug}:latest", "-f", dockerfile, contextDir];
+
+    /// <summary>Move the live image aside before a build overwrites its tag, so it can be rolled back to.</summary>
+    internal static IReadOnlyList<string> BuildRetagArguments(string host, string slug, string from, string to) =>
+        [.. Prefix(host), "tag", $"{slug}:{from}", $"{slug}:{to}"];
+
+    /// <summary>Does this tag exist on the host? Used to tell "nothing to roll back to" from a failure.</summary>
+    internal static IReadOnlyList<string> BuildImageExistsArguments(string host, string slug, string tag) =>
+        [.. Prefix(host), "image", "inspect", "--format", "{{.Id}}", $"{slug}:{tag}"];
 
     internal static IReadOnlyList<string> BuildNetworkCreateArguments(string host, string network) =>
         [.. Prefix(host), "network", "create", network];
 
-    internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env, int containerPort = DefaultContainerPort)
+    internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env, int containerPort = DefaultContainerPort, string tag = CurrentTag)
     {
         var args = new List<string>(Prefix(host)) { "run", "-d" };
         if (domain is null)
@@ -670,7 +738,7 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
             args.AddRange(["-e", entry]);
         }
 
-        args.Add($"{slug}:latest");
+        args.Add($"{slug}:{tag}");
         return args;
     }
 
@@ -708,8 +776,17 @@ internal sealed class DeployCommand(IConsole console, IFileSystem fileSystem, IP
         "-fsS", "-m", "5", $"http://localhost:{containerPort}{healthPath}",
     ];
 
-    internal static IReadOnlyList<string> BuildLogsArguments(string host, string container) =>
-        [.. Prefix(host), "logs", "--tail", "50", container];
+    internal static IReadOnlyList<string> BuildLogsArguments(string host, string container, string tail = "50", bool follow = false)
+    {
+        var args = new List<string>(Prefix(host)) { "logs", "--tail", tail };
+        if (follow)
+        {
+            args.Add("--follow");
+        }
+
+        args.Add(container);
+        return args;
+    }
 
     internal static IReadOnlyList<string> BuildRemoveArguments(string host, string container) =>
         [.. Prefix(host), "rm", "-f", container];

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -15,7 +15,11 @@ public sealed class DeployCommandTests
     {
         var args = DeployCommand.BuildBuildArguments("deploy@box", "shop", "/proj/Dockerfile", "/proj");
 
-        Assert.Equal(["-H", "ssh://deploy@box", "build", "-t", "shop:latest", "-f", "/proj/Dockerfile", "/proj"], args);
+        // Two tags: :current is what runs and what the next deploy moves aside to :previous, and :latest
+        // is kept so the box still reads the way a person expects from `docker images`.
+        Assert.Equal(
+            ["-H", "ssh://deploy@box", "build", "-t", "shop:current", "-t", "shop:latest", "-f", "/proj/Dockerfile", "/proj"],
+            args);
     }
 
     [Fact]
@@ -31,7 +35,7 @@ public sealed class DeployCommandTests
             "--label", "rask.port=8080",
             // The persistent DB volume + connection string come before the user env, so --env A=1 still wins.
             "-v", "shop-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db",
-            "-e", "A=1", "shop:latest",
+            "-e", "A=1", "shop:current",
         ], args);
     }
 
@@ -47,7 +51,7 @@ public sealed class DeployCommandTests
             // Labelled but with no rask.domain, so the host inventory sees it and the proxy doesn't.
             "--label", "rask.managed=true", "--label", "rask.app=shop", "--label", "rask.port=8080",
             "-v", "shop-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db",
-            "shop:latest",
+            "shop:current",
         ], args);
     }
 
@@ -216,7 +220,7 @@ public sealed class DeployCommandTests
 
         Assert.Equal(0, exit);
         Assert.Empty(runner.Invocations);
-        Assert.Contains("docker -H ssh://deploy@box build -t shop:latest", console.OutText);
+        Assert.Contains("docker -H ssh://deploy@box build -t shop:current -t shop:latest", console.OutText);
         Assert.Contains("caddy reload", console.OutText);
     }
 

--- a/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
+++ b/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
@@ -172,6 +172,90 @@ public sealed class DeployHostE2ETests(DeployHostFixture host) : IClassFixture<D
     }
 
     /// <summary>
+    /// The day-two verbs, against a real deployment. Rollback is the one that most needs a live host: it
+    /// depends on image tags surviving a build that reuses them, which no mock can tell you.
+    /// </summary>
+    [SkippableFact]
+    public async Task Status_logs_and_rollback_operate_on_the_live_deployment()
+    {
+        var project = Start(out var console, out var command);
+        string[] args = ["--host", host.Host, "--domain", "rask-ops.test", "--name", "opsapp"];
+
+        // v1 — the version we will roll back to. A marker in the served body identifies it.
+        File.WriteAllText(Path.Combine(project, "Dockerfile"), AppWithMarker("VERSION-ONE"));
+        Assert.True(await command.ExecuteAsync(args, CancellationToken.None) == 0, $"v1 deploy failed.\n{console.ErrorText}");
+
+        // v2 — starts and answers, so every deploy-time gate passes. It's simply the wrong build; that is
+        // precisely the failure the blue-green rollback cannot help with, and what `rollback` is for.
+        File.WriteAllText(Path.Combine(project, "Dockerfile"), AppWithMarker("VERSION-TWO"));
+        Assert.True(await command.ExecuteAsync(args, CancellationToken.None) == 0, $"v2 deploy failed.\n{console.ErrorText}");
+        Assert.Equal("VERSION-TWO", await ServedBodyAsync("opsapp"));
+
+        var status = new StringConsole();
+        var statusCommand = Command(project, status);
+        Assert.Equal(0, await statusCommand.ExecuteAsync(["status", "--host", host.Host, "--name", "opsapp"], CancellationToken.None));
+        Assert.Contains("opsapp", status.OutText, StringComparison.Ordinal);
+        Assert.Contains("rask-ops.test", status.OutText, StringComparison.Ordinal);
+        Assert.Contains("rollback", status.OutText, StringComparison.Ordinal); // ...and that one is possible
+
+        var logs = new StringConsole();
+        Assert.Equal(0, await Command(project, logs).ExecuteAsync(["logs", "--host", host.Host, "--name", "opsapp", "--tail", "10"], CancellationToken.None));
+
+        var back = new StringConsole();
+        var exit = await Command(project, back).ExecuteAsync(["rollback", "--host", host.Host, "--name", "opsapp"], CancellationToken.None);
+        Assert.True(exit == 0, $"rollback failed.\n{back.OutText}\n{back.ErrorText}");
+
+        // The proof: the live site serves v1 again, through the proxy, after a health-gated swap.
+        Assert.Equal("VERSION-ONE", await ServedBodyAsync("opsapp"));
+
+        // ...and rolling back again returns to v2, because the tags were swapped rather than consumed.
+        var forward = new StringConsole();
+        Assert.Equal(0, await Command(project, forward).ExecuteAsync(["rollback", "--host", host.Host, "--name", "opsapp"], CancellationToken.None));
+        Assert.Equal("VERSION-TWO", await ServedBodyAsync("opsapp"));
+    }
+
+    [SkippableFact]
+    public async Task Rollback_refuses_when_there_is_no_previous_image()
+    {
+        var project = Start(out var console, out var command);
+        Assert.True(
+            await command.ExecuteAsync(["--host", host.Host, "--port", "8090", "--name", "onlyonce"], CancellationToken.None) == 0,
+            $"first deploy failed.\n{console.ErrorText}");
+
+        var back = new StringConsole();
+        var exit = await Command(project, back).ExecuteAsync(["rollback", "--host", host.Host, "--name", "onlyonce"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("nothing to roll back to", back.ErrorText, StringComparison.Ordinal);
+    }
+
+    /// <summary>An app whose body identifies which build is serving.</summary>
+    private static string AppWithMarker(string marker) =>
+        $$"""
+        FROM docker.io/library/nginx:alpine
+        RUN mkdir -p /data \
+         && printf 'server { listen 8080; location /health { return 200 "{{marker}}"; } }\n' > /etc/nginx/conf.d/default.conf
+        EXPOSE 8080
+        CMD ["/bin/sh","-c","echo boot >> /data/boots.txt; exec nginx -g 'daemon off;'"]
+        """.ReplaceLineEndings("\n");
+
+    /// <summary>What the app is actually serving right now, fetched from inside the host.</summary>
+    private async Task<string> ServedBodyAsync(string slug)
+    {
+        var (_, container) = await host.DockerAsync("ps", "--filter", $"label=rask.app={slug}", "--format", "{{.Names}}");
+        var (_, body) = await host.DockerAsync("exec", container.Trim(), "wget", "-qO-", "http://127.0.0.1:8080/health");
+        return body.Trim();
+    }
+
+    /// <summary>A second command against the same project directory (each verb gets a fresh console).</summary>
+    private DeployCommand Command(string project, StringConsole console) =>
+        new(console, new SystemFileSystem(), new EnvScopedProcessRunner(host.Environment, host.Executables), project)
+        {
+            ReadinessDelay = TimeSpan.FromMilliseconds(500),
+            ReadinessAttempts = 30,
+        };
+
+    /// <summary>
     /// Set up a project directory holding the app's Dockerfile and a <see cref="DeployCommand"/> wired to the
     /// real filesystem and a process runner scoped to the fixture's ssh identity. Skips when the gate is off
     /// or the fake VPS couldn't start, so a machine without Docker reports SKIPPED rather than failing.

--- a/tests/Rask.Cli.Tests/DeployOpsTests.cs
+++ b/tests/Rask.Cli.Tests/DeployOpsTests.cs
@@ -1,0 +1,255 @@
+using Rask.Cli.Commands;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// The day-two verbs: <c>rask deploy status | logs | rollback</c>. The builders and parsers are asserted
+/// directly; the behaviour that only a real host can prove (that an image tag survives a build which
+/// reuses it, so a rollback has something to restore) lives in <see cref="DeployHostE2ETests"/>.
+/// </summary>
+public sealed class DeployOpsTests
+{
+    private const string WorkingDir = "/proj";
+
+    private static DeployCommand Create(FakeFileSystem fs, FakeProcessRunner runner, StringConsole console)
+    {
+        fs.Seed("/proj/Dockerfile", "FROM scratch");
+        return new DeployCommand(console, fs, runner, WorkingDir) { ReadinessDelay = TimeSpan.Zero, ReadinessAttempts = 1 };
+    }
+
+    /// <summary>A ready host, a scripted `docker ps` listing, containers up, and an image for a tag query.</summary>
+    private static Func<IReadOnlyList<string>, ProcessResult> Captures(string psListing = "", bool hasPrevious = true) => args =>
+        DeployCommandTests.IsHostProbe(args) ? new ProcessResult(0, DeployCommandTests.ReadyHostProbe, string.Empty)
+        : args.Contains("inspect") && args.Contains("image") ? new ProcessResult(hasPrevious ? 0 : 1, hasPrevious ? "sha256:0123456789abcdef\n" : string.Empty, string.Empty)
+        : args.Contains("ps") ? new ProcessResult(0, psListing, string.Empty)
+        : args.Contains("inspect") ? new ProcessResult(0, "true\n", string.Empty)
+        : new ProcessResult(0, string.Empty, string.Empty);
+
+    // ── Builders / parsers ──────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Build_tags_the_image_current_and_latest()
+    {
+        // :current is what containers run and what the next deploy moves aside; :latest is kept so the
+        // box still reads the way a person expects from `docker images`.
+        var args = DeployCommand.BuildBuildArguments("deploy@box", "shop", "/proj/Dockerfile", "/proj");
+
+        Assert.Equal(
+            ["-H", "ssh://deploy@box", "build", "-t", "shop:current", "-t", "shop:latest", "-f", "/proj/Dockerfile", "/proj"],
+            args);
+    }
+
+    [Fact]
+    public void Retag_moves_a_tag_without_rebuilding() =>
+        Assert.Equal(
+            ["-H", "ssh://deploy@box", "tag", "shop:current", "shop:previous"],
+            DeployCommand.BuildRetagArguments("deploy@box", "shop", "current", "previous"));
+
+    [Fact]
+    public void Run_arguments_can_start_a_chosen_tag() =>
+        Assert.Contains(
+            "shop:previous",
+            DeployCommand.BuildRunArguments("deploy@box", "shop", domain: null, color: null, 9000, [], 8080, "previous"));
+
+    [Theory]
+    [InlineData("50", false, new[] { "logs", "--tail", "50" })]
+    [InlineData("all", false, new[] { "logs", "--tail", "all" })]
+    [InlineData("10", true, new[] { "logs", "--tail", "10", "--follow" })]
+    public void Logs_arguments_carry_tail_and_follow(string tail, bool follow, string[] expected)
+    {
+        var args = DeployCommand.BuildLogsArguments("deploy@box", "shop-blue", tail, follow);
+
+        Assert.Equal([.. new[] { "-H", "ssh://deploy@box" }.Concat(expected).Append("shop-blue")], args);
+    }
+
+    [Fact]
+    public void ParseStatusRows_reads_the_listing_and_skips_malformed_lines()
+    {
+        var rows = DeployCommand.ParseStatusRows(
+            "shop-blue\tshop\tshop.example.com\tblue\tUp 2 hours\t\n"
+            + "api\tapi\t<no value>\t<no value>\tUp 5 minutes\t0.0.0.0:9000->8080/tcp\n"
+            + "garbage-line\n");
+
+        Assert.Equal(2, rows.Count);
+        Assert.Equal(new StatusRow("shop-blue", "shop", "shop.example.com", "blue", "Up 2 hours", string.Empty), rows[0]);
+        Assert.Equal("0.0.0.0:9000->8080/tcp", rows[1].Ports);
+    }
+
+    // ── status ──────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Status_lists_every_app_on_the_box()
+    {
+        // Apps share a host and a proxy, so "what else is here" is part of the answer — it's how you
+        // notice the second app you'd forgotten was holding a domain.
+        var runner = new FakeProcessRunner
+        {
+            CaptureHandler = Captures("shop-blue\tshop\tshop.example.com\tblue\tUp 2 hours\t\napi\tapi\t<no value>\t<no value>\tUp 5 minutes\t0.0.0.0:9000->8080/tcp\n"),
+        };
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        var exit = await command.ExecuteAsync(["status", "--host", "deploy@box", "--name", "shop"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("https://shop.example.com", console.OutText, StringComparison.Ordinal);
+        Assert.Contains("0.0.0.0:9000->8080/tcp", console.OutText, StringComparison.Ordinal);
+        Assert.Contains("Up 2 hours", console.OutText, StringComparison.Ordinal);
+        Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("build")); // status changes nothing
+    }
+
+    [Fact]
+    public async Task Status_on_an_empty_host_says_so_rather_than_printing_an_empty_table()
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        var exit = await command.ExecuteAsync(["status", "--host", "deploy@box", "--name", "shop"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Nothing deployed", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Status_says_whether_a_rollback_is_possible()
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures("shop-blue\tshop\tshop.example.com\tblue\tUp 2 hours\t\n", hasPrevious: false) };
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        await command.ExecuteAsync(["status", "--host", "deploy@box", "--name", "shop"], CancellationToken.None);
+
+        Assert.Contains("nothing to go back to", console.OutText, StringComparison.Ordinal);
+    }
+
+    // ── logs ────────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Logs_target_the_live_container_for_this_app()
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures("shop-green\tshop\tshop.example.com\tgreen\t8080\n") };
+        var command = Create(new FakeFileSystem(), runner, new StringConsole());
+
+        var exit = await command.ExecuteAsync(["logs", "--host", "deploy@box", "--name", "shop", "--tail", "25"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        var logs = runner.Invocations.Single(i => i.Arguments.Contains("logs"));
+        Assert.Equal(["-H", "ssh://deploy@box", "logs", "--tail", "25", "shop-green"], logs.Arguments);
+    }
+
+    [Fact]
+    public async Task Logs_for_an_app_that_is_not_running_explain_rather_than_show_nothing()
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        var exit = await command.ExecuteAsync(["logs", "--host", "deploy@box", "--name", "shop"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("isn't running", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-5")]
+    [InlineData("lots")]
+    public async Task An_invalid_tail_is_rejected(string value)
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures("shop-blue\tshop\tshop.example.com\tblue\t8080\n") };
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        var exit = await command.ExecuteAsync(["logs", "--host", "deploy@box", "--name", "shop", "--tail", value], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("--tail must be", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    // ── rollback ────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Rollback_starts_the_previous_image_and_swaps_the_tags()
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures("shop-blue\tshop\tshop.example.com\tblue\t8080\n") };
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/.rask/deploy.json", """{"host":"deploy@box","name":"shop","domain":"shop.example.com"}""");
+        var command = Create(fs, runner, console);
+
+        var exit = await command.ExecuteAsync(["rollback"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+
+        // The new colour runs the PREVIOUS image, and nothing was rebuilt.
+        var run = runner.Invocations.Single(i => i.Arguments.Contains("rask.app=shop"));
+        Assert.Contains("shop:previous", run.Arguments);
+        Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("build"));
+
+        // ...and the tags were exchanged, so :current still names what is serving and rolling back again
+        // returns to the version we just left rather than repeating this one.
+        var tags = runner.Invocations.Where(i => i.Arguments.Contains("tag")).Select(i => string.Join(' ', i.Arguments)).ToArray();
+        Assert.Contains(tags, t => t.EndsWith("tag shop:current shop:rollback-swap", StringComparison.Ordinal));
+        Assert.Contains(tags, t => t.EndsWith("tag shop:previous shop:current", StringComparison.Ordinal));
+        Assert.Contains(tags, t => t.EndsWith("tag shop:rollback-swap shop:previous", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Rollback_without_a_previous_image_refuses_and_changes_nothing()
+    {
+        var runner = new FakeProcessRunner { CaptureHandler = Captures("shop-blue\tshop\tshop.example.com\tblue\t8080\n", hasPrevious: false) };
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), runner, console);
+
+        var exit = await command.ExecuteAsync(["rollback", "--host", "deploy@box", "--name", "shop"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("nothing to roll back to", console.ErrorText, StringComparison.Ordinal);
+        Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("run"));
+    }
+
+    // ── argument discipline ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task An_unknown_action_lists_the_real_ones()
+    {
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), new FakeProcessRunner(), console);
+
+        var exit = await command.ExecuteAsync(["restart"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Unknown deploy action 'restart'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("status, logs, rollback", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(new[] { "status", "--domain", "x.example.com" }, "--domain")]
+    [InlineData(new[] { "rollback", "--dockerfile", "/tmp/Dockerfile" }, "--dockerfile")]
+    [InlineData(new[] { "logs", "--github-actions" }, "--github-actions")]
+    [InlineData(new[] { "status", "--dry-run" }, "--dry-run")]
+    public async Task Options_that_belong_to_a_deploy_are_refused_not_ignored(string[] args, string option)
+    {
+        // Accepting and silently ignoring them would leave the user believing something happened.
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), new FakeProcessRunner(), console);
+
+        var exit = await command.ExecuteAsync([.. args, "--host", "deploy@box"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains(option, console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Logs_only_options_are_refused_on_a_plain_deploy()
+    {
+        var console = new StringConsole();
+        var command = Create(new FakeFileSystem(), new FakeProcessRunner(), console);
+
+        var exit = await command.ExecuteAsync(["--host", "deploy@box", "--follow"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("only apply to `rask deploy logs`", console.ErrorText, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
> Stacked on #505 → #503 → #502. This PR's own diff is `DeployCommand.Ops.cs`, the dispatch + tagging changes in `DeployCommand.cs`, `DeployOpsTests.cs`, the hook clause, and docs.

## Summary

`rask deploy` took you to production and **left you there**. Seeing what was running, reading its logs, or
undoing a bad release all meant hand-writing `docker -H ssh://…` commands — precisely the SSH session the
deploy story promises you never have to open. For a framework whose thesis is that one person can *operate*
the whole product, that was the biggest remaining hole.

```bash
rask deploy status          # every Rask app on the box: URL/port, colour, uptime, rollback availability
rask deploy logs --follow   # the live container's logs
rask deploy rollback        # put the previous image back, health-gated
```

All three read the same `rask.*` container labels a deploy writes, so they describe the box **as it
actually is** rather than as `.rask/deploy.json` remembers it. None needs a Dockerfile or a build.

## Why rollback needed a change to how images are tagged

The blue-green swap already protects you from a release that **fails** — one that won't start, or won't
answer its probe. It can do nothing about the worse case: a release that starts, answers, and is simply
**wrong**.

That was unrecoverable, because every build wrote straight to `:latest` and left the image it replaced
untagged. So deploys now build `<app>:current` (plus `:latest`, kept so `docker images` still reads the way
you'd expect) and move the outgoing image to `<app>:previous` first. `rollback` restores it **through the
same gates a deploy uses** — running → healthy → reload the proxy → retire the old container — so a
rollback can't take traffic on weaker evidence than the deploy it's undoing. It then swaps the two tags, so
running it again undoes the rollback rather than repeating it.

## Testing

**Verified on a live container host** (7/7), including the case that only a real host can prove — that an
image tag survives a build which reuses it:

- deploy v1 → deploy v2 → site serves `VERSION-TWO`
- `rollback` → site serves **`VERSION-ONE`** again, through the proxy, after a health-gated swap
- `rollback` again → back to `VERSION-TWO` (tags swapped, not consumed)
- `rollback` with no previous image refuses and changes nothing

Plus **693 CLI unit tests**, including the builders/parsers and that options describing *what to deploy*
(`--domain`, `--dockerfile`, `--dry-run`, …) are **refused** on these verbs rather than silently ignored —
accepting and dropping them would leave the user believing something happened.

Scaffold build gate 20/20; `run-unit-local.sh` green.

## Also: a DX regression I introduced in #502

The pre-push CLI build gate ran on **every** push, and it packs 15 packages and runs several full builds —
minutes of tax for a docs typo. It's now scoped to pushes that can actually change what the generators
emit (CLI scaffolding, the `Rask.*` packages a generated project references, the tutorial, or the gate
itself), the same conditional treatment the deploy gate already had. Verified both filters fire correctly
on this branch.

## Changelog

`[Unreleased] → Added` and `→ Changed`.