### PR TITLE
fix(core): refuse a client frame that cannot feed the handler its id resolved to

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,23 @@ them until tagged releases begin.
   landed became an un-retried 502 (`lb_try_duration` defaults to 0). There was previously no gap at all.
 
 ### Fixed
+- **A stale handler id can no longer fire whatever now sits in its slot.** Handler ids are positional per
+  render, so the same id names a different handler after the tree changes — and dispatch keyed on the id
+  alone. The frame's `type` was read to route a few special messages (`hello`, `navigate`, `jsResult`,
+  `dotNetInvoke`) but never cross-checked against the handler the id resolved to, so
+  `{"id":"h37","type":"input","value":"…"}` arriving at a page where `h37` is now a parameterless
+  `OnClick` **ran that callback**, with nothing to say the wrong thing had fired. Not a cross-origin hole
+  — the socket is same-origin and session-bound, so the sender is already the user whose page it is — but
+  positional ids make the collision ordinary rather than exotic, and the silence is what made it bad. The
+  frame's declared type is now checked against the argument the delegate demands (a value frame needs a
+  value handler, a `submit` needs `FormData`, a click needs a parameterless one), and a mismatch is
+  answered exactly like the stale id it is: `false`, no handler, no render. Deliberately **not** a
+  whitelist — a type this build has never heard of is still dispatched, so a browser holding a cached
+  client from another deploy doesn't have its events silently swallowed. Two events of the *same* shape
+  (a `focus` frame against a `click` handler, both parameterless) still pass; separating those needs the
+  event name carried per live handler, which costs a reference per handler in every session and buys
+  nothing for two empty payloads. The check reads the frame's raw UTF-8 through `JsonElement.ValueEquals`
+  — 14 ns and **zero allocation** on the accepted path, on a path that already parses JSON.
 - **The style pass is part of the local gate again, and the "spurious CS1503" that kept it out is
   root-caused.** `dotnet format Rask.slnx` failed on `main` with `error IMPORTS: Fix imports ordering` in
   `RaskEndpointExtensions.cs` — a `using` that drifted out of order and stayed there, because nothing ran

--- a/benchmarks/Rask.Benchmarks/HandlerFrameShapeBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/HandlerFrameShapeBenchmarks.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using BenchmarkDotNet.Attributes;
+using Rask.Core;
+using Rask.Core.Live;
+
+namespace Rask.Benchmarks;
+
+// The frame-type cross-check Component.TryInvokeHandlerAsync runs before invoking a handler (#587): the
+// frame declares what it carries, and a delegate that cannot be fed it is refused instead of being run.
+// This is on the per-event dispatch path — every click, every coalesced keystroke, every 60 Hz scroll
+// tick — so it has to cost effectively nothing and allocate nothing.
+//
+// Three shapes, because they exercise different amounts of the table:
+//   • ClickOnParameterless — the common accept. First entry of the first row: one ValueEquals.
+//   • ScrollOnScroll       — a single-entry row, the shape a high-frequency event takes.
+//   • InputOnParameterless — the refusal. Misses its own row, then scans the rest to establish the type
+//                            is claimed by another shape rather than simply unknown. The worst case, and
+//                            the one that only happens when something already went wrong.
+//   • UnknownTypeOnParameterless — a frame this build has never heard of: the full scan, then allowed.
+[MemoryDiagnoser]
+public class HandlerFrameShapeBenchmarks
+{
+    private readonly Callback _parameterless = () => { };
+    private readonly Callback<ScrollEvent> _scroll = _ => { };
+    private JsonDocument _click = null!;
+    private JsonDocument _input = null!;
+    private JsonDocument _scrollFrame = null!;
+    private JsonDocument _unknown = null!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _click = JsonDocument.Parse("""{"id":"h17","type":"click"}"""u8.ToArray());
+        _input = JsonDocument.Parse("""{"id":"h17","type":"input","value":"hello world"}"""u8.ToArray());
+        _scrollFrame = JsonDocument.Parse(
+            """{"id":"h17","type":"scroll","scrollTop":400,"clientHeight":800,"scrollHeight":9000}"""u8
+                .ToArray());
+        _unknown = JsonDocument.Parse("""{"id":"h17","type":"someFutureEvent"}"""u8.ToArray());
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        _click.Dispose();
+        _input.Dispose();
+        _scrollFrame.Dispose();
+        _unknown.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool ClickOnParameterless() => HandlerFrameShape.Accepts(_click.RootElement, _parameterless);
+
+    [Benchmark]
+    public bool ScrollOnScroll() => HandlerFrameShape.Accepts(_scrollFrame.RootElement, _scroll);
+
+    [Benchmark]
+    public bool InputOnParameterless() => HandlerFrameShape.Accepts(_input.RootElement, _parameterless);
+
+    [Benchmark]
+    public bool UnknownTypeOnParameterless() => HandlerFrameShape.Accepts(_unknown.RootElement, _parameterless);
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -244,7 +244,11 @@ Payload shapes by event:
 - input / change → `{"value":"…"}`
 - submit → `{"form":{"FieldName":"value", …}}`
 
-`TryInvokeHandlerAsync` returns `false` when no handler matches the id.
+`TryInvokeHandlerAsync` returns `false` when no handler matches the id — and, when the payload carries
+the client's `"type"` field, when that event cannot feed the handler the id resolved to (an `"input"`
+frame landing on a parameterless `OnClick`). Handler ids are positional per render, so a frame that
+outlived its render would otherwise run whatever now occupies that slot. A payload with no `"type"` — the
+shape these examples use — makes no claim, so it dispatches on the id alone as before.
 
 ---
 

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1354,6 +1354,17 @@ public abstract class Component
         }
 
         var (owner, handler) = entry;
+
+        // The id said WHICH handler; the frame's own `type` says what it is carrying. Ids are positional
+        // per render, so a frame that outlived its render resolves to whatever now occupies that slot —
+        // and running it because the id happened to resolve is how an `input` message ends up invoking a
+        // parameterless callback. A frame that cannot feed the handler it landed on is a stale id, and is
+        // answered exactly like one.
+        if (!HandlerFrameShape.Accepts(payload, handler))
+        {
+            return false;
+        }
+
         using var __dispatchScope = DispatchServicesScope.Push(services);
 
         // When the host supplied a cancellable dispatch token (a handler timeout is configured), make

--- a/src/Rask.Core/Live/HandlerFrameShape.cs
+++ b/src/Rask.Core/Live/HandlerFrameShape.cs
@@ -1,0 +1,183 @@
+using System.Text.Json;
+using Rask.Core.Forms;
+
+namespace Rask.Core.Live;
+
+// Cross-checks the `type` a client frame declares against the argument shape the handler its `id`
+// resolved to actually demands.
+//
+// Handler ids are POSITIONAL per render (Component.HandlerId over Live.NextHandlerId), so the same id
+// names a different handler after the tree changes. Dispatch used to key on the id alone: a frame that
+// outlived the render it was issued against resolved to whatever now sits in that slot and ran it, with
+// no complaint — `{"id":"h37","type":"input","value":"…"}` arriving at a page where h37 is now a
+// parameterless Callback invoked that callback. Not a cross-origin hole (the socket is same-origin and
+// session-bound), but positional ids make the collision ordinary rather than exotic, and the silence is
+// what makes it bad: nothing says the wrong thing ran.
+//
+// The check is the frame's own claim about what it carries, versus what the delegate needs to be fed. A
+// mismatch is a stale id by definition, so it is answered exactly like one — `false`, no render.
+//
+// Deliberately NOT a whitelist: a type this build has never heard of is ALLOWED through. A browser
+// holding a cached client from another deploy must not have its events silently swallowed; the point is
+// to refuse frames that are provably for a different kind of handler, not to police the vocabulary.
+// This does mean two events of the same shape (a `focus` frame against a `click` handler — both
+// parameterless) still pass. Telling those apart needs the event NAME carried per handler, which costs a
+// reference per live handler in every session; that trade is not worth it for two events whose payloads
+// are both empty.
+internal static class HandlerFrameShape
+{
+    /// <summary>The argument a handler demands — equivalently, the payload a frame has to carry to feed it.</summary>
+    internal enum Shape
+    {
+        None = 0,
+        Modifiers,
+        Value,
+        Form,
+        Files,
+        Scroll,
+        Keyboard,
+        Mouse,
+        Wheel,
+        Pointer,
+        Touch,
+        Clipboard,
+        Media
+    }
+
+    // The frame types that legitimately feed each shape, indexed by (int)Shape. Rows overlap on purpose:
+    // `click` feeds a parameterless handler, the legacy MouseModifiers one, and a MouseEventArgs one, so
+    // it appears in three rows. Kept in step with the client's send sites (rask.js / rask.wasm.js /
+    // rask.native.js + the shared rask-input.js / rask-events.js splices) and with the delegate cases in
+    // Component.TryInvokeHandlerAsync.
+    //
+    // Held as UTF-8 so the comparison runs against the frame's raw bytes — JsonElement.ValueEquals over a
+    // byte span, the same shape the inbound type routing uses, so no frame type is ever materialised as a
+    // string. Built once at class init.
+    private static readonly byte[][][] Feeders =
+    {
+        // None — parameterless. The frames that carry nothing beyond their id.
+        new[]
+        {
+            "click"u8.ToArray(), "dragstart"u8.ToArray(), "dragover"u8.ToArray(), "drop"u8.ToArray(),
+            "dragend"u8.ToArray(), "drag"u8.ToArray(), "dragenter"u8.ToArray(), "dragleave"u8.ToArray(),
+            "focus"u8.ToArray(), "blur"u8.ToArray(), "focusin"u8.ToArray(), "focusout"u8.ToArray(),
+            "select"u8.ToArray(), "invalid"u8.ToArray(), "reset"u8.ToArray()
+        },
+        // Modifiers — MouseModifiers (click only).
+        new[] { "click"u8.ToArray() },
+        // Value — the string payload.
+        new[] { "input"u8.ToArray(), "change"u8.ToArray(), "beforeinput"u8.ToArray() },
+        // Form — FormData.
+        new[] { "submit"u8.ToArray() },
+        // Files — the uploaded-file metadata.
+        new[] { "files"u8.ToArray() },
+        // Scroll — ScrollEvent.
+        new[] { "scroll"u8.ToArray() },
+        // Keyboard — KeyboardEventArgs.
+        new[] { "keydown"u8.ToArray(), "keyup"u8.ToArray() },
+        // Mouse — MouseEventArgs.
+        new[]
+        {
+            "click"u8.ToArray(), "dblclick"u8.ToArray(), "mousedown"u8.ToArray(), "mouseup"u8.ToArray(),
+            "mousemove"u8.ToArray(), "mouseenter"u8.ToArray(), "mouseleave"u8.ToArray(),
+            "mouseover"u8.ToArray(), "mouseout"u8.ToArray(), "contextmenu"u8.ToArray()
+        },
+        // Wheel — WheelEventArgs.
+        new[] { "wheel"u8.ToArray() },
+        // Pointer — PointerEventArgs.
+        new[]
+        {
+            "pointerdown"u8.ToArray(), "pointerup"u8.ToArray(), "pointermove"u8.ToArray(),
+            "pointerenter"u8.ToArray(), "pointerleave"u8.ToArray(), "pointerover"u8.ToArray(),
+            "pointerout"u8.ToArray(), "pointercancel"u8.ToArray()
+        },
+        // Touch — TouchEventArgs.
+        new[]
+        {
+            "touchstart"u8.ToArray(), "touchend"u8.ToArray(),
+            "touchmove"u8.ToArray(), "touchcancel"u8.ToArray()
+        },
+        // Clipboard — ClipboardEventArgs.
+        new[] { "copy"u8.ToArray(), "cut"u8.ToArray(), "paste"u8.ToArray() },
+        // Media — MediaEventArgs.
+        new[]
+        {
+            "play"u8.ToArray(), "pause"u8.ToArray(), "playing"u8.ToArray(), "ended"u8.ToArray(),
+            "timeupdate"u8.ToArray(), "volumechange"u8.ToArray(), "ratechange"u8.ToArray(),
+            "durationchange"u8.ToArray(), "loadedmetadata"u8.ToArray(), "seeked"u8.ToArray(),
+            "seeking"u8.ToArray(), "waiting"u8.ToArray()
+        }
+    };
+
+    /// <summary>
+    ///     Whether <paramref name="handler" /> may be invoked for this frame. True when the frame declares
+    ///     no type (a host that doesn't tag frames, or a direct <c>RaskTest</c> dispatch), when the type
+    ///     feeds the handler's shape, or when no shape claims the type at all.
+    /// </summary>
+    public static bool Accepts(JsonElement payload, Delegate handler)
+    {
+        if (payload.ValueKind != JsonValueKind.Object
+            || !payload.TryGetProperty("type", out var type)
+            || type.ValueKind != JsonValueKind.String)
+        {
+            return true;
+        }
+
+        // The happy path is one row: the shape the handler demands, scanned against the frame's raw
+        // UTF-8. Nothing is allocated, and nothing else is consulted unless the frame is refused.
+        if (Contains(Feeders[(int)ShapeOf(handler)], type))
+        {
+            return true;
+        }
+
+        // Not a feeder for this shape. Refuse only if some OTHER shape claims it; an unrecognised type
+        // is a client this build doesn't know, not a misfire.
+        foreach (var row in Feeders)
+        {
+            if (Contains(row, type))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool Contains(byte[][] types, JsonElement type)
+    {
+        foreach (var candidate in types)
+        {
+            if (type.ValueEquals(candidate))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    // Mirrors the delegate cases of Component.TryInvokeHandlerAsync one-for-one. Anything it doesn't
+    // recognise is parameterless as far as dispatch is concerned: the switch's `default` arm reaches it
+    // through DynamicInvoke() with NO arguments, so a data-carrying frame has nothing to give it.
+    private static Shape ShapeOf(Delegate handler) => handler switch
+    {
+        Action or Func<Task> or Callback or CallbackAsync => Shape.None,
+        Action<MouseModifiers> or Func<MouseModifiers, Task>
+            or Callback<MouseModifiers> or CallbackAsync<MouseModifiers> => Shape.Modifiers,
+        Action<string> or Func<string, Task> or Callback<string> or CallbackAsync<string> => Shape.Value,
+        Action<FormData> or Func<FormData, Task> or Callback<FormData> or CallbackAsync<FormData> => Shape.Form,
+        Action<IReadOnlyList<RaskFile>> or Func<IReadOnlyList<RaskFile>, Task>
+            or Callback<IReadOnlyList<RaskFile>> or CallbackAsync<IReadOnlyList<RaskFile>> => Shape.Files,
+        Action<ScrollEvent> or Func<ScrollEvent, Task>
+            or Callback<ScrollEvent> or CallbackAsync<ScrollEvent> => Shape.Scroll,
+        Action<KeyboardEventArgs> or Func<KeyboardEventArgs, Task>
+            or Callback<KeyboardEventArgs> or CallbackAsync<KeyboardEventArgs> => Shape.Keyboard,
+        Callback<MouseEventArgs> or CallbackAsync<MouseEventArgs> => Shape.Mouse,
+        Callback<WheelEventArgs> or CallbackAsync<WheelEventArgs> => Shape.Wheel,
+        Callback<PointerEventArgs> or CallbackAsync<PointerEventArgs> => Shape.Pointer,
+        Callback<TouchEventArgs> or CallbackAsync<TouchEventArgs> => Shape.Touch,
+        Callback<ClipboardEventArgs> or CallbackAsync<ClipboardEventArgs> => Shape.Clipboard,
+        Callback<MediaEventArgs> or CallbackAsync<MediaEventArgs> => Shape.Media,
+        _ => Shape.None
+    };
+}

--- a/tests/Rask.Core.Tests/Live/HandlerFrameTypeTests.cs
+++ b/tests/Rask.Core.Tests/Live/HandlerFrameTypeTests.cs
@@ -1,0 +1,179 @@
+using System.Text.Json;
+using Rask.Core.Live;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+/// <summary>
+///     Dispatch used to key on the message id alone. Handler ids are positional per render, so a frame
+///     that outlived the render it was issued against resolves to whatever now sits in that slot — an
+///     <c>input</c> message landing on a parameterless callback ran it, silently. These pin the
+///     cross-check of the frame's declared <c>type</c> against the argument the handler demands (#587).
+/// </summary>
+public class HandlerFrameTypeTests
+{
+    private static JsonElement Frame(string json) => JsonDocument.Parse(json).RootElement;
+
+    [Fact]
+    public async Task An_input_frame_does_not_fire_a_parameterless_handler()
+    {
+        // The reported misfire: h0 was an input handler when the client read the id, and is a click
+        // handler by the time the message arrives.
+        var fired = 0;
+        var view = new StubComponent(() => Button(OnClick: () => fired++)["x"]);
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync("h0", Frame("""{"id":"h0","type":"input","value":"x"}"""));
+
+        Assert.False(ok);
+        Assert.Equal(0, fired);
+    }
+
+    [Fact]
+    public async Task A_click_frame_does_not_fire_a_value_handler()
+    {
+        // The mirror image, and the reason the check is not just "a data frame needs a data handler":
+        // a click carries nothing, so feeding it to a value handler would silently set an empty string.
+        var captured = "untouched";
+        var view = new StubComponent(() => Input<string>(OnInput: v => captured = v));
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync("h0", Frame("""{"id":"h0","type":"click"}"""));
+
+        Assert.False(ok);
+        Assert.Equal("untouched", captured);
+    }
+
+    [Fact]
+    public async Task A_submit_frame_does_not_fire_a_parameterless_handler()
+    {
+        var fired = 0;
+        var view = new StubComponent(() => Button(OnClick: () => fired++)["x"]);
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync(
+            "h0", Frame("""{"id":"h0","type":"submit","form":{"name":"Bob"}}"""));
+
+        Assert.False(ok);
+        Assert.Equal(0, fired);
+    }
+
+    [Fact]
+    public async Task A_keyboard_frame_does_not_fire_a_parameterless_handler()
+    {
+        var fired = 0;
+        var view = new StubComponent(() => Button(OnClick: () => fired++)["x"]);
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync(
+            "h0", Frame("""{"id":"h0","type":"keydown","key":"Enter","code":"Enter"}"""));
+
+        Assert.False(ok);
+        Assert.Equal(0, fired);
+    }
+
+    [Fact]
+    public async Task A_click_frame_fires_a_parameterless_handler()
+    {
+        var fired = 0;
+        var view = new StubComponent(() => Button(OnClick: () => fired++)["x"]);
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync("h0", Frame("""{"id":"h0","type":"click"}"""));
+
+        Assert.True(ok);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public async Task A_change_frame_fires_a_value_handler()
+    {
+        // input and change both feed a string handler — the client sends `change` for a select and a
+        // committed text edit, `input` for the coalesced keystroke.
+        var captured = string.Empty;
+        var view = new StubComponent(() => Input<string>(OnInput: v => captured = v));
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync(
+            "h0", Frame("""{"id":"h0","type":"change","value":"hello"}"""));
+
+        Assert.True(ok);
+        Assert.Equal("hello", captured);
+    }
+
+    [Fact]
+    public async Task A_focus_frame_fires_a_parameterless_handler()
+    {
+        // Same shape, different event: both carry nothing, so this one still dispatches. Telling them
+        // apart would need the event name stored per handler — see the remarks on HandlerFrameShape.
+        var fired = 0;
+        var view = new StubComponent(() => Div(OnFocus: () => fired++));
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync("h0", Frame("""{"id":"h0","type":"focus"}"""));
+
+        Assert.True(ok);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public async Task A_frame_type_this_build_does_not_know_is_still_dispatched()
+    {
+        // Forward compatibility: a browser holding a cached client from another deploy must not have its
+        // events swallowed. Only a type some OTHER shape claims is refused.
+        var fired = 0;
+        var view = new StubComponent(() => Button(OnClick: () => fired++)["x"]);
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync("h0", Frame("""{"id":"h0","type":"someFutureEvent"}"""));
+
+        Assert.True(ok);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public async Task A_frame_with_no_type_is_still_dispatched()
+    {
+        // RaskTest dispatches a bare payload, and so do plenty of unit tests. No claim, nothing to check.
+        var fired = 0;
+        var view = new StubComponent(() => Button(OnClick: () => fired++)["x"]);
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync("h0", Frame("""{"value":"x"}"""));
+
+        Assert.True(ok);
+        Assert.Equal(1, fired);
+    }
+
+    [Fact]
+    public async Task A_files_frame_does_not_fire_a_value_handler()
+    {
+        // Both carry data, so neither is parameterless — the shapes still have to match.
+        var captured = "untouched";
+        var view = new StubComponent(() => Input<string>(OnInput: v => captured = v));
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync(
+            "h0",
+            Frame("""{"id":"h0","type":"files","files":[{"token":"t","name":"a.txt","size":1}]}"""));
+
+        Assert.False(ok);
+        Assert.Equal("untouched", captured);
+    }
+
+    [Fact]
+    public async Task A_scroll_frame_fires_a_scroll_handler()
+    {
+        ScrollEvent? captured = null;
+        var view = new StubComponent(() => Div(OnScroll: e => captured = e));
+        view.RenderAsLiveRoot();
+
+        var ok = await view.TryInvokeHandlerAsync(
+            "h0",
+            Frame("""{"id":"h0","type":"scroll","scrollTop":40,"clientHeight":10,"scrollHeight":100}"""));
+
+        Assert.True(ok);
+        Assert.Equal(40, captured?.ScrollTop);
+    }
+}

--- a/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HandlerDispatchTests.cs
@@ -53,6 +53,36 @@ public class HandlerDispatchTests
     }
 
     [Fact]
+    public async Task HandlerId_FrameTypeThatCannotFeedTheHandler_IsIgnored()
+    {
+        // Handler ids are positional per render, so a frame the client sent against an earlier tree
+        // resolves to whatever now occupies that slot. h0 here is the parameterless "bump" click; an
+        // `input` frame landing on it used to RUN it, with nothing to say the wrong thing had fired.
+        using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);
+        var initial = await host.Http.GetAsync("/start");
+        var initialHtml = await initial.Content.ReadAsStringAsync();
+        var sessionId = MarkupAssert.SessionId(initialHtml);
+        var handlerId = MarkupAssert.FirstHandlerId(initialHtml);
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        await ws.SendJsonAsync(new { id = handlerId, type = "input", value = "x" });
+
+        // No render: the counter was never bumped. Answered exactly like the stale id it is.
+        Assert.Null(await ws.TryReceiveTextAsync(TimeSpan.FromMilliseconds(400)));
+        Assert.Equal(WebSocketState.Open, ws.State);
+
+        // ...and the socket still dispatches the frame that DOES fit.
+        await ws.SendJsonAsync(new { id = handlerId, type = "click" });
+        var text = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(text);
+        using var doc = JsonDocument.Parse(text!);
+        Assert.Contains("count=1", doc.RootElement.GetProperty("html").GetString()!);
+    }
+
+    [Fact]
     public async Task Message_NoIdAndNoType_Ignored()
     {
         using var host = RaskTestHost.Create<TestApp>(diffMode: LiveDiffMode.DisabledFull);


### PR DESCRIPTION
Fixes #587.

## What was wrong

Handler ids are **positional per render** (`Component.HandlerId` over `Live.NextHandlerId`), so the same
id names a different handler as soon as the tree changes. Dispatch keyed on the id alone — the frame's
`type` was read to route `hello` / `navigate` / `jsResult` / `dotNetInvoke`, but never cross-checked
against what the id actually resolved to. An `input` frame arriving at a page where its id is now a
parameterless `OnClick` **ran that callback**, and nothing said the wrong thing had fired.

Not a cross-origin hole — the socket is same-origin and session-bound, so the sender is already the user
whose page it is. What makes it worth fixing is that positional ids make the collision *ordinary* rather
than exotic, and that the misfire is silent.

## The fix

`HandlerFrameShape` (Rask.Core/Live) classifies the delegate — parameterless, value, form, files, scroll,
keyboard, mouse, wheel, pointer, touch, clipboard, media, mouse-modifiers — one-for-one with the cases in
`TryInvokeHandlerAsync`, and holds the frame types that legitimately feed each. A frame that feeds the
shape dispatches; one claimed by a *different* shape is answered exactly like the stale id it is:
`false`, no handler, no render.

Three deliberate boundaries:

- **Not a whitelist.** A type this build has never heard of is still dispatched, so a browser holding a
  cached client from another deploy isn't silently ignored. Only a type some other shape claims is refused.
- **Same-shape events still pass** (a `focus` frame against a `click` handler — both parameterless).
  Separating those needs the event *name* carried per live handler, which costs a reference per handler in
  every session and buys nothing for two empty payloads. Recorded in the type's remarks.
- **A payload with no `type` makes no claim** and dispatches on the id as before — that's `RaskTest` and
  most unit tests, which stay unchanged.

It lives in Core rather than the Server endpoint, so all three hosts (Server, WASM, Native) are covered by
one check. The registration surface was enumerated before choosing the shapes: every DOM handler is
strongly typed per event (`ElementEvents`' `Callback<T>` props), and the form controls' `input`/`change`
handlers are uniformly `CallbackAsync<string>` (`BindingHelpers`, `ControlledChangeHandler`), so no
legitimate registration can be refused.

## Testing

- **`HandlerFrameTypeTests`** (11) — the reported misfire (`input` → parameterless), its mirror
  (`click` → value), `submit`/`keydown`/`files` mismatches, the accepted pairs, unknown-type pass-through,
  and no-type pass-through. Verified they actually bite: with the guard short-circuited, **5 of the 11 go
  red**; with it, 11/11 pass.
- **`HandlerDispatchTests.HandlerId_FrameTypeThatCannotFeedTheHandler_IsIgnored`** — end-to-end over a real
  socket: an `input` frame against the page's click handler produces no render, the socket stays open, and
  the matching `click` frame right after still dispatches.
- `scripts/run-unit-local.sh` (format + warnings-as-errors + full unit/integration suite): green.

## Benchmarks

New `HandlerFrameShapeBenchmarks` — the check runs on every dispatched event, so it has to be free:

| Case | Mean | Allocated |
|---|---:|---:|
| `ClickOnParameterless` (the common accept) | 14.4 ns | **0 B** |
| `ScrollOnScroll` (high-frequency event) | 27.5 ns | **0 B** |
| `InputOnParameterless` (a refusal) | 98.0 ns | **0 B** |
| `UnknownTypeOnParameterless` (full scan, then allowed) | 213.8 ns | **0 B** |

Zero allocation throughout: the comparison runs against the frame's raw UTF-8 via
`JsonElement.ValueEquals`, the same idiom `WsInboundTypeMatchBenchmarks` established for the inbound type
routing. No render-path code changed, so no render benchmark moves.

## Changelog / docs

`CHANGELOG.md` under Fixed. `docs/testing.md` §3 gains the new `false` case, and notes that a payload
without `"type"` behaves as before.

## E2E

`scripts/run-e2e-local.sh`: **38 of 39 pass.** The one failure —
`PlaygroundExampleTests.Compiles_and_runs_user_code_live_in_the_browser` — is **not** from this change and
is red on `main`: it waits for `.pg-ide.is-ready`, but #470 replaced that class with a `BsBadge` colour
(`IdeBadge()` now renders `Class: "pg-ide"` only), so the selector has matched nothing since. `is-ready`
appears nowhere in `src/` or `samples/` — only in the assertion. The run's own aria snapshot shows the app
*was* ready ("IntelliSense ready", "Compiled ✓"), and the playground's compiled component clicked and
re-rendered fine, which is the dispatch path this PR touches. Filed separately; the push skipped the
already-run gate rather than repeating a 10-minute run for the same known failure.
