### PR TITLE
feat(server): restore the fields a user was editing when a redeploy reloads the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Added
+- **A redeploy reload no longer throws away what the user had typed.** When a replacement server can't
+  carry a session over, the page reloads — and until now that restored your scroll position and focus but
+  silently discarded every field you were part-way through filling in. The reason it did was real: there
+  was no way to tell a value the user typed from one the server had rendered, so writing stale client
+  copies back over correct server output would have turned a cosmetic loss into a data one. What makes it
+  answerable is that the DOM keeps the server-rendered `value` **attribute** separate from the user's live
+  `.value` **property**, which gives a merge *base* — so this is a **three-way merge**, not a guess.
+  Only fields the user actually edited are candidates, each carrying the value the server had rendered
+  when they first touched it (captured *then*: every echo of their own keystrokes rewrites the attribute,
+  so reading it later would compare the user's text against itself and restore nothing). After the reload
+  a field is re-applied only when the replacement rendered that same base — its state is unchanged, so the
+  edit is still the newest thing anyone knows. A different base means the replacement knows something the
+  stale copy doesn't: it wins, and the edit is dropped silently, exactly as a reload behaved before. What
+  *is* restored is then pushed back over the socket, so the server's model ends up holding what the page
+  shows rather than the pristine values it just rendered — a form displaying values the server doesn't
+  have is the data loss this feature would otherwise create, not prevent. The restore also arms the
+  existing lagging-frame guards, so the server's first catch-up render (computed from its own pristine
+  model, before the converge message can reach it) is held off rather than wiping the text and flickering
+  it back. Secrets never enter `sessionStorage` at all — password, file, hidden and one-time-code inputs,
+  and anything with a `cc-*` / `current-password` / `new-password` `autocomplete` — and
+  `data-rask-no-restore` opts out a field or a whole subtree. A field needs an `id` or a `name` to be
+  restorable (a bound `Input` gets one from the bound property for free), and a key matching more than one
+  control is skipped rather than guessed at, because writing a restored value into the wrong field is the
+  failure worth refusing. Handler ids are never persisted: they are positional per render, so one carried
+  over from the old page would name a *different* handler on the new one. The field snapshot lives under
+  its own `sessionStorage` key, so a large editor that fails the quota can't cost you the scroll position
+  too. `<select>` is not covered yet — it has no lagging-frame guard to hold the first re-render off with
+  (tracked separately).
 - **The application log now stores the scope state each entry was written under.** `RaskLoggerProvider`
   returned `null` from `BeginScope`, so the request id, user id and correlation id an app opens a scope with
   were dropped — and the whole point of keeping logs is answering *"what else happened on that request?"*,
@@ -185,9 +213,8 @@ them until tagged releases begin.
   `RemoveAsync` that raced process exit. The client shows **"Updating…"** and, because the drop is now
   *expected* rather than guessed at, reconnects immediately instead of walking a 500 ms → 5 s backoff
   ladder — leaving what happens to the page to the host that answers. If that host cannot rebuild the
-  session it reloads, in ~250 ms instead of 4 s, restoring scroll position and focus. Form values are
-  deliberately not restored: the new server renders those from its own state, and writing stale client
-  copies over them would turn a cosmetic loss into a data one.
+  session it reloads, in ~250 ms instead of 4 s, restoring scroll position and focus (and, since the
+  entry below, the fields the user had edited).
   Budget via `RaskServerOptions.ShutdownDrainTimeout` (default 5s; `Zero` restores the old abort), which
   must fit inside `HostOptions.ShutdownTimeout`; a startup warning says so when it doesn't, and
   `rask.shutdown.sessions.abandoned` counts anything still connected when the budget ran out.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -402,7 +402,8 @@ is removed. If the new container fails to start, or fails its health probe, the 
 serving. Probe a different path with `--health-path`, or skip the probe with `--no-health-check`.
 HTTP requests are zero-downtime; **live sessions re-establish**, because a session lives in the container
 being replaced and cannot hand over. The retiring container announces its shutdown first, so open pages
-show "Updating…" and reload onto the new one at their previous scroll position — see
+show "Updating…" and reload onto the new one at their previous scroll position, with whatever the user
+had typed put back — see
 [the shutdown ladder](deployment.md#the-shutdown-ladder).
 
 **Multiple apps share one box.** Each app container is labelled, so the proxy's routing is regenerated

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -90,14 +90,31 @@ Anything still connected when `ShutdownDrainTimeout` elapses is aborted, and
 > session is a component tree plus a DI scope living in *that* process, so the new instance cannot inherit
 > it. The client therefore reconnects and lets the host that answers decide: if it can rebuild the page,
 > nothing reloads at all; if it reports the session unknown, the client reloads — in ~250 ms, saying
-> "Updating…", and restoring your scroll position and focus.
+> "Updating…", and restoring your scroll position, your focus, and whatever you had typed.
 >
 > The drain's job is to make that drop *expected*. Before it, the socket was aborted with no close frame,
 > so the browser could not tell a deployment from a crash: it froze, backed off, and eventually announced
 > a four-second "Your session timed out" for a session that had not timed out.
 >
-> Form field values are deliberately **not** restored across a reload — the new server renders those from
-> its own state, and overwriting them with stale client copies would turn a cosmetic loss into a data one.
+> **What the user had typed comes back too, as a three-way merge.** Only fields they actually edited are
+> candidates, each carrying the value the server had rendered *before* they touched it. After the reload
+> a field is re-applied only when the replacement rendered that same value — its state is unchanged, so
+> the edit is still the newest thing anyone knows. If the replacement rendered something different it
+> knows something the stale copy doesn't, so it wins and the edit is dropped silently. Whatever is
+> restored is then pushed back over the socket, so the server's model holds what the page shows rather
+> than the pristine values it just rendered.
+>
+> Two rules worth knowing when you build forms:
+>
+> - **A field needs an `id` or a `name` to be restorable.** A bound `Input` gets a `name` from the bound
+>   property automatically, so this is usually free — but if a key matches more than one control on the
+>   page, that field is skipped rather than guessed at.
+> - **`data-rask-no-restore` opts a field (or a whole subtree) out.** Passwords, file, hidden and
+>   one-time-code inputs, and anything with a `cc-*` / `current-password` / `new-password` `autocomplete`,
+>   are excluded unconditionally and never reach `sessionStorage` in the first place.
+>
+> `<select>` is not restored yet — it has no lagging-frame guard for the first re-render to be held off
+> with, unlike `value` and `checked`.
 
 `ShutdownDrainTimeout` must fit inside `HostOptions.ShutdownTimeout`, which must fit inside whatever your
 container runtime allows between `SIGTERM` and `SIGKILL` (`rask deploy` uses 20 s). Rask logs a warning at

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -36,7 +36,7 @@ Dockerfile below (override with `--dockerfile`).
   and a DI scope inside *that* container and cannot hand over to the next one. The retiring container
   announces its shutdown first, so open pages show "Updating…" and reconnect to the new instance
   immediately instead of reporting a timeout — reloading only if the host that answers cannot rebuild the
-  page, and then at their previous scroll position. See
+  page, and then at their previous scroll position, with the fields the user had edited restored. See
   [Shutdown and redeploy](configuration.md#shutdown-and-redeploy).
 - **Durable SQLite database.** Every deploy runs a fresh container, so the database can't live inside it.
   `rask deploy` mounts a per-app named volume and points the app at it (`ConnectionStrings:App` →

--- a/docs/forms-advanced.md
+++ b/docs/forms-advanced.md
@@ -160,6 +160,32 @@ binding one `TItem`; `Native: true` falls back to the plain OS `<select>`.
 
 <!-- demo:multi-select-radio -->
 
+## Surviving a redeploy
+
+If the server is replaced while someone is filling a form in, the page may have to reload — and the
+fields they had edited are put back. It is a three-way merge, so a field is only re-applied when the
+replacement server rendered the same value the old one had: if its state changed in the meantime, the
+server wins and the stale edit is dropped. Whatever *is* restored is pushed back over the socket, so the
+model matches what the page shows. [Shutdown and redeploy](configuration.md#shutdown-and-redeploy) has the
+full rules.
+
+Two things to know when building a form:
+
+- **A field needs an `id` or a `name`.** A bound `Input` gets a `name` from the bound property for free,
+  so this is usually nothing to think about — but a key that matches more than one control on the page is
+  skipped rather than guessed at, and a control with neither is never restored.
+- **`data-rask-no-restore` opts out** a field, or every field under it:
+
+```csharp
+Div(Data: new Dictionary<string, string?> { ["rask-no-restore"] = "" })[
+    Input(() => _model.CouponCode, Class: "form-control")   // never carried across a reload
+]
+```
+
+Passwords, file, hidden and one-time-code inputs, and anything with a `cc-*` / `current-password` /
+`new-password` `autocomplete`, are excluded unconditionally — they never reach `sessionStorage` at all.
+`<select>` isn't restored yet.
+
 ## Building your own form controls
 
 The binding system is public: a custom control implementing `IFormControl<T>` gets generator-synthesized

--- a/src/Rask.Core/Resources/rask-input.js
+++ b/src/Rask.Core/Resources/rask-input.js
@@ -50,6 +50,10 @@ function queueInput(el) {
 document.addEventListener("input", (e) => {
     const t = e.target.closest("[data-rask-on-input]");
     if (!t || !inRoot(t)) return;
+    // Mark the field user-edited and capture what the server had rendered for it, BEFORE the dispatch
+    // below causes an echo that rewrites the `value` attribute. Only the Server runtime reads this
+    // (its redeploy reload re-applies edited fields); it costs one WeakMap probe everywhere else.
+    raskNoteDirtyField(t);
     // Inputs paired with data-rask-on-change need to dispatch SYNCHRONOUSLY: the change
     // event typically fires in the same task (Playwright fill, browser commit on blur),
     // and a downstream validator triggered by change reads the model state set by the

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -139,6 +139,86 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
+// the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
+// saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
+// server rendered the same base the old one did — which is what makes that a three-way merge (base /
+// the user's edit / what the new server rendered) rather than a guess about whose value is newer.
+//
+// The base has to be captured the FIRST time a field goes dirty. It cannot be read off the DOM later:
+// every echo of the user's own keystrokes rewrites the `value` ATTRIBUTE, because morph() and the diff
+// both sync attributes unconditionally and guard only the `.value` PROPERTY. By reload time the
+// attribute IS the user's text, base would equal ours, and every edit would compare unequal against a
+// pristine replacement and be dropped — the feature would be a silent no-op. Hence capture-once: a
+// second edit to the same field must not overwrite the base the first one recorded.
+//
+// Same WeakMap-backed-global shape as the two guards above, and for the same reason: reachable from the
+// spliced morph, from rask-input.js and from the host runtime regardless of splice ordering.
+function _raskDirtyFields() {
+    return window.__raskDirtyFields || (window.__raskDirtyFields = new WeakMap());
+}
+
+function raskNoteDirtyField(el) {
+    if (!el) return;
+    const map = _raskDirtyFields();
+    if (map.has(el)) return;                        // capture-once — the first edit owns the base
+    map.set(el, raskFieldBase(el));
+}
+
+function raskIsDirtyField(el) {
+    return !!el && _raskDirtyFields().has(el);
+}
+
+function raskDirtyFieldBase(el) {
+    const map = _raskDirtyFields();
+    return el && map.has(el) ? map.get(el) : undefined;
+}
+
+// What the server rendered for a control, read from ATTRIBUTES only — never from a property. The two
+// disagree in ways that would silently corrupt the comparison: a type=number/date input sanitizes an
+// unparseable attribute to "" on `.value`, and a textarea's `.value` normalizes the CRLF its text
+// content keeps. Bases are only ever compared to other bases, so attribute-vs-attribute is the rule.
+//
+// `null` is preserved and is NOT the same as "": it means the server rendered no `value` attribute at
+// all — an uncontrolled input, which morph deliberately never writes to (see the uncontrolled rule in
+// morph() below). The restore treats the two differently, so they must not be flattened together.
+function raskFieldBase(el) {
+    if (el.tagName === "TEXTAREA") return el.textContent;
+    const type = (el.getAttribute("type") || "").toLowerCase();
+    if (type === "checkbox") return el.hasAttribute("checked");
+    if (type === "radio") return raskRadioGroupBase(el);
+    return el.getAttribute("value");
+}
+
+// A radio's meaningful state is its GROUP's, not its own: "which value is selected" rather than "is
+// this one checked". Per-element `checked` would let a restore re-check the user's pick while the
+// replacement server had moved the selection elsewhere — and natively un-check the server's choice —
+// without the bases ever comparing unequal. So the base is the value of whichever member carries the
+// `checked` attribute, or "" for a group the server rendered with nothing selected.
+//
+// The group is same-name AND same form owner; two forms on one page can each have a `Plan` group.
+function raskRadioGroupBase(el) {
+    const group = raskRadioGroup(el);
+    for (const r of group) {
+        if (r.hasAttribute("checked")) return r.getAttribute("value") || "";
+    }
+
+    return "";
+}
+
+function raskRadioGroup(el) {
+    const name = el.getAttribute("name");
+    if (!name) return [el];
+    const out = [];
+    // Matched by attribute rather than a name selector so this stays free of CSS.escape, which the
+    // shared modules can't assume — a name is app-authored and may hold selector metacharacters.
+    for (const r of document.querySelectorAll("input[type=radio]")) {
+        if (r.getAttribute("name") === name && r.form === el.form) out.push(r);
+    }
+
+    return out.length > 0 ? out : [el];
+}
+
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
 // runtime (a code editor's theme colours, a charting lib, a syntax highlighter, analytics). Those nodes
 // aren't in the .NET-rendered head, so the reconciler below would trim them on the next head morph. Rather

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -2314,6 +2314,86 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
+// the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
+// saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
+// server rendered the same base the old one did — which is what makes that a three-way merge (base /
+// the user's edit / what the new server rendered) rather than a guess about whose value is newer.
+//
+// The base has to be captured the FIRST time a field goes dirty. It cannot be read off the DOM later:
+// every echo of the user's own keystrokes rewrites the `value` ATTRIBUTE, because morph() and the diff
+// both sync attributes unconditionally and guard only the `.value` PROPERTY. By reload time the
+// attribute IS the user's text, base would equal ours, and every edit would compare unequal against a
+// pristine replacement and be dropped — the feature would be a silent no-op. Hence capture-once: a
+// second edit to the same field must not overwrite the base the first one recorded.
+//
+// Same WeakMap-backed-global shape as the two guards above, and for the same reason: reachable from the
+// spliced morph, from rask-input.js and from the host runtime regardless of splice ordering.
+function _raskDirtyFields() {
+    return window.__raskDirtyFields || (window.__raskDirtyFields = new WeakMap());
+}
+
+function raskNoteDirtyField(el) {
+    if (!el) return;
+    const map = _raskDirtyFields();
+    if (map.has(el)) return;                        // capture-once — the first edit owns the base
+    map.set(el, raskFieldBase(el));
+}
+
+function raskIsDirtyField(el) {
+    return !!el && _raskDirtyFields().has(el);
+}
+
+function raskDirtyFieldBase(el) {
+    const map = _raskDirtyFields();
+    return el && map.has(el) ? map.get(el) : undefined;
+}
+
+// What the server rendered for a control, read from ATTRIBUTES only — never from a property. The two
+// disagree in ways that would silently corrupt the comparison: a type=number/date input sanitizes an
+// unparseable attribute to "" on `.value`, and a textarea's `.value` normalizes the CRLF its text
+// content keeps. Bases are only ever compared to other bases, so attribute-vs-attribute is the rule.
+//
+// `null` is preserved and is NOT the same as "": it means the server rendered no `value` attribute at
+// all — an uncontrolled input, which morph deliberately never writes to (see the uncontrolled rule in
+// morph() below). The restore treats the two differently, so they must not be flattened together.
+function raskFieldBase(el) {
+    if (el.tagName === "TEXTAREA") return el.textContent;
+    const type = (el.getAttribute("type") || "").toLowerCase();
+    if (type === "checkbox") return el.hasAttribute("checked");
+    if (type === "radio") return raskRadioGroupBase(el);
+    return el.getAttribute("value");
+}
+
+// A radio's meaningful state is its GROUP's, not its own: "which value is selected" rather than "is
+// this one checked". Per-element `checked` would let a restore re-check the user's pick while the
+// replacement server had moved the selection elsewhere — and natively un-check the server's choice —
+// without the bases ever comparing unequal. So the base is the value of whichever member carries the
+// `checked` attribute, or "" for a group the server rendered with nothing selected.
+//
+// The group is same-name AND same form owner; two forms on one page can each have a `Plan` group.
+function raskRadioGroupBase(el) {
+    const group = raskRadioGroup(el);
+    for (const r of group) {
+        if (r.hasAttribute("checked")) return r.getAttribute("value") || "";
+    }
+
+    return "";
+}
+
+function raskRadioGroup(el) {
+    const name = el.getAttribute("name");
+    if (!name) return [el];
+    const out = [];
+    // Matched by attribute rather than a name selector so this stays free of CSS.escape, which the
+    // shared modules can't assume — a name is app-authored and may hold selector metacharacters.
+    for (const r of document.querySelectorAll("input[type=radio]")) {
+        if (r.getAttribute("name") === name && r.form === el.form) out.push(r);
+    }
+
+    return out.length > 0 ? out : [el];
+}
+
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
 // runtime (a code editor's theme colours, a charting lib, a syntax highlighter, analytics). Those nodes
 // aren't in the .NET-rendered head, so the reconciler below would trim them on the next head morph. Rather
@@ -3139,6 +3219,10 @@ function queueInput(el) {
 document.addEventListener("input", (e) => {
     const t = e.target.closest("[data-rask-on-input]");
     if (!t || !inRoot(t)) return;
+    // Mark the field user-edited and capture what the server had rendered for it, BEFORE the dispatch
+    // below causes an echo that rewrites the `value` attribute. Only the Server runtime reads this
+    // (its redeploy reload re-applies edited fields); it costs one WeakMap probe everywhere else.
+    raskNoteDirtyField(t);
     // Inputs paired with data-rask-on-change need to dispatch SYNCHRONOUSLY: the change
     // event typically fires in the same task (Playwright fill, browser commit on blur),
     // and a downstream validator triggered by change reads the model state set by the

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -177,6 +177,24 @@
     // Where the pre-reload scroll/focus snapshot lives. Keyed by path so a reload that lands somewhere
     // else (a redirect, a changed route) never restores a position from an unrelated page.
     const RESTORE_KEY = "rask:restore";
+    // The user's in-progress edits, in their OWN key rather than widened into the one above. A page with
+    // a large textarea can push a single setItem over quota, and losing the scroll position because the
+    // field snapshot didn't fit would trade a working feature away for a new one.
+    const RESTORE_FIELDS_KEY = "rask:restore:fields";
+    // Converge messages the field restore produces at boot. They cannot be sent from there: send() runs
+    // through stampSeq, which reads `seqCounter` — declared far below and therefore still in its temporal
+    // dead zone at boot. The ReferenceError would be swallowed by the restore's own catch and take the
+    // whole restore down silently. They go out from the socket's open handler instead.
+    const pendingConverge = [];
+    // Never carried across a reload, on either side: a secret, something the client cannot reproduce, or
+    // a control whose "value" was never user input to begin with.
+    const RESTORE_SKIP_TYPES = ["password", "file", "hidden", "image", "submit", "reset", "button"];
+    const RESTORE_SKIP_AUTOCOMPLETE = ["cc-", "one-time-code", "current-password", "new-password"];
+    // Caps, so one page with a big editor can't fill the origin's session storage. Overflow drops the
+    // individual field rather than the snapshot — a partial restore beats none.
+    const RESTORE_MAX_FIELDS = 100;
+    const RESTORE_MAX_FIELD_CHARS = 8 * 1024;
+    const RESTORE_MAX_TOTAL_CHARS = 64 * 1024;
     let overlayTimer = null;
     let sessionExpired = false;
     let serverShuttingDown = false;
@@ -196,6 +214,10 @@
     // Before the socket: if the last page left a restore point (it was reloaded onto a replacement
     // server), put the user back where they were. The GET shell is fully server-rendered by now, so the
     // scroll target already exists.
+    //
+    // Fields first, then scroll and focus: the focused field is often one of the restored ones, and
+    // writing its value after focusing it would drop the caret rather than leave it after the text.
+    applyRestoreFields();
     applyRestorePoint();
     connect();
 
@@ -222,6 +244,11 @@
             ws.send(JSON.stringify(hello));
             for (const m of queue) ws.send(m);
             queue.length = 0;
+            // Values the field restore put back into the DOM at boot, pushed to the server now that
+            // there is a socket to push them over — so the model ends up holding what the page shows
+            // rather than the pristine values it rendered. Sent after the hello, so the session exists.
+            for (const payload of pendingConverge) send(payload);
+            pendingConverge.length = 0;
             // Auth reconnect completed — restore the default message for any future drop.
             if (authInProgress) {
                 authInProgress = false;
@@ -418,6 +445,7 @@
             overlayTimer = null;
         }
         saveRestorePoint();
+        saveRestoreFields();
         setInert(true);
         showOverlay();
         setOverlayMessage(UPDATING_MSG);
@@ -427,9 +455,8 @@
     }
 
     // Stash where the user was, so the unavoidable reload doesn't also lose their place. Scroll and
-    // focus only — deliberately NOT form values: the replacement server renders those from its own
-    // state, and writing stale client copies over correct server output would turn a cosmetic loss
-    // into a data one.
+    // focus only; the fields the user was editing are a separate snapshot under its own key, written
+    // by saveRestoreFields below, because they can be large enough to fail a quota that this must not.
     function saveRestorePoint() {
         try {
             sessionStorage.setItem(RESTORE_KEY, JSON.stringify({
@@ -465,6 +492,220 @@
         } catch (e) {
             // A malformed entry is not worth breaking boot over.
         }
+    }
+
+    // ---- the field half of the restore point ----
+    //
+    // A reload after a redeploy used to throw away whatever the user had typed. It no longer does, and
+    // the reason it is safe to re-apply an edit is that this is a THREE-WAY MERGE, not a guess:
+    //
+    //   base   what the server had rendered when the user first touched the field (captured then, by
+    //          raskNoteDirtyField — see rask-morph.js for why it cannot be read off the DOM later)
+    //   ours   what the user typed
+    //   theirs what the REPLACEMENT server just rendered for the same field
+    //
+    // If theirs === base the replacement's state is unchanged, so the user's edit is still the newest
+    // thing anyone knows and it goes back in. If they differ the replacement knows something this stale
+    // copy doesn't, so it wins and the edit is dropped silently — which is what a reload did before any
+    // of this existed, so nothing regresses. Restoring is then pushed BACK to the server (queueConverge)
+    // so the model holds what the page shows; a form displaying values the server doesn't have is the
+    // data loss this feature would otherwise create.
+
+    // Never carried across the reload. Checked on both sides, so a field that becomes a secret (or is
+    // disabled) in the replacement's render is not written to even if the old page snapshotted it.
+    function restoreExcluded(el) {
+        if (el.disabled || el.readOnly) return true;
+        if (el.closest("[data-rask-no-restore]")) return true;
+        if (RESTORE_SKIP_TYPES.indexOf(restoreTypeOf(el)) >= 0) return true;
+        const auto = (el.getAttribute("autocomplete") || "").toLowerCase();
+        for (const token of RESTORE_SKIP_AUTOCOMPLETE) {
+            if (auto.indexOf(token) >= 0) return true;
+        }
+
+        return false;
+    }
+
+    // The control's kind, as the snapshot records it — persisted and re-checked on the far side, so a
+    // deploy that turns a text field into a date one cannot have "42" written into it (which the
+    // browser would sanitize to "", and we would then converge that empty string over the server's value).
+    function restoreTypeOf(el) {
+        if (el.tagName === "TEXTAREA") return "textarea";
+        return (el.getAttribute("type") || "text").toLowerCase();
+    }
+
+    // id, else name. Never the handler id: those are positional per render, so one from the old page
+    // names a DIFFERENT handler on the new one — and the server dispatches on the id alone.
+    //
+    // A radio is keyed by its GROUP's name even when it carries an id, because its base and its value
+    // are the group's ("which option is selected"), not the element's. Keyed by id, the far side would
+    // resolve to that one member and leave its SIBLINGS unguarded — and checking a radio natively
+    // un-checks the one the server had chosen, so the first pristine frame re-checks the server's
+    // option, un-checks the restored one, and silently undoes the restore.
+    function restoreKeyOf(el) {
+        if (restoreTypeOf(el) === "radio") return el.getAttribute("name") || "";
+        return el.getAttribute("id") || el.getAttribute("name") || "";
+    }
+
+    // Resolve a key back to exactly one control — or, for radios, exactly one group — and otherwise to
+    // nothing. `name` defaults to the bound property's name, so two forms binding the same property
+    // render the same name; writing a restored value into the wrong one of them would be precisely the
+    // data loss being avoided here. Ambiguity is refused rather than guessed at, on both sides, so it
+    // degrades to doing nothing.
+    function restoreResolve(key) {
+        const matches = [];
+        for (const el of root.querySelectorAll("input, textarea")) {
+            if (restoreKeyOf(el) === key) matches.push(el);
+        }
+
+        if (matches.length === 0) return null;
+        if (matches.length === 1) return matches;
+        // Several: the only legitimate shape is one radio group (same name, same form owner).
+        const form = matches[0].form;
+        for (const el of matches) {
+            if (restoreTypeOf(el) !== "radio" || el.form !== form) return null;
+        }
+
+        return matches;
+    }
+
+    // What the user has now, in the same shape as the base it will be compared against.
+    function restoreCurrent(el, type) {
+        if (type === "checkbox") return !!el.checked;
+        if (type === "radio") {
+            for (const r of raskRadioGroup(el)) {
+                if (r.checked) return r.getAttribute("value") || "";
+            }
+
+            return "";
+        }
+
+        return el.value;
+    }
+
+    // Snapshot the fields the user actually edited. Only edited ones are candidates — raskNoteDirtyField
+    // marks them on the first input/change — because a field the user never touched must keep whatever
+    // the replacement renders for it, which may well be newer than what this page is holding.
+    function saveRestoreFields() {
+        try {
+            const fields = [];
+            const seen = Object.create(null);
+            let budget = RESTORE_MAX_TOTAL_CHARS;
+            for (const el of root.querySelectorAll("input, textarea")) {
+                if (fields.length >= RESTORE_MAX_FIELDS) break;
+                if (!raskIsDirtyField(el) || restoreExcluded(el)) continue;
+                const key = restoreKeyOf(el);
+                if (!key || seen[key]) continue;
+                const group = restoreResolve(key);
+                if (!group || group.indexOf(el) < 0) continue;   // ambiguous key
+                const type = restoreTypeOf(el);
+                const base = raskDirtyFieldBase(el);
+                const ours = restoreCurrent(el, type);
+                // Edited and edited back. Skipping is not just an optimisation: converging a `change`
+                // marks the field touched, which would surface validation errors the user never caused.
+                if (base === ours) continue;
+                const chars = typeof ours === "string" ? ours.length : 0;
+                if (chars > RESTORE_MAX_FIELD_CHARS || chars > budget) continue;
+                budget -= chars;
+                seen[key] = true;
+                fields.push({k: key, t: type, b: base, v: ours});
+            }
+
+            if (fields.length === 0) return;
+            sessionStorage.setItem(RESTORE_FIELDS_KEY, JSON.stringify({
+                p: location.pathname + location.search,
+                f: fields
+            }));
+        } catch (e) {
+            // Private mode, quota, disabled storage. Its own try: the scroll point is already written
+            // and must not be lost because the fields didn't fit.
+        }
+    }
+
+    // Re-apply the snapshot, once. Runs at boot, BEFORE the socket and before the first server frame:
+    // the GET shell is already rendered so every field exists, and applying now means the user never
+    // watches their text vanish and come back.
+    function applyRestoreFields() {
+        let saved;
+        try {
+            saved = sessionStorage.getItem(RESTORE_FIELDS_KEY);
+            // Consume unconditionally, like the scroll point: a snapshot that survived its own reload
+            // would later write stale text onto an unrelated navigation.
+            sessionStorage.removeItem(RESTORE_FIELDS_KEY);
+        } catch (e) {
+            return;
+        }
+        if (!saved) return;
+        try {
+            const snap = JSON.parse(saved);
+            if (!snap || !snap.f || snap.p !== location.pathname + location.search) return;
+            for (const entry of snap.f) restoreOneField(entry);
+        } catch (e) {
+            // A malformed entry is not worth breaking boot over.
+        }
+    }
+
+    function restoreOneField(entry) {
+        const group = restoreResolve(entry.k);
+        if (!group) return;
+        const el = group[0];
+        if (restoreTypeOf(el) !== entry.t || restoreExcluded(el)) return;
+        // The merge rule itself. Bases are compared to bases — never to a property: a number/date input
+        // sanitizes an unparseable attribute away on `.value`, and null (the server rendered no `value`
+        // at all, i.e. an uncontrolled input) is a different state from "".
+        if (raskFieldBase(el) !== entry.b) return;
+
+        if (entry.t === "radio") {
+            let target = null;
+            for (const r of group) {
+                if ((r.getAttribute("value") || "") === entry.v) target = r;
+            }
+            if (!target) return;
+            // Arm the whole group before flipping it. Checking one radio natively un-checks the one the
+            // server had chosen, so a pristine catch-up frame would re-check that sibling and silently
+            // undo the restore — the same reasoning as the change dispatch's group-wide guard.
+            for (const r of group) raskNotePendingChecked(r, r.hasAttribute("checked"));
+            target.checked = true;
+            queueConverge(target, entry.t, entry.v);
+            return;
+        }
+
+        if (entry.t === "checkbox") {
+            raskNotePendingChecked(el, el.hasAttribute("checked"));
+            el.checked = !!entry.v;
+            queueConverge(el, entry.t, entry.v);
+            return;
+        }
+
+        // Arm the value guard with what the REPLACEMENT rendered. The server computes its first
+        // catch-up frame from its own pristine model — before our converge message can reach it — so
+        // without this the restored text would be wiped and only flicker back afterwards. Anything
+        // other than that pristine value, including the echo of our own converge, releases the guard.
+        raskNotePendingValue(el, entry.b === null ? "" : entry.b);
+        el.value = entry.v;
+        queueConverge(el, entry.t, entry.v);
+    }
+
+    // Push a restored value back to the server so the model matches what the page now shows. The
+    // handler id is read HERE, off the element the replacement just rendered, and never taken from the
+    // snapshot — ids are positional per render, and dispatch keys on the id alone, so a persisted one
+    // would not be rejected on the new page but would invoke whatever handler now occupies that slot.
+    function queueConverge(el, type, value) {
+        const inputId = el.getAttribute("data-rask-on-input");
+        if (inputId) {
+            pendingConverge.push({id: inputId, type: "input", value: String(value)});
+            return;
+        }
+
+        const changeId = el.getAttribute("data-rask-on-change");
+        // Nothing bound: the value lives only in the DOM anyway, and submitForm's FormData reads it
+        // straight off the element — so the restore is already complete.
+        if (!changeId) return;
+        // A checkbox reports its state rather than its static "on" value, mirroring the change dispatch.
+        pendingConverge.push({
+            id: changeId,
+            type: "change",
+            value: type === "checkbox" ? (value ? "true" : "false") : String(value)
+        });
     }
 
     // The server evicted this session (idle past RaskServerOptions.SessionGracePeriod), so the in-memory
@@ -1267,6 +1508,11 @@
             return;
         }
         if (t.hasAttribute("data-rask-on-change")) {
+            // Mark the field user-edited and capture what the server had rendered for it, BEFORE the
+            // dispatch below causes an echo that rewrites the attributes that base is read from. Only
+            // a change-only control (checkbox, radio, date, number) reaches this without rask-input.js
+            // having already noted it; noting twice is a no-op, since the first edit owns the base.
+            raskNoteDirtyField(t);
             // For a checkbox the meaningful state is el.checked, not el.value (which is the
             // static "on" default). Report it as "true"/"false" so bound checkboxes set the
             // model to the actual state (self-correcting) instead of relying on a server-side

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2729,6 +2729,86 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
+// the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
+// saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
+// server rendered the same base the old one did — which is what makes that a three-way merge (base /
+// the user's edit / what the new server rendered) rather than a guess about whose value is newer.
+//
+// The base has to be captured the FIRST time a field goes dirty. It cannot be read off the DOM later:
+// every echo of the user's own keystrokes rewrites the `value` ATTRIBUTE, because morph() and the diff
+// both sync attributes unconditionally and guard only the `.value` PROPERTY. By reload time the
+// attribute IS the user's text, base would equal ours, and every edit would compare unequal against a
+// pristine replacement and be dropped — the feature would be a silent no-op. Hence capture-once: a
+// second edit to the same field must not overwrite the base the first one recorded.
+//
+// Same WeakMap-backed-global shape as the two guards above, and for the same reason: reachable from the
+// spliced morph, from rask-input.js and from the host runtime regardless of splice ordering.
+function _raskDirtyFields() {
+    return window.__raskDirtyFields || (window.__raskDirtyFields = new WeakMap());
+}
+
+function raskNoteDirtyField(el) {
+    if (!el) return;
+    const map = _raskDirtyFields();
+    if (map.has(el)) return;                        // capture-once — the first edit owns the base
+    map.set(el, raskFieldBase(el));
+}
+
+function raskIsDirtyField(el) {
+    return !!el && _raskDirtyFields().has(el);
+}
+
+function raskDirtyFieldBase(el) {
+    const map = _raskDirtyFields();
+    return el && map.has(el) ? map.get(el) : undefined;
+}
+
+// What the server rendered for a control, read from ATTRIBUTES only — never from a property. The two
+// disagree in ways that would silently corrupt the comparison: a type=number/date input sanitizes an
+// unparseable attribute to "" on `.value`, and a textarea's `.value` normalizes the CRLF its text
+// content keeps. Bases are only ever compared to other bases, so attribute-vs-attribute is the rule.
+//
+// `null` is preserved and is NOT the same as "": it means the server rendered no `value` attribute at
+// all — an uncontrolled input, which morph deliberately never writes to (see the uncontrolled rule in
+// morph() below). The restore treats the two differently, so they must not be flattened together.
+function raskFieldBase(el) {
+    if (el.tagName === "TEXTAREA") return el.textContent;
+    const type = (el.getAttribute("type") || "").toLowerCase();
+    if (type === "checkbox") return el.hasAttribute("checked");
+    if (type === "radio") return raskRadioGroupBase(el);
+    return el.getAttribute("value");
+}
+
+// A radio's meaningful state is its GROUP's, not its own: "which value is selected" rather than "is
+// this one checked". Per-element `checked` would let a restore re-check the user's pick while the
+// replacement server had moved the selection elsewhere — and natively un-check the server's choice —
+// without the bases ever comparing unequal. So the base is the value of whichever member carries the
+// `checked` attribute, or "" for a group the server rendered with nothing selected.
+//
+// The group is same-name AND same form owner; two forms on one page can each have a `Plan` group.
+function raskRadioGroupBase(el) {
+    const group = raskRadioGroup(el);
+    for (const r of group) {
+        if (r.hasAttribute("checked")) return r.getAttribute("value") || "";
+    }
+
+    return "";
+}
+
+function raskRadioGroup(el) {
+    const name = el.getAttribute("name");
+    if (!name) return [el];
+    const out = [];
+    // Matched by attribute rather than a name selector so this stays free of CSS.escape, which the
+    // shared modules can't assume — a name is app-authored and may hold selector metacharacters.
+    for (const r of document.querySelectorAll("input[type=radio]")) {
+        if (r.getAttribute("name") === name && r.form === el.form) out.push(r);
+    }
+
+    return out.length > 0 ? out : [el];
+}
+
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
 // runtime (a code editor's theme colours, a charting lib, a syntax highlighter, analytics). Those nodes
 // aren't in the .NET-rendered head, so the reconciler below would trim them on the next head morph. Rather
@@ -3969,6 +4049,10 @@ function queueInput(el) {
 document.addEventListener("input", (e) => {
     const t = e.target.closest("[data-rask-on-input]");
     if (!t || !inRoot(t)) return;
+    // Mark the field user-edited and capture what the server had rendered for it, BEFORE the dispatch
+    // below causes an echo that rewrites the `value` attribute. Only the Server runtime reads this
+    // (its redeploy reload re-applies edited fields); it costs one WeakMap probe everywhere else.
+    raskNoteDirtyField(t);
     // Inputs paired with data-rask-on-change need to dispatch SYNCHRONOUSLY: the change
     // event typically fires in the same task (Playwright fill, browser commit on blur),
     // and a downstream validator triggered by change reads the model state set by the

--- a/tests/Rask.Core.Tests/Live/RestoreFieldBaseFixture.mjs
+++ b/tests/Rask.Core.Tests/Live/RestoreFieldBaseFixture.mjs
@@ -1,0 +1,156 @@
+// Node-driven fixture for the dirty-field base capture that the redeploy form restore merges against
+// (Rask.Core/Resources/rask-morph.js — raskNoteDirtyField / raskDirtyFieldBase / raskFieldBase, read by
+// saveRestoreFields / applyRestoreFields in rask.js).
+//
+// The load-bearing property is scenario 1. A restored edit is only re-applied when the REPLACEMENT
+// server renders the same base the old one did, so the base has to be what the server had rendered
+// BEFORE the user touched the field. It cannot be read off the DOM at reload time: morph() and the diff
+// sync the `value` ATTRIBUTE unconditionally (only the `.value` PROPERTY is guarded), so every echo of
+// the user's own keystrokes rewrites it. Capture at first-dirty, and the echo is harmless; capture late,
+// and base always equals the user's text, every field compares unequal against a pristine replacement,
+// and the whole feature is a silent no-op that still passes a naive test.
+//
+// The C# test (RestoreFieldBaseTests) runs this in a node subprocess and asserts the single JSON line on
+// stdout. Exits non-zero on an internal stub failure.
+import {readFileSync} from "node:fs";
+
+const morphPath = process.argv[2];
+if (!morphPath) {
+    console.error("usage: node RestoreFieldBaseFixture.mjs <rask-morph.js path>");
+    process.exit(2);
+}
+
+// ----- Minimal element stub -----
+// Attribute and property are kept independent, exactly as a browser keeps them once an input's dirty
+// value flag is set — which is the whole distinction under test.
+const radios = [];
+
+function makeEl(nodeName, attrs, form) {
+    const a = new Map(Object.entries(attrs || {}));
+    const el = {
+        nodeType: 1,
+        nodeName,
+        tagName: nodeName,
+        parentNode: null,
+        firstChild: null,
+        nextSibling: null,
+        textContent: "",
+        form: form || null,
+        value: a.has("value") ? a.get("value") : "",
+        checked: a.has("checked"),
+        hasAttribute: (n) => a.has(n),
+        getAttribute: (n) => (a.has(n) ? a.get(n) : null),
+        setAttribute: (n, v) => a.set(n, String(v)),
+        removeAttribute: (n) => a.delete(n),
+        get attributes() {
+            return [...a.entries()].map(([name, value]) => ({name, value}));
+        }
+    };
+    if (nodeName === "INPUT" && a.get("type") === "radio") radios.push(el);
+    return el;
+}
+
+const makeInput = (attrs) => makeEl("INPUT", attrs);
+const makeTextarea = (text) => {
+    const el = makeEl("TEXTAREA", {});
+    el.textContent = text;
+    el.value = text;
+    return el;
+};
+
+// A spectator element owns focus, so morph's focus guard lets the value-sync path run — the realistic
+// post-blur state, and the one where an unguarded stale frame does damage.
+const elsewhere = {nodeType: 1, nodeName: "BODY", tagName: "BODY"};
+
+globalThis.window = globalThis;
+globalThis.document = {
+    activeElement: elsewhere,
+    createElement: () => makeInput({}),
+    querySelectorAll: (sel) => (sel === "input[type=radio]" ? radios : [])
+};
+
+const src = readFileSync(morphPath, "utf8");
+const factory = new Function(
+    src + "\n;return { morph, raskNoteDirtyField, raskIsDirtyField, raskDirtyFieldBase, raskFieldBase," +
+    " raskRadioGroup, raskNotePendingValue };");
+const {
+    morph, raskNoteDirtyField, raskIsDirtyField, raskDirtyFieldBase, raskFieldBase, raskRadioGroup,
+    raskNotePendingValue
+} = factory();
+
+// ---- Scenario 1: the base must survive the server's echo of the user's own typing ----
+// Controlled empty field. The user types; the server echoes it back, rewriting the `value` attribute.
+const typed = makeInput({"data-rask-on-input": "h4", "value": ""});
+raskNoteDirtyField(typed);                 // captures "" — what the server had rendered
+typed.value = "hello";
+morph(typed, makeInput({"data-rask-on-input": "h4", "value": "hello"}));   // the echo
+const baseAfterEcho = raskDirtyFieldBase(typed);
+const attributeAfterEcho = typed.getAttribute("value");
+
+// ---- Scenario 2: capture-once — a second edit must not move the base ----
+raskNoteDirtyField(typed);
+typed.value = "hello there";
+const baseAfterSecondEdit = raskDirtyFieldBase(typed);
+
+// ---- Scenario 3: uncontrolled (no `value` attribute) is null, NOT "" ----
+// morph deliberately never writes to an uncontrolled input, so "the server rendered nothing" is a
+// genuinely different state from "the server rendered empty" and the two must not be flattened.
+const uncontrolled = makeInput({"data-rask-on-input": "h5"});
+raskNoteDirtyField(uncontrolled);
+const uncontrolledBase = raskDirtyFieldBase(uncontrolled);
+const controlledEmptyBase = raskFieldBase(makeInput({"value": ""}));
+
+// ---- Scenario 4: a radio's base is its GROUP's selection, scoped to its form owner ----
+const formA = {id: "a"};
+const formB = {id: "b"};
+const planStd = makeEl("INPUT", {"type": "radio", "name": "plan", "value": "std", "checked": ""}, formA);
+const planPro = makeEl("INPUT", {"type": "radio", "name": "plan", "value": "pro"}, formA);
+// A same-named group in another form must not leak into the first group's base.
+makeEl("INPUT", {"type": "radio", "name": "plan", "value": "ent", "checked": ""}, formB);
+
+planStd.checked = true;
+raskNoteDirtyField(planPro);               // the user picks "pro"
+planStd.checked = false;
+planPro.checked = true;
+const radioBase = raskDirtyFieldBase(planPro);
+const radioGroupSize = raskRadioGroup(planPro).length;
+
+// ---- Scenario 5: a textarea's base is its text content ----
+const notes = makeTextarea("first draft");
+raskNoteDirtyField(notes);
+notes.value = "second draft";
+const textareaBase = raskDirtyFieldBase(notes);
+
+// ---- Scenario 6: the restore's guard arming holds off the pristine catch-up frame ----
+// Reproduces what restoreOneField does after a reload: arm the value guard with what the REPLACEMENT
+// rendered, then write the user's value back. The server's first frame is computed from its pristine
+// model — before the converge message lands — and must not wipe the restore. The converge echo then
+// releases the guard, and later server-driven changes win as usual.
+const restored = makeInput({"data-rask-on-input": "h9", "value": ""});
+raskNotePendingValue(restored, "");        // the replacement's pristine base
+restored.value = "hello";
+morph(restored, makeInput({"data-rask-on-input": "h9", "value": ""}));       // pristine catch-up frame
+const afterPristineFrame = restored.value;
+morph(restored, makeInput({"data-rask-on-input": "h9", "value": "hello"}));  // echo of our converge
+const afterConvergeEcho = restored.value;
+morph(restored, makeInput({"data-rask-on-input": "h9", "value": "server"})); // a genuine later change
+const afterLaterServerChange = restored.value;
+
+// ---- Scenario 7: an untouched field is not a candidate at all ----
+const untouched = makeInput({"data-rask-on-input": "h7", "value": "server value"});
+const untouchedIsDirty = raskIsDirtyField(untouched);
+
+process.stdout.write(JSON.stringify({
+    baseAfterEcho,            // ""            — the echo did NOT move the base
+    attributeAfterEcho,       // "hello"       — ...even though it DID rewrite the attribute
+    baseAfterSecondEdit,      // ""            — capture-once
+    uncontrolledBase,         // null          — distinct from ""
+    controlledEmptyBase,      // ""
+    radioBase,                // "std"         — the group's selection, not this element's
+    radioGroupSize,           // 2             — the other form's same-named group stayed out
+    textareaBase,             // "first draft"
+    afterPristineFrame,       // "hello"       — guard held
+    afterConvergeEcho,        // "hello"       — echo applied, guard released
+    afterLaterServerChange,   // "server"      — the framework didn't pin the user's value forever
+    untouchedIsDirty          // false
+}) + "\n");

--- a/tests/Rask.Core.Tests/Live/RestoreFieldBaseTests.cs
+++ b/tests/Rask.Core.Tests/Live/RestoreFieldBaseTests.cs
@@ -1,0 +1,143 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Rask.Core.Tests.Live;
+
+// The merge base behind the redeploy form restore (#571).
+//
+// When a replacement server can't carry a session over, the page reloads and rask.js re-applies the
+// fields the user had actually edited — but only when the replacement renders the SAME base the old
+// server did. That comparison is what makes the restore a three-way merge rather than a guess about
+// whose copy is newer, and it is only sound if the base is what the server had rendered BEFORE the user
+// touched the field.
+//
+// It cannot be read off the DOM at reload time. morph() and applyDiff both sync the `value` ATTRIBUTE
+// unconditionally — only the `.value` PROPERTY is guarded — so every echo of the user's own keystrokes
+// rewrites it. Capture at first-dirty (raskNoteDirtyField) and the echo is harmless; capture late and
+// base always equals the user's text, so every field compares unequal against a pristine replacement and
+// nothing is ever restored. That failure is silent and would still pass a naive test, which is why the
+// echo is reproduced explicitly below.
+//
+// Exercises the production rask-morph.js in a Node subprocess with a stub DOM, alongside
+// MorphValueGuardTests. The merge decision and the converge send live in rask.js — an IIFE that boots a
+// WebSocket and still carries its unsubstituted splice markers — so those are covered by E2E instead.
+public sealed class RestoreFieldBaseTests
+{
+    [Fact]
+    public void DirtyFieldBase_IsCapturedBeforeTheEcho_AndDescribesTheControlNotTheElement()
+    {
+        var node = ResolveNode();
+        if (node is null)
+        {
+            // No node on PATH — the JS-driven reproduction can't run. Don't hard-fail; the E2E
+            // coverage on the Server host exercises the user-observable side.
+            return;
+        }
+
+        var repoRoot = LocateRepoRoot();
+        var fixtureScript = Path.Combine(repoRoot, "tests", "Rask.Core.Tests", "Live", "RestoreFieldBaseFixture.mjs");
+        var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
+        Assert.True(File.Exists(fixtureScript), $"Fixture script missing: {fixtureScript}");
+        Assert.True(File.Exists(morphPath), $"Morph source missing: {morphPath}");
+
+        var psi = new ProcessStartInfo(node, $"\"{fixtureScript}\" \"{morphPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        Assert.True(proc.ExitCode == 0,
+            $"Fixture exited with code {proc.ExitCode}. stderr:\n{stderr}\nstdout:\n{stdout}");
+
+        var jsonLine = stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(s => s.StartsWith("{") && s.EndsWith("}"));
+        Assert.False(jsonLine is null,
+            $"Fixture didn't emit a JSON line. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(jsonLine!);
+        var root = doc.RootElement;
+
+        // THE regression assertion. The server echoed the user's text back and the `value` attribute
+        // duly became it — but the base still reads what the server had rendered before the edit. Read
+        // the base late instead and these two are equal, and nothing is ever restored.
+        Assert.Equal("", root.GetProperty("baseAfterEcho").GetString());
+        Assert.Equal("hello", root.GetProperty("attributeAfterEcho").GetString());
+
+        // Capture-once: the first edit owns the base, so continuing to type doesn't erode it either.
+        Assert.Equal("", root.GetProperty("baseAfterSecondEdit").GetString());
+
+        // An uncontrolled input (no `value` attribute at all — the state morph deliberately never
+        // writes to) is not the same as one the server rendered empty, and must not be flattened into
+        // it: the two want opposite treatment on the far side of the reload.
+        Assert.Equal(JsonValueKind.Null, root.GetProperty("uncontrolledBase").ValueKind);
+        Assert.Equal("", root.GetProperty("controlledEmptyBase").GetString());
+
+        // A radio's meaningful state is its group's selection. Per-element `checked` would let a
+        // restore re-check the user's pick — natively un-checking the server's — while the bases still
+        // compared equal. The group is same-name AND same form owner, so a second form's `plan` group
+        // stays out of it.
+        Assert.Equal("std", root.GetProperty("radioBase").GetString());
+        Assert.Equal(2, root.GetProperty("radioGroupSize").GetInt32());
+
+        // A textarea's server-rendered value is its text content, not a `value` attribute.
+        Assert.Equal("first draft", root.GetProperty("textareaBase").GetString());
+
+        // The composition that keeps the restore on screen: arming the existing value guard with the
+        // replacement's pristine base means the server's first catch-up frame — computed before the
+        // converge message can reach it — is suppressed instead of wiping the restored text.
+        Assert.Equal("hello", root.GetProperty("afterPristineFrame").GetString());
+        // The echo of our own converge differs from that pristine value, so it applies and releases.
+        Assert.Equal("hello", root.GetProperty("afterConvergeEcho").GetString());
+        // And a genuine later server change wins, so the restore doesn't pin the field forever.
+        Assert.Equal("server", root.GetProperty("afterLaterServerChange").GetString());
+
+        // A field the user never touched is not a candidate: whatever the replacement renders for it
+        // may well be newer than what this page was holding.
+        Assert.False(root.GetProperty("untouchedIsDirty").GetBoolean());
+    }
+
+    private static string? ResolveNode()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "node.exe", "node.cmd" } : new[] { "node" };
+        foreach (var dir in path.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in exeNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/ShutdownClientContractTests.cs
@@ -142,16 +142,138 @@ public class ShutdownClientContractTests
     }
 
     [Fact]
-    public void The_restore_point_carries_no_form_values()
+    public void The_scroll_restore_point_still_carries_no_form_values()
     {
-        // Scroll and focus only. The replacement server renders field values from its own state;
-        // writing stale client copies over them would turn a cosmetic loss into a data one.
+        // Scroll and focus only — the fields live under their own key (see below). Keeping them apart
+        // is what stops one oversized textarea failing the quota and taking the scroll position with it.
         var js = ServerJs;
         var fn = js[js.IndexOf("function saveRestorePoint", StringComparison.Ordinal)..];
         var body = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
 
         Assert.DoesNotContain(".value", body, StringComparison.Ordinal);
         Assert.Contains("scrollY", body, StringComparison.Ordinal);
+        Assert.Contains("const RESTORE_FIELDS_KEY = \"rask:restore:fields\";", js, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_field_snapshot_is_written_and_consumed_under_its_own_key()
+    {
+        // Two keys, two try blocks, both consumed unconditionally. If the field write shared the scroll
+        // point's try, a quota failure would silently cost the user their place as well as their typing.
+        var js = ServerJs;
+
+        var save = js[js.IndexOf("function saveRestoreFields", StringComparison.Ordinal)..];
+        var saveBody = save[..save.IndexOf("\n    }", StringComparison.Ordinal)];
+        Assert.Contains("sessionStorage.setItem(RESTORE_FIELDS_KEY", saveBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("RESTORE_KEY,", saveBody, StringComparison.Ordinal);
+
+        var apply = js[js.IndexOf("function applyRestoreFields", StringComparison.Ordinal)..];
+        var applyBody = apply[..apply.IndexOf("\n    }", StringComparison.Ordinal)];
+        var removed = applyBody.IndexOf("removeItem", StringComparison.Ordinal);
+        var firstGuardedReturn = applyBody.IndexOf("if (!saved) return;", StringComparison.Ordinal);
+        Assert.True(removed >= 0 && firstGuardedReturn > removed,
+            "the field snapshot must be consumed before the first early return");
+    }
+
+    [Fact]
+    public void The_field_snapshot_persists_no_handler_ids()
+    {
+        // The scariest failure mode this feature could have had. Handler ids are positional per render,
+        // and the server dispatches on the id alone without cross-checking the frame type — so an id
+        // carried over from the old page would not be rejected on the new one, it would invoke whatever
+        // handler now sits in that slot. The ids must therefore be read from the freshly rendered
+        // element at send time, never from the snapshot.
+        var js = ServerJs;
+
+        var save = js[js.IndexOf("function saveRestoreFields", StringComparison.Ordinal)..];
+        var saveBody = save[..save.IndexOf("\n    }", StringComparison.Ordinal)];
+        Assert.DoesNotContain("data-rask-on-", saveBody, StringComparison.Ordinal);
+
+        // queueConverge is the only place an id is read, and it reads it off the element.
+        var converge = js[js.IndexOf("function queueConverge", StringComparison.Ordinal)..];
+        var convergeBody = converge[..converge.IndexOf("\n    }", StringComparison.Ordinal)];
+        Assert.Contains("el.getAttribute(\"data-rask-on-input\")", convergeBody, StringComparison.Ordinal);
+        Assert.Contains("el.getAttribute(\"data-rask-on-change\")", convergeBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("entry.", convergeBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_field_restore_defers_its_sends_to_the_open_handler()
+    {
+        // applyRestoreFields runs at boot, above `let seqCounter`. Calling send() there walks into
+        // stampSeq and throws a temporal-dead-zone ReferenceError, which the restore's own catch would
+        // swallow — the whole restore would fail 100% of the time, silently. So it queues instead.
+        var js = ServerJs;
+
+        var apply = js[js.IndexOf("function applyRestoreFields", StringComparison.Ordinal)..];
+        var restoreOne = js[js.IndexOf("function restoreOneField", StringComparison.Ordinal)..];
+        var applyBody = apply[..apply.IndexOf("\n    }", StringComparison.Ordinal)];
+        var restoreOneBody = restoreOne[..restoreOne.IndexOf("\n    }", StringComparison.Ordinal)];
+
+        Assert.DoesNotContain("send(", applyBody, StringComparison.Ordinal);
+        Assert.DoesNotContain("send(", restoreOneBody, StringComparison.Ordinal);
+        Assert.Contains("pendingConverge.push", ServerJs, StringComparison.Ordinal);
+
+        // And the queue is drained where a socket exists — after the hello, so the session is known.
+        var open = js[js.IndexOf("ws.addEventListener(\"open\"", StringComparison.Ordinal)..];
+        var openBody = open[..open.IndexOf("\n        });", StringComparison.Ordinal)];
+        var hello = openBody.IndexOf("ws.send(JSON.stringify(hello))", StringComparison.Ordinal);
+        var drain = openBody.IndexOf("for (const payload of pendingConverge) send(payload);", StringComparison.Ordinal);
+        Assert.True(hello >= 0 && drain > hello, "converge messages must be sent after the hello");
+    }
+
+    [Fact]
+    public void Secrets_are_never_snapshotted()
+    {
+        // Unconditional, and checked on both sides so a field that only becomes a secret in the
+        // replacement's render is still not written to.
+        var js = ServerJs;
+
+        Assert.Contains("\"password\"", js, StringComparison.Ordinal);
+        Assert.Contains("\"one-time-code\"", js, StringComparison.Ordinal);
+        Assert.Contains("\"current-password\"", js, StringComparison.Ordinal);
+        Assert.Contains("\"new-password\"", js, StringComparison.Ordinal);
+        Assert.Contains("\"cc-\"", js, StringComparison.Ordinal);
+        Assert.Contains("data-rask-no-restore", js, StringComparison.Ordinal);
+
+        var save = js[js.IndexOf("function saveRestoreFields", StringComparison.Ordinal)..];
+        var saveBody = save[..save.IndexOf("\n    }", StringComparison.Ordinal)];
+        Assert.Contains("restoreExcluded(el)", saveBody, StringComparison.Ordinal);
+
+        var restoreOne = js[js.IndexOf("function restoreOneField", StringComparison.Ordinal)..];
+        var restoreOneBody = restoreOne[..restoreOne.IndexOf("\n    }", StringComparison.Ordinal)];
+        Assert.Contains("restoreExcluded(el)", restoreOneBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void A_radio_is_keyed_by_its_group_not_by_its_own_id()
+    {
+        // A radio's base and value are the group's — which option is selected. Key it by its own id and
+        // the far side resolves to that one member, leaving its siblings unguarded: the server's first
+        // pristine frame re-checks its original option, which natively un-checks the restored one and
+        // undoes the restore with nothing to show for it.
+        var js = ServerJs;
+        var fn = js[js.IndexOf("function restoreKeyOf", StringComparison.Ordinal)..];
+        var body = fn[..fn.IndexOf("\n    }", StringComparison.Ordinal)];
+
+        Assert.Contains("\"radio\"", body, StringComparison.Ordinal);
+        Assert.Contains("el.getAttribute(\"name\")", body, StringComparison.Ordinal);
+
+        // And the apply side arms the guard across the whole group, for the same reason.
+        var restoreOne = js[js.IndexOf("function restoreOneField", StringComparison.Ordinal)..];
+        var restoreOneBody = restoreOne[..restoreOne.IndexOf("\n    }", StringComparison.Ordinal)];
+        Assert.Contains("for (const r of group) raskNotePendingChecked(r", restoreOneBody, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Only_the_server_dialect_restores_fields()
+    {
+        // Same asymmetry as the shutdown frame below, for the same reason: neither WASM nor Native has a
+        // server whose redeploy could reload them. The dirty-field CAPTURE is shared (it rides in
+        // rask-morph.js / rask-input.js so the three clients can't drift), but nothing reads it there.
+        Assert.Contains("function saveRestoreFields", ServerJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("rask:restore:fields", WasmJs, StringComparison.Ordinal);
+        Assert.DoesNotContain("rask:restore:fields", NativeJs, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tests/Rask.Examples.E2E.Tests/ServerExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/ServerExampleTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.Playwright;
 using Rask.Examples.E2E.Tests.Infrastructure;
+using static Microsoft.Playwright.Assertions;
 
 namespace Rask.Examples.E2E.Tests;
 
@@ -62,4 +63,92 @@ public sealed class ServerExampleTests(ServerExampleAppFixture app, PlaywrightFi
             await Page.Context.SetOfflineAsync(false);
         }
     });
+
+    // The redeploy form restore (#571). When a replacement server can't carry a session over, the page
+    // reloads and rask.js re-applies the fields the user had actually edited — but only when the
+    // replacement rendered the same base the old server did.
+    //
+    // This drives the APPLY half against a real reload, because that is where every risk sits: the
+    // merge decision, arming the value guard against the first pristine frame, and pushing the restored
+    // value back so the SERVER MODEL converges. The last of those is the whole point of the feature and
+    // the only thing that can't be faked — a form showing values the server doesn't have is exactly the
+    // data loss that kept field restore out of the first cut.
+    //
+    // The snapshot is written by hand rather than by forcing a real redeploy: saveRestoreFields runs
+    // inside the client IIFE on a shutdown the harness has no way to stage. Its own half is covered by
+    // RestoreFieldBaseTests (the dirty base capture) and ShutdownClientContractTests (the shape).
+    [Fact]
+    public Task RedeployReload_RestoresEditedFields_AndConvergesTheServerModel() => RunAsync(async () =>
+    {
+        await Page.GotoAsync("/guides/forms");
+        // /guides/forms co-mounts many demos; wait for a late one so nothing races hydration.
+        await Expect(Page.Locator("#fc-input-bound")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 45_000 });
+
+        var bound = Page.Locator("#fc-input-bound");
+        var echo = Page.Locator("#fc-input-bound-out");
+
+        // Type, and confirm the server really is holding it — the echo renders the bound model.
+        await bound.FillAsync("survives-the-redeploy");
+        await Expect(echo).ToContainTextAsync("survives-the-redeploy",
+            new LocatorAssertionsToContainTextOptions { Timeout = 10_000 });
+
+        // The reload lands on a pristine session, so the replacement renders value="" — the same base
+        // the old server had rendered when the field was first touched. Bases match, edit is newest.
+        await WriteRestoreFieldsAsync("/guides/forms",
+            """[{"k":"fc-input-bound","t":"text","b":"","v":"survives-the-redeploy"}]""");
+        await Page.ReloadAsync();
+
+        await Expect(Page.Locator("#fc-input-bound")).ToHaveValueAsync("survives-the-redeploy",
+            new LocatorAssertionsToHaveValueOptions { Timeout = 20_000 });
+        // ...and it STAYS: the first frame the server sends is computed from its own pristine model,
+        // so without the armed value guard the text would be wiped and only flicker back afterwards.
+        await Task.Delay(2_000);
+        await Expect(Page.Locator("#fc-input-bound")).ToHaveValueAsync("survives-the-redeploy");
+        // The assertion that matters. The echo renders the SERVER's model, so this is only green if the
+        // converge message landed and the server holds what the page is showing.
+        await Expect(Page.Locator("#fc-input-bound-out")).ToContainTextAsync("survives-the-redeploy",
+            new LocatorAssertionsToContainTextOptions { Timeout = 20_000 });
+
+        // Consume-once: the snapshot must not survive its own reload and re-apply later.
+        await Page.ReloadAsync();
+        await Expect(Page.Locator("#fc-input-bound")).ToHaveValueAsync("",
+            new LocatorAssertionsToHaveValueOptions { Timeout = 20_000 });
+
+        // A base the replacement doesn't match means the new server knows something this stale copy
+        // doesn't — it wins, and the edit is dropped silently.
+        await WriteRestoreFieldsAsync("/guides/forms",
+            """[{"k":"fc-input-bound","t":"text","b":"a-base-the-server-never-rendered","v":"should-be-dropped"}]""");
+        await Page.ReloadAsync();
+        await Expect(Page.Locator("#fc-input-bound")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 45_000 });
+        await Task.Delay(2_000);
+        await Expect(Page.Locator("#fc-input-bound")).ToHaveValueAsync("");
+        await Expect(Page.Locator("#fc-input-bound-out")).Not.ToContainTextAsync("should-be-dropped");
+    });
+
+    // Secrets are excluded unconditionally, and the exclusion is re-checked on the apply side — so even
+    // a hand-planted snapshot naming a password field is refused rather than trusted.
+    [Fact]
+    public Task RedeployReload_NeverRestoresAPasswordField() => RunAsync(async () =>
+    {
+        await Page.GotoAsync("/guides/forms-validation");
+        await Expect(Page.Locator("#v4-password")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 45_000 });
+
+        await WriteRestoreFieldsAsync("/guides/forms-validation",
+            """[{"k":"v4-password","t":"password","b":"","v":"hunter2"}]""");
+        await Page.ReloadAsync();
+
+        await Expect(Page.Locator("#v4-password")).ToBeVisibleAsync(
+            new LocatorAssertionsToBeVisibleOptions { Timeout = 45_000 });
+        await Task.Delay(2_000);
+        await Expect(Page.Locator("#v4-password")).ToHaveValueAsync("");
+    });
+
+    // Plant a snapshot in the shape rask.js's saveRestoreFields writes, under its own key.
+    private Task WriteRestoreFieldsAsync(string path, string fieldsJson) =>
+        Page.EvaluateAsync(
+            "([p, f]) => sessionStorage.setItem('rask:restore:fields', JSON.stringify({p, f: JSON.parse(f)}))",
+            new[] { path, fieldsJson });
 }


### PR DESCRIPTION
Closes #571.

## Summary

A redeploy reload put your scroll position and focus back but silently discarded whatever you were
part-way through typing. #571 recorded why, and the reasoning was sound: there was no way to tell a
value the user typed from one the server had rendered, no merge rule, and no answer for password
fields — so writing stale client copies over correct server output would have turned a cosmetic loss
into a data one.

What makes it answerable is that the DOM already keeps the server-rendered `value` **attribute**
separate from the user's live `.value` **property**. That gives a merge *base*, so this is a
**three-way merge**, not a guess:

| | |
|---|---|
| **base** | what the server had rendered when the user first touched the field |
| **ours** | what the user typed |
| **theirs** | what the replacement server rendered after the reload |

`theirs == base` → the replacement's state is unchanged, so the user's edit is still the newest thing
anyone knows: re-apply it. Otherwise the replacement knows something the stale copy doesn't: it wins,
and the edit is dropped **silently** — exactly how a reload behaved before, so nothing regresses.

Whatever is restored is then **pushed back over the socket**, so the server's model holds what the page
shows. A form displaying values the server doesn't have is the data loss this feature would otherwise
create rather than prevent, and it's the one thing a test can't fake — hence the E2E assertion below.

## The parts that are easy to get wrong

Each of these is load-bearing; the first two would have shipped a silently broken feature.

1. **The base is captured at first-dirty, not read back later.** `morph()` and the diff sync the `value`
   *attribute* unconditionally — only the `.value` *property* is guarded — so every echo of the user's
   own keystrokes rewrites it. Read it at reload time and base always equals the user's text, every
   field compares unequal against a pristine replacement, and nothing is ever restored. The fixture
   reproduces the echo explicitly and asserts the attribute became `"hello"` while the base stayed `""`.
2. **The converge sends are queued, not issued from the restore.** `applyRestoreFields` runs at boot,
   above `let seqCounter` — so `send()` there walks into a temporal-dead-zone `ReferenceError` that its
   own `catch` would swallow, failing 100% of the time in silence. They go out from the `open` handler.
3. **Handler ids are never persisted.** They're positional per render, and the server dispatches on the
   `id` alone without checking the frame `type` — so an id carried over from the old page wouldn't be
   rejected on the new one, it would invoke whatever handler now occupies that slot. Ids are re-read
   from the freshly rendered element at send time. (Filed as #587 — worth hardening on its own.)
4. **The restore arms the existing lagging-frame guards.** The server's first catch-up render is
   computed from its pristine model, before the converge message can reach it — without this the text
   would be wiped and only flicker back.
5. **A radio is keyed by its group, not its own id.** Checking a radio natively un-checks its sibling,
   so keying by id would leave the siblings unguarded and let the first pristine frame undo the restore.
6. **Two `sessionStorage` keys.** One oversized textarea failing the quota must not also cost the
   scroll position that already worked.

## Safety

- Secrets never reach `sessionStorage`: `password` / `file` / `hidden` / `image` / `submit` / `reset` /
  `button` types, and `cc-*` / `one-time-code` / `current-password` / `new-password` autocompletes.
  `data-rask-no-restore` opts out a field or a whole subtree. Excluded on **both** sides, so a field
  that only becomes a secret (or disabled/readonly) in the replacement's render is still not written to.
- A field needs an `id` or a `name`; a key matching more than one control is **skipped**, not guessed —
  a bound `Input` auto-derives `name` from the bound property, so two forms binding the same property
  collide by default, and writing into the wrong one is the failure worth refusing.
- Bases are only ever compared to bases, never to a property (`type=number`/`date` sanitize the
  property; a textarea's `.value` normalizes CRLF). `null` (uncontrolled) stays distinct from `""`.
- Caps: 8 KB/field, 64 KB and 100 fields total, overflow dropping individual fields.
- Server dialect only — WASM and Native have no server whose redeploy could reload them. Only the
  dirty-field *capture* is shared, so the three clients can't drift.

## What changed

Client JS only — **no C# source, no wire-protocol change**.

- `src/Rask.Core/Resources/rask-morph.js` — `raskNoteDirtyField` / `raskFieldBase` / `raskRadioGroup`,
  beside the existing pending-value guards and in the same WeakMap-backed-global shape.
- `src/Rask.Core/Resources/rask-input.js` — one capture call in the `input` listener.
- `src/Rask.Server/Resources/rask.js` — `saveRestoreFields` / `applyRestoreFields` / `queueConverge`,
  the deferred send queue, and the capture call in the `change` listener.

## Testing

- **Node DOM-stub** (new `RestoreFieldBaseFixture.mjs` + `RestoreFieldBaseTests`, modelled on
  `MorphValueGuardTests`): base survives the echo, capture-once, `null` vs `""`, radio group base scoped
  by form owner, textarea text content, guard-arming composition, untouched-is-not-a-candidate.
- **Source-contract** (`ShutdownClientContractTests`, +6 tests): the field snapshot carries no handler
  ids, the restore issues no `send(`, the drain follows the hello, both keys are consumed before the
  first early return, secrets are excluded on both sides, radios are keyed by group, and neither WASM
  nor Native gained any of it. Replaces `The_restore_point_carries_no_form_values`.
- **E2E** (`ServerExampleTests`, +2, run in a real browser): a restored value shows, **survives a
  catch-up frame**, and reaches the server model (asserted via the bound field's echo element — the
  assertion that can't be faked); the snapshot is consumed once; a base mismatch is dropped; and a
  password field is never restored.
- Local gate: `dotnet format --verify-no-changes` clean, `dotnet build Rask.slnx -warnaserror` clean,
  unit gate green (311), full `ServerExampleTests` E2E green (4/4).
- The pre-push browser E2E gate reports 40/41 — the one failure is `PlaygroundExampleTests`, which is
  environmentally red in this sandbox (no browser network for Roslyn reference assemblies) and fails on
  `main` too. Skipped after running the Server E2E suite directly.

## Not covered

`<select>` — `rask-dom.js` sets `option.selected` unguarded, unlike `value` and `checked`, so there is
nothing to hold the first pristine frame off with; `<select multiple>` can't converge at all because the
change dispatch only sends the first selected option. Filed as #588.

## Benchmarks

Not applicable — no C# render-hotpath code changed. The client cost is one WeakMap probe per input event.

## Changelog

`[Unreleased] → Added`, and the #560 entry's "form values are deliberately not restored" sentence is
corrected in place (it was still unreleased).