### PR TITLE
fix(core): give a fractional Input step=any so it can actually submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ them until tagged releases begin.
   the docs are deliberately hub-and-subpage; being findable from *nowhere* is the failure.
 
 ### Fixed
+- **A `decimal` input no longer silently refuses to submit.** An `Input` bound to a fractional type
+  rendered `<input type="number">` with no `step`, and HTML's default is `step="1"` — so the browser's own
+  constraint validation rejected `42.50` and never fired the submit event. Nothing threw, no validation
+  message appeared, and the form simply did nothing, which reads as the framework being broken rather than
+  an attribute being missing. `decimal`/`double`/`float`/`Half` now default to `step="any"`; integral types
+  keep the implicit whole-number constraint, and an explicit `Step:` still wins. `BsInput` needed the same
+  fix separately: it renders through `Input<string>` with a pre-formatted value, so `Input<T>`'s own default
+  never saw the bound type.
 - **The wasm-hosted build gate no longer fails at random.** `Generated_wasm_hosted_solution_builds` is
   the only gate that built a `.sln`, and the generated Server carries a cross-TFM `ProjectReference` to the
   Client whose target framework is deliberately never negotiated. That put the Client in the restore graph

--- a/docs/forms.md
+++ b/docs/forms.md
@@ -59,6 +59,13 @@ label), `Spellcheck` (the enumerated `spellcheck="true|false"`), `Capture` (came
 input), and `Dirname`. The Bootstrap `BsInput`/`BsTextarea` forward all of these (see
 [bootstrap-forms.md](bootstrap-forms.md)).
 
+> **Fractional numbers get `step="any"` automatically.** A `decimal`/`double`/`float`/`Half` binding
+> renders `<input type="number" step="any">`. Without it HTML's default is `step="1"`, so the browser's own
+> constraint validation rejects `42.50` and **refuses to fire submit** — silently, with nothing thrown and
+> no validation message, which reads as the form being broken. Integral types keep the implicit whole-number
+> constraint. An explicit `Step:` always wins, and is worth setting for money (`Step: "0.01"` makes the
+> spinner step by cents).
+
 ### File inputs
 
 `InputType.File` turns an `<input>` into a file picker. Instead of binding a value, hand it an

--- a/src/Rask.Bootstrap/BsInput.cs
+++ b/src/Rask.Bootstrap/BsInput.cs
@@ -42,12 +42,17 @@ public sealed class BsInput<T> : BsFormControl<T>
         // selector drives the effect); fall back to the label text when none is given.
         var placeholder = Floating is true ? Placeholder ?? Label ?? " " : Placeholder;
 
+        // Derived here rather than inside Input<T>: this renders through Input<string> with a pre-formatted
+        // value, so `typeof(T)` in there is `string` and its own default step would never see the decimal.
+        var derivedType = DeriveType();
+
         var control = Input<string>(
-            Type: DeriveType(),
+            Type: derivedType,
             Name: Name ?? b.Accessor?.PropertyName,
             Value: BindingHelpers.FormatValue(b.Current),
             Placeholder: placeholder, Disabled: Disabled, ReadOnly: ReadOnly, Required: Required,
-            Min: Min, Max: Max, Step: Step, Pattern: Pattern, MaxLength: MaxLength, MinLength: MinLength,
+            Min: Min, Max: Max, Pattern: Pattern, MaxLength: MaxLength, MinLength: MinLength,
+            Step: Step ?? (derivedType == InputType.Number ? BindingHelpers.DefaultStep(typeof(T)) : null),
             Multiple: Multiple, Accept: Accept, Capture: Capture, List: List, Autofocus: Autofocus,
             Autocomplete: Autocomplete, InputMode: InputMode, EnterKeyHint: EnterKeyHint, Spellcheck: Spellcheck,
             Class: cls, Id: controlId, Aria: FieldAria(b, controlId),

--- a/src/Rask.Core/Components/Input.cs
+++ b/src/Rask.Core/Components/Input.cs
@@ -184,9 +184,13 @@ public sealed class Input<T> : Element, IFormControl<T>
             AppendAttr(sb, "max", Max);
         }
 
-        if (Step is not null)
+        // An explicit Step always wins. Otherwise a fractional bound type needs step="any": HTML defaults
+        // to step="1", so the browser's own constraint validation rejects 42.50 and never fires submit —
+        // silently, with no validation message and nothing thrown. Same hazard on a range input.
+        var step = Step ?? (resolvedType is "number" or "range" ? BindingHelpers.DefaultStep(typeof(T)) : null);
+        if (step is not null)
         {
-            AppendAttr(sb, "step", Step);
+            AppendAttr(sb, "step", step);
         }
 
         if (Pattern is not null)

--- a/src/Rask.Core/Forms/BindingHelpers.cs
+++ b/src/Rask.Core/Forms/BindingHelpers.cs
@@ -44,6 +44,25 @@ public static class BindingHelpers
     // the native numeric keypad and increment buttons; the actual round-trip through
     // RouteValueParser uses T.TryParse(raw, InvariantCulture, out) so the parse side is
     // already polymorphic across the whole set.
+    /// <summary>
+    /// The <c>step</c> a numeric input needs by default, or <see langword="null"/> when the HTML default is
+    /// right.
+    /// </summary>
+    /// <remarks>
+    /// HTML's default is <c>step="1"</c>, so an <c>&lt;input type="number"&gt;</c> bound to a fractional
+    /// type makes the <b>browser's own constraint validation</b> reject a value like <c>42.50</c> and
+    /// refuse to fire submit. Nothing throws and no validation message renders — the form simply does
+    /// nothing, which reads as the framework being broken rather than an attribute being missing.
+    /// Integral types keep the implicit <c>step="1"</c>: there, whole numbers are the constraint you want.
+    /// </remarks>
+    public static string? DefaultStep(Type propType)
+    {
+        var t = Nullable.GetUnderlyingType(propType) ?? propType;
+        return t == typeof(decimal) || t == typeof(double) || t == typeof(float) || t == typeof(Half)
+            ? "any"
+            : null;
+    }
+
     public static string DefaultInputType(Type propType)
     {
         var t = Nullable.GetUnderlyingType(propType) ?? propType;

--- a/tests/Rask.Bootstrap.Tests/BsFormControlTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsFormControlTests.cs
@@ -44,6 +44,17 @@ public class BsFormControlTests
             BsInput<int>(Value: 5, Min: "0", Max: "120", Step: "1").ToHtml());
 
     [Fact]
+    public void Input_DecimalWithoutAnExplicitStep_GetsStepAny() =>
+        // BsInput renders through Input<string> with a pre-formatted value, so Input<T>'s own default step
+        // never sees the decimal — BsInput has to derive it from its own T. Without it the browser silently
+        // refuses to submit a fractional price.
+        Assert.Contains("step=\"any\"", BsInput<decimal>(Value: 12.50m).ToHtml(), StringComparison.Ordinal);
+
+    [Fact]
+    public void Input_IntWithoutAnExplicitStep_KeepsTheWholeNumberConstraint() =>
+        Assert.DoesNotContain("step=", BsInput<int>(Value: 5).ToHtml(), StringComparison.Ordinal);
+
+    [Fact]
     public void Input_TextConstraints_ForwardPatternAndLengths() =>
         Assert.Contains("pattern=\"[a-z]&#x2B;\" maxlength=\"10\" minlength=\"2\"",
             BsInput<string>(Value: "x", Pattern: "[a-z]+", MaxLength: 10, MinLength: 2).ToHtml());

--- a/tests/Rask.Core.Tests/Components/InputTests.cs
+++ b/tests/Rask.Core.Tests/Components/InputTests.cs
@@ -9,6 +9,43 @@ public class InputTests
         Assert.Equal("<input />", Input<string>().ToHtml());
 
     [Fact]
+    public void Render_DecimalBinding_EmitsStepAnyBetweenMaxAndPattern()
+    {
+        // HTML defaults to step="1", so without this the browser's own constraint validation rejects a
+        // fractional value and refuses to fire submit — silently, with nothing thrown and no message shown.
+        // Asserted as exact markup because `step` has to keep its slot in the attribute order.
+        var model = new PriceModel();
+
+        Assert.Equal(
+            "<input type=\"number\" name=\"Price\" value=\"0\" max=\"10\" step=\"any\" pattern=\"p\" />",
+            Input(() => model.Price, Max: "10", Pattern: "p").ToHtml());
+    }
+
+    [Fact]
+    public void Render_IntBinding_KeepsTheImplicitWholeNumberStep()
+    {
+        // Integral types must NOT get step="any" — there, whole numbers are the constraint you want.
+        var model = new PriceModel();
+
+        Assert.DoesNotContain("step=", Input(() => model.Quantity).ToHtml(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Render_ExplicitStep_WinsOverTheDefault()
+    {
+        var model = new PriceModel();
+
+        Assert.Contains("step=\"0.01\"", Input(() => model.Price, Step: "0.01").ToHtml(), StringComparison.Ordinal);
+    }
+
+    private sealed class PriceModel
+    {
+        public decimal Price { get; set; }
+
+        public int Quantity { get; set; }
+    }
+
+    [Fact]
     public void Render_AllPropsSet_EmitsExpectedAttributes()
     {
         Assert.Equal(

--- a/tests/Rask.Examples.E2E.Tests/ShopExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/ShopExampleTests.cs
@@ -82,10 +82,10 @@ public sealed class ShopExampleTests(ShopExampleAppFixture app, PlaywrightFixtur
         await Assertions.Expect(_page.Locator("#customer")).ToBeVisibleAsync();
 
         await _page.FillAsync("#customer", "Ada Lovelace");
-        // A whole number on purpose: a decimal Input renders <input type="number"> with no step, so the
-        // browser's own constraint validation silently blocks the submit for a fractional value and the
-        // framework never sees the event. Tracked in pal-tamas/rask#518 — switch this to 42.50 once fixed.
-        await _page.FillAsync("#total", "42");
+        // Fractional on purpose: a decimal Input now emits step="any", without which the browser's own
+        // constraint validation rejects this and never fires submit — silently, with nothing thrown and no
+        // validation message. This line is the regression proof for that fix.
+        await _page.FillAsync("#total", "42.50");
         await _page.ClickAsync("button[type=submit]");
 
         // The handler navigates to the list on success. This is a client-side route change, so there is no


### PR DESCRIPTION
Closes #518.

## Summary

An `Input` bound to a `decimal` rendered `<input type="number">` with **no `step`**, and HTML's default is `step="1"` — so the browser's own constraint validation rejected `42.50` and **never fired the submit event**. Nothing threw, no validation message appeared, and the form simply did nothing. That reads as the framework's form handling being broken rather than one attribute being missing, which is what made it worth fixing properly.

`decimal`/`double`/`float`/`Half` now default to `step="any"`. Integral types keep the implicit whole-number constraint — that's the constraint you want there — and an explicit `Step:` still wins.

## The part an `Input`-only fix would have missed

`BsInput<T>` renders through **`Input<string>`** with a pre-formatted value, so `typeof(T)` inside `Input<T>` is `string` and the default would never see the `decimal`. Every Bootstrap money field would have stayed broken while the core tests went green. `BsInput` derives and forwards its own default.

## Deliberately *not* changed

The four `Step: "0.01"` call sites in `samples/`. Those aren't workarounds — on a money field, stepping by cents is better UX than `any`, and they now double as coverage that an explicit `Step` still wins.

## Testing

- Exact-markup assertion proving `step` lands **between `max` and `pattern`** — the attribute-order contract the suite asserts.
- An `int` gets no `step`; an explicit `Step` overrides the default; the same two for `BsInput`.
- **The regression proof:** the Shop sample's browser test was parked on a whole-number total with a comment pointing at this issue. It now submits `42.50`, and the full 9-test suite passes.

## Benchmarks

`HtmlSerializer` (render hot path), before vs after — **`Allocated` identical**: `3.67 / 67.23 / 1398.91 / 32.58 / 73.9 KB`. The added check is a null-coalesce over string literals and allocates nothing.