### PR TITLE
docs: how far one box goes, measured — and why there is no --replicas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -271,6 +271,19 @@ them until tagged releases begin.
   beside the existing live tail. Two modes rather than one merged view because the store's writer flushes on
   an interval — the newest lines are buffered but not yet on disk, and a merged view would quietly disagree
   with itself for a second at a time. Live remains the default and still reads nothing from disk.
+- **[`docs/scaling.md`](docs/scaling.md) — how far one box goes, measured rather than asserted.** The docs
+  said "one server runs the whole product" in several places and then never said what one server does. This
+  puts both numbers next to each other — sessions held and events served, each reproducible from a report
+  in this repo — and they turn out to have different shapes: in memory a 5-row page already costs 3× an
+  empty shell, while in throughput the two are within noise and the cost arrives later but harder. The
+  practical version: **look at your largest page before you look at your user count.**
+  It also states where the wall is, which is not the session count or the event rate but the single SQLite
+  writer, and what it takes to get past it. And it says plainly that `rask deploy` ships **no `--replicas`
+  flag** — every DB-backed pillar writes to the app's own database, so a second replica of a normal Rask
+  app is a corruption risk rather than a scaling step. Recorded in the roadmap's "not shipped" list next to
+  the other honest gaps. What did change: a session reconnecting to a host that never knew it is now
+  rebuilt rather than refused, so sticky routing is an optimisation for sessions — though uploads,
+  downloads and sign-in redeem still require it.
 - **`rask db backup` and `rask db restore` — get the deployed database down, and a copy back up.** Continuous
   backup (Litestream) covers the box dying; this covers the two things a solo developer actually reaches
   for: *"something looks wrong in production, let me get a copy"* and *"that migration was a mistake,

--- a/docs/README.md
+++ b/docs/README.md
@@ -68,6 +68,7 @@ in the [Tutorial](tutorial/00-overview.md); the reference for each is here.
 | [Observability](observability.md) | Structured logging, the `Rask.Server` meter and activity source, health checks — what to export and what the numbers mean. |
 | [Configuration](configuration.md) | The options every host reads, and where to set them. |
 | [Deployment](deployment.md) | Ship to a single box with `rask deploy`: Docker over SSH, a shared Caddy proxy for automatic HTTPS, zero-downtime blue-green swaps gated on `/health`, and bare-VPS setup. |
+| [Scaling](scaling.md) | How far one box goes — measured, in sessions and in events per second — what survives a restart or a deploy, where the wall actually is, and what it takes to get past it. |
 
 ## Bootstrap components
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -49,6 +49,8 @@ Dockerfile below (override with `--dockerfile`).
   host's live containers on every deploy, so a second app never disturbs the first.
 - **No domain?** Omit `--domain` to publish the app on `--port` (default `8080`) and put your own
   reverse proxy / TLS in front — see the container sections below.
+- **One box, and how far it goes.** [Scaling](scaling.md) has the measured numbers — sessions held and
+  events served — plus where the wall actually is and what to do when you reach it.
 
 **Prerequisites:** the Docker CLI locally, and a host you can `ssh` into non-interactively with a key.
 That's it — **you never have to SSH in and prepare the box yourself**; see below. The host, domain, and

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,6 +73,18 @@ built-in login-attempt throttle**.
 ### Secrets beyond environment variables
 See [`secrets.md`](secrets.md) for what does exist and, at the bottom, a blunt list of what doesn't.
 
+### Horizontal scale
+No `rask deploy --replicas`. Not an oversight, and not a "later" — it would be a flag that is wrong for
+the shape of app this framework tells you to build. Every DB-backed pillar writes to the app's own SQLite
+database, and [SQLite runs one writer](sqlite.md#in-a-docker-container), so a second replica of a normal
+Rask app is a corruption risk rather than a scaling step.
+
+What one box actually does is [measured, not asserted](scaling.md) — sessions held and events served,
+both reproducible from reports in this repo. Read that before assuming you need a second box; the usual
+answer is a smaller page. If you genuinely do outgrow it, the door is a client-server database, and
+`scaling.md` covers what else would have to change (uploads, downloads and sign-in redeem still require
+sticky routing; sessions no longer do).
+
 ---
 
 Every pillar above is wired together in [`samples/Rask.Example.Shop`](../samples/Rask.Example.Shop), and

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -1,0 +1,133 @@
+# Scaling
+
+How far one box goes, what happens when it restarts, and where the wall is.
+
+Rask is built around one server running the whole product. That is a real position, not a limitation
+we're apologising for — but it is only useful if you know what one server actually does, and what it
+would take to need a second. Both numbers below come from reports in this repo, so you can rerun them
+against your own app rather than trusting a table.
+
+## What one box holds
+
+Every live session pins a component tree, a DI scope, and a few buffers. Measure it:
+
+```bash
+dotnet run -c Release --project benchmarks/Rask.Benchmarks -- session-footprint
+```
+
+| Page | Connected | Sessions per GiB |
+| --- | ---: | ---: |
+| Empty shell | 16 KB | ~66,000 |
+| 5-row table | 52 KB | ~20,300 |
+| 200-row grid | 1.39 MB | ~735 |
+| 1,000-row grid | 7.0 MB | ~146 |
+
+**Page size, not user count, is what moves this** — a ~450× swing across the sweep. Sessions are cheap
+until the page isn't. See [sizing `MaxSessions`](configuration.md#sizing-maxsessions-for-a-memory-budget)
+for turning that into a cap, and note the two exclusions: Kestrel's ~32 KB per connection, and your own
+scoped services — one `DbContext` per session can dwarf everything in the table.
+
+## What one box serves
+
+Fitting is not the same as serving. Measure that too:
+
+```bash
+dotnet run -c Release --project benchmarks/Rask.Benchmarks -- session-load
+```
+
+| Page | Events/sec | p50 | p99 |
+| --- | ---: | ---: | ---: |
+| Empty shell | ~100,000 | 0.15 ms | ~1 ms |
+| 5-row table | ~85,000 | 0.19 ms | ~1 ms |
+| 200-row grid | ~26,000 | 0.53 ms | ~6 ms |
+
+Read the shape rather than the absolutes, because **the two tables have different shapes**. In memory, a
+5-row page already costs 3× an empty shell. In throughput, they're within noise of each other, and the
+cost arrives later but harder: a 200-row grid runs ~4× slower per event, because every interaction
+re-renders and re-diffs the whole page.
+
+The practical consequence: if you're worried about scale, **look at your largest page before you look at
+your user count.** Splitting a 200-row grid into pages of 20 buys more than a bigger box will.
+
+## What survives what
+
+| Event | What the user sees |
+| --- | --- |
+| Brief network blip | Nothing. The socket reconnects against the intact session within `SessionGracePeriod` (30 s). |
+| Tab backgrounded past the grace period | The session is gone, but the page is [rebuilt from the client's resume record](configuration.md#surviving-a-restart-or-a-redeploy) — same route, whatever state the app declared. |
+| Deploy or restart | The departing host [hands clients over](deployment.md#connected-clients-are-handed-over-not-dropped): they reconnect immediately and rebuild, rather than sitting out a backoff and reloading. |
+| Host at capacity | New sessions get `503` + `Retry-After`; `/health` reports Degraded at 80% of `MaxSessions` so an orchestrator sheds first. |
+| Host killed outright | Whatever was in flight is lost. Sessions rebuild on the next reconnect if their record is still valid. |
+
+Two of those depend on a **persisted data-protection key ring**, which `rask new` scaffolds to
+`/data/keys`. Without it, a record sealed before a redeploy can't be opened after one, and you're back to
+a reload. Watch `rask.sessions.resume_rejected{reason="unprotect"}` — a spike right after a deploy is
+exactly that failure.
+
+## The wall
+
+**A Rask app on SQLite runs one writer.** [`sqlite.md`](sqlite.md#in-a-docker-container) already says
+don't run `replicas > 1` against the same database, and that stands. Every DB-backed pillar — jobs, the outbox,
+cache, mail, logging — writes to that database, so a second replica of a normal Rask app is not a
+scaling step, it's a corruption risk.
+
+That is the wall, and it is worth being precise about where it is:
+
+- **It is not the session count.** A box holding tens of thousands of sessions of a modest page is
+  ordinary.
+- **It is not the event rate.** Tens of thousands of round trips per second is not where an app breaks.
+- **It is the single writer**, and after that, whatever your own `DbContext` costs per session.
+
+So `rask deploy` deliberately ships **no `--replicas` flag**. It would be a flag that is wrong for the
+shape of app this framework tells you to build.
+
+### Getting past it
+
+In rough order of how much they buy for the effort:
+
+1. **Shrink the page.** Paginate the grid, split the route. Cheapest, and it moves both tables at once.
+2. **Get work off the request path.** [Jobs](jobs.md) and the [outbox](outbox.md) exist for this — a
+   session waiting on a slow handler is a session holding its render lock.
+3. **Get a bigger box.** Unfashionable and frequently correct. The measurements above are per-core-ish
+   work; vertical headroom is real and requires changing nothing.
+4. **Move the database.** Point EF Core at Postgres or SQL Server and the single-writer wall goes away.
+   Rask has no opinion about your provider — but the [pillars are SQLite-shaped](one-person-framework.md),
+   so this is where you start leaving the framework's happy path.
+5. **Then, and only then, more than one host.** See below for what would need to change.
+
+## If you run more than one host anyway
+
+Some apps genuinely are read-mostly, or already on a client-server database. Nothing stops you putting
+several Rask hosts behind a load balancer. What you need to know:
+
+**Sessions no longer require sticky routing — but still prefer it.** A reconnect that lands on a host
+which has never heard of the session used to mean "session timed out, reload". It now means the page is
+rebuilt from the client's record. So affinity is an optimisation (an intact session is always better than
+a rebuilt one), not a correctness requirement. For that to work across hosts, **every host must share a
+data-protection key ring** — the record is sealed with it.
+
+**Three things still require affinity, and will fail without it:**
+
+| Surface | Why |
+| --- | --- |
+| File uploads | Staged to a node-local temp file; the WebSocket message that consumes them must reach the same host. |
+| Downloads | `GET /_rask/download/{session}/{token}` reads a node-local entry. |
+| Sign-in redeem | `POST /_rask/auth/redeem` reads an in-memory ticket issued on the host that authenticated you. |
+
+Cookie-based affinity in the proxy covers all three. Rask does not configure one for you, and the
+`rask deploy` Caddy setup routes to a single container per app.
+
+**And the pillars assume one writer.** If jobs, the outbox or the cache are enabled and pointed at
+SQLite, more than one host will fight over the same file. Move them to a shared database first, or don't
+run them on more than one host.
+
+## Where to look when it's slow
+
+| Signal | Meaning |
+| --- | --- |
+| `rask.sessions.active` near `MaxSessions` | Capacity, not performance. Size the cap against your largest page. |
+| `rask.handler.duration` p99 climbing | Your handlers, not the framework — the framework's own round trip is in the table above. |
+| `rask.ws.frames.rejected{reason=backlog}` | A client is outrunning its own dispatch; the backpressure breaker is holding. |
+| `rask.sessions.resume_rejected{reason=unprotect}` | The key ring isn't surviving deploys. |
+
+Full list in [observability](observability.md).

--- a/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
+++ b/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
@@ -81,6 +81,8 @@ public static class GuideCatalog
             "bi-hdd-stack", "One Person Framework"),
         new("deployment", "Deployment", "rask deploy: a bare VPS to a live HTTPS site, zero downtime.",
             "bi-rocket", "One Person Framework"),
+        new("scaling", "Scaling", "How far one box goes, measured — and where the wall actually is.",
+            "bi-graph-up", "One Person Framework"),
         new("secrets", "Secrets", "Where passwords and API keys live, and how they reach the server.",
             "bi-key", "One Person Framework"),
 


### PR DESCRIPTION
Phase 3 of the server-host scaling plan — but **not the shape the plan proposed**. Read the last section before the rest.

⚠️ **Merge last.** It describes behaviour from #559 (resume), #572 (drain) and #573 (`session-load`), and deep-links to sections those PRs add. File-level links resolve today; the anchors and the numbers only become true once those land.

## What this adds

The docs said "one server runs the whole product" in several places and then never said what one server *does*. `docs/scaling.md` puts both numbers next to each other, each reproducible from a report in this repo.

**They have different shapes, which is the useful part:**

| | Empty shell | 5-row | 200-row grid |
| --- | ---: | ---: | ---: |
| Sessions per GiB | ~66,000 | ~20,300 | ~735 |
| Events/sec | ~100,000 | ~85,000 | ~26,000 |

In memory a 5-row page already costs 3× an empty shell. In throughput the two are within noise, and the cost arrives later but harder — a 200-row grid runs ~4× slower per event, because every interaction re-renders and re-diffs the whole page.

The practical version: **look at your largest page before you look at your user count.** Splitting a 200-row grid into pages of 20 buys more than a bigger box will.

It also says where the wall is — not the session count, not the event rate, but the single SQLite writer and then whatever your own `DbContext` costs per session — with an ordered list of what to do about it, cheapest first, ending at a client-server database rather than at more hosts.

## Why there's no `--replicas`

The plan called for `rask deploy --replicas N` with cookie affinity (PR 9) and a SQLite-backed auth-ticket store to go with it (PR 8). I'm recommending against both, and this PR records that decision instead of implementing them.

`docs/sqlite.md` already tells users not to run `replicas > 1` against the same database. Every DB-backed pillar — jobs, outbox, cache, mail, logging — writes to the app's own SQLite database, and `rask new --data` wires exactly that. So `--replicas` would be a flag that is **wrong for the framework's own default and recommended app shape**: not a scaling step, a corruption risk.

The plan itself half-saw this — its PR 10 text was going to tell readers "if your product writes on every request, scale the box, not the count", i.e. document people out of using the feature its PR 9 built. That tension resolves in favour of the docs.

PR 8 (a SQLite-backed `IAuthTicketStore`) follows: without replicas there is no node to fail over to, so it would be speculative surface for a problem nobody has — the same reasoning that dropped `ILiveSessionHandoffStore` earlier in this epic.

It's now in the roadmap's **"not shipped"** list, next to the other honest gaps, rather than sitting as an assumed future.

## What genuinely changed about affinity

Worth stating precisely, because the resume work moved it:

- **Sessions no longer require sticky routing.** A reconnect landing on a host that never knew the session used to mean "session timed out, reload"; it now rebuilds from the client's record. Affinity became an optimisation — an intact session still beats a rebuilt one.
- **Uploads, downloads and sign-in redeem still require it**, and will fail without it. The doc has the table and the reason for each.
- Cross-host resume needs a **shared data-protection key ring**, which is why #549 matters beyond cookies.

## Testing

Both docs guards pass — the `docs/README.md` reachability check and the site's `GuideCatalog` parity check (the new guide is registered). Full local gate green.