### PR TITLE
feat(dashboard): a built-in operator dashboard for the batteries

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -135,6 +135,7 @@ jobs:
           dotnet pack src/Rask.Jobs/Rask.Jobs.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Mail/Rask.Mail.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Cache/Rask.Cache.csproj -c Release -o ./artifacts
+          dotnet pack src/Rask.Dashboard/Rask.Dashboard.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Testing/Rask.Testing.csproj -c Release -o ./artifacts
           dotnet pack src/Rask.Cli/Rask.Cli.csproj -c Release -o ./artifacts
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
       - name: Pack Rask.Cache
         run: dotnet pack src/Rask.Cache/Rask.Cache.csproj -c Release --no-build -o ./artifacts
 
+      - name: Pack Rask.Dashboard
+        run: dotnet pack src/Rask.Dashboard/Rask.Dashboard.csproj -c Release --no-build -o ./artifacts
+
       - name: Pack Rask.Testing
         run: dotnet pack src/Rask.Testing/Rask.Testing.csproj -c Release --no-build -o ./artifacts
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Added
+- **`Rask.Dashboard` — a built-in operator dashboard for the batteries.** One package reference and one
+  `AddRaskDashboard<AppDbContext>()` mounts `/_ops`, reading the outbox, jobs, mail and cache out of the
+  app's own database. Every queue is split into due / delayed / **failed** / processed, where failed means
+  what the processors mean by giving up — out of attempts and still unprocessed — with the last error and
+  the stored payload one click away. This closes the roadmap's *"no UI, CLI command, or metric shows you
+  what has given up"* gap for reading; the retry actions follow.
+  A panel appears only when its battery is both registered *and* mapped into the `DbContext`, so the nav is
+  an inventory of what the deployment actually runs. Also shows cache keys with size and expiry, SQLite
+  pragmas read live, database size, and the recurring-job schedule joined to when each job last fired.
+  **It fails closed:** pages are gated on a `RaskDashboard` authorization policy applied to the route
+  layout (so it covers every page and is re-checked on in-app navigation). Define that policy and it
+  decides; leave it undefined and the dashboard is open only in Development — with a warning banner — and
+  **denies everyone** in every other environment. Panels poll, compare, and re-render only on a real
+  change, and the loop is bounded, because every open tab competes with the processors for SQLite's single
+  write lock.
+- **`BsStat`** — a stat-tile primitive for `Rask.Bootstrap`: a number, its label, an optional caption and
+  tone. Tone colours the value rather than the card, so one red number reads as a signal instead of one
+  panel among many coloured panels.
+- **`LitestreamStatus`** — a singleton published by the Litestream supervisor reporting whether replication is
+  currently running, when it last started and exited, its last exit code or error, and how many times it has
+  restarted. "Is my backup actually running?" was previously answerable only by the absence of a log line.
+- **`ISqliteSnapshotStore.ListAsync`** — enumerate stored snapshots (name, size, timestamp), newest first and
+  scoped to the store's search pattern, so what you can see is what retention manages. A default interface
+  implementation returns an empty list, so existing custom stores keep compiling.
+- **`JobOptions.RecurringJobs`** — the registered recurring schedule (name, interval, factory) is now public.
+  Pair an entry with the `RecurringJobState` row of the same name to see when it last fired, or call its
+  factory to enqueue an off-schedule run.
+
 ### Fixed
 - **A row changing underneath the jobs or outbox drain no longer discards the whole batch's progress.** Both
   processors ran a batch and then wrote every outcome in a single `SaveChangesAsync`. Anything else modifying

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -22,6 +22,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="5.3.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.10" />

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -32,6 +32,7 @@
         <Project Path="src/Rask.Core/Rask.Core.csproj"/>
         <Project Path="src/Rask.Cqrs/Rask.Cqrs.csproj"/>
         <Project Path="src/Rask.Cqrs.Generators/Rask.Cqrs.Generators.csproj"/>
+        <Project Path="src/Rask.Dashboard/Rask.Dashboard.csproj"/>
         <Project Path="src/Rask.Data/Rask.Data.csproj"/>
         <Project Path="src/Rask.Jobs/Rask.Jobs.csproj"/>
         <Project Path="src/Rask.Jobs.Generators/Rask.Jobs.Generators.csproj"/>
@@ -62,6 +63,7 @@
         <Project Path="tests/Rask.Core.Tests/Rask.Core.Tests.csproj"/>
         <Project Path="tests/Rask.Cqrs.Tests/Rask.Cqrs.Tests.csproj"/>
         <Project Path="tests/Rask.Cqrs.Generators.Tests/Rask.Cqrs.Generators.Tests.csproj"/>
+        <Project Path="tests/Rask.Dashboard.Tests/Rask.Dashboard.Tests.csproj"/>
         <Project Path="tests/Rask.Data.Tests/Rask.Data.Tests.csproj"/>
         <Project Path="tests/Rask.Jobs.Tests/Rask.Jobs.Tests.csproj"/>
         <Project Path="tests/Rask.Jobs.Generators.Tests/Rask.Jobs.Generators.Tests.csproj"/>

--- a/src/Rask.Bootstrap/BsStat.cs
+++ b/src/Rask.Bootstrap/BsStat.cs
@@ -1,0 +1,50 @@
+namespace Rask.Bootstrap;
+
+// A stat tile: one number, what it means, and optionally why you should care. The shape every
+// dashboard needs and Bootstrap has no primitive for — built from BsCard rather than raw markup, per
+// the library convention that a Bs component composes other Bs components.
+//
+// Tone drives the number's colour, not the card's background: a wall of coloured panels reads as
+// decoration, whereas one red number among grey ones reads as a signal. Callers are expected to leave
+// Tone unset for ordinary counters and set Danger only when the value genuinely demands action (a
+// dead-letter count above zero, say).
+public sealed class BsStat : BsBlock
+{
+    // The number (or short string) — the reason the tile exists.
+    public required string Value { get; set; }
+
+    // What the number counts, shown above it in small caps.
+    public required string Label { get; set; }
+
+    // Optional supporting line under the number: a unit, a threshold, a timestamp.
+    public string? Caption { get; set; }
+
+    // Colours the value. Leave unset for the neutral default.
+    public BsColor? Tone { get; set; }
+
+    // Optional icon shown beside the label.
+    public BsIconName? Icon { get; set; }
+
+    // Renders the whole tile as a link to this URL, so a tile can be the way into its detail page.
+    public string? Href { get; set; }
+
+    protected override Component? Render()
+    {
+        var body = BsCardBody(Class: "py-3")[
+            Div(Class: "d-flex align-items-center gap-2 text-body-secondary text-uppercase small fw-semibold")[
+                Icon is { } icon ? BsIcon(Name: icon) : null,
+                Span()[Label]
+            ],
+            Div(Class: BsClass.Join("fs-3 fw-semibold lh-1 mt-2", Tone is { } t ? t.Text() : null))[Value],
+            Caption is { } caption ? Div(Class: "small text-body-secondary mt-1")[caption] : null
+        ];
+
+        // A linked tile must not look like body text, and must not lose the card's own affordances —
+        // stretched-link would need positioning on the card, so the anchor wraps it instead.
+        return Href is { } href
+            ? A(href, Class: BsClass.Join("text-decoration-none text-reset d-block h-100", Class), Id: Id)[
+                BsCard(Class: "h-100")[body]
+            ]
+            : BsCard(Id: Id, Class: BsClass.Join("h-100", Class))[body];
+    }
+}

--- a/src/Rask.Dashboard/DashboardSecurityState.cs
+++ b/src/Rask.Dashboard/DashboardSecurityState.cs
@@ -1,0 +1,28 @@
+namespace Rask.Dashboard;
+
+/// <summary>
+/// Whether the dashboard ended up on its own fallback authorization policy or on one the application
+/// defined. The layout reads this to decide whether to warn — a banner that appears even when the app has
+/// configured real access control would be noise, and noise is how a genuine warning gets ignored.
+/// </summary>
+/// <remarks>
+/// Written once, from the <c>AuthorizationOptions</c> post-configure callback, before the first request is
+/// served; read-only from then on.
+/// </remarks>
+public sealed class DashboardSecurityState
+{
+    /// <summary>
+    /// <c>true</c> when no <see cref="RaskDashboardPolicies.Access"/> policy was defined and the dashboard
+    /// supplied its own.
+    /// </summary>
+    public bool UsingFallbackPolicy { get; internal set; }
+
+    /// <summary>
+    /// <c>true</c> when that fallback lets everyone in — Development, or
+    /// <see cref="RaskDashboardOptions.AllowAnonymousAccess"/>. <c>false</c> means it denies everyone.
+    /// </summary>
+    public bool FallbackIsOpen { get; internal set; }
+
+    /// <summary>The dashboard is reachable by anyone because nothing was configured.</summary>
+    public bool IsUnsecured => UsingFallbackPolicy && FallbackIsOpen;
+}

--- a/src/Rask.Dashboard/GlobalUsings.cs
+++ b/src/Rask.Dashboard/GlobalUsings.cs
@@ -1,0 +1,11 @@
+// Framework projects opt out of the generator's global usings (Directory.Build.props sets
+// RaskGlobalUsings=false for non-Rask.Example projects), so import the primitives explicitly —
+// exactly as Rask.Bootstrap does. This makes Component/Element and Div()/Span()/Text available
+// unqualified, plus the Bs* factories the dashboard's pages are built from.
+global using Rask.Bootstrap;
+global using Rask.Core;
+global using Rask.Core.Components;
+global using static Rask.Bootstrap.Generated;
+global using static Rask.Core.Components.Generated;
+// Router()/Outlet() — the dashboard ships a route chain of its own, so it needs the routing factories.
+global using static Rask.Core.Routing.Generated;

--- a/src/Rask.Dashboard/NUGET.md
+++ b/src/Rask.Dashboard/NUGET.md
@@ -1,0 +1,70 @@
+# Rask.Dashboard
+
+An operator dashboard for the [Rask](https://github.com/pal-tamas/rask) One Person Framework batteries.
+Mounts at `/_ops` and reads the outbox, background jobs, queued mail and cache **out of your application's
+own database** — the tables are already there, so there is nothing to run and nothing to export.
+
+- **Dead letters, named as such.** Every queue is split into due / delayed / **failed** / processed, where
+  failed means what the processors mean by giving up: out of attempts and still unprocessed. Processed
+  climbing looks healthy while a queue retries itself to death, so the dead-letter count gets a banner of
+  its own rather than a tile among tiles.
+- **The error behind the row.** Expand any row for its last failure message and its stored payload.
+- **Only what you run.** A panel appears only when its battery is both registered *and* mapped into the
+  `DbContext`, so the nav is an inventory of this deployment rather than a menu of dead links.
+- **Cache, system and schedule.** Cache keys with sizes and expiry, SQLite pragmas read live, database
+  size, and the recurring-job schedule joined to when each job last actually fired.
+- **Fail-closed by default.** See below — this matters more than any of the above.
+
+## Use
+
+```bash
+dotnet add package Rask.Dashboard
+```
+
+```csharp
+builder.Services.AddRaskDashboard<AppDbContext>();
+
+// Who may operate the app. Without this the dashboard denies everyone outside Development.
+builder.Services.AddAuthorization(o =>
+    o.AddPolicy(RaskDashboardPolicies.Access, p => p.RequireRole("Admin")));
+```
+
+Then browse to `/_ops`.
+
+## Security
+
+The dashboard shows job payloads, stored email bodies and log lines. An open one is close to publishing
+your database, so it is designed to be safe when you configure nothing:
+
+| Situation | Result |
+| --- | --- |
+| You define the `RaskDashboard` policy | Your policy decides, always. |
+| No policy, `Development` | Open, with a warning banner on every page. |
+| No policy, anything else | **Denied for everyone**, and a warning logged at startup. |
+
+The policy is applied to the route layout, so it covers every dashboard page — including ones added by a
+future version — and is re-checked on each in-app navigation, not just the first request.
+
+## Options
+
+```csharp
+builder.Services.AddRaskDashboard<AppDbContext>(o =>
+{
+    o.RefreshInterval = TimeSpan.FromSeconds(2);   // how often an open panel re-reads
+    o.MaxPollDuration = TimeSpan.FromMinutes(5);   // then it parks and offers Resume
+    o.PageSize        = 25;
+});
+```
+
+Panels poll, compare, and only re-render on a real change — an idle system produces no diff and no
+WebSocket traffic. The loop is bounded on purpose: every open tab is a reader competing with the
+processors for SQLite's single write lock.
+
+## Backups
+
+The backup card is opt-in, because reading Litestream and snapshot state would otherwise force a native
+SQLite provider bundle onto every consumer and tie a provider-agnostic dashboard to SQLite. Implement
+`IDashboardBackupProbe` (about ten lines over `LitestreamStatus.Current` and
+`ISqliteSnapshotStore.ListAsync`) and register it to light the card up.
+
+Full documentation: <https://github.com/pal-tamas/rask/blob/main/docs/dashboard.md>

--- a/src/Rask.Dashboard/Pages/CachePage.cs
+++ b/src/Rask.Dashboard/Pages/CachePage.cs
@@ -1,0 +1,121 @@
+using Rask.Core.Routing;
+using Rask.Dashboard.Panels;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// What's in the cache. Neither <c>ICache</c> nor <c>IDistributedCache</c> can enumerate keys, so this
+/// reads the table directly — which is the point of a DB-backed cache.
+/// </summary>
+[Route("cache")]
+[ParentRoute(typeof(DashboardLayout))]
+public sealed class CachePage(
+    ICachePanelReader cache,
+    RaskDashboardOptions options,
+    TimeProvider timeProvider) : PollingPanel
+{
+    private CacheStats _stats;
+    private IReadOnlyList<CacheKeyRow> _rows = [];
+    private int _total;
+    private int _page;
+
+    /// <summary>Substring filter on the key, from the query string so a search is a shareable link.</summary>
+    [QueryParam("q")]
+    public string? Search { get; set; }
+
+    protected override RaskDashboardOptions Options => options;
+
+    protected override async Task<object?> LoadAsync(CancellationToken cancellationToken)
+    {
+        if (!cache.IsAvailable)
+        {
+            return null;
+        }
+
+        _stats = await cache.StatsAsync(cancellationToken).ConfigureAwait(false);
+        (_rows, _total) = await cache
+            .PageAsync(Search, _page * options.PageSize, options.PageSize, cancellationToken)
+            .ConfigureAwait(false);
+
+        return string.Join('|',
+            [$"{_stats.Entries}:{_stats.Bytes}:{_stats.Expired}:{_total}",
+             .. _rows.Select(r => $"{r.Key}:{r.ExpiresAt.Ticks}")]);
+    }
+
+    protected override Component? Render()
+    {
+        if (IsLoading)
+        {
+            return DashboardParts.Loading();
+        }
+
+        if (!cache.IsAvailable)
+        {
+            return DashboardParts.Empty(
+                "Cache isn't registered",
+                "Call AddRaskCache<TContext>() and modelBuilder.AddRaskCache() to see cache entries here.");
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        return [
+            H1(Class: "h4 mb-3")["Cache"],
+            DashboardParts.Error(LoadError),
+            BsRow(Class: "g-3 mb-4")[
+                BsCol(Sm: 4)[BsStat(Value: _stats.Entries.ToString(), Label: "Entries", Icon: BsIconName.Archive)],
+                BsCol(Sm: 4)[BsStat(Value: DashboardParts.Bytes(_stats.Bytes), Label: "Stored", Icon: BsIconName.Database)],
+                BsCol(Sm: 4)[BsStat(
+                    Value: _stats.Expired.ToString(),
+                    Label: "Expired, not yet swept",
+                    Icon: BsIconName.ClockHistory,
+                    Caption: "removed by the purge sweep")]
+            ],
+            _rows.Count == 0
+                ? DashboardParts.Empty(
+                    Search is { Length: > 0 } ? $"No keys matching \"{Search}\"" : "Cache is empty",
+                    "Entries appear here as soon as something is cached.")
+                : Table(now),
+            Pager(),
+            DashboardParts.Parked(IsParked, ResumeAsync),
+        ];
+    }
+
+    private Component Table(DateTime now) =>
+        BsTable(Small: true, Hover: true, Responsive: true)[
+            Thead()[Tr()[Th()["Key"], Th()["Size"], Th()["Written"], Th()["Expires"], Th()["Sliding"]]],
+            Tbody()[_rows.Select(r => Tr(Key: r.Key, Class: r.ExpiresAt <= now ? "text-body-secondary" : null)[
+                Td()[Div(Class: "text-truncate font-monospace small", Style: "max-width:28rem")[r.Key]],
+                Td()[DashboardParts.Bytes(r.Bytes)],
+                Td()[DashboardParts.Ago(r.CreatedAt, now)],
+                Td()[
+                    r.ExpiresAt <= now
+                        ? BsBadge(Color: BsColor.Secondary)["expired"]
+                        : Span()[DashboardParts.Ago(r.ExpiresAt, now)]
+                ],
+                Td()[r.SlidingSeconds is { } s ? DashboardParts.Duration(TimeSpan.FromSeconds(s)) : "—"]
+            ])]
+        ];
+
+    private Component? Pager()
+    {
+        var pages = (int)Math.Ceiling(_total / (double)options.PageSize);
+        if (pages <= 1)
+        {
+            return null;
+        }
+
+        return Div(Class: "d-flex align-items-center gap-2")[
+            BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
+                Disabled: _page == 0, OnClickAsync: () => GoAsync(_page - 1))["Previous"],
+            Span(Class: "small text-body-secondary")[$"Page {_page + 1} of {pages} — {_total} keys"],
+            BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
+                Disabled: _page >= pages - 1, OnClickAsync: () => GoAsync(_page + 1))["Next"]
+        ];
+    }
+
+    private async Task GoAsync(int page)
+    {
+        _page = Math.Max(0, page);
+        await LoadAsync(CancellationToken).ConfigureAwait(false);
+        StateHasChanged();
+    }
+}

--- a/src/Rask.Dashboard/Pages/DashboardLayout.cs
+++ b/src/Rask.Dashboard/Pages/DashboardLayout.cs
@@ -1,0 +1,103 @@
+using Microsoft.AspNetCore.Authorization;
+using Rask.Core.Routing;
+using Rask.Dashboard.Panels;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// The dashboard's shell and the single place access is enforced.
+/// <para>
+/// <see cref="AuthorizeAttribute" /> sits on the layout, not on each page:
+/// <c>RouteAuthorizationGuard</c> evaluates the whole route chain, so one attribute here protects every
+/// child — on the initial GET and again on each in-app WebSocket navigation. A page added later is
+/// protected by construction rather than by remembering to annotate it.
+/// </para>
+/// <para>
+/// The layout contributes its own stylesheet links via <see cref="Head" />. Head contributions are
+/// collected from every component in the tree and deduplicated by rendered HTML, so the dashboard is
+/// styled correctly inside a host that never linked Bootstrap, without double-linking in one that did —
+/// and they drop out again when the operator navigates back into the app.
+/// </para>
+/// </summary>
+[Route("_ops")]
+[Authorize(Policy = RaskDashboardPolicies.Access)]
+public sealed class DashboardLayout(
+    IEnumerable<IQueuePanel> queues,
+    RouteState route,
+    DashboardSecurityState security) : Component
+{
+    protected override Component? Head =>
+    [
+        Title()["Ops"],
+        // An operator surface has no business in a search index, even behind a policy.
+        Meta(Name: "robots", Content: "noindex, nofollow"),
+        BootstrapStyles(),
+        RaskTokens(),
+    ];
+
+    protected override Component? Render() =>
+    [
+        BsNavbar(Class: "border-bottom mb-4")[
+            BsContainer(Fluid: true)[
+                BsNavbarBrand(Href: Routes.OverviewPage(), Class: "d-flex align-items-center gap-2")[
+                    BsIcon(Name: BsIconName.Speedometer2),
+                    Span()["Ops"]
+                ],
+                BsNav(Class: "ms-auto")[NavItems()]
+            ]
+        ],
+        BsContainer(Fluid: true)[
+            UnsecuredWarning(),
+            Outlet()
+        ],
+    ];
+
+    private IEnumerable<Component> NavItems()
+    {
+        yield return NavLink(Routes.OverviewPage(), "Overview", BsIconName.Speedometer2, exact: true);
+
+        // Only the batteries the app actually registered get a tab, so the nav is an honest inventory of
+        // what this deployment runs rather than a menu of mostly-dead links.
+        foreach (var queue in queues.Where(q => q.IsAvailable).OrderBy(q => q.Title, StringComparer.Ordinal))
+        {
+            yield return NavLink(Routes.QueuePage(queue.Slug), queue.Title, queue.Icon, exact: false);
+        }
+
+        yield return NavLink(Routes.CachePage(), "Cache", BsIconName.Archive, exact: false);
+        yield return NavLink(Routes.SystemPage(), "System", BsIconName.HddStack, exact: false);
+    }
+
+    private Component NavLink(RouteUrl url, string label, BsIconName icon, bool exact) =>
+        BsNavItem(Key: label)[
+            BsLink(url, Class: Bs.Join(
+                "nav-link d-flex align-items-center gap-1",
+                IsActive(url.Path, exact) ? "active" : null))[
+                BsIcon(Name: icon),
+                Span()[label]
+            ]
+        ];
+
+    // Exact for the overview, prefix for the rest — otherwise "/_ops" would light up on every page,
+    // since every dashboard path starts with it.
+    private bool IsActive(string href, bool exact)
+    {
+        var path = route.Path.TrimEnd('/');
+        var target = href.TrimEnd('/');
+        return exact ? path == target : path.StartsWith(target, StringComparison.Ordinal);
+    }
+
+    // The fail-closed default is permissive in Development so `rask dev` just works. That convenience is
+    // exactly the thing that gets shipped by accident, so it says so on every page while it applies — and
+    // only while it applies: an app that defined the policy has real access control and gets no banner.
+    private Component? UnsecuredWarning() =>
+        security.IsUnsecured
+            ? BsAlert(Color: BsColor.Warning, Class: "d-flex align-items-center gap-2")[
+                BsIcon(Name: BsIconName.ExclamationTriangle),
+                Span()[
+                    "Unsecured — anyone who can reach this URL can read job payloads, stored emails and logs. Define the ",
+                    Code()[RaskDashboardPolicies.Access],
+                    " authorization policy; without one the dashboard denies everyone outside Development."
+                ]
+            ]
+            : null;
+}

--- a/src/Rask.Dashboard/Pages/DashboardParts.cs
+++ b/src/Rask.Dashboard/Pages/DashboardParts.cs
@@ -1,0 +1,78 @@
+using System.Globalization;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// The small pieces every panel repeats — a loading placeholder, an empty state, the read-failure alert,
+/// the parked-poll notice, and the two formatters. Kept in one place so the panels read as their data
+/// rather than as markup.
+/// </summary>
+internal static class DashboardParts
+{
+    public static Component Loading() =>
+        Div(Class: "d-flex align-items-center gap-2 text-body-secondary py-4")[
+            BsSpinner(Small: true),
+            Span()["Reading…"]
+        ];
+
+    public static Component Empty(string title, string detail) =>
+        BsCard(Class: "text-center py-5")[
+            BsCardBody()[
+                Div(Class: "fs-5 fw-semibold")[title],
+                Div(Class: "text-body-secondary mt-1")[detail]
+            ]
+        ];
+
+    /// <summary>
+    /// Shown when a read threw. A dashboard that silently stops updating is worse than one that says it
+    /// couldn't read, so the panel keeps its last values and puts the reason on top.
+    /// </summary>
+    public static Component? Error(string? message) =>
+        message is null
+            ? null
+            : BsAlert(Color: BsColor.Danger, Class: "d-flex align-items-center gap-2")[
+                BsIcon(Name: BsIconName.ExclamationTriangle),
+                Span()["Couldn't read: ", message]
+            ];
+
+    public static Component? Parked(bool parked, Func<Task> resume) =>
+        parked
+            ? Div(Class: "d-flex align-items-center gap-2 text-body-secondary small mt-3")[
+                Span()["Live updates paused to keep the database free."],
+                BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClickAsync: () => resume())["Resume"]
+            ]
+            : null;
+
+    /// <summary>
+    /// A UTC instant as "how long ago", which is what an operator actually reads a queue timestamp for.
+    /// Element carries no title attribute, so the absolute instant is shown in the row detail instead.
+    /// </summary>
+    public static string Ago(DateTime utc, DateTime now)
+    {
+        var delta = now - utc;
+        if (delta < TimeSpan.Zero)
+        {
+            return "in " + Humanize(delta.Negate());
+        }
+
+        return delta < TimeSpan.FromSeconds(5) ? "just now" : Humanize(delta) + " ago";
+    }
+
+    public static string Bytes(long bytes) => bytes switch
+    {
+        < 1024 => $"{bytes} B",
+        < 1024 * 1024 => $"{bytes / 1024.0:0.#} KB",
+        < 1024L * 1024 * 1024 => $"{bytes / (1024.0 * 1024):0.#} MB",
+        _ => $"{bytes / (1024.0 * 1024 * 1024):0.##} GB",
+    };
+
+    public static string Duration(TimeSpan span) => Humanize(span);
+
+    private static string Humanize(TimeSpan span) => span switch
+    {
+        { TotalSeconds: < 60 } => $"{span.TotalSeconds.ToString("0", CultureInfo.InvariantCulture)}s",
+        { TotalMinutes: < 60 } => $"{span.TotalMinutes.ToString("0", CultureInfo.InvariantCulture)}m",
+        { TotalHours: < 24 } => $"{span.TotalHours.ToString("0.#", CultureInfo.InvariantCulture)}h",
+        _ => $"{span.TotalDays.ToString("0.#", CultureInfo.InvariantCulture)}d",
+    };
+}

--- a/src/Rask.Dashboard/Pages/OverviewPage.cs
+++ b/src/Rask.Dashboard/Pages/OverviewPage.cs
@@ -1,0 +1,96 @@
+using Rask.Core.Routing;
+using Rask.Dashboard.Panels;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// The landing panel: one tile per queue, plus the cache. Deliberately counters-only — the question it
+/// answers is "is anything wrong?", and the answer should be readable without reading.
+/// </summary>
+[Route("")]
+[ParentRoute(typeof(DashboardLayout))]
+public sealed class OverviewPage(IEnumerable<IQueuePanel> queues, RaskDashboardOptions options) : PollingPanel
+{
+    private readonly List<(IQueuePanel Panel, QueueCounts Counts)> _queues = [];
+
+    protected override RaskDashboardOptions Options => options;
+
+    protected override async Task<object?> LoadAsync(CancellationToken cancellationToken)
+    {
+        _queues.Clear();
+        foreach (var queue in queues.Where(q => q.IsAvailable).OrderBy(q => q.Title, StringComparer.Ordinal))
+        {
+            _queues.Add((queue, await queue.CountsAsync(cancellationToken).ConfigureAwait(false)));
+        }
+
+        // The comparison key is every number on screen, flattened — a value tuple of a list would compare
+        // by reference, so the counts are folded into a string instead.
+        return string.Join('|', _queues.Select(q =>
+            $"{q.Panel.Slug}:{q.Counts.Due}:{q.Counts.Delayed}:{q.Counts.Failed}:{q.Counts.Processed}"));
+    }
+
+    protected override Component? Render()
+    {
+        if (IsLoading)
+        {
+            return DashboardParts.Loading();
+        }
+
+        if (_queues.Count == 0)
+        {
+            return DashboardParts.Empty(
+                "No batteries registered",
+                "Add Rask.Jobs, Rask.Outbox, Rask.Mail or Rask.Cache and map their tables to see them here.");
+        }
+
+        return [
+            DashboardParts.Error(LoadError),
+            FailureBanner(),
+            BsRow(Class: "g-3")[_queues.SelectMany(q => Tiles(q.Panel, q.Counts))],
+            DashboardParts.Parked(IsParked, ResumeAsync),
+        ];
+    }
+
+    // The one number worth interrupting for. Processed climbing looks healthy while a queue retries itself
+    // to death, so the dead-letter total gets its own banner rather than only a tile among tiles.
+    private Component? FailureBanner()
+    {
+        var failed = _queues.Sum(q => q.Counts.Failed);
+        if (failed == 0)
+        {
+            return null;
+        }
+
+        var worst = _queues.Where(q => q.Counts.Failed > 0).OrderByDescending(q => q.Counts.Failed).ToList();
+        return BsAlert(Color: BsColor.Danger, Class: "d-flex align-items-center gap-2")[
+            BsIcon(Name: BsIconName.ExclamationTriangle),
+            Span()[
+                $"{failed} dead letter{(failed == 1 ? "" : "s")} — ",
+                Span()[string.Join(", ", worst.Select(q => $"{q.Counts.Failed} in {q.Panel.Title.ToLowerInvariant()}"))],
+                ". These have run out of attempts and will not be retried."
+            ]
+        ];
+    }
+
+    private IEnumerable<Component> Tiles(IQueuePanel panel, QueueCounts counts)
+    {
+        yield return BsCol(Sm: 6, Lg: 3)[
+            BsStat(
+                Value: counts.Outstanding.ToString(),
+                Label: $"{panel.Title} outstanding",
+                Icon: panel.Icon,
+                Caption: counts.Delayed > 0 ? $"{counts.Delayed} waiting on a retry" : "nothing waiting",
+                Href: Routes.QueuePage(panel.Slug))
+        ];
+
+        yield return BsCol(Sm: 6, Lg: 3)[
+            BsStat(
+                Value: counts.Failed.ToString(),
+                Label: $"{panel.Title} failed",
+                Icon: BsIconName.ExclamationTriangle,
+                Tone: counts.Failed > 0 ? BsColor.Danger : null,
+                Caption: $"after {panel.MaxAttempts} attempts",
+                Href: Routes.QueuePage(panel.Slug))
+        ];
+    }
+}

--- a/src/Rask.Dashboard/Pages/PollingComponent.cs
+++ b/src/Rask.Dashboard/Pages/PollingComponent.cs
@@ -1,0 +1,165 @@
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// A panel that re-reads itself on a timer while it is on screen.
+/// <para>
+/// Four things here are load-bearing, and all four exist because the dashboard reads the same database the
+/// processors are writing to:
+/// </para>
+/// <list type="number">
+///   <item>
+///     <b>The loop is fire-and-forget.</b> <see cref="OnMountAsync" /> awaits only the first read; awaiting
+///     the loop itself would never return and the page would never mount.
+///   </item>
+///   <item>
+///     <b>Compare before re-rendering.</b> <see cref="LoadAsync" /> returns a value compared with the
+///     previous one, so an unchanged reading produces no <c>StateHasChanged</c> — an idle system generates
+///     no diff and no WebSocket traffic at all.
+///   </item>
+///   <item>
+///     <b>The loop is bounded.</b> After <see cref="RaskDashboardOptions.MaxPollDuration" /> the panel parks
+///     and offers a Resume button. Every open tab is a reader competing for the write lock, and a dashboard
+///     left open on a wall display would otherwise poll forever.
+///   </item>
+///   <item>
+///     <b><c>ConfigureAwait(false)</c> throughout.</b> Staying off the lifecycle synchronization context
+///     keeps the loop from triggering a render per await.
+///   </item>
+/// </list>
+/// </summary>
+public abstract class PollingPanel : Component
+{
+    private object? _previous;
+    private bool _running;
+
+    /// <summary>The dashboard options. Inject them and return them.</summary>
+    protected abstract RaskDashboardOptions Options { get; }
+
+    /// <summary>
+    /// Reads the panel's data into fields and returns a value used purely for change detection — return a
+    /// value type or record whose equality means "the screen would look the same".
+    /// </summary>
+    protected abstract Task<object?> LoadAsync(CancellationToken cancellationToken);
+
+    /// <summary><c>true</c> once the loop has stopped and the Resume affordance should show.</summary>
+    protected bool IsParked { get; private set; }
+
+    /// <summary><c>true</c> until the first read completes, so the panel can show a placeholder.</summary>
+    protected bool IsLoading { get; private set; } = true;
+
+    /// <summary>The most recent read that failed, if the last one did.</summary>
+    protected string? LoadError { get; private set; }
+
+    /// <inheritdoc />
+    protected override async Task OnMountAsync()
+    {
+        // Captured here, in a lifecycle hook, where CancellationToken is the component's LIFETIME token —
+        // read inside a handler dispatch it would also carry that dispatch's timeout, which would kill the
+        // loop early. It is cancelled when the component leaves the tree, so no teardown code is needed.
+        var lifetime = CancellationToken;
+
+        await ReadAsync(lifetime).ConfigureAwait(false);
+        IsLoading = false;
+        Start(lifetime);
+    }
+
+    /// <summary>Restarts the loop after it parked.</summary>
+    protected Task ResumeAsync()
+    {
+        if (IsParked)
+        {
+            IsParked = false;
+            Start(CancellationToken);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void Start(CancellationToken cancellationToken)
+    {
+        if (_running || Options.RefreshInterval <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        _running = true;
+        _ = PollAsync(cancellationToken);
+    }
+
+    private async Task PollAsync(CancellationToken cancellationToken)
+    {
+        var deadline = Options.MaxPollDuration > TimeSpan.Zero
+            ? DateTimeOffset.UtcNow + Options.MaxPollDuration
+            : DateTimeOffset.MaxValue;
+
+        try
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    await Task.Delay(Options.RefreshInterval, cancellationToken).ConfigureAwait(false);
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+
+                if (!await ReadAsync(cancellationToken).ConfigureAwait(false))
+                {
+                    return; // cancelled mid-read: the component is gone
+                }
+
+                if (DateTimeOffset.UtcNow >= deadline)
+                {
+                    IsParked = true;
+                    StateHasChanged();
+                    return;
+                }
+            }
+        }
+        finally
+        {
+            _running = false;
+        }
+    }
+
+    // Returns false only when the component is going away. A query that throws is shown in the panel
+    // rather than silently ending the loop: a dashboard that quietly stops updating is worse than one
+    // that says it couldn't read.
+    private async Task<bool> ReadAsync(CancellationToken cancellationToken)
+    {
+        object? current;
+        string? error;
+        try
+        {
+            current = await LoadAsync(cancellationToken).ConfigureAwait(false);
+            error = null;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return false;
+        }
+#pragma warning disable CA1031 // A failed read must not tear the panel down — surface it and keep polling.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            current = null;
+            error = ex.Message;
+        }
+
+        // The error is part of what's on screen, so it joins the comparison — otherwise a database that
+        // stays down would re-render identical content on every tick. Equals(null, null) is true, so a
+        // panel whose battery isn't present settles after the first read and then stays silent.
+        var reading = (current, error);
+        if (Equals(_previous, reading))
+        {
+            return true;
+        }
+
+        _previous = reading;
+        LoadError = error;
+        StateHasChanged();
+        return true;
+    }
+}

--- a/src/Rask.Dashboard/Pages/QueuePage.cs
+++ b/src/Rask.Dashboard/Pages/QueuePage.cs
@@ -1,0 +1,202 @@
+using Rask.Core.Routing;
+using Rask.Dashboard.Panels;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// One queue in detail: the counts as filter tabs, then the rows behind whichever is selected. The same
+/// page serves the outbox, jobs and mail — they differ in which columns mean what, not in what an operator
+/// needs from them.
+/// </summary>
+[Route("queues/{queue}")]
+[ParentRoute(typeof(DashboardLayout))]
+public sealed class QueuePage(
+    IEnumerable<IQueuePanel> queues,
+    RaskDashboardOptions options,
+    TimeProvider timeProvider) : PollingPanel
+{
+    private IQueuePanel? _panel;
+    private QueueCounts _counts;
+    private IReadOnlyList<QueueRow> _rows = [];
+    private int _total;
+    private int _page;
+    private long? _expanded;
+
+    /// <summary>Which queue, from the route.</summary>
+    [RouteParam]
+    public string Queue { get; set; } = "";
+
+    /// <summary>Which slice, from the query string, so a filtered view is a shareable link.</summary>
+    [QueryParam("show")]
+    public string? Show { get; set; }
+
+    protected override RaskDashboardOptions Options => options;
+
+    private QueueFilter Filter =>
+        Enum.TryParse<QueueFilter>(Show, ignoreCase: true, out var parsed) ? parsed : QueueFilter.Outstanding;
+
+    protected override async Task<object?> LoadAsync(CancellationToken cancellationToken)
+    {
+        _panel = queues.FirstOrDefault(q =>
+            string.Equals(q.Slug, Queue, StringComparison.OrdinalIgnoreCase) && q.IsAvailable);
+
+        if (_panel is null)
+        {
+            _rows = [];
+            _total = 0;
+            return null;
+        }
+
+        _counts = await _panel.CountsAsync(cancellationToken).ConfigureAwait(false);
+        (_rows, _total) = await _panel
+            .PageAsync(Filter, _page * options.PageSize, options.PageSize, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Row identity plus attempt count is enough to notice any change that matters: a row moving state
+        // changes the filter it appears in, and a retry bumps Attempts.
+        return string.Join('|',
+            [$"{_counts.Due}:{_counts.Delayed}:{_counts.Failed}:{_counts.Processed}:{_total}",
+             .. _rows.Select(r => $"{r.Id}:{r.Attempts}:{r.ProcessedAt?.Ticks ?? 0}")]);
+    }
+
+    protected override Component? Render()
+    {
+        if (IsLoading)
+        {
+            return DashboardParts.Loading();
+        }
+
+        if (_panel is null)
+        {
+            return DashboardParts.Empty(
+                $"No queue called \"{Queue}\"",
+                "Either that battery isn't registered, or its table isn't mapped into the DbContext.");
+        }
+
+        return [
+            Div(Class: "d-flex align-items-center gap-2 mb-3")[
+                BsIcon(Name: _panel.Icon, Class: "fs-4"),
+                H1(Class: "h4 mb-0")[_panel.Title]
+            ],
+            DashboardParts.Error(LoadError),
+            FilterTabs(),
+            _rows.Count == 0 ? EmptyForFilter() : RowsTable(),
+            Pager(),
+            DashboardParts.Parked(IsParked, ResumeAsync),
+        ];
+    }
+
+    private Component FilterTabs() =>
+        BsNav(Class: "nav-pills gap-1 mb-3")[
+            Tab(QueueFilter.Outstanding, "Outstanding", _counts.Outstanding, null),
+            Tab(QueueFilter.Due, "Due", _counts.Due, null),
+            Tab(QueueFilter.Delayed, "Delayed", _counts.Delayed, null),
+            Tab(QueueFilter.Failed, "Failed", _counts.Failed, _counts.Failed > 0 ? BsColor.Danger : null),
+            Tab(QueueFilter.Processed, "Processed", _counts.Processed, null)
+        ];
+
+    private Component Tab(QueueFilter filter, string label, int count, BsColor? tone) =>
+        BsNavItem()[
+            BsLink(
+                Routes.QueuePage(_panel!.Slug, Show: filter.ToString().ToLowerInvariant()),
+                Class: Bs.Join("nav-link d-flex align-items-center gap-2", Filter == filter ? "active" : null))[
+                Span()[label],
+                BsBadge(Color: tone ?? (Filter == filter ? BsColor.Light : BsColor.Secondary), Pill: true)[count.ToString()]
+            ]
+        ];
+
+    private Component EmptyForFilter() => DashboardParts.Empty(
+        $"Nothing {Filter.ToString().ToLowerInvariant()}",
+        Filter == QueueFilter.Failed
+            ? "No dead letters. This is the number you want at zero."
+            : "Nothing in this slice right now.");
+
+    private Component RowsTable()
+    {
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        return BsTable(Small: true, Hover: true, Responsive: true)[
+            Thead()[Tr()[
+                Th()["#"], Th()[TypeColumnLabel()], Th()["When"], Th()["Attempts"], Th()["Status"], Th()
+            ]],
+            Tbody()[_rows.SelectMany(r => Row(r, now))]
+        ];
+    }
+
+    // Mail's "type" column is really its subject; calling it Type on that page would be a small lie.
+    private string TypeColumnLabel() => _panel!.Slug == "mail" ? "Subject" : "Type";
+
+    private IEnumerable<Component> Row(QueueRow row, DateTime now)
+    {
+        var isDead = row.ProcessedAt is null && row.Attempts >= _panel!.MaxAttempts;
+        yield return Tr(Key: row.Id, Class: isDead ? "table-danger" : null)[
+            Td(Class: "text-body-secondary")[row.Id.ToString()],
+            Td()[Div(Class: "text-truncate", Style: "max-width:28rem")[row.Type]],
+            Td()[DashboardParts.Ago(row.CreatedAt, now)],
+            Td()[row.Attempts.ToString()],
+            Td()[StatusBadge(row, isDead, now)],
+            Td(Class: "text-end")[
+                BsButton(
+                    Color: BsColor.Secondary,
+                    Outline: true,
+                    Size: BsSize.Sm,
+                    OnClick: () => Toggle(row.Id))[_expanded == row.Id ? "Hide" : "Details"]
+            ]
+        ];
+
+        if (_expanded == row.Id)
+        {
+            yield return Tr(Key: $"{row.Id}-details")[Td(Colspan: 6, Class: "bg-body-tertiary")[Details(row)]];
+        }
+    }
+
+    private Component StatusBadge(QueueRow row, bool isDead, DateTime now) => row switch
+    {
+        { ProcessedAt: not null } => BsBadge(Color: BsColor.Success)["done"],
+        _ when isDead => BsBadge(Color: BsColor.Danger)["dead letter"],
+        _ when row.RunAt > now => BsBadge(Color: BsColor.Secondary)[$"retries in {DashboardParts.Duration(row.RunAt - now)}"],
+        _ => BsBadge(Color: BsColor.Info)["due"],
+    };
+
+    private static Component Details(QueueRow row) =>
+        Div(Class: "small")[
+            row.Error is { } error
+                ? Div(Class: "mb-2")[
+                    Div(Class: "fw-semibold text-danger")["Last error"],
+                    Pre(Class: "mb-0 text-body-secondary text-wrap")[error]
+                ]
+                : null,
+            Div(Class: "fw-semibold")["Payload"],
+            Pre(Class: "mb-0 text-body-secondary text-wrap")[row.Payload]
+        ];
+
+    private void Toggle(long id)
+    {
+        _expanded = _expanded == id ? null : id;
+        StateHasChanged();
+    }
+
+    private Component? Pager()
+    {
+        var pages = (int)Math.Ceiling(_total / (double)options.PageSize);
+        if (pages <= 1)
+        {
+            return null;
+        }
+
+        return Div(Class: "d-flex align-items-center gap-2")[
+            BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
+                Disabled: _page == 0, OnClickAsync: () => GoAsync(_page - 1))["Previous"],
+            Span(Class: "small text-body-secondary")[$"Page {_page + 1} of {pages} — {_total} rows"],
+            BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
+                Disabled: _page >= pages - 1, OnClickAsync: () => GoAsync(_page + 1))["Next"]
+        ];
+    }
+
+    private async Task GoAsync(int page)
+    {
+        _page = Math.Max(0, page);
+        _expanded = null;
+        await LoadAsync(CancellationToken).ConfigureAwait(false);
+        StateHasChanged();
+    }
+}

--- a/src/Rask.Dashboard/Pages/SystemPage.cs
+++ b/src/Rask.Dashboard/Pages/SystemPage.cs
@@ -1,0 +1,172 @@
+using Rask.Core.Routing;
+using Rask.Dashboard.Panels;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// The host: how the database is configured, what is scheduled to run, and whether backups are actually
+/// happening. Everything here is read-only and cheap — it is the page you screenshot when someone asks
+/// "is production set up correctly?".
+/// </summary>
+[Route("system")]
+[ParentRoute(typeof(DashboardLayout))]
+public sealed class SystemPage(
+    ISystemPanelReader system,
+    RaskDashboardOptions options,
+    TimeProvider timeProvider) : PollingPanel
+{
+    private DatabaseInfo? _database;
+    private IReadOnlyList<RecurringJobRow> _recurring = [];
+    private BackupReplicationInfo? _replication;
+    private IReadOnlyList<BackupSnapshotInfo> _snapshots = [];
+
+    protected override RaskDashboardOptions Options => options;
+
+    protected override async Task<object?> LoadAsync(CancellationToken cancellationToken)
+    {
+        _database = await system.DatabaseAsync(cancellationToken).ConfigureAwait(false);
+        _recurring = await system.RecurringJobsAsync(cancellationToken).ConfigureAwait(false);
+        _replication = await system.ReplicationAsync(cancellationToken).ConfigureAwait(false);
+        _snapshots = await system.SnapshotsAsync(cancellationToken).ConfigureAwait(false);
+
+        return string.Join('|',
+            [$"{_database?.SizeBytes}:{_database?.JournalMode}:{_database?.ForeignKeys}",
+             $"{_replication?.IsReplicating}:{_replication?.RestartCount}:{_replication?.LastError}",
+             $"{_snapshots.Count}:{_snapshots.FirstOrDefault()?.Name}",
+             .. _recurring.Select(r => $"{r.Name}:{r.LastEnqueuedAt?.Ticks ?? 0}")]);
+    }
+
+    protected override Component? Render()
+    {
+        if (IsLoading)
+        {
+            return DashboardParts.Loading();
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        return [
+            H1(Class: "h4 mb-3")["System"],
+            DashboardParts.Error(LoadError),
+            DatabaseCard(),
+            BackupCard(now),
+            RecurringCard(now),
+            DashboardParts.Parked(IsParked, ResumeAsync),
+        ];
+    }
+
+    private Component? DatabaseCard()
+    {
+        if (_database is not { } db)
+        {
+            return null;
+        }
+
+        return BsCard(Class: "mb-4")[
+            BsCardHeader()["Database"],
+            BsCardBody()[
+                BsRow(Class: "g-3")[
+                    BsCol(Sm: 6, Lg: 3)[BsStat(
+                        Value: db.SizeBytes is { } size ? DashboardParts.Bytes(size) : "—",
+                        Label: "Size",
+                        Icon: BsIconName.Database)],
+                    BsCol(Sm: 6, Lg: 3)[BsStat(
+                        Value: db.JournalMode?.ToUpperInvariant() ?? "n/a",
+                        Label: "Journal mode",
+                        // WAL is the pragma that makes concurrent reads and continuous backup work at all,
+                        // so anything else on SQLite is worth flagging rather than just displaying.
+                        Tone: db.JournalMode is null ? null
+                            : db.JournalMode.Equals("wal", StringComparison.OrdinalIgnoreCase)
+                                ? BsColor.Success
+                                : BsColor.Warning,
+                        Icon: BsIconName.HddStack)],
+                    BsCol(Sm: 6, Lg: 3)[BsStat(
+                        Value: db.ForeignKeys switch { true => "on", false => "off", null => "n/a" },
+                        Label: "Foreign keys",
+                        Tone: db.ForeignKeys is false ? BsColor.Warning : null,
+                        Icon: BsIconName.Diagram3)],
+                    BsCol(Sm: 6, Lg: 3)[BsStat(
+                        Value: ShortProvider(db.Provider),
+                        Label: "Provider",
+                        Icon: BsIconName.Database)]
+                ]
+            ]
+        ];
+    }
+
+    private Component? BackupCard(DateTime now)
+    {
+        // No probe registered means the app didn't say how it backs up — showing "no backups" would be a
+        // claim the dashboard can't support, so the card stays away entirely.
+        if (!system.HasBackupProbe)
+        {
+            return null;
+        }
+
+        return BsCard(Class: "mb-4")[
+            BsCardHeader()["Backup"],
+            BsCardBody()[
+                _replication is { } r
+                    ? BsRow(Class: "g-3 mb-3")[
+                        BsCol(Sm: 6, Lg: 4)[BsStat(
+                            Value: r.IsReplicating ? "running" : "stopped",
+                            Label: "Continuous replication",
+                            Tone: r.IsReplicating ? BsColor.Success : BsColor.Danger,
+                            Caption: r.LastStartedAt is { } started
+                                ? $"since {DashboardParts.Ago(started.UtcDateTime, now)}"
+                                : "never started",
+                            Icon: BsIconName.ArrowRepeat)],
+                        BsCol(Sm: 6, Lg: 4)[BsStat(
+                            Value: r.RestartCount.ToString(),
+                            Label: "Restarts",
+                            // Backups that keep restarting are the failure that looks like success in a log.
+                            Tone: r.RestartCount > 0 ? BsColor.Warning : null,
+                            Caption: r.LastError ?? "no failures recorded",
+                            Icon: BsIconName.ExclamationTriangle)]
+                    ]
+                    : null,
+                SnapshotList(now)
+            ]
+        ];
+    }
+
+    private Component SnapshotList(DateTime now) =>
+        _snapshots.Count == 0
+            ? Div(Class: "text-body-secondary small")["No snapshots stored."]
+            : BsTable(Small: true, Responsive: true, Class: "mb-0")[
+                Thead()[Tr()[Th()["Snapshot"], Th()["Size"], Th()["Taken"]]],
+                Tbody()[_snapshots.Take(10).Select(s => Tr(Key: s.Name)[
+                    Td(Class: "font-monospace small")[s.Name],
+                    Td()[DashboardParts.Bytes(s.SizeBytes)],
+                    Td()[DashboardParts.Ago(s.CreatedAt, now)]
+                ])]
+            ];
+
+    private Component? RecurringCard(DateTime now)
+    {
+        if (_recurring.Count == 0)
+        {
+            return null;
+        }
+
+        return BsCard()[
+            BsCardHeader()["Recurring jobs"],
+            BsCardBody()[
+                BsTable(Small: true, Responsive: true, Class: "mb-0")[
+                    Thead()[Tr()[Th()["Name"], Th()["Every"], Th()["Last enqueued"]]],
+                    Tbody()[_recurring.Select(r => Tr(Key: r.Name)[
+                        Td(Class: "font-monospace small")[r.Name],
+                        Td()[DashboardParts.Duration(r.Interval)],
+                        Td()[r.LastEnqueuedAt is { } last
+                            ? Span()[DashboardParts.Ago(last, now)]
+                            // Declared but never fired: either the app just started, or this one is stuck.
+                            : BsBadge(Color: BsColor.Secondary)["never"]]
+                    ])]
+                ]
+            ]
+        ];
+    }
+
+    // "Microsoft.EntityFrameworkCore.Sqlite" reads better as "Sqlite" in a tile.
+    private static string ShortProvider(string provider) =>
+        provider.Split('.').LastOrDefault() is { Length: > 0 } last ? last : provider;
+}

--- a/src/Rask.Dashboard/Panels/BatteryQueuePanels.cs
+++ b/src/Rask.Dashboard/Panels/BatteryQueuePanels.cs
@@ -1,0 +1,199 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Cache;
+using Rask.Jobs;
+using Rask.Mail;
+using Rask.Outbox;
+
+namespace Rask.Dashboard.Panels;
+
+/// <summary>Background jobs — <see cref="Job"/>.</summary>
+internal sealed class JobsQueuePanel<TContext>(
+    IDbContextFactory<TContext> contextFactory,
+    TimeProvider timeProvider,
+    IServiceProvider services)
+    : QueuePanelBase<TContext, Job>(contextFactory, timeProvider)
+    where TContext : DbContext
+{
+    private readonly JobOptions? _options = services.GetService<JobOptions>();
+
+    public override string Slug => "jobs";
+
+    public override string Title => "Jobs";
+
+    public override BsIconName Icon => BsIconName.GearWideConnected;
+
+    public override int MaxAttempts => _options?.MaxAttempts ?? 0;
+
+    protected override bool IsRegistered => _options is not null;
+
+    protected override string RunAtProperty => nameof(Job.RunAt);
+
+    protected override Expression<Func<Job, QueueRow>> Projection => j => new QueueRow(
+        j.Id, j.Type, j.Payload, j.CreatedAt, j.RunAt, j.ProcessedAt, j.Attempts, j.Error, j.Payload);
+}
+
+/// <summary>Domain events awaiting publication — <see cref="OutboxMessage"/>.</summary>
+internal sealed class OutboxQueuePanel<TContext>(
+    IDbContextFactory<TContext> contextFactory,
+    TimeProvider timeProvider,
+    IServiceProvider services)
+    : QueuePanelBase<TContext, OutboxMessage>(contextFactory, timeProvider)
+    where TContext : DbContext
+{
+    private readonly OutboxOptions? _options = services.GetService<OutboxOptions>();
+
+    public override string Slug => "outbox";
+
+    public override string Title => "Outbox";
+
+    public override BsIconName Icon => BsIconName.BoxArrowUpRight;
+
+    public override int MaxAttempts => _options?.MaxAttempts ?? 0;
+
+    protected override bool IsRegistered => _options is not null;
+
+    // The outbox has no scheduled-run column: an event is eligible the moment it is written, and a retry
+    // is immediate rather than backed off. OccurredAt stands in for both so the shared projection holds —
+    // which correctly leaves the Delayed count permanently zero for this queue.
+    protected override string RunAtProperty => nameof(OutboxMessage.OccurredAt);
+
+    protected override Expression<Func<OutboxMessage, QueueRow>> Projection => m => new QueueRow(
+        m.Id, m.Type, m.Payload, m.OccurredAt, m.OccurredAt, m.ProcessedAt, m.Attempts, m.Error, m.Payload);
+}
+
+/// <summary>Queued email — <see cref="QueuedMail"/>.</summary>
+internal sealed class MailQueuePanel<TContext>(
+    IDbContextFactory<TContext> contextFactory,
+    TimeProvider timeProvider,
+    IServiceProvider services)
+    : QueuePanelBase<TContext, QueuedMail>(contextFactory, timeProvider)
+    where TContext : DbContext
+{
+    private readonly MailOptions? _options = services.GetService<MailOptions>();
+
+    public override string Slug => "mail";
+
+    public override string Title => "Mail";
+
+    public override BsIconName Icon => BsIconName.Envelope;
+
+    public override int MaxAttempts => _options?.MaxAttempts ?? 0;
+
+    protected override bool IsRegistered => _options is not null;
+
+    // For mail the useful "type" is the subject and the useful summary is who it went to — the two things
+    // you scan a mail log for. Recipients are stored as a JSON array; the detail page deserializes it
+    // properly, the list just shows the raw string.
+    protected override string RunAtProperty => nameof(QueuedMail.RunAt);
+
+    protected override Expression<Func<QueuedMail, QueueRow>> Projection => m => new QueueRow(
+        m.Id, m.Subject, m.To, m.CreatedAt, m.RunAt, m.ProcessedAt, m.Attempts, m.Error, m.To);
+}
+
+/// <summary>
+/// The cache reader, without the context type parameter — pages aren't generic, so they resolve this.
+/// </summary>
+public interface ICachePanelReader
+{
+    /// <summary><c>false</c> when Rask.Cache isn't registered or its table isn't mapped.</summary>
+    bool IsAvailable { get; }
+
+    /// <summary>Entry count, total stored bytes, and how many are expired but not yet swept.</summary>
+    Task<CacheStats> StatsAsync(CancellationToken cancellationToken);
+
+    /// <summary>One page of keys, soonest to expire first.</summary>
+    Task<(IReadOnlyList<CacheKeyRow> Rows, int Total)> PageAsync(
+        string? search, int skip, int take, CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// The cache is not a queue — no attempts, no dead letters — so it gets its own small panel rather than
+/// being forced through <see cref="IQueuePanel"/>.
+/// </summary>
+internal sealed class CachePanel<TContext>(
+    IDbContextFactory<TContext> contextFactory,
+    TimeProvider timeProvider,
+    IServiceProvider services) : ICachePanelReader
+    where TContext : DbContext
+{
+    private readonly CacheOptions? _options = services.GetService<CacheOptions>();
+    private bool? _mapped;
+
+    public bool IsAvailable => _options is not null && IsMapped();
+
+    /// <summary>Entry count, total stored bytes, and how many are expired but not yet swept.</summary>
+    public async Task<CacheStats> StatsAsync(CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return default;
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var entries = db.Set<CacheEntry>();
+
+        return new CacheStats(
+            Entries: await entries.CountAsync(cancellationToken).ConfigureAwait(false),
+            // SUM over an empty table is NULL in SQL, hence the nullable projection rather than a plain Sum.
+            Bytes: await entries.SumAsync(e => (long?)e.Value.Length, cancellationToken).ConfigureAwait(false) ?? 0,
+            Expired: await entries.CountAsync(e => e.ExpiresAt <= now, cancellationToken).ConfigureAwait(false));
+    }
+
+    /// <summary>One page of keys, soonest to expire first — the ones about to vanish are the interesting ones.</summary>
+    public async Task<(IReadOnlyList<CacheKeyRow> Rows, int Total)> PageAsync(
+        string? search, int skip, int take, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return ([], 0);
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var query = db.Set<CacheEntry>().AsQueryable();
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            query = query.Where(e => e.Key.Contains(search));
+        }
+
+        var total = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+        var rows = await query
+            .OrderBy(e => e.ExpiresAt)
+            .Skip(skip)
+            .Take(take)
+            .Select(e => new CacheKeyRow(e.Key, e.Value.Length, e.CreatedAt, e.ExpiresAt, e.SlidingSeconds))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return (rows, total);
+    }
+
+    private bool IsMapped()
+    {
+        if (_mapped is { } known)
+        {
+            return known;
+        }
+
+        using var db = contextFactory.CreateDbContext();
+        var mapped = db.Model.FindEntityType(typeof(CacheEntry)) is not null;
+        _mapped = mapped;
+        return mapped;
+    }
+}
+
+/// <summary>Cache totals for the overview tiles.</summary>
+/// <param name="Entries">Rows in the cache table.</param>
+/// <param name="Bytes">Total stored value bytes.</param>
+/// <param name="Expired">Rows past their expiry that the purge sweep hasn't removed yet.</param>
+public readonly record struct CacheStats(int Entries, long Bytes, int Expired);
+
+/// <summary>One cache entry, without its value.</summary>
+/// <param name="Key">The cache key.</param>
+/// <param name="Bytes">Size of the stored value.</param>
+/// <param name="CreatedAt">When it was written (UTC).</param>
+/// <param name="ExpiresAt">When it stops being served (UTC).</param>
+/// <param name="SlidingSeconds">The sliding window, if it has one.</param>
+public sealed record CacheKeyRow(string Key, int Bytes, DateTime CreatedAt, DateTime ExpiresAt, double? SlidingSeconds);

--- a/src/Rask.Dashboard/Panels/QueuePanel.cs
+++ b/src/Rask.Dashboard/Panels/QueuePanel.cs
@@ -1,0 +1,93 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Dashboard.Panels;
+
+/// <summary>
+/// One row of a queue table, projected to the shape the outbox, jobs and mail tables share. Keeping the
+/// panel generic over this rather than over the three entity types is what lets a single page serve all
+/// three — they differ only in which columns exist, not in what an operator needs to see.
+/// </summary>
+/// <param name="Id">The row's key.</param>
+/// <param name="Type">The registered type name (or, for mail, the subject).</param>
+/// <param name="Summary">A one-line description — the recipient list for mail, the payload preview otherwise.</param>
+/// <param name="CreatedAt">When the row was enqueued (UTC).</param>
+/// <param name="RunAt">When it next becomes eligible (UTC). Equal to <paramref name="CreatedAt"/> for the outbox, which has no delay.</param>
+/// <param name="ProcessedAt">When it completed (UTC), or <c>null</c> while outstanding.</param>
+/// <param name="Attempts">How many times it has been tried.</param>
+/// <param name="Error">The last failure message.</param>
+/// <param name="Payload">The stored payload, for the drill-down.</param>
+public sealed record QueueRow(
+    long Id,
+    string Type,
+    string Summary,
+    DateTime CreatedAt,
+    DateTime RunAt,
+    DateTime? ProcessedAt,
+    int Attempts,
+    string? Error,
+    string Payload);
+
+/// <summary>Which slice of a queue to show.</summary>
+public enum QueueFilter
+{
+    /// <summary>Everything still outstanding — due, delayed, and dead-lettered.</summary>
+    Outstanding,
+
+    /// <summary>Eligible to run now and not yet exhausted.</summary>
+    Due,
+
+    /// <summary>Waiting on a backoff or a scheduled time.</summary>
+    Delayed,
+
+    /// <summary>Given up: out of attempts, still unprocessed. The number that matters.</summary>
+    Failed,
+
+    /// <summary>Completed.</summary>
+    Processed,
+}
+
+/// <summary>
+/// The counts an operator reads at a glance. <see cref="Failed"/> is the headline: processed climbing is
+/// normal, but a system that retries itself to death still reports a healthy processed count.
+/// </summary>
+/// <param name="Due">Eligible to run now.</param>
+/// <param name="Delayed">Waiting on a backoff or a scheduled time.</param>
+/// <param name="Failed">Out of attempts and still unprocessed — dead letters.</param>
+/// <param name="Processed">Completed.</param>
+public readonly record struct QueueCounts(int Due, int Delayed, int Failed, int Processed)
+{
+    /// <summary>Everything not yet processed, whatever the reason.</summary>
+    public int Outstanding => Due + Delayed + Failed;
+}
+
+/// <summary>
+/// A queue the dashboard can show. Implemented once per battery; the page never names an entity type.
+/// </summary>
+public interface IQueuePanel
+{
+    /// <summary>URL-safe identity, e.g. <c>jobs</c>. Also the route segment.</summary>
+    string Slug { get; }
+
+    /// <summary>Display name, e.g. "Jobs".</summary>
+    string Title { get; }
+
+    /// <summary>The icon for the nav entry and the overview tile.</summary>
+    BsIconName Icon { get; }
+
+    /// <summary>
+    /// <c>false</c> when this battery isn't part of the app — either not registered, or registered without
+    /// its table mapped into the model. The dashboard hides the panel entirely rather than showing an
+    /// empty one, so what you see is what the app actually runs.
+    /// </summary>
+    bool IsAvailable { get; }
+
+    /// <summary>The attempt count at which this queue gives up — needed to tell a retry from a dead letter.</summary>
+    int MaxAttempts { get; }
+
+    /// <summary>The five counts, in one round-trip per count.</summary>
+    Task<QueueCounts> CountsAsync(CancellationToken cancellationToken);
+
+    /// <summary>One page of rows, newest activity first, plus the total behind it for the pager.</summary>
+    Task<(IReadOnlyList<QueueRow> Rows, int Total)> PageAsync(
+        QueueFilter filter, int skip, int take, CancellationToken cancellationToken);
+}

--- a/src/Rask.Dashboard/Panels/QueuePanelBase.cs
+++ b/src/Rask.Dashboard/Panels/QueuePanelBase.cs
@@ -1,0 +1,145 @@
+using System.Linq.Expressions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Dashboard.Panels;
+
+/// <summary>
+/// The counting, filtering and paging every queue panel shares, so there is a single definition of what
+/// "failed" means rather than three that can drift.
+/// <para>
+/// The predicates are written with <see cref="EF.Property{T}" /> against the three columns the outbox,
+/// jobs and mail tables have in common — <c>ProcessedAt</c>, <c>Attempts</c>, and a run-time column each
+/// adapter names. That is what allows one predicate to serve three entity types: filtering has to happen
+/// on the entity, because EF cannot compose a <c>Where</c> onto a projection into a non-entity type.
+/// </para>
+/// </summary>
+/// <typeparam name="TContext">The application context that owns the table.</typeparam>
+/// <typeparam name="TEntity">The battery's entity type.</typeparam>
+internal abstract class QueuePanelBase<TContext, TEntity>(IDbContextFactory<TContext> contextFactory, TimeProvider timeProvider)
+    : IQueuePanel
+    where TContext : DbContext
+    where TEntity : class
+{
+    private bool? _mapped;
+
+    public abstract string Slug { get; }
+
+    public abstract string Title { get; }
+
+    public abstract BsIconName Icon { get; }
+
+    public abstract int MaxAttempts { get; }
+
+    /// <summary><c>true</c> when the battery's <c>AddRaskX</c> ran — probed via its options singleton.</summary>
+    protected abstract bool IsRegistered { get; }
+
+    /// <summary>
+    /// The column holding "not eligible before this time" — <c>RunAt</c> for jobs and mail. The outbox has
+    /// no such column and names <c>OccurredAt</c> here, which correctly leaves its Delayed count at zero.
+    /// </summary>
+    protected abstract string RunAtProperty { get; }
+
+    /// <summary>Maps the entity onto the shared row shape. Applied after filtering, never before.</summary>
+    protected abstract Expression<Func<TEntity, QueueRow>> Projection { get; }
+
+    /// <summary>
+    /// Registered AND mapped. Both halves matter: a package reference without
+    /// <c>modelBuilder.AddRaskX()</c> leaves the service registered but every query throwing, which is
+    /// exactly the state a dashboard should report as "not here" rather than crash on.
+    /// </summary>
+    public bool IsAvailable => IsRegistered && IsMapped();
+
+    public async Task<QueueCounts> CountsAsync(CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return default;
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+
+        // Counted on the entity set — no projection needed just to count rows.
+        return new QueueCounts(
+            Due: await CountAsync(db, QueueFilter.Due, now, cancellationToken).ConfigureAwait(false),
+            Delayed: await CountAsync(db, QueueFilter.Delayed, now, cancellationToken).ConfigureAwait(false),
+            Failed: await CountAsync(db, QueueFilter.Failed, now, cancellationToken).ConfigureAwait(false),
+            Processed: await CountAsync(db, QueueFilter.Processed, now, cancellationToken).ConfigureAwait(false));
+    }
+
+    public async Task<(IReadOnlyList<QueueRow> Rows, int Total)> PageAsync(
+        QueueFilter filter, int skip, int take, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return ([], 0);
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var filtered = Filter(db.Set<TEntity>(), filter, now);
+
+        var total = await filtered.CountAsync(cancellationToken).ConfigureAwait(false);
+        var rows = await Order(filtered, filter)
+            .Skip(skip)
+            .Take(take)
+            .Select(Projection)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return (rows, total);
+    }
+
+    private Task<int> CountAsync(TContext db, QueueFilter filter, DateTime now, CancellationToken ct) =>
+        Filter(db.Set<TEntity>(), filter, now).CountAsync(ct);
+
+    // The one definition of each slice. "Failed" is the inverse of the processors' own drain predicate
+    // (ProcessedAt == null && Attempts < MaxAttempts && RunAt <= now) — a row they will never take again.
+    private IQueryable<TEntity> Filter(IQueryable<TEntity> rows, QueueFilter filter, DateTime now)
+    {
+        var runAt = RunAtProperty;
+        var max = MaxAttempts;
+
+        return filter switch
+        {
+            QueueFilter.Due => rows.Where(e =>
+                EF.Property<DateTime?>(e, "ProcessedAt") == null
+                && EF.Property<int>(e, "Attempts") < max
+                && EF.Property<DateTime>(e, runAt) <= now),
+            QueueFilter.Delayed => rows.Where(e =>
+                EF.Property<DateTime?>(e, "ProcessedAt") == null
+                && EF.Property<int>(e, "Attempts") < max
+                && EF.Property<DateTime>(e, runAt) > now),
+            QueueFilter.Failed => rows.Where(e =>
+                EF.Property<DateTime?>(e, "ProcessedAt") == null
+                && EF.Property<int>(e, "Attempts") >= max),
+            QueueFilter.Processed => rows.Where(e => EF.Property<DateTime?>(e, "ProcessedAt") != null),
+            _ => rows.Where(e => EF.Property<DateTime?>(e, "ProcessedAt") == null),
+        };
+    }
+
+    // Outstanding work reads best in the order the processor will actually take it; finished and
+    // given-up work reads best newest-first, because that's where you look after something broke.
+    private IQueryable<TEntity> Order(IQueryable<TEntity> rows, QueueFilter filter)
+    {
+        var runAt = RunAtProperty;
+        return filter is QueueFilter.Processed or QueueFilter.Failed
+            ? rows.OrderByDescending(e => EF.Property<long>(e, "Id"))
+            : rows.OrderBy(e => EF.Property<DateTime>(e, runAt)).ThenBy(e => EF.Property<long>(e, "Id"));
+    }
+
+    // EF builds the model once per app and caches it, so this is a dictionary lookup after the first call;
+    // cached per panel instance anyway to keep it off the render path.
+    private bool IsMapped()
+    {
+        if (_mapped is { } known)
+        {
+            return known;
+        }
+
+        using var db = contextFactory.CreateDbContext();
+        var mapped = db.Model.FindEntityType(typeof(TEntity)) is not null;
+        _mapped = mapped;
+        return mapped;
+    }
+}

--- a/src/Rask.Dashboard/Panels/SystemPanel.cs
+++ b/src/Rask.Dashboard/Panels/SystemPanel.cs
@@ -1,0 +1,160 @@
+using System.Data.Common;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Jobs;
+
+namespace Rask.Dashboard.Panels;
+
+/// <summary>
+/// Backup state for the system panel. The dashboard deliberately takes no dependency on
+/// <c>Rask.SQLite.Litestream</c> or <c>Rask.SQLite.Snapshots</c>: those pull a native SQLitePCLRaw provider
+/// bundle, and the dashboard itself is provider-agnostic — it reads EF entities and works just as well on
+/// Postgres. Register an implementation to light up the backup tiles; without one they stay hidden.
+/// <para>
+/// The data it needs is public API: <c>LitestreamStatus.Current</c> and
+/// <c>ISqliteSnapshotStore.ListAsync(ct)</c>.
+/// </para>
+/// </summary>
+public interface IDashboardBackupProbe
+{
+    /// <summary>Continuous-replication state, or <c>null</c> if the app doesn't run any.</summary>
+    Task<BackupReplicationInfo?> ReplicationAsync(CancellationToken cancellationToken);
+
+    /// <summary>Stored snapshots, newest first. Empty when the app takes none.</summary>
+    Task<IReadOnlyList<BackupSnapshotInfo>> SnapshotsAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>Continuous-backup liveness, as the dashboard displays it.</summary>
+/// <param name="IsReplicating">Whether replication is running right now.</param>
+/// <param name="LastStartedAt">When the current or most recent run started.</param>
+/// <param name="RestartCount">How many times it has restarted — climbing means flapping.</param>
+/// <param name="LastError">The most recent failure, if any.</param>
+public sealed record BackupReplicationInfo(
+    bool IsReplicating, DateTimeOffset? LastStartedAt, int RestartCount, string? LastError);
+
+/// <summary>One stored snapshot.</summary>
+/// <param name="Name">The snapshot's name.</param>
+/// <param name="SizeBytes">Its size on disk.</param>
+/// <param name="CreatedAt">When it was taken (UTC).</param>
+public sealed record BackupSnapshotInfo(string Name, long SizeBytes, DateTime CreatedAt);
+
+/// <summary>A recurring job's schedule joined to when it actually last fired.</summary>
+/// <param name="Name">The durable name.</param>
+/// <param name="Interval">How often it should run.</param>
+/// <param name="LastEnqueuedAt">When it was last enqueued, or <c>null</c> if it never has been.</param>
+public sealed record RecurringJobRow(string Name, TimeSpan Interval, DateTime? LastEnqueuedAt);
+
+/// <summary>How the database is configured, as far as the dashboard can see from the open connection.</summary>
+/// <param name="Provider">The EF provider name.</param>
+/// <param name="JournalMode">SQLite <c>journal_mode</c>, or <c>null</c> on another provider.</param>
+/// <param name="ForeignKeys">SQLite <c>foreign_keys</c>, or <c>null</c> on another provider.</param>
+/// <param name="SizeBytes">Database size in bytes, or <c>null</c> when the provider can't report it cheaply.</param>
+public sealed record DatabaseInfo(string Provider, string? JournalMode, bool? ForeignKeys, long? SizeBytes);
+
+/// <summary>
+/// The system reader, without the context type parameter — pages aren't generic, so they resolve this.
+/// </summary>
+public interface ISystemPanelReader
+{
+    /// <summary>Whether an <see cref="IDashboardBackupProbe"/> is registered, so the backup card can hide.</summary>
+    bool HasBackupProbe { get; }
+
+    /// <summary>Provider, SQLite pragmas where applicable, and database size.</summary>
+    Task<DatabaseInfo> DatabaseAsync(CancellationToken cancellationToken);
+
+    /// <summary>The declared recurring schedule joined to when each job last fired.</summary>
+    Task<IReadOnlyList<RecurringJobRow>> RecurringJobsAsync(CancellationToken cancellationToken);
+
+    /// <summary>Continuous-replication state, or <c>null</c>.</summary>
+    Task<BackupReplicationInfo?> ReplicationAsync(CancellationToken cancellationToken);
+
+    /// <summary>Stored snapshots, newest first.</summary>
+    Task<IReadOnlyList<BackupSnapshotInfo>> SnapshotsAsync(CancellationToken cancellationToken);
+}
+
+/// <summary>Host-level facts: how the database is configured, what is scheduled, and whether backups run.</summary>
+internal sealed class SystemPanel<TContext>(
+    IDbContextFactory<TContext> contextFactory,
+    IServiceProvider services) : ISystemPanelReader
+    where TContext : DbContext
+{
+    private readonly JobOptions? _jobOptions = services.GetService<JobOptions>();
+    private readonly IDashboardBackupProbe? _backup = services.GetService<IDashboardBackupProbe>();
+
+    public bool HasBackupProbe => _backup is not null;
+
+    public async Task<DatabaseInfo> DatabaseAsync(CancellationToken cancellationToken)
+    {
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        var provider = db.Database.ProviderName ?? "unknown";
+
+        // Read through the raw DbConnection rather than a SQLite package: PRAGMA is just SQL, so this needs
+        // no provider reference and simply reports nothing on a provider that doesn't understand it.
+        if (!provider.Contains("Sqlite", StringComparison.OrdinalIgnoreCase))
+        {
+            return new DatabaseInfo(provider, null, null, null);
+        }
+
+        var connection = db.Database.GetDbConnection();
+        await db.Database.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var journalMode = await ScalarAsync(connection, "PRAGMA journal_mode;", cancellationToken).ConfigureAwait(false);
+            var foreignKeys = await ScalarAsync(connection, "PRAGMA foreign_keys;", cancellationToken).ConfigureAwait(false);
+            var pageCount = await ScalarAsync(connection, "PRAGMA page_count;", cancellationToken).ConfigureAwait(false);
+            var pageSize = await ScalarAsync(connection, "PRAGMA page_size;", cancellationToken).ConfigureAwait(false);
+
+            long? size = long.TryParse(pageCount, out var pages) && long.TryParse(pageSize, out var bytes)
+                ? pages * bytes
+                : null;
+
+            return new DatabaseInfo(provider, journalMode, foreignKeys == "1", size);
+        }
+        finally
+        {
+            await db.Database.CloseConnectionAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// The registered recurring schedule joined to its durable state. Reads the schedule from
+    /// <see cref="JobOptions.RecurringJobs"/>, so it shows what the app declares even for a job that has
+    /// never run yet — a table-only view would silently omit exactly the one that is failing to fire.
+    /// </summary>
+    public async Task<IReadOnlyList<RecurringJobRow>> RecurringJobsAsync(CancellationToken cancellationToken)
+    {
+        if (_jobOptions is null || _jobOptions.RecurringJobs.Count == 0)
+        {
+            return [];
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        if (db.Model.FindEntityType(typeof(RecurringJobState)) is null)
+        {
+            return [];
+        }
+
+        var names = _jobOptions.RecurringJobs.Select(r => r.Name).ToList();
+        var state = await db.Set<RecurringJobState>()
+            .Where(s => names.Contains(s.Name))
+            .ToDictionaryAsync(s => s.Name, s => s.LastEnqueuedAt, cancellationToken)
+            .ConfigureAwait(false);
+
+        return [.. _jobOptions.RecurringJobs.Select(r =>
+            new RecurringJobRow(r.Name, r.Interval, state.GetValueOrDefault(r.Name)))];
+    }
+
+    public Task<BackupReplicationInfo?> ReplicationAsync(CancellationToken cancellationToken) =>
+        _backup?.ReplicationAsync(cancellationToken) ?? Task.FromResult<BackupReplicationInfo?>(null);
+
+    public Task<IReadOnlyList<BackupSnapshotInfo>> SnapshotsAsync(CancellationToken cancellationToken) =>
+        _backup?.SnapshotsAsync(cancellationToken) ?? Task.FromResult<IReadOnlyList<BackupSnapshotInfo>>([]);
+
+    private static async Task<string?> ScalarAsync(DbConnection connection, string sql, CancellationToken cancellationToken)
+    {
+        await using var command = connection.CreateCommand();
+        command.CommandText = sql;
+        var value = await command.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+        return value?.ToString();
+    }
+}

--- a/src/Rask.Dashboard/Rask.Dashboard.csproj
+++ b/src/Rask.Dashboard/Rask.Dashboard.csproj
@@ -1,0 +1,62 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <!-- Server-only: every panel reads the application's DbContext, and a WASM app has no database.
+         Single-targeted (no net10.0-browser) so that constraint is enforced by the compiler. -->
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+
+    <PackageId>Rask.Dashboard</PackageId>
+    <Title>Rask — Batteries Dashboard</Title>
+    <Description>A built-in operator dashboard for the Rask One Person Framework batteries. Mounts at /_ops and shows the outbox, background jobs, queued mail and cache from the application's own database — queue depth, dead letters, the errors behind them, stored email previews, the recurring-job schedule, SQLite pragmas and backup status. Panels appear only for the batteries the app actually registered. Protected by an authorization policy that fails closed outside Development.</Description>
+    <PackageTags>web component framework net10 dashboard ops admin observability jobs outbox mail cache sqlite</PackageTags>
+  </PropertyGroup>
+
+  <!-- Ship a package-specific README (this project's NUGET.md) instead of the shared framework
+       overview that Directory.Build.props packs by default; PackageReadmeFile=NUGET.md is inherited. -->
+  <ItemGroup>
+    <None Remove="$(MSBuildThisFileDirectory)..\..\NUGET.md" />
+    <None Update="NUGET.md" Pack="true" PackagePath="" Visible="false" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <InternalsVisibleTo Include="Rask.Dashboard.Tests"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- PrivateAssets="all": Rask.Core is IsPackable=false and ships transitively from the host
+         packages (Rask.Server), so listing it as a nuspec dependency would reference a package that
+         exists on no feed and make Rask.Dashboard unrestorable. Guarded by PackageDependencyTests. -->
+    <ProjectReference Include="..\Rask.Core\Rask.Core.csproj" PrivateAssets="all"/>
+
+    <!-- The panels read these packages' entity types directly. Referencing all four is what lets a
+         single package light up whichever batteries an app registered, with no glue from the caller. -->
+    <ProjectReference Include="..\Rask.Bootstrap\Rask.Bootstrap.csproj"/>
+    <ProjectReference Include="..\Rask.Cache\Rask.Cache.csproj"/>
+    <ProjectReference Include="..\Rask.Jobs\Rask.Jobs.csproj"/>
+    <ProjectReference Include="..\Rask.Mail\Rask.Mail.csproj"/>
+    <ProjectReference Include="..\Rask.Outbox\Rask.Outbox.csproj"/>
+
+    <!-- Emits this assembly's own Generated.* factories and the __RaskRoutesRegistry module
+         initializer that registers the dashboard's [Route] pages into the host's RouteRegistry. -->
+    <ProjectReference Include="..\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore"/>
+    <!-- The system panel reads SQLite PRAGMAs through the open DbConnection. Relational (not a provider)
+         is what exposes DatabaseFacade.GetDbConnection; every app with a relational provider already has
+         it, and depending on it here keeps the dashboard provider-agnostic. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational"/>
+    <!-- The dashboard defines its own authorization policy default, so it references authorization
+         directly rather than relying on Rask.Core's (PrivateAssets) transitive reference. -->
+    <PackageReference Include="Microsoft.AspNetCore.Authorization"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions"/>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions"/>
+  </ItemGroup>
+
+</Project>

--- a/src/Rask.Dashboard/RaskDashboardOptions.cs
+++ b/src/Rask.Dashboard/RaskDashboardOptions.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Dashboard;
+
+/// <summary>
+/// What the dashboard is allowed to do beyond looking. Actions are opt-in by tier because the dashboard
+/// sits over the same tables the processors are draining.
+/// </summary>
+[Flags]
+public enum RaskDashboardActions
+{
+    /// <summary>Read-only. No button on any panel mutates anything.</summary>
+    None = 0,
+
+    /// <summary>
+    /// Retry a dead letter (and retry-all), purge processed rows, evict a cache key, take a snapshot now.
+    /// Each is scoped by a predicate that excludes rows a processor could currently hold, so none of them
+    /// races the drain. This is the default.
+    /// </summary>
+    Safe = 1,
+
+    /// <summary>
+    /// Delete a row, cancel a pending job, flush the whole cache, force a recurring job to run now. These
+    /// destroy work rather than reschedule it, so they stay off unless you ask for them.
+    /// </summary>
+    Destructive = 2,
+
+    /// <summary>Everything.</summary>
+    All = Safe | Destructive,
+}
+
+/// <summary>Options for the batteries dashboard.</summary>
+public sealed class RaskDashboardOptions
+{
+    /// <summary>
+    /// Which actions the dashboard offers. Defaults to <see cref="RaskDashboardActions.Safe"/> — the
+    /// destructive tier is deliberately not on by default, even for an operator page behind a policy.
+    /// </summary>
+    public RaskDashboardActions Actions { get; set; } = RaskDashboardActions.Safe;
+
+    /// <summary>
+    /// How often an open panel re-reads its counts. Default 2s.
+    /// <para>
+    /// Every open tab is a reader competing with the processors for SQLite's single write lock, so this is
+    /// a real cost, not a free knob. Panels also stop polling after <see cref="MaxPollDuration"/>.
+    /// </para>
+    /// </summary>
+    public TimeSpan RefreshInterval { get; set; } = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// How long a panel keeps polling before it parks and offers a Resume button. Default 5 minutes.
+    /// A dashboard left open on a wall display would otherwise poll forever.
+    /// </summary>
+    public TimeSpan MaxPollDuration { get; set; } = TimeSpan.FromMinutes(5);
+
+    /// <summary>How many rows a queue panel shows per page. Default 25.</summary>
+    public int PageSize { get; set; } = 25;
+
+    /// <summary>Whether to capture logs for the log panel. Default <c>true</c>.</summary>
+    public bool CaptureLogs { get; set; } = true;
+
+    /// <summary>
+    /// How many log entries the in-memory ring buffer holds. Default 500. The buffer is bounded by count,
+    /// not bytes, and is dropped entirely when the process restarts — it is a tail, not a log store.
+    /// </summary>
+    public int LogBufferSize { get; set; } = 500;
+
+    /// <summary>The lowest level the log panel captures. Default <see cref="LogLevel.Information"/>.</summary>
+    public LogLevel LogMinimumLevel { get; set; } = LogLevel.Information;
+
+    /// <summary>
+    /// Serve the dashboard to anyone, with no authorization, in every environment. Default <c>false</c>,
+    /// and there is no reason to change it on a reachable host: the panels expose job payloads, stored
+    /// email bodies and log lines, so an open dashboard is close to publishing your database. It exists
+    /// only so a deliberately unauthenticated internal tool doesn't have to invent a dummy policy.
+    /// <para>
+    /// Leaving this <c>false</c> and defining no <c>RaskDashboard</c> policy is the safe path: the
+    /// dashboard denies everyone outside Development rather than opening.
+    /// </para>
+    /// </summary>
+    public bool AllowAnonymousAccess { get; set; }
+
+    /// <summary>Validates the option values at registration, so a bad value fails fast.</summary>
+    internal void Validate()
+    {
+        if (RefreshInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(RefreshInterval), RefreshInterval, "RefreshInterval must be positive.");
+        }
+
+        if (MaxPollDuration < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxPollDuration), MaxPollDuration, "MaxPollDuration cannot be negative.");
+        }
+
+        if (PageSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(PageSize), PageSize, "PageSize must be at least 1.");
+        }
+
+        if (LogBufferSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(LogBufferSize), LogBufferSize, "LogBufferSize must be at least 1.");
+        }
+    }
+}

--- a/src/Rask.Dashboard/RaskDashboardServiceCollectionExtensions.cs
+++ b/src/Rask.Dashboard/RaskDashboardServiceCollectionExtensions.cs
@@ -1,0 +1,93 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Hosting;
+using Rask.Dashboard.Panels;
+
+namespace Rask.Dashboard;
+
+/// <summary>The authorization policy the dashboard's pages are gated on.</summary>
+public static class RaskDashboardPolicies
+{
+    /// <summary>
+    /// The policy name every dashboard page carries. Define it in your own <c>AddAuthorization</c> to say
+    /// who may operate the app:
+    /// <code>
+    /// builder.Services.AddAuthorization(o =>
+    ///     o.AddPolicy(RaskDashboardPolicies.Access, p => p.RequireRole("Admin")));
+    /// </code>
+    /// If you don't, the dashboard supplies a default — permissive in Development, <b>deny-all</b>
+    /// everywhere else.
+    /// </summary>
+    public const string Access = "RaskDashboard";
+}
+
+/// <summary>Registers the batteries dashboard into an <see cref="IServiceCollection"/>.</summary>
+public static class RaskDashboardServiceCollectionExtensions
+{
+    /// <summary>
+    /// Mounts the operator dashboard at <c>/_ops</c>, reading the battery tables owned by
+    /// <typeparamref name="TContext"/>. Call it after the <c>AddRaskX&lt;TContext&gt;()</c> registrations —
+    /// a panel appears only when its battery is both registered and mapped in the model, so an app with
+    /// only jobs gets only the jobs panel.
+    /// <para>
+    /// Access is gated on the <see cref="RaskDashboardPolicies.Access"/> policy. Define it yourself, or get
+    /// the fail-closed default: permissive in Development, deny-all in every other environment. Calling
+    /// this does not open anything by accident.
+    /// </para>
+    /// </summary>
+    /// <typeparam name="TContext">The application <see cref="DbContext"/> that owns the battery tables.</typeparam>
+    public static IServiceCollection AddRaskDashboard<TContext>(
+        this IServiceCollection services,
+        Action<RaskDashboardOptions>? configure = null)
+        where TContext : DbContext
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var options = new RaskDashboardOptions();
+        configure?.Invoke(options);
+        options.Validate();
+
+        services.TryAddSingleton(options);
+        services.TryAddSingleton(TimeProvider.System);
+        services.TryAddSingleton<DashboardSecurityState>();
+
+        // One adapter per battery. Each decides at request time whether it has anything to show, so the
+        // registration stays unconditional and the app's own wiring is the single source of truth.
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IQueuePanel, JobsQueuePanel<TContext>>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IQueuePanel, OutboxQueuePanel<TContext>>());
+        services.TryAddEnumerable(ServiceDescriptor.Scoped<IQueuePanel, MailQueuePanel<TContext>>());
+        services.AddScoped<ICachePanelReader, CachePanel<TContext>>();
+        services.AddScoped<ISystemPanelReader, SystemPanel<TContext>>();
+
+        AddDefaultPolicy(services, options);
+        return services;
+    }
+
+    // PostConfigure runs after every AddAuthorization(...) delegate the app registered, whatever the order
+    // of the AddRaskDashboard call — so this fills a gap rather than overwriting an intent. Taking
+    // IHostEnvironment as a dependency is what lets the default differ by environment without the
+    // extension method needing the environment at registration time.
+    private static void AddDefaultPolicy(IServiceCollection services, RaskDashboardOptions options)
+    {
+        // AddAuthorizationCore, not AddAuthorization: the latter lives in the ASP.NET shared framework, and
+        // this package deliberately takes no FrameworkReference. The core registration is what supplies the
+        // IAuthorizationPolicyProvider and IAuthorizationService that RouteAuthorizationGuard resolves; the
+        // host's own AddRask() calls the full AddAuthorization() anyway.
+        services.AddAuthorizationCore();
+        services.AddOptions<AuthorizationOptions>()
+            .PostConfigure<IHostEnvironment, DashboardSecurityState>((authz, environment, state) =>
+            {
+                if (authz.GetPolicy(RaskDashboardPolicies.Access) is not null)
+                {
+                    return; // the app said who may operate it — never second-guess that
+                }
+
+                var open = options.AllowAnonymousAccess || environment.IsDevelopment();
+                state.UsingFallbackPolicy = true;
+                state.FallbackIsOpen = open;
+                authz.AddPolicy(RaskDashboardPolicies.Access, policy => policy.RequireAssertion(_ => open));
+            });
+    }
+}

--- a/tests/Rask.Bootstrap.Tests/BsStatTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsStatTests.cs
@@ -1,0 +1,64 @@
+namespace Rask.Bootstrap.Tests;
+
+// Rendered-HTML assertions for BsStat — the card wrapper, the label/value/caption structure, the tone
+// applied to the VALUE rather than the card, the optional icon, and the linked variant.
+public class BsStatTests
+{
+    [Fact]
+    public void Stat_RendersLabelAboveValueInACard() =>
+        Assert.Equal(
+            "<div class=\"card h-100\"><div class=\"card-body py-3\">"
+            + "<div class=\"d-flex align-items-center gap-2 text-body-secondary text-uppercase small fw-semibold\">"
+            + "<span>Failed</span></div>"
+            + "<div class=\"fs-3 fw-semibold lh-1 mt-2\">0</div>"
+            + "</div></div>",
+            BsStat(Value: "0", Label: "Failed").ToHtml());
+
+    [Fact]
+    // The tone colours the number, not the card: one red value among grey ones reads as a signal, whereas
+    // a wall of coloured panels reads as decoration.
+    public void Stat_Tone_ColorsTheValueNotTheCard()
+    {
+        var html = BsStat(Value: "3", Label: "Failed", Tone: BsColor.Danger).ToHtml();
+
+        Assert.Contains("<div class=\"fs-3 fw-semibold lh-1 mt-2 text-danger\">3</div>", html, StringComparison.Ordinal);
+        Assert.Contains("<div class=\"card h-100\">", html, StringComparison.Ordinal);   // card itself stays neutral
+        Assert.DoesNotContain("text-bg-danger", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Stat_Caption_RendersUnderTheValue() =>
+        Assert.Contains(
+            "<div class=\"small text-body-secondary mt-1\">after 25 attempts</div>",
+            BsStat(Value: "3", Label: "Failed", Caption: "after 25 attempts").ToHtml(),
+            StringComparison.Ordinal);
+
+    [Fact]
+    public void Stat_Icon_RendersBesideTheLabel() =>
+        Assert.Contains(
+            // BsIcon marks itself aria-hidden — the label beside it already carries the meaning.
+            "<i class=\"bi bi-envelope\" aria-hidden=\"true\"></i><span>Mail</span>",
+            BsStat(Value: "1", Label: "Mail", Icon: BsIconName.Envelope).ToHtml(),
+            StringComparison.Ordinal);
+
+    [Fact]
+    // A linked tile must be a link without looking like body text, and must keep the card intact inside it.
+    public void Stat_Href_WrapsTheCardInAResetLink()
+    {
+        var html = BsStat(Value: "2", Label: "Jobs", Href: "/_ops/queues/jobs").ToHtml();
+
+        Assert.StartsWith(
+            "<a class=\"text-decoration-none text-reset d-block h-100\" href=\"/_ops/queues/jobs\">",
+            html,
+            StringComparison.Ordinal);
+        Assert.Contains("<div class=\"card h-100\">", html, StringComparison.Ordinal);
+        Assert.EndsWith("</a>", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Stat_MergesUserClassOntoTheCard() =>
+        Assert.Contains(
+            "<div class=\"card h-100 border-danger\">",
+            BsStat(Value: "9", Label: "Dead letters", Class: "border-danger").ToHtml(),
+            StringComparison.Ordinal);
+}

--- a/tests/Rask.Dashboard.Tests/AssemblyInfo.cs
+++ b/tests/Rask.Dashboard.Tests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// HarnessDbContext.Mapped is static (EF's DbContextFactory requires a single options-only constructor,
+// so the per-test model shape can't be a constructor argument). Running the classes serially keeps one
+// test's mapping from leaking into another's context. Matches the other SQLite-backed suites.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/tests/Rask.Dashboard.Tests/DashboardAuthorizationTests.cs
+++ b/tests/Rask.Dashboard.Tests/DashboardAuthorizationTests.cs
@@ -1,0 +1,104 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Rask.Dashboard.Tests;
+
+/// <summary>
+/// The dashboard exposes job payloads, stored email bodies and log lines, so the question "who can reach
+/// it if I configure nothing?" has exactly one acceptable answer outside Development: nobody.
+/// </summary>
+public sealed class DashboardAuthorizationTests
+{
+    [Fact]
+    public async Task With_no_policy_configured_production_denies_everyone()
+    {
+        await using var h = new DashboardHarness(environment: Environments.Production);
+
+        Assert.False(await AuthorizeAsync(h, Anonymous()));
+        Assert.False(await AuthorizeAsync(h, SignedIn("admin")));   // even a real user
+    }
+
+    [Fact]
+    public async Task With_no_policy_configured_development_allows_everyone()
+    {
+        await using var h = new DashboardHarness(environment: Environments.Development);
+
+        Assert.True(await AuthorizeAsync(h, Anonymous()));
+        Assert.True(h.Get<DashboardSecurityState>().IsUnsecured);   // and says so in the UI
+    }
+
+    [Fact]
+    public async Task An_application_policy_wins_over_the_fallback()
+    {
+        // Registered BEFORE AddRaskDashboard, which is the order that would break a naive
+        // Configure-based default — PostConfigure is what makes the order irrelevant.
+        await using var h = new DashboardHarness(
+            environment: Environments.Development,
+            extra: services => services.AddAuthorizationCore(o =>
+                o.AddPolicy(RaskDashboardPolicies.Access, p => p.RequireRole("Ops"))));
+
+        Assert.False(await AuthorizeAsync(h, SignedIn("admin")));
+        Assert.True(await AuthorizeAsync(h, SignedIn("admin", role: "Ops")));
+
+        // The app configured access, so the "unsecured" banner must not appear even in Development.
+        Assert.False(h.Get<DashboardSecurityState>().IsUnsecured);
+    }
+
+    [Fact]
+    public async Task AllowAnonymousAccess_opens_it_deliberately_outside_development()
+    {
+        await using var h = new DashboardHarness(
+            environment: Environments.Production,
+            configure: o => o.AllowAnonymousAccess = true);
+
+        Assert.True(await AuthorizeAsync(h, Anonymous()));
+        Assert.True(h.Get<DashboardSecurityState>().IsUnsecured);
+    }
+
+    [Fact]
+    public async Task The_layout_carries_the_policy_so_every_page_inherits_it()
+    {
+        await using var h = new DashboardHarness();
+
+        // RouteAuthorizationGuard walks the whole route chain, so one [Authorize] on the layout covers
+        // every child page — including pages added later, which is the point of putting it there.
+        var attribute = typeof(Pages.DashboardLayout)
+            .GetCustomAttributes(typeof(AuthorizeAttribute), inherit: true)
+            .Cast<AuthorizeAttribute>()
+            .Single();
+
+        Assert.Equal(RaskDashboardPolicies.Access, attribute.Policy);
+
+        var children = new[]
+        {
+            typeof(Pages.OverviewPage), typeof(Pages.QueuePage),
+            typeof(Pages.CachePage), typeof(Pages.SystemPage),
+        };
+
+        // None of them may carry [AllowAnonymous] — that would punch a hole straight through the chain.
+        Assert.All(children, page =>
+            Assert.Empty(page.GetCustomAttributes(typeof(AllowAnonymousAttribute), inherit: true)));
+    }
+
+    private static async Task<bool> AuthorizeAsync(DashboardHarness harness, ClaimsPrincipal user)
+    {
+        var authorization = harness.Services.GetRequiredService<IAuthorizationService>();
+        var result = await authorization.AuthorizeAsync(user, resource: null, RaskDashboardPolicies.Access);
+        return result.Succeeded;
+    }
+
+    private static ClaimsPrincipal Anonymous() => new(new ClaimsIdentity());
+
+    private static ClaimsPrincipal SignedIn(string name, string? role = null)
+    {
+        List<Claim> claims = [new(ClaimTypes.Name, name)];
+        if (role is not null)
+        {
+            claims.Add(new Claim(ClaimTypes.Role, role));
+        }
+
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "Test"));
+    }
+}

--- a/tests/Rask.Dashboard.Tests/DashboardHarness.cs
+++ b/tests/Rask.Dashboard.Tests/DashboardHarness.cs
@@ -1,0 +1,171 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Rask.Cache;
+using Rask.Jobs;
+using Rask.Mail;
+using Rask.Outbox;
+
+namespace Rask.Dashboard.Tests;
+
+/// <summary>Which batteries a harness should wire up.</summary>
+[Flags]
+public enum Batteries
+{
+    None = 0,
+    Jobs = 1,
+    Outbox = 2,
+    Mail = 4,
+    Cache = 8,
+    All = Jobs | Outbox | Mail | Cache,
+}
+
+/// <summary>
+/// A context that maps only the batteries it was told to. The point of most of these tests is what the
+/// dashboard does when a table ISN'T there, so the mapping has to be selectable.
+/// </summary>
+public sealed class HarnessDbContext(DbContextOptions<HarnessDbContext> options) : DbContext(options)
+{
+    /// <summary>
+    /// Set by the harness before the provider is built, read by every factory-created context. Static
+    /// because EF's DbContextFactory needs exactly one options-only constructor — which is also why this
+    /// assembly disables test parallelization (see AssemblyInfo.cs).
+    /// </summary>
+    public static Batteries Mapped { get; set; } = Batteries.All;
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        if (Mapped.HasFlag(Batteries.Jobs))
+        {
+            modelBuilder.AddRaskJobs();
+        }
+
+        if (Mapped.HasFlag(Batteries.Outbox))
+        {
+            modelBuilder.AddRaskOutbox();
+        }
+
+        if (Mapped.HasFlag(Batteries.Mail))
+        {
+            modelBuilder.AddRaskMail();
+        }
+
+        if (Mapped.HasFlag(Batteries.Cache))
+        {
+            modelBuilder.AddRaskCache();
+        }
+    }
+}
+
+/// <summary>A real-SQLite provider wired for the dashboard, with a controllable clock.</summary>
+public sealed class DashboardHarness : IAsyncDisposable
+{
+    private readonly ServiceProvider _provider;
+
+    public DashboardHarness(
+        Batteries registered = Batteries.All,
+        Batteries? mapped = null,
+        string? environment = null,
+        Action<RaskDashboardOptions>? configure = null,
+        Action<IServiceCollection>? extra = null)
+    {
+        DbPath = Path.Combine(Path.GetTempPath(), $"rask-dash-test-{Guid.NewGuid():N}.db");
+        HarnessDbContext.Mapped = mapped ?? registered;
+
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton<TimeProvider>(Clock);
+        services.AddSingleton<IHostEnvironment>(new HostingEnvironment
+        {
+            EnvironmentName = environment ?? Environments.Production,
+        });
+        services.AddRaskCqrs();
+
+        if (registered.HasFlag(Batteries.Jobs))
+        {
+            services.AddRaskJobs<HarnessDbContext>();
+        }
+
+        if (registered.HasFlag(Batteries.Outbox))
+        {
+            services.AddRaskOutbox<HarnessDbContext>();
+        }
+
+        if (registered.HasFlag(Batteries.Mail))
+        {
+            services.AddRaskMail<HarnessDbContext>(o => o.From = "test@example.com");
+        }
+
+        if (registered.HasFlag(Batteries.Cache))
+        {
+            services.AddRaskCache<HarnessDbContext>();
+        }
+
+        extra?.Invoke(services);
+        services.AddRaskDashboard<HarnessDbContext>(configure);
+        services.AddDbContextFactory<HarnessDbContext>(o => o
+            .UseSqlite($"Data Source={DbPath}")
+            // EF caches the compiled model per context type, so without folding the mapping into the
+            // cache key the FIRST shape built would be reused for every later harness in the process —
+            // and the "table isn't mapped" tests would silently see a fully-mapped model.
+            .ReplaceService<IModelCacheKeyFactory, HarnessModelCacheKeyFactory>());
+
+        _provider = services.BuildServiceProvider();
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+    }
+
+    public string DbPath { get; }
+
+    public FakeClock Clock { get; } = new(new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero));
+
+    public IServiceProvider Services => _provider;
+
+    public HarnessDbContext NewContext() =>
+        _provider.GetRequiredService<IDbContextFactory<HarnessDbContext>>().CreateDbContext();
+
+    public IQueuePanel Queue(string slug) =>
+        _provider.GetServices<IQueuePanel>().Single(q => q.Slug == slug);
+
+    public T Get<T>() where T : notnull => _provider.GetRequiredService<T>();
+
+    public async ValueTask DisposeAsync()
+    {
+        await _provider.DisposeAsync();
+        if (File.Exists(DbPath))
+        {
+            File.Delete(DbPath);
+        }
+    }
+}
+
+/// <summary>
+/// Makes <see cref="HarnessDbContext.Mapped"/> part of EF's model cache key, so each mapping shape gets
+/// its own compiled model instead of reusing whichever one was built first.
+/// </summary>
+internal sealed class HarnessModelCacheKeyFactory : IModelCacheKeyFactory
+{
+    public object Create(DbContext context, bool designTime) =>
+        (context.GetType(), HarnessDbContext.Mapped, designTime);
+}
+
+/// <summary>A hand-rolled controllable clock — no external package, matching the other suites.</summary>
+public sealed class FakeClock(DateTimeOffset start) : TimeProvider
+{
+    private long _ticks = start.UtcTicks;
+
+    public override DateTimeOffset GetUtcNow() => new(Interlocked.Read(ref _ticks), TimeSpan.Zero);
+
+    public void Advance(TimeSpan by) => Interlocked.Add(ref _ticks, by.Ticks);
+}
+
+/// <summary>Minimal <see cref="IHostEnvironment"/> so the environment-dependent policy can be tested.</summary>
+internal sealed class HostingEnvironment : IHostEnvironment
+{
+    public string EnvironmentName { get; set; } = Environments.Production;
+    public string ApplicationName { get; set; } = "Tests";
+    public string ContentRootPath { get; set; } = AppContext.BaseDirectory;
+    public Microsoft.Extensions.FileProviders.IFileProvider ContentRootFileProvider { get; set; } =
+        new Microsoft.Extensions.FileProviders.NullFileProvider();
+}

--- a/tests/Rask.Dashboard.Tests/QueuePanelTests.cs
+++ b/tests/Rask.Dashboard.Tests/QueuePanelTests.cs
@@ -1,0 +1,156 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Jobs;
+using Rask.Outbox;
+
+namespace Rask.Dashboard.Tests;
+
+/// <summary>
+/// The counts are the product. "Failed" in particular has to mean exactly what the processors mean by
+/// giving up, or the dashboard reports a healthy system while a queue retries itself to death.
+/// </summary>
+public sealed class QueuePanelTests
+{
+    [Fact]
+    public async Task Counts_split_a_queue_into_due_delayed_failed_and_processed()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        await SeedJobsAsync(h,
+            Job(runAt: now.AddMinutes(-1)),                       // due
+            Job(runAt: now.AddMinutes(-1)),                       // due
+            Job(runAt: now.AddMinutes(5)),                        // delayed (backoff or schedule)
+            Job(runAt: now.AddMinutes(-1), attempts: max),        // dead letter
+            Job(runAt: now.AddMinutes(-1), processedAt: now));    // done
+
+        var counts = await h.Queue("jobs").CountsAsync(CancellationToken.None);
+
+        Assert.Equal(2, counts.Due);
+        Assert.Equal(1, counts.Delayed);
+        Assert.Equal(1, counts.Failed);
+        Assert.Equal(1, counts.Processed);
+        Assert.Equal(4, counts.Outstanding);   // everything not processed, dead letters included
+    }
+
+    [Fact]
+    public async Task A_row_is_failed_only_once_it_is_out_of_attempts()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        // One attempt short is still a retry, not a dead letter — the boundary the processors use.
+        await SeedJobsAsync(h,
+            Job(runAt: now.AddMinutes(-1), attempts: max - 1),
+            Job(runAt: now.AddMinutes(-1), attempts: max));
+
+        var counts = await h.Queue("jobs").CountsAsync(CancellationToken.None);
+
+        Assert.Equal(1, counts.Failed);
+        Assert.Equal(1, counts.Due);
+    }
+
+    [Fact]
+    public async Task The_failed_filter_returns_exactly_the_dead_letters()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        await SeedJobsAsync(h,
+            Job(runAt: now, attempts: max, error: "boom"),
+            Job(runAt: now));
+
+        var (rows, total) = await h.Queue("jobs").PageAsync(QueueFilter.Failed, 0, 25, CancellationToken.None);
+
+        Assert.Equal(1, total);
+        Assert.Equal("boom", Assert.Single(rows).Error);
+    }
+
+    [Fact]
+    public async Task Paging_reports_the_total_behind_the_page()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        await SeedJobsAsync(h, [.. Enumerable.Range(0, 7).Select(_ => Job(runAt: now))]);
+
+        var (rows, total) = await h.Queue("jobs").PageAsync(QueueFilter.Outstanding, 0, 3, CancellationToken.None);
+
+        Assert.Equal(3, rows.Count);
+        Assert.Equal(7, total);   // the pager needs what's behind the page, not the page size
+    }
+
+    [Fact]
+    public async Task An_unregistered_battery_is_unavailable_and_reads_as_empty()
+    {
+        // Jobs only: the outbox panel is registered but its battery is not.
+        await using var h = new DashboardHarness(Batteries.Jobs);
+
+        var outbox = h.Queue("outbox");
+        Assert.False(outbox.IsAvailable);
+
+        // And it must not throw when something asks anyway — an unavailable panel reads as nothing.
+        Assert.Equal(default, await outbox.CountsAsync(CancellationToken.None));
+        Assert.Empty((await outbox.PageAsync(QueueFilter.Outstanding, 0, 25, CancellationToken.None)).Rows);
+    }
+
+    [Fact]
+    public async Task A_registered_battery_whose_table_is_not_mapped_is_unavailable()
+    {
+        // The trap this guards: AddRaskOutbox() called, modelBuilder.AddRaskOutbox() forgotten. The
+        // service resolves, so a registration-only probe would call it available and every query would
+        // throw. Reporting "not here" is the only honest answer.
+        await using var h = new DashboardHarness(registered: Batteries.All, mapped: Batteries.Jobs);
+
+        Assert.True(h.Queue("jobs").IsAvailable);
+        Assert.False(h.Queue("outbox").IsAvailable);
+        Assert.False(h.Queue("mail").IsAvailable);
+    }
+
+    [Fact]
+    public async Task The_outbox_panel_maps_OccurredAt_onto_the_shared_shape()
+    {
+        await using var h = new DashboardHarness(Batteries.Outbox);
+        var occurred = h.Clock.GetUtcNow().UtcDateTime.AddMinutes(-3);
+
+        await using (var db = h.NewContext())
+        {
+            db.Set<OutboxMessage>().Add(new OutboxMessage
+            {
+                Type = "Some.Event",
+                Payload = "{}",
+                OccurredAt = occurred,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        var row = Assert.Single(
+            (await h.Queue("outbox").PageAsync(QueueFilter.Outstanding, 0, 25, CancellationToken.None)).Rows);
+
+        Assert.Equal(occurred, row.CreatedAt);
+        // The outbox has no scheduled-run column, so RunAt mirrors OccurredAt — which correctly leaves
+        // its Delayed count permanently zero rather than inventing a delay it doesn't have.
+        Assert.Equal(occurred, row.RunAt);
+        Assert.Equal(0, (await h.Queue("outbox").CountsAsync(CancellationToken.None)).Delayed);
+    }
+
+    private static Job Job(DateTime runAt, int attempts = 0, DateTime? processedAt = null, string? error = null) =>
+        new()
+        {
+            Type = "Some.Job",
+            Payload = "{}",
+            RunAt = runAt,
+            CreatedAt = runAt,
+            Attempts = attempts,
+            ProcessedAt = processedAt,
+            Error = error,
+        };
+
+    private static async Task SeedJobsAsync(DashboardHarness harness, params Job[] jobs)
+    {
+        await using var db = harness.NewContext();
+        db.Set<Job>().AddRange(jobs);
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/Rask.Dashboard.Tests/Rask.Dashboard.Tests.csproj
+++ b/tests/Rask.Dashboard.Tests/Rask.Dashboard.Tests.csproj
@@ -1,0 +1,47 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite"/>
+    <!-- Security: pulls the patched SQLitePCLRaw 3.x bundle over the 2.1.11 one
+         Microsoft.Data.Sqlite / EF Core pin (CVE-2025-6965). A direct reference is the only
+         lever under CPM — transitive pinning does not move it. See Directory.Packages.props. -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3"/>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection"/>
+    <PackageReference Include="Microsoft.Extensions.Hosting"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+    <Using Include="Rask.Dashboard"/>
+    <Using Include="Rask.Dashboard.Panels"/>
+    <Using Include="Rask.Cqrs"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Dashboard\Rask.Dashboard.csproj"/>
+    <!-- Rask.Core is PrivateAssets="all" from Rask.Dashboard (it ships transitively from a host
+         package), so an in-repo consumer must reference it directly. -->
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <!-- AddRaskCqrs: the jobs and outbox processors dispatch through the mediator, so registering
+         those batteries in the harness needs it. -->
+    <ProjectReference Include="..\..\src\Rask.Cqrs\Rask.Cqrs.csproj"/>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
**Stacked on #526** — review that first; this branch contains its commit.

## Summary

The roadmap says it plainly, under *Not shipped*:

> Jobs, mail and the outbox each retry with backoff and then stop… there is no UI, CLI command, or metric
> that shows you what has given up — inspecting or retrying a dead letter means SQL against `app.db`.

This is the **reading** half. One package reference and one line mounts an operator dashboard at `/_ops`
over the batteries' own tables:

```csharp
builder.Services.AddRaskDashboard<AppDbContext>();
builder.Services.AddAuthorization(o =>
    o.AddPolicy(RaskDashboardPolicies.Access, p => p.RequireRole("Admin")));
```

- **Queues** — outbox, jobs and mail in one view, split into due / delayed / **failed** / processed, where
  failed means what the processors mean by giving up: `ProcessedAt == null && Attempts >= MaxAttempts`, the
  inverse of their own drain predicate. Expand a row for its last error and stored payload.
- **The dead-letter total gets a banner**, not a tile among tiles — processed climbing looks healthy while
  a queue retries itself to death.
- **Cache** — keys, sizes, expiry, and how many are expired but not yet swept. Neither `ICache` nor
  `IDistributedCache` can enumerate keys, so this reads the table, which is the point of a DB-backed cache.
- **System** — SQLite pragmas read live through the open connection, database size, provider, and the
  recurring-job schedule joined to `RecurringJobState` so a job that has *never* fired is visible (a
  table-only view would omit exactly the one that's stuck).

## Security — the part I'd most like reviewed

The dashboard exposes job payloads and stored email bodies, so it is built to be safe when you configure
nothing.

`[Authorize(Policy = "RaskDashboard")]` sits on the **route layout**, not each page: `RouteAuthorizationGuard`
walks the whole chain, so one attribute covers every child — including pages a later version adds — and is
re-evaluated on in-app WebSocket navigation, not only the first GET.

The default policy is installed with `PostConfigure<AuthorizationOptions>`, which runs after every
`AddAuthorization` delegate the app registered. That makes call order irrelevant and means it only ever
*fills a gap*:

| Situation | Result |
| --- | --- |
| App defines the policy | The app's policy decides. No banner. |
| No policy, Development | Open, with a warning banner on every page. |
| No policy, anything else | **Denied for everyone.** |

## Two deliberate limits

**The backup card is opt-in via `IDashboardBackupProbe`** rather than referencing
`Rask.SQLite.Litestream`/`.Snapshots` directly. Those pull `SQLitePCLRaw.bundle_e_sqlite3` — a *native
provider bundle* — which would force a provider choice onto every consumer and tie a provider-agnostic EF
dashboard to SQLite (the panels work fine on Postgres). The probe is ~10 lines over the
`LitestreamStatus` / `ISqliteSnapshotStore.ListAsync` APIs added in #526. This is the one place I departed
from "one package, accept the transitive deps"; the four battery panels work exactly as decided.

**No sparkline.** A trend line needs a stored time series the dashboard doesn't keep, and a chart drawn
over nothing is worse than a number.

## Notes on the implementation

- **EF can't compose a `Where` onto a projection into a non-entity type** (it throws at translation), so
  the shared filter runs on the *entity* via `EF.Property` against the three columns all three tables have
  in common. One predicate definition, still fully translatable, counts done without projecting at all.
- **Availability is two probes, not one:** the options singleton (`AddRaskX` ran) *and*
  `Model.FindEntityType` (the table is mapped). A registration-only probe would call a battery available
  when `modelBuilder.AddRaskX()` was forgotten, and every query would throw.
- **Polling** awaits the first read then fire-and-forgets the loop — awaiting it in `OnMountAsync` would
  never return. It captures the component's lifetime `CancellationToken` in the lifecycle hook (read inside
  a handler dispatch it would also carry that dispatch's timeout), compares before re-rendering, and is
  bounded so a dashboard left open doesn't poll forever against SQLite's single write lock.
- **`BsStat`** is new in `Rask.Bootstrap`: tone colours the value, not the card.

## Testing

- `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings** (the RASK
  analyzers police the dashboard's own pages: RASK033 pushed every nav link onto generated `Routes.*()`,
  RASK022 onto keyed list rows).
- `scripts/run-unit-local.sh` → **4807 tests, 0 failed** across 36 assemblies.
- New `Rask.Dashboard.Tests` (12): the three authorization outcomes plus "an app policy wins over the
  fallback" and "no page carries `[AllowAnonymous]`"; the count split; the failed boundary at exactly
  `MaxAttempts`; paging totals; unregistered *and* registered-but-unmapped both reading as unavailable
  without throwing; the outbox's `OccurredAt` mapping leaving Delayed at zero.
- New `BsStatTests` (6), including that tone lands on the value and not the card.
- `dotnet pack` inspected: the nuspec lists no `Rask.Core` dependency (`PrivateAssets="all"` holding), and
  `PackageDependencyTests` covers it automatically.
- Pack steps added to **both** `release.yml` and `nightly.yml` — the omission #455 had to fix for
  Jobs/Mail.
- `scripts/run-e2e-local.sh` → only the four pre-existing sandbox failures (playground needs browser
  network for Roslyn refs; the three journey transports hit the one-shot composition-guide count assertion).

Benchmarks: not applicable — nothing here is on the render hot path.

## Not in this PR

Logs panel and the retry/purge/delete actions (next), then the `rask new --ops` flag, the Shop sample
wiring, `docs/dashboard.md` and the roadmap flip.
