### PR TITLE
feat(server): drain live sessions on shutdown instead of severing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,27 @@ them until tagged releases begin.
   `ResumeTokenLifetime` (default 1 hour). **Requires a persisted data-protection key ring** — a record
   sealed before a redeploy cannot be opened after one otherwise, which is what the scaffold's `/data/keys`
   change below is for.
+- **A graceful shutdown for live sessions — a redeploy no longer tells every user their session timed
+  out.** `rask deploy` advertises zero-downtime deploys, and the container swap really is blue-green, but
+  the app had no drain: `ApplicationStopping` fired `ws.Abort()` on every socket, so the browser saw an
+  abnormal (1006) closure with no close frame, reconnected onto the replacement container, was told
+  `session/unknown`, and displayed **"Your session timed out. Reload to continue."** for four seconds
+  before reloading. Nothing had timed out. On `SIGTERM` the host now closes admission (new sessions get
+  `503` + `Retry-After: 1`, and a new readiness health check goes unhealthy so a probing proxy stops
+  routing), tells every connected browser it is going away, lets in-flight handlers finish — a click that
+  was mid-`SaveChangesAsync` used to be cancelled and dropped — closes each socket with a real `1001`
+  "going away" handshake, and disposes the sessions *awaited*, where the old path fired an unawaited
+  `RemoveAsync` that raced process exit. The client shows **"Updating…"**, reloads in ~250 ms instead of
+  4 s, and restores scroll position and focus. Form values are deliberately not restored: the new server
+  renders those from its own state, and writing stale client copies over them would turn a cosmetic loss
+  into a data one. A redeploy still reloads open pages — a session is a component tree plus a DI scope
+  inside one process and cannot hand over — but it now reads as an update rather than a failure.
+  Budget via `RaskServerOptions.ShutdownDrainTimeout` (default 5s; `Zero` restores the old abort), which
+  must fit inside `HostOptions.ShutdownTimeout`; a startup warning says so when it doesn't, and
+  `rask.shutdown.sessions.abandoned` counts anything still connected when the budget ran out.
+  The load-bearing change is a one-line token substitution: the socket's cancellation token now derives
+  from the drain's hard deadline rather than from `ApplicationStopping`, which is what makes it possible
+  to send anything at all — including the shutdown frame — after the stop signal arrives.
 - **`rask db backup` and `rask db restore` — get the deployed database down, and a copy back up.** Continuous
   backup (Litestream) covers the box dying; this covers the two things a solo developer actually reaches
   for: *"something looks wrong in production, let me get a copy"* and *"that migration was a mistake,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,16 +53,18 @@ them until tagged releases begin.
   the app had no drain: `ApplicationStopping` fired `ws.Abort()` on every socket, so the browser saw an
   abnormal (1006) closure with no close frame, reconnected onto the replacement container, was told
   `session/unknown`, and displayed **"Your session timed out. Reload to continue."** for four seconds
-  before reloading. Nothing had timed out. On `SIGTERM` the host now closes admission (new sessions get
+  before reloading. Nothing had timed out — and because the browser could not tell a deployment from a
+  crash, it had no better option. On `SIGTERM` the host now closes admission (new sessions get
   `503` + `Retry-After: 1`, and a new readiness health check goes unhealthy so a probing proxy stops
   routing), tells every connected browser it is going away, lets in-flight handlers finish — a click that
   was mid-`SaveChangesAsync` used to be cancelled and dropped — closes each socket with a real `1001`
   "going away" handshake, and disposes the sessions *awaited*, where the old path fired an unawaited
-  `RemoveAsync` that raced process exit. The client shows **"Updating…"**, reloads in ~250 ms instead of
-  4 s, and restores scroll position and focus. Form values are deliberately not restored: the new server
-  renders those from its own state, and writing stale client copies over them would turn a cosmetic loss
-  into a data one. A redeploy still reloads open pages — a session is a component tree plus a DI scope
-  inside one process and cannot hand over — but it now reads as an update rather than a failure.
+  `RemoveAsync` that raced process exit. The client shows **"Updating…"** and, because the drop is now
+  *expected* rather than guessed at, reconnects immediately instead of walking a 500 ms → 5 s backoff
+  ladder — leaving what happens to the page to the host that answers. If that host cannot rebuild the
+  session it reloads, in ~250 ms instead of 4 s, restoring scroll position and focus. Form values are
+  deliberately not restored: the new server renders those from its own state, and writing stale client
+  copies over them would turn a cosmetic loss into a data one.
   Budget via `RaskServerOptions.ShutdownDrainTimeout` (default 5s; `Zero` restores the old abort), which
   must fit inside `HostOptions.ShutdownTimeout`; a startup warning says so when it doesn't, and
   `rask.shutdown.sessions.abandoned` counts anything still connected when the budget ran out.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ them until tagged releases begin.
   Budget via `RaskServerOptions.ShutdownDrainTimeout` (default 5s; `Zero` restores the old abort), which
   must fit inside `HostOptions.ShutdownTimeout`; a startup warning says so when it doesn't, and
   `rask.shutdown.sessions.abandoned` counts anything still connected when the budget ran out.
+  `LiveSessionStore.DisposeAsync` also became idempotent: the store is a DI singleton, so a host or a test
+  that disposed it *as well as* the container reached `Cancel()` on an already-disposed token source.
   The load-bearing change is a one-line token substitution: the socket's cancellation token now derives
   from the drain's hard deadline rather than from `ApplicationStopping`, which is what makes it possible
   to send anything at all — including the shutdown frame — after the stop signal arrives.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -76,7 +76,8 @@ wiring on your part:
 1. **Admission closes.** New sessions are refused with `503` + `Retry-After: 1`, and the `ready`-tagged
    health check goes unhealthy so a proxy or load balancer with active probes stops routing here.
 2. **Connected browsers are told.** Every live session gets a `{"type":"shutdown"}` frame, so the client
-   shows **"Updating…"** rather than the reconnect spinner.
+   shows **"Updating…"** rather than the reconnect spinner — and, because the drop is now *expected* rather
+   than guessed at, it reconnects immediately instead of walking a 500 ms → 5 s backoff ladder first.
 3. **In-flight handlers finish.** A click that is mid-`SaveChangesAsync` completes rather than being
    cancelled halfway.
 4. **Sockets close cleanly** — WebSocket status `1001` ("going away"), not an abort — and the sessions
@@ -85,13 +86,18 @@ wiring on your part:
 Anything still connected when `ShutdownDrainTimeout` elapses is aborted, and
 `rask.shutdown.sessions.abandoned` counts it.
 
-> **A redeploy does reload connected browsers, and that is not avoidable.** A live session is a component
-> tree plus a DI scope living in *that* process; the replacement container cannot inherit it. What the
-> drain fixes is the *experience*: instead of a frozen page, an abnormal disconnect, and a four-second
-> "Your session timed out", the page says "Updating…", reloads onto the new instance in ~250 ms, and
-> restores your scroll position and focus. Form field values are deliberately **not** restored — the new
-> server renders those from its own state, and overwriting them with stale client copies would turn a
-> cosmetic loss into a data one.
+> **What happens to the page itself is the replacement server's decision, not the client's.** A live
+> session is a component tree plus a DI scope living in *that* process, so the new instance cannot inherit
+> it. The client therefore reconnects and lets the host that answers decide: if it can rebuild the page,
+> nothing reloads at all; if it reports the session unknown, the client reloads — in ~250 ms, saying
+> "Updating…", and restoring your scroll position and focus.
+>
+> The drain's job is to make that drop *expected*. Before it, the socket was aborted with no close frame,
+> so the browser could not tell a deployment from a crash: it froze, backed off, and eventually announced
+> a four-second "Your session timed out" for a session that had not timed out.
+>
+> Form field values are deliberately **not** restored across a reload — the new server renders those from
+> its own state, and overwriting them with stale client copies would turn a cosmetic loss into a data one.
 
 `ShutdownDrainTimeout` must fit inside `HostOptions.ShutdownTimeout`, which must fit inside whatever your
 container runtime allows between `SIGTERM` and `SIGKILL` (`rask deploy` uses 20 s). Rask logs a warning at

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,37 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `SessionResume` | `true` | Let a client rebuild its page on a host that has never heard of its session — after a restart or a redeploy. See [surviving a restart](#surviving-a-restart-or-a-redeploy). Turn it off to keep the reload. |
 | `ResumeTokenLifetime` | `1 h` | How long a resume record stays redeemable. Not the reconnect grace period: that covers a blip against the *intact* session, this covers the session being gone. |
 | `HandlerTimeout` | `0` (off) | Cancel a handler's `Component.CancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
+| `ShutdownDrainTimeout` | `5 s` | Budget for the graceful shutdown drain: announce the shutdown, let in-flight handlers finish, close each socket with a real handshake, dispose the sessions. `0` disables the drain (abort immediately). See [Shutdown and redeploy](#shutdown-and-redeploy). |
+
+### Shutdown and redeploy
+
+On `SIGTERM` — a redeploy, a container recycle, `Ctrl+C` — Rask drains instead of severing, with no
+wiring on your part:
+
+1. **Admission closes.** New sessions are refused with `503` + `Retry-After: 1`, and the `ready`-tagged
+   health check goes unhealthy so a proxy or load balancer with active probes stops routing here.
+2. **Connected browsers are told.** Every live session gets a `{"type":"shutdown"}` frame, so the client
+   shows **"Updating…"** rather than the reconnect spinner.
+3. **In-flight handlers finish.** A click that is mid-`SaveChangesAsync` completes rather than being
+   cancelled halfway.
+4. **Sockets close cleanly** — WebSocket status `1001` ("going away"), not an abort — and the sessions
+   are disposed before the host stops.
+
+Anything still connected when `ShutdownDrainTimeout` elapses is aborted, and
+`rask.shutdown.sessions.abandoned` counts it.
+
+> **A redeploy does reload connected browsers, and that is not avoidable.** A live session is a component
+> tree plus a DI scope living in *that* process; the replacement container cannot inherit it. What the
+> drain fixes is the *experience*: instead of a frozen page, an abnormal disconnect, and a four-second
+> "Your session timed out", the page says "Updating…", reloads onto the new instance in ~250 ms, and
+> restores your scroll position and focus. Form field values are deliberately **not** restored — the new
+> server renders those from its own state, and overwriting them with stale client copies would turn a
+> cosmetic loss into a data one.
+
+`ShutdownDrainTimeout` must fit inside `HostOptions.ShutdownTimeout`, which must fit inside whatever your
+container runtime allows between `SIGTERM` and `SIGKILL` (`rask deploy` uses 20 s). Rask logs a warning at
+startup if the first of those doesn't hold. Note that `HostOptions.ServicesStopConcurrently` is `false` by
+default, so other hosted services' shutdown work is spent from the same budget first.
 
 ### Reconnect UX
 
@@ -81,6 +112,8 @@ overlay handles the user-facing side automatically — nothing to configure:
   the client then shows "Your session timed out. Reload to continue." with a **Reload** button (and a
   fallback auto-reload) instead of silently reloading and wiping in-progress UI state. Raise
   `SessionGracePeriod` if your users routinely background the tab longer than the 30 s default.
+- **Deploy aware.** A drop caused by the server shutting down is *not* reported as a timeout — see
+  [Shutdown and redeploy](#shutdown-and-redeploy).
 
 > **Using `HandlerTimeout`:** thread `Component.CancellationToken` into the cancellable async work your
 > event handlers start, so the timeout (or socket close) can unwind them. Inside a handler that token

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -32,6 +32,11 @@ Dockerfile below (override with `--dockerfile`).
   to start — or that starts but fails its probe (bad config, a failed migration) — is removed and the
   previous version keeps serving. Apps scaffolded with `rask new` ship the `/health` endpoint; probe a
   different path with `--health-path <path>`, or skip the probe with `--no-health-check`.
+  HTTP requests are zero-downtime; **live sessions re-establish**, because a session is a component tree
+  and a DI scope inside *that* container and cannot hand over to the next one. The retiring container
+  announces its shutdown first, so open pages show "Updating…" and reload onto the new instance at their
+  previous scroll position rather than reporting a timeout — see
+  [Shutdown and redeploy](configuration.md#shutdown-and-redeploy).
 - **Durable SQLite database.** Every deploy runs a fresh container, so the database can't live inside it.
   `rask deploy` mounts a per-app named volume and points the app at it (`ConnectionStrings:App` →
   `Data Source=/data/app.db`), so your data persists across redeploys; the old container is stopped
@@ -164,10 +169,15 @@ Beyond your own `--env` values, every deployed container gets:
 | `--restart unless-stopped` | The app comes back after a reboot or a daemon restart. |
 
 The scaffolded app is set up to match: it honours forwarded headers (so `Request.Scheme` and the client
-IP are the visitor's, not the proxy's), reports live-session capacity on `/health` (so a host that is
-refusing sessions with `503` says so rather than answering a bare "up"), and shuts down within 15s — inside
-the 20s grace period the deploy allows before `SIGKILL`, so in-flight requests drain and SQLite checkpoints
-cleanly.
+IP are the visitor's, not the proxy's), reports live-session capacity and readiness on `/health` (so a host
+that is refusing sessions with `503` — because it is full, or because it is draining — says so rather than
+answering a bare "up"), and gives itself a **15 s shutdown budget**, inside the 20 s the deploy allows
+before `SIGKILL`.
+
+Within that budget the app closes admission, tells connected browsers it is going away, lets in-flight
+HTTP requests and event handlers finish, closes each WebSocket with a proper `1001` handshake, and
+checkpoints SQLite. These are budgets, not guarantees: work that outlives its budget is cancelled, and
+`rask.shutdown.sessions.abandoned` (plus a warning in the logs) tells you when that happened.
 
 ### Your users stay signed in across a deploy
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -34,8 +34,9 @@ Dockerfile below (override with `--dockerfile`).
   different path with `--health-path <path>`, or skip the probe with `--no-health-check`.
   HTTP requests are zero-downtime; **live sessions re-establish**, because a session is a component tree
   and a DI scope inside *that* container and cannot hand over to the next one. The retiring container
-  announces its shutdown first, so open pages show "Updating…" and reload onto the new instance at their
-  previous scroll position rather than reporting a timeout — see
+  announces its shutdown first, so open pages show "Updating…" and reconnect to the new instance
+  immediately instead of reporting a timeout — reloading only if the host that answers cannot rebuild the
+  page, and then at their previous scroll position. See
   [Shutdown and redeploy](configuration.md#shutdown-and-redeploy).
 - **Durable SQLite database.** Every deploy runs a fresh container, so the database can't live inside it.
   `rask deploy` mounts a per-app named volume and points the app at it (`ConnectionStrings:App` →

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -64,6 +64,13 @@ All metrics publish on the meter named **`Rask.Server`** (`RaskTelemetry.MeterNa
 | `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` \| `idle` | Inbound frames refused by a safety limit. |
 | `rask.sessions.resumed` | Counter | | Pages rebuilt on a host that had never heard of the session, from the client's [resume record](configuration.md#surviving-a-restart-or-a-redeploy). |
 | `rask.sessions.resume_rejected` | Counter | `reason` = `malformed` \| `unprotect` \| `principal` \| `toolarge` \| `atcapacity` | Resume records refused. |
+| `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` | Inbound frames refused by a safety limit. |
+| `rask.shutdown.sessions.abandoned` | Counter | | Sessions still connected when the shutdown drain budget ran out; their sockets were aborted. |
+
+A nonzero `rask.shutdown.sessions.abandoned` is the signal that `ShutdownDrainTimeout` — or the
+`HostOptions.ShutdownTimeout` containing it — is shorter than your app's real shutdown, so some users saw
+an abnormal disconnect instead of a clean "Updating…" reload. Because it is emitted *during* shutdown, its
+delivery depends on your exporter's final flush; the same fact is logged, which is the more reliable read.
 
 The `rask.ws.frames.rejected` counter is the headline DoS-visibility signal: a spike on
 `reason=rate` or `reason=backlog` means a client is being throttled by the per-connection frame-rate
@@ -133,7 +140,9 @@ above (or any `ActivityListener`).
 
 ## Health checks
 
-`RaskLiveHealthCheck` reports live-session capacity. Register it on your health-checks pipeline:
+`AddRaskLiveSessions()` registers two checks, because they answer different questions: capacity
+(`RaskLiveHealthCheck`, tagged `live`) and readiness (`RaskReadinessHealthCheck`, tagged `ready`).
+Register them on your health-checks pipeline:
 
 ```csharp
 builder.Services.AddRask(o => o.MaxSessions = 1000);
@@ -151,3 +160,21 @@ app.UseRask<App>();
 
 The active and maximum session counts are attached to the health-check result `data` for dashboards.
 Pair the capacity cap with a reverse-proxy rate limit for precise admission control.
+
+### Readiness
+
+`RaskReadinessHealthCheck` answers one question: *is this instance still accepting live sessions?* It is
+`Healthy` normally and `Unhealthy` from the moment a graceful shutdown begins, so an aggregate `/health`
+returns `503` while draining and a load balancer with active probes stops routing here.
+
+It is kept separate from the capacity check on purpose — that one's `Unhealthy` already means "at
+`MaxSessions`, refusing with `503`", and folding a second cause into it would make both readings
+ambiguous exactly when someone is diagnosing an incident. Split them with the tags when you want distinct
+probes:
+
+```csharp
+app.MapHealthChecks("/health/ready",
+    new HealthCheckOptions { Predicate = c => c.Tags.Contains("ready") });
+app.MapHealthChecks("/health/live",
+    new HealthCheckOptions { Predicate = c => c.Tags.Contains("live") });
+```

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -45,6 +45,26 @@ public static class LivePayload
     internal static readonly byte[] HotReloadAppliedFrame = Encoding.UTF8.GetBytes(HotReloadAppliedJson);
 
     /// <summary>
+    ///     The "this server is going away — reconnect somewhere else" control frame, broadcast to every
+    ///     connected session at the top of a graceful shutdown. A fixed literal for the same reasons as
+    ///     <see cref="HotReloadAppliedJson" />: no reflection-based serialization, no allocation.
+    ///     <para>
+    ///         Unlike the hot-reload frame this is <b>not</b> dev-gated. A production redeploy is exactly
+    ///         when it matters: it is what lets the client say "Updating…" and come back where it was,
+    ///         instead of reading the new process's <c>session/unknown</c> reply as an idle timeout and
+    ///         showing "Your session timed out".
+    ///     </para>
+    ///     <para>
+    ///         The client branches on this exact text; <c>ShutdownDrainTests</c> and the
+    ///         <c>rask.js</c> source contract both assert against this same constant so the two halves
+    ///         cannot drift.
+    ///     </para>
+    /// </summary>
+    internal const string ServerShutdownJson = """{"type":"shutdown","status":"draining"}""";
+
+    internal static readonly byte[] ServerShutdownFrame = Encoding.UTF8.GetBytes(ServerShutdownJson);
+
+    /// <summary>
     ///     Stamps the session id onto <c>&lt;body&gt;</c> as <c>data-rask-root</c>, and in development
     ///     also <c>data-rask-dev</c> — the flag the client requires before it will act on any dev-only
     ///     frame. Production HTML never carries it, so those branches are unreachable there even if a

--- a/src/Rask.Server/Diagnostics/RaskHealthCheckExtensions.cs
+++ b/src/Rask.Server/Diagnostics/RaskHealthCheckExtensions.cs
@@ -9,21 +9,48 @@ namespace Rask.Server.Diagnostics;
 public static class RaskHealthCheckExtensions
 {
     /// <summary>
-    ///     Adds the <see cref="RaskLiveHealthCheck" /> (live-session capacity) to the health-checks
-    ///     pipeline. Requires <c>AddRask()</c> to have registered the <see cref="LiveSessionStore" />.
-    ///     Usage: <c>services.AddHealthChecks().AddRaskLiveSessions();</c>
+    ///     Adds the Rask health checks to the pipeline. Requires <c>AddRask()</c> to have registered the
+    ///     <see cref="LiveSessionStore" />. Usage:
+    ///     <c>services.AddHealthChecks().AddRaskLiveSessions();</c>
+    ///     <para>
+    ///         Registers two checks, because they answer different questions:
+    ///         <see cref="RaskLiveHealthCheck" /> (tagged <c>live</c>) reports live-session
+    ///         <em>capacity</em>, and <see cref="RaskReadinessHealthCheck" /> (tagged <c>ready</c>)
+    ///         reports whether this instance is still accepting sessions at all — it goes unhealthy the
+    ///         moment a graceful shutdown begins. An aggregate endpoint therefore returns 503 while
+    ///         draining, with no extra wiring.
+    ///     </para>
+    ///     <para>
+    ///         Split them with the tags when you want separate probes:
+    ///         <c>app.MapHealthChecks("/health/ready", new HealthCheckOptions { Predicate = c =&gt; c.Tags.Contains("ready") })</c>.
+    ///     </para>
     /// </summary>
     /// <param name="builder">The health-checks builder.</param>
-    /// <param name="name">The health-check registration name.</param>
+    /// <param name="name">The capacity check's registration name. The readiness check appends <c>_ready</c>.</param>
     /// <param name="failureStatus">
-    ///     The status reported when the check fails. Defaults to the check's own
+    ///     The status reported when the capacity check fails. Defaults to the check's own
     ///     <see cref="HealthStatus.Unhealthy" /> result.
     /// </param>
-    /// <param name="tags">Optional tags for filtering this check (e.g. <c>"ready"</c>, <c>"rask"</c>).</param>
+    /// <param name="tags">
+    ///     Optional tags for the capacity check, replacing the default <c>live</c>. The readiness check
+    ///     always carries <c>ready</c> — that tag is the documented way to build a readiness probe.
+    /// </param>
     public static IHealthChecksBuilder AddRaskLiveSessions(
         this IHealthChecksBuilder builder,
         string name = "rask_live_sessions",
         HealthStatus? failureStatus = null,
-        IEnumerable<string>? tags = null) =>
-        builder.AddCheck<RaskLiveHealthCheck>(name, failureStatus, tags ?? []);
+        IEnumerable<string>? tags = null)
+    {
+        builder.AddCheck<RaskLiveHealthCheck>(name, failureStatus, tags ?? ["live"]);
+        // Registered with an explicit factory rather than AddCheck<T>: the health-check infrastructure
+        // activates a check through ActivatorUtilities, which only considers PUBLIC constructors, and
+        // this one takes the internal drain coordinator. AddCheck<T> would compile and then throw on the
+        // first probe — which is how it was caught.
+        builder.Add(new HealthCheckRegistration(
+            name + "_ready",
+            sp => new RaskReadinessHealthCheck(sp.GetRequiredService<RaskDrainCoordinator>()),
+            failureStatus: null,
+            tags: ["ready"]));
+        return builder;
+    }
 }

--- a/src/Rask.Server/Diagnostics/RaskMetrics.cs
+++ b/src/Rask.Server/Diagnostics/RaskMetrics.cs
@@ -24,6 +24,7 @@ public sealed class RaskMetrics : IDisposable
     private readonly Counter<long> _handlersTimedOut;
     private readonly Histogram<double> _handlerDuration;
     private readonly Meter _meter;
+    private readonly Counter<long> _sessionsAbandonedAtDrain;
     private readonly Counter<long> _sessionsCreated;
     private readonly Counter<long> _sessionsEvicted;
     private readonly Counter<long> _sessionsRejected;
@@ -58,6 +59,9 @@ public sealed class RaskMetrics : IDisposable
             "rask.sessions.resumed", "{session}", "Sessions rebuilt from a client's resume record.");
         _sessionsResumeRejected = _meter.CreateCounter<long>(
             "rask.sessions.resume_rejected", "{session}", "Resume records refused, tagged with the reason.");
+        _sessionsAbandonedAtDrain = _meter.CreateCounter<long>(
+            "rask.shutdown.sessions.abandoned", "{session}",
+            "Live sessions still connected when the shutdown drain budget ran out (their sockets were aborted).");
     }
 
     // Exposed for tests so a MeterListener can scope to this exact meter instance and ignore
@@ -76,6 +80,13 @@ public sealed class RaskMetrics : IDisposable
     public void SessionRejected() => _sessionsRejected.Add(1);
 
     public void SessionEvicted() => _sessionsEvicted.Add(1);
+
+    /// <summary>
+    ///     Records sessions whose sockets had to be aborted because the drain budget ran out. A nonzero
+    ///     reading is the signal that <c>RaskServerOptions.ShutdownDrainTimeout</c> (or the
+    ///     <c>HostOptions.ShutdownTimeout</c> containing it) is shorter than the app's real shutdown.
+    /// </summary>
+    public void SessionsAbandonedAtDrain(int count) => _sessionsAbandonedAtDrain.Add(count);
 
     public void HandlerDispatched() => _handlersDispatched.Add(1);
 

--- a/src/Rask.Server/Diagnostics/RaskReadinessHealthCheck.cs
+++ b/src/Rask.Server/Diagnostics/RaskReadinessHealthCheck.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Rask.Server.Diagnostics;
+
+/// <summary>
+///     An ASP.NET health check reporting whether this instance is still accepting live sessions.
+///     <c>Unhealthy</c> from the moment a graceful shutdown begins, so a proxy or load balancer with
+///     active probes stops routing at a host that is on its way out — and an operator watching
+///     <c>/health</c> can see the difference between "draining" and "dead".
+///     <para>
+///         Deliberately separate from <see cref="RaskLiveHealthCheck" /> rather than folded into it.
+///         That check's <c>Unhealthy</c> already means one specific thing — "at the session cap,
+///         refusing with 503" — and overloading it with a second cause would make both readings
+///         ambiguous exactly when someone is trying to diagnose a live incident.
+///     </para>
+/// </summary>
+public sealed class RaskReadinessHealthCheck : IHealthCheck
+{
+    // Cached: the check runs on every probe and neither result carries per-call data.
+    private static readonly HealthCheckResult Draining =
+        HealthCheckResult.Unhealthy("Rask is draining; this instance is no longer accepting live sessions.");
+
+    private static readonly HealthCheckResult Ready =
+        HealthCheckResult.Healthy("Rask is accepting live sessions.");
+
+    private readonly RaskDrainCoordinator _drain;
+
+    internal RaskReadinessHealthCheck(RaskDrainCoordinator drain) => _drain = drain;
+
+    /// <inheritdoc />
+    public Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default) =>
+        Task.FromResult(_drain.IsDraining ? Draining : Ready);
+}

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -113,15 +113,30 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     public IServiceScope Scope { get; }
     public SemaphoreSlim Lock { get; } = new(1, 1);
 
+    private Task _lastHandlerTask = Task.CompletedTask;
+
     /// <summary>
     ///     Tail of the WS-message handler chain. Each inbound handler dispatch awaits
     ///     this task before running, then assigns its own continuation back here, so
-    ///     handlers run strictly in WS-arrival order. The WS receive loop is single-
-    ///     threaded for this session, so reads / writes of this property don't race —
-    ///     no synchronisation needed. <see cref="Task.CompletedTask" /> initially so
-    ///     the first handler runs immediately.
+    ///     handlers run strictly in WS-arrival order. <see cref="Task.CompletedTask" />
+    ///     initially so the first handler runs immediately.
+    ///     <para>
+    ///         The WS receive loop is this property's sole <em>writer</em> and is single-threaded per
+    ///         session, so writes never race each other. It gained a second <em>reader</em> on another
+    ///         thread when the shutdown drain began awaiting the chain
+    ///         (<see cref="RaskDrainService" />), hence the volatile accessors: reference assignment is
+    ///         already atomic, but without the fence the drain thread can observe a stale tail on a weak
+    ///         memory model and conclude a still-running handler had finished.
+    ///     </para>
     /// </summary>
-    internal Task LastHandlerTask { get; set; } = Task.CompletedTask;
+    internal Task LastHandlerTask
+    {
+        get => Volatile.Read(ref _lastHandlerTask);
+        set => Volatile.Write(ref _lastHandlerTask, value);
+    }
+
+    /// <summary>Handler dispatches queued on the chain but not yet complete. Read by the drain to settle.</summary>
+    internal int PendingHandlers => Volatile.Read(ref _pendingHandlers);
 
     // Number of handler dispatches queued on the LastHandlerTask chain but not yet completed.
     // Each queued dispatch retains a cloned JsonElement, so an unbounded chain (a flood of input
@@ -456,6 +471,57 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             }
 
             await SendGuardedAsync(payload).ConfigureAwait(false);
+        }
+        finally
+        {
+            _renderLock.Release();
+        }
+    }
+
+    /// <summary>
+    ///     Sends the WebSocket close frame for a graceful shutdown: status 1001
+    ///     (<see cref="WebSocketCloseStatus.EndpointUnavailable" />, "going away") with a reason the
+    ///     client can read. Best-effort — a socket already closing or faulted is not an error here.
+    ///     <para>
+    ///         <b>Why <c>CloseOutputAsync</c> and not <c>CloseAsync</c>.</b> This is called from the drain,
+    ///         not from the receive loop, and the receive loop is parked in <c>ReceiveAsync</c> at the
+    ///         time. <c>CloseAsync</c> sends the close frame <em>and then receives</em> until the peer
+    ///         echoes, which would be a second concurrent receive and throws. <c>CloseOutputAsync</c> is
+    ///         send-only: the parked <c>ReceiveAsync</c> then observes the browser's echo as an ordinary
+    ///         close message and the loop unwinds through its own <c>finally</c>.
+    ///     </para>
+    ///     <para>
+    ///         <b>Why not just cancel the socket token.</b> Cancelling a token a <c>ReceiveAsync</c> is
+    ///         using <em>aborts</em> the WebSocket — no close frame, and the browser sees 1006. That is
+    ///         precisely the behaviour this method exists to replace, so the cancellation path must stay
+    ///         the deadline backstop and never the ordinary route.
+    ///     </para>
+    /// </summary>
+    /// <param name="ct">
+    ///     The drain's budget token. Deliberately not <c>_socketCt</c>: that one is cancelled by the
+    ///     deadline, and using it here would make the close throw at exactly the moment it most needs to
+    ///     complete.
+    /// </param>
+    internal async Task CloseForShutdownAsync(CancellationToken ct)
+    {
+        if (_socket is null || _socket.State != WebSocketState.Open)
+        {
+            return;
+        }
+
+        // Behind the render lock so the close frame cannot interleave a render's SendAsync — the same
+        // discipline SendOutOfBandAsync uses, and the reason the shutdown announcement is guaranteed to
+        // reach the wire before this close does.
+        await _renderLock.WaitAsync(ct).ConfigureAwait(false);
+        try
+        {
+            if (_socket is null || _socket.State != WebSocketState.Open)
+            {
+                return;
+            }
+
+            await _socket.CloseOutputAsync(
+                WebSocketCloseStatus.EndpointUnavailable, "server-shutdown", ct).ConfigureAwait(false);
         }
         finally
         {

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -50,6 +50,27 @@ public sealed class LiveSessionStore : IAsyncDisposable
     public int Count => _sessions.Count;
 
     /// <summary>
+    ///     The host's shutdown state, set by <c>AddRask</c> right after construction. Assigned rather than
+    ///     injected because this type's constructor is public while <see cref="RaskDrainCoordinator" /> is
+    ///     internal — and because leaving it null keeps every directly-constructed test store working
+    ///     unchanged (it simply never drains).
+    /// </summary>
+    internal RaskDrainCoordinator? Drain { get; set; }
+
+    /// <summary>True while the host is shutting down: admission is closed and the drain owns teardown.</summary>
+    internal bool IsDraining => Drain?.IsDraining == true;
+
+    /// <summary>
+    ///     A point-in-time snapshot of the live sessions. <c>ConcurrentDictionary.Values</c> already
+    ///     copies, which is what the broadcast path relies on, so the drain can iterate while the socket
+    ///     loops are still removing themselves.
+    /// </summary>
+    internal ICollection<LiveSession> Snapshot() => _sessions.Values;
+
+    /// <summary>Ids of the live sessions, for a teardown loop that must tolerate concurrent removal.</summary>
+    internal ICollection<string> SessionIds() => _sessions.Keys;
+
+    /// <summary>
     ///     Reserved + in-flight + committed session count — the authoritative capacity number that
     ///     <see cref="TryCreate" /> / <see cref="AtCapacity" /> gate on. Differs from
     ///     <see cref="Count" /> (committed sessions only) during the window where a reserved session's
@@ -150,6 +171,15 @@ public sealed class LiveSessionStore : IAsyncDisposable
     /// </summary>
     internal LiveSession? TryCreate(Func<IServiceProvider, Component> factory)
     {
+        // Refuse before reserving anything: a session minted during the drain is one the drain has
+        // already snapshotted past, so it would be built (component tree + DI scope) only to be torn
+        // down moments later — and the client would be handed a page whose session is already dead.
+        if (IsDraining)
+        {
+            _metrics?.SessionRejected();
+            return null;
+        }
+
         var reserved = Interlocked.Increment(ref _liveCount);
         if (MaxSessions > 0 && reserved > MaxSessions)
         {
@@ -227,6 +257,14 @@ public sealed class LiveSessionStore : IAsyncDisposable
 
     internal void ScheduleRemoval(string id, TimeSpan delay)
     {
+        // Draining: the drain owns teardown and disposes every session awaited, inside the shutdown
+        // window. Doing anything here would be worse than nothing — this used to fire off an unawaited
+        // RemoveAsync, so a component's async unmount raced process exit with nobody observing it.
+        if (IsDraining)
+        {
+            return;
+        }
+
         if (_stopping.IsCancellationRequested)
         {
             _ = RemoveAsync(id);

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -28,6 +28,9 @@ public sealed class LiveSessionStore : IAsyncDisposable
     // on a failed build), so a concurrent GET burst can never exceed MaxSessions.
     private int _liveCount;
 
+    // 1 once DisposeAsync has run. See DisposeAsync for why it must be once-only.
+    private int _disposed;
+
     public LiveSessionStore(
         IServiceScopeFactory scopeFactory,
         IHostApplicationLifetime? lifetime = null,
@@ -107,6 +110,14 @@ public sealed class LiveSessionStore : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        // Runs once. The store is a DI singleton, so the container disposes it — and a host or a test that
+        // disposes it too would otherwise reach a Cancel() on an already-disposed token source. Salvaged
+        // from #572, which found it; the rest of that PR is superseded by this drain.
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
         CancelAllPending();
         foreach (var key in _sessions.Keys.ToArray())
         {

--- a/src/Rask.Server/RaskDrainCoordinator.cs
+++ b/src/Rask.Server/RaskDrainCoordinator.cs
@@ -1,0 +1,122 @@
+namespace Rask.Server;
+
+/// <summary>
+///     The per-host shutdown state the live subsystem drains against — pure state, no dependencies, so
+///     the store can ask it "am I draining?" without a construction cycle. One singleton per host (like
+///     <see cref="RaskServerLimits" />), so two hosts in one process — or parallel tests — never observe
+///     each other's shutdown. <see cref="RaskDrainService" /> owns the routine that drives it.
+///     <para>
+///         <b>Why the abort moved.</b> What shipped before registered <c>ws.Abort()</c> directly on the
+///         host's <c>ApplicationStopping</c>, which made the hard kill the <em>first</em> move of every
+///         shutdown: no close frame, so every browser saw an abnormal 1006 closure and no client could
+///         tell a redeploy from a crash. <see cref="HardStopping" /> is that same abort, moved to the end
+///         of the budget where a backstop belongs.
+///     </para>
+/// </summary>
+internal sealed class RaskDrainCoordinator : IDisposable
+{
+    private readonly CancellationTokenSource _hardStopping = new();
+
+    // Completed once every tracked socket loop has returned. Single-shot: the drain awaits it exactly
+    // once at shutdown, so a count that dips to zero earlier in the host's life (every client
+    // disconnected for a moment) completing it early is harmless — by the time it is awaited, admission
+    // is already closed and no new loop can start.
+    private readonly TaskCompletionSource _socketsDrained =
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private int _activeSockets;
+    private volatile bool _draining;
+
+    /// <summary>
+    ///     True once the drain has begun. Gates admission (<see cref="LiveSessionStore.TryCreate" />
+    ///     refuses) and readiness (<c>RaskReadinessHealthCheck</c> reports unhealthy), so a proxy or load
+    ///     balancer stops routing at a host that is on its way out.
+    /// </summary>
+    public bool IsDraining => _draining;
+
+    /// <summary>
+    ///     Trips when the drain budget is spent. Every live socket's cancellation token derives from this
+    ///     — <em>not</em> from <c>ApplicationStopping</c> — which is what lets the drain send a shutdown
+    ///     frame and finish in-flight handlers on a socket the host has already been asked to stop.
+    /// </summary>
+    public CancellationToken HardStopping => _hardStopping.Token;
+
+    /// <summary>Socket loops still running. Metered at the drain deadline.</summary>
+    public int ActiveSockets => Volatile.Read(ref _activeSockets);
+
+    public void Dispose() => _hardStopping.Dispose();
+
+    /// <summary>Marks the host as draining. Idempotent.</summary>
+    public void BeginDrain() => _draining = true;
+
+    /// <summary>
+    ///     Arms the backstop: every socket still open when <paramref name="budget" /> elapses is aborted.
+    ///     Armed from the synchronous <c>ApplicationStopping</c> callback so it holds even if
+    ///     <see cref="RaskDrainService.StopAsync" /> never runs (or runs far too late — hosted services
+    ///     stop in reverse registration order, and <c>AddRask</c> is typically the first line of
+    ///     <c>Program.cs</c>, so Rask stops after every battery that was registered below it).
+    /// </summary>
+    public void ArmDeadline(TimeSpan budget)
+    {
+        try
+        {
+            _hardStopping.CancelAfter(budget);
+        }
+        catch (ObjectDisposedException)
+        {
+        }
+    }
+
+    /// <summary>Trips the deadline now, aborting any socket still open. Safe to call more than once.</summary>
+    public void TripDeadline()
+    {
+        try
+        {
+            _hardStopping.Cancel();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The host disposed the container while the drain was still unwinding. Benign: the signal
+            // has no one left to reach.
+        }
+    }
+
+    /// <summary>
+    ///     Tracks one running socket loop for the duration of the returned scope. The drain waits on
+    ///     these rather than on <c>LiveSession</c> state, because the loop detaches its session
+    ///     <em>before</em> it finishes unwinding — so a session-based wait would report "done" while the
+    ///     close handshake was still in flight, which is the one thing the drain exists to complete.
+    /// </summary>
+    public IDisposable TrackSocket()
+    {
+        Interlocked.Increment(ref _activeSockets);
+        return new SocketScope(this);
+    }
+
+    /// <summary>Completes when no socket loop is running. Await with a timeout — this has no budget of its own.</summary>
+    public Task WhenSocketsDrained() =>
+        Volatile.Read(ref _activeSockets) == 0 ? Task.CompletedTask : _socketsDrained.Task;
+
+    private void ReleaseSocket()
+    {
+        if (Interlocked.Decrement(ref _activeSockets) == 0)
+        {
+            _socketsDrained.TrySetResult();
+        }
+    }
+
+    private sealed class SocketScope(RaskDrainCoordinator owner) : IDisposable
+    {
+        private int _released;
+
+        public void Dispose()
+        {
+            // `using` runs once, but making a double dispose harmless is cheaper than relying on every
+            // caller — a negative count would make WhenSocketsDrained never complete.
+            if (Interlocked.Exchange(ref _released, 1) == 0)
+            {
+                owner.ReleaseSocket();
+            }
+        }
+    }
+}

--- a/src/Rask.Server/RaskDrainService.cs
+++ b/src/Rask.Server/RaskDrainService.cs
@@ -1,0 +1,216 @@
+using System.Globalization;
+using Microsoft.Extensions.Hosting;
+using Rask.Core.Diagnostics;
+using Rask.Core.Live;
+using Rask.Server.Diagnostics;
+
+namespace Rask.Server;
+
+/// <summary>
+///     Drains the live sessions on a graceful shutdown: announce, let in-flight handlers finish, close
+///     each socket with a real handshake, dispose awaited. Registered by <c>AddRask</c>; there is nothing
+///     to opt into.
+///     <para>
+///         <b>Why the work is split across two moments.</b> Hosted services stop in reverse registration
+///         order, and <c>AddRask</c> is typically the first line of <c>Program.cs</c> — so this service's
+///         <see cref="StopAsync" /> runs <em>after</em> every battery registered below it, and a
+///         Litestream flush can have spent most of <c>HostOptions.ShutdownTimeout</c> before we are even
+///         entered. Anything that must happen at t=0 therefore happens in the synchronous
+///         <c>ApplicationStopping</c> callback registered by <see cref="StartAsync" />: closing admission,
+///         flipping readiness, arming the backstop, and starting the announcement. Only the parts that
+///         must be <em>awaited</em> wait for <see cref="StopAsync" />, which the host does block on.
+///     </para>
+/// </summary>
+internal sealed class RaskDrainService : IHostedService, IDisposable
+{
+    // Ceiling on the post-deadline teardown pass. Disposal is local work (unmount hooks, DI scope
+    // disposal) with every socket already aborted, so this is a wedge-guard, not a budget.
+    private static readonly TimeSpan TeardownTimeout = TimeSpan.FromSeconds(2);
+
+    private readonly RaskDrainCoordinator _coordinator;
+    private readonly IHostApplicationLifetime? _lifetime;
+    private readonly RaskServerLimits _limits;
+    private readonly RaskMetrics? _metrics;
+    private readonly LiveSessionStore _store;
+
+    private Task _announce = Task.CompletedTask;
+    private CancellationTokenRegistration _stoppingRegistration;
+
+    public RaskDrainService(
+        LiveSessionStore store,
+        RaskDrainCoordinator coordinator,
+        RaskServerLimits limits,
+        IHostApplicationLifetime? lifetime = null,
+        RaskMetrics? metrics = null)
+    {
+        _store = store;
+        _coordinator = coordinator;
+        _limits = limits;
+        _lifetime = lifetime;
+        _metrics = metrics;
+    }
+
+    public void Dispose() => _stoppingRegistration.Dispose();
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (_lifetime is not null)
+        {
+            _stoppingRegistration = _lifetime.ApplicationStopping.Register(BeginDrain);
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        // StopAsync can be reached without ApplicationStopping having fired (a host stopped directly, or
+        // a test that calls StopAsync on the app). Begin here too so the drain is never skipped.
+        BeginDrain();
+
+        if (_limits.ShutdownDrainTimeout <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        using var budget = new CancellationTokenSource(_limits.ShutdownDrainTimeout);
+        var token = budget.Token;
+
+        try
+        {
+            await SwallowAsync(_announce).ConfigureAwait(false);
+            await SettleHandlersAsync(token).ConfigureAwait(false);
+            await CloseSocketsAsync(token).ConfigureAwait(false);
+            await SwallowAsync(_coordinator.WhenSocketsDrained().WaitAsync(token)).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // Budget spent. Fall through: the abandoned count is reported below and the deadline is
+            // tripped either way, so a wedged handler costs the budget rather than the shutdown.
+        }
+
+        var abandoned = _coordinator.ActiveSockets;
+
+        // Trip the deadline BEFORE the dispose loop, not after. A session whose handler still holds the
+        // render lock would otherwise block DisposeAsync indefinitely; aborting the socket makes its
+        // in-flight send fail, the render unwinds, and the lock is released.
+        _coordinator.TripDeadline();
+        await DisposeSessionsAsync().ConfigureAwait(false);
+
+        if (abandoned > 0)
+        {
+            _metrics?.SessionsAbandonedAtDrain(abandoned);
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.Live",
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Rask: {abandoned} live session(s) were still connected when the {_limits.ShutdownDrainTimeout.TotalSeconds:0.##}s drain budget ran out; their sockets were aborted. Raise RaskServerOptions.ShutdownDrainTimeout, or HostOptions.ShutdownTimeout if it is the tighter of the two."));
+        }
+    }
+
+    // Every per-session await goes through this. One session whose socket already faulted, whose handler
+    // threw, or whose wait outran the budget must not stop the drain — the other sessions still need it.
+    // Cancellation is an expected outcome here, not an error, so it is swallowed too; the budget is
+    // enforced by the loops that own a token, and by the deadline the coordinator armed at t=0.
+    private static async Task SwallowAsync(Task task)
+    {
+        try
+        {
+            await task.ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Deliberate: see above.
+        catch
+#pragma warning restore CA1031
+        {
+        }
+    }
+
+    private void BeginDrain()
+    {
+        if (_coordinator.IsDraining)
+        {
+            return;
+        }
+
+        _coordinator.BeginDrain();
+
+        if (_limits.ShutdownDrainTimeout <= TimeSpan.Zero)
+        {
+            // Drain disabled: restore the historical behaviour of aborting immediately.
+            _coordinator.TripDeadline();
+            return;
+        }
+
+        // The backstop is armed here rather than in StopAsync so it holds even if StopAsync never runs,
+        // or runs so late that the budget is already gone.
+        _coordinator.ArmDeadline(_limits.ShutdownDrainTimeout);
+
+        var sessions = _store.Count;
+        if (sessions > 0)
+        {
+            RaskDiagnostics.Report(
+                RaskLogLevel.Information, "Rask.Live",
+                string.Create(
+                    CultureInfo.InvariantCulture,
+                    $"Rask: draining {sessions} live session(s) with a {_limits.ShutdownDrainTimeout.TotalSeconds:0.##}s budget."));
+        }
+
+        _announce = Task.Run(AnnounceAsync);
+    }
+
+    /// <summary>
+    ///     Tells every connected browser the server is going away, so the client shows "Updating…" and
+    ///     comes back where it was instead of reading the replacement process's <c>session/unknown</c>
+    ///     reply as an idle timeout.
+    ///     <para>
+    ///         Fanned out concurrently rather than through <c>LiveSessionStore.BroadcastAsync</c>, which
+    ///         is sequential: one session blocked on its render lock mid-frame would otherwise delay the
+    ///         announcement to every session behind it. Sends to <em>different</em> sessions are safe in
+    ///         parallel — each owns its own lock and socket.
+    ///     </para>
+    /// </summary>
+    private Task AnnounceAsync() =>
+        Task.WhenAll(_store.Snapshot().Select(s => SwallowAsync(s.SendOutOfBandAsync(LivePayload.ServerShutdownFrame))));
+
+    /// <summary>
+    ///     Waits for in-flight handler dispatches to finish. This is the part that only became meaningful
+    ///     once the socket token stopped deriving from <c>ApplicationStopping</c>: the chain now runs on a
+    ///     live token instead of unwinding on a cancelled one, so awaiting it actually lets a click that
+    ///     is mid-<c>SaveChangesAsync</c> complete.
+    /// </summary>
+    private async Task SettleHandlersAsync(CancellationToken token)
+    {
+        foreach (var session in _store.Snapshot())
+        {
+            // Poll the count before awaiting the tail: reading LastHandlerTask once can be stale, because
+            // the receive loop may chain another dispatch onto it immediately after the read.
+            while (session.PendingHandlers > 0)
+            {
+                await Task.Delay(15, token).ConfigureAwait(false);
+            }
+
+            await SwallowAsync(session.LastHandlerTask.WaitAsync(token)).ConfigureAwait(false);
+        }
+    }
+
+    private Task CloseSocketsAsync(CancellationToken token) =>
+        Task.WhenAll(_store.Snapshot().Select(s => SwallowAsync(s.CloseForShutdownAsync(token))));
+
+    private async Task DisposeSessionsAsync()
+    {
+        // Bounded even though Detach removes before disposing (so Count strictly decreases): a component
+        // whose unmount hangs would otherwise wedge shutdown here forever. The deadline was tripped just
+        // above, so anything blocked on a render lock has already been unblocked.
+        using var teardown = new CancellationTokenSource(TeardownTimeout);
+
+        // A loop rather than one pass: TryCreate can have admitted a session microseconds before the
+        // draining flag flipped, and that one is not in the snapshot the drain started from.
+        while (_store.Count > 0 && !teardown.IsCancellationRequested)
+        {
+            foreach (var id in _store.SessionIds())
+            {
+                await SwallowAsync(_store.RemoveAsync(id).WaitAsync(teardown.Token)).ConfigureAwait(false);
+            }
+        }
+    }
+}

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -18,6 +18,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Microsoft.JSInterop;
 using Microsoft.JSInterop.Infrastructure;
@@ -177,11 +178,24 @@ public static class RaskEndpointExtensions
 
         // Metrics singleton (Meter "Rask.Server"). TryAdd so a host can pre-register its own.
         services.TryAddSingleton<RaskMetrics>();
+        // Per-host shutdown state. Pure state with no dependencies, so the store can read it without a
+        // construction cycle; RaskDrainService drives it.
+        services.AddSingleton<RaskDrainCoordinator>();
         services.AddSingleton(sp => new LiveSessionStore(
             sp.GetRequiredService<IServiceScopeFactory>(),
             sp.GetService<IHostApplicationLifetime>(),
             sp.GetService<RaskMetrics>())
-        { MaxSessions = maxSessions, DiffMode = diffMode });
+        {
+            MaxSessions = maxSessions,
+            DiffMode = diffMode,
+            // Assigned rather than passed: LiveSessionStore's constructor is public and
+            // RaskDrainCoordinator is internal, and every directly-constructed test store keeps working
+            // (it simply never drains).
+            Drain = sp.GetRequiredService<RaskDrainCoordinator>(),
+        });
+        // Graceful shutdown for the live sessions: announce, settle in-flight handlers, close each socket
+        // with a real handshake, dispose awaited. Registered unconditionally — a drain is not an opt-in.
+        services.AddHostedService<RaskDrainService>();
         services.AddSingleton<RaskLiveMarker>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
@@ -263,6 +277,8 @@ public static class RaskEndpointExtensions
         else
             Console.WriteLine($"Rask {RaskVersion.Current} (Server) starting");
 
+        WarnOnTightShutdownLadder(app.Services, logger);
+
         // Resolve the scoped-CSS minification default from the host environment unless an explicit
         // true/false was already set (via AddRask or directly): minify outside Development, and keep it
         // readable + hot-reloadable in Development.
@@ -271,6 +287,39 @@ public static class RaskEndpointExtensions
         app.UseWebSockets();
         ((IEndpointRouteBuilder)app).UseRask<TApp>(pattern, pathBase);
         return app;
+    }
+
+    /// <summary>
+    ///     Warns when the shutdown drain cannot fit inside the host's own shutdown budget. A warning and
+    ///     not a throw: <c>Validate</c> throws for values that are <em>invalid</em>, whereas a tight
+    ///     ladder is merely suboptimal, and refusing to start a production app over it would be a far
+    ///     worse failure than the degraded shutdown it is warning about.
+    /// </summary>
+    private static void WarnOnTightShutdownLadder(IServiceProvider services, ILogger? logger)
+    {
+        if (logger is null || services.GetService<RaskServerLimits>() is not { } limits)
+        {
+            return;
+        }
+
+        var drain = limits.ShutdownDrainTimeout;
+        if (drain <= TimeSpan.Zero || services.GetService<IOptions<HostOptions>>()?.Value is not { } host)
+        {
+            return;
+        }
+
+        if (host.ShutdownTimeout > drain)
+        {
+            return;
+        }
+
+        logger.LogWarning(
+            "Rask: ShutdownDrainTimeout ({Drain}) is not below HostOptions.ShutdownTimeout ({Shutdown}), so live "
+            + "sessions will be aborted at shutdown (the browser sees an abnormal 1006 close and reports a timed-out "
+            + "session) instead of closed cleanly. Raise ShutdownTimeout or lower ShutdownDrainTimeout. Note that "
+            + "HostOptions.ServicesStopConcurrently is false by default, so other hosted services spend from the same "
+            + "budget before Rask's drain is even entered.",
+            drain, host.ShutdownTimeout);
     }
 
     /// <summary>
@@ -350,6 +399,19 @@ public static class RaskEndpointExtensions
             if (session is null)
             {
                 httpContext.Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                // Both refusals are 503, but they mean different things to whatever is retrying. A
+                // draining host is being replaced right now and its stand-in is already up, so a second
+                // is the honest hint; a host at capacity needs longer than that to free a slot. No-store
+                // on the drain path so a shared cache can never pin this page after the swap.
+                if (store.IsDraining)
+                {
+                    httpContext.Response.Headers.RetryAfter = "1";
+                    httpContext.Response.Headers.CacheControl = "no-store";
+                    await httpContext.Response.WriteAsync("Server is shutting down; please retry shortly.")
+                        .ConfigureAwait(false);
+                    return;
+                }
+
                 httpContext.Response.Headers.RetryAfter = "5";
                 await httpContext.Response.WriteAsync("Server is at session capacity; please retry shortly.")
                     .ConfigureAwait(false);
@@ -457,7 +519,6 @@ public static class RaskEndpointExtensions
         endpoints.Map(pathBase + WebSocketPath, (RequestDelegate)(async ctx =>
             {
                 var store = ctx.RequestServices.GetRequiredService<LiveSessionStore>();
-                var lifetime = ctx.RequestServices.GetRequiredService<IHostApplicationLifetime>();
                 // Resolve the per-host safety limits once per connection (not per frame) — the receive
                 // loop reads them via instance fields on the hot path.
                 var limits = ctx.RequestServices.GetRequiredService<RaskServerLimits>();
@@ -489,11 +550,19 @@ public static class RaskEndpointExtensions
                 // frames carry the user's own rendered view, no cross-origin mixing).
                 using var ws = await ctx.WebSockets.AcceptWebSocketAsync(
                     new WebSocketAcceptContext { DangerousEnableCompression = true });
+                // The socket's lifetime hangs off the drain's HARD deadline, not off ApplicationStopping.
+                // This one substitution is what makes a graceful shutdown possible at all: this token
+                // becomes LiveSession._socketCt, so while it was ApplicationStopping every send — the
+                // shutdown announcement included — threw the instant SIGTERM landed, and every in-flight
+                // handler was cancelled before it could finish. Now it trips only when the drain budget
+                // is spent, which is also when the ws.Abort() registered below becomes the right answer.
+                var drain = ctx.RequestServices.GetRequiredService<RaskDrainCoordinator>();
+                using var socketScope = drain.TrackSocket();
                 using var linked = CancellationTokenSource.CreateLinkedTokenSource(
-                    ctx.RequestAborted, lifetime.ApplicationStopping);
+                    ctx.RequestAborted, drain.HardStopping);
                 var resume = ctx.RequestServices.GetRequiredService<SessionResumeSupport>();
                 await RunSocketLoop(ws, store, limits, wsUser, resume, appFactory, linked.Token,
-                    lifetime.ApplicationStopping);
+                    drain.HardStopping);
             }));
 
         var script = LoadEmbeddedScript();

--- a/src/Rask.Server/RaskServerLimits.cs
+++ b/src/Rask.Server/RaskServerLimits.cs
@@ -45,6 +45,9 @@ internal sealed class RaskServerLimits
     /// <summary>How long a resume record stays redeemable. See <see cref="RaskServerOptions.ResumeTokenLifetime" />.</summary>
     public TimeSpan ResumeTokenLifetime { get; init; } = TimeSpan.FromHours(1);
 
+    /// <summary>Budget for the graceful shutdown drain. Zero = off (abort immediately, as before).</summary>
+    public TimeSpan ShutdownDrainTimeout { get; init; } = TimeSpan.FromSeconds(5);
+
     /// <summary>Projects a validated <see cref="RaskServerOptions" /> into the per-host limit snapshot.</summary>
     public static RaskServerLimits From(RaskServerOptions o) => new()
     {
@@ -59,5 +62,6 @@ internal sealed class RaskServerLimits
         SendTimeout = o.SendTimeout,
         SessionResume = o.SessionResume,
         ResumeTokenLifetime = o.ResumeTokenLifetime,
+        ShutdownDrainTimeout = o.ShutdownDrainTimeout,
     };
 }

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -155,6 +155,25 @@ public sealed class RaskServerOptions
     public TimeSpan ResumeTokenLifetime { get; set; } = TimeSpan.FromHours(1);
 
     /// <summary>
+    ///     Budget for the graceful shutdown drain: announcing the shutdown to every connected browser,
+    ///     letting in-flight event handlers finish, closing each WebSocket with a real handshake (status
+    ///     1001, "going away") and disposing the sessions. Sockets still open when it elapses are aborted.
+    ///     <para>
+    ///         Must fit inside <c>HostOptions.ShutdownTimeout</c>, which in turn must fit inside whatever
+    ///         your container runtime allows between <c>SIGTERM</c> and <c>SIGKILL</c> (<c>rask deploy</c>
+    ///         uses 20&#160;seconds). Note that <c>HostOptions.ServicesStopConcurrently</c> is <c>false</c>
+    ///         by default, so other hosted services' shutdown work is spent from the same budget before
+    ///         this drain is even entered.
+    ///     </para>
+    ///     <para>
+    ///         <see cref="TimeSpan.Zero" /> disables the drain and restores the previous behaviour —
+    ///         every socket aborted the moment shutdown begins, which the browser sees as an abnormal
+    ///         (1006) closure. Default 5&#160;seconds; a drain normally completes in one round trip.
+    ///     </para>
+    /// </summary>
+    public TimeSpan ShutdownDrainTimeout { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
     ///     Throws <see cref="ArgumentOutOfRangeException" /> if any value is out of range. Called by
     ///     <c>AddRask</c> after the caller's <c>configureServer</c> runs, so a bad value (a negative
     ///     grace period that would crash <c>Task.Delay</c> and leak the session, a non-positive
@@ -232,6 +251,22 @@ public sealed class RaskServerOptions
             throw new ArgumentOutOfRangeException(
                 nameof(ResumeTokenLifetime), ResumeTokenLifetime,
                 "ResumeTokenLifetime must be positive. Set SessionResume = false to disable resume.");
+        }
+
+        if (ShutdownDrainTimeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownDrainTimeout), ShutdownDrainTimeout,
+                "ShutdownDrainTimeout must be >= TimeSpan.Zero (Zero disables the drain).");
+        }
+
+        // CancellationTokenSource.CancelAfter throws above int.MaxValue milliseconds, and it would throw
+        // from the shutdown path — the worst possible place to discover a bad value.
+        if (ShutdownDrainTimeout.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownDrainTimeout), ShutdownDrainTimeout,
+                $"ShutdownDrainTimeout must be at most {TimeSpan.FromMilliseconds(int.MaxValue)}.");
         }
     }
 }

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -169,8 +169,17 @@
     // Dev-only counterpart: under `dotnet watch` an unknown session means the app just restarted for
     // a rude edit, so there is nothing to wait for — get back on screen.
     const DEV_RESTART_RELOAD_MS = 250;
+    // The server told us it is shutting down, so the reload is a deployment, not a timeout. Reload fast:
+    // a blue-green swap moves the proxy to the replacement BEFORE stopping this one, so the replacement
+    // is already serving by the time we get here.
+    const SHUTDOWN_RELOAD_MS = 250;
+    const UPDATING_MSG = "Updating…";
+    // Where the pre-reload scroll/focus snapshot lives. Keyed by path so a reload that lands somewhere
+    // else (a redirect, a changed route) never restores a position from an unrelated page.
+    const RESTORE_KEY = "rask:restore";
     let overlayTimer = null;
     let sessionExpired = false;
+    let serverShuttingDown = false;
 
     function setOverlayMessage(text) {
         if (overlayMsg) overlayMsg.textContent = text;
@@ -180,6 +189,10 @@
         if ("inert" in document.body) document.body.inert = value;
     }
 
+    // Before the socket: if the last page left a restore point (it was reloaded onto a replacement
+    // server), put the user back where they were. The GET shell is fully server-rendered by now, so the
+    // scroll target already exists.
+    applyRestorePoint();
     connect();
 
     function connect() {
@@ -242,6 +255,23 @@
                 if (devMode && data.status === "applied") window.__raskHotReloadPill();
                 return;
             }
+            // The server is shutting down (a redeploy, a restart). Live session state is per-process and
+            // cannot hand over, so a reload is unavoidable — but it is an update, not an expiry, and
+            // saying so is the difference between "Updating…" and a four-second "Your session timed
+            // out". Carries no html, so like the hotReload frame it must NOT fall through to
+            // applyFullReply. Deliberately not dev-gated: production is exactly where this matters.
+            if (data.type === "shutdown") {
+                serverShuttingDown = true;
+                setInert(true);
+                if (overlayTimer !== null) {
+                    clearTimeout(overlayTimer);
+                    overlayTimer = null;
+                }
+                showOverlay();
+                setOverlayMessage(UPDATING_MSG);
+                setRetryButton(null);
+                return;
+            }
             // Handler ack: resolve the slow-link pending bar. Handled synchronously here
             // (not inside _renderQueue) so a CSS-gated deferred body swap can't keep the
             // bar up after the round-trip has actually completed.
@@ -269,8 +299,16 @@
         ws.addEventListener("error", scheduleReconnect);
     }
 
-    function scheduleReconnect() {
+    function scheduleReconnect(e) {
         if (reconnectTimer !== null || sessionExpired) return;
+        // Close code 1001 is "going away" — the drain's own close handshake. It is the belt to the
+        // shutdown frame's braces: if the frame was missed (sent while this socket was mid-render, say),
+        // the close status still identifies a deployment. An aborted socket is 1006, which is not this.
+        // `error` passes a plain Event with no code, hence the feature test.
+        if (serverShuttingDown || (e && e.code === 1001)) {
+            reloadForUpdate();
+            return;
+        }
         open = false;
         resetPending();
         // Freeze interaction immediately (inert) so events during the outage can't queue up and replay
@@ -320,6 +358,72 @@
         attempt = 0;
         updateOverlayState();
         connect();
+    }
+
+    // The server is being replaced. Reload onto the replacement, quickly and quietly: this is a
+    // deployment, not a failure, and the user should end up back where they were.
+    function reloadForUpdate() {
+        serverShuttingDown = true;
+        // Reuse the expiry latch rather than running a parallel state machine: it drops late frames,
+        // short-circuits scheduleReconnect, freezes updateOverlayState, and makes the overlay button
+        // reload — all four of which are exactly what's wanted here too.
+        sessionExpired = true;
+        if (reconnectTimer !== null) {
+            clearTimeout(reconnectTimer);
+            reconnectTimer = null;
+        }
+        if (overlayTimer !== null) {
+            clearTimeout(overlayTimer);
+            overlayTimer = null;
+        }
+        saveRestorePoint();
+        setInert(true);
+        showOverlay();
+        setOverlayMessage(UPDATING_MSG);
+        setRetryButton("Reload");
+        setTimeout(function () { location.reload(); },
+            devMode ? DEV_RESTART_RELOAD_MS : SHUTDOWN_RELOAD_MS);
+    }
+
+    // Stash where the user was, so the unavoidable reload doesn't also lose their place. Scroll and
+    // focus only — deliberately NOT form values: the replacement server renders those from its own
+    // state, and writing stale client copies over correct server output would turn a cosmetic loss
+    // into a data one.
+    function saveRestorePoint() {
+        try {
+            sessionStorage.setItem(RESTORE_KEY, JSON.stringify({
+                path: location.pathname + location.search,
+                y: window.scrollY || 0,
+                id: (document.activeElement && document.activeElement.id) || ""
+            }));
+        } catch (e) {
+            // Private mode, quota, disabled storage — losing the scroll position is not worth throwing.
+        }
+    }
+
+    // Apply a restore point left by the reload above, once. Runs at boot: the GET shell is fully
+    // server-rendered by the time this script executes, so the page is already tall enough to scroll.
+    function applyRestorePoint() {
+        let saved;
+        try {
+            saved = sessionStorage.getItem(RESTORE_KEY);
+            // Consume unconditionally — a restore point must never apply to a second navigation.
+            sessionStorage.removeItem(RESTORE_KEY);
+        } catch (e) {
+            return;
+        }
+        if (!saved) return;
+        try {
+            const point = JSON.parse(saved);
+            if (!point || point.path !== location.pathname + location.search) return;
+            if (point.y) window.scrollTo(0, point.y);
+            if (point.id) {
+                const el = document.getElementById(point.id);
+                if (el && typeof el.focus === "function") el.focus({preventScroll: true});
+            }
+        } catch (e) {
+            // A malformed entry is not worth breaking boot over.
+        }
     }
 
     // The server evicted this session (idle past RaskServerOptions.SessionGracePeriod), so the in-memory

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -364,12 +364,18 @@
     // explanatory one and reveal a manual "Retry now" button. Left alone during an auth handshake and
     // once the session has expired (both own the overlay message).
     function updateOverlayState() {
-        // serverShuttingDown owns the message for the same reason authInProgress does: the drop is
-        // explained, so escalating to "Still trying to reconnect…" would be telling the user something is
-        // wrong when we know exactly what is happening and that it ends.
-        if (authInProgress || sessionExpired || serverShuttingDown) return;
+        if (authInProgress || sessionExpired) return;
         const offline = ("onLine" in navigator) && !navigator.onLine;
         const escalated = offline || attempt > ESCALATE_AFTER_ATTEMPTS;
+        // A redeploy keeps its own wording: the drop is explained, so "Still trying to reconnect…" would
+        // report something wrong when we know exactly what is happening. But the escape hatch still
+        // appears once the replacement is clearly not coming — a deploy CAN fail, and leaving the user on
+        // a frozen "Updating…" with nothing to click would be worse than the reconnect state it replaced.
+        if (serverShuttingDown) {
+            setOverlayMessage(UPDATING_MSG);
+            setRetryButton(escalated ? "Retry now" : null);
+            return;
+        }
         setOverlayMessage(escalated
             ? (offline ? "You're offline — waiting to reconnect…" : "Still trying to reconnect…")
             : RECONNECT_MSG);

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -180,6 +180,10 @@
     let overlayTimer = null;
     let sessionExpired = false;
     let serverShuttingDown = false;
+    // The one free retry a known redeploy gets before the ordinary backoff takes over. Without it a
+    // replacement that isn't up yet would spin: every failed connect closes, and every close would take
+    // the immediate-retry branch again.
+    let shutdownRetryUsed = false;
 
     function setOverlayMessage(text) {
         if (overlayMsg) overlayMsg.textContent = text;
@@ -255,11 +259,15 @@
                 if (devMode && data.status === "applied") window.__raskHotReloadPill();
                 return;
             }
-            // The server is shutting down (a redeploy, a restart). Live session state is per-process and
-            // cannot hand over, so a reload is unavoidable — but it is an update, not an expiry, and
-            // saying so is the difference between "Updating…" and a four-second "Your session timed
-            // out". Carries no html, so like the hotReload frame it must NOT fall through to
-            // applyFullReply. Deliberately not dev-gated: production is exactly where this matters.
+            // The server is shutting down (a redeploy, a restart). This frame only *announces* it — the
+            // close that follows drives what happens next, and deliberately so: the announcement's job is
+            // to make the drop expected, so the client can reconnect at once instead of walking the
+            // backoff ladder guessing whether the server is coming back. Whether the reconnect lands on a
+            // host that can rebuild this page, or on one that has never heard of it, is the server's
+            // answer to give — not something to pre-empt here with a reload.
+            //
+            // Carries no html, so like the hotReload frame it must NOT fall through to applyFullReply.
+            // Deliberately not dev-gated: production is exactly where this matters.
             if (data.type === "shutdown") {
                 serverShuttingDown = true;
                 setInert(true);
@@ -305,8 +313,28 @@
         // shutdown frame's braces: if the frame was missed (sent while this socket was mid-render, say),
         // the close status still identifies a deployment. An aborted socket is 1006, which is not this.
         // `error` passes a plain Event with no code, hence the feature test.
-        if (serverShuttingDown || (e && e.code === 1001)) {
-            reloadForUpdate();
+        //
+        // A known redeploy earns exactly ONE immediate retry, not a reload. Under a blue-green swap the
+        // replacement is already serving before the old container is stopped, so the backoff's first
+        // 500 ms is pure latency — and reloading here would throw away everything the reconnect could
+        // still recover, since it is the reconnect (not this handler) that carries whatever the client
+        // holds to a host that never knew this session. If that attempt also drops we fall through to the
+        // ordinary ladder below, which is the right shape when the replacement genuinely is not up yet.
+        if ((serverShuttingDown || (e && e.code === 1001)) && !shutdownRetryUsed) {
+            shutdownRetryUsed = true;
+            serverShuttingDown = true;
+            open = false;
+            resetPending();
+            setInert(true);
+            if (overlayTimer !== null) {
+                clearTimeout(overlayTimer);
+                overlayTimer = null;
+            }
+            showOverlay();
+            setOverlayMessage(UPDATING_MSG);
+            setRetryButton(null);
+            attempt = 0;
+            connect();
             return;
         }
         open = false;
@@ -336,7 +364,10 @@
     // explanatory one and reveal a manual "Retry now" button. Left alone during an auth handshake and
     // once the session has expired (both own the overlay message).
     function updateOverlayState() {
-        if (authInProgress || sessionExpired) return;
+        // serverShuttingDown owns the message for the same reason authInProgress does: the drop is
+        // explained, so escalating to "Still trying to reconnect…" would be telling the user something is
+        // wrong when we know exactly what is happening and that it ends.
+        if (authInProgress || sessionExpired || serverShuttingDown) return;
         const offline = ("onLine" in navigator) && !navigator.onLine;
         const escalated = offline || attempt > ESCALATE_AFTER_ATTEMPTS;
         setOverlayMessage(escalated
@@ -360,8 +391,12 @@
         connect();
     }
 
-    // The server is being replaced. Reload onto the replacement, quickly and quietly: this is a
-    // deployment, not a failure, and the user should end up back where they were.
+    // The FALLBACK for a redeploy: we reconnected, and the host that answered could not carry this page
+    // over — so a reload is the only way back. Quiet and quick, because this is still a deployment rather
+    // than a failure, and the user should land where they were.
+    //
+    // Reached only from showSessionExpired, never from the close handler: a redeploy reconnects first (see
+    // scheduleReconnect), and only the server's answer decides whether the page survives.
     function reloadForUpdate() {
         serverShuttingDown = true;
         // Reuse the expiry latch rather than running a parallel state machine: it drops late frames,
@@ -430,6 +465,14 @@
     // UI state is gone and a reload is unavoidable. Warn the user and give them the click instead of
     // yanking the page out from under them mid-action; auto-reload as a fallback after a few seconds.
     function showSessionExpired() {
+        // Same reply, two very different causes. During a redeploy this means the host we reconnected to
+        // could not carry the page over, which is an update finishing — not a session that sat idle too
+        // long. Say the true thing and get back on screen fast.
+        if (serverShuttingDown) {
+            reloadForUpdate();
+            return;
+        }
+
         sessionExpired = true;
         if (reconnectTimer !== null) {
             clearTimeout(reconnectTimer);

--- a/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
@@ -51,6 +51,62 @@ public class ShutdownClientContractTests
     }
 
     [Fact]
+    public void A_known_redeploy_reconnects_rather_than_reloading()
+    {
+        // The load-bearing property. Reloading straight from the close handler would throw away whatever
+        // the reconnect could still recover — it is the reconnect that carries the client's state to a
+        // host which never knew this session, so only the server's answer may decide the page is lost.
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function scheduleReconnect", StringComparison.Ordinal)..];
+        var branch = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
+
+        var fastPath = branch[..branch.IndexOf("open = false;\n        resetPending();", StringComparison.Ordinal)];
+        Assert.Contains("connect();", fastPath, StringComparison.Ordinal);
+        Assert.DoesNotContain("location.reload", fastPath, StringComparison.Ordinal);
+        Assert.DoesNotContain("reloadForUpdate()", fastPath, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_immediate_retry_happens_once_so_a_missing_replacement_cannot_spin()
+    {
+        // Every failed connect closes, and every close re-enters scheduleReconnect. Without a latch the
+        // redeploy branch would take itself again forever, hammering a host that is not up yet.
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function scheduleReconnect", StringComparison.Ordinal)..];
+        var branch = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
+
+        Assert.Contains("!shutdownRetryUsed", branch, StringComparison.Ordinal);
+        Assert.Contains("shutdownRetryUsed = true;", branch, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_reload_is_reachable_only_from_the_servers_own_answer()
+    {
+        // reloadForUpdate is the fallback for "we reconnected and the new host could not rebuild us",
+        // which is showSessionExpired's job to detect. Any other caller would be pre-empting the server.
+        var js = ServerJs;
+        // The trailing semicolon is what distinguishes a call from the `function reloadForUpdate() {`
+        // declaration.
+        var callSites = js.Split("reloadForUpdate();", StringSplitOptions.None).Length - 1;
+
+        Assert.Equal(1, callSites);
+        var expired = js[js.IndexOf("function showSessionExpired", StringComparison.Ordinal)..];
+        Assert.Contains("reloadForUpdate();", expired[..400], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_redeploy_never_escalates_to_the_something_is_wrong_wording()
+    {
+        // The drop is explained and it ends, so "Still trying to reconnect…" would be telling the user
+        // something is broken while we know exactly what is happening.
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function updateOverlayState", StringComparison.Ordinal)..];
+        var guard = fn[..fn.IndexOf(';', StringComparison.Ordinal)];
+
+        Assert.Contains("serverShuttingDown", guard, StringComparison.Ordinal);
+    }
+
+    [Fact]
     public void The_update_reload_says_updating_not_timed_out()
     {
         var js = ServerJs;

--- a/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
@@ -1,0 +1,120 @@
+namespace Rask.Core.Tests.Resources;
+
+/// <summary>
+///     Source-level contract for the graceful-shutdown affordances in the client runtimes. Structural
+///     assertions over the shipped <c>.js</c>, for the same reason as
+///     <see cref="HotReloadClientContractTests" />: <c>rask.js</c> is an IIFE that boots a WebSocket
+///     against a live document and still carries its unsubstituted <c>@@RASK_*@@</c> splice markers in
+///     the Resources copy, so it cannot be executed in Node. What is worth pinning here are the
+///     invariants that fail silently — a branch that falls through, a gate that shouldn't be there, a
+///     restore that never gets consumed.
+/// </summary>
+public class ShutdownClientContractTests
+{
+    private static readonly string _repoRoot = LocateRepoRoot();
+
+    private static string ServerJs => Read("src", "Rask.Server", "Resources", "rask.js");
+    private static string WasmJs => Read("src", "Rask.Wasm", "Resources", "rask.wasm.js");
+    private static string NativeJs => Read("src", "Rask.Native", "Resources", "rask.native.js");
+
+    [Fact]
+    public void The_server_client_handles_the_shutdown_frame_and_returns()
+    {
+        var js = ServerJs;
+
+        // Like the hotReload frame, this one carries no html. Falling through to applyFullReply would
+        // morph the document against a non-payload.
+        var branch = js[js.IndexOf("data.type === \"shutdown\"", StringComparison.Ordinal)..];
+        var end = branch.IndexOf("\n            }", StringComparison.Ordinal);
+        Assert.Contains("return;", branch[..end], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_shutdown_branch_is_not_dev_gated()
+    {
+        // The opposite of the hotReload contract, and deliberately so: a production redeploy is exactly
+        // when this matters. Gating it on devMode would leave production showing "Your session timed
+        // out" on every deploy — the bug this whole path exists to fix.
+        var js = ServerJs;
+        var branch = js[js.IndexOf("data.type === \"shutdown\"", StringComparison.Ordinal)..];
+        var end = branch.IndexOf("\n            }", StringComparison.Ordinal);
+
+        Assert.DoesNotContain("devMode", branch[..end], StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_going_away_close_is_treated_as_a_deployment()
+    {
+        // Belt and braces for a missed frame: 1001 is the drain's own close status. Before this, the
+        // close code was never inspected at all — close and error shared one handler.
+        Assert.Contains("e.code === 1001", ServerJs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_update_reload_says_updating_not_timed_out()
+    {
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function reloadForUpdate", StringComparison.Ordinal)..];
+        var end = fn.IndexOf("\n    }", StringComparison.Ordinal);
+
+        Assert.Contains("UPDATING_MSG", fn[..end], StringComparison.Ordinal);
+        Assert.Contains("saveRestorePoint()", fn[..end], StringComparison.Ordinal);
+        // Fast, because a blue-green swap has already moved the proxy to the replacement.
+        Assert.Contains("const SHUTDOWN_RELOAD_MS = 250;", js, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_restore_point_is_consumed_even_when_it_does_not_apply()
+    {
+        // A restore point that survives its own reload would later yank an unrelated navigation back to
+        // a stale scroll position. The removeItem must therefore run before any early return.
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function applyRestorePoint", StringComparison.Ordinal)..];
+        var body = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
+
+        var removed = body.IndexOf("removeItem", StringComparison.Ordinal);
+        var firstGuardedReturn = body.IndexOf("if (!saved) return;", StringComparison.Ordinal);
+
+        Assert.True(removed >= 0 && firstGuardedReturn > removed,
+            "the restore point must be consumed before the first early return");
+    }
+
+    [Fact]
+    public void The_restore_point_carries_no_form_values()
+    {
+        // Scroll and focus only. The replacement server renders field values from its own state;
+        // writing stale client copies over them would turn a cosmetic loss into a data one.
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function saveRestorePoint", StringComparison.Ordinal)..];
+        var body = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
+
+        Assert.DoesNotContain(".value", body, StringComparison.Ordinal);
+        Assert.Contains("scrollY", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Only_the_server_dialect_branches_on_the_shutdown_frame()
+    {
+        // Same asymmetry as the hotReload contract, for the same reason: WASM runs the session
+        // in-browser and Native is fed by its host over the WebView bridge, so neither has a server
+        // whose shutdown could reach them. Neither file contains a WebSocket at all.
+        Assert.Contains("data.type === \"shutdown\"", ServerJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"shutdown\"", WasmJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("\"shutdown\"", NativeJs, StringComparison.Ordinal);
+    }
+
+    private static string Read(params string[] parts) =>
+        File.ReadAllText(Path.Combine([_repoRoot, .. parts]));
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+}

--- a/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
@@ -95,15 +95,21 @@ public class ShutdownClientContractTests
     }
 
     [Fact]
-    public void A_redeploy_never_escalates_to_the_something_is_wrong_wording()
+    public void A_redeploy_keeps_its_wording_but_still_offers_a_way_out()
     {
-        // The drop is explained and it ends, so "Still trying to reconnect…" would be telling the user
-        // something is broken while we know exactly what is happening.
+        // Two things at once, and the second is the easy one to lose. The drop is explained, so escalating
+        // to "Still trying to reconnect…" would report something broken — but a deploy CAN fail, and
+        // leaving the user frozen on "Updating…" with nothing to click would be worse than the reconnect
+        // state this replaced. Keep the wording, keep the escape hatch.
         var js = ServerJs;
         var fn = js[js.IndexOf("function updateOverlayState", StringComparison.Ordinal)..];
-        var guard = fn[..fn.IndexOf(';', StringComparison.Ordinal)];
+        var body = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
+        var branch = body[body.IndexOf("if (serverShuttingDown)", StringComparison.Ordinal)..];
+        var branchEnd = branch[..branch.IndexOf("return;", StringComparison.Ordinal)];
 
-        Assert.Contains("serverShuttingDown", guard, StringComparison.Ordinal);
+        Assert.Contains("setOverlayMessage(UPDATING_MSG)", branchEnd, StringComparison.Ordinal);
+        Assert.Contains("setRetryButton(escalated ? \"Retry now\" : null)", branchEnd, StringComparison.Ordinal);
+        Assert.DoesNotContain("Still trying to reconnect", branchEnd, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
+++ b/tests/Rask.Server.Tests/Configuration/ConfigurableLimitsTests.cs
@@ -118,6 +118,44 @@ public class ConfigurableLimitsTests
     }
 
     [Fact]
+    public void Validate_RejectsANegativeShutdownDrainTimeout()
+    {
+        var o = new RaskServerOptions { ShutdownDrainTimeout = TimeSpan.FromSeconds(-1) };
+
+        Assert.Throws<ArgumentOutOfRangeException>(o.Validate);
+    }
+
+    [Fact]
+    public void Validate_RejectsAShutdownDrainTimeoutCancelAfterCannotTake()
+    {
+        // CancellationTokenSource.CancelAfter throws above int.MaxValue milliseconds — and it would
+        // throw from the shutdown path, the worst possible place to find out.
+        var o = new RaskServerOptions { ShutdownDrainTimeout = TimeSpan.FromDays(30) };
+
+        Assert.Throws<ArgumentOutOfRangeException>(o.Validate);
+    }
+
+    [Fact]
+    public void Validate_AllowsZeroToDisableTheDrain()
+    {
+        // The documented opt-out: Zero restores the pre-drain behaviour of aborting immediately.
+        var o = new RaskServerOptions { ShutdownDrainTimeout = TimeSpan.Zero };
+
+        Assert.Null(Record.Exception(o.Validate));
+    }
+
+    [Fact]
+    public void ShutdownDrainTimeout_FlowsIntoThePerHostLimits()
+    {
+        var services = new ServiceCollection()
+            .AddRask(configureServer: o => o.ShutdownDrainTimeout = TimeSpan.FromSeconds(3));
+
+        var limits = services.BuildServiceProvider().GetRequiredService<RaskServerLimits>();
+
+        Assert.Equal(TimeSpan.FromSeconds(3), limits.ShutdownDrainTimeout);
+    }
+
+    [Fact]
     public void AppSettings_BindIntoServerOptions_RoundTrips()
     {
         // The documented operator pattern: AddRask(configureServer: o => config.GetSection("Rask").Bind(o)).

--- a/tests/Rask.Server.Tests/Infrastructure/DrainGateApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/DrainGateApp.cs
@@ -1,0 +1,32 @@
+using Rask.Core;
+using Rask.Core.Components;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Infrastructure;
+
+// A gated handler for the shutdown-drain tests, deliberately NOT sharing GatedCounterApp.
+//
+// That app's Gate is a mutable static, and HandlerExceptionIsolationTests already owns it. xUnit runs test
+// classes in parallel, so a second class reassigning the same static races the first: one test replaces the
+// TaskCompletionSource the other is parked on, and both fail intermittently. Cheaper to have our own app
+// than to serialize two unrelated classes against each other.
+public sealed class DrainGateApp : Component
+{
+    public static TaskCompletionSource Gate = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public int Counter;
+
+    protected override Component? Render() =>
+    [
+        Doctype(),
+        new Html()[new Head()[new Title()["drain"]],
+            new Body()[
+                new P()[$"count={Counter}"],
+                Button(OnClickAsync: async () =>
+                {
+                    await Gate.Task;
+                    Counter++;
+                })["hang"]]]
+    ];
+}

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -28,6 +28,13 @@ internal sealed class RaskTestHost : IDisposable
 
     public Uri WebSocketUri => new(new Uri(Server.BaseAddress, "/rask/ws").ToString().Replace("http://", "ws://"));
 
+    /// <summary>
+    ///     Stops the host the way a SIGTERM does — fires <c>ApplicationStopping</c>, then awaits every
+    ///     hosted service's <c>StopAsync</c>. Lets a test observe the shutdown drain (and assert on what
+    ///     is true *when the stop returns*) instead of disposing and losing the host.
+    /// </summary>
+    public Task StopAsync() => _app.StopAsync();
+
     public void Dispose()
     {
         Http.Dispose();

--- a/tests/Rask.Server.Tests/Infrastructure/WebSocketHelper.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/WebSocketHelper.cs
@@ -39,4 +39,40 @@ internal static class WebSocketHelper
             return null;
         }
     }
+
+    /// <summary>
+    ///     Receives until the peer's close frame arrives and returns its status and reason, or
+    ///     <c>null</c> if the socket was aborted instead (no close frame — a <see cref="WebSocketException" />
+    ///     out of the receive) or nothing arrived in time. The distinction is the whole point: a graceful
+    ///     shutdown must produce a status here, and an abort must not.
+    /// </summary>
+    public static async Task<(WebSocketCloseStatus? Status, string? Reason)?> TryReceiveCloseAsync(
+        this WebSocket ws, TimeSpan timeout)
+    {
+        using var cts = new CancellationTokenSource(timeout);
+        var buffer = new byte[16 * 1024];
+        try
+        {
+            while (true)
+            {
+                var result = await ws.ReceiveAsync(buffer, cts.Token);
+                if (result.MessageType == WebSocketMessageType.Close)
+                {
+                    return (ws.CloseStatus, ws.CloseStatusDescription);
+                }
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            return null;
+        }
+        catch (Exception ex) when (ex is WebSocketException or IOException or ObjectDisposedException)
+        {
+            // Aborted: the connection died without a close frame. Which of these surfaces depends on
+            // the transport — a real socket raises WebSocketException, TestHost's in-memory pipe raises
+            // IOException/ObjectDisposedException — and the distinction the caller cares about is only
+            // "was there a close frame", so all three mean the same thing here.
+            return null;
+        }
+    }
 }

--- a/tests/Rask.Server.Tests/Live/LiveSessionStoreTests.cs
+++ b/tests/Rask.Server.Tests/Live/LiveSessionStoreTests.cs
@@ -97,6 +97,22 @@ public class LiveSessionStoreTests
         Assert.Equal(0, store.Count);
     }
 
+    // The store is a DI singleton, so the container disposes it — and a host or a test that disposes it
+    // as well used to reach Cancel() on an already-disposed token source. A second dispose must be inert,
+    // including with a pending removal outstanding, which is what owns that token source.
+    [Fact]
+    public async Task DisposeAsync_IsIdempotent()
+    {
+        var store = NewStore();
+        var session = store.Create(_ => new BasicComponent());
+        store.ScheduleRemoval(session.Id, TimeSpan.FromMinutes(5));
+
+        await store.DisposeAsync();
+        await store.DisposeAsync();
+
+        Assert.Equal(0, store.Count);
+    }
+
     private static LiveSessionStore NewStore()
     {
         var sp = new ServiceCollection().BuildServiceProvider();

--- a/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
@@ -1,0 +1,227 @@
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Rask.Core.Live;
+using Rask.Server.Diagnostics;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+/// <summary>
+///     The graceful shutdown drain. What shipped before aborted every socket the instant
+///     <c>ApplicationStopping</c> fired: no close frame, so the browser saw an abnormal 1006 closure,
+///     read the replacement process's <c>session/unknown</c> reply as an idle timeout, and told the user
+///     "Your session timed out" on what the docs call a zero-downtime deploy.
+/// </summary>
+public class ShutdownDrainTests
+{
+    [Fact]
+    public void The_shutdown_frame_has_the_exact_shape_the_client_branches_on()
+    {
+        // Asserted as a whole literal for the same reason as the hot-reload frame: rask.js switches on
+        // `data.type` as a literal string, so a rename on either side would leave both halves compiling
+        // and silently restore the old, wrong behaviour.
+        Assert.Equal("""{"type":"shutdown","status":"draining"}""", LivePayload.ServerShutdownJson);
+        Assert.Equal(
+            LivePayload.ServerShutdownJson,
+            Encoding.UTF8.GetString(LivePayload.ServerShutdownFrame));
+    }
+
+    [Fact]
+    public async Task A_connected_client_is_told_the_server_is_going_away()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        using var ws = await ConnectAsync(host);
+
+        await host.StopAsync();
+
+        Assert.Equal(LivePayload.ServerShutdownJson, await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2)));
+    }
+
+    [Fact]
+    public async Task The_socket_is_closed_with_going_away_not_aborted()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        using var ws = await ConnectAsync(host);
+
+        await host.StopAsync();
+
+        // The announcement rides the same render lock as the close, and TCP preserves order, so the
+        // frame is always ahead of the close on the wire.
+        Assert.Equal(LivePayload.ServerShutdownJson, await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2)));
+
+        var close = await ws.TryReceiveCloseAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(close);
+        Assert.Equal(WebSocketCloseStatus.EndpointUnavailable, close.Value.Status);
+        Assert.Equal("server-shutdown", close.Value.Reason);
+    }
+
+    [Fact]
+    public async Task An_in_flight_handler_finishes_instead_of_being_cancelled_mid_call()
+    {
+        // The regression that matters most behind the UI: a click that is mid-SaveChangesAsync used to
+        // be cancelled and dropped, because the socket's token was ApplicationStopping itself.
+        GatedCounterApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var host = RaskTestHost.Create<GatedCounterApp>();
+        var html = await host.Http.GetStringAsync("/start");
+        var sessionId = MarkupAssert.SessionId(html);
+        var handlerId = MarkupAssert.FirstHandlerId(html);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        var session = host.Store.Get(sessionId)!;
+        await ws.SendJsonAsync(new { id = handlerId });
+        await WaitForAsync(() => session.PendingHandlers > 0, TimeSpan.FromSeconds(2));
+
+        var stop = host.StopAsync();
+
+        // The drain is settling on this handler, so the stop must not have completed yet.
+        await Task.Delay(150);
+        Assert.False(stop.IsCompleted);
+
+        GatedCounterApp.Gate.SetResult();
+        await stop;
+
+        Assert.Equal(0, session.PendingHandlers);
+    }
+
+    [Fact]
+    public async Task Sessions_are_disposed_by_the_time_the_stop_returns()
+    {
+        // Not "eventually, via container teardown" — the old path fired an unawaited RemoveAsync, so a
+        // component's async unmount raced process exit with nobody observing it.
+        using var host = RaskTestHost.Create<TestApp>();
+        using var ws = await ConnectAsync(host);
+        Assert.Equal(1, host.Store.Count);
+
+        await host.StopAsync();
+
+        Assert.Equal(0, host.Store.Count);
+    }
+
+    [Fact]
+    public async Task A_handler_that_never_returns_costs_the_budget_not_the_shutdown()
+    {
+        HangingApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        try
+        {
+            using var host = RaskTestHost.Create<HangingApp>(
+                configureServer: o => o.ShutdownDrainTimeout = TimeSpan.FromMilliseconds(200));
+            var html = await host.Http.GetStringAsync("/start");
+            var sessionId = MarkupAssert.SessionId(html);
+            var handlerId = MarkupAssert.FirstHandlerId(html);
+
+            using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+            await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+            _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+            await ws.SendJsonAsync(new { id = handlerId });
+
+            var session = host.Store.Get(sessionId)!;
+            await WaitForAsync(() => session.PendingHandlers > 0, TimeSpan.FromSeconds(2));
+
+            var started = Environment.TickCount64;
+            await host.StopAsync();
+
+            // The backstop is what bounds this: the budget elapses, the socket is aborted, teardown runs.
+            Assert.True(Environment.TickCount64 - started < 5_000,
+                "a wedged handler must not hold the host open past the drain budget");
+            Assert.Equal(0, host.Store.Count);
+        }
+        finally
+        {
+            HangingApp.Gate.TrySetResult();
+        }
+    }
+
+    [Fact]
+    public async Task A_draining_host_refuses_new_sessions_and_says_to_retry_at_once()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        await host.StopAsync();
+
+        var response = await host.Http.GetAsync("/start");
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+        // Distinct from the capacity 503's Retry-After: 5 — the replacement instance is already up.
+        Assert.Equal("1", response.Headers.GetValues("Retry-After").Single());
+        Assert.Equal(0, host.Store.Count);
+    }
+
+    [Fact]
+    public async Task Readiness_goes_unhealthy_while_draining_but_capacity_still_reports_capacity()
+    {
+        using var host = RaskTestHost.Create<TestApp>();
+        var drain = host.Services.GetRequiredService<RaskDrainCoordinator>();
+        var readiness = new RaskReadinessHealthCheck(drain);
+        var context = new HealthCheckContext();
+
+        Assert.Equal(HealthStatus.Healthy, (await readiness.CheckHealthAsync(context)).Status);
+
+        await host.StopAsync();
+
+        Assert.Equal(HealthStatus.Unhealthy, (await readiness.CheckHealthAsync(context)).Status);
+        // The capacity check keeps its own meaning — an empty store is not "at capacity".
+        Assert.Equal(
+            HealthStatus.Healthy,
+            (await new RaskLiveHealthCheck(host.Store).CheckHealthAsync(context)).Status);
+    }
+
+    [Fact]
+    public async Task The_health_endpoint_answers_503_while_draining()
+    {
+        // Probed through the real pipeline, not by constructing the check: the health-check
+        // infrastructure activates checks through ActivatorUtilities, which only sees public
+        // constructors. A direct-construction test passes happily while every actual probe throws.
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServices: s => s.AddHealthChecks().AddRaskLiveSessions(),
+            configureMiddleware: app => app.UseHealthChecks("/health"));
+
+        var before = await host.Http.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.OK, before.StatusCode);
+        Assert.Equal("Healthy", await before.Content.ReadAsStringAsync());
+
+        await host.StopAsync();
+
+        var during = await host.Http.GetAsync("/health");
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, during.StatusCode);
+    }
+
+    [Fact]
+    public async Task A_zero_budget_disables_the_drain_and_restores_the_old_abort()
+    {
+        // The documented opt-out. Worth pinning: it is the escape hatch for anyone whose shutdown the
+        // drain would otherwise lengthen, and it is easy to break without noticing.
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o => o.ShutdownDrainTimeout = TimeSpan.Zero);
+        using var ws = await ConnectAsync(host);
+
+        await host.StopAsync();
+
+        Assert.Null(await ws.TryReceiveCloseAsync(TimeSpan.FromSeconds(2)));
+    }
+
+    private static async Task<WebSocket> ConnectAsync(RaskTestHost host)
+    {
+        var sessionId = MarkupAssert.SessionId(await host.Http.GetStringAsync("/start"));
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        return ws;
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (!condition() && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(condition(), "condition was not met within the timeout");
+    }
+}

--- a/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
@@ -64,8 +64,8 @@ public class ShutdownDrainTests
     {
         // The regression that matters most behind the UI: a click that is mid-SaveChangesAsync used to
         // be cancelled and dropped, because the socket's token was ApplicationStopping itself.
-        GatedCounterApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        using var host = RaskTestHost.Create<GatedCounterApp>();
+        DrainGateApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var host = RaskTestHost.Create<DrainGateApp>();
         var html = await host.Http.GetStringAsync("/start");
         var sessionId = MarkupAssert.SessionId(html);
         var handlerId = MarkupAssert.FirstHandlerId(html);
@@ -84,7 +84,7 @@ public class ShutdownDrainTests
         await Task.Delay(150);
         Assert.False(stop.IsCompleted);
 
-        GatedCounterApp.Gate.SetResult();
+        DrainGateApp.Gate.SetResult();
         await stop;
 
         Assert.Equal(0, session.PendingHandlers);
@@ -107,10 +107,12 @@ public class ShutdownDrainTests
     [Fact]
     public async Task A_handler_that_never_returns_costs_the_budget_not_the_shutdown()
     {
-        HangingApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        // Own app again, not HangingApp: HandlerBackpressureTests owns that static gate, and xUnit runs the
+        // two classes in parallel.
+        DrainGateApp.Gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         try
         {
-            using var host = RaskTestHost.Create<HangingApp>(
+            using var host = RaskTestHost.Create<DrainGateApp>(
                 configureServer: o => o.ShutdownDrainTimeout = TimeSpan.FromMilliseconds(200));
             var html = await host.Http.GetStringAsync("/start");
             var sessionId = MarkupAssert.SessionId(html);
@@ -134,7 +136,7 @@ public class ShutdownDrainTests
         }
         finally
         {
-            HangingApp.Gate.TrySetResult();
+            DrainGateApp.Gate.TrySetResult();
         }
     }
 


### PR DESCRIPTION
## Why

`rask deploy` advertises **zero-downtime, health-gated** deploys, and the container swap really is
blue-green. But the *app* had no graceful shutdown, so what a connected user saw on every redeploy was a
frozen, blurred page and then:

> **Your session timed out. Reload to continue.**

…followed by a forced reload 4 seconds later. Nothing had timed out. The server was replaced.

The mechanism, end to end:

1. `ApplicationStopping` fired. `LiveSessionStore.CancelAllPending` cancelled the *eviction timers* only —
   it never touched the sessions.
2. `RunSocketLoop` hard-aborted every socket from a token callback (`ws.Abort()`). No close frame, so the
   browser saw code **1006**. The graceful `CloseAsync` in the `finally` was guarded on
   `ws.State == Open || CloseReceived`, and after `Abort()` the state is `Aborted` — so on the shutdown
   path it was unreachable.
3. In-flight handler chains were never awaited. A click mid-`SaveChangesAsync` was cancelled and dropped.
4. `ScheduleRemoval` degraded to a **fire-and-forget, unawaited** `RemoveAsync`, so component unmount work
   raced process exit.
5. `TryCreate` had no stopping gate, so the GET catch-all kept minting sessions that were killed on
   arrival, and `/health` stayed **Healthy** throughout shutdown.
6. The client wired `close` and `error` to one handler and **never inspected the close code**. It
   reconnected, landed on the replacement, sent `hello` with the old id, got `session/unknown`, and ran
   `showSessionExpired()` — wrong message, a wasted round trip, and a 4 s wait.

## What changed

On `SIGTERM`, in order: admission closes (`503` + `Retry-After: 1`, and a new readiness health check goes
unhealthy so a probing proxy stops routing) → every browser is told the server is going away → in-flight
handlers finish → each socket closes with a real **1001 "going away"** handshake → sessions are disposed
**awaited**, before the stop returns.

**The load-bearing change is one token substitution.** The socket's cancellation token now derives from
the drain's hard deadline instead of `ApplicationStopping`. That token becomes `LiveSession._socketCt`, so
while it was `ApplicationStopping` *every send threw the instant SIGTERM landed* — the shutdown
announcement included — and every in-flight handler was cancelled before it could finish. `ws.Abort()` is
still registered, unchanged; it just fires at the end of the budget now, where a backstop belongs.

Two details worth flagging for review, both of which invalidated my first approach:

- **`CloseOutputAsync`, not `CloseAsync`.** The drain closes from outside the receive loop, which is parked
  in `ReceiveAsync`. `CloseAsync` sends *and then receives* until the peer echoes — a second concurrent
  receive, which throws. `CloseOutputAsync` is send-only; the parked `ReceiveAsync` then observes the
  browser's echo as an ordinary close and the loop unwinds through its own `finally`.
- **Cancelling the socket token can't be the ordinary route.** Cancelling a token a `ReceiveAsync` is using
  *aborts* the WebSocket — no close frame, browser sees 1006. That is the exact behaviour being replaced,
  so "trip the token and let the loop close itself" would have reproduced the bug.

The drain also splits across two moments deliberately: hosted services stop in **reverse registration
order** and `AddRask` is typically the first line of `Program.cs`, so `StopAsync` runs *after* every
battery registered below it (a Litestream flush can spend most of the budget first). Everything that must
happen at t=0 — closing admission, flipping readiness, arming the backstop, starting the announcement —
happens in the synchronous `ApplicationStopping` callback; only the awaited parts wait for `StopAsync`.

### Client

`{"type":"shutdown","status":"draining"}` (a fixed literal, following the hot-reload frame precedent, and
deliberately **not** dev-gated). The client shows **"Updating…"**, reloads in ~250 ms instead of 4 s, and
restores scroll position and focus via `sessionStorage`. Close code `1001` is a second signal if the frame
was missed.

Form field values are deliberately **not** restored: the replacement server renders those from its own
state, and writing stale client copies over them would turn a cosmetic loss into a data one.

**A redeploy still reloads open pages, and that is not fixable here** — a live session is a component tree
plus a DI scope inside one process and cannot hand over to the next container. What this fixes is that it
now reads as an update rather than a failure.

## Config

`RaskServerOptions.ShutdownDrainTimeout`, default 5 s; `Zero` restores the old abort. Must fit inside
`HostOptions.ShutdownTimeout` — a startup warning says so when it doesn't (a warning, not a throw: a tight
ladder is suboptimal, not invalid, and refusing to start a production app over it would be the worse
failure). `rask.shutdown.sessions.abandoned` counts anything still connected when the budget ran out.

## Testing

- `ShutdownDrainTests` (10) — frame arrives before the close; close is `EndpointUnavailable`/`server-shutdown`
  and not an abort; an in-flight handler *completes* rather than being cancelled; a wedged handler costs
  the budget, not the shutdown; `503` + `Retry-After: 1` while draining; `/health` returns 503 while
  draining; sessions disposed by the time `StopAsync` returns; `Zero` restores the old behaviour.
- `ShutdownClientContractTests` (7) — source-level contract on `rask.js`: the branch returns, is *not*
  dev-gated, 1001 is inspected, the restore point is consumed before any early return and carries no form
  values, and neither the WASM nor the Native dialect carries the branch.
- `ConfigurableLimitsTests` — validation and per-host flow-through for the new option.
- Full local gate: `dotnet format` clean, `dotnet build -warnaserror` clean, **entire unit suite green**.

**One bug this caught late, worth noting:** the readiness check was first registered with `AddCheck<T>`,
which activates through `ActivatorUtilities` — public constructors only — while the check takes the
internal drain coordinator. It compiled and threw on the first real probe. Fixed with an explicit factory
registration, and `The_health_endpoint_answers_503_while_draining` now probes through the real pipeline
rather than constructing the check, which is what a direct-construction test had missed.

### Not verified

- **No benchmark delta to quote.** The suite drives `Rask.Core`'s `RenderAsLiveRoot`; nothing on that path
  changed. The one changed per-dispatch item is `LastHandlerTask` gaining volatile accessors (it has a
  second reader now — the drain — and its doc comment previously asserted single-threaded access, so the
  fence is required rather than defensive). No benchmark covers WS handler dispatch, so I have no honest
  before/after to report.
- **E2E**: 33 passed. 4 failures are all pre-existing on `main` and unrelated — three journeys fail in
  `TestCompositionGuideAsync` (open issue #550) and `PlaygroundExampleTests` is the known sandbox failure
  (no browser network for Roslyn refs). Pushed with `RASK_SKIP_E2E=1`.
- **Not run against a real deployment.** The drain is proven in-process via `TestServer`; nobody has
  watched a real container swap with this in place.

The first commit is an unrelated mechanical fix: `dotnet format --verify-no-changes` was already failing
on `main` for two Shop-sample files, so the pre-commit gate was red for everyone.

## Follow-ups (PRs 2 and 3 of this series)

- Jobs/Outbox/Mail pass the host `stoppingToken` straight into user code, so SIGTERM cancels an in-flight
  handler mid-call — for Mail that can mean a send cut *after* delivery but before the row is marked, i.e.
  a duplicate on restart. `Rask.SQLite.Litestream` already solves this correctly and is the pattern to copy.
- The budget ladder is three unrelated constants (`docker stop -t 20`, a scaffolded `ShutdownTimeout = 15s`
  coupled to it only by a comment, Litestream's 10 s) with `ServicesStopConcurrently` never set, so hosted
  services stop sequentially. Every sample except `Rask.Example.Shop` inherits .NET's 30 s default, which
  *exceeds* the docker window.
