### PR TITLE
feat(batteries): let in-flight jobs, outbox messages and mail finish on shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,30 @@ them until tagged releases begin.
   said it. The reading comes from `GCMemoryInfo`, which honours a container limit, so it reflects the
   ceiling a deployed app actually runs under. A memory position the runtime won't disclose is treated as
   healthy rather than full — a host must not shed load because it can't measure itself.
+- **Jobs, the outbox and mail now let in-flight work finish when the host shuts down.** All three passed the
+  host's stopping token straight into user code, so a `SIGTERM` — a redeploy, a container recycle —
+  cancelled a handler *mid-call*: a job halfway through a `SaveChangesAsync` was simply torn in two. For mail
+  it was worse than untidy: cancelling during the SMTP `DATA` phase drops the connection, but the server may
+  already have accepted the message, so the row stayed unsent and the next boot **sent it again**. Each
+  pillar now gives the item already running a bounded `ShutdownGracePeriod` (jobs and outbox 5s, mail 10s)
+  before cancelling it, using the same shape `Rask.SQLite.Litestream` already used for its final WAL flush:
+  the host token *arms* a deadline rather than cancelling, so user code keeps a live token past the stop
+  signal. The loop still refuses to *start* anything new the instant the stop arrives, so shutdown is
+  extended by at most one grace period, never one per remaining item. Work that outlives its grace is
+  cancelled and re-runs whole on the next boot, and deliberately **does not count a failed attempt** — a
+  redeploy is not a failure, and counting it would march never-failing work toward its dead letter at the
+  cadence you deploy (`MaxAttempts` is 10 for outbox and mail). New `rask.{jobs,outbox,mail}.interrupted`
+  counters plus a warning make a too-short grace visible instead of silent; `rask.mail.interrupted` is the
+  direct answer to "did that deploy duplicate any mail?". `Rask.Cache` deliberately gets no knob: its only
+  in-flight work is one bulk delete of expired rows, which is abort-safe by construction.
+
+### Fixed
+- **`AddRaskOutbox` now validates its options.** It was the only battery whose registration didn't — jobs,
+  mail and cache all call `Validate()` — and `OutboxOptions` had no `Validate()` method at all. So
+  `PollInterval = TimeSpan.Zero` didn't fail fast at registration; it threw out of `new PeriodicTimer(...)`
+  on the background thread, which with the default `BackgroundServiceExceptionBehavior.StopHost` took the
+  host down at an unrelated moment with an unrelated-looking stack. Every value it now rejects already threw
+  at runtime, just later and less legibly.
 - **`rask db backup` and `rask db restore` — get the deployed database down, and a copy back up.** Continuous
   backup (Litestream) covers the box dying; this covers the two things a solo developer actually reaches
   for: *"something looks wrong in production, let me get a copy"* and *"that migration was a mistake,

--- a/docs/cache.md
+++ b/docs/cache.md
@@ -94,6 +94,12 @@ The `IDistributedCache` (`byte[]`) surface is fully trim-safe.
 
 - **Server-side.** The store is your EF Core database and the purger is a hosted service — this is not a
   browser/WASM concern. (For client-side browser storage, see [`apis/storage.md`](apis/storage.md).)
+- **No `ShutdownGracePeriod`, on purpose.** Jobs, the outbox and mail each take one, because they run *your*
+  code and cancelling it halfway is destructive. The purger's only in-flight work is a single bulk delete of
+  expired rows: cancel it and either the statement rolls back (the next sweep redoes it) or it committed (the
+  work is done). There is no user code, no external side effect and no per-row state to lose, so the purge is
+  abort-safe by construction and a knob would be pure surface area. See
+  [Shutdown and redeploy](configuration.md#shutdown-and-redeploy).
 - **SQLite is single-writer**, so writes serialize. Use [`UseRaskSqlite`](sqlite.md) (WAL + a `busy_timeout`)
   on your context so a concurrent write waits for the lock instead of failing with `SQLITE_BUSY`. Run **one
   purger per app**.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -81,6 +81,28 @@ await jobs.ScheduleAsync(new SendReminder(order.Id), delay: TimeSpan.FromHours(2
 - **The `Rask.Jobs` source generator** registers every `IJob` type (name → CLR type) at module load, so the
   processor rehydrates a stored job with no runtime `Type.GetType` or assembly scanning.
 
+## Shutdown
+
+On `SIGTERM` — a redeploy, a container recycle, `Ctrl+C` — the processor stops picking up **new** jobs
+immediately, but the job already inside your handler gets `JobOptions.ShutdownGracePeriod` (default 5s) to
+finish rather than being cancelled mid-call. A job halfway through a `SaveChangesAsync` completes instead of
+being torn in two.
+
+Only one job is ever in that window: because no new job starts once the stop signal arrives, shutdown is
+extended by at most a single grace period, never one per remaining job.
+
+A job that outlives its grace **is** cancelled, and re-runs from the top on the next boot. It does **not**
+count a failed attempt — a redeploy is not a failure, and counting it would march never-failing work toward
+its dead letter at the cadence you deploy. `rask.jobs.interrupted` counts these, and a warning is logged;
+a nonzero rate means your grace period is shorter than your work.
+
+> **Handlers must be idempotent regardless.** There is no lease, claim or visibility-timeout column — an
+> interrupted job re-runs *whole*, not from where it stopped. That is also why an interrupted job is
+> immediately eligible again rather than waiting out a lease after a redeploy.
+
+`ShutdownGracePeriod` cannot exceed `HostOptions.ShutdownTimeout`: once that elapses the host stops waiting
+for hosted services, so a longer grace silently does not happen. `TimeSpan.Zero` cancels immediately.
+
 ## Notes
 
 - **Server-side.** The processor is a hosted service and the store is your EF Core database — this is not a

--- a/docs/mail.md
+++ b/docs/mail.md
@@ -98,6 +98,31 @@ Switch to real delivery in production by setting `o.Smtp`. Nothing else changes.
   else `PickupDirectoryMailSender`, else `LogMailSender`. Register your own `IMailSender` **before**
   `AddRaskMail` to send through a provider API instead.
 
+## Shutdown, and the duplicate-send window
+
+On `SIGTERM` the processor stops picking up **new** messages immediately, but the send already talking to
+your SMTP server gets `MailOptions.ShutdownGracePeriod` (default **10s** — double the other pillars) to
+finish rather than being cancelled mid-conversation.
+
+That default is deliberate, and this is the one place where at-least-once has a visible cost:
+
+> **A shutdown-interrupted send may already have been delivered.** Delivery and the row update are not one
+> transaction. Cancel during the SMTP `DATA` phase and the client drops the connection to avoid protocol
+> desync — but the server may already have accepted and queued the message. The row still reads unsent, so
+> the next boot sends it again, and the recipient gets it twice.
+>
+> There is no local fix: the send is not idempotent and its outcome is genuinely unknown to us. The only two
+> options are *duplicate* (leave the row pending) or *silent loss* (mark it sent optimistically). Rask
+> chooses **duplicate** — a duplicate email is an annoyance, a lost transactional email is a bug.
+
+What the grace period buys is that the send is no longer racing a token that fires at `SIGTERM`; it is racing
+one that fires ten seconds later, which converts nearly every deploy-interrupted send into a completed one.
+`rask.mail.interrupted` is the direct answer to *"did that deploy duplicate any mail?"* — a nonzero rate means
+your grace period is shorter than your SMTP server's round trip.
+
+An interrupted send does **not** count a failed attempt, so a redeploy never marches mail toward its dead
+letter. `ShutdownGracePeriod` cannot exceed `HostOptions.ShutdownTimeout`; `TimeSpan.Zero` cancels immediately.
+
 ## Notes
 
 - **Server-side.** The processor is a hosted service and the store is your EF Core database — this is not a

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -96,12 +96,19 @@ for all three — only the noun changes.
 | `rask.jobs.processed` | Counter | `job.type` | Jobs that ran to completion. |
 | `rask.jobs.failed` | Counter | `job.type` | Attempts that threw — **every attempt**, not every job. |
 | `rask.jobs.deadlettered` | Counter | `job.type` | Jobs that exhausted `MaxAttempts`, counted once. |
+| `rask.jobs.interrupted` | Counter | `job.type` | Cancelled by shutdown past `ShutdownGracePeriod`. Re-runs on restart; counts **no** attempt. |
 | `rask.jobs.duration` | Histogram (ms) | `job.type` | Wall-clock duration of one execution. |
 | `rask.jobs.pending` | Gauge | | Not yet processed and not yet exhausted. |
 | `rask.jobs.deadletters` | Gauge | | **The number worth alerting on.** |
 
-`Rask.Outbox` publishes the same six as `rask.outbox.*` tagged by `message.type`; `Rask.Mail` publishes
-`rask.mail.sent` / `failed` / `deadlettered` / `duration` / `pending` / `deadletters`.
+`Rask.Outbox` publishes the same seven as `rask.outbox.*` tagged by `message.type`; `Rask.Mail` publishes
+`rask.mail.sent` / `failed` / `deadlettered` / `interrupted` / `duration` / `pending` / `deadletters`.
+
+**`rask.*.interrupted` says your shutdown budget is too short.** It counts work that a `SIGTERM` cancelled
+after its `ShutdownGracePeriod` — which re-runs from the top on the next boot, so any non-idempotent handler
+is repeating its side effects. For `rask.mail.interrupted` it is sharper than that: because a cancelled SMTP
+conversation can be accepted by the server before the row is marked, it is the direct answer to *"did that
+deploy duplicate any mail?"* See [Shutdown and redeploy](configuration.md#shutdown-and-redeploy).
 
 **`rask.*.deadletters` is the alert.** Delivery is at-least-once with backoff, so a pillar retrying itself
 to death still shows a healthy `processed` rate — the dead-letter gauge is the one that says work has been

--- a/docs/outbox.md
+++ b/docs/outbox.md
@@ -74,6 +74,19 @@ Add a migration for the new table before running — `rask db add AddOutbox && r
 - **The `Rask.Outbox` source generator** registers every `IOutboxEvent` type (name → CLR type) at module
   load, so the processor rehydrates a stored message with no runtime `Type.GetType` or assembly scanning.
 
+## Shutdown
+
+On `SIGTERM` the processor stops picking up **new** messages immediately, but the one already inside your
+handler gets `OutboxOptions.ShutdownGracePeriod` (default 5s) to finish rather than being cancelled
+mid-call. Only one message is ever in that window, so shutdown is extended by at most a single grace period.
+
+A message that outlives its grace is cancelled and re-published whole on the next boot. It does **not** count
+a failed attempt — `MaxAttempts` defaults to 10, so counting redeploys would let ten unlucky deploys abandon
+a message nobody ever failed to publish. `rask.outbox.interrupted` counts these, and a warning is logged.
+
+`ShutdownGracePeriod` cannot exceed `HostOptions.ShutdownTimeout`: once that elapses the host stops waiting
+for hosted services, so a longer grace silently does not happen. `TimeSpan.Zero` cancels immediately.
+
 ## Notes
 
 - **Server-side.** The processor is a hosted service and the store is your EF Core database — this is not a

--- a/src/Rask.Jobs/JobMetrics.cs
+++ b/src/Rask.Jobs/JobMetrics.cs
@@ -27,6 +27,7 @@ public sealed class JobMetrics : IDisposable
     private readonly Counter<long> _processed;
     private readonly Counter<long> _failed;
     private readonly Counter<long> _deadLettered;
+    private readonly Counter<long> _interrupted;
     private readonly Histogram<double> _duration;
     private readonly ObservableGauge<int> _pendingGauge;
     private readonly ObservableGauge<int> _deadLetterGauge;
@@ -49,6 +50,9 @@ public sealed class JobMetrics : IDisposable
             "rask.jobs.failed", "{attempt}", "Job attempts that threw. Counts every attempt, not every job.");
         _deadLettered = _meter.CreateCounter<long>(
             "rask.jobs.deadlettered", "{job}", "Jobs that exhausted MaxAttempts and will not be retried.");
+        _interrupted = _meter.CreateCounter<long>(
+            "rask.jobs.interrupted", "{job}",
+            "Jobs cancelled by shutdown after ShutdownGracePeriod. They re-run on restart and count no attempt.");
         _duration = _meter.CreateHistogram<double>(
             "rask.jobs.duration", "ms", "Wall-clock duration of a job execution.");
 
@@ -97,6 +101,16 @@ public sealed class JobMetrics : IDisposable
     /// <summary>Records a job crossing into dead-letter state — counted once, on the attempt that exhausts it.</summary>
     public void DeadLettered(string jobType) =>
         _deadLettered.Add(1, new KeyValuePair<string, object?>("job.type", jobType));
+
+    /// <summary>
+    ///     Records a job that shutdown cancelled after its grace period. Deliberately not a
+    ///     <see cref="Failed" />: the job did not fail, it was interrupted, and it re-runs on restart with
+    ///     its attempt count untouched. A nonzero rate means <c>JobOptions.ShutdownGracePeriod</c> is
+    ///     shorter than the work — and, since an interrupted job re-runs from the top, that any
+    ///     non-idempotent handler is repeating its side effects.
+    /// </summary>
+    public void Interrupted(string jobType) =>
+        _interrupted.Add(1, new KeyValuePair<string, object?>("job.type", jobType));
 
     /// <inheritdoc/>
     public void Dispose() => _meter.Dispose();

--- a/src/Rask.Jobs/JobOptions.cs
+++ b/src/Rask.Jobs/JobOptions.cs
@@ -21,6 +21,27 @@ public sealed class JobOptions
     /// <summary>How long completed jobs are kept before being purged. <see cref="TimeSpan.Zero"/> keeps them forever. Default 7 days.</summary>
     public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(7);
 
+    /// <summary>
+    /// How long a job that is already running may keep running after the host is asked to stop.
+    /// <para>
+    /// On <c>SIGTERM</c> the processor immediately stops picking up <em>new</em> jobs, but the one already
+    /// in your handler is given this long to finish rather than being cancelled mid-call — so a job that
+    /// is halfway through a <c>SaveChangesAsync</c> completes instead of being torn in two.
+    /// </para>
+    /// <para>
+    /// A job that outlives the grace is cancelled and re-runs from the top on the next boot. It does
+    /// <b>not</b> count a failed attempt: a redeploy is not a failure, and counting it would march
+    /// never-failing work toward its dead letter at the cadence you deploy. Handlers must be idempotent
+    /// either way — there is no lease or claim column, so an interrupted job always re-runs whole.
+    /// </para>
+    /// <para>
+    /// Cannot exceed <c>HostOptions.ShutdownTimeout</c>: once that elapses the host stops waiting for
+    /// hosted services, so a grace longer than it silently does not happen. Default 5s;
+    /// <see cref="TimeSpan.Zero"/> cancels immediately.
+    /// </para>
+    /// </summary>
+    public TimeSpan ShutdownGracePeriod { get; set; } = TimeSpan.FromSeconds(5);
+
     /// <summary>The registered interval-recurring jobs.</summary>
     internal List<RecurringJobDefinition> Recurring { get; } = [];
 
@@ -63,6 +84,29 @@ public sealed class JobOptions
         if (RetentionPeriod < TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(nameof(RetentionPeriod), RetentionPeriod, "RetentionPeriod cannot be negative.");
+        }
+
+        ValidateShutdownGracePeriod(ShutdownGracePeriod);
+    }
+
+    /// <summary>
+    /// Range check for the shutdown grace. The upper bound is not pedantry:
+    /// <see cref="CancellationTokenSource.CancelAfter(TimeSpan)"/> throws above <see cref="int.MaxValue"/>
+    /// milliseconds, and it would throw from the shutdown path — the worst place to find out. Each
+    /// battery carries its own copy; they are independent packages that must not reference each other.
+    /// </summary>
+    private static void ValidateShutdownGracePeriod(TimeSpan value)
+    {
+        if (value < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownGracePeriod), value, "ShutdownGracePeriod cannot be negative (Zero cancels immediately).");
+        }
+
+        if (value.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownGracePeriod), value, $"ShutdownGracePeriod must be at most {TimeSpan.FromMilliseconds(int.MaxValue)}.");
         }
     }
 

--- a/src/Rask.Jobs/JobProcessor.cs
+++ b/src/Rask.Jobs/JobProcessor.cs
@@ -84,6 +84,20 @@ public sealed class JobProcessor<TContext>(
             return;
         }
 
+        // The in-flight job gets a bounded grace after SIGTERM instead of being cancelled mid-call. The
+        // host token ARMS a deadline on this source rather than cancelling it, so user code keeps a live
+        // token for ShutdownGracePeriod past the stop signal. (Same shape as the Litestream executor's
+        // graceful stop.) One CTS per batch, not per job: the loop's pre-check below refuses to START
+        // anything new the moment the host token fires, so at most ONE job is ever behind this deadline —
+        // the extra shutdown time is bounded by a single grace period, not one per remaining job.
+        //
+        // Declaration order is load-bearing: `graceCts` must be declared before `registration` so
+        // disposal runs registration-first. The reverse order lets the callback call CancelAfter on an
+        // already-disposed source and throw during shutdown.
+        using var graceCts = new CancellationTokenSource();
+        using var registration = cancellationToken.Register(() => graceCts.CancelAfter(options.ShutdownGracePeriod));
+        var graceToken = graceCts.Token;
+
         foreach (var job in batch)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -115,14 +129,29 @@ public sealed class JobProcessor<TContext>(
                     // A fresh scope per job isolates scoped handler dependencies (e.g. a DbContext) between jobs.
                     await using var scope = scopeFactory.CreateAsyncScope();
                     var dispatcher = scope.ServiceProvider.GetRequiredService<IDispatcher>();
-                    await dispatcher.DispatchAsync(command, cancellationToken).ConfigureAwait(false);
+                    await dispatcher.DispatchAsync(command, graceToken).ConfigureAwait(false);
                     job.ProcessedAt = timeProvider.GetUtcNow().UtcDateTime;
                     job.Error = null;
                     metrics.Processed(job.Type, timeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    break; // shutting down — leave this and the rest for the next run
+                    // Shutdown outlived the grace. Attempts and RunAt are deliberately untouched: a
+                    // redeploy is not a failed attempt, and counting it would march never-failing work
+                    // toward its dead letter at the cadence you deploy. The row stays immediately eligible
+                    // and re-runs whole on restart — metered and logged so a grace period that is too
+                    // short for the work is visible rather than silent.
+                    //
+                    // The filter stays on the HOST token, not the grace token: the grace deadline is only
+                    // ever armed by the host token firing, so any grace expiry necessarily satisfies it,
+                    // while a handler's own OperationCanceledException still falls through to the generic
+                    // catch below and counts as the real failure it is.
+                    metrics.Interrupted(job.Type);
+                    logger.LogWarning(
+                        "Job {Id} ({Type}) was interrupted by shutdown after its {Grace} grace period; it will run "
+                        + "again on restart, so its handler must be idempotent.",
+                        job.Id, job.Type, options.ShutdownGracePeriod);
+                    break; // leave this and the rest for the next run
                 }
 #pragma warning disable CA1031 // A failing job must not stop the drain or crash the app — record + retry with backoff.
                 catch (Exception ex)

--- a/src/Rask.Mail/MailMetrics.cs
+++ b/src/Rask.Mail/MailMetrics.cs
@@ -32,6 +32,7 @@ public sealed class MailMetrics : IDisposable
     private readonly Counter<long> _sent;
     private readonly Counter<long> _failed;
     private readonly Counter<long> _deadLettered;
+    private readonly Counter<long> _interrupted;
     private readonly Histogram<double> _duration;
     private readonly ObservableGauge<int> _pendingGauge;
     private readonly ObservableGauge<int> _deadLetterGauge;
@@ -53,6 +54,9 @@ public sealed class MailMetrics : IDisposable
             "rask.mail.failed", "{attempt}", "Delivery attempts that threw. Counts every attempt, not every email.");
         _deadLettered = _meter.CreateCounter<long>(
             "rask.mail.deadlettered", "{mail}", "Emails that exhausted MaxAttempts and will not be retried.");
+        _interrupted = _meter.CreateCounter<long>(
+            "rask.mail.interrupted", "{mail}",
+            "Sends cancelled by shutdown after ShutdownGracePeriod. They re-send on restart and may already have been delivered.");
         _duration = _meter.CreateHistogram<double>(
             "rask.mail.duration", "ms", "Wall-clock duration of delivering one email.");
 
@@ -94,6 +98,19 @@ public sealed class MailMetrics : IDisposable
 
     /// <summary>Records an email crossing into dead-letter state — counted once, on the attempt that exhausts it.</summary>
     public void DeadLettered() => _deadLettered.Add(1);
+
+    /// <summary>
+    ///     Records a send that shutdown cancelled after its grace period. Deliberately not a
+    ///     <see cref="Failed" />: it did not fail, it was interrupted, and it re-sends on restart with its
+    ///     attempt count untouched.
+    ///     <para>
+    ///         This is the most operationally interesting counter in the pillar. Because a cancelled SMTP
+    ///         conversation can be accepted by the server before the row is marked, this is the direct
+    ///         answer to "did that deploy duplicate any mail?" — and a nonzero rate means
+    ///         <c>MailOptions.ShutdownGracePeriod</c> is shorter than your SMTP server's round trip.
+    ///     </para>
+    /// </summary>
+    public void Interrupted() => _interrupted.Add(1);
 
     /// <inheritdoc/>
     public void Dispose() => _meter.Dispose();

--- a/src/Rask.Mail/MailOptions.cs
+++ b/src/Rask.Mail/MailOptions.cs
@@ -75,6 +75,29 @@ public sealed class MailOptions
     /// <summary>How long sent messages are kept before being purged. <see cref="TimeSpan.Zero"/> keeps them forever. Default 7 days.</summary>
     public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(7);
 
+    /// <summary>
+    /// How long a send that is already in flight may keep going after the host is asked to stop.
+    /// <para>
+    /// On <c>SIGTERM</c> the processor immediately stops picking up <em>new</em> messages, but the send
+    /// already talking to your SMTP server is given this long to finish rather than being cancelled
+    /// mid-conversation.
+    /// </para>
+    /// <para>
+    /// <b>This is the one battery where the grace period buys more than tidiness.</b> Delivery and the row
+    /// update are not one transaction, so a send cancelled during the SMTP <c>DATA</c> phase may already
+    /// have been accepted and queued by the server while the row still reads unsent — and the next boot
+    /// re-sends it. Mail is at-least-once and cannot be made otherwise from here; the grace period is what
+    /// makes that window rare rather than routine. Default 10s — double the other batteries, because an
+    /// interrupted send is a possible <em>duplicate</em>, not a clean retry.
+    /// </para>
+    /// <para>
+    /// Cannot exceed <c>HostOptions.ShutdownTimeout</c>: once that elapses the host stops waiting for
+    /// hosted services, so a grace longer than it silently does not happen.
+    /// <see cref="TimeSpan.Zero"/> cancels immediately.
+    /// </para>
+    /// </summary>
+    public TimeSpan ShutdownGracePeriod { get; set; } = TimeSpan.FromSeconds(10);
+
     /// <summary>Validates the option values (called at registration, so a bad value fails fast rather than tearing down the host later).</summary>
     internal void Validate()
     {
@@ -116,6 +139,20 @@ public sealed class MailOptions
         if (RetentionPeriod < TimeSpan.Zero)
         {
             throw new ArgumentOutOfRangeException(nameof(RetentionPeriod), RetentionPeriod, "RetentionPeriod cannot be negative.");
+        }
+
+        if (ShutdownGracePeriod < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownGracePeriod), ShutdownGracePeriod, "ShutdownGracePeriod cannot be negative (Zero cancels immediately).");
+        }
+
+        // CancellationTokenSource.CancelAfter throws above int.MaxValue milliseconds, and it would throw
+        // from the shutdown path — the worst place to find out.
+        if (ShutdownGracePeriod.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownGracePeriod), ShutdownGracePeriod, $"ShutdownGracePeriod must be at most {TimeSpan.FromMilliseconds(int.MaxValue)}.");
         }
     }
 

--- a/src/Rask.Mail/MailProcessor.cs
+++ b/src/Rask.Mail/MailProcessor.cs
@@ -76,6 +76,25 @@ public sealed class MailProcessor<TContext>(
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
+        // The in-flight send gets a bounded grace after SIGTERM instead of being cancelled mid-call. The
+        // host token ARMS a deadline on this source rather than cancelling it, so the SMTP conversation
+        // keeps a live token for ShutdownGracePeriod past the stop signal. (Same shape as the Litestream
+        // executor's graceful stop.) One CTS per batch, not per message: the loop's pre-check below
+        // refuses to START anything new the moment the host token fires, so at most ONE send is ever
+        // behind this deadline.
+        //
+        // This matters more here than in Jobs/Outbox. Delivery and the row update are not one
+        // transaction, so a send cancelled during the SMTP DATA phase may already have been accepted by
+        // the server while the row still reads unsent — and the next boot re-sends it. The grace period
+        // cannot close that window (nothing local can), it makes it rare.
+        //
+        // Declaration order is load-bearing: `graceCts` must be declared before `registration` so
+        // disposal runs registration-first. The reverse order lets the callback call CancelAfter on an
+        // already-disposed source and throw during shutdown.
+        using var graceCts = new CancellationTokenSource();
+        using var registration = cancellationToken.Register(() => graceCts.CancelAfter(options.ShutdownGracePeriod));
+        var graceToken = graceCts.Token;
+
         foreach (var message in batch)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -91,14 +110,30 @@ public sealed class MailProcessor<TContext>(
                 // IMailSender isn't captured by this singleton processor.
                 await using var scope = scopeFactory.CreateAsyncScope();
                 var sender = scope.ServiceProvider.GetRequiredService<IMailSender>();
-                await sender.SendAsync(outgoing, cancellationToken).ConfigureAwait(false);
+                await sender.SendAsync(outgoing, graceToken).ConfigureAwait(false);
                 message.ProcessedAt = timeProvider.GetUtcNow().UtcDateTime;
                 message.Error = null;
                 metrics.Sent(timeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
             }
             catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
             {
-                break; // shutting down — leave this and the rest for the next run
+                // Shutdown outlived the grace. Attempts is deliberately untouched: a redeploy is not a
+                // failed attempt, and counting it would march never-failing mail toward its dead letter at
+                // the cadence you deploy. The row stays immediately eligible and is re-sent on restart —
+                // and because delivery may already have happened, this counter is the direct answer to
+                // "did that deploy duplicate any mail?".
+                //
+                // The filter stays on the HOST token, not the grace token: the grace deadline is only ever
+                // armed by the host token firing, so any grace expiry necessarily satisfies it, while a
+                // sender's own OperationCanceledException still falls through to the generic catch below
+                // and counts as the real failure it is.
+                metrics.Interrupted();
+                logger.LogWarning(
+                    "Email {Id} was interrupted by shutdown after its {Grace} grace period. It will be sent again on "
+                    + "restart — and it may already have been delivered, since a cancelled SMTP conversation can be "
+                    + "accepted by the server before the row is marked.",
+                    message.Id, options.ShutdownGracePeriod);
+                break; // leave this and the rest for the next run
             }
 #pragma warning disable CA1031 // A failing send must not stop the drain or crash the app — record + retry with backoff.
             catch (Exception ex)

--- a/src/Rask.Outbox/OutboxMetrics.cs
+++ b/src/Rask.Outbox/OutboxMetrics.cs
@@ -27,6 +27,7 @@ public sealed class OutboxMetrics : IDisposable
     private readonly Counter<long> _processed;
     private readonly Counter<long> _failed;
     private readonly Counter<long> _deadLettered;
+    private readonly Counter<long> _interrupted;
     private readonly Histogram<double> _duration;
     private readonly ObservableGauge<int> _pendingGauge;
     private readonly ObservableGauge<int> _deadLetterGauge;
@@ -49,6 +50,9 @@ public sealed class OutboxMetrics : IDisposable
             "rask.outbox.failed", "{attempt}", "Outbox attempts that threw. Counts every attempt, not every message.");
         _deadLettered = _meter.CreateCounter<long>(
             "rask.outbox.deadlettered", "{message}", "Outbox that exhausted MaxAttempts and will not be retried.");
+        _interrupted = _meter.CreateCounter<long>(
+            "rask.outbox.interrupted", "{message}",
+            "Messages cancelled by shutdown after ShutdownGracePeriod. They re-publish on restart and count no attempt.");
         _duration = _meter.CreateHistogram<double>(
             "rask.outbox.duration", "ms", "Wall-clock duration of publishing one outbox message.");
 
@@ -97,6 +101,16 @@ public sealed class OutboxMetrics : IDisposable
     /// <summary>Records a message crossing into dead-letter state — counted once, on the attempt that exhausts it.</summary>
     public void DeadLettered(string messageType) =>
         _deadLettered.Add(1, new KeyValuePair<string, object?>("message.type", messageType));
+
+    /// <summary>
+    ///     Records a message that shutdown cancelled after its grace period. Deliberately not a
+    ///     <see cref="Failed" />: the publish did not fail, it was interrupted, and it runs again on
+    ///     restart with its attempt count untouched. A nonzero rate means
+    ///     <c>OutboxOptions.ShutdownGracePeriod</c> is shorter than the work — and, since an interrupted
+    ///     message re-publishes whole, that any non-idempotent handler is repeating its side effects.
+    /// </summary>
+    public void Interrupted(string messageType) =>
+        _interrupted.Add(1, new KeyValuePair<string, object?>("message.type", messageType));
 
     /// <inheritdoc/>
     public void Dispose() => _meter.Dispose();

--- a/src/Rask.Outbox/OutboxOptions.cs
+++ b/src/Rask.Outbox/OutboxOptions.cs
@@ -22,4 +22,68 @@ public sealed class OutboxOptions
     /// </para>
     /// </summary>
     public TimeSpan RetentionPeriod { get; set; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// How long a message that is already being published may keep publishing after the host is asked to
+    /// stop.
+    /// <para>
+    /// On <c>SIGTERM</c> the processor immediately stops picking up <em>new</em> messages, but the one
+    /// already in your handler is given this long to finish rather than being cancelled mid-call.
+    /// </para>
+    /// <para>
+    /// A message that outlives the grace is cancelled and re-published from the top on the next boot. It
+    /// does <b>not</b> count a failed attempt: a redeploy is not a failure, and counting it would march
+    /// never-failing work toward its dead letter at the cadence you deploy. Handlers must be idempotent
+    /// either way — there is no lease or claim column, so an interrupted message always re-runs whole.
+    /// </para>
+    /// <para>
+    /// Cannot exceed <c>HostOptions.ShutdownTimeout</c>: once that elapses the host stops waiting for
+    /// hosted services, so a grace longer than it silently does not happen. Default 5s;
+    /// <see cref="TimeSpan.Zero"/> cancels immediately.
+    /// </para>
+    /// </summary>
+    public TimeSpan ShutdownGracePeriod { get; set; } = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// Validates the option values. Called from <c>AddRaskOutbox</c>, so a bad value fails fast at
+    /// registration rather than throwing out of <c>new PeriodicTimer(...)</c> on the background thread —
+    /// which, with the default <c>BackgroundServiceExceptionBehavior.StopHost</c>, takes the host down at
+    /// an unrelated moment with an unrelated-looking stack.
+    /// </summary>
+    internal void Validate()
+    {
+        if (PollInterval <= TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(PollInterval), PollInterval, "PollInterval must be positive.");
+        }
+
+        if (BatchSize < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(BatchSize), BatchSize, "BatchSize must be at least 1.");
+        }
+
+        if (MaxAttempts < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(MaxAttempts), MaxAttempts, "MaxAttempts must be at least 1.");
+        }
+
+        if (RetentionPeriod < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(nameof(RetentionPeriod), RetentionPeriod, "RetentionPeriod cannot be negative.");
+        }
+
+        if (ShutdownGracePeriod < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownGracePeriod), ShutdownGracePeriod, "ShutdownGracePeriod cannot be negative (Zero cancels immediately).");
+        }
+
+        // CancellationTokenSource.CancelAfter throws above int.MaxValue milliseconds, and it would throw
+        // from the shutdown path — the worst place to find out.
+        if (ShutdownGracePeriod.TotalMilliseconds > int.MaxValue)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(ShutdownGracePeriod), ShutdownGracePeriod, $"ShutdownGracePeriod must be at most {TimeSpan.FromMilliseconds(int.MaxValue)}.");
+        }
+    }
 }

--- a/src/Rask.Outbox/OutboxProcessor.cs
+++ b/src/Rask.Outbox/OutboxProcessor.cs
@@ -82,6 +82,20 @@ public sealed class OutboxProcessor<TContext>(
         await using var scope = scopeFactory.CreateAsyncScope();
         var dispatcher = scope.ServiceProvider.GetRequiredService<IDispatcher>();
 
+        // The in-flight message gets a bounded grace after SIGTERM instead of being cancelled mid-call.
+        // The host token ARMS a deadline on this source rather than cancelling it, so user code keeps a
+        // live token for ShutdownGracePeriod past the stop signal. (Same shape as the Litestream
+        // executor's graceful stop.) One CTS per batch, not per message: the loop's pre-check below
+        // refuses to START anything new the moment the host token fires, so at most ONE message is ever
+        // behind this deadline.
+        //
+        // Declaration order is load-bearing: `graceCts` must be declared before `registration` so
+        // disposal runs registration-first. The reverse order lets the callback call CancelAfter on an
+        // already-disposed source and throw during shutdown.
+        using var graceCts = new CancellationTokenSource();
+        using var registration = cancellationToken.Register(() => graceCts.CancelAfter(options.ShutdownGracePeriod));
+        var graceToken = graceCts.Token;
+
         foreach (var message in batch)
         {
             if (cancellationToken.IsCancellationRequested)
@@ -111,14 +125,29 @@ public sealed class OutboxProcessor<TContext>(
                 var startedAt = timeProvider.GetTimestamp();
                 try
                 {
-                    await dispatcher.PublishAsync(notification, cancellationToken).ConfigureAwait(false);
+                    await dispatcher.PublishAsync(notification, graceToken).ConfigureAwait(false);
                     message.ProcessedAt = timeProvider.GetUtcNow().UtcDateTime;
                     message.Error = null;
                     metrics.Processed(message.Type, timeProvider.GetElapsedTime(startedAt).TotalMilliseconds);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
-                    break; // shutting down — leave this and the rest for the next run
+                    // Shutdown outlived the grace. Attempts is deliberately untouched: a redeploy is not a
+                    // failed attempt, and counting it would march never-failing work toward its dead
+                    // letter at the cadence you deploy. The row stays immediately eligible and is
+                    // re-published whole on restart — metered and logged so a grace period that is too
+                    // short for the work is visible rather than silent.
+                    //
+                    // The filter stays on the HOST token, not the grace token: the grace deadline is only
+                    // ever armed by the host token firing, so any grace expiry necessarily satisfies it,
+                    // while a handler's own OperationCanceledException still falls through to the generic
+                    // catch below and counts as the real failure it is.
+                    metrics.Interrupted(message.Type);
+                    logger.LogWarning(
+                        "Outbox message {Id} ({Type}) was interrupted by shutdown after its {Grace} grace period; it "
+                        + "will be published again on restart, so its handlers must be idempotent.",
+                        message.Id, message.Type, options.ShutdownGracePeriod);
+                    break; // leave this and the rest for the next run
                 }
 #pragma warning disable CA1031 // A failing handler must not stop the drain or crash the app — record + retry.
                 catch (Exception ex)

--- a/src/Rask.Outbox/RaskOutboxServiceCollectionExtensions.cs
+++ b/src/Rask.Outbox/RaskOutboxServiceCollectionExtensions.cs
@@ -23,6 +23,10 @@ public static class RaskOutboxServiceCollectionExtensions
 
         var options = new OutboxOptions();
         configure?.Invoke(options);
+        // Fail fast here, the way AddRaskJobs/AddRaskMail/AddRaskCache already do. Without this a value
+        // like PollInterval = Zero throws out of `new PeriodicTimer(...)` on the background thread, which
+        // (BackgroundServiceExceptionBehavior.StopHost) tears the host down at an unrelated moment.
+        options.Validate();
 
         services.TryAddSingleton(options);
         services.TryAddSingleton(TimeProvider.System);

--- a/tests/Rask.Jobs.Tests/JobShutdownGraceTests.cs
+++ b/tests/Rask.Jobs.Tests/JobShutdownGraceTests.cs
@@ -1,0 +1,150 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Rask.Jobs.Tests;
+
+/// <summary>
+///     What happens to a job that is already running when the host is asked to stop. Before
+///     <c>ShutdownGracePeriod</c>, the host's stopping token was passed straight into user code, so
+///     <c>SIGTERM</c> cancelled a handler mid-call — a job halfway through a <c>SaveChangesAsync</c> was
+///     simply torn in two and re-run whole on the next boot.
+/// </summary>
+public sealed class JobShutdownGraceTests
+{
+    [Fact]
+    public async Task An_in_flight_job_finishes_within_the_grace()
+    {
+        await using var h = new JobsHarness(o => o.ShutdownGracePeriod = TimeSpan.FromSeconds(5));
+        await h.Queue.EnqueueAsync(new GateJob());
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        await h.Gate.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Stop while the handler is parked. The grace deadline is armed by this, not tripped.
+        var stop = h.Processor.StopAsync(CancellationToken.None);
+        h.Gate.Release.SetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(h.Gate.Completed.Task.IsCompletedSuccessfully, "the handler ran to completion");
+        var job = await h.SingleJobAsync();
+        Assert.NotNull(job.ProcessedAt);
+        Assert.Equal(0, job.Attempts);
+        Assert.Null(job.Error);
+    }
+
+    [Fact]
+    public async Task Shutdown_still_refuses_to_start_the_next_job()
+    {
+        // The grace covers the job already running — it must not turn into "drain the whole batch",
+        // which would make shutdown take one grace period per remaining job.
+        await using var h = new JobsHarness(o => o.ShutdownGracePeriod = TimeSpan.FromSeconds(5));
+        await h.Queue.EnqueueAsync(new GateJob());
+        await h.Queue.EnqueueAsync(new RecordJob("second"));
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        await h.Gate.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var stop = h.Processor.StopAsync(CancellationToken.None);
+        h.Gate.Release.SetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await using var db = h.NewContext();
+        var jobs = await db.Set<Job>().OrderBy(j => j.Id).ToListAsync();
+        Assert.NotNull(jobs[0].ProcessedAt);
+        Assert.Null(jobs[1].ProcessedAt);
+        Assert.Equal(0, jobs[1].Attempts);
+        Assert.DoesNotContain("second", h.Recorder.Values);
+    }
+
+    [Fact]
+    public async Task A_grace_expiry_does_not_count_a_failed_attempt()
+    {
+        // The decision this test exists to protect. MaxAttempts defaults to 25 here and 10 in Outbox/Mail;
+        // counting a redeploy as an attempt would let deploy cadence alone march never-failing work to its
+        // dead letter. The row must stay exactly as eligible as it was.
+        await using var h = new JobsHarness(o => o.ShutdownGracePeriod = TimeSpan.FromMilliseconds(50));
+        await h.Queue.EnqueueAsync(new GateJob());
+        var runAtBefore = (await h.SingleJobAsync()).RunAt;
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        await h.Gate.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        // Never released: the grace expires and the handler is cancelled.
+        await h.Processor.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        var job = await h.SingleJobAsync();
+        Assert.Null(job.ProcessedAt);
+        Assert.Equal(0, job.Attempts);
+        Assert.Null(job.Error);
+        Assert.Equal(runAtBefore, job.RunAt);
+    }
+
+    [Fact]
+    public async Task A_zero_grace_cancels_immediately()
+    {
+        // The documented opt-out, and the pre-existing behaviour.
+        await using var h = new JobsHarness(o => o.ShutdownGracePeriod = TimeSpan.Zero);
+        await h.Queue.EnqueueAsync(new GateJob());
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        await h.Gate.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var started = Environment.TickCount64;
+        await h.Processor.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(Environment.TickCount64 - started < 2_000, "a zero grace must not wait");
+        Assert.False(h.Gate.Completed.Task.IsCompleted);
+        Assert.Null((await h.SingleJobAsync()).ProcessedAt);
+    }
+
+    [Fact]
+    public void The_grace_defaults_to_five_seconds()
+    {
+        // Sized to fit the deploy ladder: `docker stop -t 20` ⊃ HostOptions.ShutdownTimeout 15s ⊃ this.
+        Assert.Equal(TimeSpan.FromSeconds(5), new JobOptions().ShutdownGracePeriod);
+    }
+
+    [Fact]
+    public void A_negative_grace_is_rejected_at_registration()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            new JobOptions { ShutdownGracePeriod = TimeSpan.FromSeconds(-1) }.Validate);
+    }
+
+    [Fact]
+    public void A_grace_CancelAfter_cannot_take_is_rejected_at_registration()
+    {
+        // CancellationTokenSource.CancelAfter throws above int.MaxValue ms — and it would throw from the
+        // shutdown path, the worst place to find out.
+        Assert.Throws<ArgumentOutOfRangeException>(
+            new JobOptions { ShutdownGracePeriod = TimeSpan.FromDays(30) }.Validate);
+    }
+
+    [Fact]
+    public async Task A_handler_that_cancels_itself_still_counts_as_a_failure()
+    {
+        // Pins the catch filter. It tests the HOST token, not the grace token, precisely so a handler's own
+        // OperationCanceledException stays an ordinary failure — the grace deadline is only ever armed by
+        // the host token firing, so a real grace expiry always satisfies the filter anyway.
+        await using var h = new JobsHarness();
+        await h.Queue.EnqueueAsync(new SelfCancellingJob());
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        try
+        {
+            await h.WaitUntilAsync(async () =>
+            {
+                await using var db = h.NewContext();
+                return await db.Set<Job>().AnyAsync(j => j.Attempts > 0);
+            });
+        }
+        finally
+        {
+            await h.Processor.StopAsync(CancellationToken.None);
+        }
+
+        var job = await h.SingleJobAsync();
+        Assert.Equal(1, job.Attempts);
+        Assert.Null(job.ProcessedAt);
+        Assert.Contains("gave up on its own", job.Error);
+    }
+}

--- a/tests/Rask.Jobs.Tests/JobsHarness.cs
+++ b/tests/Rask.Jobs.Tests/JobsHarness.cs
@@ -22,6 +22,42 @@ public sealed record TickJob : IJob;
 /// </summary>
 public sealed record SaboteurJob : IJob;
 
+/// <summary>A job whose handler parks until the test releases it — the lever for the shutdown-grace tests.</summary>
+public sealed record GateJob : IJob;
+
+/// <summary>
+/// A job whose handler throws <see cref="OperationCanceledException"/> from its <em>own</em> reasoning, with
+/// no shutdown in progress. Pins the catch-filter: only a cancellation that coincides with the host stopping
+/// is an interruption; this one is an ordinary failure and must count an attempt.
+/// </summary>
+public sealed record SelfCancellingJob : IJob;
+
+/// <summary>Latches for driving a handler across a shutdown: entered → (test acts) → released → completed.</summary>
+public sealed class Gate
+{
+    public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource Completed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+public sealed class GateJobHandler(Gate gate) : ICommandHandler<GateJob>
+{
+    public async Task HandleAsync(GateJob command, CancellationToken cancellationToken)
+    {
+        gate.Entered.TrySetResult();
+        // Observes the token, so a grace expiry actually cancels it — a handler that ignored its token
+        // could not be cancelled at all and would prove nothing about the grace period.
+        await gate.Release.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        gate.Completed.TrySetResult();
+    }
+}
+
+public sealed class SelfCancellingJobHandler : ICommandHandler<SelfCancellingJob>
+{
+    public Task HandleAsync(SelfCancellingJob command, CancellationToken cancellationToken) =>
+        throw new OperationCanceledException("the handler gave up on its own");
+}
+
 /// <summary>Thread-safe sink the job handlers write to (they run on the processor's background thread).</summary>
 public sealed class Recorder
 {
@@ -117,6 +153,7 @@ public sealed class JobsHarness : IAsyncDisposable
         var services = new ServiceCollection();
         services.AddLogging();
         services.AddSingleton(Recorder);
+        services.AddSingleton(Gate);
         services.AddSingleton<TimeProvider>(Clock); // registered first so AddRaskJobs' TryAddSingleton keeps it
         services.AddRaskCqrs();
         services.AddRaskJobs<JobsDbContext>(o =>
@@ -136,6 +173,9 @@ public sealed class JobsHarness : IAsyncDisposable
     public FakeTimeProvider Clock { get; }
 
     public Recorder Recorder { get; } = new();
+
+    /// <summary>Latches for <see cref="GateJob"/>, so a test can hold a handler open across a shutdown.</summary>
+    public Gate Gate { get; } = new();
 
     public IJobQueue Queue => _provider.GetRequiredService<IJobQueue>();
 

--- a/tests/Rask.Mail.Tests/MailHarness.cs
+++ b/tests/Rask.Mail.Tests/MailHarness.cs
@@ -27,6 +27,16 @@ public sealed class RecordingMailSender : IMailSender
     /// <summary>Fail every attempt.</summary>
     public bool AlwaysFail { get; set; }
 
+    /// <summary>
+    /// When set, the send parks on <see cref="Release"/> instead of completing — standing in for an SMTP
+    /// conversation still in flight when the host is asked to stop. <see cref="Entered"/> signals that the
+    /// send has actually begun, so a test never races the poll loop.
+    /// </summary>
+    public TaskCompletionSource? Release { get; set; }
+
+    /// <summary>Signalled once a gated send has started. Pairs with <see cref="Release"/>.</summary>
+    public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     public IReadOnlyList<OutgoingMail> Sent
     {
         get { lock (_sent) { return _sent.ToArray(); } }
@@ -34,7 +44,7 @@ public sealed class RecordingMailSender : IMailSender
 
     public int Attempts => Volatile.Read(ref _attempts);
 
-    public Task SendAsync(OutgoingMail mail, CancellationToken cancellationToken = default)
+    public async Task SendAsync(OutgoingMail mail, CancellationToken cancellationToken = default)
     {
         var n = Interlocked.Increment(ref _attempts);
         if (AlwaysFail || n <= FailFirst)
@@ -42,8 +52,15 @@ public sealed class RecordingMailSender : IMailSender
             throw new InvalidOperationException("smtp boom");
         }
 
+        if (Release is { } gate)
+        {
+            Entered.TrySetResult();
+            // Observes the token, so a grace expiry actually cancels the send — a sender that ignored its
+            // token could not be cancelled at all and would prove nothing about the grace period.
+            await gate.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         lock (_sent) { _sent.Add(mail); }
-        return Task.CompletedTask;
     }
 }
 

--- a/tests/Rask.Mail.Tests/MailShutdownGraceTests.cs
+++ b/tests/Rask.Mail.Tests/MailShutdownGraceTests.cs
@@ -1,0 +1,82 @@
+namespace Rask.Mail.Tests;
+
+/// <summary>
+///     What happens to a send that is already talking to the SMTP server when the host is asked to stop.
+///     This is the battery where the grace period earns the most: delivery and the row update are not one
+///     transaction, so a send cancelled mid-conversation may already have been accepted by the server while
+///     the row still reads unsent — and the next boot sends it again.
+/// </summary>
+public sealed class MailShutdownGraceTests
+{
+    [Fact]
+    public async Task An_in_flight_send_finishes_within_the_grace()
+    {
+        var sender = new RecordingMailSender
+        {
+            Release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        await using var h = new MailHarness(o => o.ShutdownGracePeriod = TimeSpan.FromSeconds(5), sender);
+        await h.Queue.SendAsync(Email.To("ada@example.com").Subject("Hi").Body("<p>hi</p>"));
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        await sender.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var stop = h.Processor.StopAsync(CancellationToken.None);
+        sender.Release!.SetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.Single(sender.Sent);
+        var mail = await h.SingleMailAsync();
+        Assert.NotNull(mail.ProcessedAt);
+        Assert.Equal(0, mail.Attempts);
+    }
+
+    [Fact]
+    public async Task A_grace_expiry_leaves_the_row_eligible_without_counting_an_attempt()
+    {
+        // The send is cancelled and the row stays unsent, so it goes out again on the next boot. That is
+        // the deliberate choice: a duplicate email is an annoyance, a lost transactional email is a bug.
+        var sender = new RecordingMailSender
+        {
+            Release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        await using var h = new MailHarness(o => o.ShutdownGracePeriod = TimeSpan.FromMilliseconds(50), sender);
+        await h.Queue.SendAsync(Email.To("ada@example.com").Subject("Hi").Body("<p>hi</p>"));
+
+        await h.Processor.StartAsync(CancellationToken.None);
+        await sender.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await h.Processor.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        var mail = await h.SingleMailAsync();
+        Assert.Null(mail.ProcessedAt);
+        Assert.Equal(0, mail.Attempts);
+        Assert.Null(mail.Error);
+    }
+
+    [Fact]
+    public async Task Mail_grace_defaults_to_double_the_other_batteries()
+    {
+        // 10s rather than 5s, and deliberately: an interrupted send is a possible duplicate, not a clean
+        // retry, so halving the interruption rate is worth five extra seconds on an unlucky redeploy.
+        Assert.Equal(TimeSpan.FromSeconds(10), new MailOptions().ShutdownGracePeriod);
+    }
+
+    [Fact]
+    public void A_negative_grace_is_rejected_at_registration()
+    {
+        var options = new MailOptions { From = "a@example.com", ShutdownGracePeriod = TimeSpan.FromSeconds(-1) };
+
+        Assert.Throws<ArgumentOutOfRangeException>(options.Validate);
+    }
+
+    [Fact]
+    public void A_grace_CancelAfter_cannot_take_is_rejected_at_registration()
+    {
+        // CancellationTokenSource.CancelAfter throws above int.MaxValue ms — and it would throw from the
+        // shutdown path, the worst place to find out.
+        var options = new MailOptions { From = "a@example.com", ShutdownGracePeriod = TimeSpan.FromDays(30) };
+
+        Assert.Throws<ArgumentOutOfRangeException>(options.Validate);
+    }
+}

--- a/tests/Rask.Outbox.Tests/OutboxShutdownGraceTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxShutdownGraceTests.cs
@@ -1,0 +1,153 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Rask.Outbox.Tests;
+
+/// <summary>An event whose handler parks until the test releases it — the lever for the shutdown-grace tests.</summary>
+public sealed record GatedEvent : IOutboxEvent;
+
+/// <summary>Latches for driving a handler across a shutdown: entered → (test acts) → released.</summary>
+public sealed class OutboxGate
+{
+    public TaskCompletionSource Entered { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource Release { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+    public TaskCompletionSource Completed { get; } = new(TaskCreationOptions.RunContinuationsAsynchronously);
+}
+
+public sealed class GatedEventHandler(OutboxGate gate) : INotificationHandler<GatedEvent>
+{
+    public async Task HandleAsync(GatedEvent notification, CancellationToken cancellationToken)
+    {
+        gate.Entered.TrySetResult();
+        // Observes the token, so a grace expiry actually cancels it.
+        await gate.Release.Task.WaitAsync(cancellationToken).ConfigureAwait(false);
+        gate.Completed.TrySetResult();
+    }
+}
+
+/// <summary>
+///     What happens to an outbox message that is already being published when the host is asked to stop.
+///     Before <c>ShutdownGracePeriod</c>, the host's stopping token went straight into the handler, so
+///     <c>SIGTERM</c> cancelled a publish mid-call.
+/// </summary>
+public sealed class OutboxShutdownGraceTests : IDisposable
+{
+    private readonly string _dbPath = Path.Combine(Path.GetTempPath(), $"rask-outbox-grace-{Guid.NewGuid():N}.db");
+    private ServiceProvider? _provider;
+
+    public void Dispose()
+    {
+        _provider?.Dispose();
+        if (File.Exists(_dbPath))
+        {
+            File.Delete(_dbPath);
+        }
+    }
+
+    [Fact]
+    public async Task An_in_flight_publish_finishes_within_the_grace()
+    {
+        var gate = Build(TimeSpan.FromSeconds(5));
+        await EnqueueGatedAsync();
+
+        await Processor.StartAsync(CancellationToken.None);
+        await gate.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        var stop = Processor.StopAsync(CancellationToken.None);
+        gate.Release.SetResult();
+        await stop.WaitAsync(TimeSpan.FromSeconds(10));
+
+        Assert.True(gate.Completed.Task.IsCompletedSuccessfully, "the handler ran to completion");
+        var message = await SingleMessageAsync();
+        Assert.NotNull(message.ProcessedAt);
+        Assert.Equal(0, message.Attempts);
+    }
+
+    [Fact]
+    public async Task A_grace_expiry_does_not_count_a_failed_attempt()
+    {
+        // MaxAttempts is 10 here: counting a redeploy as an attempt would let ten unlucky deploys abandon
+        // a message nobody ever failed to publish.
+        var gate = Build(TimeSpan.FromMilliseconds(50));
+        await EnqueueGatedAsync();
+
+        await Processor.StartAsync(CancellationToken.None);
+        await gate.Entered.Task.WaitAsync(TimeSpan.FromSeconds(10));
+
+        await Processor.StopAsync(CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));
+
+        var message = await SingleMessageAsync();
+        Assert.Null(message.ProcessedAt);
+        Assert.Equal(0, message.Attempts);
+        Assert.Null(message.Error);
+    }
+
+    [Fact]
+    public void AddRaskOutbox_now_validates_its_options()
+    {
+        // Outbox was the only battery whose registration never validated (Jobs, Mail and Cache all did), so
+        // PollInterval = Zero used to throw out of `new PeriodicTimer(...)` on the background thread and
+        // take the host down at an unrelated moment. Closes #562.
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddRaskOutbox<OutboxDbContext>(o => o.PollInterval = TimeSpan.Zero));
+    }
+
+    [Fact]
+    public void A_negative_grace_is_rejected_at_registration()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddRaskOutbox<OutboxDbContext>(o => o.ShutdownGracePeriod = TimeSpan.FromSeconds(-1)));
+    }
+
+    private IHostedService Processor =>
+        _provider!.GetServices<IHostedService>().OfType<OutboxProcessor<OutboxDbContext>>().Single();
+
+    private OutboxGate Build(TimeSpan grace)
+    {
+        var gate = new OutboxGate();
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddSingleton(gate);
+        services.AddRaskCqrs();
+        services.AddRaskData(o => o.DispatchDomainEventsInProcess = false);
+        services.AddRaskOutbox<OutboxDbContext>(o =>
+        {
+            o.PollInterval = TimeSpan.FromMilliseconds(20);
+            o.ShutdownGracePeriod = grace;
+        });
+        services.AddDbContextFactory<OutboxDbContext>((sp, o) => o
+            .UseSqlite($"Data Source={_dbPath}")
+            .AddInterceptors(sp.GetServices<ISaveChangesInterceptor>()));
+
+        _provider = services.BuildServiceProvider();
+        using var db = NewContext();
+        db.Database.EnsureCreated();
+        return gate;
+    }
+
+    private OutboxDbContext NewContext() =>
+        _provider!.GetRequiredService<IDbContextFactory<OutboxDbContext>>().CreateDbContext();
+
+    private async Task EnqueueGatedAsync()
+    {
+        // Raises only the gated event, so the batch holds exactly one message and the assertions below are
+        // unambiguous.
+        await using var db = NewContext();
+        db.Orders.Add(Order.PlaceRaisingGated());
+        await db.SaveChangesAsync();
+    }
+
+    private async Task<OutboxMessage> SingleMessageAsync()
+    {
+        await using var db = NewContext();
+        return await db.Set<OutboxMessage>().SingleAsync();
+    }
+}

--- a/tests/Rask.Outbox.Tests/OutboxTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxTests.cs
@@ -27,6 +27,14 @@ public sealed class Order : Entity<Guid>
         return order;
     }
 
+    // Raises the event whose handler parks until a test releases it — see OutboxShutdownGraceTests.
+    public static Order PlaceRaisingGated()
+    {
+        var order = new Order { Id = Guid.NewGuid(), Customer = "gated" };
+        order.Raise(new GatedEvent());
+        return order;
+    }
+
     // Raises the event whose handler deletes a message out of the batch being drained — see SaboteurEvent.
     public static Order PlaceRaisingSaboteur()
     {


### PR DESCRIPTION
PR 2 of the graceful-shutdown series (#560 is PR 1). **Independent of it** — disjoint files, so it can merge
in either order.

## Why

`JobProcessor`, `OutboxProcessor` and `MailProcessor` all passed the host's `stoppingToken` **straight into
user code**:

```csharp
await dispatcher.DispatchAsync(command, cancellationToken);   // JobProcessor.cs:118
await dispatcher.PublishAsync(notification, cancellationToken); // OutboxProcessor.cs:114
await sender.SendAsync(outgoing, cancellationToken);           // MailProcessor.cs:94
```

So a `SIGTERM` — a redeploy, a container recycle — cancelled a handler *mid-call*. A job halfway through a
`SaveChangesAsync` was simply torn in two and re-run whole on the next boot.

**For mail it was worse than untidy.** Cancel during the SMTP `DATA` phase and MailKit drops the connection
to avoid protocol desync — but the server may already have accepted and queued the message. The row still
read unsent, so the next boot **sent it again**. Every redeploy was a chance to double-send a transactional
email.

## What changed

Each pillar gives the item *already running* a bounded `ShutdownGracePeriod` before cancelling it, copying
the shape `Rask.SQLite.Litestream` already used for its final WAL flush — the host token **arms** a deadline
rather than cancelling it, so user code keeps a live token past the stop signal:

```csharp
using var graceCts = new CancellationTokenSource();
using var registration = cancellationToken.Register(() => graceCts.CancelAfter(options.ShutdownGracePeriod));
```

The batch pre-check still tests the **raw host token**, so the loop refuses to *start* anything new the
instant the stop arrives. That is what bounds the cost: at most one item is ever behind the deadline, so
shutdown is extended by a single grace period, never one per remaining item.

Declaration order is load-bearing and matches the Litestream original — `graceCts` before `registration`, so
disposal runs registration-first; the reverse lets the callback call `CancelAfter` on a disposed source and
throw during shutdown.

## Two decisions worth reviewing

**A shutdown cancel does not count a failed attempt.** `Attempts` and `RunAt` are left untouched, exactly as
before. The alternative is a data-abandonment bug whose trigger is *deploy cadence*: `MaxAttempts` is 10 for
outbox and mail, so ten unlucky deploys over a few months would dead-letter a message nobody ever failed to
deliver, and the operator would have no reason to connect the two. Not incrementing has the opposite failure
mode — an item that is *always* caught by shutdown never progresses — but that requires deploys more frequent
than the item's own runtime, and in that scenario incrementing doesn't rescue anything, it just converts
"keeps retrying" into "abandoned". Mild and self-correcting beats silent and destructive.

To keep the mild mode from being *silent*, the cancel path now meters and logs:
`rask.{jobs,outbox,mail}.interrupted` plus a warning naming the grace period. That is the signal that your
budget is shorter than your work.

**Mail stays at-least-once, and the docs now say so out loud.** A grace period shrinks the duplicate-send
window; it cannot close it, because delivery and the row update are not one transaction and the outcome of a
cancelled send is genuinely unknown to us. The only two options are *duplicate* (leave the row pending) or
*silent loss* (mark it sent optimistically) — Rask chooses duplicate, because a duplicate email is an
annoyance and a lost transactional email is a bug. `docs/mail.md` states this plainly rather than hiding it
behind "at-least-once". Mail's grace defaults to **10s**, double the others, because an interrupted send is a
possible duplicate rather than a clean retry. No dedup subsystem was smuggled into a shutdown PR.

## Also fixed: #562

`AddRaskOutbox` never validated its options — it was the only battery that didn't (jobs, mail and cache all
call `Validate()`), and `OutboxOptions` had **no `Validate()` method at all**. `PollInterval = TimeSpan.Zero`
therefore threw out of `new PeriodicTimer(...)` on the background thread, which with the default
`BackgroundServiceExceptionBehavior.StopHost` took the host down at an unrelated moment with an
unrelated-looking stack. Every value it now rejects already threw at runtime, just later and less legibly.

## `Rask.Cache` deliberately gets no knob

Its only in-flight work is a single bulk delete of expired rows. Cancel it and either the statement rolls
back (the next sweep redoes it) or it committed (the work is done). No user code, no external side effect, no
per-row state. Documented as a decision in `docs/cache.md` so its absence doesn't read as an oversight.

## Testing

14 new tests across the three packages, all following the same shape (a handler that parks on a
`TaskCompletionSource` and **observes its token**, so a grace expiry genuinely cancels it):

- in-flight item **finishes** within the grace, with `Attempts == 0`;
- shutdown still **refuses to start the next item** (the bound that keeps this cheap);
- a grace expiry leaves `Attempts`, `Error` and `RunAt` untouched — this is the regression test for the
  decision above, and the one that fails if someone "fixes" it by incrementing;
- `Zero` cancels immediately (the documented opt-out, and the old behaviour);
- **a handler that cancels itself still counts as a failure** — pins why the catch filter tests the *host*
  token rather than the grace token;
- option defaults and validation, including the `int.MaxValue`-ms bound `CancelAfter` would otherwise throw
  on from the shutdown path;
- `AddRaskOutbox` now throws at registration.

Full local gate: `dotnet format` clean, `dotnet build -warnaserror` clean, **entire unit suite green**.

### Not verified

- **No benchmarks.** Nothing here is on the render hot path; the change is one CTS per poll batch (not per
  item, deliberately — that would allocate 100 CTSes per batch at the default `BatchSize`).
- **No E2E.** These are background processors with no UI surface. The pre-push E2E gate is red on `main` for
  unrelated reasons (#550, plus the known Playground sandbox failure), so this was pushed with
  `RASK_SKIP_E2E=1`.
- **Not observed against a real SMTP server or a real redeploy.** The duplicate-send reasoning is from
  MailKit's cancellation behaviour and the non-transactional send/mark split; the tests use a fake sender.

The first commit is an unrelated mechanical fix (`dotnet format` was already red on `main` for two
Shop-sample files) — the same fix as in #560, so whichever merges second is a no-op.

## Remaining in the series

PR 3: the budget ladder — `docker stop -t 20`, the scaffolded `HostOptions.ShutdownTimeout = 15s` coupled to
it only by a comment, and Litestream's 10s are three unrelated constants; `ServicesStopConcurrently` is never
set, so these grace periods currently **sum** rather than overlap; and every sample except
`Rask.Example.Shop` inherits .NET's 30s default, which *exceeds* the 20s docker window.
