### PR TITLE
fix(cli): restore the previous image on a failed port-mode deploy, and de-flake the gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,18 @@ them until tagged releases begin.
   landed became an un-retried 502 (`lb_try_duration` defaults to 0). There was previously no gap at all.
 
 ### Fixed
+- **A failed port-mode deploy no longer leaves the box serving nothing.** Without `--domain` the app is
+  published on a single port, so the old container is stopped before the new one starts — there is no
+  blue-green swap to fall back on, and the health gate could only report the failure. A bad image (bad
+  config, a migration that won't apply) therefore took the app down and left it down, with the gate's own
+  code comment admitting it "can't roll back". It now re-enters the deploy with `:previous` — the last
+  image that passed this same gate — on either post-start failure: a container that doesn't stay running,
+  or one that never answers the health probe. The deploy still exits non-zero, because it still failed;
+  the difference is that the box is serving the previous version rather than nothing. The `tag` parameter
+  is its own recursion guard (the restore passes `:previous`, so it cannot re-enter), and tags are
+  deliberately *not* swapped the way `rask deploy rollback` swaps them — nothing about the configuration
+  succeeded, so the next deploy should overwrite `:current` rather than file the last known-good image
+  away as `:previous`. The inherent downtime of one published port is unchanged and still documented.
 - **Every web-host sample now budgets its shutdown.** Nine of the ten inherited .NET's default 30s
   `ShutdownTimeout`, which *exceeds* the 20s `rask deploy` allows between SIGTERM and SIGKILL — so a sample
   deployed as written would be killed mid-shutdown. Only `Rask.Example.Shop` was right, which meant a reader

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,16 @@ them until tagged releases begin.
   landed became an un-retried 502 (`lb_try_duration` defaults to 0). There was previously no gap at all.
 
 ### Fixed
+- **The local unit gate no longer flakes on two background-processor tests.** Both passed every time in
+  isolation and failed only under a full-suite load, which is the worst shape for a gate the pre-commit
+  hook enforces: the practical workaround is `--no-verify`, which skips the format and unit checks
+  entirely. `OutboxRetentionTests` started the real hosted service and slept a fixed 500 ms per step, so
+  under load the first poll had not finished when the processor was stopped and the retention sweep never
+  ran — the assertions then read as "the sweep is broken" rather than "the sweep never happened". It now
+  drives `OutboxProcessor.RunCycleAsync` directly (one explicit poll per step; retention is throttled on
+  the injected clock, so that is exactly what the test means). `MailProcessorTests` waited for
+  `Sender.Sent.Count == 1` and then asserted on `ProcessedAt`, which the processor writes *after* the
+  sender returns — so it asserted on state it had never waited for. It now waits for the row.
 - **A failed port-mode deploy no longer leaves the box serving nothing.** Without `--domain` the app is
   published on a single port, so the old container is stopped before the new one starts — there is no
   blue-green swap to fall back on, and the health gate could only report the failure. A bad image (bad

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -405,6 +405,10 @@ show "Updating…" and reload onto the new one at their previous scroll position
 from the host's live containers on every deploy — deploying a second app (a different `--domain`)
 leaves the first untouched. Without `--domain`, the app is published on `--port` (default `8080`) and
 you put your own TLS/reverse proxy in front (there's no zero-downtime swap on a single published port).
+That downtime is inherent to publishing one port; *staying* down is not. If the new container fails to
+start or fails its health check, port mode brings `:previous` back automatically — the last image that
+passed the same gate — and still exits non-zero, so a bad image costs you a blip rather than an outage.
+Use `rask deploy rollback` to undo a deploy that *did* come up healthy.
 
 **Your database survives redeploys.** Each deploy runs a fresh container, so `rask deploy` mounts a
 per-app named volume and points the app at it (`ConnectionStrings:App` → `Data Source=/data/app.db`) — the

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -432,16 +432,21 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         if (!await WaitUntilRunningAsync(host, slug, cancellationToken).ConfigureAwait(false))
         {
             await DumpLogsAsync(host, slug, env, cancellationToken).ConfigureAwait(false);
-            return 1;
+            return await RestorePreviousAsync(
+                host, slug, port, containerPort, env, healthEnabled, healthPath, provider, tag,
+                "The new container did not stay running.", cancellationToken).ConfigureAwait(false);
         }
 
-        // No blue-green here (the old container is already gone), so a failed probe can't roll back — it
-        // surfaces the broken deploy with logs rather than leaving it to fail silently under traffic.
+        // There is no blue-green swap on a single published port — the old container is stopped before the
+        // new one starts, so the downtime is real and documented. What is NOT acceptable is *staying* down:
+        // on a bad image the gate used to report the failure and leave nothing serving. It now re-enters
+        // with `:previous`, which is the last image that passed this same gate.
         if (healthEnabled && !await WaitUntilHealthyAsync(host, slug, healthPath, containerPort, cancellationToken).ConfigureAwait(false))
         {
             await DumpLogsAsync(host, slug, env, cancellationToken).ConfigureAwait(false);
-            Console.WriteErrorLine(HealthFailureMessage(healthPath, rolledBack: false), ConsoleStyle.Error);
-            return 1;
+            return await RestorePreviousAsync(
+                host, slug, port, containerPort, env, healthEnabled, healthPath, provider, tag,
+                HealthFailureMessage(healthPath, rolledBack: false), cancellationToken).ConfigureAwait(false);
         }
 
         if (persist)
@@ -450,6 +455,60 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         }
         Console.WriteLine($"Deployed. The app is live at http://{HostName(host)}:{port}", ConsoleStyle.Success);
         return 0;
+    }
+
+    /// <summary>
+    ///     Port mode's automatic rollback: bring <c>:previous</c> back after a deploy that started but did
+    ///     not come up healthy. Always returns a non-zero exit code — the deploy failed either way; the
+    ///     only question is whether the box is left serving something.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Guarded by <paramref name="tag" />: this only fires for a deploy of <c>:current</c>, so the
+    ///         re-entry (which passes <see cref="PreviousTag" />) cannot recurse. That condition is the
+    ///         whole recursion guard — there is no depth counter to get wrong.
+    ///     </para>
+    ///     <para>
+    ///         Tags are deliberately left alone, unlike <c>rask deploy rollback</c>, which swaps them.
+    ///         Nothing about the *configuration* succeeded here: the operator fixes the image and deploys
+    ///         again, which overwrites <c>:current</c>. Swapping would file the last known-good image away
+    ///         as <c>:previous</c> and let the next deploy lose it.
+    ///     </para>
+    /// </remarks>
+    private async Task<int> RestorePreviousAsync(
+        string host, string slug, int port, int containerPort, IReadOnlyList<string> env,
+        bool healthEnabled, string healthPath, DatabaseProvider provider, string tag, string reason,
+        CancellationToken cancellationToken)
+    {
+        if (tag != CurrentTag)
+        {
+            // Already the restore attempt. Report plainly rather than trying again.
+            Console.WriteErrorLine($"{reason} The previous version did not come up either.", ConsoleStyle.Error);
+            return 1;
+        }
+
+        if (await ResolveRollbackImageAsync(host, slug, cancellationToken).ConfigureAwait(false) is null)
+        {
+            Console.WriteErrorLine($"{reason} There is no previous image to fall back to.", ConsoleStyle.Error);
+            Console.Error.WriteLine($"{slug}:{PreviousTag} is written by the deploy that replaces it, so the first deploy of an app has no predecessor.");
+            return 1;
+        }
+
+        Console.WriteErrorLine(reason, ConsoleStyle.Error);
+        WriteHeading($"Restoring {slug}:{PreviousTag}…");
+
+        var restored = await DeployPortAsync(
+            host, slug, port, containerPort, env, project: null, envFile: null, healthEnabled, healthPath,
+            provider, cancellationToken, tag: PreviousTag, persist: false).ConfigureAwait(false);
+
+        if (restored == 0)
+        {
+            Console.WriteLine(
+                $"The previous version is serving again on port {port}. The deploy itself failed — fix the image and deploy again.",
+                ConsoleStyle.Warning);
+        }
+
+        return 1;
     }
 
     // ── The domain path: blue-green swap behind a shared, multi-app Caddy proxy (zero downtime). ────────

--- a/src/Rask.Outbox/OutboxProcessor.cs
+++ b/src/Rask.Outbox/OutboxProcessor.cs
@@ -144,7 +144,13 @@ public sealed class OutboxProcessor<TContext>(
         }
     }
 
-    private async Task RunCycleAsync(CancellationToken cancellationToken)
+    /// <summary>
+    ///     One poll: drain the queue, sweep retention, sample the depth. Internal so a test can drive
+    ///     exactly one cycle instead of starting the hosted service and sleeping — a fixed sleep is a race
+    ///     the machine wins or loses depending on what else is running, which is how these tests came to
+    ///     fail only under a full-suite load.
+    /// </summary>
+    internal async Task RunCycleAsync(CancellationToken cancellationToken)
     {
         try
         {

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -277,6 +277,63 @@ public sealed class DeployCommandTests
         Assert.Equal(9000, config.Port);
     }
 
+    /// <summary>
+    ///     Port mode stops the old container before starting the new one, so a bad image used to leave the
+    ///     box serving nothing at all — the health gate reported the failure and stopped there. The
+    ///     downtime is inherent to a single published port and is documented; staying down is not.
+    /// </summary>
+    [Fact]
+    public async Task Port_mode_restores_the_previous_image_when_the_health_gate_fails()
+    {
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner
+        {
+            CaptureHandler = Captures(),
+            // The probe fails for the image being deployed, and would fail for any probe — so the restore
+            // is asserted on the run that happens, not on a second probe passing.
+            RunHandler = args => args.Contains("curlimages/curl:8.11.1") ? 1 : 0,
+        };
+        var console = new StringConsole();
+        var command = Create(fs, runner, console);
+
+        var exit = await command.ExecuteAsync(["--host", "deploy@box", "--name", "shop", "--port", "9000"], CancellationToken.None);
+
+        // The deploy still failed — that is not in question.
+        Assert.Equal(1, exit);
+
+        // But :previous was started again, so the box is serving the last image that passed this gate.
+        var runs = runner.Invocations.Where(i => !i.Captured && i.Arguments.Contains("run")).ToList();
+        Assert.Contains(runs, i => i.Arguments.Contains("shop:previous"));
+        Assert.Contains("Restoring shop:previous", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Port_mode_says_so_when_there_is_no_previous_image_to_restore()
+    {
+        var fs = new FakeFileSystem();
+        var runner = new FakeProcessRunner
+        {
+            // A first deploy: :current exists, :previous does not.
+            CaptureHandler = args =>
+                IsHostProbe(args) ? new ProcessResult(0, ReadyHostProbe, string.Empty)
+                : args.Contains("inspect") && args.Contains("image") ? new ProcessResult(1, string.Empty, string.Empty)
+                : args.Contains("ps") ? new ProcessResult(0, string.Empty, string.Empty)
+                : args.Contains("inspect") ? new ProcessResult(0, "true\n", string.Empty)
+                : new ProcessResult(0, string.Empty, string.Empty),
+            RunHandler = args => args.Contains("curlimages/curl:8.11.1") ? 1 : 0,
+        };
+        var console = new StringConsole();
+        var command = Create(fs, runner, console);
+
+        var exit = await command.ExecuteAsync(["--host", "deploy@box", "--name", "shop", "--port", "9000"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("no previous image", console.ErrorText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain(
+            runner.Invocations.Where(i => !i.Captured && i.Arguments.Contains("run")),
+            i => i.Arguments.Contains("shop:previous"));
+    }
+
     [Fact]
     public async Task Port_mode_persists_env_file_and_project_for_the_next_deploy()
     {

--- a/tests/Rask.Mail.Tests/MailProcessorTests.cs
+++ b/tests/Rask.Mail.Tests/MailProcessorTests.cs
@@ -15,7 +15,10 @@ public sealed class MailProcessorTests
         try
         {
             await harness.Queue.SendAsync(SampleEmail());
-            await harness.WaitUntilAsync(async () => harness.Sender.Sent.Count == 1);
+            // Wait for the ROW, not for the send. The processor marks the row after the sender returns, so
+            // waiting on Sent.Count leaves the ProcessedAt assertion below racing that write — which is
+            // exactly how this failed under a full-suite load while passing every time in isolation.
+            await harness.WaitUntilAsync(async () => (await harness.SingleMailAsync()).ProcessedAt is not null);
 
             var sent = Assert.Single(harness.Sender.Sent);
             Assert.Equal("Welcome", sent.Subject);

--- a/tests/Rask.Outbox.Tests/OutboxRetentionTests.cs
+++ b/tests/Rask.Outbox.Tests/OutboxRetentionTests.cs
@@ -141,12 +141,15 @@ public sealed class OutboxRetentionTests : IDisposable
     // One poll cycle, deterministically: start the processor, wait for the sweep, stop. Driving the real
     // hosted service (rather than calling a private method) is what proves the purge is actually wired
     // into the cycle — a PurgeAsync nobody calls would pass every other assertion here.
-    private async Task RunCycleAsync()
+    // Drives exactly one poll, rather than starting the hosted service and sleeping for a fixed 500 ms.
+    // That sleep was a race against the machine: under a full-suite load the first cycle had not finished
+    // when the processor was stopped, so the retention sweep never ran and the assertions below read as
+    // "the sweep is broken" instead of "the sweep never happened". Retention is throttled on the injected
+    // clock, so one explicit cycle per step is exactly what these tests mean.
+    private Task RunCycleAsync()
     {
         var processor = _provider.GetServices<IHostedService>().OfType<OutboxProcessor<OutboxDbContext>>().Single();
-        await processor.StartAsync(CancellationToken.None);
-        await Task.Delay(500);
-        await processor.StopAsync(CancellationToken.None);
+        return processor.RunCycleAsync(CancellationToken.None);
     }
 
     private OutboxDbContext NewContext() =>


### PR DESCRIPTION
Two independent fixes from the post-merge issue sweep. Closes #563, #567, #577.

## 1. A failed port-mode deploy no longer leaves the box serving nothing (#563)

Without `--domain` the app is published on a single port, so `DeployPortAsync` stops the old container
before starting the new one. There is no blue-green swap to fall back on, and the health gate could only
report the failure — its own code comment admitted it "can't roll back". A bad image (bad config, a
migration that won't apply) therefore took the app down and left it down.

It now re-enters with `:previous`, the last image that passed this same gate, on **either** post-start
failure:

- the container does not stay running — the usual shape of a failed migration, and the more likely
  trigger of the two;
- the container never answers the health probe.

The deploy still exits non-zero, because it still failed. The difference is what is serving afterwards.

Two decisions worth reviewing:

- **`tag` is its own recursion guard.** The restore passes `PreviousTag`, and the guard fires only for
  `CurrentTag`, so it cannot re-enter. No depth counter to get wrong.
- **Tags are deliberately *not* swapped**, unlike `rask deploy rollback`. Nothing about the configuration
  succeeded, so the operator fixes the image and deploys again, overwriting `:current`. Swapping would
  file the last known-good image away as `:previous` and let the next deploy lose it.

The inherent downtime of one published port is unchanged and still documented — `docs/cli.md` now
distinguishes it from *staying* down.

**Verified by negative control**: with the rollback reverted,
`Port_mode_restores_the_previous_image_when_the_health_gate_fails` fails. The no-previous-image path has
its own test asserting nothing is started.

## 2. The local unit gate no longer flakes on two processor tests (#567, #577)

Both passed every time in isolation and failed only under a full-suite load — the worst shape for a gate
the pre-commit hook enforces, because the practical workaround is `--no-verify`, which skips the format
and unit checks entirely. Two *different* root causes, both fixed at the cause rather than by widening a
tolerance:

- **`OutboxRetentionTests`** started the real hosted service and slept a fixed `Task.Delay(500)` per step.
  Under load the first poll had not finished when the processor was stopped, so the retention sweep never
  ran — and the assertions then read as "the sweep is broken" rather than "the sweep never happened".
  `OutboxProcessor.RunCycleAsync` is now `internal` and the test drives exactly one cycle. Retention is
  throttled on the injected clock, so one explicit cycle per step is precisely what these tests mean.
  As a side effect the suite stops sleeping ~3s.
- **`MailProcessorTests.Send_delivers_the_email_and_marks_it_processed`** waited for
  `Sender.Sent.Count == 1` and then asserted on `row.ProcessedAt`, which the processor writes *after* the
  sender returns. It was asserting on state it had never waited for. It now waits for the row.

## Testing

Full local gate green, zero failures. `Rask.Cli.Tests` deploy suites 105/105.

Browser E2E skipped (`RASK_SKIP_E2E=1`): no UI surface here, and the sandbox's Playwright suite is
environmentally red on `main` for an unrelated reason (`PlaygroundExampleTests` needs browser network for
Roslyn refs).

No benchmarks — nothing on the render or runtime hot path.

## Not in this PR

**#555** was investigated and deliberately not fixed here. The root cause turns out to be broader than the
issue described — `RaskTest.Render(instance)` never mounts the component at all, synchronously or
asynchronously — and the obvious fix breaks `RaskTest.Render(Div()[…])` by dropping its children on
re-render. Full diagnosis, the measured failure, and three options are on the issue, which has been
retitled to the actual defect.
