### PR TITLE
fix(cli): stop a redeploy silently dropping your secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **A redeploy can no longer silently drop your secrets.** `--env` values were never remembered — only the
+  `--env-file` *path* was — so a bare `rask deploy` after one that carried `--env`, and the workflow
+  `--github-actions` writes (which passes no `--env` at all), would start the app **without** its database
+  password. It boots, answers its health check, takes traffic, and is quietly misconfigured: the worst shape
+  a failure can take. `.rask/deploy.json` now records the variables' **names** (never their values — that
+  file is committed), and a deploy that doesn't supply one of them refuses, naming it and listing the four
+  ways to resolve it. New [`docs/secrets.md`](docs/secrets.md) covers the whole story, including what Rask
+  deliberately doesn't do.
+- **`rask deploy rollback` no longer erases remembered settings.** It reuses the deploy path, which ended by
+  rewriting `.rask/deploy.json` — with the nulls a rollback passes for `project`/`envFile`, wiping both. A
+  rollback changes which image runs, not how the app is configured, so it no longer persists at all.
+
+### Security
+- **Runtime environment values are passed to Docker through a file, not the command line.** `-e KEY=VALUE`
+  puts every secret in the local process table, readable by any other user on the machine — and on the CI
+  runner, in the workflow `--github-actions` writes. They now go through `--env-file`, which the docker CLI
+  reads locally and sends over the API; the temporary file is deleted as soon as the container has them.
+  Values that span lines (a PEM key) can't round-trip through that format and are still passed inline
+  rather than being silently truncated.
+
 ### Added
 - **A scaffolded app is now configured for the place it gets deployed to.** `rask new` produced an app that
   compiled and ran locally but was missing the pieces that only matter once something is in front of it:

--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ in the [Tutorial](tutorial/00-overview.md); the reference for each is here.
 | [Cache](cache.md) | A developer-facing cache on the app's own database via `AddRaskCache<Ctx>()` (standalone `Rask.Cache`) — standard `IDistributedCache` plus a typed `ICache` with `GetOrCreateAsync`, absolute/sliding expiry. |
 | [Outbox](outbox.md) | Durable, crash-safe domain-event delivery via `AddRaskOutbox<Ctx>()` (standalone `Rask.Outbox`) — events committed in the same transaction as your data, delivered post-commit with retries. |
 | [Web Push](webpush.md) | Server-sent Web Push from your backend via `AddRaskWebPush(...)` + `IWebPushSender` (standalone `Rask.WebPush`) — VAPID + aes128gcm, zero deps; pairs with the client `IWebPush`. |
+| [Secrets](secrets.md) | Where an app's passwords and API keys live, how they reach the server, and what Rask deliberately doesn't do with them. |
 | [Deployment](deployment.md) | Ship to a single box with `rask deploy`: Docker over SSH, a shared Caddy proxy for automatic HTTPS, zero-downtime blue-green swaps gated on `/health`, and bare-VPS setup. |
 
 ## Bootstrap components

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -118,6 +118,10 @@ deploy step. The generated workflow deploys with `--no-setup-host` on purpose: *
 from your own machine**, where you can see what's about to change — a host that isn't ready should fail
 the job, not get reconfigured by CI.
 
+> **App secrets** — passwords, API keys, SMTP logins — have their own page: **[Secrets](secrets.md)**.
+> `.rask/deploy.json` records the *names* of the variables your app needs (never their values), and a
+> deploy that doesn't supply one of them refuses rather than starting the app misconfigured.
+
 ## What `rask deploy` sets on the container
 
 Beyond your own `--env` values, every deployed container gets:

--- a/docs/secrets.md
+++ b/docs/secrets.md
@@ -1,0 +1,101 @@
+# Secrets
+
+Every app needs values it can't commit — a database password, an SMTP login, an API key. This page is the
+whole story for a Rask app: where they live, how they reach the server, and what Rask deliberately does
+*not* do with them.
+
+> **The short version.** Put them in a `.env.production` file that git ignores, deploy with
+> `rask deploy --env-file .env.production`, and read them through `IConfiguration`. Rask remembers the
+> *names* of the variables your app needs and refuses to deploy without them.
+
+## Reading a secret in your app
+
+Secrets arrive as environment variables, which ASP.NET Core's configuration system already reads. Nothing
+Rask-specific is involved:
+
+```csharp
+// A nested key uses a double underscore in the variable name:
+//   ConnectionStrings__App  →  Configuration["ConnectionStrings:App"]
+var smtpPassword = builder.Configuration["Smtp:Password"];
+```
+
+Environment variables override anything in `appsettings.json`, which is why the same key can hold a
+harmless default in the committed file and the real value in production.
+
+## Getting them onto the server
+
+```bash
+rask deploy --env "Smtp__Password=…" --env "Stripe__ApiKey=…"   # one-offs
+rask deploy --env-file .env.production                          # a file of KEY=VALUE lines
+```
+
+`--env-file` takes the format you'd expect — `KEY=VALUE` per line, `#` comments and blank lines ignored.
+**Add it to `.gitignore`.** Rask reads it on *your* machine and hands the values to Docker over the SSH
+connection; the file itself never leaves your laptop.
+
+Values are passed to `docker run` through a file rather than as `-e KEY=VALUE` arguments, so they don't
+appear in your machine's process table where any other local user could read them with `ps`.
+
+## Rask remembers the names, never the values
+
+`.rask/deploy.json` is **committed** — it's how CI knows which host to deploy to — so no secret value is
+ever written to it. What *is* recorded is the list of variable names the app was last deployed with:
+
+```jsonc
+{
+  "host": "deploy@box.example.com",
+  "domain": "app.example.com",
+  "envKeys": ["Smtp__Password", "Stripe__ApiKey"]   // names only
+}
+```
+
+That exists to prevent one specific, nasty failure. Without it, a bare `rask deploy` — or the CI workflow,
+which passes no `--env` of its own — would start your app *without* its database password. The app boots,
+answers its health check, takes traffic, and is quietly misconfigured. So a deploy that doesn't supply a
+remembered variable **fails**:
+
+```
+This app was last deployed with Smtp__Password, which isn't set now.
+
+Deploying without it would start the app misconfigured, so this is a refusal rather than a warning.
+  • pass it again:      rask deploy --env Smtp__Password=…
+  • or from a file:     rask deploy --env-file .env.production
+  • deploying from CI?  add it to the deploy step in .github/workflows/deploy.yml
+  • no longer needed?   remove it from "envKeys" in .rask/deploy.json
+```
+
+## Deploying from CI
+
+`rask deploy --github-actions` writes a workflow that needs two repository secrets of its own (an SSH key
+and the host's fingerprint). Your **app's** secrets are separate — add them to the deploy step:
+
+```yaml
+- name: Deploy
+  run: rask deploy --no-setup-host --env "Smtp__Password=${{ secrets.SMTP_PASSWORD }}"
+```
+
+If that job starts failing after you deploy a new variable from your own machine, that's the check above
+doing its job: add the same `--env` to the workflow.
+
+## What Rask doesn't do
+
+Being explicit, because "secret management" means a lot of different things:
+
+- **No secret store.** Values live in your `.env.production` (or your CI's secret store) and become plain
+  environment variables on the container. There's no vault, no encryption at rest, and no rotation.
+- **No protection from anyone with Docker access on the box.** `docker inspect` shows a container's
+  environment. Anyone in the host's `docker` group is effectively root there anyway — which is why
+  [`rask deploy`](deployment.md) creates a dedicated deploy login rather than sharing one.
+- **No masking of what your app prints.** If your app logs its own configuration, it logs its secrets.
+  Rask masks the values *it* passed when it dumps a failed container's logs, but it can only mask what it
+  knows.
+
+For a single-operator product this is usually the right amount of machinery. If you outgrow it, the
+environment-variable interface is the standard one — any secret store that can populate env vars at deploy
+time drops in without changing your app.
+
+## See also
+
+- [Deployment](deployment.md) — what else `rask deploy` sets on the container.
+- [Configuration](configuration.md) — the non-secret half.
+- [The `rask` CLI](cli.md#rask-deploy--ship-to-a-single-host-over-ssh) — every deploy option.

--- a/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
+++ b/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
@@ -75,6 +75,8 @@ public static class GuideCatalog
             "bi-database", "One Person Framework"),
         new("deployment", "Deployment", "rask deploy: a bare VPS to a live HTTPS site, zero downtime.",
             "bi-rocket", "One Person Framework"),
+        new("secrets", "Secrets", "Where passwords and API keys live, and how they reach the server.",
+            "bi-key", "One Person Framework"),
 
         // ---- Core ----
         new("elements", "Elements & the DSL", "Primitives, tag factories, universal props, SVG, the element catalog.",

--- a/src/Rask.Cli/Commands/DeployCommand.Ops.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.Ops.cs
@@ -200,9 +200,11 @@ internal sealed partial class DeployCommand
 
         WriteHeading($"Rolling {slug} back to {slug}:{PreviousTag} ({image})…");
 
+        // persist: false — a rollback changes which image is running, not how the app is configured. Left
+        // on, the nulls passed for project/envFile below would erase those keys from .rask/deploy.json.
         var result = domain is null
-            ? await DeployPortAsync(host, slug, port, containerPort, env, project: null, envFile: null, healthEnabled, healthPath, cancellationToken, tag: PreviousTag).ConfigureAwait(false)
-            : await DeployWithProxyAsync(host, slug, domain, containerPort, env, project: null, envFile: null, healthEnabled, healthPath, cancellationToken, tag: PreviousTag).ConfigureAwait(false);
+            ? await DeployPortAsync(host, slug, port, containerPort, env, project: null, envFile: null, healthEnabled, healthPath, cancellationToken, tag: PreviousTag, persist: false).ConfigureAwait(false)
+            : await DeployWithProxyAsync(host, slug, domain, containerPort, env, project: null, envFile: null, healthEnabled, healthPath, cancellationToken, tag: PreviousTag, persist: false).ConfigureAwait(false);
 
         if (result != 0)
         {

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -245,6 +245,24 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             return 1;
         }
 
+        // A variable this app was deployed with last time, and isn't being given now, is almost never
+        // intentional — it's a bare `rask deploy` after one that carried --env, or the generated CI
+        // workflow, which passes none at all. Starting the app without it produces the worst kind of
+        // failure: it boots, answers its health check, takes traffic, and is quietly misconfigured.
+        if (action is null && MissingEnvKeys(config.EnvKeys, env) is { Count: > 0 } missing)
+        {
+            Console.WriteErrorLine(
+                $"This app was last deployed with {string.Join(", ", missing)}, which {(missing.Count == 1 ? "isn't" : "aren't")} set now.",
+                ConsoleStyle.Error);
+            Console.Error.WriteLine();
+            Console.Error.WriteLine("Deploying without it would start the app misconfigured, so this is a refusal rather than a warning.");
+            Console.Error.WriteLine($"  • pass it again:      rask deploy {string.Join(' ', missing.Select(k => $"--env {k}=…"))}");
+            Console.Error.WriteLine("  • or from a file:     rask deploy --env-file .env.production");
+            Console.Error.WriteLine("  • deploying from CI?  add it to the deploy step in .github/workflows/deploy.yml");
+            Console.Error.WriteLine($"  • no longer needed?   remove it from \"envKeys\" in {Path.Combine(".rask", "deploy.json")}");
+            return 1;
+        }
+
         // Readiness probe: once the container reports Running, confirm the app answers HTTP 2xx at the
         // health path before switching traffic. --no-health-check gates on Running only; --health-path
         // overrides the path (and re-enables a config-remembered disable). Both are remembered.
@@ -272,7 +290,7 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             // thing you do in a repo, rather than emitting a workflow that can't resolve a host.
             if (!dryRun)
             {
-                PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath, containerPort);
+                PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath, containerPort, env);
             }
 
             return WriteGitHubActionsWorkflow(sshTarget, host, dryRun);
@@ -313,7 +331,7 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         if (!string.Equals(newHost, host, StringComparison.Ordinal))
         {
             host = newHost;
-            PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath, containerPort);
+            PersistConfig(host, domain, domain is null ? port : null, slug, projectSetting, envFile, healthEnabled, healthPath, containerPort, env);
             Console.WriteLine($"  Remembered {host} in {Path.Combine(".rask", "deploy.json")} — deploy as that from now on.", ConsoleStyle.Dim);
         }
 
@@ -344,14 +362,29 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     }
 
     // ── The bare port path: stop-old-start-new (brief downtime — no proxy to swap behind). ──────────────
-    private async Task<int> DeployPortAsync(string host, string slug, int port, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag)
+    private async Task<int> DeployPortAsync(string host, string slug, int port, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag, bool persist = true)
     {
         // Retire the old container gracefully (SIGTERM → Litestream flush + WAL checkpoint) before removing it,
         // so the last writes reach the replica; both no-op on the first deploy (no container yet).
         await Run(BuildStopArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         await Run(BuildRemoveArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         Console.Out.WriteLine($"Starting {slug} on port {port}…");
-        if (await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env, containerPort, tag), cancellationToken).ConfigureAwait(false) != 0)
+        var runtimeEnv = WriteEnvFile(slug, env);
+        int started;
+        try
+        {
+            started = await Run(BuildRunArguments(host, slug, domain: null, color: null, port, env, containerPort, tag, runtimeEnv), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            // The values are inside the container now; the local copy has no reason to outlive the call.
+            if (runtimeEnv is not null)
+            {
+                _fileSystem.TryDelete(runtimeEnv);
+            }
+        }
+
+        if (started != 0)
         {
             Console.WriteErrorLine("Failed to start the container.", ConsoleStyle.Error);
             return 1;
@@ -372,14 +405,17 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             return 1;
         }
 
-        PersistConfig(host, domain: null, port, slug, project, envFile, healthEnabled, healthPath, containerPort);
+        if (persist)
+        {
+            PersistConfig(host, domain: null, port, slug, project, envFile, healthEnabled, healthPath, containerPort, env);
+        }
         Console.WriteLine($"Deployed. The app is live at http://{HostName(host)}:{port}", ConsoleStyle.Success);
         return 0;
     }
 
     // ── The domain path: blue-green swap behind a shared, multi-app Caddy proxy (zero downtime). ────────
     private async Task<int> DeployWithProxyAsync(
-        string host, string slug, string domain, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag)
+        string host, string slug, string domain, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag, bool persist = true)
     {
         // The live containers are the source of truth. Read them once: the current color of this app (to
         // pick the next), plus every other app's route (to regenerate the full Caddyfile).
@@ -396,7 +432,21 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
         Console.Out.WriteLine($"Starting {newContainer} ({domain})…");
         // In domain mode the app is reached internally on its container port; no host port is published.
-        if (await Run(BuildRunArguments(host, slug, domain, newColor, containerPort, env, containerPort, tag), cancellationToken).ConfigureAwait(false) != 0)
+        var runtimeEnv = WriteEnvFile(slug, env);
+        int started;
+        try
+        {
+            started = await Run(BuildRunArguments(host, slug, domain, newColor, containerPort, env, containerPort, tag, runtimeEnv), cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            if (runtimeEnv is not null)
+            {
+                _fileSystem.TryDelete(runtimeEnv);
+            }
+        }
+
+        if (started != 0)
         {
             Console.WriteErrorLine("Failed to start the new container.", ConsoleStyle.Error);
             return 1;
@@ -456,7 +506,10 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             await Run(BuildRemoveArguments(host, stale.Container), cancellationToken).ConfigureAwait(false);
         }
 
-        PersistConfig(host, domain, port: null, slug, project, envFile, healthEnabled, healthPath, containerPort);
+        if (persist)
+        {
+            PersistConfig(host, domain, port: null, slug, project, envFile, healthEnabled, healthPath, containerPort, env);
+        }
         Console.WriteLine($"Deployed. The app is live at https://{domain}", ConsoleStyle.Success);
         Console.WriteLine($"  (make sure {domain}'s DNS A/AAAA record points at {HostName(host)})", ConsoleStyle.Dim);
         return 0;
@@ -509,7 +562,31 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         return 0;
     }
 
-    private void PersistConfig(string host, string? domain, int? port, string slug, string? project, string? envFile, bool healthEnabled, string healthPath, int containerPort) =>
+    /// <summary>
+    /// Remembered keys that aren't being supplied this time. Ordinal + sorted so the message is stable.
+    /// </summary>
+    internal static IReadOnlyList<string> MissingEnvKeys(IReadOnlyList<string>? remembered, IReadOnlyList<string> supplied)
+    {
+        if (remembered is null || remembered.Count == 0)
+        {
+            return [];
+        }
+
+        var have = EnvKeysOf(supplied).ToHashSet(StringComparer.Ordinal);
+        return [.. remembered.Where(k => !have.Contains(k)).Order(StringComparer.Ordinal)];
+    }
+
+    /// <summary>The KEY halves of a set of KEY=VALUE entries, de-duplicated and sorted.</summary>
+    internal static string[] EnvKeysOf(IReadOnlyList<string> env) =>
+    [
+        .. env
+            .Select(e => e.IndexOf('=', StringComparison.Ordinal) is var i and >= 0 ? e[..i] : e)
+            .Where(k => k.Length > 0)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal),
+    ];
+
+    private void PersistConfig(string host, string? domain, int? port, string slug, string? project, string? envFile, bool healthEnabled, string healthPath, int containerPort, IReadOnlyList<string>? env = null) =>
         new DeployConfig
         {
             Host = host,
@@ -522,6 +599,8 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             HealthPath = healthPath == DefaultHealthPath ? null : healthPath,
             HealthCheckDisabled = healthEnabled ? null : true,
             ContainerPort = containerPort == DefaultContainerPort ? null : containerPort,
+            // Keys only — this file is committed. See DeployConfig.EnvKeys.
+            EnvKeys = env is { Count: > 0 } ? EnvKeysOf(env) : null,
         }.Save(_fileSystem, _workingDirectory);
 
     private async Task<bool> WaitUntilRunningAsync(string host, string container, CancellationToken cancellationToken)
@@ -609,6 +688,31 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         {
             Console.Error.WriteLine(MaskSecrets(logs.StandardError.TrimEnd(), env));
         }
+    }
+
+    /// <summary>
+    /// An env file is line-oriented, so a value containing a newline can't round-trip through one.
+    /// Those entries keep going in as <c>-e</c> rather than being silently truncated.
+    /// </summary>
+    internal static bool CanGoInEnvFile(string entry) =>
+        entry.IndexOf('=', StringComparison.Ordinal) > 0 && !entry.Contains('\n') && !entry.Contains('\r');
+
+    /// <summary>
+    /// Write the runtime environment to a local file for <c>--env-file</c>, or return null when there is
+    /// nothing it can carry. The file is this machine's, not the host's: the docker CLI reads it here and
+    /// sends the values over the API, which is the point — they never reach an argv anyone can read.
+    /// </summary>
+    private string? WriteEnvFile(string slug, IReadOnlyList<string> env)
+    {
+        var carriable = env.Where(CanGoInEnvFile).ToArray();
+        if (carriable.Length == 0)
+        {
+            return null;
+        }
+
+        var path = Path.Combine(Path.GetTempPath(), $"rask-{slug}-{Guid.NewGuid():N}.env");
+        _fileSystem.WriteAllText(path, string.Join('\n', carriable) + "\n");
+        return path;
     }
 
     /// <summary>Replace every non-trivial <c>--env</c> value found in <paramref name="text"/> with an ellipsis.</summary>
@@ -707,7 +811,13 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     internal static IReadOnlyList<string> BuildNetworkCreateArguments(string host, string network) =>
         [.. Prefix(host), "network", "create", network];
 
-    internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env, int containerPort = DefaultContainerPort, string tag = CurrentTag)
+    /// <summary>
+    /// The <c>docker run</c> for an app container. Runtime environment goes in through
+    /// <paramref name="envFilePath"/> when there is one: <c>--env-file</c> is read by the local docker CLI,
+    /// so the values never appear in this machine's process table the way <c>-e KEY=VALUE</c> does. Entries
+    /// whose value spans lines can't be expressed in that format and stay inline.
+    /// </summary>
+    internal static IReadOnlyList<string> BuildRunArguments(string host, string slug, string? domain, string? color, int port, IReadOnlyList<string> env, int containerPort = DefaultContainerPort, string tag = CurrentTag, string? envFilePath = null)
     {
         var args = new List<string>(Prefix(host)) { "run", "-d" };
 
@@ -744,9 +854,18 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         args.AddRange(["-e", "ASPNETCORE_ENVIRONMENT=Production"]);
         args.AddRange(["-v", $"{slug}-data:/data", "-e", "ConnectionStrings__App=Data Source=/data/app.db"]);
 
+        if (envFilePath is not null)
+        {
+            args.AddRange(["--env-file", envFilePath]);
+        }
+
         foreach (var entry in env)
         {
-            args.AddRange(["-e", entry]);
+            // With an env file, only the entries it cannot carry are still passed inline.
+            if (envFilePath is null || !CanGoInEnvFile(entry))
+            {
+                args.AddRange(["-e", entry]);
+            }
         }
 
         args.Add($"{slug}:{tag}");

--- a/src/Rask.Cli/Scaffolding/DeployConfig.cs
+++ b/src/Rask.Cli/Scaffolding/DeployConfig.cs
@@ -30,6 +30,16 @@ internal sealed class DeployConfig
     public bool? HealthCheckDisabled { get; set; }
 
     /// <summary>
+    /// The <b>names</b> of the environment variables this app was last deployed with — never their values.
+    ///
+    /// <para>Values deliberately aren't remembered: this file is committed. But forgetting that the
+    /// variables <em>exist</em> is how a redeploy silently starts the app without its database password.
+    /// Recording the keys lets the next deploy notice one is missing and refuse, instead of shipping a
+    /// half-configured app that starts, answers its health check, and is quietly broken.</para>
+    /// </summary>
+    public string[]? EnvKeys { get; set; }
+
+    /// <summary>
     /// The port the app listens on <em>inside</em> its container — what the proxy is pointed at and what the
     /// health probe hits (default <c>8080</c>, which every Dockerfile <c>rask new --docker</c> emits uses).
     /// Only needed for a hand-written Dockerfile that listens elsewhere.

--- a/src/Rask.Cli/Scaffolding/GitHubActionsWorkflow.cs
+++ b/src/Rask.Cli/Scaffolding/GitHubActionsWorkflow.cs
@@ -78,6 +78,11 @@ internal static class GitHubActionsWorkflow
               #
               # Pass app secrets through here as environment variables, e.g.
               #   run: rask deploy --no-setup-host --env "ConnectionStrings__Db=${{ secrets.DB_CONNECTION }}"
+              #
+              # Every variable the app was last deployed with is recorded by name in .rask/deploy.json, and
+              # a deploy that doesn't supply one of them FAILS rather than quietly starting the app without
+              # it. So if this job starts failing after you deploy with a new --env from your machine, add
+              # the same --env here — that's the check doing its job.
               - name: Deploy
                 run: rask deploy --no-setup-host
 

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -325,8 +325,10 @@ public sealed class DeployCommandTests
     }
 
     [Fact]
-    public async Task Env_flags_and_env_file_become_docker_e_arguments()
+    public async Task Env_flags_and_env_file_both_reach_the_container()
     {
+        // --env-file lines (comments and blanks skipped) and repeated --env flags are merged into the one
+        // runtime environment, which is handed to docker through a file rather than the command line.
         var fs = new FakeFileSystem();
         fs.Seed("/proj/.env.prod", "# comment\nDB=postgres\n\nTOKEN=abc\n");
         var runner = new FakeProcessRunner { CaptureHandler = Captures() };
@@ -336,9 +338,12 @@ public sealed class DeployCommandTests
 
         Assert.Equal(0, exit);
         var run = runner.Invocations.First(i => !i.Captured && i.Arguments.Contains("run"));
-        Assert.Contains("DB=postgres", run.Arguments);
-        Assert.Contains("TOKEN=abc", run.Arguments);
-        Assert.Contains("EXTRA=1", run.Arguments);
+        var written = fs.Written[Path.GetFullPath(run.Arguments[run.Arguments.ToList().IndexOf("--env-file") + 1])];
+
+        Assert.Contains("DB=postgres", written, StringComparison.Ordinal);
+        Assert.Contains("TOKEN=abc", written, StringComparison.Ordinal);
+        Assert.Contains("EXTRA=1", written, StringComparison.Ordinal);
+        Assert.DoesNotContain("# comment", written, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -830,6 +835,125 @@ public sealed class DeployCommandTests
         var theirs = args.ToList().IndexOf("ASPNETCORE_ENVIRONMENT=Staging");
         Assert.True(ours >= 0 && theirs > ours, "the user's own --env must come last so it wins.");
     }
+
+    // ── Runtime environment: remembered by name, never by value ─────────────────────────────────────
+
+    [Fact]
+    public async Task Env_keys_are_remembered_but_values_never_are()
+    {
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var command = Create(fs, runner, new StringConsole());
+
+        await command.ExecuteAsync(
+            ["--host", "deploy@box", "--name", "shop", "--port", "9000", "--env", "DB_PASSWORD=hunter2", "--env", "API_KEY=abc123"],
+            CancellationToken.None);
+
+        var config = fs.Files[Path.GetFullPath("/proj/.rask/deploy.json")];
+        Assert.Contains("API_KEY", config, StringComparison.Ordinal);
+        Assert.Contains("DB_PASSWORD", config, StringComparison.Ordinal);
+
+        // The whole reason keys are stored rather than pairs: this file is committed.
+        Assert.DoesNotContain("hunter2", config, StringComparison.Ordinal);
+        Assert.DoesNotContain("abc123", config, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_redeploy_missing_a_remembered_variable_refuses_rather_than_starting_without_it()
+    {
+        // The bug this prevents: a bare `rask deploy` — or the generated CI workflow, which passes no
+        // --env at all — silently starting the app without its database password. It boots, answers its
+        // health check, takes traffic, and is quietly misconfigured.
+        var fs = new FakeFileSystem();
+        fs.Seed(
+            "/proj/.rask/deploy.json",
+            """{"host":"deploy@box","name":"shop","port":9000,"envKeys":["API_KEY","DB_PASSWORD"]}""");
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var console = new StringConsole();
+        var command = Create(fs, runner, console);
+
+        var exit = await command.ExecuteAsync([], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("API_KEY", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("DB_PASSWORD", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("deploy.json", console.ErrorText, StringComparison.Ordinal); // ...and how to stop wanting it
+        Assert.DoesNotContain(runner.Invocations, i => i.Arguments.Contains("build"));
+    }
+
+    [Fact]
+    public async Task Supplying_the_remembered_variables_again_deploys_normally()
+    {
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/.rask/deploy.json", """{"host":"deploy@box","name":"shop","port":9000,"envKeys":["API_KEY"]}""");
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var command = Create(fs, runner, new StringConsole());
+
+        var exit = await command.ExecuteAsync(["--env", "API_KEY=abc123"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public async Task An_env_file_satisfies_a_remembered_key_too()
+    {
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/.rask/deploy.json", """{"host":"deploy@box","name":"shop","port":9000,"envKeys":["API_KEY"]}""");
+        fs.Seed("/proj/.env.production", "API_KEY=abc123\n");
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var command = Create(fs, runner, new StringConsole());
+
+        var exit = await command.ExecuteAsync(["--env-file", "/proj/.env.production"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+    }
+
+    [Fact]
+    public async Task Runtime_values_go_through_an_env_file_not_the_command_line()
+    {
+        // -e KEY=VALUE puts the secret in this machine's process table, readable by any local user (and,
+        // in the workflow --github-actions writes, on the CI runner). --env-file is read by the docker
+        // CLI locally and sent over the API instead.
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner { CaptureHandler = Captures() };
+        var command = Create(fs, runner, new StringConsole());
+
+        await command.ExecuteAsync(
+            ["--host", "deploy@box", "--name", "shop", "--port", "9000", "--env", "DB_PASSWORD=hunter2"],
+            CancellationToken.None);
+
+        var run = runner.Invocations.Single(i => i.Arguments.Contains("rask.app=shop"));
+        Assert.DoesNotContain("DB_PASSWORD=hunter2", run.Arguments);
+        Assert.Contains("--env-file", run.Arguments);
+
+        // ...and the file itself is deleted once the container has it.
+        var envFile = run.Arguments[run.Arguments.ToList().IndexOf("--env-file") + 1];
+        Assert.Contains("hunter2", fs.Written[Path.GetFullPath(envFile)], StringComparison.Ordinal);
+        Assert.False(fs.FileExists(envFile), "the local env file must not outlive the run.");
+    }
+
+    [Fact]
+    public void A_multiline_value_stays_inline_because_an_env_file_cannot_carry_it()
+    {
+        // A PEM key is the realistic case. Writing it to a line-oriented file would truncate it silently.
+        Assert.False(DeployCommand.CanGoInEnvFile("KEY=-----BEGIN-----\nabc\n-----END-----"));
+        Assert.True(DeployCommand.CanGoInEnvFile("KEY=simple"));
+
+        var args = DeployCommand.BuildRunArguments(
+            "deploy@box", "shop", domain: null, color: null, 9000,
+            ["PEM=a\nb", "SIMPLE=1"], 8080, "current", "/tmp/x.env");
+
+        Assert.Contains("PEM=a\nb", args);          // inline — the file can't hold it
+        Assert.DoesNotContain("SIMPLE=1", args);   // in the file
+    }
+
+    [Theory]
+    [InlineData(new[] { "A=1", "B=2" }, new[] { "A", "B" })]
+    [InlineData(new[] { "B=2", "A=1" }, new[] { "A", "B" })]          // sorted, so the file is stable
+    [InlineData(new[] { "A=1", "A=2" }, new[] { "A" })]               // de-duplicated
+    [InlineData(new[] { "A=x=y" }, new[] { "A" })]                    // only the first '=' splits
+    public void EnvKeysOf_extracts_stable_sorted_names(string[] env, string[] expected) =>
+        Assert.Equal(expected, DeployCommand.EnvKeysOf(env));
 
     /// <summary>The Caddyfile the deploy generated — read from the write history, since it is deleted
     /// once it has been copied to the host.</summary>

--- a/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
+++ b/tests/Rask.Cli.Tests/DeployHostE2ETests.cs
@@ -229,6 +229,37 @@ public sealed class DeployHostE2ETests(DeployHostFixture host) : IClassFixture<D
         Assert.Contains("nothing to roll back to", back.ErrorText, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Secrets now reach the container through a file rather than the command line, and a redeploy that
+    /// forgets one is refused. Both are worth proving against a real daemon: the first only works if
+    /// docker actually applies <c>--env-file</c>, and the second has to survive a real round-trip through
+    /// <c>.rask/deploy.json</c>.
+    /// </summary>
+    [SkippableFact]
+    public async Task Runtime_env_reaches_the_container_and_is_required_on_the_next_deploy()
+    {
+        var project = Start(out var console, out var command);
+        string[] args = ["--host", host.Host, "--port", "8095", "--name", "envapp"];
+
+        var exit = await command.ExecuteAsync([.. args, "--env", "DB_PASSWORD=hunter2"], CancellationToken.None);
+        Assert.True(exit == 0, $"deploy with --env failed.\n{console.ErrorText}");
+
+        // docker really did apply the env file: the value is live inside the container.
+        var (_, value) = await host.DockerAsync("exec", "envapp", "printenv", "DB_PASSWORD");
+        Assert.Equal("hunter2", value.Trim());
+
+        // ...and the very next deploy, without it, is refused rather than starting the app unconfigured.
+        var second = new StringConsole();
+        var again = await Command(project, second).ExecuteAsync(args, CancellationToken.None);
+
+        Assert.Equal(1, again);
+        Assert.Contains("DB_PASSWORD", second.ErrorText, StringComparison.Ordinal);
+
+        // The old container is untouched — a refusal changes nothing.
+        var (_, still) = await host.DockerAsync("exec", "envapp", "printenv", "DB_PASSWORD");
+        Assert.Equal("hunter2", still.Trim());
+    }
+
     /// <summary>An app whose body identifies which build is serving.</summary>
     private static string AppWithMarker(string marker) =>
         $$"""


### PR DESCRIPTION
> Stacked on #507 → #506 → #505 → #503 → #502.

## The bug

`--env` values were **never remembered** — only the `--env-file` *path* was. So:

- a bare `rask deploy` after one that carried `--env`, and
- **the workflow `rask deploy --github-actions` writes**, which passes no `--env` at all

would start the app *without* its database password. The app boots, answers its health check, takes
traffic, and is quietly misconfigured. That's the worst shape a failure can take, because nothing tells you
it happened — no error, no log line, just an app talking to the wrong thing (or nothing).

## The fix

`.rask/deploy.json` now records the variables' **names** — never their values, since that file is
committed:

```jsonc
{ "host": "deploy@box", "envKeys": ["Smtp__Password", "Stripe__ApiKey"] }
```

A deploy that doesn't supply one of them **refuses**, and says how to resolve it:

```
This app was last deployed with Smtp__Password, which isn't set now.

Deploying without it would start the app misconfigured, so this is a refusal rather than a warning.
  • pass it again:      rask deploy --env Smtp__Password=…
  • or from a file:     rask deploy --env-file .env.production
  • deploying from CI?  add it to the deploy step in .github/workflows/deploy.yml
  • no longer needed?   remove it from "envKeys" in .rask/deploy.json
```

A refusal, not a warning: a warning scrolls past in a CI log and the broken app ships anyway.

## Secrets off the command line

`-e KEY=VALUE` puts every secret in the local process table, readable by any other user with `ps` — and on
the CI runner, in the generated workflow. Values now go through `--env-file`, which the docker CLI reads
locally and sends over the API; the temp file is deleted as soon as the container has them.

Values that span lines (a PEM key) can't round-trip through a line-oriented file, so those stay inline
rather than being **silently truncated** — which is what a naive version of this change would do.

## Also fixes a bug from #506

`rask deploy rollback` reused the deploy path, which ends by rewriting `.rask/deploy.json` — with the
`null`s a rollback passes for `project`/`envFile`, **erasing both**. A rollback changes which image runs,
not how the app is configured, so it no longer persists at all. Caught while threading env keys through the
same method.

## Testing

**8/8 on the live container host**, including a new case that proves the mechanism end to end: the value is
readable inside the container with `printenv` (so docker really did apply the env file), the next deploy
without it is refused, and the running container is left untouched by the refusal.

**709 CLI unit tests**, including that values never reach `deploy.json`, that the local env file doesn't
outlive the run, that a multi-line value stays inline, and that `--env-file` satisfies a remembered key.

## Docs

New **[`docs/secrets.md`](docs/secrets.md)** — the page the audit found missing. It covers reading secrets,
getting them to the server, CI, and a blunt "what Rask doesn't do" section (no vault, no rotation, no
protection from anyone with docker access on the box). Linked from the docs index and `deployment.md`, and
added to the site's guide catalog — the reverse-parity guard caught that omission, which was a nice check.

## Changelog

`[Unreleased] → Fixed` and `→ Security`.