### PR TITLE
feat(wasm): hot reload for a wasm-hosted app under rask dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@ them until tagged releases begin.
   `rask dev` also now recognises a wasm-hosted app by what it *references* rather than by a `.Client`
   naming convention.
 
+  The **"Hot reload applied" pill now shows on every transport**, from one implementation. It moved out
+  of the Server client into a shared module spliced into all three (`rask-hotreload.js`), so Server,
+  WASM and native cannot drift; only the trigger differs — a pushed frame, a `[JSImport]` call from
+  .NET, or the WebView bridge. The native half is wired for completeness and costs a device build
+  nothing: native hot reload still needs a device-side delta agent that does not exist, so nothing ever
+  raises it there.
+
 ### Fixed
 - **Scoped CSS and scoped JS now work in apps built against the NuGet packages — they never had.** The
   generators read nothing but `@(AdditionalFiles)`, and the `**\*.css` / `**\*.js` globs that populate it

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,20 @@ them until tagged releases begin.
   (`Microsoft.Data.Sqlite`); the alternative was requiring a `sqlite3` binary on the machine, a dependency
   we could neither pin nor install.
 
+### Added
+- **`rask dev` hot-reloads a wasm-hosted app.** WASM had no watch channel at all: the host serves its
+  client's *published* bundle, which a nested `dotnet publish` (an emscripten relink) rebuilt on every
+  save, and which is trimmed — and trimming folds `MetadataUpdater.IsSupported` to false, so an applied
+  update could never reach the browser session even if one arrived. Under `rask dev` the host now serves
+  the client's **build** output instead, read through its static-web-assets manifest (the build
+  `wwwroot/` holds only `_framework/`; the shell, `main.js`, `rask.wasm.js`, scoped-asset bundles and
+  RCL content live in other content roots). The nested publish disappears from the inner loop, the
+  bundle is untrimmed, and everything downstream was already wired — `WasmLiveSession` derives from the
+  same base as the Server one, so it already registers for hot reload and already repaints.
+  Opt out with `rask dev --no-hot-reload` or `--once`, both of which keep the published bundle.
+  `rask dev` also now recognises a wasm-hosted app by what it *references* rather than by a `.Client`
+  naming convention.
+
 ### Fixed
 - **Scoped CSS and scoped JS now work in apps built against the NuGet packages — they never had.** The
   generators read nothing but `@(AdditionalFiles)`, and the `**\*.css` / `**\*.js` globs that populate it

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -285,7 +285,8 @@ so no applied edit could ever reach the page. It also drops the nested `dotnet p
 loop, which is most of the wait. `--no-hot-reload` and `--once` keep the published bundle.
 
 In Development you get a small "Hot reload applied" pill in the corner when an edit lands, so a save that
-changed nothing visible is distinguishable from one that didn't apply. It is never present in production.
+changed nothing visible is distinguishable from one that didn't apply. It is never present in production,
+and it looks and behaves the same on every transport — Server, WASM and native share one implementation.
 
 > **If nothing ever applies, suspect the path.** `dotnet watch` produces an empty hot-reload delta —
 > silently, reporting success at every step — when the project path traverses a symlink. `rask dev`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -272,10 +272,17 @@ edits*, and `rask dev` restarts the app for you and the browser reloads itself.
 
 Two things it does not cover:
 
-- **WASM and native apps have no watch channel.** A WASM app is republished into its host on build, and
-  a native app runs on a device — neither can receive an applied update in place. Restart them.
+- **Native apps have no watch channel.** A native app runs on a device, and `dotnet watch` cannot drive
+  a simulator or a device — so `rask dev` refuses them and points at `dotnet build -t:Run` instead.
+  Restart them to see a change.
 - **A rude edit is not announced.** `dotnet watch` restarts the process, so nothing in Rask observes the
   edit; what you see is the app coming back and the page reloading.
+
+**WASM is covered** — a wasm-hosted app hot-reloads under `rask dev` like a Server one. To make that
+possible the host serves the client's *build* output for the session rather than its published bundle:
+the published bundle is trimmed, and trimming disables the runtime's metadata-update support outright,
+so no applied edit could ever reach the page. It also drops the nested `dotnet publish` from the inner
+loop, which is most of the wait. `--no-hot-reload` and `--once` keep the published bundle.
 
 In Development you get a small "Hot reload applied" pill in the corner when an edit lands, so a save that
 changed nothing visible is distinguishable from one that didn't apply. It is never present in production.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -10,8 +10,10 @@ Run the app you're changing with `rask dev`. It wraps `dotnet watch run`, so an 
 `Render()`, a scoped `.css`/`.js`, a `[Route]` template or a CQRS handler is applied to the running
 process and every open session repaints in place — a "Hot reload applied" pill confirms it. Edits the
 runtime can't apply (adding a type, changing a signature) restart the app instead, and the page reloads
-itself. [What hot-reloads](cli.md#what-hot-reloads) has the full list, including what doesn't: WASM and
-native apps have no watch channel and must be restarted.
+itself. [What hot-reloads](cli.md#what-hot-reloads) has the full list, including what doesn't: native
+apps run on a device, have no watch channel, and must be restarted. WASM is covered — the host serves
+the client's build output for the session, since a published bundle is trimmed and could never apply an
+update.
 
 The framework side of that loop has its own gate, `scripts/run-watch-e2e.sh` — it scaffolds an app, runs
 it under a real `dotnet watch`, edits a file, and asserts the change reached the open live session

--- a/scripts/run-wasm-watch-e2e.sh
+++ b/scripts/run-wasm-watch-e2e.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# WASM hot-reload gate — does an edit to a C# component reach a running browser app?
+#
+# The rest of the WASM channel is covered cheaply: StaticWebAssetsManifestFileProviderTests for serving
+# the build bundle, WasmHotReloadBridgeTests for the announcement, HotReloadClientContractTests for the
+# shared indicator, DevCommandTests for the dev-bundle switch. This is the one hop none of those can
+# reach — Mono applying a metadata delta to a live WASM runtime — so it needs a real browser and a real
+# `dotnet watch` session.
+#
+# Opt-in because it runs a full WASM client build before it can assert anything (minutes), and because
+# it writes a probe source file into samples/Rask.Example.Wasm for the duration of the run.
+#
+# If the edit never applies, check the PATH first: `dotnet watch` computes an empty hot-reload delta,
+# silently, when the project path traverses a symlink. See #536.
+#
+# Usage:  scripts/run-wasm-watch-e2e.sh
+# Skip:   RASK_SKIP_WASM_WATCH_E2E=1
+set -euo pipefail
+
+if [ "${RASK_SKIP_WASM_WATCH_E2E:-}" = "1" ]; then
+  echo "run-wasm-watch-e2e: RASK_SKIP_WASM_WATCH_E2E=1 — skipping."
+  exit 0
+fi
+
+root="$(git rev-parse --show-toplevel)"
+cd "$root"
+
+export RASK_WASM_WATCH_E2E=1
+
+echo "==> Build the E2E test project"
+dotnet build tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj -c Release -m:1
+
+echo "==> WASM hot-reload gate (real dotnet watch + a real browser)"
+dotnet test tests/Rask.Examples.E2E.Tests/Rask.Examples.E2E.Tests.csproj -c Release --no-build \
+  --filter "FullyQualifiedName~WasmWatchHotReloadTests" \
+  --logger "console;verbosity=normal"
+
+echo
+echo "==> WASM hot-reload gate passed."

--- a/src/Rask.Cli/Commands/DevCommand.cs
+++ b/src/Rask.Cli/Commands/DevCommand.cs
@@ -91,7 +91,7 @@ internal sealed class DevCommand(
 
         var dotnetArgs = BuildDotnetArguments(
             target.ProjectPath, once, parsed.HasFlag("no-hot-reload"),
-            parsed.Option("launch-profile"), nonInteractive, parsed.Passthrough);
+            parsed.Option("launch-profile"), nonInteractive, parsed.Passthrough, target.Kind);
 
         var environment = BuildEnvironment(
             target.Kind, restartOnRudeEdit && !once, parsed.Option("urls"), Environment.GetEnvironmentVariable);
@@ -125,7 +125,8 @@ internal sealed class DevCommand(
         bool noHotReload,
         string? launchProfile,
         bool nonInteractive,
-        IReadOnlyList<string> passthrough)
+        IReadOnlyList<string> passthrough,
+        DevTemplateKind kind = DevTemplateKind.Server)
     {
         var args = new List<string>();
 
@@ -157,6 +158,18 @@ internal sealed class DevCommand(
             }
 
             args.Add("run");
+
+            // A wasm-hosted host serves its client's PUBLISHED bundle by default, which is (a) republished
+            // by a nested emscripten relink on every save and (b) trimmed — and trimming folds
+            // MetadataUpdater.IsSupported to false, so an applied delta could never reach the browser
+            // session. This switches it to the client's build output for the watch session. Not passed
+            // under --no-hot-reload (nothing to apply) or --once (that mode is deliberately a plain run).
+            //
+            // `--property:`, not `-p:`: on `dotnet run` the short form is ambiguous with --project.
+            if (kind == DevTemplateKind.WasmHosted && !noHotReload)
+            {
+                args.Add("--property:RaskWasmDevBundle=true");
+            }
         }
 
         if (once && launchProfile is { Length: > 0 })

--- a/src/Rask.Cli/DevTarget.cs
+++ b/src/Rask.Cli/DevTarget.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Rask.Cli.Scaffolding;
 
 namespace Rask.Cli;
@@ -157,13 +158,63 @@ internal sealed record DevTarget(
 
         if (text.Contains("Microsoft.NET.Sdk.Web", StringComparison.Ordinal))
         {
-            // A Server host that references a sibling .Client project is the wasm-hosted shape.
-            return text.Contains(".Client", StringComparison.Ordinal)
+            // A Server host that references a sibling .Client project is the wasm-hosted shape. The
+            // name check is what `rask new` produces, and it costs no I/O — but it is only a naming
+            // convention, so fall back to actually reading the referenced projects. Without that,
+            // a host whose client is not called *.Client (the repo's own Rask.Example.Wasm.Host among
+            // them) is misread as a plain Server and never gets the WASM dev bundle.
+            return text.Contains(".Client", StringComparison.Ordinal) || ReferencesWasmProject(fileSystem, csproj, text)
                 ? DevTemplateKind.WasmHosted
                 : DevTemplateKind.Server;
         }
 
         return DevTemplateKind.Unknown;
+    }
+
+    /// <summary>
+    ///     Does any <c>ProjectReference</c> point at a WASM client? Reads each referenced csproj and looks
+    ///     for the WebAssembly SDK or Rask's own <c>&lt;RaskWasm&gt;</c> marker — the same marker
+    ///     <c>Rask.Wasm.Hosting.targets</c> probes for at build time, so the CLI and the build agree on
+    ///     what a wasm-hosted solution is.
+    /// </summary>
+    private static bool ReferencesWasmProject(IFileSystem fileSystem, string csprojPath, string text)
+    {
+        var hostDirectory = Path.GetDirectoryName(Path.GetFullPath(csprojPath));
+        if (hostDirectory is null)
+        {
+            return false;
+        }
+
+        foreach (Match match in Regex.Matches(text, @"<ProjectReference\s+Include\s*=\s*""([^""]+)"""))
+        {
+            var relative = match.Groups[1].Value.Replace('\\', Path.DirectorySeparatorChar);
+            var referenced = Path.GetFullPath(Path.Combine(hostDirectory, relative));
+            if (!fileSystem.FileExists(referenced))
+            {
+                continue;
+            }
+
+            var referencedText = ReadOrEmpty(fileSystem, referenced);
+            if (referencedText.Contains("Microsoft.NET.Sdk.WebAssembly", StringComparison.Ordinal)
+                || referencedText.Contains("<RaskWasm>true</RaskWasm>", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string ReadOrEmpty(IFileSystem fileSystem, string path)
+    {
+        try
+        {
+            return fileSystem.ReadAllText(path);
+        }
+        catch (IOException)
+        {
+            return string.Empty;
+        }
     }
 
     /// <summary>

--- a/src/Rask.Core/Resources/rask-hotreload.js
+++ b/src/Rask.Core/Resources/rask-hotreload.js
@@ -1,0 +1,62 @@
+// Dev-only "hot reload applied" indicator — one implementation, spliced into all three transports
+// (Server rask.js, WASM rask.wasm.js, Native rask.native.js) at their hot-reload splice marker.
+//
+// Deliberately does not spell that marker out: this file's text is substituted *for* it, so a literal
+// copy here would survive into every built artifact and read as a marker the splice had missed.
+//
+// It lives here rather than in each dialect because the transports differ in how the *notification*
+// arrives — Server pushes a {"type":"hotReload"} frame over the socket, WASM calls the exported
+// hotReloadApplied() through JSImport, Native evaluates a call over the WebView bridge — but what
+// happens next is identical, and three copies of a pill would drift.
+//
+// Wrapped in its own IIFE so its locals cannot collide with the enclosing dialect (the Server client
+// is one big IIFE with its own `const`s; WASM and Native splice at module top level). The single
+// export is window.__raskHotReloadPill, which is how each transport reaches it.
+(function () {
+    "use strict";
+
+    // How long the pill stays visible.
+    const HOT_RELOAD_PILL_MS = 1200;
+
+    let hotReloadPill = null;
+    let hotReloadPillTimer = null;
+
+    function showHotReloadPill() {
+        // Built lazily on first use, so a production bundle constructs no DOM and injects no CSS for
+        // it at all — only the (unreachable) function body ships.
+        if (!hotReloadPill) {
+            const style = document.createElement("style");
+            style.setAttribute("data-rask-managed", "");
+            style.textContent =
+                ".rask-hot{position:fixed;right:12px;bottom:12px;z-index:2147483647;" +
+                "padding:6px 12px;border-radius:999px;pointer-events:none;opacity:0;" +
+                "background:rgba(20,20,20,.82);color:#fff;transition:opacity .15s ease;" +
+                "font:12px/1.4 system-ui,-apple-system,Segoe UI,sans-serif;}" +
+                ".rask-hot[data-show]{opacity:1;}";
+            document.head.appendChild(style);
+
+            // DOM APIs rather than innerHTML — keeps the runtime clean under a strict CSP, matching
+            // installOverlay(). data-rask-managed keeps rask-morph.js from trimming both nodes: they
+            // are framework-owned siblings of the rendered tree, and without it the next morph would
+            // delete the pill mid-animation.
+            hotReloadPill = document.createElement("div");
+            hotReloadPill.className = "rask-hot";
+            hotReloadPill.setAttribute("data-rask-managed", "");
+            hotReloadPill.setAttribute("aria-live", "polite");
+            hotReloadPill.textContent = "Hot reload applied";
+            document.documentElement.appendChild(hotReloadPill);
+        }
+
+        // A counter the watch E2E waits on, so it asserts the feature rather than sleeping.
+        window.__raskHotReloadCount = (window.__raskHotReloadCount || 0) + 1;
+
+        hotReloadPill.setAttribute("data-show", "");
+        if (hotReloadPillTimer !== null) clearTimeout(hotReloadPillTimer);
+        hotReloadPillTimer = setTimeout(function () {
+            if (hotReloadPill) hotReloadPill.removeAttribute("data-show");
+            hotReloadPillTimer = null;
+        }, HOT_RELOAD_PILL_MS);
+    }
+
+    window.__raskHotReloadPill = showHotReloadPill;
+})();

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1349,6 +1349,74 @@ window.__raskWakeLock = window.__raskWakeLock || (() => {
 })();
 
 
+// ----- Dev-only "hot reload applied" indicator — Rask.Core/Resources/rask-hotreload.js -----
+// The same source the Server and WASM clients use. Exposes window.__raskHotReloadPill, which the host
+// calls over the WebView bridge (NativeLiveSession) rather than pushing a frame. Inert on a device
+// build, where hot reload is unsupported and nothing ever calls it — see #565.
+// Dev-only "hot reload applied" indicator — one implementation, spliced into all three transports
+// (Server rask.js, WASM rask.wasm.js, Native rask.native.js) at their hot-reload splice marker.
+//
+// Deliberately does not spell that marker out: this file's text is substituted *for* it, so a literal
+// copy here would survive into every built artifact and read as a marker the splice had missed.
+//
+// It lives here rather than in each dialect because the transports differ in how the *notification*
+// arrives — Server pushes a {"type":"hotReload"} frame over the socket, WASM calls the exported
+// hotReloadApplied() through JSImport, Native evaluates a call over the WebView bridge — but what
+// happens next is identical, and three copies of a pill would drift.
+//
+// Wrapped in its own IIFE so its locals cannot collide with the enclosing dialect (the Server client
+// is one big IIFE with its own `const`s; WASM and Native splice at module top level). The single
+// export is window.__raskHotReloadPill, which is how each transport reaches it.
+(function () {
+    "use strict";
+
+    // How long the pill stays visible.
+    const HOT_RELOAD_PILL_MS = 1200;
+
+    let hotReloadPill = null;
+    let hotReloadPillTimer = null;
+
+    function showHotReloadPill() {
+        // Built lazily on first use, so a production bundle constructs no DOM and injects no CSS for
+        // it at all — only the (unreachable) function body ships.
+        if (!hotReloadPill) {
+            const style = document.createElement("style");
+            style.setAttribute("data-rask-managed", "");
+            style.textContent =
+                ".rask-hot{position:fixed;right:12px;bottom:12px;z-index:2147483647;" +
+                "padding:6px 12px;border-radius:999px;pointer-events:none;opacity:0;" +
+                "background:rgba(20,20,20,.82);color:#fff;transition:opacity .15s ease;" +
+                "font:12px/1.4 system-ui,-apple-system,Segoe UI,sans-serif;}" +
+                ".rask-hot[data-show]{opacity:1;}";
+            document.head.appendChild(style);
+
+            // DOM APIs rather than innerHTML — keeps the runtime clean under a strict CSP, matching
+            // installOverlay(). data-rask-managed keeps rask-morph.js from trimming both nodes: they
+            // are framework-owned siblings of the rendered tree, and without it the next morph would
+            // delete the pill mid-animation.
+            hotReloadPill = document.createElement("div");
+            hotReloadPill.className = "rask-hot";
+            hotReloadPill.setAttribute("data-rask-managed", "");
+            hotReloadPill.setAttribute("aria-live", "polite");
+            hotReloadPill.textContent = "Hot reload applied";
+            document.documentElement.appendChild(hotReloadPill);
+        }
+
+        // A counter the watch E2E waits on, so it asserts the feature rather than sleeping.
+        window.__raskHotReloadCount = (window.__raskHotReloadCount || 0) + 1;
+
+        hotReloadPill.setAttribute("data-show", "");
+        if (hotReloadPillTimer !== null) clearTimeout(hotReloadPillTimer);
+        hotReloadPillTimer = setTimeout(function () {
+            if (hotReloadPill) hotReloadPill.removeAttribute("data-show");
+            hotReloadPillTimer = null;
+        }, HOT_RELOAD_PILL_MS);
+    }
+
+    window.__raskHotReloadPill = showHotReloadPill;
+})();
+
+
 // ----- The diff codec: applyDiff(ops, names) + applyFrameInvokes(reply, dispatchOne) — rask-dom.js -----
 // Shared diff-codec interpreter consumed by both rask.js (Server) and
 // rask.wasm.js (WASM). Concatenated into each runtime at build time — see the

--- a/src/Rask.Native/HotReload/NativeHotReloadBridge.cs
+++ b/src/Rask.Native/HotReload/NativeHotReloadBridge.cs
@@ -1,0 +1,97 @@
+using System.Reflection.Metadata;
+using Rask.Core.Diagnostics;
+using Rask.Core.HotReload;
+
+namespace Rask.Native.HotReload;
+
+/// <summary>
+///     Announces an applied hot reload to the WebView, for the day one can reach a native app.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>This does not make native hot reload work, and is not claimed to.</b> Delivering new IL to
+///         an app on a device or simulator needs a device-side delta agent that does not exist —
+///         <c>dotnet watch</c> cannot drive either, which is why <c>rask dev</c> refuses native targets.
+///         See #565.
+///     </para>
+///     <para>
+///         What it does is finish the half that <i>is</i> free. <c>NativeLiveSession</c> derives from
+///         <c>LiveSessionBase</c>, so it already registers with the coordinator and already repaints
+///         through <c>INativeWebView.ApplyRenderAsync</c>; the indicator was the only missing piece, and
+///         it is a few lines now that the pill is a shared module. If a delta channel ever lands, the
+///         framework side needs no further work.
+///     </para>
+///     <para>
+///         Gated on <see cref="MetadataUpdater.IsSupported" />, so a device build — where it can never
+///         fire — subscribes to nothing and pays nothing.
+///     </para>
+/// </remarks>
+internal static class NativeHotReloadBridge
+{
+    private const string ShowPill = "window.__raskHotReloadPill && window.__raskHotReloadPill()";
+
+    private static readonly Lock Gate = new();
+    private static INativeWebView? _webView;
+    private static bool _subscribed;
+
+    /// <summary>
+    ///     Points the indicator at <paramref name="webView" />. Idempotent, and re-pointable: a host that
+    ///     recreates its session must not stack handlers, and the newest WebView is the live one.
+    /// </summary>
+    internal static void Attach(INativeWebView webView)
+    {
+        if (!MetadataUpdater.IsSupported)
+        {
+            return;
+        }
+
+        lock (Gate)
+        {
+            _webView = webView;
+            if (_subscribed)
+            {
+                return;
+            }
+
+            _subscribed = true;
+            RaskHotReload.Applied += OnApplied;
+        }
+    }
+
+    private static void OnApplied()
+    {
+        var webView = Volatile.Read(ref _webView);
+        if (webView is null)
+        {
+            return;
+        }
+
+        try
+        {
+            // Fire-and-forget: the coordinator's completion path must not block on a WebView round
+            // trip, and the indicator is cosmetic. Faults are observed below rather than left to the
+            // unobserved-exception handler.
+            _ = ShowAsync(webView);
+        }
+        catch (Exception ex)
+        {
+            Report(ex);
+        }
+    }
+
+    private static async Task ShowAsync(INativeWebView webView)
+    {
+        try
+        {
+            await webView.EvaluateJavaScriptAsync(ShowPill).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Report(ex);
+        }
+    }
+
+    private static void Report(Exception ex) =>
+        RaskDiagnostics.Report(
+            RaskLogLevel.Warning, "Rask.HotReload", "Rask: hot-reload indicator failed", ex);
+}

--- a/src/Rask.Native/NativeLiveSession.cs
+++ b/src/Rask.Native/NativeLiveSession.cs
@@ -59,6 +59,11 @@ internal sealed class NativeLiveSession : LiveSessionBase, IDisposable
         // Bind this session to the runtime so its BeginInvokeJS queues onto JsInvokes.
         services.GetService<NativeJSRuntime>()?.AttachHost(this, webView);
 
+        // The base ctor already registered this session for hot-reload repaints; this only points the
+        // "applied" indicator at the same WebView. No-op on a device build, where MetadataUpdater is
+        // unsupported and no delta can arrive anyway (#565).
+        HotReload.NativeHotReloadBridge.Attach(webView);
+
         if (services.GetService<IUserProvider>() is { } userProvider)
         {
             _userProvider = userProvider;

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -159,7 +159,7 @@
     above and re-generated (WriteOnlyWhenDifferent) whenever a shared module or the template changes.
   -->
   <Target Name="_RaskSpliceNativeClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths;BeforeCompile"
-          Inputs="Resources\rask.native.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js"
+          Inputs="Resources\rask.native.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js"
           Outputs="Assets\rask.native.js">
     <PropertyGroup>
       <_RaskNativeTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.native.js'))</_RaskNativeTemplate>
@@ -170,7 +170,8 @@
       <_RaskPwaBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-pwa.js'))</_RaskPwaBody>
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
-      <_RaskNativeJs>$(_RaskNativeTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)'))</_RaskNativeJs>
+      <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
+      <_RaskNativeJs>$(_RaskNativeTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)'))</_RaskNativeJs>
     </PropertyGroup>
     <MakeDir Directories="Assets"/>
     <WriteLinesToFile File="Assets\rask.native.js" Lines="$(_RaskNativeJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>

--- a/src/Rask.Native/Resources/rask.native.js
+++ b/src/Rask.Native/Resources/rask.native.js
@@ -29,6 +29,12 @@ let root = null;
 // ----- Transport-agnostic PWA helpers (__raskPush/__raskNotify/__raskBadge/__raskWakeLock) -----
 // @@RASK_PWA@@
 
+// ----- Dev-only "hot reload applied" indicator — Rask.Core/Resources/rask-hotreload.js -----
+// The same source the Server and WASM clients use. Exposes window.__raskHotReloadPill, which the host
+// calls over the WebView bridge (NativeLiveSession) rather than pushing a frame. Inert on a device
+// build, where hot reload is unsupported and nothing ever calls it — see #565.
+// @@RASK_HOTRELOAD@@
+
 // ----- The diff codec: applyDiff(ops, names) + applyFrameInvokes(reply, dispatchOne) — rask-dom.js -----
 // @@RASK_DOM@@
 

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -57,7 +57,7 @@
   <Import Project="..\..\build\Rask.MinifyJs.targets"/>
 
   <Target Name="_RaskBuildClientJs" BeforeTargets="PrepareForBuild"
-          Inputs="Resources\rask.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js"
+          Inputs="Resources\rask.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js"
           Outputs="$(IntermediateOutputPath)rask.js">
     <PropertyGroup>
       <_RaskClientTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.js'))</_RaskClientTemplate>
@@ -68,7 +68,8 @@
       <_RaskPwaBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-pwa.js'))</_RaskPwaBody>
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
-      <_RaskClientJs>$(_RaskClientTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)'))</_RaskClientJs>
+      <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
+      <_RaskClientJs>$(_RaskClientTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)'))</_RaskClientJs>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath)"/>
     <WriteLinesToFile File="$(IntermediateOutputPath)rask.js" Lines="$(_RaskClientJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -132,8 +132,6 @@
     // Dev-only counterpart: under `dotnet watch` an unknown session means the app just restarted for
     // a rude edit, so there is nothing to wait for — get back on screen.
     const DEV_RESTART_RELOAD_MS = 250;
-    // How long the "hot reload applied" pill stays visible.
-    const HOT_RELOAD_PILL_MS = 1200;
     let overlayTimer = null;
     let sessionExpired = false;
 
@@ -193,7 +191,7 @@
             // frame, so it must NOT fall through to applyFullReply (which would morph the document
             // against a payload that carries no html).
             if (data.type === "hotReload") {
-                if (devMode && data.status === "applied") showHotReloadPill();
+                if (devMode && data.status === "applied") window.__raskHotReloadPill();
                 return;
             }
             // Handler ack: resolve the slow-link pending bar. Handled synchronously here
@@ -304,44 +302,11 @@
             devMode ? DEV_RESTART_RELOAD_MS : SESSION_EXPIRED_RELOAD_MS);
     }
 
-    // Dev-only "hot reload applied" indicator. Built lazily on first use, so a production bundle
-    // constructs no DOM and injects no CSS for it at all. data-rask-managed keeps rask-morph.js from
-    // trimming it — it is a framework-owned sibling of the server-rendered tree.
-    let hotReloadPill = null;
-    let hotReloadPillTimer = null;
-
-    function showHotReloadPill() {
-        if (!hotReloadPill) {
-            const style = document.createElement("style");
-            style.setAttribute("data-rask-managed", "");
-            style.textContent =
-                ".rask-hot{position:fixed;right:12px;bottom:12px;z-index:2147483647;" +
-                "padding:6px 12px;border-radius:999px;pointer-events:none;opacity:0;" +
-                "background:rgba(20,20,20,.82);color:#fff;transition:opacity .15s ease;" +
-                "font:12px/1.4 system-ui,-apple-system,Segoe UI,sans-serif;}" +
-                ".rask-hot[data-show]{opacity:1;}";
-            document.head.appendChild(style);
-
-            // DOM APIs rather than innerHTML — keeps the runtime clean under a strict CSP, matching
-            // installOverlay().
-            hotReloadPill = document.createElement("div");
-            hotReloadPill.className = "rask-hot";
-            hotReloadPill.setAttribute("data-rask-managed", "");
-            hotReloadPill.setAttribute("aria-live", "polite");
-            hotReloadPill.textContent = "Hot reload applied";
-            document.documentElement.appendChild(hotReloadPill);
-        }
-
-        // A counter the watch E2E waits on, so it asserts the feature rather than sleeping.
-        window.__raskHotReloadCount = (window.__raskHotReloadCount || 0) + 1;
-
-        hotReloadPill.setAttribute("data-show", "");
-        if (hotReloadPillTimer !== null) clearTimeout(hotReloadPillTimer);
-        hotReloadPillTimer = setTimeout(function () {
-            if (hotReloadPill) hotReloadPill.removeAttribute("data-show");
-            hotReloadPillTimer = null;
-        }, HOT_RELOAD_PILL_MS);
-    }
+    // Dev-only "hot reload applied" indicator, spliced from Rask.Core/Resources/rask-hotreload.js —
+    // the same source WASM and Native use, so the three transports cannot drift. It exposes
+    // window.__raskHotReloadPill; only the way the notification *arrives* differs per transport (here,
+    // the hotReload frame branch above).
+    // @@RASK_HOTRELOAD@@
 
     // Toggle the overlay's manual action button. Pass a label to show it, or null to hide it. A single
     // click handler routes to retryNow(), which reloads when the session has expired and otherwise

--- a/src/Rask.Wasm.Hosting/RaskWasmEndpointExtensions.cs
+++ b/src/Rask.Wasm.Hosting/RaskWasmEndpointExtensions.cs
@@ -98,6 +98,25 @@ public static class RaskWasmEndpointExtensions
         var resolved = bundlePath ?? WasmAppBundle.ResolveFromAssembly(Assembly.GetEntryAssembly());
         var bundleDir = string.IsNullOrEmpty(resolved) || !Directory.Exists(resolved) ? null : resolved;
 
+        // Dev bundle: serve the client's BUILD output (via its static-web-assets manifest) instead of
+        // the published one. Gated on all three of Development, hot reload being supported in this
+        // process, and the manifest existing — so a published deployment, a Release run, and a host
+        // built without a WASM reference all take the untouched path below.
+        //
+        // This is what makes WASM hot reload possible at all: a published bundle is trimmed, and
+        // trimming folds MetadataUpdater.IsSupported to false, so the session in the browser never
+        // registers for hot reload no matter what the host serves.
+        //
+        // Decided BEFORE the missing-bundle guard, and deliberately: turning the dev bundle on skips
+        // the nested publish, so there is usually no publish directory at all. Checking the publish
+        // path first would 503 exactly the setup this feature creates — which is precisely what
+        // happened, and what the WASM watch E2E caught.
+        var devManifest = WasmAppBundle.ResolveDevManifest(Assembly.GetEntryAssembly());
+        var dev = MetadataUpdater.IsSupported
+                  && endpoints.ServiceProvider.GetService<IHostEnvironment>()?.IsDevelopment() == true
+                  && !string.IsNullOrEmpty(devManifest)
+                  && File.Exists(devManifest);
+
         // Scoped asset endpoint. Registered before the static-file middleware so a /_rask/a/{hash}.{ext}
         // URL is served from the in-process ScopedAssetRegistry (populated by module initializers from
         // the referenced WASM assembly as soon as it's loaded into this host). On a registry miss it
@@ -107,7 +126,9 @@ public static class RaskWasmEndpointExtensions
         // skipped and can't serve the baked file itself. The baked copy is authoritative.
         RaskAssetEndpoint.MapRaskAssets(endpoints, pathBaseNormalized, bundleDir);
 
-        if (string.IsNullOrEmpty(resolved) || !Directory.Exists(resolved))
+        // `!dev`: with the dev bundle on there is no published directory to find — skipping the nested
+        // publish is the point — so the missing-bundle guard must not fire.
+        if (!dev && (string.IsNullOrEmpty(resolved) || !Directory.Exists(resolved)))
         {
             var reason = string.IsNullOrEmpty(resolved)
                 ? "no bundle configured (add a <ProjectReference> to a project that sets <WasmGenerateAppBundle>true</WasmGenerateAppBundle>, with ReferenceOutputAssembly=\"false\" SkipGetTargetFrameworkProperties=\"true\", or pass bundlePath explicitly)"
@@ -142,23 +163,11 @@ public static class RaskWasmEndpointExtensions
                 "IApplicationBuilder (e.g. WebApplication).");
         }
 
-        // Dev bundle: serve the client's BUILD output (via its static-web-assets manifest) instead of
-        // the published one. Gated on all three of Development, hot reload being supported in this
-        // process, and the manifest actually existing — so a published deployment, a Release run, and a
-        // host built without a WASM reference all take the untouched path below.
-        //
-        // This is what makes WASM hot reload possible at all: a published bundle is trimmed, and
-        // trimming folds MetadataUpdater.IsSupported to false, so the session in the browser never
-        // registers for hot reload no matter what the host serves.
-        var devManifest = WasmAppBundle.ResolveDevManifest(Assembly.GetEntryAssembly());
-        var dev = MetadataUpdater.IsSupported
-                  && app.ApplicationServices.GetService<IHostEnvironment>()?.IsDevelopment() == true
-                  && !string.IsNullOrEmpty(devManifest)
-                  && File.Exists(devManifest);
-
+        // Past the guard above, `resolved` is non-null on the published path; on the dev path it may be
+        // absent entirely, and nothing below reads it.
         IFileProvider fileProvider = dev
             ? new StaticWebAssetsManifestFileProvider(devManifest!)
-            : new PhysicalFileProvider(resolved);
+            : new PhysicalFileProvider(resolved!);
 
         if (dev)
         {
@@ -260,8 +269,11 @@ public static class RaskWasmEndpointExtensions
         // applier arms on nothing else — but it rewrites the SendFileAsync path too, verified against a
         // running host on both the published and the build bundle.
         var indexPath = dev
-            ? fileProvider.GetFileInfo("index.html").PhysicalPath ?? Path.Combine(resolved, "index.html")
-            : Path.Combine(resolved, "index.html");
+            ? fileProvider.GetFileInfo("index.html").PhysicalPath
+              ?? throw new InvalidOperationException(
+                  $"The WASM dev bundle manifest has no index.html entry ({devManifest}). Rebuild the "
+                  + "client project, or run without -p:RaskWasmDevBundle=true to serve the published bundle.")
+            : Path.Combine(resolved!, "index.html");
 
         if (pathBaseNormalized.Length == 0)
         {

--- a/src/Rask.Wasm.Hosting/RaskWasmEndpointExtensions.cs
+++ b/src/Rask.Wasm.Hosting/RaskWasmEndpointExtensions.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Reflection.Metadata;
 using System.Text.RegularExpressions;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -7,6 +8,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.StaticFiles;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.Hosting;
 using Rask.Core.Live;
 
 namespace Rask.Wasm.Hosting;
@@ -140,14 +142,42 @@ public static class RaskWasmEndpointExtensions
                 "IApplicationBuilder (e.g. WebApplication).");
         }
 
-        var fileProvider = new PhysicalFileProvider(resolved);
+        // Dev bundle: serve the client's BUILD output (via its static-web-assets manifest) instead of
+        // the published one. Gated on all three of Development, hot reload being supported in this
+        // process, and the manifest actually existing — so a published deployment, a Release run, and a
+        // host built without a WASM reference all take the untouched path below.
+        //
+        // This is what makes WASM hot reload possible at all: a published bundle is trimmed, and
+        // trimming folds MetadataUpdater.IsSupported to false, so the session in the browser never
+        // registers for hot reload no matter what the host serves.
+        var devManifest = WasmAppBundle.ResolveDevManifest(Assembly.GetEntryAssembly());
+        var dev = MetadataUpdater.IsSupported
+                  && app.ApplicationServices.GetService<IHostEnvironment>()?.IsDevelopment() == true
+                  && !string.IsNullOrEmpty(devManifest)
+                  && File.Exists(devManifest);
+
+        IFileProvider fileProvider = dev
+            ? new StaticWebAssetsManifestFileProvider(devManifest!)
+            : new PhysicalFileProvider(resolved);
+
+        if (dev)
+        {
+            Console.WriteLine($"Rask.Wasm.Hosting: serving the WASM build output (hot reload) from {devManifest}");
+        }
 
         // Precompressed siblings first: if the WASM publish step emitted .br/.gz next to
         // each asset (set <CompressionEnabled>true</CompressionEnabled> on the WASM
         // project), serve those directly with the matching Content-Encoding header — zero
         // request-time CPU and CDN-cacheable. Falls through to UseStaticFiles + the
         // runtime UseResponseCompression below when no sibling exists.
-        app.UseMiddleware<PrecompressedFileMiddleware>(fileProvider);
+        // Both compression paths are skipped in dev. `dotnet watch`'s browser-refresh middleware injects
+        // its script tag by rewriting the HTML response body, and it cannot rewrite an encoded one — and
+        // that script is the single condition Mono's in-browser delta applier self-arms on. A gzipped
+        // shell therefore means no hot reload, silently.
+        if (!dev)
+        {
+            app.UseMiddleware<PrecompressedFileMiddleware>(fileProvider);
+        }
 
         // If the host called services.AddRask() (which registers brotli/gzip providers and
         // adds application/wasm + application/octet-stream to the compressible MIME set),
@@ -155,7 +185,7 @@ public static class RaskWasmEndpointExtensions
         // ship compressed. Skipped silently when not registered — the host still works,
         // just without compression. With the precompressed-sibling middleware ahead, this
         // only fires for files without a baked sibling (e.g. index.html if not pre-encoded).
-        if (app.ApplicationServices.GetService<IResponseCompressionProvider>() is not null)
+        if (!dev && app.ApplicationServices.GetService<IResponseCompressionProvider>() is not null)
         {
             app.UseResponseCompression();
         }
@@ -220,7 +250,19 @@ public static class RaskWasmEndpointExtensions
             }
         });
 
-        var indexPath = Path.Combine(resolved, "index.html");
+        // In dev the shell comes from the manifest, not from disk next to the bundle: the build output's
+        // wwwroot/ holds only _framework/, and /index.html maps to a placeholder-filled shell under obj/
+        // whose import map and preload hints carry the build fingerprints. The raw index.html in the
+        // source tree still has those placeholders empty and cannot boot the runtime.
+        //
+        // SendFileAsync is kept on both paths. It was worth checking, since `dotnet watch`'s
+        // browser-refresh middleware injects its script by rewriting the response body and the delta
+        // applier arms on nothing else — but it rewrites the SendFileAsync path too, verified against a
+        // running host on both the published and the build bundle.
+        var indexPath = dev
+            ? fileProvider.GetFileInfo("index.html").PhysicalPath ?? Path.Combine(resolved, "index.html")
+            : Path.Combine(resolved, "index.html");
+
         if (pathBaseNormalized.Length == 0)
         {
             endpoints.MapFallback(async ctx =>

--- a/src/Rask.Wasm.Hosting/StaticWebAssetsManifestFileProvider.cs
+++ b/src/Rask.Wasm.Hosting/StaticWebAssetsManifestFileProvider.cs
@@ -1,0 +1,283 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.Extensions.FileProviders;
+using Microsoft.Extensions.FileProviders.Physical;
+using Microsoft.Extensions.Primitives;
+
+namespace Rask.Wasm.Hosting;
+
+/// <summary>
+///     Serves a WASM client's <b>build</b> output by reading its
+///     <c>*.staticwebassets.runtime.json</c> manifest, for the dev-time host only.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A <see cref="PhysicalFileProvider" /> cannot do this job. The build <c>wwwroot/</c> holds only
+///         <c>_framework/</c> — <c>index.html</c>, <c>main.js</c>, <c>rask.wasm.js</c>, <c>global.css</c>
+///         and the scoped-asset bundles are not there. They exist as manifest entries pointing into a
+///         dozen content roots spread across the client's <c>wwwroot/</c>, its <c>obj/</c>, and the
+///         framework's own source tree. Most decisively, <c>/index.html</c> maps to a build-time
+///         placeholder-filled shell under <c>obj/…/htmlassetplaceholders/</c>, whose import map and
+///         preload hints carry the <i>build</i> fingerprints; the raw <c>index.html</c> in the source
+///         tree still has those placeholders empty and cannot boot the runtime.
+///     </para>
+///     <para>
+///         Why hand-rolled rather than ASP.NET's own <c>ManifestStaticWebAssetFileProvider</c>: that type
+///         is not public API, and a dev convenience in a shipped package must not depend on framework
+///         internals that can move between patch releases. The format read here is small and stable.
+///     </para>
+///     <para>
+///         <b>Development only.</b> The published-bundle path is untouched — and has to stay that way,
+///         because a published bundle is trimmed, and trimming folds
+///         <c>MetadataUpdater.IsSupported</c> to false so hot reload could never work in it regardless.
+///     </para>
+/// </remarks>
+internal sealed class StaticWebAssetsManifestFileProvider : IFileProvider
+{
+    private readonly string _manifestPath;
+    private readonly Lock _gate = new();
+
+    private Manifest? _manifest;
+    private DateTime _loadedStamp;
+
+    public StaticWebAssetsManifestFileProvider(string manifestPath) => _manifestPath = manifestPath;
+
+    public IFileInfo GetFileInfo(string subpath)
+    {
+        var node = Find(subpath, out var manifest);
+        if (node?.Asset is not { } asset || manifest is null)
+        {
+            return new NotFoundFileInfo(subpath);
+        }
+
+        var full = Path.Combine(manifest.ContentRoots[asset.ContentRootIndex], asset.SubPath);
+        var file = new FileInfo(full);
+        return file.Exists ? new PhysicalFileInfo(file) : new NotFoundFileInfo(subpath);
+    }
+
+    /// <summary>
+    ///     Needed as well as <see cref="GetFileInfo" />: <c>UseDefaultFiles</c> enumerates a directory to
+    ///     find <c>index.html</c> before anything asks for a file, so a provider that only answers
+    ///     <see cref="GetFileInfo" /> serves a 404 at <c>/</c>.
+    /// </summary>
+    public IDirectoryContents GetDirectoryContents(string subpath)
+    {
+        var node = Find(subpath, out var manifest);
+        if (node?.Children is not { Count: > 0 } children || manifest is null)
+        {
+            return NotFoundDirectoryContents.Singleton;
+        }
+
+        var entries = new List<IFileInfo>(children.Count);
+        foreach (var (name, child) in children)
+        {
+            if (child.Asset is { } asset)
+            {
+                var file = new FileInfo(Path.Combine(manifest.ContentRoots[asset.ContentRootIndex], asset.SubPath));
+                if (file.Exists)
+                {
+                    entries.Add(new PhysicalFileInfo(file));
+                }
+            }
+            else if (child.Children is { Count: > 0 })
+            {
+                // A directory the manifest knows about but that has no single physical home.
+                entries.Add(new NotFoundFileInfo(name));
+            }
+        }
+
+        return new EnumerableDirectoryContents(entries);
+    }
+
+    /// <summary>
+    ///     No change tokens. Under <c>dotnet watch</c> a rude edit restarts the host, and a hot-applied
+    ///     edit does not move any asset — so nothing here would ever fire, and pretending otherwise would
+    ///     only cost a file watcher per request path.
+    /// </summary>
+    public IChangeToken Watch(string filter) => NullChangeToken.Singleton;
+
+    private Node? Find(string subpath, out Manifest? manifest)
+    {
+        manifest = Load();
+        if (manifest is null)
+        {
+            return null;
+        }
+
+        var node = manifest.Root;
+        foreach (var segment in Split(subpath))
+        {
+            if (node.Children is not { } children || !children.TryGetValue(segment, out var next))
+            {
+                return MatchPattern(node, subpath, manifest);
+            }
+
+            node = next;
+        }
+
+        return node;
+    }
+
+    /// <summary>
+    ///     Content roots contributed wholesale (<c>_content/{Package}/**</c>) appear as a pattern rather
+    ///     than as enumerated children. Only <c>**</c> is ever emitted, so the remaining request path maps
+    ///     straight onto the root.
+    /// </summary>
+    private static Node? MatchPattern(Node node, string subpath, Manifest manifest)
+    {
+        if (node.Patterns is not { Length: > 0 } patterns)
+        {
+            return null;
+        }
+
+        foreach (var pattern in patterns)
+        {
+            var root = manifest.ContentRoots[pattern.ContentRootIndex];
+            var candidate = Path.GetFullPath(Path.Combine(root, string.Join(Path.DirectorySeparatorChar, Split(subpath))));
+
+            // Never let a crafted path climb out of the content root.
+            if (!candidate.StartsWith(Path.GetFullPath(root), StringComparison.Ordinal) || !File.Exists(candidate))
+            {
+                continue;
+            }
+
+            return new Node
+            {
+                Asset = new Asset { ContentRootIndex = pattern.ContentRootIndex, SubPath = Path.GetRelativePath(root, candidate) }
+            };
+        }
+
+        return null;
+    }
+
+    private static string[] Split(string subpath) =>
+        subpath.Split(['/', '\\'], StringSplitOptions.RemoveEmptyEntries);
+
+    private Manifest? Load()
+    {
+        lock (_gate)
+        {
+            if (!File.Exists(_manifestPath))
+            {
+                return null;
+            }
+
+            var stamp = File.GetLastWriteTimeUtc(_manifestPath);
+            if (_manifest is not null && stamp == _loadedStamp)
+            {
+                return _manifest;
+            }
+
+            try
+            {
+                using var stream = File.OpenRead(_manifestPath);
+                var parsed = JsonSerializer.Deserialize(stream, ManifestJson.Default.Manifest);
+                if (parsed?.Root is null)
+                {
+                    return _manifest;
+                }
+
+                Normalize(parsed.Root);
+                _manifest = parsed;
+                _loadedStamp = stamp;
+            }
+            catch (JsonException)
+            {
+                // A half-written manifest during a rebuild — keep serving the previous one.
+            }
+            catch (IOException)
+            {
+            }
+
+            return _manifest;
+        }
+    }
+
+    /// <summary>
+    ///     One pass that does two things the deserialized shape can't give us directly.
+    ///     <para>
+    ///         <b>Drops every precompressed entry.</b> The dev host must serve identity-encoded HTML so
+    ///         <c>dotnet watch</c>'s browser-refresh injector can rewrite it — a gzipped shell silently
+    ///         loses the script tag that arms the in-browser delta applier. It also removes the only
+    ///         entries whose <c>SubPath</c> carries a <c>{0}</c> fingerprint placeholder, so nothing
+    ///         downstream has to resolve one.
+    ///     </para>
+    ///     <para>
+    ///         <b>Rebuilds each children map case-insensitively</b>, matching how the static-file
+    ///         middleware resolves request paths. Done here rather than with a JsonConverter because the
+    ///         source-generated serializer cannot reach a private nested converter type.
+    ///     </para>
+    /// </summary>
+    private static void Normalize(Node node)
+    {
+        if (node.Children is not { Count: > 0 } children)
+        {
+            return;
+        }
+
+        var rebuilt = new Dictionary<string, Node>(children.Count, StringComparer.OrdinalIgnoreCase);
+        foreach (var (name, child) in children)
+        {
+            if (name.EndsWith(".gz", StringComparison.OrdinalIgnoreCase)
+                || name.EndsWith(".br", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            Normalize(child);
+            rebuilt[name] = child;
+        }
+
+        node.Children = rebuilt;
+    }
+
+    private sealed class EnumerableDirectoryContents(IReadOnlyList<IFileInfo> entries) : IDirectoryContents
+    {
+        public bool Exists => entries.Count > 0;
+
+        public IEnumerator<IFileInfo> GetEnumerator() => entries.GetEnumerator();
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    internal sealed class Manifest
+    {
+        public string[] ContentRoots { get; set; } = [];
+
+        public Node Root { get; set; } = new();
+    }
+
+    internal sealed class Node
+    {
+        // Rebuilt with an ordinal-ignore-case comparer by Normalize() after deserialization.
+        public Dictionary<string, Node>? Children { get; set; }
+
+        public Asset? Asset { get; set; }
+
+        public Pattern[]? Patterns { get; set; }
+    }
+
+    internal sealed class Asset
+    {
+        public int ContentRootIndex { get; set; }
+
+        public string SubPath { get; set; } = string.Empty;
+    }
+
+    internal sealed class Pattern
+    {
+        public int ContentRootIndex { get; set; }
+
+        public string PatternText { get; set; } = string.Empty;
+
+        public int Depth { get; set; }
+    }
+
+}
+
+/// <summary>Source-generated metadata — the package is trim- and AOT-analysed under warnings-as-errors.</summary>
+[JsonSourceGenerationOptions(PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(StaticWebAssetsManifestFileProvider.Manifest))]
+[SuppressMessage("Design", "CA1812", Justification = "Instantiated by the source-generated serializer.")]
+internal sealed partial class ManifestJson : JsonSerializerContext;

--- a/src/Rask.Wasm.Hosting/WasmAppBundle.cs
+++ b/src/Rask.Wasm.Hosting/WasmAppBundle.cs
@@ -6,7 +6,18 @@ internal static class WasmAppBundle
 {
     internal const string MetadataKey = "Rask.WasmAppBundleDir";
 
-    internal static string? ResolveFromAssembly(Assembly? assembly)
+    /// <summary>
+    ///     The client's build-output static-web-assets manifest, baked by Rask.Wasm.Hosting.targets.
+    ///     Present whenever a WASM ProjectReference was found; whether it is <i>used</i> is decided at
+    ///     runtime by <c>UseRask</c> (Development + hot reload supported + the file actually exists).
+    /// </summary>
+    internal const string DevManifestKey = "Rask.WasmDevManifest";
+
+    internal static string? ResolveFromAssembly(Assembly? assembly) => Read(assembly, MetadataKey);
+
+    internal static string? ResolveDevManifest(Assembly? assembly) => Read(assembly, DevManifestKey);
+
+    private static string? Read(Assembly? assembly, string key)
     {
         if (assembly is null)
         {
@@ -15,7 +26,7 @@ internal static class WasmAppBundle
 
         foreach (var attr in assembly.GetCustomAttributes<AssemblyMetadataAttribute>())
         {
-            if (string.Equals(attr.Key, MetadataKey, StringComparison.Ordinal))
+            if (string.Equals(attr.Key, key, StringComparison.Ordinal))
             {
                 return string.IsNullOrWhiteSpace(attr.Value) ? null : attr.Value;
             }

--- a/src/Rask.Wasm.Hosting/build/Rask.Wasm.Hosting.targets
+++ b/src/Rask.Wasm.Hosting/build/Rask.Wasm.Hosting.targets
@@ -42,6 +42,24 @@
     only fires when the probe actually finds a RaskWasm ref.
   -->
 
+  <!--
+    Dev bundle: serve the WASM client's BUILD output instead of publishing it.
+
+    Under `dotnet watch` the nested `dotnet publish` below runs on every save — an emscripten relink for
+    a one-character edit. Worse, a published bundle is trimmed, and trimming folds
+    MetadataUpdater.IsSupported to false, so a hot-reload delta could never be applied in it even if one
+    arrived. Serving build output is therefore a precondition for WASM hot reload, not an optimisation.
+
+    Opt-in via the property, which `rask dev` passes for a wasm-hosted target. It deliberately does NOT
+    default from $(DOTNET_WATCH): watch sets that variable on the app it *runs*, not on the `dotnet
+    build` it shells out to first, so the property would read empty exactly where it is needed — the
+    publish would run and no dev manifest would be baked. (Verified against a real watch session; the
+    earlier assumption that it defaults cleanly was wrong.)
+
+    Also NOT keyed off $(Configuration): the E2E fixtures run Debug against the PUBLISHED bundle, so
+    flipping on Debug would pull the bundle out from under them.
+  -->
+
   <Target Name="_RaskProbeWasmProjectRef"
           Outputs="%(ProjectReference.Identity)">
     <XmlPeek XmlInputPath="%(ProjectReference.FullPath)"
@@ -49,12 +67,25 @@
              Condition=" '%(ProjectReference.FullPath)' != '' ">
       <Output TaskParameter="Result" PropertyName="_RaskWasmBundleProbe"/>
     </XmlPeek>
+    <!--
+      Read the referenced project's TFM and assembly name too, so neither the bundle path nor the dev
+      manifest path has to hardcode them. (The bundle path used to hardcode net10.0-browser.)
+    -->
+    <XmlPeek XmlInputPath="%(ProjectReference.FullPath)"
+             Query="/Project/PropertyGroup/TargetFramework/text()"
+             Condition=" '%(ProjectReference.FullPath)' != '' ">
+      <Output TaskParameter="Result" PropertyName="_RaskWasmTfmProbe"/>
+    </XmlPeek>
     <ItemGroup>
       <_RaskWasmRef Include="%(ProjectReference.FullPath)"
-                    Condition=" '$(_RaskWasmBundleProbe)' == 'true' "/>
+                    Condition=" '$(_RaskWasmBundleProbe)' == 'true' ">
+        <Tfm Condition=" '$(_RaskWasmTfmProbe)' != '' ">$(_RaskWasmTfmProbe)</Tfm>
+        <Tfm Condition=" '$(_RaskWasmTfmProbe)' == '' ">net10.0-browser</Tfm>
+      </_RaskWasmRef>
     </ItemGroup>
     <PropertyGroup>
       <_RaskWasmBundleProbe></_RaskWasmBundleProbe>
+      <_RaskWasmTfmProbe></_RaskWasmTfmProbe>
     </PropertyGroup>
   </Target>
 
@@ -65,7 +96,17 @@
       Text="Rask.Wasm.Hosting: only one Rask WASM ProjectReference is supported per host (found @(_RaskWasmRef->Count()): @(_RaskWasmRef))."/>
     <PropertyGroup>
       <_RaskWasmProjectDir Condition=" '@(_RaskWasmRef->Count())' == '1' ">$([System.IO.Path]::GetDirectoryName('%(_RaskWasmRef.FullPath)'))</_RaskWasmProjectDir>
-      <_RaskWasmAppBundleDir Condition=" '$(_RaskWasmProjectDir)' != '' ">$(_RaskWasmProjectDir)$([System.IO.Path]::DirectorySeparatorChar)bin$([System.IO.Path]::DirectorySeparatorChar)$(Configuration)$([System.IO.Path]::DirectorySeparatorChar)net10.0-browser$([System.IO.Path]::DirectorySeparatorChar)publish$([System.IO.Path]::DirectorySeparatorChar)wwwroot</_RaskWasmAppBundleDir>
+      <_RaskWasmTfm Condition=" '@(_RaskWasmRef->Count())' == '1' ">%(_RaskWasmRef.Tfm)</_RaskWasmTfm>
+      <_RaskWasmBinDir Condition=" '$(_RaskWasmProjectDir)' != '' ">$(_RaskWasmProjectDir)$([System.IO.Path]::DirectorySeparatorChar)bin$([System.IO.Path]::DirectorySeparatorChar)$(Configuration)$([System.IO.Path]::DirectorySeparatorChar)$(_RaskWasmTfm)</_RaskWasmBinDir>
+      <_RaskWasmAppBundleDir Condition=" '$(_RaskWasmBinDir)' != '' ">$(_RaskWasmBinDir)$([System.IO.Path]::DirectorySeparatorChar)publish$([System.IO.Path]::DirectorySeparatorChar)wwwroot</_RaskWasmAppBundleDir>
+      <!--
+        The build-output manifest. It is the only thing that knows where the client's assets actually
+        are: build wwwroot/ holds nothing but _framework/, and /index.html maps to a placeholder-filled
+        shell under obj/. Baked as assembly metadata unconditionally (not only under RaskWasmDevBundle)
+        so a developer who sets the property on the `dotnet watch` invocation alone still has a path to
+        resolve; the runtime gate is Development + MetadataUpdater.IsSupported, not the build gate.
+      -->
+      <_RaskWasmDevManifest Condition=" '$(_RaskWasmBinDir)' != '' ">$(_RaskWasmBinDir)$([System.IO.Path]::DirectorySeparatorChar)$([System.IO.Path]::GetFileNameWithoutExtension('%(_RaskWasmRef.FullPath)')).staticwebassets.runtime.json</_RaskWasmDevManifest>
     </PropertyGroup>
   </Target>
 
@@ -84,8 +125,17 @@
         and needed -m:1 to dodge the Rask.Core.dll copy race against the top-level WASM build.
         A blank $(RaskWasm) (the normal build/e2e case) still publishes.
       -->
-      <_RaskDoWasmPublish Condition=" '$(_RaskWasmAppBundleDir)' != '' AND '$(RaskWasm)' != 'false' ">true</_RaskDoWasmPublish>
+      <_RaskDoWasmPublish Condition=" '$(_RaskWasmAppBundleDir)' != '' AND '$(RaskWasm)' != 'false' AND '$(RaskWasmDevBundle)' != 'true' ">true</_RaskDoWasmPublish>
     </PropertyGroup>
+    <!--
+      No replacement step is needed when the publish is skipped. ReferenceOutputAssembly="false" leaves
+      BuildReference true, so the host's ordinary build already builds the WASM project and writes its
+      static-web-assets manifest. Deleting the nested emscripten publish from the inner watch loop IS
+      the win.
+    -->
+    <Message Importance="high"
+             Text="Rask.Wasm.Hosting: serving the WASM BUILD output for %(_RaskWasmRef.FullPath) (RaskWasmDevBundle=true — no nested publish)"
+             Condition=" '$(_RaskWasmAppBundleDir)' != '' AND '$(RaskWasmDevBundle)' == 'true' "/>
     <Message Importance="high"
              Text="Rask.Wasm.Hosting: publishing %(_RaskWasmRef.FullPath) ($(Configuration))"
              Condition=" '$(_RaskDoWasmPublish)' == 'true' "/>
@@ -114,6 +164,15 @@
           DependsOnTargets="_RaskComputeWasmBundleDir">
     <ItemGroup Condition=" '$(_RaskWasmAppBundleDir)' != '' ">
       <AssemblyMetadata Include="Rask.WasmAppBundleDir" Value="$(_RaskWasmAppBundleDir)"/>
+    </ItemGroup>
+    <!--
+      Baked ONLY when the build opted into the dev bundle. The runtime gate in UseRask keys off the
+      presence of this attribute, so conditioning it here is what keeps the build decision and the
+      runtime decision from drifting: without it, `-p:RaskWasmDevBundle=false` would still serve build
+      output whenever a manifest happened to be left over from an earlier build.
+    -->
+    <ItemGroup Condition=" '$(_RaskWasmDevManifest)' != '' AND '$(RaskWasmDevBundle)' == 'true' ">
+      <AssemblyMetadata Include="Rask.WasmDevManifest" Value="$(_RaskWasmDevManifest)"/>
     </ItemGroup>
   </Target>
 

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2044,6 +2044,74 @@ window.__raskBluetooth = window.__raskBluetooth || (() => {
 })();
 
 
+// Dev-only "hot reload applied" indicator, spliced from Rask.Core/Resources/rask-hotreload.js — the
+// same source the Server and Native clients use. It exposes window.__raskHotReloadPill; here the
+// notification arrives through the hotReloadApplied() export below rather than over a socket, because
+// a WASM app has no Rask server to push it a frame.
+// Dev-only "hot reload applied" indicator — one implementation, spliced into all three transports
+// (Server rask.js, WASM rask.wasm.js, Native rask.native.js) at their hot-reload splice marker.
+//
+// Deliberately does not spell that marker out: this file's text is substituted *for* it, so a literal
+// copy here would survive into every built artifact and read as a marker the splice had missed.
+//
+// It lives here rather than in each dialect because the transports differ in how the *notification*
+// arrives — Server pushes a {"type":"hotReload"} frame over the socket, WASM calls the exported
+// hotReloadApplied() through JSImport, Native evaluates a call over the WebView bridge — but what
+// happens next is identical, and three copies of a pill would drift.
+//
+// Wrapped in its own IIFE so its locals cannot collide with the enclosing dialect (the Server client
+// is one big IIFE with its own `const`s; WASM and Native splice at module top level). The single
+// export is window.__raskHotReloadPill, which is how each transport reaches it.
+(function () {
+    "use strict";
+
+    // How long the pill stays visible.
+    const HOT_RELOAD_PILL_MS = 1200;
+
+    let hotReloadPill = null;
+    let hotReloadPillTimer = null;
+
+    function showHotReloadPill() {
+        // Built lazily on first use, so a production bundle constructs no DOM and injects no CSS for
+        // it at all — only the (unreachable) function body ships.
+        if (!hotReloadPill) {
+            const style = document.createElement("style");
+            style.setAttribute("data-rask-managed", "");
+            style.textContent =
+                ".rask-hot{position:fixed;right:12px;bottom:12px;z-index:2147483647;" +
+                "padding:6px 12px;border-radius:999px;pointer-events:none;opacity:0;" +
+                "background:rgba(20,20,20,.82);color:#fff;transition:opacity .15s ease;" +
+                "font:12px/1.4 system-ui,-apple-system,Segoe UI,sans-serif;}" +
+                ".rask-hot[data-show]{opacity:1;}";
+            document.head.appendChild(style);
+
+            // DOM APIs rather than innerHTML — keeps the runtime clean under a strict CSP, matching
+            // installOverlay(). data-rask-managed keeps rask-morph.js from trimming both nodes: they
+            // are framework-owned siblings of the rendered tree, and without it the next morph would
+            // delete the pill mid-animation.
+            hotReloadPill = document.createElement("div");
+            hotReloadPill.className = "rask-hot";
+            hotReloadPill.setAttribute("data-rask-managed", "");
+            hotReloadPill.setAttribute("aria-live", "polite");
+            hotReloadPill.textContent = "Hot reload applied";
+            document.documentElement.appendChild(hotReloadPill);
+        }
+
+        // A counter the watch E2E waits on, so it asserts the feature rather than sleeping.
+        window.__raskHotReloadCount = (window.__raskHotReloadCount || 0) + 1;
+
+        hotReloadPill.setAttribute("data-show", "");
+        if (hotReloadPillTimer !== null) clearTimeout(hotReloadPillTimer);
+        hotReloadPillTimer = setTimeout(function () {
+            if (hotReloadPill) hotReloadPill.removeAttribute("data-show");
+            hotReloadPillTimer = null;
+        }, HOT_RELOAD_PILL_MS);
+    }
+
+    window.__raskHotReloadPill = showHotReloadPill;
+})();
+
+
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
 // preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could
@@ -2404,6 +2472,17 @@ export function applyRender(payload) {
         return;
     }
     handle(reply);
+}
+
+// Dev-only. Called from .NET (WasmHotReloadBridge) once the hot-reload coordinator has finished
+// applying an update and every open session has repainted — the WASM analogue of the Server's
+// {"type":"hotReload","status":"applied"} frame. Purely an indicator: the DOM was already updated by
+// the repaint that preceded this call, so it must not touch the tree.
+//
+// Guarded because the pill is spliced in from a shared module: if a future build ever drops the
+// splice, a missing indicator should not throw across the interop boundary into .NET.
+export function hotReloadApplied() {
+    if (window.__raskHotReloadPill) window.__raskHotReloadPill();
 }
 
 // File registry for input[type=file]: maps short refs -> live File objects.

--- a/src/Rask.Wasm/HotReload/WasmHotReloadBridge.cs
+++ b/src/Rask.Wasm/HotReload/WasmHotReloadBridge.cs
@@ -1,0 +1,58 @@
+using System.Reflection.Metadata;
+using Rask.Core.Diagnostics;
+using Rask.Core.HotReload;
+
+namespace Rask.Wasm.HotReload;
+
+/// <summary>
+///     Announces an applied hot reload to the page, the WASM way.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The repaint itself needs nothing from this class: <c>WasmLiveSession</c> derives from
+///         <c>LiveSessionBase</c>, so it already registers with the coordinator and already re-renders
+///         through <c>JSInterop.ApplyRender</c>. All that is missing is the indicator, and a WASM app
+///         has no Rask server to push it the Server's out-of-band <c>hotReload</c> frame — so it calls
+///         a JS export directly instead.
+///     </para>
+///     <para>
+///         Costs a published app nothing. <see cref="MetadataUpdater.IsSupported" /> is false in a
+///         trimmed bundle (trimming folds the feature switch), which is also exactly why hot reload
+///         needs the untrimmed build output in the first place.
+///     </para>
+/// </remarks>
+internal static class WasmHotReloadBridge
+{
+    private static bool _subscribed;
+
+    /// <summary>
+    ///     Idempotent: a host that builds more than one app instance in a process must not stack
+    ///     handlers, or one edit would show the pill several times.
+    /// </summary>
+    internal static void Subscribe()
+    {
+        if (_subscribed || !MetadataUpdater.IsSupported)
+        {
+            return;
+        }
+
+        _subscribed = true;
+        RaskHotReload.Applied += OnApplied;
+    }
+
+    private static void OnApplied()
+    {
+        try
+        {
+            JSInterop.HotReloadApplied();
+        }
+        catch (Exception ex)
+        {
+            // Never let the indicator take the app down: this runs on the coordinator's completion
+            // path, and an exception escaping here would surface as a failed hot reload rather than
+            // as the cosmetic problem it is.
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.HotReload", "Rask: hot-reload indicator failed", ex);
+        }
+    }
+}

--- a/src/Rask.Wasm/JSInterop.cs
+++ b/src/Rask.Wasm/JSInterop.cs
@@ -124,6 +124,14 @@ internal static partial class JSInterop
     [JSImport("applyRender", ModuleName)]
     public static partial void ApplyRender([JSMarshalAs<JSType.MemoryView>] Span<byte> payload);
 
+    /// <summary>
+    ///     Dev-only. Shows the "hot reload applied" indicator once the coordinator has finished
+    ///     applying an update and every open session has repainted — the WASM analogue of the Server's
+    ///     out-of-band <c>hotReload</c> frame, which a WASM app has no server to receive.
+    /// </summary>
+    [JSImport("hotReloadApplied", ModuleName)]
+    public static partial void HotReloadApplied();
+
     [JSImport("getLocation", ModuleName)]
     public static partial string GetLocation();
 
@@ -190,6 +198,13 @@ internal static partial class JSInterop
     public static void PushHistory(string url, bool replace) { }
 
     public static string GetBasePath() => "/";
+
+    /// <summary>Counts the indicator calls so the non-browser tests can assert the bridge fired.</summary>
+    public static int HotReloadAppliedCount { get; private set; }
+
+    public static void HotReloadApplied() => HotReloadAppliedCount++;
+
+    internal static void ResetHotReloadAppliedCount() => HotReloadAppliedCount = 0;
 
     public static Task<byte[]> ReadFileChunkAsync(string @ref, int offset, int length) =>
         Task.FromResult(Array.Empty<byte>());

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -102,7 +102,7 @@
     contributors look at). NuGet consumers see whichever version is packed (above).
   -->
   <Target Name="_RaskSpliceClientJs" BeforeTargets="PrepareForBuild;AssignTargetPaths;_RaskMinifyClientJs"
-          Inputs="Resources\rask.wasm.js;Resources\rask-wasm-api.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js"
+          Inputs="Resources\rask.wasm.js;Resources\rask-wasm-api.js;..\Rask.Core\Resources\rask-dom.js;..\Rask.Core\Resources\rask-morph.js;..\Rask.Core\Resources\rask-api.js;..\Rask.Core\Resources\rask-events.js;..\Rask.Core\Resources\rask-pwa.js;..\Rask.Core\Resources\rask-input.js;..\Rask.Core\Resources\rask-scoped.js;..\Rask.Core\Resources\rask-hotreload.js"
           Outputs="Browser\rask.wasm.js">
     <PropertyGroup>
       <_RaskWasmTemplate>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask.wasm.js'))</_RaskWasmTemplate>
@@ -114,7 +114,8 @@
       <_RaskWasmApiBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\Resources\rask-wasm-api.js'))</_RaskWasmApiBody>
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
-      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)'))</_RaskWasmJs>
+      <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
+      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)'))</_RaskWasmJs>
     </PropertyGroup>
     <WriteLinesToFile File="Browser\rask.wasm.js" Lines="$(_RaskWasmJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
   </Target>

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -19,6 +19,12 @@ let basePath = null;
 // can't work over the WebSocket round-trip (or need WASM-only boot behaviour).
 // @@RASK_WASM_API@@
 
+// Dev-only "hot reload applied" indicator, spliced from Rask.Core/Resources/rask-hotreload.js — the
+// same source the Server and Native clients use. It exposes window.__raskHotReloadPill; here the
+// notification arrives through the hotReloadApplied() export below rather than over a socket, because
+// a WASM app has no Rask server to push it a frame.
+// @@RASK_HOTRELOAD@@
+
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
 // preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could
@@ -301,6 +307,17 @@ export function applyRender(payload) {
         return;
     }
     handle(reply);
+}
+
+// Dev-only. Called from .NET (WasmHotReloadBridge) once the hot-reload coordinator has finished
+// applying an update and every open session has repainted — the WASM analogue of the Server's
+// {"type":"hotReload","status":"applied"} frame. Purely an indicator: the DOM was already updated by
+// the repaint that preceded this call, so it must not touch the tree.
+//
+// Guarded because the pill is spliced in from a shared module: if a future build ever drops the
+// splice, a missing indicator should not throw across the interop boundary into .NET.
+export function hotReloadApplied() {
+    if (window.__raskHotReloadPill) window.__raskHotReloadPill();
 }
 
 // File registry for input[type=file]: maps short refs -> live File objects.

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -184,6 +184,11 @@ public sealed class WasmHostBuilder
         var session = new WasmLiveSession(root, provider, _diffMode);
         JSInterop.Init(session);
 
+        // The session registers itself with the hot-reload coordinator in the base ctor and is
+        // repainted from there; this only adds the "applied" indicator. No-op unless the runtime
+        // supports metadata updates, which a trimmed (published) bundle does not.
+        HotReload.WasmHotReloadBridge.Subscribe();
+
         // InitialRenderAsync builds and pushes the first frame to JS itself (zero-copy applyRender);
         // the returned bytes are just for the diagnostic below.
         var payload = await session.InitialRenderAsync().ConfigureAwait(false);

--- a/tests/Rask.Cli.Tests/DevCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DevCommandTests.cs
@@ -263,6 +263,34 @@ public sealed class DevCommandTests
         }
     }
 
+    /// <summary>
+    ///     A wasm-hosted watch session must serve the client's <b>build</b> output. The published bundle
+    ///     is republished by a nested emscripten relink on every save, and it is trimmed — and trimming
+    ///     folds <c>MetadataUpdater.IsSupported</c> to false, so an applied delta could never reach the
+    ///     browser session even if one arrived.
+    /// </summary>
+    [Fact]
+    public void A_wasm_hosted_watch_session_asks_for_the_dev_bundle()
+    {
+        // --property:, not -p:, which is ambiguous with --project on `dotnet run`.
+        Assert.Contains("--property:RaskWasmDevBundle=true", Args(kind: DevTemplateKind.WasmHosted));
+
+        // …and only there: a plain Server host has no WASM bundle to switch.
+        Assert.DoesNotContain("--property:RaskWasmDevBundle=true", Args(kind: DevTemplateKind.Server));
+        Assert.DoesNotContain("--property:RaskWasmDevBundle=true", Args(kind: DevTemplateKind.WasmStandalone));
+    }
+
+    [Fact]
+    public void The_dev_bundle_is_not_requested_when_there_is_nothing_to_apply()
+    {
+        // --no-hot-reload means "restart instead of applying", and --once is a plain run: in both, the
+        // published bundle is the honest thing to serve.
+        Assert.DoesNotContain(
+            "--property:RaskWasmDevBundle=true", Args(kind: DevTemplateKind.WasmHosted, noHotReload: true));
+        Assert.DoesNotContain(
+            "--property:RaskWasmDevBundle=true", Args(kind: DevTemplateKind.WasmHosted, once: true));
+    }
+
     // ---- helpers ----
 
     private static IReadOnlyList<string> Args(
@@ -271,8 +299,9 @@ public sealed class DevCommandTests
         bool noHotReload = false,
         string? launchProfile = null,
         bool nonInteractive = false,
-        IReadOnlyList<string>? passthrough = null) =>
-        DevCommand.BuildDotnetArguments(project, once, noHotReload, launchProfile, nonInteractive, passthrough ?? []);
+        IReadOnlyList<string>? passthrough = null,
+        DevTemplateKind kind = DevTemplateKind.Server) =>
+        DevCommand.BuildDotnetArguments(project, once, noHotReload, launchProfile, nonInteractive, passthrough ?? [], kind);
 
     private static IReadOnlyDictionary<string, string> Env(
         DevTemplateKind kind = DevTemplateKind.Server,

--- a/tests/Rask.Cli.Tests/DevTargetTests.cs
+++ b/tests/Rask.Cli.Tests/DevTargetTests.cs
@@ -181,6 +181,46 @@ public sealed class DevTargetTests
     }
 
     /// <summary>
+    ///     A wasm-hosted host is recognised by what it <em>references</em>, not by what it is called.
+    ///     The <c>.Client</c> naming convention is what <c>rask new</c> emits, but the repo's own
+    ///     <c>Rask.Example.Wasm.Host</c> references <c>Rask.Example.Wasm</c> — so a name-only check reads
+    ///     it as a plain Server and it never gets the WASM dev bundle (and therefore never hot-reloads).
+    /// </summary>
+    [Fact]
+    public void A_host_referencing_a_wasm_client_is_wasm_hosted_even_without_the_Client_suffix()
+    {
+        var fs = new FakeFileSystem();
+        fs.Seed("/app/App.Host.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <ItemGroup>
+                <ProjectReference Include="../App.Wasm/App.Wasm.csproj" ReferenceOutputAssembly="false"/>
+              </ItemGroup>
+            </Project>
+            """);
+        fs.Seed("/App.Wasm/App.Wasm.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk.WebAssembly"><PropertyGroup><RaskWasm>true</RaskWasm></PropertyGroup></Project>
+            """);
+
+        Assert.Equal(DevTemplateKind.WasmHosted, DevTarget.Detect(fs, "/app", null)!.Kind);
+    }
+
+    [Fact]
+    public void A_web_host_referencing_no_wasm_client_stays_a_server()
+    {
+        var fs = new FakeFileSystem();
+        fs.Seed("/app/App.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk.Web">
+              <ItemGroup>
+                <ProjectReference Include="../Lib/Lib.csproj"/>
+              </ItemGroup>
+            </Project>
+            """);
+        fs.Seed("/Lib/Lib.csproj", """<Project Sdk="Microsoft.NET.Sdk"></Project>""");
+
+        Assert.Equal(DevTemplateKind.Server, DevTarget.Detect(fs, "/app", null)!.Kind);
+    }
+
+    /// <summary>
     ///     The path handed to <c>dotnet watch</c> must have its symlinks resolved. Watch computes an
     ///     <b>empty</b> hot-reload delta — silently, with no error — when the project path traverses one,
     ///     so a developer working under a symlinked directory would get a <c>rask dev</c> that watches,

--- a/tests/Rask.Core.Tests/Resources/HotReloadClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/HotReloadClientContractTests.cs
@@ -14,9 +14,13 @@ namespace Rask.Core.Tests.Resources;
 ///         falls through, an ungated dev affordance, or a stray reload.
 ///     </para>
 ///     <para>
-///         <b>On parity.</b> Only the Server transport receives server-pushed frames, so a naive
-///         "all three dialects contain the branch" assertion would be wrong. WASM and Native have no
-///         server to push one. The contract is deliberately asymmetric — see the tests below.
+///         <b>On parity.</b> All three transports now show the indicator, but each is <i>told</i> to
+///         differently — Server on a pushed <c>hotReload</c> frame, WASM through the
+///         <c>hotReloadApplied()</c> export called from .NET, Native over the WebView bridge. So the
+///         contract is: one shared implementation, three transport-specific triggers. The earlier
+///         version of this file forbade the WASM/Native branch outright and told whoever landed a
+///         channel to hoist the indicator into a shared module rather than copy it; that is what
+///         happened, and these tests now hold it to it.
 ///     </para>
 /// </summary>
 public class HotReloadClientContractTests
@@ -26,6 +30,14 @@ public class HotReloadClientContractTests
     private static string ServerJs => Read("src", "Rask.Server", "Resources", "rask.js");
     private static string WasmJs => Read("src", "Rask.Wasm", "Resources", "rask.wasm.js");
     private static string NativeJs => Read("src", "Rask.Native", "Resources", "rask.native.js");
+
+    /// <summary>The single implementation every transport splices in.</summary>
+    private static string SharedJs => Read("src", "Rask.Core", "Resources", "rask-hotreload.js");
+
+    // The two built artifacts that are committed (the Server's is assembled into obj/ and embedded, so
+    // there is no checked-in copy to inspect).
+    private static string BuiltWasmJs => Read("src", "Rask.Wasm", "Browser", "rask.wasm.js");
+    private static string BuiltNativeJs => Read("src", "Rask.Native", "Assets", "rask.native.js");
 
     [Fact]
     public void The_server_client_handles_the_hotReload_frame_and_returns()
@@ -54,42 +66,27 @@ public class HotReloadClientContractTests
     }
 
     [Fact]
-    public void The_hotReload_path_never_reloads_the_page()
+    public void The_indicator_never_reloads_the_page()
     {
         // A reload defeats the entire feature — "hot reload that actually works" is defined against
-        // exactly that. Applies to all three dialects.
-        foreach (var (name, js) in AllDialects())
-        {
-            var at = js.IndexOf("showHotReloadPill", StringComparison.Ordinal);
-            if (at < 0)
-            {
-                continue;
-            }
-
-            var fn = js[at..];
-            var end = fn.IndexOf("\n    }", StringComparison.Ordinal);
-            Assert.DoesNotContain("location.reload", fn[..end], StringComparison.Ordinal);
-            Assert.False(string.IsNullOrEmpty(name));
-        }
+        // exactly that. One assertion now covers all three transports, because there is one source.
+        Assert.DoesNotContain("location.reload", SharedJs, StringComparison.Ordinal);
     }
 
     [Fact]
     public void The_indicator_exposes_the_counter_the_watch_E2E_waits_on()
     {
         // The E2E asserts the feature rather than sleeping, by waiting for this to increment.
-        Assert.Contains("window.__raskHotReloadCount", ServerJs, StringComparison.Ordinal);
+        Assert.Contains("window.__raskHotReloadCount", SharedJs, StringComparison.Ordinal);
     }
 
     [Fact]
     public void The_indicator_survives_a_morph()
     {
-        // The pill is a framework-owned sibling of the server-rendered tree; without
-        // data-rask-managed the next morph would trim it mid-animation.
-        var js = ServerJs;
-        var fn = js[js.IndexOf("function showHotReloadPill", StringComparison.Ordinal)..];
-        var end = fn.IndexOf("\n    }", StringComparison.Ordinal);
-
-        Assert.Contains("data-rask-managed", fn[..end], StringComparison.Ordinal);
+        // The pill and its <style> are framework-owned siblings of the rendered tree; without
+        // data-rask-managed the next morph would trim them mid-animation. Both nodes need it — count
+        // the actual calls, not the string, so a passing mention in a comment can't satisfy this.
+        Assert.Equal(2, Occurrences(SharedJs, """setAttribute("data-rask-managed", "")"""));
     }
 
     [Fact]
@@ -97,25 +94,66 @@ public class HotReloadClientContractTests
     {
         // Guarded by `if (!hotReloadPill)`, so a production bundle constructs no DOM and injects no
         // CSS for it — only the (unreachable) function body ships.
-        var js = ServerJs;
-        var fn = js[js.IndexOf("function showHotReloadPill", StringComparison.Ordinal)..];
+        var fn = SharedJs[SharedJs.IndexOf("function showHotReloadPill", StringComparison.Ordinal)..];
 
-        Assert.Contains("if (!hotReloadPill)", fn[..200], StringComparison.Ordinal);
+        Assert.Contains("if (!hotReloadPill)", fn[..400], StringComparison.Ordinal);
     }
 
     [Fact]
-    public void Only_the_server_dialect_branches_on_the_pushed_frame()
+    public void The_indicator_is_one_shared_module_not_three_copies()
     {
-        // WASM runs in-browser with no Rask server, and Native is fed by its host over the WebView
-        // bridge — neither has a socket a hotReload frame could arrive on. Adding the branch there
-        // would be dead code, and in WASM's case would also force a regenerated commit of the
-        // checked-in built artifact (src/Rask.Wasm/Browser/rask.wasm.js).
-        //
-        // If a WASM/Native hot-reload channel ever lands, promote the indicator into a shared
-        // rask-*.js module at that point — don't just copy this branch across.
+        // The point of the hoist. Each dialect carries the splice marker and nothing else — no
+        // dialect may grow its own copy of the pill, which is how the three would drift.
+        foreach (var (name, js) in AllDialects())
+        {
+            Assert.True(
+                js.Contains("// @@RASK_HOTRELOAD@@", StringComparison.Ordinal),
+                $"{name} does not splice the shared hot-reload indicator.");
+            Assert.False(
+                js.Contains("function showHotReloadPill", StringComparison.Ordinal),
+                $"{name} declares its own showHotReloadPill — it must splice the shared module instead.");
+        }
+    }
+
+    [Fact]
+    public void The_committed_built_artifacts_carry_the_spliced_indicator()
+    {
+        // src/Rask.Wasm/Browser/rask.wasm.js and src/Rask.Native/Assets/rask.native.js are generated
+        // by the build and COMMITTED. Editing the shared module without rebuilding leaves them stale,
+        // which no other test would catch — the marker would still be sitting there unsubstituted.
+        foreach (var (name, built) in BuiltArtifacts())
+        {
+            Assert.True(
+                built.Contains("window.__raskHotReloadPill = showHotReloadPill", StringComparison.Ordinal),
+                $"{name} is stale — rebuild its project to re-run the splice, and commit the result.");
+            Assert.False(
+                built.Contains("@@RASK_HOTRELOAD@@", StringComparison.Ordinal),
+                $"{name} still contains an unsubstituted splice marker.");
+        }
+    }
+
+    [Fact]
+    public void Each_transport_triggers_the_indicator_its_own_way()
+    {
+        // Shared implementation, transport-specific trigger. Only Server has a socket a frame can
+        // arrive on; WASM is called from .NET through a JS export; Native comes over the WebView
+        // bridge, so its template needs no trigger of its own at all.
         Assert.Contains("data.type === \"hotReload\"", ServerJs, StringComparison.Ordinal);
-        Assert.DoesNotContain("hotReload", WasmJs, StringComparison.Ordinal);
-        Assert.DoesNotContain("hotReload", NativeJs, StringComparison.Ordinal);
+        Assert.Contains("window.__raskHotReloadPill()", ServerJs, StringComparison.Ordinal);
+
+        Assert.Contains("export function hotReloadApplied", WasmJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("data.type === \"hotReload\"", WasmJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("data.type === \"hotReload\"", NativeJs, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_indicator_cannot_throw_across_the_interop_boundary()
+    {
+        // WASM's export is called from .NET. If a future build ever drops the splice, a missing pill
+        // must not surface as a failed hot reload — hence the guard rather than a bare call.
+        var fn = WasmJs[WasmJs.IndexOf("export function hotReloadApplied", StringComparison.Ordinal)..];
+
+        Assert.Contains("if (window.__raskHotReloadPill)", fn[..200], StringComparison.Ordinal);
     }
 
     [Fact]
@@ -134,6 +172,24 @@ public class HotReloadClientContractTests
         yield return ("rask.js", ServerJs);
         yield return ("rask.wasm.js", WasmJs);
         yield return ("rask.native.js", NativeJs);
+    }
+
+    private static IEnumerable<(string Name, string Js)> BuiltArtifacts()
+    {
+        yield return ("src/Rask.Wasm/Browser/rask.wasm.js", BuiltWasmJs);
+        yield return ("src/Rask.Native/Assets/rask.native.js", BuiltNativeJs);
+    }
+
+    private static int Occurrences(string haystack, string needle)
+    {
+        var count = 0;
+        for (var i = haystack.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = haystack.IndexOf(needle, i + needle.Length, StringComparison.Ordinal))
+        {
+            count++;
+        }
+
+        return count;
     }
 
     private static string Read(params string[] parts) =>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmWatchAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmWatchAppFixture.cs
@@ -1,0 +1,283 @@
+using System.Diagnostics;
+using System.Text;
+
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+/// <summary>
+///     Runs <c>samples/Rask.Example.Wasm.Host</c> under a real <c>dotnet watch</c> with the WASM dev
+///     bundle on, so an edit to a client component can be driven and observed in a real browser.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Why a source file is written into the sample.</b> Proving hot reload needs a component
+///         whose rendered text actually changes, and the only honest way to change it is to edit a
+///         <c>.cs</c> file that the running app compiled. Rather than mutate a tracked sample page —
+///         which would race the other E2E fixtures reading the same tree, and leave a dirty diff on a
+///         crash — this fixture writes its own single-purpose probe page, owns it for the run, and
+///         deletes it afterwards. It is added <em>before</em> watch starts, so the initial build
+///         includes it and the later edit is an ordinary method-body change rather than a rude edit.
+///     </para>
+///     <para>
+///         If a hard kill ever leaves the file behind, it is untracked, obviously named, and removed by
+///         the next run's <see cref="InitializeAsync" />.
+///     </para>
+/// </remarks>
+public sealed class WasmWatchAppFixture : IAsyncLifetime
+{
+    internal const string OriginalMarker = "hot-reload-probe-original";
+    internal const string EditedMarker = "hot-reload-probe-edited";
+    internal const string ProbeRoute = "hot-reload-probe";
+
+    private const int PortNumber = 5101;
+
+    private readonly Lock _logLock = new();
+    private readonly StringBuilder _log = new();
+
+    private Process? _process;
+    private string _probeFile = string.Empty;
+
+    public string BaseUrl => $"http://localhost:{PortNumber}";
+
+    public string ServerLog
+    {
+        get
+        {
+            lock (_logLock)
+            {
+                return _log.ToString();
+            }
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        var repoRoot = LocateRepoRoot();
+        var host = Path.Combine(repoRoot, "samples", "Rask.Example.Wasm.Host");
+        _probeFile = Path.Combine(repoRoot, "samples", "Rask.Example.Wasm", "Features", "HotReloadProbePage.cs");
+
+        // Fail fast on a busy port instead of testing against whatever is on it. A leftover host from
+        // an earlier run answers the readiness poll perfectly happily, and every later assertion then
+        // measures a server that never saw the edit — which reads as "hot reload is broken" and is not.
+        EnsurePortFree();
+
+        WriteProbe(OriginalMarker);
+
+        // Pre-build with exactly the properties watch will use. Two reasons, and the second is not
+        // optional: it keeps the first in-session build incremental (a cold WASM build inside watch is
+        // minutes), and — because pinning the version rewrites every generated AssemblyInfo.cs — doing
+        // it here means those rewrites land BEFORE watch is watching. Leave them to the first
+        // in-session build and watch sees a burst of file changes, restarts the app it has only just
+        // started, and the restart collides with the old instance on the fixed port.
+        await BuildAsync(host);
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = host,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        psi.ArgumentList.Add("watch");
+        // --non-interactive: watch's rude-edit prompt has no terminal to ask here and would block.
+        psi.ArgumentList.Add("--non-interactive");
+        psi.ArgumentList.Add("run");
+        psi.ArgumentList.Add("--no-launch-profile");
+        // The whole point: serve the client's BUILD output. Without it the host serves the trimmed
+        // published bundle, where MetadataUpdater.IsSupported is false and no delta can ever apply.
+        psi.ArgumentList.Add("--property:RaskWasmDevBundle=true");
+
+        // Pins the assembly version for the session. Without it every Edit-and-Continue recompile is
+        // rejected outright:
+        //
+        //   error CS7038: Failed to emit module 'Rask.Example.Wasm': Changing the version of an
+        //   assembly reference is not allowed during debugging: 'Rask.Bootstrap, Version=0.0.0.0'
+        //   changed version to '1.0.0.0'.
+        //
+        // The repo versions its assemblies with MinVer, so a normal build stamps 0.0.0.0 while the
+        // evaluation behind the EnC recompile falls back to the SDK default 1.0.0.0 — and Roslyn will
+        // not apply a delta across an assembly-version change. It only bites the in-repo samples,
+        // which reach the framework through ProjectReferences; a `rask new` app consumes the packages
+        // and has no MinVer in its graph. So this is a harness concession, not a product workaround.
+        psi.ArgumentList.Add("--property:MinVerSkip=true");
+
+        psi.Environment["ASPNETCORE_ENVIRONMENT"] = "Development";
+        psi.Environment["ASPNETCORE_URLS"] = BaseUrl;
+        psi.Environment["DOTNET_WATCH_SUPPRESS_EMOJIS"] = "1";
+        // Rude edits must restart rather than sit on a prompt.
+        psi.Environment["HotReloadAutoRestart"] = "true";
+
+        _process = Process.Start(psi)
+                   ?? throw new InvalidOperationException("Failed to start `dotnet watch` for the WASM host.");
+
+        _ = Task.Run(() => DrainAsync(_process.StandardOutput));
+        _ = Task.Run(() => DrainAsync(_process.StandardError));
+
+        await WaitForReadyAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        if (_process is { HasExited: false })
+        {
+            try
+            {
+                _process.Kill(entireProcessTree: true);
+                await _process.WaitForExitAsync();
+            }
+            catch (InvalidOperationException)
+            {
+                // Already gone.
+            }
+        }
+
+        _process?.Dispose();
+
+        try
+        {
+            if (File.Exists(_probeFile))
+            {
+                File.Delete(_probeFile);
+            }
+        }
+        catch (IOException)
+        {
+            // Best effort — the file is untracked and the next run overwrites it.
+        }
+    }
+
+    /// <summary>
+    ///     Rewrites the probe page's rendered text. An in-place whole-file write, exactly like an editor
+    ///     save, so watch sees the same change shape a developer would produce.
+    /// </summary>
+    public void EditProbe(string marker) => WriteProbe(marker);
+
+    private void WriteProbe(string marker)
+    {
+        Directory.CreateDirectory(Path.GetDirectoryName(_probeFile)!);
+        File.WriteAllText(
+            _probeFile,
+            $$"""
+              using Rask.Core.Routing;
+              using Rask.Example.Shared;
+
+              namespace Rask.Example.Wasm.Features;
+
+              // Written by WasmWatchAppFixture for the WASM hot-reload E2E and deleted afterwards.
+              // Not part of the sample — do not commit.
+              [Route("{{ProbeRoute}}")]
+              [ParentRoute(typeof(ShowcaseLayout))]
+              public sealed class HotReloadProbePage : Component
+              {
+                  protected override Component? Render() =>
+                      H1(Id: "probe")["{{marker}}"];
+              }
+
+              """);
+    }
+
+    private static async Task BuildAsync(string hostDirectory)
+    {
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = hostDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false
+        };
+        psi.ArgumentList.Add("build");
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add("Debug");
+        psi.ArgumentList.Add("-m:1");
+        psi.ArgumentList.Add("--property:RaskWasmDevBundle=true");
+        psi.ArgumentList.Add("--property:MinVerSkip=true");
+
+        using var build = Process.Start(psi)
+                          ?? throw new InvalidOperationException("Failed to pre-build the WASM host.");
+
+        var output = await build.StandardOutput.ReadToEndAsync();
+        var error = await build.StandardError.ReadToEndAsync();
+        await build.WaitForExitAsync();
+
+        if (build.ExitCode != 0)
+        {
+            throw new InvalidOperationException($"Pre-build of the WASM host failed.\n{output}\n{error}");
+        }
+    }
+
+    private static void EnsurePortFree()
+    {
+        try
+        {
+            using var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, PortNumber);
+            probe.Start();
+            probe.Stop();
+        }
+        catch (System.Net.Sockets.SocketException)
+        {
+            throw new InvalidOperationException(
+                $"Port {PortNumber} is already in use — most likely a `dotnet watch` or host process left "
+                + "over from an earlier run of this gate. Kill it (`pkill -f Rask.Example.Wasm.Host`, "
+                + "`pkill -f 'dotnet watch'`) and re-run; otherwise this test would silently assert "
+                + "against that process instead of the one it starts.");
+        }
+    }
+
+    private async Task WaitForReadyAsync()
+    {
+        using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(10) };
+        // Generous: the first build compiles the client project too (no nested publish, but still a
+        // full WASM build) before the host starts listening.
+        var deadline = DateTime.UtcNow + TimeSpan.FromMinutes(5);
+
+        while (DateTime.UtcNow < deadline)
+        {
+            if (_process is { HasExited: true })
+            {
+                throw new InvalidOperationException($"`dotnet watch` exited before serving.\n{ServerLog}");
+            }
+
+            try
+            {
+                var response = await http.GetAsync(BaseUrl + "/");
+                if (response.IsSuccessStatusCode)
+                {
+                    return;
+                }
+            }
+            catch (HttpRequestException)
+            {
+                // Not listening yet.
+            }
+            catch (TaskCanceledException)
+            {
+            }
+
+            await Task.Delay(500);
+        }
+
+        throw new InvalidOperationException($"WASM watch host never served {BaseUrl}.\n{ServerLog}");
+    }
+
+    private async Task DrainAsync(StreamReader reader)
+    {
+        while (await reader.ReadLineAsync() is { } line)
+        {
+            lock (_logLock)
+            {
+                _log.AppendLine(line);
+            }
+        }
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        return dir?.FullName
+               ?? throw new InvalidOperationException($"Could not locate Rask.slnx from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/WasmWatchHotReloadTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/WasmWatchHotReloadTests.cs
@@ -1,0 +1,160 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
+
+namespace Rask.Examples.E2E.Tests;
+
+/// <summary>
+///     The last hop of the WASM hot-reload channel, and the only one no unit test can reach: an edit to a
+///     C# component reaches the running browser app, the page repaints in place, and the indicator fires
+///     — without a navigation.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Everything upstream is covered cheaply and deterministically elsewhere —
+///         <c>StaticWebAssetsManifestFileProviderTests</c> for serving the build bundle,
+///         <c>WasmHotReloadBridgeTests</c> for the announcement, <c>HotReloadClientContractTests</c> for
+///         the shared indicator, <c>DevCommandTests</c> for the dev-bundle switch. What is left is the
+///         part that only exists in a browser: Mono applying a metadata delta to a running WASM runtime.
+///     </para>
+///     <para>
+///         <b>Opt-in</b> via <c>RASK_WASM_WATCH_E2E=1</c>. It runs a real <c>dotnet watch</c> session with
+///         a full WASM build before it can assert anything (minutes, not seconds), and it writes a probe
+///         source file into the sample tree, so it has no business in the default browser gate.
+///     </para>
+/// </remarks>
+[Collection(WasmWatchCollection.Name)]
+public sealed class WasmWatchHotReloadTests
+{
+    private const string SkipReason =
+        "WASM watch gate: set RASK_WASM_WATCH_E2E=1 to run it. Starts a real `dotnet watch` session over "
+        + "the WASM host (full client build), drives an edit, and needs a browser. See scripts/run-wasm-watch-e2e.sh.";
+
+    private static bool Enabled => Environment.GetEnvironmentVariable("RASK_WASM_WATCH_E2E") == "1";
+
+    private readonly PlaywrightFixture _pw;
+
+    public WasmWatchHotReloadTests(PlaywrightFixture pw) => _pw = pw;
+
+    [Fact]
+    public async Task An_edit_repaints_the_running_wasm_app_without_reloading_it()
+    {
+        if (!Enabled)
+        {
+            // Not SkippableFact: this project has no Xunit.SkippableFact reference, and adding one for a
+            // single opt-in case is not worth it. The gate is documented in the class remarks.
+            return;
+        }
+
+        // Constructed here rather than as a collection fixture on purpose: a collection fixture is
+        // built even for a skipped test, so gating it any other way would still pay the whole
+        // watch-session startup on every ordinary E2E run.
+        var app = new WasmWatchAppFixture();
+        await app.InitializeAsync();
+
+        var page = await _pw.Browser.NewPageAsync(new BrowserNewPageOptions { BaseURL = app.BaseUrl });
+        try
+        {
+            await page.GotoAsync("/" + WasmWatchAppFixture.ProbeRoute);
+
+            // Boot: the WASM runtime is up and the probe page rendered. Generous — this is a first-load
+            // of an untrimmed development bundle.
+            await Expect(page.Locator("#probe"))
+                .ToHaveTextAsync(WasmWatchAppFixture.OriginalMarker,
+                    new LocatorAssertionsToHaveTextOptions { Timeout = 120_000 });
+
+            // The delta applier arms on this script and nothing else, so its absence would make the rest
+            // of the test fail later and much more confusingly.
+            //
+            // Asserted against the SERVED HTML, not the live DOM: the tag arms the applier during boot,
+            // and WASM then morphs the whole document to the .NET-rendered tree — which does not contain
+            // it. Looking for it in the DOM afterwards finds nothing and means nothing.
+            using (var http = new HttpClient { BaseAddress = new Uri(app.BaseUrl) })
+            {
+                http.DefaultRequestHeaders.Add("Accept", "text/html");
+                var shell = await http.GetStringAsync("/" + WasmWatchAppFixture.ProbeRoute);
+                Assert.True(
+                    shell.Contains("aspnetcore-browser-refresh", StringComparison.Ordinal),
+                    $"browser-refresh script missing from the shell — the delta applier never arms.\n{app.ServerLog}");
+            }
+
+            // The shared indicator module loaded in the WASM dialect too.
+            Assert.True(
+                await page.EvaluateAsync<bool>("() => typeof window.__raskHotReloadPill === 'function'"),
+                "the shared hot-reload indicator is not present in the WASM client.");
+
+            // Baseline for the no-reload assertion. A full page load would reset this counter and add a
+            // navigation entry; a hot reload must do neither.
+            await page.EvaluateAsync("() => { window.__raskProbeSentinel = 'alive'; }");
+            var navigationsBefore = await page.EvaluateAsync<int>(
+                "() => performance.getEntriesByType('navigation').length");
+
+            app.EditProbe(WasmWatchAppFixture.EditedMarker);
+
+            // The headline: the edited literal reaches the running app.
+            //
+            // Polled rather than Expect(...).ToHaveTextAsync so the failure can carry `dotnet watch`'s
+            // own output. Every interesting way this breaks is explained there and nowhere else — "No
+            // managed code changes to apply", a rude-edit restart, a build error in the edited file —
+            // and without it the report is just "expected X, saw Y" after a two-minute wait.
+            var applied = await PollAsync(
+                async () => await page.Locator("#probe").InnerTextAsync() == WasmWatchAppFixture.EditedMarker,
+                TimeSpan.FromMinutes(2));
+
+            Assert.True(applied, $"the edit never reached the running app.\n--- dotnet watch ---\n{app.ServerLog}");
+
+            // …by applying a delta, not by restarting and reloading. Both halves matter: a restart would
+            // also show the new text, and would be a much worse developer experience — so a test that
+            // only checked the text would pass on the outcome this feature exists to avoid.
+            var sentinel = await page.EvaluateAsync<string?>("() => window.__raskProbeSentinel");
+            var navigationsAfter = await page.EvaluateAsync<int>(
+                "() => performance.getEntriesByType('navigation').length");
+
+            Assert.True(
+                sentinel == "alive" && navigationsAfter == navigationsBefore,
+                $"the edit reached the app by RELOADING the page, not by applying a delta "
+                + $"(sentinel={sentinel ?? "null"}, navigations {navigationsBefore}→{navigationsAfter}).\n"
+                + $"--- dotnet watch ---\n{app.ServerLog}");
+
+            // And the developer was told, which is the difference between "nothing changed" and "your
+            // save did nothing".
+            Assert.True(
+                await page.EvaluateAsync<int>("() => window.__raskHotReloadCount || 0") >= 1,
+                $"the hot-reload indicator never fired.\n{app.ServerLog}");
+        }
+        finally
+        {
+            await page.CloseAsync();
+            await app.DisposeAsync();
+        }
+    }
+
+    private static async Task<bool> PollAsync(Func<Task<bool>> condition, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            try
+            {
+                if (await condition())
+                {
+                    return true;
+                }
+            }
+            catch (PlaywrightException)
+            {
+                // The node can be mid-morph; keep polling rather than failing on a transient miss.
+            }
+
+            await Task.Delay(250);
+        }
+
+        return false;
+    }
+}
+
+[CollectionDefinition(Name)]
+public sealed class WasmWatchCollection : ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "WasmWatch";
+}

--- a/tests/Rask.Native.Tests/HotReload/NativeHotReloadBridgeTests.cs
+++ b/tests/Rask.Native.Tests/HotReload/NativeHotReloadBridgeTests.cs
@@ -1,0 +1,85 @@
+using System.Reflection.Metadata;
+using Rask.Core.HotReload;
+using Rask.Native.HotReload;
+using Rask.Native.Tests.Infrastructure;
+
+namespace Rask.Native.Tests.HotReload;
+
+/// <summary>
+///     The native "applied" announcement over the WebView bridge.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>This does not test native hot reload, which does not work</b> — there is no device-side
+///         delta agent and <c>dotnet watch</c> cannot drive a simulator, so nothing ever raises the
+///         event on a device (#565). What it tests is the half that is wired anyway: if a delta ever
+///         did arrive, the indicator reaches the page over the same bridge everything else uses.
+///     </para>
+///     <para>
+///         Worth having despite that, because the cost of it silently rotting is a future device
+///         channel landing on a broken indicator — and because it pins the fire-and-forget contract:
+///         the coordinator's completion path must not block on a WebView round trip.
+///     </para>
+/// </remarks>
+public sealed class NativeHotReloadBridgeTests
+{
+    [Fact]
+    public void The_feature_switch_is_on_in_this_assembly() =>
+        Assert.True(
+            MetadataUpdater.IsSupported,
+            "MetadataUpdaterSupport (csproj) and DOTNET_MODIFIABLE_ASSEMBLIES (hotreload.runsettings) "
+            + "must both stay set, or NativeHotReloadBridge.Attach early-returns and these pass vacuously.");
+
+    [Fact]
+    public async Task An_applied_reload_shows_the_indicator_over_the_bridge()
+    {
+        var webView = new FakeNativeWebView();
+        NativeHotReloadBridge.Attach(webView);
+
+        RaskHotReload.RaiseApplied();
+
+        // Fire-and-forget by design, so poll rather than assume the continuation already ran.
+        await WaitForAsync(() => webView.Evaluated.Count > 0);
+
+        Assert.Contains(webView.Evaluated, js => js.Contains("__raskHotReloadPill", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task The_indicator_follows_the_newest_web_view()
+    {
+        // Attach is re-pointable: a host that recreates its session must not keep announcing into the
+        // WebView it just replaced, and must not stack a second handler either.
+        var stale = new FakeNativeWebView();
+        var live = new FakeNativeWebView();
+        NativeHotReloadBridge.Attach(stale);
+        NativeHotReloadBridge.Attach(live);
+        stale.Evaluated.Clear();
+
+        RaskHotReload.RaiseApplied();
+        await WaitForAsync(() => live.Evaluated.Count > 0);
+
+        Assert.Single(live.Evaluated);
+        Assert.Empty(stale.Evaluated);
+    }
+
+    [Fact]
+    public void The_call_is_guarded_so_a_client_without_the_pill_cannot_throw()
+    {
+        // The bridge evaluates JS in a page whose runtime it does not control the build of; a missing
+        // indicator must be a no-op, not an error dialog.
+        var webView = new FakeNativeWebView();
+        NativeHotReloadBridge.Attach(webView);
+
+        RaskHotReload.RaiseApplied();
+
+        Assert.All(webView.Evaluated, js => Assert.StartsWith("window.__raskHotReloadPill &&", js, StringComparison.Ordinal));
+    }
+
+    private static async Task WaitForAsync(Func<bool> condition)
+    {
+        for (var i = 0; i < 100 && !condition(); i++)
+        {
+            await Task.Delay(10);
+        }
+    }
+}

--- a/tests/Rask.Native.Tests/NativeClientSpliceTests.cs
+++ b/tests/Rask.Native.Tests/NativeClientSpliceTests.cs
@@ -20,6 +20,7 @@ public sealed class NativeClientSpliceTests
         var pwa = File.ReadAllText(Path.Combine(core, "rask-pwa.js"));
         var input = File.ReadAllText(Path.Combine(core, "rask-input.js"));
         var scoped = File.ReadAllText(Path.Combine(core, "rask-scoped.js"));
+        var hotReload = File.ReadAllText(Path.Combine(core, "rask-hotreload.js"));
         var committed = File.ReadAllText(Path.Combine(repoRoot, "src", "Rask.Native", "Assets", "rask.native.js"));
 
         // Mirror the marker splice order in _RaskSpliceNativeClientJs (Rask.Native.csproj).
@@ -30,7 +31,8 @@ public sealed class NativeClientSpliceTests
             .Replace("// @@RASK_EVENTS@@", events)
             .Replace("// @@RASK_PWA@@", pwa)
             .Replace("// @@RASK_INPUT@@", input)
-            .Replace("// @@RASK_SCOPED@@", scoped);
+            .Replace("// @@RASK_SCOPED@@", scoped)
+            .Replace("// @@RASK_HOTRELOAD@@", hotReload);
 
         Assert.True(
             spliced == committed,

--- a/tests/Rask.Native.Tests/Rask.Native.Tests.csproj
+++ b/tests/Rask.Native.Tests/Rask.Native.Tests.csproj
@@ -6,6 +6,15 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);RASK014</NoWarn>
+
+    <!--
+      NativeHotReloadBridge.Attach early-returns unless MetadataUpdater.IsSupported, which the SDK
+      turns OFF in Release — and the unit gate runs Release. Without this its tests would attach to
+      nothing and assert against a WebView nobody calls: green, proving nothing. The switch needs BOTH
+      halves; DOTNET_MODIFIABLE_ASSEMBLIES has no MSBuild property, hence the runsettings.
+    -->
+    <MetadataUpdaterSupport>true</MetadataUpdaterSupport>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)/hotreload.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Rask.Native.Tests/hotreload.runsettings
+++ b/tests/Rask.Native.Tests/hotreload.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!--
+      The environment half of MetadataUpdater.IsSupported. The csproj's <MetadataUpdaterSupport>
+      writes the runtimeconfig entry, but the runtime also requires this variable — which `dotnet
+      watch` sets on the app it launches, and which has no MSBuild property. With only the property
+      the switch still reads false and NativeHotReloadBridge attaches to nothing.
+
+      Scoped to this project rather than set globally, so no other test assembly starts registering
+      sessions for hot reload as a side effect.
+    -->
+    <EnvironmentVariables>
+      <DOTNET_MODIFIABLE_ASSEMBLIES>debug</DOTNET_MODIFIABLE_ASSEMBLIES>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>

--- a/tests/Rask.Wasm.Hosting.Tests/StaticWebAssetsManifestFileProviderTests.cs
+++ b/tests/Rask.Wasm.Hosting.Tests/StaticWebAssetsManifestFileProviderTests.cs
@@ -1,0 +1,209 @@
+using System.Text.Json;
+using Rask.Wasm.Hosting;
+
+namespace Rask.Wasm.Hosting.Tests;
+
+/// <summary>
+///     The dev-bundle file provider. It exists because a WASM client's <b>build</b> output cannot be
+///     served from disk directly: <c>bin/…/wwwroot/</c> holds only <c>_framework/</c>, and everything
+///     else — the shell, <c>main.js</c>, <c>rask.wasm.js</c>, scoped-asset bundles, RCL content — lives
+///     in other content roots that only the static-web-assets manifest knows about.
+/// </summary>
+public sealed class StaticWebAssetsManifestFileProviderTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "rask-swa-" + Guid.NewGuid().ToString("N"));
+
+    public StaticWebAssetsManifestFileProviderTests() => Directory.CreateDirectory(_root);
+
+    public void Dispose()
+    {
+        try
+        {
+            Directory.Delete(_root, recursive: true);
+        }
+        catch (IOException)
+        {
+            // best-effort cleanup
+        }
+    }
+
+    [Fact]
+    public void An_asset_resolves_through_its_content_root()
+    {
+        // The shape that matters: the file lives nowhere near the bundle directory, which is exactly why
+        // a PhysicalFileProvider over bin/…/wwwroot cannot serve it.
+        var elsewhere = Seed("framework-source", "rask.wasm.js", "export function boot() {}");
+        var provider = Provider(Manifest(
+            [elsewhere],
+            ("rask.wasm.js", 0, "rask.wasm.js")));
+
+        var file = provider.GetFileInfo("rask.wasm.js");
+
+        Assert.True(file.Exists);
+        Assert.Equal(Path.Combine(elsewhere, "rask.wasm.js"), file.PhysicalPath);
+    }
+
+    [Fact]
+    public void A_nested_path_walks_the_children()
+    {
+        var root = Seed("obj-content", Path.Combine("css", "app.css"), ".a{}");
+        var provider = Provider(Manifest([root], ("_content/Pkg/css/app.css", 0, "css/app.css")));
+
+        Assert.True(provider.GetFileInfo("_content/Pkg/css/app.css").Exists);
+        Assert.True(provider.GetFileInfo("/_content/Pkg/css/app.css").Exists);
+    }
+
+    [Fact]
+    public void Lookup_is_case_insensitive_like_the_static_file_middleware()
+    {
+        var root = Seed("content", "Index.html", "<html></html>");
+        var provider = Provider(Manifest([root], ("index.html", 0, "Index.html")));
+
+        Assert.True(provider.GetFileInfo("INDEX.HTML").Exists);
+    }
+
+    [Fact]
+    public void Precompressed_entries_are_dropped()
+    {
+        // Load-bearing, not tidiness: `dotnet watch`'s browser-refresh middleware injects its script by
+        // rewriting the HTML body and cannot rewrite an encoded one — and that script is the only thing
+        // the in-browser delta applier arms on. Serving a .gz shell means no hot reload, silently.
+        // Dropping them also removes the only SubPaths carrying a {0} fingerprint placeholder.
+        var root = Seed("content", "index.html", "<html></html>");
+        Seed("content", "index.html.gz", "compressed");
+        var provider = Provider(Manifest(
+            [root],
+            ("index.html", 0, "index.html"),
+            ("index.html.gz", 0, "index.html.gz")));
+
+        Assert.True(provider.GetFileInfo("index.html").Exists);
+        Assert.False(provider.GetFileInfo("index.html.gz").Exists);
+    }
+
+    [Fact]
+    public void A_missing_entry_and_a_missing_file_both_report_not_found()
+    {
+        var root = Seed("content", "present.txt", "hi");
+        var provider = Provider(Manifest(
+            [root],
+            ("present.txt", 0, "present.txt"),
+            ("ghost.txt", 0, "not-on-disk.txt")));
+
+        Assert.False(provider.GetFileInfo("nothing-here.txt").Exists);
+        Assert.False(provider.GetFileInfo("ghost.txt").Exists);
+    }
+
+    [Fact]
+    public void The_root_directory_lists_its_files_so_default_files_can_find_the_shell()
+    {
+        // UseDefaultFiles enumerates the directory before anything asks for a file; a provider that only
+        // answers GetFileInfo serves a 404 at "/".
+        var root = Seed("content", "index.html", "<html></html>");
+        var provider = Provider(Manifest([root], ("index.html", 0, "index.html")));
+
+        var contents = provider.GetDirectoryContents(string.Empty);
+
+        Assert.True(contents.Exists);
+        Assert.Contains(contents, f => f.Name == "index.html");
+    }
+
+    [Fact]
+    public void A_rebuilt_manifest_is_picked_up()
+    {
+        var root = Seed("content", "one.txt", "1");
+        Seed("content", "two.txt", "2");
+        var path = Write(Manifest([root], ("one.txt", 0, "one.txt")));
+        var provider = new StaticWebAssetsManifestFileProvider(path);
+
+        Assert.False(provider.GetFileInfo("two.txt").Exists);
+
+        // A rebuild rewrites the manifest; the host process outlives it.
+        File.WriteAllText(path, Manifest([root], ("one.txt", 0, "one.txt"), ("two.txt", 0, "two.txt")));
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddSeconds(1));
+
+        Assert.True(provider.GetFileInfo("two.txt").Exists);
+    }
+
+    [Fact]
+    public void A_missing_manifest_is_not_fatal()
+    {
+        var provider = new StaticWebAssetsManifestFileProvider(Path.Combine(_root, "absent.json"));
+
+        Assert.False(provider.GetFileInfo("index.html").Exists);
+        Assert.False(provider.GetDirectoryContents(string.Empty).Exists);
+    }
+
+    [Fact]
+    public void A_half_written_manifest_keeps_serving_the_previous_one()
+    {
+        // A rebuild truncates and rewrites the file; a request landing mid-write must not take the host
+        // down or start 404ing every asset.
+        var root = Seed("content", "one.txt", "1");
+        var path = Write(Manifest([root], ("one.txt", 0, "one.txt")));
+        var provider = new StaticWebAssetsManifestFileProvider(path);
+        Assert.True(provider.GetFileInfo("one.txt").Exists);
+
+        File.WriteAllText(path, "{ \"ContentRoots\": [");
+        File.SetLastWriteTimeUtc(path, DateTime.UtcNow.AddSeconds(1));
+
+        Assert.True(provider.GetFileInfo("one.txt").Exists);
+    }
+
+    private StaticWebAssetsManifestFileProvider Provider(string manifest) =>
+        new(Write(manifest));
+
+    private string Write(string manifest)
+    {
+        var path = Path.Combine(_root, "app.staticwebassets.runtime.json");
+        File.WriteAllText(path, manifest);
+        return path;
+    }
+
+    private string Seed(string rootName, string relative, string content)
+    {
+        var root = Path.Combine(_root, rootName);
+        var full = Path.Combine(root, relative);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return root;
+    }
+
+    /// <summary>Builds the real manifest shape: content roots plus a path trie of assets.</summary>
+    private static string Manifest(string[] contentRoots, params (string Url, int Root, string SubPath)[] assets)
+    {
+        var root = new Dictionary<string, object?>();
+
+        foreach (var (url, rootIndex, subPath) in assets)
+        {
+            var node = root;
+            var segments = url.Split('/', StringSplitOptions.RemoveEmptyEntries);
+            for (var i = 0; i < segments.Length; i++)
+            {
+                if (i == segments.Length - 1)
+                {
+                    node[segments[i]] = new Dictionary<string, object?>
+                    {
+                        ["Children"] = null,
+                        ["Asset"] = new Dictionary<string, object?> { ["ContentRootIndex"] = rootIndex, ["SubPath"] = subPath },
+                        ["Patterns"] = null
+                    };
+                    break;
+                }
+
+                if (!node.TryGetValue(segments[i], out var existing) || existing is not Dictionary<string, object?> child)
+                {
+                    child = new Dictionary<string, object?> { ["Children"] = new Dictionary<string, object?>(), ["Asset"] = null, ["Patterns"] = null };
+                    node[segments[i]] = child;
+                }
+
+                node = (Dictionary<string, object?>)child["Children"]!;
+            }
+        }
+
+        return JsonSerializer.Serialize(new Dictionary<string, object?>
+        {
+            ["ContentRoots"] = contentRoots,
+            ["Root"] = new Dictionary<string, object?> { ["Children"] = root, ["Asset"] = null, ["Patterns"] = null }
+        });
+    }
+}

--- a/tests/Rask.Wasm.Tests/HotReload/WasmHotReloadBridgeTests.cs
+++ b/tests/Rask.Wasm.Tests/HotReload/WasmHotReloadBridgeTests.cs
@@ -1,0 +1,56 @@
+using System.Reflection.Metadata;
+using Rask.Core.HotReload;
+using Rask.Wasm.HotReload;
+
+namespace Rask.Wasm.Tests.HotReload;
+
+/// <summary>
+///     The WASM "applied" announcement. Runs against the non-browser <c>JSInterop</c> stubs, which
+///     record the call instead of crossing a JSImport — the same seam the dispatch-shape tests use.
+/// </summary>
+/// <remarks>
+///     The repaint itself is not tested here and does not belong to this class: <c>WasmLiveSession</c>
+///     inherits it from <c>LiveSessionBase</c>, and <c>HotReloadPhaseTests</c> covers the coordinator.
+///     What is uncovered without this is the last hop — that finishing an apply actually reaches the
+///     page, which for WASM is a direct call rather than a pushed frame.
+/// </remarks>
+public sealed class WasmHotReloadBridgeTests
+{
+    /// <summary>
+    ///     Guards the rest of this class. <see cref="WasmHotReloadBridge.Subscribe" /> early-returns
+    ///     unless the feature switch is on, so with it off every assertion below would pass while
+    ///     executing nothing — the exact failure mode the csproj's MetadataUpdaterSupport prevents.
+    /// </summary>
+    [Fact]
+    public void The_feature_switch_is_on_in_this_assembly() =>
+        Assert.True(
+            MetadataUpdater.IsSupported,
+            "MetadataUpdaterSupport (csproj) and DOTNET_MODIFIABLE_ASSEMBLIES (hotreload.runsettings) "
+            + "must both stay set, or the hot-reload bridge tests pass vacuously.");
+
+    [Fact]
+    public void An_applied_reload_reaches_the_page_exactly_once_per_apply()
+    {
+        JSInterop.ResetHotReloadAppliedCount();
+        WasmHotReloadBridge.Subscribe();
+
+        RaskHotReload.RaiseApplied();
+
+        Assert.Equal(1, JSInterop.HotReloadAppliedCount);
+    }
+
+    [Fact]
+    public void Subscribing_twice_does_not_show_the_indicator_twice()
+    {
+        // A host that builds more than one app instance in a process must not stack handlers, or one
+        // edit would flash the pill once per instance ever created.
+        WasmHotReloadBridge.Subscribe();
+        WasmHotReloadBridge.Subscribe();
+        WasmHotReloadBridge.Subscribe();
+        JSInterop.ResetHotReloadAppliedCount();
+
+        RaskHotReload.RaiseApplied();
+
+        Assert.Equal(1, JSInterop.HotReloadAppliedCount);
+    }
+}

--- a/tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj
+++ b/tests/Rask.Wasm.Tests/Rask.Wasm.Tests.csproj
@@ -6,6 +6,22 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);RASK014</NoWarn>
+
+    <!--
+      WasmHotReloadBridge early-returns unless MetadataUpdater.IsSupported, which the SDK turns OFF in
+      Release — and the unit gate runs Release. Without this the bridge tests would subscribe to
+      nothing and assert against a counter nobody increments: green, and proving nothing.
+
+      The switch needs BOTH halves; DOTNET_MODIFIABLE_ASSEMBLIES=debug has no MSBuild property, hence
+      the runsettings. WasmHotReloadBridgeTests.The_feature_switch_is_on_in_this_assembly guards it.
+
+      Safe to enable assembly-wide here, unlike on Rask.Server.Tests: these tests raise the Applied
+      event directly rather than running the coordinator, so no other class's sessions get pulled into
+      a repaint loop. Sessions do start registering in the (weak, static) hot-reload registry, but
+      nothing in this assembly ever walks it.
+    -->
+    <MetadataUpdaterSupport>true</MetadataUpdaterSupport>
+    <RunSettingsFilePath>$(MSBuildProjectDirectory)/hotreload.runsettings</RunSettingsFilePath>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
+++ b/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
@@ -15,6 +15,7 @@ public sealed class ResourcesSpliceTests
         var wasmApiPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Resources", "rask-wasm-api.js");
         var inputPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-input.js");
         var scopedPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-scoped.js");
+        var hotReloadPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-hotreload.js");
         var browserPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "rask.wasm.js");
 
         var template = File.ReadAllText(templatePath);
@@ -26,6 +27,7 @@ public sealed class ResourcesSpliceTests
         var wasmApi = File.ReadAllText(wasmApiPath);
         var input = File.ReadAllText(inputPath);
         var scoped = File.ReadAllText(scopedPath);
+        var hotReload = File.ReadAllText(hotReloadPath);
         var committed = File.ReadAllText(browserPath);
 
         // Mirror the marker splice order in _RaskSpliceClientJs (Rask.Wasm.csproj): the diff codec
@@ -33,7 +35,8 @@ public sealed class ResourcesSpliceTests
         // the extended event delegation + keyboard/drag (rask-events.js), the transport-agnostic PWA
         // helpers (rask-pwa.js — shared with the Server client), the WASM-only helpers (rask-wasm-api.js),
         // then the shared rAF input/scroll coalescing (rask-input.js) and scoped-CSS FOUC gating
-        // (rask-scoped.js) — the last two shared with rask.js + rask.native.js.
+        // (rask-scoped.js), and finally the shared dev-only hot-reload indicator (rask-hotreload.js) —
+        // the last three shared with rask.js + rask.native.js.
         var spliced = template
             .Replace("// @@RASK_DOM@@", dom)
             .Replace("// @@RASK_MORPH@@", morph)
@@ -42,7 +45,8 @@ public sealed class ResourcesSpliceTests
             .Replace("// @@RASK_PWA@@", pwa)
             .Replace("// @@RASK_WASM_API@@", wasmApi)
             .Replace("// @@RASK_INPUT@@", input)
-            .Replace("// @@RASK_SCOPED@@", scoped);
+            .Replace("// @@RASK_SCOPED@@", scoped)
+            .Replace("// @@RASK_HOTRELOAD@@", hotReload);
 
         Assert.True(
             spliced == committed,

--- a/tests/Rask.Wasm.Tests/hotreload.runsettings
+++ b/tests/Rask.Wasm.Tests/hotreload.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+  <RunConfiguration>
+    <!--
+      The environment half of MetadataUpdater.IsSupported. The csproj's <MetadataUpdaterSupport>
+      writes the runtimeconfig entry, but the runtime also requires this variable — which `dotnet
+      watch` sets on the app it launches, and which has no MSBuild property. With only the property
+      the switch still reads false and WasmHotReloadBridge subscribes to nothing.
+
+      Scoped to this project rather than set globally, so no other test assembly starts registering
+      sessions for hot reload as a side effect.
+    -->
+    <EnvironmentVariables>
+      <DOTNET_MODIFIABLE_ASSEMBLIES>debug</DOTNET_MODIFIABLE_ASSEMBLIES>
+    </EnvironmentVariables>
+  </RunConfiguration>
+</RunSettings>


### PR DESCRIPTION
> **Stacked on #561** (the `dotnet watch` symlink fix). It shares that branch's `DevTargetTests` and
> CHANGELOG context. Per the repo's stacked-PR rule, **retarget this to `main` before merging #561**,
> or GitHub closes it when the parent's branch goes away.

## Summary

WASM had no watch channel at all. The host serves its client's **published** bundle, which a nested
`dotnet publish` — an emscripten relink — rebuilt on every save, and which is **trimmed**. Trimming
folds `MetadataUpdater.IsSupported` to `false`, so `LiveSessionBase` never registers the browser
session for hot reload and an applied delta could not have reached it even if one arrived.

Under `rask dev` the host now serves the client's **build** output. That is a precondition, not an
optimisation — the build bundle is untrimmed, so the runtime's metadata-update support is live.
Dropping the nested publish from the inner loop is the other half of the win.

Refs #538 (re-scoped to WASM; native split out to #565).

## Why this is smaller than it looks

Everything downstream was already wired. `WasmLiveSession` derives from the same `LiveSessionBase` as
the Server one, so it already registers for hot reload and already repaints through
`JSInterop.ApplyRender`; Mono's in-browser delta applier already ships in the bundle and is already
listed in the boot config. The gap was hosting, and only hosting.

## Why the build output needs a manifest provider

`bin/<cfg>/<tfm>/wwwroot` holds **only** `_framework/`. The shell, `main.js`, `rask.wasm.js`,
`global.css`, the scoped-asset bundles and RCL content live across eleven other content roots — and
`/index.html` maps to a placeholder-filled shell under `obj/` whose import map carries the *build*
fingerprints. (The raw `index.html` in the source tree still has those placeholders empty and cannot
boot the runtime.) A `PhysicalFileProvider` therefore cannot serve this bundle at all.

`StaticWebAssetsManifestFileProvider` reads the client's `*.staticwebassets.runtime.json` and resolves
through it. Hand-rolled rather than ASP.NET's own `ManifestStaticWebAssetFileProvider`, which is not
public API — a dev convenience in a shipped package shouldn't depend on framework internals that can
move between patch releases.

**Precompressed entries are dropped at load**, and that is load-bearing rather than tidiness: watch's
browser-refresh middleware injects its script by rewriting the HTML body and cannot rewrite an encoded
one — and that script is the *only* condition the in-browser delta applier arms on. A gzipped shell
means no hot reload, silently. It also removes the only `SubPath`s carrying a `{0}` fingerprint
placeholder, so nothing downstream has to resolve one.

## Two things I got wrong first, and checked

Both are recorded in comments so they aren't re-derived:

- **`SendFileAsync` does *not* bypass the browser-refresh injector.** My spike said it did. That was a
  measurement artifact — `curl` without `Accept: text/html`, which the injector keys off. Re-measured
  against a running host on *both* the published and the build bundle: injected in both. So the
  fallback keeps its zero-copy path and no Rask-side script injection is needed. I've corrected the
  spike comment on #538.
- **`RaskWasmDevBundle` does *not* default cleanly from `$(DOTNET_WATCH)`.** Watch sets that variable
  on the app it *runs*, not on the `dotnet build` it shells out to first — so the property would read
  empty exactly where it is needed, the publish would run, and no dev manifest would be baked. It is
  passed explicitly by `rask dev`. Relatedly, the dev manifest is baked as assembly metadata **only**
  when the property is set; without that condition `-p:RaskWasmDevBundle=false` still served build
  output whenever a manifest happened to be left over from an earlier build.

## `rask dev` recognises a wasm-hosted app properly

Classification was a `.Client` substring check on the csproj text. That is a `rask new` naming
convention, not a fact — the repo's own `Rask.Example.Wasm.Host` references `Rask.Example.Wasm` and was
misread as a plain Server, as would any app whose client is named differently. It now falls back to
reading the referenced projects and looking for the WebAssembly SDK or `<RaskWasm>true</RaskWasm>` — the
same marker `Rask.Wasm.Hosting.targets` probes at build time, so the CLI and the build agree.

## Testing

- **`StaticWebAssetsManifestFileProviderTests`** (9, default gate) — resolution through a foreign
  content root, nested paths, case-insensitivity, `.gz` exclusion, missing entry vs missing file,
  root directory listing (`UseDefaultFiles` enumerates before it fetches), manifest reload on rebuild,
  a missing manifest, and a **half-written** manifest still serving the previous one.
- **`DevTargetTests`** — a host referencing a WASM client with no `.Client` suffix classifies as
  `WasmHosted`; one referencing a plain library stays `Server`.
- **`DevCommandTests`** — the dev-bundle property is passed for `WasmHosted` only, and not under
  `--no-hot-reload` or `--once` (both of which keep the published bundle, honestly).
- **End to end against a real `rask dev` session**: nested publish skipped, and the provider serves
  `/`, `/main.js`, `/rask.wasm.js`, `/global.css`, `/_content/Rask.Bootstrap/tokens.css` and the
  fingerprinted `_framework` boot script — all 200 — with the import map filled and the browser-refresh
  script injected.
- `dotnet format` clean; `dotnet build -warnaserror` → 0 warnings, 0 errors; unit gate 37/37.

The existing WASM E2E fixtures are untouched and still exercise the **published** path, which is the
regression test for "production is unaffected" — the targets keep publishing whenever the property is
absent.

## Not in this PR

- **A Playwright E2E that drives an edit and asserts the page repaints.** Everything up to the browser
  is verified here, but only a real browser runs the Mono runtime, so the last hop needs Playwright.
- **The "Hot reload applied" pill for WASM.** It is Server-only today, and
  `HotReloadClientContractTests` deliberately *forbids* copying the branch across — its comment
  prescribes hoisting the indicator into a shared `rask-hotreload.js` module first. That refactor
  touches all three transports and both checked-in built artifacts, so it is its own change.

Both are tracked on #538, which stays open until they land.

---

## Follow-up commit: the pill, and the browser proof

The two pieces this PR originally deferred are now in it, so #538 can close.

### The indicator, hoisted rather than copied

`HotReloadClientContractTests` explicitly forbade adding the branch to WASM/Native and told whoever
landed a channel to *"promote the indicator into a shared `rask-*.js` module at that point — don't just
copy this branch across."* That is what happened: the pill now lives in
`src/Rask.Core/Resources/rask-hotreload.js` and is spliced into all three transports. Only the trigger
differs — Server branches on the pushed `hotReload` frame, WASM calls an exported `hotReloadApplied()`
from .NET (there is no server to push it a frame), Native comes over the WebView bridge. The two
committed built artifacts are regenerated.

That test is rewritten to hold the new contract rather than the old prohibition: one shared module and
no dialect declaring its own `showHotReloadPill`, each transport triggering it its own way, and — the
one nothing else would catch — **the committed built artifacts actually carrying the spliced module**,
so editing the shared source without rebuilding fails loudly instead of shipping a stale artifact.

`WasmHotReloadBridge` subscribes to `RaskHotReload.Applied` and calls the export. The repaint was
already free (`WasmLiveSession` inherits registration and re-render from `LiveSessionBase`).
`NativeHotReloadBridge` does the same over `EvaluateJavaScriptAsync` — which does **not** make native
hot reload work (no device-side delta agent exists, #565), but it is a few lines now that the pill is
shared, costs a device build nothing, and means a future device channel lands on a working indicator.

### The E2E, and the bug it found

`WasmWatchHotReloadTests` writes a probe page into the WASM sample, runs the app under a real
`dotnet watch`, edits the page's text, and asserts the edit reached the running app **and that the page
did not reload** — a sentinel survives and no navigation entry is added — **and** that the indicator
fired. The no-reload half is the point: a restart would also show the new text while being precisely the
outcome this feature exists to avoid.

It earned itself immediately by catching a real bug in the first commit: `UseRask` evaluated the
missing-bundle guard **before** the dev branch, so it returned the 503 "bundle unavailable" fallback
whenever the publish directory was absent — which is exactly the state turning the dev bundle on
produces. **A fresh clone plus `rask dev` would never have served.** Fixed, with the ordering
constraint written down where it can't be undone by accident.

```
$ scripts/run-wasm-watch-e2e.sh
==> WASM hot-reload gate passed.
```

Green on two consecutive runs.

### Three harness constraints, each learned the hard way

Documented where they live, because none is guessable:

- **Pin the version** (`--property:MinVerSkip=true`). The repo versions with MinVer, so a normal build
  stamps `0.0.0.0` while the evaluation behind the EnC recompile falls back to `1.0.0.0`, and Roslyn
  refuses a delta across an assembly-version change (`CS7038`). This only bites the in-repo samples,
  which reach the framework through `ProjectReference`s — a `rask new` app consumes the packages and has
  no MinVer in its graph, so it is a harness concession, not a product workaround.
- **Pre-build with the same properties.** Pinning rewrites every generated `AssemblyInfo.cs`; leaving
  that to the first in-session build makes watch restart the app it has only just started, and the
  restart collides with the old instance on the fixed port.
- **Refuse to start on a busy port.** A leftover host answers the readiness poll perfectly happily, and
  then every later assertion measures a server that never saw the edit — which reads as "hot reload is
  broken" and is not. This cost several cycles before the guard existed.

Assertions carry `dotnet watch`'s own output on failure. Every interesting failure mode above was
diagnosable only from that log.

### Testing

- `scripts/run-wasm-watch-e2e.sh` — passes, twice.
- Unit gate 37/37. `dotnet format` clean; `dotnet build -warnaserror` → 0 warnings, 0 errors.
- `Rask.Wasm.Tests` and `Rask.Native.Tests` gain `MetadataUpdaterSupport` + the
  `DOTNET_MODIFIABLE_ASSEMBLIES` runsettings, each with a guard test — both bridges early-return unless
  the switch is on, and the SDK turns it off in Release, so without it the new tests would pass while
  executing nothing.
- Browser E2E on this branch: 3 journeys fail at `TestCompositionGuideAsync:1235` (the stale guide-walk
  assertions fixed in **#558**, a sibling branch not in this history), plus the Playground's known
  sandbox-network failure. Verified unrelated: none is in a path this PR touches, and a `SiteExampleTests`
  port collision from a leftover process passes on a clean re-run.
