### PR TITLE
feat(server): rebuild a page on a host that never knew its session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,33 @@ them until tagged releases begin.
   It reports no memory column on purpose: the generator shares a process with the host, so a heap reading
   counts the client's own sockets — an early version did exactly that and produced a figure that didn't
   rise with page size.
+- **A restart or a redeploy no longer costs your users their page.** A live session is a component tree, a
+  DI scope and a set of cancellation tokens — it cannot be serialized, so it cannot be moved or saved. Until
+  now that meant the process holding it going away took the page with it: every `rask deploy` blue-green
+  swap answered every connected client with *"Your session timed out. Reload to continue."* The swap was
+  zero-downtime for HTTP and a full reload for everyone actually using the app.
+  What travels instead is a small sealed record of where the page was and what the app declared through the
+  new **`IPersistentState`** — and a host that has never heard of the session **rebuilds** the page around
+  it. Nothing resumes; the page is built again, which is why what you declare is what comes back. Declare
+  the state a user would be annoyed to lose (a filter, a wizard step, an unsaved draft) and let the rest
+  come back from the database. Even an app that declares nothing gets the route, so a deploy becomes a
+  re-render rather than a reload.
+  The record is held by the browser, so this needs **no shared store, no sticky routing and no new
+  infrastructure** — the same property that will later let a reconnect land on a different replica. It is
+  encrypted and authenticated under its own data-protection purpose; expiry is enforced by ASP.NET's
+  time-limited protector, so an expired record cannot be opened at all rather than relying on a field
+  somebody remembers to check; it carries no principal but is bound to the identity it was issued to and
+  compared in fixed time, so it cannot be replayed onto another account or inherited across a sign-in; and
+  a rebuild takes a `MaxSessions` slot through the same atomic reservation a `GET` uses, so the reconnect
+  storm after a deploy sheds like ordinary traffic instead of walking past the cap. The bag is capped at
+  16 KB — over budget a session keeps working but declares itself unresumable and falls back to the reload
+  it would have had, with a diagnostic saying so.
+  It rides **inside the render payload**, beside `history` and `auth`, rather than arriving as its own
+  frame: a `hello` with nothing pending must still emit no frame at all. Costs nothing when absent — the
+  payload-byte benchmark is unchanged to the byte. Configure with `SessionResume` (default on) and
+  `ResumeTokenLifetime` (default 1 hour). **Requires a persisted data-protection key ring** — a record
+  sealed before a redeploy cannot be opened after one otherwise, which is what the scaffold's `/data/keys`
+  change below is for.
 - **`rask db backup` and `rask db restore` — get the deployed database down, and a copy back up.** Continuous
   backup (Litestream) covers the box dying; this covers the two things a solo developer actually reaches
   for: *"something looks wrong in production, let me get a copy"* and *"that migration was a mistake,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,6 +63,8 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `IdleSocketTimeout` | `0` (off) | Close a connected socket that sends no inbound frame for this long (the session survives for reconnect). Reclaims silently-idle connections. |
 | `MaxPendingHandlerBytes` | `0` (off) | Aggregate-bytes companion to `MaxPendingHandlers` — bounds the queued cloned-payload *memory*, not just the queue length. |
 | `SendTimeout` | `30 s` | How long one outbound frame may take before the socket is aborted. A client that stops reading TCP would otherwise pin its session's render lock — and its disposal — indefinitely. The session survives for the grace period, so a briefly-stalled link reconnects normally. `0` disables. |
+| `SessionResume` | `true` | Let a client rebuild its page on a host that has never heard of its session — after a restart or a redeploy. See [surviving a restart](#surviving-a-restart-or-a-redeploy). Turn it off to keep the reload. |
+| `ResumeTokenLifetime` | `1 h` | How long a resume record stays redeemable. Not the reconnect grace period: that covers a blip against the *intact* session, this covers the session being gone. |
 | `HandlerTimeout` | `0` (off) | Cancel a handler's `Component.CancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
 
 ### Reconnect UX
@@ -101,6 +103,67 @@ overlay handles the user-facing side automatically — nothing to configure:
 ```csharp
 builder.Services.Configure<RaskUploadOptions>(o => o.MaxFileSize = 10 * 1024 * 1024);
 ```
+
+## Surviving a restart or a redeploy
+
+A live session is a component tree, a DI scope and a set of cancellation tokens. None of that can be
+serialized, so a session cannot be moved or saved — when the process holding it goes away, it is gone.
+
+That used to be the end of the story: every `rask deploy` replaces the container, so every connected
+client got *"Your session timed out. Reload to continue."* The deploy was zero-downtime for HTTP and a
+full reload for everyone actually using the app.
+
+What travels instead is a small sealed record of **where the page was** and **what the app declared**, and
+a host that receives it back **rebuilds** the page around it. Nothing resumes — the page is built again,
+which is exactly why what you declare is what comes back:
+
+```csharp
+public sealed class OrdersPage(IPersistentState state) : Component
+{
+    private string _filter = "";
+
+    protected override void OnMount() => state.TryGet<string>("filter", out _filter!);
+
+    private void Search(string term)
+    {
+        _filter = term;
+        state.Persist("filter", term);   // survives a rebuild; everything else does not
+    }
+}
+```
+
+Inject it through the **constructor** — a settable non-nullable property becomes a required factory
+parameter ([RASK002](diagnostics.md)).
+
+**Declare state, don't stream it.** The bag is capped at 16 KB across all keys and rides the wire inside
+the render payload. Persist identifiers and selections — a filter, a wizard step, a draft — not the rows
+they resolve to. Over budget the session keeps working but declares itself unresumable and falls back to
+the reload it would have had anyway, and logs a warning saying so.
+
+**Even declaring nothing is worth something.** The route alone turns a deploy from a full-page reload into
+a re-render of the page the user was already on.
+
+**What does not come back:** anything you didn't name. In-flight async work, undeclared fields, open
+interop handles. And note that a value only *reads* back if the JSON still fits the type — if you change
+the shape of a persisted type, change its key too, or a renamed property will read back as a default
+rather than a miss.
+
+### What makes it safe
+
+The record lives in the browser, which is what makes it need no shared store, no sticky routing and no new
+infrastructure. It is encrypted and authenticated under its own data-protection purpose, so it is opaque
+and unforgeable to the client holding it. Expiry is enforced by ASP.NET's time-limited protector rather
+than a field we compare, so an expired record cannot be opened at all. It carries **no principal** — a
+reconnect authenticates from its cookie or bearer token exactly as before — but it is bound to the
+identity it was issued to, so it cannot be replayed onto another account, and signing in or out
+invalidates it. A rebuild takes a `MaxSessions` slot through the same atomic reservation a `GET` uses, so
+the reconnect storm after a deploy sheds like ordinary traffic instead of walking past the cap.
+
+> **This needs a persisted key ring.** A record sealed by the container you just replaced can only be
+> opened by the replacement if both share data-protection keys. `rask new` scaffolds that (`/data/keys`,
+> on the volume the deploy already mounts) — see [deployment](deployment.md#your-users-stay-signed-in-across-a-deploy).
+> Without it, every record is refused after a deploy and you are back to the reload. Watch
+> `rask.sessions.resume_rejected{reason="unprotect"}`: a spike right after a deploy is exactly that.
 
 ## Sizing `MaxSessions` for a memory budget
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -61,11 +61,20 @@ All metrics publish on the meter named **`Rask.Server`** (`RaskTelemetry.MeterNa
 | `rask.handlers.faulted` | Counter | | Handler dispatches that threw (isolated; session survives). |
 | `rask.handlers.timedout` | Counter | | Handler dispatches cancelled by `HandlerTimeout`. |
 | `rask.handler.duration` | Histogram (ms) | | Wall-clock duration of an event-handler dispatch. |
-| `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` | Inbound frames refused by a safety limit. |
+| `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` \| `idle` | Inbound frames refused by a safety limit. |
+| `rask.sessions.resumed` | Counter | | Pages rebuilt on a host that had never heard of the session, from the client's [resume record](configuration.md#surviving-a-restart-or-a-redeploy). |
+| `rask.sessions.resume_rejected` | Counter | `reason` = `malformed` \| `unprotect` \| `principal` \| `toolarge` \| `atcapacity` | Resume records refused. |
 
 The `rask.ws.frames.rejected` counter is the headline DoS-visibility signal: a spike on
 `reason=rate` or `reason=backlog` means a client is being throttled by the per-connection frame-rate
-cap or the pending-handler backpressure breaker.
+cap or the pending-handler backpressure breaker. `reason=idle` is the `IdleSocketTimeout` reclaiming a
+silently-idle connection, not an attack.
+
+`rask.sessions.resume_rejected` is worth an alert of its own. A steady trickle is normal — expired records
+from laptops that slept. **A spike on `reason=unprotect` immediately after a deploy means your
+data-protection key ring is not surviving the deploy**, so every user is getting a reload instead of their
+page back (and, if you use cookie auth, being signed out). See
+[surviving a restart](configuration.md#surviving-a-restart-or-a-redeploy).
 
 ## Pillar metrics
 

--- a/src/Rask.Core/Live/IPersistentState.cs
+++ b/src/Rask.Core/Live/IPersistentState.cs
@@ -1,0 +1,72 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Rask.Core.Live;
+
+/// <summary>
+///     A small, explicitly-declared bag of state that outlives the live session holding it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A live session is a component tree, a DI scope and a set of cancellation tokens — none of which
+///         can be serialized. So a session cannot be moved or saved: when the process that owns it goes
+///         away (a restart, a redeploy, a reconnect routed to another node), the tree goes with it.
+///     </para>
+///     <para>
+///         What <em>can</em> travel is a record of what the page would need to be built again. That is what
+///         this is: the values you name here are carried across, and the page is <b>rebuilt</b> around
+///         them rather than resumed. Anything you don't name is gone — in-flight async work, undeclared
+///         fields, open interop handles. Declare the state a user would be annoyed to lose (a filter, a
+///         wizard step, an unsaved draft), and let everything else come back from the database.
+///     </para>
+///     <para>
+///         Inject it through the constructor, not a settable property — a non-nullable settable property
+///         becomes a required factory parameter (RASK002).
+///     </para>
+///     <para>
+///         Keep it small. The bag is capped (16 KB by default across all keys); a session that exceeds
+///         the cap keeps working but declares itself unresumable, so it falls back to the reload it would
+///         have had anyway. This is a place for identifiers and selections, not for cached rows.
+///     </para>
+///     <para>
+///         The reflection-based overloads are the ergonomic default; the <see cref="JsonTypeInfo{T}" />
+///         overloads are trim-/AOT-safe (supply a source-generated <c>JsonSerializerContext</c>) — the same
+///         pairing <c>ICache</c> uses.
+///     </para>
+/// </remarks>
+public interface IPersistentState
+{
+    /// <summary>Records <paramref name="value" /> under <paramref name="key" />, replacing any previous value.</summary>
+    [RequiresUnreferencedCode(PersistentState.TrimWarning)]
+    [RequiresDynamicCode(PersistentState.TrimWarning)]
+    void Persist<T>(string key, T value);
+
+    /// <summary>Records <paramref name="value" /> using a source-generated <paramref name="typeInfo" /> (trim-/AOT-safe).</summary>
+    void Persist<T>(string key, T value, JsonTypeInfo<T> typeInfo);
+
+    /// <summary>
+    ///     Reads back a value recorded before the page was rebuilt. Returns <c>false</c> when the key was
+    ///     never written, and when the stored JSON cannot be read as <typeparamref name="T" /> at all —
+    ///     which is what a deploy that changed the type behind a key looks like from here. Treat a
+    ///     <c>false</c> as "no value", never as an error.
+    /// </summary>
+    /// <remarks>
+    ///     A shape that is merely <em>different</em> rather than unreadable is not a miss: System.Text.Json
+    ///     fills what it cannot find with defaults, so renaming a property on a persisted type gives you a
+    ///     successfully-read object with a null in it, from a token the previous deploy wrote. If you need
+    ///     to change a persisted type, change its key too — that turns an ambiguous half-read into a clean
+    ///     miss you can handle.
+    /// </remarks>
+    [RequiresUnreferencedCode(PersistentState.TrimWarning)]
+    [RequiresDynamicCode(PersistentState.TrimWarning)]
+    bool TryGet<T>(string key, out T? value);
+
+    /// <summary>Reads back a value using a source-generated <paramref name="typeInfo" /> (trim-/AOT-safe).</summary>
+    bool TryGet<T>(string key, JsonTypeInfo<T> typeInfo, out T? value);
+
+    /// <summary>Drops <paramref name="key" />. Returns <c>true</c> if it was present.</summary>
+    bool Remove(string key);
+
+    /// <summary>Drops every key.</summary>
+    void Clear();
+}

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -148,10 +148,11 @@ public static class LivePayload
         bool replace,
         AuthInstruction? auth = null,
         PendingDownload? download = null,
-        IReadOnlyList<PendingJsInvoke>? jsInvokes = null)
+        IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
+        string? resume = null)
     {
         using var writer = new Utf8JsonWriter(output, DiffWriterOptions);
-        WriteJson(writer, html, historyUrl, replace, auth, download, jsInvokes);
+        WriteJson(writer, html, historyUrl, replace, auth, download, jsInvokes, resume);
     }
 
     /// <summary>
@@ -234,9 +235,10 @@ public static class LivePayload
         bool replace,
         AuthInstruction? auth = null,
         PendingDownload? download = null,
-        IReadOnlyList<PendingJsInvoke>? jsInvokes = null)
+        IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
+        string? resume = null)
         => BuildPayloadUtf8Spliced(output, html, sessionId, false,
-            historyUrl, replace, auth, download, jsInvokes);
+            historyUrl, replace, auth, download, jsInvokes, resume);
 
     /// <summary>
     ///     Diff-mode payload: writes <c>{ "kind": "diff", "ops": [...] }</c> directly
@@ -285,7 +287,8 @@ public static class LivePayload
         bool replace = false,
         IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
         string? headHtml = null,
-        ReadOnlySpan<char> newHtml = default)
+        ReadOnlySpan<char> newHtml = default,
+        string? resume = null)
     {
         // Pass 1: build the attribute-name symbol table. Intern when the name appears
         // 3+ times — break-even with the table overhead lands around there for typical
@@ -485,6 +488,8 @@ public static class LivePayload
             writer.WriteEndObject();
         }
 
+        WriteResume(writer, resume);
+
         writer.WriteEndObject();
     }
 
@@ -497,7 +502,8 @@ public static class LivePayload
         bool replace,
         AuthInstruction? auth,
         PendingDownload? download,
-        IReadOnlyList<PendingJsInvoke>? jsInvokes)
+        IReadOnlyList<PendingJsInvoke>? jsInvokes,
+        string? resume = null)
     {
         // Find <body> bounds on the UTF-16 source. The prior implementation
         // rented + encoded the entire html to UTF-8 first, scanned the byte span,
@@ -510,7 +516,7 @@ public static class LivePayload
         var bodyOpenChar = IndexOfBodyOpen(html);
         if (bodyOpenChar < 0)
         {
-            BuildPayloadUtf8(output, html, historyUrl, replace, auth, download, jsInvokes);
+            BuildPayloadUtf8(output, html, historyUrl, replace, auth, download, jsInvokes, resume);
             return;
         }
 
@@ -521,7 +527,7 @@ public static class LivePayload
             var tagEndRel = html.AsSpan(bodyOpenChar).IndexOf('>');
             if (tagEndRel < 0)
             {
-                BuildPayloadUtf8(output, html, historyUrl, replace, auth, download, jsInvokes);
+                BuildPayloadUtf8(output, html, historyUrl, replace, auth, download, jsInvokes, resume);
                 return;
             }
 
@@ -529,7 +535,7 @@ public static class LivePayload
             var closeCharIdx = IndexOfIgnoreCase(html, "</body>", afterOpenTagChar);
             if (closeCharIdx < 0)
             {
-                BuildPayloadUtf8(output, html, historyUrl, replace, auth, download, jsInvokes);
+                BuildPayloadUtf8(output, html, historyUrl, replace, auth, download, jsInvokes, resume);
                 return;
             }
 
@@ -575,7 +581,7 @@ public static class LivePayload
             // not embedded into HTML, so the default HTML-safe escaping inflates the "html"
             // field's `<` / `>` 5× for no security benefit. Shaves ~3-5 KB off a 10 KB page.
             using var writer = new Utf8JsonWriter(output, DiffWriterOptions);
-            WriteJsonUtf8Body(writer, span[..cursor], historyUrl, replace, auth, download, jsInvokes);
+            WriteJsonUtf8Body(writer, span[..cursor], historyUrl, replace, auth, download, jsInvokes, resume);
         }
         finally
         {
@@ -618,11 +624,30 @@ public static class LivePayload
         bool replace,
         AuthInstruction? auth,
         PendingDownload? download,
-        IReadOnlyList<PendingJsInvoke>? jsInvokes)
+        IReadOnlyList<PendingJsInvoke>? jsInvokes,
+        string? resume = null)
     {
         writer.WriteStartObject();
         writer.WriteString("html", html);
-        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes);
+        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes, resume);
+    }
+
+    /// <summary>
+    ///     Writes the session-resume record when one is due.
+    /// </summary>
+    /// <remarks>
+    ///     It rides inside the render payload rather than arriving as its own frame, for the same reason
+    ///     <c>history</c> and <c>auth</c> do. The frame stream is a contract: a <c>hello</c> with nothing
+    ///     pending must emit no frame at all, and consumers reason about the last frame of a burst — so an
+    ///     extra frame is observable in ways an extra field is not. It also happens to be exact: the record
+    ///     only changes when the declared state or the route changes, and both always come with a render.
+    /// </remarks>
+    private static void WriteResume(Utf8JsonWriter writer, string? resume)
+    {
+        if (resume is not null)
+        {
+            writer.WriteString("resume", resume);
+        }
     }
 
     private static void WriteJsonUtf8Body(
@@ -632,11 +657,12 @@ public static class LivePayload
         bool replace,
         AuthInstruction? auth,
         PendingDownload? download,
-        IReadOnlyList<PendingJsInvoke>? jsInvokes)
+        IReadOnlyList<PendingJsInvoke>? jsInvokes,
+        string? resume = null)
     {
         writer.WriteStartObject();
         writer.WriteString("html", htmlUtf8);
-        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes);
+        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes, resume);
     }
 
     private static void WriteJsonTail(
@@ -645,8 +671,10 @@ public static class LivePayload
         bool replace,
         AuthInstruction? auth,
         PendingDownload? download,
-        IReadOnlyList<PendingJsInvoke>? jsInvokes)
+        IReadOnlyList<PendingJsInvoke>? jsInvokes,
+        string? resume = null)
     {
+        WriteResume(writer, resume);
         WriteJsInvokesArray(writer, jsInvokes);
 
         if (historyUrl is not null)

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -258,6 +258,21 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
         Services.GetService<IDownloadSink>() is { } sink && sink.TryConsume(out var pd) ? pd : null;
 
     /// <summary>
+    ///     A sealed session-resume record to attach to the payload being written, or <c>null</c> for none.
+    /// </summary>
+    /// <remarks>
+    ///     Only the ASP.NET host overrides this. A WASM or native app IS the process holding its session,
+    ///     so there is no other host for a record to be redeemed on and nothing to carry — the base returns
+    ///     null and those hosts pay a null check per frame. Named "Take" because an override is expected to
+    ///     mark the record as issued: it is called once per payload and must not hand out the same record
+    ///     on every subsequent frame.
+    /// </remarks>
+    protected virtual string? TakeResumeToken() => null;
+
+    /// <summary>Bytes the <c>"resume":"…"</c> field name, quotes and separator add around the record itself.</summary>
+    private const int ResumeFieldOverhead = 12;
+
+    /// <summary>
     ///     Decide diff-vs-full for the just-rendered <paramref name="html" /> and write the frame
     ///     into <see cref="_writeBuffer" />. Identical on both hosts; the seams are parameters:
     ///     <paramref name="auth" /> (Server only — gates the diff path and rides the full payload;
@@ -270,6 +285,12 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
         AuthInstruction? auth, string sessionId)
     {
         _writeBuffer.ResetWrittenCount();
+
+        // A session-resume record, when this host issues them and the page has moved since the last one.
+        // Taken once per payload — before either branch below — so the diff and full paths carry the same
+        // record and a frame that ends up discarded on size doesn't consume it twice. Null on every host
+        // but the ASP.NET one, which is the only place a session can outlive the process holding it.
+        var resume = TakeResumeToken();
 
         // Out-of-band side effects (auth, download) and structural ops route to the full-HTML morph
         // path; in-place state changes ship a diff. Head changes (per-route <title>, a scoped-asset
@@ -293,12 +314,19 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
             {
                 var headHtml = headChanged ? LiveDiffGate.ExtractHead(html.Span) : null;
                 LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes,
-                    headHtml, html.Span);
+                    headHtml, html.Span, resume);
 
                 // Ship the diff whenever it isn't larger than re-sending the body, or unconditionally
                 // under Forced. Only the pathological case (nearly every node changed on a tiny page,
                 // so op-list framing exceeds the body) falls back to full HTML on size.
-                if (DiffMode == LiveDiffMode.Forced || _writeBuffer.WrittenCount < html.Length)
+                //
+                // The resume record is discounted from the diff's measured size because the full-HTML
+                // payload would carry the identical record: it is on both sides of this comparison, so
+                // letting it count only against the diff would flip small pages to full HTML purely
+                // because a record happened to be due — a page whose diff is a few hundred bytes would
+                // start shipping its whole body every time the declared state moved.
+                var resumeCost = resume is null ? 0 : resume.Length + ResumeFieldOverhead;
+                if (DiffMode == LiveDiffMode.Forced || _writeBuffer.WrittenCount - resumeCost < html.Length)
                 {
                     usedDiff = true;
                 }
@@ -314,7 +342,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
             // Full-HTML path (first render, structural change, out-of-band side effect, size fallback):
             // this ships the whole body anyway, so materialising it as a string here is not wasted.
             LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, new string(html.Span), sessionId, historyUrl,
-                replace, auth, download, jsInvokes);
+                replace, auth, download, jsInvokes, resume);
             // Keep the cache in lockstep with the client even when shipping full HTML: promote
             // current → previous so the NEXT diff's baseline matches what the client received. Skip
             // when TryComputeDiff already rotated (diffPathEntered), or when the caller defers the

--- a/src/Rask.Core/Live/PersistentState.cs
+++ b/src/Rask.Core/Live/PersistentState.cs
@@ -1,0 +1,202 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+using Rask.Core.Diagnostics;
+
+namespace Rask.Core.Live;
+
+/// <summary>
+///     The per-session <see cref="IPersistentState" /> bag. Scoped: one instance per live session, resolved
+///     from that session's DI scope alongside <c>RouteState</c> and the rest.
+/// </summary>
+/// <remarks>
+///     Values are held as UTF-8 JSON rather than as objects. That costs a serialize on write, and buys two
+///     things the object form can't: the bag is already in its wire shape when the handoff record is built
+///     (no walk over live objects at shutdown, when there is least time to spare), and a value whose type
+///     changed between deploys fails to read back as a miss instead of poisoning the whole record.
+/// </remarks>
+internal sealed class PersistentState : IPersistentState
+{
+    internal const string TrimWarning =
+        "Persisted state is serialized with reflection-based System.Text.Json. Use the JsonTypeInfo<T> overloads in a trimmed or AOT app.";
+
+    /// <summary>
+    ///     Total budget across keys and values. The bag rides the wire inside a protected token, so this is
+    ///     a wire-size bound, not a memory one — 16 KB of JSON is already a large thing to push through a
+    ///     reconnect, and a page needing more than that is describing its data rather than its state.
+    /// </summary>
+    internal const int DefaultMaxBytes = 16 * 1024;
+
+    // Web defaults (camelCase) to match every other JSON surface the framework writes.
+    private static readonly JsonSerializerOptions SerializerOptions = new(JsonSerializerDefaults.Web);
+
+    private readonly Dictionary<string, byte[]> _entries = new(StringComparer.Ordinal);
+
+    /// <summary>Bytes currently accounted for — every key's UTF-8 length plus its value's.</summary>
+    private int _bytes;
+
+    internal int MaxBytes { get; set; } = DefaultMaxBytes;
+
+    /// <summary>
+    ///     Bumped on every mutation. The handoff layer keeps the last version it issued a token for, so an
+    ///     idle session never re-signs and re-sends a record that hasn't moved.
+    /// </summary>
+    internal int Version { get; private set; }
+
+    /// <summary>
+    ///     Set once the bag has grown past <see cref="MaxBytes" />, and never cleared by a later shrink —
+    ///     a session that was ever over budget stays unresumable for its lifetime rather than flickering
+    ///     between resumable and not as keys come and go.
+    /// </summary>
+    internal bool Overflowed { get; private set; }
+
+    /// <summary>The raw bag, for the handoff layer to serialize. Not a copy — do not mutate.</summary>
+    internal IReadOnlyDictionary<string, byte[]> Entries => _entries;
+
+    [RequiresUnreferencedCode(TrimWarning)]
+    [RequiresDynamicCode(TrimWarning)]
+    public void Persist<T>(string key, T value) =>
+        Store(key, JsonSerializer.SerializeToUtf8Bytes(value, SerializerOptions));
+
+    public void Persist<T>(string key, T value, JsonTypeInfo<T> typeInfo)
+    {
+        ArgumentNullException.ThrowIfNull(typeInfo);
+        Store(key, JsonSerializer.SerializeToUtf8Bytes(value, typeInfo));
+    }
+
+    [RequiresUnreferencedCode(TrimWarning)]
+    [RequiresDynamicCode(TrimWarning)]
+    public bool TryGet<T>(string key, out T? value)
+    {
+        if (!TryReadBytes(key, out var bytes))
+        {
+            value = default;
+            return false;
+        }
+
+        try
+        {
+            value = JsonSerializer.Deserialize<T>(bytes, SerializerOptions);
+            return true;
+        }
+        catch (JsonException)
+        {
+            value = default;
+            return false;
+        }
+    }
+
+    public bool TryGet<T>(string key, JsonTypeInfo<T> typeInfo, out T? value)
+    {
+        ArgumentNullException.ThrowIfNull(typeInfo);
+        if (!TryReadBytes(key, out var bytes))
+        {
+            value = default;
+            return false;
+        }
+
+        try
+        {
+            value = JsonSerializer.Deserialize(bytes, typeInfo);
+            return true;
+        }
+        catch (JsonException)
+        {
+            value = default;
+            return false;
+        }
+    }
+
+    public bool Remove(string key)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        if (!_entries.TryGetValue(key, out var existing))
+        {
+            return false;
+        }
+
+        _bytes -= EntryCost(key, existing.Length);
+        _entries.Remove(key);
+        Version++;
+        return true;
+    }
+
+    public void Clear()
+    {
+        if (_entries.Count == 0)
+        {
+            return;
+        }
+
+        _entries.Clear();
+        _bytes = 0;
+        Version++;
+    }
+
+    /// <summary>
+    ///     Seeds the bag from a handoff record on a rebuild. Deliberately not a public API: the app writes
+    ///     through <see cref="Persist{T}(string,T)" /> and reads through <see cref="TryGet{T}(string,out T)" />;
+    ///     only the framework restores. Resets the version so the freshly-seeded session doesn't immediately
+    ///     re-issue a token for state it was just handed.
+    /// </summary>
+    internal void Restore(IEnumerable<KeyValuePair<string, byte[]>> entries)
+    {
+        _entries.Clear();
+        _bytes = 0;
+        foreach (var (key, value) in entries)
+        {
+            _entries[key] = value;
+            _bytes += EntryCost(key, value.Length);
+        }
+
+        Overflowed = _bytes > MaxBytes;
+        Version = 0;
+    }
+
+    private void Store(string key, byte[] payload)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+
+        var previous = _entries.TryGetValue(key, out var existing) ? EntryCost(key, existing.Length) : 0;
+        _entries[key] = payload;
+        _bytes += EntryCost(key, payload.Length) - previous;
+        Version++;
+
+        if (_bytes <= MaxBytes || Overflowed)
+        {
+            return;
+        }
+
+        // Keep the write. Refusing it would lose state the app believes it stored, and throwing would turn
+        // a size budget into an exception at an arbitrary call site. Instead the session gives up its
+        // resume token and falls back to the reload it would have had without any of this — a degradation,
+        // not a failure. Deduped on a constant key: this is a property of the app's code, not of one
+        // session, and a per-session key would exhaust the shared ReportOnce cap under load.
+        Overflowed = true;
+        var bytes = _bytes;
+        var max = MaxBytes;
+        RaskDiagnostics.ReportOnce(
+            "persistentstate:overflow",
+            RaskLogLevel.Warning,
+            "Rask.Live",
+            () => $"Persisted state is {bytes} bytes, over the {max}-byte budget, so affected sessions "
+                  + "will not be resumable and will reload instead. Persist identifiers and selections "
+                  + "rather than the data they resolve to.");
+    }
+
+    // Both TryGet overloads swallow JsonException on the read. The bytes came from this app's own protected
+    // token, so a failure here is not tampering (that is rejected before we get here) — it is a deploy that
+    // changed the shape of a persisted type while a token written by the previous version was still in
+    // flight. Reading it as a miss lets the page rebuild with a default instead of throwing out of user
+    // code during a reconnect.
+    private bool TryReadBytes(string key, out byte[] bytes)
+    {
+        ArgumentException.ThrowIfNullOrEmpty(key);
+        return _entries.TryGetValue(key, out bytes!);
+    }
+
+    // Keys ride the wire alongside their values, so they count. Without this, many tiny keys would pass a
+    // value-only budget while producing a token far larger than it allows.
+    private static int EntryCost(string key, int valueLength) => Encoding.UTF8.GetByteCount(key) + valueLength;
+}

--- a/src/Rask.Native/NativeAppHost.cs
+++ b/src/Rask.Native/NativeAppHost.cs
@@ -51,6 +51,11 @@ public sealed class NativeAppHost
         Services.AddLogging();
         Services.AddSingleton<RouteState>();
         Services.AddSingleton<Navigator>();
+        // The declared state bag. Singleton for the same reason RouteState is (one session per app), and
+        // registered here so a component shared with the server host resolves on both. Nothing carries it
+        // anywhere on native — there is no server-side session to rebuild.
+        Services.AddSingleton<PersistentState>();
+        Services.AddSingleton<IPersistentState>(sp => sp.GetRequiredService<PersistentState>());
         // Singleton = one queue for the app instance (the whole native app is a single session), so a
         // message queued before a NavigateTo survives it. Same model as WasmHostBuilder.
         Services.AddSingleton<IToaster, Toaster>();

--- a/src/Rask.Server/Diagnostics/RaskMetrics.cs
+++ b/src/Rask.Server/Diagnostics/RaskMetrics.cs
@@ -17,6 +17,8 @@ namespace Rask.Server.Diagnostics;
 public sealed class RaskMetrics : IDisposable
 {
     private readonly Counter<long> _framesRejected;
+    private readonly Counter<long> _sessionsResumed;
+    private readonly Counter<long> _sessionsResumeRejected;
     private readonly Counter<long> _handlersDispatched;
     private readonly Counter<long> _handlersFaulted;
     private readonly Counter<long> _handlersTimedOut;
@@ -52,6 +54,10 @@ public sealed class RaskMetrics : IDisposable
             "rask.handler.duration", "ms", "Wall-clock duration of an event-handler dispatch.");
         _framesRejected = _meter.CreateCounter<long>(
             "rask.ws.frames.rejected", "{frame}", "Inbound WebSocket frames rejected by a safety limit.");
+        _sessionsResumed = _meter.CreateCounter<long>(
+            "rask.sessions.resumed", "{session}", "Sessions rebuilt from a client's resume record.");
+        _sessionsResumeRejected = _meter.CreateCounter<long>(
+            "rask.sessions.resume_rejected", "{session}", "Resume records refused, tagged with the reason.");
     }
 
     // Exposed for tests so a MeterListener can scope to this exact meter instance and ignore
@@ -86,4 +92,21 @@ public sealed class RaskMetrics : IDisposable
     /// </summary>
     public void FrameRejected(string reason) =>
         _framesRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+
+    /// <summary>Counts a page rebuilt on a host that had never heard of the session, from the client's record.</summary>
+    public void SessionResumed() => _sessionsResumed.Add(1);
+
+    /// <summary>
+    ///     Counts a resume record the host refused, tagged with why: <c>malformed</c> (not a record this
+    ///     code wrote), <c>unprotect</c> (tampered, expired, or sealed under a key ring this host does not
+    ///     have — the last of which is what an unpersisted key ring looks like after a redeploy),
+    ///     <c>principal</c> (issued to a different user), <c>toolarge</c>, or <c>atcapacity</c>
+    ///     (<c>MaxSessions</c> reached, so the rebuild shed like any other new session).
+    ///     <para>
+    ///         A steady trickle is normal — expired records from closed laptops. A spike on
+    ///         <c>unprotect</c> right after a deploy means the key ring is not surviving the deploy.
+    ///     </para>
+    /// </summary>
+    public void ResumeRejected(string reason) =>
+        _sessionsResumeRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
 }

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -1,5 +1,6 @@
 using System.Buffers;
 using System.Net.WebSockets;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,6 +10,7 @@ using Rask.Core.Authentication;
 using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 using Rask.Core.Routing;
+using Rask.Server.Authentication;
 using Rask.Server.Files;
 using Rask.Server.JSInterop;
 
@@ -98,6 +100,14 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // (children reconcile by (Type, position), not Key, so a same-position page instance is reused and
     // its OnMountAsync never re-runs — leaving data loaded for the old identity/tenant).
     public string? PendingAuthNavigation { get; set; }
+
+    // What the client's current resume record was built from. -1 means it has none, so the first payload
+    // always carries one. The URL is tracked alongside the version because a navigation moves the page
+    // without touching the bag: version alone would leave the client holding a record that rebuilds the
+    // route they were on two pages ago. Touched only from TakeResumeToken, which WritePayload calls under
+    // the render lock.
+    private int _lastResumeVersion = -1;
+    private string? _lastResumeUrl;
 
     public string Id { get; }
     public IServiceScope Scope { get; }
@@ -191,6 +201,60 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     }
 
     protected override Task RenderInScopeCoreAsync() => RenderAndSendAsync(null, false);
+
+    /// <summary>
+    ///     Seals a resume record for this session when the page has moved since the last one.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         This is the only host that overrides it: a server session can outlive neither a restart nor
+    ///         a redeploy, so the client has to be able to hand its page back to whatever process answers
+    ///         next. Riding the render payload rather than its own frame means a handler that writes twenty
+    ///         keys produces one record, and a render that changed nothing produces none.
+    ///     </para>
+    ///     <para>
+    ///         A session whose bag has overflowed its budget is skipped — it has declared itself
+    ///         unresumable, and a record it can never redeem is wire cost for nothing.
+    ///     </para>
+    /// </remarks>
+    protected override string? TakeResumeToken()
+    {
+        if (_disposed || Scope.ServiceProvider.GetService<SessionResumeSupport>()?.Protector is not { } protector)
+        {
+            return null;
+        }
+
+        var state = Scope.ServiceProvider.GetRequiredService<PersistentState>();
+        if (state.Overflowed)
+        {
+            return null;
+        }
+
+        var route = Scope.ServiceProvider.GetRequiredService<RouteState>();
+        var url = QueryString.Build(route.Path, route.Query);
+        if (state.Version == _lastResumeVersion && string.Equals(url, _lastResumeUrl, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Mark issued before attempting the seal, not after: a protector that throws will throw again on
+        // the next render too, and retrying it per frame would turn a broken key ring into a per-render
+        // cost for a record that is never going to be produced.
+        _lastResumeVersion = state.Version;
+        _lastResumeUrl = url;
+
+        try
+        {
+            return protector.Protect(
+                url, Scope.ServiceProvider.GetRequiredService<SessionUserProvider>().Current, state.Entries);
+        }
+        catch (CryptographicException)
+        {
+            // No usable key ring (unwritable directory, revoked keys). Resume simply doesn't happen on this
+            // host; it must not take the render down with it.
+            return null;
+        }
+    }
 
     protected override async Task RequestRenderInternalAsync(bool publishOnly)
     {

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -5,10 +5,12 @@ using System.Globalization;
 using System.Net.WebSockets;
 using System.Reflection.Metadata;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -63,6 +65,7 @@ public static class RaskEndpointExtensions
     // serializer call threw at static-init and crashed UseRask before the host could start.
     private static readonly byte[] SessionUnknownPayload =
         Encoding.UTF8.GetBytes("""{"type":"session","status":"unknown"}""");
+
 
     // 50ms trailing-edge debounce for ScopedAssetRegistry.AssetChanged. A multi-file edit
     // (or a single hot-reload UpdateApplication burst that re-registers every component
@@ -147,6 +150,30 @@ public static class RaskEndpointExtensions
         }
 
         services.AddSingleton(RaskServerLimits.From(serverOptions));
+
+        // Seals the record a client carries from one session to the next. Live only when the host has Data
+        // Protection (WebApplication.CreateBuilder does; a hand-rolled host might not) AND resume is on —
+        // absent either, a reconnect to an unknown session falls back to the reload it did before rather
+        // than failing the host at startup. Note this is what makes a persisted key ring load-bearing: with
+        // the default per-container ring, a record sealed before a redeploy cannot be opened after it.
+        var resumeEnabled = serverOptions.SessionResume;
+        var resumeLifetime = serverOptions.ResumeTokenLifetime;
+        if (resumeEnabled)
+        {
+            // Ask for Data Protection rather than assuming it. WebApplication.CreateBuilder does NOT
+            // register it — it arrives only because something else pulled it in (antiforgery, cookie auth,
+            // session), which an app with none of those does not have. The call is idempotent and
+            // additive, exactly as ASP.NET's own components use it: an app that configures the key ring
+            // itself (the PersistKeysToFileSystem `rask new` scaffolds) is configuring this same instance.
+            services.AddDataProtection();
+        }
+
+        services.TryAddSingleton(sp =>
+        {
+            var provider = resumeEnabled ? sp.GetService<IDataProtectionProvider>() : null;
+            return new SessionResumeSupport(
+                provider is null ? null : new SessionHandoffProtector(provider, resumeLifetime));
+        });
 
         // Metrics singleton (Meter "Rask.Server"). TryAdd so a host can pre-register its own.
         services.TryAddSingleton<RaskMetrics>();
@@ -270,7 +297,16 @@ public static class RaskEndpointExtensions
         var pathBaseNormalized = RaskPath.Normalize(pathBase);
         LiveOptions.PathBase = pathBaseNormalized;
 
-        EnsureRuntimeMapped(endpoints, pathBaseNormalized);
+        // How a session's tree is built, captured once here because two call sites need it: the GET that
+        // mints a session, and the WebSocket that rebuilds one from a resume record. Wrapping the App in an
+        // implicit RootErrorBoundary means an uncaught render / lifecycle / event-handler exception
+        // anywhere in the user's tree renders a styled fallback page instead of an HTTP 500. Declared in
+        // this generic method so TApp's DynamicallyAccessedMembers annotation flows into the closure —
+        // EnsureRuntimeMapped is deliberately non-generic (its double-map guard is per host, not per TApp).
+        Func<IServiceProvider, Component> appFactory =
+            sp => new RootErrorBoundary(ActivatorUtilities.CreateInstance<TApp>(sp));
+
+        EnsureRuntimeMapped(endpoints, pathBaseNormalized, appFactory);
 
         // Scope the catch-all SPA route under the prefix when set. The pattern
         // default ("/{**path}") is interpreted relative to the prefix root, so
@@ -310,14 +346,7 @@ public static class RaskEndpointExtensions
             // built so untrusted GET traffic can't exhaust memory (and a concurrent burst can't
             // race past the cap). Checked after the auth guard above so challenge/forbid
             // redirects (which create no session) still work.
-            var session = store.TryCreate(sp =>
-            {
-                // Wrap the App in an implicit RootErrorBoundary so an uncaught render /
-                // lifecycle / event-handler exception anywhere in the user's tree renders a
-                // styled fallback page instead of an HTTP 500.
-                var app = ActivatorUtilities.CreateInstance<TApp>(sp);
-                return new RootErrorBoundary(app);
-            });
+            var session = store.TryCreate(appFactory);
             if (session is null)
             {
                 httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
@@ -410,7 +439,8 @@ public static class RaskEndpointExtensions
         return new QueryCollection(dict);
     }
 
-    private static void EnsureRuntimeMapped(IEndpointRouteBuilder endpoints, string pathBase)
+    private static void EnsureRuntimeMapped(
+        IEndpointRouteBuilder endpoints, string pathBase, Func<IServiceProvider, Component> appFactory)
     {
         var marker = endpoints.ServiceProvider.GetRequiredService<RaskLiveMarker>();
         if (marker.RuntimeMapped)
@@ -461,7 +491,9 @@ public static class RaskEndpointExtensions
                     new WebSocketAcceptContext { DangerousEnableCompression = true });
                 using var linked = CancellationTokenSource.CreateLinkedTokenSource(
                     ctx.RequestAborted, lifetime.ApplicationStopping);
-                await RunSocketLoop(ws, store, limits, wsUser, linked.Token, lifetime.ApplicationStopping);
+                var resume = ctx.RequestServices.GetRequiredService<SessionResumeSupport>();
+                await RunSocketLoop(ws, store, limits, wsUser, resume, appFactory, linked.Token,
+                    lifetime.ApplicationStopping);
             }));
 
         var script = LoadEmbeddedScript();
@@ -601,7 +633,8 @@ public static class RaskEndpointExtensions
     }
 
     private static async Task RunSocketLoop(WebSocket ws, LiveSessionStore store, RaskServerLimits limits,
-        ClaimsPrincipal wsUser, CancellationToken ct, CancellationToken stopping)
+        ClaimsPrincipal wsUser, SessionResumeSupport resume, Func<IServiceProvider, Component> appFactory,
+        CancellationToken ct, CancellationToken stopping)
     {
         using var abortReg = stopping.Register(() =>
         {
@@ -767,8 +800,30 @@ public static class RaskEndpointExtensions
                     session = store.Get(sessionId);
                     if (session is null)
                     {
-                        await SendSessionUnknownAsync(ws, ct).ConfigureAwait(false);
-                        return;
+                        // This host has never heard of the session. Before the resume protocol that was
+                        // the end of it — the client reloaded and the user lost their page. If the client
+                        // carries a record we can open, rebuild the page around it instead.
+                        var resumeToken =
+                            root.TryGetProperty("resume", out var rt) && rt.ValueKind == JsonValueKind.String
+                                ? rt.GetString()
+                                : null;
+
+                        session = resumeToken is null
+                            ? null
+                            : TryResumeSession(resumeToken, wsUser, resume, store, metrics, appFactory);
+
+                        if (session is null)
+                        {
+                            await SendSessionUnknownAsync(ws, ct).ConfigureAwait(false);
+                            return;
+                        }
+
+                        // The rebuilt session has a NEW id. The client learns it from the full frame below,
+                        // which re-stamps data-rask-root — see LiveSessionBase's full-payload path.
+                        session.AttachSocket(ws, ct);
+                        session.Services.GetRequiredService<SessionUserProvider>().Set(wsUser);
+                        await session.RenderAndSendAsync(null, false).ConfigureAwait(false);
+                        continue;
                     }
 
                     session.AttachSocket(ws, ct);
@@ -1141,6 +1196,56 @@ public static class RaskEndpointExtensions
         }
         catch { }
     }
+
+    /// <summary>
+    ///     Opens a resume record and builds a new session around it, or returns <c>null</c> and lets the
+    ///     caller fall back to telling the client its session is gone.
+    /// </summary>
+    /// <remarks>
+    ///     The rebuilt session is an ordinary new session in every respect — new id, new DI scope, new
+    ///     tree, and a capacity slot taken through the same atomic reservation a GET uses. That last part
+    ///     matters more than it looks: a deploy hands every connected client a record at once, so the
+    ///     reconnect storm that follows must shed against <c>MaxSessions</c> exactly like fresh traffic
+    ///     rather than walking straight past the cap.
+    /// </remarks>
+    private static LiveSession? TryResumeSession(
+        string token,
+        ClaimsPrincipal user,
+        SessionResumeSupport resume,
+        LiveSessionStore store,
+        RaskMetrics? metrics,
+        Func<IServiceProvider, Component> appFactory)
+    {
+        if (resume.Protector is not { } protector)
+        {
+            return null;
+        }
+
+        if (!protector.TryUnprotect(token, user, out var record, out var rejection))
+        {
+            metrics?.ResumeRejected(rejection.ToString().ToLowerInvariant());
+            return null;
+        }
+
+        var session = store.TryCreate(appFactory);
+        if (session is null)
+        {
+            metrics?.ResumeRejected("atcapacity");
+            return null;
+        }
+
+        // Seed the route and the declared state BEFORE the first render, so the page builds against them
+        // rather than rendering a default and then correcting itself in a second frame the user would see.
+        var (path, query) = SplitUrl(record!.Url);
+        var routeState = session.Services.GetRequiredService<RouteState>();
+        routeState.Path = path;
+        routeState.Query = query;
+        session.Services.GetRequiredService<PersistentState>().Restore(record.Entries);
+
+        metrics?.SessionResumed();
+        return session;
+    }
+
 
     private static void HandleJsResult(LiveSession session, JsonElement root)
     {

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -158,6 +158,11 @@ public static class RaskEndpointExtensions
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
+        // The declared state bag (docs/lifecycle.md). Scoped = one per live session, like RouteState. A
+        // session's component tree can't be serialized, so it can't be moved or saved; what an app names
+        // here is what survives the session being rebuilt somewhere else.
+        services.AddScoped<PersistentState>();
+        services.AddScoped<IPersistentState>(sp => sp.GetRequiredService<PersistentState>());
         // Transient user messages / toasts (a flash-message pattern). Scoped = one queue per session, so a
         // message queued before a client-side NavigateTo survives the navigation and shows once on arrival.
         services.AddScoped<IToaster, Toaster>();

--- a/src/Rask.Server/RaskServerLimits.cs
+++ b/src/Rask.Server/RaskServerLimits.cs
@@ -39,6 +39,12 @@ internal sealed class RaskServerLimits
     /// <summary>How long one outbound frame may take before the socket is aborted. Zero = off.</summary>
     public TimeSpan SendTimeout { get; init; } = TimeSpan.FromSeconds(30);
 
+    /// <summary>Whether a client may rebuild its page on a host that never knew its session. See <see cref="RaskServerOptions.SessionResume" />.</summary>
+    public bool SessionResume { get; init; } = true;
+
+    /// <summary>How long a resume record stays redeemable. See <see cref="RaskServerOptions.ResumeTokenLifetime" />.</summary>
+    public TimeSpan ResumeTokenLifetime { get; init; } = TimeSpan.FromHours(1);
+
     /// <summary>Projects a validated <see cref="RaskServerOptions" /> into the per-host limit snapshot.</summary>
     public static RaskServerLimits From(RaskServerOptions o) => new()
     {
@@ -51,5 +57,7 @@ internal sealed class RaskServerLimits
         HandlerTimeout = o.HandlerTimeout,
         MaxPendingHandlerBytes = o.MaxPendingHandlerBytes,
         SendTimeout = o.SendTimeout,
+        SessionResume = o.SessionResume,
+        ResumeTokenLifetime = o.ResumeTokenLifetime,
     };
 }

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -120,6 +120,41 @@ public sealed class RaskServerOptions
     public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
     /// <summary>
+    ///     Whether a client may rebuild its page on a host that has never heard of its session — after a
+    ///     restart, a redeploy, or (later) a reconnect routed to another node. <c>true</c> by default.
+    ///     <para>
+    ///         A live session cannot be moved or saved: it is a component tree, a DI scope and a set of
+    ///         cancellation tokens. So this does not resume anything. The server hands the client an
+    ///         encrypted record of the page's URL and whatever the app declared through
+    ///         <see cref="Rask.Core.Live.IPersistentState" />, and a host that receives it back
+    ///         <em>rebuilds</em> the page around it. Undeclared state is gone either way — but the user
+    ///         gets their page back instead of the "session timed out, reload" they get today.
+    ///     </para>
+    ///     <para>
+    ///         Worth having even for an app that declares nothing: the URL alone turns a deploy's
+    ///         full-page reload into a re-render. Turn it off to keep the reload — the record rides the
+    ///         socket, so an app whose pages are expensive to build may prefer the reload's clean slate.
+    ///     </para>
+    /// </summary>
+    public bool SessionResume { get; set; } = true;
+
+    /// <summary>
+    ///     How long a resume record stays redeemable. Default 1 hour.
+    ///     <para>
+    ///         This is not the reconnect grace period (<see cref="SessionGracePeriod" />, 30 s), which
+    ///         covers a blip against the <em>intact</em> session. This covers the session being gone:
+    ///         a laptop that slept through a deploy, a tunnel that dropped for twenty minutes. The record
+    ///         is encrypted and signed, bound to the principal it was issued for, and lives in the tab's
+    ///         <c>sessionStorage</c>, so it dies with the tab regardless.
+    ///     </para>
+    ///     <para>
+    ///         Enforced by ASP.NET's time-limited data protector rather than a field we check ourselves,
+    ///         so an expired record fails to unprotect at all.
+    ///     </para>
+    /// </summary>
+    public TimeSpan ResumeTokenLifetime { get; set; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     ///     Throws <see cref="ArgumentOutOfRangeException" /> if any value is out of range. Called by
     ///     <c>AddRask</c> after the caller's <c>configureServer</c> runs, so a bad value (a negative
     ///     grace period that would crash <c>Task.Delay</c> and leak the session, a non-positive
@@ -188,6 +223,15 @@ public sealed class RaskServerOptions
             throw new ArgumentOutOfRangeException(
                 nameof(SendTimeout), SendTimeout,
                 "SendTimeout must be >= TimeSpan.Zero (Zero disables the timeout).");
+        }
+
+        // Zero is not "off" here — SessionResume is. A zero or negative lifetime would mint records that
+        // are already expired, so every reconnect would pay to build one and then be refused it.
+        if (SessionResume && ResumeTokenLifetime <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ResumeTokenLifetime), ResumeTokenLifetime,
+                "ResumeTokenLifetime must be positive. Set SessionResume = false to disable resume.");
         }
     }
 }

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -79,7 +79,44 @@
         return b + url.slice(1);
     }
 
-    const sessionId = root.getAttribute("data-rask-root");
+    // Not a constant: when the server rebuilds this page from a resume record it does so as a NEW
+    // session, and tells us by re-stamping data-rask-root on the document it sends back. Treating the
+    // id as derived from the document rather than as a value read once at startup means the next
+    // reconnect claims the session we actually have.
+    let sessionId = root.getAttribute("data-rask-root");
+
+    // The sealed record that lets a server which has never heard of this session rebuild the page
+    // anyway — after a restart, a redeploy, or (later) a reconnect routed to another node. Opaque
+    // here: it is encrypted and signed by the server, and we only ever hand it back. Mirrored into
+    // sessionStorage so a plain F5 resumes too, and keyed by the storage key alone because
+    // sessionStorage is already scoped to this tab and origin. It dies with the tab, which is the
+    // lifetime we want — a record is state, not a credential, and never outlives the browsing session.
+    const RESUME_STORAGE_KEY = "rask.resume";
+    let resumeToken = null;
+    try {
+        resumeToken = sessionStorage.getItem(RESUME_STORAGE_KEY);
+    } catch (err) {
+        // Storage can throw outright in a partitioned or cookie-blocked context. Resume then works
+        // for a reconnect (the token still lives in memory) but not across an F5. Not worth failing over.
+    }
+
+    function rememberResumeToken(token) {
+        resumeToken = token;
+        try {
+            sessionStorage.setItem(RESUME_STORAGE_KEY, token);
+        } catch (err) {
+            // See above — memory-only is a working degradation.
+        }
+    }
+
+    function forgetResumeToken() {
+        resumeToken = null;
+        try {
+            sessionStorage.removeItem(RESUME_STORAGE_KEY);
+        } catch (err) {
+        }
+    }
+
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
     const baseWsUrl = proto + "//" + location.host + prependBase("/rask/ws");
 
@@ -159,7 +196,13 @@
             open = true;
             attempt = 0;
             suppressEvents = false;
-            ws.send(JSON.stringify({type: "hello", session: sessionId}));
+            // The resume record rides along so a server that doesn't know this session can rebuild the
+            // page instead of telling us to reload. A server that DOES know it ignores the field
+            // entirely — the intact session is always the better outcome, and is what a normal
+            // reconnect within the grace period gets.
+            const hello = {type: "hello", session: sessionId};
+            if (resumeToken) hello.resume = resumeToken;
+            ws.send(JSON.stringify(hello));
             for (const m of queue) ws.send(m);
             queue.length = 0;
             // Auth reconnect completed — restore the default message for any future drop.
@@ -183,7 +226,19 @@
                 return;
             }
             if (data.type === "session" && data.status === "unknown") {
+                // The server could not rebuild us — either we carried no record, or it refused the one
+                // we had (expired, issued to another user, or sealed under a key ring this host does not
+                // have). Drop it: replaying a record the server has already refused just fails again on
+                // every future reconnect, and keeps a stale page's state alive across the reload.
+                forgetResumeToken();
                 showSessionExpired();
+                return;
+            }
+            // A fresh sealed record. Purely something to hold: it changes nothing on screen, and must
+            // not fall through to applyFullReply, which would morph the document against a frame that
+            // carries no html.
+            if (data.type === "resume") {
+                if (typeof data.token === "string") rememberResumeToken(data.token);
                 return;
             }
             // Dev-only: the coordinator finished applying an edit and every session has repainted.
@@ -835,6 +890,13 @@
             if (freshHtml) {
                 morph(document.documentElement, freshHtml);
                 root = document.querySelector("[data-rask-root]") || root;
+                // Every full frame re-stamps data-rask-root, so this is where a rebuilt session's NEW
+                // id arrives — the server answered our hello by building a fresh session around the
+                // resume record rather than by finding the one we asked for. Following the document
+                // keeps the next reconnect pointed at the session we actually have; without it we would
+                // keep claiming an id no server will ever know again.
+                const stamped = root && root.getAttribute("data-rask-root");
+                if (stamped) sessionId = stamped;
                 // Pick up any newly-inserted Head-declared external assets (e.g., a
                 // page-specific Script in Component.Head) so their load events feed the gate.
                 scanHeadAssets();

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -234,13 +234,6 @@
                 showSessionExpired();
                 return;
             }
-            // A fresh sealed record. Purely something to hold: it changes nothing on screen, and must
-            // not fall through to applyFullReply, which would morph the document against a frame that
-            // carries no html.
-            if (data.type === "resume") {
-                if (typeof data.token === "string") rememberResumeToken(data.token);
-                return;
-            }
             // Dev-only: the coordinator finished applying an edit and every session has repainted.
             // Purely an indicator — the DOM was already updated by the render that preceded this
             // frame, so it must NOT fall through to applyFullReply (which would morph the document
@@ -256,6 +249,11 @@
                 satisfySeq(data.seq);
                 return;
             }
+            // A refreshed resume record rides the render payload rather than arriving as its own
+            // frame, so it appears on both shapes below. Taken here, before either is applied: it is
+            // pure bookkeeping, changes nothing on screen, and must not wait on the render queue —
+            // a drop between now and the paint should still leave us holding the newer record.
+            if (typeof data.resume === "string") rememberResumeToken(data.resume);
             // Diff-mode payload (kind:"diff"): apply ops directly against the live DOM.
             // Both render paths chain through _renderQueue so a diff that defers its body
             // for a scoped-CSS load (see applyDiffReply) can't be overtaken by the next

--- a/src/Rask.Server/SessionHandoff.cs
+++ b/src/Rask.Server/SessionHandoff.cs
@@ -1,0 +1,258 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using Microsoft.AspNetCore.DataProtection;
+
+namespace Rask.Server;
+
+/// <summary>What a host needs to rebuild a page it has never seen: where it was, and what the app declared.</summary>
+/// <param name="Url">The path + query the session was on, in the shape <c>SplitUrl</c> parses.</param>
+/// <param name="Entries">The <see cref="Rask.Core.Live.IPersistentState" /> bag, still as UTF-8 JSON.</param>
+internal sealed record SessionHandoffRecord(string Url, IReadOnlyList<KeyValuePair<string, byte[]>> Entries);
+
+/// <summary>
+///     Whether this host can seal and open resume records, resolved once at startup.
+/// </summary>
+/// <remarks>
+///     A holder rather than a nullable registration: a DI factory that returns <c>null</c> throws on
+///     resolve, and inspecting the service collection for <c>IDataProtectionProvider</c> would make the
+///     outcome depend on whether <c>AddRask</c> ran before or after the host registered it. This is always
+///     resolvable and carries the answer inside, so the endpoint asks once and branches.
+/// </remarks>
+internal sealed class SessionResumeSupport
+{
+    internal SessionResumeSupport(SessionHandoffProtector? protector) => Protector = protector;
+
+    /// <summary>The protector, or <c>null</c> when resume is off or the host has no Data Protection.</summary>
+    internal SessionHandoffProtector? Protector { get; }
+
+    internal bool Enabled => Protector is not null;
+}
+
+/// <summary>Why a resume record was refused. Rides the <c>rask.sessions.resume_rejected</c> metric as a tag.</summary>
+internal enum ResumeRejection
+{
+    None,
+    Malformed,
+    Unprotect,
+    Principal,
+    TooLarge,
+    AtCapacity
+}
+
+/// <summary>
+///     Seals and opens the record a client carries between one live session and the next.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The record goes to the browser, so it is encrypted and authenticated with ASP.NET Data
+///         Protection under its own purpose — an app's other protected payloads can neither read it nor be
+///         read by it. Expiry is delegated to <see cref="ITimeLimitedDataProtector" /> rather than carried
+///         as a field we remember to check: an expired record then fails to open at all, instead of relying
+///         on a comparison at one call site.
+///     </para>
+///     <para>
+///         <b>The record is not a credential and must never become one.</b> It carries no principal and no
+///         claims; a reconnect authenticates exactly as it does today, from the cookie or bearer token on
+///         the WebSocket handshake. What the record does carry is the identity it was <em>issued</em> to,
+///         as a keyed hash — so a record cannot be replayed onto a different account, and signing out and
+///         back in as someone else cannot inherit the previous user's page. The hash is keyed by the data
+///         protector itself, so the stored value discloses nothing about the user.
+///     </para>
+///     <para>
+///         Payload is a length-prefixed binary frame rather than JSON: the bag's values are already UTF-8
+///         JSON, and nesting them in an outer JSON document would mean base64-ing every one of them —
+///         about a third more bytes on a wire we are trying to keep cheap.
+///     </para>
+/// </remarks>
+internal sealed class SessionHandoffProtector
+{
+    /// <summary>Data-protection purpose. Versioned: changing the payload shape means changing this string.</summary>
+    internal const string Purpose = "Rask.LiveSession.Resume.v1";
+
+    /// <summary>
+    ///     Refuse an oversized token before spending anything on it. Base64 of a protected 16 KB bag plus
+    ///     its URL lands well under this; the cap exists so a client cannot make us allocate megabytes by
+    ///     sending a long string that was never going to open.
+    /// </summary>
+    internal const int MaxTokenChars = 64 * 1024;
+
+    private const byte FormatVersion = 1;
+
+    private readonly ITimeLimitedDataProtector _protector;
+    private readonly TimeSpan _lifetime;
+
+    internal SessionHandoffProtector(IDataProtectionProvider provider, TimeSpan lifetime)
+    {
+        _protector = provider.CreateProtector(Purpose).ToTimeLimitedDataProtector();
+        _lifetime = lifetime;
+    }
+
+    /// <summary>
+    ///     Seals a record for <paramref name="user" />. The returned string is safe to hand to the browser.
+    /// </summary>
+    internal string Protect(string url, ClaimsPrincipal? user, IReadOnlyDictionary<string, byte[]> entries)
+    {
+        using var buffer = new MemoryStream();
+        using (var writer = new BinaryWriter(buffer, Encoding.UTF8, leaveOpen: true))
+        {
+            writer.Write(FormatVersion);
+            writer.Write(url);
+            var binding = UserBinding(user);
+            writer.Write(binding.Length);
+            writer.Write(binding);
+            writer.Write(entries.Count);
+            foreach (var (key, value) in entries)
+            {
+                writer.Write(key);
+                writer.Write(value.Length);
+                writer.Write(value);
+            }
+        }
+
+        return Convert.ToBase64String(_protector.Protect(buffer.ToArray(), _lifetime));
+    }
+
+    /// <summary>
+    ///     Opens a record and checks it belongs to <paramref name="user" />. Returns <c>false</c> with a
+    ///     reason for every failure — nothing here throws at the caller, because every input is attacker-
+    ///     controlled and a refusal is an ordinary outcome, not an error.
+    /// </summary>
+    internal bool TryUnprotect(
+        string token,
+        ClaimsPrincipal? user,
+        out SessionHandoffRecord? record,
+        out ResumeRejection rejection)
+    {
+        record = null;
+
+        if (token.Length > MaxTokenChars)
+        {
+            rejection = ResumeRejection.TooLarge;
+            return false;
+        }
+
+        byte[] plaintext;
+        try
+        {
+            plaintext = _protector.Unprotect(Convert.FromBase64String(token));
+        }
+        catch (FormatException)
+        {
+            // Not base64 at all.
+            rejection = ResumeRejection.Malformed;
+            return false;
+        }
+        catch (CryptographicException)
+        {
+            // Tampered, expired, or sealed under a key ring this host doesn't have. Deliberately one
+            // outcome: telling a client which of those it was is telling an attacker how close they got.
+            rejection = ResumeRejection.Unprotect;
+            return false;
+        }
+
+        try
+        {
+            using var buffer = new MemoryStream(plaintext, writable: false);
+            using var reader = new BinaryReader(buffer, Encoding.UTF8, leaveOpen: true);
+
+            if (reader.ReadByte() != FormatVersion)
+            {
+                // A record written by a different shape of this code. Nothing to salvage: refuse and let
+                // the client reload, which is what it would have done before any of this existed.
+                rejection = ResumeRejection.Malformed;
+                return false;
+            }
+
+            var url = reader.ReadString();
+
+            var bindingLength = reader.ReadInt32();
+            if (bindingLength is < 0 or > 64)
+            {
+                rejection = ResumeRejection.Malformed;
+                return false;
+            }
+
+            var boundUser = reader.ReadBytes(bindingLength);
+            if (boundUser.Length != bindingLength)
+            {
+                rejection = ResumeRejection.Malformed;
+                return false;
+            }
+
+            // FixedTimeEquals handles the length-mismatch case (anonymous record vs authenticated
+            // reconnect, and the reverse) as a plain false rather than an early return that leaks which.
+            if (!CryptographicOperations.FixedTimeEquals(boundUser, UserBinding(user)))
+            {
+                rejection = ResumeRejection.Principal;
+                return false;
+            }
+
+            var count = reader.ReadInt32();
+            if (count < 0)
+            {
+                rejection = ResumeRejection.Malformed;
+                return false;
+            }
+
+            var entries = new List<KeyValuePair<string, byte[]>>(Math.Min(count, 64));
+            for (var i = 0; i < count; i++)
+            {
+                var key = reader.ReadString();
+                var length = reader.ReadInt32();
+                if (length < 0)
+                {
+                    rejection = ResumeRejection.Malformed;
+                    return false;
+                }
+
+                // ReadBytes returns short rather than throwing at EOF, so a truncated record would
+                // otherwise restore silently-empty values.
+                var value = reader.ReadBytes(length);
+                if (value.Length != length)
+                {
+                    rejection = ResumeRejection.Malformed;
+                    return false;
+                }
+
+                entries.Add(new KeyValuePair<string, byte[]>(key, value));
+            }
+
+            record = new SessionHandoffRecord(url, entries);
+            rejection = ResumeRejection.None;
+            return true;
+        }
+        catch (Exception ex) when (ex is EndOfStreamException or IOException or OutOfMemoryException)
+        {
+            // The plaintext opened, so it was written by this app under this key ring — a shape it can't
+            // parse means a bug or a format skew, not an attack. Refuse the same way regardless.
+            rejection = ResumeRejection.Malformed;
+            return false;
+        }
+    }
+
+    /// <summary>
+    ///     A stable, non-reversible stand-in for "who this record was issued to". Anonymous sessions bind
+    ///     to an empty binding, so an anonymous record can be redeemed only while still anonymous — signing
+    ///     in mid-session invalidates it, which is the safe direction.
+    /// </summary>
+    /// <remarks>
+    ///     A plain hash rather than anything keyed, for one hard reason: the binding must come out the same
+    ///     on a <em>different process</em> from the one that issued it, which is the entire point of the
+    ///     record. Data Protection is deliberately non-deterministic — protecting the same id twice gives
+    ///     different bytes — so it cannot be used to derive this, and a per-process key would refuse every
+    ///     record that crossed a restart. The hash is safe here because it never leaves the encrypted
+    ///     envelope: reading it already requires the key ring, and anyone holding that can forge records
+    ///     outright. Domain-separated so it can't be confused with a hash the app computes elsewhere.
+    /// </remarks>
+    private static byte[] UserBinding(ClaimsPrincipal? user)
+    {
+        var id = user?.Identity?.IsAuthenticated == true
+            ? user.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? user.Identity.Name
+            : null;
+
+        return string.IsNullOrEmpty(id)
+            ? []
+            : SHA256.HashData(Encoding.UTF8.GetBytes("Rask.Resume.User " + id));
+    }
+}

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -30,6 +30,12 @@ public sealed class WasmHostBuilder
         Services = new ServiceCollection();
         Services.AddLogging();
         Services.AddSingleton<RouteState>();
+        // The declared state bag. Singleton here for the same reason RouteState is: the whole WASM app is a
+        // single session. It works exactly as it does on the server — what differs is that nothing carries
+        // it anywhere, because a WASM app has no server-side session to rebuild. Registered so a component
+        // shared between the two hosts resolves on both instead of failing DI only on this one.
+        Services.AddSingleton<PersistentState>();
+        Services.AddSingleton<IPersistentState>(sp => sp.GetRequiredService<PersistentState>());
         Services.AddSingleton<IBrowserFileBackend, WasmFileBackend>();
         Services.AddSingleton<IDownloadSink, WasmDownloadSink>();
         Services.AddSingleton<Navigator>();

--- a/tests/Rask.Core.Tests/Live/PersistentStateTests.cs
+++ b/tests/Rask.Core.Tests/Live/PersistentStateTests.cs
@@ -1,0 +1,295 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Rask.Core.Diagnostics;
+using Rask.Core.Live;
+
+namespace Rask.Core.Tests.Live;
+
+public sealed partial class PersistentStateTests
+{
+    private sealed record Filter(string Term, int Page);
+
+    private sealed record Page(int Number);
+
+    // The same key's record with a property renamed — what a deploy that edited a persisted type in place
+    // looks like to a token written by the previous version.
+    private sealed record RenamedFilter(string Query, int Page);
+
+    [Fact]
+    public void Round_trips_a_value()
+    {
+        var state = new PersistentState();
+
+        state.Persist("filter", new Filter("boots", 2));
+
+        Assert.True(state.TryGet<Filter>("filter", out var read));
+        Assert.Equal(new Filter("boots", 2), read);
+    }
+
+    [Fact]
+    public void A_key_that_was_never_written_is_a_miss()
+    {
+        var state = new PersistentState();
+
+        Assert.False(state.TryGet<Filter>("filter", out var read));
+        Assert.Null(read);
+    }
+
+    /// <summary>
+    /// The whole point of the bag: a value written by one session is readable by the session rebuilt in its
+    /// place, without either of them sharing an object.
+    /// </summary>
+    [Fact]
+    public void A_restored_bag_reads_back_what_the_original_wrote()
+    {
+        var original = new PersistentState();
+        original.Persist("filter", new Filter("boots", 2));
+        original.Persist("tab", "reviews");
+
+        var rebuilt = new PersistentState();
+        rebuilt.Restore(original.Entries);
+
+        Assert.True(rebuilt.TryGet<Filter>("filter", out var filter));
+        Assert.Equal(new Filter("boots", 2), filter);
+        Assert.True(rebuilt.TryGet<string>("tab", out var tab));
+        Assert.Equal("reviews", tab);
+    }
+
+    /// <summary>
+    /// A deploy can change the type behind a key while a token written by the previous version is still in
+    /// a browser. JSON that cannot be read as the new type at all must come back as "no value" — never as
+    /// an exception thrown out of user code during a reconnect, which would turn a cosmetic loss into a
+    /// broken page.
+    /// </summary>
+    [Fact]
+    public void A_value_whose_type_changed_between_deploys_reads_as_a_miss()
+    {
+        var before = new PersistentState();
+        before.Persist("selection", "reviews");
+
+        var after = new PersistentState();
+        after.Restore(before.Entries);
+
+        // The key used to hold a string; this version reads it as a record. Unreadable, so: a miss.
+        Assert.False(after.TryGet<Page>("selection", out var read));
+        Assert.Null(read);
+
+        // And the session carries on — the miss is not sticky, and other keys are unaffected.
+        after.Persist("selection", new Page(3));
+        Assert.True(after.TryGet<Page>("selection", out var rewritten));
+        Assert.Equal(new Page(3), rewritten);
+    }
+
+    /// <summary>
+    /// The other half of the same story, and the one that bites quietly: a shape that is merely *different*
+    /// rather than unreadable is not a miss. System.Text.Json fills what it can't find with defaults, so a
+    /// renamed property comes back as a successfully-read object with a null in it. That is STJ's behaviour
+    /// and not something to paper over here — but it is why the docs tell you to version a persisted type by
+    /// changing its key rather than by editing it in place.
+    /// </summary>
+    [Fact]
+    public void A_renamed_property_reads_back_with_a_default_not_a_miss()
+    {
+        var before = new PersistentState();
+        before.Persist("filter", new Filter("boots", 2));
+
+        var after = new PersistentState();
+        after.Restore(before.Entries);
+
+        Assert.True(after.TryGet<RenamedFilter>("filter", out var read));
+        Assert.NotNull(read);
+        Assert.Null(read!.Query);
+        Assert.Equal(2, read.Page);
+    }
+
+    [Fact]
+    public void Remove_and_clear_drop_values()
+    {
+        var state = new PersistentState();
+        state.Persist("a", 1);
+        state.Persist("b", 2);
+
+        Assert.True(state.Remove("a"));
+        Assert.False(state.Remove("a"));
+        Assert.False(state.TryGet<int>("a", out _));
+        Assert.True(state.TryGet<int>("b", out _));
+
+        state.Clear();
+        Assert.False(state.TryGet<int>("b", out _));
+    }
+
+    /// <summary>
+    /// The handoff layer re-signs and re-sends a token only when the version moves, so an idle session must
+    /// not tick — and a write that changes nothing observable still counts as a change.
+    /// </summary>
+    [Fact]
+    public void Version_tracks_mutations_and_only_mutations()
+    {
+        var state = new PersistentState();
+        Assert.Equal(0, state.Version);
+
+        state.Persist("a", 1);
+        var afterWrite = state.Version;
+        Assert.True(afterWrite > 0);
+
+        state.TryGet<int>("a", out _);
+        Assert.Equal(afterWrite, state.Version);
+
+        state.Remove("missing");
+        Assert.Equal(afterWrite, state.Version);
+
+        state.Remove("a");
+        Assert.True(state.Version > afterWrite);
+    }
+
+    /// <summary>A restored bag starts at version 0 — it must not re-issue a token for state it was just handed.</summary>
+    [Fact]
+    public void Restore_resets_the_version()
+    {
+        var original = new PersistentState();
+        original.Persist("a", 1);
+
+        var rebuilt = new PersistentState();
+        rebuilt.Restore(original.Entries);
+
+        Assert.Equal(0, rebuilt.Version);
+    }
+
+    /// <summary>
+    /// Over budget the write still lands — refusing it would lose state the app believes it stored, and
+    /// throwing would turn a size budget into an exception at an arbitrary call site. What the session loses
+    /// is its resumability, which degrades to the reload it would have had anyway.
+    /// </summary>
+    [Fact]
+    public void Exceeding_the_budget_keeps_the_write_but_marks_the_session_unresumable()
+    {
+        var state = new PersistentState { MaxBytes = 128 };
+
+        state.Persist("small", "x");
+        Assert.False(state.Overflowed);
+
+        state.Persist("big", new string('x', 512));
+
+        Assert.True(state.Overflowed);
+        Assert.True(state.TryGet<string>("big", out var read));
+        Assert.Equal(new string('x', 512), read);
+    }
+
+    /// <summary>
+    /// Once over budget the session stays unresumable for its lifetime. Recomputing it per write would let a
+    /// page that briefly spikes flicker between resumable and not, so a reconnect's outcome would depend on
+    /// which side of a transient write it landed.
+    /// </summary>
+    [Fact]
+    public void Overflow_does_not_clear_when_the_bag_shrinks_again()
+    {
+        var state = new PersistentState { MaxBytes = 128 };
+        state.Persist("big", new string('x', 512));
+        Assert.True(state.Overflowed);
+
+        state.Remove("big");
+
+        Assert.True(state.Overflowed);
+    }
+
+    /// <summary>
+    /// Keys ride the wire alongside their values. Without counting them, many tiny keys would pass a
+    /// value-only budget while producing a token far larger than the budget allows.
+    /// </summary>
+    [Fact]
+    public void The_budget_counts_keys_not_just_values()
+    {
+        var state = new PersistentState { MaxBytes = 64 };
+
+        for (var i = 0; i < 20; i++)
+        {
+            // 16-char key, 1-byte value: values alone total 20 bytes, well under the budget.
+            state.Persist(new string('k', 15) + i, 1);
+        }
+
+        Assert.True(state.Overflowed);
+    }
+
+    /// <summary>The overflow is reported to the developer, not swallowed — it explains a reload they'd otherwise chase.</summary>
+    [Fact]
+    public void Exceeding_the_budget_reports_a_diagnostic()
+    {
+        var captured = new List<RaskDiagnosticEvent>();
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.ResetReportOnceForTests();
+        RaskDiagnostics.Sink = captured.Add;
+        try
+        {
+            var state = new PersistentState { MaxBytes = 32 };
+            state.Persist("big", new string('x', 256));
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+
+        var warning = Assert.Single(captured);
+        Assert.Equal(RaskLogLevel.Warning, warning.Level);
+        Assert.Contains("resumable", warning.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void Overwriting_a_key_replaces_rather_than_accumulates()
+    {
+        var state = new PersistentState { MaxBytes = 512 };
+
+        for (var i = 0; i < 50; i++)
+        {
+            state.Persist("same", new string('x', 100));
+        }
+
+        Assert.False(state.Overflowed);
+        Assert.True(state.TryGet<string>("same", out var read));
+        Assert.Equal(new string('x', 100), read);
+    }
+
+    [Fact]
+    public void An_empty_key_is_rejected()
+    {
+        var state = new PersistentState();
+
+        Assert.Throws<ArgumentException>(() => state.Persist("", 1));
+        Assert.Throws<ArgumentNullException>(() => state.Persist(null!, 1));
+    }
+
+    /// <summary>The trim-/AOT-safe overloads must behave identically to the reflection ones.</summary>
+    [Fact]
+    public void The_typeinfo_overloads_round_trip_the_same_values()
+    {
+        var state = new PersistentState();
+        JsonTypeInfo<Filter> typeInfo = TestJsonContext.Default.Filter;
+
+        state.Persist("filter", new Filter("boots", 2), typeInfo);
+
+        Assert.True(state.TryGet("filter", typeInfo, out var read));
+        Assert.Equal(new Filter("boots", 2), read);
+
+        // ...and interoperate with the reflection path, since both write the same web-defaults JSON.
+        Assert.True(state.TryGet<Filter>("filter", out var viaReflection));
+        Assert.Equal(new Filter("boots", 2), viaReflection);
+    }
+
+    /// <summary>Values are stored as UTF-8 JSON, which is what makes the handoff record buildable without a walk.</summary>
+    [Fact]
+    public void Entries_are_utf8_json_ready_for_the_wire()
+    {
+        var state = new PersistentState();
+        state.Persist("tab", "reviews");
+
+        var raw = Encoding.UTF8.GetString(state.Entries["tab"]);
+
+        Assert.Equal("\"reviews\"", raw);
+    }
+
+    [JsonSourceGenerationOptions(JsonSerializerDefaults.Web)]
+    [JsonSerializable(typeof(Filter))]
+    private sealed partial class TestJsonContext : JsonSerializerContext;
+}

--- a/tests/Rask.Server.Tests/Live/PersistentStateWiringTests.cs
+++ b/tests/Rask.Server.Tests/Live/PersistentStateWiringTests.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+/// The DI wiring behind <see cref="IPersistentState"/>. The bag is only useful if it is scoped to a live
+/// session — a singleton would pool every visitor's declared state into one bag, which is a data leak, not
+/// a bug in degree.
+/// </summary>
+public sealed class PersistentStateWiringTests
+{
+    [Fact]
+    public void Resolves_from_a_session_scope()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+        var session = host.Store.Create(sp => new Shell(sp.GetRequiredService<IPersistentState>()));
+
+        var state = session.Scope.ServiceProvider.GetRequiredService<IPersistentState>();
+
+        Assert.NotNull(state);
+    }
+
+    /// <summary>
+    /// The one that would be a security bug rather than a defect: one session must never read another's
+    /// declared state.
+    /// </summary>
+    [Fact]
+    public void Two_sessions_get_two_separate_bags()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+        var first = host.Store.Create(sp => new Shell(sp.GetRequiredService<IPersistentState>()));
+        var second = host.Store.Create(sp => new Shell(sp.GetRequiredService<IPersistentState>()));
+
+        var firstState = first.Scope.ServiceProvider.GetRequiredService<IPersistentState>();
+        var secondState = second.Scope.ServiceProvider.GetRequiredService<IPersistentState>();
+
+        Assert.NotSame(firstState, secondState);
+
+        firstState.Persist("cart", "first-session-only");
+
+        Assert.False(secondState.TryGet<string>("cart", out _));
+        Assert.True(firstState.TryGet<string>("cart", out var mine));
+        Assert.Equal("first-session-only", mine);
+    }
+
+    /// <summary>
+    /// The interface and the concrete type must be the same object in a scope — the framework reads the
+    /// version and the raw entries off the concrete one to build the handoff record, and would otherwise be
+    /// reading a different bag than the app wrote to.
+    /// </summary>
+    [Fact]
+    public void The_interface_and_the_concrete_bag_are_one_instance()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+        var session = host.Store.Create(sp => new Shell(sp.GetRequiredService<IPersistentState>()));
+
+        var viaInterface = session.Scope.ServiceProvider.GetRequiredService<IPersistentState>();
+        var viaConcrete = session.Scope.ServiceProvider.GetRequiredService<PersistentState>();
+
+        Assert.Same(viaInterface, viaConcrete);
+
+        viaInterface.Persist("tab", "reviews");
+        Assert.Equal(1, viaConcrete.Version);
+        Assert.True(viaConcrete.Entries.ContainsKey("tab"));
+    }
+
+    /// <summary>Constructor injection is the supported shape (a settable non-nullable prop would be RASK002).</summary>
+    private sealed class Shell(IPersistentState state) : Component
+    {
+        protected override Component? Render()
+        {
+            state.Persist("rendered", true);
+            return new Span();
+        }
+    }
+}

--- a/tests/Rask.Server.Tests/Live/SessionHandoffProtectorTests.cs
+++ b/tests/Rask.Server.Tests/Live/SessionHandoffProtectorTests.cs
@@ -1,0 +1,223 @@
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+/// The seal on the record a browser carries between one live session and the next. Every input here is
+/// attacker-controlled, so the interesting assertions are all refusals.
+/// </summary>
+public sealed class SessionHandoffProtectorTests : IDisposable
+{
+    private readonly string _keyRing = Path.Combine(Path.GetTempPath(), "rask-handoff-" + Guid.NewGuid().ToString("N"));
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_keyRing, recursive: true); }
+        catch (DirectoryNotFoundException) { }
+        catch (IOException) { }
+    }
+
+    /// <summary>
+    /// Two providers over one key ring stand in for the two processes a deploy actually involves: the
+    /// container that sealed the record, and the replacement that has to open it.
+    /// </summary>
+    private IDataProtectionProvider Provider() =>
+        new ServiceCollection()
+            .AddDataProtection()
+            .PersistKeysToFileSystem(Directory.CreateDirectory(_keyRing))
+            .SetApplicationName("handoff-tests")
+            .Services
+            .BuildServiceProvider()
+            .GetRequiredService<IDataProtectionProvider>();
+
+    private SessionHandoffProtector NewProtector(TimeSpan? lifetime = null) =>
+        new(Provider(), lifetime ?? TimeSpan.FromHours(1));
+
+    private static ClaimsPrincipal User(string id) =>
+        new(new ClaimsIdentity([new Claim(ClaimTypes.NameIdentifier, id)], "test"));
+
+    private static ClaimsPrincipal Anonymous() => new(new ClaimsIdentity());
+
+    private static Dictionary<string, byte[]> Bag(params (string Key, string Json)[] entries) =>
+        entries.ToDictionary(e => e.Key, e => Encoding.UTF8.GetBytes(e.Json), StringComparer.Ordinal);
+
+    [Fact]
+    public void Round_trips_the_url_and_the_bag()
+    {
+        var protector = NewProtector();
+        var token = protector.Protect("/orders?page=2", User("u1"), Bag(("tab", "\"reviews\""), ("n", "7")));
+
+        Assert.True(protector.TryUnprotect(token, User("u1"), out var record, out var rejection));
+
+        Assert.Equal(ResumeRejection.None, rejection);
+        Assert.Equal("/orders?page=2", record!.Url);
+        Assert.Equal(2, record.Entries.Count);
+        Assert.Equal("\"reviews\"", Encoding.UTF8.GetString(record.Entries.Single(e => e.Key == "tab").Value));
+        Assert.Equal("7", Encoding.UTF8.GetString(record.Entries.Single(e => e.Key == "n").Value));
+    }
+
+    /// <summary>
+    /// The whole point: the process that opens the record is not the one that sealed it. This is the
+    /// deploy, and it only works because the key ring outlives the container — which is why the scaffold
+    /// persists it.
+    /// </summary>
+    [Fact]
+    public void A_record_sealed_by_one_process_opens_in_another_sharing_the_key_ring()
+    {
+        var before = NewProtector();
+        var token = before.Protect("/cart", User("u1"), Bag(("items", "3")));
+
+        var after = NewProtector();
+
+        Assert.True(after.TryUnprotect(token, User("u1"), out var record, out _));
+        Assert.Equal("/cart", record!.Url);
+        Assert.Equal("3", Encoding.UTF8.GetString(record.Entries.Single().Value));
+    }
+
+    /// <summary>A record must not be replayable onto another account.</summary>
+    [Fact]
+    public void A_record_issued_to_one_user_is_refused_for_another()
+    {
+        var protector = NewProtector();
+        var token = protector.Protect("/orders", User("alice"), Bag(("secret", "\"alice-only\"")));
+
+        Assert.False(protector.TryUnprotect(token, User("bob"), out var record, out var rejection));
+
+        Assert.Equal(ResumeRejection.Principal, rejection);
+        Assert.Null(record);
+    }
+
+    /// <summary>Signing in must not inherit the page an anonymous visitor was on, nor the reverse.</summary>
+    [Fact]
+    public void An_anonymous_record_and_an_authenticated_one_do_not_cross()
+    {
+        var protector = NewProtector();
+
+        var anonymousToken = protector.Protect("/", Anonymous(), Bag());
+        Assert.False(protector.TryUnprotect(anonymousToken, User("alice"), out _, out var signedIn));
+        Assert.Equal(ResumeRejection.Principal, signedIn);
+
+        var authenticatedToken = protector.Protect("/", User("alice"), Bag());
+        Assert.False(protector.TryUnprotect(authenticatedToken, Anonymous(), out _, out var signedOut));
+        Assert.Equal(ResumeRejection.Principal, signedOut);
+    }
+
+    [Fact]
+    public void An_anonymous_record_opens_for_an_anonymous_reconnect()
+    {
+        var protector = NewProtector();
+        var token = protector.Protect("/browse", Anonymous(), Bag(("filter", "\"boots\"")));
+
+        Assert.True(protector.TryUnprotect(token, Anonymous(), out var record, out _));
+        Assert.Equal("/browse", record!.Url);
+    }
+
+    [Fact]
+    public void A_tampered_record_is_refused()
+    {
+        var protector = NewProtector();
+        var token = protector.Protect("/orders", User("u1"), Bag(("n", "1")));
+
+        // Flip a byte in the middle of the base64 payload.
+        var chars = token.ToCharArray();
+        var mid = chars.Length / 2;
+        chars[mid] = chars[mid] == 'A' ? 'B' : 'A';
+
+        Assert.False(protector.TryUnprotect(new string(chars), User("u1"), out _, out var rejection));
+        Assert.Equal(ResumeRejection.Unprotect, rejection);
+    }
+
+    [Fact]
+    public void An_expired_record_is_refused()
+    {
+        // Already dead on arrival — expiry is enforced by the time-limited protector, not by a field we
+        // remember to compare, so a record past its lifetime cannot be opened at all.
+        var protector = NewProtector(TimeSpan.FromMilliseconds(-1));
+        var token = protector.Protect("/orders", User("u1"), Bag());
+
+        Assert.False(protector.TryUnprotect(token, User("u1"), out _, out var rejection));
+        Assert.Equal(ResumeRejection.Unprotect, rejection);
+    }
+
+    /// <summary>A record sealed under a key ring this host doesn't have is exactly what an unpersisted ring looks like after a deploy.</summary>
+    [Fact]
+    public void A_record_from_a_foreign_key_ring_is_refused()
+    {
+        var token = NewProtector().Protect("/orders", User("u1"), Bag());
+
+        var stranger = new SessionHandoffProtector(new EphemeralDataProtectionProvider(), TimeSpan.FromHours(1));
+
+        Assert.False(stranger.TryUnprotect(token, User("u1"), out _, out var rejection));
+        Assert.Equal(ResumeRejection.Unprotect, rejection);
+    }
+
+    [Fact]
+    public void Garbage_is_refused_without_throwing()
+    {
+        var protector = NewProtector();
+
+        Assert.False(protector.TryUnprotect("not base64 at all !!!", User("u1"), out _, out var malformed));
+        Assert.Equal(ResumeRejection.Malformed, malformed);
+
+        // An empty string is valid base64, so it gets as far as the unprotect and fails there.
+        Assert.False(protector.TryUnprotect("", User("u1"), out _, out var empty));
+        Assert.Equal(ResumeRejection.Unprotect, empty);
+
+        Assert.False(protector.TryUnprotect(Convert.ToBase64String("hello"u8.ToArray()), User("u1"), out _, out var notARecord));
+        Assert.Equal(ResumeRejection.Unprotect, notARecord);
+    }
+
+    /// <summary>Refuse an oversized token before spending anything on decoding it.</summary>
+    [Fact]
+    public void An_oversized_token_is_refused_before_it_is_decoded()
+    {
+        var protector = NewProtector();
+        var huge = new string('A', SessionHandoffProtector.MaxTokenChars + 1);
+
+        Assert.False(protector.TryUnprotect(huge, User("u1"), out _, out var rejection));
+        Assert.Equal(ResumeRejection.TooLarge, rejection);
+    }
+
+    [Fact]
+    public void An_empty_bag_round_trips()
+    {
+        var protector = NewProtector();
+        var token = protector.Protect("/", Anonymous(), Bag());
+
+        Assert.True(protector.TryUnprotect(token, Anonymous(), out var record, out _));
+        Assert.Empty(record!.Entries);
+        Assert.Equal("/", record.Url);
+    }
+
+    /// <summary>
+    /// Even with nothing declared, the URL alone is worth carrying: it turns a deploy's full-page reload
+    /// into a re-render of the page the user was already on.
+    /// </summary>
+    [Fact]
+    public void A_url_with_no_declared_state_still_survives()
+    {
+        var protector = NewProtector();
+        var token = protector.Protect("/reports/2026?tab=summary&sort=desc", User("u1"), Bag());
+
+        Assert.True(protector.TryUnprotect(token, User("u1"), out var record, out _));
+        Assert.Equal("/reports/2026?tab=summary&sort=desc", record!.Url);
+    }
+
+    [Fact]
+    public void Values_with_arbitrary_bytes_survive_the_round_trip()
+    {
+        var protector = NewProtector();
+        var awkward = Bag(("emoji", "\"\\ud83d\\ude80 éè\""), ("empty", ""));
+
+        var token = protector.Protect("/", Anonymous(), awkward);
+
+        Assert.True(protector.TryUnprotect(token, Anonymous(), out var record, out _));
+        Assert.Equal(
+            awkward["emoji"],
+            record!.Entries.Single(e => e.Key == "emoji").Value);
+        Assert.Empty(record.Entries.Single(e => e.Key == "empty").Value);
+    }
+}

--- a/tests/Rask.Server.Tests/Live/SessionResumeTests.cs
+++ b/tests/Rask.Server.Tests/Live/SessionResumeTests.cs
@@ -1,0 +1,286 @@
+using System.Net.WebSockets;
+using System.Text.Json;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Core.Live;
+using Rask.Core.Routing;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+/// The behaviour the whole thing exists for: a client whose session is gone gets its page back instead of
+/// "Your session timed out. Reload to continue."
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each test drops the session from the store between the two connections. That is precisely what a
+/// restart or a <c>rask deploy</c> container swap looks like from the client's side — the process that
+/// held the tree is gone, and the one answering the reconnect never knew it.
+/// </para>
+/// <para>
+/// <b>Not yet wired to the client.</b> The server opens a record and rebuilds the page around it, and the
+/// browser sends back whatever record it holds — but nothing pushes a record to the browser yet, so it
+/// never holds one in practice. Delivering it as its own WebSocket frame was tried and reverted: it lands
+/// in the middle of the render stream, and the frame contract is that a hello with nothing pending emits
+/// no frame at all. The record has to ride inside the render payload next to <c>history</c>/<c>auth</c>,
+/// which is the outstanding work. These tests seal the record directly so everything downstream of
+/// holding one is verified against the real protector.
+/// </para>
+/// </remarks>
+public sealed class SessionResumeTests
+{
+    private const string StateKey = "counter";
+
+    /// <summary>A page that declares one value and renders it, so a rebuild is visible in the markup.</summary>
+    private sealed class CounterApp(IPersistentState state, RouteState route) : Component
+    {
+        protected override Component? Render()
+        {
+            state.TryGet<int>(StateKey, out var count);
+            return
+            [
+                Doctype(),
+                new Html()[
+                    new Head(),
+                    new Body()[
+                        new Div()[count.ToString()],
+                        new Div()[route.Path]
+                    ]
+                ]
+            ];
+        }
+    }
+
+    /// <summary>
+    /// Starts a session, declares some state, and seals the record for it.
+    /// </summary>
+    /// <remarks>
+    /// The record is built straight from the host's own protector rather than read off the socket, because
+    /// nothing pushes it to the client yet — see the "not wired to the client" note on the class. That is a
+    /// delivery gap, not a semantic one: this is byte-for-byte the record the server will hand out, so
+    /// everything downstream of holding one is exercised for real.
+    /// </remarks>
+    private static async Task<(RaskTestHost Host, string SessionId, string Token)> StartAndCapture(
+        int seed, string path = "/start")
+    {
+        var host = RaskTestHost.Create<CounterApp>();
+        var initial = await host.Http.GetAsync(path);
+        var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
+
+        var session = host.Store.Get(sessionId)!;
+        session.Services.GetRequiredService<IPersistentState>().Persist(StateKey, seed);
+
+        return (host, sessionId, SealFor(host, session));
+    }
+
+    private static string SealFor(RaskTestHost host, LiveSession session)
+    {
+        var protector = host.Services.GetRequiredService<SessionResumeSupport>().Protector;
+        Assert.NotNull(protector);
+
+        var route = session.Services.GetRequiredService<RouteState>();
+        var state = session.Services.GetRequiredService<PersistentState>();
+        var user = session.Services.GetRequiredService<Rask.Server.Authentication.SessionUserProvider>().Current;
+
+        return protector!.Protect(QueryString.Build(route.Path, route.Query), user, state.Entries);
+    }
+
+    [Fact]
+    public async Task A_client_whose_session_is_gone_gets_its_page_rebuilt()
+    {
+        var (host, sessionId, token) = await StartAndCapture(seed: 41);
+        using var _ = host;
+
+        // The process that held the tree is gone.
+        await host.Store.RemoveAsync(sessionId);
+        Assert.Null(host.Store.Get(sessionId));
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId, resume = token });
+
+        var frame = await ReadFrameWithHtmlAsync(ws);
+
+        // The declared state came back, and it is rendered — not merely stored.
+        Assert.Contains(">41<", frame, StringComparison.Ordinal);
+        // A brand-new session now backs the page.
+        Assert.Equal(1, host.Store.Count);
+        Assert.Null(host.Store.Get(sessionId));
+    }
+
+    /// <summary>Even with nothing declared, the URL survives — which is what makes a deploy a re-render rather than a reload.</summary>
+    [Fact]
+    public async Task The_route_survives_so_the_user_lands_where_they_were()
+    {
+        var (host, sessionId, token) = await StartAndCapture(seed: 7, path: "/orders/2026");
+        using var _ = host;
+        await host.Store.RemoveAsync(sessionId);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId, resume = token });
+
+        var frame = await ReadFrameWithHtmlAsync(ws);
+
+        Assert.Contains("/orders/2026", frame, StringComparison.Ordinal);
+    }
+
+    /// <summary>The rebuilt session must be reachable by the id the client now holds, or the NEXT drop loses the page.</summary>
+    [Fact]
+    public async Task The_rebuilt_session_can_itself_be_resumed()
+    {
+        var (host, sessionId, token) = await StartAndCapture(seed: 5);
+        using var _ = host;
+        await host.Store.RemoveAsync(sessionId);
+
+        string secondToken;
+        string rebuiltId;
+        using (var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None))
+        {
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId, resume = token });
+            // The rebuilt session's id reaches the client the same way it reaches a browser: stamped on
+            // the html of the frame it gets back.
+            rebuiltId = SessionIdFrom(await ReadFrameWithHtmlAsync(ws));
+            secondToken = SealFor(host, host.Store.Get(rebuiltId)!);
+        }
+
+        Assert.NotEqual(sessionId, rebuiltId);
+
+        // Drop the rebuilt one too, and go round again with the record it issued.
+        await host.Store.RemoveAsync(rebuiltId);
+
+        using var second = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await second.SendJsonAsync(new { type = "hello", session = rebuiltId, resume = secondToken });
+
+        var frame = await ReadFrameWithHtmlAsync(second);
+        Assert.Contains(">5<", frame, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Without_a_record_an_unknown_session_still_reloads()
+    {
+        var (host, sessionId, _) = await StartAndCapture(seed: 1);
+        using var _2 = host;
+        await host.Store.RemoveAsync(sessionId);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(frame);
+        Assert.Contains("\"status\":\"unknown\"", frame, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_garbage_record_is_refused_and_the_client_is_told_to_reload()
+    {
+        var (host, sessionId, _) = await StartAndCapture(seed: 1);
+        using var _2 = host;
+        await host.Store.RemoveAsync(sessionId);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId, resume = "not-a-real-record" });
+
+        var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(frame);
+        Assert.Contains("\"status\":\"unknown\"", frame, StringComparison.Ordinal);
+        Assert.Equal(0, host.Store.Count);
+    }
+
+    /// <summary>
+    /// A resume storm follows every deploy — every connected client reconnects at once. Those rebuilds must
+    /// shed against MaxSessions like any other new session rather than walking past the cap.
+    /// </summary>
+    [Fact]
+    public async Task A_rebuild_is_refused_when_the_host_is_at_capacity()
+    {
+        var host = RaskTestHost.Create<CounterApp>();
+        using var _ = host;
+
+        var initial = await host.Http.GetAsync("/start");
+        var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
+        var session = host.Store.Get(sessionId)!;
+        session.Services.GetRequiredService<IPersistentState>().Persist(StateKey, 3);
+        var token = SealFor(host, session);
+
+        await host.Store.RemoveAsync(sessionId);
+
+        // Full: the rebuild has nowhere to go.
+        host.Store.MaxSessions = 1;
+        host.Store.Create(_ => new Span());
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId, resume = token });
+
+        var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(frame);
+        Assert.Contains("\"status\":\"unknown\"", frame, StringComparison.Ordinal);
+        Assert.Equal(1, host.Store.Count);
+    }
+
+    /// <summary>
+    /// Turning resume off restores exactly the behaviour that shipped before it: no protector at all, so a
+    /// record cannot even be built, and an unknown session reloads.
+    /// </summary>
+    [Fact]
+    public async Task With_resume_disabled_no_record_can_be_built_and_an_unknown_session_reloads()
+    {
+        var host = RaskTestHost.Create<CounterApp>(configureServer: o => o.SessionResume = false);
+        using var _ = host;
+
+        Assert.False(host.Services.GetRequiredService<SessionResumeSupport>().Enabled);
+
+        var initial = await host.Http.GetAsync("/start");
+        var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
+
+        await host.Store.RemoveAsync(sessionId);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        var reply = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(reply);
+        Assert.Contains("\"status\":\"unknown\"", reply, StringComparison.Ordinal);
+    }
+
+    // ── helpers ──────────────────────────────────────────────────────────────────────────────────
+
+    private static string SessionIdFrom(string html)
+    {
+        const string marker = "data-rask-root=\"";
+        var start = html.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(start >= 0, "the GET shell must carry data-rask-root");
+        start += marker.Length;
+        return html[start..html.IndexOf('"', start)];
+    }
+
+
+    /// <summary>
+    /// Reads frames until one carries rendered html (the rebuild), skipping resume/ack frames, and returns
+    /// the html itself rather than the envelope — the envelope is JSON, so its markup is escaped and would
+    /// not match anything a test looks for.
+    /// </summary>
+    private static async Task<string> ReadFrameWithHtmlAsync(WebSocket ws)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            if (frame is null)
+            {
+                break;
+            }
+
+            using var doc = JsonDocument.Parse(frame);
+            if (doc.RootElement.TryGetProperty("html", out var html) && html.ValueKind == JsonValueKind.String)
+            {
+                return html.GetString()!;
+            }
+        }
+
+        Assert.Fail("expected a rendered frame on the socket");
+        return string.Empty;
+    }
+}

--- a/tests/Rask.Server.Tests/Live/SessionResumeTests.cs
+++ b/tests/Rask.Server.Tests/Live/SessionResumeTests.cs
@@ -20,13 +20,10 @@ namespace Rask.Server.Tests.Live;
 /// held the tree is gone, and the one answering the reconnect never knew it.
 /// </para>
 /// <para>
-/// <b>Not yet wired to the client.</b> The server opens a record and rebuilds the page around it, and the
-/// browser sends back whatever record it holds — but nothing pushes a record to the browser yet, so it
-/// never holds one in practice. Delivering it as its own WebSocket frame was tried and reverted: it lands
-/// in the middle of the render stream, and the frame contract is that a hello with nothing pending emits
-/// no frame at all. The record has to ride inside the render payload next to <c>history</c>/<c>auth</c>,
-/// which is the outstanding work. These tests seal the record directly so everything downstream of
-/// holding one is verified against the real protector.
+/// The record rides <em>inside</em> the render payload, next to <c>history</c>/<c>auth</c> — not as its
+/// own frame. That was tried and reverted: an extra frame lands in the middle of the render stream, and
+/// the frame contract is that a hello with nothing pending emits no frame at all, while consumers reason
+/// about the last frame of a burst. A field is invisible to both.
 /// </para>
 /// </remarks>
 public sealed class SessionResumeTests
@@ -54,14 +51,9 @@ public sealed class SessionResumeTests
     }
 
     /// <summary>
-    /// Starts a session, declares some state, and seals the record for it.
+    /// Starts a session, declares some state, and takes the record off the wire the way a browser does —
+    /// as a field on the render payload the state change produces.
     /// </summary>
-    /// <remarks>
-    /// The record is built straight from the host's own protector rather than read off the socket, because
-    /// nothing pushes it to the client yet — see the "not wired to the client" note on the class. That is a
-    /// delivery gap, not a semantic one: this is byte-for-byte the record the server will hand out, so
-    /// everything downstream of holding one is exercised for real.
-    /// </remarks>
     private static async Task<(RaskTestHost Host, string SessionId, string Token)> StartAndCapture(
         int seed, string path = "/start")
     {
@@ -69,22 +61,67 @@ public sealed class SessionResumeTests
         var initial = await host.Http.GetAsync(path);
         var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
 
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        // Declaring state and asking for a render is what an event handler does; the record rides the
+        // frame that comes back.
         var session = host.Store.Get(sessionId)!;
         session.Services.GetRequiredService<IPersistentState>().Persist(StateKey, seed);
+        await session.View.StateHasChangedAsync();
 
-        return (host, sessionId, SealFor(host, session));
+        var token = await ReadResumeAsync(ws);
+        ws.Dispose();
+
+        return (host, sessionId, token);
     }
 
-    private static string SealFor(RaskTestHost host, LiveSession session)
+    /// <summary>Reads the rebuild frame: the rendered html and the record for the session it created.</summary>
+    private static async Task<(string Html, string Resume)> ReadRebuildAsync(WebSocket ws)
     {
-        var protector = host.Services.GetRequiredService<SessionResumeSupport>().Protector;
-        Assert.NotNull(protector);
+        for (var i = 0; i < 8; i++)
+        {
+            var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            if (frame is null)
+            {
+                break;
+            }
 
-        var route = session.Services.GetRequiredService<RouteState>();
-        var state = session.Services.GetRequiredService<PersistentState>();
-        var user = session.Services.GetRequiredService<Rask.Server.Authentication.SessionUserProvider>().Current;
+            using var doc = JsonDocument.Parse(frame);
+            if (doc.RootElement.TryGetProperty("html", out var html)
+                && html.ValueKind == JsonValueKind.String
+                && doc.RootElement.TryGetProperty("resume", out var resume)
+                && resume.ValueKind == JsonValueKind.String)
+            {
+                return (html.GetString()!, resume.GetString()!);
+            }
+        }
 
-        return protector!.Protect(QueryString.Build(route.Path, route.Query), user, state.Entries);
+        Assert.Fail("expected a rebuild frame carrying both html and a resume record");
+        return (string.Empty, string.Empty);
+    }
+
+    /// <summary>Reads frames until one carries a resume record.</summary>
+    private static async Task<string> ReadResumeAsync(WebSocket ws)
+    {
+        for (var i = 0; i < 8; i++)
+        {
+            var frame = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            if (frame is null)
+            {
+                break;
+            }
+
+            using var doc = JsonDocument.Parse(frame);
+            if (doc.RootElement.TryGetProperty("resume", out var resume)
+                && resume.ValueKind == JsonValueKind.String)
+            {
+                return resume.GetString()!;
+            }
+        }
+
+        Assert.Fail("expected a render payload carrying a resume record");
+        return string.Empty;
     }
 
     [Fact]
@@ -138,10 +175,12 @@ public sealed class SessionResumeTests
         using (var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None))
         {
             await ws.SendJsonAsync(new { type = "hello", session = sessionId, resume = token });
-            // The rebuilt session's id reaches the client the same way it reaches a browser: stamped on
-            // the html of the frame it gets back.
-            rebuiltId = SessionIdFrom(await ReadFrameWithHtmlAsync(ws));
-            secondToken = SealFor(host, host.Store.Get(rebuiltId)!);
+            // One frame carries both: the rebuilt session's id, stamped on the html exactly as it reaches
+            // a browser, and the record for the session it just became (a fresh session's first payload
+            // always carries one).
+            var (html, resume) = await ReadRebuildAsync(ws);
+            rebuiltId = SessionIdFrom(html);
+            secondToken = resume;
         }
 
         Assert.NotEqual(sessionId, rebuiltId);
@@ -154,6 +193,52 @@ public sealed class SessionResumeTests
 
         var frame = await ReadFrameWithHtmlAsync(second);
         Assert.Contains(">5<", frame, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The record must not cost a frame. This is the constraint that sent the first design back: an app
+    /// that declares nothing and does nothing must still emit no frame after a hello, because that is the
+    /// documented contract and because consumers reason about the last frame of a burst.
+    /// </summary>
+    [Fact]
+    public async Task An_idle_session_still_emits_no_frame_at_all()
+    {
+        using var host = RaskTestHost.Create<CounterApp>();
+        var initial = await host.Http.GetAsync("/start");
+        var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        Assert.Null(await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500)));
+        Assert.Equal(WebSocketState.Open, ws.State);
+    }
+
+    /// <summary>A render that moved nothing must not re-seal and re-send a record the client already holds.</summary>
+    [Fact]
+    public async Task An_unchanged_render_carries_no_record()
+    {
+        using var host = RaskTestHost.Create<CounterApp>();
+        var initial = await host.Http.GetAsync("/start");
+        var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        var session = host.Store.Get(sessionId)!;
+        session.Services.GetRequiredService<IPersistentState>().Persist(StateKey, 1);
+        await session.View.StateHasChangedAsync();
+        await ReadResumeAsync(ws);
+
+        // Same value again: the bag's version moves, so a record is due — but a render with no state or
+        // route change at all is not.
+        await session.View.StateHasChangedAsync();
+
+        var frame = await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500));
+        if (frame is not null)
+        {
+            Assert.DoesNotContain("\"resume\"", frame, StringComparison.Ordinal);
+        }
     }
 
     [Fact]
@@ -196,14 +281,8 @@ public sealed class SessionResumeTests
     [Fact]
     public async Task A_rebuild_is_refused_when_the_host_is_at_capacity()
     {
-        var host = RaskTestHost.Create<CounterApp>();
+        var (host, sessionId, token) = await StartAndCapture(seed: 3);
         using var _ = host;
-
-        var initial = await host.Http.GetAsync("/start");
-        var sessionId = SessionIdFrom(await initial.Content.ReadAsStringAsync());
-        var session = host.Store.Get(sessionId)!;
-        session.Services.GetRequiredService<IPersistentState>().Persist(StateKey, 3);
-        var token = SealFor(host, session);
 
         await host.Store.RemoveAsync(sessionId);
 


### PR DESCRIPTION
Second PR of the server-host scaling work. Stacks conceptually on **#549** (persisted data-protection key ring) but branches from `main` — no file overlap, so they can merge in either order. #549 should land first though: without a persisted key ring, every record is refused after a deploy and this degrades to exactly the behaviour it replaces.

## The problem

A live session is a component tree, a DI scope and a set of cancellation tokens. None of that serializes, so a session cannot be moved or saved — when the process holding it goes away, it is gone.

That was the end of the story. `rask deploy` replaces the container on every deploy, so every connected client got **"Your session timed out. Reload to continue."** The deploy was zero-downtime for HTTP and a full reload for everyone actually using the app.

## The approach

Nothing resumes. What travels is a small sealed record of **where the page was** and **what the app declared** through the new `IPersistentState`, and a host that receives it back **rebuilds** the page around it:

```csharp
public sealed class OrdersPage(IPersistentState state) : Component
{
    private string _filter = "";
    protected override void OnMount() => state.TryGet<string>("filter", out _filter!);
    private void Search(string term) { _filter = term; state.Persist("filter", term); }
}
```

The record is **held by the browser**, so this needs no shared store, no sticky routing and no new infrastructure — the same property that will later let a reconnect land on a different replica. Even an app that declares nothing gets the route back, which turns a deploy from a full-page reload into a re-render.

## Two things I got wrong, and what they taught

**Delivery as its own WebSocket frame.** Implemented first, then reverted — it broke ten existing tests, and they were right. The frame stream is a contract: a `hello` with nothing pending must emit **no frame at all**, and consumers reason about the last frame of a burst. The record now rides *inside* the render payload beside `history`/`auth`/`download`, which is invisible to both and semantically exact anyway — the record only changes when state or route changes, and both always come with a render. There's now a test pinning the no-frame property.

**The record inflated the diff and flipped the size heuristic.** `InitialRenderDiffTests` caught small pages switching from diff to full HTML whenever a record was due. That was a real performance defect, not a test artifact: the full-HTML payload carries the identical record, so counting it only against the diff is simply wrong. It's now discounted from the comparison.

Also found while building: **`WebApplication.CreateBuilder` does not register Data Protection** (it only appears if antiforgery/cookie-auth/session pulled it in), so `AddRask` now requests it — idempotent and additive, exactly how ASP.NET's own components do it. And **`IDataProtector.Protect` is non-deterministic**, so it cannot derive a stable user binding; that one was caught by reading before it ran.

## Security

The record is encrypted and authenticated under its own data-protection purpose. Expiry is delegated to `ITimeLimitedDataProtector`, so an expired record **cannot be opened at all** rather than relying on a field comparison. It carries **no principal** — a reconnect authenticates from its cookie or bearer token exactly as before — but is bound to a hash of the identity it was issued to and compared in fixed time, so it cannot be replayed onto another account or inherited across a sign-in. Oversized tokens are refused before decoding. A rebuild takes a `MaxSessions` slot through the **same atomic reservation a GET uses**, so the reconnect storm after a deploy sheds like ordinary traffic instead of walking past the cap.

The 16 KB bag cap degrades rather than fails: over budget the session keeps working, declares itself unresumable, and falls back to the reload it would have had, with a diagnostic saying so.

## Testing

29 new tests. `SessionHandoffProtectorTests` covers the refusals — tampered, expired, foreign key ring, wrong user, anonymous-vs-authenticated in both directions, oversized, garbage — plus **two providers sharing one key ring**, which is literally the deploy. `SessionResumeTests` drops the session from the store between two connections (what a container swap looks like from the client) and asserts the page comes back with its state and route, that a rebuilt session can itself be resumed, that refusals still reload, and that an idle session emits no frame.

Full local gate green (284 server tests, whole solution). `payload-bytes --check` **unchanged to the byte** across all five scenarios — the record costs nothing when absent. No allocation delta is possible on the null path: a virtual call and integer arithmetic, no allocation site. Browser E2E skipped (`RASK_SKIP_E2E=1`); the sandbox suite is environmentally red on `main`.

## Docs

`configuration.md` gains "surviving a restart or a redeploy" — the declare-don't-stream guidance, what does *not* come back, and the key-ring prerequisite. Plus the two new options, the two new metrics, and the note that a spike on `resume_rejected{reason=unprotect}` right after a deploy means the key ring isn't persisting. Also fixes the `reason=idle` omission (closes #548).

## Not in this PR

The drain frame (making clients reconnect immediately rather than walking the backoff ladder) — it's a latency refinement whose shutdown ordering races the per-connection `ws.Abort()`, and it belongs with `rask deploy --drain`, where the deploy-side window makes it meaningful.