### PR TITLE
feat(dashboard): retry what failed, and tail the log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,22 @@ them until tagged releases begin.
   **denies everyone** in every other environment. Panels poll, compare, and re-render only on a real
   change, and the loop is bounded, because every open tab competes with the processors for SQLite's single
   write lock.
+- **The dashboard can fix what it finds, and tail the log.** `Retry` puts a dead letter back in the queue
+  (`Attempts = 0`, due now, error cleared); `Retry all failed` does the queue at once; `Purge processed`
+  clears completed rows older than a week. Each is a single `ExecuteUpdate`/`ExecuteDelete` whose guard
+  lives in the `WHERE` clause, evaluated by the database at the moment of the write — and the retry guard
+  is the **inverse of the drain query**, so it can only ever match rows a processor has already given up
+  on. A row in flight is invisible to it, which is what makes retry safe against a live queue with no
+  coordination. Purge only ever touches `ProcessedAt IS NOT NULL`, so outstanding work and dead letters
+  survive whatever cutoff you pass.
+  Deleting a row, and flushing the whole cache, destroy work rather than reschedule it, so they need
+  `Actions = RaskDashboardActions.All`; the default stays `Safe`. Buttons for a tier that's off are hidden
+  rather than disabled.
+  A new **Logs** panel keeps a bounded in-memory tail of the standard `ILogger` pipeline (last N entries at
+  or above a level, filterable by level and category, with stack traces inline). It is fed by a registered
+  `ILoggerProvider`, so it sees exactly what every other sink sees — including Litestream exiting, a job
+  type that won't deserialize, and handler faults, none of which leave a row in any table. It's a tail,
+  not a log store: the buffer is memory-only and gone on restart.
 - **`BsStat`** — a stat-tile primitive for `Rask.Bootstrap`: a number, its label, an optional caption and
   tone. Tone colours the value rather than the card, so one red number reads as a signal instead of one
   panel among many coloured panels.

--- a/src/Rask.Dashboard/Logging/DashboardLogBuffer.cs
+++ b/src/Rask.Dashboard/Logging/DashboardLogBuffer.cs
@@ -1,0 +1,109 @@
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Dashboard.Logging;
+
+/// <summary>One captured log entry.</summary>
+/// <param name="Sequence">Monotonic id — the stable key for a list row, since timestamps can collide.</param>
+/// <param name="Timestamp">When it was logged (UTC).</param>
+/// <param name="Level">Its severity.</param>
+/// <param name="Category">The logger category, e.g. <c>Rask.Live</c>.</param>
+/// <param name="Message">The formatted message.</param>
+/// <param name="Exception">The exception's <c>ToString()</c>, if one was attached.</param>
+public sealed record DashboardLogEntry(
+    long Sequence,
+    DateTimeOffset Timestamp,
+    LogLevel Level,
+    string Category,
+    string Message,
+    string? Exception);
+
+/// <summary>
+/// A bounded, in-memory tail of the application's log — <b>not</b> a log store. It holds the last
+/// <see cref="RaskDashboardOptions.LogBufferSize" /> entries at or above
+/// <see cref="RaskDashboardOptions.LogMinimumLevel" /> and is gone when the process restarts; point a real
+/// logging provider somewhere durable for anything you need to keep.
+/// <para>
+/// It exists because the failures that matter most here leave no row in any table: Litestream exiting,
+/// a job type that won't deserialize, a handler that threw. Those are log lines, and the dashboard would
+/// otherwise send you to the container's stdout to read them.
+/// </para>
+/// </summary>
+public sealed class DashboardLogBuffer(RaskDashboardOptions options, TimeProvider timeProvider)
+{
+    private readonly Lock _gate = new();
+    private readonly Queue<DashboardLogEntry> _entries = new();
+    private long _sequence;
+
+    /// <summary>Raised after an entry is added, so the log panel can push instead of poll.</summary>
+    public event Action? Changed;
+
+    /// <summary>Whether this entry would be kept, checked before the message is even formatted.</summary>
+    public bool IsEnabled(LogLevel level) =>
+        options.CaptureLogs && level != LogLevel.None && level >= options.LogMinimumLevel;
+
+    /// <summary>The buffered entries, newest first, optionally filtered.</summary>
+    public IReadOnlyList<DashboardLogEntry> Snapshot(LogLevel? minimumLevel = null, string? category = null)
+    {
+        lock (_gate)
+        {
+            IEnumerable<DashboardLogEntry> query = _entries;
+
+            if (minimumLevel is { } level)
+            {
+                query = query.Where(e => e.Level >= level);
+            }
+
+            if (!string.IsNullOrWhiteSpace(category))
+            {
+                query = query.Where(e => e.Category.Contains(category, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return [.. query.Reverse()];
+        }
+    }
+
+    /// <summary>The distinct categories currently in the buffer, for the filter dropdown.</summary>
+    public IReadOnlyList<string> Categories()
+    {
+        lock (_gate)
+        {
+            return [.. _entries.Select(e => e.Category).Distinct(StringComparer.Ordinal).Order(StringComparer.Ordinal)];
+        }
+    }
+
+    /// <summary>Drops everything currently buffered.</summary>
+    public void Clear()
+    {
+        lock (_gate)
+        {
+            _entries.Clear();
+        }
+
+        Changed?.Invoke();
+    }
+
+    internal void Add(LogLevel level, string category, string message, Exception? exception)
+    {
+        lock (_gate)
+        {
+            _entries.Enqueue(new DashboardLogEntry(
+                ++_sequence,
+                timeProvider.GetUtcNow(),
+                level,
+                category,
+                message,
+                exception?.ToString()));
+
+            // Bounded by count: the oldest entry leaves as the newest arrives, so memory is flat no matter
+            // how chatty the app gets.
+            while (_entries.Count > options.LogBufferSize)
+            {
+                _entries.Dequeue();
+            }
+        }
+
+        // Raised outside the lock: a subscriber re-rendering must never block the logging call that
+        // triggered it, and re-entering Add from a handler would otherwise deadlock.
+        Changed?.Invoke();
+    }
+}

--- a/src/Rask.Dashboard/Logging/DashboardLoggerProvider.cs
+++ b/src/Rask.Dashboard/Logging/DashboardLoggerProvider.cs
@@ -1,0 +1,46 @@
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Dashboard.Logging;
+
+/// <summary>
+/// Feeds <see cref="DashboardLogBuffer" /> from the standard logging pipeline. Registering a provider
+/// rather than inventing a channel means the dashboard sees exactly what every other sink sees — the
+/// framework's own <c>Rask.Live</c>/<c>Rask.Diff</c>/<c>Rask.Lifecycle</c> categories, the processors'
+/// failure logs, and the application's own — with no extra wiring at the call sites.
+/// </summary>
+[ProviderAlias("RaskDashboard")]
+internal sealed class DashboardLoggerProvider(DashboardLogBuffer buffer) : ILoggerProvider
+{
+    public ILogger CreateLogger(string categoryName) => new BufferLogger(buffer, categoryName);
+
+    public void Dispose()
+    {
+        // Nothing to release: the buffer is a DI singleton with no unmanaged state.
+    }
+
+    private sealed class BufferLogger(DashboardLogBuffer buffer, string category) : ILogger
+    {
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        // Checked by the logging infrastructure before it formats anything, so an entry below the
+        // dashboard's threshold costs a comparison rather than a string.
+        public bool IsEnabled(LogLevel logLevel) => buffer.IsEnabled(logLevel);
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+
+            if (!IsEnabled(logLevel))
+            {
+                return;
+            }
+
+            buffer.Add(logLevel, category, formatter(state, exception), exception);
+        }
+    }
+}

--- a/src/Rask.Dashboard/NUGET.md
+++ b/src/Rask.Dashboard/NUGET.md
@@ -11,8 +11,13 @@ own database** — the tables are already there, so there is nothing to run and 
 - **The error behind the row.** Expand any row for its last failure message and its stored payload.
 - **Only what you run.** A panel appears only when its battery is both registered *and* mapped into the
   `DbContext`, so the nav is an inventory of this deployment rather than a menu of dead links.
-- **Cache, system and schedule.** Cache keys with sizes and expiry, SQLite pragmas read live, database
-  size, and the recurring-job schedule joined to when each job last actually fired.
+- **Fix it from here.** Retry a dead letter (or all of them), purge processed rows, evict a cache key. The
+  retry guard is the inverse of the processors' own drain query, so it can only match rows they've already
+  given up on — a row in flight is untouchable, and no coordination with a running processor is needed.
+- **Cache, logs, system and schedule.** Cache keys with sizes and expiry; a bounded in-memory tail of the
+  `ILogger` pipeline (the failures that leave no row anywhere — Litestream exiting, an unregistered job
+  type, handler faults); SQLite pragmas read live, database size, and the recurring-job schedule joined to
+  when each job last actually fired.
 - **Fail-closed by default.** See below — this matters more than any of the above.
 
 ## Use
@@ -53,6 +58,13 @@ builder.Services.AddRaskDashboard<AppDbContext>(o =>
     o.RefreshInterval = TimeSpan.FromSeconds(2);   // how often an open panel re-reads
     o.MaxPollDuration = TimeSpan.FromMinutes(5);   // then it parks and offers Resume
     o.PageSize        = 25;
+
+    o.Actions         = RaskDashboardActions.Safe; // default: retry, purge, evict
+    // o.Actions      = RaskDashboardActions.All;  // adds delete-a-row and flush-the-cache
+
+    o.LogBufferSize   = 500;
+    o.LogMinimumLevel = LogLevel.Information;
+    // o.CaptureLogs  = false;                     // no logging provider is registered at all
 });
 ```
 

--- a/src/Rask.Dashboard/Pages/CachePage.cs
+++ b/src/Rask.Dashboard/Pages/CachePage.cs
@@ -18,6 +18,8 @@ public sealed class CachePage(
     private IReadOnlyList<CacheKeyRow> _rows = [];
     private int _total;
     private int _page;
+    private string? _message;
+    private bool _confirmFlush;
 
     /// <summary>Substring filter on the key, from the query string so a search is a shareable link.</summary>
     [QueryParam("q")]
@@ -58,8 +60,12 @@ public sealed class CachePage(
 
         var now = timeProvider.GetUtcNow().UtcDateTime;
         return [
-            H1(Class: "h4 mb-3")["Cache"],
+            Div(Class: "d-flex align-items-center gap-2 mb-3")[
+                H1(Class: "h4 mb-0")["Cache"],
+                Div(Class: "ms-auto")[FlushButton()]
+            ],
             DashboardParts.Error(LoadError),
+            ActionResult(),
             BsRow(Class: "g-3 mb-4")[
                 BsCol(Sm: 4)[BsStat(Value: _stats.Entries.ToString(), Label: "Entries", Icon: BsIconName.Archive)],
                 BsCol(Sm: 4)[BsStat(Value: DashboardParts.Bytes(_stats.Bytes), Label: "Stored", Icon: BsIconName.Database)],
@@ -81,7 +87,7 @@ public sealed class CachePage(
 
     private Component Table(DateTime now) =>
         BsTable(Small: true, Hover: true, Responsive: true)[
-            Thead()[Tr()[Th()["Key"], Th()["Size"], Th()["Written"], Th()["Expires"], Th()["Sliding"]]],
+            Thead()[Tr()[Th()["Key"], Th()["Size"], Th()["Written"], Th()["Expires"], Th()["Sliding"], Th()]],
             Tbody()[_rows.Select(r => Tr(Key: r.Key, Class: r.ExpiresAt <= now ? "text-body-secondary" : null)[
                 Td()[Div(Class: "text-truncate font-monospace small", Style: "max-width:28rem")[r.Key]],
                 Td()[DashboardParts.Bytes(r.Bytes)],
@@ -91,7 +97,8 @@ public sealed class CachePage(
                         ? BsBadge(Color: BsColor.Secondary)["expired"]
                         : Span()[DashboardParts.Ago(r.ExpiresAt, now)]
                 ],
-                Td()[r.SlidingSeconds is { } s ? DashboardParts.Duration(TimeSpan.FromSeconds(s)) : "—"]
+                Td()[r.SlidingSeconds is { } s ? DashboardParts.Duration(TimeSpan.FromSeconds(s)) : "—"],
+                Td(Class: "text-end")[EvictButton(r.Key)]
             ])]
         ];
 
@@ -110,6 +117,77 @@ public sealed class CachePage(
             BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm,
                 Disabled: _page >= pages - 1, OnClickAsync: () => GoAsync(_page + 1))["Next"]
         ];
+    }
+
+    // Evicting one key is a recompute, not a lost fact, so it sits in the Safe tier and needs no
+    // confirmation. Flushing everything is correctness-safe too, but a cold cache on a busy app means a
+    // stampede — hence the Destructive tier and a confirmation.
+    private Component? EvictButton(string key) =>
+        options.Actions.HasFlag(RaskDashboardActions.Safe)
+            ? BsButton(
+                Color: BsColor.Secondary,
+                Outline: true,
+                Size: BsSize.Sm,
+                OnClickAsync: () => EvictAsync(key))["Evict"]
+            : null;
+
+    private Component? FlushButton() =>
+        options.Actions.HasFlag(RaskDashboardActions.Destructive) && _stats.Entries > 0
+            ? BsButton(Color: BsColor.Danger, Size: BsSize.Sm, OnClick: () => Confirm(true))["Flush cache"]
+            : null;
+
+    private Component? ActionResult()
+    {
+        if (_confirmFlush)
+        {
+            return BsAlert(Color: BsColor.Warning, Class: "d-flex align-items-center gap-2")[
+                Span(Class: "flex-grow-1")[
+                    $"Drop all {_stats.Entries} cache entries? Nothing is lost permanently, but everything is recomputed at once."
+                ],
+                BsButton(Color: BsColor.Danger, Size: BsSize.Sm, OnClickAsync: FlushAsync)["Confirm"],
+                BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClick: () => Confirm(false))["Cancel"]
+            ];
+        }
+
+        return _message is { } message
+            ? BsAlert(Color: BsColor.Info, Class: "d-flex align-items-center gap-2")[
+                Span(Class: "flex-grow-1")[message],
+                BsCloseButton(OnClick: Dismiss)
+            ]
+            : null;
+    }
+
+    private void Confirm(bool pending)
+    {
+        _confirmFlush = pending;
+        StateHasChanged();
+    }
+
+    private void Dismiss()
+    {
+        _message = null;
+        StateHasChanged();
+    }
+
+    private async Task EvictAsync(string key)
+    {
+        var removed = await cache.EvictAsync(key, CancellationToken).ConfigureAwait(false);
+        _message = removed > 0 ? $"Evicted \"{key}\"." : $"\"{key}\" was already gone.";
+        await RefreshAsync().ConfigureAwait(false);
+    }
+
+    private async Task FlushAsync()
+    {
+        _confirmFlush = false;
+        _message = $"Flushed {await cache.FlushAsync(CancellationToken).ConfigureAwait(false)} entries.";
+        _page = 0;
+        await RefreshAsync().ConfigureAwait(false);
+    }
+
+    private async Task RefreshAsync()
+    {
+        await LoadAsync(CancellationToken).ConfigureAwait(false);
+        StateHasChanged();
     }
 
     private async Task GoAsync(int page)

--- a/src/Rask.Dashboard/Pages/DashboardLayout.cs
+++ b/src/Rask.Dashboard/Pages/DashboardLayout.cs
@@ -64,6 +64,7 @@ public sealed class DashboardLayout(
         }
 
         yield return NavLink(Routes.CachePage(), "Cache", BsIconName.Archive, exact: false);
+        yield return NavLink(Routes.LogsPage(), "Logs", BsIconName.ListUl, exact: false);
         yield return NavLink(Routes.SystemPage(), "System", BsIconName.HddStack, exact: false);
     }
 

--- a/src/Rask.Dashboard/Pages/LogsPage.cs
+++ b/src/Rask.Dashboard/Pages/LogsPage.cs
@@ -1,0 +1,164 @@
+using Microsoft.Extensions.Logging;
+using Rask.Core.Routing;
+using Rask.Dashboard.Logging;
+
+namespace Rask.Dashboard.Pages;
+
+/// <summary>
+/// The recent log tail. Unlike the other panels this one doesn't poll: the buffer raises an event when an
+/// entry arrives, so the page renders on a real log line rather than on a timer. Nothing is read from the
+/// database, so there is no write-lock cost either.
+/// </summary>
+[Route("logs")]
+[ParentRoute(typeof(DashboardLayout))]
+public sealed class LogsPage(
+    DashboardLogBuffer buffer,
+    RaskDashboardOptions options,
+    TimeProvider timeProvider) : Component, IDisposable
+{
+    private bool _subscribed;
+
+    /// <summary>Minimum level to show, from the query string so a filtered view is a shareable link.</summary>
+    [QueryParam("level")]
+    public string? Level { get; set; }
+
+    /// <summary>Category substring filter, likewise.</summary>
+    [QueryParam("category")]
+    public string? Category { get; set; }
+
+    private LogLevel? MinimumLevel =>
+        Enum.TryParse<LogLevel>(Level, ignoreCase: true, out var parsed) ? parsed : null;
+
+    protected override void OnMount()
+    {
+        buffer.Changed += OnLogged;
+        _subscribed = true;
+    }
+
+    protected override void OnUnmount() => Unsubscribe();
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        Unsubscribe();
+        GC.SuppressFinalize(this);
+    }
+
+    protected override Component? Render()
+    {
+        if (!options.CaptureLogs)
+        {
+            return DashboardParts.Empty(
+                "Log capture is off",
+                "Set CaptureLogs = true on RaskDashboardOptions to keep a tail of recent entries.");
+        }
+
+        var entries = buffer.Snapshot(MinimumLevel, Category);
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+
+        return [
+            Div(Class: "d-flex align-items-center gap-3 mb-3")[
+                H1(Class: "h4 mb-0")["Logs"],
+                Span(Class: "text-body-secondary small")[
+                    $"last {options.LogBufferSize} entries at {options.LogMinimumLevel} and above, in memory only"
+                ]
+            ],
+            Filters(),
+            entries.Count == 0
+                ? DashboardParts.Empty("Nothing captured yet", "Entries appear here as the application logs them.")
+                : Table(entries, now),
+        ];
+    }
+
+    private Component Filters() =>
+        Div(Class: "d-flex flex-wrap align-items-center gap-2 mb-3")[
+            BsNav(Class: "nav-pills gap-1")[
+                LevelPill(null, "All"),
+                LevelPill(LogLevel.Information, "Info+"),
+                LevelPill(LogLevel.Warning, "Warning+"),
+                LevelPill(LogLevel.Error, "Error+")
+            ],
+            CategoryFilter()
+        ];
+
+    private Component LevelPill(LogLevel? level, string label) =>
+        BsNavItem(Key: label)[
+            BsLink(
+                Routes.LogsPage(Level: level?.ToString(), Category: Category),
+                Class: Bs.Join("nav-link", MinimumLevel == level ? "active" : null))[label]
+        ];
+
+    // A dropdown rather than a pill row: a real application has dozens of logger categories, and only the
+    // ones currently in the buffer are worth offering.
+    private Component? CategoryFilter()
+    {
+        var categories = buffer.Categories();
+        if (categories.Count == 0)
+        {
+            return null;
+        }
+
+        return BsDropdown(
+            Label: Category is { Length: > 0 } ? Category : "All categories",
+            Color: BsColor.Secondary,
+            Outline: true,
+            Size: BsSize.Sm)[CategoryItems(categories)];
+    }
+
+    // One sequence rather than a mixed argument list: the children indexer takes either individual
+    // components or an enumerable, not both.
+    private IEnumerable<Component> CategoryItems(IReadOnlyList<string> categories)
+    {
+        yield return BsDropdownItem(
+            Key: "__all",
+            Href: Routes.LogsPage(Level: Level),
+            Active: string.IsNullOrEmpty(Category))["All categories"];
+
+        yield return BsDropdownItem(Key: "__divider", Divider: true);
+
+        foreach (var category in categories)
+        {
+            yield return BsDropdownItem(
+                Key: category,
+                Href: Routes.LogsPage(Level: Level, Category: category),
+                Active: string.Equals(category, Category, StringComparison.Ordinal))[category];
+        }
+    }
+
+    private static Component Table(IReadOnlyList<DashboardLogEntry> entries, DateTime now) =>
+        BsTable(Small: true, Hover: true, Responsive: true)[
+            Thead()[Tr()[Th()["When"], Th()["Level"], Th()["Category"], Th()["Message"]]],
+            Tbody()[entries.Select(e => Tr(Key: e.Sequence)[
+                Td(Class: "text-nowrap text-body-secondary")[DashboardParts.Ago(e.Timestamp.UtcDateTime, now)],
+                Td()[LevelBadge(e.Level)],
+                Td(Class: "font-monospace small text-body-secondary")[e.Category],
+                Td()[
+                    Div()[e.Message],
+                    // The stack trace is the reason an error entry is worth surfacing at all, but it would
+                    // drown the table, so it renders muted beneath rather than in a separate view.
+                    e.Exception is { } ex
+                        ? Pre(Class: "small text-body-secondary text-wrap mb-0 mt-1")[ex]
+                        : null
+                ]
+            ])]
+        ];
+
+    private static Component LevelBadge(LogLevel level) => BsBadge(Color: level switch
+    {
+        LogLevel.Critical or LogLevel.Error => BsColor.Danger,
+        LogLevel.Warning => BsColor.Warning,
+        LogLevel.Information => BsColor.Info,
+        _ => BsColor.Secondary,
+    })[level.ToString()];
+
+    private void OnLogged() => StateHasChanged();
+
+    private void Unsubscribe()
+    {
+        if (_subscribed)
+        {
+            buffer.Changed -= OnLogged;
+            _subscribed = false;
+        }
+    }
+}

--- a/src/Rask.Dashboard/Pages/QueuePage.cs
+++ b/src/Rask.Dashboard/Pages/QueuePage.cs
@@ -21,6 +21,8 @@ public sealed class QueuePage(
     private int _total;
     private int _page;
     private long? _expanded;
+    private string? _message;
+    private (string Prompt, Func<CancellationToken, Task<string>> Action)? _pending;
 
     /// <summary>Which queue, from the route.</summary>
     [RouteParam]
@@ -76,9 +78,11 @@ public sealed class QueuePage(
         return [
             Div(Class: "d-flex align-items-center gap-2 mb-3")[
                 BsIcon(Name: _panel.Icon, Class: "fs-4"),
-                H1(Class: "h4 mb-0")[_panel.Title]
+                H1(Class: "h4 mb-0")[_panel.Title],
+                Div(Class: "ms-auto d-flex gap-2")[QueueActionButtons()]
             ],
             DashboardParts.Error(LoadError),
+            ActionResult(),
             FilterTabs(),
             _rows.Count == 0 ? EmptyForFilter() : RowsTable(),
             Pager(),
@@ -135,11 +139,7 @@ public sealed class QueuePage(
             Td()[row.Attempts.ToString()],
             Td()[StatusBadge(row, isDead, now)],
             Td(Class: "text-end")[
-                BsButton(
-                    Color: BsColor.Secondary,
-                    Outline: true,
-                    Size: BsSize.Sm,
-                    OnClick: () => Toggle(row.Id))[_expanded == row.Id ? "Hide" : "Details"]
+                Div(Class: "d-flex gap-1 justify-content-end")[RowButtons(row, isDead)]
             ]
         ];
 
@@ -147,6 +147,21 @@ public sealed class QueuePage(
         {
             yield return Tr(Key: $"{row.Id}-details")[Td(Colspan: 6, Class: "bg-body-tertiary")[Details(row)]];
         }
+    }
+
+    private IEnumerable<Component> RowButtons(QueueRow row, bool isDead)
+    {
+        foreach (var button in RowActionButtons(row, isDead))
+        {
+            yield return button;
+        }
+
+        yield return BsButton(
+            Key: "details",
+            Color: BsColor.Secondary,
+            Outline: true,
+            Size: BsSize.Sm,
+            OnClick: () => Toggle(row.Id))[_expanded == row.Id ? "Hide" : "Details"];
     }
 
     private Component StatusBadge(QueueRow row, bool isDead, DateTime now) => row switch
@@ -172,6 +187,142 @@ public sealed class QueuePage(
     private void Toggle(long id)
     {
         _expanded = _expanded == id ? null : id;
+        StateHasChanged();
+    }
+
+    // ── Actions ─────────────────────────────────────────────────────────────────────────────────────
+    // Every button is hidden, not merely disabled, when its tier is off: an operator shouldn't have to
+    // discover by clicking that the deployment doesn't allow something.
+
+    private IEnumerable<Component> QueueActionButtons()
+    {
+        if (!options.Actions.HasFlag(RaskDashboardActions.Safe))
+        {
+            yield break;
+        }
+
+        if (_counts.Failed > 0)
+        {
+            yield return BsButton(
+                Key: "retry-all",
+                Color: BsColor.Danger,
+                Size: BsSize.Sm,
+                OnClickAsync: () => RunAsync(
+                    $"Retry all {_counts.Failed} dead letters?",
+                    async ct => $"Re-queued {await _panel!.RetryAllAsync(ct).ConfigureAwait(false)}."))[
+                BsIcon(Name: BsIconName.ArrowRepeat),
+                Span(Class: "ms-1")["Retry all failed"]
+            ];
+        }
+
+        if (_counts.Processed > 0)
+        {
+            yield return BsButton(
+                Key: "purge",
+                Color: BsColor.Secondary,
+                Outline: true,
+                Size: BsSize.Sm,
+                OnClickAsync: () => RunAsync(
+                    "Delete processed rows older than 7 days? Outstanding work and dead letters are kept.",
+                    async ct => $"Purged {await _panel!.PurgeProcessedAsync(TimeSpan.FromDays(7), ct).ConfigureAwait(false)}."))[
+                "Purge processed"
+            ];
+        }
+    }
+
+    private IEnumerable<Component> RowActionButtons(QueueRow row, bool isDead)
+    {
+        if (isDead && options.Actions.HasFlag(RaskDashboardActions.Safe))
+        {
+            yield return BsButton(
+                Key: "retry",
+                Color: BsColor.Danger,
+                Outline: true,
+                Size: BsSize.Sm,
+                OnClickAsync: () => RunAsync(
+                    null,   // retrying one dead letter is reversible enough not to need a confirmation
+                    async ct => await _panel!.RetryAsync(row.Id, ct).ConfigureAwait(false) > 0
+                        ? $"Re-queued #{row.Id}."
+                        : $"#{row.Id} was already picked up."))["Retry"];
+        }
+
+        if (row.ProcessedAt is null && options.Actions.HasFlag(RaskDashboardActions.Destructive))
+        {
+            yield return BsButton(
+                Key: "delete",
+                Color: BsColor.Danger,
+                Outline: true,
+                Size: BsSize.Sm,
+                OnClickAsync: () => RunAsync(
+                    $"Delete #{row.Id}? The work is discarded and cannot be recovered.",
+                    async ct => await _panel!.DeleteAsync(row.Id, ct).ConfigureAwait(false) > 0
+                        ? $"Deleted #{row.Id}."
+                        : $"#{row.Id} had already completed and was left alone."))["Delete"];
+        }
+    }
+
+    // Confirmation is a state flip rather than a JS dialog: the prompt renders as an alert with the
+    // pending action attached, so it works on the Server transport with no client script.
+    private Task RunAsync(string? confirm, Func<CancellationToken, Task<string>> action)
+    {
+        if (confirm is not null)
+        {
+            _pending = (confirm, action);
+            StateHasChanged();
+            return Task.CompletedTask;
+        }
+
+        return ExecuteAsync(action);
+    }
+
+    private async Task ExecuteAsync(Func<CancellationToken, Task<string>> action)
+    {
+        _pending = null;
+        try
+        {
+            _message = await action(CancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // A failed action must report itself, not tear the page down.
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _message = $"Failed: {ex.Message}";
+        }
+
+        _page = 0;
+        _expanded = null;
+        await LoadAsync(CancellationToken).ConfigureAwait(false);
+        StateHasChanged();
+    }
+
+    private Component? ActionResult()
+    {
+        if (_pending is { } pending)
+        {
+            return BsAlert(Color: BsColor.Warning, Class: "d-flex align-items-center gap-2")[
+                Span(Class: "flex-grow-1")[pending.Prompt],
+                BsButton(Color: BsColor.Danger, Size: BsSize.Sm, OnClickAsync: () => ExecuteAsync(pending.Action))["Confirm"],
+                BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, OnClick: Cancel)["Cancel"]
+            ];
+        }
+
+        return _message is { } message
+            ? BsAlert(Color: BsColor.Info, Class: "d-flex align-items-center gap-2")[
+                Span(Class: "flex-grow-1")[message],
+                BsCloseButton(OnClick: Dismiss)
+            ]
+            : null;
+    }
+
+    private void Cancel()
+    {
+        _pending = null;
+        StateHasChanged();
+    }
+
+    private void Dismiss()
+    {
+        _message = null;
         StateHasChanged();
     }
 

--- a/src/Rask.Dashboard/Panels/BatteryQueuePanels.cs
+++ b/src/Rask.Dashboard/Panels/BatteryQueuePanels.cs
@@ -106,6 +106,18 @@ public interface ICachePanelReader
     /// <summary>One page of keys, soonest to expire first.</summary>
     Task<(IReadOnlyList<CacheKeyRow> Rows, int Total)> PageAsync(
         string? search, int skip, int take, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Drops one key. Safe by nature — a cache miss is a recompute, not a lost fact — which is why this
+    /// sits in the Safe action tier while flushing everything does not.
+    /// </summary>
+    Task<int> EvictAsync(string key, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Drops every entry. Correctness-safe for the same reason, but a cold cache on a busy app means a
+    /// stampede of recomputes, so it needs <see cref="RaskDashboardActions.Destructive"/>.
+    /// </summary>
+    Task<int> FlushAsync(CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -168,6 +180,33 @@ internal sealed class CachePanel<TContext>(
             .ConfigureAwait(false);
 
         return (rows, total);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> EvictAsync(string key, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return 0;
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await db.Set<CacheEntry>()
+            .Where(e => e.Key == key)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    public async Task<int> FlushAsync(CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return 0;
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await db.Set<CacheEntry>().ExecuteDeleteAsync(cancellationToken).ConfigureAwait(false);
     }
 
     private bool IsMapped()

--- a/src/Rask.Dashboard/Panels/QueueActions.cs
+++ b/src/Rask.Dashboard/Panels/QueueActions.cs
@@ -1,0 +1,38 @@
+namespace Rask.Dashboard.Panels;
+
+/// <summary>
+/// The mutations a queue panel can perform.
+/// <para>
+/// Every one is a single <c>ExecuteUpdate</c>/<c>ExecuteDelete</c> statement with its guard in the
+/// <c>WHERE</c> clause — never a tracked entity. That matters for two reasons: the dashboard can't itself
+/// raise a concurrency exception, and the guard is evaluated by the database at the moment of the write
+/// rather than by the dashboard a few hundred milliseconds earlier.
+/// </para>
+/// </summary>
+public interface IQueueActions
+{
+    /// <summary>
+    /// Puts a dead letter back in the queue: <c>Attempts = 0</c>, <c>RunAt = now</c>, <c>Error = null</c>.
+    /// <para>
+    /// Guarded by <c>ProcessedAt IS NULL AND Attempts &gt;= MaxAttempts</c> — the exact set the drain
+    /// query excludes. A row a processor could currently be holding is therefore untouchable by this
+    /// operation, so it needs no coordination with the drain at all. Returns rows affected.
+    /// </para>
+    /// </summary>
+    Task<int> RetryAsync(long id, CancellationToken cancellationToken);
+
+    /// <summary>Retries every dead letter in this queue. Same guard, no id.</summary>
+    Task<int> RetryAllAsync(CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes completed rows older than <paramref name="olderThan"/>. Guarded on
+    /// <c>ProcessedAt IS NOT NULL</c>, so nothing outstanding — and no dead letter — is ever removed.
+    /// </summary>
+    Task<int> PurgeProcessedAsync(TimeSpan olderThan, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Deletes one outstanding row, destroying the work. Guarded on <c>ProcessedAt IS NULL</c> so a
+    /// completed row's record is never lost; requires <see cref="RaskDashboardActions.Destructive"/>.
+    /// </summary>
+    Task<int> DeleteAsync(long id, CancellationToken cancellationToken);
+}

--- a/src/Rask.Dashboard/Panels/QueuePanel.cs
+++ b/src/Rask.Dashboard/Panels/QueuePanel.cs
@@ -61,9 +61,10 @@ public readonly record struct QueueCounts(int Due, int Delayed, int Failed, int 
 }
 
 /// <summary>
-/// A queue the dashboard can show. Implemented once per battery; the page never names an entity type.
+/// A queue the dashboard can show and act on. Implemented once per battery; the page never names an
+/// entity type.
 /// </summary>
-public interface IQueuePanel
+public interface IQueuePanel : IQueueActions
 {
     /// <summary>URL-safe identity, e.g. <c>jobs</c>. Also the route segment.</summary>
     string Slug { get; }

--- a/src/Rask.Dashboard/Panels/QueuePanelBase.cs
+++ b/src/Rask.Dashboard/Panels/QueuePanelBase.cs
@@ -90,6 +90,76 @@ internal abstract class QueuePanelBase<TContext, TEntity>(IDbContextFactory<TCon
         return (rows, total);
     }
 
+    public Task<int> RetryAsync(long id, CancellationToken cancellationToken) =>
+        RetryWhereAsync(e => EF.Property<long>(e, "Id") == id, cancellationToken);
+
+    public Task<int> RetryAllAsync(CancellationToken cancellationToken) =>
+        RetryWhereAsync(_ => true, cancellationToken);
+
+    public async Task<int> PurgeProcessedAsync(TimeSpan olderThan, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return 0;
+        }
+
+        var cutoff = timeProvider.GetUtcNow().UtcDateTime - olderThan;
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // ProcessedAt IS NOT NULL is the whole guard: outstanding work and dead letters are both
+        // untouched, whatever cutoff the caller passes.
+        return await db.Set<TEntity>()
+            .Where(e => EF.Property<DateTime?>(e, "ProcessedAt") != null
+                        && EF.Property<DateTime?>(e, "ProcessedAt") < cutoff)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<int> DeleteAsync(long id, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return 0;
+        }
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+
+        // Outstanding only. Deleting a processed row would erase the record of work that actually
+        // happened, which is the one thing an operator can never undo.
+        return await db.Set<TEntity>()
+            .Where(e => EF.Property<long>(e, "Id") == id && EF.Property<DateTime?>(e, "ProcessedAt") == null)
+            .ExecuteDeleteAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    // The retry guard is the inverse of the drain query, so it can only ever match rows the processor has
+    // already given up on — a row in flight is invisible to it, which is what makes this safe to run
+    // against a live queue with no coordination.
+    private async Task<int> RetryWhereAsync(
+        Expression<Func<TEntity, bool>> scope, CancellationToken cancellationToken)
+    {
+        if (!IsAvailable)
+        {
+            return 0;
+        }
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var max = MaxAttempts;
+        var runAt = RunAtProperty;
+
+        await using var db = await contextFactory.CreateDbContextAsync(cancellationToken).ConfigureAwait(false);
+        return await db.Set<TEntity>()
+            .Where(scope)
+            .Where(e => EF.Property<DateTime?>(e, "ProcessedAt") == null && EF.Property<int>(e, "Attempts") >= max)
+            .ExecuteUpdateAsync(
+                s => s
+                    .SetProperty(e => EF.Property<int>(e, "Attempts"), 0)
+                    .SetProperty(e => EF.Property<DateTime>(e, runAt), now)
+                    .SetProperty(e => EF.Property<string?>(e, "Error"), (string?)null),
+                cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     private Task<int> CountAsync(TContext db, QueueFilter filter, DateTime now, CancellationToken ct) =>
         Filter(db.Set<TEntity>(), filter, now).CountAsync(ct);
 

--- a/src/Rask.Dashboard/RaskDashboardServiceCollectionExtensions.cs
+++ b/src/Rask.Dashboard/RaskDashboardServiceCollectionExtensions.cs
@@ -3,6 +3,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Rask.Dashboard.Logging;
 using Rask.Dashboard.Panels;
 
 namespace Rask.Dashboard;
@@ -52,6 +54,16 @@ public static class RaskDashboardServiceCollectionExtensions
         services.TryAddSingleton(options);
         services.TryAddSingleton(TimeProvider.System);
         services.TryAddSingleton<DashboardSecurityState>();
+        services.TryAddSingleton<DashboardLogBuffer>();
+
+        // Registered as a logging provider rather than a bespoke channel, so the log panel sees exactly
+        // what every other sink sees. TryAddEnumerable keys on the implementation type, so a repeated
+        // AddRaskDashboard call doesn't double-capture every entry.
+        if (options.CaptureLogs)
+        {
+            services.TryAddEnumerable(
+                ServiceDescriptor.Singleton<ILoggerProvider, DashboardLoggerProvider>());
+        }
 
         // One adapter per battery. Each decides at request time whether it has anything to show, so the
         // registration stays unconditional and the app's own wiring is the single source of truth.

--- a/tests/Rask.Dashboard.Tests/CacheActionTests.cs
+++ b/tests/Rask.Dashboard.Tests/CacheActionTests.cs
@@ -1,0 +1,96 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Cache;
+
+namespace Rask.Dashboard.Tests;
+
+/// <summary>
+/// Cache actions are correctness-safe by nature — a miss is a recompute, not a lost fact — so what these
+/// pin is scope: evicting one key must not take the others with it.
+/// </summary>
+public sealed class CacheActionTests
+{
+    [Fact]
+    public async Task Evict_removes_exactly_one_key()
+    {
+        await using var h = new DashboardHarness(Batteries.Cache);
+        await SeedAsync(h, "a", "b", "c");
+
+        Assert.Equal(1, await h.Get<ICachePanelReader>().EvictAsync("b", CancellationToken.None));
+
+        await using var db = h.NewContext();
+        Assert.Equal(["a", "c"], await db.Set<CacheEntry>().Select(e => e.Key).OrderBy(k => k).ToListAsync());
+    }
+
+    [Fact]
+    public async Task Evicting_a_missing_key_reports_zero_rather_than_throwing()
+    {
+        await using var h = new DashboardHarness(Batteries.Cache);
+        Assert.Equal(0, await h.Get<ICachePanelReader>().EvictAsync("nope", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Flush_drops_everything_and_reports_the_count()
+    {
+        await using var h = new DashboardHarness(Batteries.Cache);
+        await SeedAsync(h, "a", "b", "c");
+
+        Assert.Equal(3, await h.Get<ICachePanelReader>().FlushAsync(CancellationToken.None));
+        Assert.Equal(0, (await h.Get<ICachePanelReader>().StatsAsync(CancellationToken.None)).Entries);
+    }
+
+    [Fact]
+    public async Task Stats_report_entries_bytes_and_the_expired_backlog()
+    {
+        await using var h = new DashboardHarness(Batteries.Cache);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+
+        await using (var db = h.NewContext())
+        {
+            db.Set<CacheEntry>().AddRange(
+                new CacheEntry { Key = "fresh", Value = new byte[10], ExpiresAt = now.AddHours(1), CreatedAt = now },
+                // Past its expiry but still a row: the purge sweep runs on its own schedule, and the gap
+                // between "stops being served" and "actually deleted" is worth showing.
+                new CacheEntry { Key = "stale", Value = new byte[5], ExpiresAt = now.AddHours(-1), CreatedAt = now });
+            await db.SaveChangesAsync();
+        }
+
+        var stats = await h.Get<ICachePanelReader>().StatsAsync(CancellationToken.None);
+
+        Assert.Equal(2, stats.Entries);
+        Assert.Equal(15, stats.Bytes);
+        Assert.Equal(1, stats.Expired);
+    }
+
+    [Fact]
+    public async Task An_empty_cache_reports_zero_bytes_rather_than_failing()
+    {
+        // SUM over no rows is NULL in SQL; a plain Sum() would throw on the nullable-to-long conversion.
+        await using var h = new DashboardHarness(Batteries.Cache);
+        Assert.Equal(0, (await h.Get<ICachePanelReader>().StatsAsync(CancellationToken.None)).Bytes);
+    }
+
+    [Fact]
+    public async Task Actions_on_an_unmapped_cache_are_no_ops()
+    {
+        await using var h = new DashboardHarness(registered: Batteries.All, mapped: Batteries.Jobs);
+        var cache = h.Get<ICachePanelReader>();
+
+        Assert.False(cache.IsAvailable);
+        Assert.Equal(0, await cache.EvictAsync("a", CancellationToken.None));
+        Assert.Equal(0, await cache.FlushAsync(CancellationToken.None));
+    }
+
+    private static async Task SeedAsync(DashboardHarness harness, params string[] keys)
+    {
+        var now = harness.Clock.GetUtcNow().UtcDateTime;
+        await using var db = harness.NewContext();
+        db.Set<CacheEntry>().AddRange(keys.Select(k => new CacheEntry
+        {
+            Key = k,
+            Value = [1, 2, 3],
+            ExpiresAt = now.AddHours(1),
+            CreatedAt = now,
+        }));
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/Rask.Dashboard.Tests/DashboardAuthorizationTests.cs
+++ b/tests/Rask.Dashboard.Tests/DashboardAuthorizationTests.cs
@@ -73,8 +73,8 @@ public sealed class DashboardAuthorizationTests
 
         var children = new[]
         {
-            typeof(Pages.OverviewPage), typeof(Pages.QueuePage),
-            typeof(Pages.CachePage), typeof(Pages.SystemPage),
+            typeof(Pages.OverviewPage), typeof(Pages.QueuePage), typeof(Pages.CachePage),
+            typeof(Pages.LogsPage), typeof(Pages.SystemPage),
         };
 
         // None of them may carry [AllowAnonymous] — that would punch a hole straight through the chain.

--- a/tests/Rask.Dashboard.Tests/LogBufferTests.cs
+++ b/tests/Rask.Dashboard.Tests/LogBufferTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Rask.Dashboard.Logging;
+
+namespace Rask.Dashboard.Tests;
+
+/// <summary>
+/// The log tail is bounded in-memory state fed by the standard logging pipeline. What matters is that it
+/// stays bounded, that it filters before formatting, and that it really is wired into <c>ILogger</c> —
+/// a buffer nobody writes to would look identical to a quiet application.
+/// </summary>
+public sealed class LogBufferTests
+{
+    [Fact]
+    public void The_buffer_keeps_only_the_newest_entries()
+    {
+        var buffer = Buffer(size: 3);
+
+        for (var i = 1; i <= 10; i++)
+        {
+            buffer.Add(LogLevel.Information, "Cat", $"message {i}", exception: null);
+        }
+
+        // Bounded by count, so a chatty application can't grow it without limit.
+        Assert.Equal(
+            ["message 10", "message 9", "message 8"],
+            buffer.Snapshot().Select(e => e.Message));
+    }
+
+    [Fact]
+    public void Entries_below_the_minimum_level_are_never_captured()
+    {
+        var buffer = Buffer(minimum: LogLevel.Warning);
+
+        Assert.False(buffer.IsEnabled(LogLevel.Information));
+        Assert.True(buffer.IsEnabled(LogLevel.Error));
+
+        buffer.Add(LogLevel.Warning, "Cat", "kept", exception: null);
+        Assert.Single(buffer.Snapshot());
+    }
+
+    [Fact]
+    public void Capture_can_be_turned_off_entirely()
+    {
+        var buffer = Buffer(capture: false);
+
+        // IsEnabled is what the logging infrastructure checks before formatting a message, so switching
+        // capture off has to cost nothing rather than merely discarding afterwards.
+        Assert.False(buffer.IsEnabled(LogLevel.Critical));
+    }
+
+    [Fact]
+    public void Snapshot_filters_by_level_and_category()
+    {
+        var buffer = Buffer();
+        buffer.Add(LogLevel.Information, "Rask.Live", "info", null);
+        buffer.Add(LogLevel.Error, "Rask.Diff", "boom", null);
+        buffer.Add(LogLevel.Error, "App.Orders", "order failed", null);
+
+        Assert.Equal(2, buffer.Snapshot(minimumLevel: LogLevel.Error).Count);
+        Assert.Equal("boom", Assert.Single(buffer.Snapshot(category: "Rask.Diff")).Message);
+        Assert.Equal(["App.Orders", "Rask.Diff", "Rask.Live"], buffer.Categories());
+    }
+
+    [Fact]
+    public void An_exception_is_captured_alongside_the_message()
+    {
+        var buffer = Buffer();
+        buffer.Add(LogLevel.Error, "Rask.Jobs", "Job 7 failed", new InvalidOperationException("boom"));
+
+        var entry = Assert.Single(buffer.Snapshot());
+        Assert.Contains("boom", entry.Exception!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Adding_raises_Changed_so_the_panel_can_push_instead_of_poll()
+    {
+        var buffer = Buffer();
+        var raised = 0;
+        buffer.Changed += () => raised++;
+
+        buffer.Add(LogLevel.Information, "Cat", "one", null);
+        buffer.Clear();
+
+        Assert.Equal(2, raised);   // once for the entry, once for the clear
+    }
+
+    [Fact]
+    public async Task Logging_through_ILogger_reaches_the_buffer()
+    {
+        // The wiring test: registration has to actually attach a provider to the logging pipeline, or the
+        // panel silently shows nothing on a perfectly busy application.
+        await using var h = new DashboardHarness(Batteries.Jobs);
+
+        h.Get<ILoggerFactory>().CreateLogger("App.Thing").LogWarning("through the pipeline");
+
+        var entry = Assert.Single(h.Get<DashboardLogBuffer>().Snapshot(category: "App.Thing"));
+        Assert.Equal(LogLevel.Warning, entry.Level);
+        Assert.Equal("through the pipeline", entry.Message);
+    }
+
+    [Fact]
+    public async Task Capture_off_registers_no_provider()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs, configure: o => o.CaptureLogs = false);
+
+        h.Get<ILoggerFactory>().CreateLogger("App.Thing").LogError("ignored");
+
+        Assert.Empty(h.Get<DashboardLogBuffer>().Snapshot());
+    }
+
+    private static DashboardLogBuffer Buffer(
+        int size = 100, LogLevel minimum = LogLevel.Information, bool capture = true) =>
+        new(
+            new RaskDashboardOptions { LogBufferSize = size, LogMinimumLevel = minimum, CaptureLogs = capture },
+            TimeProvider.System);
+}

--- a/tests/Rask.Dashboard.Tests/QueueActionTests.cs
+++ b/tests/Rask.Dashboard.Tests/QueueActionTests.cs
@@ -1,0 +1,170 @@
+using Microsoft.EntityFrameworkCore;
+using Rask.Jobs;
+
+namespace Rask.Dashboard.Tests;
+
+/// <summary>
+/// The actions run against tables a processor is actively draining, so each one's guard is the whole
+/// safety argument. These tests pin the guards, not the happy path.
+/// </summary>
+public sealed class QueueActionTests
+{
+    [Fact]
+    public async Task Retry_puts_a_dead_letter_back_in_the_queue()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+        var id = await SeedAsync(h, Job(runAt: now.AddHours(-1), attempts: max, error: "boom"));
+
+        var affected = await h.Queue("jobs").RetryAsync(id, CancellationToken.None);
+
+        Assert.Equal(1, affected);
+        var job = await SingleAsync(h);
+        Assert.Equal(0, job.Attempts);      // eligible again
+        Assert.Equal(now, job.RunAt);       // and due now, not after another backoff
+        Assert.Null(job.Error);             // the stale error would otherwise read as a fresh failure
+        Assert.Null(job.ProcessedAt);
+    }
+
+    [Fact]
+    public async Task Retry_cannot_touch_a_row_the_processor_might_be_holding()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        // Due and not yet exhausted: exactly what the drain query selects. The guard is the inverse of
+        // that query, so this row is invisible to retry — which is why the action needs no coordination
+        // with a running processor.
+        var id = await SeedAsync(h, Job(runAt: now.AddMinutes(-1), attempts: max - 1, error: "transient"));
+
+        Assert.Equal(0, await h.Queue("jobs").RetryAsync(id, CancellationToken.None));
+
+        var job = await SingleAsync(h);
+        Assert.Equal(max - 1, job.Attempts);         // untouched
+        Assert.Equal("transient", job.Error);
+    }
+
+    [Fact]
+    public async Task Retry_cannot_resurrect_a_processed_row()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        // Attempts is high but it finished — re-running it would duplicate a side effect that already
+        // happened, so ProcessedAt IS NULL is part of the guard rather than just Attempts >= max.
+        var id = await SeedAsync(h, Job(runAt: now, attempts: max, processedAt: now));
+
+        Assert.Equal(0, await h.Queue("jobs").RetryAsync(id, CancellationToken.None));
+        Assert.NotNull((await SingleAsync(h)).ProcessedAt);
+    }
+
+    [Fact]
+    public async Task RetryAll_takes_every_dead_letter_and_nothing_else()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        await SeedAsync(h,
+            Job(runAt: now, attempts: max),          // dead
+            Job(runAt: now, attempts: max),          // dead
+            Job(runAt: now, attempts: max - 1),      // still retrying
+            Job(runAt: now, processedAt: now));      // done
+
+        Assert.Equal(2, await h.Queue("jobs").RetryAllAsync(CancellationToken.None));
+
+        var counts = await h.Queue("jobs").CountsAsync(CancellationToken.None);
+        Assert.Equal(0, counts.Failed);
+        Assert.Equal(3, counts.Due);        // the two revived plus the one that was already retrying
+        Assert.Equal(1, counts.Processed);
+    }
+
+    [Fact]
+    public async Task PurgeProcessed_never_removes_outstanding_work_or_a_dead_letter()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+        var max = h.Get<JobOptions>().MaxAttempts;
+
+        await SeedAsync(h,
+            Job(runAt: now, processedAt: now.AddDays(-10)),   // old and done → goes
+            Job(runAt: now, processedAt: now.AddHours(-1)),   // done but recent → stays
+            Job(runAt: now, attempts: max),                   // dead letter → must survive
+            Job(runAt: now));                                 // pending → must survive
+
+        Assert.Equal(1, await h.Queue("jobs").PurgeProcessedAsync(TimeSpan.FromDays(7), CancellationToken.None));
+
+        var counts = await h.Queue("jobs").CountsAsync(CancellationToken.None);
+        Assert.Equal(1, counts.Failed);
+        Assert.Equal(1, counts.Due);
+        Assert.Equal(1, counts.Processed);
+    }
+
+    [Fact]
+    public async Task Delete_removes_an_outstanding_row_but_never_a_processed_one()
+    {
+        await using var h = new DashboardHarness(Batteries.Jobs);
+        var now = h.Clock.GetUtcNow().UtcDateTime;
+
+        var pending = await SeedAsync(h, Job(runAt: now));
+        var done = await SeedAsync(h, Job(runAt: now, processedAt: now));
+
+        Assert.Equal(1, await h.Queue("jobs").DeleteAsync(pending, CancellationToken.None));
+
+        // Deleting a completed row would erase the record of work that actually happened.
+        Assert.Equal(0, await h.Queue("jobs").DeleteAsync(done, CancellationToken.None));
+
+        await using var db = h.NewContext();
+        Assert.Equal(done, (await db.Set<Job>().SingleAsync()).Id);
+    }
+
+    [Fact]
+    public async Task Actions_on_an_unavailable_queue_are_no_ops()
+    {
+        // Registered but unmapped: every action must report zero rather than throw, matching how the
+        // read side reports an unavailable panel as empty.
+        await using var h = new DashboardHarness(registered: Batteries.All, mapped: Batteries.Jobs);
+        var outbox = h.Queue("outbox");
+
+        Assert.Equal(0, await outbox.RetryAsync(1, CancellationToken.None));
+        Assert.Equal(0, await outbox.RetryAllAsync(CancellationToken.None));
+        Assert.Equal(0, await outbox.PurgeProcessedAsync(TimeSpan.Zero, CancellationToken.None));
+        Assert.Equal(0, await outbox.DeleteAsync(1, CancellationToken.None));
+    }
+
+    private static Job Job(DateTime runAt, int attempts = 0, DateTime? processedAt = null, string? error = null) =>
+        new()
+        {
+            Type = "Some.Job",
+            Payload = "{}",
+            RunAt = runAt,
+            CreatedAt = runAt,
+            Attempts = attempts,
+            ProcessedAt = processedAt,
+            Error = error,
+        };
+
+    private static async Task<long> SeedAsync(DashboardHarness harness, Job job)
+    {
+        await using var db = harness.NewContext();
+        db.Set<Job>().Add(job);
+        await db.SaveChangesAsync();
+        return job.Id;
+    }
+
+    private static async Task SeedAsync(DashboardHarness harness, params Job[] jobs)
+    {
+        await using var db = harness.NewContext();
+        db.Set<Job>().AddRange(jobs);
+        await db.SaveChangesAsync();
+    }
+
+    private static async Task<Job> SingleAsync(DashboardHarness harness)
+    {
+        await using var db = harness.NewContext();
+        return await db.Set<Job>().SingleAsync();
+    }
+}


### PR DESCRIPTION
**Stacked on #529** (which is stacked on #526) — review those first; this branch contains their commits.

## Summary

#529 made the dashboard show you what has given up. This makes it able to **do something about it**, and
adds the one surface that isn't in any table: the log.

### Actions

| Action | Tier | Guard |
| --- | --- | --- |
| Retry a dead letter | Safe | `ProcessedAt IS NULL AND Attempts >= MaxAttempts` |
| Retry all failed | Safe | same, no id |
| Purge processed | Safe | `ProcessedAt IS NOT NULL AND ProcessedAt < cutoff` |
| Evict a cache key | Safe | key match |
| Delete a row | **Destructive** | `ProcessedAt IS NULL` |
| Flush the cache | **Destructive** | — |

Every one is a single `ExecuteUpdate`/`ExecuteDelete` with its guard in the `WHERE` clause, never a tracked
entity. Two consequences worth stating:

- **The dashboard can't raise a concurrency exception of its own** — nothing is tracked, so there is no
  0-rows-affected check to fail.
- **The guard is evaluated by the database at the moment of the write**, not by the dashboard a few hundred
  milliseconds earlier when it rendered the page.

The retry guard is deliberately the **inverse of the processors' own drain query**
(`ProcessedAt == null && Attempts < MaxAttempts && RunAt <= now`). A row a processor could currently be
holding is therefore *invisible* to retry, so the action needs no coordination with a running drain at all.
There's a test that seeds exactly such a row and asserts retry leaves it alone.

`Actions` defaults to `Safe`. Destructive buttons are **hidden, not disabled** — an operator shouldn't
discover by clicking that the deployment doesn't allow something. Confirmation is a state flip rendered as
an alert, so it works on the Server transport with no client script.

### Logs

A bounded in-memory tail fed by a registered `ILoggerProvider`, so the panel sees exactly what every other
sink sees. That matters because the failures this dashboard exists for often leave **no row in any table**:
Litestream exiting (`LogCritical`), a job type that won't deserialize, a handler that threw. Filterable by
level and by category, with stack traces inline.

It is a tail, not a log store — memory-only, bounded by count, gone on restart, and the doc comments say so
rather than letting anyone assume otherwise. `CaptureLogs = false` registers no provider at all, and
`IsEnabled` is checked before a message is ever formatted.

## Testing

`Rask.Dashboard.Tests` is now **33 tests** (was 12). The new ones:

- **`QueueActionTests` (7)** — retry restores `Attempts`/`RunAt`/`Error`; retry **cannot** touch a
  due-and-not-exhausted row (the in-flight case) or resurrect a processed one; retry-all takes only dead
  letters; purge spares outstanding work *and* dead letters whatever the cutoff; delete refuses a processed
  row; every action on an unavailable queue returns 0 instead of throwing.
- **`CacheActionTests` (6)** — evict is scoped to one key, a missing key is 0 not an exception, flush
  reports its count, stats cover the expired-but-unswept backlog, and an empty cache reports 0 bytes (SQL
  `SUM` over no rows is `NULL`, which a plain `Sum()` would throw on).
- **`LogBufferTests` (8)** — bounded eviction, level filtering before formatting, capture-off costing
  nothing, level/category filters, exception capture, the `Changed` event, and — the wiring test —
  that logging through `ILoggerFactory` actually reaches the buffer. A buffer nobody writes to looks
  identical to a quiet application, so that one matters.

Gates: `dotnet format` clean · `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings** ·
`scripts/run-unit-local.sh` green · `scripts/run-e2e-local.sh` unchanged from baseline (the four
pre-existing sandbox failures only).

Benchmarks: not applicable — nothing here is on the render hot path.

## Not in this PR

`rask new --ops`, the Shop sample wiring, `docs/dashboard.md`, and the roadmap flip.

Also filed while writing this: #530 — `Element` has no `title` attribute, so tooltips can't be expressed
(the queue tables show relative times with the absolute instant in the row detail as a result).
