### PR TITLE
feat(cli): scaffold a production error page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,15 @@ them until tagged releases begin.
   [`cli.md`](docs/cli.md).
 
 ### Added
+- **Scaffolded apps get a production error page.** An unhandled exception thrown *outside* a component
+  tree used to return a bare 500 with an empty body (`ErrorBoundary` already covered inside one).
+  `rask new` now emits `Features/Shared/ErrorPage.cs` — a routed `/error` page that renders through the app
+  shell — and registers `app.UseExceptionHandler("/error")` outside Development, where the developer
+  exception page is strictly better. The page shows a correlation id (`Activity.Current?.Id`) and
+  deliberately nothing about the exception: it is served to whoever hit the error, so rendering the message
+  or a stack trace would be worse than the blank page it replaces. The detail goes to `ILogger`, matched by
+  that id. `[AllowAnonymous]`, so adding a fallback authorization policy later can't make the error page
+  redirect to `/login`.
 - **Continuous backup is on the golden path.** `Rask.SQLite.Litestream` shipped, was documented, and was
   referenced by **no template** — so `rask new --data` → `rask deploy` produced a live app whose only copy of
   the database was a volume on one box, while `rask deploy`'s own code comments explained that the graceful

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,13 @@ Add pages and components to taste — `rask generate` is the fast path.
 
 The flags wire a feature up; they don't scaffold sample pages for you to delete.
 
+Every server app also gets `Features/Shared/ErrorPage.cs` and `app.UseExceptionHandler("/error")` outside
+Development. `ErrorBoundary` already catches anything thrown *inside* a component tree; this covers
+everything outside it, which would otherwise be a bare 500 with an empty body. The page renders through
+your app shell and shows a **correlation id and nothing else** — the exception goes to `ILogger`, where you
+match it by that id. Locally the handler stays off, because the developer exception page is strictly more
+useful than a page designed to reveal nothing.
+
 The battery flags are **server-only** — they all ride the app's own database, and only the `server`
 template has one. Each implies what it needs (`--jobs` implies `--data` implies `--cqrs`), so you can ask
 for the pillar you want without also remembering its dependencies:

--- a/samples/Rask.Example.Shop/Features/Shared/ErrorPage.cs
+++ b/samples/Rask.Example.Shop/Features/Shared/ErrorPage.cs
@@ -1,0 +1,41 @@
+using System.Diagnostics;
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Routing;
+
+// The generated Routes class is per-namespace, and this page lives in Features.Shared while the
+// home page lives in Features.Home — alias it rather than fully qualifying at the call site.
+using HomeRoutes = Rask.Example.Shop.Features.Home.Routes;
+
+namespace Rask.Example.Shop.Features.Shared;
+
+// [AllowAnonymous] because an error page that redirects to /login is worse than the error: if you
+// later add a fallback authorization policy, this route must stay reachable.
+[Route("/error")]
+[AllowAnonymous]
+public sealed class ErrorPage : Component
+{
+    protected override Component? Head => [Title()["Something went wrong"]];
+
+    protected override Component? Render() =>
+        Div(Class: "mx-auto my-5", Style: "max-width:540px")[
+            BsCard(Class: "shadow-sm")[
+                BsCardBody()[
+                    BsCardTitle()["Something went wrong"],
+                    BsCardText(Class: "text-body-secondary")[
+                        "The request couldn't be completed. The error has been logged."
+                    ],
+                    // The correlation id, and deliberately nothing else. Never render the
+                    // exception, its message, or a stack trace here — this page is served to
+                    // whoever hit the error, and the detail already went to ILogger where you can
+                    // match it by this id.
+                    Activity.Current?.Id is { Length: > 0 } traceId
+                        ? P(Class: "mb-3 small text-body-secondary")[
+                            "Reference: ",
+                            Code()[traceId]
+                        ]
+                        : null,
+                    NavLink(HomeRoutes.HomePage(), Class: "btn btn-primary")["Back to the app"]
+                ]
+            ]
+        ];
+}

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -42,6 +42,8 @@ internal static partial class ProjectGenerator
             files.Add(("Features/Push/PushSubscriptions.cs", PushSubscriptionsCs));
         }
 
+        files.Add(("Features/Shared/ErrorPage.cs", ErrorPageCs));
+
         if (batteries.Pwa)
         {
             files.Add(("wwwroot/icon.svg", IconSvg));
@@ -460,6 +462,15 @@ internal static partial class ProjectGenerator
             // (no X-Forwarded-Proto), where a redirected endpoint would 307 to a port nothing listens on.
             app.UseHealthChecks("/health");
 
+            // Unhandled exceptions. ErrorBoundary already covers anything thrown inside a component tree;
+            // this catches everything outside it, which would otherwise be a bare 500 with an empty body.
+            // Non-Development only — the developer exception page is strictly more useful locally, and this
+            // one deliberately shows nothing about the exception.
+            if (!app.Environment.IsDevelopment())
+            {
+                app.UseExceptionHandler("/error");
+            }
+
             // Transport security (applies whether or not auth is enabled): redirect HTTP→HTTPS, and in
             // non-Development emit HSTS so browsers refuse plain-HTTP for the configured max-age.
             if (!app.Environment.IsDevelopment())
@@ -665,6 +676,54 @@ internal static partial class ProjectGenerator
 
         """;
     }
+
+    // The production error page. UseExceptionHandler re-executes the pipeline at this route, so it renders
+    // through the app shell like any other page rather than looking like a framework error.
+    private const string ErrorPageCs =
+        """
+        using System.Diagnostics;
+        using Microsoft.AspNetCore.Authorization;
+        using Rask.Core.Routing;
+
+        // The generated Routes class is per-namespace, and this page lives in Features.Shared while the
+        // home page lives in Features.Home — alias it rather than fully qualifying at the call site.
+        using HomeRoutes = Company.RaskServer.Features.Home.Routes;
+
+        namespace Company.RaskServer.Features.Shared;
+
+        // [AllowAnonymous] because an error page that redirects to /login is worse than the error: if you
+        // later add a fallback authorization policy, this route must stay reachable.
+        [Route("/error")]
+        [AllowAnonymous]
+        public sealed class ErrorPage : Component
+        {
+            protected override Component? Head => [Title()["Something went wrong"]];
+
+            protected override Component? Render() =>
+                Div(Class: "mx-auto my-5", Style: "max-width:540px")[
+                    BsCard(Class: "shadow-sm")[
+                        BsCardBody()[
+                            BsCardTitle()["Something went wrong"],
+                            BsCardText(Class: "text-body-secondary")[
+                                "The request couldn't be completed. The error has been logged."
+                            ],
+                            // The correlation id, and deliberately nothing else. Never render the
+                            // exception, its message, or a stack trace here — this page is served to
+                            // whoever hit the error, and the detail already went to ILogger where you can
+                            // match it by this id.
+                            Activity.Current?.Id is { Length: > 0 } traceId
+                                ? P(Class: "mb-3 small text-body-secondary")[
+                                    "Reference: ",
+                                    Code()[traceId]
+                                ]
+                                : null,
+                            NavLink(HomeRoutes.HomePage(), Class: "btn btn-primary")["Back to the app"]
+                        ]
+                    ]
+                ];
+        }
+
+        """;
 
     // ---- --push template files ----
 

--- a/tests/Rask.Cli.Tests/ErrorPageScaffoldTests.cs
+++ b/tests/Rask.Cli.Tests/ErrorPageScaffoldTests.cs
@@ -1,0 +1,87 @@
+using Rask.Cli.Commands;
+using Rask.Cli.Scaffolding;
+
+namespace Rask.Cli.Tests;
+
+/// <summary>
+/// The production error page a scaffolded app gets for exceptions thrown <b>outside</b> a component tree.
+/// (Inside one, <c>ErrorBoundary</c> already handles it.)
+/// </summary>
+public sealed class ErrorPageScaffoldTests
+{
+    private const string Root = "/proj/App";
+    private const string Version = "9.9.9";
+
+    private static Dictionary<string, string> Generate(params string[] flags) =>
+        ProjectGenerator.GenerateServer(Root, "App", NewCommand.ToBatteries(flags), Version).Files
+            .ToDictionary(
+                f => Path.GetRelativePath(Root, f.Path).Replace('\\', '/'),
+                f => f.Content,
+                StringComparer.Ordinal);
+
+    [Theory]
+    [InlineData]
+    [InlineData("auth")]
+    [InlineData("all-batteries")]
+    public void Every_server_app_gets_an_error_page(params string[] flags)
+    {
+        // Not a battery and not opt-in: without it an unhandled exception is a bare 500 with an empty body.
+        var files = Generate(flags);
+
+        Assert.Contains("Features/Shared/ErrorPage.cs", files.Keys);
+        Assert.Contains("""[Route("/error")]""", files["Features/Shared/ErrorPage.cs"], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_handler_is_registered_only_outside_development()
+    {
+        // Locally the developer exception page is strictly more useful — it shows the exception this page
+        // deliberately hides.
+        var program = Generate()["Program.cs"];
+
+        var handler = program.IndexOf("""app.UseExceptionHandler("/error");""", StringComparison.Ordinal);
+        Assert.True(handler > 0, "The scaffold should register an exception handler.");
+
+        var guard = program.LastIndexOf("if (!app.Environment.IsDevelopment())", handler, StringComparison.Ordinal);
+        Assert.True(guard > 0, "UseExceptionHandler must sit inside a non-Development guard.");
+    }
+
+    [Fact]
+    public void The_handler_runs_before_the_UseRask_catch_all()
+    {
+        // Exception handling has to wrap the middleware that actually renders the app, and UseRask's
+        // catch-all is what serves it.
+        var program = Generate()["Program.cs"];
+
+        Assert.True(
+            program.IndexOf("""app.UseExceptionHandler("/error");""", StringComparison.Ordinal) <
+            program.IndexOf("app.UseRask<App>();", StringComparison.Ordinal),
+            "UseExceptionHandler must precede UseRask.");
+    }
+
+    [Fact]
+    public void The_page_shows_a_correlation_id_and_nothing_about_the_exception()
+    {
+        // The whole point. This page is served to whoever hit the error, so leaking the message or a stack
+        // trace is an information disclosure — a prettier empty 500 would be no improvement, but a page
+        // that renders `ex.Message` is actively worse than the blank one it replaces. The detail goes to
+        // ILogger; the id is what ties the two together.
+        var page = Generate()["Features/Shared/ErrorPage.cs"];
+
+        Assert.Contains("Activity.Current?.Id", page, StringComparison.Ordinal);
+
+        foreach (var leak in new[] { "IExceptionHandlerFeature", "StackTrace", ".Message", "exception.ToString" })
+        {
+            Assert.DoesNotContain(leak, page, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void The_page_is_reachable_without_signing_in()
+    {
+        // An error page that redirects to /login is worse than the error. The attribute is emitted whether
+        // or not --auth is on, so adding a fallback authorization policy later can't lock it away.
+        Assert.Contains("[AllowAnonymous]", Generate("auth")["Features/Shared/ErrorPage.cs"], StringComparison.Ordinal);
+        Assert.Contains("[AllowAnonymous]", Generate()["Features/Shared/ErrorPage.cs"], StringComparison.Ordinal);
+    }
+}

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -14,6 +14,7 @@ public sealed class ProjectGeneratorTests
     private static readonly string[] AlwaysPresent =
     [
         "App.csproj", "Program.cs", "Features/Shared/App.cs", "Features/Home/HomePage.cs",
+        "Features/Shared/ErrorPage.cs",
         "Properties/launchSettings.json", "appsettings.json", "appsettings.Production.json",
     ];
 


### PR DESCRIPTION
Closes #508.

## Summary

An unhandled exception thrown **outside** a component tree returned a bare 500 with an empty body. `ErrorBoundary` already covers anything thrown inside the tree; this covers everything else.

`rask new` now emits `Features/Shared/ErrorPage.cs` — a routed `/error` page that renders through the app shell, so a failure looks like the app rather than a framework page — and registers `app.UseExceptionHandler("/error")` **outside Development**. Locally the handler stays off, because the developer exception page is strictly more useful than a page designed to reveal nothing.

## It shows a correlation id and nothing else

That's the whole design. The page is served to whoever hit the error, so rendering `ex.Message` or a stack trace would be **worse** than the blank page it replaces — and #508 explicitly notes that a handler which swallows the exception into a prettier empty 500 is no improvement either. So: `Activity.Current?.Id`, and the exception goes to `ILogger` where you match it by that id.

A test asserts the *absence* of `IExceptionHandlerFeature`, `StackTrace` and `.Message`, so that can't quietly change later.

`[AllowAnonymous]` is emitted whether or not `--auth` is on — adding a fallback authorization policy later must not make the error page redirect to `/login`.

## Two things the build gate caught

Worth recording, because both would have shipped as broken scaffold output:

- **`Routes` is generated per namespace.** A page in `Features.Shared` can't write `Routes.HomePage()` for a page in `Features.Home` — that's why `MembersPage` can say `Routes.LoginPage()` (same namespace) and this can't. It uses a `using` alias.
- **The scaffolded file has to satisfy `dotnet format` itself.** A fully-qualified call site was long enough that the formatter reflowed it, and the generated project then failed its own whitespace check.

## Testing

7 new tests (page emitted for every flag combination, handler present and environment-gated, ordered before `UseRask`, no exception detail, reachable anonymously), plus the existing build gates now compile the page — `RASK_CLI_BUILD_E2E=1` green at 788 passed.

Verified by hand end to end: published the Shop sample, ran it with `ASPNETCORE_ENVIRONMENT=Production`, and fetched `/error` — it renders "Something went wrong" and a `Reference:` id, with no `StackTrace` or `Exception` anywhere in the body.