### PR TITLE
perf(core): return a session's pooled arrays when it is disposed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,18 @@ them until tagged releases begin.
   drives the real chain over a real WebSocket: an applied update repaints every open session and *then*
   announces itself, in that order. It is a separate assembly because the session registry is
   process-global.
+- **A live session now hands its pooled arrays back when it ends.** Tearing a session down released its
+  file stores, its locks and its DI scope, but simply dropped the rendered-HTML buffer pair and the two
+  frame writers behind the render cache — all of them `ArrayPool` rentals held for the session's whole
+  life. Not a leak: they were collected. But they never went *back*, so every teardown quietly cost the
+  pool the arrays it had just sized to the page, and the next session paid to allocate them again. On a
+  large page these are the dominant per-session term, so the waste scaled with page size. `FrameWriter`
+  gained the return path it never had (it rented in its constructor and had no way to give the array
+  back), and the session releases both **inside** the render lock — everything else in teardown fails
+  loudly on a racing caller, whereas returning an array early would fail silently, in whichever unrelated
+  session later rented it. Worth **~19% of the allocation** a create-render-dispose cycle costs on a
+  200-row page (2,418,177 → 1,959,329 bytes/cycle, `session-churn`), and the residue a 500-cycle run
+  leaves behind drops from 96 bytes to zero.
 - **A contended write no longer fails with "cannot start a transaction within a transaction".** The
   busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
   cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -138,8 +138,9 @@ Every one of these is rented at the size the page turns out to need, then grows 
 and is reused, so per-session cost converges. Cost is a function of your largest page, not of uptime.
 
 These are steady-state figures, and steady state is what a session settles into: a soak of 100 sessions
-over 200 updates each holds flat to the byte, and 500 create-and-dispose cycles leave under 100 bytes
-behind.
+over 200 updates each holds flat to the byte, and 500 create-and-dispose cycles leave nothing behind at
+all. Teardown also hands every pooled array back, so the next session reuses them instead of paying to
+allocate its own — worth ~19% of the allocation a create-render-dispose cycle costs on a 200-row page.
 
 ### Fitting is not the same as serving
 

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -134,7 +134,7 @@ public struct LeanFrame
 ///     a regular class (not a <c>ref struct</c>) so <see cref="HtmlSerializer" /> can
 ///     thread an optional reference through its recursive call chain without ceremony.
 /// </summary>
-public sealed class FrameWriter
+public sealed class FrameWriter : IDisposable
 {
     private RenderFrame[] _buffer;
 
@@ -286,13 +286,41 @@ public sealed class FrameWriter
         };
     }
 
+    /// <summary>
+    ///     Returns the frame buffer to the pool. A live session holds two of these for its whole life, so
+    ///     without this their rentals were simply never given back — collected rather than reused, leaving
+    ///     the pool to allocate a fresh array for the next session that came along.
+    /// </summary>
+    /// <remarks>
+    ///     Cleared on return because a <see cref="RenderFrame" /> holds string references: handing the
+    ///     array back dirty would keep a disposed session's tag and attribute strings alive for as long as
+    ///     the pool held the array. Safe to call more than once, and safe to keep using the writer
+    ///     afterwards — it re-rents on the next growth.
+    /// </remarks>
+    public void Dispose()
+    {
+        if (_buffer.Length > 0)
+        {
+            ArrayPool<RenderFrame>.Shared.Return(_buffer, true);
+        }
+
+        _buffer = [];
+        Count = 0;
+    }
+
     private int Reserve()
     {
         if (Count == _buffer.Length)
         {
-            var bigger = ArrayPool<RenderFrame>.Shared.Rent(_buffer.Length * 2);
+            // Math.Max keeps the doubling honest from a zero-length buffer, which is what a disposed
+            // writer holds — otherwise Rent(0) would hand back an array that can never fit a frame.
+            var bigger = ArrayPool<RenderFrame>.Shared.Rent(Math.Max(16, _buffer.Length * 2));
             Array.Copy(_buffer, bigger, Count);
-            ArrayPool<RenderFrame>.Shared.Return(_buffer, true);
+            if (_buffer.Length > 0)
+            {
+                ArrayPool<RenderFrame>.Shared.Return(_buffer, true);
+            }
+
             _buffer = bigger;
         }
 

--- a/src/Rask.Core/Live/SessionRenderCache.cs
+++ b/src/Rask.Core/Live/SessionRenderCache.cs
@@ -46,6 +46,11 @@ public sealed class SessionRenderCache : IDisposable
 
     public void Dispose()
     {
+        // Dispose, not just null: each FrameWriter holds a pooled RenderFrame[] that dropping the
+        // reference would abandon rather than return. The scratch owns only plain managed objects, so
+        // releasing it is enough.
+        _previous?.Dispose();
+        _current?.Dispose();
         _previous = null;
         _current = null;
         _hasPrevious = false;

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -143,6 +143,11 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         try
         {
             await ComponentLifecycle.DisposeComponentTreeAsync(View).ConfigureAwait(false);
+            // Inside the lock, unlike the rest of teardown: these arrays go back to a shared pool, and a
+            // render that raced this would then be writing into an array another session already owns.
+            // Everything below fails loudly on a racing caller (a disposed semaphore or scope); this
+            // would fail silently, which is the one outcome worth paying a few microseconds to avoid.
+            ReleasePooledBuffers();
         }
         finally
         {
@@ -164,6 +169,9 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         try
         {
             ComponentLifecycle.DisposeComponentTree(View);
+            // See DisposeAsync: returned under the lock so a racing render cannot write into an array
+            // that now belongs to another session.
+            ReleasePooledBuffers();
         }
         finally
         {
@@ -213,6 +221,22 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             InHandlerScope = false;
             Lock.Release();
         }
+    }
+
+    /// <summary>
+    ///     Hands this session's pooled arrays back to <see cref="ArrayPool{T}" />.
+    /// </summary>
+    /// <remarks>
+    ///     The rendered-HTML buffer pair and the two frame writers behind the render cache are all pool
+    ///     rentals held for the session's whole life. Dropping the references collects them but never
+    ///     returns them, so every session teardown quietly cost the pool the arrays it had just warmed —
+    ///     and the next session paid to allocate them again. On a large page these are the dominant
+    ///     per-session term, so the cost scaled with page size.
+    /// </remarks>
+    private void ReleasePooledBuffers()
+    {
+        _htmlBuffers.Dispose();
+        _renderCache?.Dispose();
     }
 
     private void ReleaseFileStores()

--- a/tests/Rask.Core.Tests/Live/FrameWriterDisposeTests.cs
+++ b/tests/Rask.Core.Tests/Live/FrameWriterDisposeTests.cs
@@ -1,0 +1,106 @@
+using Rask.Core.Live;
+
+namespace Rask.Core.Tests.Live;
+
+/// <summary>
+/// <see cref="FrameWriter"/> rents its frame buffer from <see cref="System.Buffers.ArrayPool{T}"/> and a
+/// live session holds two of them for its whole life, so it needs a way to give them back.
+/// </summary>
+/// <remarks>
+/// The failure mode worth guarding is not the leak — that was merely wasteful — but the fix's own hazard:
+/// returning the same array twice hands one array to two owners, and the corruption surfaces later, in
+/// whichever unrelated session was unlucky enough to rent it.
+/// </remarks>
+public sealed class FrameWriterDisposeTests
+{
+    private static FrameWriter Written(int frames)
+    {
+        var writer = new FrameWriter();
+        for (var i = 0; i < frames; i++)
+        {
+            writer.OpenElement("div", null, false, i);
+        }
+
+        return writer;
+    }
+
+    [Fact]
+    public void Dispose_clears_the_writer()
+    {
+        var writer = Written(5);
+        Assert.Equal(5, writer.Count);
+
+        writer.Dispose();
+
+        Assert.Equal(0, writer.Count);
+        Assert.Equal(0, writer.WrittenSpan.Length);
+    }
+
+    /// <summary>Double-dispose must not return the same array twice — that corrupts the shared pool.</summary>
+    [Fact]
+    public void Dispose_is_idempotent()
+    {
+        var writer = Written(3);
+
+        writer.Dispose();
+        writer.Dispose();
+        writer.Dispose();
+
+        Assert.Equal(0, writer.Count);
+    }
+
+    /// <summary>
+    /// A disposed writer holds a zero-length buffer, so the growth path has to re-rent rather than double
+    /// zero forever. Reachable through the render cache, whose writers are disposed and could in principle
+    /// be handed another render.
+    /// </summary>
+    [Fact]
+    public void A_disposed_writer_still_works_if_used_again()
+    {
+        var writer = Written(2);
+        writer.Dispose();
+
+        for (var i = 0; i < 50; i++)
+        {
+            writer.OpenElement("span", null, false, i);
+        }
+
+        Assert.Equal(50, writer.Count);
+        Assert.Equal(50, writer.WrittenSpan.Length);
+
+        writer.Dispose();
+    }
+
+    /// <summary>Growth past the initial rental must not double-return the buffer it replaced.</summary>
+    [Fact]
+    public void Growing_then_disposing_returns_only_the_live_buffer()
+    {
+        var writer = new FrameWriter();
+
+        // Well past the 16-frame initial rental, so Reserve has grown (and returned) several times.
+        for (var i = 0; i < 500; i++)
+        {
+            writer.OpenElement("li", null, false, i);
+        }
+
+        Assert.Equal(500, writer.Count);
+        writer.Dispose();
+        writer.Dispose();
+
+        Assert.Equal(0, writer.Count);
+    }
+
+    /// <summary>The session-level owner has to release both writers, not just drop them.</summary>
+    [Fact]
+    public void The_render_cache_releases_its_writers()
+    {
+        var cache = new SessionRenderCache();
+        var current = cache.PrepareCurrentBuffer();
+        current.OpenElement("div", null, false, 0);
+
+        cache.Dispose();
+        cache.Dispose();
+
+        Assert.Equal(0, current.Count);
+    }
+}


### PR DESCRIPTION
Closes #547. Branches from `main`, independent of #549 / #559 / #564.

## The bug

Tearing a live session down released its file stores, its locks and its DI scope — but simply dropped the rendered-HTML buffer pair and the two frame writers behind the render cache. All of them are `ArrayPool` rentals held for the session's whole life.

Not a leak; they were collected. But they never went **back**, so every teardown cost the pool the arrays it had just sized to the page, and the next session paid to allocate its own. On a large page these are the dominant per-session term (`docs/configuration.md` puts them at ~4 bytes of RAM per HTML character plus ~40 B/node × 2), so the waste scaled with page size.

## Three layers, not one

The issue reads like a two-line fix. It wasn't:

1. **`FrameWriter` had no return path at all.** It rents in its constructor and never gave the array back — so `SessionRenderCache.Dispose` nulling its writers could never have worked, however it was called. It now implements `IDisposable`, and **clears on return**: a `RenderFrame` holds string references, and handing the array back dirty would pin a disposed session's tag and attribute strings for as long as the pool held it.
2. **`SessionRenderCache.Dispose` nulled instead of disposing.** Now disposes both writers. Its `DiffScratch` holds only plain managed objects, so releasing it is still enough.
3. **`LiveSession` never called either.** Now does, in both teardown paths.

`Reserve`'s doubling also became `Math.Max(16, _buffer.Length * 2)` — a disposed writer holds a zero-length buffer, and doubling zero stays zero forever.

## One deliberate placement

The release happens **inside** the render lock, unlike the rest of teardown. Everything below it fails loudly on a racing caller — a disposed semaphore or a disposed scope. Handing an array back early fails *silently*, in whichever unrelated session later rents it. That asymmetry is worth a few microseconds.

## Measured

`session-churn`, 200-row page, before/after on the same machine:

| | Allocated bytes per create-render-dispose cycle |
|---|---:|
| before | 2,418,177 |
| after | **1,959,329** |

**−458,848 bytes/cycle, −19.0%.** The residue a 500-cycle run leaves behind also drops from 96 bytes to zero.

(Measured by reverting the three files to `HEAD` in place and re-running, then reapplying — not by switching branches, which would have picked up another worktree's build.)

## Testing

Five tests, aimed at the hazard the *fix* introduces rather than the leak it removes: returning the same array twice hands one array to two owners and corrupts the shared pool, and the damage surfaces later in unrelated code. So: double-dispose is idempotent, growth past the initial rental doesn't double-return, a disposed writer still works if reused, and the render cache releases both writers.

Full local gate green. One `Rask.Outbox` timing flake (a "runs at most once an hour" window test, untouched by this change) appeared in one gate run; it passes 3/3 in isolation and the gate passed clean on re-run and again in the commit hook.