### PR TITLE
fix(sqlite): stop the transaction helper discarding a failed rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ them until tagged releases begin.
   the docs are deliberately hub-and-subpage; being findable from *nowhere* is the failure.
 
 ### Fixed
+- **The raw SQLite transaction helper no longer discards a failed rollback.**
+  `ExecuteInImmediateTransactionAsync` clears a leaked transaction from a pooled handle before
+  `BEGIN IMMEDIATE`, but it dropped that `ROLLBACK`'s result code and ran `BEGIN` regardless — so a
+  rollback that failed turned into the misleading, non-retryable "cannot start a transaction within a
+  transaction". The rollback now goes through the same fair-interval retry as everything else (it has to:
+  `busy_timeout` is set to `0` just above it, so nothing else waits). `BEGIN` also moved inside the `try`,
+  so a partially-failed begin can no longer return a mid-transaction handle to the pool and poison every
+  later lease of it. Hardening rather than a confirmed fix for #504 — see that issue for what was ruled
+  out.
 - **A `decimal` input no longer silently refuses to submit.** An `Input` bound to a fractional type
   rendered `<input type="number">` with no `step`, and HTML's default is `step="1"` — so the browser's own
   constraint validation rejected `42.50` and never fired the submit event. Nothing threw, no validation

--- a/src/Rask.SQLite/SqliteConnectionExtensions.cs
+++ b/src/Rask.SQLite/SqliteConnectionExtensions.cs
@@ -71,15 +71,24 @@ public static class SqliteConnectionExtensions
         // SqliteTransaction bookkeeping, and the underlying sqlite3 handle is pooled and reused. If an
         // earlier lease left a transaction open on it, BEGIN IMMEDIATE here would hit "cannot start a
         // transaction within a transaction" (SQLITE_ERROR) — a non-retryable fast failure. Clear any
-        // leaked transaction first so BEGIN always starts from autocommit (guarding against a leaked transaction).
+        // leaked transaction first so BEGIN always starts from autocommit.
+        //
+        // Retried, not fire-and-forget: a ROLLBACK can itself return SQLITE_BUSY ("cannot rollback
+        // transaction - SQL statements in progress") when a GC-orphaned reader's statement is still active
+        // on the pooled handle — the same hazard docs/sqlite.md documents for EF's pool return. Dropping
+        // that result code and running BEGIN anyway is what turned a transient into the misleading
+        // non-retryable error above. Note the busy_timeout was set to 0 just now, so the native handler
+        // won't wait for us either; this managed retry is the only thing that does.
         if (raw.sqlite3_get_autocommit(handle) == 0)
         {
-            raw.sqlite3_exec(handle, "ROLLBACK;");
+            await SqliteBusyRetry.ExecAsync(handle, "ROLLBACK;", retry, time, cancellationToken).ConfigureAwait(false);
         }
 
-        await SqliteBusyRetry.ExecAsync(handle, "BEGIN IMMEDIATE;", retry, time, cancellationToken).ConfigureAwait(false);
         try
         {
+            // Inside the try: a BEGIN that fails partway must still go through the cleanup below, or the
+            // handle goes back to the pool mid-transaction and poisons every later lease of it.
+            await SqliteBusyRetry.ExecAsync(handle, "BEGIN IMMEDIATE;", retry, time, cancellationToken).ConfigureAwait(false);
             var result = await work(connection, cancellationToken).ConfigureAwait(false);
             await SqliteBusyRetry.ExecAsync(handle, "COMMIT;", retry, time, cancellationToken).ConfigureAwait(false);
             return result;

--- a/tests/Rask.SQLite.Tests/SqliteImmediateTransactionTests.cs
+++ b/tests/Rask.SQLite.Tests/SqliteImmediateTransactionTests.cs
@@ -140,6 +140,40 @@ public sealed class SqliteImmediateTransactionTests : IDisposable
     }
 
     [Fact]
+    public async Task Recovers_when_the_leaked_transaction_also_has_an_active_statement()
+    {
+        // A pooled handle can arrive not just mid-transaction but with a statement still active on it — a
+        // reader the GC collected whose finalizer hasn't run yet, the hazard docs/sqlite.md describes for
+        // EF's pool return. Modern SQLite permits ROLLBACK in that state (the active statements abort on
+        // their next step), so this documents that the entry guard copes rather than reproducing a failure:
+        // it passes both before and after the retry hardening.
+        await using var connection = new SqliteConnection(_connectionString);
+        await connection.OpenAsync();
+        Exec(connection, "INSERT INTO t(v) VALUES('seed');");
+        Exec(connection, "BEGIN IMMEDIATE;");
+
+        var command = connection.CreateCommand();
+        command.CommandText = "SELECT v FROM t;";
+        var reader = await command.ExecuteReaderAsync();
+        await reader.ReadAsync(); // mid-scan: the statement is active on the handle
+
+        await connection.ExecuteInImmediateTransactionAsync(
+            new SqliteBusyRetryOptions { Timeout = TimeSpan.FromSeconds(5) },
+            async (c, ct) =>
+            {
+                await using var cmd = c.CreateCommand();
+                cmd.CommandText = "INSERT INTO t(v) VALUES('recovered');";
+                await cmd.ExecuteNonQueryAsync(ct);
+            });
+
+        await reader.DisposeAsync();
+        await command.DisposeAsync();
+
+        Assert.Equal(2, Count());
+        Assert.Equal(1, raw.sqlite3_get_autocommit(connection.Handle!)); // handle left clean
+    }
+
+    [Fact]
     public async Task Leaves_the_handle_in_autocommit_after_work_throws()
     {
         // The finally guard must never return a mid-transaction handle to the pool, even when work throws.


### PR DESCRIPTION
Related to #504 — **does not close it**, see below.

## Summary

`ExecuteInImmediateTransactionAsync` clears a leaked transaction from a pooled handle before `BEGIN IMMEDIATE`, but it **dropped that `ROLLBACK`'s result code** and ran `BEGIN` regardless. A rollback that failed therefore surfaced as the misleading, non-retryable *"cannot start a transaction within a transaction"* rather than as itself.

The rollback now goes through the same fair-interval retry as everything else. It has to: `busy_timeout` is set to `0` immediately above it, so nothing else waits.

`BEGIN` also moved **inside the `try`**. A begin that failed partway previously skipped the cleanup guard entirely and could return a mid-transaction handle to the pool, where it would poison every later lease of that handle.

Both are real defects on their own merits — discarding a result code and proceeding, and a window where a handle escapes the cleanup guard.

## What this is *not*

I set out to fix #504 and could not confirm it. Being explicit, because a plausible-sounding fix on an intermittent bug is worse than none:

- **The hypothesis was that `ROLLBACK` returns `SQLITE_BUSY`** when a GC-orphaned reader's statement is still active on the handle. I couldn't reproduce that: modern SQLite permits `ROLLBACK` in that state (the active statements abort on their next step). The test I wrote for it **passes with and without this change**, so it is labelled as documenting survivability rather than dressed up as a regression proof.
- **The stress test still reproduced once with this applied**, during a full `scripts/run-unit-local.sh` run. So whatever causes #504 is still there.

#504 stays open, with a comment recording what's been ruled out so the next person doesn't repeat it.

## Testing

`scripts/run-unit-local.sh` green (41 SQLite tests). The existing `Recovers_when_the_handle_arrives_with_a_leaked_transaction` and `Leaves_the_handle_in_autocommit_after_work_throws` still pass, which is what guards the behaviour this touches.