### PR TITLE
feat(server): hand connected clients over on shutdown instead of dropping them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,21 @@ them until tagged releases begin.
   we could neither pin nor install.
 
 ### Fixed
+- **A client that stops reading can no longer wedge its live session, or hold up delivery to everyone
+  else.** `WebSocket.SendAsync` completes when a frame reaches the transport, not when the client reads it,
+  so a client that simply stops reading TCP fills the send buffer and the send never returns. Every send
+  happens under the session's render lock, which also guards its teardown — so that one client cost its
+  session every future render *and* a `Dispose` that could never take the lock, for as long as it cared to
+  stall. A new `SendTimeout` (default 30 s, `0` disables) bounds it: on expiry the socket is aborted, which
+  unwinds the receive loop and releases the lock, while the **session** is left alone to live out its
+  normal grace period — so a briefly-stalled link reconnects to the page it already had. The default is a
+  stuck-connection backstop, not a latency budget; a slow mobile link will not trip it.
+  The store's whole-session fan-outs (`RerenderAllAsync`, `BroadcastAsync`) were also sequential, so their
+  cost was the *sum* of every session's send rather than the slowest, and one stalled client held up every
+  session behind it. Both now run with a bounded degree of concurrency. Only the dev-time hot-reload
+  signal uses them today, but this is the code the planned Broadcast pillar inherits, where a fan-out is a
+  user-facing feature — and it is a prerequisite for the deploy-drain broadcast, which has to finish
+  inside the shutdown budget before `SIGKILL` interrupts a SQLite checkpoint.
 - **A contended write no longer fails with "cannot start a transaction within a transaction".** The
   busy-retry loop re-issued the identical statement on every pass with no cleanup between attempts, and
   cleared a leaked transaction only *once*, before the loop. That caught a transaction the pooled handle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,24 @@ them until tagged releases begin.
   (`Microsoft.Data.Sqlite`); the alternative was requiring a `sqlite3` binary on the machine, a dependency
   we could neither pin nor install.
 
+### Added
+- **A deploy now hands its connected clients over instead of dropping them.** The proxy is pointed at the
+  new container before the old one is stopped, so the replacement is already serving by the time anything
+  goes away — but a browser has no way to know that. Left to itself it discovers the drop when its socket
+  dies, then waits out a reconnect backoff (up to five seconds, page frozen) before trying an address that
+  has been healthy the whole time. The departing host now says so: on `SIGTERM` it sends every connected
+  client a `drain` frame *while their sockets still work*, and the client reconnects on the next tick
+  rather than backing off. Paired with session resume, a deploy stops being visible at all — the client
+  reconnects immediately and has its page rebuilt.
+  Nothing to configure and no flag to tune: the graceful stop `rask deploy` already performs is the
+  window. The ordering is the load-bearing part — sockets are now released when the drain *finishes*, not
+  when shutdown begins, because `CancellationToken` callback order is not guaranteed and the previous
+  arrangement would have raced the frame against the socket teardown. The drain is bounded at two seconds
+  and is awaited by a hosted service rather than blocking a thread, since a host shutting down under load
+  has a busy thread pool — exactly when blocking on work that needs the pool stops making progress.
+  Everything after it (disposing sessions, the WAL checkpoint, a Litestream flush) keeps the rest of the
+  budget, because that is the part that loses data if it runs out.
+
 ### Fixed
 - **A client that stops reading can no longer wedge its live session, or hold up delivery to everyone
   else.** `WebSocket.SendAsync` completes when a frame reaches the transport, not when the client reads it,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -62,6 +62,7 @@ WebSocket safety caps and session grace periods — only the ASP.NET host has th
 | `UnconnectedSessionGracePeriod` | `10 s` | How long a GET-minted session is retained before its first `hello` arrives. |
 | `IdleSocketTimeout` | `0` (off) | Close a connected socket that sends no inbound frame for this long (the session survives for reconnect). Reclaims silently-idle connections. |
 | `MaxPendingHandlerBytes` | `0` (off) | Aggregate-bytes companion to `MaxPendingHandlers` — bounds the queued cloned-payload *memory*, not just the queue length. |
+| `SendTimeout` | `30 s` | How long one outbound frame may take before the socket is aborted. A client that stops reading TCP would otherwise pin its session's render lock — and its disposal — indefinitely. The session survives for the grace period, so a briefly-stalled link reconnects normally. `0` disables. |
 | `HandlerTimeout` | `0` (off) | Cancel a handler's `Component.CancellationToken` after this long. A handler that threads that token into its async work unwinds cleanly instead of pinning the render pipeline (cooperative — a token-ignoring handler can't be force-aborted). |
 
 ### Reconnect UX

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -169,6 +169,27 @@ refusing sessions with `503` says so rather than answering a bare "up"), and shu
 the 20s grace period the deploy allows before `SIGKILL`, so in-flight requests drain and SQLite checkpoints
 cleanly.
 
+### Connected clients are handed over, not dropped
+
+A deploy swaps containers under people who are actively using the app. The proxy is pointed at the new
+container **before** the old one is stopped, so the replacement is already serving by the time anything
+goes away — but a browser has no way to know that. Left to itself it discovers the drop when its socket
+dies, then waits out a reconnect backoff (up to five seconds, page frozen) before trying an address that
+has been healthy the whole time.
+
+So the old container says goodbye on its way out. On `SIGTERM` it sends every connected client a
+`drain` frame while their sockets still work; the client reconnects on the next tick instead of backing
+off, and lands on the new container. Nothing to configure, and no flag to tune — the graceful stop the
+deploy already performs (`docker stop -t 20`) *is* the window.
+
+The drain is bounded at two seconds and never blocks a thread waiting for it. What follows shutdown —
+disposing sessions, checkpointing the WAL, flushing a Litestream replica — is the part that loses data if
+the budget runs out, so it keeps the lion's share of it. A client that doesn't take its frame in time
+simply reconnects the old way.
+
+Pair it with [session resume](configuration.md#surviving-a-restart-or-a-redeploy) and the handover
+finishes the job: the client reconnects immediately *and* gets its page rebuilt, rather than reloading.
+
 ## Scaffolding a Dockerfile — `--docker`
 
 The three web templates take an opt-in `--docker` flag that drops a production-ready multi-stage

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -45,6 +45,20 @@ public static class LivePayload
     internal static readonly byte[] HotReloadAppliedFrame = Encoding.UTF8.GetBytes(HotReloadAppliedJson);
 
     /// <summary>
+    ///     "This host is going away — reconnect now rather than waiting to notice."
+    /// </summary>
+    /// <remarks>
+    ///     Sent to every connected session as the host shuts down. Without it a client learns its host is
+    ///     gone only when the socket drops, then walks its reconnect backoff — up to five seconds of a
+    ///     frozen page — before trying the replacement that has been serving the whole time. A fixed
+    ///     literal like the hot-reload and session-unknown frames, so it needs no serializer and can be
+    ///     sent without allocating on a path that has none to spare.
+    /// </remarks>
+    internal const string DrainJson = """{"type":"drain"}""";
+
+    internal static readonly byte[] DrainFrame = Encoding.UTF8.GetBytes(DrainJson);
+
+    /// <summary>
     ///     Stamps the session id onto <c>&lt;body&gt;</c> as <c>data-rask-root</c>, and in development
     ///     also <c>data-rask-dev</c> — the flag the client requires before it will act on any dev-only
     ///     frame. Production HTML never carries it, so those branches are unreachable there even if a

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -76,11 +76,17 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // thread-pool worker) run on different threads. Mirrors the detached-socket early-return.
     private volatile bool _disposed;
 
+    // How long one outbound frame may take before we give up on the client. Read from the per-host limits
+    // when the host has them (a bare test store built straight from a ServiceCollection does not), so the
+    // value is fixed for the session's lifetime rather than resolved on every send.
+    private readonly TimeSpan _sendTimeout;
+
     public LiveSession(string id, Component view, IServiceScope scope, LiveDiffMode diffMode)
         : base(view, scope.ServiceProvider, diffMode)
     {
         Id = id;
         Scope = scope;
+        _sendTimeout = scope.ServiceProvider.GetService<RaskServerLimits>()?.SendTimeout ?? TimeSpan.Zero;
     }
 
     public bool SuppressEventsUntilReconnect { get; set; }
@@ -361,7 +367,7 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
                 return;
             }
 
-            await _socket.SendAsync(payload, WebSocketMessageType.Text, true, _socketCt).ConfigureAwait(false);
+            await SendGuardedAsync(payload).ConfigureAwait(false);
         }
         finally
         {
@@ -372,8 +378,60 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // Host transport for LiveSessionBase.TryEmitFrameAsync: write the frame's bytes to the WebSocket
     // (ReadOnlyMemory<byte>, zero-copy). RenderAndSendAsync guards _socket non-null/Open before the
     // shared send runs, and the render lock serialises teardown, so _socket is valid here.
-    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) =>
-        _socket!.SendAsync(frame, WebSocketMessageType.Text, true, _socketCt);
+    protected override ValueTask SendFrameAsync(ReadOnlyMemory<byte> frame) => SendGuardedAsync(frame);
+
+    /// <summary>
+    ///     Writes one frame to the socket, giving up on a client that has stopped reading.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>SendAsync</c> completes when the frame reaches the transport, not when the client reads
+    ///         it. A client that stops reading fills the send buffer and the send simply never returns —
+    ///         and because every send here happens under <c>_renderLock</c>, which also guards teardown,
+    ///         that one client would pin its session forever: no further renders, and a <c>Dispose</c> that
+    ///         can never take the lock.
+    ///     </para>
+    ///     <para>
+    ///         On timeout the socket is aborted, which is what unwinds the receive loop and releases the
+    ///         lock. The <em>session</em> is left alone: it lives out its normal grace period, so a client
+    ///         whose link stalled briefly reconnects to the page it already had.
+    ///     </para>
+    /// </remarks>
+    private async ValueTask SendGuardedAsync(ReadOnlyMemory<byte> payload)
+    {
+        if (_sendTimeout <= TimeSpan.Zero)
+        {
+            await _socket!.SendAsync(payload, WebSocketMessageType.Text, true, _socketCt).ConfigureAwait(false);
+            return;
+        }
+
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(_socketCt);
+        cts.CancelAfter(_sendTimeout);
+        try
+        {
+            await _socket!.SendAsync(payload, WebSocketMessageType.Text, true, cts.Token).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (!_socketCt.IsCancellationRequested)
+        {
+            // Ours, not the caller's: the send timed out rather than the session being torn down. Abort so
+            // the receive loop unwinds, then report it as a transport failure — which is what it is, and
+            // what every caller here already handles.
+            RaskDiagnostics.Report(
+                RaskLogLevel.Warning, "Rask.Live",
+                $"Aborting a socket whose send did not complete within {_sendTimeout}. The client stopped "
+                + "reading; its session is kept for the reconnect grace period.");
+            try
+            {
+                _socket!.Abort();
+            }
+            catch
+            {
+                // Already torn down by the receive loop — nothing left to abort.
+            }
+
+            throw new WebSocketException(WebSocketError.ConnectionClosedPrematurely, "Send timed out.");
+        }
+    }
 
     internal async Task RenderAndSendAsync(string? historyUrl, bool replace, AuthInstruction? auth = null,
         bool publishOnly = false)

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -278,6 +278,13 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         return html;
     }
 
+    /// <summary>
+    ///     Whether a socket is currently attached — i.e. whether this session can be sent to at all. Tests
+    ///     wait on it to know the server has processed a <c>hello</c>, which is otherwise unobservable from
+    ///     the client side and races anything that then asks the session to send.
+    /// </summary>
+    internal bool IsAttached => _socket is not null;
+
     public void AttachSocket(WebSocket socket, CancellationToken ct)
     {
         _socketCt = ct;

--- a/src/Rask.Server/LiveSessionDrainService.cs
+++ b/src/Rask.Server/LiveSessionDrainService.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Hosting;
+
+namespace Rask.Server;
+
+/// <summary>
+///     Runs the shutdown drain: tells every connected client to reconnect now, then releases the sockets.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A hosted service rather than an <c>ApplicationStopping</c> callback, for one reason that only
+///         shows up under load. Those callbacks are synchronous, so driving the sends from one means
+///         blocking a thread until they finish — and a host shutting down while serving traffic has a busy
+///         thread pool, which is precisely when blocking on work that needs the pool to progress stops
+///         progressing. <c>StopAsync</c> is awaited by the host instead, with no thread held hostage.
+///     </para>
+///     <para>
+///         The ordering still works because sockets watch <see cref="LiveSessionStore.Drained" /> and not
+///         <c>ApplicationStopping</c>: by the time this runs, shutdown has begun but every socket is still
+///         open, which is exactly the window the drain needs.
+///     </para>
+/// </remarks>
+internal sealed class LiveSessionDrainService(LiveSessionStore store) : IHostedService
+{
+    public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    public Task StopAsync(CancellationToken cancellationToken) => store.DrainAsync();
+}

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -20,13 +20,35 @@ public sealed class LiveSessionStore : IAsyncDisposable
     // planned Broadcast pillar inherits, where the fan-out is a user-facing feature.
     private const int FanOutConcurrency = 32;
 
+    // How long the shutdown drain may take in total. Generous enough for a large fan-out, small enough to
+    // leave the rest of the shutdown budget intact: the scaffolded host allows 15s and `rask deploy`
+    // SIGKILLs 20s after SIGTERM, and what runs after this — disposing every session, checkpointing the
+    // WAL, flushing a Litestream replica — is the part that loses data if it is cut short.
+    private static readonly TimeSpan DrainTimeout = TimeSpan.FromSeconds(2);
+
     private readonly ConcurrentDictionary<string, LiveSession> _sessions = new();
     private readonly CancellationToken _stopping;
+
+    // Cancelled once the shutdown drain has finished (or given up). Sockets abort on THIS, not on
+    // ApplicationStopping: the drain has to reach clients while their sockets are still alive, and
+    // CancellationToken callback order is not guaranteed, so registering the aborts on the same token the
+    // drain runs from would be a coin flip. Also cancelled by DisposeAsync so a host with no lifetime
+    // (tests, a hand-rolled host) still tears its sockets down.
+    private readonly CancellationTokenSource _drained = new();
+
+    /// <summary>
+    ///     Cancelled when connected sockets should stop. See <see cref="_drained" /> for why this exists
+    ///     rather than the sockets simply watching <c>ApplicationStopping</c>.
+    /// </summary>
+    public CancellationToken Drained => _drained.Token;
 
     // Atomic count of live + in-flight sessions, used by the hard capacity reservation in
     // TryCreate. Incremented BEFORE the component tree is built and decremented on removal (or
     // on a failed build), so a concurrent GET burst can never exceed MaxSessions.
     private int _liveCount;
+
+    // 1 once DisposeAsync has run. See DisposeAsync for why it must be once-only.
+    private int _disposed;
 
     public LiveSessionStore(
         IServiceScopeFactory scopeFactory,
@@ -86,7 +108,20 @@ public sealed class LiveSessionStore : IAsyncDisposable
 
     public async ValueTask DisposeAsync()
     {
+        // Runs once. The store is a DI singleton, so the container disposes it — and a host or a test that
+        // disposes it too would otherwise reach a Cancel() on an already-disposed token source.
+        if (Interlocked.Exchange(ref _disposed, 1) == 1)
+        {
+            return;
+        }
+
         CancelAllPending();
+
+        // Backstop for a host that never raised ApplicationStopping — a test server, or one built without
+        // an IHostApplicationLifetime. Sockets watch this token, so leaving it uncancelled would leave
+        // their receive loops waiting on a store that no longer exists.
+        _drained.Cancel();
+
         foreach (var key in _sessions.Keys.ToArray())
         {
             if (Detach(key) is { } session)
@@ -94,6 +129,8 @@ public sealed class LiveSessionStore : IAsyncDisposable
                 await session.DisposeAsync().ConfigureAwait(false);
             }
         }
+
+        _drained.Dispose();
     }
 
     // The single removal point all three paths (Remove / RemoveAsync / DisposeAsync) funnel through:
@@ -110,6 +147,57 @@ public sealed class LiveSessionStore : IAsyncDisposable
         }
 
         return null;
+    }
+
+    /// <summary>
+    ///     Tells every connected client to reconnect now, then releases the sockets.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Without this, a client discovers its host is gone only when the socket drops, and then walks
+    ///         a backoff ladder — up to five seconds of a frozen page — before trying the replacement that
+    ///         has already been serving the whole time. During a <c>rask deploy</c> the new container is
+    ///         live and the proxy is pointed at it before the old one is stopped, so a client told to
+    ///         reconnect immediately lands on the new host and (with a resume record) gets its page rebuilt
+    ///         with no visible interruption at all.
+    ///     </para>
+    ///     <para>
+    ///         Awaited by <see cref="LiveSessionDrainService" /> rather than run from an
+    ///         <c>ApplicationStopping</c> callback. Those callbacks are synchronous, so reaching this from
+    ///         one meant blocking a thread on the sends — and a host shutting down under load has a busy
+    ///         thread pool, which is exactly when blocking on work that needs the pool to make progress
+    ///         stops making progress. A hosted service's <c>StopAsync</c> is awaited properly and still
+    ///         runs while the sockets are alive, because they now watch <see cref="Drained" />.
+    ///     </para>
+    ///     <para>
+    ///         Bounded twice over — by <see cref="DrainTimeout" /> here and per-send by <c>SendTimeout</c>
+    ///         — because everything that follows (disposing sessions, the WAL checkpoint, a Litestream
+    ///         flush) is what actually loses data if the shutdown budget runs out.
+    ///     </para>
+    /// </remarks>
+    internal async Task DrainAsync()
+    {
+        try
+        {
+            if (!_sessions.IsEmpty)
+            {
+                await BroadcastAsync(LivePayload.DrainFrame).WaitAsync(DrainTimeout).ConfigureAwait(false);
+            }
+        }
+        catch (TimeoutException)
+        {
+            // Someone did not take their frame in time. Their loss is a reload; everyone else already has
+            // theirs, and the rest of the shutdown budget belongs to the database now.
+        }
+        catch
+        {
+            // A faulted broadcast must never be the reason a host fails to shut down cleanly.
+        }
+        finally
+        {
+            // Whatever happened above, the sockets go now — they are waiting on this.
+            _drained.Cancel();
+        }
     }
 
     private void CancelAllPending()

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -14,6 +14,12 @@ public sealed class LiveSessionStore : IAsyncDisposable
     private readonly RaskMetrics? _metrics;
     private readonly ConcurrentDictionary<string, CancellationTokenSource> _pendingRemovals = new();
     private readonly IServiceScopeFactory _scopeFactory;
+    // How many sessions a whole-store fan-out touches at once. Bounded so a host with thousands of
+    // sessions doesn't hand the thread pool thousands of simultaneous socket writes; large enough that a
+    // handful of slow clients can't dominate. Both fan-outs are dev-time today, but this is the code the
+    // planned Broadcast pillar inherits, where the fan-out is a user-facing feature.
+    private const int FanOutConcurrency = 32;
+
     private readonly ConcurrentDictionary<string, LiveSession> _sessions = new();
     private readonly CancellationToken _stopping;
 
@@ -319,18 +325,25 @@ public sealed class LiveSessionStore : IAsyncDisposable
             return;
         }
 
-        foreach (var session in _sessions.Values)
-        {
-            try
+        // Bounded-concurrent for the same reason as BroadcastAsync: sequentially, one session stuck on a
+        // send holds up every session behind it. Rendering distinct sessions on distinct threads is not a
+        // new property — independent handler dispatches already do it — because each session serialises
+        // itself on its own render lock and the render walk's ambient scopes are thread-static.
+        await Parallel.ForEachAsync(
+            _sessions.Values,
+            new ParallelOptions { MaxDegreeOfParallelism = FanOutConcurrency },
+            async (session, _) =>
             {
-                Component.MarkSubtreeDirtyForHotReload(session.View);
-                await session.View.StateHasChangedAsync().ConfigureAwait(false);
-            }
-            catch
-            {
-                // One bad tree must not stop the rest — matches RerenderAllForHotReloadAsync.
-            }
-        }
+                try
+                {
+                    Component.MarkSubtreeDirtyForHotReload(session.View);
+                    await session.View.StateHasChangedAsync().ConfigureAwait(false);
+                }
+                catch
+                {
+                    // One bad tree must not stop the rest — matches RerenderAllForHotReloadAsync.
+                }
+            }).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -346,16 +359,24 @@ public sealed class LiveSessionStore : IAsyncDisposable
             return;
         }
 
-        foreach (var session in _sessions.Values)
-        {
-            try
+        // Concurrently, with a bounded degree. Sequentially, the cost of a broadcast is the SUM of every
+        // session's send rather than the slowest one — and each of those sends waits on that session's
+        // render lock behind whatever frame is already in flight. One session on a stalled link would
+        // hold up delivery to everyone behind it in the dictionary's enumeration order. The bound keeps a
+        // large fan-out from saturating the pool; a session whose send faults is skipped, not propagated.
+        await Parallel.ForEachAsync(
+            _sessions.Values,
+            new ParallelOptions { MaxDegreeOfParallelism = FanOutConcurrency },
+            async (session, _) =>
             {
-                await session.SendOutOfBandAsync(payload).ConfigureAwait(false);
-            }
-            catch
-            {
-                // A closed/faulted socket must not stop the broadcast.
-            }
-        }
+                try
+                {
+                    await session.SendOutOfBandAsync(payload).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // A closed/faulted socket must not stop the broadcast.
+                }
+            }).ConfigureAwait(false);
     }
 }

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -156,6 +156,9 @@ public static class RaskEndpointExtensions
             sp.GetService<RaskMetrics>())
         { MaxSessions = maxSessions, DiffMode = diffMode });
         services.AddSingleton<RaskLiveMarker>();
+        // Drains connected clients on shutdown so a deploy doesn't leave them staring at a frozen page
+        // while they back off from a host that announced its own departure. See LiveSessionDrainService.
+        services.AddHostedService<LiveSessionDrainService>();
         services.AddScoped<RouteState>();
         services.AddScoped<Navigator>();
         // Transient user messages / toasts (a flash-message pattern). Scoped = one queue per session, so a
@@ -422,7 +425,6 @@ public static class RaskEndpointExtensions
         endpoints.Map(pathBase + WebSocketPath, (RequestDelegate)(async ctx =>
             {
                 var store = ctx.RequestServices.GetRequiredService<LiveSessionStore>();
-                var lifetime = ctx.RequestServices.GetRequiredService<IHostApplicationLifetime>();
                 // Resolve the per-host safety limits once per connection (not per frame) — the receive
                 // loop reads them via instance fields on the hot path.
                 var limits = ctx.RequestServices.GetRequiredService<RaskServerLimits>();
@@ -454,9 +456,14 @@ public static class RaskEndpointExtensions
                 // frames carry the user's own rendered view, no cross-origin mixing).
                 using var ws = await ctx.WebSockets.AcceptWebSocketAsync(
                     new WebSocketAcceptContext { DangerousEnableCompression = true });
+                // store.Drained, NOT lifetime.ApplicationStopping. The shutdown drain has to reach clients
+                // while their sockets are still usable, so the socket's lifetime is tied to the point the
+                // drain FINISHES rather than the point shutdown begins. The store cancels it either way —
+                // after the broadcast, after the timeout, or from its own disposal — so a socket can never
+                // outlive the host by waiting on a token nobody trips.
                 using var linked = CancellationTokenSource.CreateLinkedTokenSource(
-                    ctx.RequestAborted, lifetime.ApplicationStopping);
-                await RunSocketLoop(ws, store, limits, wsUser, linked.Token, lifetime.ApplicationStopping);
+                    ctx.RequestAborted, store.Drained);
+                await RunSocketLoop(ws, store, limits, wsUser, linked.Token, store.Drained);
             }));
 
         var script = LoadEmbeddedScript();
@@ -596,9 +603,11 @@ public static class RaskEndpointExtensions
     }
 
     private static async Task RunSocketLoop(WebSocket ws, LiveSessionStore store, RaskServerLimits limits,
-        ClaimsPrincipal wsUser, CancellationToken ct, CancellationToken stopping)
+        ClaimsPrincipal wsUser, CancellationToken ct, CancellationToken drained)
     {
-        using var abortReg = stopping.Register(() =>
+        // Fires once the shutdown drain has finished, not when shutdown began — so a client gets its
+        // "reconnect now" frame before its socket is pulled out from under it. See LiveSessionStore.Drained.
+        using var abortReg = drained.Register(() =>
         {
             try { ws.Abort(); }
             catch { }

--- a/src/Rask.Server/RaskServerLimits.cs
+++ b/src/Rask.Server/RaskServerLimits.cs
@@ -36,6 +36,9 @@ internal sealed class RaskServerLimits
     /// <summary>Aggregate queued cloned-payload bytes before the backpressure breaker closes the socket. 0 = off.</summary>
     public long MaxPendingHandlerBytes { get; init; }
 
+    /// <summary>How long one outbound frame may take before the socket is aborted. Zero = off.</summary>
+    public TimeSpan SendTimeout { get; init; } = TimeSpan.FromSeconds(30);
+
     /// <summary>Projects a validated <see cref="RaskServerOptions" /> into the per-host limit snapshot.</summary>
     public static RaskServerLimits From(RaskServerOptions o) => new()
     {
@@ -47,5 +50,6 @@ internal sealed class RaskServerLimits
         IdleSocketTimeout = o.IdleSocketTimeout,
         HandlerTimeout = o.HandlerTimeout,
         MaxPendingHandlerBytes = o.MaxPendingHandlerBytes,
+        SendTimeout = o.SendTimeout,
     };
 }

--- a/src/Rask.Server/RaskServerOptions.cs
+++ b/src/Rask.Server/RaskServerOptions.cs
@@ -96,6 +96,30 @@ public sealed class RaskServerOptions
     public long MaxPendingHandlerBytes { get; set; }
 
     /// <summary>
+    ///     How long a single outbound frame may take before the socket is aborted. Default 30 s;
+    ///     <c>TimeSpan.Zero</c> disables the cap.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         <c>WebSocket.SendAsync</c> completes when the frame reaches the transport, not when the
+    ///         client reads it — so a client that simply stops reading fills the send buffer and the send
+    ///         never returns. Sends happen under the session's render lock, which also guards its teardown,
+    ///         so without this one unresponsive client pins its own session indefinitely: no further
+    ///         renders, and a <c>Dispose</c> that cannot complete.
+    ///     </para>
+    ///     <para>
+    ///         On timeout the socket is aborted rather than the session discarded. The session survives for
+    ///         <see cref="SessionGracePeriod" /> exactly as it would after any other drop, so a client on a
+    ///         briefly-stalled link reconnects to the page it had.
+    ///     </para>
+    ///     <para>
+    ///         The default is deliberately generous: this is a stuck-connection backstop, not a latency
+    ///         budget. A slow mobile link should never trip it.
+    ///     </para>
+    /// </remarks>
+    public TimeSpan SendTimeout { get; set; } = TimeSpan.FromSeconds(30);
+
+    /// <summary>
     ///     Throws <see cref="ArgumentOutOfRangeException" /> if any value is out of range. Called by
     ///     <c>AddRask</c> after the caller's <c>configureServer</c> runs, so a bad value (a negative
     ///     grace period that would crash <c>Task.Delay</c> and leak the session, a non-positive
@@ -157,6 +181,13 @@ public sealed class RaskServerOptions
             throw new ArgumentOutOfRangeException(
                 nameof(MaxPendingHandlerBytes), MaxPendingHandlerBytes,
                 "MaxPendingHandlerBytes must be >= 0 (0 disables the cap).");
+        }
+
+        if (SendTimeout < TimeSpan.Zero)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(SendTimeout), SendTimeout,
+                "SendTimeout must be >= TimeSpan.Zero (Zero disables the timeout).");
         }
     }
 }

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -136,6 +136,9 @@
     const HOT_RELOAD_PILL_MS = 1200;
     let overlayTimer = null;
     let sessionExpired = false;
+    // Set by a "drain" frame: the host announced its own shutdown, so the drop that follows is expected
+    // and the replacement is already up. Makes the next reconnect immediate instead of backed off.
+    let draining = false;
 
     function setOverlayMessage(text) {
         if (overlayMsg) overlayMsg.textContent = text;
@@ -196,6 +199,15 @@
                 if (devMode && data.status === "applied") showHotReloadPill();
                 return;
             }
+            // The host is shutting down and told us so while our socket still works. During a deploy the
+            // replacement is already serving and the proxy already points at it, so reconnecting NOW
+            // lands there — instead of discovering the drop on our own and sitting out up to five
+            // seconds of backoff first, with the page frozen, while a perfectly good host waits.
+            // Carries no html: it must not fall through to applyFullReply.
+            if (data.type === "drain") {
+                draining = true;
+                return;
+            }
             // Handler ack: resolve the slow-link pending bar. Handled synchronously here
             // (not inside _renderQueue) so a CSS-gated deferred body swap can't keep the
             // bar up after the round-trip has actually completed.
@@ -233,8 +245,17 @@
             overlayTimer = setTimeout(showOverlay, OVERLAY_GRACE_MS);
         }
         const delays = [500, 1000, 2000, 4000, 5000];
-        const delay = delays[Math.min(attempt, delays.length - 1)];
-        attempt++;
+        // A drop we were WARNED about is not a failure to back off from: the host told us it was going
+        // away, which during a deploy means the replacement is already serving behind the same address.
+        // Reconnect on the next tick and don't count the attempt, so a genuine failure to reach the new
+        // host still escalates normally from zero. One-shot — cleared here so only the drop the host
+        // announced skips the wait, not every drop after it.
+        const delay = draining ? 0 : delays[Math.min(attempt, delays.length - 1)];
+        if (draining) {
+            draining = false;
+        } else {
+            attempt++;
+        }
         reconnectTimer = setTimeout(() => {
             reconnectTimer = null;
             connect();

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -28,6 +28,13 @@ internal sealed class RaskTestHost : IDisposable
 
     public Uri WebSocketUri => new(new Uri(Server.BaseAddress, "/rask/ws").ToString().Replace("http://", "ws://"));
 
+    /// <summary>
+    ///     Stops the host the way a SIGTERM does — running hosted services' <c>StopAsync</c>, which is
+    ///     where the live-session drain lives. Signalling <c>IHostApplicationLifetime.StopApplication</c>
+    ///     alone is not equivalent: nothing awaits the hosted services, so the drain never runs.
+    /// </summary>
+    public Task StopAsync() => _app.StopAsync();
+
     public void Dispose()
     {
         Http.Dispose();

--- a/tests/Rask.Server.Tests/Live/SendTimeoutTests.cs
+++ b/tests/Rask.Server.Tests/Live/SendTimeoutTests.cs
@@ -1,0 +1,168 @@
+using System.Diagnostics;
+using System.Net.WebSockets;
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Components;
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+/// A client that stops reading must not be able to pin its session forever.
+/// </summary>
+/// <remarks>
+/// <c>WebSocket.SendAsync</c> completes when the frame reaches the transport, not when the client reads
+/// it, so a client that simply stops reading fills the send buffer and the send never returns. Every send
+/// happens under the session's render lock, which also guards its teardown — so without a bound, one
+/// unresponsive client costs its session every future render and a <c>Dispose</c> that can never take the
+/// lock. The stalling socket below is that client, made deterministic.
+/// </remarks>
+public sealed class SendTimeoutTests
+{
+    /// <summary>An open socket whose sends never complete until the test says so.</summary>
+    private sealed class StallingWebSocket : WebSocket
+    {
+        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public int Aborted { get; private set; }
+
+        public override WebSocketState State { get; } = WebSocketState.Open;
+        public override WebSocketCloseStatus? CloseStatus => null;
+        public override string? CloseStatusDescription => null;
+        public override string? SubProtocol => null;
+
+        public void Release() => _released.TrySetResult();
+
+        public override async Task SendAsync(
+            ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
+            await _released.Task.WaitAsync(ct);
+
+        public override async ValueTask SendAsync(
+            ReadOnlyMemory<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
+            await _released.Task.WaitAsync(ct);
+
+        public override void Abort()
+        {
+            Aborted++;
+            _released.TrySetCanceled();
+        }
+
+        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken ct) =>
+            throw new NotSupportedException("This socket only ever sends.");
+
+        public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+        public override Task CloseOutputAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+        public override void Dispose() { }
+    }
+
+    private sealed class Shell : Component
+    {
+        protected override Component? Render() =>
+            [Doctype(), new Html()[new Head(), new Body()[new H1()["hi"]]]];
+    }
+
+    private static LiveSessionStore NewStore(TimeSpan sendTimeout)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton(new RaskServerLimits { SendTimeout = sendTimeout });
+        var sp = services.BuildServiceProvider();
+        return new LiveSessionStore(sp.GetRequiredService<IServiceScopeFactory>());
+    }
+
+    [Fact]
+    public async Task A_send_that_never_completes_is_abandoned_and_the_socket_aborted()
+    {
+        var store = NewStore(TimeSpan.FromMilliseconds(200));
+        var session = store.Create(_ => new Shell());
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        var started = Stopwatch.GetTimestamp();
+        await Assert.ThrowsAsync<WebSocketException>(
+            () => session.SendOutOfBandAsync("hello"u8.ToArray()));
+
+        Assert.True(Stopwatch.GetElapsedTime(started) < TimeSpan.FromSeconds(5), "the send must not have waited out the test");
+        Assert.Equal(1, socket.Aborted);
+    }
+
+    /// <summary>
+    /// The point of the abort: the render lock comes back. Without it the session is not merely slow, it is
+    /// permanently wedged — nothing can render and nothing can dispose it.
+    /// </summary>
+    [Fact]
+    public async Task The_session_is_usable_again_after_a_send_times_out()
+    {
+        var store = NewStore(TimeSpan.FromMilliseconds(200));
+        var session = store.Create(_ => new Shell());
+        session.AttachSocket(new StallingWebSocket(), CancellationToken.None);
+
+        await Assert.ThrowsAsync<WebSocketException>(
+            () => session.SendOutOfBandAsync("hello"u8.ToArray()));
+
+        // Dispose takes the same lock the wedged send was holding. If it returns, the lock was released.
+        var disposed = Task.Run(() => session.Dispose());
+        Assert.True(await Task.WhenAny(disposed, Task.Delay(TimeSpan.FromSeconds(5))) == disposed,
+            "Dispose must not block on a lock the timed-out send still holds");
+        await disposed;
+    }
+
+    /// <summary>A send that completes normally must be untouched by any of this.</summary>
+    [Fact]
+    public async Task A_healthy_send_is_unaffected()
+    {
+        var store = NewStore(TimeSpan.FromSeconds(30));
+        var session = store.Create(_ => new Shell());
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        socket.Release();
+        await session.SendOutOfBandAsync("hello"u8.ToArray());
+
+        Assert.Equal(0, socket.Aborted);
+    }
+
+    /// <summary>Zero restores the prior unbounded behaviour for anyone who needs it back.</summary>
+    [Fact]
+    public async Task A_zero_timeout_does_not_arm_the_bound()
+    {
+        var store = NewStore(TimeSpan.Zero);
+        var session = store.Create(_ => new Shell());
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        var send = session.SendOutOfBandAsync("hello"u8.ToArray());
+        var finished = await Task.WhenAny(send, Task.Delay(TimeSpan.FromMilliseconds(400)));
+
+        Assert.NotSame(send, finished);
+        Assert.Equal(0, socket.Aborted);
+
+        socket.Release();
+        await send;
+    }
+
+    /// <summary>
+    /// One stalled session must not hold up delivery to the rest. Sequentially this took the sum of every
+    /// session's timeout; concurrently it takes roughly one.
+    /// </summary>
+    [Fact]
+    public async Task A_broadcast_is_not_held_up_by_one_stalled_session()
+    {
+        var store = NewStore(TimeSpan.FromMilliseconds(300));
+        var sockets = new List<StallingWebSocket>();
+        for (var i = 0; i < 6; i++)
+        {
+            var session = store.Create(_ => new Shell());
+            var socket = new StallingWebSocket();
+            session.AttachSocket(socket, CancellationToken.None);
+            sockets.Add(socket);
+        }
+
+        var started = Stopwatch.GetTimestamp();
+        await store.BroadcastAsync("hello"u8.ToArray());
+        var elapsed = Stopwatch.GetElapsedTime(started);
+
+        // Six sessions × 300 ms is 1.8 s sequentially. Concurrently it is one timeout plus scheduling.
+        Assert.True(elapsed < TimeSpan.FromSeconds(1),
+            $"broadcast took {elapsed.TotalMilliseconds:F0} ms — it is serialising on the stalled sessions");
+        Assert.All(sockets, s => Assert.Equal(1, s.Aborted));
+    }
+}

--- a/tests/Rask.Server.Tests/Live/ShutdownDrainTests.cs
+++ b/tests/Rask.Server.Tests/Live/ShutdownDrainTests.cs
@@ -1,0 +1,116 @@
+using System.Diagnostics;
+using System.Net.WebSockets;
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Live;
+
+/// <summary>
+/// On shutdown the host tells its clients to reconnect, while their sockets still work.
+/// </summary>
+/// <remarks>
+/// Without it a client learns its host is gone only when the socket drops, and then walks a backoff
+/// ladder — up to five seconds of a frozen page — before trying the replacement that has been serving the
+/// whole time. During a <c>rask deploy</c> the proxy is switched to the new container <em>before</em> the
+/// old one is stopped, so the reconnect this frame triggers lands on a host that is already up.
+/// </remarks>
+public sealed class ShutdownDrainTests
+{
+    private sealed class Shell : Component
+    {
+        protected override Component? Render() =>
+            [Doctype(), new Html()[new Head(), new Body()[new H1()["hi"]]]];
+    }
+
+    private static async Task<(RaskTestHost Host, WebSocket Ws)> ConnectAsync()
+    {
+        var host = RaskTestHost.Create<Shell>();
+        var html = await host.Http.GetStringAsync("/start");
+        var sessionId = MarkupAssert.SessionId(html);
+        var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        // Wait for the server to actually process the hello. Sending it only queues bytes; the attach
+        // happens on the server's receive loop, and a session with no socket attached cannot be sent to —
+        // so without this a loaded machine can shut the host down first and legitimately drain nobody.
+        var session = host.Store.Get(sessionId)!;
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+        while (!session.IsAttached && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(session.IsAttached, "the socket never attached, so there was nothing to drain");
+        return (host, ws);
+    }
+
+    [Fact]
+    public async Task A_connected_client_is_told_to_reconnect_before_its_socket_goes()
+    {
+        var (host, ws) = await ConnectAsync();
+        using var _ = host;
+        using var _2 = ws;
+
+        // Receive FIRST. A browser sits in a receive loop; a test that stops the host and only then
+        // starts reading is racing the socket teardown that follows the drain, and under load loses.
+        var receive = ws.TryReceiveTextAsync(TimeSpan.FromSeconds(10));
+        await host.StopAsync();
+
+        var frame = await receive;
+
+        Assert.NotNull(frame);
+        Assert.Contains("\"type\":\"drain\"", frame, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The drain must not become a way to hang shutdown. Everything after it — disposing sessions, the WAL
+    /// checkpoint, a Litestream flush — is what actually loses data if the budget runs out, and
+    /// `rask deploy` SIGKILLs 20 s after SIGTERM regardless.
+    /// </summary>
+    [Fact]
+    public async Task Shutdown_is_not_delayed_by_the_drain()
+    {
+        var (host, ws) = await ConnectAsync();
+        using var _ = host;
+        using var _2 = ws;
+
+        var started = Stopwatch.GetTimestamp();
+        await host.StopAsync();
+        var elapsed = Stopwatch.GetElapsedTime(started);
+
+        Assert.True(elapsed < TimeSpan.FromSeconds(5),
+            $"the drain took {elapsed.TotalMilliseconds:F0} ms of the shutdown budget");
+    }
+
+    /// <summary>
+    /// The ordering the whole design turns on. Sockets are aborted on a token the store cancels once the
+    /// drain has finished — not on ApplicationStopping, whose callback order is not guaranteed. If that
+    /// regressed, the socket would be gone before the frame reached it and this would time out.
+    /// </summary>
+    [Fact]
+    public async Task The_socket_survives_long_enough_to_carry_the_frame()
+    {
+        var (host, ws) = await ConnectAsync();
+        using var _ = host;
+        using var _2 = ws;
+
+        var receive = ws.TryReceiveTextAsync(TimeSpan.FromSeconds(10));
+        await host.StopAsync();
+
+        var frame = await receive;
+        Assert.NotNull(frame);
+        Assert.Contains("\"drain\"", frame, StringComparison.Ordinal);
+    }
+
+    /// <summary>A host with nobody connected must not pay for, or trip over, the drain.</summary>
+    [Fact]
+    public async Task An_idle_host_shuts_down_without_incident()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+
+        await host.StopAsync();
+
+        Assert.Equal(0, host.Store.Count);
+    }
+}


### PR DESCRIPTION
⚠️ **Retargeted to `main`** (was `worktree-bound-outbound-send`), so this survives #564's branch being deleted on merge.

**It still contains #564's commit, and should** — the drain broadcast runs during shutdown against a hard SIGKILL deadline, and is only safe because of that PR's bounded send and concurrent fan-out. Without them one slow client would consume the whole shutdown budget and take the SQLite checkpoint with it. So the diff below is two commits; [the drain itself is the top one](https://github.com/pal-tamas/rask/commit/22f4d8b6).

Merge order either way works, but they differ:
- **#564 first** (squash) — this branch then needs `git rebase --onto <squashed-sha> 97dcae21` and a force-push to drop the now-duplicated commit, since a squash rewrites the SHA and git won't see it as merged.
- **This one first** — it carries both changes, and #564 becomes an empty PR to close.

Completes PR 4 of the server-host scaling plan.

## The gap

A deploy swaps containers under people actively using the app. The proxy is pointed at the new container **before** the old one is stopped, so the replacement is already serving by the time anything goes away — but a browser has no way to know that. Left to itself it discovers the drop when its socket dies, then waits out a reconnect backoff (up to five seconds, page frozen) before trying an address that has been healthy the whole time.

The departing host now says goodbye: on `SIGTERM` it sends every connected client a `drain` frame **while their sockets still work**, and the client reconnects on the next tick instead of backing off. Paired with #559, a deploy stops being visible at all.

## The ordering is the whole design

Sockets are now released when the drain **finishes**, not when shutdown begins — they watch a store-owned token the drain cancels, rather than `ApplicationStopping`. `CancellationToken` callback order isn't guaranteed, so registering the aborts on the same token the drain runs from would have been a coin flip between delivering the frame and destroying the socket first. Linking the session's send token to the same thing is also what keeps it usable during the drain, which removed the need for a separate send path I'd expected to write.

## A bug my own tests caught

The drain first ran from an `ApplicationStopping` callback. Those are synchronous, so it blocked a thread on the sends — and a host shutting down under load has a busy thread pool, which is exactly when blocking on work that needs the pool stops making progress. It passed in isolation and **failed only under the full parallel suite**. It's now a hosted service: awaited by the host, running while sockets are still alive, holding no thread.

Two further test-shape bugs from the same signal, both real rather than flakes: the tests read *after* `StopAsync` returned (racing the teardown the drain precedes — a browser sits in a receive loop, so they now receive first), and they never waited for the server to actually attach the socket, so under load shutdown could legitimately drain nobody.

## Bounds

Two seconds overall, plus #564's per-send timeout. Everything after the drain — disposing sessions, the WAL checkpoint, a Litestream flush — keeps the rest of the shutdown budget, because that's the part that loses data if it runs out. A client that misses its frame simply reconnects the old way.

## No `--drain` flag

The plan called for `rask deploy --drain <seconds>`. I dropped it: the deploy already stops the old container gracefully (`docker stop -t 20`) **after** reloading the proxy, so the window exists. A flag would have added a knob that changed nothing.

## Also fixed

A double-dispose this surfaced: the store is a DI singleton, so a host or test disposing it *as well as* the container reached `Cancel()` on an already-disposed token source. `DisposeAsync` now runs once.

## Testing

Four tests: the frame arrives before the socket goes, the socket survives long enough to carry it (the ordering regression guard), shutdown isn't delayed, and an idle host doesn't trip over the drain. Full local gate green **twice consecutively** — worth stating given the first two "green" runs on this branch weren't.
