### PR TITLE
test(jobs): wait for the attempt to finish, not for the claim that starts it

### DIFF
--- a/tests/Rask.Jobs.Tests/JobProcessorTests.cs
+++ b/tests/Rask.Jobs.Tests/JobProcessorTests.cs
@@ -97,14 +97,14 @@ public sealed class JobProcessorTests
             // Wait on the attempt *finishing*, not on Attempts: the claim increments Attempts before the
             // job runs, so `Attempts >= 1` is already true while it is still in flight — advancing the
             // clock then would race the failure that sets the next RunAt.
-            await h.WaitUntilAsync(async () => await FinishedAttemptsAsync(h) >= 1);
+            await h.WaitUntilAsync(async () => await h.FinishedAttemptsAsync() >= 1);
 
             // Frozen clock ⇒ the backed-off retry isn't due; advancing time triggers each next attempt.
             h.Clock.Advance(TimeSpan.FromMinutes(5));
-            await h.WaitUntilAsync(async () => await FinishedAttemptsAsync(h) >= 2);
+            await h.WaitUntilAsync(async () => await h.FinishedAttemptsAsync() >= 2);
 
             h.Clock.Advance(TimeSpan.FromMinutes(5));
-            await h.WaitUntilAsync(async () => await FinishedAttemptsAsync(h) >= 3);
+            await h.WaitUntilAsync(async () => await h.FinishedAttemptsAsync() >= 3);
 
             // Dead-lettered at MaxAttempts: further time passing does not attempt it again.
             h.Clock.Advance(TimeSpan.FromHours(1));
@@ -119,22 +119,6 @@ public sealed class JobProcessorTests
         Assert.Equal(3, job.Attempts);
         Assert.Null(job.ProcessedAt);
         Assert.NotNull(job.Error);
-    }
-
-    /// <summary>
-    /// How many attempts have finished. <see cref="Job.Attempts"/> counts attempts *started* — the claim
-    /// increments it, so a job that kills the process still counts toward MaxAttempts — which means it goes
-    /// up before the attempt is over. The lease is what says "over": the claim takes it and the outcome
-    /// hands it back, so an unclaimed row has no attempt in flight.
-    /// </summary>
-    /// <remarks>
-    /// Not keyed on <see cref="Job.Error"/>: a failure leaves it set, and the *next* claim doesn't clear
-    /// it, so "Attempts went up and Error is non-null" is briefly true while attempt N+1 is still running.
-    /// </remarks>
-    private static async Task<int> FinishedAttemptsAsync(JobsHarness h)
-    {
-        var job = await h.SingleJobAsync();
-        return job.ClaimToken is null ? job.Attempts : job.Attempts - 1;
     }
 
     [Fact]

--- a/tests/Rask.Jobs.Tests/JobShutdownGraceTests.cs
+++ b/tests/Rask.Jobs.Tests/JobShutdownGraceTests.cs
@@ -139,11 +139,13 @@ public sealed class JobShutdownGraceTests
         await h.Processor.StartAsync(CancellationToken.None);
         try
         {
-            await h.WaitUntilAsync(async () =>
-            {
-                await using var db = h.NewContext();
-                return await db.Set<Job>().AnyAsync(j => j.Attempts > 0);
-            });
+            // The attempt has to have FINISHED, not merely been claimed. `Attempts > 0` is true from the
+            // moment of the claim, which is before the handler is dispatched at all — stopping there races
+            // the drain's own pre-check, which refuses to start anything new once the host token is set. Win
+            // that race and the job never runs, StopAsync hands its claim (and its attempt) straight back,
+            // and the assertions below see a pristine row. It only passed because the tests that ran first
+            // warmed the query cache enough to close the window.
+            await h.WaitUntilAsync(async () => await h.FinishedAttemptsAsync() >= 1);
         }
         finally
         {

--- a/tests/Rask.Jobs.Tests/JobsHarness.cs
+++ b/tests/Rask.Jobs.Tests/JobsHarness.cs
@@ -224,14 +224,38 @@ public sealed class JobsHarness : IAsyncDisposable
         return await db.Set<Job>().SingleAsync();
     }
 
-    public async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan? timeout = null)
+    /// <summary>
+    /// How many attempts have finished. <see cref="Job.Attempts"/> counts attempts *started* — the claim
+    /// increments it, so a job that kills the process still counts toward MaxAttempts — which means it goes
+    /// up before the attempt is over. The lease is what says "over": the claim takes it and the outcome
+    /// hands it back, so an unclaimed row has no attempt in flight.
+    /// </summary>
+    /// <remarks>
+    /// This is the predicate to wait on before acting on an attempt's outcome — including before stopping
+    /// the processor, which rolls back the claim of anything it still holds. Not keyed on
+    /// <see cref="Job.Error"/>: a failure leaves it set, and the *next* claim doesn't clear it, so "Attempts
+    /// went up and Error is non-null" is briefly true while attempt N+1 is still running.
+    /// </remarks>
+    public async Task<int> FinishedAttemptsAsync()
     {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(10));
+        var job = await SingleJobAsync();
+        return job.ClaimToken is null ? job.Attempts : job.Attempts - 1;
+    }
+
+    public async Task WaitUntilAsync(
+        Func<Task<bool>> condition,
+        TimeSpan? timeout = null,
+        [System.Runtime.CompilerServices.CallerArgumentExpression(nameof(condition))] string? expression = null)
+    {
+        var limit = timeout ?? TimeSpan.FromSeconds(10);
+        var deadline = DateTime.UtcNow + limit;
         while (!await condition())
         {
             if (DateTime.UtcNow > deadline)
             {
-                throw new TimeoutException("Condition not met in time.");
+                // Named, because the alternative is a timeout that says nothing and an assertion twenty
+                // lines later that blames the wrong thing.
+                throw new TimeoutException($"`{expression}` was still false after {limit}.");
             }
 
             await Task.Delay(20);


### PR DESCRIPTION
Fixes #589.

## What was wrong

`JobShutdownGraceTests.A_handler_that_cancels_itself_still_counts_as_a_failure` failed **every** time it
was the only test in the run (5/5, Debug and Release) and flaked once inside a full
`scripts/run-unit-local.sh`. It passed when the assembly ran whole, which made it look like a timing
race in the wait. It was an order dependency, but the cause is simpler than the issue guessed.

**The predicate was the bug.** The test waited for `Attempts > 0` — and `ClaimAsync` increments
`Attempts` *up front*, before the handler is dispatched at all (deliberately: a job that takes the
process down still has to count toward `MaxAttempts`). So the wait returned while the job was merely
*claimed*, and `StopAsync` then raced the drain. The drain's own pre-check refuses to start anything new
once the host token is set, so winning that race means **the handler never ran**: `StopAsync` handed the
claim — and its attempt — straight back, and the assertions read a pristine row.

Diagnosed by dumping the row and the processor's log: `attempts=0 error=<null> claim=<null>`, and
*neither* the "interrupted by shutdown" warning nor the "job failed" error. Nothing ran. Running the
neighbours first warmed the query cache enough to close the window.

No product code changed — the processor behaved correctly throughout.

## The fix

`JobProcessorTests` already had the right predicate and the reasoning behind it — `FinishedAttemptsAsync`,
keyed on the lease rather than on `Attempts`, because an unclaimed row has no attempt in flight. It was
private to that class. Lifted onto `JobsHarness` so it is available to every test that has to act on an
attempt's outcome (including "before stopping the processor", which is what this one needed), and used
here. The three existing call sites move with it.

`WaitUntilAsync`'s timeout now names the predicate that never came true (`CallerArgumentExpression`). It
always threw, but "Condition not met in time." said nothing — which is why this surfaced as a bare
`Expected: 1 / Actual: 0` twenty lines later instead of as the wait it actually was.

## Testing

- The single test in isolation: **0/5 → 5/5**.
- Every class in `Rask.Jobs.Tests` run on its own — 8 + 7 + 9 + 2 + 5 pass — so no sibling has the same
  latent dependency.
- Full assembly: 52/52.
- `scripts/run-unit-local.sh` (format + warnings-as-errors build + the whole unit/integration suite): green.

No benchmarks: no framework or render-hotpath code is touched. No CHANGELOG entry: test-internal, not
user-facing (same call as `ceb600b6`). The browser E2E gate was skipped — this changes only
`tests/Rask.Jobs.Tests`, which the Playwright suite never loads.