### PR TITLE
feat(cli): scaffold an app configured for where it gets deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A scaffolded app is now configured for the place it gets deployed to.** `rask new` produced an app that
+  compiled and ran locally but was missing the pieces that only matter once something is in front of it:
+  - **`appsettings.json` + `appsettings.Production.json` are scaffolded.** Neither existed, so there was
+    nowhere to put the `Logging:LogLevel:Rask.Live` setting [`observability.md`](docs/observability.md)
+    tells you to write, and all production configuration had to arrive as environment variables.
+  - **Health checks report live-session capacity** (`AddRaskLiveSessions`). The endpoint `rask deploy` gates
+    its blue-green swap on answered a flat 200 even while the host was refusing new sessions with `503` — so
+    a deploy could switch traffic onto a server that couldn't take it. (Server template only: a wasm-hosted
+    host has no live-session pool.)
+  - **Forwarded headers are honoured**, so behind the Caddy proxy `rask deploy` runs, `Request.Scheme` is
+    `https` and `RemoteIpAddress` is the visitor rather than the proxy. Without it `UseHsts` never emitted
+    and every logged client IP was wrong.
+  - **Shutdown completes inside the deploy's grace period** (15s vs the 20s before `SIGKILL`), so in-flight
+    requests drain and SQLite checkpoints instead of being killed mid-write. The host default of 30s was
+    longer than the deploy would wait.
+  - `UseStatusCodePages()` gives an unmatched route a readable body instead of a blank page.
+- **Deployed containers get production runtime defaults**: `ASPNETCORE_ENVIRONMENT=Production` (previously
+  left to whatever the base image assumed — so `appsettings.Production.json` would never have been read),
+  bounded logs (`max-size=10m`, `max-file=3` — Docker's default is unbounded, and on a one-box deploy an app
+  filling the disk takes every other app down with it), and `--security-opt no-new-privileges`.
 - **`rask deploy status` / `logs` / `rollback` — the CLI now covers operating the app, not just shipping
   it.** Until now `rask deploy` took you to production and left you there: seeing what was running,
   reading its logs, or undoing a bad release all meant hand-writing `docker -H ssh://…` commands, which is

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -65,6 +65,8 @@ scaffolds already follows the vertical-slice layout the CLI generates into: feat
 MyApp/
   MyApp.csproj
   Program.cs
+  appsettings.json                logging levels (incl. Rask's own diagnostic categories)
+  appsettings.Production.json     overrides applied when deployed
   Features/
     Shared/App.cs                 the root shell every page renders through
     Home/HomePage.cs              a [Route("/")] welcome page that teaches the CLI

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,6 +118,24 @@ deploy step. The generated workflow deploys with `--no-setup-host` on purpose: *
 from your own machine**, where you can see what's about to change — a host that isn't ready should fail
 the job, not get reconfigured by CI.
 
+## What `rask deploy` sets on the container
+
+Beyond your own `--env` values, every deployed container gets:
+
+| Setting | Why |
+| --- | --- |
+| `ASPNETCORE_ENVIRONMENT=Production` | Selects `appsettings.Production.json` and turns off the developer exception page. Your own `--env` wins if you set it. |
+| `ConnectionStrings__App=Data Source=/data/app.db` | Points the app at the mounted volume, so the database survives container replacement. |
+| `--log-opt max-size=10m --log-opt max-file=3` | Docker's `json-file` logs are unbounded by default; on a one-box deploy a chatty app filling the disk takes down every other app sharing it. |
+| `--security-opt no-new-privileges` | A compromised process can't gain rights through setuid binaries. Nothing a Rask app does needs to escalate. |
+| `--restart unless-stopped` | The app comes back after a reboot or a daemon restart. |
+
+The scaffolded app is set up to match: it honours forwarded headers (so `Request.Scheme` and the client
+IP are the visitor's, not the proxy's), reports live-session capacity on `/health` (so a host that is
+refusing sessions with `503` says so rather than answering a bare "up"), and shuts down within 15s — inside
+the 20s grace period the deploy allows before `SIGKILL`, so in-flight requests drain and SQLite checkpoints
+cleanly.
+
 ## Scaffolding a Dockerfile — `--docker`
 
 The three web templates take an opt-in `--docker` flag that drops a production-ready multi-stage

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -710,6 +710,13 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env, int containerPort = DefaultContainerPort, string tag = CurrentTag)
     {
         var args = new List<string>(Prefix(host)) { "run", "-d" };
+
+        // Container-runtime hygiene for a box that is expected to run unattended for months:
+        //  • json-file logs are unbounded by default, and a chatty app filling the disk takes the whole
+        //    host down with it — including every other app sharing the box.
+        //  • no-new-privileges stops a compromised process gaining rights via setuid binaries. It costs
+        //    nothing here: nothing a Rask app does needs to escalate.
+        args.AddRange(["--log-opt", "max-size=10m", "--log-opt", "max-file=3", "--security-opt", "no-new-privileges"]);
         if (domain is null)
         {
             args.AddRange(["--name", slug, "--restart", "unless-stopped", "-p", $"{port}:{containerPort}"]);
@@ -731,6 +738,10 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         // destroyed on every redeploy. Point the app at it via ConnectionStrings:App, which Rask-scaffolded
         // apps honour; the volume is shared by both blue/green colors so the swap keeps the same database. A
         // user-supplied --env / --env-file value is appended after, so an explicit override still wins.
+        // ASPNETCORE_ENVIRONMENT is what selects appsettings.Production.json and turns off the developer
+        // exception page; relying on the base image's default left a deployed app in whatever environment
+        // the image happened to assume. Set before the user's own --env, so an explicit override still wins.
+        args.AddRange(["-e", "ASPNETCORE_ENVIRONMENT=Production"]);
         args.AddRange(["-v", $"{slug}-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db"]);
 
         foreach (var entry in env)

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -20,6 +20,8 @@ internal static partial class ProjectGenerator
             ("Features/Shared/App.cs", AppShellCs),
             ("Features/Home/HomePage.cs", HomePageCs),
             ("Properties/launchSettings.json", LaunchSettings),
+            ("appsettings.json", AppSettings),
+            ("appsettings.Production.json", AppSettingsProduction),
         };
 
         if (auth)
@@ -96,7 +98,7 @@ internal static partial class ProjectGenerator
     {
         var sb = new StringBuilder();
         // App (and, with --data, AppDbContext) live in the Features/Shared bucket.
-        sb.Append("using Company.RaskServer.Features.Shared;\nusing Rask.Server;\n");
+        sb.Append("using Company.RaskServer.Features.Shared;\nusing Microsoft.AspNetCore.HttpOverrides;\nusing Rask.Server;\nusing Rask.Server.Diagnostics;\n");
         if (auth)
         {
             sb.Append("using Company.RaskServer.Features.Auth;\n");
@@ -123,10 +125,35 @@ internal static partial class ProjectGenerator
 
         sb.Append("\nvar builder = WebApplication.CreateBuilder(args);\n\n");
         sb.Append("builder.Services.AddRask();\n");
-        // A liveness/readiness endpoint (mapped below) — reports the app is up and serving. `rask deploy`
-        // probes it to gate the blue-green swap; also useful for any load balancer or orchestrator. Register
-        // real dependency checks later, e.g. builder.Services.AddHealthChecks().AddDbContextCheck<AppDb>().
-        sb.Append("builder.Services.AddHealthChecks();\n");
+        sb.Append("""
+
+            // A liveness/readiness endpoint (mapped below) — `rask deploy` probes it to gate the blue-green
+            // swap, and any load balancer or orchestrator can use it too. AddRaskLiveSessions reports the
+            // live-session pool: Degraded at 80% of MaxSessions, Unhealthy once new sessions are being
+            // refused with 503 — so a host that is full says so instead of answering a bare "up". Add real
+            // dependency checks alongside it, e.g. .AddDbContextCheck<AppDbContext>().
+            builder.Services.AddHealthChecks().AddRaskLiveSessions();
+
+            // Behind a reverse proxy (`rask deploy` runs Caddy in front), the app sees the proxy's own
+            // address and a plain-HTTP request. Without this Request.Scheme is "http", so UseHsts never
+            // emits, RemoteIpAddress is the proxy rather than the visitor, and any redirect you build is
+            // wrong. The proxy's container IP is assigned by Docker and changes, so it can't be named in
+            // KnownProxies — clearing the lists is what makes this work, and it is safe in that topology
+            // because the container publishes no host port: only the proxy can reach it. If you expose this
+            // app directly to the internet, delete this block (a client could otherwise forge its own IP).
+            builder.Services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                options.KnownIPNetworks.Clear();
+                options.KnownProxies.Clear();
+            });
+
+            // Finish shutting down before the container runtime loses patience. `rask deploy` sends SIGTERM
+            // and SIGKILLs 20s later, so a budget under that is what lets in-flight requests drain and a
+            // SQLite WAL checkpoint / Litestream flush complete instead of being killed mid-write.
+            builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
+
+            """.TrimStart('\n'));
 
         if (cqrs)
         {
@@ -207,7 +234,11 @@ internal static partial class ProjectGenerator
 
             var app = builder.Build();
 
-            // Health endpoint FIRST — as terminal middleware it short-circuits before UseHttpsRedirection,
+            // FIRST: rewrite Request.Scheme/RemoteIpAddress from the proxy's headers, so everything below
+            // (HSTS, redirects, your own logging) sees the request the visitor actually made.
+            app.UseForwardedHeaders();
+
+            // Health endpoint next — as terminal middleware it short-circuits before UseHttpsRedirection,
             // so /health answers 200 over plain HTTP. `rask deploy` probes it internally on http://…:8080
             // (no X-Forwarded-Proto), where a redirected endpoint would 307 to a port nothing listens on.
             app.UseHealthChecks("/health");
@@ -222,6 +253,9 @@ internal static partial class ProjectGenerator
             app.UseHttpsRedirection();
 
             app.MapStaticAssets();
+
+            // Give bare status codes (a 404 from an unmatched route) a readable body instead of a blank page.
+            app.UseStatusCodePages();
 
             """.TrimStart('\n'));
 
@@ -245,6 +279,57 @@ internal static partial class ProjectGenerator
 
         return sb.ToString();
     }
+
+    /// <summary>
+    /// The app's configuration file. Scaffolded (rather than left to the reader) because
+    /// <see href="https://learn.microsoft.com/aspnet/core/fundamentals/configuration/">configuration</see>
+    /// is where Rask's own diagnostics are tuned — <c>docs/observability.md</c> tells you to set
+    /// <c>Logging:LogLevel:Rask.Live</c>, and without this file there is nowhere to put it.
+    /// </summary>
+    private const string AppSettings =
+        """
+        {
+          "Logging": {
+            "LogLevel": {
+              "Default": "Information",
+              "Microsoft.AspNetCore": "Warning",
+
+              // Rask reports framework faults through these categories — a lifecycle hook that threw with
+              // no ErrorBoundary above it, a duplicate sibling Key, a handler fault, a rejected WebSocket
+              // frame. See docs/observability.md for the full table.
+              "Rask.Lifecycle": "Warning",
+              "Rask.Live": "Warning",
+              "Rask.Diff": "Warning"
+            }
+          },
+          "AllowedHosts": "*"
+        }
+
+        """;
+
+    /// <summary>
+    /// Production overrides. Kept separate so a value you change for the live site can't quietly change
+    /// how the app behaves on your machine. `rask deploy` runs the container with
+    /// <c>ASPNETCORE_ENVIRONMENT=Production</c>, which is what selects this file.
+    /// </summary>
+    private const string AppSettingsProduction =
+        """
+        {
+          "Logging": {
+            "LogLevel": {
+              // Quieter than development: request logging on a live site is mostly noise, and the
+              // Rask.Server meter + activity source carry the operational signal instead.
+              "Default": "Warning",
+              "Microsoft.AspNetCore": "Error"
+            }
+          }
+
+          // Secrets do NOT belong here — this file is committed. Pass them at deploy time with
+          // `rask deploy --env KEY=VALUE` / `--env-file`, which become environment variables and
+          // override anything set here (ConnectionStrings__App, for example).
+        }
+
+        """;
 
     private static string ServerNextSteps(string name, bool docker, bool data)
     {

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
@@ -35,6 +35,8 @@ internal static partial class ProjectGenerator
             ($"{NameToken}.Server/{NameToken}.Server.csproj", WasmHostedServerCsproj(version)),
             ($"{NameToken}.Server/Program.cs", WasmHostedServerProgram(auth)),
             ($"{NameToken}.Server/Properties/launchSettings.json", WasmHostedServerLaunchSettings),
+            ($"{NameToken}.Server/appsettings.json", AppSettings),
+            ($"{NameToken}.Server/appsettings.Production.json", AppSettingsProduction),
         };
 
         if (auth)
@@ -148,6 +150,7 @@ internal static partial class ProjectGenerator
             sb.Append("using Microsoft.AspNetCore.Authentication.Cookies;\n");
         }
 
+        sb.Append("using Microsoft.AspNetCore.HttpOverrides;\n");
         sb.Append("using Rask.Wasm.Hosting;\n");
 
         sb.Append("""
@@ -159,8 +162,25 @@ internal static partial class ProjectGenerator
 
             // A liveness/readiness endpoint (mapped below). `rask deploy` probes it to gate the blue-green
             // swap; also useful for any load balancer or orchestrator. Add real checks later, e.g.
-            // .AddHealthChecks().AddDbContextCheck<AppDb>().
+            // .AddDbContextCheck<AppDb>(). (No AddRaskLiveSessions here: this host serves a WASM bundle and
+            // an API — the live-session pool it reports on belongs to the server-rendered template.)
             builder.Services.AddHealthChecks();
+
+            // Behind a reverse proxy (`rask deploy` runs Caddy in front), the app otherwise sees the proxy's
+            // address and a plain-HTTP request — so Request.Scheme is "http", UseHsts never emits, and
+            // RemoteIpAddress is the proxy. The proxy's container IP is assigned by Docker, so it can't be
+            // named in KnownProxies; clearing the lists is safe here because the container publishes no host
+            // port. Delete this block if you expose the app directly (a client could then forge its IP).
+            builder.Services.Configure<ForwardedHeadersOptions>(options =>
+            {
+                options.ForwardedHeaders = ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto;
+                options.KnownIPNetworks.Clear();
+                options.KnownProxies.Clear();
+            });
+
+            // Finish shutting down before the container runtime loses patience: `rask deploy` sends SIGTERM
+            // and SIGKILLs 20s later.
+            builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
 
             """.TrimStart('\n'));
 
@@ -187,7 +207,11 @@ internal static partial class ProjectGenerator
 
             var app = builder.Build();
 
-            // Health endpoint FIRST — as terminal middleware it short-circuits before UseHttpsRedirection,
+            // FIRST: rewrite Request.Scheme/RemoteIpAddress from the proxy's headers, so everything below
+            // sees the request the visitor actually made.
+            app.UseForwardedHeaders();
+
+            // Health endpoint next — as terminal middleware it short-circuits before UseHttpsRedirection,
             // so /health answers 200 over plain HTTP. `rask deploy` probes it internally on http://…:8080
             // (no X-Forwarded-Proto), where a redirected endpoint would 307 to a port nothing listens on.
             app.UseHealthChecks("/health");

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -29,11 +29,14 @@ public sealed class DeployCommandTests
 
         Assert.Equal(
         [
-            "-H", "ssh://deploy@box", "run", "-d", "--name", "shop-green", "--restart", "unless-stopped",
+            "-H", "ssh://deploy@box", "run", "-d",
+            "--log-opt", "max-size=10m", "--log-opt", "max-file=3", "--security-opt", "no-new-privileges",
+            "--name", "shop-green", "--restart", "unless-stopped",
             "--network", "rask", "--label", "rask.managed=true", "--label", "rask.app=shop",
             "--label", "rask.domain=shop.example.com", "--label", "rask.color=green",
             "--label", "rask.port=8080",
-            // The persistent DB volume + connection string come before the user env, so --env A=1 still wins.
+            // The environment, DB volume and connection string all come before the user env, so --env wins.
+            "-e", "ASPNETCORE_ENVIRONMENT=Production",
             "-v", "shop-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db",
             "-e", "A=1", "shop:current",
         ], args);
@@ -46,10 +49,13 @@ public sealed class DeployCommandTests
 
         Assert.Equal(
         [
-            "-H", "ssh://deploy@box", "run", "-d", "--name", "shop", "--restart", "unless-stopped",
+            "-H", "ssh://deploy@box", "run", "-d",
+            "--log-opt", "max-size=10m", "--log-opt", "max-file=3", "--security-opt", "no-new-privileges",
+            "--name", "shop", "--restart", "unless-stopped",
             "-p", "9000:8080",
             // Labelled but with no rask.domain, so the host inventory sees it and the proxy doesn't.
             "--label", "rask.managed=true", "--label", "rask.app=shop", "--label", "rask.port=8080",
+            "-e", "ASPNETCORE_ENVIRONMENT=Production",
             "-v", "shop-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db",
             "shop:current",
         ], args);
@@ -799,6 +805,30 @@ public sealed class DeployCommandTests
 
         Assert.DoesNotContain("s3cr3t-value-here", masked, StringComparison.Ordinal);
         Assert.Contains("port 8080", masked, StringComparison.Ordinal); // short value left alone
+    }
+
+    [Fact]
+    public void Run_arguments_bound_the_logs_and_drop_privilege_escalation()
+    {
+        // A one-box deploy runs unattended for months: json-file logs are unbounded by default, and an
+        // app filling the disk takes down every other app sharing the host with it.
+        var args = DeployCommand.BuildRunArguments("deploy@box", "shop", domain: null, color: null, 9000, []);
+
+        Assert.Contains("max-size=10m", args);
+        Assert.Contains("max-file=3", args);
+        Assert.Contains("no-new-privileges", args);
+    }
+
+    [Fact]
+    public void Run_arguments_set_the_production_environment_but_let_the_user_override_it()
+    {
+        // Without this the deployed app runs in whatever environment the base image assumes — which is
+        // what selects appsettings.Production.json and turns off the developer exception page.
+        var args = DeployCommand.BuildRunArguments("deploy@box", "shop", domain: null, color: null, 9000, ["ASPNETCORE_ENVIRONMENT=Staging"]);
+
+        var ours = args.ToList().IndexOf("ASPNETCORE_ENVIRONMENT=Production");
+        var theirs = args.ToList().IndexOf("ASPNETCORE_ENVIRONMENT=Staging");
+        Assert.True(ours >= 0 && theirs > ours, "the user's own --env must come last so it wins.");
     }
 
     /// <summary>The Caddyfile the deploy generated — read from the write history, since it is deleted

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using Rask.Cli.Scaffolding;
 
@@ -13,7 +14,7 @@ public sealed class ProjectGeneratorTests
     private static readonly string[] AlwaysPresent =
     [
         "App.csproj", "Program.cs", "Features/Shared/App.cs", "Features/Home/HomePage.cs",
-        "Properties/launchSettings.json",
+        "Properties/launchSettings.json", "appsettings.json", "appsettings.Production.json",
     ];
 
     // Demo content `rask new` used to scaffold and deliberately no longer does — a new project ships one
@@ -37,6 +38,71 @@ public sealed class ProjectGeneratorTests
         Assert.DoesNotContain("Features/Auth/CredentialStore.cs", files.Keys);
         Assert.DoesNotContain("Dockerfile", files.Keys);
         Assert.DoesNotContain("wwwroot/icon.svg", files.Keys);
+    }
+
+    /// <summary>
+    /// The endpoint `rask deploy` gates its blue-green swap on has to be able to say "full". A bare
+    /// AddHealthChecks() answers 200 while the host is refusing new sessions with 503, so a deploy would
+    /// happily switch traffic onto a server that can't take it.
+    /// </summary>
+    [Fact]
+    public void Health_checks_report_live_session_capacity()
+    {
+        var (files, _) = Generate();
+
+        Assert.Contains("AddHealthChecks().AddRaskLiveSessions()", files["Program.cs"], StringComparison.Ordinal);
+        Assert.Contains("using Rask.Server.Diagnostics;", files["Program.cs"], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Behind the proxy `rask deploy` runs, without this the app sees plain HTTP from the proxy's own
+    /// address — so UseHsts never emits and every client IP is the proxy's.
+    /// </summary>
+    [Fact]
+    public void Forwarded_headers_are_honoured_before_anything_reads_the_request()
+    {
+        var (files, _) = Generate();
+        var program = files["Program.cs"];
+
+        Assert.Contains("ForwardedHeaders.XForwardedFor | ForwardedHeaders.XForwardedProto", program, StringComparison.Ordinal);
+        Assert.Contains("options.KnownIPNetworks.Clear();", program, StringComparison.Ordinal);
+
+        // Must run before UseHsts, which only emits when the request already looks like HTTPS.
+        Assert.True(
+            program.IndexOf("app.UseForwardedHeaders();", StringComparison.Ordinal) < program.IndexOf("app.UseHsts();", StringComparison.Ordinal),
+            "UseForwardedHeaders must come before UseHsts, or the scheme it corrects is read too late.");
+    }
+
+    /// <summary>`rask deploy` SIGKILLs 20s after SIGTERM, so the host's own budget must be under that.</summary>
+    [Fact]
+    public void Shutdown_finishes_inside_the_deploy_grace_period()
+    {
+        var (files, _) = Generate();
+
+        Assert.Contains("ShutdownTimeout = TimeSpan.FromSeconds(15)", files["Program.cs"], StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// docs/observability.md tells the reader to set Logging:LogLevel:Rask.Live — which needs somewhere
+    /// to put it. The files must also be real JSON to the provider that will load them (it skips comments).
+    /// </summary>
+    [Fact]
+    public void Configuration_files_are_scaffolded_and_parse()
+    {
+        var (files, _) = Generate();
+
+        Assert.Contains("Rask.Live", files["appsettings.json"], StringComparison.Ordinal);
+
+        // Production overrides live in their own file, selected by ASPNETCORE_ENVIRONMENT, which
+        // `rask deploy` sets on the container.
+        Assert.Contains("Logging", files["appsettings.Production.json"], StringComparison.Ordinal);
+
+        var options = new JsonDocumentOptions { CommentHandling = JsonCommentHandling.Skip, AllowTrailingCommas = true };
+        foreach (var name in new[] { "appsettings.json", "appsettings.Production.json" })
+        {
+            var error = Record.Exception(() => JsonDocument.Parse(files[name], options));
+            Assert.True(error is null, $"{name} isn't valid JSON: {error?.Message}");
+        }
     }
 
     [Fact]
@@ -523,6 +589,7 @@ public sealed class ProjectGeneratorTests
         "App.Client/Features/Shared/App.cs", "App.Client/Features/Home/HomePage.cs",
         "App.Client/wwwroot/index.html", "App.Client/runtimeconfig.template.json",
         "App.Server/App.Server.csproj", "App.Server/Program.cs", "App.Server/Properties/launchSettings.json",
+        "App.Server/appsettings.json", "App.Server/appsettings.Production.json",
     ];
 
     private static Dictionary<string, string> GenerateWasmHosted(bool auth = false, bool pwa = false, bool docker = false) =>


### PR DESCRIPTION
> Stacked on #506 → #505 → #503 → #502.

## Summary

`rask new` produced an app that compiled and ran locally but was missing the pieces that only matter once
something is **in front of it**. Each of these was a real defect against the deploy path this repo ships:

| Gap | What it actually broke |
|-----|------------------------|
| No `appsettings.json` at all | Nowhere to put the `Logging:LogLevel:Rask.Live` setting [`observability.md`](docs/observability.md) instructs the reader to write; all production config had to be environment variables |
| `AddHealthChecks()` without `AddRaskLiveSessions()` | `/health` answered a flat 200 **while the host was refusing new sessions with 503** — and that's the endpoint `rask deploy` gates its blue-green swap on, so a deploy could switch traffic onto a server that couldn't take it. The showcase sample already wired this; the scaffold didn't |
| `UseForwardedHeaders` called **nowhere in the repo** | Behind the Caddy proxy `rask deploy` runs, `Request.Scheme` was `http` → `UseHsts` never emitted, and every logged client IP was the proxy's |
| Host shutdown budget 30s vs the deploy's 20s `SIGKILL` | A slow shutdown was killed mid-write instead of draining and checkpointing SQLite |
| No `ASPNETCORE_ENVIRONMENT` on the container | The app ran in whatever environment the base image assumed — so `appsettings.Production.json` would never have been read |
| Unbounded `json-file` logs | On a one-box deploy, an app filling the disk takes **every other app sharing it** down too |

Plus `--security-opt no-new-privileges` and `UseStatusCodePages()`.

## Two judgement calls worth reviewing

**`KnownIPNetworks.Clear()` trusts any proxy.** The proxy's container IP is assigned by Docker and changes,
so it can't be named in `KnownProxies`. Clearing is safe in *this* topology because the container publishes
no host port — only the proxy can reach it — and the scaffold says so in a comment, including what to delete
if you expose the app directly. If you'd rather it be opt-in via config, say so and I'll change it.

**`AddRaskLiveSessions` is server-template only.** I initially added it to `wasm-hosted` too and then
checked: `Rask.Wasm.Hosting` doesn't reference `Rask.Server`, so it wouldn't have compiled — and a static
bundle host has no live-session pool to report on anyway. That template gets the forwarded-headers and
shutdown fixes only.

## Testing

- **The build gate caught a real bug before it shipped**: `ForwardedHeadersOptions.KnownNetworks` is
  obsolete in .NET 10 (`ASPDEPR005`), which under `-warnaserror` meant *every scaffolded project failed to
  compile* — 16/20 red. Fixed to `KnownIPNetworks`; now 20/20. This is precisely what #502 turned back on.
- The scaffolded `appsettings` were verified against the **real** `Microsoft.Extensions.Configuration.Json`
  provider (it skips the `//` comments they carry) rather than assumed — a malformed config would fail at
  startup, which no compile gate would catch.
- 699 CLI unit tests, including that `UseForwardedHeaders` precedes `UseHsts` (ordering is the whole point)
  and that a user's own `--env ASPNETCORE_ENVIRONMENT` still wins.
- 7/7 deploy host gate; `run-unit-local.sh` green.

## Not done

A production error page. `UseExceptionHandler("/error")` needs a routed error component to be worth having,
and half-doing it (a bare handler that swallows the exception into an empty 500) is worse than the current
behaviour. Filing it separately rather than padding this PR.

## Changelog

`[Unreleased] → Added`.