### PR TITLE
fix(cli): persist the data-protection key ring so a deploy stops signing every user out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,18 @@ them until tagged releases begin.
   Note NuGet applies `build/` only to a **direct** `PackageReference`, so a class library that gets a host
   package transitively still needs its own reference to glob — the same reach the global usings in
   `build/Rask.Server.props` have always had.
+- **A deploy no longer signs out every user.** Nothing in the scaffolded app persisted the Data Protection
+  key ring, so it landed in the container's own filesystem — and `rask deploy` replaces the container on
+  every deploy. The replacement came up with a fresh ring, every auth cookie already issued failed to
+  unprotect, and everyone who was signed in was silently signed out. Nothing said so: the deploy reported
+  success, `/health` was green, and users simply found themselves logged out. `rask new` now writes the ring
+  to `/data/keys` — the volume the deploy already mounts for the database — so it outlives the container the
+  same way the data does. `SetApplicationName` is set alongside the path and is equally load-bearing: the
+  default discriminator is derived from the content root, which differs between the build and runtime
+  images, so a persisted ring on its own would still have failed to unprotect. Override the location with
+  `Rask:DataProtection:KeyPath`; a plain `dotnet run` has neither that nor `/data`, so it skips the block
+  and keeps ASP.NET's per-user development ring. Existing deployments sign everyone out once more, when the
+  persisted ring first replaces the ephemeral one, and never again.
 - **A contended write no longer fails with "cannot start a transaction within a transaction".** The
   busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
   cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle

--- a/docs/authentication-hardening.md
+++ b/docs/authentication-hardening.md
@@ -120,4 +120,8 @@ origins you actually use, and consider `report-uri`/`report-to` to catch violati
 - ☑ Treat the **session id as a bearer secret** — HTTPS only, never logged or placed in URLs that leak via `Referer`.
 - ☑ Behind a reverse proxy, wire **ForwardedHeaders** so the host-only same-origin checks (redeem + WS) see the public host.
 - ☑ For untrusted-traffic hosts, set `RaskLiveOptions.MaxSessions` and a reverse-proxy rate limit to bound session creation. The receive loop also bounds per-connection inbound-frame size, rate, and handler backlog automatically (see [Hardening reference](#hardening-reference)).
-- ☑ Rotate signing keys; manage the Data Protection key ring (persisted, encrypted at rest).
+- ☑ Rotate signing keys; manage the Data Protection key ring (persisted, encrypted at rest). `rask new`
+  scaffolds the persistence half: the ring is written to `/data/keys`, the volume `rask deploy` mounts,
+  because the default ring lives inside the container and **a deploy replaces the container** — new keys,
+  and every cookie already issued stops validating, so every user is silently signed out. Override the
+  location with `Rask:DataProtection:KeyPath`; encryption at rest is still yours to add.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -169,6 +169,34 @@ refusing sessions with `503` says so rather than answering a bare "up"), and shu
 the 20s grace period the deploy allows before `SIGKILL`, so in-flight requests drain and SQLite checkpoints
 cleanly.
 
+### Your users stay signed in across a deploy
+
+The same volume holds the **Data Protection key ring**, at `/data/keys`. This matters more than it looks.
+Those keys sign the auth cookie, and the default ring is written inside the container — so a deploy, which
+replaces the container, would mint a fresh ring and invalidate every cookie already issued. Every signed-in
+user would be silently signed out by every deploy, with nothing in the logs to say why.
+
+`rask new` scaffolds the fix, and it has two halves that are equally load-bearing:
+
+```csharp
+var keyRingPath = builder.Configuration["Rask:DataProtection:KeyPath"]
+                  ?? (Directory.Exists("/data") ? "/data/keys" : null);
+if (keyRingPath is not null)
+{
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(Directory.CreateDirectory(keyRingPath))
+        .SetApplicationName(builder.Environment.ApplicationName);
+}
+```
+
+`SetApplicationName` is not optional garnish: the default discriminator is derived from the content root,
+which differs between the build and runtime images, so a persisted ring alone would still fail to unprotect.
+Set `Rask:DataProtection:KeyPath` to put the ring elsewhere. On a plain `dotnet run` there is no `/data`
+and no override, so the block is skipped and ASP.NET's per-user development ring applies.
+
+If you're carrying an app that predates this, add the block — an existing deployment will sign everyone out
+once, when the persisted ring first replaces the ephemeral one, and never again.
+
 ## Scaffolding a Dockerfile — `--docker`
 
 The three web templates take an opt-in `--docker` flag that drops a production-ready multi-stage

--- a/samples/Rask.Example.Shop/Program.cs
+++ b/samples/Rask.Example.Shop/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
@@ -51,6 +52,25 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 // and SIGKILLs 20s later, so a budget under that is what lets in-flight requests drain and a
 // SQLite WAL checkpoint / Litestream flush complete instead of being killed mid-write.
 builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
+
+// Data-protection keys sign the auth cookie (and anything else the app protects). The default key
+// ring is written inside the container, and every deploy replaces the container — so without this
+// a redeploy mints a fresh ring and every cookie already issued stops validating: all your
+// signed-in users are silently signed out. `rask deploy` mounts a volume at /data, so persisting
+// the ring there makes it outlive the container the same way the database does. SetApplicationName
+// matters as much as the path: the default discriminator is derived from the content root, which
+// differs between the build and runtime images. Set Rask:DataProtection:KeyPath to override the
+// location; when neither it nor /data exists (a plain `dotnet run`), this is skipped and ASP.NET's
+// per-user development key ring applies.
+var keyRingPath = builder.Configuration["Rask:DataProtection:KeyPath"]
+                  ?? (Directory.Exists("/data") ? "/data/keys" : null);
+if (keyRingPath is not null)
+{
+    builder.Services.AddDataProtection()
+        .PersistKeysToFileSystem(Directory.CreateDirectory(keyRingPath))
+        .SetApplicationName(builder.Environment.ApplicationName);
+}
+
 // CQRS mediator: one call registers every IQueryHandler/ICommandHandler/INotificationHandler in
 // this assembly (source-generated, reflection-free — trim/AOT-safe). Inject IDispatcher to send
 // messages; add pipeline behaviors with o.AddOpenBehavior(...). See docs/cqrs.md.

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -169,7 +169,7 @@ internal static partial class ProjectGenerator
     {
         var sb = new StringBuilder();
         // App (and, with --data, AppDbContext) live in the Features/Shared bucket.
-        sb.Append("using Company.RaskServer.Features.Shared;\nusing Microsoft.AspNetCore.HttpOverrides;\nusing Rask.Server;\nusing Rask.Server.Diagnostics;\n");
+        sb.Append("using Company.RaskServer.Features.Shared;\nusing Microsoft.AspNetCore.DataProtection;\nusing Microsoft.AspNetCore.HttpOverrides;\nusing Rask.Server;\nusing Rask.Server.Diagnostics;\n");
         if (batteries.Auth)
         {
             sb.Append("using Company.RaskServer.Features.Auth;\n");
@@ -261,6 +261,24 @@ internal static partial class ProjectGenerator
             // and SIGKILLs 20s later, so a budget under that is what lets in-flight requests drain and a
             // SQLite WAL checkpoint / Litestream flush complete instead of being killed mid-write.
             builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
+
+            // Data-protection keys sign the auth cookie (and anything else the app protects). The default key
+            // ring is written inside the container, and every deploy replaces the container — so without this
+            // a redeploy mints a fresh ring and every cookie already issued stops validating: all your
+            // signed-in users are silently signed out. `rask deploy` mounts a volume at /data, so persisting
+            // the ring there makes it outlive the container the same way the database does. SetApplicationName
+            // matters as much as the path: the default discriminator is derived from the content root, which
+            // differs between the build and runtime images. Set Rask:DataProtection:KeyPath to override the
+            // location; when neither it nor /data exists (a plain `dotnet run`), this is skipped and ASP.NET's
+            // per-user development key ring applies.
+            var keyRingPath = builder.Configuration["Rask:DataProtection:KeyPath"]
+                              ?? (Directory.Exists("/data") ? "/data/keys" : null);
+            if (keyRingPath is not null)
+            {
+                builder.Services.AddDataProtection()
+                    .PersistKeysToFileSystem(Directory.CreateDirectory(keyRingPath))
+                    .SetApplicationName(builder.Environment.ApplicationName);
+            }
 
             """.TrimStart('\n'));
 

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
@@ -150,6 +150,7 @@ internal static partial class ProjectGenerator
             sb.Append("using Microsoft.AspNetCore.Authentication.Cookies;\n");
         }
 
+        sb.Append("using Microsoft.AspNetCore.DataProtection;\n");
         sb.Append("using Microsoft.AspNetCore.HttpOverrides;\n");
         sb.Append("using Rask.Wasm.Hosting;\n");
 
@@ -181,6 +182,23 @@ internal static partial class ProjectGenerator
             // Finish shutting down before the container runtime loses patience: `rask deploy` sends SIGTERM
             // and SIGKILLs 20s later.
             builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
+
+            // Data-protection keys sign the auth cookie (and anything else the app protects). The default key
+            // ring is written inside the container, and every deploy replaces the container — so without this
+            // a redeploy mints a fresh ring and every cookie already issued stops validating: all your
+            // signed-in users are silently signed out. `rask deploy` mounts a volume at /data, so persisting
+            // the ring there makes it outlive the container. SetApplicationName matters as much as the path:
+            // the default discriminator is derived from the content root, which differs between the build and
+            // runtime images. Set Rask:DataProtection:KeyPath to override the location; when neither it nor
+            // /data exists (a plain `dotnet run`), this is skipped and the development key ring applies.
+            var keyRingPath = builder.Configuration["Rask:DataProtection:KeyPath"]
+                              ?? (Directory.Exists("/data") ? "/data/keys" : null);
+            if (keyRingPath is not null)
+            {
+                builder.Services.AddDataProtection()
+                    .PersistKeysToFileSystem(Directory.CreateDirectory(keyRingPath))
+                    .SetApplicationName(builder.Environment.ApplicationName);
+            }
 
             """.TrimStart('\n'));
 

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -84,6 +84,34 @@ public sealed class ProjectGeneratorTests
     }
 
     /// <summary>
+    /// Every deploy replaces the container. With the default key ring — written inside that container —
+    /// the replacement mints new keys and every auth cookie already issued stops validating, so a deploy
+    /// silently signs out every user. The ring has to live on the volume `rask deploy` mounts.
+    /// </summary>
+    [Fact]
+    public void Data_protection_keys_outlive_the_container_a_deploy_replaces()
+    {
+        var (files, _) = Generate();
+        var program = files["Program.cs"];
+
+        Assert.Contains("using Microsoft.AspNetCore.DataProtection;", program, StringComparison.Ordinal);
+        Assert.Contains(".PersistKeysToFileSystem(", program, StringComparison.Ordinal);
+
+        // The volume `rask deploy` mounts (DeployCommand mounts {slug}-data at /data), overridable for
+        // hosts that put it elsewhere.
+        Assert.Contains("\"/data/keys\"", program, StringComparison.Ordinal);
+        Assert.Contains("Rask:DataProtection:KeyPath", program, StringComparison.Ordinal);
+
+        // Load-bearing alongside the path: the default discriminator comes from the content root, which
+        // differs between the build and runtime images — so a persisted ring alone still wouldn't validate.
+        Assert.Contains(".SetApplicationName(", program, StringComparison.Ordinal);
+
+        // A plain `dotnet run` has no /data and no override, and must not try to create one at the
+        // filesystem root — the block is skipped entirely there.
+        Assert.Contains("Directory.Exists(\"/data\")", program, StringComparison.Ordinal);
+    }
+
+    /// <summary>
     /// docs/observability.md tells the reader to set Logging:LogLevel:Rask.Live — which needs somewhere
     /// to put it. The files must also be real JSON to the provider that will load them (it skips comments).
     /// </summary>
@@ -735,6 +763,20 @@ public sealed class ProjectGeneratorTests
         var health = program.IndexOf("UseHealthChecks(\"/health\")", StringComparison.Ordinal);
         var redirect = program.IndexOf("UseHttpsRedirection()", StringComparison.Ordinal);
         Assert.True(health >= 0 && redirect >= 0 && health < redirect, "/health precedes UseHttpsRedirection");
+    }
+
+    // ...and the same key-ring contract: this host issues the auth cookie for the WASM client, so a
+    // deploy that replaces the container would sign every user out without a persisted ring.
+    [Fact]
+    public void WasmHosted_server_persists_data_protection_keys_to_the_mounted_volume()
+    {
+        var program = GenerateWasmHosted()["App.Server/Program.cs"];
+
+        Assert.Contains("using Microsoft.AspNetCore.DataProtection;", program, StringComparison.Ordinal);
+        Assert.Contains(".PersistKeysToFileSystem(", program, StringComparison.Ordinal);
+        Assert.Contains("\"/data/keys\"", program, StringComparison.Ordinal);
+        Assert.Contains(".SetApplicationName(", program, StringComparison.Ordinal);
+        Assert.Contains("Directory.Exists(\"/data\")", program, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #545. First PR of the [server-host scaling](https://github.com/pal-tamas/rask/issues/545) work — it lands on its own because the bug it fixes is live today, and because everything after it needs a key ring that survives a container swap.

## The bug

Nothing in the repo persisted the Data Protection key ring. The only `AddDataProtection()` call was in `samples/Rask.Example.Auth.Jwt`, with default storage; the `rask new` scaffold — which wires **cookie auth** — never called it at all.

Default storage puts the ring inside the container. `rask deploy` replaces the container on every deploy (`DeployCommand.cs:517-521` removes the old one after the Caddy swap). So the replacement came up with a fresh ring, every auth cookie already issued failed to unprotect, and **every signed-in user was silently signed out by every deploy**.

Nothing surfaced it: the deploy reported success, `/health` was green, and users just found themselves logged out. Single box, no replicas needed.

## The fix

`rask new` now writes the ring to `/data/keys` — the volume the deploy already mounts for the database (`{slug}-data:/data`), so nothing new to provision:

```csharp
var keyRingPath = builder.Configuration["Rask:DataProtection:KeyPath"]
                  ?? (Directory.Exists("/data") ? "/data/keys" : null);
if (keyRingPath is not null)
{
    builder.Services.AddDataProtection()
        .PersistKeysToFileSystem(Directory.CreateDirectory(keyRingPath))
        .SetApplicationName(builder.Environment.ApplicationName);
}
```

`SetApplicationName` is not garnish — it's the half that's easy to miss. The default discriminator is derived from the content root, which differs between the build and runtime images, so a persisted ring *on its own* would still have failed to unprotect. Both halves or neither.

Guarded so a plain `dotnet run` (no `/data`, no override) skips the block entirely and keeps ASP.NET's per-user development ring, rather than trying to create a directory at the filesystem root.

Applied to the `server` and `wasm-hosted` scaffolds and to the Shop sample, which mirrors scaffold output.

## Testing

- Two new scaffold assertions in `ProjectGeneratorTests` — one per template — covering the path, the config override, `SetApplicationName`, and the dev-box guard.
- `ProjectGeneratorBuildE2ETests` (`RASK_CLI_BUILD_E2E=1`): **20/20**, so every `rask new` combination still compiles with the new block. This is the assertion that matters for emitted code.
- `scripts/run-unit-local.sh`: green.
- Shop sample builds warnings-as-errors clean.

No benchmarks — this is scaffold text and docs, nothing on the render or runtime path.

**Browser E2E skipped** (`RASK_SKIP_E2E=1`). The sample change is a DI registration that is inert on a dev box, so there is no UI behaviour for E2E to reach; the sandbox's Playwright suite is also environmentally red on `main`.

## Docs

- `deployment.md` — new "Your users stay signed in across a deploy" section with the recipe and why `SetApplicationName` is load-bearing.
- `authentication-hardening.md` — the existing "manage the Data Protection key ring" checklist item now says which half the scaffold does for you and which is still yours (encryption at rest).
- CHANGELOG `[Unreleased]` → Fixed, including the one-time sign-out existing deployments will see when the persisted ring first replaces the ephemeral one.