### PR TITLE
fix(server): bound the shutdown announcement by the drain budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,11 @@ them until tagged releases begin.
   `rask.shutdown.sessions.abandoned` counts anything still connected when the budget ran out.
   `LiveSessionStore.DisposeAsync` also became idempotent: the store is a DI singleton, so a host or a test
   that disposed it *as well as* the container reached `Cancel()` on an already-disposed token source.
+  The announcement itself is bounded by the drain budget and fanned out with a bounded degree of
+  concurrency. Neither was true when the drain and the outbound-send bound were written against separate
+  bases: a client that had stopped reading TCP held the announcement for the whole 30s `SendTimeout` —
+  longer than the drain budget, longer than `HostOptions.ShutdownTimeout`, and long enough for `rask
+  deploy`'s `SIGKILL` to land in the middle of a SQLite checkpoint. Measured at 30s before, 200ms after.
   The load-bearing change is a one-line token substitution: the socket's cancellation token now derives
   from the drain's hard deadline rather than from `ApplicationStopping`, which is what makes it possible
   to send anything at all — including the shutdown frame — after the stop signal arrives.
@@ -400,7 +405,7 @@ them until tagged releases begin.
   cost was the *sum* of every session's send rather than the slowest, and one stalled client held up every
   session behind it. Both now run with a bounded degree of concurrency. Only the dev-time hot-reload
   signal uses them today, but this is the code the planned Broadcast pillar inherits, where a fan-out is a
-  user-facing feature — and it is a prerequisite for the deploy-drain broadcast, which has to finish
+  user-facing feature — and it is what the shutdown drain's announcement rides, which has to finish
   inside the shutdown budget before `SIGKILL` interrupts a SQLite checkpoint.
 - **The jobs retention sweep fought a second instance.** `JobProcessor.PurgeAsync` loaded the stale rows and
   `RemoveRange`d them; a tracked delete of a row that vanished underneath the sweep raises

--- a/src/Rask.Server/RaskDrainService.cs
+++ b/src/Rask.Server/RaskDrainService.cs
@@ -78,7 +78,12 @@ internal sealed class RaskDrainService : IHostedService, IDisposable
 
         try
         {
-            await SwallowAsync(_announce).ConfigureAwait(false);
+            // Bounded by the drain budget like every other step. Un-bounded, a client that has stopped
+            // reading TCP holds the announcement for the whole per-send SendTimeout (30s by default) —
+            // longer than the drain budget, longer than HostOptions.ShutdownTimeout, and long enough for
+            // `rask deploy`'s SIGKILL to land in the middle of a SQLite checkpoint. Anyone who misses
+            // their frame simply reconnects the old way, which is a far cheaper loss.
+            await SwallowAsync(_announce.WaitAsync(token)).ConfigureAwait(false);
             await SettleHandlersAsync(token).ConfigureAwait(false);
             await CloseSocketsAsync(token).ConfigureAwait(false);
             await SwallowAsync(_coordinator.WhenSocketsDrained().WaitAsync(token)).ConfigureAwait(false);
@@ -163,14 +168,14 @@ internal sealed class RaskDrainService : IHostedService, IDisposable
     ///     comes back where it was instead of reading the replacement process's <c>session/unknown</c>
     ///     reply as an idle timeout.
     ///     <para>
-    ///         Fanned out concurrently rather than through <c>LiveSessionStore.BroadcastAsync</c>, which
-    ///         is sequential: one session blocked on its render lock mid-frame would otherwise delay the
-    ///         announcement to every session behind it. Sends to <em>different</em> sessions are safe in
-    ///         parallel — each owns its own lock and socket.
+    ///         Goes through <c>LiveSessionStore.BroadcastAsync</c>, which fans out concurrently with a
+    ///         bounded degree and skips a session whose send faults. Sends to <em>different</em> sessions
+    ///         are safe in parallel — each owns its own lock and socket — but the bound matters most
+    ///         precisely here: a host shutting down under load has a busy thread pool, and an unbounded
+    ///         fan-out across thousands of sessions is the wrong thing to add to it.
     ///     </para>
     /// </summary>
-    private Task AnnounceAsync() =>
-        Task.WhenAll(_store.Snapshot().Select(s => SwallowAsync(s.SendOutOfBandAsync(LivePayload.ServerShutdownFrame))));
+    private Task AnnounceAsync() => _store.BroadcastAsync(LivePayload.ServerShutdownFrame);
 
     /// <summary>
     ///     Waits for in-flight handler dispatches to finish. This is the part that only became meaningful

--- a/tests/Rask.Server.Tests/Infrastructure/StallingWebSocket.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/StallingWebSocket.cs
@@ -1,0 +1,48 @@
+using System.Net.WebSockets;
+
+namespace Rask.Server.Tests.Infrastructure;
+
+/// <summary>
+/// An open socket whose sends never complete until the test says so — a client that has stopped reading,
+/// made deterministic.
+/// </summary>
+/// <remarks>
+/// <c>WebSocket.SendAsync</c> completes when the frame reaches the transport, not when the client reads it,
+/// so a real client that stops reading fills the send buffer and the send never returns. That is not
+/// reproducible against an in-memory test host (the OS absorbs a small frame either way), which is why the
+/// behaviour is modelled here instead.
+/// </remarks>
+internal sealed class StallingWebSocket : WebSocket
+{
+    private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    public int Aborted { get; private set; }
+
+    public override WebSocketState State { get; } = WebSocketState.Open;
+    public override WebSocketCloseStatus? CloseStatus => null;
+    public override string? CloseStatusDescription => null;
+    public override string? SubProtocol => null;
+
+    public void Release() => _released.TrySetResult();
+
+    public override async Task SendAsync(
+        ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
+        await _released.Task.WaitAsync(ct);
+
+    public override async ValueTask SendAsync(
+        ReadOnlyMemory<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
+        await _released.Task.WaitAsync(ct);
+
+    public override void Abort()
+    {
+        Aborted++;
+        _released.TrySetCanceled();
+    }
+
+    public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken ct) =>
+        throw new NotSupportedException("This socket only ever sends.");
+
+    public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+    public override Task CloseOutputAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
+    public override void Dispose() { }
+}

--- a/tests/Rask.Server.Tests/Live/SendTimeoutTests.cs
+++ b/tests/Rask.Server.Tests/Live/SendTimeoutTests.cs
@@ -3,6 +3,7 @@ using System.Net.WebSockets;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core;
 using Rask.Core.Components;
+using Rask.Server.Tests.Infrastructure;
 
 namespace Rask.Server.Tests.Live;
 
@@ -18,42 +19,6 @@ namespace Rask.Server.Tests.Live;
 /// </remarks>
 public sealed class SendTimeoutTests
 {
-    /// <summary>An open socket whose sends never complete until the test says so.</summary>
-    private sealed class StallingWebSocket : WebSocket
-    {
-        private readonly TaskCompletionSource _released = new(TaskCreationOptions.RunContinuationsAsynchronously);
-
-        public int Aborted { get; private set; }
-
-        public override WebSocketState State { get; } = WebSocketState.Open;
-        public override WebSocketCloseStatus? CloseStatus => null;
-        public override string? CloseStatusDescription => null;
-        public override string? SubProtocol => null;
-
-        public void Release() => _released.TrySetResult();
-
-        public override async Task SendAsync(
-            ArraySegment<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
-            await _released.Task.WaitAsync(ct);
-
-        public override async ValueTask SendAsync(
-            ReadOnlyMemory<byte> buffer, WebSocketMessageType type, bool end, CancellationToken ct) =>
-            await _released.Task.WaitAsync(ct);
-
-        public override void Abort()
-        {
-            Aborted++;
-            _released.TrySetCanceled();
-        }
-
-        public override Task<WebSocketReceiveResult> ReceiveAsync(ArraySegment<byte> buffer, CancellationToken ct) =>
-            throw new NotSupportedException("This socket only ever sends.");
-
-        public override Task CloseAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
-        public override Task CloseOutputAsync(WebSocketCloseStatus s, string? d, CancellationToken ct) => Task.CompletedTask;
-        public override void Dispose() { }
-    }
-
     private sealed class Shell : Component
     {
         protected override Component? Render() =>

--- a/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/ShutdownDrainTests.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using Rask.Core.Live;
+using Rask.Core.Routing;
 using Rask.Server.Diagnostics;
 using Rask.Server.Tests.Infrastructure;
 
@@ -139,6 +140,39 @@ public class ShutdownDrainTests
         {
             DrainGateApp.Gate.TrySetResult();
         }
+    }
+
+    /// <summary>
+    ///     A client that has stopped reading must not be able to hold the shutdown announcement past the
+    ///     drain budget.
+    /// </summary>
+    /// <remarks>
+    ///     The announcement is bounded per-send by <c>SendTimeout</c> — 30 seconds by default, which is
+    ///     longer than the drain budget, longer than <c>HostOptions.ShutdownTimeout</c>, and long enough
+    ///     for <c>rask deploy</c>'s <c>SIGKILL</c> to land in the middle of a SQLite checkpoint. So the
+    ///     announcement is bounded by the budget as well. This is an interaction between two changes that
+    ///     do not touch the same file, which is exactly the kind nothing else would catch.
+    /// </remarks>
+    [Fact]
+    public async Task A_client_that_stopped_reading_cannot_hold_the_announcement_past_the_budget()
+    {
+        using var host = RaskTestHost.Create<TestApp>(
+            configureServer: o =>
+            {
+                o.ShutdownDrainTimeout = TimeSpan.FromMilliseconds(200);
+                // Deliberately far longer than the budget: the point is that the budget wins.
+                o.SendTimeout = TimeSpan.FromSeconds(30);
+            });
+
+        var session = host.Store.Create(sp => new TestApp(sp.GetRequiredService<RouteState>()));
+        var socket = new StallingWebSocket();
+        session.AttachSocket(socket, CancellationToken.None);
+
+        var started = Environment.TickCount64;
+        await host.StopAsync();
+
+        Assert.True(Environment.TickCount64 - started < 10_000,
+            "the drain waited on a stalled client's send instead of its own budget");
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

The shutdown drain announced to every connected session and then awaited that announcement **with no
timeout**, fanning it out unbounded. Every individual send is bounded by `SendTimeout` (30s by default,
from #564) — so a client that has stopped reading TCP held the whole shutdown for 30 seconds.

That is longer than the drain budget (5s), longer than the scaffolded `HostOptions.ShutdownTimeout`
(15s), and longer than the 20s `rask deploy` allows between `SIGTERM` and `SIGKILL`. The kill lands in
the middle of whatever runs *after* the drain — disposing sessions, the SQLite WAL checkpoint, a
Litestream flush. Which is precisely the failure #564's own description said the drain had to avoid.

## Why no single PR contained this

Neither half is wrong on its own, and the two do not touch the same file.

#560 wrote the drain against a tree where `LiveSessionStore.BroadcastAsync` was sequential, and said so
in a comment justifying its own private fan-out:

> Fanned out concurrently rather than through `LiveSessionStore.BroadcastAsync`, **which is sequential**

#564 then made `BroadcastAsync` bounded-concurrent and fault-skipping. The comment stopped being true,
the duplicate fan-out stopped being justified, and the unbounded await became load-bearing — all without
either diff changing a line the other touched. Git merges them cleanly.

## The fix

- The announcement goes through `BroadcastAsync`, so there is one fan-out policy rather than two, and it
  is bounded (`MaxDegreeOfParallelism = 32`). A host shutting down under load has a busy thread pool;
  an unbounded fan-out across thousands of sessions is the wrong thing to add to it.
- It is awaited under the budget token, like every other step of the drain. A client that misses its
  frame simply reconnects the old way, which is a far cheaper loss than a killed checkpoint.

## Testing

`ShutdownDrainTests.A_client_that_stopped_reading_cannot_hold_the_announcement_past_the_budget`, built
on the deterministic stalled socket that already existed for `SendTimeoutTests`. That socket moved to
`tests/Rask.Server.Tests/Infrastructure/StallingWebSocket.cs` so both suites share it — a real client
that stops reading is not reproducible against an in-memory host, since the OS absorbs a small frame
either way.

**Verified by negative control**, which is the part that matters:

| | drain duration, 200 ms budget |
| --- | ---: |
| without the bound | **30 s** (the full `SendTimeout`) |
| with the bound | **200 ms** |

Full local gate green. Browser E2E skipped (`RASK_SKIP_E2E=1`) — no UI surface, and the sandbox's
Playwright suite is environmentally red on `main` for an unrelated reason (`PlaygroundExampleTests`
needs browser network for Roslyn refs).

No benchmarks: this is shutdown-path only, nothing on the render or payload hot path.

## Changelog

Folded into the existing graceful-shutdown entry under `[Unreleased]`, with the measured before/after,
rather than added as a separate line — it is a correction to behaviour that has not shipped yet.
