### PR TITLE
fix(server): bound the outbound send and stop one stalled client blocking the rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,21 @@ them until tagged releases begin.
   session later rented it. Worth **~19% of the allocation** a create-render-dispose cycle costs on a
   200-row page (2,418,177 → 1,959,329 bytes/cycle, `session-churn`), and the residue a 500-cycle run
   leaves behind drops from 96 bytes to zero.
+- **A client that stops reading can no longer wedge its live session, or hold up delivery to everyone
+  else.** `WebSocket.SendAsync` completes when a frame reaches the transport, not when the client reads it,
+  so a client that simply stops reading TCP fills the send buffer and the send never returns. Every send
+  happens under the session's render lock, which also guards its teardown — so that one client cost its
+  session every future render *and* a `Dispose` that could never take the lock, for as long as it cared to
+  stall. A new `SendTimeout` (default 30 s, `0` disables) bounds it: on expiry the socket is aborted, which
+  unwinds the receive loop and releases the lock, while the **session** is left alone to live out its
+  normal grace period — so a briefly-stalled link reconnects to the page it already had. The default is a
+  stuck-connection backstop, not a latency budget; a slow mobile link will not trip it.
+  The store's whole-session fan-outs (`RerenderAllAsync`, `BroadcastAsync`) were also sequential, so their
+  cost was the *sum* of every session's send rather than the slowest, and one stalled client held up every
+  session behind it. Both now run with a bounded degree of concurrency. Only the dev-time hot-reload
+  signal uses them today, but this is the code the planned Broadcast pillar inherits, where a fan-out is a
+  user-facing feature — and it is a prerequisite for the deploy-drain broadcast, which has to finish
+  inside the shutdown budget before `SIGKILL` interrupts a SQLite checkpoint.
 - **A contended write no longer fails with "cannot start a transaction within a transaction".** The
   busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
   cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `UnconnectedSessionGracePeriod` | `10 s` | How long a GET-minted session is retained before its first `hello` arrives. |
 | `IdleSocketTimeout` | `0` (off) | Close a connected socket that sends no inbound frame for this long (the session survives for reconnect). Reclaims silently-idle connections. |
 | `MaxPendingHandlerBytes` | `0` (off) | Aggregate-bytes companion to `MaxPendingHandlers` — bounds the queued cloned-payload *memory*, not just the queue length. |
+| `SendTimeout` | `30 s` | How long one outbound frame may take before the socket is aborted. A client that stops reading TCP would otherwise pin its session's render lock — and its disposal — indefinitely. The session survives for the grace period, so a briefly-stalled link reconnects normally. `0` disables. |
 | `HandlerTimeout` | `0` (off) | Cancel a handler's `Component.CancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
 
 ### Reconnect UX

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -76,11 +76,17 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // thread-pool worker) run on different threads. Mirrors the detached-socket early-return.
     private volatile bool _disposed;
 
+    // How long one outbound frame may take before we give up on the client. Read from the per-host limits
+    // when the host has them (a bare test store built straight from a ServiceCollection does not), so the
+    // value is fixed for the session's lifetime rather than resolved on every send.
+    private readonly TimeSpan _sendTimeout;
+
     public LiveSession(string id, Component view, IServiceScope scope, LiveDiffMode diffMode)
         : base(view, scope.ServiceProvider, diffMode)
     {
         Id = id;
         Scope = scope;
+        _sendTimeout = scope.ServiceProvider.GetService<RaskServerLimits>()?.SendTimeout ?? TimeSpan.Zero;
     }
 
     public bool SuppressEventsUntilReconnect { get; set; }
@@ -385,7 +391,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
                 return;
             }
 
-            await _socket.SendAsync(payload, WebSocketMessageType.Text, true, _socketCt).ConfigureAwait(false);
+            await SendGuardedAsync(payload).ConfigureAwait(false);
         }
         finally
         {
@@ -396,8 +402,60 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // Host transport for LiveSessionBase.TryEmitFrameAsync: write the frame's bytes to the WebSocket
     // (ReadOnlyMemory<byte>, zero-copy). RenderAndSendAsync guards _socket non-null/Open before the
     // shared send runs, and the render lock serialises teardown, so _socket is valid here.
-    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) =>
-        _socket!.SendAsync(frame, WebSocketMessageType.Text, true, _socketCt);
+    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) => SendGuardedAsync(frame);
+
+    /// <summary>
+    ///     Writes one frame to the socket, giving up on a client that has stopped reading.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>SendAsync</c> completes when the frame reaches the transport, not when the client reads
+    ///         it. A client that stops reading fills the send buffer and the send simply never returns —
+    ///         and because every send here happens under <c>_renderLock</c>, which also guards teardown,
+    ///         that one client would pin its session forever: no further renders, and a <c>Dispose</c> that
+    ///         can never take the lock.
+    ///     </para>
+    ///     <para>
+    ///         On timeout the socket is aborted, which is what unwinds the receive loop and releases the
+    ///         lock. The <em>session</em> is left alone: it lives out its normal grace period, so a client
+    ///         whose link stalled briefly reconnects to the page it already had.
+    ///     </para>
+    /// </remarks>
+    private async ValueTask SendGuardedAsync(ReadOnlyMemory<byte> payload)
+    {
+        if (_sendTimeout <= TimeSpan.Zero)
+        {
+            await _socket!.SendAsync(payload, WebSocketMessageType.Text, true, _socketCt).ConfigureAwait(false);
+            return;
+        }
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(_socketCt);
+        cts.CancelAfter(_sendTimeout);
+        try
+        {
+            await _socket!.SendAsync(payload, WebSocketMessageType.Text, true, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!_socketCt.IsCancellationRequested)
+        {
+            // Ours, not the caller's: the send timed out rather than the session being torn down. Abort so
+            // the receive loop unwinds, then report it as a transport failure — which is what it is, and
+            // what every caller here already handles.
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.Live",
+                $"Aborting a socket whose send did not complete within {_sendTimeout}. The client stopped "
+                + "reading; its session is kept for the reconnect grace period.");
+            try
+            {
+                _socket!.Abort();
+            }
+            catch
+            {
+                // Already torn down by the receive loop — nothing left to abort.
+            }
+
+            throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely, "Send timed out.");
+        }
+    }
 
     internal async Task RenderAndSendAsync(string? historyUrl, bool replace, AuthInstruction? auth = null,
         bool publishOnly = false)

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -14,6 +14,12 @@ public sealed class LiveSessionStore : IAsyncDisposable
     private readonly RaskMetrics? _metrics;
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _pendingRemovals = new();
     private readonly IServiceScopeFactory _scopeFactory;
+    // How many sessions a whole-store fan-out touches at once. Bounded so a host with thousands of
+    // sessions doesn't hand the thread pool thousands of simultaneous socket writes; large enough that a
+    // handful of slow clients can't dominate. Both fan-outs are dev-time today, but this is the code the
+    // planned Broadcast pillar inherits, where the fan-out is a user-facing feature.
+    private const int FanOutConcurrency = 32;
+
     private readonly ConcurrentDictionary<string, LiveSession> _sessions = new();
     private readonly CancellationToken _stopping;
 
@@ -319,18 +325,25 @@ public sealed class LiveSessionStore : IAsyncDisposable
             return;
         }
 
-        foreach (var session in _sessions.Values)
-        {
-            try
+        // Bounded-concurrent for the same reason as BroadcastAsync: sequentially, one session stuck on a
+        // send holds up every session behind it. Rendering distinct sessions on distinct threads is not a
+        // new property — independent handler dispatches already do it — because each session serialises
+        // itself on its own render lock and the render walk's ambient scopes are thread-static.
+        await Parallel.ForEachAsync(
+            _sessions.Values,
+            new ParallelOptions { MaxDegreeOfParallelism = FanOutConcurrency },
+            async (session, _) =>
             {
-                Component.MarkSubtreeDirtyForHotReload(session.View);
-                await session.View.StateHasChangedAsync().ConfigureAwait(false);
-            }
-            catch
-            {
-                // One bad tree must not stop the rest — matches RerenderAllForHotReloadAsync.
-            }
-        }
+                try
+                {
+                    Component.MarkSubtreeDirtyForHotReload(session.View);
+                    await session.View.StateHasChangedAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // One bad tree must not stop the rest — matches RerenderAllForHotReloadAsync.
+                }
+            }).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -346,16 +359,24 @@ public sealed class LiveSessionStore : IAsyncDisposable
             return;
         }
 
-        foreach (var session in _sessions.Values)
-        {
-            try
+        // Concurrently, with a bounded degree. Sequentially, the cost of a broadcast is the SUM of every
+        // session's send rather than the slowest one — and each of those sends waits on that session's
+        // render lock behind whatever frame is already in flight. One session on a stalled link would
+        // hold up delivery to everyone behind it in the dictionary's enumeration order. The bound keeps a
+        // large fan-out from saturating the pool; a session whose send faults is skipped, not propagated.
+        await Parallel.ForEachAsync(
+            _sessions.Values,
+            new ParallelOptions { MaxDegreeOfParallelism = FanOutConcurrency },
+            async (session, _) =>
             {
-                await session.SendOutOfBandAsync(payload).ConfigureAwait(false);
-            }
-            catch
-            {
-                // A closed/faulted socket must not stop the broadcast.
-            }
-        }
+                try
+                {
+                    await session.SendOutOfBandAsync(payload).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // A closed/faulted socket must not stop the broadcast.
+                }
+            }).ConfigureAwait(false);
     }
 }

--- a/src/Rask.Server/RaskServerLimits.cs
+++ b/src/Rask.Server/RaskServerLimits.cs
@@ -36,6 +36,9 @@ internal sealed class RaskServerLimits
     /// <summary>Aggregate queued cloned-payload bytes before the backpressure breaker closes the socket. 0 = off.</summary>
     public long MaxPendingHandlerBytes { get; init; }
 
+    /// <summary>How long one outbound frame may take before the socket is aborted. Zero = off.</summary>
+    public TimeSpan SendTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
     /// <summary>Projects a validated <see cref="RaskServerOptions" /> into the per-host limit snapshot.</summary>
     public static RaskServerLimits From(RaskServerOptions o) => new()
     {
@@ -47,5 +50,6 @@ internal sealed class RaskServerLimits
         IdleSocketTimeout = o.IdleSocketTimeout,
         HandlerTimeout = o.HandlerTimeout,
         MaxPendingHandlerBytes = o.MaxPendingHandlerBytes,
+        SendTimeout = o.SendTimeout,
     };
 }

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -96,6 +96,30 @@ public sealed class RaskServerOptions
     public long MaxPendingHandlerBytes { get; set; }
 
     /// <summary>
+    ///     How long a single outbound frame may take before the socket is aborted. Default 30 s;
+    ///     <c>TimeSpan.Zero</c> disables the cap.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>WebSocket.SendAsync</c> completes when the frame reaches the transport, not when the
+    ///         client reads it — so a client that simply stops reading fills the send buffer and the send
+    ///         never returns. Sends happen under the session's render lock, which also guards its teardown,
+    ///         so without this one unresponsive client pins its own session indefinitely: no further
+    ///         renders, and a <c>Dispose</c> that cannot complete.
+    ///     </para>
+    ///     <para>
+    ///         On timeout the socket is aborted rather than the session discarded. The session survives for
+    ///         <see cref="SessionGracePeriod" /> exactly as it would after any other drop, so a client on a
+    ///         briefly-stalled link reconnects to the page it had.
+    ///     </para>
+    ///     <para>
+    ///         The default is deliberately generous: this is a stuck-connection backstop, not a latency
+    ///         budget. A slow mobile link should never trip it.
+    ///     </para>
+    /// </remarks>
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     ///     Throws <see cref="ArgumentOutOfRangeException" /> if any value is out of range. Called by
     ///     <c>AddRask</c> after the caller's <c>configureServer</c> runs, so a bad value (a negative
     ///     grace period that would crash <c>Task.Delay</c> and leak the session, a non-positive
@@ -157,6 +181,13 @@ public sealed class RaskServerOptions
             throw new ArgumentOutOfRangeException(
                 nameof(MaxPendingHandlerBytes), MaxPendingHandlerBytes,
                 "MaxPendingHandlerBytes must be >= 0 (0 disables the cap).");
+        }
+
+        if (SendTimeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SendTimeout), SendTimeout,
+                "SendTimeout must be >= TimeSpan.Zero (Zero disables the timeout).");
         }
     }
 }

--- a/tests/Rask.Server.Tests/Live/SendTimeoutTests.cs
+++ b/tests/Rask.Server.Tests/Live/SendTimeoutTests.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using System.Net.WebSockets;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Components;
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+/// A client that stops reading must not be able to pin its session forever.
+/// </summary>
+/// <remarks>
+/// <c>WebSocket.SendAsync</c> completes when the frame reaches the transport, not when the client reads
+/// it, so a client that simply stops reading fills the send buffer and the send never returns. Every send
+/// happens under the session's render lock, which also guards its teardown — so without a bound, one
+/// unresponsive client costs its session every future render and a <c>Dispose</c> that can never take the
+/// lock. The stalling socket below is that client, made deterministic.
+/// </remarks>
+public sealed class SendTimeoutTests
+{
+    /// <summary>An open socket whose sends never complete until the test says so.</summary>
+    private sealed class StallingWebSocket : WebSocket
+    {
+        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int Aborted { get; private set; }
+
+        public override WebSocketState State { get; } = WebSocketState.Open;
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override string? SubProtocol => null;
+
+        public void Release() => _released.TrySetResult();
+
+        public override async Task SendAsync(
+            ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
+            await _released.Task.WaitAsync(ct);
+
+        public override async ValueTask SendAsync(
+            ReadOnlyMemory<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
+            await _released.Task.WaitAsync(ct);
+
+        public override void Abort()
+        {
+            Aborted++;
+            _released.TrySetCanceled();
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken ct) =>
+            throw new NotSupportedException("This socket only ever sends.");
+
+        public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+        public override Task CloseOutputAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+        public override void Dispose() { }
+    }
+
+    private sealed class Shell : Component
+    {
+        protected override Component? Render() =>
+            [Doctype(), new Html()[new Head(), new Body()[new H1()["hi"]]]];
+    }
+
+    private static LiveSessionStore NewStore(TimeSpan sendTimeout)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new RaskServerLimits { SendTimeout = sendTimeout });
+        var sp = services.BuildServiceProvider();
+        return new LiveSessionStore(sp.GetRequiredService<IServiceScopeFactory>());
+    }
+
+    [Fact]
+    public async Task A_send_that_never_completes_is_abandoned_and_the_socket_aborted()
+    {
+        var store = NewStore(TimeSpan.FromMilliseconds(200));
+        var session = store.Create(_ => new Shell());
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        var started = Stopwatch.GetTimestamp();
+        await Assert.ThrowsAsync<WebSocketException>(
+            () => session.SendOutOfBandAsync("hello"u8.ToArray()));
+
+        Assert.True(Stopwatch.GetElapsedTime(started) < TimeSpan.FromSeconds(5), "the send must not have waited out the test");
+        Assert.Equal(1, socket.Aborted);
+    }
+
+    /// <summary>
+    /// The point of the abort: the render lock comes back. Without it the session is not merely slow, it is
+    /// permanently wedged — nothing can render and nothing can dispose it.
+    /// </summary>
+    [Fact]
+    public async Task The_session_is_usable_again_after_a_send_times_out()
+    {
+        var store = NewStore(TimeSpan.FromMilliseconds(200));
+        var session = store.Create(_ => new Shell());
+        session.AttachSocket(new StallingWebSocket(), CancellationToken.None);
+
+        await Assert.ThrowsAsync<WebSocketException>(
+            () => session.SendOutOfBandAsync("hello"u8.ToArray()));
+
+        // Dispose takes the same lock the wedged send was holding. If it returns, the lock was released.
+        var disposed = Task.Run(() => session.Dispose());
+        Assert.True(await Task.WhenAny(disposed, Task.Delay(TimeSpan.FromSeconds(5))) == disposed,
+            "Dispose must not block on a lock the timed-out send still holds");
+        await disposed;
+    }
+
+    /// <summary>A send that completes normally must be untouched by any of this.</summary>
+    [Fact]
+    public async Task A_healthy_send_is_unaffected()
+    {
+        var store = NewStore(TimeSpan.FromSeconds(30));
+        var session = store.Create(_ => new Shell());
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        socket.Release();
+        await session.SendOutOfBandAsync("hello"u8.ToArray());
+
+        Assert.Equal(0, socket.Aborted);
+    }
+
+    /// <summary>Zero restores the prior unbounded behaviour for anyone who needs it back.</summary>
+    [Fact]
+    public async Task A_zero_timeout_does_not_arm_the_bound()
+    {
+        var store = NewStore(TimeSpan.Zero);
+        var session = store.Create(_ => new Shell());
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        var send = session.SendOutOfBandAsync("hello"u8.ToArray());
+        var finished = await Task.WhenAny(send, Task.Delay(TimeSpan.FromMilliseconds(400)));
+
+        Assert.NotSame(send, finished);
+        Assert.Equal(0, socket.Aborted);
+
+        socket.Release();
+        await send;
+    }
+
+    /// <summary>
+    /// One stalled session must not hold up delivery to the rest. Sequentially this took the sum of every
+    /// session's timeout; concurrently it takes roughly one.
+    /// </summary>
+    [Fact]
+    public async Task A_broadcast_is_not_held_up_by_one_stalled_session()
+    {
+        var store = NewStore(TimeSpan.FromMilliseconds(300));
+        var sockets = new List<StallingWebSocket>();
+        for (var i = 0; i < 6; i++)
+        {
+            var session = store.Create(_ => new Shell());
+            var socket = new StallingWebSocket();
+            session.AttachSocket(socket, CancellationToken.None);
+            sockets.Add(socket);
+        }
+
+        var started = Stopwatch.GetTimestamp();
+        await store.BroadcastAsync("hello"u8.ToArray());
+        var elapsed = Stopwatch.GetElapsedTime(started);
+
+        // Six sessions × 300 ms is 1.8 s sequentially. Concurrently it is one timeout plus scheduling.
+        Assert.True(elapsed < TimeSpan.FromSeconds(1),
+            $"broadcast took {elapsed.TotalMilliseconds:F0} ms — it is serialising on the stalled sessions");
+        Assert.All(sockets, s => Assert.Equal(1, s.Aborted));
+    }
+}


### PR DESCRIPTION
Closes #546. Branches from `main`, independent of #549 and #559.

This started as PR 4 of the scaling plan (`rask deploy --drain`) and turned into its prerequisite — see the bottom for why.

## The bug

`WebSocket.SendAsync` completes when a frame reaches the transport, **not when the client reads it**. A client that simply stops reading TCP fills the send buffer and the send never returns.

Every send here happens under the session's `_renderLock`, which also guards its teardown. So one unresponsive client cost its session **every future render** and a `Dispose` that could never take the lock — for as long as it cared to stall. No timeout, no queue bound, no policy.

The store's fan-outs made it everyone's problem: `RerenderAllAsync` and `BroadcastAsync` were both `foreach ... await`, so a broadcast cost the **sum** of every session's send rather than the slowest, and one stalled client held up every session behind it in enumeration order.

## The fix

**`SendTimeout`** (default 30 s, `0` disables). On expiry the socket is aborted — which is what unwinds the receive loop and releases the lock — while the **session** is left alone and lives out its normal grace period. That distinction is the point: a client whose link stalled briefly reconnects to the page it already had rather than losing it. The default is a stuck-connection backstop, not a latency budget; a slow mobile link will not trip it.

Both fan-outs now run with a bounded degree of concurrency (32). Rendering distinct sessions on distinct threads isn't a new property — independent handler dispatches already do it, each session serialises on its own render lock, and the render walk's ambient scopes are thread-static.

## Testing

Five tests built on a socket whose sends never complete until released, which makes the wedge deterministic:

- the send is abandoned and the socket aborted;
- **`Dispose` then completes** — proving the lock really came back, which is the part that mattered;
- a healthy send is untouched;
- `0` restores the previous unbounded behaviour;
- a six-session broadcast finishes in roughly one timeout instead of six (asserted under 1 s against a 1.8 s sequential cost).

Full local gate green. No benchmarks: this adds a linked CTS only on the timeout path and touches no render or payload code.

## Why this came out of the deploy-drain work

`rask deploy --drain` needs to broadcast a "reconnect now" frame as the host shuts down, so clients move to the replacement container instead of walking their backoff ladder into one that's already gone. That broadcast runs **during shutdown against a hard deadline** — `rask deploy` SIGKILLs 20 s after SIGTERM, and the scaffolded host budgets 15 s.

With the fan-out sequential and the send unbounded, a single slow client would have consumed the entire shutdown budget and taken the SQLite WAL checkpoint down with it — a worse failure than the reload the drain was meant to avoid. So this had to land first.

Two further details the drain still needs, both found while building #559 and recorded on #546: the per-connection `ws.Abort()` is registered on `ApplicationStopping` (callback order isn't guaranteed, so a store-level broadcast can't reliably get ahead of it), and the session's send token is already cancelled by then, so the drain frame needs a send path that doesn't use `_socketCt`.