### PR TITLE
fix(core): guard a select against a re-render computed before the user picked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,25 @@ them until tagged releases begin.
   hot-reloads` and the Local-vs-Server section now all draw the same line.
 
 ### Fixed
+- **A `<select>` no longer snaps back to the old option when a lagging re-render lands.** `value` and
+  `checked` each had a guard against a frame the server computed *before* the user's edit reached it;
+  `selected` — the third property the diff codec mirrors onto its IDL twin — had none, so it was applied
+  unconditionally. Pick an option, have a re-render computed a moment earlier arrive, and the box reverted
+  to the server's older answer until the echo caught up. The focus guard doesn't help, for the same reason
+  it doesn't help a date input: a select commits on *change*, so focus has already moved on by the time
+  the stale frame lands. The change dispatch now records the pre-pick `selected` attribute of **every**
+  option in the select — the whole control, exactly as the checked guard records the whole radio group,
+  because a stale frame re-selecting the previously chosen option natively deselects the new one — and the
+  apply path suppresses a frame that still carries it, releasing as soon as an authoritative frame differs
+  so server-driven changes keep winning. Selection is also applied through the `<select>` itself rather
+  than by poking each option, so one write moves the whole group instead of leaving a single-select
+  momentarily showing its first option between the remove and the set. And the three guards are now armed
+  from **one** shared recorder rather than a copy hand-maintained in each host runtime — the drift that
+  produced this bug, since both copies covered `value` and `checked` and neither covered `selected`; a
+  source contract test now pins that both hosts go through it. Restoring a `<select>` across a redeploy
+  reload is still not covered (see `docs/configuration.md`): the guard it was waiting on now exists, but
+  the save/apply side is separate work, and `<select multiple>` first needs a change dispatch that reports
+  every selected option rather than just the first.
 - **The style pass is part of the local gate again, and the "spurious CS1503" that kept it out is
   root-caused.** `dotnet format Rask.slnx` failed on `main` with `error IMPORTS: Fix imports ordering` in
   `RaskEndpointExtensions.cs` — a `using` that drifted out of order and stayed there, because nothing ran

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,8 +113,10 @@ Anything still connected when `ShutdownDrainTimeout` elapses is aborted, and
 >   one-time-code inputs, and anything with a `cc-*` / `current-password` / `new-password` `autocomplete`,
 >   are excluded unconditionally and never reach `sessionStorage` in the first place.
 >
-> `<select>` is not restored yet — it has no lagging-frame guard for the first re-render to be held off
-> with, unlike `value` and `checked`.
+> `<select>` is not restored yet. The lagging-frame guard it needs — to hold off the replacement's first
+> catch-up render — now exists alongside the ones for `value` and `checked`, but the save/apply side does
+> not cover it. A `<select multiple>` needs one more thing first: the change dispatch reports the select's
+> single `value`, which is only its first selected option.
 
 `ShutdownDrainTimeout` must fit inside `HostOptions.ShutdownTimeout`, which must fit inside whatever your
 container runtime allows between `SIGTERM` and `SIGKILL` (`rask deploy` uses 20 s). Rask logs a warning at

--- a/src/Rask.Core/Resources/rask-dom.js
+++ b/src/Rask.Core/Resources/rask-dom.js
@@ -125,8 +125,24 @@ function syncFormProperty(el, name, value, isPresent) {
         if (raskShouldSuppressChecked(el, !!isPresent)) return;
         el.checked = !!isPresent;
     } else if (name === "selected" && tag === "OPTION") {
-        el.selected = !!isPresent;
+        if (raskShouldSuppressSelected(el, !!isPresent)) return;
+        applySelected(el, !!isPresent);
     }
+}
+
+// Selecting through the option's own IDL property leaves the group inconsistent between ops: a diff
+// that moves the selection emits a remove on one option and a set on another, and in between a
+// single-select with nothing selected falls back to displaying its first option. Where the option
+// belongs to a single-select, move the SELECT instead — one write that lands on this exact option, by
+// index rather than by value so duplicate option values can't redirect it. Multi-selects (where more
+// than one option is legitimately on) and an option with no select fall back to the property.
+function applySelected(opt, on) {
+    const sel = opt.closest ? opt.closest("select") : null;
+    if (on && sel && !sel.multiple && typeof opt.index === "number") {
+        sel.selectedIndex = opt.index;
+        return;
+    }
+    opt.selected = on;
 }
 
 function applyDiff(ops, names) {

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -139,6 +139,32 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// The `selected` analogue of the two guards above, for <select>. A select commits like a radio: the
+// user picks an option, the browser flips that option's `selected` PROPERTY, and the `selected`
+// ATTRIBUTE — the last server-rendered default — stays exactly where the server put it. So a frame the
+// server computed BEFORE the pick still marks the old option, and applying it snaps the box back until
+// the echo lands. The focus guard doesn't help here for the same reason it doesn't help a date input:
+// a select commits on change, so focus has moved on by the time the lagging frame arrives.
+//
+// Recorded like the radio group, and for the same reason: the change dispatch notes the pre-pick
+// attribute state of EVERY option in the select, not just the two that moved, because a stale frame
+// that re-selects the previously chosen option natively deselects the new one.
+function _raskPendingSelected() {
+    return window.__raskPendingSelected || (window.__raskPendingSelected = new WeakMap());
+}
+
+function raskNotePendingSelected(el, supersededSelected) {
+    if (el) _raskPendingSelected().set(el, !!supersededSelected);
+}
+
+function raskShouldSuppressSelected(el, incoming) {
+    const map = _raskPendingSelected();
+    if (!el || !map.has(el)) return false;
+    if (map.get(el) === !!incoming) return true;   // lagging frame carrying the stale selection
+    map.delete(el);                                 // authoritative response — release the guard
+    return false;
+}
+
 // User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
 // the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
 // saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
@@ -217,6 +243,42 @@ function raskRadioGroup(el) {
     }
 
     return out.length > 0 ? out : [el];
+}
+
+// The whole pre-dispatch recording in one call, so the two host runtimes (rask.js, rask.wasm.js) can't
+// drift on which controls get a guard — each carried a hand-copied version of this block, which is
+// exactly how <select> came to have no guard at all while value and checked had one. Called from the
+// change dispatch with the element that changed, just before the message goes out.
+function raskNotePendingFormState(el) {
+    if (!el || !el.tagName) return;
+    const tag = el.tagName;
+    const isCheckbox = tag === "INPUT" && el.type === "checkbox";
+    // The PRE-EDIT value (the last server-rendered `value` attribute) — exactly what a lagging frame
+    // carries. Checkboxes self-correct through the checked guard, so they stay out of the value guard.
+    if (!isCheckbox) {
+        const sv = el.getAttribute("value");
+        raskNotePendingValue(el, sv === null ? "" : sv);
+    }
+    // The PRE-CLICK checked (the `checked` attribute, which a native click leaves untouched). A radio
+    // needs its whole group: a stale frame re-checking the previously selected member would natively
+    // uncheck the new one. raskRadioGroup is the same same-name-AND-same-form lookup the restore uses —
+    // narrower than the hosts' old root-wide `name` selector (two forms can each own a `Plan` group),
+    // and free of CSS.escape, which the shared modules can't assume for an app-authored name.
+    if (tag === "INPUT" && (isCheckbox || el.type === "radio")) {
+        const group = el.type === "radio" ? raskRadioGroup(el) : [el];
+        for (const r of group) {
+            raskNotePendingChecked(r, r.hasAttribute("checked"));
+        }
+    }
+    // The PRE-PICK selected state of every option in the select — same reasoning as the radio group.
+    if (tag === "SELECT") {
+        const opts = el.options || (el.getElementsByTagName ? el.getElementsByTagName("option") : null);
+        if (opts) {
+            for (let i = 0; i < opts.length; i++) {
+                raskNotePendingSelected(opts[i], opts[i].hasAttribute("selected"));
+            }
+        }
+    }
 }
 
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1545,8 +1545,24 @@ function syncFormProperty(el, name, value, isPresent) {
         if (raskShouldSuppressChecked(el, !!isPresent)) return;
         el.checked = !!isPresent;
     } else if (name === "selected" && tag === "OPTION") {
-        el.selected = !!isPresent;
+        if (raskShouldSuppressSelected(el, !!isPresent)) return;
+        applySelected(el, !!isPresent);
     }
+}
+
+// Selecting through the option's own IDL property leaves the group inconsistent between ops: a diff
+// that moves the selection emits a remove on one option and a set on another, and in between a
+// single-select with nothing selected falls back to displaying its first option. Where the option
+// belongs to a single-select, move the SELECT instead — one write that lands on this exact option, by
+// index rather than by value so duplicate option values can't redirect it. Multi-selects (where more
+// than one option is legitimately on) and an option with no select fall back to the property.
+function applySelected(opt, on) {
+    const sel = opt.closest ? opt.closest("select") : null;
+    if (on && sel && !sel.multiple && typeof opt.index === "number") {
+        sel.selectedIndex = opt.index;
+        return;
+    }
+    opt.selected = on;
 }
 
 function applyDiff(ops, names) {
@@ -2314,6 +2330,32 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// The `selected` analogue of the two guards above, for <select>. A select commits like a radio: the
+// user picks an option, the browser flips that option's `selected` PROPERTY, and the `selected`
+// ATTRIBUTE — the last server-rendered default — stays exactly where the server put it. So a frame the
+// server computed BEFORE the pick still marks the old option, and applying it snaps the box back until
+// the echo lands. The focus guard doesn't help here for the same reason it doesn't help a date input:
+// a select commits on change, so focus has moved on by the time the lagging frame arrives.
+//
+// Recorded like the radio group, and for the same reason: the change dispatch notes the pre-pick
+// attribute state of EVERY option in the select, not just the two that moved, because a stale frame
+// that re-selects the previously chosen option natively deselects the new one.
+function _raskPendingSelected() {
+    return window.__raskPendingSelected || (window.__raskPendingSelected = new WeakMap());
+}
+
+function raskNotePendingSelected(el, supersededSelected) {
+    if (el) _raskPendingSelected().set(el, !!supersededSelected);
+}
+
+function raskShouldSuppressSelected(el, incoming) {
+    const map = _raskPendingSelected();
+    if (!el || !map.has(el)) return false;
+    if (map.get(el) === !!incoming) return true;   // lagging frame carrying the stale selection
+    map.delete(el);                                 // authoritative response — release the guard
+    return false;
+}
+
 // User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
 // the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
 // saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
@@ -2392,6 +2434,42 @@ function raskRadioGroup(el) {
     }
 
     return out.length > 0 ? out : [el];
+}
+
+// The whole pre-dispatch recording in one call, so the two host runtimes (rask.js, rask.wasm.js) can't
+// drift on which controls get a guard — each carried a hand-copied version of this block, which is
+// exactly how <select> came to have no guard at all while value and checked had one. Called from the
+// change dispatch with the element that changed, just before the message goes out.
+function raskNotePendingFormState(el) {
+    if (!el || !el.tagName) return;
+    const tag = el.tagName;
+    const isCheckbox = tag === "INPUT" && el.type === "checkbox";
+    // The PRE-EDIT value (the last server-rendered `value` attribute) — exactly what a lagging frame
+    // carries. Checkboxes self-correct through the checked guard, so they stay out of the value guard.
+    if (!isCheckbox) {
+        const sv = el.getAttribute("value");
+        raskNotePendingValue(el, sv === null ? "" : sv);
+    }
+    // The PRE-CLICK checked (the `checked` attribute, which a native click leaves untouched). A radio
+    // needs its whole group: a stale frame re-checking the previously selected member would natively
+    // uncheck the new one. raskRadioGroup is the same same-name-AND-same-form lookup the restore uses —
+    // narrower than the hosts' old root-wide `name` selector (two forms can each own a `Plan` group),
+    // and free of CSS.escape, which the shared modules can't assume for an app-authored name.
+    if (tag === "INPUT" && (isCheckbox || el.type === "radio")) {
+        const group = el.type === "radio" ? raskRadioGroup(el) : [el];
+        for (const r of group) {
+            raskNotePendingChecked(r, r.hasAttribute("checked"));
+        }
+    }
+    // The PRE-PICK selected state of every option in the select — same reasoning as the radio group.
+    if (tag === "SELECT") {
+        const opts = el.options || (el.getElementsByTagName ? el.getElementsByTagName("option") : null);
+        if (opts) {
+            for (let i = 0; i < opts.length; i++) {
+                raskNotePendingSelected(opts[i], opts[i].hasAttribute("selected"));
+            }
+        }
+    }
 }
 
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -1521,28 +1521,11 @@
             const changeVal = (t.tagName === "INPUT" && t.type === "checkbox")
                 ? (t.checked ? "true" : "false")
                 : t.value;
-            // Record the PRE-EDIT value (the last server-rendered `value` attribute)
-            // so a lagging re-render carrying that stale value can't clobber the
-            // user's fresh edit before the server's authoritative response lands —
-            // see raskShouldSuppressValue. Checkboxes self-correct via the checked
-            // path, so they don't participate in the value guard.
-            if (!(t.tagName === "INPUT" && t.type === "checkbox")) {
-                const sv = t.getAttribute("value");
-                raskNotePendingValue(t, sv === null ? "" : sv);
-            }
-            // Same guard for the `.checked` property: record the PRE-CLICK checked (the `checked`
-            // attribute, which a native click leaves untouched) so a lagging re-render can't revert
-            // the just-committed selection before the server echoes it — see raskShouldSuppressChecked.
-            // For a radio, note the whole same-name group: a stale frame that re-checks the previously
-            // selected radio would natively uncheck the new one, so the siblings need the guard too.
-            if (t.tagName === "INPUT" && (t.type === "checkbox" || t.type === "radio")) {
-                if (t.type === "radio" && t.name) {
-                    root.querySelectorAll('input[type=radio][name="' + CSS.escape(t.name) + '"]')
-                        .forEach((r) => raskNotePendingChecked(r, r.hasAttribute("checked")));
-                } else {
-                    raskNotePendingChecked(t, t.hasAttribute("checked"));
-                }
-            }
+            // Record what a lagging re-render would have to carry to be stale — the pre-edit value,
+            // the pre-click checked (whole radio group), the pre-pick selected (whole select) — so the
+            // apply paths can tell "the frame that predates the user's action" from "the server's
+            // authoritative answer to it". Shared with the WASM runtime, in rask-morph.js.
+            raskNotePendingFormState(t);
             send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
         }
     });

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2729,6 +2729,32 @@ function raskShouldSuppressChecked(el, incoming) {
     return false;
 }
 
+// The `selected` analogue of the two guards above, for <select>. A select commits like a radio: the
+// user picks an option, the browser flips that option's `selected` PROPERTY, and the `selected`
+// ATTRIBUTE — the last server-rendered default — stays exactly where the server put it. So a frame the
+// server computed BEFORE the pick still marks the old option, and applying it snaps the box back until
+// the echo lands. The focus guard doesn't help here for the same reason it doesn't help a date input:
+// a select commits on change, so focus has moved on by the time the lagging frame arrives.
+//
+// Recorded like the radio group, and for the same reason: the change dispatch notes the pre-pick
+// attribute state of EVERY option in the select, not just the two that moved, because a stale frame
+// that re-selects the previously chosen option natively deselects the new one.
+function _raskPendingSelected() {
+    return window.__raskPendingSelected || (window.__raskPendingSelected = new WeakMap());
+}
+
+function raskNotePendingSelected(el, supersededSelected) {
+    if (el) _raskPendingSelected().set(el, !!supersededSelected);
+}
+
+function raskShouldSuppressSelected(el, incoming) {
+    const map = _raskPendingSelected();
+    if (!el || !map.has(el)) return false;
+    if (map.get(el) === !!incoming) return true;   // lagging frame carrying the stale selection
+    map.delete(el);                                 // authoritative response — release the guard
+    return false;
+}
+
 // User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
 // the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
 // saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
@@ -2807,6 +2833,42 @@ function raskRadioGroup(el) {
     }
 
     return out.length > 0 ? out : [el];
+}
+
+// The whole pre-dispatch recording in one call, so the two host runtimes (rask.js, rask.wasm.js) can't
+// drift on which controls get a guard — each carried a hand-copied version of this block, which is
+// exactly how <select> came to have no guard at all while value and checked had one. Called from the
+// change dispatch with the element that changed, just before the message goes out.
+function raskNotePendingFormState(el) {
+    if (!el || !el.tagName) return;
+    const tag = el.tagName;
+    const isCheckbox = tag === "INPUT" && el.type === "checkbox";
+    // The PRE-EDIT value (the last server-rendered `value` attribute) — exactly what a lagging frame
+    // carries. Checkboxes self-correct through the checked guard, so they stay out of the value guard.
+    if (!isCheckbox) {
+        const sv = el.getAttribute("value");
+        raskNotePendingValue(el, sv === null ? "" : sv);
+    }
+    // The PRE-CLICK checked (the `checked` attribute, which a native click leaves untouched). A radio
+    // needs its whole group: a stale frame re-checking the previously selected member would natively
+    // uncheck the new one. raskRadioGroup is the same same-name-AND-same-form lookup the restore uses —
+    // narrower than the hosts' old root-wide `name` selector (two forms can each own a `Plan` group),
+    // and free of CSS.escape, which the shared modules can't assume for an app-authored name.
+    if (tag === "INPUT" && (isCheckbox || el.type === "radio")) {
+        const group = el.type === "radio" ? raskRadioGroup(el) : [el];
+        for (const r of group) {
+            raskNotePendingChecked(r, r.hasAttribute("checked"));
+        }
+    }
+    // The PRE-PICK selected state of every option in the select — same reasoning as the radio group.
+    if (tag === "SELECT") {
+        const opts = el.options || (el.getElementsByTagName ? el.getElementsByTagName("option") : null);
+        if (opts) {
+            for (let i = 0; i < opts.length; i++) {
+                raskNotePendingSelected(opts[i], opts[i].hasAttribute("selected"));
+            }
+        }
+    }
 }
 
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
@@ -3192,8 +3254,24 @@ function syncFormProperty(el, name, value, isPresent) {
         if (raskShouldSuppressChecked(el, !!isPresent)) return;
         el.checked = !!isPresent;
     } else if (name === "selected" && tag === "OPTION") {
-        el.selected = !!isPresent;
+        if (raskShouldSuppressSelected(el, !!isPresent)) return;
+        applySelected(el, !!isPresent);
     }
+}
+
+// Selecting through the option's own IDL property leaves the group inconsistent between ops: a diff
+// that moves the selection emits a remove on one option and a set on another, and in between a
+// single-select with nothing selected falls back to displaying its first option. Where the option
+// belongs to a single-select, move the SELECT instead — one write that lands on this exact option, by
+// index rather than by value so duplicate option values can't redirect it. Multi-selects (where more
+// than one option is legitimately on) and an option with no select fall back to the property.
+function applySelected(opt, on) {
+    const sel = opt.closest ? opt.closest("select") : null;
+    if (on && sel && !sel.multiple && typeof opt.index === "number") {
+        sel.selectedIndex = opt.index;
+        return;
+    }
+    opt.selected = on;
 }
 
 function applyDiff(ops, names) {
@@ -4120,28 +4198,11 @@ document.addEventListener("change", (e) => {
         const changeVal = (t.tagName === "INPUT" && t.type === "checkbox")
             ? (t.checked ? "true" : "false")
             : t.value;
-        // Record the PRE-EDIT value (the last server-rendered `value` attribute) so a
-        // lagging re-render carrying that stale value can't clobber the user's fresh
-        // edit before the server's authoritative response lands — see
-        // raskShouldSuppressValue. Checkboxes self-correct via the checked path, so
-        // they stay out of the value guard.
-        if (!(t.tagName === "INPUT" && t.type === "checkbox")) {
-            const sv = t.getAttribute("value");
-            raskNotePendingValue(t, sv === null ? "" : sv);
-        }
-        // Same guard for the `.checked` property: record the PRE-CLICK checked (the `checked`
-        // attribute, which a native click leaves untouched) so a lagging re-render can't revert
-        // the just-committed selection before the authoritative frame lands — see
-        // raskShouldSuppressChecked. For a radio, note the whole same-name group: a stale frame that
-        // re-checks the previously selected radio would natively uncheck the new one.
-        if (t.tagName === "INPUT" && (t.type === "checkbox" || t.type === "radio")) {
-            if (t.type === "radio" && t.name) {
-                root.querySelectorAll('input[type=radio][name="' + CSS.escape(t.name) + '"]')
-                    .forEach((r) => raskNotePendingChecked(r, r.hasAttribute("checked")));
-            } else {
-                raskNotePendingChecked(t, t.hasAttribute("checked"));
-            }
-        }
+        // Record what a lagging re-render would have to carry to be stale — the pre-edit value, the
+        // pre-click checked (whole radio group), the pre-pick selected (whole select) — so the apply
+        // paths can tell "the frame that predates the user's action" from "the server's authoritative
+        // answer to it". Shared with the Server runtime, in rask-morph.js.
+        raskNotePendingFormState(t);
         send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
     }
 });

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -667,28 +667,11 @@ document.addEventListener("change", (e) => {
         const changeVal = (t.tagName === "INPUT" && t.type === "checkbox")
             ? (t.checked ? "true" : "false")
             : t.value;
-        // Record the PRE-EDIT value (the last server-rendered `value` attribute) so a
-        // lagging re-render carrying that stale value can't clobber the user's fresh
-        // edit before the server's authoritative response lands — see
-        // raskShouldSuppressValue. Checkboxes self-correct via the checked path, so
-        // they stay out of the value guard.
-        if (!(t.tagName === "INPUT" && t.type === "checkbox")) {
-            const sv = t.getAttribute("value");
-            raskNotePendingValue(t, sv === null ? "" : sv);
-        }
-        // Same guard for the `.checked` property: record the PRE-CLICK checked (the `checked`
-        // attribute, which a native click leaves untouched) so a lagging re-render can't revert
-        // the just-committed selection before the authoritative frame lands — see
-        // raskShouldSuppressChecked. For a radio, note the whole same-name group: a stale frame that
-        // re-checks the previously selected radio would natively uncheck the new one.
-        if (t.tagName === "INPUT" && (t.type === "checkbox" || t.type === "radio")) {
-            if (t.type === "radio" && t.name) {
-                root.querySelectorAll('input[type=radio][name="' + CSS.escape(t.name) + '"]')
-                    .forEach((r) => raskNotePendingChecked(r, r.hasAttribute("checked")));
-            } else {
-                raskNotePendingChecked(t, t.hasAttribute("checked"));
-            }
-        }
+        // Record what a lagging re-render would have to carry to be stale — the pre-edit value, the
+        // pre-click checked (whole radio group), the pre-pick selected (whole select) — so the apply
+        // paths can tell "the frame that predates the user's action" from "the server's authoritative
+        // answer to it". Shared with the Server runtime, in rask-morph.js.
+        raskNotePendingFormState(t);
         send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
     }
 });

--- a/tests/Rask.Core.Tests/Live/MorphSelectedGuardFixture.mjs
+++ b/tests/Rask.Core.Tests/Live/MorphSelectedGuardFixture.mjs
@@ -1,0 +1,144 @@
+// Node-driven fixture for the shared client's `selected` echo guard
+// (raskNotePendingSelected / raskShouldSuppressSelected in rask-morph.js, consumed by the diff codec's
+// syncFormProperty in rask-dom.js, which in turn feeds rask.js and rask.wasm.js).
+//
+// Reproduces the <select> desync: the user picks an option (the browser flips that option's `selected`
+// PROPERTY and leaves every `selected` ATTRIBUTE where the server put it), and a re-render the server
+// computed BEFORE the pick reached it lands afterwards. Pre-fix the diff codec set `.selected`
+// unconditionally — the third form property, and the only one with no guard — so the box snapped back to
+// the old option until the echo arrived. The focus guard doesn't help: a select commits on change, so
+// focus has moved on by then, exactly as with the date/number inputs the value guard was written for.
+//
+// Also covers the group-atomicity part: applying a selection through the SELECT (by index) rather than
+// through the option's own property, so a diff that moves the selection can't leave a single-select
+// briefly showing its first option.
+//
+// The C# test (MorphSelectedGuardTests) runs this in a node subprocess and asserts the single JSON line
+// on stdout. Exits non-zero on an internal stub failure.
+import {readFileSync} from "node:fs";
+
+const morphPath = process.argv[2];
+const domPath = process.argv[3];
+if (!morphPath || !domPath) {
+    console.error("usage: node MorphSelectedGuardFixture.mjs <rask-morph.js path> <rask-dom.js path>");
+    process.exit(2);
+}
+
+// ----- Minimal <option> / <select> stubs -----
+// Models the real state AFTER a native pick: the `selected` attribute (the last server-rendered default)
+// and the live `.selected` property are independent — picking flips the property on two options and
+// never touches either attribute.
+function makeOption(value, selectedAttr) {
+    const a = new Map([["value", value]]);
+    if (selectedAttr) a.set("selected", "");
+    const el = {
+        nodeType: 1, nodeName: "OPTION", tagName: "OPTION",
+        value, selected: !!selectedAttr, index: 0, parentNode: null,
+        hasAttribute: (n) => a.has(n),
+        getAttribute: (n) => (a.has(n) ? a.get(n) : null),
+        setAttribute: (n, v) => a.set(n, String(v)),
+        removeAttribute: (n) => a.delete(n),
+        // The only selector applySelected asks for.
+        closest: (sel) => (sel === "select" ? el.parentNode : null),
+        get attributes() { return [...a.entries()].map(([name, value]) => ({name, value})); }
+    };
+    return el;
+}
+
+function makeSelect(options, multiple) {
+    const a = new Map([["data-rask-on-change", "hS"]]);
+    const sel = {
+        nodeType: 1, nodeName: "SELECT", tagName: "SELECT", multiple: !!multiple, options,
+        hasAttribute: (n) => a.has(n),
+        getAttribute: (n) => (a.has(n) ? a.get(n) : null),
+        setAttribute: (n, v) => a.set(n, String(v)),
+        removeAttribute: (n) => a.delete(n),
+        get attributes() { return [...a.entries()].map(([name, value]) => ({name, value})); },
+        // Mirrors the browser: setting the index selects exactly one option and clears the rest, which is
+        // the whole reason applySelected prefers it over poking each option.
+        get selectedIndex() { return options.findIndex((o) => o.selected); },
+        set selectedIndex(i) { options.forEach((o, j) => { o.selected = j === i; }); }
+    };
+    options.forEach((o, i) => { o.parentNode = sel; o.index = i; });
+    return sel;
+}
+
+const elsewhere = {nodeType: 1, nodeName: "BODY", tagName: "BODY"};
+globalThis.window = globalThis;
+globalThis.document = {activeElement: elsewhere, createElement: () => makeOption("", false)};
+
+// ----- Load the shared snippets (plain function declarations, not modules) -----
+// Concat both: rask-dom.js's syncFormProperty calls raskShouldSuppressSelected, which lives in
+// rask-morph.js — the runtime splices them into one scope.
+const src = readFileSync(morphPath, "utf8") + "\n" + readFileSync(domPath, "utf8");
+const factory = new Function(
+    src + "\n;return { syncFormProperty, raskNotePendingSelected, raskNotePendingFormState };");
+const {syncFormProperty, raskNotePendingFormState} = factory();
+
+// ---- Scenario 1: a lagging frame must not undo the user's pick ----
+// Server rendered "a" selected. The user picks "b"; the browser moves the property, both attributes
+// still say what the server last sent. The dispatch notes the pre-pick attribute state of every option.
+const s1a = makeOption("a", true);
+const s1b = makeOption("b", false);
+const s1 = makeSelect([s1a, s1b]);
+s1a.selected = false;
+s1b.selected = true;
+raskNotePendingFormState(s1);
+
+// The lagging frame (computed with "a" still chosen) re-marks a and un-marks b. Both are suppressed.
+syncFormProperty(s1a, "selected", "", true);
+syncFormProperty(s1b, "selected", "", false);
+const s1AfterStaleA = s1a.selected;   // expect false — the old option was not re-selected
+const s1AfterStaleB = s1b.selected;   // expect true  — the user's pick survived
+
+// The authoritative echo ("b" chosen) applies and releases both guards.
+syncFormProperty(s1a, "selected", "", false);
+syncFormProperty(s1b, "selected", "", true);
+const s1AfterEchoA = s1a.selected;    // expect false
+const s1AfterEchoB = s1b.selected;    // expect true
+
+// Released: a later server-driven change back to "a" is not pinned by the guard.
+syncFormProperty(s1a, "selected", "", true);
+const s1AfterLaterA = s1a.selected;   // expect true
+const s1AfterLaterB = s1b.selected;   // expect false — moving the select cleared the other option
+
+// ---- Scenario 2: a select nobody has touched still follows the server ----
+// No dispatch, so no guard: the ordinary server-driven selection must apply unchanged.
+const s2a = makeOption("a", true);
+const s2b = makeOption("b", false);
+makeSelect([s2a, s2b]);
+syncFormProperty(s2a, "selected", "", false);
+syncFormProperty(s2b, "selected", "", true);
+const s2AfterServerA = s2a.selected;  // expect false
+const s2AfterServerB = s2b.selected;  // expect true
+
+// ---- Scenario 3: selecting moves the whole group in one write ----
+// Applying through the SELECT's index (not the option's property) means the option that was on is off
+// again without needing its own op — a diff whose remove-op is dropped can't leave two options selected.
+const s3a = makeOption("a", true);
+const s3b = makeOption("b", false);
+const s3c = makeOption("c", false);
+makeSelect([s3a, s3b, s3c]);
+syncFormProperty(s3c, "selected", "", true);
+const s3OnlyCSelected = s3c.selected && !s3a.selected && !s3b.selected;   // expect true
+
+// ---- Scenario 4: a multi-select keeps per-option control ----
+// Several options are legitimately on at once, so the atomic single-select path must not apply.
+const s4a = makeOption("a", true);
+const s4b = makeOption("b", false);
+makeSelect([s4a, s4b], true);
+syncFormProperty(s4b, "selected", "", true);
+const s4BothSelected = s4a.selected && s4b.selected;                      // expect true
+
+process.stdout.write(JSON.stringify({
+    s1AfterStaleA,      // false — stale frame didn't re-select the old option
+    s1AfterStaleB,      // true  — stale frame didn't revert the user's pick
+    s1AfterEchoA,       // false — echo applied
+    s1AfterEchoB,       // true  — echo applied
+    s1AfterLaterA,      // true  — guard released, later server change wins
+    s1AfterLaterB,      // false
+    s2AfterServerA,     // false — an untouched select still follows the server
+    s2AfterServerB,     // true
+    s3OnlyCSelected,    // true  — one write moved the whole group
+    s4BothSelected      // true  — multi-select keeps per-option control
+}) + "\n");

--- a/tests/Rask.Core.Tests/Live/MorphSelectedGuardTests.cs
+++ b/tests/Rask.Core.Tests/Live/MorphSelectedGuardTests.cs
@@ -1,0 +1,137 @@
+using System.Diagnostics;
+using System.Text.Json;
+
+namespace Rask.Core.Tests.Live;
+
+// Regression guard for the <select> desync (#588) — the third form property, and the only one that had
+// no lagging-frame guard.
+//
+// Symptom: the user picks an option (the browser flips that option's `selected` PROPERTY and leaves
+// every `selected` ATTRIBUTE where the server put it), then a re-render the server computed BEFORE the
+// pick reached it lands. The diff codec's syncFormProperty set `.selected` unconditionally, so the box
+// snapped back to the old option until the echo arrived. The focus guard in morph() doesn't help, for
+// the same reason it doesn't help a date input: a select commits on change, so focus has moved on by
+// the time the lagging frame lands (see MorphValueGuardTests).
+//
+// Fix: raskNotePendingSelected records the pre-pick `selected` attribute of EVERY option on dispatch —
+// the whole select, exactly as the checked guard records the whole radio group, because a stale frame
+// re-selecting the previously chosen option natively deselects the new one. raskShouldSuppressSelected
+// then suppresses any frame still carrying that state until an authoritative one differs and releases.
+//
+// Second half: applying a selection through the SELECT's index rather than the option's own property,
+// so one write moves the whole group instead of leaving a single-select momentarily showing its first
+// option between a remove-op and a set-op.
+//
+// Exercises the production rask-morph.js + rask-dom.js in a Node subprocess with a stub DOM, alongside
+// MorphCheckedGuardTests. Pairs with the WASM/Server E2E journeys, which cover the user-visible side.
+public sealed class MorphSelectedGuardTests
+{
+    [Fact]
+    public void Selected_StaleRender_DoesNotClobberTheJustPickedOption_ThenReleases()
+    {
+        var node = ResolveNode();
+        if (node is null)
+        {
+            // No node on PATH — the JS-driven reproduction can't run. Don't hard-fail; the E2E
+            // journeys cover the user-observable side.
+            return;
+        }
+
+        var repoRoot = LocateRepoRoot();
+        var fixtureScript = Path.Combine(repoRoot, "tests", "Rask.Core.Tests", "Live", "MorphSelectedGuardFixture.mjs");
+        var morphPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-morph.js");
+        var domPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-dom.js");
+        Assert.True(File.Exists(fixtureScript), $"Fixture script missing: {fixtureScript}");
+        Assert.True(File.Exists(morphPath), $"Morph source missing: {morphPath}");
+        Assert.True(File.Exists(domPath), $"Dom source missing: {domPath}");
+
+        var psi = new ProcessStartInfo(node, $"\"{fixtureScript}\" \"{morphPath}\" \"{domPath}\"")
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        using var proc = Process.Start(psi)!;
+        var stdout = proc.StandardOutput.ReadToEnd();
+        var stderr = proc.StandardError.ReadToEnd();
+        proc.WaitForExit(30_000);
+
+        Assert.True(proc.ExitCode == 0,
+            $"Fixture exited with code {proc.ExitCode}. stderr:\n{stderr}\nstdout:\n{stdout}");
+
+        var jsonLine = stdout
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault(s => s.StartsWith("{") && s.EndsWith("}"));
+        Assert.False(jsonLine is null,
+            $"Fixture didn't emit a JSON line. stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        using var doc = JsonDocument.Parse(jsonLine!);
+        var root = doc.RootElement;
+
+        bool Get(string name) => root.GetProperty(name).GetBoolean();
+
+        // THE regression assertion. A lagging frame must neither re-select the option the server still
+        // thinks is chosen (which natively deselects the new one) nor clear the one the user picked.
+        Assert.False(Get("s1AfterStaleA"), "stale frame re-selected the old option");
+        Assert.True(Get("s1AfterStaleB"), "stale frame reverted the user's pick");
+
+        // The authoritative echo applies and releases both guards.
+        Assert.False(Get("s1AfterEchoA"), "echo didn't clear the old option");
+        Assert.True(Get("s1AfterEchoB"), "echo didn't apply to the picked option");
+
+        // Released — a later server-driven change is not pinned by the guard.
+        Assert.True(Get("s1AfterLaterA"), "guard pinned the selection after the echo");
+        Assert.False(Get("s1AfterLaterB"), "moving the selection left the old option selected");
+
+        // A select nobody has touched has no guard at all, so ordinary server-driven selection is
+        // untouched by any of this.
+        Assert.False(Get("s2AfterServerA"), "server-driven deselect didn't apply");
+        Assert.True(Get("s2AfterServerB"), "server-driven select didn't apply");
+
+        // Selecting moves the whole group in one write, rather than depending on a sibling's op also
+        // arriving (and surviving the guard) to clear the option that was on.
+        Assert.True(Get("s3OnlyCSelected"), "selecting one option didn't clear its siblings");
+
+        // ...except on a multi-select, where several options are legitimately on at once.
+        Assert.True(Get("s4BothSelected"), "a multi-select lost an already-selected option");
+    }
+
+    private static string? ResolveNode()
+    {
+        var path = Environment.GetEnvironmentVariable("PATH") ?? string.Empty;
+        var separator = OperatingSystem.IsWindows() ? ';' : ':';
+        var exeNames = OperatingSystem.IsWindows() ? new[] { "node.exe", "node.cmd" } : new[] { "node" };
+        foreach (var dir in path.Split(separator, StringSplitOptions.RemoveEmptyEntries))
+        {
+            foreach (var name in exeNames)
+            {
+                var candidate = Path.Combine(dir, name);
+                if (File.Exists(candidate))
+                {
+                    return candidate;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Core.Tests/Resources/FormGuardClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/FormGuardClientContractTests.cs
@@ -1,0 +1,98 @@
+namespace Rask.Core.Tests.Resources;
+
+/// <summary>
+///     Source-level contract for the lagging-frame guards the change dispatch arms. Structural
+///     assertions over the shipped <c>.js</c>, for the same reason as
+///     <see cref="ShutdownClientContractTests" />: the host runtimes are IIFEs that boot against a live
+///     document and still carry unsubstituted <c>@@RASK_*@@</c> splice markers in the Resources copy, so
+///     they cannot be executed in Node. The behaviour of the guards themselves is covered by
+///     MorphValueGuardTests / MorphCheckedGuardTests / MorphSelectedGuardTests, which do run the shared
+///     modules; what is pinned here is that the hosts actually ARM them, which nothing else would catch.
+/// </summary>
+public class FormGuardClientContractTests
+{
+    private static readonly string _repoRoot = LocateRepoRoot();
+
+    private static string ServerJs => Read("src", "Rask.Server", "Resources", "rask.js");
+    private static string WasmJs => Read("src", "Rask.Wasm", "Resources", "rask.wasm.js");
+    private static string MorphJs => Read("src", "Rask.Core", "Resources", "rask-morph.js");
+
+    [Fact]
+    public void Both_hosts_arm_the_guards_through_the_shared_recorder()
+    {
+        // The invariant #588 came from. Each host carried its own hand-copied block of "record what a
+        // lagging frame would have to carry" — and the two copies covered `value` and `checked` while
+        // neither covered `selected`, so a <select> had no guard at all. One recorder, called from both,
+        // is what stops that recurring: a control added to it is covered everywhere at once.
+        foreach (var js in new[] { ServerJs, WasmJs })
+        {
+            var dispatch = ChangeDispatch(js);
+            Assert.Contains("raskNotePendingFormState(t);", dispatch, StringComparison.Ordinal);
+
+            // And it may not go back to noting a guard inline, which is how the two copies drifted
+            // apart. (The Server's redeploy restore arms raskNotePendingChecked separately and
+            // legitimately — see ShutdownClientContractTests — hence scoping this to the dispatch.)
+            Assert.DoesNotContain("raskNotePendingValue(", dispatch, StringComparison.Ordinal);
+            Assert.DoesNotContain("raskNotePendingChecked(", dispatch, StringComparison.Ordinal);
+            Assert.DoesNotContain("raskNotePendingSelected(", dispatch, StringComparison.Ordinal);
+        }
+    }
+
+    // The change listener, up to the message it sends — the window in which a guard has to be armed,
+    // because after the send the server's answer is already on its way.
+    private static string ChangeDispatch(string js)
+    {
+        var listener = js[js.IndexOf("addEventListener(\"change\"", StringComparison.Ordinal)..];
+        var end = listener.IndexOf("data-rask-on-change\"), type: \"change\"", StringComparison.Ordinal);
+        Assert.True(end > 0, "could not find the change dispatch's send in this client");
+        return listener[..end];
+    }
+
+    [Fact]
+    public void The_recorder_covers_all_three_form_properties()
+    {
+        // syncFormProperty mirrors exactly three attributes onto their IDL properties (value, checked,
+        // selected). Each needs a guard, or a re-render the server computed before the user's edit
+        // overwrites it — the desync that produced #588 for the one that was missing.
+        var js = MorphJs;
+        var fn = js[js.IndexOf("function raskNotePendingFormState", StringComparison.Ordinal)..];
+        var body = fn[..fn.IndexOf("\n}", StringComparison.Ordinal)];
+
+        Assert.Contains("raskNotePendingValue(", body, StringComparison.Ordinal);
+        Assert.Contains("raskNotePendingChecked(", body, StringComparison.Ordinal);
+        Assert.Contains("raskNotePendingSelected(", body, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Every_guarded_property_is_consulted_where_the_diff_applies_it()
+    {
+        // The other half: recording is useless unless the apply path asks. syncFormProperty is the diff
+        // codec's single write point for all three, and `selected` was the branch that never asked.
+        var js = Read("src", "Rask.Core", "Resources", "rask-dom.js");
+        var fn = js[js.IndexOf("function syncFormProperty", StringComparison.Ordinal)..];
+        var body = fn[..fn.IndexOf("\n}", StringComparison.Ordinal)];
+
+        Assert.Contains("raskShouldSuppressValue(", body, StringComparison.Ordinal);
+        Assert.Contains("raskShouldSuppressChecked(", body, StringComparison.Ordinal);
+        Assert.Contains("raskShouldSuppressSelected(", body, StringComparison.Ordinal);
+    }
+
+    private static string Read(params string[] parts) => File.ReadAllText(Path.Combine([_repoRoot, .. parts]));
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}


### PR DESCRIPTION
Fixes #588.

## What was wrong

`syncFormProperty` (`rask-dom.js`) mirrors three attributes onto their IDL twins, and only two were
guarded against a frame the server computed *before* the user's edit reached it:

- `value` — focus check + `raskShouldSuppressValue`
- `checked` — `raskShouldSuppressChecked`
- `selected` on an `<option>` — `el.selected = !!isPresent`, **unguarded**

So a `<select>` had exactly the desync the value guard was introduced to fix. The user picks an option
(the browser flips that option's `selected` **property** and leaves every `selected` **attribute** where
the server put it), a re-render computed a moment earlier lands, and the box snaps back to the old option
until the echo catches up. The focus guard doesn't help for the same reason it doesn't help a date input:
a select commits on *change*, so focus has already moved on.

Reproduced against the production sources with a stub DOM before touching anything — a lagging frame
re-selected the old option (`true`) and cleared the user's pick (`false`).

## The fix

`raskNotePendingSelected` / `raskShouldSuppressSelected` in `rask-morph.js`, beside the two existing
WeakMap-backed guards. The dispatch records the pre-pick `selected` attribute of **every** option in the
select — the whole control, exactly as the checked guard records the whole radio group, because a stale
frame re-selecting the previously chosen option natively deselects the new one. A frame still carrying
that state is suppressed; the first frame that *differs* is authoritative, so it applies and releases.

**Selection is applied through the `<select>`**, by index rather than by value (duplicate option values
can't redirect it), instead of poking each option — the trap the issue flagged. One write moves the whole
group, so a diff that moves the selection can't leave a single-select momentarily showing its first option
between the remove-op and the set-op. Multi-selects, where several options are legitimately on, keep the
per-option path.

**One recorder instead of two copies.** Each host runtime carried a hand-maintained "record what a lagging
frame would have to carry" block — which is exactly how this bug happened: both copies covered `value` and
`checked`, and neither covered `selected`. `raskNotePendingFormState` in `rask-morph.js` is now the single
place, called from both hosts. It reuses `raskRadioGroup` (added by #591) for the checked group, which is
also *more correct* than the hosts' old root-wide `name` selector: same-name **and** same form owner, so
two forms can each hold a `Plan` group, and no `CSS.escape` on an app-authored name.

## Testing

- **`MorphSelectedGuardTests` + `MorphSelectedGuardFixture.mjs`** — runs the production `rask-morph.js` +
  `rask-dom.js` in a Node subprocess against a stub DOM, the same shape as the existing value/checked
  guard pair. Ten assertions: the stale frame neither re-selects the old option nor reverts the pick; the
  echo applies and releases; a later server-driven change still wins; an untouched select is unaffected;
  one write moves the whole group; a multi-select keeps per-option control.
- **`FormGuardClientContractTests`** (new) — pins the anti-drift property that caused this: both hosts arm
  the guards *through the shared recorder* and may not note one inline in the change dispatch, the recorder
  covers all three properties, and `syncFormProperty` consults all three. (Scoped to the dispatch, because
  the Server's redeploy restore legitimately arms `raskNotePendingChecked` separately — see
  `ShutdownClientContractTests`.)
- The existing `MorphValueGuardTests` / `MorphCheckedGuardTests` / `RestoreFieldBaseTests` stay green, so
  the radio-group lookup swap didn't disturb the value, checked or restore paths.
- `scripts/run-unit-local.sh`: green, zero failures.
- `scripts/run-e2e-local.sh`: see below. The journey's existing select step
  (`SharedSmokeTests.Journey`, `select#bs-tier` → `SelectOptionAsync("team")` → asserts the box *holds*
  the new value) is the user-visible regression guard for this area.

No benchmarks: this is client JS on the change dispatch, with no .NET render-path code touched.

## Generated bundles

`src/Rask.Wasm/Browser/rask.wasm.js` and `src/Rask.Native/Assets/rask.native.js` are the committed splice
outputs; both are regenerated here. Native's change dispatch arms no guards (it never did), so it only
picks up the shared definitions.

## Docs / changelog

`CHANGELOG.md` under Fixed. `docs/configuration.md` said `<select>` isn't restored across a redeploy
*because it has no lagging-frame guard* — that reason is now gone, so it says what is actually left: the
save/apply side, plus a multi-select change dispatch that reports more than the first option.

## Follow-ups filed (not fixed here)

- **#595** — `<select multiple>` reports only its first selected option to the server. The guard can't fix
  it: nothing is lagging, the *report* is the wrong shape, and fixing it reaches into the binding surface
  (the value path is `string`-shaped end to end).
- **#596** — a full morph never syncs a select's live selection, only its `selected` attribute. The
  opposite failure to this one, on the other apply path, and a behaviour change that wants its own test.

## E2E result

`scripts/run-e2e-local.sh`: **40 of 41 pass.** The one failure is
`PlaygroundExampleTests.Compiles_and_runs_user_code_live_in_the_browser`, waiting on `.pg-ide.is-ready` —
a selector #470 deleted, red on `main`, filed as #593. Byte-identical failure to the run on #592, and it
exercises no `<select>`. The push skipped the pre-push gate rather than repeating a 10-minute run for the
same known failure.
