### PR TITLE
docs: say what isn't shipped, and make every guide findable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Docs
+- **The roadmap says what isn't shipped, not only what is.** Every pillar was marked ✅, which made the page
+  useless for the decision it exists to support — whether Rask fits your product. A new **Not shipped**
+  section names the gaps and what to reach for instead: a **user store and account lifecycle** (registration,
+  password hashing, reset, lockout, MFA), **file/blob storage**, **rate limiting** (including the absence of
+  any login-attempt throttle), and a **dead-letter surface** for jobs/mail/outbox, which retry, give up, and
+  leave the row with nothing to show you it happened.
+- **Auth is split into what ships and what doesn't.** The sign-in machinery is real — cookie and JWT
+  sessions, claims, authorization, hardening guidance — but `rask new --auth` scaffolds a *demo* credential
+  store with hardcoded logins, and one ✅ covering both read as a user system that exists. The doctrine
+  page's battery list and its "everything a solo developer needs" claim now carry the same caveat.
+- **Every doc is reachable from the docs index**, which the doctrine page calls "the full map".
+  `elements.md` (the DSL reference) and `repo-administration.md` were reachable from nothing at all; the
+  operationally important `observability.md` and `configuration.md` now have index rows of their own rather
+  than being buried a level down. A new test enforces reachability — links through a hub page count, since
+  the docs are deliberately hub-and-subpage; being findable from *nowhere* is the failure.
+
 ### Fixed
 - **`rask new` no longer overwrites files it didn't create.** The guard checked only for the project file, so
   scaffolding into a directory that already held a `Program.cs`, a `Features/` tree or a `wwwroot` silently

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ and reach for the [**Recipes**](recipes.md) when you need "how do I do X?".
 | [The `rask` CLI](cli.md) | The `Rask.Cli` .NET tool — the whole lifecycle: `rask new` (scaffold), `rask generate` (pages, components, CRUD slices), `rask db` (migrations), `rask dev` (hot-reload run), `rask deploy` (bare box → live HTTPS site), `rask info`. |
 | [Live playground](playground.md) | Write Rask C# in the browser with IntelliSense, as-you-type diagnostics, and a gallery of examples, then see it compile & render live (Roslyn in WebAssembly) — how it works, the entry-point convention, and its limitations. |
 | [Best practices](best-practices.md) | Production patterns and common pitfalls across component design, state, forms, data access, security, accessibility, performance and testing — each linking to the deep dive. |
+| [Elements & the DSL](elements.md) | The primitives every component is built from: tag factories, universal attributes, the children indexer, `Text`/`Raw`, SVG, and the element catalog. |
 | [Routing](routing.md) | `[Route]`, route/query params, nested routes, type-safe `Routes.*` URLs, `Navigator`, `RouteState`. |
 | [Composition](composition.md) | Children & fragments, callbacks (child→parent), context (provide/consume), toast messages (`IToaster`/`ToastOutlet`), `VirtualizeModel`, drag-and-drop. |
 | [JS interop](js-interop.md) | Scoped CSS & JS conventions, calling JS via `IJSRuntime`, element refs (`Ref:`), typed browser APIs, asset delivery. |
@@ -61,6 +62,8 @@ in the [Tutorial](tutorial/00-overview.md); the reference for each is here.
 | [Outbox](outbox.md) | Durable, crash-safe domain-event delivery via `AddRaskOutbox<Ctx>()` (standalone `Rask.Outbox`) — events committed in the same transaction as your data, delivered post-commit with retries. |
 | [Web Push](webpush.md) | Server-sent Web Push from your backend via `AddRaskWebPush(...)` + `IWebPushSender` (standalone `Rask.WebPush`) — VAPID + aes128gcm, zero deps; pairs with the client `IWebPush`. |
 | [Secrets](secrets.md) | Where an app's passwords and API keys live, how they reach the server, and what Rask deliberately doesn't do with them. |
+| [Observability](observability.md) | Structured logging, the `Rask.Server` meter and activity source, health checks — what to export and what the numbers mean. |
+| [Configuration](configuration.md) | The options every host reads, and where to set them. |
 | [Deployment](deployment.md) | Ship to a single box with `rask deploy`: Docker over SSH, a shared Caddy proxy for automatic HTTPS, zero-downtime blue-green swaps gated on `/health`, and bare-VPS setup. |
 
 ## Bootstrap components
@@ -99,6 +102,7 @@ its own page:
 | Doc | What it covers |
 |-----|----------------|
 | [Development workflow](development-workflow.md) | The format → warnings-as-errors → tests → benchmarks → docs → review → PR gate, CI, nightly, releases. |
+| [Repo administration](repo-administration.md) | Branch protection, required checks, secrets, and the settings this repository expects. |
 
 ## Architecture
 

--- a/docs/one-person-framework.md
+++ b/docs/one-person-framework.md
@@ -70,10 +70,19 @@ Everything a solo developer needs to go from empty folder to shipped, in the box
 | **[`Rask.Cache`](cache.md)** | A database-backed cache: the standard `IDistributedCache` plus a typed `ICache` with `GetOrCreateAsync` and absolute/sliding expiry. |
 | **[`Rask.Outbox`](outbox.md)** | Transactional outbox — domain events captured in the same transaction and relayed at-least-once, no external broker. |
 | **[Production SQLite](sqlite.md)** | WAL + busy-timeout pragmas, continuous backup (Litestream), scheduled snapshots. |
-| **[Auth](authentication.md)** | Cookie & JWT login/session scaffolding in the templates. |
+| **[Auth](authentication.md)** | Cookie & JWT sessions, claims and authorization. The **user store is yours** — `--auth` scaffolds a demo one; see the [roadmap](roadmap.md#not-shipped). |
 | **[PWA & native](pwa.md)** | Installable offline apps and real iOS/Android from the same components. |
 | **[Web Push](webpush.md)** | Server-sent Web Push on your own VAPID keys (RFC 8292/8291), zero external deps — pairs with the client `IWebPush`. |
+| **[Secrets](secrets.md)** | Environment variables, remembered by name so a redeploy can't silently drop one. No vault or rotation. |
 | **[Deploy](deployment.md)** | `rask deploy` takes a bare VPS to a live HTTPS site — installs Docker, a non-root deploy login, a firewall and SSH hardening, then builds on the box and swaps in with zero downtime. No SSH session of your own required. |
+
+## What isn't in the box
+
+The claim above is "everything a solo developer needs to go from empty folder to shipped", and it's worth
+being precise about the edges. Rask does **not** ship a user store (registration, password hashing, reset,
+MFA — `--auth` scaffolds a demo credential store you replace), file/blob storage, rate limiting, or a
+secret store beyond environment variables. The [roadmap](roadmap.md#not-shipped) lists each one and what
+you'd reach for instead. Knowing that before you start is worth more than a longer list of batteries.
 
 ## DB-backed by default
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,6 +8,8 @@ service to operate.
 
 ## Shipped
 
+✅ shipped · ◐ partly, with documented limits · ❌ [not shipped](#not-shipped)
+
 | Pillar | Status | Where |
 |--------|--------|-------|
 | **UI across three hosts** | ✅ | Server (WebSocket live diff), WASM (client-side + PWA), Native iOS/Android *(preview)* — one component. |
@@ -20,10 +22,14 @@ service to operate.
 | **Transactional email** | ✅ | [`Rask.Mail`](mail.md) — durable email queued on the app's own database, delivered off the request thread over SMTP; bodies are Rask components. |
 | **Cache** | ✅ | [`Rask.Cache`](cache.md) — a developer-facing cache on the app's own database; standard `IDistributedCache` plus a typed `ICache` with `GetOrCreateAsync`, absolute/sliding expiry. |
 | **Production SQLite** | ✅ | [`sqlite.md`](sqlite.md) — WAL/busy-timeout pragmas, continuous backup (Litestream), snapshots. |
-| **Auth** | ✅ | [`authentication.md`](authentication.md) — cookie & JWT login/session in the templates. |
+| **Auth — sign-in** | ✅ | [`authentication.md`](authentication.md) — cookie & JWT sessions, claims, authorization, and hardening guidance. |
+| **Auth — user store** | ❌ | Not shipped. `rask new --auth` scaffolds a **demo** `ICredentialStore` with hardcoded logins, clearly marked as such; you supply the real one. See [below](#not-shipped). |
 | **PWA & native** | ✅ | [`pwa.md`](pwa.md) / [`native.md`](native.md). |
 | **Web Push (server send)** | ✅ | [`webpush.md`](webpush.md) — `Rask.WebPush`: VAPID (RFC 8292) + aes128gcm (RFC 8291), zero deps. |
 | **Deploy to one box** | ✅ | [`rask deploy`](cli.md) — bare-VPS setup (Docker, deploy login, firewall, SSH hardening), build over SSH, zero-downtime, auto-HTTPS (Caddy), multi-app on one host, GitHub Actions. |
+| **Operate what you shipped** | ✅ | [`rask deploy status` / `logs` / `rollback`](cli.md) — what's running, its logs, and putting the previous image back. |
+| **Continuous backup** | ✅ | [`sqlite.md`](sqlite.md) — `rask new --data` wires [Litestream](sqlite.md#continuous-backup-with-litestream); one variable at deploy time turns it on. |
+| **Secrets** | ◐ | [`secrets.md`](secrets.md) — environment variables, remembered by name so a redeploy can't drop one. **No** vault, rotation, or encryption at rest. |
 
 ## Planned — DB-backed pillars
 
@@ -37,6 +43,37 @@ framework's existing subtree-cache machinery, to memoize a component subtree acr
 ### Broadcast
 Server-to-many-clients pub/sub over the existing WebSocket channel — subscribe to a topic, push a live diff
 to every subscriber. Unlocks realtime UI without new infrastructure.
+
+## Not shipped
+
+Listed because a roadmap that only says what exists isn't much use when you're deciding whether Rask fits.
+None of these has an implementation today — if your product needs one, you'll be writing or renting it.
+
+### A user store and account lifecycle
+The [sign-in machinery](authentication.md) is real: cookie and JWT sessions, claims, authorization,
+hardening guidance. What `rask new --auth` scaffolds behind it is a **demo** credential store with
+hardcoded logins — honestly labelled in the generated code, but it is not a user system. There is no
+registration, password hashing, reset flow, email verification, lockout, or MFA. Bring ASP.NET Core
+Identity or a users table of your own.
+
+### File and blob storage
+No `IBlobStorage`. Rask can move bytes between the browser and the server
+([`http-and-files.md`](http-and-files.md)), but where an uploaded avatar is *kept* is your decision — the
+local disk, S3, or a provider SDK you reference directly.
+
+### Rate limiting
+Nothing in the framework. The docs point you at a reverse-proxy rate limit in several places, and
+`rask deploy` provisions a stock Caddy, which can't do it without a plugin — so today that means adding one
+yourself, or a WAF in front. Worth knowing before you put a login form on the internet: there is **no
+built-in login-attempt throttle**.
+
+### A dead-letter surface for the background pillars
+[Jobs](jobs.md), [mail](mail.md) and the [outbox](outbox.md) each retry with backoff and then stop, leaving
+the row in place. That's the right durability behaviour, but there is no UI, CLI command, or metric that
+shows you what has given up — inspecting or retrying a dead letter means SQL against `app.db`.
+
+### Secrets beyond environment variables
+See [`secrets.md`](secrets.md) for what does exist and, at the bottom, a blunt list of what doesn't.
 
 ---
 

--- a/tests/Rask.Example.Shared.Tests/Pages/DocsIndexTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Pages/DocsIndexTests.cs
@@ -1,0 +1,80 @@
+using System.Text.RegularExpressions;
+
+namespace Rask.Example.Shared.Tests.Pages;
+
+/// <summary>
+/// <c>docs/README.md</c> is described as "the full map", and the doctrine page sends readers to it. This
+/// guards that claim: every guide must be reachable from it, directly or through a hub page.
+///
+/// <para>Reachability, not a direct link — the docs are deliberately hub-and-subpage
+/// (<c>authentication.md</c> → <c>authentication-cookie.md</c> …), so demanding a top-level row for each
+/// would fight the structure. What must never happen is a doc reachable from <em>nothing</em>: written,
+/// committed, and findable only by someone who already knows the filename.</para>
+/// </summary>
+public sealed class DocsIndexTests
+{
+    [Fact]
+    public void Every_doc_is_reachable_from_the_docs_index()
+    {
+        var docs = DocsDirectory();
+        var all = Directory.GetFiles(docs, "*.md", SearchOption.AllDirectories)
+            .Select(path => Path.GetRelativePath(docs, path).Replace('\\', '/'))
+            .ToHashSet(StringComparer.Ordinal);
+
+        var reachable = new HashSet<string>(StringComparer.Ordinal) { "README.md" };
+        var queue = new Queue<string>([.. reachable]);
+        while (queue.Count > 0)
+        {
+            foreach (var link in LinksIn(Path.Combine(docs, queue.Dequeue()), all))
+            {
+                if (reachable.Add(link))
+                {
+                    queue.Enqueue(link);
+                }
+            }
+        }
+
+        var orphaned = all.Except(reachable).Order(StringComparer.Ordinal).ToArray();
+        Assert.True(
+            orphaned.Length == 0,
+            "These docs can't be reached from docs/README.md by any path, so a reader has no way to find "
+            + $"them — link each from the index or from the hub page it belongs under:{Environment.NewLine}  "
+            + string.Join($"{Environment.NewLine}  ", orphaned));
+    }
+
+    /// <summary>Markdown links to a sibling doc, resolved relative to the linking file's own folder.</summary>
+    private static IEnumerable<string> LinksIn(string path, IReadOnlySet<string> known)
+    {
+        if (!File.Exists(path))
+        {
+            yield break;
+        }
+
+        var folder = Path.GetDirectoryName(Path.GetRelativePath(DocsDirectory(), path).Replace('\\', '/')) ?? string.Empty;
+        foreach (Match match in Regex.Matches(File.ReadAllText(path), @"\]\(([^)#\s]+\.md)"))
+        {
+            var target = match.Groups[1].Value;
+            var combined = folder.Length == 0 ? target : $"{folder}/{target}";
+
+            // Normalize "tutorial/../cli.md" and the like without touching the filesystem.
+            var resolved = new Uri(new Uri("doc:///"), combined).AbsolutePath.TrimStart('/');
+            if (known.Contains(resolved))
+            {
+                yield return resolved;
+            }
+        }
+    }
+
+    private static string DocsDirectory()
+    {
+        for (var dir = AppContext.BaseDirectory; dir is not null; dir = Path.GetDirectoryName(dir))
+        {
+            if (File.Exists(Path.Combine(dir, "Rask.slnx")))
+            {
+                return Path.Combine(dir, "docs");
+            }
+        }
+
+        throw new InvalidOperationException("Could not locate the repo root (Rask.slnx) from the test base directory.");
+    }
+}


### PR DESCRIPTION
> Final PR of the stack: #502 → #503 → #505 → #506 → #507 → #509 → #511 → #515 → this. Docs-only, plus one guard test.

## The roadmap was all green ticks

Every pillar was marked ✅, which made the page useless for the decision it exists to support — whether Rask
fits your product. A reader comparing frameworks got a wall of ticks and no way to learn there is no user
store, no blob storage, and no rate limiting until they went looking in the source.

A new **Not shipped** section names each gap and what to reach for instead:

- **A user store and account lifecycle** — registration, password hashing, reset, lockout, MFA.
- **File/blob storage** — Rask moves bytes browser↔server, but where an upload is *kept* is your call.
- **Rate limiting** — nothing in the framework, and `rask deploy` provisions a stock Caddy that can't do it
  without a plugin. Called out explicitly: **there is no built-in login-attempt throttle.**
- **A dead-letter surface** for jobs/mail/outbox. They retry with backoff, give up, and leave the row —
  correct durability, but nothing shows you it happened. Today that's SQL against `app.db`.

## Auth is split in two

The sign-in machinery is real (cookie/JWT sessions, claims, authorization, hardening guidance). What
`rask new --auth` scaffolds behind it is a **demo** credential store with hardcoded logins — honestly
labelled in the generated code, but a single ✅ covering both read as a user system that exists. Now two
rows, and the doctrine page's "everything a solo developer needs" claim carries the same caveat.

## Findability

`elements.md` — the DSL reference, one of the most fundamental pages — and `repo-administration.md` were
reachable from **nothing at all**. `observability.md` and `configuration.md`, the two you reach for when
something is wrong in production, were buried a level down. All four now have index rows.

A new test enforces reachability from `docs/README.md`, which the doctrine page calls "the full map".
Links *through a hub page* count — the docs are deliberately hub-and-subpage, and demanding a top-level row
for every subpage would fight that structure. Being findable from **nowhere** is the failure.

I verified the guard fails on a planted orphan and names it, then removed the probe. A guard that can't
fail isn't one.

## A correction to my own audit

I reported earlier that **21 docs were unlinked** from the index. That measured *direct links only*.
Measured properly — reachable by any path — it was **2**. The other 19 are subpages reachable through their
hubs, which is the intended design. I fixed the 2 that were real rather than restructuring 19 that weren't.

## Testing

`scripts/run-unit-local.sh` green (the new guard runs in it). No production code changed.

## Changelog

`[Unreleased] → Docs`.