### PR TITLE
fix(hot-reload): make the generated registries replace their set, not add to it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,15 @@ them until tagged releases begin.
   retried on the same footing rather than fire-and-forget, so a still-active statement no longer returns a
   mid-transaction handle to the pool. Only ever seen under real multi-writer WAL load — it was the
   intermittent stress-test failure that blocked commits.
+- **Renaming or deleting a job, outbox event or handler under `rask dev` now takes effect.** The generated
+  registries upserted their entries, so a refresh could only ever add or overwrite: rename
+  `SendWelcomeEmail` to `SendWelcomeMail` and the registry held *both*, with the old name still resolving to
+  a type the generator no longer produced. The same shape bit CQRS harder — delete the last handler for a
+  command and dispatch kept succeeding through the invoker built from the old IL, instead of reporting that
+  nothing handles it. Each generated `RefreshAll()` now installs its assembly's complete set in one call,
+  keyed on its own registry class, so a removal is a removal while every other assembly's contributions and
+  any direct registration are left alone. The swap lands in a single store, so a job dequeued mid-refresh
+  cannot observe a half-built table.
 
 ### Added
 - **`Element.Title`** — the global `title` attribute, available on every element, so a cell can show an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -267,7 +267,7 @@ edits*, and `rask dev` restarts the app for you and the browser reloads itself.
 | A job or outbox event type's body | ✅ Applied live. |
 | **Adding or removing a type** — a new component, page, handler, job | ⚠️ Rude edit → the app restarts, and the browser reloads itself. |
 | **Changing a signature** — a new factory parameter, a changed method signature | ⚠️ Rude edit → restart. |
-| Renaming a job or outbox event type | ⚠️ Applied, but the old name stays registered until the next restart. |
+| Renaming a job or outbox event type | ✅ Applied. The old name stops resolving too. |
 
 Two things it does not cover:
 

--- a/src/Rask.Cqrs.Generators/CqrsDispatchGenerator.cs
+++ b/src/Rask.Cqrs.Generators/CqrsDispatchGenerator.cs
@@ -278,9 +278,10 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
 
         // Init() runs once, at module load. RefreshAll() is the re-invocable half the hot-reload
         // coordinator calls after a metadata update (see RaskHotReload.RefreshTargetTypeNames) —
-        // so it must hold ONLY idempotent work. The dispatch tables qualify: RegisterRequest /
-        // RegisterNotification are dictionary upserts, so re-running them swaps in the invoker
-        // built from the new IL. The DI registrations below deliberately do NOT: RegisterServices
+        // so it must hold ONLY idempotent work. The dispatch tables qualify: ReplaceRequests /
+        // ReplaceNotifications install this assembly's whole contribution, so re-running them swaps in
+        // the invokers built from the new IL and drops handlers that no longer exist. The DI
+        // registrations below deliberately do NOT belong there: RegisterServices
         // enqueues onto a queue that is never drained, so refreshing it on every save would grow
         // that queue without bound for the life of the watch session.
         sb.AppendLine("    [global::System.Runtime.CompilerServices.ModuleInitializer]");
@@ -306,18 +307,34 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
         sb.AppendLine("    internal static void RefreshAll()");
         sb.AppendLine("    {");
 
+        // One Replace per table, keyed on this class, rather than a run of upserts. An upsert only ever
+        // adds or overwrites, so deleting the last handler for a request left its invoker in the table and
+        // dispatch kept succeeding through IL that no longer had a handler behind it. Replacing this
+        // assembly's whole contribution makes a deletion take effect, while leaving other assemblies alone.
+        sb.AppendLine(
+            "        global::Rask.Cqrs.CqrsRegistry.ReplaceRequests(typeof(__RaskCqrsRegistry), " +
+            "new (global::System.Type, global::Rask.Cqrs.CqrsRegistry.RequestInvoker)[]");
+        sb.AppendLine("        {");
         for (var i = 0; i < requests.Count; i++)
         {
-            sb.Append("        global::Rask.Cqrs.CqrsRegistry.RegisterRequest(typeof(")
-                .Append(requests[i].RequestTypeFqn).Append("), __Request_").Append(i).AppendLine(");");
+            sb.Append("            (typeof(")
+                .Append(requests[i].RequestTypeFqn).Append("), __Request_").Append(i).AppendLine("),");
         }
 
+        sb.AppendLine("        });");
+        sb.AppendLine();
+
+        sb.AppendLine(
+            "        global::Rask.Cqrs.CqrsRegistry.ReplaceNotifications(typeof(__RaskCqrsRegistry), " +
+            "new (global::System.Type, global::Rask.Cqrs.CqrsRegistry.NotificationInvoker)[]");
+        sb.AppendLine("        {");
         for (var i = 0; i < notificationTypes.Count; i++)
         {
-            sb.Append("        global::Rask.Cqrs.CqrsRegistry.RegisterNotification(typeof(")
-                .Append(notificationTypes[i]).Append("), __Notify_").Append(i).AppendLine(");");
+            sb.Append("            (typeof(")
+                .Append(notificationTypes[i]).Append("), __Notify_").Append(i).AppendLine("),");
         }
 
+        sb.AppendLine("        });");
         sb.AppendLine("    }");
         sb.AppendLine();
 

--- a/src/Rask.Cqrs/CqrsRegistry.cs
+++ b/src/Rask.Cqrs/CqrsRegistry.cs
@@ -19,23 +19,164 @@ public static class CqrsRegistry
     /// <summary>Invokes every handler for a notification.</summary>
     public delegate Task NotificationInvoker(IServiceProvider provider, object notification, CancellationToken cancellationToken);
 
-    private static readonly ConcurrentDictionary<Type, RequestInvoker> Requests = new();
-    private static readonly ConcurrentDictionary<Type, NotificationInvoker> Notifications = new();
+    private static readonly object _lock = new();
+    private static readonly Dictionary<Type, RequestInvoker> _manualRequests = new();
+    private static readonly Dictionary<Type, NotificationInvoker> _manualNotifications = new();
+
+    // One entry per contributing assembly, keyed by that assembly's generated registry type.
+    private static readonly List<(object Key, (Type Type, RequestInvoker Invoker)[] Items)> _requestGroups = new();
+    private static readonly List<(object Key, (Type Type, NotificationInvoker Invoker)[] Items)> _notificationGroups = new();
+
+    // The flattened dispatch tables. Rebuilt under the lock and installed in a single store, so a
+    // dispatch in flight observes either the complete old table or the complete new one.
+    private static volatile IReadOnlyDictionary<Type, RequestInvoker> _requests =
+        new Dictionary<Type, RequestInvoker>();
+
+    private static volatile IReadOnlyDictionary<Type, NotificationInvoker> _notifications =
+        new Dictionary<Type, NotificationInvoker>();
+
     private static readonly ConcurrentQueue<Action<IServiceCollection, ServiceLifetime>> Registrations = new();
 
-    /// <summary>Called by generated code to map a query/command type to its dispatch invoker.</summary>
-    public static void RegisterRequest(Type requestType, RequestInvoker invoker) => Requests[requestType] = invoker;
+    /// <summary>Maps a query/command type to its dispatch invoker.</summary>
+    public static void RegisterRequest(Type requestType, RequestInvoker invoker)
+    {
+        ArgumentNullException.ThrowIfNull(requestType);
+        ArgumentNullException.ThrowIfNull(invoker);
+        lock (_lock)
+        {
+            _manualRequests[requestType] = invoker;
+            RebuildRequests();
+        }
+    }
 
-    /// <summary>Called by generated code to map a notification type to its fan-out invoker.</summary>
-    public static void RegisterNotification(Type notificationType, NotificationInvoker invoker) =>
-        Notifications[notificationType] = invoker;
+    /// <summary>Maps a notification type to its fan-out invoker.</summary>
+    public static void RegisterNotification(Type notificationType, NotificationInvoker invoker)
+    {
+        ArgumentNullException.ThrowIfNull(notificationType);
+        ArgumentNullException.ThrowIfNull(invoker);
+        lock (_lock)
+        {
+            _manualNotifications[notificationType] = invoker;
+            RebuildNotifications();
+        }
+    }
+
+    /// <summary>
+    ///     Installs <paramref name="registrations" /> as the complete set of request invokers owned by
+    ///     <paramref name="groupKey" />. Generated per-assembly initializers call this with their own
+    ///     <c>typeof(__RaskCqrsRegistry)</c>, so re-running one under hot reload swaps that assembly's
+    ///     dispatch table rather than merging into it — deleting the last handler for a request now stops
+    ///     dispatching it, instead of silently keeping the invoker built from the old IL.
+    /// </summary>
+    public static void ReplaceRequests(object groupKey, IEnumerable<(Type Type, RequestInvoker Invoker)> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(groupKey);
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var items = registrations as (Type Type, RequestInvoker Invoker)[] ?? registrations.ToArray();
+        lock (_lock)
+        {
+            if (ReplaceGroup(_requestGroups, groupKey, items))
+            {
+                RebuildRequests();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     The notification counterpart of <see cref="ReplaceRequests" />.
+    /// </summary>
+    public static void ReplaceNotifications(
+        object groupKey,
+        IEnumerable<(Type Type, NotificationInvoker Invoker)> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(groupKey);
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var items = registrations as (Type Type, NotificationInvoker Invoker)[] ?? registrations.ToArray();
+        lock (_lock)
+        {
+            if (ReplaceGroup(_notificationGroups, groupKey, items))
+            {
+                RebuildNotifications();
+            }
+        }
+    }
+
+    // Caller holds _lock. Returns false when the group's contribution is unchanged, so an unrelated hot
+    // reload — which re-runs every RefreshAll() — does not rebuild a table nothing changed in. The
+    // invokers are static lambdas, so a regenerated set compares equal when the handlers are unchanged.
+    private static bool ReplaceGroup<TInvoker>(
+        List<(object Key, (Type Type, TInvoker Invoker)[] Items)> groups,
+        object groupKey,
+        (Type Type, TInvoker Invoker)[] items)
+    {
+        for (var i = 0; i < groups.Count; i++)
+        {
+            if (!ReferenceEquals(groups[i].Key, groupKey))
+            {
+                continue;
+            }
+
+            if (groups[i].Items.AsSpan().SequenceEqual(items))
+            {
+                return false;
+            }
+
+            groups[i] = (groupKey, items);
+            return true;
+        }
+
+        groups.Add((groupKey, items));
+        return true;
+    }
+
+    // Caller holds _lock. Manual registrations are applied last so an explicit one is never clobbered.
+    private static void RebuildRequests()
+    {
+        var map = new Dictionary<Type, RequestInvoker>();
+        foreach (var (_, items) in _requestGroups)
+        {
+            foreach (var (type, invoker) in items)
+            {
+                map[type] = invoker;
+            }
+        }
+
+        foreach (var (type, invoker) in _manualRequests)
+        {
+            map[type] = invoker;
+        }
+
+        _requests = map;
+    }
+
+    // Caller holds _lock.
+    private static void RebuildNotifications()
+    {
+        var map = new Dictionary<Type, NotificationInvoker>();
+        foreach (var (_, items) in _notificationGroups)
+        {
+            foreach (var (type, invoker) in items)
+            {
+                map[type] = invoker;
+            }
+        }
+
+        foreach (var (type, invoker) in _manualNotifications)
+        {
+            map[type] = invoker;
+        }
+
+        _notifications = map;
+    }
 
     /// <summary>Called by generated code to enqueue a handler's DI registration (applied by <c>AddRaskCqrs</c>).</summary>
     public static void RegisterServices(Action<IServiceCollection, ServiceLifetime> registration) =>
         Registrations.Enqueue(registration);
 
     internal static RequestInvoker GetRequestInvoker(Type requestType) =>
-        Requests.TryGetValue(requestType, out var invoker)
+        _requests.TryGetValue(requestType, out var invoker)
             ? invoker
             : throw new InvalidOperationException(
                 $"No handler is registered for '{requestType}'. Ensure a handler implementing " +
@@ -43,7 +184,7 @@ public static class CqrsRegistry
                 "AddRaskCqrs() was called during startup.");
 
     internal static NotificationInvoker? GetNotificationInvoker(Type notificationType) =>
-        Notifications.TryGetValue(notificationType, out var invoker) ? invoker : null;
+        _notifications.TryGetValue(notificationType, out var invoker) ? invoker : null;
 
     internal static void ApplyRegistrations(IServiceCollection services, ServiceLifetime lifetime)
     {

--- a/src/Rask.Generators.Shared/RegistryGeneratorBase.cs
+++ b/src/Rask.Generators.Shared/RegistryGeneratorBase.cs
@@ -41,8 +41,12 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
     /// <summary>Name of the generated registry class.</summary>
     protected abstract string RegistryClassName { get; }
 
-    /// <summary>Fully-qualified registration method, e.g. <c>global::Rask.Jobs.JobSerializerRegistry.RegisterJob</c>.</summary>
-    protected abstract string RegisterMethod { get; }
+    /// <summary>
+    /// Fully-qualified group-replacing registration method, e.g.
+    /// <c>global::Rask.Jobs.JobSerializerRegistry.Replace</c>. It takes this assembly's generated registry
+    /// class as the group key and the complete set of entries it owns.
+    /// </summary>
+    protected abstract string ReplaceMethod { get; }
 
     /// <summary>Hint name of the generated file.</summary>
     protected abstract string HintName { get; }
@@ -59,7 +63,7 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
         var noun = ArtifactNoun;
         var generatedNamespace = GeneratedNamespace;
         var registryClass = RegistryClassName;
-        var registerMethod = RegisterMethod;
+        var replaceMethod = ReplaceMethod;
         var hintName = HintName;
 
         var candidates = context.SyntaxProvider
@@ -71,7 +75,7 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
 
         context.RegisterSourceOutput(
             candidates.Collect(),
-            (spc, all) => Emit(spc, all, generatedNamespace, registryClass, registerMethod, hintName));
+            (spc, all) => Emit(spc, all, generatedNamespace, registryClass, replaceMethod, hintName));
     }
 
     private static Candidate? GetCandidate(GeneratorSyntaxContext ctx, string markerInterface, string noun)
@@ -120,7 +124,7 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
         ImmutableArray<Candidate> candidates,
         string generatedNamespace,
         string registryClass,
-        string registerMethod,
+        string replaceMethod,
         string hintName)
     {
         // Warn once per unreachable type. A type split across partial declarations that each carry the
@@ -160,26 +164,33 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
         sb.AppendLine("    {");
         // Init() only bootstraps; RefreshAll() holds the registrations so the hot-reload
         // coordinator can re-invoke them after a metadata update ([ModuleInitializer] never runs
-        // twice). Both registries are name->Type dictionary upserts, so re-running is idempotent.
-        // RaskHotReload.RefreshTargetTypeNames lists both emitted classes by name.
+        // twice). RaskHotReload.RefreshTargetTypeNames lists both emitted classes by name.
+        //
+        // One Replace call keyed on this class, not a run of upserts: an upsert makes a rename
+        // *additive*, so renaming a job or event under `rask dev` would leave the old name resolving
+        // to a type no longer produced until the process restarted. Replace swaps this assembly's whole
+        // contribution in a single store and leaves every other contributor alone.
         sb.AppendLine("        [global::System.Runtime.CompilerServices.ModuleInitializer]");
         sb.AppendLine("        internal static void Init() => RefreshAll();");
         sb.AppendLine();
         sb.AppendLine("        internal static void RefreshAll()");
         sb.AppendLine("        {");
+        sb.Append("            ")
+          .Append(replaceMethod)
+          .AppendLine("(typeof(" + registryClass + "), new (string, global::System.Type)[]");
+        sb.AppendLine("            {");
         foreach (var (key, typeExpression) in entries)
         {
             // The key is the runtime Type.FullName; the expression is escaped, fully-qualified C#.
             // They are deliberately different strings — see SymbolRegistration.
-            sb.Append("            ")
-              .Append(registerMethod)
-              .Append('(')
+            sb.Append("                (")
               .Append(SymbolDisplay.FormatLiteral(key, quote: true))
               .Append(", typeof(")
               .Append(typeExpression)
-              .AppendLine("));");
+              .AppendLine(")),");
         }
 
+        sb.AppendLine("            });");
         sb.AppendLine("        }");
         sb.AppendLine("    }");
         sb.AppendLine("}");

--- a/src/Rask.Jobs.Generators/JobRegistryGenerator.cs
+++ b/src/Rask.Jobs.Generators/JobRegistryGenerator.cs
@@ -21,7 +21,7 @@ public sealed class JobRegistryGenerator : RegistryGeneratorBase
     protected override string RegistryClassName => "__RaskJobsRegistry";
 
     /// <inheritdoc/>
-    protected override string RegisterMethod => "global::Rask.Jobs.JobSerializerRegistry.RegisterJob";
+    protected override string ReplaceMethod => "global::Rask.Jobs.JobSerializerRegistry.Replace";
 
     /// <inheritdoc/>
     protected override string HintName => "__RaskJobsRegistry.g.cs";

--- a/src/Rask.Jobs/JobSerializerRegistry.cs
+++ b/src/Rask.Jobs/JobSerializerRegistry.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Text.Json;
 using Rask.Cqrs;
 
@@ -12,15 +11,102 @@ namespace Rask.Jobs;
 /// </summary>
 public static class JobSerializerRegistry
 {
-    private static readonly ConcurrentDictionary<string, Type> Types = new(StringComparer.Ordinal);
+    private static readonly object _lock = new();
+
+    // Registrations made directly rather than by a generated initializer. Kept apart from the generated
+    // groups so a refresh can replace a group's contribution without dropping these.
+    private static readonly Dictionary<string, Type> _manual = new(StringComparer.Ordinal);
+
+    // One entry per contributing assembly, keyed by that assembly's generated registry type. Replace
+    // swaps a group wholesale, which is what makes a rename drop the old name instead of keeping both.
+    private static readonly List<(object Key, (string TypeName, Type Type)[] Items)> _groups = new();
+
+    // The flattened lookup Deserialize reads. Rebuilt under the lock and installed in a single store, so
+    // a reader observes either the complete old map or the complete new one, never a half-built one.
+    private static volatile IReadOnlyDictionary<string, Type> _types =
+        new Dictionary<string, Type>(StringComparer.Ordinal);
+
     private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
-    /// <summary>Registers a job type by name. Called by the generated module initializer.</summary>
+    /// <summary>Registers a job type by name.</summary>
     public static void RegisterJob(string typeName, Type type)
     {
         ArgumentNullException.ThrowIfNull(typeName);
         ArgumentNullException.ThrowIfNull(type);
-        Types[typeName] = type;
+        lock (_lock)
+        {
+            _manual[typeName] = type;
+            Rebuild();
+        }
+    }
+
+    /// <summary>
+    ///     Installs <paramref name="registrations" /> as the complete set owned by
+    ///     <paramref name="groupKey" />, replacing any set previously registered under that key.
+    ///     Generated per-assembly initializers call this (passing their own
+    ///     <c>typeof(__RaskJobsRegistry)</c>), so re-running one under hot reload swaps that assembly's
+    ///     jobs — picking up added, renamed and deleted ones — while leaving every other contributor and
+    ///     any direct <see cref="RegisterJob" /> call untouched.
+    ///     <para>
+    ///         Upserting instead would make a rename additive: the old name would keep resolving to a
+    ///         type no longer produced until the process restarted.
+    ///     </para>
+    ///     <para>
+    ///         The key is compared by reference and is never used for reflection, so it attracts no
+    ///         trimmer analysis.
+    ///     </para>
+    /// </summary>
+    public static void Replace(object groupKey, IEnumerable<(string TypeName, Type Type)> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(groupKey);
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var items = registrations as (string TypeName, Type Type)[] ?? registrations.ToArray();
+        lock (_lock)
+        {
+            for (var i = 0; i < _groups.Count; i++)
+            {
+                if (!ReferenceEquals(_groups[i].Key, groupKey))
+                {
+                    continue;
+                }
+
+                // An unrelated hot reload re-runs every RefreshAll(); skip the rebuild when this
+                // contributor's jobs are unchanged.
+                if (_groups[i].Items.AsSpan().SequenceEqual(items))
+                {
+                    return;
+                }
+
+                _groups[i] = (groupKey, items);
+                Rebuild();
+                return;
+            }
+
+            _groups.Add((groupKey, items));
+            Rebuild();
+        }
+    }
+
+    // Caller holds _lock. Manual registrations are applied last so an explicit one is never clobbered by
+    // a generated refresh.
+    private static void Rebuild()
+    {
+        var map = new Dictionary<string, Type>(StringComparer.Ordinal);
+        foreach (var (_, items) in _groups)
+        {
+            foreach (var (typeName, type) in items)
+            {
+                map[typeName] = type;
+            }
+        }
+
+        foreach (var (typeName, type) in _manual)
+        {
+            map[typeName] = type;
+        }
+
+        _types = map;
     }
 
     /// <summary>Serializes a job to its stored (type-name, JSON-payload) pair.</summary>
@@ -41,7 +127,7 @@ public static class JobSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(typeName);
         ArgumentNullException.ThrowIfNull(payload);
-        return Types.TryGetValue(typeName, out var type)
+        return _types.TryGetValue(typeName, out var type)
             ? JsonSerializer.Deserialize(payload, type, Json) as ICommand
             : null;
     }

--- a/src/Rask.Outbox.Generators/OutboxRegistryGenerator.cs
+++ b/src/Rask.Outbox.Generators/OutboxRegistryGenerator.cs
@@ -21,7 +21,7 @@ public sealed class OutboxRegistryGenerator : RegistryGeneratorBase
     protected override string RegistryClassName => "__RaskOutboxRegistry";
 
     /// <inheritdoc/>
-    protected override string RegisterMethod => "global::Rask.Outbox.OutboxSerializerRegistry.RegisterEvent";
+    protected override string ReplaceMethod => "global::Rask.Outbox.OutboxSerializerRegistry.Replace";
 
     /// <inheritdoc/>
     protected override string HintName => "__RaskOutboxRegistry.g.cs";

--- a/src/Rask.Outbox/OutboxSerializerRegistry.cs
+++ b/src/Rask.Outbox/OutboxSerializerRegistry.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using System.Text.Json;
 using Rask.Cqrs;
 
@@ -12,15 +11,102 @@ namespace Rask.Outbox;
 /// </summary>
 public static class OutboxSerializerRegistry
 {
-    private static readonly ConcurrentDictionary<string, Type> Types = new(StringComparer.Ordinal);
+    private static readonly object _lock = new();
+
+    // Registrations made directly rather than by a generated initializer. Kept apart from the generated
+    // groups so a refresh can replace a group's contribution without dropping these.
+    private static readonly Dictionary<string, Type> _manual = new(StringComparer.Ordinal);
+
+    // One entry per contributing assembly, keyed by that assembly's generated registry type. Replace
+    // swaps a group wholesale, which is what makes a rename drop the old name instead of keeping both.
+    private static readonly List<(object Key, (string TypeName, Type Type)[] Items)> _groups = new();
+
+    // The flattened lookup Deserialize reads. Rebuilt under the lock and installed in a single store, so
+    // a reader observes either the complete old map or the complete new one, never a half-built one.
+    private static volatile IReadOnlyDictionary<string, Type> _types =
+        new Dictionary<string, Type>(StringComparer.Ordinal);
+
     private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
-    /// <summary>Registers an event type by name. Called by the generated module initializer.</summary>
+    /// <summary>Registers an event type by name.</summary>
     public static void RegisterEvent(string typeName, Type type)
     {
         ArgumentNullException.ThrowIfNull(typeName);
         ArgumentNullException.ThrowIfNull(type);
-        Types[typeName] = type;
+        lock (_lock)
+        {
+            _manual[typeName] = type;
+            Rebuild();
+        }
+    }
+
+    /// <summary>
+    ///     Installs <paramref name="registrations" /> as the complete set owned by
+    ///     <paramref name="groupKey" />, replacing any set previously registered under that key.
+    ///     Generated per-assembly initializers call this (passing their own
+    ///     <c>typeof(__RaskOutboxRegistry)</c>), so re-running one under hot reload swaps that assembly's
+    ///     events — picking up added, renamed and deleted ones — while leaving every other contributor
+    ///     and any direct <see cref="RegisterEvent" /> call untouched.
+    ///     <para>
+    ///         Upserting instead would make a rename additive: the old name would keep resolving to a
+    ///         type no longer produced until the process restarted.
+    ///     </para>
+    ///     <para>
+    ///         The key is compared by reference and is never used for reflection, so it attracts no
+    ///         trimmer analysis.
+    ///     </para>
+    /// </summary>
+    public static void Replace(object groupKey, IEnumerable<(string TypeName, Type Type)> registrations)
+    {
+        ArgumentNullException.ThrowIfNull(groupKey);
+        ArgumentNullException.ThrowIfNull(registrations);
+
+        var items = registrations as (string TypeName, Type Type)[] ?? registrations.ToArray();
+        lock (_lock)
+        {
+            for (var i = 0; i < _groups.Count; i++)
+            {
+                if (!ReferenceEquals(_groups[i].Key, groupKey))
+                {
+                    continue;
+                }
+
+                // An unrelated hot reload re-runs every RefreshAll(); skip the rebuild when this
+                // contributor's events are unchanged.
+                if (_groups[i].Items.AsSpan().SequenceEqual(items))
+                {
+                    return;
+                }
+
+                _groups[i] = (groupKey, items);
+                Rebuild();
+                return;
+            }
+
+            _groups.Add((groupKey, items));
+            Rebuild();
+        }
+    }
+
+    // Caller holds _lock. Manual registrations are applied last so an explicit one is never clobbered by
+    // a generated refresh.
+    private static void Rebuild()
+    {
+        var map = new Dictionary<string, Type>(StringComparer.Ordinal);
+        foreach (var (_, items) in _groups)
+        {
+            foreach (var (typeName, type) in items)
+            {
+                map[typeName] = type;
+            }
+        }
+
+        foreach (var (typeName, type) in _manual)
+        {
+            map[typeName] = type;
+        }
+
+        _types = map;
     }
 
     /// <summary>Serializes an outbox event to its stored (type-name, JSON-payload) pair.</summary>
@@ -41,7 +127,7 @@ public static class OutboxSerializerRegistry
     {
         ArgumentNullException.ThrowIfNull(typeName);
         ArgumentNullException.ThrowIfNull(payload);
-        return Types.TryGetValue(typeName, out var type)
+        return _types.TryGetValue(typeName, out var type)
             ? JsonSerializer.Deserialize(payload, type, Json) as INotification
             : null;
     }

--- a/tests/Rask.Cqrs.Generators.Tests/CqrsDispatchGeneratorTests.cs
+++ b/tests/Rask.Cqrs.Generators.Tests/CqrsDispatchGeneratorTests.cs
@@ -23,7 +23,7 @@ public sealed class CqrsDispatchGeneratorTests
         Assert.Empty(run.GeneratedCompileErrors());
         var source = run.GeneratedSource("__RaskCqrsRegistry");
         Assert.Contains("[global::System.Runtime.CompilerServices.ModuleInitializer]", source);
-        Assert.Contains("RegisterRequest(typeof(global::Demo.GetValue)", source);
+        Assert.Contains("(typeof(global::Demo.GetValue), __Request_", source);
         Assert.Contains("DynamicDependency", source);
         Assert.Contains("typeof(global::Demo.GetValueHandler)", source);
         Assert.Contains("global::Rask.Cqrs.IQueryHandler<global::Demo.GetValue, string>", source);
@@ -43,7 +43,7 @@ public sealed class CqrsDispatchGeneratorTests
         Assert.Empty(run.GeneratedCompileErrors());
         var source = run.GeneratedSource("__RaskCqrsRegistry");
         Assert.Contains("global::Rask.Cqrs.Unit", source);
-        Assert.Contains("RegisterRequest(typeof(global::Demo.DoIt)", source);
+        Assert.Contains("(typeof(global::Demo.DoIt), __Request_", source);
     }
 
     [Fact]
@@ -63,7 +63,7 @@ public sealed class CqrsDispatchGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         var source = run.GeneratedSource("__RaskCqrsRegistry");
-        Assert.Contains("RegisterNotification(typeof(global::Demo.Ping)", source);
+        Assert.Contains("(typeof(global::Demo.Ping), __Notify_", source);
         Assert.Contains("NotificationDispatch.PublishAll", source);
         Assert.Contains("TryAddEnumerable", source);
     }
@@ -114,7 +114,7 @@ public sealed class CqrsDispatchGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         var source = run.GeneratedSource("__RaskCqrsRegistry");
-        Assert.Contains("RegisterRequest(typeof(global::Demo.GetValue)", source);
+        Assert.Contains("(typeof(global::Demo.GetValue), __Request_", source);
         Assert.Contains("typeof(global::Demo.GetValueHandler)", source);
     }
 

--- a/tests/Rask.Cqrs.Generators.Tests/CqrsRegistryRefreshTests.cs
+++ b/tests/Rask.Cqrs.Generators.Tests/CqrsRegistryRefreshTests.cs
@@ -47,8 +47,29 @@ public class CqrsRegistryRefreshTests
         Assert.Contains("internal static void RefreshAll()", source, StringComparison.Ordinal);
 
         var refresh = Body(source, "internal static void RefreshAll()");
-        Assert.Contains("RegisterRequest(typeof(global::Demo.Ping)", refresh, StringComparison.Ordinal);
-        Assert.Contains("RegisterNotification(typeof(global::Demo.Pinged)", refresh, StringComparison.Ordinal);
+        Assert.Contains("(typeof(global::Demo.Ping), __Request_", refresh, StringComparison.Ordinal);
+        Assert.Contains("(typeof(global::Demo.Pinged), __Notify_", refresh, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RefreshAll_replaces_both_dispatch_tables_rather_than_upserting_into_them()
+    {
+        // Sibling of #537 in the two serializer registries, and the same shape of bug: upserts only ever
+        // add or overwrite, so deleting the last handler for a request left its invoker in the table and
+        // dispatch kept succeeding through IL that no longer had a handler behind it. Replacing this
+        // assembly's whole contribution makes a deletion take effect under `rask dev`.
+        var source = CqrsGeneratorFixture.Run(OneCommandOneNotification).GeneratedSource(RefreshTargetTypeName);
+
+        Assert.Contains(
+            "global::Rask.Cqrs.CqrsRegistry.ReplaceRequests(typeof(__RaskCqrsRegistry), ",
+            source,
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "global::Rask.Cqrs.CqrsRegistry.ReplaceNotifications(typeof(__RaskCqrsRegistry), ",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("CqrsRegistry.RegisterRequest(", source, StringComparison.Ordinal);
+        Assert.DoesNotContain("CqrsRegistry.RegisterNotification(", source, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Cqrs.Tests/CqrsRegistryReplaceTests.cs
+++ b/tests/Rask.Cqrs.Tests/CqrsRegistryReplaceTests.cs
@@ -1,0 +1,117 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rask.Cqrs.Tests;
+
+// The dispatch tables are process-global and the generated module initializer already owns a group in
+// them, so every test here drives its own group key with types that have no generated handler of their
+// own. Everything is asserted through the public dispatch surface — Rask.Cqrs exposes no internals.
+public sealed class CqrsRegistryReplaceTests
+{
+    // A type per test rather than shared ones: the tables are keyed by Type and live for the process, so
+    // two tests registering the same type under different group keys would depend on registration order.
+    public sealed record Kept(int N) : ICommand;
+
+    public sealed record Removed(int N) : ICommand;
+
+    public sealed record Noticed(int N) : INotification;
+
+    public sealed record OtherGroupKept(int N) : ICommand;
+
+    public sealed record OtherGroupRemoved(int N) : ICommand;
+
+    public sealed record Orphaned(int N) : ICommand;
+
+    private static IDispatcher Dispatcher() =>
+        new ServiceCollection().AddRaskCqrs().BuildServiceProvider().GetRequiredService<IDispatcher>();
+
+    private static CqrsRegistry.RequestInvoker Records(List<string> log, string label) =>
+        (_, _, _) =>
+        {
+            log.Add(label);
+            return Task.FromResult(Unit.Value);
+        };
+
+    private static CqrsRegistry.NotificationInvoker Notes(List<string> log, string label) =>
+        (_, _, _) =>
+        {
+            log.Add(label);
+            return Task.CompletedTask;
+        };
+
+    [Fact]
+    public async Task Replacing_a_group_drops_a_request_it_no_longer_registers()
+    {
+        // The sibling of #537 in the two serializer registries. RegisterRequest upserted, so deleting the
+        // last handler for a command under `rask dev` left its invoker behind — dispatch kept succeeding
+        // through IL that no longer had a handler, instead of reporting that nothing handles it.
+        var log = new List<string>();
+        var key = new object();
+        CqrsRegistry.ReplaceRequests(key, [(typeof(Kept), Records(log, "kept")), (typeof(Removed), Records(log, "removed"))]);
+        await Dispatcher().DispatchAsync(new Removed(1));
+        Assert.Equal(["removed"], log);
+
+        CqrsRegistry.ReplaceRequests(key, [(typeof(Kept), Records(log, "kept"))]);
+
+        await Dispatcher().DispatchAsync(new Kept(1));
+        Assert.Equal(["removed", "kept"], log);
+        await Assert.ThrowsAsync<InvalidOperationException>(() => Dispatcher().DispatchAsync(new Removed(1)));
+    }
+
+    [Fact]
+    public async Task Replacing_a_group_drops_a_notification_it_no_longer_registers()
+    {
+        // A notification with no invoker is a silent no-op, so a stale one is the worse failure: the fan-out
+        // keeps running handlers that were deleted.
+        var log = new List<string>();
+        var key = new object();
+        CqrsRegistry.ReplaceNotifications(key, [(typeof(Noticed), Notes(log, "noticed"))]);
+        await Dispatcher().PublishAsync(new Noticed(1));
+        Assert.Equal(["noticed"], log);
+
+        CqrsRegistry.ReplaceNotifications(key, []);
+
+        await Dispatcher().PublishAsync(new Noticed(1));
+        Assert.Equal(["noticed"], log); // no second entry: the deleted handler is gone
+    }
+
+    [Fact]
+    public async Task Replacing_one_group_leaves_another_groups_entries_alone()
+    {
+        // A hot reload re-runs RefreshAll() for every loaded assembly, so refreshing one contributor must
+        // not empty the others' dispatch tables.
+        var log = new List<string>();
+        var mine = new object();
+        var theirs = new object();
+        CqrsRegistry.ReplaceRequests(theirs, [(typeof(OtherGroupKept), Records(log, "theirs"))]);
+        CqrsRegistry.ReplaceRequests(mine, [(typeof(OtherGroupRemoved), Records(log, "mine"))]);
+
+        CqrsRegistry.ReplaceRequests(mine, []);
+
+        await Dispatcher().DispatchAsync(new OtherGroupKept(1));
+        Assert.Equal(["theirs"], log);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Dispatcher().DispatchAsync(new OtherGroupRemoved(1)));
+    }
+
+    [Fact]
+    public async Task A_dropped_request_reports_the_type_that_has_no_handler()
+    {
+        var key = new object();
+        CqrsRegistry.ReplaceRequests(key, [(typeof(Orphaned), Records([], "x"))]);
+        CqrsRegistry.ReplaceRequests(key, []);
+
+        var exception = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Dispatcher().DispatchAsync(new Orphaned(1)));
+
+        Assert.Contains(nameof(Orphaned), exception.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Replace_rejects_a_null_group_key_or_set()
+    {
+        Assert.Throws<ArgumentNullException>(() => CqrsRegistry.ReplaceRequests(null!, []));
+        Assert.Throws<ArgumentNullException>(() => CqrsRegistry.ReplaceRequests(new object(), null!));
+        Assert.Throws<ArgumentNullException>(() => CqrsRegistry.ReplaceNotifications(null!, []));
+        Assert.Throws<ArgumentNullException>(() => CqrsRegistry.ReplaceNotifications(new object(), null!));
+    }
+}

--- a/tests/Rask.Jobs.Generators.Tests/JobRegistryGeneratorTests.cs
+++ b/tests/Rask.Jobs.Generators.Tests/JobRegistryGeneratorTests.cs
@@ -28,7 +28,7 @@ public class JobRegistryGeneratorTests
 
         var source = run.GeneratedSource("__RaskJobsRegistry");
         Assert.Contains(
-            """RegisterJob("Demo.SendWelcomeEmail", typeof(global::Demo.SendWelcomeEmail));""",
+            """("Demo.SendWelcomeEmail", typeof(global::Demo.SendWelcomeEmail)),""",
             source,
             StringComparison.Ordinal);
         Assert.Contains("[global::System.Runtime.CompilerServices.ModuleInitializer]", source, StringComparison.Ordinal);
@@ -50,7 +50,7 @@ public class JobRegistryGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         Assert.Contains(
-            """RegisterJob("Demo.OrderJobs.RequestReview", typeof(global::Demo.OrderJobs.RequestReview));""",
+            """("Demo.OrderJobs.RequestReview", typeof(global::Demo.OrderJobs.RequestReview)),""",
             run.GeneratedSource("__RaskJobsRegistry"),
             StringComparison.Ordinal);
     }
@@ -71,7 +71,7 @@ public class JobRegistryGeneratorTests
 
         var source = run.GeneratedSource("__RaskJobsRegistry");
         Assert.Contains(
-            """RegisterJob("Demo.event.RequestReview", typeof(global::Demo.@event.RequestReview));""",
+            """("Demo.event.RequestReview", typeof(global::Demo.@event.RequestReview)),""",
             source,
             StringComparison.Ordinal);
         Assert.DoesNotContain("\"Demo.@event", source, StringComparison.Ordinal);
@@ -88,7 +88,7 @@ public class JobRegistryGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         Assert.Contains(
-            """RegisterJob("Demo.class", typeof(global::Demo.@class));""",
+            """("Demo.class", typeof(global::Demo.@class)),""",
             run.GeneratedSource("__RaskJobsRegistry"),
             StringComparison.Ordinal);
     }
@@ -125,7 +125,7 @@ public class JobRegistryGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         Assert.Contains(
-            """RegisterJob("RequestReview", typeof(global::RequestReview));""",
+            """("RequestReview", typeof(global::RequestReview)),""",
             run.GeneratedSource("__RaskJobsRegistry"),
             StringComparison.Ordinal);
     }
@@ -182,7 +182,7 @@ public class JobRegistryGeneratorTests
         Assert.DoesNotContain(run.Diagnostics, d => d.Id == "RASK035");
 
         var source = run.GeneratedSource("__RaskJobsRegistry");
-        Assert.Contains("""RegisterJob("Demo.PurgeCancelled", """, source, StringComparison.Ordinal);
+        Assert.Contains("""("Demo.PurgeCancelled", """, source, StringComparison.Ordinal);
         Assert.DoesNotContain("Demo.MaintenanceJob\"", source, StringComparison.Ordinal);
     }
 
@@ -213,7 +213,7 @@ public class JobRegistryGeneratorTests
             """);
 
         Assert.Empty(run.GeneratedCompileErrors());
-        Assert.Equal(1, CountOccurrences(run.GeneratedSource("__RaskJobsRegistry"), "RegisterJob("));
+        Assert.Equal(1, CountOccurrences(run.GeneratedSource("__RaskJobsRegistry"), "(\"Demo.RequestReview\", "));
     }
 
     [Fact]

--- a/tests/Rask.Jobs.Generators.Tests/JobRegistryRefreshTests.cs
+++ b/tests/Rask.Jobs.Generators.Tests/JobRegistryRefreshTests.cs
@@ -49,10 +49,25 @@ public class JobRegistryRefreshTests
         // be reachable from a refresh.
         var init = source[source.IndexOf("void Init()", StringComparison.Ordinal)..];
         var refreshAt = init.IndexOf("RefreshAll()\n", StringComparison.Ordinal);
-        Assert.DoesNotContain("RegisterJob", init[..Math.Max(refreshAt, 0)], StringComparison.Ordinal);
+        Assert.DoesNotContain("Replace(", init[..Math.Max(refreshAt, 0)], StringComparison.Ordinal);
 
         var refresh = source[source.IndexOf("void RefreshAll()", StringComparison.Ordinal)..];
-        Assert.Contains("RegisterJob(\"Demo.SendWelcomeEmail\"", refresh, StringComparison.Ordinal);
+        Assert.Contains("(\"Demo.SendWelcomeEmail\", ", refresh, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RefreshAll_replaces_this_assemblys_whole_set_rather_than_upserting()
+    {
+        // #537. A run of upserts made a rename additive: the old name kept resolving to a type the
+        // generator no longer produced until the process restarted. One Replace call, keyed on this
+        // assembly's own registry class, swaps the whole contribution and leaves other assemblies alone.
+        var source = Run(OneJob).GeneratedSource("__RaskJobsRegistry");
+
+        Assert.Contains(
+            "global::Rask.Jobs.JobSerializerRegistry.Replace(typeof(__RaskJobsRegistry), ",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("RegisterJob(", source, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Jobs.Tests/JobSerializerRegistryReplaceTests.cs
+++ b/tests/Rask.Jobs.Tests/JobSerializerRegistryReplaceTests.cs
@@ -1,0 +1,89 @@
+using Rask.Cqrs;
+
+namespace Rask.Jobs.Tests;
+
+// The registry is process-global and the generated module initializer already owns a group in it, so
+// every test here drives its own group key. That is the point of the group key: a contributor can only
+// ever replace its own set.
+//
+// The stand-in types are plain ICommands rather than IJobs on purpose. The generator registers every IJob
+// in the compilation, so an IJob here would sit in the *generated* group as well and could never be
+// dropped by replacing a test-owned one. Deserialize only needs an ICommand to hand back.
+public sealed class JobSerializerRegistryReplaceTests
+{
+    public sealed record Original(int N) : ICommand;
+
+    public sealed record Renamed(int N) : ICommand;
+
+    public sealed record Other(int N) : ICommand;
+
+    private static string Name<T>() => typeof(T).FullName!.Replace('+', '.');
+
+    [Fact]
+    public void Replacing_a_group_drops_the_name_it_no_longer_registers()
+    {
+        // #537. RegisterJob upserted, so a rename under `rask dev` left BOTH names registered: the new one
+        // worked, and the old one kept resolving to a type the generator no longer produced, until restart.
+        var key = new object();
+        JobSerializerRegistry.Replace(key, [(Name<Original>(), typeof(Original))]);
+        Assert.NotNull(JobSerializerRegistry.Deserialize(Name<Original>(), """{"n":1}"""));
+
+        JobSerializerRegistry.Replace(key, [(Name<Renamed>(), typeof(Renamed))]);
+
+        Assert.Null(JobSerializerRegistry.Deserialize(Name<Original>(), """{"n":1}"""));
+        Assert.NotNull(JobSerializerRegistry.Deserialize(Name<Renamed>(), """{"n":1}"""));
+    }
+
+    [Fact]
+    public void Replacing_one_group_leaves_another_groups_entries_alone()
+    {
+        // Each assembly's generated initializer passes its own registry class as the key, and a hot reload
+        // re-runs RefreshAll() for every loaded assembly — so refreshing one must not empty the others.
+        var mine = new object();
+        var theirs = new object();
+        JobSerializerRegistry.Replace(theirs, [(Name<Other>(), typeof(Other))]);
+        JobSerializerRegistry.Replace(mine, [(Name<Original>(), typeof(Original))]);
+
+        JobSerializerRegistry.Replace(mine, [(Name<Renamed>(), typeof(Renamed))]);
+
+        Assert.NotNull(JobSerializerRegistry.Deserialize(Name<Other>(), """{"n":1}"""));
+    }
+
+    [Fact]
+    public void A_direct_registration_survives_a_group_replace()
+    {
+        // RegisterJob is public and belongs to no group, so a generated refresh must not drop it.
+        var key = new object();
+        JobSerializerRegistry.RegisterJob("Manual.Job", typeof(Other));
+        JobSerializerRegistry.Replace(key, [(Name<Original>(), typeof(Original))]);
+
+        JobSerializerRegistry.Replace(key, []);
+
+        Assert.NotNull(JobSerializerRegistry.Deserialize("Manual.Job", """{"n":1}"""));
+    }
+
+    [Fact]
+    public void The_generated_group_still_resolves_a_nested_job()
+    {
+        // The generator keys on Roslyn's dotted display name; Serialize normalizes Type.FullName's '+'.
+        // Moving the generated call to Replace must not disturb that agreement — a mismatch dead-letters.
+        var (typeName, payload) = JobSerializerRegistry.Serialize(new Outer.NestedJob(7));
+
+        var rehydrated = JobSerializerRegistry.Deserialize(typeName, payload);
+
+        Assert.Equal(new Outer.NestedJob(7), Assert.IsType<Outer.NestedJob>(rehydrated));
+    }
+
+    [Fact]
+    public void Deserialize_returns_null_for_a_name_no_contributor_registers()
+    {
+        Assert.Null(JobSerializerRegistry.Deserialize("Nobody.Registers.This", "{}"));
+    }
+
+    [Fact]
+    public void Replace_rejects_a_null_group_key_or_set()
+    {
+        Assert.Throws<ArgumentNullException>(() => JobSerializerRegistry.Replace(null!, []));
+        Assert.Throws<ArgumentNullException>(() => JobSerializerRegistry.Replace(new object(), null!));
+    }
+}

--- a/tests/Rask.Outbox.Generators.Tests/OutboxRegistryGeneratorTests.cs
+++ b/tests/Rask.Outbox.Generators.Tests/OutboxRegistryGeneratorTests.cs
@@ -28,7 +28,7 @@ public class OutboxRegistryGeneratorTests
 
         var source = run.GeneratedSource("__RaskOutboxRegistry");
         Assert.Contains(
-            """RegisterEvent("Demo.OrderPlaced", typeof(global::Demo.OrderPlaced));""",
+            """("Demo.OrderPlaced", typeof(global::Demo.OrderPlaced)),""",
             source,
             StringComparison.Ordinal);
         Assert.Contains("[global::System.Runtime.CompilerServices.ModuleInitializer]", source, StringComparison.Ordinal);
@@ -50,7 +50,7 @@ public class OutboxRegistryGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         Assert.Contains(
-            """RegisterEvent("Demo.OrderEvents.Placed", typeof(global::Demo.OrderEvents.Placed));""",
+            """("Demo.OrderEvents.Placed", typeof(global::Demo.OrderEvents.Placed)),""",
             run.GeneratedSource("__RaskOutboxRegistry"),
             StringComparison.Ordinal);
     }
@@ -70,7 +70,7 @@ public class OutboxRegistryGeneratorTests
 
         var source = run.GeneratedSource("__RaskOutboxRegistry");
         Assert.Contains(
-            """RegisterEvent("Demo.event.Raised", typeof(global::Demo.@event.Raised));""",
+            """("Demo.event.Raised", typeof(global::Demo.@event.Raised)),""",
             source,
             StringComparison.Ordinal);
         Assert.DoesNotContain("\"Demo.@event", source, StringComparison.Ordinal);
@@ -87,7 +87,7 @@ public class OutboxRegistryGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         Assert.Contains(
-            """RegisterEvent("Demo.class", typeof(global::Demo.@class));""",
+            """("Demo.class", typeof(global::Demo.@class)),""",
             run.GeneratedSource("__RaskOutboxRegistry"),
             StringComparison.Ordinal);
     }
@@ -124,7 +124,7 @@ public class OutboxRegistryGeneratorTests
 
         Assert.Empty(run.GeneratedCompileErrors());
         Assert.Contains(
-            """RegisterEvent("Raised", typeof(global::Raised));""",
+            """("Raised", typeof(global::Raised)),""",
             run.GeneratedSource("__RaskOutboxRegistry"),
             StringComparison.Ordinal);
     }
@@ -181,7 +181,7 @@ public class OutboxRegistryGeneratorTests
         Assert.DoesNotContain(run.Diagnostics, d => d.Id == "RASK035");
 
         var source = run.GeneratedSource("__RaskOutboxRegistry");
-        Assert.Contains("""RegisterEvent("Demo.Placed", """, source, StringComparison.Ordinal);
+        Assert.Contains("""("Demo.Placed", """, source, StringComparison.Ordinal);
         Assert.DoesNotContain("Demo.OrderEvent\"", source, StringComparison.Ordinal);
     }
 
@@ -212,7 +212,7 @@ public class OutboxRegistryGeneratorTests
             """);
 
         Assert.Empty(run.GeneratedCompileErrors());
-        Assert.Equal(1, CountOccurrences(run.GeneratedSource("__RaskOutboxRegistry"), "RegisterEvent("));
+        Assert.Equal(1, CountOccurrences(run.GeneratedSource("__RaskOutboxRegistry"), "(\"Demo.Raised\", "));
     }
 
     [Fact]

--- a/tests/Rask.Outbox.Generators.Tests/OutboxRegistryRefreshTests.cs
+++ b/tests/Rask.Outbox.Generators.Tests/OutboxRegistryRefreshTests.cs
@@ -49,10 +49,25 @@ public class OutboxRegistryRefreshTests
         // be reachable from a refresh.
         var init = source[source.IndexOf("void Init()", StringComparison.Ordinal)..];
         var refreshAt = init.IndexOf("RefreshAll()\n", StringComparison.Ordinal);
-        Assert.DoesNotContain("RegisterEvent", init[..Math.Max(refreshAt, 0)], StringComparison.Ordinal);
+        Assert.DoesNotContain("Replace(", init[..Math.Max(refreshAt, 0)], StringComparison.Ordinal);
 
         var refresh = source[source.IndexOf("void RefreshAll()", StringComparison.Ordinal)..];
-        Assert.Contains("RegisterEvent(\"Demo.OrderPlaced\"", refresh, StringComparison.Ordinal);
+        Assert.Contains("(\"Demo.OrderPlaced\", ", refresh, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void RefreshAll_replaces_this_assemblys_whole_set_rather_than_upserting()
+    {
+        // #537. A run of upserts made a rename additive: the old name kept resolving to a type the
+        // generator no longer produced until the process restarted. One Replace call, keyed on this
+        // assembly's own registry class, swaps the whole contribution and leaves other assemblies alone.
+        var source = Run(OneEvent).GeneratedSource("__RaskOutboxRegistry");
+
+        Assert.Contains(
+            "global::Rask.Outbox.OutboxSerializerRegistry.Replace(typeof(__RaskOutboxRegistry), ",
+            source,
+            StringComparison.Ordinal);
+        Assert.DoesNotContain("RegisterEvent(", source, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Outbox.Tests/OutboxSerializerRegistryReplaceTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxSerializerRegistryReplaceTests.cs
@@ -1,0 +1,94 @@
+using Rask.Cqrs;
+
+namespace Rask.Outbox.Tests;
+
+// The registry is process-global and the generated module initializer already owns a group in it, so
+// every test here drives its own group key. That is the point of the group key: a contributor can only
+// ever replace its own set.
+//
+// The stand-in types are plain INotifications rather than IOutboxEvents on purpose. The generator
+// registers every IOutboxEvent in the compilation, so one here would sit in the *generated* group as well
+// and could never be dropped by replacing a test-owned one. Deserialize only needs an INotification back.
+//
+// Kept in lockstep with JobSerializerRegistryReplaceTests — the two registries share a shape and have
+// drifted into the same bug together before.
+public sealed class OutboxSerializerRegistryReplaceTests
+{
+    public sealed record Original(int N) : INotification;
+
+    public sealed record Renamed(int N) : INotification;
+
+    public sealed record Other(int N) : INotification;
+
+    private static string Name<T>() => typeof(T).FullName!.Replace('+', '.');
+
+    [Fact]
+    public void Replacing_a_group_drops_the_name_it_no_longer_registers()
+    {
+        // #537. RegisterEvent upserted, so a rename under `rask dev` left BOTH names registered: the new
+        // one worked, and the old one kept resolving to a type the generator no longer produced.
+        var key = new object();
+        OutboxSerializerRegistry.Replace(key, [(Name<Original>(), typeof(Original))]);
+        Assert.NotNull(OutboxSerializerRegistry.Deserialize(Name<Original>(), """{"n":1}"""));
+
+        OutboxSerializerRegistry.Replace(key, [(Name<Renamed>(), typeof(Renamed))]);
+
+        Assert.Null(OutboxSerializerRegistry.Deserialize(Name<Original>(), """{"n":1}"""));
+        Assert.NotNull(OutboxSerializerRegistry.Deserialize(Name<Renamed>(), """{"n":1}"""));
+    }
+
+    [Fact]
+    public void Replacing_one_group_leaves_another_groups_entries_alone()
+    {
+        // Each assembly's generated initializer passes its own registry class as the key, and a hot reload
+        // re-runs RefreshAll() for every loaded assembly — so refreshing one must not empty the others.
+        var mine = new object();
+        var theirs = new object();
+        OutboxSerializerRegistry.Replace(theirs, [(Name<Other>(), typeof(Other))]);
+        OutboxSerializerRegistry.Replace(mine, [(Name<Original>(), typeof(Original))]);
+
+        OutboxSerializerRegistry.Replace(mine, [(Name<Renamed>(), typeof(Renamed))]);
+
+        Assert.NotNull(OutboxSerializerRegistry.Deserialize(Name<Other>(), """{"n":1}"""));
+    }
+
+    [Fact]
+    public void A_direct_registration_survives_a_group_replace()
+    {
+        // RegisterEvent is public and belongs to no group, so a generated refresh must not drop it.
+        var key = new object();
+        OutboxSerializerRegistry.RegisterEvent("Manual.Event", typeof(Other));
+        OutboxSerializerRegistry.Replace(key, [(Name<Original>(), typeof(Original))]);
+
+        OutboxSerializerRegistry.Replace(key, []);
+
+        Assert.NotNull(OutboxSerializerRegistry.Deserialize("Manual.Event", """{"n":1}"""));
+    }
+
+    [Fact]
+    public void The_generated_group_still_resolves_a_nested_event()
+    {
+        // The generator keys on Roslyn's dotted display name; Serialize normalizes Type.FullName's '+'.
+        // Moving the generated call to Replace must not disturb that agreement — a mismatch never publishes.
+        var (typeName, payload) = OutboxSerializerRegistry.Serialize(new OuterScope.NestedEvent(7));
+
+        var rehydrated = OutboxSerializerRegistry.Deserialize(typeName, payload);
+
+        Assert.Equal(
+            new OuterScope.NestedEvent(7),
+            Assert.IsType<OuterScope.NestedEvent>(rehydrated));
+    }
+
+    [Fact]
+    public void Deserialize_returns_null_for_a_name_no_contributor_registers()
+    {
+        Assert.Null(OutboxSerializerRegistry.Deserialize("Nobody.Registers.This", "{}"));
+    }
+
+    [Fact]
+    public void Replace_rejects_a_null_group_key_or_set()
+    {
+        Assert.Throws<ArgumentNullException>(() => OutboxSerializerRegistry.Replace(null!, []));
+        Assert.Throws<ArgumentNullException>(() => OutboxSerializerRegistry.Replace(new object(), null!));
+    }
+}


### PR DESCRIPTION
Closes #537.

## The bug

#534 made the generated registries re-invocable so a hot reload reaches them. Re-invocable was necessary
but not sufficient: each `RefreshAll()` emitted a **run of dictionary upserts**, and an upsert can only ever
add or overwrite.

So a *removal* never took:

- **Jobs / Outbox.** Rename `SendWelcomeEmail` to `SendWelcomeMail` under `rask dev` and
  `JobSerializerRegistry` ends up holding **both** — the new name works, and the old one keeps resolving to
  a type the generator no longer produces, until the process restarts.
- **CQRS — the same shape, unreported, and worse.** The entry is keyed by `Type` and holds a compiled
  invoker, so deleting the last handler for a command left the invoker in the dispatch table and `Send`
  kept **succeeding** through IL that no longer had a handler behind it, instead of reporting that nothing
  handles it. A deleted notification handler kept receiving fan-out — silently, since a notification with
  no invoker is a no-op either way.

## The fix — `RouteRegistry.Replace`, not the `ScopedAssetRegistry` mirror

The issue proposed mirroring `ScopedAssetRegistry.Begin/EndCssRefresh`. `RouteRegistry.Replace` is the
better precedent, and it already solved exactly this problem for `[Route]` templates: each registry takes a
**group key** — the calling assembly's own generated registry class — and `Replace` installs that group's
complete set.

That is strictly smaller than the Begin/End mirror:

- no bracketing for the coordinator to drive, and no per-name loop to wrap;
- no cross-assembly coordination — `Collect` returns one `RefreshAll` per assembly, and each now owns only
  its own group;
- **no reflective plumbing from `Rask.Core`**, which Begin/End would have needed: `Rask.Jobs` and
  `Rask.Outbox` deliberately don't reference Core and are reached by name precisely to keep that boundary.

It also closes the window the issue worried about. The rebuilt lookup is installed in a **single volatile
store**, so a job dequeued mid-refresh observes either the complete old table or the complete new one,
never a half-built one.

Two details worth stating:

- Direct `RegisterJob`/`RegisterEvent`/`RegisterRequest` calls are kept in their own bucket and applied
  last, so a generated refresh cannot drop them — the same split `RouteRegistry` makes between `_manual`
  and `_groups`.
- An unchanged set short-circuits before the rebuild, so an unrelated assembly's reload (a hot reload
  re-runs *every* `RefreshAll()`) costs nothing.

## Testing

New registry suites for Jobs, Outbox and CQRS, plus a generator assertion per registry that `RefreshAll()`
emits one `Replace` and no `Register*`.

The registry tests use plain `ICommand`/`INotification` stand-ins rather than `IJob`/`IOutboxEvent`. That
is load-bearing: the generator registers **every** marker-implementing type in the compilation, so a real
one would also sit in the generated group and could never be dropped by replacing a test-owned one. I hit
exactly that while writing them.

The CQRS suite asserts through the public dispatch surface only (`Rask.Cqrs` exposes no internals), and
gives each test its own request types — the tables are keyed by `Type` and live for the process, so shared
types would make the assertions depend on registration order.

Gates:

- `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` → **0 warnings**.
- `scripts/run-unit-local.sh` → **4994 passed, 0 failed**.
- `scripts/run-cli-build-e2e.sh` → **21/21**.
- `scripts/run-watch-e2e.sh` → **passed** (the real `dotnet watch` session; its two apply-dependent cases
  remain skipped under `dotnet test`, which is #536).

Benchmarks: not applicable — registration is startup/refresh work, not the render hot path.

## Docs

`docs/cli.md`'s "what hot-reloads" table listed renaming a job or outbox event as *"⚠️ Applied, but the old
name stays registered until the next restart."* It now reads ✅.