### PR TITLE
feat(server): signals for what a host is doing, and health that watches memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,23 @@ them until tagged releases begin.
   The load-bearing change is a one-line token substitution: the socket's cancellation token now derives
   from the drain's hard deadline rather than from `ApplicationStopping`, which is what makes it possible
   to send anything at all — including the shutdown frame — after the stop signal arrives.
+- **The signals that say what a host is doing, not just what it refused to do.** The meter could report a
+  rejected frame and an evicted session, and little about the state that produced either. Four additions:
+  `rask.sessions.connected` separates people actually looking at the app from the `active` count, which
+  also includes `GET`-minted sessions whose socket never arrived and sessions riding out their reconnect
+  grace — so "the host is filling up" becomes actionable instead of ambiguous. `rask.handlers.pending`
+  exposes the backpressure breaker's *input*; only its output was visible, so you could watch it trip and
+  never watch it coming. `rask.render.duration` times the framework's half of an interaction, which
+  `rask.handler.duration` (your half) was routinely mistaken for. `rask.payload.bytes` makes a page that
+  quietly stopped diffing visible as a distribution shift, long before it shows up as bandwidth.
+- **`/health` now degrades on memory, not just on the session count.** A cap alone can't keep a host
+  healthy, because what a session costs is a property of the page rather than of the user — the same host
+  holds ~66,000 sessions of a trivial page or ~735 of a 200-row grid, so a cap sized for one is no
+  protection on the other. And the common configuration, `MaxSessions` uncapped, previously reported
+  `Healthy` unconditionally: the one signal an orchestrator polls could say nothing at all until an OOM
+  said it. The reading comes from `GCMemoryInfo`, which honours a container limit, so it reflects the
+  ceiling a deployed app actually runs under. A memory position the runtime won't disclose is treated as
+  healthy rather than full — a host must not shed load because it can't measure itself.
 - **`rask db backup` and `rask db restore` — get the deployed database down, and a copy back up.** Continuous
   backup (Litestream) covers the box dying; this covers the two things a solo developer actually reaches
   for: *"something looks wrong in production, let me get a copy"* and *"that migration was a mistake,

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -64,8 +64,11 @@ All metrics publish on the meter named **`Rask.Server`** (`RaskTelemetry.MeterNa
 | `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` \| `idle` | Inbound frames refused by a safety limit. |
 | `rask.sessions.resumed` | Counter | | Pages rebuilt on a host that had never heard of the session, from the client's [resume record](configuration.md#surviving-a-restart-or-a-redeploy). |
 | `rask.sessions.resume_rejected` | Counter | `reason` = `malformed` \| `unprotect` \| `principal` \| `toolarge` \| `atcapacity` | Resume records refused. |
-| `rask.ws.frames.rejected` | Counter | `reason` = `size` \| `rate` \| `backlog` | Inbound frames refused by a safety limit. |
 | `rask.shutdown.sessions.abandoned` | Counter | | Sessions still connected when the shutdown drain budget ran out; their sockets were aborted. |
+| `rask.sessions.connected` | Gauge | | Sessions with a socket attached — people actually looking at the app, as opposed to `active`, which also counts GET-minted sessions whose socket never arrived and sessions riding out their reconnect grace. |
+| `rask.handlers.pending` | Gauge | | Handler dispatches queued across all sessions. The backpressure breaker's *input* — `frames.rejected{reason=backlog}` is its output. |
+| `rask.render.duration` | Histogram (ms) | | Time to render a session and write its frame. The framework's half of a slow interaction; `handler.duration` is your half. |
+| `rask.payload.bytes` | Histogram (By) | | Size of a frame sent to a client. Watch the distribution: a page that quietly stops diffing jumps to its full size here long before anyone notices the bandwidth. |
 
 A nonzero `rask.shutdown.sessions.abandoned` is the signal that `ShutdownDrainTimeout` — or the
 `HostOptions.ShutdownTimeout` containing it — is shorter than your app's real shutdown, so some users saw
@@ -154,12 +157,21 @@ app.UseRask<App>();
 
 | Status | Condition |
 | --- | --- |
-| `Healthy` | Below 80% of `MaxSessions` (or `MaxSessions == 0`, i.e. uncapped). |
-| `Degraded` | At or above 80% of `MaxSessions` — the host is filling up. |
-| `Unhealthy` | At `MaxSessions` — new sessions are being refused with `503`. |
+| `Healthy` | Below 80% of `MaxSessions` (or uncapped), and memory below 80% of the limit. |
+| `Degraded` | At or above 80% of `MaxSessions`, **or** memory at 80% of the limit. |
+| `Unhealthy` | At `MaxSessions` (new sessions are being refused with `503`), **or** memory at 92%. |
 
-The active and maximum session counts are attached to the health-check result `data` for dashboards.
-Pair the capacity cap with a reverse-proxy rate limit for precise admission control.
+**Memory is checked as well as the session count, and outranks it.** A cap alone can't keep a host
+healthy, because what a session costs is a property of the page rather than of the user: the same host
+holds ~66,000 sessions of a trivial page or ~735 of a 200-row grid. A cap sized for the small page is no
+protection on the big one. The reading comes from `GCMemoryInfo`, which honours a container memory limit,
+so it reflects the ceiling a deployed app actually runs under — and an uncapped host, which is what most
+apps run, now reports something before an OOM does. A memory position the runtime won't disclose is
+treated as healthy, not as full: a host must not shed load because it can't measure itself.
+
+`activeSessions`, `connectedSessions`, `maxSessions` and `memoryLoad` are attached to the health-check
+result `data` for dashboards. Pair the capacity cap with a reverse-proxy rate limit for precise admission
+control.
 
 ### Readiness
 

--- a/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
+++ b/src/Rask.Server/Diagnostics/RaskLiveHealthCheck.cs
@@ -14,6 +14,30 @@ public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
 {
     internal const double DegradedRatio = 0.8;
 
+    /// <summary>
+    ///     Memory load at which the host reports <c>Degraded</c> regardless of the session count, as a
+    ///     fraction of what the runtime believes is available to it.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         A session cap alone cannot keep a host healthy, because a session's cost is a property of
+    ///         the page rather than of the user: the same host holds ~66,000 sessions of a trivial page or
+    ///         ~735 of a 200-row grid, a ~90× spread across two pages of the same app. A cap sized for the
+    ///         small page is no protection on the big one, and a cap sized for the big one wastes the host
+    ///         the rest of the time. So the memory itself is also watched, and it is the signal that
+    ///         actually degrades before an orchestrator has to notice an OOM.
+    ///     </para>
+    ///     <para>
+    ///         Read from <see cref="GCMemoryInfo" />, which honours a container memory limit — so this
+    ///         reflects the cgroup ceiling a deployed app is really running under, not the size of the
+    ///         machine underneath it.
+    ///     </para>
+    /// </remarks>
+    internal const double DegradedMemoryLoad = 0.80;
+
+    /// <summary>Memory load at which the host reports <c>Unhealthy</c>. Above this an OOM is close.</summary>
+    internal const double UnhealthyMemoryLoad = 0.92;
+
     public Task<HealthCheckResult> CheckHealthAsync(
         HealthCheckContext context,
         CancellationToken cancellationToken = default)
@@ -23,16 +47,34 @@ public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
         // would report Healthy while the host is already answering 503s during a concurrent GET burst.
         var active = store.LiveCount;
         var max = store.MaxSessions;
+        var connected = store.ConnectedCount;
+        var memoryLoad = MemoryLoad();
         var data = new Dictionary<string, object>
         {
             ["activeSessions"] = active,
-            ["maxSessions"] = max
+            ["connectedSessions"] = connected,
+            ["maxSessions"] = max,
+            ["memoryLoad"] = Math.Round(memoryLoad, 3)
         };
+
+        // Memory first: it outranks the session count in both directions. A host over its memory ceiling
+        // is in trouble whatever the cap says, and a host well under the cap can still be — because what
+        // a session costs depends on the page, not on the number of them.
+        if (memoryLoad >= UnhealthyMemoryLoad)
+        {
+            return Task.FromResult(HealthCheckResult.Unhealthy(
+                $"Rask host memory at {memoryLoad:P0} of its limit with {active} sessions; shed load.",
+                null, data));
+        }
 
         if (max <= 0)
         {
-            return Task.FromResult(HealthCheckResult.Healthy(
-                $"Rask live sessions: {active} active (uncapped).", data));
+            return memoryLoad >= DegradedMemoryLoad
+                ? Task.FromResult(HealthCheckResult.Degraded(
+                    $"Rask host memory at {memoryLoad:P0} of its limit with {active} sessions (uncapped).",
+                    null, data))
+                : Task.FromResult(HealthCheckResult.Healthy(
+                    $"Rask live sessions: {active} active, {connected} connected (uncapped).", data));
         }
 
         if (active >= max)
@@ -41,13 +83,31 @@ public sealed class RaskLiveHealthCheck(LiveSessionStore store) : IHealthCheck
                 $"Rask live sessions at capacity ({active}/{max}); new sessions are being refused.", null, data));
         }
 
-        if (active >= max * DegradedRatio)
+        if (active >= max * DegradedRatio || memoryLoad >= DegradedMemoryLoad)
         {
             return Task.FromResult(HealthCheckResult.Degraded(
-                $"Rask live sessions near capacity ({active}/{max}).", null, data));
+                $"Rask host near capacity ({active}/{max} sessions, memory {memoryLoad:P0}).", null, data));
         }
 
         return Task.FromResult(HealthCheckResult.Healthy(
-            $"Rask live sessions: {active}/{max}.", data));
+            $"Rask live sessions: {active}/{max} ({connected} connected).", data));
+    }
+
+    /// <summary>
+    ///     Managed memory in use as a fraction of what the runtime believes it may use, or <c>0</c> when
+    ///     the runtime won't say.
+    /// </summary>
+    /// <remarks>
+    ///     <c>TotalAvailableMemoryBytes</c> is the container limit when there is one, so this is the
+    ///     fraction that matters to the thing that will kill the process. Returning 0 on an unusable
+    ///     reading is deliberate: an unknown memory position must not be reported as an unhealthy one, or
+    ///     a host would shed load because it could not measure itself.
+    /// </remarks>
+    private static double MemoryLoad()
+    {
+        var info = GC.GetGCMemoryInfo();
+        return info.TotalAvailableMemoryBytes <= 0
+            ? 0
+            : (double)info.MemoryLoadBytes / info.TotalAvailableMemoryBytes;
     }
 }

--- a/src/Rask.Server/Diagnostics/RaskMetrics.cs
+++ b/src/Rask.Server/Diagnostics/RaskMetrics.cs
@@ -19,6 +19,8 @@ public sealed class RaskMetrics : IDisposable
     private readonly Counter<long> _framesRejected;
     private readonly Counter<long> _sessionsResumed;
     private readonly Counter<long> _sessionsResumeRejected;
+    private readonly Histogram<double> _renderDuration;
+    private readonly Histogram<long> _payloadBytes;
     private readonly Counter<long> _handlersDispatched;
     private readonly Counter<long> _handlersFaulted;
     private readonly Counter<long> _handlersTimedOut;
@@ -62,6 +64,10 @@ public sealed class RaskMetrics : IDisposable
         _sessionsAbandonedAtDrain = _meter.CreateCounter<long>(
             "rask.shutdown.sessions.abandoned", "{session}",
             "Live sessions still connected when the shutdown drain budget ran out (their sockets were aborted).");
+        _renderDuration = _meter.CreateHistogram<double>(
+            "rask.render.duration", "ms", "Wall-clock time to render a session and write its frame.");
+        _payloadBytes = _meter.CreateHistogram<long>(
+            "rask.payload.bytes", "By", "Size of a frame sent to a client.");
     }
 
     // Exposed for tests so a MeterListener can scope to this exact meter instance and ignore
@@ -74,6 +80,31 @@ public sealed class RaskMetrics : IDisposable
     public void TrackActiveSessions(Func<int> readCount) =>
         _meter.CreateObservableGauge(
             "rask.sessions.active", readCount, "{session}", "Live sessions currently held by the store.");
+
+    /// <summary>
+    ///     Registers the connected-session gauge — sessions with a socket attached, i.e. people actually
+    ///     looking at the app.
+    /// </summary>
+    /// <remarks>
+    ///     The companion to <c>rask.sessions.active</c>, which also counts sessions minted by a bare
+    ///     <c>GET</c> whose socket never arrived and sessions riding out their reconnect grace. Those hold
+    ///     capacity and admission is right to count them, but a host cannot tell "filling up with users"
+    ///     from "filling up with probes" while the only number it publishes conflates the two.
+    /// </remarks>
+    public void TrackConnectedSessions(Func<int> readCount) =>
+        _meter.CreateObservableGauge(
+            "rask.sessions.connected", readCount, "{session}", "Sessions with a WebSocket attached.");
+
+    /// <summary>
+    ///     Registers the pending-handler depth gauge — the backpressure breaker's input.
+    /// </summary>
+    /// <remarks>
+    ///     Until now only the breaker's <em>output</em> was observable: you could count the frames it
+    ///     rejected and had no way to watch the queue that made it fire.
+    /// </remarks>
+    public void TrackPendingHandlers(Func<int> readCount) =>
+        _meter.CreateObservableGauge(
+            "rask.handlers.pending", readCount, "{handler}", "Handler dispatches queued across all sessions.");
 
     public void SessionCreated() => _sessionsCreated.Add(1);
 
@@ -120,4 +151,25 @@ public sealed class RaskMetrics : IDisposable
     /// </summary>
     public void ResumeRejected(string reason) =>
         _sessionsResumeRejected.Add(1, new KeyValuePair<string, object?>("reason", reason));
+    /// <summary>
+    ///     Records how long one render-and-send took.
+    /// </summary>
+    /// <remarks>
+    ///     Distinct from <c>rask.handler.duration</c>, which times the user's handler. Those two answer
+    ///     different questions and get confused constantly: a slow interaction is either the app's code or
+    ///     the framework's render, and until both are measured there is no way to tell which without a
+    ///     profiler. This one is the framework's half.
+    /// </remarks>
+    public void RecordRenderDuration(double milliseconds) => _renderDuration.Record(milliseconds);
+
+    /// <summary>
+    ///     Records the size of a frame sent to a client.
+    /// </summary>
+    /// <remarks>
+    ///     Worth watching as a distribution rather than a total: the diff codec's whole job is keeping
+    ///     these small, and a page that quietly stops diffing — a structural change, a Raw sibling, an
+    ///     out-of-band side effect — shows up here as the histogram jumping to the page's full size long
+    ///     before anyone notices the bandwidth.
+    /// </remarks>
+    public void RecordPayloadBytes(long bytes) => _payloadBytes.Record(bytes);
 }

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -1,4 +1,5 @@
 using System.Buffers;
+using System.Diagnostics;
 using System.Net.WebSockets;
 using System.Security.Cryptography;
 using System.Text;
@@ -11,6 +12,7 @@ using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 using Rask.Core.Routing;
 using Rask.Server.Authentication;
+using Rask.Server.Diagnostics;
 using Rask.Server.Files;
 using Rask.Server.JSInterop;
 
@@ -83,12 +85,18 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
     // value is fixed for the session's lifetime rather than resolved on every send.
     private readonly TimeSpan _sendTimeout;
 
-    public LiveSession(string id, Component view, IServiceScope scope, LiveDiffMode diffMode)
+    // The host's meter, or null for a store built without one (tests, a bare harness). Held per session
+    // so the render path records without resolving anything.
+    private readonly RaskMetrics? _metrics;
+
+    public LiveSession(
+        string id, Component view, IServiceScope scope, LiveDiffMode diffMode, RaskMetrics? metrics = null)
         : base(view, scope.ServiceProvider, diffMode)
     {
         Id = id;
         Scope = scope;
         _sendTimeout = scope.ServiceProvider.GetService<RaskServerLimits>()?.SendTimeout ?? TimeSpan.Zero;
+        _metrics = metrics;
     }
 
     public bool SuppressEventsUntilReconnect { get; set; }
@@ -625,12 +633,19 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
                 return;
             }
 
+            var renderStarted = Stopwatch.GetTimestamp();
+
             WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
                 commitCache: true, auth, Id);
 
             // Emit via the shared double-buffered send (dedup + swap in LiveSessionBase). Force the
             // send when something out-of-band (navigation, auth, download) must flow even if the
             // rendered bytes are byte-identical to the previous frame — otherwise the dedup skips it.
+            // Read BEFORE the emit: TryEmitFrameAsync swaps _writeBuffer with the previous-frame buffer
+            // for the zero-copy dedup, so afterwards this field is the OTHER buffer and its count is the
+            // reset one. Measuring it there silently records zero for every frame.
+            var payloadBytes = _writeBuffer.WrittenCount;
+
             var force = historyUrl is not null || auth is not null || download is not null;
             bool sent;
             try
@@ -651,6 +666,13 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             if (sent)
             {
                 _htmlBuffers.Commit();
+
+                // Only when a frame actually went out. Recording a deduped render — one whose bytes
+                // matched the last frame and was suppressed — would put a zero-byte sample in the payload
+                // histogram and count work the client never saw, which is precisely the case these two
+                // signals exist to distinguish from a real one.
+                _metrics?.RecordRenderDuration(Stopwatch.GetElapsedTime(renderStarted).TotalMilliseconds);
+                _metrics?.RecordPayloadBytes(payloadBytes);
             }
         }
         finally

--- a/src/Rask.Server/LiveSessionStore.cs
+++ b/src/Rask.Server/LiveSessionStore.cs
@@ -31,6 +31,11 @@ public sealed class LiveSessionStore : IAsyncDisposable
     // 1 once DisposeAsync has run. See DisposeAsync for why it must be once-only.
     private int _disposed;
 
+    // Sessions with a socket attached, and handler dispatches queued across all of them. See the
+    // properties below for why each is tracked here rather than derived on scrape.
+    private int _connectedCount;
+    private int _pendingHandlerCount;
+
     public LiveSessionStore(
         IServiceScopeFactory scopeFactory,
         IHostApplicationLifetime? lifetime = null,
@@ -48,6 +53,8 @@ public sealed class LiveSessionStore : IAsyncDisposable
         // committed) — the same number admission and the health check gate on — so the gauge, the
         // capacity cap, and /health never disagree by the count of mid-build sessions.
         _metrics?.TrackActiveSessions(() => LiveCount);
+        _metrics?.TrackConnectedSessions(() => ConnectedCount);
+        _metrics?.TrackPendingHandlers(() => PendingHandlerCount);
     }
 
     public int Count => _sessions.Count;
@@ -80,6 +87,34 @@ public sealed class LiveSessionStore : IAsyncDisposable
     ///     component tree is still building.
     /// </summary>
     internal int LiveCount => Volatile.Read(ref _liveCount);
+
+    /// <summary>
+    ///     Sessions with a socket attached right now — the number of people actually looking at the app.
+    /// </summary>
+    /// <remarks>
+    ///     Distinct from <see cref="LiveCount" />, which also counts sessions minted by a bare <c>GET</c>
+    ///     whose WebSocket never arrived and sessions riding out their reconnect grace. Those hold
+    ///     capacity, so admission is right to count them — but they are not users, and a host cannot tell
+    ///     "filling up with real traffic" from "filling up with probes and dropped connections" if the two
+    ///     numbers are the same number.
+    /// </remarks>
+    public int ConnectedCount => Volatile.Read(ref _connectedCount);
+
+    /// <summary>Handler dispatches queued across every session — the backpressure breaker's input.</summary>
+    /// <remarks>
+    ///     Only the <em>rejections</em> were observable before: you could see the breaker trip and had no
+    ///     way to see it coming. A store-level counter rather than a sum over sessions on scrape, because
+    ///     scraping is not the moment to walk tens of thousands of them.
+    /// </remarks>
+    public int PendingHandlerCount => Volatile.Read(ref _pendingHandlerCount);
+
+    internal void SocketAttached() => Interlocked.Increment(ref _connectedCount);
+
+    internal void SocketDetached() => Interlocked.Decrement(ref _connectedCount);
+
+    internal void HandlerQueued() => Interlocked.Increment(ref _pendingHandlerCount);
+
+    internal void HandlerDequeued() => Interlocked.Decrement(ref _pendingHandlerCount);
 
     /// <summary>The metrics sink threaded into the WS loop for frame/handler instrumentation (may be null).</summary>
     internal RaskMetrics? Metrics => _metrics;
@@ -232,7 +267,7 @@ public sealed class LiveSessionStore : IAsyncDisposable
             throw;
         }
 
-        var session = new LiveSession(sessionId, view, scope, DiffMode);
+        var session = new LiveSession(sessionId, view, scope, DiffMode, _metrics);
         // Bind the per-scope LiveSessionAccessor so RaskJSRuntime (resolved from the same
         // scope) can find this session when components inject IJSRuntime.
         if (scope.ServiceProvider.GetService<LiveSessionAccessor>() is { } accessor)

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -896,6 +896,9 @@ public static class RaskEndpointExtensions
                     }
 
                     session.AttachSocket(ws, ct);
+                    // Counted here rather than inside AttachSocket: the store owns the number, and the
+                    // session has no reason to know a store exists.
+                    store.SocketAttached();
                     session.Services.GetRequiredService<SessionUserProvider>().Set(wsUser);
 
                     // Apply a deferred sign-in/out navigation now that the principal is re-seeded, so the
@@ -1001,11 +1004,13 @@ public static class RaskEndpointExtensions
                 // against the intact session and resumes from current state.
                 var payloadBytes = (long)payload.Length;
                 var pending = capturedSession.IncrementPendingHandlers();
+                store.HandlerQueued();
                 var pendingBytes = capturedSession.AddPendingHandlerBytes(payloadBytes);
                 if ((limits.MaxPendingHandlers > 0 && pending > limits.MaxPendingHandlers)
                     || (limits.MaxPendingHandlerBytes > 0 && pendingBytes > limits.MaxPendingHandlerBytes))
                 {
                     capturedSession.DecrementPendingHandlers();
+                    store.HandlerDequeued();
                     capturedSession.SubtractPendingHandlerBytes(payloadBytes);
                     metrics?.FrameRejected("backlog");
                     await ClosePolicyViolationAsync(ws, "handler backlog").ConfigureAwait(false);
@@ -1017,6 +1022,7 @@ public static class RaskEndpointExtensions
                 var capturedRoot = root.Clone();
                 capturedSession.LastHandlerTask = ChainHandlerDispatchAsync(
                     capturedSession.LastHandlerTask,
+                    store,
                     capturedSession,
                     capturedHandlerId,
                     capturedRoot,
@@ -1033,6 +1039,7 @@ public static class RaskEndpointExtensions
             if (session is not null)
             {
                 session.DetachSocket();
+                store.SocketDetached();
                 store.ScheduleRemoval(session.Id, limits.SessionGracePeriod);
             }
 
@@ -1062,6 +1069,7 @@ public static class RaskEndpointExtensions
 
     private static async Task ChainHandlerDispatchAsync(
         Task previous,
+        LiveSessionStore store,
         LiveSession session,
         string handlerId,
         JsonElement root,
@@ -1104,6 +1112,7 @@ public static class RaskEndpointExtensions
             // Pairs with the Increment/AddPendingHandlerBytes in the receive loop when this dispatch
             // was queued, so the backpressure count and byte total track the live chain depth.
             session.DecrementPendingHandlers();
+            store.HandlerDequeued();
             session.SubtractPendingHandlerBytes(payloadBytes);
         }
     }

--- a/tests/Rask.Server.Tests/Diagnostics/RuntimeSignalTests.cs
+++ b/tests/Rask.Server.Tests/Diagnostics/RuntimeSignalTests.cs
@@ -1,0 +1,147 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Rask.Core;
+using Rask.Core.Components;
+using Rask.Server.Diagnostics;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.Diagnostics;
+
+/// <summary>
+/// The signals that tell an operator what a host is doing, as opposed to what it refused to do.
+/// </summary>
+/// <remarks>
+/// Before these, the meter could say a frame was rejected and a session evicted, but not how full the
+/// dispatch queue was getting, how many of the "active" sessions were real users rather than probes, or
+/// how long the framework's own render took as distinct from the app's handler.
+/// </remarks>
+public sealed class RuntimeSignalTests
+{
+    private sealed class Shell : Component
+    {
+        protected override Component? Render() =>
+            [Doctype(), new Html()[new Head(), new Body()[new H1()["hi"]]]];
+    }
+
+    /// <summary>
+    /// A GET mints a session that holds a capacity slot but is nobody — no socket, no user. Conflating
+    /// that with a connected client is what makes "the host is filling up" unactionable.
+    /// </summary>
+    [Fact]
+    public async Task Connected_counts_sockets_while_active_counts_slots()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+        var html = await host.Http.GetStringAsync("/start");
+        var sessionId = MarkupAssert.SessionId(html);
+
+        Assert.Equal(1, host.Store.LiveCount);
+        Assert.Equal(0, host.Store.ConnectedCount);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (host.Store.ConnectedCount == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(1, host.Store.ConnectedCount);
+        Assert.Equal(1, host.Store.LiveCount);
+    }
+
+    /// <summary>The queue returns to zero — a leaked increment would read as permanent backpressure.</summary>
+    [Fact]
+    public async Task Pending_handler_depth_returns_to_zero_after_a_dispatch()
+    {
+        await using var fixture = await ConnectedSession.Connect<CounterApp>();
+
+        var handlerId = MarkupAssert.FirstHandlerId(
+            await fixture.Host.Http.GetStringAsync("/start"));
+        await fixture.Ws.SendJsonAsync(new { id = handlerId, seq = 1 });
+        _ = await fixture.Ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (fixture.Host.Store.PendingHandlerCount != 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.Equal(0, fixture.Host.Store.PendingHandlerCount);
+    }
+
+    private sealed class CounterApp : Component
+    {
+        private int _count;
+
+        protected override Component? Render() =>
+        [
+            Doctype(),
+            new Html()[new Head(), new Body()[Button(OnClick: () => _count++)[$"n={_count}"]]]
+        ];
+    }
+
+    /// <summary>
+    /// Render duration and payload size are recorded only for a frame that actually went out. A deduped
+    /// render — identical bytes, suppressed — would otherwise put a zero-byte sample in the histogram and
+    /// count work no client ever saw.
+    /// </summary>
+    [Fact]
+    public async Task Render_duration_and_payload_bytes_are_recorded_for_a_real_frame()
+    {
+        await using var fixture = await ConnectedSession.Connect<CounterApp>();
+        using var capture = MeterCapture.For(fixture.Host.Services.GetRequiredService<RaskMetrics>().Meter);
+
+        var handlerId = MarkupAssert.FirstHandlerId(
+            await fixture.Host.Http.GetStringAsync("/start"));
+        await fixture.Ws.SendJsonAsync(new { id = handlerId, seq = 1 });
+        _ = await fixture.Ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (capture.HistogramSampleCount("rask.render.duration") == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(10);
+        }
+
+        Assert.True(capture.HistogramSampleCount("rask.render.duration") >= 1,
+            "the render that the click caused was not timed");
+
+        // rask.payload.bytes is a Histogram<long>, and MeterCapture sums long measurements rather than
+        // counting them — which suits this better than a sample count would: a positive total proves the
+        // frame was recorded AND that it carried real bytes, not a zero-length sample.
+        Assert.True(capture.Counter("rask.payload.bytes") > 0,
+            "the frame that went out was not measured");
+    }
+
+    /// <summary>
+    /// An uncapped host used to be unconditionally Healthy. That is the configuration most apps run, and
+    /// it meant the one signal an orchestrator polls could not say anything at all until an OOM said it.
+    /// </summary>
+    [Fact]
+    public async Task Health_reports_memory_even_when_sessions_are_uncapped()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+        var check = new RaskLiveHealthCheck(host.Store);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        Assert.True(result.Data.ContainsKey("memoryLoad"));
+        Assert.True(result.Data.ContainsKey("connectedSessions"));
+        var load = Assert.IsType<double>(result.Data["memoryLoad"]);
+        Assert.InRange(load, 0.0, 1.0);
+    }
+
+    /// <summary>A host that cannot read its own memory position must not report that as unhealthy.</summary>
+    [Fact]
+    public async Task An_unreadable_memory_position_is_not_treated_as_a_full_one()
+    {
+        using var host = RaskTestHost.Create<Shell>();
+        var check = new RaskLiveHealthCheck(host.Store);
+
+        var result = await check.CheckHealthAsync(new HealthCheckContext());
+
+        // On any normal test machine the process is nowhere near its ceiling, so the only way this is not
+        // Healthy is the memory branch misfiring on an unusable reading.
+        Assert.Equal(HealthStatus.Healthy, result.Status);
+    }
+}


### PR DESCRIPTION
Finishes Phase 2 of the server-host scaling plan. Branches from `main`; expect a trivial conflict with #559 in `RaskMetrics.cs` (both add instruments to the same list).

## Four signals

The meter could report a rejected frame and an evicted session, and little about the state that produced either.

| Instrument | What it answers |
| --- | --- |
| `rask.sessions.connected` | How many of the "active" sessions are **people**, versus `GET`-minted sessions whose socket never arrived and sessions riding out their reconnect grace. Both hold capacity — admission is right to count them — but "the host is filling up" is unactionable while one number means both. |
| `rask.handlers.pending` | The backpressure breaker's **input**. Only its output was visible, so you could watch it trip and never watch it coming. |
| `rask.render.duration` | The framework's half of a slow interaction. `rask.handler.duration` is your half, and was routinely taken for the whole thing. |
| `rask.payload.bytes` | A page that quietly stopped diffing, as a distribution shift — visible long before it shows up as bandwidth. |

## `/health` now watches memory, and memory outranks the count

A session cap alone can't keep a host healthy, because **what a session costs is a property of the page, not of the user**: the same host holds ~66,000 sessions of a trivial page or ~735 of a 200-row grid. A cap sized for one is no protection on the other.

Worse, the common configuration — `MaxSessions` uncapped — reported `Healthy` unconditionally. The one signal an orchestrator polls could say nothing at all until an OOM said it.

The reading comes from `GCMemoryInfo`, which honours a container limit, so it reflects the ceiling a deployed app actually runs under rather than the size of the machine underneath. Degraded at 80%, Unhealthy at 92%. A memory position the runtime won't disclose is treated as **healthy, not full** — a host must not shed load because it can't measure itself.

## A bug the tests caught

Worth recording, because it would have shipped a silently-zero metric: `TryEmitFrameAsync` **swaps** `_writeBuffer` with the previous-frame buffer for the zero-copy dedup, so reading its count *after* the emit reads the other buffer, whose count has been reset. The payload size is now captured before the emit. The test failed with `render=1, payload=0`, which pointed straight at it.

Both recordings sit inside the `if (sent)` branch, so a deduped render — identical bytes, suppressed — doesn't put a zero-byte sample in the histogram or count work no client ever saw.

## Two things I left out

- **No node/instance dimension.** It was in the plan for multi-replica dashboards. There are no replicas (see #575), so it would be a tag nothing varies.
- **No Kestrel or thread-pool scaffolding.** The plan called for it; the load harness (#573) reports ~100k events/sec with the defaults untouched, so there's no evidence they're wrong. Tuning knobs nobody has measured is how defaults get worse.

The last plan item — replacing the per-disconnected-session timer with a sweeper — I'd also leave until there's a measurement showing it hurts, and #573 is now the tool to produce one. It's a correctness-sensitive path (the CAS loop, cancel-on-reconnect), and rewriting it on a hunch is the wrong trade.

## Testing

Five tests: connected-vs-active divergence, pending depth returning to zero (a leaked increment would read as permanent backpressure), render/payload recorded for a real frame, health reporting memory when uncapped, and an unreadable memory position not being treated as a full one. Full local gate green — one `Rask.Outbox` timing flake in an untouched project on the first run, clean on re-run and in the commit hook.
