### PR TITLE
feat(core): add the global title attribute to Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`Element.Title`** — the global `title` attribute, available on every element, so a cell can show an
+  abbreviated value with the exact one behind it on hover. There was previously no way to express a
+  tooltip at all: `Aria` reaches screen readers but renders nothing visible, and `Data` only emits
+  `data-*`. The dashboard now puts precise UTC instants behind its relative timestamps, and the full text
+  behind its truncated cells.
+  Two details. It renders in a new slot — `id, class, style, **title**, data-*, role, tabindex, aria-*` —
+  and it is **declared last among `Element`'s properties on purpose**: factory parameters are ordered
+  derived-first then by declaration span, so putting it beside `Style` would have shifted the positional
+  index of `Data`/`Role`/`TabIndex`/`Aria` on every element in the framework. `Style` no longer declares
+  its own `Title`; it inherits the global one, which moves `<style title="…">` into the global attribute
+  group (the one observable behaviour change here).
 - **Every DB-backed pillar now publishes metrics.** `Rask.Jobs`, `Rask.Outbox` and `Rask.Mail` each own a
   meter (`Rask.Jobs`, `Rask.Outbox`, `Rask.Mail`) with processed/failed/**dead-lettered** counters, a
   duration histogram, and pending/dead-letter gauges — so the number that matters can drive an alert

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ dotnet run --project samples/Rask.Example.Server
 ## Primitives & rules (the load-bearing invariants)
 - `Component` (base: `Render`, `Children`, `Key`, `TagName`, `WriteAttributes`) → `Element` (universal
   HTML attrs). `Text` encodes; `Raw` is verbatim. `Fragment`/`Doctype` special-cased in `HtmlSerializer`.
-- **Attribute render order: id, class, style, data-*, role, tabindex, aria-*, then tag-specific — tests assert it; preserve it.**
+- **Attribute render order: id, class, style, title, data-*, role, tabindex, aria-*, then tag-specific — tests assert it; preserve it.**
 - Children via the indexer `Div()[Span(), "hi"]` (no `Children:` param; `..` spread breaks — pass enumerables).
   Page root must render the full shell (`Doctype`/`Html`/`Head`/`Body`) — RASK021. Runtime `<script>` auto-appended.
 - **Factory params** (generated per public prop): nullable→optional(null); non-nullable no-initializer→**required**

--- a/docs/elements.md
+++ b/docs/elements.md
@@ -95,8 +95,15 @@ analyzer.
 
 <!-- demo:props-aria -->
 
-**Attribute order** is fixed: base props first (`id`, `class`, `style`, `data-*`, `role`, `tabindex`,
-`aria-*`), then tag-specific. Tests enforce it, so the output is predictable for diffing and DOM tooling:
+**Attribute order** is fixed: base props first (`id`, `class`, `style`, `title`, `data-*`, `role`,
+`tabindex`, `aria-*`), then tag-specific. Tests enforce it, so the output is predictable for diffing and
+DOM tooling:
+
+`Title` is the global `title` attribute — the browser's hover tooltip. Reach for it where a cell shows an
+abbreviated value and the exact one belongs behind it (a relative timestamp over the precise instant, a
+truncated string over its full text). It is **not** a label: `title` is invisible to touch users,
+unreliable with screen readers, and unfocusable, so it may carry supplementary detail but never the only
+copy of something the reader needs — use `Aria` for an accessible name.
 
 <!-- demo:props-attribute-order -->
 

--- a/src/Rask.Core/Components/Style.cs
+++ b/src/Rask.Core/Components/Style.cs
@@ -8,7 +8,10 @@ public sealed class Style : Element
 
     public string? Type { get; set; }
     public string? Media { get; set; }
-    public string? Title { get; set; }
+
+    // `title` on <style> names an alternative stylesheet, but it is the same global attribute every
+    // element has — so it is inherited from Element rather than redeclared here, and renders in the
+    // global slot (with id/class/style) instead of among the tag-specific ones.
     public string? Nonce { get; set; }
 
     protected override void WriteAttributes(StringBuilder sb)
@@ -22,11 +25,6 @@ public sealed class Style : Element
         if (Media is not null)
         {
             AppendAttr(sb, "media", Media);
-        }
-
-        if (Title is not null)
-        {
-            AppendAttr(sb, "title", Title);
         }
 
         if (Nonce is not null)

--- a/src/Rask.Core/Element.cs
+++ b/src/Rask.Core/Element.cs
@@ -12,6 +12,7 @@ public abstract partial class Element : Component
     public string? Id { get; set; }
     public string? Class { get; set; }
     public string? Style { get; set; }
+
     public IReadOnlyDictionary<string, string?>? Data { get; set; }
 
     // Accessibility, available on every element. `Aria` is the data-* model applied to ARIA: each
@@ -39,6 +40,24 @@ public abstract partial class Element : Component
         get => AriaInternal;
         set => AriaInternal = value;
     }
+
+    /// <summary>
+    ///     The global <c>title</c> attribute — advisory text the browser shows as a tooltip on hover.
+    ///     Useful wherever a cell shows an abbreviated value and the precise one belongs behind it: a
+    ///     relative timestamp over the exact instant, a truncated string over its full text.
+    ///     <para>
+    ///         Not a substitute for a label. <c>title</c> is invisible to touch users, unreliable for
+    ///         screen readers, and cannot be focused — so it may carry supplementary detail, never the
+    ///         only copy of something the user needs. For an accessible name use <see cref="Aria" />.
+    ///     </para>
+    ///     <para>
+    ///         Declared last among Element's own properties on purpose. Factory parameters are ordered
+    ///         derived-first, then by declaration span, so inserting this next to <see cref="Style" />
+    ///         would have shifted the positional index of Data/Role/TabIndex/Aria for every element in
+    ///         the framework — a silent source break for anyone passing them positionally.
+    ///     </para>
+    /// </summary>
+    public string? Title { get; set; }
 
     // A stable DOM handle for JS interop. When set, emits data-rask-ref="{id}" in the data-* group;
     // the client reviver resolves an ElementRef arg to this element via [data-rask-ref="..."].
@@ -91,6 +110,13 @@ public abstract partial class Element : Component
         if (Style is not null)
         {
             AppendAttr(sb, "style", Style);
+        }
+
+        // Slotted with the other plain global attributes (id/class/style) and ahead of the prefixed
+        // data-*/aria-* groups, so the documented order stays "globals first, grouped".
+        if (Title is not null)
+        {
+            AppendAttr(sb, "title", Title);
         }
 
         // Effective keyed-list identity: this element's own Key, else a key forwarded from a

--- a/src/Rask.Dashboard/Pages/CachePage.cs
+++ b/src/Rask.Dashboard/Pages/CachePage.cs
@@ -89,10 +89,10 @@ public sealed class CachePage(
         BsTable(Small: true, Hover: true, Responsive: true)[
             Thead()[Tr()[Th()["Key"], Th()["Size"], Th()["Written"], Th()["Expires"], Th()["Sliding"], Th()]],
             Tbody()[_rows.Select(r => Tr(Key: r.Key, Class: r.ExpiresAt <= now ? "text-body-secondary" : null)[
-                Td()[Div(Class: "text-truncate font-monospace small", Style: "max-width:28rem")[r.Key]],
+                Td()[Div(Class: "text-truncate font-monospace small", Style: "max-width:28rem", Title: r.Key)[r.Key]],
                 Td()[DashboardParts.Bytes(r.Bytes)],
-                Td()[DashboardParts.Ago(r.CreatedAt, now)],
-                Td()[
+                Td(Title: r.CreatedAt.ToString("u"))[DashboardParts.Ago(r.CreatedAt, now)],
+                Td(Title: r.ExpiresAt.ToString("u"))[
                     r.ExpiresAt <= now
                         ? BsBadge(Color: BsColor.Secondary)["expired"]
                         : Span()[DashboardParts.Ago(r.ExpiresAt, now)]

--- a/src/Rask.Dashboard/Pages/DashboardParts.cs
+++ b/src/Rask.Dashboard/Pages/DashboardParts.cs
@@ -45,7 +45,7 @@ internal static class DashboardParts
 
     /// <summary>
     /// A UTC instant as "how long ago", which is what an operator actually reads a queue timestamp for.
-    /// Element carries no title attribute, so the absolute instant is shown in the row detail instead.
+    /// Callers put the exact instant in the cell's Title, so hovering gives the precise value.
     /// </summary>
     public static string Ago(DateTime utc, DateTime now)
     {

--- a/src/Rask.Dashboard/Pages/LogsPage.cs
+++ b/src/Rask.Dashboard/Pages/LogsPage.cs
@@ -137,7 +137,9 @@ public sealed class LogsPage(
         BsTable(Small: true, Hover: true, Responsive: true)[
             Thead()[Tr()[Th()["When"], Th()["Level"], Th()["Category"], Th()["Message"]]],
             Tbody()[entries.Select(e => Tr(Key: e.Sequence)[
-                Td(Class: "text-nowrap text-body-secondary")[DashboardParts.Ago(e.Timestamp.UtcDateTime, now)],
+                Td(Class: "text-nowrap text-body-secondary", Title: e.Timestamp.UtcDateTime.ToString("u"))[
+                    DashboardParts.Ago(e.Timestamp.UtcDateTime, now)
+                ],
                 Td()[LevelBadge(e.Level)],
                 Td(Class: "font-monospace small text-body-secondary")[e.Category],
                 Td()[

--- a/src/Rask.Dashboard/Pages/QueuePage.cs
+++ b/src/Rask.Dashboard/Pages/QueuePage.cs
@@ -134,8 +134,8 @@ public sealed class QueuePage(
         var isDead = row.ProcessedAt is null && row.Attempts >= _panel!.MaxAttempts;
         yield return Tr(Key: row.Id, Class: isDead ? "table-danger" : null)[
             Td(Class: "text-body-secondary")[row.Id.ToString()],
-            Td()[Div(Class: "text-truncate", Style: "max-width:28rem")[row.Type]],
-            Td()[DashboardParts.Ago(row.CreatedAt, now)],
+            Td()[Div(Class: "text-truncate", Style: "max-width:28rem", Title: row.Type)[row.Type]],
+            Td(Title: row.CreatedAt.ToString("u"))[DashboardParts.Ago(row.CreatedAt, now)],
             Td()[row.Attempts.ToString()],
             Td()[StatusBadge(row, isDead, now)],
             Td(Class: "text-end")[

--- a/src/Rask.Dashboard/Pages/SystemPage.cs
+++ b/src/Rask.Dashboard/Pages/SystemPage.cs
@@ -137,7 +137,7 @@ public sealed class SystemPage(
                 Tbody()[_snapshots.Take(10).Select(s => Tr(Key: s.Name)[
                     Td(Class: "font-monospace small")[s.Name],
                     Td()[DashboardParts.Bytes(s.SizeBytes)],
-                    Td()[DashboardParts.Ago(s.CreatedAt, now)]
+                    Td(Title: s.CreatedAt.ToString("u"))[DashboardParts.Ago(s.CreatedAt, now)]
                 ])]
             ];
 
@@ -157,7 +157,7 @@ public sealed class SystemPage(
                         Td(Class: "font-monospace small")[r.Name],
                         Td()[DashboardParts.Duration(r.Interval)],
                         Td()[r.LastEnqueuedAt is { } last
-                            ? Span()[DashboardParts.Ago(last, now)]
+                            ? Span(Title: last.ToString("u"))[DashboardParts.Ago(last, now)]
                             // Declared but never fired: either the app just started, or this one is stuck.
                             : BsBadge(Color: BsColor.Secondary)["never"]]
                     ])]

--- a/tests/Rask.Core.Tests/Components/DivTests.cs
+++ b/tests/Rask.Core.Tests/Components/DivTests.cs
@@ -56,4 +56,32 @@ public class DivTests
                 Role: "dialog",
                 TabIndex: 0,
                 Aria: new Dictionary<string, string?> { ["label"] = "L" }).ToHtml());
+
+    [Fact]
+    public void Render_Title_EmitsTheGlobalTooltipAttribute() =>
+        Assert.Equal("<div title=\"2026-01-01 12:00:00Z\"></div>", Div(Title: "2026-01-01 12:00:00Z").ToHtml());
+
+    [Fact]
+    public void Render_Title_IsEncoded() =>
+        Assert.Equal("<div title=\"a &amp; &lt;b&gt;\"></div>", Div(Title: "a & <b>").ToHtml());
+
+    [Fact]
+    // Title joins the plain global attributes after style, ahead of the prefixed data-*/aria-* groups.
+    public void Render_Title_SitsAfterStyleAndBeforeData() =>
+        Assert.Equal(
+            "<div id=\"i\" class=\"c\" style=\"s\" title=\"t\" data-k=\"v\" role=\"dialog\" tabindex=\"0\" aria-label=\"L\"></div>",
+            Div(
+                Id: "i",
+                Class: "c",
+                Style: "s",
+                Title: "t",
+                Data: new Dictionary<string, string?> { ["k"] = "v" },
+                Role: "dialog",
+                TabIndex: 0,
+                Aria: new Dictionary<string, string?> { ["label"] = "L" }).ToHtml());
+
+    [Fact]
+    // An unset Title must emit nothing — every element in the framework gained this property, and any
+    // stray attribute would change the rendered output (and the diff) of every existing page.
+    public void Render_TitleUnset_EmitsNothing() => Assert.Equal("<div></div>", Div().ToHtml());
 }

--- a/tests/Rask.Core.Tests/Components/StyleTests.cs
+++ b/tests/Rask.Core.Tests/Components/StyleTests.cs
@@ -8,9 +8,13 @@ public class StyleTests
     [Fact]
     public void Render_AllPropsSet_EmitsExpectedAttributes()
     {
+        // `title` is the ordinary global attribute (on <style> it names an alternative stylesheet), so it
+        // is inherited from Element and renders in the global group after style — not among <style>'s own
+        // type/media/nonce, where it used to sit as a redeclared property.
         Assert.Equal(
-            "<style id=\"i\" class=\"c\" style=\"s\" data-k=\"v\" type=\"text/css\" media=\"all\" title=\"main\" nonce=\"abc\"></style>",
-            Style("text/css", "all", "main", "abc", "i", "c", "s", new Dictionary<string, string?> { ["k"] = "v" })
+            "<style id=\"i\" class=\"c\" style=\"s\" title=\"main\" data-k=\"v\" type=\"text/css\" media=\"all\" nonce=\"abc\"></style>",
+            Style("text/css", "all", "abc", "i", "c", "s", new Dictionary<string, string?> { ["k"] = "v" },
+                    Title: "main")
                 .ToHtml());
     }
 


### PR DESCRIPTION
Closes #530. **Stacked on #535 → #533 → #532 → #531 → #529 → #526.**

## Summary

`Element` exposed `Id`, `Class`, `Style`, `Data`, `Role`, `TabIndex` and `Aria` — but not `title`, so the
global tooltip attribute could not be expressed at all. `Aria` reaches screen readers and renders nothing
visible; `Data` only emits `data-*`. There was no escape hatch.

I hit this building the dashboard: queue tables show relative times ("3m ago") because that is what an
operator scans for, and the exact instant belongs behind them on hover. It had to go into an expandable
row detail instead. This PR adds the attribute and uses it — precise UTC instants behind every relative
timestamp, and full text behind every truncated cell.

## The part worth reviewing: where it is declared

Factory parameters are ordered **derived-first, then by declaration span**. `Element`'s own properties
therefore land after every tag-specific one, and their relative order is the order they appear in
`Element.cs`.

Declaring `Title` next to `Style` — where it reads best — shifted the positional index of `Data`, `Role`,
`TabIndex` and `Aria` **for every element in the framework**. That is a silent source break for anyone
passing them positionally, and it is not hypothetical: it broke ~100 in-repo test files on the first build,
which all call `Abbr("id", "class", "style", data)` style.

So `Title` is declared **last among `Element`'s properties**, which shifts nothing that existed. The
comment on the property says why, so nobody "tidies" it back up next to `Style`.

Render order is independent of declaration order, so the attribute still emits where it belongs:

```
id, class, style, title, data-*, role, tabindex, aria-*, then tag-specific
```

## One real behaviour change

`Style` declared its own `Title` for `<style title="…">`. That is the same global attribute every element
has, so it now inherits rather than redeclaring — which moves it out of `<style>`'s tag-specific group and
into the global one:

```diff
-<style id="i" class="c" style="s" data-k="v" type="text/css" media="all" title="main" nonce="abc">
+<style id="i" class="c" style="s" title="main" data-k="v" type="text/css" media="all" nonce="abc">
```

`StyleTests` is updated to match. This is the only rendered output in the repo that changes.

## Cost

Every element gained a nullable property and a null check on the render path, so this needed measuring
rather than asserting. `HtmlSerializerBenchmarks`, short job, before/after:

| Benchmark | Allocated before | Allocated after |
| --- | ---: | ---: |
| RenderTiny | 3.67 KB | **3.67 KB** |
| RenderMedium | 67.23 KB | **67.23 KB** |
| RenderLarge | 1398.91 KB | **1398.91 KB** |
| RenderTreeWithScopedCss | 32.58 KB | **32.58 KB** |
| RenderTextHeavyTree | 73.9 KB | **73.9 KB** |

Byte-identical — an unset `Title` allocates nothing and emits nothing. Means are within noise (the short
job's error bars are wider than the deltas, e.g. RenderLarge 416.9 µs before vs 413.0 µs after, ±22/±42).

## Testing

Four new `DivTests`, including the one that matters most for a property added to *every* element:
`Render_TitleUnset_EmitsNothing` — a stray attribute here would change the rendered output, and therefore
the diff, of every existing page. Plus emission, HTML-encoding, and the slot between `style` and `data-*`.

Gates: `dotnet format` clean · `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings** ·
`scripts/run-unit-local.sh` green.

Docs: `CLAUDE.md` and `docs/elements.md` both carry the documented order, and `elements.md` gains the
accessibility caveat — `title` is invisible to touch, unreliable with screen readers, and unfocusable, so
it may carry supplementary detail but never the only copy of something the reader needs.
