### PR TITLE
fix(sqlite): stop the busy retry re-issuing BEGIN inside its own transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **A contended write no longer fails with "cannot start a transaction within a transaction".** The
+  busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
+  cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle
+  arrived with, and missed one that appeared later — including `BEGIN IMMEDIATE`'s own, which an extended
+  `SQLITE_BUSY` (`BUSY_SNAPSHOT`, `BUSY_RECOVERY`, hidden behind the primary result code) can leave open.
+  The next pass then began a transaction inside the one its own previous attempt had opened, turning a
+  waitable lock into a non-retryable `SQLITE_ERROR`. The rollback is now part of every attempt, so a
+  contended rollback simply costs a pass instead of poisoning the next one. The `finally` rollback is
+  retried on the same footing rather than fire-and-forget, so a still-active statement no longer returns a
+  mid-transaction handle to the pool. Only ever seen under real multi-writer WAL load — it was the
+  intermittent stress-test failure that blocked commits.
+
 ### Added
 - **Every DB-backed pillar now publishes metrics.** `Rask.Jobs`, `Rask.Outbox` and `Rask.Mail` each own a
   meter (`Rask.Jobs`, `Rask.Outbox`, `Rask.Mail`) with processed/failed/**dead-lettered** counters, a

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -140,9 +140,15 @@ that took the write lock up front (its wait, though, blocks the thread inside Mi
 use `ExecuteInImmediateTransactionAsync` when you want the non-blocking retry).
 
 Because the lock is taken through the pooled native handle, the path is defensive about connection
-reuse: it clears a leaked transaction before `BEGIN IMMEDIATE`, and never hands a mid-transaction handle
-back to the pool. If a statement genuinely fails it throws a `SqliteException` carrying the extended
-result code and the autocommit state, so a rare failure is attributable rather than an opaque
+reuse: it clears a leaked transaction before **every** `BEGIN IMMEDIATE` attempt, and never hands a
+mid-transaction handle back to the pool. Before every attempt rather than once, because a transaction can
+appear between passes as well as arrive with the handle — an extended `SQLITE_BUSY` (`BUSY_SNAPSHOT`,
+`BUSY_RECOVERY`, which the primary result code hides) can leave `BEGIN`'s own transaction open, and
+retrying `BEGIN` inside it fails with the non-retryable "cannot start a transaction within a transaction".
+Both rollbacks — the one before each attempt and the one that cleans up on the way out — go through the
+same retry, so a rollback blocked by a still-active statement costs a pass instead of poisoning the next
+lease. If a statement genuinely fails it throws a `SqliteException` carrying the extended result code and
+the autocommit state, so a rare failure is attributable rather than an opaque
 `SQLite Error 1: 'not an error'`.
 
 ### Entity Framework Core — opt-in retry strategy

--- a/src/Rask.SQLite/SqliteBusyRetry.cs
+++ b/src/Rask.SQLite/SqliteBusyRetry.cs
@@ -12,12 +12,19 @@ namespace Rask.SQLite;
 /// </summary>
 internal static class SqliteBusyRetry
 {
+    // requiresAutocommit: roll back any transaction open on the handle before EVERY attempt, not just
+    // the first. Set it for BEGIN, the one statement that cannot run inside a transaction: a BEGIN
+    // IMMEDIATE answered with an extended SQLITE_BUSY variant (BUSY_SNAPSHOT, BUSY_RECOVERY) can leave
+    // the transaction open, and re-issuing the same BEGIN on the next pass then fails with the
+    // non-retryable "cannot start a transaction within a transaction" instead of the contended lock it
+    // actually met.
     internal static async Task ExecAsync(
         sqlite3 handle,
         string sql,
         SqliteBusyRetryOptions options,
         TimeProvider timeProvider,
-        CancellationToken cancellationToken)
+        CancellationToken cancellationToken,
+        bool requiresAutocommit = false)
     {
         var startedAt = timeProvider.GetTimestamp();
 
@@ -25,10 +32,20 @@ internal static class SqliteBusyRetry
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var rc = raw.sqlite3_exec(handle, sql);
+            // The precondition is part of the attempt, so a rollback that is itself contended simply
+            // costs this pass and is retried like any other busy result — it never runs `sql` on a
+            // handle that is still mid-transaction.
+            var rc = requiresAutocommit && raw.sqlite3_get_autocommit(handle) == 0
+                ? raw.sqlite3_exec(handle, "ROLLBACK;")
+                : raw.SQLITE_OK;
+
             if (rc == raw.SQLITE_OK)
             {
-                return;
+                rc = raw.sqlite3_exec(handle, sql);
+                if (rc == raw.SQLITE_OK)
+                {
+                    return;
+                }
             }
 
             // Only a contended lock is retryable; every other result code is a real error. Compare the

--- a/src/Rask.SQLite/SqliteConnectionExtensions.cs
+++ b/src/Rask.SQLite/SqliteConnectionExtensions.cs
@@ -67,28 +67,32 @@ public static class SqliteConnectionExtensions
         // Thread.Sleep retry (governed by CommandTimeout) never runs either.
         raw.sqlite3_busy_timeout(handle, 0);
 
-        // BEGIN/COMMIT/ROLLBACK run through the raw handle, bypassing Microsoft.Data.Sqlite's
-        // SqliteTransaction bookkeeping, and the underlying sqlite3 handle is pooled and reused. If an
-        // earlier lease left a transaction open on it, BEGIN IMMEDIATE here would hit "cannot start a
-        // transaction within a transaction" (SQLITE_ERROR) — a non-retryable fast failure. Clear any
-        // leaked transaction first so BEGIN always starts from autocommit.
-        //
-        // Retried, not fire-and-forget: a ROLLBACK can itself return SQLITE_BUSY ("cannot rollback
-        // transaction - SQL statements in progress") when a GC-orphaned reader's statement is still active
-        // on the pooled handle — the same hazard docs/sqlite.md documents for EF's pool return. Dropping
-        // that result code and running BEGIN anyway is what turned a transient into the misleading
-        // non-retryable error above. Note the busy_timeout was set to 0 just now, so the native handler
-        // won't wait for us either; this managed retry is the only thing that does.
-        if (raw.sqlite3_get_autocommit(handle) == 0)
-        {
-            await SqliteBusyRetry.ExecAsync(handle, "ROLLBACK;", retry, time, cancellationToken).ConfigureAwait(false);
-        }
-
         try
         {
+            // BEGIN/COMMIT/ROLLBACK run through the raw handle, bypassing Microsoft.Data.Sqlite's
+            // SqliteTransaction bookkeeping, and the underlying sqlite3 handle is pooled and reused. If a
+            // transaction is open on it, BEGIN IMMEDIATE hits "cannot start a transaction within a
+            // transaction" (SQLITE_ERROR) — a non-retryable fast failure. requiresAutocommit clears any
+            // such transaction before every attempt, so BEGIN always starts from autocommit.
+            //
+            // Before *every* attempt, not just the first, because the handle can enter a transaction
+            // between passes as well as arrive in one: an earlier lease can leak one, and a BEGIN
+            // answered with an extended SQLITE_BUSY (BUSY_SNAPSHOT / BUSY_RECOVERY, which the primary
+            // result code hides) can leave one behind of its own. A guard that ran once, before the loop,
+            // caught the first case and missed the second — the retry then re-issued BEGIN inside the
+            // transaction its own previous attempt had opened, turning a contended lock into that
+            // misleading non-retryable error. That is #504.
+            //
+            // The rollback is retried rather than fire-and-forget: it can itself return SQLITE_BUSY
+            // ("cannot rollback transaction - SQL statements in progress") when a GC-orphaned reader's
+            // statement is still active on the pooled handle — the same hazard docs/sqlite.md documents
+            // for EF's pool return. The busy_timeout was set to 0 just now, so the native handler won't
+            // wait for us either; this managed retry is the only thing that does.
+            //
             // Inside the try: a BEGIN that fails partway must still go through the cleanup below, or the
             // handle goes back to the pool mid-transaction and poisons every later lease of it.
-            await SqliteBusyRetry.ExecAsync(handle, "BEGIN IMMEDIATE;", retry, time, cancellationToken).ConfigureAwait(false);
+            await SqliteBusyRetry.ExecAsync(
+                handle, "BEGIN IMMEDIATE;", retry, time, cancellationToken, requiresAutocommit: true).ConfigureAwait(false);
             var result = await work(connection, cancellationToken).ConfigureAwait(false);
             await SqliteBusyRetry.ExecAsync(handle, "COMMIT;", retry, time, cancellationToken).ConfigureAwait(false);
             return result;
@@ -97,11 +101,29 @@ public static class SqliteConnectionExtensions
         {
             // Never hand a mid-transaction handle back to the pool. On the happy path COMMIT already
             // restored autocommit and this is a no-op; on any failure (a throwing work, or a COMMIT that
-            // never completed) this rolls the open transaction back. Best-effort: ignore the result code —
-            // the transaction may already be gone.
+            // never completed) this rolls the open transaction back.
+            //
+            // Retried, for the same reason the entry rollback is: a single fire-and-forget exec here
+            // returns a mid-transaction handle to the pool whenever the rollback meets a still-active
+            // statement. It stays best-effort — a rollback that cannot run must not replace the
+            // exception that brought us here, and the next lease's requiresAutocommit guard clears the
+            // handle anyway — so every failure is swallowed. It honours the caller's token, so a
+            // cancelled operation gives up immediately rather than stalling teardown.
             if (raw.sqlite3_get_autocommit(handle) == 0)
             {
-                raw.sqlite3_exec(handle, "ROLLBACK;");
+                try
+                {
+                    await SqliteBusyRetry.ExecAsync(handle, "ROLLBACK;", retry, time, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+                catch (SqliteException)
+                {
+                    // The transaction may already be gone, or the handle may still be busy.
+                }
+                catch (OperationCanceledException)
+                {
+                    // Teardown under cancellation: leave it to the next lease's guard.
+                }
             }
         }
     }

--- a/tests/Rask.SQLite.Tests/SqliteImmediateTransactionTests.cs
+++ b/tests/Rask.SQLite.Tests/SqliteImmediateTransactionTests.cs
@@ -174,6 +174,51 @@ public sealed class SqliteImmediateTransactionTests : IDisposable
     }
 
     [Fact]
+    public async Task Recovers_when_a_transaction_appears_between_retry_attempts()
+    {
+        // #504. The entry guard ran once, before the retry loop, so it only ever caught a transaction the
+        // handle *arrived* with. A transaction that appears after the first BEGIN attempt was missed
+        // entirely, and the next pass re-issued BEGIN inside it — SQLITE_ERROR "cannot start a transaction
+        // within a transaction", which is not BUSY/LOCKED, so it threw instead of retrying.
+        //
+        // In production that second transaction is BEGIN's own: an extended SQLITE_BUSY (BUSY_SNAPSHOT /
+        // BUSY_RECOVERY, which the primary result code hides) can leave one open, and those need real
+        // multi-writer WAL contention to provoke. Here it is injected deterministically instead: hold the
+        // write lock so BEGIN must retry, then open a *deferred* transaction on the waiting handle mid-loop
+        // — deferred takes no write lock, so it only flips autocommit, which is exactly the state the bug
+        // needs. Fails with SQLITE_ERROR (1) before the fix; passes after.
+        await using var holder = new SqliteConnection(_connectionString);
+        await holder.OpenAsync();
+        using var holderTx = holder.BeginImmediate();
+
+        await using var waiter = new SqliteConnection(_connectionString);
+        await waiter.OpenAsync();
+        var waiterHandle = waiter.Handle!;
+
+        var injected = Task.Run(async () =>
+        {
+            await Task.Delay(150); // the retry loop is polling by now
+            raw.sqlite3_exec(waiterHandle, "BEGIN;"); // autocommit -> 0, no write lock taken
+            await Task.Delay(150);
+            holderTx.Commit(); // release the write lock so BEGIN IMMEDIATE can finally succeed
+        });
+
+        await waiter.ExecuteInImmediateTransactionAsync(
+            new SqliteBusyRetryOptions { Timeout = TimeSpan.FromSeconds(10), PollInterval = TimeSpan.FromMilliseconds(10) },
+            async (c, ct) =>
+            {
+                await using var cmd = c.CreateCommand();
+                cmd.CommandText = "INSERT INTO t(v) VALUES('after-injected-transaction');";
+                await cmd.ExecuteNonQueryAsync(ct);
+            });
+
+        await injected;
+
+        Assert.Equal(1, Count());
+        Assert.Equal(1, raw.sqlite3_get_autocommit(waiterHandle)); // handle left clean
+    }
+
+    [Fact]
     public async Task Leaves_the_handle_in_autocommit_after_work_throws()
     {
         // The finally guard must never return a mid-transaction handle to the pool, even when work throws.


### PR DESCRIPTION
Closes #504.

## The bug

`SqliteBusyRetry.ExecAsync` re-issues the **identical** statement on every pass with no rollback, no
autocommit re-check, no cleanup of any kind between attempts. The transaction helper cleared a leaked
transaction exactly once, *before* the loop.

That guard catches a transaction the pooled handle **arrived** with. It misses one that appears later —
including `BEGIN IMMEDIATE`'s own. An extended `SQLITE_BUSY` (`BUSY_SNAPSHOT`, `BUSY_RECOVERY` — both
hidden behind the primary result code the loop compares) can leave the transaction open. The next pass
then begins a transaction inside the one its own previous attempt opened, and SQLite answers
`SQLITE_ERROR: cannot start a transaction within a transaction` — neither BUSY nor LOCKED, so the loop
throws it instead of waiting the lock out.

### Why the issue's pooling hypothesis was the wrong tree

- The **first** BEGIN attempt cannot be the failing one: the autocommit guard and the first
  `sqlite3_exec` run synchronously with no `await` between them, on a handle exclusively leased by this
  connection. The failing `BEGIN` is necessarily iteration ≥ 2.
- The **plain write-lock BUSY** case is empirically ruled out — `SqliteImmediateTransactionTests` already
  drives ~150 contended `BEGIN IMMEDIATE` retries against a held lock and never sees it.
- Assembly-level `DisableTestParallelization` couldn't have covered it: in a full-solution run each test
  project gets its own testhost, so cross-assembly `ClearAllPools` interference is impossible. What a
  full-solution run *does* add is CPU pressure — which lengthens contention windows and multiplies retry
  iterations. That explains "only in full-solution runs" with no cross-process mechanism at all.

#527 is consistent with this: its own commit message records that the stress test still reproduced once
with it applied, because neither of its changes touched the intra-loop retry.

## The fix

- **The rollback is part of every attempt**, not a one-shot guard before the loop. A rollback that is
  itself contended now costs a pass and is retried like any other busy result, instead of poisoning the
  next one — and `BEGIN` never runs on a handle that is still mid-transaction.
- **The `finally` rollback goes through the same retry.** A single fire-and-forget exec returned a
  mid-transaction handle to the pool whenever it met a still-active statement — the exact mirror of what
  #527 fixed at the entry guard. It stays best-effort: it must never replace the exception that brought
  us there, and it honours the caller's token so a cancelled operation doesn't stall teardown.

## Testing

`Recovers_when_a_transaction_appears_between_retry_attempts` injects the second transaction
deterministically, because the production trigger needs real multi-writer WAL contention: hold the write
lock so `BEGIN` must retry, then open a **deferred** transaction on the waiting handle mid-loop —
deferred takes no write lock, so it only flips autocommit, which is exactly the state the bug needs.

Verified it fails against the old code first, with the issue's own error:

```
SQLite Error 1 (errcode 1, extended 1, autocommit 0): 'cannot start a transaction within a transaction'.
   at Rask.SQLite.SqliteBusyRetry.ExecAsync (SqliteBusyRetry.cs:40)
   at Rask.SQLite.SqliteConnectionExtensions.ExecuteInImmediateTransactionAsync (SqliteConnectionExtensions.cs:91)
```

Gates:

- `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings**.
- `scripts/run-unit-local.sh` → **4975 passed, 0 failed** across 36 assemblies.
- `SqliteConcurrencyStressTests` (the 200/500-writer burst) looped **12/12 clean**.

Benchmarks: not applicable — this is the SQLite write path, not the render hot path.

## Docs

`docs/sqlite.md` said the path "clears a leaked transaction before `BEGIN IMMEDIATE`". It now says before
**every** attempt, and explains why once wasn't enough.