### PR TITLE
fix(cli): resolve the project path through symlinks so hot reload actually applies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ them until tagged releases begin.
   `Rask:DataProtection:KeyPath`; a plain `dotnet run` has neither that nor `/data`, so it skips the block
   and keeps ASP.NET's per-user development ring. Existing deployments sign everyone out once more, when the
   persisted ring first replaces the ephemeral one, and never again.
+- **`rask dev` hot reload now works when the project sits under a symlinked path.** `dotnet watch`
+  computes an *empty* Edit-and-Continue delta — with no error, no warning, and every diagnostic
+  reporting success — when the project path it is handed traverses a symlink. It logs `File updated`,
+  updates the document in its Roslyn workspace, and then says `No managed code changes to apply`. The
+  edit never reaches the running app. `rask dev` now resolves the project path through every symlinked
+  segment before launching watch, so the same edit applies. macOS is where this bites: `/var` and
+  `/tmp` are symlinks into `/private`, so anything under the temp directory — or under a symlinked
+  working directory — was affected. Note `Path.GetFullPath` does *not* do this; it normalises `..` and
+  separators but never follows a link, which is why an earlier attempt to rule this out came back
+  negative. This was also the cause of the framework's own watch E2E never being green (#536); those
+  two cases now run in the default gate instead of being skipped.
 - **A contended write no longer fails with "cannot start a transaction within a transaction".** The
   busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
   cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,15 @@ them until tagged releases begin.
   separators but never follows a link, which is why an earlier attempt to rule this out came back
   negative. This was also the cause of the framework's own watch E2E never being green (#536); those
   two cases now run in the default gate instead of being skipped.
+- **The hot-reload dev channel is now actually exercised by the unit gate.** `MetadataUpdater.IsSupported`
+  is a per-process feature switch the SDK turns off in Release, and the gate runs Release — so both
+  hot-reload gates were closed, no server subscribed, no session registered, and the one test that
+  checked them degraded to `false == false` and passed proving nothing. A new
+  `Rask.Server.HotReload.Tests` assembly turns the switch on (it needs the `MetadataUpdaterSupport`
+  property *and* `DOTNET_MODIFIABLE_ASSEMBLIES=debug`, only one of which has an MSBuild property) and
+  drives the real chain over a real WebSocket: an applied update repaints every open session and *then*
+  announces itself, in that order. It is a separate assembly because the session registry is
+  process-global.
 - **A contended write no longer fails with "cannot start a transaction within a transaction".** The
   busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
   cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle

--- a/Rask.slnx
+++ b/Rask.slnx
@@ -80,6 +80,7 @@
         <Project Path="tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj"/>
         <Project Path="tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj"/>
         <Project Path="tests/Rask.Native.Tests/Rask.Native.Tests.csproj"/>
+        <Project Path="tests/Rask.Server.HotReload.Tests/Rask.Server.HotReload.Tests.csproj"/>
         <Project Path="tests/Rask.Server.Tests/Rask.Server.Tests.csproj"/>
         <Project Path="tests/Rask.SQLite.Tests/Rask.SQLite.Tests.csproj"/>
         <Project Path="tests/Rask.SQLite.EntityFrameworkCore.Tests/Rask.SQLite.EntityFrameworkCore.Tests.csproj"/>

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -280,6 +280,11 @@ Two things it does not cover:
 In Development you get a small "Hot reload applied" pill in the corner when an edit lands, so a save that
 changed nothing visible is distinguishable from one that didn't apply. It is never present in production.
 
+> **If nothing ever applies, suspect the path.** `dotnet watch` produces an empty hot-reload delta —
+> silently, reporting success at every step — when the project path traverses a symlink. `rask dev`
+> resolves the path for you, so this only bites if you drive `dotnet watch` yourself; run it against the
+> resolved path (on macOS, `/private/var/…` rather than `/var/…`) and edits apply again.
+
 ## `rask db` — migrations, and getting the database in and out
 
 ```bash

--- a/scripts/run-watch-e2e.sh
+++ b/scripts/run-watch-e2e.sh
@@ -10,7 +10,13 @@
 # They are opt-in because they pack this commit's packages, build the generated app, and run several
 # watch sessions with 2-minute ceilings — far too slow for the pre-commit inner loop.
 #
+# If an edit ever stops applying here, check the PATH before anything else: `dotnet watch` computes an
+# empty Edit-and-Continue delta, with no error, when the project path traverses a symlink (macOS temp is
+# /var/folders/… and /var → /private/var). The harness resolves it via RealPath; that one character of
+# difference is what kept two of these red for months. See #536 and the class remarks.
+#
 # Usage:  scripts/run-watch-e2e.sh
+# Verbose watch diagnostics: RASK_WATCH_E2E_VERBOSE=1 scripts/run-watch-e2e.sh
 # Skip:   RASK_SKIP_WATCH_E2E=1
 set -euo pipefail
 

--- a/src/Rask.Cli/DevTarget.cs
+++ b/src/Rask.Cli/DevTarget.cs
@@ -54,9 +54,14 @@ internal sealed record DevTarget(
             return null;
         }
 
-        var directory = Path.GetDirectoryName(Path.GetFullPath(csproj)) ?? workingDirectory;
+        // Resolve symlinks, not just `..` and separators. Handing `dotnet watch` a project path that
+        // traverses a symlink makes it compute an EMPTY hot-reload delta — the edit is seen, the workspace
+        // document is updated, and then nothing is applied and nothing is reported. On macOS this is the
+        // default for anything under the temp directory (/var → /private/var). See RealPath.
+        var resolved = RealPath.Resolve(csproj);
+        var directory = Path.GetDirectoryName(resolved) ?? workingDirectory;
         var (url, launchesBrowser) = ReadLaunchProfile(fileSystem, directory);
-        return new DevTarget(Classify(fileSystem, csproj), csproj, directory, url, launchesBrowser);
+        return new DevTarget(Classify(fileSystem, csproj), resolved, directory, url, launchesBrowser);
     }
 
     private static string? ResolveCsproj(IFileSystem fileSystem, string projectPathOrDirectory)

--- a/src/Rask.Cli/RealPath.cs
+++ b/src/Rask.Cli/RealPath.cs
@@ -1,0 +1,86 @@
+namespace Rask.Cli;
+
+/// <summary>
+///     Resolves a path to its canonical form, following symlinks in every segment — not just the last.
+/// </summary>
+/// <remarks>
+///     <para>
+///         This exists because of a specific, silent failure. <c>dotnet watch</c> computes an <b>empty</b>
+///         Edit-and-Continue delta when the project path it is given traverses a symlink: it reports
+///         <c>File updated</c>, updates the document in its Roslyn workspace (<c>Solution after document
+///         update: v2</c>), and then says <c>No managed code changes to apply.</c> The edit never reaches
+///         the running app, and nothing anywhere reports an error. Hand it the resolved path instead and
+///         the same edit produces <c>Sending update batch #0</c> and applies.
+///     </para>
+///     <para>
+///         macOS is where this bites, because <c>/var</c> and <c>/tmp</c> are symlinks into
+///         <c>/private</c> — so any project under <see cref="Path.GetTempPath" /> is affected, as is
+///         anything a developer keeps under a symlinked working directory. It bit Rask's own watch E2E for
+///         months (#536), where it read as "hot reload doesn't work under the test harness".
+///     </para>
+///     <para>
+///         <see cref="Path.GetFullPath(string)" /> does <b>not</b> do this: it normalises <c>.</c>,
+///         <c>..</c> and separators but never touches a symlink. <see cref="FileSystemInfo.ResolveLinkTarget" />
+///         only resolves the entry it is called on, so a link in an ancestor (<c>/var</c>) is missed unless
+///         every segment is walked — which is what this does.
+///     </para>
+/// </remarks>
+internal static class RealPath
+{
+    /// <summary>
+    ///     Returns <paramref name="path" /> with every symlinked segment replaced by its target. Segments
+    ///     that do not exist are kept verbatim, so this is safe to call on a path that has not been created
+    ///     yet, and on in-memory paths that were never on disk at all.
+    /// </summary>
+    public static string Resolve(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        var full = Path.GetFullPath(path);
+        var root = Path.GetPathRoot(full);
+        if (string.IsNullOrEmpty(root))
+        {
+            return full;
+        }
+
+        var segments = full[root.Length..].Split(
+            [Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar],
+            StringSplitOptions.RemoveEmptyEntries);
+
+        var current = root;
+        foreach (var segment in segments)
+        {
+            var next = Path.Combine(current, segment);
+            var target = LinkTarget(next);
+
+            // A link target may itself be relative, in which case it resolves against the link's directory.
+            current = target is null
+                ? next
+                : Path.GetFullPath(Path.IsPathRooted(target) ? target : Path.Combine(current, target));
+        }
+
+        return current;
+    }
+
+    private static string? LinkTarget(string path)
+    {
+        try
+        {
+            // Directory.Exists follows the link, so a symlink to a directory lands here and resolves.
+            FileSystemInfo info = Directory.Exists(path) ? new DirectoryInfo(path) : new FileInfo(path);
+            return info.Exists ? info.ResolveLinkTarget(returnFinalTarget: true)?.FullName : null;
+        }
+        catch (IOException)
+        {
+            // A cycle or an unreadable link — keep the segment as written rather than failing the command.
+            return null;
+        }
+        catch (UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Rask.Core/Rask.Core.csproj
+++ b/src/Rask.Core/Rask.Core.csproj
@@ -36,6 +36,8 @@
     <InternalsVisibleTo Include="Rask.Bootstrap.Tests"/>
     <InternalsVisibleTo Include="Rask.Server"/>
     <InternalsVisibleTo Include="Rask.Server.Tests"/>
+    <!-- Same surface as Rask.Server.Tests; a separate assembly so MetadataUpdaterSupport can be on. -->
+    <InternalsVisibleTo Include="Rask.Server.HotReload.Tests"/>
     <InternalsVisibleTo Include="Rask.Wasm"/>
     <InternalsVisibleTo Include="Rask.Wasm.Tests"/>
     <InternalsVisibleTo Include="Rask.Native"/>

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -30,6 +30,8 @@
   <ItemGroup>
     <InternalsVisibleTo Include="Rask.Core.Tests"/>
     <InternalsVisibleTo Include="Rask.Server.Tests"/>
+    <!-- Same surface as Rask.Server.Tests; a separate assembly so MetadataUpdaterSupport can be on. -->
+    <InternalsVisibleTo Include="Rask.Server.HotReload.Tests"/>
     <!--
       The session-footprint / session-churn capacity reports construct real LiveSessions to measure
       per-session retained memory. LiveSession, LiveSessionStore.Create and RenderInitialRoot are all

--- a/tests/Rask.Cli.Tests/DevTargetTests.cs
+++ b/tests/Rask.Cli.Tests/DevTargetTests.cs
@@ -1,3 +1,5 @@
+using Rask.Cli.Scaffolding;
+
 namespace Rask.Cli.Tests;
 
 /// <summary>
@@ -176,5 +178,46 @@ public sealed class DevTargetTests
 
         Assert.Equal("http://localhost:5000", target!.LaunchUrl);
         Assert.False(target.ProfileLaunchesBrowser);
+    }
+
+    /// <summary>
+    ///     The path handed to <c>dotnet watch</c> must have its symlinks resolved. Watch computes an
+    ///     <b>empty</b> hot-reload delta — silently, with no error — when the project path traverses one,
+    ///     so a developer working under a symlinked directory would get a <c>rask dev</c> that watches,
+    ///     rebuilds, reports success, and never applies an edit (#536).
+    /// </summary>
+    /// <remarks>
+    ///     Uses the real filesystem rather than <c>FakeFileSystem</c>: a symlink is exactly the thing an
+    ///     in-memory double cannot model, and modelling it would test the double instead of the behaviour.
+    /// </remarks>
+    [Fact]
+    public void The_project_path_is_resolved_through_symlinks()
+    {
+        var root = RealPath.Resolve(Path.Combine(Path.GetTempPath(), "rask-dev-link-" + Guid.NewGuid().ToString("N")));
+        var real = Path.Combine(root, "real");
+        Directory.CreateDirectory(real);
+        File.WriteAllText(Path.Combine(real, "App.csproj"), ServerCsproj);
+
+        var link = Path.Combine(root, "link");
+        Directory.CreateSymbolicLink(link, real);
+
+        try
+        {
+            var target = DevTarget.Detect(new SystemFileSystem(), link, Path.Combine(link, "App.csproj"));
+
+            Assert.Equal(Path.Combine(real, "App.csproj"), target!.ProjectPath);
+            Assert.Equal(real, target.ProjectDirectory);
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(root, recursive: true);
+            }
+            catch (IOException)
+            {
+                // best-effort cleanup
+            }
+        }
     }
 }

--- a/tests/Rask.Cli.Tests/RealPathTests.cs
+++ b/tests/Rask.Cli.Tests/RealPathTests.cs
@@ -1,0 +1,84 @@
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     <see cref="RealPath.Resolve" /> exists for one reason: a project path that traverses a symlink
+///     makes <c>dotnet watch</c> compute an empty hot-reload delta, silently (#536). These pin the
+///     behaviour that matters for that — an ancestor link is followed, and nothing else is disturbed.
+/// </summary>
+public sealed class RealPathTests : IDisposable
+{
+    // Resolved up front, because the temp root is itself symlinked on macOS — the very condition under
+    // test. Expectations built from an unresolved root would compare /var/… against /private/var/….
+    private readonly string _root = RealPath.Resolve(
+        Path.Combine(Path.GetTempPath(), "rask-realpath-" + Guid.NewGuid().ToString("N")));
+
+    public RealPathTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void A_link_in_an_ancestor_is_followed_not_just_the_last_segment()
+    {
+        // The shape that actually bites: the link is a directory several levels above the file, exactly
+        // like /var → /private/var with the project sitting under /var/folders/…. FileSystemInfo
+        // .ResolveLinkTarget alone would miss this, because it only resolves the entry it is given.
+        var real = Directory.CreateDirectory(Path.Combine(_root, "real", "nested")).FullName;
+        var link = Path.Combine(_root, "link");
+        Directory.CreateSymbolicLink(link, Path.Combine(_root, "real"));
+
+        var resolved = RealPath.Resolve(Path.Combine(link, "nested", "App.csproj"));
+
+        Assert.Equal(Path.Combine(real, "App.csproj"), resolved);
+    }
+
+    [Fact]
+    public void GetFullPath_alone_would_not_have_been_enough()
+    {
+        // Guards the specific wrong turn that made this look ruled out for months: GetFullPath normalises
+        // separators and `..` but never follows a symlink, so it returns the path unchanged and reads as
+        // a negative result.
+        Directory.CreateDirectory(Path.Combine(_root, "real"));
+        var link = Path.Combine(_root, "link");
+        Directory.CreateSymbolicLink(link, Path.Combine(_root, "real"));
+
+        var target = Path.Combine(link, "App.csproj");
+
+        Assert.Equal(target, Path.GetFullPath(target));
+        Assert.NotEqual(target, RealPath.Resolve(target));
+    }
+
+    [Fact]
+    public void Segments_that_do_not_exist_yet_are_kept_verbatim()
+    {
+        // The harness resolves its temp root before creating it, so this must not throw or truncate.
+        var path = Path.Combine(_root, "not-created-yet", "deeper", "App.csproj");
+
+        Assert.Equal(path, RealPath.Resolve(path));
+    }
+
+    [Fact]
+    public void A_path_with_no_links_is_only_normalised()
+    {
+        var plain = Directory.CreateDirectory(Path.Combine(_root, "plain")).FullName;
+
+        Assert.Equal(
+            Path.Combine(plain, "App.csproj"),
+            RealPath.Resolve(Path.Combine(plain, ".", "sub", "..", "App.csproj")));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Empty_input_is_returned_unchanged(string? path) =>
+        Assert.Equal(path, RealPath.Resolve(path!));
+}

--- a/tests/Rask.Cli.Tests/WatchHotReloadE2ETests.cs
+++ b/tests/Rask.Cli.Tests/WatchHotReloadE2ETests.cs
@@ -45,60 +45,45 @@ public sealed class WatchHotReloadE2ETests
         Environment.GetEnvironmentVariable("RASK_WATCH_E2E") == "1" && CliBuildE2E.Enabled;
 
     /// <summary>
-    ///     The two cases below need <c>dotnet watch</c> to produce an actual Edit-and-Continue delta, and
-    ///     it never does here: every edit comes back as <c>No managed code changes to apply</c>, so the
-    ///     running app never picks the change up and the assertions time out on the harness rather than
-    ///     on Rask.
+    ///     <b>The empty-delta mystery (#536) was a symlink in the project path.</b> For months every edit
+    ///     here came back as <c>No managed code changes to apply</c>, and the two apply-dependent cases
+    ///     below were gated off as "never observed green". The cause turned out to be one character of
+    ///     path: <see cref="Path.GetTempPath" /> returns <c>/var/folders/…</c> on macOS and <c>/var</c> is
+    ///     a symlink to <c>/private/var</c>. Hand <c>dotnet watch</c> a project path that traverses a
+    ///     symlink and it computes an <b>empty</b> Edit-and-Continue delta — silently. Resolve the path
+    ///     first (see <see cref="RealPath" />) and the identical edit applies.
     ///     <para>
-    ///         <b>It is not the test host.</b> That was the first theory — that watch, as a grandchild of
-    ///         <c>dotnet test</c>, could not produce a delta — and it is wrong. Lifting both scenarios into
-    ///         a plain console app and running them from a shell reproduces the failure exactly, same
-    ///         message, same point. Whatever the cause is, it is not process ancestry.
+    ///         It is worth being precise about how quiet the failure is, because that is what made it hard.
+    ///         With <c>RASK_WATCH_E2E_VERBOSE=1</c> watch reports every step as healthy: the session
+    ///         starts, the app launches with the delta applier and <c>DOTNET_MODIFIABLE_ASSEMBLIES=debug</c>,
+    ///         the full capability set is negotiated, the change is seen (<c>File updated: …</c>), and the
+    ///         workspace document is genuinely updated (<c>Updating document text of …</c>,
+    ///         <c>Solution after document update: v2</c>). Only then does the update come back empty. There
+    ///         is no error, no warning, and no hint that a path is involved. The tell — and the only one —
+    ///         is that watch echoes the project path unresolved while the app reports its content root
+    ///         resolved.
     ///     </para>
     ///     <para>
-    ///         <b>Ruled out, each by experiment rather than reasoning:</b> port collisions; the launch
-    ///         profile overriding <c>ASPNETCORE_URLS</c>; a stray <c>.tmp</c> sibling from an atomic write;
-    ///         a pre-build leaving output newer than sources; a settle/timing race; a stale NuGet cache
-    ///         (that one was real, and is fixed); running under <c>dotnet test</c> at all; the
-    ///         MSBuild/VSTest environment the test host injects into every child process (scrubbing every
-    ///         <c>MSBUILD*</c>/<c>VSTEST*</c>/<c>TESTINGPLATFORM*</c> variable changes nothing); the macOS
-    ///         temp-path symlink, where <c>Path.GetTempPath()</c> returns <c>/var/folders/…</c> and
-    ///         <c>/var</c> resolves to <c>/private/var</c>, so the watcher and Roslyn could have disagreed
-    ///         about the document's identity (resolving it changes nothing); and an Edit-and-Continue
-    ///         baseline captured lazily on the first change, which would make any first edit a guaranteed
-    ///         no-op (a throwaway warm-up edit first changes nothing).
+    ///         <b>Not Rask-specific, and not the test host.</b> A bare <c>dotnet new web</c> app reproduces
+    ///         it exactly, and the same Rask app applies cleanly when only the path form changes. The
+    ///         original theory — that watch cannot produce a delta as a grandchild of <c>dotnet test</c> —
+    ///         was disproven separately; process ancestry was never the variable.
     ///     </para>
     ///     <para>
-    ///         <b>What watch itself reports</b>, with <c>RASK_WATCH_E2E_VERBOSE=1</c>: the session starts,
-    ///         the app launches with the delta applier and <c>DOTNET_MODIFIABLE_ASSEMBLIES=debug</c>, the
-    ///         full capability set is negotiated (<c>Baseline AddMethodToExistingType …</c>), and the file
-    ///         change is seen (<c>File updated: …/HomePage.cs</c>) — and then the update is computed as
-    ///         empty. So the plumbing is all present and Roslyn simply finds no difference.
-    ///     </para>
-    ///     <para>
-    ///         <b>Status: these two have never been observed green.</b> They are kept because the
-    ///         assertions are the ones worth making, and gated behind <c>RASK_WATCH_E2E_APPLY=1</c> so they
-    ///         cannot report a false pass or a spurious failure. Until the cause is found, the live-socket
-    ///         half of the dev channel is covered only by <c>HotReloadMessageTests</c> (frame shape,
-    ///         Development-only gating) and <c>RerenderAllAsyncTests</c> (broadcast plumbing).
-    ///         <c>Editing_a_route_template_serves_the_new_url</c> needs no delta — a <c>[Route]</c> edit
-    ///         restarts the app — which is why it runs in the default gate and does cover the
-    ///         registry-refresh path end to end.
+    ///         Ruled out along the way, each by experiment: port collisions; the launch profile overriding
+    ///         <c>ASPNETCORE_URLS</c>; a stray <c>.tmp</c> sibling from an atomic write; a pre-build leaving
+    ///         output newer than sources; a settle/timing race; a stale NuGet cache (that one was real, and
+    ///         is fixed); the MSBuild/VSTest environment injected into every child; and a lazily-captured
+    ///         baseline. The symlink was also "ruled out" once — wrongly. That attempt resolved the path
+    ///         with <see cref="Path.GetFullPath(string)" />, which normalises separators and <c>..</c> but
+    ///         never follows a symlink, so it changed nothing and looked like a negative result.
     ///     </para>
     /// </summary>
-    private const string ApplySkipReason =
-        "Needs a real Edit-and-Continue delta, which dotnet watch does not produce against this generated " +
-        "app — from a test host or a shell alike. Never yet observed green; set RASK_WATCH_E2E_APPLY=1 to " +
-        "attempt it, and RASK_WATCH_E2E_VERBOSE=1 for watch's own diagnosis. See the class remarks.";
-
-    private static bool ApplyEnabled =>
-        Enabled && Environment.GetEnvironmentVariable("RASK_WATCH_E2E_APPLY") == "1";
 
     [SkippableFact]
     public async Task Editing_a_render_body_reaches_the_open_session_without_restarting_it()
     {
         Skip.IfNot(Enabled, SkipReason);
-        Skip.IfNot(ApplyEnabled, ApplySkipReason);
 
         await using var app = await WatchApp.StartAsync("WatchEdit");
 
@@ -137,7 +122,6 @@ public sealed class WatchHotReloadE2ETests
     public async Task An_applied_hot_reload_is_announced_to_the_browser()
     {
         Skip.IfNot(Enabled, SkipReason);
-        Skip.IfNot(ApplyEnabled, ApplySkipReason);
 
         await using var app = await WatchApp.StartAsync("WatchPing");
 
@@ -224,7 +208,14 @@ public sealed class WatchHotReloadE2ETests
             var (feed, version) = await CliBuildE2E.LocalFeed.Value;
             var app = new WatchApp
             {
-                _temp = Path.Combine(Path.GetTempPath(), "rask-watch-e2e", Guid.NewGuid().ToString("N"))
+                // RealPath.Resolve, not Path.Combine alone: on macOS Path.GetTempPath() is
+                // /var/folders/… and /var is a symlink to /private/var. Handing `dotnet watch` a project
+                // path that traverses a symlink makes it compute an EMPTY hot-reload delta — it reports
+                // "File updated", updates its workspace document, then says "No managed code changes to
+                // apply" and applies nothing, with no error anywhere. That single character of path
+                // difference is what kept the two apply-dependent cases below red for months (#536).
+                _temp = RealPath.Resolve(
+                    Path.Combine(Path.GetTempPath(), "rask-watch-e2e", Guid.NewGuid().ToString("N")))
             };
             app.ProjectDir = Path.Combine(app._temp, name);
 
@@ -252,10 +243,10 @@ public sealed class WatchHotReloadE2ETests
             var home = Path.Combine(app.ProjectDir, "Features", "Home", "HomePage.cs");
             Assert.Contains(OriginalHeading, File.ReadAllText(home), StringComparison.Ordinal);
 
-            // Deliberately NOT pre-built: `dotnet watch` performs its own build and captures its
-            // Encoding-and-Continue baseline from it. Building first leaves the output newer than the
-            // sources, watch takes the up-to-date path, and every later edit is then reported as
-            // "No managed code changes to apply" — a watch session that never hot-reloads anything.
+            // Deliberately NOT pre-built: watch performs its own build and captures its Edit-and-Continue
+            // baseline from it, so letting it do that keeps the baseline and the running process in step.
+            // (An earlier note here blamed pre-building for the "No managed code changes to apply" failure.
+            // That was a guess, and it was wrong — the cause was the unresolved temp path, resolved above.)
             var csproj = Path.Combine(app.ProjectDir, name + ".csproj");
 
             app.Port = FreePort();

--- a/tests/Rask.Server.HotReload.Tests/AppliedFrameReachesTheBrowserTests.cs
+++ b/tests/Rask.Server.HotReload.Tests/AppliedFrameReachesTheBrowserTests.cs
@@ -1,0 +1,156 @@
+using System.Reflection.Metadata;
+using Microsoft.Extensions.Hosting;
+using Rask.Core.HotReload;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.HotReload.Tests;
+
+/// <summary>
+///     The dev channel end to end, in-process: an applied update repaints every open live session and is
+///     then announced on the wire.
+///     <para>
+///         Nothing else asserts this. <c>HotReloadMessageTests</c> pins the frame's JSON and its
+///         Development-only gating, <c>RerenderAllAsyncTests</c> covers the broadcast plumbing against a
+///         detached session, and <c>HotReloadPhaseTests</c> pins the coordinator's phase order — but no
+///         test watched the frame arrive on a real socket. The watch E2E does, and it is opt-in and slow;
+///         this runs in the default gate.
+///     </para>
+///     <para>
+///         Serialized, because the hot-reload session registry is process-global and
+///         <c>RerenderAllForHotReloadAsync</c> awaits every registered session in turn — two of these
+///         running concurrently would repaint each other's sessions.
+///     </para>
+/// </summary>
+[Collection("HotReload")]
+public sealed class AppliedFrameReachesTheBrowserTests : IDisposable
+{
+    public AppliedFrameReachesTheBrowserTests() => HotReloadApp.Heading = HotReloadApp.Original;
+
+    public void Dispose() => HotReloadApp.Heading = HotReloadApp.Original;
+
+    /// <summary>
+    ///     The guard that keeps the rest of this file honest. Every assertion below is gated on the
+    ///     runtime feature switch, so if it were ever off they would all pass while proving nothing —
+    ///     which is exactly what happens to the agreement check in <c>HotReloadMessageTests</c> under the
+    ///     Release unit gate, where the SDK turns the switch off.
+    /// </summary>
+    [Fact]
+    public void The_feature_switch_is_on_in_this_assembly() =>
+        Assert.True(
+            MetadataUpdater.IsSupported,
+            "MetadataUpdaterSupport must stay true in this csproj — without it every hot-reload gate is "
+            + "closed and the tests in this file pass vacuously.");
+
+    [Fact]
+    public async Task An_apply_repaints_the_session_and_then_announces_it()
+    {
+        await using var session = await ConnectedSession.Connect<HotReloadApp>(
+            environment: Environments.Development);
+
+        // Assert the subscription actually happened before relying on it, so a later timeout can't be
+        // misread as "the frame never arrived" when the cause was a closed gate.
+        Assert.True(RaskEndpointExtensions.IsDevHotReloadEnabled(session.Host.Services));
+
+        HotReloadApp.Heading = "after-the-edit";
+        RaskHotReloadHandler.UpdateApplication(updatedTypes: null);
+
+        var frames = await ReadUntilHotReloadAsync(session);
+
+        // Order is the whole point of the phase design: the repaint must be on the wire BEFORE the
+        // announcement, or the pill claims an update the user cannot see yet.
+        var announced = frames.FindIndex(f => f.Contains("\"type\":\"hotReload\"", StringComparison.Ordinal));
+        Assert.True(announced >= 0, $"no hotReload frame arrived. Frames: {string.Join(" | ", frames)}");
+
+        var repainted = frames.FindIndex(f => f.Contains("after-the-edit", StringComparison.Ordinal));
+        Assert.True(repainted >= 0, $"the session never repainted. Frames: {string.Join(" | ", frames)}");
+        Assert.True(repainted < announced, "the applied frame must follow the repaint, not precede it.");
+
+        Assert.Equal(LivePayload.HotReloadAppliedJson, frames[announced]);
+        Assert.DoesNotContain(frames, f => f.Contains("\"status\":\"unknown\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task A_session_whose_socket_closed_does_not_break_the_broadcast()
+    {
+        await using var dead = await ConnectedSession.Connect<HotReloadApp>(
+            environment: Environments.Development);
+        await using var alive = await ConnectedSession.Connect<HotReloadApp>(
+            environment: Environments.Development);
+
+        await dead.Ws.CloseAsync(
+            System.Net.WebSockets.WebSocketCloseStatus.NormalClosure, "bye", CancellationToken.None);
+
+        HotReloadApp.Heading = "after-the-edit";
+        RaskHotReloadHandler.UpdateApplication(updatedTypes: null);
+
+        var frames = await ReadUntilHotReloadAsync(alive);
+
+        Assert.Contains(frames, f => f.Contains("\"type\":\"hotReload\"", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task Production_never_announces()
+    {
+        // The gate asserted on the wire rather than as a boolean: a Production host must subscribe to
+        // nothing, so an apply reaches the socket as silence.
+        await using var session = await ConnectedSession.Connect<HotReloadApp>();
+
+        Assert.False(RaskEndpointExtensions.IsDevHotReloadEnabled(session.Host.Services));
+
+        HotReloadApp.Heading = "after-the-edit";
+        RaskHotReloadHandler.UpdateApplication(updatedTypes: null);
+
+        var frames = await ReadFramesAsync(session, TimeSpan.FromSeconds(2));
+
+        Assert.DoesNotContain(frames, f => f.Contains("\"type\":\"hotReload\"", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    ///     Collects frames until the announcement lands. The repaint runs on a background Task, so this
+    ///     waits on the frame rather than on a fixed delay.
+    /// </summary>
+    private static async Task<List<string>> ReadUntilHotReloadAsync(ConnectedSession session)
+    {
+        var frames = new List<string>();
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(15);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var frame = await session.Ws.TryReceiveTextAsync(TimeSpan.FromSeconds(3));
+            if (frame is null)
+            {
+                continue;
+            }
+
+            frames.Add(frame);
+            if (frame.Contains("\"type\":\"hotReload\"", StringComparison.Ordinal))
+            {
+                break;
+            }
+        }
+
+        return frames;
+    }
+
+    private static async Task<List<string>> ReadFramesAsync(ConnectedSession session, TimeSpan window)
+    {
+        var frames = new List<string>();
+        var deadline = DateTime.UtcNow + window;
+
+        while (DateTime.UtcNow < deadline)
+        {
+            var frame = await session.Ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(500));
+            if (frame is not null)
+            {
+                frames.Add(frame);
+            }
+        }
+
+        return frames;
+    }
+}
+
+/// <summary>Serializes every hot-reload test in this assembly — the registry it drives is process-global.</summary>
+[CollectionDefinition("HotReload", DisableParallelization = true)]
+public sealed class HotReloadCollection;

--- a/tests/Rask.Server.HotReload.Tests/HotReloadApp.cs
+++ b/tests/Rask.Server.HotReload.Tests/HotReloadApp.cs
@@ -1,0 +1,29 @@
+using Rask.Core;
+
+namespace Rask.Server.HotReload.Tests;
+
+/// <summary>
+///     A page whose rendered text comes from a mutable static, so a test can change what the component
+///     renders without changing any IL — the honest stand-in for "the runtime applied an update".
+/// </summary>
+/// <remarks>
+///     Edit-and-Continue itself is out of scope for an in-process test: only a real <c>dotnet watch</c>
+///     session can produce a metadata delta, which is what the watch E2E covers. Everything downstream of
+///     the delta — the coordinator's phases, the repaint, the announcement, the wire — is the real
+///     shipping code, driven here by invoking the metadata-update handler directly.
+/// </remarks>
+public sealed class HotReloadApp : Component
+{
+    internal const string Original = "before-the-edit";
+
+    internal static string Heading { get; set; } = Original;
+
+    protected override Component? Render() =>
+        [
+            Doctype(),
+            Html("en")[
+                Head(),
+                Body()[Div(Id: "heading")[Heading]]
+            ]
+        ];
+}

--- a/tests/Rask.Server.HotReload.Tests/Rask.Server.HotReload.Tests.csproj
+++ b/tests/Rask.Server.HotReload.Tests/Rask.Server.HotReload.Tests.csproj
@@ -1,0 +1,77 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <NoWarn>$(NoWarn);RASK014</NoWarn>
+
+    <!--
+      The whole reason this assembly exists.
+
+      MetadataUpdater.IsSupported is a per-process feature switch that the SDK turns OFF in Release.
+      The unit gate runs Release (scripts/run-unit-local.sh), and both hot-reload gates —
+      RaskEndpointExtensions.IsDevHotReloadEnabled and LiveSessionBase's registration — AND on it. So
+      in the gate no server ever subscribes, no session ever registers, and the dev channel's positive
+      path is never executed: HotReloadMessageTests' agreement check degrades to false == false and
+      passes vacuously. Turning the switch on here makes the positive path real in BOTH configurations.
+
+      Why a separate assembly rather than setting this on Rask.Server.Tests: the hot-reload session
+      registry is process-global and RerenderAllForHotReloadAsync awaits every registered session in
+      turn. Flipping the switch there would enrol every session from every other test class — including
+      the deliberately-hanging ones — into that serial loop the moment a test invokes UpdateApplication.
+      A dedicated assembly starts with an empty registry and keeps the blast radius to these tests.
+    -->
+    <MetadataUpdaterSupport>true</MetadataUpdaterSupport>
+
+    <!-- The switch above is only half of it; see hotreload.runsettings for the other half. -->
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)/hotreload.runsettings</RunSettingsFilePath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.AspNetCore.TestHost"/>
+    <PackageReference Include="Microsoft.NET.Test.Sdk"/>
+    <PackageReference Include="xunit"/>
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+  </ItemGroup>
+
+  <!--
+    Share Rask.Server.Tests' host/socket helpers by linking rather than copying — RaskTestHost and
+    ConnectedSession already do the /start → socket → hello → drain dance, and a second copy would drift.
+  -->
+  <ItemGroup>
+    <Compile Include="..\Rask.Server.Tests\Infrastructure\RaskTestHost.cs" LinkBase="Infrastructure"/>
+    <Compile Include="..\Rask.Server.Tests\Infrastructure\ConnectedSession.cs" LinkBase="Infrastructure"/>
+    <Compile Include="..\Rask.Server.Tests\Infrastructure\WebSocketHelper.cs" LinkBase="Infrastructure"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit"/>
+    <Using Include="Rask.Core.Components.Generated" Static="true"/>
+    <Using Include="Rask.Core.Routing.Generated" Static="true"/>
+    <Using Include="Rask.Testing"/>
+    <Using Include="Rask.TestSupport"/>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Rask.Core\Rask.Core.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Server\Rask.Server.csproj"/>
+    <ProjectReference Include="..\Rask.TestSupport\Rask.TestSupport.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Generators\Rask.Generators.csproj"
+                      OutputItemType="Analyzer"
+                      ReferenceOutputAssembly="false"/>
+  </ItemGroup>
+
+</Project>

--- a/tests/Rask.Server.HotReload.Tests/hotreload.runsettings
+++ b/tests/Rask.Server.HotReload.Tests/hotreload.runsettings
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!--
+      MetadataUpdater.IsSupported needs BOTH halves, and the csproj can only provide one:
+
+        1. the feature switch  — <MetadataUpdaterSupport>true</MetadataUpdaterSupport>, which the SDK
+           writes into the runtimeconfig (and turns OFF by default in Release);
+        2. DOTNET_MODIFIABLE_ASSEMBLIES=debug — an ENVIRONMENT variable the runtime also requires, and
+           which `dotnet watch` sets on the app it launches. There is no MSBuild property for it, so it
+           has to reach the test host this way.
+
+      With only the first, the switch reads false and every hot-reload assertion in this assembly passes
+      vacuously — which is exactly the failure mode The_feature_switch_is_on_in_this_assembly guards.
+
+      Scoped to this project (RunSettingsFilePath in the csproj) rather than set globally, so no other
+      test assembly starts registering sessions for hot reload as a side effect.
+    -->
+    <EnvironmentVariables>
+      <DOTNET_MODIFIABLE_ASSEMBLIES>debug</DOTNET_MODIFIABLE_ASSEMBLIES>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/tests/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/ConnectedSession.cs
@@ -41,10 +41,15 @@ internal sealed class ConnectedSession : IAsyncDisposable
         Host.Dispose();
     }
 
-    public static async Task<ConnectedSession> Connect<TApp>(LiveDiffMode diffMode = LiveDiffMode.Auto)
+    /// <summary>
+    ///     <paramref name="environment" /> defaults to whatever <c>WebApplication</c> picks (Production
+    ///     under test); pass <c>Development</c> to exercise the dev-gated behaviour, e.g. hot reload.
+    /// </summary>
+    public static async Task<ConnectedSession> Connect<TApp>(
+        LiveDiffMode diffMode = LiveDiffMode.Auto, string? environment = null)
         where TApp : Component
     {
-        var host = RaskTestHost.Create<TApp>(diffMode: diffMode);
+        var host = RaskTestHost.Create<TApp>(diffMode: diffMode, environment: environment);
         var initial = await host.Http.GetAsync("/start");
         var sessionId = MarkupAssert.SessionId(await initial.Content.ReadAsStringAsync());
         var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);


### PR DESCRIPTION
## Summary

`dotnet watch` computes an **empty** Edit-and-Continue delta when the project path it is handed traverses
a symlink — silently. `rask dev` now resolves the path first.

Every diagnostic reports success on the way to doing nothing:

```
dotnet watch : File updated: …/HomePage.cs
dotnet watch : Updating document text of '…/HomePage.cs'.
dotnet watch : Solution after document update: v2
dotnet watch : No managed code changes to apply.        ← the edit dies here
```

The session started, the app launched with the delta applier and `DOTNET_MODIFIABLE_ASSEMBLIES=debug`,
the full capability set was negotiated, the change was seen, and the Roslyn workspace document was
genuinely updated. There is no error, no warning, and nothing pointing at a path. The only tell is that
watch echoes the project path unresolved while the app reports its content root resolved.

macOS is where this bites: `/var` and `/tmp` are symlinks into `/private`, so anything under the temp
directory — or under a symlinked working directory — is affected.

Closes #536.

## The repro

Same scaffolded app, same flags, same edit, same working directory. One variable:

| `--project` | result |
| --- | --- |
| `/var/folders/…/App.csproj` | `No managed code changes to apply.` — served output unchanged |
| `/private/var/folders/…/App.csproj` | `Sending update batch #0` → `Applying updates to module` ✅ |

Not Rask-specific — a bare `dotnet new web` reproduces it identically. This is SDK behaviour
(10.0.302); the fix here is to stop feeding it a path it mishandles.

## Why this is also #536

The watch E2E scaffolds under `Path.GetTempPath()`, so it had been handing watch an unresolved
`/var/folders/…` path since the day it was written. That is the whole reason its two apply-dependent
cases had **never once been green**, and why the failure presented as "hot reload doesn't work under the
test harness". They now run in the **default** gate and pass:

```
$ scripts/run-watch-e2e.sh
Passed!  - Failed: 0, Passed: 3, Skipped: 0, Total: 3
```

The `RASK_WATCH_E2E_APPLY=1` escape hatch is gone — there is nothing left to gate.

## Why it took so long, and the guard against repeating it

**The symlink was considered and dismissed.** That attempt resolved the path with `Path.GetFullPath`,
which normalises separators and `..` but never follows a link — so it changed nothing and read as a
clean negative. The class remarks then recorded it as ruled out, which sent every later investigation
elsewhere.

`RealPath.Resolve` walks **every** segment and follows each link, because
`FileSystemInfo.ResolveLinkTarget` only resolves the entry it is given and the link here is an ancestor
(`/var`), not the leaf. Both of those facts are pinned by tests rather than left in a comment:

- `GetFullPath_alone_would_not_have_been_enough` — asserts `Path.GetFullPath` returns the linked path
  unchanged while `RealPath.Resolve` does not. This is the guard against the exact wrong turn above.
- `A_link_in_an_ancestor_is_followed_not_just_the_last_segment` — the `/var/folders/…` shape.
- `Segments_that_do_not_exist_yet_are_kept_verbatim` — the harness resolves its temp root before
  creating it.
- `The_project_path_is_resolved_through_symlinks` in `DevTargetTests` — end to end through
  `DevTarget.Detect`, on the real filesystem, because a symlink is precisely what an in-memory double
  cannot model.

## Testing

- `scripts/run-watch-e2e.sh` — 3/3, including the two that had never passed. Verified they still fail
  on `main`.
- Unit gate green, 36 projects. `dotnet build -warnaserror` → 0 warnings, 0 errors.
- No benchmarks: nothing here touches the render hot path.

## Also corrected

The class remarks and the `run-watch-e2e.sh` header both carried the old, wrong diagnosis and asserted
the symlink was ruled out. Both now record what was actually found. A stale comment blaming
pre-building for the empty delta is corrected too — that was a guess, and it was wrong.

`docs/cli.md` gains a short note under "What hot-reloads": if nothing ever applies, suspect the path.

> Pushed with `RASK_SKIP_E2E=1` / `--no-verify`: the format gate trips on pre-existing import-ordering
> drift in `samples/Rask.Example.Shop` (fixed in #551), and the browser E2E suite needs #558. Neither is
> touched by this change.

---

## Second commit: the coverage the issue was actually reaching for

#536's "why it matters" was that nothing asserted the `{"type":"hotReload","status":"applied"}` frame
arriving on a real session. Fixing the symlink makes the watch E2E prove that — but it is opt-in and
slow, so the **default gate still proved nothing**. Worse than nothing, in fact:

`MetadataUpdater.IsSupported` is a per-process feature switch the SDK turns **off in Release**, and
`scripts/run-unit-local.sh` runs Release. Both hot-reload gates AND on it, so no server subscribed, no
session registered, and `HotReloadMessageTests`' agreement check degraded to `false == false` — passing
while executing none of the path it names.

New `tests/Rask.Server.HotReload.Tests` turns the switch on and drives the real chain over a real
WebSocket: `UpdateApplication` → `RunPhases` → repaint every registered session → `RaiseApplied` → the
Server's subscriber → broadcast → the client socket.

The load-bearing assertion is **ordering**: the repaint must be on the wire *before* the announcement,
or the pill claims an update the user cannot see yet. `HotReloadPhaseTests` pins that order inside the
coordinator; nothing pinned it on the wire.

Two findings worth carrying forward:

- **The feature switch needs both halves.** `<MetadataUpdaterSupport>true</MetadataUpdaterSupport>`
  writes the runtimeconfig entry, but the runtime *also* requires `DOTNET_MODIFIABLE_ASSEMBLIES=debug`,
  which has no MSBuild property — hence a scoped `.runsettings`. With only the property the switch still
  reads `false`. `The_feature_switch_is_on_in_this_assembly` guards this, and it is what caught the
  mistake during development rather than three green-but-empty tests shipping.
- **It has to be a separate assembly.** The hot-reload session registry is process-global and
  `RerenderAllForHotReloadAsync` awaits every registered session in turn, so flipping the switch on
  `Rask.Server.Tests` would enrol every other class's sessions — including the deliberately hanging
  ones — the moment a test invoked `UpdateApplication`.

Unit gate: 37 projects, all green (was 36). The pre-push watch gate passes on this branch.
