### PR TITLE
feat(cli): put continuous backup on the golden path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **Continuous backup is on the golden path.** `Rask.SQLite.Litestream` shipped, was documented, and was
+  referenced by **no template** — so `rask new --data` → `rask deploy` produced a live app whose only copy of
+  the database was a volume on one box, while `rask deploy`'s own code comments explained that the graceful
+  stop existed to let "the Litestream replicator flush" — protecting a replicator that was never running.
+  Now `--data` wires it: the replication code is scaffolded but **inert until you set a replica URL**, so
+  turning it on is one variable at deploy time (`rask deploy --env "Litestream__ReplicaUrl=s3://bucket/app"`)
+  rather than a docs safari. `--docker` puts the `litestream` binary in the image (copied from its official
+  image — one layer, no package manager), because wiring without the binary would be a backup that silently
+  never runs. The startup restore is guarded: `RestoreSqliteFromLitestreamAsync` throws when no replica is
+  configured, so an unguarded call would stop every app without one from starting at all.
+- **A deploy with no replica configured says so**, every time: `! No Litestream replica configured — this
+  app's database exists only on this box's disk.` The one-box story is only safe when the box is disposable,
+  and that is worth stating rather than assuming.
+
 ### Fixed
 - **A redeploy can no longer silently drop your secrets.** `--env` values were never remembered — only the
   `--env-file` *path* was — so a bare `rask deploy` after one that carried `--env`, and the workflow

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -84,7 +84,7 @@ Add pages and components to taste — `rask generate` is the fast path.
 | `--auth` | Scaffold a cookie login/session (web templates). |
 | `--pwa` | Web app manifest + service worker + icon, and the wiring to serve them (web templates). |
 | `--cqrs` | Wire up `Rask.Cqrs` — `AddRaskCqrs()` + the package reference (the `server` template only). |
-| `--data` | Pre-wire a SQLite database: an empty `AppDbContext`, `AddRaskData()`, and a `UseRaskSqlite` (WAL + `busy_timeout`) DbContext factory — so the first `rask generate feature <Name> --context AppDbContext` is immediately runnable with `rask db add`/`update`. Implies `--cqrs` (the `server` template only). |
+| `--data` | Pre-wire a SQLite database: an empty `AppDbContext`, `AddRaskData()`, and a `UseRaskSqlite` (WAL + `busy_timeout`) DbContext factory — so the first `rask generate feature <Name> --context AppDbContext` is immediately runnable with `rask db add`/`update`. It also wires **continuous backup** ([Litestream](sqlite.md#continuous-backup-with-litestream)) — inert until you set `Litestream:ReplicaUrl`, so turning it on is one env var at deploy time (`rask deploy --env "Litestream__ReplicaUrl=s3://bucket/app"`), and `--docker` puts the replicator binary in the image. Implies `--cqrs` (the `server` template only). |
 | `--docker` | Emit a production `Dockerfile` + `.dockerignore` (web templates). |
 | `--host` | `local` (default) or `server` — which native mode to scaffold (the `native` template only). |
 | `--output`, `-o` | Target directory (defaults to a folder named after the project). |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -122,6 +122,27 @@ the job, not get reconfigured by CI.
 > `.rask/deploy.json` records the *names* of the variables your app needs (never their values), and a
 > deploy that doesn't supply one of them refuses rather than starting the app misconfigured.
 
+## Backups
+
+`rask deploy` mounts a named volume so the database survives redeploys — but a volume is still **one copy
+on one disk**. An app scaffolded with `--data` is already wired for [Litestream](sqlite.md#continuous-backup-with-litestream),
+which streams the write-ahead log to object storage; it stays inert until you point it somewhere:
+
+```bash
+rask deploy --env "Litestream__ReplicaUrl=s3://your-bucket/app" \
+            --env "AWS_ACCESS_KEY_ID=…" --env "AWS_SECRET_ACCESS_KEY=…"
+```
+
+With that set, a fresh box restores the database from the replica on startup — which is what makes "one
+server" a reasonable place to keep your only copy. Until it is, every deploy says so:
+
+```
+! No Litestream replica configured — this app's database exists only on this box's disk.
+```
+
+The replica URL is remembered by name like any other variable, so once set, a later deploy that forgets it
+[fails rather than silently dropping it](secrets.md).
+
 ## What `rask deploy` sets on the container
 
 Beyond your own `--env` values, every deployed container gets:

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -48,8 +48,9 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     /// <summary>The default path the HTTP readiness probe hits — the endpoint <c>rask new</c> scaffolds.</summary>
     internal const string DefaultHealthPath = "/health";
 
-    /// <summary>Seconds a graceful <c>docker stop</c> waits after SIGTERM before SIGKILL — long enough for the
-    /// app's Litestream flush + SQLite WAL checkpoint (Litestream's default shutdown grace is 10s).</summary>
+    /// <summary>Seconds a graceful <c>docker stop</c> waits after SIGTERM before SIGKILL — long enough for a
+    /// SQLite WAL checkpoint and, when one is configured, the app's Litestream flush (whose own shutdown
+    /// grace is 10s).</summary>
     internal const int StopTimeoutSeconds = 20;
 
     /// <summary>
@@ -349,6 +350,18 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         // recoverable by `rask deploy rollback`. It fails harmlessly on a first deploy (no :current yet).
         await Run(BuildRetagArguments(host, slug, CurrentTag, PreviousTag), cancellationToken).ConfigureAwait(false); // ignore-absent
 
+        // The deploy mounts a volume and points the app at a SQLite file on it, and the graceful-stop
+        // budget below exists so a replicator can flush before the container dies. Say plainly when there
+        // is no replicator: the database is then a single copy on one disk, and the "the box is
+        // disposable" story the docs tell is not true of this deployment.
+        if (!env.Any(e => e.StartsWith("Litestream__ReplicaUrl=", StringComparison.Ordinal)))
+        {
+            Console.WriteErrorLine(
+                "  ! No Litestream replica configured — this app's database exists only on this box's disk.",
+                ConsoleStyle.Warning);
+            Console.Error.WriteLine("    Turn on continuous backup:  rask deploy --env \"Litestream__ReplicaUrl=s3://your-bucket/app\"  (see docs/sqlite.md)");
+        }
+
         WriteHeading($"Building {slug}:{CurrentTag} on {host}…");
         if (await Run(BuildBuildArguments(host, slug, dockerfile, contextDir), cancellationToken).ConfigureAwait(false) != 0)
         {
@@ -364,8 +377,9 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     // ── The bare port path: stop-old-start-new (brief downtime — no proxy to swap behind). ──────────────
     private async Task<int> DeployPortAsync(string host, string slug, int port, int containerPort, IReadOnlyList<string> env, string? project, string? envFile, bool healthEnabled, string healthPath, CancellationToken cancellationToken, string tag = CurrentTag, bool persist = true)
     {
-        // Retire the old container gracefully (SIGTERM → Litestream flush + WAL checkpoint) before removing it,
-        // so the last writes reach the replica; both no-op on the first deploy (no container yet).
+        // Retire the old container gracefully (SIGTERM → WAL checkpoint, and a Litestream flush when a
+        // replica is configured) before removing it, so the last writes are durable; both no-op on the
+        // first deploy (no container yet).
         await Run(BuildStopArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         await Run(BuildRemoveArguments(host, slug), cancellationToken).ConfigureAwait(false); // ignore-absent
         Console.Out.WriteLine($"Starting {slug} on port {port}…");
@@ -497,9 +511,9 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
             return 1;
         }
 
-        // Traffic is on the new color: retire the old container(s) of this app. Graceful stop first so the
-        // retiring container's Litestream replicator flushes and SQLite checkpoints the WAL before removal — a
-        // plain rm -f (SIGKILL) would drop the last synced frames.
+        // Traffic is on the new color: retire the old container(s) of this app. Graceful stop first so
+        // SQLite checkpoints the WAL — and, when a replica is configured, the Litestream replicator flushes
+        // — before removal. A plain rm -f (SIGKILL) would drop the last frames.
         foreach (var stale in apps.Where(a => a.App == slug && a.Container != newContainer))
         {
             await Run(BuildStopArguments(host, stale.Container), cancellationToken).ConfigureAwait(false);
@@ -874,8 +888,9 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
     /// <summary>
     /// Gracefully stop a container: SIGTERM, then SIGKILL after <see cref="StopTimeoutSeconds"/>. Used before
-    /// retiring a container that's serving, so its in-process Litestream replicator flushes and SQLite
-    /// checkpoints the WAL cleanly before exit — a plain <c>rm -f</c> (SIGKILL) would lose the last frames.
+    /// retiring a container that's serving, so SQLite checkpoints the WAL cleanly before exit — and, when a
+    /// replica is configured, the in-process Litestream replicator flushes. A plain <c>rm -f</c> (SIGKILL)
+    /// would lose the last frames.
     /// </summary>
     internal static IReadOnlyList<string> BuildStopArguments(string host, string container) =>
         [.. Prefix(host), "stop", "-t", StopTimeoutSeconds.ToString(CultureInfo.InvariantCulture), container];

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -44,7 +44,7 @@ internal static partial class ProjectGenerator
 
         if (docker)
         {
-            files.Add(("Dockerfile", Dockerfile));
+            files.Add(("Dockerfile", Dockerfile(data)));
             files.Add((".dockerignore", DockerIgnore));
         }
 
@@ -60,6 +60,7 @@ internal static partial class ProjectGenerator
         {
             packages.Add("Rask.Data");
             packages.Add("Rask.SQLite.EntityFrameworkCore");
+            packages.Add("Rask.SQLite.Litestream");
         }
 
         return new ScaffoldResult(scaffoldFiles, ServerNextSteps(name, docker, data)) { Packages = packages };
@@ -74,6 +75,10 @@ internal static partial class ProjectGenerator
         var dataRef = data
             ? $"\n    <PackageReference Include=\"Rask.Data\" Version=\"{version}\"/>"
               + $"\n    <PackageReference Include=\"Rask.SQLite.EntityFrameworkCore\" Version=\"{version}\"/>"
+              // Continuous backup. Referenced whenever there's a database: the wiring in Program.cs stays
+              // inert until Litestream:ReplicaUrl is set, so this costs an unused reference and buys a
+              // one-env-var path from "single copy on one disk" to "the box is disposable".
+              + $"\n    <PackageReference Include=\"Rask.SQLite.Litestream\" Version=\"{version}\"/>"
             : "";
         return $"""
         <Project Sdk="Microsoft.NET.Sdk.Web">
@@ -121,6 +126,8 @@ internal static partial class ProjectGenerator
             sb.Append("using Microsoft.EntityFrameworkCore.Diagnostics;\n");
             sb.Append("using Rask.Data;\n");
             sb.Append("using Rask.SQLite;\n");
+            sb.Append("using Microsoft.Data.Sqlite;\n");
+            sb.Append("using Rask.SQLite.Litestream;\n");
         }
 
         sb.Append("\nvar builder = WebApplication.CreateBuilder(args);\n\n");
@@ -179,9 +186,29 @@ internal static partial class ProjectGenerator
                 // `rask generate feature X --context AppDbContext` adds a DbSet to AppDbContext;
                 // `rask db add <Name>` / `rask db update` create and apply the migration.
                 builder.Services.AddRaskData();
+                var connectionString = builder.Configuration.GetConnectionString("App") ?? "Data Source=app.db";
                 builder.Services.AddDbContextFactory<AppDbContext>((sp, o) => o
-                    .UseRaskSqlite(builder.Configuration.GetConnectionString("App") ?? "Data Source=app.db")
+                    .UseRaskSqlite(connectionString)
                     .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));
+
+                // Continuous backup. Litestream streams the write-ahead log to object storage, which is what
+                // makes one box a safe place to keep your only copy: if the machine dies, a fresh one restores
+                // the database from the replica on startup and carries on. Durability stops depending on that
+                // one disk — the whole premise of running a real product on a single server.
+                //
+                // Inert until you point it somewhere. To turn it on:
+                //   rask deploy --env "Litestream__ReplicaUrl=s3://your-bucket/app"
+                // plus whatever credentials your provider needs (e.g. AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY).
+                // s3://, gcs://, abs:// and file:// replicas are all supported — see docs/sqlite.md.
+                var replicaUrl = builder.Configuration["Litestream:ReplicaUrl"];
+                if (!string.IsNullOrWhiteSpace(replicaUrl))
+                {
+                    builder.Services.AddRaskSqliteLitestream(o =>
+                    {
+                        o.DatabasePath = new SqliteConnectionStringBuilder(connectionString).DataSource;
+                        o.ReplicaUrl = replicaUrl;
+                    });
+                }
 
                 """.TrimStart('\n'));
         }
@@ -258,6 +285,23 @@ internal static partial class ProjectGenerator
             app.UseStatusCodePages();
 
             """.TrimStart('\n'));
+
+        if (data)
+        {
+            sb.Append("""
+
+                // Restore before anything opens the database (migrations, the first query). On a box that
+                // already has app.db this is a no-op and never clobbers it; on a fresh one it pulls the
+                // database back from the replica — which is the moment the "disposable box" promise is kept
+                // or broken. Guarded because RestoreSqliteFromLitestreamAsync throws when no replica is
+                // configured, and an app without one must still start.
+                if (!string.IsNullOrWhiteSpace(replicaUrl))
+                {
+                    await app.Services.RestoreSqliteFromLitestreamAsync();
+                }
+
+                """.TrimStart('\n'));
+        }
 
         if (auth)
         {
@@ -463,7 +507,23 @@ internal static partial class ProjectGenerator
 
         """;
 
-    private const string Dockerfile =
+    /// <summary>
+    /// The production image. With <c>--data</c> it also carries the <c>litestream</c> binary the app's
+    /// replicator drives: the wiring in Program.cs is inert without it, so shipping one without the other
+    /// would mean a "continuous backup" that silently never runs. Copied from Litestream's own published
+    /// image — one layer, no package manager, and the right architecture picked by the manifest.
+    /// </summary>
+    private static string Dockerfile(bool data) =>
+        data
+            ? DockerfileTemplate.Replace(
+                "@@LITESTREAM@@",
+                "\n# The replicator binary Program.cs drives when Litestream__ReplicaUrl is set (see docs/sqlite.md).\n"
+                + "COPY --from=litestream/litestream:0.3.13 /usr/local/bin/litestream /usr/local/bin/litestream\n",
+                StringComparison.Ordinal)
+            : DockerfileTemplate.Replace("@@LITESTREAM@@\n", string.Empty, StringComparison.Ordinal)
+                .Replace("@@LITESTREAM@@", string.Empty, StringComparison.Ordinal);
+
+    private const string DockerfileTemplate =
         """
         # Multi-stage build: compile on the .NET SDK image, run on the smaller aspnet runtime.
         # The aspnet:10.0 image already runs as a non-root user and listens on port 8080
@@ -480,6 +540,7 @@ internal static partial class ProjectGenerator
         FROM mcr.microsoft.com/dotnet/aspnet:10.0
         WORKDIR /app
         COPY --from=build /app .
+        @@LITESTREAM@@
 
         # A writable data directory for the SQLite database, owned by the image's non-root runtime user
         # ($APP_UID). `rask deploy` mounts a named volume here and points the app at /data/app.db (via

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -105,6 +105,53 @@ public sealed class ProjectGeneratorTests
         }
     }
 
+    /// <summary>
+    /// A database-backed app gets continuous backup wired in, inert until a replica URL is configured.
+    /// The framework's own deploy comments already assumed a replicator was running; before this, nothing
+    /// scaffolded ever started one.
+    /// </summary>
+    [Fact]
+    public void A_database_app_is_wired_for_continuous_backup()
+    {
+        var (files, result) = Generate(data: true);
+        var program = files["Program.cs"];
+
+        Assert.Contains("Rask.SQLite.Litestream", result.Packages);
+        Assert.Contains("Rask.SQLite.Litestream", files["App.csproj"], StringComparison.Ordinal);
+
+        // Inert by default: no replica URL, no replicator, and the app still starts.
+        Assert.Contains("""builder.Configuration["Litestream:ReplicaUrl"]""", program, StringComparison.Ordinal);
+        Assert.Contains("AddRaskSqliteLitestream", program, StringComparison.Ordinal);
+
+        // The restore must be guarded — RestoreSqliteFromLitestreamAsync throws when nothing is registered,
+        // so an unguarded call would stop every app without a replica from starting at all.
+        var restore = program.IndexOf("RestoreSqliteFromLitestreamAsync", StringComparison.Ordinal);
+        Assert.True(restore > 0, "the restore call is missing.");
+        Assert.Contains(
+            "if (!string.IsNullOrWhiteSpace(replicaUrl))",
+            program[..restore],
+            StringComparison.Ordinal);
+
+        // ...and it must run before anything opens the database.
+        Assert.True(
+            restore < program.IndexOf("app.UseRask<App>()", StringComparison.Ordinal),
+            "the restore must happen before the app starts serving.");
+    }
+
+    /// <summary>
+    /// The wiring is useless without the binary it drives, so the image carries one — but only when there
+    /// is a database to replicate.
+    /// </summary>
+    [Fact]
+    public void The_image_carries_the_replicator_binary_only_when_there_is_a_database()
+    {
+        var (withData, _) = Generate(data: true, docker: true);
+        Assert.Contains("COPY --from=litestream/litestream:", withData["Dockerfile"], StringComparison.Ordinal);
+
+        var (without, _) = Generate(docker: true);
+        Assert.DoesNotContain("litestream", without["Dockerfile"], StringComparison.OrdinalIgnoreCase);
+    }
+
     [Fact]
     public void The_shell_and_welcome_page_are_feature_slices_and_no_demo_files_are_scaffolded()
     {


### PR DESCRIPTION
> Stacked on #509 → #507 → #506 → #505 → #503 → #502.

## The incoherence this fixes

`Rask.SQLite.Litestream` shipped (494 LOC, 30 tests), was documented, and was referenced by **no template**.
So the default `rask new --data` → `rask deploy` path produced a live app whose only copy of the database
was a volume on one box — while `DeployCommand`'s own comments explained that its 20-second graceful stop
existed so *"the Litestream replicator flushes"*.

It was protecting a replicator that was never running. The one-box thesis rests on the box being
disposable, and nothing on the golden path made it so.

## What changed

`--data` now wires it, **inert until you point it somewhere**:

```csharp
var replicaUrl = builder.Configuration["Litestream:ReplicaUrl"];
if (!string.IsNullOrWhiteSpace(replicaUrl)) { builder.Services.AddRaskSqliteLitestream(…); }
```

So turning it on is one variable at deploy time rather than a docs safari:

```bash
rask deploy --env "Litestream__ReplicaUrl=s3://your-bucket/app"
```

`--docker` puts the binary in the image:

```dockerfile
COPY --from=litestream/litestream:0.3.13 /usr/local/bin/litestream /usr/local/bin/litestream
```

One layer from Litestream's own published image — no package manager, no download script, architecture
picked by the manifest. **Wiring without the binary would be a "continuous backup" that silently never
runs**, which is worse than none at all.

And every deploy without a replica now says so, rather than leaving it to prose the reader may never have
opened:

```
! No Litestream replica configured — this app's database exists only on this box's disk.
```

## Two things that would have shipped broken

- **`RestoreSqliteFromLitestreamAsync` throws** when no replica is registered. An unguarded call — the shape
  the tutorial shows, where a replica is always configured — would have stopped *every* app without one from
  starting. It's guarded, and there's a test asserting the guard is there and that the restore is ordered
  before anything opens the database.
- **The package reference was missing** from the generated csproj (the generator has two separate lists).
  The build gate caught it: 18/20 with `CS0234`. Now 20/20.

## Testing

- Scaffold build gate **20/20** — the wired app compiles.
- **711 CLI unit tests**, including that the restore is guarded, that it precedes `UseRask`, and that the
  binary is in the image only when there's a database to replicate.
- Deploy host gate **8/8**.
- Generated real projects with and without `--data` and inspected both Dockerfiles.

## Deliberately not in this PR

**`rask db backup` / `rask db restore`.** The plan paired these with the Litestream work, but they're a
distinct capability (pulling the deployed database down and pushing one back), each needing local and
remote paths plus a consistent-copy strategy, and this PR is already large. Doing them badly — a plain file
copy of a live SQLite database is *not* a valid backup — would be worse than not shipping them. Filed as a
follow-up with the design notes.

## Changelog

`[Unreleased] → Added`.