### PR TITLE
feat(logging): store the scope state each log entry was written under

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **The application log now stores the scope state each entry was written under.** `RaskLoggerProvider`
+  returned `null` from `BeginScope`, so the request id, user id and correlation id an app opens a scope with
+  were dropped — and the whole point of keeping logs is answering *"what else happened on that request?"*,
+  which without them has to be reconstructed from message text. Whatever `ILogger.BeginScope` was given is
+  now flattened (outermost first, message templates keeping their values and dropping the format string) and
+  stored beside the entry, queryable through `LogQuery.ScopeKey` / `ScopeValue` and shown on the row in the
+  dashboard's History mode. The filter matches the stored key exactly via `json_extract`, so a request id
+  cannot match an entry that merely mentioned it in a message. Cost sits where it must: flattening happens at
+  the log call, because scope state is short-lived and may be reused the moment the scope closes, while the
+  JSON encoding is deferred to the writer's own thread — the "a log call never waits on the disk" invariant
+  is intact. Bounded by `MaxScopeValues` (16) and `MaxScopeValueLength` (256) so nested scopes can't grow a
+  row without limit, and switchable off with `CaptureScopes = false` for scopes carrying values you would
+  rather not keep at rest. A store created by the previous release gains the column on first use — there is
+  no migration to run, because this database is framework-owned and deliberately outside yours.
 - **`session-load` — what a host does when its sessions are actually used.** The existing capacity reports
   answer how many sessions *fit*: a retained-memory question, measured against a stub socket that never
   receives. Nothing said what happens when those sessions are used, and a capacity number you can't serve

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -47,8 +47,35 @@ builder.Services.AddRaskLogging(connectionString, o =>
     o.BatchSize     = 500;
     o.QueueCapacity = 10_000;
     o.ExcludedCategories.Add("Microsoft.AspNetCore.");
+
+    o.CaptureScopes        = true;  // store ambient ILogger.BeginScope state (default)
+    o.MaxScopeValues       = 16;    // per entry
+    o.MaxScopeValueLength  = 256;   // per value
 });
 ```
+
+### Scopes
+
+Whatever an `ILogger.BeginScope` was opened with is stored alongside the entry, so the log answers *"what
+else happened on that request?"* instead of leaving it to be reconstructed from message text:
+
+```csharp
+using (logger.BeginScope("request {RequestId} for {UserId}", requestId, user.Id))
+{
+    logger.LogInformation("charging {Amount}", amount);   // stored with RequestId and UserId
+}
+```
+
+Nested scopes are flattened outermost-first; a scope opened with a bare value (`BeginScope("checkout")`) is
+stored under the key `Scope`. The message template itself is not stored — only the values it formats.
+
+The cost sits where it has to: flattening happens at the log call, because scope state is short-lived and
+may be reused the moment the scope closes. Encoding it to JSON does not — the writer does that on its own
+thread, so the request path keeps the "a log call never waits on the disk" property. Both bounds above exist
+so a runaway loop of nested scopes, or one large object's `ToString()`, cannot grow a row without limit.
+
+Turn `CaptureScopes` off if your scopes carry values you would rather not have at rest. Note the same
+caveat as the rest of the store: **log lines can contain secrets** — treat the file as sensitive.
 
 ### Keeping the noise down
 
@@ -80,12 +107,18 @@ public sealed class IncidentPage(ILogStore store) : Component
         MinimumLevel = LogLevel.Error,
         Category = "Shop.Checkout",
         Search = "declined",
+        ScopeKey = "RequestId",       // entries captured under this scope key…
+        ScopeValue = "0HN7…",         // …with this value. Key alone finds every entry that carried it.
         From = DateTimeOffset.UtcNow.AddHours(-6),
         Page = 1,
         PageSize = 50,
     });
 }
 ```
+
+Each `LogRecord` carries its `Scopes` as key/value pairs. The scope filter matches the stored key exactly
+(via SQLite's `json_extract`) rather than searching the row as text, so a request id cannot match an entry
+that merely mentioned it in a message.
 
 `LogPage` carries the matching entries (newest first), the `TotalCount` behind the filter, and a `PageCount`.
 `ILogStore` also exposes `CategoriesAsync()`, `CountAsync()`, `PurgeAsync(retention, maxRows)` and
@@ -161,10 +194,12 @@ very restart it exists to survive.
 
 - **One writer per app.** SQLite is single-writer; run one process against a given `logs.db`, exactly as with
   the jobs and outbox processors.
-- **Scopes are not captured.** `BeginScope` state (a request id, a user id) is not stored yet — the message,
-  category, level, event id, timestamp and exception are.
-- **Trim / AOT safe.** No reflection, no serializer; the package depends only on `Microsoft.Data.Sqlite` and
-  the logging/hosting abstractions.
+- **Trim / AOT safe.** No reflection. Scope state is encoded with a source-generated
+  `JsonSerializerContext`, not the reflection serializer, so the package stays free of IL2026/IL3050 in a
+  published WASM or AOT app. It depends only on `Microsoft.Data.Sqlite` and the logging/hosting abstractions.
+- **The schema upgrades itself.** The `Scopes` column is added to a store created by an earlier version on
+  first use — this database is framework-owned and deliberately outside your migration history, so there is
+  nothing for you to run.
 
 ## See also
 

--- a/src/Rask.Dashboard/Pages/LogsPage.cs
+++ b/src/Rask.Dashboard/Pages/LogsPage.cs
@@ -319,11 +319,14 @@ public sealed class LogsPage(
             Aria: disabled ? new Dictionary<string, string?> { ["disabled"] = "true" } : null)[label];
 
     // One row shape for both surfaces, so the two modes cannot drift into rendering an entry differently.
+    // The live tail has no scopes: it is the in-memory ring buffer, which predates the store and captures
+    // only what it is handed. History reads them from the stored row.
     private static LogRow ToRow(DashboardLogEntry entry) => new(
-        entry.Sequence, entry.Timestamp, entry.Level, entry.Category, entry.Message, entry.Exception);
+        entry.Sequence, entry.Timestamp, entry.Level, entry.Category, entry.Message, entry.Exception, null);
 
     private static LogRow ToRow(LogRecord record) => new(
-        record.Id, record.Timestamp, record.Level, record.Category, record.Message, record.Exception);
+        record.Id, record.Timestamp, record.Level, record.Category, record.Message, record.Exception,
+        record.Scopes);
 
     private static Component Table(IEnumerable<LogRow> rows, DateTime now) =>
         BsTable(Small: true, Hover: true, Responsive: true)[
@@ -340,10 +343,24 @@ public sealed class LogsPage(
                     // drown the table, so it renders muted beneath rather than in a separate view.
                     r.Exception is { } ex
                         ? Pre(Class: "small text-body-secondary text-wrap mb-0 mt-1")[ex]
-                        : null
+                        : null,
+                    // The ambient state the entry was written under — the request id, the user id. This is
+                    // what turns one line into a thread you can pull: copy a value into the scope filter
+                    // and the page shows everything else that happened on the same request.
+                    ScopeChips(r.Scopes)
                 ]
             ])]
         ];
+
+    private static Component? ScopeChips(IReadOnlyList<LogScopeValue>? scopes) =>
+        scopes is null || scopes.Count == 0
+            ? null
+            : Div(Class: "d-flex flex-wrap gap-1 mt-1")[
+                scopes.Select(s =>
+                    BsBadge(Color: BsColor.Secondary, Class: "fw-normal font-monospace", Key: s.Key)[
+                        $"{s.Key}={s.Value}"
+                    ])
+            ];
 
     private static Component LevelBadge(LogLevel level) => BsBadge(Color: level switch
     {
@@ -379,5 +396,6 @@ public sealed class LogsPage(
         LogLevel Level,
         string Category,
         string Message,
-        string? Exception);
+        string? Exception,
+        IReadOnlyList<LogScopeValue>? Scopes);
 }

--- a/src/Rask.Logging/LogRecord.cs
+++ b/src/Rask.Logging/LogRecord.cs
@@ -13,6 +13,12 @@ namespace Rask.Logging;
 /// <param name="EventId">The <see cref="Microsoft.Extensions.Logging.EventId"/>'s numeric id, or 0.</param>
 /// <param name="Message">The formatted message.</param>
 /// <param name="Exception">The exception's <c>ToString()</c>, if one was attached.</param>
+/// <param name="Scopes">
+/// The ambient <see cref="ILogger.BeginScope{TState}"/> state the entry was written under — the request id,
+/// the user id, whatever correlation id the app opened a scope with — flattened outermost-first, or
+/// <c>null</c> when no scope was open. This is what makes a stored log answer <em>"what else happened on
+/// that request?"</em> rather than leaving it to be reconstructed from message text.
+/// </param>
 public sealed record LogRecord(
     long Id,
     DateTimeOffset Timestamp,
@@ -20,7 +26,20 @@ public sealed record LogRecord(
     string Category,
     int EventId,
     string Message,
-    string? Exception);
+    string? Exception,
+    IReadOnlyList<LogScopeValue>? Scopes = null);
+
+/// <summary>One key/value pair captured from an open logging scope.</summary>
+/// <param name="Key">
+/// The state key, e.g. <c>RequestId</c>. A scope opened with a bare object rather than key/value state
+/// (<c>BeginScope("checkout")</c>) is stored under <see cref="LogScopeValue.MessageKey"/>.
+/// </param>
+/// <param name="Value">The value, already converted to a string at the call site.</param>
+public readonly record struct LogScopeValue(string Key, string Value)
+{
+    /// <summary>The key a scope with no structured state is stored under.</summary>
+    public const string MessageKey = "Scope";
+}
 
 /// <summary>
 /// A filter over the stored log. Every property is optional; leaving them all unset asks for the newest page
@@ -36,6 +55,19 @@ public sealed record LogQuery
 
     /// <summary>Only entries whose message or exception contains this substring (case-insensitive).</summary>
     public string? Search { get; init; }
+
+    /// <summary>
+    /// Only entries captured under a scope with this key, e.g. <c>RequestId</c>. Combine with
+    /// <see cref="ScopeValue"/> to pin one request; on its own it finds every entry that carried the key.
+    /// </summary>
+    public string? ScopeKey { get; init; }
+
+    /// <summary>
+    /// Only entries whose <see cref="ScopeKey"/> holds this value. Ignored unless <see cref="ScopeKey"/> is
+    /// set — a value without a key would match the same string appearing under any key, which is a
+    /// different (and much less useful) question.
+    /// </summary>
+    public string? ScopeValue { get; init; }
 
     /// <summary>Only entries logged at or after this instant.</summary>
     public DateTimeOffset? From { get; init; }

--- a/src/Rask.Logging/LogScopeJson.cs
+++ b/src/Rask.Logging/LogScopeJson.cs
@@ -1,0 +1,74 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Rask.Logging;
+
+/// <summary>
+///     Encodes captured scope state for the <c>Scopes</c> column and reads it back.
+/// </summary>
+/// <remarks>
+///     <para>
+///         A JSON object rather than a side table. A side table would be the textbook answer, but it buys
+///         normalisation nobody here needs and costs an insert per pair on the highest-frequency writer in
+///         the framework — plus a join on every read of a log that is already read far less often than it
+///         is written. The store is append-only and expendable; the column is the right shape for it.
+///     </para>
+///     <para>
+///         Serialized with an explicit context so the package stays trim- and AOT-safe: the reflection
+///         serializer would be an IL2026/IL3050 site in a published WASM or AOT app.
+///     </para>
+/// </remarks>
+internal static class LogScopeJson
+{
+    internal static string? Encode(IReadOnlyList<LogScopeValue>? scopes)
+    {
+        if (scopes is null || scopes.Count == 0)
+        {
+            return null;
+        }
+
+        // A flat object: duplicate keys across nested scopes are rare, and last-wins matches how a reader
+        // would interpret "the innermost value of RequestId" anyway.
+        var map = new Dictionary<string, string>(scopes.Count, StringComparer.Ordinal);
+        foreach (var scope in scopes)
+        {
+            map[scope.Key] = scope.Value;
+        }
+
+        return JsonSerializer.Serialize(map, LogScopeJsonContext.Default.DictionaryStringString);
+    }
+
+    internal static IReadOnlyList<LogScopeValue>? Decode(string? json)
+    {
+        if (string.IsNullOrEmpty(json))
+        {
+            return null;
+        }
+
+        try
+        {
+            var map = JsonSerializer.Deserialize(json, LogScopeJsonContext.Default.DictionaryStringString);
+            if (map is null || map.Count == 0)
+            {
+                return null;
+            }
+
+            var values = new List<LogScopeValue>(map.Count);
+            foreach (var pair in map)
+            {
+                values.Add(new LogScopeValue(pair.Key, pair.Value));
+            }
+
+            return values;
+        }
+        catch (JsonException)
+        {
+            // A row written by something else, or a truncated write. A log viewer must not throw on one
+            // malformed row and take the whole page with it.
+            return null;
+        }
+    }
+}
+
+[JsonSerializable(typeof(Dictionary<string, string>))]
+internal sealed partial class LogScopeJsonContext : JsonSerializerContext;

--- a/src/Rask.Logging/LogScopes.cs
+++ b/src/Rask.Logging/LogScopes.cs
@@ -1,0 +1,157 @@
+using System.Collections;
+
+namespace Rask.Logging;
+
+/// <summary>
+///     The ambient stack of open <see cref="Microsoft.Extensions.Logging.ILogger.BeginScope{TState}" />
+///     scopes, and the snapshot a log call takes of it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         An <see cref="AsyncLocal{T}" /> linked list rather than a mutable collection: a scope opened on
+///         one request must not be visible to another, and the list flows into awaited continuations the
+///         way the surrounding request does. Disposing restores the previous head, so an out-of-order
+///         dispose truncates rather than corrupting.
+///     </para>
+///     <para>
+///         <b>What happens on the request thread, and what does not.</b> The snapshot flattens the stack
+///         into a small array and calls <c>ToString()</c> on each value — that has to happen here, because
+///         scope state is short-lived and may be mutated or pooled the moment the scope closes. Turning
+///         that array into JSON does <em>not</em>; the writer does it on its own thread, off the request
+///         path, in keeping with "a log call never waits on the disk".
+///     </para>
+/// </remarks>
+internal static class LogScopes
+{
+    private static readonly AsyncLocal<Scope?> Current = new();
+
+    /// <summary>Opens a scope. Disposing it restores the previous one.</summary>
+    internal static IDisposable Push(object? state)
+    {
+        var scope = new Scope(state, Current.Value);
+        Current.Value = scope;
+        return scope;
+    }
+
+    /// <summary>
+    ///     Flattens the open scopes, outermost first, or returns <c>null</c> when none are open — the
+    ///     common case, which must cost nothing but one <see cref="AsyncLocal{T}" /> read.
+    /// </summary>
+    /// <param name="maxValues">
+    ///     Upper bound on captured pairs. A scope stack is bounded in practice, but a log store must not
+    ///     be a way for a runaway loop of nested scopes to consume memory per entry.
+    /// </param>
+    /// <param name="maxValueLength">Upper bound on each value, so one huge object can't dominate a row.</param>
+    internal static IReadOnlyList<LogScopeValue>? Capture(int maxValues, int maxValueLength)
+    {
+        var head = Current.Value;
+        if (head is null)
+        {
+            return null;
+        }
+
+        // Outermost first: the request id is more useful ahead of the innermost detail, and it reads the
+        // way the code nests.
+        var stack = new List<Scope>();
+        for (var s = head; s is not null; s = s.Parent)
+        {
+            stack.Add(s);
+        }
+
+        stack.Reverse();
+
+        var captured = new List<LogScopeValue>();
+        foreach (var scope in stack)
+        {
+            if (captured.Count >= maxValues)
+            {
+                break;
+            }
+
+            Flatten(scope.State, captured, maxValues, maxValueLength);
+        }
+
+        return captured.Count == 0 ? null : captured;
+    }
+
+    private static void Flatten(object? state, List<LogScopeValue> into, int maxValues, int maxValueLength)
+    {
+        switch (state)
+        {
+            case null:
+                return;
+
+            // The shape BeginScope("{RequestId} {UserId}", a, b) and BeginScope(new Dictionary<,>) both
+            // produce. Preferred over ToString() because it is the structured state the caller meant.
+            case IReadOnlyList<KeyValuePair<string, object?>> pairs:
+                foreach (var pair in pairs)
+                {
+                    if (into.Count >= maxValues)
+                    {
+                        return;
+                    }
+
+                    // The original format string is the template, not data — storing it would put
+                    // "{RequestId} {UserId}" in every row alongside the values it formats.
+                    if (pair.Key == "{OriginalFormat}")
+                    {
+                        continue;
+                    }
+
+                    into.Add(new LogScopeValue(pair.Key, Truncate(pair.Value?.ToString(), maxValueLength)));
+                }
+
+                return;
+
+            case IEnumerable<KeyValuePair<string, object?>> pairs:
+                foreach (var pair in pairs)
+                {
+                    if (into.Count >= maxValues)
+                    {
+                        return;
+                    }
+
+                    if (pair.Key == "{OriginalFormat}")
+                    {
+                        continue;
+                    }
+
+                    into.Add(new LogScopeValue(pair.Key, Truncate(pair.Value?.ToString(), maxValueLength)));
+                }
+
+                return;
+
+            // A bare scope — BeginScope("checkout"). Still worth keeping: it is how most people reach for
+            // this before they discover structured state.
+            default:
+                into.Add(new LogScopeValue(
+                    LogScopeValue.MessageKey,
+                    Truncate(state.ToString(), maxValueLength)));
+                return;
+        }
+    }
+
+    private static string Truncate(string? value, int max) =>
+        value is null ? string.Empty
+        : value.Length <= max ? value
+        : value[..max];
+
+    private sealed class Scope(object? state, Scope? parent) : IDisposable
+    {
+        private bool _disposed;
+
+        internal object? State { get; } = state;
+        internal Scope? Parent { get; } = parent;
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            Current.Value = Parent;
+        }
+    }
+}

--- a/src/Rask.Logging/RaskLoggerProvider.cs
+++ b/src/Rask.Logging/RaskLoggerProvider.cs
@@ -47,10 +47,11 @@ internal sealed class RaskLoggerProvider(
             _excluded = options.IsExcluded(category);
         }
 
-        // Scopes are not captured. The existing dashboard tail doesn't capture them either, and storing
-        // them properly means a schema for structured state rather than a string column — a deliberate
-        // follow-up, not a silent half-implementation.
-        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        // Captured when CaptureScopes is on (the default). Returning null here — as this did — is what
+        // dropped the request id, the user id and every correlation id an app opened a scope with, which
+        // is precisely the state that makes a stored log answer "what else happened on that request?".
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull =>
+            _options.CaptureScopes ? LogScopes.Push(state) : null;
 
         // Checked by the logging infrastructure before it formats anything, so an entry below the store's
         // threshold costs a comparison rather than a string.
@@ -79,7 +80,10 @@ internal sealed class RaskLoggerProvider(
                 _category,
                 eventId.Id,
                 formatter(state, exception),
-                exception?.ToString()));
+                exception?.ToString(),
+                _options.CaptureScopes
+                    ? LogScopes.Capture(_options.MaxScopeValues, _options.MaxScopeValueLength)
+                    : null));
         }
     }
 }

--- a/src/Rask.Logging/RaskLoggingOptions.cs
+++ b/src/Rask.Logging/RaskLoggingOptions.cs
@@ -66,6 +66,30 @@ public sealed class RaskLoggingOptions
     public TimeSpan ShutdownDrainTimeout { get; set; } = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// Whether the ambient <c>ILogger.BeginScope</c> state — a request id, a user id, a correlation id — is
+    /// stored alongside each entry. On by default: it is what lets the store answer "what else happened on
+    /// that request?" instead of leaving it to be reconstructed from message text.
+    /// <para>
+    /// Turn it off if your scopes carry values you do not want at rest. Note the cost is paid at the log
+    /// call: flattening has to happen there, because scope state is short-lived and may be reused the
+    /// moment the scope closes. Only the JSON encoding is deferred to the writer's own thread.
+    /// </para>
+    /// </summary>
+    public bool CaptureScopes { get; set; } = true;
+
+    /// <summary>
+    /// Upper bound on captured scope pairs per entry. Default 16 — deep enough for any realistic nesting,
+    /// and a bound so a runaway loop of nested scopes cannot grow a row without limit.
+    /// </summary>
+    public int MaxScopeValues { get; set; } = 16;
+
+    /// <summary>
+    /// Upper bound on each captured scope value, in characters. Default 256, so one large object's
+    /// <c>ToString()</c> cannot dominate the store.
+    /// </summary>
+    public int MaxScopeValueLength { get; set; } = 256;
+
+    /// <summary>
     /// The production pragmas applied to every connection the store opens. Defaults to the same tuned set
     /// <c>Rask.SQLite</c> applies to the application database — WAL matters here in particular, since it is
     /// what lets a dashboard read the store while the writer is flushing.
@@ -131,6 +155,19 @@ public sealed class RaskLoggingOptions
         if (BatchSize < 1)
         {
             throw new ArgumentOutOfRangeException(nameof(BatchSize), BatchSize, "BatchSize must be at least 1.");
+        }
+
+        if (MaxScopeValues < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxScopeValues), MaxScopeValues,
+                "MaxScopeValues must be at least 1. Set CaptureScopes = false to store no scope state.");
+        }
+
+        if (MaxScopeValueLength < 1)
+        {
+            throw new ArgumentOutOfRangeException(
+                nameof(MaxScopeValueLength), MaxScopeValueLength, "MaxScopeValueLength must be at least 1.");
         }
 
         if (QueueCapacity < 1)

--- a/src/Rask.Logging/SqliteLogStore.cs
+++ b/src/Rask.Logging/SqliteLogStore.cs
@@ -26,8 +26,8 @@ namespace Rask.Logging;
 internal sealed class SqliteLogStore : ILogStore
 {
     private const string InsertSql = """
-        INSERT INTO RaskLog (Timestamp, Level, Category, EventId, Message, Exception)
-        VALUES ($timestamp, $level, $category, $eventId, $message, $exception);
+        INSERT INTO RaskLog (Timestamp, Level, Category, EventId, Message, Exception, Scopes)
+        VALUES ($timestamp, $level, $category, $eventId, $message, $exception, $scopes);
         """;
 
     // Deletes are paged so a single unbounded DELETE never holds SQLite's write lock for the length of a
@@ -79,6 +79,7 @@ internal sealed class SqliteLogStore : ILogStore
                         var eventId = command.Parameters.Add("$eventId", SqliteType.Integer);
                         var message = command.Parameters.Add("$message", SqliteType.Text);
                         var exception = command.Parameters.Add("$exception", SqliteType.Text);
+                        var scopes = command.Parameters.Add("$scopes", SqliteType.Text);
 
                         foreach (var record in records)
                         {
@@ -88,6 +89,9 @@ internal sealed class SqliteLogStore : ILogStore
                             eventId.Value = record.EventId;
                             message.Value = record.Message;
                             exception.Value = (object?)record.Exception ?? DBNull.Value;
+                            // Encoded here, on the writer's thread, rather than at the log call — the call
+                            // site only pays for the flattened snapshot (see LogScopes).
+                            scopes.Value = (object?)LogScopeJson.Encode(record.Scopes) ?? DBNull.Value;
                             await command.ExecuteNonQueryAsync(token).ConfigureAwait(false);
                         }
                     }
@@ -124,7 +128,7 @@ internal sealed class SqliteLogStore : ILogStore
                 // inside the same clock tick deterministically, and paging over a stable order is the only
                 // way a page boundary doesn't drop or repeat a row.
                 command.CommandText =
-                    $"SELECT Id, Timestamp, Level, Category, EventId, Message, Exception FROM RaskLog{where} "
+                    $"SELECT Id, Timestamp, Level, Category, EventId, Message, Exception, Scopes FROM RaskLog{where} "
                     + "ORDER BY Id DESC LIMIT $limit OFFSET $offset;";
                 Bind(command, filters);
                 command.Parameters.AddWithValue("$limit", pageSize);
@@ -143,7 +147,8 @@ internal sealed class SqliteLogStore : ILogStore
                             reader.GetString(3),
                             reader.GetInt32(4),
                             reader.GetString(5),
-                            reader.IsDBNull(6) ? null : reader.GetString(6)));
+                            reader.IsDBNull(6) ? null : reader.GetString(6),
+                            reader.IsDBNull(7) ? null : LogScopeJson.Decode(reader.GetString(7))));
                     }
                 }
 
@@ -316,7 +321,8 @@ internal sealed class SqliteLogStore : ILogStore
                             Category  TEXT    NOT NULL,
                             EventId   INTEGER NOT NULL,
                             Message   TEXT    NOT NULL,
-                            Exception TEXT
+                            Exception TEXT,
+                            Scopes    TEXT
                         );
                         CREATE INDEX IF NOT EXISTS IX_RaskLog_Timestamp ON RaskLog (Timestamp);
                         CREATE INDEX IF NOT EXISTS IX_RaskLog_Level_Id ON RaskLog (Level, Id DESC);
@@ -324,6 +330,14 @@ internal sealed class SqliteLogStore : ILogStore
                         """;
                     await command.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
                 }
+
+                // Scopes arrived after the first release of this package, and CREATE TABLE IF NOT EXISTS
+                // does nothing to a table that already exists — so a store created by that release would
+                // otherwise fail every insert with "no such column". There is no migration history here
+                // (this database is framework-owned and deliberately outside the app's), so the check is
+                // the schema itself.
+                await AddColumnIfMissingAsync(connection, "Scopes", "TEXT", cancellationToken)
+                    .ConfigureAwait(false);
             }
 
             _schemaReady = true;
@@ -331,6 +345,40 @@ internal sealed class SqliteLogStore : ILogStore
         finally
         {
             _schemaGate.Release();
+        }
+    }
+
+    /// <summary>
+    ///     Adds a column when the table predates it. Idempotent, and cheap enough to run on every schema
+    ///     check — <c>PRAGMA table_info</c> reads the schema SQLite already has in memory.
+    /// </summary>
+    private static async Task AddColumnIfMissingAsync(
+        SqliteConnection connection,
+        string column,
+        string type,
+        CancellationToken cancellationToken)
+    {
+        var probe = connection.CreateCommand();
+        await using (probe.ConfigureAwait(false))
+        {
+            probe.CommandText = "SELECT COUNT(*) FROM pragma_table_info('RaskLog') WHERE name = $name;";
+            probe.Parameters.AddWithValue("$name", column);
+            var present = Convert.ToInt64(
+                await probe.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false),
+                CultureInfo.InvariantCulture);
+            if (present > 0)
+            {
+                return;
+            }
+        }
+
+        var alter = connection.CreateCommand();
+        await using (alter.ConfigureAwait(false))
+        {
+            // Interpolated rather than parameterised because an identifier cannot be a parameter. Both
+            // values are compile-time constants from this file, never user input.
+            alter.CommandText = $"ALTER TABLE RaskLog ADD COLUMN {column} {type};";
+            await alter.ExecuteNonQueryAsync(cancellationToken).ConfigureAwait(false);
         }
     }
 
@@ -439,6 +487,26 @@ internal sealed class SqliteLogStore : ILogStore
                 "$search",
                 SqliteType.Text,
                 $"%{EscapeLike(query.Search)}%");
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.ScopeKey))
+        {
+            // json_extract rather than a LIKE over the raw column: a LIKE for "RequestId" would also match
+            // an entry whose *message* merely mentioned it, and a value search would match a prefix of a
+            // different id. SQLite ships JSON1 in every build Microsoft.Data.Sqlite bundles.
+            //
+            // The key is concatenated into the JSON path as a PARAMETER, not into the SQL, so a key
+            // containing quotes cannot change the shape of the statement.
+            var clause = string.IsNullOrWhiteSpace(query.ScopeValue)
+                ? "json_extract(Scopes, '$.' || $scopeKey) IS NOT NULL"
+                : "json_extract(Scopes, '$.' || $scopeKey) = $scopeValue";
+
+            Add(clause, "$scopeKey", SqliteType.Text, query.ScopeKey);
+
+            if (!string.IsNullOrWhiteSpace(query.ScopeValue))
+            {
+                filters.Add(new SqliteParameter("$scopeValue", SqliteType.Text) { Value = query.ScopeValue });
+            }
         }
 
         if (query.From is { } from)

--- a/tests/Rask.Logging.Tests/LogScopeTests.cs
+++ b/tests/Rask.Logging.Tests/LogScopeTests.cs
@@ -1,0 +1,206 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.Extensions.Logging;
+
+namespace Rask.Logging.Tests;
+
+/// <summary>
+///     Scope capture: the request id, user id and correlation id an application opens a scope with, stored
+///     alongside the entry so the log can answer "what else happened on that request?" without anyone
+///     having to reconstruct it from message text.
+/// </summary>
+public sealed class LogScopeTests
+{
+    [Fact]
+    public async Task A_scope_is_stored_with_the_entry_it_wrapped()
+    {
+        await using var harness = new LoggingHarness();
+        var logger = harness.Logger();
+
+        using (logger.BeginScope(new Dictionary<string, object?> { ["RequestId"] = "abc123" }))
+        {
+            logger.LogInformation("inside");
+        }
+
+        logger.LogInformation("outside");
+        await harness.RunUntilStoredAsync(2);
+
+        var page = await harness.Store.QueryAsync(new LogQuery());
+        var inside = page.Entries.Single(e => e.Message == "inside");
+        var outside = page.Entries.Single(e => e.Message == "outside");
+
+        Assert.NotNull(inside.Scopes);
+        Assert.Equal("abc123", inside.Scopes!.Single(s => s.Key == "RequestId").Value);
+        // The scope closed before this one was written — capturing it here would be worse than capturing
+        // nothing, because it would attribute the entry to a request it did not belong to.
+        Assert.Null(outside.Scopes);
+    }
+
+    [Fact]
+    public async Task Nested_scopes_are_flattened_outermost_first()
+    {
+        await using var harness = new LoggingHarness();
+        var logger = harness.Logger();
+
+        using (logger.BeginScope(new Dictionary<string, object?> { ["RequestId"] = "r1" }))
+        using (logger.BeginScope(new Dictionary<string, object?> { ["UserId"] = "u9" }))
+        {
+            logger.LogWarning("nested");
+        }
+
+        await harness.RunUntilStoredAsync(1);
+
+        var entry = Assert.Single((await harness.Store.QueryAsync(new LogQuery())).Entries);
+        Assert.NotNull(entry.Scopes);
+        Assert.Equal("r1", entry.Scopes!.Single(s => s.Key == "RequestId").Value);
+        Assert.Equal("u9", entry.Scopes.Single(s => s.Key == "UserId").Value);
+    }
+
+    [Fact]
+    public async Task A_message_template_scope_keeps_its_values_and_drops_the_template()
+    {
+        await using var harness = new LoggingHarness();
+        var logger = harness.Logger();
+
+        using (logger.BeginScope("request {RequestId} for {UserId}", "r2", "u7"))
+        {
+            logger.LogError("boom");
+        }
+
+        await harness.RunUntilStoredAsync(1);
+
+        var entry = Assert.Single((await harness.Store.QueryAsync(new LogQuery())).Entries);
+        Assert.NotNull(entry.Scopes);
+        Assert.Equal("r2", entry.Scopes!.Single(s => s.Key == "RequestId").Value);
+        Assert.Equal("u7", entry.Scopes.Single(s => s.Key == "UserId").Value);
+        // "{OriginalFormat}" is the template, not data — storing it would repeat the format string on
+        // every row that used it.
+        Assert.DoesNotContain(entry.Scopes, s => s.Key == "{OriginalFormat}");
+    }
+
+    [Fact]
+    public async Task Querying_by_scope_finds_one_request_out_of_many()
+    {
+        await using var harness = new LoggingHarness();
+        var logger = harness.Logger();
+
+        foreach (var id in new[] { "r1", "r2", "r3" })
+        {
+            using (logger.BeginScope(new Dictionary<string, object?> { ["RequestId"] = id }))
+            {
+                logger.LogInformation("work for {Id}", id);
+            }
+        }
+
+        await harness.RunUntilStoredAsync(3);
+
+        var mine = await harness.Store.QueryAsync(new LogQuery { ScopeKey = "RequestId", ScopeValue = "r2" });
+        var entry = Assert.Single(mine.Entries);
+        Assert.Equal("work for r2", entry.Message);
+
+        // Key alone finds every entry that carried it, which is the "which entries are request-scoped at
+        // all?" question.
+        var anyRequest = await harness.Store.QueryAsync(new LogQuery { ScopeKey = "RequestId" });
+        Assert.Equal(3, anyRequest.Entries.Count);
+
+        // A value that belongs to a different key must not match. This is why the filter uses
+        // json_extract rather than a LIKE over the raw column.
+        var wrongKey = await harness.Store.QueryAsync(new LogQuery { ScopeKey = "UserId", ScopeValue = "r2" });
+        Assert.Empty(wrongKey.Entries);
+    }
+
+    [Fact]
+    public async Task Capture_can_be_turned_off()
+    {
+        await using var harness = new LoggingHarness(o => o.CaptureScopes = false);
+        var logger = harness.Logger();
+
+        using (logger.BeginScope(new Dictionary<string, object?> { ["Secret"] = "value" }))
+        {
+            logger.LogInformation("quiet");
+        }
+
+        await harness.RunUntilStoredAsync(1);
+
+        var entry = Assert.Single((await harness.Store.QueryAsync(new LogQuery())).Entries);
+        Assert.Null(entry.Scopes);
+    }
+
+    [Fact]
+    public async Task Capture_is_bounded_in_count_and_length()
+    {
+        await using var harness = new LoggingHarness(o =>
+        {
+            o.MaxScopeValues = 2;
+            o.MaxScopeValueLength = 4;
+        });
+        var logger = harness.Logger();
+
+        using (logger.BeginScope(new Dictionary<string, object?> { ["A"] = "aaaaaaaaaa" }))
+        using (logger.BeginScope(new Dictionary<string, object?> { ["B"] = "bbbbbbbbbb" }))
+        using (logger.BeginScope(new Dictionary<string, object?> { ["C"] = "cccccccccc" }))
+        {
+            logger.LogInformation("bounded");
+        }
+
+        await harness.RunUntilStoredAsync(1);
+
+        var entry = Assert.Single((await harness.Store.QueryAsync(new LogQuery())).Entries);
+        Assert.NotNull(entry.Scopes);
+        Assert.Equal(2, entry.Scopes!.Count);                 // the third scope is dropped
+        Assert.All(entry.Scopes, s => Assert.Equal(4, s.Value.Length)); // each value truncated
+    }
+
+    /// <summary>
+    ///     The store shipped before scopes existed, so a database created by that release has a RaskLog
+    ///     table with no Scopes column — and <c>CREATE TABLE IF NOT EXISTS</c> does nothing about it. Without
+    ///     the migration every insert fails with "no such column" and the whole log stops being written.
+    /// </summary>
+    [Fact]
+    public async Task A_store_created_before_scopes_existed_is_migrated_rather_than_broken()
+    {
+        var dbPath = Path.Combine(Path.GetTempPath(), $"rask-logs-legacy-{Guid.NewGuid():N}.db");
+        try
+        {
+            // Exactly the pre-scopes schema.
+            await using (var seed = new SqliteConnection($"Data Source={dbPath}"))
+            {
+                await seed.OpenAsync();
+                var create = seed.CreateCommand();
+                create.CommandText = """
+                    CREATE TABLE RaskLog (
+                        Id        INTEGER PRIMARY KEY,
+                        Timestamp TEXT    NOT NULL,
+                        Level     INTEGER NOT NULL,
+                        Category  TEXT    NOT NULL,
+                        EventId   INTEGER NOT NULL,
+                        Message   TEXT    NOT NULL,
+                        Exception TEXT
+                    );
+                    INSERT INTO RaskLog (Timestamp, Level, Category, EventId, Message, Exception)
+                    VALUES ('2026-01-01T00:00:00.0000000Z', 2, 'Old.Category', 0, 'from the old schema', NULL);
+                    """;
+                await create.ExecuteNonQueryAsync();
+            }
+
+            var options = new RaskLoggingOptions();
+            var store = new SqliteLogStore($"Data Source={dbPath}", options, TimeProvider.System);
+
+            await store.AppendAsync(
+                [new LogRecord(0, DateTimeOffset.UtcNow, LogLevel.Information, "New.Category", 0, "after upgrade", null,
+                    [new LogScopeValue("RequestId", "r9")])]);
+
+            var page = await store.QueryAsync(new LogQuery());
+            Assert.Equal(2, page.Entries.Count);
+
+            // The old row survives with no scopes, and the new one round-trips its own.
+            Assert.Null(page.Entries.Single(e => e.Message == "from the old schema").Scopes);
+            var upgraded = page.Entries.Single(e => e.Message == "after upgrade");
+            Assert.Equal("r9", upgraded.Scopes!.Single().Value);
+        }
+        finally
+        {
+            SqliteConnection.ClearAllPools();
+            File.Delete(dbPath);
+        }
+    }
+}


### PR DESCRIPTION
Closes #556.

## The gap

`RaskLoggerProvider`'s logger returned `null` from `BeginScope`, so scope state was dropped. A stored entry
carried timestamp, level, category, event id, message and exception — but not the ambient state that makes a
log searchable during an incident: the request id, the user id, the correlation id the app opened a scope
with.

That matters more for a *store* than it did for the in-memory dashboard tail, because the whole point of
keeping logs is answering **"what else happened on that request?"** — and without scopes that answer has to
be reconstructed from message text.

## What it does

```csharp
using (logger.BeginScope("request {RequestId} for {UserId}", requestId, user.Id))
{
    logger.LogInformation("charging {Amount}", amount);   // stored with RequestId and UserId
}
```

- Nested scopes flatten **outermost first** — the request id reads ahead of the innermost detail, and it
  matches how the code nests.
- A message-template scope keeps its *values* and drops `{OriginalFormat}`: the template is not data, and
  storing it would repeat the format string on every row that used it.
- A bare `BeginScope("checkout")` is kept under the key `Scope` — it is how most people reach for this
  before discovering structured state.
- Queryable via `LogQuery.ScopeKey` / `ScopeValue`, and shown as chips on the row in the dashboard's
  History mode.

## Three decisions worth reviewing

**A JSON column, not the side table the issue sketched.** A side table is the textbook answer, but it buys
normalisation nobody here needs and costs an insert per pair on the framework's highest-frequency writer,
plus a join on every read of a log that is written far more often than it is read. The store is append-only
and expendable; a column fits it.

**Where the cost lands.** Flattening happens at the log call — it has to, because scope state is short-lived
and may be mutated or pooled the moment the scope closes. Encoding to JSON does *not*: the writer does that
on its own thread. So the "a log call never waits on the disk" invariant is intact, and the request path
pays only for a small array and a `ToString()` per value. Bounded by `MaxScopeValues` (16) and
`MaxScopeValueLength` (256) so a runaway loop of nested scopes, or one large object, cannot grow a row
without limit.

**`json_extract`, not a `LIKE` over the column.** A `LIKE` for a request id would also match an entry whose
*message* merely mentioned it, and a value search would match a prefix of a different id. The key is
concatenated into the JSON path as a **parameter**, never into the SQL, so a key containing quotes cannot
change the statement's shape.

## The migration is the load-bearing part

`Rask.Logging` already shipped, so real `logs.db` files exist with no `Scopes` column — and
`CREATE TABLE IF NOT EXISTS` does nothing to a table that already exists. Without a migration **every insert
would fail with "no such column" and the log would silently stop being written by an upgrade**. There is no
migration history to hook into (this database is framework-owned and deliberately outside the app's), so the
schema itself is the check, via `pragma_table_info`.

`A_store_created_before_scopes_existed_is_migrated_rather_than_broken` seeds exactly the pre-scopes schema
with a row in it, then asserts the old row survives without scopes and a new one round-trips its own.
**Negative-control verified**: disable the migration and that test fails.

## Testing

7 new tests (`LogScopeTests`), full `Rask.Logging.Tests` suite 55/55, full local gate green.

`docs/logging.md` gains a **Scopes** section, the new options, the scope filter, and a corrected note — it
previously advertised "no reflection, **no serializer**". Scope state is encoded with a source-generated
`JsonSerializerContext` rather than the reflection serializer, so the package stays free of IL2026/IL3050 in
a published WASM or AOT app; the note now says that instead of a claim that no longer matches the code.

Browser E2E skipped (`RASK_SKIP_E2E=1`): the sandbox's Playwright suite is environmentally red on `main` for
an unrelated reason (`PlaygroundExampleTests` needs browser network for Roslyn refs).

No benchmarks — nothing on the render or runtime hot path.
