### PR TITLE
test(cli): stop the wasm-hosted build gate racing on restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ them until tagged releases begin.
   the docs are deliberately hub-and-subpage; being findable from *nowhere* is the failure.
 
 ### Fixed
+- **The wasm-hosted build gate no longer fails at random.** `Generated_wasm_hosted_solution_builds` is
+  the only gate that built a `.sln`, and the generated Server carries a cross-TFM `ProjectReference` to the
+  Client whose target framework is deliberately never negotiated. That put the Client in the restore graph
+  twice — once as a solution entry, once as that reference — and the two writers raced on its `obj/`
+  restore artefacts, failing with `The file '…project.assets.json' already exists`. `-m:1` doesn't help (it
+  caps MSBuild nodes, not NuGet's parallelism) and neither does splitting restore from build, since both
+  entries are present within the single restore. The gate now builds the Server project, which references
+  the other two, so all three still compile with one graph entry each. Since #502 wired this gate into
+  `pre-push`, the flake had gone from an occasional annoyance to intermittently blocking pushes.
 - **`rask new` no longer overwrites files it didn't create.** The guard checked only for the project file, so
   scaffolding into a directory that already held a `Program.cs`, a `Features/` tree or a `wwwroot` silently
   overwrote them — with no `--force` to consent to and nothing to undo it. Any existing file the template

--- a/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorBuildE2ETests.cs
@@ -179,7 +179,21 @@ public sealed class ProjectGeneratorBuildE2ETests
 
             CliBuildE2E.WriteNuGetConfig(fs, projectDir, feed);
 
-            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{Path.Combine(projectDir, name + ".sln")}\" -warnaserror -m:1");
+            // Build the Server project, not the .sln.
+            //
+            // The Server references both the Client and the Shared library, so all three still compile and
+            // the WASM bundle is still baked — but building the solution put the Client in the restore graph
+            // *twice*: once as a solution entry, and once as the Server's cross-TFM ProjectReference
+            // (ReferenceOutputAssembly=false, SkipGetTargetFrameworkProperties=true, so its TFM is never
+            // negotiated). Those two graph entries race on the Client's obj/ restore artefacts and fail with
+            // "The file '…project.assets.json' already exists".
+            //
+            // `-m:1` doesn't help — it caps MSBuild nodes, not NuGet's own parallelism — and neither does
+            // splitting restore from build, because both entries are present within the single restore.
+            // Dropping the duplicate entry is what removes the racing writer. The .sln's own shape stays
+            // covered by ProjectGeneratorTests.
+            var server = Path.Combine(projectDir, name + ".Server", name + ".Server.csproj");
+            var (exit, output) = await CliBuildE2E.RunDotnet($"build \"{server}\" -warnaserror -m:1");
             Assert.True(exit == 0, $"[auth={auth},pwa={pwa}] generated wasm-hosted solution failed to build.{CliBuildE2E.Diagnostics(output)}");
         }
         finally


### PR DESCRIPTION
Closes #517.

## Summary

`Generated_wasm_hosted_solution_builds` is the only gate that built a **`.sln`**, and the generated Server carries a cross-TFM `ProjectReference` to the Client whose target framework is deliberately never negotiated (`ReferenceOutputAssembly=false`, `SkipGetTargetFrameworkProperties=true`). That puts the Client in the restore graph **twice** — once as a solution entry, once as that reference — and the two writers race on its `obj/` restore artefacts:

```
error : The file '…/HE2EP.Client/obj/project.assets.json' already exists.
```

## What didn't work

- **`-m:1`** caps MSBuild nodes, not NuGet's own parallelism.
- **Splitting restore from build** (the issue's own suggestion, and my first attempt) — measured, and it *still failed one run in three*, because both graph entries are present within the single `dotnet restore`.

Building the **Server project** removes the duplicate entry. It references both the Client and the Shared library, so all three still compile and the WASM bundle is still baked; the `.sln`'s own shape stays covered by `ProjectGeneratorTests`.

## Testing

Four consecutive full runs of the gate, all green — a flake that reproduced roughly one run in two or three proves nothing on a single pass.

This had stopped being cosmetic: since #502 wired the gate into `pre-push`, it was intermittently **blocking pushes**. It blocked one of mine, which is how it got fixed now rather than later.