### PR TITLE
fix(cli)!: make the CLI honest about failure, and safe about overwriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **`rask new` no longer overwrites files it didn't create.** The guard checked only for the project file, so
+  scaffolding into a directory that already held a `Program.cs`, a `Features/` tree or a `wwwroot` silently
+  overwrote them — with no `--force` to consent to and nothing to undo it. Any existing file the template
+  would write now stops the command and lists what it would have replaced; `--force` opts in.
+- **A failed `dotnet restore` is reported as a failure.** It was a warning followed by exit `0`, so
+  `rask new && dotnet build` walked straight past a project whose packages hadn't restored. New
+  `--no-restore` covers the deliberate offline case.
+- **`rask generate` reports the packages it couldn't add.** A `dotnet add package` failure (offline, say)
+  printed a warning and exited `0` — a success from a project that cannot compile. Falling back to *printing*
+  the `Program.cs` registrations stays exit `0`: that's a documented fallback for a project shape Rask won't
+  edit blind, not a failed action.
+- **`rask generate --output` must stay inside the project.** `--output ../../..` wrote files outside it and
+  quietly gave them the root namespace instead of failing — generated code is namespaced by its folder, so a
+  folder outside the project can't produce a coherent one. Combining `--output` with `--feature` is also
+  rejected now instead of silently discarding `--feature`.
+- **`rask db drop` asks before dropping the database**, which its own `--force` help has always claimed it
+  did. `dotnet ef` prompts only when it has a terminal, so a drop run from a script destroyed the database
+  with nothing asked. Without a terminal it now refuses unless `--force` is given.
+- **`rask info` rejects arguments it doesn't understand**, instead of ignoring them and printing the plain
+  report for `rask info --json`.
+- **The pinned package version for generated projects is derived, not hardcoded.** It was a constant that had
+  rotted two minor versions behind the repo. A released CLI pins itself; a dev/CI prerelease walks back to
+  the release it came after.
+- **A filesystem error is a message, not a stack trace.** A read-only directory or a file held open by an
+  editor surfaced as an unhandled .NET exception, burying the one line naming the path. `RASK_DEBUG=1` still
+  prints the full trace.
+
+### Changed
+- **Usage errors exit with `2`**, distinct from `1` ("what you asked for failed"), so a script driving the
+  CLI can tell a mistyped invocation from a broken deploy. Exit codes are now documented in
+  [`cli.md`](docs/cli.md).
+
 ### Added
 - **Continuous backup is on the golden path.** `Rask.SQLite.Litestream` shipped, was documented, and was
   referenced by **no template** — so `rask new --data` → `rask deploy` produced a live app whose only copy of

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -89,6 +89,8 @@ Add pages and components to taste — `rask generate` is the fast path.
 | `--host` | `local` (default) or `server` — which native mode to scaffold (the `native` template only). |
 | `--output`, `-o` | Target directory (defaults to a folder named after the project). |
 | `--dry-run` | Print the files that would be created and write nothing (skips `dotnet restore`). |
+| `--force` | Scaffold into a directory that already contains files, overwriting on collision. Without it, any existing file the template would overwrite stops the command. |
+| `--no-restore` | Skip `dotnet restore` (for offline use). Without it, a restore failure is reported as a failure — the files are written, but the project won't build until it succeeds. |
 
 The flags wire a feature up; they don't scaffold sample pages for you to delete.
 
@@ -168,6 +170,17 @@ to create and apply with [`rask db`](#rask-db--ef-core-migrations) before it wor
 
 Every command has short aliases: `rask g` = `rask generate`, and `g f` / `g c` / `g p` scaffold a
 feature / component / page.
+
+### Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | Success. |
+| `1` | The command ran and what you asked for failed — a build error, an unreachable host, a refused deploy. |
+| `2` | The command line was wrong — an unknown option, a missing value, options that contradict each other. |
+| `130` | Interrupted with Ctrl+C. |
+
+The `1` / `2` split is what lets a script tell a broken invocation from a broken deploy.
 
 ## `rask dev` — run with hot reload
 

--- a/src/Rask.Cli/CliCommand.cs
+++ b/src/Rask.Cli/CliCommand.cs
@@ -46,7 +46,14 @@ internal abstract class CliCommand(IConsole console)
     /// <summary>Print a non-fatal caution (yellow) to stderr — the tool carries on.</summary>
     protected void WriteWarning(string message) => Console.WriteErrorLine(message, ConsoleStyle.Warning);
 
-    /// <summary>Report parse errors to stderr and return the conventional usage exit code.</summary>
+    /// <summary>
+    /// The exit code for "you typed something wrong", kept distinct from 1 ("what you asked for failed").
+    /// A script driving the CLI can then tell a broken invocation from a broken deploy, which is the whole
+    /// reason the convention exists.
+    /// </summary>
+    internal const int UsageExitCode = 2;
+
+    /// <summary>Report parse errors to stderr and return the usage exit code.</summary>
     protected int Fail(IReadOnlyList<string> errors)
     {
         foreach (var error in errors)
@@ -56,6 +63,6 @@ internal abstract class CliCommand(IConsole console)
 
         Console.Error.WriteLine($"Usage: {Usage}");
         Console.Error.WriteLine($"Run 'rask {Name} --help' for details.");
-        return 1;
+        return UsageExitCode;
     }
 }

--- a/src/Rask.Cli/Commands/DbCommand.cs
+++ b/src/Rask.Cli/Commands/DbCommand.cs
@@ -118,6 +118,25 @@ internal sealed class DbCommand(IConsole console, IFileSystem fileSystem, IProce
         // same project that owns the migrations, so it defaults to --project.
         var startupProject = parsed.Option("startup-project") ?? project;
 
+        // `--force`'s own help has always said it "skips the confirmation prompt" — and there was no
+        // prompt. `dotnet ef database drop` does its own, but only when it has a terminal, so a drop run
+        // from a script destroyed the database with nothing asked. Ask here, where we know the answer
+        // matters, and refuse rather than guess when there's nobody to ask.
+        if (subcommand == "drop" && !parsed.HasFlag("force"))
+        {
+            if (Console.IsInputRedirected)
+            {
+                Console.WriteErrorLine("`rask db drop` deletes the database. Pass --force to confirm — there's no terminal to ask on.", ConsoleStyle.Error);
+                return 1;
+            }
+
+            if (!new Prompt(Console).Confirm($"Drop the database for '{Path.GetFileName(startupProject)}'? This deletes it and everything in it.", @default: false))
+            {
+                Console.Out.WriteLine("Left it alone.");
+                return 0;
+            }
+        }
+
         if (!await EfToolProbe.EnsureAsync(_process, Console, cancellationToken).ConfigureAwait(false))
         {
             return 1;

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -98,6 +98,19 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         _ => $"{string.Join(", ", items.Take(items.Count - 1))}, and {items[^1]}",
     };
 
+    /// <summary>
+    /// Set when a step we <em>attempted</em> failed — adding a package the generated code needs. The files
+    /// are written and correct, but the project cannot build, so the command must not report success:
+    /// before this, an offline `rask generate feature` exited 0 with its packages missing and a script or
+    /// CI step carried straight on.
+    ///
+    /// <para>Deliberately not set when we <em>declined</em> to act — a Program.cs that isn't top-level
+    /// statements gets its registrations printed instead of spliced. That's a documented fallback for a
+    /// project shape we won't edit blind, not a failure, and treating it as one would make every generate
+    /// in such a project exit non-zero.</para>
+    /// </summary>
+    private bool _wiringIncomplete;
+
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
         if (args.Count == 0)
@@ -154,6 +167,17 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         // --feature co-locates a component/job/email into a slice folder. It's meaningless for a page (its
         // slice comes from the class name) and for a feature (which *is* a slice), so reject it there.
         var feature = parsed.Option("feature");
+
+        // --output names the folder outright; --feature asks for one to be chosen. Passing both looks like
+        // it should co-locate inside the output folder, but --output simply wins and --feature is
+        // discarded — so the file lands somewhere the user didn't ask for, under a namespace they didn't
+        // expect. Reject the combination rather than silently pick one.
+        if (feature is not null && parsed.Option("output") is not null)
+        {
+            Console.Error.WriteLine("--output and --feature can't be combined — --output already says where the file goes.");
+            return CliCommand.UsageExitCode;
+        }
+
         if (feature is not null && kind is "page" or "feature")
         {
             Console.Error.WriteLine("--feature only applies to 'generate component', 'job', or 'email'.");
@@ -200,6 +224,20 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             return 1;
         }
 
+        // --output names a folder INSIDE the project: the namespace is derived from its path, so a folder
+        // outside can't produce a coherent one. It used to be accepted — files were written outside the
+        // project and quietly given the root namespace instead of failing.
+        if (parsed.Option("output") is { } outputOverride)
+        {
+            var target = Scaffold.TargetDirectory(_workingDirectory, outputOverride);
+            if (!Scaffold.IsInside(project.ProjectDirectory, target))
+            {
+                Console.WriteErrorLine($"--output '{outputOverride}' resolves outside the project ({target}).", ConsoleStyle.Error);
+                Console.Error.WriteLine($"Generated code is namespaced by its folder, so it has to live under '{project.ProjectDirectory}'.");
+                return CliCommand.UsageExitCode;
+            }
+        }
+
         if (!TryBuild(kind, name, project, parsed, out var result, out var buildError))
         {
             Console.Error.WriteLine(buildError);
@@ -236,6 +274,15 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         if (written == 0)
         {
             WriteNotes(result.Notes);
+        }
+
+        if (written == 0 && _wiringIncomplete)
+        {
+            Console.Out.WriteLine();
+            Console.WriteErrorLine(
+                "The files were written, but the wiring above didn't complete — the project won't build until you finish it.",
+                ConsoleStyle.Error);
+            return 1;
         }
 
         return written;
@@ -554,6 +601,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
     private void PrintManualRegistrations(ScaffoldResult result, string heading)
     {
+
         Console.WriteLine(heading, ConsoleStyle.Dim);
         foreach (var ns in result.ProgramUsings)
         {
@@ -597,6 +645,7 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             if (exit != 0)
             {
                 var manual = isRask ? $"dotnet add package {package} --version {raskVersion}" : $"dotnet add package {package}";
+                _wiringIncomplete = true;
                 WriteWarning($"  Couldn't add {package} automatically — add it manually: {manual}");
             }
         }

--- a/src/Rask.Cli/Commands/InfoCommand.cs
+++ b/src/Rask.Cli/Commands/InfoCommand.cs
@@ -20,6 +20,13 @@ internal sealed class InfoCommand(IConsole console, IProcessRunner process) : Cl
 
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
+        // Every other command rejects what it doesn't understand; this one used to ignore its arguments
+        // entirely, so `rask info --json` "succeeded" while quietly printing the plain report.
+        if (args.Count > 0)
+        {
+            return Fail([$"'{args[0]}' isn't an option of `rask info`."]);
+        }
+
         var sdkVersion = await CaptureSingleLineAsync(["--version"], cancellationToken).ConfigureAwait(false);
 
         Console.Out.WriteLine(FormatReport(CliMetadata.Version, sdkVersion, RuntimeInformation.OSDescription));

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Rask.Cli.Scaffolding;
 using Rask.Cli.Templates;
 
@@ -19,10 +20,6 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     /// <summary>The opt-in feature flags <c>rask new</c> forwards to a template (as <c>--flag</c>).</summary>
     internal static readonly string[] FeatureFlags = ["auth", "pwa", "cqrs", "data", "docker"];
 
-    // Latest published stable used when the running CLI's own version isn't a resolvable package (a dev/CI
-    // build stamps a prerelease like "0.17.1-alpha.0.5+sha" that isn't on NuGet). PR5's INuGetClient will
-    // resolve this live; until then a known-good stable keeps generated projects restorable.
-    private const string LatestStableFallback = "0.17.0";
 
     public override string Name => "new";
 
@@ -57,6 +54,8 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             .Flag("cqrs", description: "Wire up Rask.Cqrs (server template only).")
             .Flag("data", description: "Pre-wire SQLite + EF Core: an AppDbContext ready for `rask generate feature --context AppDbContext` (server only).")
             .Flag("docker", description: "Add a Dockerfile and .dockerignore for container deploys.")
+            .Flag("no-restore", description: "Don't run dotnet restore after scaffolding (for offline use).")
+            .Flag("force", description: "Scaffold into a directory that already has files in it, overwriting on collision.")
             .Flag("dry-run", description: "Print the files that would be written without touching disk.");
 
     public override Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken) =>
@@ -140,7 +139,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             }
 
             return await GenerateDirectAsync(
-                template, name, parsed.Option("output"), parsed.HasFlag("dry-run"),
+                template, name, parsed.Option("output"), parsed.HasFlag("dry-run"), parsed.HasFlag("force"), parsed.HasFlag("no-restore"),
                 (dir, version) => ProjectGenerator.GenerateNative(dir, name, host, version),
                 cancellationToken).ConfigureAwait(false);
         }
@@ -148,7 +147,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         // Every web template is generated directly by the CLI (server, wasm, wasm-hosted). native is handled
         // above with its own shape; the key here is one of those three (validated by TemplateCatalog.TryGet).
         return await GenerateDirectAsync(
-            template, name, parsed.Option("output"), parsed.HasFlag("dry-run"),
+            template, name, parsed.Option("output"), parsed.HasFlag("dry-run"), parsed.HasFlag("force"), parsed.HasFlag("no-restore"),
             (dir, version) =>
             {
                 bool auth = requestedFlags.Contains("auth"), pwa = requestedFlags.Contains("pwa"),
@@ -200,7 +199,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     }
 
     private async Task<int> GenerateDirectAsync(
-        TemplateInfo template, string name, string? output, bool dryRun,
+        TemplateInfo template, string name, string? output, bool dryRun, bool force, bool noRestore,
         Func<string, string, ScaffoldResult> build, CancellationToken cancellationToken)
     {
         // rask new MyApp → ./MyApp/ ; --output overrides the destination directory.
@@ -227,11 +226,35 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         var restoreTarget = result.RestoreTarget is { } relative
             ? Path.Combine(targetDirectory, relative)
             : Path.Combine(targetDirectory, name + ".csproj");
-        if (_fileSystem.FileExists(restoreTarget))
+        // The guard used to check only for the restore target, so scaffolding over a directory that already
+        // held a Program.cs, a Features/ tree or a wwwroot silently overwrote them — with no --force to
+        // consent to it and nothing to undo it. Any existing file is now enough to stop.
+        if (!force)
         {
-            var existing = Path.GetFileName(restoreTarget);
-            Console.Error.WriteLine($"A project already exists at '{targetDirectory}' ({existing}). Choose another name or --output.");
-            return 1;
+            if (_fileSystem.FileExists(restoreTarget))
+            {
+                var existing = Path.GetFileName(restoreTarget);
+                Console.Error.WriteLine($"A project already exists at '{targetDirectory}' ({existing}). Choose another name, --output, or pass --force.");
+                return 1;
+            }
+
+            var clashes = result.Files.Where(f => _fileSystem.FileExists(f.Path)).ToArray();
+            if (clashes.Length > 0)
+            {
+                Console.WriteErrorLine($"'{targetDirectory}' already contains files this would overwrite:", ConsoleStyle.Error);
+                foreach (var clash in clashes.Take(5))
+                {
+                    Console.Error.WriteLine($"  {Path.GetRelativePath(_workingDirectory, clash.Path)}");
+                }
+
+                if (clashes.Length > 5)
+                {
+                    Console.Error.WriteLine($"  …and {(clashes.Length - 5).ToString(CultureInfo.InvariantCulture)} more");
+                }
+
+                Console.Error.WriteLine("Choose another name or --output, or pass --force to overwrite.");
+                return 1;
+            }
         }
 
         WriteHeading($"Creating {template.DisplayName} '{name}'…");
@@ -248,18 +271,34 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         }
 
         // Package refs are already baked into the csproj(s) at the pinned version; restore pulls them so the
-        // project builds immediately. A restore failure is a warning — the files are written and correct.
-        Console.WriteLine("Restoring packages…", ConsoleStyle.Dim);
-        var restore = await _process.RunAsync("dotnet", ["restore", restoreTarget], targetDirectory, cancellationToken).ConfigureAwait(false);
-        if (restore != 0)
+        // project builds immediately. The files on disk are complete and correct either way — but a failed
+        // restore leaves a project that won't build, so it is reported as a failure rather than a warning
+        // that `rask new && dotnet build` would step straight past. --no-restore skips it deliberately.
+        var restoreFailed = false;
+        if (noRestore)
         {
-            WriteWarning("  Couldn't restore automatically — run 'dotnet restore' in the project directory.");
+            Console.WriteLine("Skipped restore (--no-restore) — run 'dotnet restore' before building.", ConsoleStyle.Dim);
+        }
+        else
+        {
+            Console.WriteLine("Restoring packages…", ConsoleStyle.Dim);
+            restoreFailed = await _process.RunAsync("dotnet", ["restore", restoreTarget], targetDirectory, cancellationToken).ConfigureAwait(false) != 0;
         }
 
         if (!string.IsNullOrEmpty(result.Notes))
         {
             Console.Out.WriteLine();
             Console.Out.WriteLine(result.Notes);
+        }
+
+        if (restoreFailed)
+        {
+            Console.Out.WriteLine();
+            Console.WriteErrorLine(
+                $"The project was written to '{targetDirectory}', but restoring its packages failed — it won't build until that succeeds.",
+                ConsoleStyle.Error);
+            Console.Error.WriteLine("Run 'dotnet restore' there once you're online, or re-run with --no-restore to skip this step.");
+            return 1;
         }
 
         return 0;
@@ -269,10 +308,55 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     /// Resolve the package version to pin in a generated project: the CLI's own version when it's a published
     /// stable, else the latest-stable fallback (a dev/CI prerelease isn't on NuGet). Pure — unit-tested directly.
     /// </summary>
-    internal static string ResolvePackageVersion(string cliVersion) =>
-        !string.IsNullOrEmpty(cliVersion)
-        && !cliVersion.Contains('-', StringComparison.Ordinal)
-        && cliVersion != "0.0.0"
-            ? cliVersion
-            : LatestStableFallback;
+    /// <summary>
+    /// The version to pin generated <c>PackageReference</c>s at.
+    ///
+    /// <para>A released CLI stamps a stable version and pins itself — the CLI and the packages ship under
+    /// one tag, so a project is pinned to the CLI that made it. A dev or CI build stamps a MinVer
+    /// prerelease (<c>0.19.1-alpha.0.5+sha</c>) that was never published, and pinning that would produce a
+    /// project which cannot restore.</para>
+    ///
+    /// <para>So a prerelease is walked back to the release it came after. MinVer names a prerelease for the
+    /// version it is <em>heading towards</em>, bumping the patch: the build after <c>v0.19.0</c> is
+    /// <c>0.19.1-alpha.N</c>, whose last published predecessor is <c>0.19.0</c>. This used to be a
+    /// hardcoded constant, which silently rotted two minor versions behind the repo.</para>
+    /// </summary>
+    internal static string ResolvePackageVersion(string cliVersion)
+    {
+        if (string.IsNullOrEmpty(cliVersion) || cliVersion == "0.0.0")
+        {
+            return cliVersion;
+        }
+
+        var dash = cliVersion.IndexOf('-', StringComparison.Ordinal);
+        if (dash < 0)
+        {
+            return cliVersion; // a released build: pin to itself
+        }
+
+        var parts = cliVersion[..dash].Split('.');
+        if (parts.Length != 3
+            || !int.TryParse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture, out var minor)
+            || !int.TryParse(parts[2], NumberStyles.None, CultureInfo.InvariantCulture, out var patch))
+        {
+            return cliVersion;
+        }
+
+        // 0.19.1-alpha.N came after v0.19.0 (MinVer's default patch bump).
+        if (patch > 0)
+        {
+            return $"{parts[0]}.{parts[1]}.{(patch - 1).ToString(CultureInfo.InvariantCulture)}";
+        }
+
+        // 0.18.0-alpha.N came after a v0.17.x — which patch, we can't know, but .0 was certainly published
+        // and restores fine. Pinning slightly behind the newest release beats not restoring at all.
+        if (minor > 0)
+        {
+            return $"{parts[0]}.{(minor - 1).ToString(CultureInfo.InvariantCulture)}.0";
+        }
+
+        // 1.0.0-alpha.N — nothing published under this major to walk back to. Pinning a guess would be
+        // worse than pinning the prerelease, which at least fails loudly and legibly at restore.
+        return cliVersion;
+    }
 }

--- a/src/Rask.Cli/Program.cs
+++ b/src/Rask.Cli/Program.cs
@@ -30,6 +30,20 @@ catch (OperationCanceledException)
     // Ctrl+C: exit cleanly with the conventional SIGINT code, not an unhandled-exception stack trace.
     return 130;
 }
+catch (Exception exception) when (exception is IOException or UnauthorizedAccessException or NotSupportedException)
+{
+    // The filesystem said no — a read-only directory, a full disk, a file held open by an editor. The
+    // scaffolder writes through raw File/Directory calls, so before this these surfaced as a .NET stack
+    // trace: alarming, and it buried the one line that says which path failed.
+    SystemConsole.Instance.WriteErrorLine(exception.Message, ConsoleStyle.Error);
+    SystemConsole.Instance.Error.WriteLine("Check the path is writable and not open elsewhere. Set RASK_DEBUG=1 for the full stack trace.");
+    if (Environment.GetEnvironmentVariable("RASK_DEBUG") == "1")
+    {
+        SystemConsole.Instance.Error.WriteLine(exception.ToString());
+    }
+
+    return 1;
+}
 finally
 {
     Console.CancelKeyPress -= OnCancel;

--- a/src/Rask.Cli/Scaffolding/Scaffold.cs
+++ b/src/Rask.Cli/Scaffolding/Scaffold.cs
@@ -21,6 +21,27 @@ internal static class Scaffold
         return Path.Combine(parts);
     }
 
+
+    /// <summary>
+    /// Is <paramref name="target"/> inside <paramref name="baseDirectory"/>?
+    ///
+    /// <para>Used by <c>rask generate</c>, whose <c>--output</c> names a folder <em>within the project</em>
+    /// — the namespace is derived from that folder's path, so a directory outside it can't produce a
+    /// coherent one. Before this, <c>--output ../../..</c> wrote files outside the project and quietly fell
+    /// back to the root namespace instead of failing. (<c>rask new --output</c> is different: naming a
+    /// directory anywhere is the whole point, so it doesn't use this.)</para>
+    /// </summary>
+    public static bool IsInside(string baseDirectory, string target)
+    {
+        var root = Path.TrimEndingDirectorySeparator(Path.GetFullPath(baseDirectory));
+        var full = Path.TrimEndingDirectorySeparator(Path.GetFullPath(target));
+        return full.Equals(root, PathComparison)
+            || full.StartsWith(root + Path.DirectorySeparatorChar, PathComparison);
+    }
+
+    /// <summary>Paths compare case-insensitively where the filesystem does.</summary>
+    private static StringComparison PathComparison =>
+        OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase;
     /// <summary>
     /// The default folder segments for a cross-cutting artifact (component/job/email): its own feature slice
     /// <c>Features/&lt;Feature&gt;</c> when <c>--feature</c> names one, otherwise the shared bucket

--- a/tests/Rask.Cli.Tests/CommandHelpTests.cs
+++ b/tests/Rask.Cli.Tests/CommandHelpTests.cs
@@ -85,7 +85,7 @@ public sealed class CommandHelpTests
 
         var exit = await app.RunAsync(["new", "--nope"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("Run 'rask new --help' for details.", console.ErrorText, StringComparison.Ordinal);
     }
 }

--- a/tests/Rask.Cli.Tests/DevCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DevCommandTests.cs
@@ -67,7 +67,7 @@ public sealed class DevCommandTests
 
         var exit = await command.ExecuteAsync(["--bogus"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
     }
 }

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -911,4 +911,31 @@ public sealed class GenerateCommandTests
         fs.Seed("/proj/MyApp.csproj", "<Project></Project>");
         return (console, fs, process, new GenerateCommand(console, fs, process, ProjectDir));
     }
+    // ── Argument discipline (PR: CLI robustness) ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Output_outside_the_project_is_refused()
+    {
+        // Generated code is namespaced by its folder, so a folder outside the project can't produce a
+        // coherent namespace. This used to write the files anyway and silently fall back to the root one.
+        var (console, _, command) = Build();
+
+        var exit = await command.ExecuteAsync(["component", "Widget", "--output", "../../../etc"], CancellationToken.None);
+
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("resolves outside the project", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Output_and_feature_together_are_refused()
+    {
+        // --output silently won and --feature was discarded, so the file landed somewhere the user didn't
+        // ask for, under a namespace they didn't expect.
+        var (console, _, command) = Build();
+
+        var exit = await command.ExecuteAsync(["component", "Widget", "--output", "Widgets", "--feature", "Orders"], CancellationToken.None);
+
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("--output and --feature", console.ErrorText, StringComparison.Ordinal);
+    }
 }

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -6,13 +6,25 @@ public sealed class NewCommandTests
 {
     private const string WorkingDirectory = "/proj";
 
+    /// <summary>
+    /// A released CLI pins generated projects to itself. A dev/CI build stamps a MinVer prerelease that was
+    /// never published, so it walks back to the release it came after — MinVer names a prerelease for the
+    /// version it is heading towards, bumping the patch, so 0.19.1-alpha.N came after 0.19.0.
+    ///
+    /// <para>This was a hardcoded "0.17.0" that silently rotted two minor versions behind the repo. Derived,
+    /// it can't.</para>
+    /// </summary>
     [Theory]
-    [InlineData("0.17.0", "0.17.0")]      // a published stable pins exactly
+    [InlineData("0.17.0", "0.17.0")]                 // a published stable pins exactly
     [InlineData("1.2.3", "1.2.3")]
-    [InlineData("0.18.0-alpha.0.5", "0.17.0")] // a dev/CI prerelease isn't on NuGet → fall back
-    [InlineData("0.0.0", "0.17.0")]       // the no-version sentinel → fall back
-    [InlineData("", "0.17.0")]
-    public void ResolvePackageVersion_falls_back_for_unpublishable_versions(string cliVersion, string expected) =>
+    [InlineData("0.18.0-alpha.0.5", "0.17.0")]       // dev build after v0.17.0
+    [InlineData("0.19.1-alpha.0.5+abc123", "0.19.0")] // ...and after v0.19.0
+    [InlineData("2.0.4-beta.1", "2.0.3")]
+    [InlineData("0.0.0", "0.0.0")]                   // the no-version sentinel: nothing to derive from
+    [InlineData("", "")]
+    [InlineData("0.20.0-alpha.0.1", "0.19.0")]       // a minor bump: .0 of the previous minor was published
+    [InlineData("1.0.0-alpha.1", "1.0.0-alpha.1")]   // nothing published under this major to walk back to
+    public void ResolvePackageVersion_walks_a_prerelease_back_to_its_release(string cliVersion, string expected) =>
         Assert.Equal(expected, NewCommand.ResolvePackageVersion(cliVersion));
 
     [Fact]
@@ -249,6 +261,65 @@ public sealed class NewCommandTests
         Assert.Contains("does not support: --cqrs", console.ErrorText, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The guard used to check only for the restore target, so scaffolding into a directory that already
+    /// held a Program.cs or a Features/ tree overwrote it — silently, with no --force to consent to and
+    /// nothing to undo it.
+    /// </summary>
+    [Fact]
+    public async Task Scaffolding_over_existing_files_is_refused_without_force()
+    {
+        var (console, fs, runner, command) = Build();
+        fs.Seed("/proj/MyApp/Program.cs", "// something the user wrote");
+
+        var exit = await command.ExecuteAsync(["MyApp"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Program.cs", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("--force", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal("// something the user wrote", fs.Files[Path.GetFullPath("/proj/MyApp/Program.cs")]);
+        Assert.Empty(runner.Invocations);
+    }
+
+    [Fact]
+    public async Task Force_scaffolds_over_them()
+    {
+        var (_, fs, _, command) = Build();
+        fs.Seed("/proj/MyApp/Program.cs", "// something the user wrote");
+
+        var exit = await command.ExecuteAsync(["MyApp", "--force"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.DoesNotContain("something the user wrote", fs.Files[Path.GetFullPath("/proj/MyApp/Program.cs")], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_failed_restore_is_reported_as_a_failure()
+    {
+        // The files are written and correct, but the project won't build — and `rask new && dotnet build`
+        // would otherwise step straight past it.
+        var (console, _, runner, command) = Build();
+        runner.RunExitCode = 1;
+
+        var exit = await command.ExecuteAsync(["MyApp"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("restoring its packages failed", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task No_restore_skips_it_and_succeeds()
+    {
+        var (console, _, runner, command) = Build();
+        runner.RunExitCode = 1; // would fail if it ran
+
+        var exit = await command.ExecuteAsync(["MyApp", "--no-restore"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Empty(runner.Invocations);
+        Assert.Contains("Skipped restore", console.OutText, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task Unknown_option_fails()
     {
@@ -256,7 +327,9 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["MyApp", "--frobnicate"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        // 2, not 1: "you typed something wrong" is a different outcome from "what you asked for failed",
+        // and a script driving the CLI should be able to tell them apart.
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("--frobnicate", console.ErrorText, StringComparison.Ordinal);
     }


### PR DESCRIPTION
> Stacked on #511 → #509 → #507 → #506 → #505 → #503 → #502.

## Summary

Eight defects from the audit, all one family: **the tool reporting success when it hadn't succeeded, or
doing something destructive without asking.**

| # | Before | Now |
|---|--------|-----|
| 1 | `rask new` checked only for the project file, so scaffolding into a directory holding a `Program.cs`, `Features/` or `wwwroot` **silently overwrote them** — no `--force` to consent to, nothing to undo | Any file the template would replace stops the command and is listed; `--force` opts in |
| 2 | A failed `dotnet restore` was a warning + **exit 0** — `rask new && dotnet build` walked past a project whose packages hadn't restored | Reported as a failure; `--no-restore` for the deliberate offline case |
| 3 | `rask generate` exited **0** when `dotnet add package` failed — success from a project that can't compile | Non-zero, with the packages named |
| 4 | `--output ../../..` wrote **outside the project** and quietly used the root namespace | Refused — generated code is namespaced by its folder |
| 5 | `--output` + `--feature` silently discarded `--feature` | Refused |
| 6 | `rask db drop` **never prompted**, though `--force`'s help has always said it skipped a prompt. `dotnet ef` prompts only with a terminal, so a scripted drop destroyed the database with nothing asked | Prompts; without a terminal it refuses unless `--force` |
| 7 | `rask info` ignored its arguments — `rask info --json` "succeeded" | Rejected |
| 8 | The pinned package version was a constant that had **rotted two minor versions** behind the repo | Derived from the CLI's own version |

Plus: a read-only directory or a file held open by an editor surfaced as an **unhandled stack trace**,
burying the one line naming the path. Now a message; `RASK_DEBUG=1` still gives the trace.

## One judgement call the tests pushed back on

My first cut also made the **`Program.cs` splice fallback** non-zero. That turned ~10 existing tests red, and
looking at why, they were right: a project whose `Program.cs` isn't top-level statements gets its
registrations *printed* instead of spliced, and that's a documented fallback for a shape Rask deliberately
won't edit blind — not a failure. Making it exit non-zero would mean **every** `rask generate` in such a
project reports failure.

So the rule is now: **a step we attempted and that failed** is non-zero (adding packages); **a step we
declined to take** is not (the splice). That distinction is in the code as a comment, because it's the kind
of thing that gets "simplified" back.

## Breaking

Usage errors exit **2** instead of 1, so a script can tell a mistyped invocation from a failed deploy.
Documented in `cli.md` with the full table. Pre-1.0, and it only affects scripts branching on exit 1 for
*argument* errors.

## Testing

**721 CLI unit tests** (up from 715), including: scaffolding over an existing file is refused and the file is
untouched, `--force` overwrites, a failed restore fails, `--no-restore` doesn't run one, `--output` outside
the project is refused, and the version derivation across released / patch-bump / minor-bump / pre-1.0
prerelease shapes.

Scaffold build gate 20/20; `run-unit-local.sh` green.

## Changelog

`[Unreleased] → Fixed` and `→ Changed`.