### PR TITLE
feat(cli): make the shutdown budget one derived ladder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,26 @@ them until tagged releases begin.
   `ResumeTokenLifetime` (default 1 hour). **Requires a persisted data-protection key ring** — a record
   sealed before a redeploy cannot be opened after one otherwise, which is what the scaffold's `/data/keys`
   change below is for.
+- **One shutdown ladder instead of three unrelated numbers.** `docker stop -t 20` and the scaffolded
+  `HostOptions.ShutdownTimeout = 15s` were two hardcoded constants coupled only by a code comment, free to
+  drift apart silently — and the generator test pinned the literal `15`, so it would have kept passing.
+  Both now derive from a single `ShutdownBudget`, and the test asserts the *relationship* (the app budget
+  fits inside the deploy grace, with margin) rather than the number. Scaffolded apps also set
+  **`ServicesStopConcurrently = true`**, which turns out to be load-bearing rather than a tune-up: stopped
+  one at a time — the .NET default — each pillar's own shutdown grace *sums* inside the single budget
+  (10 + 10 + 5 + 5 = 30s against 15s), so whichever hosted service stopped last got no grace at all, and
+  *which* one that was depended on the order of `AddRaskX` calls in someone's `Program.cs`. Stopped
+  concurrently they overlap at 10s. `rask deploy` also now pauses briefly between pointing Caddy at the new
+  container and stopping the old one: `caddy reload` returns as soon as the config applies, but Caddy still
+  holds pooled connections to the old upstream, and a request it was about to write onto one when SIGTERM
+  landed became an un-retried 502 (`lb_try_duration` defaults to 0). There was previously no gap at all.
+
+### Fixed
+- **Every web-host sample now budgets its shutdown.** Nine of the ten inherited .NET's default 30s
+  `ShutdownTimeout`, which *exceeds* the 20s `rask deploy` allows between SIGTERM and SIGKILL — so a sample
+  deployed as written would be killed mid-shutdown. Only `Rask.Example.Shop` was right, which meant a reader
+  copying from any other sample inherited the wrong lesson. A repo-scanning test now guards the next one
+  somebody adds, since that is the real failure mode.
 - **A graceful shutdown for live sessions — a redeploy no longer tells every user their session timed
   out.** `rask deploy` advertises zero-downtime deploys, and the container swap really is blue-green, but
   the app had no drain: `ApplicationStopping` fired `ws.Abort()` on every socket, so the browser saw an

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -394,6 +394,10 @@ is waited on until its container is running **and answers an HTTP health check**
 default — the endpoint `rask new` scaffolds), then Caddy is reloaded to point at it before the old one
 is removed. If the new container fails to start, or fails its health probe, the previous version keeps
 serving. Probe a different path with `--health-path`, or skip the probe with `--no-health-check`.
+HTTP requests are zero-downtime; **live sessions re-establish**, because a session lives in the container
+being replaced and cannot hand over. The retiring container announces its shutdown first, so open pages
+show "Updating…" and reload onto the new one at their previous scroll position — see
+[the shutdown ladder](deployment.md#the-shutdown-ladder).
 
 **Multiple apps share one box.** Each app container is labelled, so the proxy's routing is regenerated
 from the host's live containers on every deploy — deploying a second app (a different `--domain`)
@@ -402,7 +406,8 @@ you put your own TLS/reverse proxy in front (there's no zero-downtime swap on a 
 
 **Your database survives redeploys.** Each deploy runs a fresh container, so `rask deploy` mounts a
 per-app named volume and points the app at it (`ConnectionStrings:App` → `Data Source=/data/app.db`) — the
-SQLite database persists across container replacements. The old container is stopped gracefully (SIGTERM →
+SQLite database persists across container replacements. The old container keeps serving for a moment after
+the proxy switches (so a request already in flight to it isn't cut), then is stopped gracefully (SIGTERM →
 its Litestream flush + WAL checkpoint) before removal. The `rask new --docker` Dockerfile prepares a
 writable `/data`; a custom Dockerfile needs `RUN mkdir -p /data && chown $APP_UID:$APP_UID /data`. Add
 [`Rask.SQLite.Litestream`](sqlite.md#continuous-backup-with-litestream) to also stream it off the box.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -177,8 +177,38 @@ before `SIGKILL`.
 
 Within that budget the app closes admission, tells connected browsers it is going away, lets in-flight
 HTTP requests and event handlers finish, closes each WebSocket with a proper `1001` handshake, and
-checkpoints SQLite. These are budgets, not guarantees: work that outlives its budget is cancelled, and
-`rask.shutdown.sessions.abandoned` (plus a warning in the logs) tells you when that happened.
+checkpoints SQLite.
+
+### The shutdown ladder
+
+Every rung fits inside the one above it, and hosted services stop **concurrently** — so each pillar's own
+grace overlaps the others instead of queueing behind them:
+
+| Rung | Budget | Set by |
+| --- | --- | --- |
+| `docker stop -t` before `SIGKILL` | 20s | `rask deploy` |
+| App `HostOptions.ShutdownTimeout` | 15s | scaffolded `Program.cs` |
+| Live-session drain | 5s | `RaskServerOptions.ShutdownDrainTimeout` |
+| Litestream final WAL flush | 10s | `LitestreamOptions.ShutdownGracePeriod` |
+| In-flight email send | 10s | `MailOptions.ShutdownGracePeriod` |
+| In-flight job / outbox message | 5s | `Job`/`OutboxOptions.ShutdownGracePeriod` |
+
+> **`ServicesStopConcurrently` is load-bearing, not a micro-optimisation.** Stopped one at a time — the
+> .NET default — those inner graces *sum*: 10 + 10 + 5 + 5 = 30s against a 15s budget, so whichever hosted
+> service stops last gets none of its grace at all, decided by the order of your `AddRaskX` calls in
+> `Program.cs`. Stopped concurrently they overlap at 10s, leaving real headroom. The scaffold sets it
+> alongside the timeout for exactly this reason.
+
+These are budgets, not guarantees. Work that outlives its rung is cancelled: live sessions are aborted
+(`rask.shutdown.sessions.abandoned`), and a job, outbox message or email is re-run from the top on the next
+boot without counting a failed attempt (`rask.{jobs,outbox,mail}.interrupted`). Both are logged as warnings,
+so a budget that is too short for your app says so rather than silently degrading.
+
+One honest caveat of stopping concurrently: Litestream stops alongside a job that is still writing inside
+*its* grace, so the very last rows such a job writes may not reach the replica. Sequential stop wouldn't
+actually protect against that either — the order is reverse-registration, so nothing guarantees Litestream
+is last today — and the exposure is narrow, since the Docker volume survives redeploys and Litestream only
+matters for losing the machine itself.
 
 ### Your users stay signed in across a deploy
 

--- a/docs/sqlite.md
+++ b/docs/sqlite.md
@@ -311,7 +311,9 @@ app.Run();
 
 `AddRaskSqliteLitestream` registers a hosted `BackgroundService` that runs `litestream replicate` for
 the lifetime of the process and stops it on shutdown — sending a graceful interrupt so the last WAL
-frames flush before a force-kill (`ShutdownGracePeriod`, default 10s). The `litestream` binary is
+frames flush before a force-kill (`ShutdownGracePeriod`, default 10s) — one rung of
+[the shutdown ladder](deployment.md#the-shutdown-ladder), which it must fit inside or the host stops
+waiting for it. The `litestream` binary is
 driven through [CliWrap](https://github.com/Tyrrrz/CliWrap); a backup failure is logged at `Critical`
 but never crashes the app it protects. Point `ConfigPath` at a full `litestream.yml` for multiple
 databases or custom retention.
@@ -372,7 +374,11 @@ must respect:
   opens the database.
 - **Graceful shutdown is handled for you.** App Service recycles the container with `SIGTERM`; the
   hosted service interrupts Litestream and lets it flush within `ShutdownGracePeriod`, so you don't lose
-  the last writes on a redeploy.
+  the last writes on a redeploy. One caveat worth knowing: with `ServicesStopConcurrently` (what the
+  scaffold sets, so the pillars' grace periods overlap rather than sum), Litestream stops alongside a job
+  that is still finishing inside *its* grace — so the very last rows such a job writes may not reach the
+  replica. Sequential stop wouldn't reliably help, since the order is reverse-registration; and the
+  exposure only matters if you lose the machine in those few seconds.
 
 The same recipe applies to any ephemeral-container platform (Kubernetes, Fly.io, Container Apps):
 local-disk DB + `abs://`/`s3://` replica + single writer + restore-on-boot.

--- a/docs/tutorial/11-deploy.md
+++ b/docs/tutorial/11-deploy.md
@@ -56,7 +56,9 @@ Two layers keep the SQLite database safe, and you should understand both:
   can't live inside it. `rask deploy` mounts a per-app Docker volume and points the app at it
   (`ConnectionStrings:App` → `Data Source=/data/app.db`); the volume — and your data — persists across
   container replacements. The old container is stopped gracefully (SIGTERM) before removal, so in-flight
-  writes are checkpointed first rather than killed. *(Bringing your own Dockerfile? Give the runtime a
+  writes are checkpointed first rather than killed — inside a
+  [budget](../deployment.md#the-shutdown-ladder) that also covers open pages, running jobs and queued
+  email. *(Bringing your own Dockerfile? Give the runtime a
   writable `/data`: `RUN mkdir -p /data && chown $APP_UID:$APP_UID /data`. The one `rask new --docker`
   scaffolds already does this.)*
 - **Off the box — Litestream.** The volume survives redeploys; Litestream (Chapter 8) survives losing the

--- a/samples/Rask.Example.Auth.Jwt/Program.cs
+++ b/samples/Rask.Example.Auth.Jwt/Program.cs
@@ -14,6 +14,15 @@ builder.Services.AddSingleton<JwtIssuer>();
 builder.Services.AddSingleton<JwtValidator>();
 builder.Services.AddRask();
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 app.MapStaticAssets();

--- a/samples/Rask.Example.Auth.WasmCookie.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmCookie.Host/Program.cs
@@ -15,6 +15,15 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
 builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
 builder.Services.AddRask(); // Rask.Wasm.Hosting — response compression for the AppBundle
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 // Populates HttpContext.User from the cookie so /api/me reflects the signed-in user. (No UseAuthorization

--- a/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
+++ b/samples/Rask.Example.Auth.WasmJwt.Host/Program.cs
@@ -43,6 +43,15 @@ builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
 builder.Services.AddSingleton(new JwtIssuer(signingKey));
 builder.Services.AddRask(); // Rask.Wasm.Hosting — response compression for the AppBundle
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 app.UseAuthentication();

--- a/samples/Rask.Example.Auth/Program.cs
+++ b/samples/Rask.Example.Auth/Program.cs
@@ -17,6 +17,15 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
 builder.Services.AddSingleton<ICredentialStore, DemoCredentialStore>();
 builder.Services.AddRask();
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 app.MapStaticAssets();

--- a/samples/Rask.Example.EfCore/Program.cs
+++ b/samples/Rask.Example.EfCore/Program.cs
@@ -35,6 +35,15 @@ builder.Services.AddRaskMail<CatalogDbContext>(o =>
 // and the background CachePurger sweeps expired rows (a short interval keeps the demo tidy).
 builder.Services.AddRaskCache<CatalogDbContext>(o => o.PurgeInterval = TimeSpan.FromSeconds(30));
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 // Create the schema and seed sample data once at startup.

--- a/samples/Rask.Example.Server/Program.cs
+++ b/samples/Rask.Example.Server/Program.cs
@@ -64,6 +64,15 @@ builder.Services.AddExampleServices(sp =>
     return new Uri(origin.TrimEnd('/') + "/");
 });
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 // Serve build-time static web assets — wwwroot/** AND package _content/* (e.g. Rask.Bootstrap's

--- a/samples/Rask.Example.Shop/Program.cs
+++ b/samples/Rask.Example.Shop/Program.cs
@@ -48,10 +48,19 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
     options.KnownProxies.Clear();
 });
 
-// Finish shutting down before the container runtime loses patience. `rask deploy` sends SIGTERM
-// and SIGKILLs 20s later, so a budget under that is what lets in-flight requests drain and a
-// SQLite WAL checkpoint / Litestream flush complete instead of being killed mid-write.
-builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
+// Finish shutting down before the container runtime loses patience. `rask deploy` sends SIGTERM and
+// SIGKILLs 20s later, so a budget under that is what lets in-flight requests drain, live sessions close
+// cleanly, and a SQLite WAL checkpoint / Litestream flush complete instead of being killed mid-write.
+//
+// ServicesStopConcurrently matters as much as the number: stopped one at a time (the .NET default) each
+// hosted service's own shutdown grace — Litestream's WAL flush, an in-flight email send, a running job —
+// SUMS inside this one budget, and whichever stops last gets none of it, decided by the order of your
+// AddRaskX calls. Stopped together they overlap instead.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
 
 // Data-protection keys sign the auth cookie (and anything else the app protects). The default key
 // ring is written inside the container, and every deploy replaces the container — so without this

--- a/samples/Rask.Example.Sqlite/Program.cs
+++ b/samples/Rask.Example.Sqlite/Program.cs
@@ -30,6 +30,15 @@ builder.Services.AddRaskSqlite($"Data Source={dbPath}");
 //       o.ReplicaUrl = "s3://my-bucket/rask-sqlite";   // or abs:// (Azure Blob), gcs://, file:///…
 //   });
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 // await app.Services.RestoreSqliteFromLitestreamAsync();   // restore before opening the DB (see above)

--- a/samples/Rask.Example.Wasm.Host/Program.cs
+++ b/samples/Rask.Example.Wasm.Host/Program.cs
@@ -12,6 +12,15 @@ builder.Services.AddRask();
 // pushes it sends — the complete subscribe → send → notify loop in one app. See docs/pwa.md.
 builder.Services.AddPushDemo(builder.Configuration);
 
+// Match what `rask deploy` allows: it sends SIGTERM and SIGKILLs 20s later, so the app budgets under that.
+// ServicesStopConcurrently is the other half — stopped one at a time (the .NET default) each hosted
+// service's own shutdown grace sums inside this one budget instead of overlapping. See docs/deployment.md.
+builder.Services.Configure<HostOptions>(options =>
+{
+    options.ShutdownTimeout = TimeSpan.FromSeconds(15);
+    options.ServicesStopConcurrently = true;
+});
+
 var app = builder.Build();
 
 // Web Push backend endpoints (must precede the UseRask catch-all): GET /_push/key,

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -48,10 +48,9 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     /// <summary>The default path the HTTP readiness probe hits — the endpoint <c>rask new</c> scaffolds.</summary>
     internal const string DefaultHealthPath = "/health";
 
-    /// <summary>Seconds a graceful <c>docker stop</c> waits after SIGTERM before SIGKILL — long enough for a
-    /// SQLite WAL checkpoint and, when one is configured, the app's Litestream flush (whose own shutdown
-    /// grace is 10s).</summary>
-    internal const int StopTimeoutSeconds = 20;
+    /// <summary>Seconds a graceful <c>docker stop</c> waits after SIGTERM before SIGKILL. The top rung of
+    /// <see cref="ShutdownBudget"/> — see there for the whole ladder and why each rung is the size it is.</summary>
+    internal const int StopTimeoutSeconds = ShutdownBudget.DockerStopSeconds;
 
     /// <summary>
     /// The tag the running app is built to, and the one holding the version it replaced.
@@ -77,6 +76,10 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
     internal TimeSpan ReadinessDelay { get; set; } = TimeSpan.FromSeconds(2);
 
     internal int ReadinessAttempts { get; set; } = 10;
+
+    /// <summary>How long to wait after the proxy has been pointed at the new color before stopping the old
+    /// one — see <see cref="ShutdownBudget.PreStopDrainSeconds"/>. Overridden to zero in tests.</summary>
+    internal TimeSpan PreStopDrainDelay { get; set; } = TimeSpan.FromSeconds(ShutdownBudget.PreStopDrainSeconds);
 
     public override string Name => "deploy";
 
@@ -509,6 +512,20 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         {
             Console.WriteErrorLine("Caddy reload failed — the new container is running but not yet routed. Check `docker -H ssh://" + host + " logs rask-caddy`.", ConsoleStyle.Error);
             return 1;
+        }
+
+        // Let the proxy finish with the old color before pulling it out from under itself. `caddy reload`
+        // returns as soon as the admin API applies the config, but Caddy still holds pooled keep-alive
+        // connections to the old upstream — a request it is about to write onto one of those when SIGTERM
+        // lands gets a broken connection, and with the default lb_try_duration of 0 it is not retried, i.e.
+        // a 502 to a real user. There used to be no gap here at all.
+        //
+        // Deliberately NOT sized for live sessions: a WebSocket to the old color survives until the app
+        // closes it, so the SIGTERM is what triggers the client's move to the new container. Draining those
+        // gracefully is the app's job (RaskServerOptions.ShutdownDrainTimeout), not this pause's.
+        if (PreStopDrainDelay > TimeSpan.Zero)
+        {
+            await Task.Delay(PreStopDrainDelay, cancellationToken).ConfigureAwait(false);
         }
 
         // Traffic is on the new color: retire the old container(s) of this app. Graceful stop first so

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Server.cs
@@ -257,11 +257,6 @@ internal static partial class ProjectGenerator
                 options.KnownProxies.Clear();
             });
 
-            // Finish shutting down before the container runtime loses patience. `rask deploy` sends SIGTERM
-            // and SIGKILLs 20s later, so a budget under that is what lets in-flight requests drain and a
-            // SQLite WAL checkpoint / Litestream flush complete instead of being killed mid-write.
-            builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
-
             // Data-protection keys sign the auth cookie (and anything else the app protects). The default key
             // ring is written inside the container, and every deploy replaces the container — so without this
             // a redeploy mints a fresh ring and every cookie already issued stops validating: all your
@@ -281,6 +276,8 @@ internal static partial class ProjectGenerator
             }
 
             """.TrimStart('\n'));
+
+        sb.Append(ShutdownBudgetBlock());
 
         if (batteries.Cqrs)
         {

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.Shared.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.Shared.cs
@@ -1,9 +1,43 @@
+using System.Globalization;
+
 namespace Rask.Cli.Scaffolding;
 
 // Template content shared by more than one template, emitted verbatim with the Company.RaskServer
 // namespace token replaced centrally (see ProjectGenerator.Materialize).
 internal static partial class ProjectGenerator
 {
+    /// <summary>
+    ///     The <c>Program.cs</c> shutdown block, shared by every web template and derived from
+    ///     <see cref="ShutdownBudget"/> rather than hardcoded — the app's budget and the deploy's grace used
+    ///     to be two literals coupled only by a comment, free to drift apart silently.
+    /// </summary>
+    private static string ShutdownBudgetBlock()
+    {
+        // Pre-converted so the interpolation below formats nothing — the raw literal already contains the
+        // braces of a lambda body, which is why it is $$"""…""" with {{…}} holes.
+        var dockerStop = ShutdownBudget.DockerStopSeconds.ToString(CultureInfo.InvariantCulture);
+        var hostShutdown = ShutdownBudget.HostShutdownSeconds.ToString(CultureInfo.InvariantCulture);
+
+        return $$"""
+
+        // Finish shutting down before the container runtime loses patience. `rask deploy` sends SIGTERM and
+        // SIGKILLs {{dockerStop}}s later, so a budget under that is what lets in-flight requests drain, live
+        // sessions close cleanly, and a SQLite WAL checkpoint / Litestream flush complete instead of being
+        // killed mid-write.
+        //
+        // ServicesStopConcurrently matters as much as the number: stopped one at a time (the .NET default)
+        // each hosted service's own shutdown grace — Litestream's WAL flush, an in-flight email send, a
+        // running job — SUMS inside this one budget, and whichever stops last gets none of it, decided by
+        // the order of your AddRaskX calls. Stopped together they overlap instead.
+        builder.Services.Configure<HostOptions>(options =>
+        {
+            options.ShutdownTimeout = TimeSpan.FromSeconds({{hostShutdown}});
+            options.ServicesStopConcurrently = true;
+        });
+
+        """.TrimStart('\n');
+    }
+
     // The app shell every page renders through (RASK021), living in Features/Shared/ — the cross-cutting
     // bucket a new project shares across its feature slices. Styled with Bootstrap so there is no scoped
     // .css to pair. The welcome home page is its own Features/Home slice (see HomePageCs).

--- a/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectGenerator.WasmHosted.cs
@@ -179,10 +179,6 @@ internal static partial class ProjectGenerator
                 options.KnownProxies.Clear();
             });
 
-            // Finish shutting down before the container runtime loses patience: `rask deploy` sends SIGTERM
-            // and SIGKILLs 20s later.
-            builder.Services.Configure<HostOptions>(options => options.ShutdownTimeout = TimeSpan.FromSeconds(15));
-
             // Data-protection keys sign the auth cookie (and anything else the app protects). The default key
             // ring is written inside the container, and every deploy replaces the container — so without this
             // a redeploy mints a fresh ring and every cookie already issued stops validating: all your
@@ -201,6 +197,8 @@ internal static partial class ProjectGenerator
             }
 
             """.TrimStart('\n'));
+
+        sb.Append(ShutdownBudgetBlock());
 
         if (auth)
         {

--- a/src/Rask.Cli/ShutdownBudget.cs
+++ b/src/Rask.Cli/ShutdownBudget.cs
@@ -1,0 +1,64 @@
+namespace Rask.Cli;
+
+/// <summary>
+///     The single shutdown ladder <c>rask</c> deploys and scaffolds against. Every rung is derived from the
+///     one above it, so the numbers cannot drift apart the way two hardcoded constants coupled only by a
+///     comment can — which is exactly what <c>DeployCommand</c>'s 20 and the scaffolder's 15 used to be.
+///     <code>
+///     docker stop -t 20s                        ← DockerStopSeconds; SIGKILL lands here
+///       └─ HostOptions.ShutdownTimeout 15s      ← HostShutdownSeconds = DockerStop − HostReserve
+///            ├─ Kestrel in-flight request drain
+///            ├─ Rask live-session drain          5s  (RaskServerOptions.ShutdownDrainTimeout)
+///            └─ hosted services, stopped CONCURRENTLY (ServicesStopConcurrently in the scaffold):
+///                 Litestream final WAL flush    10s  (LitestreamOptions.ShutdownGracePeriod)
+///                 In-flight email send          10s  (MailOptions.ShutdownGracePeriod)
+///                 In-flight job / outbox item    5s  (Job/OutboxOptions.ShutdownGracePeriod)
+///     </code>
+///     <para>
+///         <b>Why the inner rungs are not constants here.</b> They live in their own NuGet packages, and
+///         <c>Rask.Cli</c> deliberately does not reference <c>Rask.Jobs</c> / <c>Rask.Mail</c> /
+///         <c>Rask.SQLite.Litestream</c> — it must not start. They are pinned instead by each package's own
+///         default test and by the table in <c>docs/deployment.md</c>, which is the one place all six
+///         numbers appear together. Inventing a shared package to hold four integers would be worse.
+///     </para>
+///     <para>
+///         <b>Concurrency is what makes the arithmetic work.</b> Stopped sequentially (the .NET default) the
+///         inner rungs <em>sum</em> — 10 + 10 + 5 + 5 = 30s against a 15s budget, so whichever hosted
+///         service stops last gets no grace at all, decided by the order of <c>AddRaskX</c> calls in someone's
+///         <c>Program.cs</c>. Stopped concurrently they overlap at <c>max(...) = 10s</c>, leaving real
+///         headroom. That is why the scaffold sets <c>ServicesStopConcurrently</c> alongside the timeout.
+///     </para>
+/// </summary>
+internal static class ShutdownBudget
+{
+    /// <summary>Seconds <c>docker stop -t</c> waits after SIGTERM before SIGKILL.</summary>
+    internal const int DockerStopSeconds = 20;
+
+    /// <summary>
+    ///     Margin between the app finishing and the SIGKILL: container teardown, log flush, DI-container
+    ///     disposal, EF connection teardown — work that happens after <c>Host.StopAsync</c> returns.
+    /// </summary>
+    internal const int HostReserveSeconds = 5;
+
+    /// <summary>Seconds the app gives itself (<c>HostOptions.ShutdownTimeout</c>) — scaffolded into Program.cs.</summary>
+    internal const int HostShutdownSeconds = DockerStopSeconds - HostReserveSeconds;
+
+    /// <summary>
+    ///     Seconds between <c>caddy reload</c> returning and the retiring container's SIGTERM.
+    ///     <para>
+    ///         Sized to Caddy's keep-alive pool turnover, not to the app's workload. <c>caddy reload</c>
+    ///         returns as soon as the admin API applies the config, but Caddy still holds pooled
+    ///         connections to the old upstream; a request it is about to write onto one of those at the
+    ///         moment SIGTERM lands gets a broken connection, and with the default <c>lb_try_duration</c>
+    ///         of 0 it is not retried — a 502 to a real user. Today there is literally zero time between
+    ///         the two.
+    ///     </para>
+    ///     <para>
+    ///         This is explicitly <b>not</b> for letting live sessions migrate. A WebSocket to the old
+    ///         color persists until the app closes it, so the SIGTERM <em>is</em> the migration trigger;
+    ///         delaying it only delays the reconnect. Draining those cleanly is the app's job, and is what
+    ///         <c>RaskServerOptions.ShutdownDrainTimeout</c> does.
+    ///     </para>
+    /// </summary>
+    internal const int PreStopDrainSeconds = 2;
+}

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Rask.Cli;
 using Rask.Cli.Commands;
 using Rask.Cli.Scaffolding;
@@ -63,8 +64,13 @@ public sealed class DeployCommandTests
 
     [Fact]
     public void Stop_arguments_use_a_graceful_timeout() =>
+        // Built from the ladder, not a literal, so the deploy's grace and the budget the scaffold hands the
+        // app cannot drift apart.
         Assert.Equal(
-            ["-H", "ssh://deploy@box", "stop", "-t", "20", "shop-blue"],
+            [
+                "-H", "ssh://deploy@box", "stop", "-t",
+                ShutdownBudget.DockerStopSeconds.ToString(CultureInfo.InvariantCulture), "shop-blue"
+            ],
             DeployCommand.BuildStopArguments("deploy@box", "shop-blue"));
 
     [Theory]
@@ -137,7 +143,13 @@ public sealed class DeployCommandTests
     private static DeployCommand Create(FakeFileSystem fs, FakeProcessRunner runner, StringConsole console)
     {
         fs.Seed("/proj/Dockerfile", "FROM scratch");
-        return new DeployCommand(console, fs, runner, WorkingDir) { ReadinessDelay = TimeSpan.Zero, ReadinessAttempts = 1 };
+        return new DeployCommand(console, fs, runner, WorkingDir)
+        {
+            ReadinessDelay = TimeSpan.Zero,
+            ReadinessAttempts = 1,
+            // Zeroed so the suite doesn't actually sleep; the real default is asserted separately.
+            PreStopDrainDelay = TimeSpan.Zero,
+        };
     }
 
     /// <summary>
@@ -390,7 +402,8 @@ public sealed class DeployCommandTests
         var runs = runner.Invocations.Where(i => !i.Captured).ToList();
         int StartNew = runs.FindIndex(i => i.Arguments.Contains("run") && i.Arguments.Contains("demo-green"));
         int Reload = runs.FindIndex(i => i.Arguments.Contains("reload"));
-        int StopOld = runs.FindIndex(i => i.Arguments is ["-H", "ssh://deploy@box", "stop", "-t", "20", "demo-blue"]);
+        int StopOld = runs.FindIndex(i =>
+            i.Arguments.SequenceEqual(DeployCommand.BuildStopArguments("deploy@box", "demo-blue")));
         int RemoveOld = runs.FindIndex(i => i.Arguments is ["-H", "ssh://deploy@box", "rm", "-f", "demo-blue"]);
 
         Assert.True(StartNew >= 0 && Reload >= 0 && StopOld >= 0 && RemoveOld >= 0);
@@ -399,6 +412,19 @@ public sealed class DeployCommandTests
         // Graceful stop (SIGTERM → Litestream flush + WAL checkpoint) before the force-remove, so the last
         // writes reach the replica instead of being SIGKILLed.
         Assert.True(StopOld < RemoveOld, "the old container is stopped gracefully before it's removed");
+    }
+
+    [Fact]
+    public void The_pre_stop_pause_defaults_to_the_ladder_value()
+    {
+        // The suite zeroes this so it doesn't sleep, which is exactly how a test-only default leaks into
+        // production unnoticed — so assert the real one on a plainly-constructed command.
+        var command = new DeployCommand(new StringConsole(), new FakeFileSystem(), new FakeProcessRunner(), WorkingDir);
+
+        Assert.Equal(TimeSpan.FromSeconds(ShutdownBudget.PreStopDrainSeconds), command.PreStopDrainDelay);
+        Assert.True(command.PreStopDrainDelay > TimeSpan.Zero,
+            "without a pause, a request Caddy is writing onto a pooled connection to the old color when "
+            + "SIGTERM lands becomes a 502 — lb_try_duration is 0, so it is not retried");
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
+++ b/tests/Rask.Cli.Tests/ProjectGeneratorTests.cs
@@ -74,13 +74,45 @@ public sealed class ProjectGeneratorTests
             "UseForwardedHeaders must come before UseHsts, or the scheme it corrects is read too late.");
     }
 
-    /// <summary>`rask deploy` SIGKILLs 20s after SIGTERM, so the host's own budget must be under that.</summary>
+    /// <summary>
+    /// The scaffold emits whatever the ladder says, whatever that is — asserted against
+    /// <see cref="ShutdownBudget"/> rather than the literal, because the app's budget and the deploy's
+    /// SIGKILL grace used to be two hardcoded numbers coupled only by a comment, free to drift apart.
+    /// </summary>
     [Fact]
-    public void Shutdown_finishes_inside_the_deploy_grace_period()
+    public void Shutdown_budget_is_scaffolded_from_the_deploy_ladder()
     {
         var (files, _) = Generate();
 
-        Assert.Contains("ShutdownTimeout = TimeSpan.FromSeconds(15)", files["Program.cs"], StringComparison.Ordinal);
+        Assert.Contains(
+            FormattableString.Invariant($"ShutdownTimeout = TimeSpan.FromSeconds({ShutdownBudget.HostShutdownSeconds})"),
+            files["Program.cs"],
+            StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Without this, each hosted service's own shutdown grace (Litestream's WAL flush, an in-flight email
+    /// send, a running job) SUMS inside the one budget instead of overlapping — and whichever service stops
+    /// last gets none of it, decided by the order of AddRaskX calls in Program.cs.
+    /// </summary>
+    [Fact]
+    public void Hosted_services_are_scaffolded_to_stop_concurrently()
+    {
+        var (files, _) = Generate();
+
+        Assert.Contains("ServicesStopConcurrently = true", files["Program.cs"], StringComparison.Ordinal);
+    }
+
+    /// <summary>The ladder itself has to be sane — this is what fails if someone edits one rung alone.</summary>
+    [Fact]
+    public void The_app_budget_leaves_room_inside_the_docker_stop_grace()
+    {
+        Assert.True(ShutdownBudget.HostShutdownSeconds < ShutdownBudget.DockerStopSeconds,
+            "the app must finish before docker SIGKILLs it");
+        Assert.True(ShutdownBudget.DockerStopSeconds - ShutdownBudget.HostShutdownSeconds >= 5,
+            "leave margin for container teardown and log flush after Host.StopAsync returns");
+        Assert.True(ShutdownBudget.PreStopDrainSeconds < ShutdownBudget.HostShutdownSeconds,
+            "the pre-stop pause must not dominate the deploy");
     }
 
     /// <summary>

--- a/tests/Rask.Cli.Tests/SamplesShutdownBudgetTests.cs
+++ b/tests/Rask.Cli.Tests/SamplesShutdownBudgetTests.cs
@@ -1,0 +1,50 @@
+namespace Rask.Cli.Tests;
+
+/// <summary>
+///     Every web-host sample must set a shutdown budget that fits the deploy window.
+///     <para>
+///         This is a repo-scanning test rather than a per-sample one because the failure mode is the
+///         <em>next</em> sample somebody adds. Before this, nine of the ten web hosts inherited .NET's
+///         default 30s <c>ShutdownTimeout</c> — which <b>exceeds</b> the 20s <c>rask deploy</c> allows
+///         between SIGTERM and SIGKILL, so a sample deployed as written would be killed mid-shutdown.
+///         Only <c>Rask.Example.Shop</c> had it right, and a reader copying from any other sample
+///         inherited the wrong lesson.
+///     </para>
+/// </summary>
+public class SamplesShutdownBudgetTests
+{
+    [Fact]
+    public void Every_web_host_sample_budgets_its_shutdown_and_stops_services_concurrently()
+    {
+        var samples = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "samples"), "Program.cs", SearchOption.AllDirectories)
+            .Select(path => (Path: path, Text: File.ReadAllText(path)))
+            // Only the web hosts: a console/WASM entry point has no HostOptions to configure.
+            .Where(f => f.Text.Contains("WebApplication.CreateBuilder", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.NotEmpty(samples);
+
+        var missing = samples
+            .Where(f => !f.Text.Contains("ShutdownTimeout", StringComparison.Ordinal)
+                        || !f.Text.Contains("ServicesStopConcurrently", StringComparison.Ordinal))
+            .Select(f => Path.GetFileName(Path.GetDirectoryName(f.Path)))
+            .ToList();
+
+        Assert.True(missing.Count == 0,
+            "these web-host samples inherit .NET's 30s default, which exceeds the 20s `rask deploy` allows "
+            + "before SIGKILL: " + string.Join(", ", missing));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+        {
+            dir = dir.Parent;
+        }
+
+        Assert.NotNull(dir);
+        return dir.FullName;
+    }
+}

--- a/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
@@ -4,6 +4,7 @@ using System.Text;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Hosting;
 using Rask.Core.Live;
 using Rask.Server.Diagnostics;
 using Rask.Server.Tests.Infrastructure;
@@ -191,6 +192,27 @@ public class ShutdownDrainTests
 
         var during = await host.Http.GetAsync("/health");
         Assert.Equal(HttpStatusCode.ServiceUnavailable, during.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_drain_still_works_when_hosted_services_stop_concurrently()
+    {
+        // The scaffold sets HostOptions.ServicesStopConcurrently = true so the batteries' shutdown grace
+        // periods overlap this drain instead of summing ahead of it. That removes the reverse-registration
+        // stop ORDER the drain would otherwise lean on — so this pins that it doesn't need it. It works
+        // because Kestrel's own StopAsync waits for in-flight requests, and a WebSocket is an in-flight
+        // request: the drain runs while Kestrel waits.
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServices: s => s.Configure<HostOptions>(o => o.ServicesStopConcurrently = true));
+        using var ws = await ConnectAsync(host);
+
+        await host.StopAsync();
+
+        Assert.Equal(LivePayload.ServerShutdownJson, await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2)));
+        var close = await ws.TryReceiveCloseAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(close);
+        Assert.Equal(WebSocketCloseStatus.EndpointUnavailable, close.Value.Status);
+        Assert.Equal(0, host.Store.Count);
     }
 
     [Fact]


### PR DESCRIPTION
PR 3 of the graceful-shutdown series. **Stacked on #560** (PR 1) — its commits are included below this
one, so review only the top commit. #566 (PR 2) is independent of both.

> Retarget this to `main` **before** #560 merges, or GitHub closes it when the base branch disappears.

## Why stacked

Because 3b below removes the stop *ordering* #560's live-session drain relies on, and I wanted to actually
run that check rather than assert it. See "The hazard" at the bottom — it holds, and is now a permanent test.

## Why

Three unrelated numbers pretending to be a budget:

- `docker stop -t 20` in `DeployCommand`
- a scaffolded `HostOptions.ShutdownTimeout = 15s`, coupled to it **only by a code comment**
- Litestream's 10s grace, plus (as of #566) mail's 10s and jobs/outbox's 5s

The generator test pinned the literal `15`, so if someone changed the deploy's 20 the test would have kept
passing while the ladder silently inverted.

Worse, `HostOptions.ServicesStopConcurrently` was never set anywhere. Stopped one at a time — the .NET
default — those inner graces **sum**: 10 + 10 + 5 + 5 = **30s against a 15s budget**. So whichever hosted
service stopped last got no grace at all, and *which one that was* depended on the order of `AddRaskX` calls
in someone's `Program.cs`. A graceful-shutdown story whose behaviour depends on the order lines appear in a
file isn't one, and it makes #566's per-pillar grace periods largely inert.

## What changed

**3a — one derived ladder.** New `ShutdownBudget` in `Rask.Cli` (which owns both `DeployCommand` and the
scaffolder). `StopTimeoutSeconds` and the scaffolded `ShutdownTimeout` now derive from it, and the tests
assert the *relationship* — app budget < deploy grace, with ≥5s margin for container teardown — instead of
the literal. The inner rungs deliberately stay non-constants: `Rask.Cli` must not reference `Rask.Jobs` /
`Rask.Mail` / `Rask.SQLite.Litestream`, so they're pinned by each package's own default test and by the
table in `docs/deployment.md`, which is now the one place all six numbers appear together. Inventing a
shared package to hold four integers would be worse.

**3b — `ServicesStopConcurrently = true`** in the scaffold and every sample, so the inner rungs overlap at
`max(...) = 10s` instead of summing to 30s.

**3c — a real pre-stop pause.** `caddy reload` returning was immediately followed by `docker stop`, with
zero time between them. Caddy hot-reload drains in-flight requests it owns, but it still holds pooled
keep-alive connections to the old upstream — a request it's about to write onto one of those when SIGTERM
lands gets a broken connection, and with the default `lb_try_duration` of 0 it is **not retried**: a 502 to a
real user. 2 seconds, sized to pool turnover, as a constant rather than a flag (it's a property of the proxy,
not of your app).

Explicitly **not** for letting live sessions migrate — a WebSocket to the old color survives until the app
closes it, so the SIGTERM *is* the migration trigger and delaying it only delays the reconnect. Draining
those is #560's job. The code comment says so, so nobody later "improves" this number for the wrong reason.

**3d — samples.** Nine of the ten web hosts inherited .NET's default **30s** `ShutdownTimeout`, which
*exceeds* the 20s `rask deploy` allows before `SIGKILL` — so a sample deployed as written would be killed
mid-shutdown. `Rask.Example.EfCore` was the sharpest case: it runs Mail and Cache and is the sample that most
looks like production. Only `Rask.Example.Shop` was right, which meant a reader copying from any other sample
inherited the wrong lesson. Guarded by a repo-scanning test, because the real failure mode is the *next*
sample somebody adds.

## The hazard, verified

#560's drain leans on hosted services stopping in reverse-registration order so it runs before Kestrel.
`ServicesStopConcurrently` removes that ordering. I said I'd verify rather than assume, so:
`The_drain_still_works_when_hosted_services_stop_concurrently` runs the full drain assertions with the flag
on. **It holds** — Kestrel's own `StopAsync` waits for in-flight requests, and a WebSocket *is* an in-flight
request, so the drain runs while Kestrel waits. That's now a permanent regression test rather than a
one-off check.

## Also fixed: a test race this series introduced

The drain tests in #560 borrowed `GatedCounterApp.Gate` and `HangingApp.Gate` — **mutable statics** that
`HandlerExceptionIsolationTests` and `HandlerBackpressureTests` already own. xUnit runs test classes in
parallel, so one class would replace the `TaskCompletionSource` the other was parked on. It surfaced as an
intermittent double failure (my drain test *and* the pre-existing reconnect test) on one full-suite run in
four. Fixed with a dedicated `DrainGateApp`; two consecutive clean full-suite runs since.

Worth flagging because it was only caught by running the whole gate repeatedly — a targeted
`--filter` run passed every time.

## Docs

`docs/deployment.md` gains **the shutdown ladder table** (the single place all six rungs appear) and states
plainly that these are budgets, not guarantees, with the metric and log line that tell you when one was
missed. `docs/cli.md`, `docs/sqlite.md` and `docs/tutorial/11-deploy.md` link to it instead of restating
numbers that will move.

One honest caveat now documented in `docs/sqlite.md`: with concurrent stop, Litestream stops alongside a job
still finishing inside *its* grace, so the last rows such a job writes may not reach the replica. Sequential
stop wouldn't reliably help either (the order is reverse-registration, so nothing guarantees Litestream is
last today), and the exposure only matters if you lose the machine in those seconds.

## Testing

`dotnet format` clean, `dotnet build -warnaserror` clean, **full unit suite green — run twice** after the
race fix. New: the ladder-relationship assertions, `ServicesStopConcurrently` in the generated `Program.cs`,
the pre-stop pause default (asserted on a plainly-constructed command, since the suite zeroes it — exactly
how a test-only default leaks into production), the samples guard, and the concurrency check above.

### Not verified

- **`rask deploy` has still never run against a real VPS** (standing caveat for this command). The pause and
  the stop arguments are asserted on built argument lists, not observed against Docker. The 502 reasoning
  is from Caddy's pooling and `lb_try_duration` default, not from a reproduction.
- **No benchmarks** — nothing here is on the render hot path.
- **E2E** unchanged and red on `main` for unrelated reasons (#550 + the Playground sandbox failure); pushed
  with `RASK_SKIP_E2E=1`.

## Deliberately not done

Port-mode's health gate still can't roll back (it stops the old container before starting the new one) —
filed as #563 rather than fixed here. Making it start-before-stop on a single published port needs a second
port plus something to swap between them, which is what `--domain` already is; reimplementing a proxy inside
the port path to avoid needing the proxy path is the wrong shape, and a shutdown PR is the wrong place to
redesign a deploy topology.
