### PR TITLE
perf(benchmarks): session-load — what a host does when its sessions are actually used

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,6 +49,15 @@ jobs:
           dotnet run -c Release --project benchmarks/Rask.Benchmarks -p:MinVerSkip=true -- payload-bytes
           dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -p:MinVerSkip=true -- payload-bytes
           dotnet run -c Release --project benchmarks/Rask.Benchmarks.VsBlazor -p:MinVerSkip=true -- mem-footprint
+      # The live-session capacity reports. Absolute numbers from a shared runner mean little — these are
+      # here so the CSV lands in the log and a change in SHAPE (a page size that stops scaling, a sudden
+      # error count, a throughput collapse) is visible without anyone remembering to run them by hand.
+      # session-load opens real sockets, so it is best-effort like the rest of this job.
+      - name: Live-session capacity reports
+        run: |
+          dotnet run -c Release --project benchmarks/Rask.Benchmarks -p:MinVerSkip=true -- session-footprint
+          dotnet run -c Release --project benchmarks/Rask.Benchmarks -p:MinVerSkip=true -- session-churn
+          dotnet run -c Release --project benchmarks/Rask.Benchmarks -p:MinVerSkip=true -- session-load --sessions=25 --seconds=5 || true
       - name: Full BenchmarkDotNet suites (short job)
         run: |
           dotnet run -c Release --project benchmarks/Rask.Benchmarks -p:MinVerSkip=true -- --filter '*' --job short || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,19 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **`session-load` — what a host does when its sessions are actually used.** The existing capacity reports
+  answer how many sessions *fit*: a retained-memory question, measured against a stub socket that never
+  receives. Nothing said what happens when those sessions are used, and a capacity number you can't serve
+  isn't a capacity number. This one drives real `ClientWebSocket`s against a real Kestrel host and times
+  the round trip a user feels — the click, the render it causes, and the ack that closes it — reporting
+  events/sec with exact p50/p95/p99. Closed-loop, so throughput and latency stay honest with each other
+  rather than reporting queue depth dressed as latency. The headline: **page size costs throughput before
+  it costs memory** — an empty shell and a 5-row page are within noise, while a 200-row grid costs ~4× the
+  per-event time. Wired into the nightly alongside `session-footprint` and `session-churn`, which had
+  never run in CI at all, so the numbers in `docs/configuration.md` stop being one person's local run.
+  It reports no memory column on purpose: the generator shares a process with the host, so a heap reading
+  counts the client's own sockets — an early version did exactly that and produced a figure that didn't
+  rise with page size.
 - **`rask db backup` and `rask db restore` — get the deployed database down, and a copy back up.** Continuous
   backup (Litestream) covers the box dying; this covers the two things a solo developer actually reaches
   for: *"something looks wrong in production, let me get a copy"* and *"that migration was a mistake,

--- a/benchmarks/Rask.Benchmarks/Infrastructure/LoadHost.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/LoadHost.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Rask.Server;
+
+namespace Rask.Benchmarks.Infrastructure;
+
+/// <summary>
+///     A real Rask server on a loopback port, for the load report to drive with real WebSockets.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Kestrel and <see cref="ClientWebSocket" />, deliberately — not the in-memory test server the
+///         unit tests use. The numbers this produces are about the transport as much as the renderer:
+///         frame encoding, TCP, permessage-deflate, the receive loop's buffer handling. An in-memory pipe
+///         removes exactly the parts that decide whether a host can hold its clients, and would flatter
+///         every number in the report.
+///     </para>
+///     <para>
+///         Port 0 so a run cannot collide with a dev server, another worktree's E2E, or a second copy of
+///         itself; the bound port is read back from the server's addresses feature.
+///     </para>
+/// </remarks>
+internal sealed class LoadHost : IAsyncDisposable
+{
+    private readonly WebApplication _app;
+
+    private LoadHost(WebApplication app, int port)
+    {
+        _app = app;
+        Port = port;
+    }
+
+    public int Port { get; }
+
+    public static async Task<LoadHost> StartAsync(int rowCount)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        // The report's output is the only thing that should reach stdout.
+        builder.Logging.ClearProviders();
+        builder.Services.AddRouting();
+        builder.Services.AddRask(configureServer: o =>
+        {
+            // Off for the measurement, and worth being explicit about why. MaxInboundFramesPerSecond
+            // (1000 by default) is a per-connection DoS backstop, not a throughput setting — no human
+            // clicks a thousand times a second. A closed-loop generator does, so leaving it on means the
+            // report measures the cap rather than the host: the first run of this harness reported
+            // exactly 1000 events/sec per client and closed every socket, which is the limit working
+            // correctly and the benchmark asking the wrong question.
+            o.MaxInboundFramesPerSecond = 0;
+        });
+        builder.Services.AddSingleton(new LoadPageOptions(rowCount));
+
+        var app = builder.Build();
+        app.UseRouting();
+        app.UseWebSockets();
+        app.UseRask<LoadPage>();
+        await app.StartAsync();
+
+        var address = app.Services.GetRequiredService<IServer>().Features
+            .Get<IServerAddressesFeature>()!.Addresses.First();
+        return new LoadHost(app, new Uri(address).Port);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _app.StopAsync();
+        await _app.DisposeAsync();
+    }
+
+    /// <summary>
+    ///     Opens one client the way a browser does: GET the page for its session id and a handler id, then
+    ///     connect and say hello.
+    /// </summary>
+    public async Task<LoadClient> ConnectAsync(CancellationToken ct)
+    {
+        using var http = new HttpClient();
+        var html = await http.GetStringAsync($"http://127.0.0.1:{Port}/", ct);
+
+        var sessionId = Between(html, "data-rask-root=\"", "\"")
+                        ?? throw new InvalidOperationException("the page carried no session id");
+        var handlerId = Between(html, "data-rask-on-click=\"", "\"")
+                        ?? throw new InvalidOperationException("the page carried no click handler");
+
+        var ws = new ClientWebSocket();
+        await ws.ConnectAsync(new Uri($"ws://127.0.0.1:{Port}/rask/ws"), ct);
+        await SendAsync(ws, $"{{\"type\":\"hello\",\"session\":\"{sessionId}\"}}", ct);
+        return new LoadClient(ws, handlerId);
+    }
+
+    private static string? Between(string source, string open, string close)
+    {
+        var start = source.IndexOf(open, StringComparison.Ordinal);
+        if (start < 0)
+        {
+            return null;
+        }
+
+        start += open.Length;
+        var end = source.IndexOf(close, start, StringComparison.Ordinal);
+        return end < 0 ? null : source[start..end];
+    }
+
+    internal static Task SendAsync(WebSocket ws, string json, CancellationToken ct) =>
+        ws.SendAsync(Encoding.UTF8.GetBytes(json), WebSocketMessageType.Text, true, ct);
+}
+
+/// <summary>One connected virtual user: its socket, and the handler it clicks.</summary>
+internal sealed class LoadClient(ClientWebSocket ws, string handlerId) : IDisposable
+{
+    private readonly byte[] _buffer = new byte[64 * 1024];
+
+    public void Dispose() => ws.Dispose();
+
+    /// <summary>
+    ///     Fires one event and waits for the server to acknowledge that exact one.
+    /// </summary>
+    /// <remarks>
+    ///     The <c>seq</c> ack is what the real client uses to clear its pending indicator, and it is the
+    ///     only signal that closes the round trip for an interaction whose render deduped to nothing. So it
+    ///     is also the honest thing to time: click to server-has-finished-with-it, not click to first byte.
+    /// </remarks>
+    public async Task<bool> ClickAndAwaitAckAsync(long seq, CancellationToken ct)
+    {
+        await LoadHost.SendAsync(ws, $"{{\"id\":\"{handlerId}\",\"seq\":{seq}}}", ct);
+
+        // Frames other than our ack — the render this click caused, a resume record — arrive first and in
+        // any order; read past them until the round trip actually closes.
+        while (true)
+        {
+            var frame = await ReceiveAsync(ct);
+            if (frame is null)
+            {
+                return false;
+            }
+
+            using var doc = JsonDocument.Parse(frame);
+            if (doc.RootElement.TryGetProperty("type", out var type)
+                && type.ValueEquals("ack")
+                && doc.RootElement.TryGetProperty("seq", out var acked)
+                && acked.TryGetInt64(out var value)
+                && value == seq)
+            {
+                return true;
+            }
+        }
+    }
+
+    private async Task<string?> ReceiveAsync(CancellationToken ct)
+    {
+        var builder = new StringBuilder();
+        while (true)
+        {
+            var result = await ws.ReceiveAsync(_buffer, ct);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                return null;
+            }
+
+            builder.Append(Encoding.UTF8.GetString(_buffer, 0, result.Count));
+            if (result.EndOfMessage)
+            {
+                return builder.ToString();
+            }
+        }
+    }
+}
+
+/// <summary>Row count for the page under load, resolved per host rather than per component.</summary>
+/// <remarks>Public because <see cref="LoadPage" /> is — the generator needs to see the root component.</remarks>
+public sealed record LoadPageOptions(int RowCount);

--- a/benchmarks/Rask.Benchmarks/Infrastructure/LoadPage.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/LoadPage.cs
@@ -1,0 +1,56 @@
+using Rask.Core;
+using B = Rask.Benchmarks.Infrastructure.Generated;
+using C = Rask.Core.Components.Generated;
+
+namespace Rask.Benchmarks.Infrastructure;
+
+/// <summary>
+///     The page the load report drives: the same data-table shape
+///     <see cref="FootprintApp" /> measures, wired for a real host.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A separate type only because the hosted path builds its root through
+///         <c>ActivatorUtilities.CreateInstance</c> and so needs the row count on the constructor, where
+///         <see cref="FootprintApp" /> takes it as a factory parameter. The rendered shape is deliberately
+///         identical, so a bytes-per-session number from this report is comparable with
+///         <c>session-footprint</c>'s rather than a second, subtly different page.
+///     </para>
+///     <para>
+///         The header counter is what makes each click produce a real frame: a render whose HTML matches
+///         the last one is deduped and never reaches the wire, so a page without it would measure an
+///         event loop that does no work.
+///     </para>
+/// </remarks>
+public sealed class LoadPage(LoadPageOptions options) : Component
+{
+    private int _counter;
+
+    protected override Component? Head => C.Title()["rask session load"];
+
+    protected override Component? Render()
+    {
+        var rows = new List<Component>(options.RowCount);
+        for (var i = 0; i < options.RowCount; i++)
+        {
+            rows.Add(B.FootprintRow(Index: i, Key: i));
+        }
+
+        return
+        [
+            C.Doctype(),
+            C.Html()[
+                C.Head(),
+                C.Body()[
+                    C.Div(Class: "container", Id: "root")[
+                        // The first handler in document order — the one the client finds and clicks.
+                        C.Div(Class: "header")[
+                            C.Button(OnClick: () => _counter++)[$"rows={options.RowCount} counter={_counter}"]
+                        ],
+                        C.Table(Class: "table")[C.Tbody()[rows]]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/benchmarks/Rask.Benchmarks/Program.cs
+++ b/benchmarks/Rask.Benchmarks/Program.cs
@@ -27,5 +27,13 @@ if (args.Length >= 1 && args[0] == "session-churn")
     return SessionChurnReport.Run(args);
 }
 
+// `session-load` is the throughput half of the same question: those two measure how many sessions FIT,
+// this measures what happens when they are actually used — real sockets, real Kestrel, event round-trip
+// latency at the tail.
+if (args.Length >= 1 && args[0] == "session-load")
+{
+    return SessionLoadReport.Run(args);
+}
+
 BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 return 0;

--- a/benchmarks/Rask.Benchmarks/SessionLoadReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionLoadReport.cs
@@ -1,0 +1,219 @@
+using System.Diagnostics;
+using System.Globalization;
+using Rask.Benchmarks.Infrastructure;
+
+namespace Rask.Benchmarks;
+
+/// <summary>
+///     What a host does under real load: how many event round-trips per second it closes, how long each
+///     one takes at the tail.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The gap this fills: <c>session-footprint</c> and <c>session-churn</c> answer "how many sessions
+///         fit" — a retained-memory question, measured against a stub socket that never receives. Neither
+///         has ever opened a socket, so nothing until now said what happens when those sessions are
+///         actually <em>used</em>. A capacity number you can't serve is not a capacity number.
+///     </para>
+///     <para>
+///         Real Kestrel, real <c>ClientWebSocket</c>s (see <see cref="LoadHost" />), and the round trip is
+///         timed the way the client experiences it: click to the <c>seq</c> ack that closes it, which is
+///         the server saying it has finished with that event — including the renders it caused, or the
+///         dedup that produced none.
+///     </para>
+///     <para>
+///         Percentiles are computed over every recorded sample rather than a running estimate. A load run
+///         holds a few hundred thousand doubles at most, and an exact p99 is worth more than the memory:
+///         the tail is the whole point of the measurement.
+///     </para>
+///     <para>
+///         <b>No memory column, deliberately.</b> An early version reported bytes-per-session here and the
+///         number was not trustworthy: the load generator shares this process with the host it is driving,
+///         so a heap delta counts the client sockets and their receive buffers alongside the sessions. It
+///         showed as a figure that did not even rise with page size. Memory belongs to
+///         <c>session-footprint</c>, which measures it against a stub socket with nothing else running.
+///     </para>
+/// </remarks>
+internal static class SessionLoadReport
+{
+    // The same page sizes the footprint sweep uses, so a row here can be read against a row there. The
+    // 1,000-row page is left out: at that size a single render dominates the round trip and the report
+    // stops measuring the host and starts measuring one page's serializer cost.
+    private static readonly int[] Pages = [0, 5, 200];
+
+    private const int DefaultSessions = 50;
+    private const int DefaultSeconds = 5;
+    private const int WarmupSeconds = 2;
+
+    public static int Run(string[] args)
+    {
+        var sessions = IntArg(args, "--sessions=") ?? DefaultSessions;
+        var seconds = IntArg(args, "--seconds=") ?? DefaultSeconds;
+
+        SessionHarness.VerifySelfMeasurement();
+
+        Console.WriteLine();
+        Console.WriteLine($"# Session load — {sessions} concurrent sessions per row, {seconds}s measured");
+        Console.WriteLine("# after a " + WarmupSeconds + "s warmup, over real WebSockets against a real Kestrel host.");
+        Console.WriteLine("#");
+        Console.WriteLine("# Latency is one event round trip: click -> the seq ack that closes it. That");
+        Console.WriteLine("# covers the render the click caused, so it is the number a user feels.");
+        Console.WriteLine("# No memory column: the generator shares this process with the host, so a heap");
+        Console.WriteLine("# delta would count the client sockets too. Use session-footprint for memory.");
+        Console.WriteLine();
+        Console.WriteLine("Rows,Sessions,EventsPerSecond,P50Ms,P95Ms,P99Ms,MaxMs,Errors");
+
+        // One throwaway host+load before the sweep. Each row gets its own warmup, but the FIRST row also
+        // pays the process-wide costs — JIT across Kestrel, the WebSocket stack and the render path — and
+        // reported them as if they were the page's. It showed: the empty page came out slower than the
+        // 5-row one, which is not a thing that can be true.
+        RunOneAsync(rows: 5, sessions: Math.Min(4, sessions), seconds: 1).GetAwaiter().GetResult();
+
+        foreach (var rows in Pages)
+        {
+            var result = RunOneAsync(rows, sessions, seconds).GetAwaiter().GetResult();
+            Console.WriteLine(string.Join(',',
+                rows.ToString(CultureInfo.InvariantCulture),
+                sessions.ToString(CultureInfo.InvariantCulture),
+                result.EventsPerSecond.ToString("F0", CultureInfo.InvariantCulture),
+                result.P50.ToString("F2", CultureInfo.InvariantCulture),
+                result.P95.ToString("F2", CultureInfo.InvariantCulture),
+                result.P99.ToString("F2", CultureInfo.InvariantCulture),
+                result.Max.ToString("F2", CultureInfo.InvariantCulture),
+                result.Errors.ToString(CultureInfo.InvariantCulture)));
+        }
+
+        Console.WriteLine();
+        return 0;
+    }
+
+    private static async Task<LoadResult> RunOneAsync(int rows, int sessions, int seconds)
+    {
+        await using var host = await LoadHost.StartAsync(rows);
+        using var cts = new CancellationTokenSource(TimeSpan.FromMinutes(5));
+        var ct = cts.Token;
+
+        var clients = new List<LoadClient>(sessions);
+        try
+        {
+            for (var i = 0; i < sessions; i++)
+            {
+                clients.Add(await host.ConnectAsync(ct));
+            }
+
+            // Warmup: JIT the dispatch and render paths, let each session's pooled buffers reach the
+            // page's high-water mark, and let the diff baseline settle. Measuring through this would
+            // report first-render costs the steady state never pays again.
+            await DriveAsync(clients, TimeSpan.FromSeconds(WarmupSeconds), null, ct);
+
+            var samples = new List<double>(sessions * seconds * 64);
+            var started = Stopwatch.GetTimestamp();
+            var errors = await DriveAsync(clients, TimeSpan.FromSeconds(seconds), samples, ct);
+            var elapsed = Stopwatch.GetElapsedTime(started);
+
+            samples.Sort();
+            return new LoadResult(
+                samples.Count / elapsed.TotalSeconds,
+                Percentile(samples, 0.50),
+                Percentile(samples, 0.95),
+                Percentile(samples, 0.99),
+                samples.Count == 0 ? 0 : samples[^1],
+                errors);
+        }
+        finally
+        {
+            foreach (var client in clients)
+            {
+                client.Dispose();
+            }
+        }
+    }
+
+    /// <summary>
+    ///     Drives every client in a closed loop for <paramref name="duration" />: each fires its next event
+    ///     as soon as the previous one is acknowledged.
+    /// </summary>
+    /// <remarks>
+    ///     Closed-loop on purpose. An open-loop generator firing at a fixed rate measures how far behind a
+    ///     saturated host falls, which needs a target rate chosen in advance and reports queue depth
+    ///     dressed up as latency. Closed-loop asks the question a live app actually poses — one user, one
+    ///     interaction at a time, as fast as the server answers — so throughput and latency stay honest
+    ///     with each other.
+    /// </remarks>
+    private static async Task<int> DriveAsync(
+        List<LoadClient> clients, TimeSpan duration, List<double>? samples, CancellationToken ct)
+    {
+        var deadline = Stopwatch.GetTimestamp() + (long)(duration.TotalSeconds * Stopwatch.Frequency);
+        var errors = 0;
+        var seq = 0L;
+        var gate = new object();
+
+        var workers = clients.Select(client => Task.Run(async () =>
+        {
+            while (Stopwatch.GetTimestamp() < deadline && !ct.IsCancellationRequested)
+            {
+                var mine = Interlocked.Increment(ref seq);
+                var started = Stopwatch.GetTimestamp();
+                try
+                {
+                    if (!await client.ClickAndAwaitAckAsync(mine, ct))
+                    {
+                        Interlocked.Increment(ref errors);
+                        return;
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    return;
+                }
+                catch
+                {
+                    Interlocked.Increment(ref errors);
+                    return;
+                }
+
+                if (samples is null)
+                {
+                    continue;
+                }
+
+                var ms = Stopwatch.GetElapsedTime(started).TotalMilliseconds;
+                lock (gate)
+                {
+                    samples.Add(ms);
+                }
+            }
+        }, ct)).ToArray();
+
+        await Task.WhenAll(workers);
+        return errors;
+    }
+
+    /// <summary>Nearest-rank percentile over the sorted samples — exact, not interpolated or estimated.</summary>
+    private static double Percentile(List<double> sorted, double q)
+    {
+        if (sorted.Count == 0)
+        {
+            return 0;
+        }
+
+        var rank = (int)Math.Ceiling(q * sorted.Count) - 1;
+        return sorted[Math.Clamp(rank, 0, sorted.Count - 1)];
+    }
+
+    private static int? IntArg(string[] args, string prefix)
+    {
+        var match = args.FirstOrDefault(a => a.StartsWith(prefix, StringComparison.Ordinal));
+        return match is not null && int.TryParse(match[prefix.Length..], CultureInfo.InvariantCulture, out var value)
+            ? value
+            : null;
+    }
+
+    private readonly record struct LoadResult(
+        double EventsPerSecond,
+        double P50,
+        double P95,
+        double P99,
+        double Max,
+        int Errors);
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -141,6 +141,35 @@ These are steady-state figures, and steady state is what a session settles into:
 over 200 updates each holds flat to the byte, and 500 create-and-dispose cycles leave under 100 bytes
 behind.
 
+### Fitting is not the same as serving
+
+The table above answers how many sessions a host can *hold*. What it costs to actually *use* them is a
+different question, and a capacity number you can't serve isn't a capacity number:
+
+```bash
+dotnet run -c Release --project benchmarks/Rask.Benchmarks -- session-load
+```
+
+That drives real WebSockets against a real host and times the round trip a user actually feels — the
+click, the render it causes, and the acknowledgement that closes it. Indicative figures (Apple M4, 20
+concurrent sessions, closed loop):
+
+| Page | Events/sec | p50 | p99 |
+| --- | ---: | ---: | ---: |
+| Empty shell | ~100,000 | 0.15 ms | ~1 ms |
+| 5-row table | ~85,000 | 0.19 ms | ~1 ms |
+| 200-row grid | ~26,000 | 0.53 ms | ~6 ms |
+
+Read the shape, not the absolutes: **page size costs you throughput before it costs you memory.** An
+empty shell and a 5-row page are within noise of each other; a 200-row grid costs roughly 4× the
+per-event time and a quarter of the throughput, because every interaction re-renders and re-diffs the
+whole page.
+
+Two things the harness deliberately does not measure. It reports no memory — the load generator shares a
+process with the host it drives, so a heap reading would count the client's own sockets; that is what
+`session-footprint` is for. And it turns off `MaxInboundFramesPerSecond`, because a closed-loop generator
+trips a per-connection DoS cap that no human ever will. Leave that cap on in production.
+
 To pick a number: take the RAM you'll give the process, subtract the app's own baseline, and divide by
 the connected cost of your **largest** page — then leave headroom, because `MaxSessions` also counts
 sessions created by a bare `GET` whose WebSocket never arrived (they hold a slot for


### PR DESCRIPTION
Phase 2 of the server-host scaling plan. Branches from `main`, independent of the four open PRs.

## The gap

`session-footprint` and `session-churn` answer how many sessions **fit** — a retained-memory question, measured against a stub socket that never receives. Nothing said what happens when those sessions are *used*. A capacity number you can't serve isn't a capacity number.

`session-load` drives real `ClientWebSocket`s against a real Kestrel host and times the round trip a user feels: the click, the render it causes, and the `seq` ack that closes it. Real sockets rather than the in-memory test server on purpose — these numbers are about the transport as much as the renderer, and an in-memory pipe removes exactly the parts that decide whether a host holds its clients.

Closed-loop rather than a fixed rate: each client fires its next event when the previous is acknowledged. That's what a live app does, and it keeps throughput and latency honest with each other instead of needing a target rate chosen in advance and reporting queue depth dressed up as latency.

## The result worth knowing

**Page size costs throughput before it costs memory.** Apple M4, 20 concurrent sessions:

| Page | Events/sec | p50 | p99 |
| --- | ---: | ---: | ---: |
| Empty shell | ~100,000 | 0.15 ms | ~1 ms |
| 5-row table | ~85,000 | 0.19 ms | ~1 ms |
| 200-row grid | ~26,000 | 0.53 ms | ~6 ms |

An empty shell and a 5-row page are within noise of each other; a 200-row grid costs ~4× the per-event time and a quarter of the throughput, because every interaction re-renders and re-diffs the whole page. That's a different shape from the memory table, where 5 rows already costs 3× an empty shell.

## Three things the first version got wrong

Worth listing, because each one produced a plausible-looking number that was measuring the wrong thing:

1. **It measured the DoS cap, not the host.** A closed loop trips `MaxInboundFramesPerSecond` (1000/sec per connection) that no human ever will — the first run reported *exactly* 1000 events/sec per client and closed every socket. The harness now disables it and says why in the code. **That cap stays on in production.**
2. **The first row of the sweep paid the process-wide JIT** and reported it as the page's cost — which showed up as the empty page benchmarking *slower* than the 5-row one, which can't be true. A throwaway warmup run now precedes the sweep.
3. **It reported bytes-per-session, and the number was junk.** The generator shares a process with the host it drives, so the heap delta counted the client's own sockets and their 64 KB receive buffers. It didn't even rise with page size. **Column removed** rather than shipped with a caveat — memory belongs to `session-footprint`, which measures it with nothing else running.

## Also

`session-footprint` and `session-churn` had **never run in CI**, so the table in `docs/configuration.md` was one person's local run. All three are now in the nightly — not as a pass/fail gate (absolute numbers from a shared runner mean little) but so a change in *shape* is visible without anyone remembering to run them by hand.

## Verification

Reproducible across runs: p50 stable to ~0.02 ms, p99 varying as tails do, throughput ±20%. Zero errors. Full local gate green.