### PR TITLE
feat(cli): make every rejected command line say what's wrong and what to run next

### DIFF
--- a/.claude/skills/run-rask-cli/smoke.sh
+++ b/.claude/skills/run-rask-cli/smoke.sh
@@ -73,7 +73,10 @@ fi
 echo "==> Shell completion (generated from the live command + option set)"
 check "completion bash"  0 "complete -F _rask_complete rask" -- completion bash
 check "completion fish"  0 "complete -c rask"                 -- completion fish
-check "completion bad shell" 1 "Specify a shell"              -- completion tcsh
+check "completion bad shell" 2 "Unknown 'rask completion' action" -- completion tcsh
+# Completion is generated from the schema, so subcommands and closed-set values come along for free.
+check "completion knows db's actions" 0 "backup"              -- completion bash
+check "completion knows --template's values" 0 "wasm-hosted"  -- completion zsh
 
 echo "==> new --dry-run previews without writing"
 check "new --dry-run"    0 "would write"      -- new Ghost --template server --output "$WORK/Ghost" --dry-run
@@ -83,7 +86,7 @@ echo "==> Scaffold a new server project"
 check "new Shop"        0 "Created Shop"      -- new Shop --template server --output "$WORK/Shop"
 have "$WORK/Shop/Shop.csproj"
 have "$WORK/Shop/Program.cs"
-have "$WORK/Shop/App.cs"
+have "$WORK/Shop/Features/Shared/App.cs"
 
 echo "==> Generate into it (real write: a page — no packages, no network)"
 ( cd "$WORK/Shop" && rask generate page Dashboard --route /dashboard ) >/dev/null 2>&1 \
@@ -116,15 +119,25 @@ else
 fi
 checkin "$WORK/Shop" "deploy --github-actions won't clobber" 1 "already exists"             -- deploy --host root@box.example.com --name shop --github-actions
 # Contradictory host-setup flags must be caught before anything reaches the network.
-checkin "$WORK/Shop" "deploy rejects a bad --deploy-user" 1 "isn't a valid Linux user name" -- deploy --host root@box --name shop --deploy-user "bad; rm -rf /"
+checkin "$WORK/Shop" "deploy rejects a bad --deploy-user" 2 "isn't a valid Linux user name" -- deploy --host root@box --name shop --deploy-user "bad; rm -rf /"
 
-echo "==> Error paths (must exit 1 with a helpful message)"
+echo "==> A wrong command line exits 2, names the fix, and guesses what you meant"
 mkdir -p "$WORK/empty"
+check                 "unknown command suggests"   2 "Did you mean 'generate'"        -- genrate
+check                 "unknown command"            2 "Unknown command"                -- frobnicate
+check                 "bad option value suggests"  2 "Did you mean 'server'"          -- new X --template srever
+check                 "unknown option suggests"    2 "Did you mean '--template'"      -- new X --tempate server
+check                 "missing action lists them"  2 "Specify a 'rask db' action"     -- db
+check                 "unknown action suggests"    2 "Did you mean 'backup'"          -- db bakcup
+check                 "every rejection says where to look" 2 "Run 'rask db --help' for details" -- db bakcup
+# `-h` is help for every command; `deploy --host` therefore has no short form.
+check                 "-h is help, not --host"     0 "Usage: rask deploy"             -- deploy -h root@box
+
+echo "==> Error paths (work that was attempted and failed still exits 1)"
 # Project is resolved by walking UP for a single .csproj — so "no project" must run in an empty dir,
 # and field validation (which happens AFTER project resolution) must run INSIDE the Shop project.
-checkin "$WORK/empty" "generate outside a project" 1 "Couldn't find a single .csproj" -- generate page Nope --dry-run
-check                 "unknown command"            1 "Unknown command"                -- frobnicate
-checkin "$WORK/Shop"  "bad field type"             1 "Unknown field type"             -- generate feature Bad Name:wobble --dry-run
+checkin "$WORK/empty" "generate outside a project" 1 "Couldn't find a .csproj"        -- generate page Nope --dry-run
+checkin "$WORK/Shop"  "bad field type"             2 "Unknown field type"             -- generate feature Bad Name:wobble --dry-run
 
 echo
 echo "==> $PASS passed, $FAIL failed."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Changed
+- **A wrong `rask` command line now tells you what's wrong, what's allowed, and what to run next.** The
+  pieces were all there — a styled console, a self-documenting argument schema, a `--help` renderer that
+  can't drift from what parses — but the *error* path had never been wired through them, so roughly forty
+  hand-written validations each printed their own phrasing, unstyled, and returned the wrong exit code.
+  They now share one path: red, followed by the usage line and `Run 'rask <command> --help' for details.`
+  A misspelling gets a nearest-match suggestion (`Unknown command 'genrate'. Did you mean 'generate'?`)
+  for commands, options, actions, and option values alike — deliberately conservative, so an
+  unrecognizable word gets no guess rather than a confident wrong one.
+  - **Options with a closed set of values are declared, not hand-checked.** `--template`, `--database`,
+    `--host`, `--id` and `--validation` now name their values in the schema, which means one phrasing for
+    a bad one, the set printed in `--help`, the values offered by tab completion, and
+    `--template SERVER` accepted and normalized rather than mysteriously rejected.
+  - **Subcommands are declared too**, so `rask db --help` lists its seven actions with descriptions, an
+    unknown one lists them back at you, and `rask db <tab>` completes them in bash, zsh and fish. This
+    also makes `rask generate`'s `ca` → `cache` alias discoverable, which it never was.
+  - **Exit code `2` now means what `docs/cli.md` always said it meant.** A wrong command line — unknown
+    command, option, action, or value, a missing value, contradictory options — exits `2`; only work that
+    was attempted and failed exits `1`. Previously only two paths in the whole CLI returned `2`, so a
+    script couldn't tell a typo from a failed deploy. **This changes the exit code of every rejected
+    invocation from `1` to `2`.**
+  - **`-h` is `--help`, everywhere.** `rask deploy -h box` used to print help and never deploy, silently:
+    the router resolves `-h` before a command parses its own arguments, and `deploy` had claimed it for
+    `--host`. `--host` keeps its long form and loses the short one, and a test now holds `-h` reserved.
+  - Fixed the "couldn't find a single .csproj" message, which said the same thing whether it found none or
+    found several. Backup, restore and the other outcomes that were printing plain text are now styled
+    like their siblings, and `rask generate`'s overwrite refusal mentions `--dry-run`.
+
 ### Added
 - **A redeploy reload no longer throws away what the user had typed.** When a replacement server can't
   carry a session over, the page reloads — and until now that restored your scroll position and focus but

--- a/docs/cheatsheet.md
+++ b/docs/cheatsheet.md
@@ -24,20 +24,33 @@ rask g component PriceTag             # → Features/Shared/PriceTag.cs
 rask g component PriceTag -F Orders   # → Features/Orders/PriceTag.cs (co-locate in a slice)
 rask g job SendWelcomeEmail           # → Features/Shared/… (IJob + handler)  + Rask.Jobs
 rask g email WelcomeEmail             # → Features/Shared/… (email-body component)  + Rask.Mail
+rask g cache PopularProducts          # → a cached read accessor  + Rask.Cache
 rask g p Orders --dry-run             # print what would be written, touch nothing
 
 # database (wraps dotnet-ef; installs it on first use)
 rask db add InitialCreate             # generate a migration from the current model
 rask db update                        # apply it — creates app.db
+rask db list                          # which migrations exist, and which are applied
+rask db remove                        # undo the last migration
+rask db drop --force                  # delete the database, no prompt
+rask db backup                        # copy it to ./<app>-<timestamp>.db
+rask db restore backups/shop.db       # put a copy back (--remote for the deployed one)
 
 # ship it
 rask deploy --host root@box --domain shop.example.com   # bare box → live HTTPS
 rask deploy                           # redeploy (host/domain remembered), zero-downtime
 rask deploy --github-actions          # write .github/workflows/deploy.yml
+rask deploy status                    # what's running, and on which color
+rask deploy logs --follow             # tail the deployed app
+rask deploy rollback                  # put the previous image back
+
+# tab completion
+rask completion zsh > "${fpath[1]}/_rask"   # also: bash, fish
 ```
 
-Short aliases everywhere: `rask g` = `rask generate`; `g f`/`g c`/`g p`/`g j`/`g e` =
-feature / component / page / job / email.
+Short aliases everywhere: `rask g` = `rask generate`; `g f`/`g c`/`g p`/`g j`/`g e`/`g ca` =
+feature / component / page / job / email / cache. Every command's own list is in
+`rask <command> --help`, and a wrong one tells you what you probably meant.
 
 ## Feature field tokens
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -205,16 +205,40 @@ to create and apply with [`rask db`](#rask-db--ef-core-migrations) before it wor
 Every command has short aliases: `rask g` = `rask generate`, and `g f` / `g c` / `g p` scaffold a
 feature / component / page.
 
+### When you get it wrong
+
+A rejected command line always names what was wrong, what is allowed, and what to run next — and,
+where there's an obvious candidate, what you probably meant:
+
+```console
+$ rask genrate
+Unknown command 'genrate'. Did you mean 'generate'?
+
+$ rask new Shop --template srever
+Option '--template' does not accept 'srever'. Did you mean 'server'? Choose one of: server, wasm, wasm-hosted, native.
+Usage: rask new <name> [options]
+Run 'rask new --help' for details.
+
+$ rask db
+Specify a 'rask db' action: add, remove, list, update, drop, backup, restore.
+```
+
+`-h` is `--help` for every command, so no option has `-h` as a short name (`rask deploy --host`
+has no short form). Anything after `--` is your app's, so `rask dev -- --help` passes it through.
+
 ### Exit codes
 
 | Code | Meaning |
 | --- | --- |
 | `0` | Success. |
 | `1` | The command ran and what you asked for failed — a build error, an unreachable host, a refused deploy. |
-| `2` | The command line was wrong — an unknown option, a missing value, options that contradict each other. |
+| `2` | The command line was wrong — an unknown command, option, action, or value; a missing value; options that contradict each other. |
 | `130` | Interrupted with Ctrl+C. |
 
-The `1` / `2` split is what lets a script tell a broken invocation from a broken deploy.
+The `1` / `2` split is what lets a script tell a broken invocation from a broken deploy. The line
+between them is where the bad input came from: anything decidable from the arguments alone is `2`,
+while a value that could have come from `.rask/deploy.json` — or from the state of the disk, the
+network, or the host — is `1`.
 
 ## `rask dev` — run with hot reload
 

--- a/src/Rask.Cli/ArgumentSchema.cs
+++ b/src/Rask.Cli/ArgumentSchema.cs
@@ -37,9 +37,10 @@ internal sealed class ParsedArguments(
 
 /// <summary>
 /// A declared flag or option: its names, whether it takes a value (and a hint for it), a one-line
-/// description, and an optional <see cref="Group"/> label so help can bucket, say, <c>generate</c>'s
-/// feature-only flags apart from the common ones. This is the single source of truth that both parses
-/// arguments and documents them — <c>--help</c> renders straight from this list, so it can never drift.
+/// description, an optional <see cref="Group"/> label so help can bucket, say, <c>generate</c>'s
+/// feature-only flags apart from the common ones, and an optional closed set of <see cref="Choices"/>.
+/// This is the single source of truth that both parses arguments and documents them — <c>--help</c> and
+/// shell completion render straight from this list, so they can never drift.
 /// </summary>
 internal sealed record OptionInfo(
     string LongName,
@@ -47,7 +48,16 @@ internal sealed record OptionInfo(
     bool IsFlag,
     string? ValueHint,
     string? Description,
-    string? Group);
+    string? Group,
+    IReadOnlyList<string>? Choices = null);
+
+/// <summary>
+/// A declared subcommand of a command, e.g. <c>add</c> under <c>rask db</c>. Recording verbs on the schema
+/// (rather than in a private array per command) means dispatch, the unknown-action error, <c>--help</c>,
+/// and shell completion all read the same list — including the aliases, which used to be invisible in
+/// both help and errors.
+/// </summary>
+internal sealed record VerbInfo(string Name, string Description, IReadOnlyList<string> Aliases);
 
 /// <summary>
 /// A tiny, dependency-free argument parser. Each command declares its boolean <see cref="Flag"/>s and
@@ -64,9 +74,13 @@ internal sealed class ArgumentSchema
     private readonly HashSet<string> _options = new(StringComparer.Ordinal);
     private readonly HashSet<string> _multiOptions = new(StringComparer.Ordinal);
     private readonly List<OptionInfo> _declared = [];
+    private readonly List<VerbInfo> _verbs = [];
 
     /// <summary>Every flag/option declared on this schema, in declaration order — the source for <c>--help</c>.</summary>
     public IReadOnlyList<OptionInfo> Declared => _declared;
+
+    /// <summary>Every subcommand declared on this schema, in declaration order.</summary>
+    public IReadOnlyList<VerbInfo> Verbs => _verbs;
 
     public ArgumentSchema Flag(string longName, char? shortName = null, string? description = null, string? group = null)
     {
@@ -76,24 +90,65 @@ internal sealed class ArgumentSchema
         return this;
     }
 
-    public ArgumentSchema Option(string longName, char? shortName = null, string? valueHint = null, string? description = null, string? group = null)
+    public ArgumentSchema Option(
+        string longName,
+        char? shortName = null,
+        string? valueHint = null,
+        string? description = null,
+        string? group = null,
+        IReadOnlyList<string>? choices = null)
     {
         _options.Add(longName);
         Register(longName, shortName);
-        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group));
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group, choices));
         return this;
+    }
+
+    /// <summary>
+    /// Declare a subcommand. <paramref name="aliases"/> resolve to the same verb, so <c>rask g f</c> and
+    /// <c>rask generate feature</c> take one path and both are documented.
+    /// </summary>
+    public ArgumentSchema Verb(string name, string description, params string[] aliases)
+    {
+        _verbs.Add(new VerbInfo(name, description, aliases));
+        return this;
+    }
+
+    /// <summary>
+    /// Resolve a typed token to a declared verb name, following aliases. False when the token names no
+    /// verb — the caller reports that through <see cref="CliCommand.FailUnknownVerb"/>.
+    /// </summary>
+    public bool TryResolveVerb(string? token, out string name)
+    {
+        foreach (var verb in _verbs)
+        {
+            if (verb.Name.Equals(token, StringComparison.Ordinal) || verb.Aliases.Contains(token, StringComparer.Ordinal))
+            {
+                name = verb.Name;
+                return true;
+            }
+        }
+
+        name = string.Empty;
+        return false;
     }
 
     /// <summary>
     /// A valued option that may be supplied more than once (e.g. <c>--env A=1 --env B=2</c>); every value is
     /// collected in order and read via <see cref="ParsedArguments.MultiOption"/> rather than overwriting.
     /// </summary>
-    public ArgumentSchema MultiOption(string longName, char? shortName = null, string? valueHint = null, string? description = null, string? group = null)
+    public ArgumentSchema MultiOption(
+        string longName,
+        char? shortName = null,
+        string? valueHint = null,
+        string? description = null,
+        string? group = null,
+        IReadOnlyList<string>? choices = null)
     {
         _options.Add(longName);
         _multiOptions.Add(longName);
         Register(longName, shortName);
-        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group));
+        _declared.Add(new OptionInfo(longName, shortName, IsFlag: false, valueHint, description, group, choices));
         return this;
     }
 
@@ -147,7 +202,12 @@ internal sealed class ArgumentSchema
 
             if (!_aliases.TryGetValue(body, out var longName))
             {
-                errors.Add($"Unknown option '{token}'.");
+                // Only long tokens get a suggestion: a mistyped single letter is as likely to be a
+                // different option as a typo of this one, so guessing there would be noise.
+                var near = isLong ? Suggest.Closest(body, _declared.Select(o => o.LongName)) : null;
+                errors.Add(near is null
+                    ? $"Unknown option '{token}'."
+                    : $"Unknown option '{token}'. Did you mean '--{near}'?");
                 continue;
             }
 
@@ -174,6 +234,11 @@ internal sealed class ArgumentSchema
                 }
             }
 
+            if (!TryNormalizeChoice(longName, ref value, errors))
+            {
+                continue;
+            }
+
             if (_multiOptions.Contains(longName))
             {
                 if (!multiOptions.TryGetValue(longName, out var values))
@@ -195,6 +260,38 @@ internal sealed class ArgumentSchema
             StringComparer.Ordinal);
 
         return new ParsedArguments(positionals, options, multi, flags, passthrough, errors);
+    }
+
+    /// <summary>
+    /// Check a value against the option's declared <see cref="OptionInfo.Choices"/>, if it has any, and
+    /// rewrite it to the declared spelling so <c>--template SERVER</c> reaches the command as
+    /// <c>server</c> — every consumer downstream compares ordinally.
+    /// <para>
+    /// One phrasing for every closed-set option in the CLI, naming both the nearest match and the whole
+    /// set: the list is short by definition, so printing it beats sending the reader to <c>--help</c>.
+    /// </para>
+    /// </summary>
+    private bool TryNormalizeChoice(string longName, ref string value, List<string> errors)
+    {
+        var choices = _declared.FirstOrDefault(o => o.LongName.Equals(longName, StringComparison.Ordinal))?.Choices;
+        if (choices is null)
+        {
+            return true;
+        }
+
+        foreach (var choice in choices)
+        {
+            if (choice.Equals(value, StringComparison.OrdinalIgnoreCase))
+            {
+                value = choice;
+                return true;
+            }
+        }
+
+        var near = Suggest.Closest(value, choices);
+        var didYouMean = near is null ? string.Empty : $" Did you mean '{near}'?";
+        errors.Add($"Option '--{longName}' does not accept '{value}'.{didYouMean} Choose one of: {string.Join(", ", choices)}.");
+        return false;
     }
 
     private static void ApplyFlag(string longName, string? inlineValue, HashSet<string> flags, List<string> errors)

--- a/src/Rask.Cli/CliApplication.cs
+++ b/src/Rask.Cli/CliApplication.cs
@@ -19,6 +19,9 @@ internal sealed class CliApplication
         _commands = commands;
     }
 
+    /// <summary>The commands this application routes to — the source for help, completion, and contract tests.</summary>
+    public IReadOnlyList<CliCommand> Commands => _commands;
+
     /// <summary>Wire the real command set with production collaborators.</summary>
     public static CliApplication CreateDefault(IConsole console, IProcessRunner process, IFileSystem fileSystem)
     {
@@ -70,9 +73,15 @@ internal sealed class CliApplication
 
         if (!TryGetCommand(first, out var command))
         {
-            _console.WriteErrorLine($"Unknown command '{first}'.", ConsoleStyle.Error);
+            var near = Suggest.Closest(first, _commands.SelectMany(c => c.Aliases.Prepend(c.Name)));
+            var resolved = near is not null && TryGetCommand(near, out var suggested) ? suggested.Name : near;
+            _console.WriteErrorLine(
+                resolved is null ? $"Unknown command '{first}'." : $"Unknown command '{first}'. Did you mean '{resolved}'?",
+                ConsoleStyle.Error);
             CommandHelp.RenderTopLevel(_console, _commands, toError: true);
-            return 1;
+
+            // A command that doesn't exist is a wrong command line, not a command that ran and failed.
+            return CliCommand.UsageExitCode;
         }
 
         var rest = args.Skip(1).ToArray();
@@ -88,6 +97,11 @@ internal sealed class CliApplication
     /// <summary>
     /// True if a top-level <c>--help</c>/<c>-h</c> precedes any <c>--</c> passthrough separator. Tokens
     /// after <c>--</c> belong to the user's app (e.g. <c>rask dev -- --help</c>), not to the CLI.
+    /// <para>
+    /// This scan is why <c>-h</c> is reserved CLI-wide and no command may declare it as a short name: it
+    /// runs before the command's own parser, so a command that spelled <c>--host</c> as <c>-h</c> would
+    /// silently print help instead of running (<c>CliApplicationTests</c> guards the reservation).
+    /// </para>
     /// </summary>
     private static bool RequestsHelp(IReadOnlyList<string> args)
     {

--- a/src/Rask.Cli/CliCommand.cs
+++ b/src/Rask.Cli/CliCommand.cs
@@ -65,4 +65,31 @@ internal abstract class CliCommand(IConsole console)
         Console.Error.WriteLine($"Run 'rask {Name} --help' for details.");
         return UsageExitCode;
     }
+
+    /// <summary>
+    /// Reject one bad thing about the command line. Every hand-written validation goes through here rather
+    /// than writing to stderr itself, so a rejected argument always looks the same, is always styled, always
+    /// ends with the way out, and always exits <see cref="UsageExitCode"/>.
+    /// </summary>
+    protected int Fail(string error) => Fail([error]);
+
+    /// <summary>
+    /// Reject a missing or misspelled subcommand against the verbs declared on <paramref name="schema"/>.
+    /// </summary>
+    protected int FailUnknownVerb(string? given, ArgumentSchema schema)
+    {
+        var names = string.Join(", ", schema.Verbs.Select(v => v.Name));
+        if (string.IsNullOrEmpty(given))
+        {
+            return Fail($"Specify a 'rask {Name}' action: {names}.");
+        }
+
+        // Aliases are candidates too: someone who typed 'rask g fe' meant the 'f' alias, and pointing at
+        // 'feature' from there is still the right answer because that is what 'f' resolves to.
+        var candidates = schema.Verbs.SelectMany(v => v.Aliases.Prepend(v.Name)).ToArray();
+        var near = Suggest.Closest(given, candidates);
+        var resolved = near is not null && schema.TryResolveVerb(near, out var canonical) ? canonical : near;
+        var didYouMean = resolved is null ? string.Empty : $" Did you mean '{resolved}'?";
+        return Fail($"Unknown 'rask {Name}' action '{given}'.{didYouMean} Choose one of: {names}.");
+    }
 }

--- a/src/Rask.Cli/CommandHelp.cs
+++ b/src/Rask.Cli/CommandHelp.cs
@@ -58,6 +58,7 @@ internal static class CommandHelp
             }
         }
 
+        RenderActions(writer, command.OptionSchema, color);
         RenderOptions(writer, command.OptionSchema, color);
 
         if (command.Examples.Count > 0)
@@ -70,6 +71,26 @@ internal static class CommandHelp
             }
         }
     }
+
+    /// <summary>The command's subcommands and their aliases, straight from the schema that dispatches them.</summary>
+    private static void RenderActions(TextWriter writer, ArgumentSchema? schema, bool color)
+    {
+        if (schema is null || schema.Verbs.Count == 0)
+        {
+            return;
+        }
+
+        writer.WriteLine();
+        writer.WriteLine(Paint("Actions:", ConsoleStyle.Heading, color));
+        var width = schema.Verbs.Max(v => VerbLabel(v).Length);
+        foreach (var verb in schema.Verbs)
+        {
+            writer.WriteLine($"  {Paint(VerbLabel(verb).PadRight(width), ConsoleStyle.Code, color)}   {verb.Description}");
+        }
+    }
+
+    private static string VerbLabel(VerbInfo verb) =>
+        verb.Aliases.Count == 0 ? verb.Name : $"{verb.Name} ({string.Join(", ", verb.Aliases)})";
 
     private static void RenderOptions(TextWriter writer, ArgumentSchema? schema, bool color)
     {
@@ -108,7 +129,11 @@ internal static class CommandHelp
     {
         var label = Label(option);
         var painted = Paint(label.PadRight(width), ConsoleStyle.Code, color);
-        writer.WriteLine(option.Description is { Length: > 0 } d ? $"  {painted}   {d}" : $"  {painted}");
+
+        // Closed sets are listed after the description rather than inside the value hint, which would
+        // widen the aligned label column for every other option on the page.
+        var choices = option.Choices is { Count: > 0 } c ? $" [{string.Join("|", c)}]" : string.Empty;
+        writer.WriteLine(option.Description is { Length: > 0 } d ? $"  {painted}   {d}{choices}" : $"  {painted}{choices}");
     }
 
     /// <summary>The left-column label, e.g. <c>-t, --template &lt;value&gt;</c> or <c>    --auth</c>.</summary>

--- a/src/Rask.Cli/Commands/CompletionCommand.cs
+++ b/src/Rask.Cli/Commands/CompletionCommand.cs
@@ -9,16 +9,19 @@ namespace Rask.Cli.Commands;
 /// </summary>
 internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliCommand> commands) : CliCommand(console)
 {
-    private static readonly string[] Shells = ["bash", "zsh", "fish"];
-
     public override string Name => "completion";
 
     public override string Summary => "Print a shell completion script (bash, zsh, or fish).";
 
-    public override string Usage => "rask completion <bash|zsh|fish>";
+    public override string Usage => "rask completion <shell>";
 
-    public override IReadOnlyList<(string Name, string Description)> Arguments =>
-        [("<bash|zsh|fish>", "The shell to generate a completion script for.")];
+    public override ArgumentSchema? OptionSchema => CreateSchema();
+
+    private static ArgumentSchema CreateSchema() =>
+        new ArgumentSchema()
+            .Verb("bash", "A bash completion function.")
+            .Verb("zsh", "A zsh completion function.")
+            .Verb("fish", "Fish completion definitions.");
 
     public override IReadOnlyList<string> Examples =>
     [
@@ -29,12 +32,9 @@ internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliComma
 
     public override Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        var shell = args.Count > 0 ? args[0] : null;
-        if (shell is null || !Shells.Contains(shell))
+        if (!CreateSchema().TryResolveVerb(args.FirstOrDefault(), out var shell))
         {
-            Console.Error.WriteLine($"Specify a shell: {string.Join(", ", Shells)}.");
-            Console.Error.WriteLine($"Usage: {Usage}");
-            return Task.FromResult(1);
+            return Task.FromResult(FailUnknownVerb(args.FirstOrDefault(), CreateSchema()));
         }
 
         // Exclude self from the completed command list — but keep it a valid word so `rask compl<tab>` works.
@@ -50,11 +50,31 @@ internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliComma
         return Task.FromResult(0);
     }
 
-    private IReadOnlyList<string> OptionsFor(string commandName)
+    private ArgumentSchema? SchemaFor(string commandName) =>
+        commands.FirstOrDefault(c => c.Name.Equals(commandName, StringComparison.Ordinal))?.OptionSchema;
+
+    /// <summary>
+    /// Every word that can follow a command: its subcommands first, then its options. Verbs come from the
+    /// same schema that dispatches them, so <c>rask db &lt;tab&gt;</c> can't drift from what <c>rask db</c> accepts.
+    /// </summary>
+    private IReadOnlyList<string> WordsFor(string commandName)
     {
-        var command = commands.FirstOrDefault(c => c.Name.Equals(commandName, StringComparison.Ordinal));
-        return command?.OptionSchema?.Declared.Select(o => "--" + o.LongName).ToArray() ?? [];
+        var schema = SchemaFor(commandName);
+        if (schema is null)
+        {
+            return [];
+        }
+
+        return
+        [
+            .. schema.Verbs.Select(v => v.Name),
+            .. schema.Declared.Select(o => "--" + o.LongName),
+        ];
     }
+
+    /// <summary>The options of <paramref name="commandName"/> that take a value from a closed set.</summary>
+    private IEnumerable<OptionInfo> ChoiceOptionsFor(string commandName) =>
+        SchemaFor(commandName)?.Declared.Where(o => o.Choices is { Count: > 0 }) ?? [];
 
     private string Bash(IReadOnlyList<string> commandNames)
     {
@@ -67,14 +87,27 @@ internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliComma
         builder.AppendLine("  if [ \"$cword\" -le 1 ]; then");
         builder.AppendLine("    COMPREPLY=( $(compgen -W \"$commands\" -- \"$cur\") ); return 0");
         builder.AppendLine("  fi");
+        builder.AppendLine("  prev=\"${words[cword-1]}\"");
         builder.AppendLine("  case \"${words[1]}\" in");
         foreach (var command in commandNames)
         {
-            var options = OptionsFor(command);
-            if (options.Count > 0)
+            var words = WordsFor(command);
+            if (words.Count == 0)
             {
-                builder.AppendLine($"    {command}) COMPREPLY=( $(compgen -W \"{string.Join(' ', options)}\" -- \"$cur\") );;");
+                continue;
             }
+
+            builder.AppendLine($"    {command})");
+
+            // An option with a closed set completes its own values, keyed off the preceding word — nested
+            // inside the command's branch because the same option name means different things elsewhere
+            // (`--host` is a set of native modes for `new`, a free-form SSH target for `deploy`).
+            foreach (var option in ChoiceOptionsFor(command))
+            {
+                builder.AppendLine($"      if [ \"$prev\" = \"--{option.LongName}\" ]; then COMPREPLY=( $(compgen -W \"{string.Join(' ', option.Choices!)}\" -- \"$cur\") ); return 0; fi");
+            }
+
+            builder.AppendLine($"      COMPREPLY=( $(compgen -W \"{string.Join(' ', words)}\" -- \"$cur\") );;");
         }
 
         builder.AppendLine("    *) COMPREPLY=( $(compgen -f -- \"$cur\") );;");
@@ -95,14 +128,23 @@ internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliComma
         builder.AppendLine("  if (( CURRENT <= 2 )); then");
         builder.AppendLine("    compadd -- $commands; return");
         builder.AppendLine("  fi");
+        builder.AppendLine("  local prev=\"${words[CURRENT-1]}\"");
         builder.AppendLine("  case \"${words[2]}\" in");
         foreach (var command in commandNames)
         {
-            var options = OptionsFor(command);
-            if (options.Count > 0)
+            var words = WordsFor(command);
+            if (words.Count == 0)
             {
-                builder.AppendLine($"    {command}) compadd -- {string.Join(' ', options)} ;;");
+                continue;
             }
+
+            builder.AppendLine($"    {command})");
+            foreach (var option in ChoiceOptionsFor(command))
+            {
+                builder.AppendLine($"      if [[ \"$prev\" == \"--{option.LongName}\" ]]; then compadd -- {string.Join(' ', option.Choices!)}; return; fi");
+            }
+
+            builder.AppendLine($"      compadd -- {string.Join(' ', words)} ;;");
         }
 
         builder.AppendLine("    *) _files ;;");
@@ -128,10 +170,20 @@ internal sealed class CompletionCommand(IConsole console, IReadOnlyList<CliComma
 
         foreach (var command in commands)
         {
+            foreach (var verb in command.OptionSchema?.Verbs ?? [])
+            {
+                var description = verb.Description.Replace("'", "", StringComparison.Ordinal);
+                builder.AppendLine($"complete -c rask -f -n '__fish_seen_subcommand_from {command.Name}' -a {verb.Name} -d '{description}'");
+            }
+
             foreach (var option in command.OptionSchema?.Declared ?? [])
             {
                 var description = (option.Description ?? string.Empty).Replace("'", "", StringComparison.Ordinal);
-                builder.AppendLine($"complete -c rask -n '__fish_seen_subcommand_from {command.Name}' -l {option.LongName} -d '{description}'");
+                // -r marks an option that takes a value, so fish stops offering it its own siblings; -a
+                // supplies that value's completions when the set is closed.
+                var takesValue = option.IsFlag ? string.Empty : " -r";
+                var values = option.Choices is { Count: > 0 } c ? $" -a '{string.Join(' ', c)}'" : string.Empty;
+                builder.AppendLine($"complete -c rask -n '__fish_seen_subcommand_from {command.Name}' -l {option.LongName}{takesValue}{values} -d '{description}'");
             }
         }
 

--- a/src/Rask.Cli/Commands/DbCommand.Backup.cs
+++ b/src/Rask.Cli/Commands/DbCommand.Backup.cs
@@ -138,9 +138,10 @@ internal sealed partial class DbCommand
         host ??= config.Host;
         if (string.IsNullOrWhiteSpace(host))
         {
-            Console.Error.WriteLine(
-                "No deployment host. Pass --host, or run this in a directory that has deployed before " +
-                "(the host is remembered in .rask/deploy.json).");
+            Console.WriteErrorLine(
+                "No deployment host. Pass --host, or run this in a directory that has deployed before "
+                + "(the host is remembered in .rask/deploy.json).",
+                ConsoleStyle.Error);
             return 1;
         }
 
@@ -149,7 +150,7 @@ internal sealed partial class DbCommand
         // on *this* machine, and the host comes from a file that is committed to the repository.
         if (!SshTarget.TryParse(host, out _, out var hostError))
         {
-            Console.Error.WriteLine(hostError!);
+            Console.WriteErrorLine(hostError!, ConsoleStyle.Error);
             return 1;
         }
 
@@ -167,13 +168,13 @@ internal sealed partial class DbCommand
         var (source, error) = SqliteDatabaseLocator.Locate(_fileSystem, projectDirectory);
         if (source is null)
         {
-            Console.Error.WriteLine(error!);
+            Console.WriteErrorLine(error!, ConsoleStyle.Error);
             return 1;
         }
 
         if (!_fileSystem.FileExists(source))
         {
-            Console.Error.WriteLine($"No database at '{source}'. Run 'rask db update' to create it first.");
+            Console.WriteErrorLine($"No database at '{source}'. Run 'rask db update' to create it first.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -191,16 +192,16 @@ internal sealed partial class DbCommand
         }
         catch (SqliteException ex)
         {
-            Console.Error.WriteLine($"Couldn't back up '{source}': {ex.Message}");
+            Console.WriteErrorLine($"Couldn't back up '{source}': {ex.Message}", ConsoleStyle.Error);
             return 1;
         }
         catch (IOException ex)
         {
-            Console.Error.WriteLine($"Couldn't write '{destination}': {ex.Message}");
+            Console.WriteErrorLine($"Couldn't write '{destination}': {ex.Message}", ConsoleStyle.Error);
             return 1;
         }
 
-        Console.Out.WriteLine($"Backed up to {destination}.");
+        Console.WriteLine($"Backed up to {destination}.", ConsoleStyle.Success);
         return 0;
     }
 
@@ -209,14 +210,17 @@ internal sealed partial class DbCommand
     {
         if (!_fileSystem.FileExists(input))
         {
-            Console.Error.WriteLine($"No such backup: '{input}'.");
+            Console.WriteErrorLine(
+                $"No such backup: '{input}'. 'rask db backup' writes into the current directory unless you "
+                + "pass --output, and prints the path it used.",
+                ConsoleStyle.Error);
             return 1;
         }
 
         var (destination, error) = SqliteDatabaseLocator.Locate(_fileSystem, projectDirectory);
         if (destination is null)
         {
-            Console.Error.WriteLine(error!);
+            Console.WriteErrorLine(error!, ConsoleStyle.Error);
             return 1;
         }
 
@@ -241,16 +245,16 @@ internal sealed partial class DbCommand
         }
         catch (SqliteException ex)
         {
-            Console.Error.WriteLine($"'{input}' isn't a readable SQLite database: {ex.Message}");
+            Console.WriteErrorLine($"'{input}' isn't a readable SQLite database: {ex.Message}", ConsoleStyle.Error);
             return 1;
         }
         catch (IOException ex)
         {
-            Console.Error.WriteLine($"Couldn't write '{destination}': {ex.Message}");
+            Console.WriteErrorLine($"Couldn't write '{destination}': {ex.Message}", ConsoleStyle.Error);
             return 1;
         }
 
-        Console.Out.WriteLine($"Restored {input} to {destination}.");
+        Console.WriteLine($"Restored {input} to {destination}.", ConsoleStyle.Success);
         return 0;
     }
 
@@ -270,10 +274,10 @@ internal sealed partial class DbCommand
         var destination = ResolveOutputPath(output, slug);
         var helper = $"rask-backup-{Guid.NewGuid():N}"[..24];
 
-        Console.Out.WriteLine($"Taking a consistent copy of {slug}'s database on {host}…");
+        Console.WriteLine($"Taking a consistent copy of {slug}'s database on {host}…", ConsoleStyle.Dim);
         if (await DockerAsync(BuildRemoteVacuumArguments(host, slug), cancellationToken).ConfigureAwait(false) != 0)
         {
-            Console.Error.WriteLine("Couldn't copy the database inside the container. Is the app deployed, and does the host have network access to pull the sqlite image?");
+            Console.WriteErrorLine("Couldn't copy the database inside the container. Is the app deployed, and does the host have network access to pull the sqlite image?", ConsoleStyle.Error);
             return 1;
         }
 
@@ -281,7 +285,7 @@ internal sealed partial class DbCommand
         {
             if (await DockerAsync(BuildHelperCreateArguments(host, slug, helper), cancellationToken).ConfigureAwait(false) != 0)
             {
-                Console.Error.WriteLine("Couldn't create the helper container that carries the copy down.");
+                Console.WriteErrorLine("Couldn't create the helper container that carries the copy down.", ConsoleStyle.Error);
                 return 1;
             }
 
@@ -293,7 +297,7 @@ internal sealed partial class DbCommand
 
             if (await DockerAsync(BuildCopyDownArguments(host, helper, destination), cancellationToken).ConfigureAwait(false) != 0)
             {
-                Console.Error.WriteLine("Couldn't copy the backup down from the host.");
+                Console.WriteErrorLine("Couldn't copy the backup down from the host.", ConsoleStyle.Error);
                 return 1;
             }
         }
@@ -305,7 +309,7 @@ internal sealed partial class DbCommand
             await DockerAsync(BuildRemoteCleanupArguments(host, slug), CancellationToken.None).ConfigureAwait(false);
         }
 
-        Console.Out.WriteLine($"Backed up to {destination}.");
+        Console.WriteLine($"Backed up to {destination}.", ConsoleStyle.Success);
         return 0;
     }
 
@@ -313,7 +317,10 @@ internal sealed partial class DbCommand
     {
         if (!_fileSystem.FileExists(input))
         {
-            Console.Error.WriteLine($"No such backup: '{input}'.");
+            Console.WriteErrorLine(
+                $"No such backup: '{input}'. 'rask db backup' writes into the current directory unless you "
+                + "pass --output, and prints the path it used.",
+                ConsoleStyle.Error);
             return 1;
         }
 
@@ -325,10 +332,10 @@ internal sealed partial class DbCommand
         // Stopping first is not politeness. Replacing the file under a live writer leaves the running
         // process holding a handle to the database it thinks it has, and the next checkpoint writes that
         // belief back over the restored one — a corrupted hybrid of the two.
-        Console.Out.WriteLine($"Stopping {slug}…");
+        Console.WriteLine($"Stopping {slug}…", ConsoleStyle.Dim);
         if (await DockerAsync(BuildStopArguments(host, slug), cancellationToken).ConfigureAwait(false) != 0)
         {
-            Console.Error.WriteLine($"Couldn't stop '{slug}' on {host}. Refusing to restore under a running app — it would corrupt the database.");
+            Console.WriteErrorLine($"Couldn't stop '{slug}' on {host}. Refusing to restore under a running app — it would corrupt the database.", ConsoleStyle.Error);
             return 1;
         }
 
@@ -338,19 +345,19 @@ internal sealed partial class DbCommand
         {
             if (await DockerAsync(BuildHelperCreateArguments(host, slug, helper), cancellationToken).ConfigureAwait(false) != 0)
             {
-                Console.Error.WriteLine("Couldn't create the helper container that carries the copy up.");
+                Console.WriteErrorLine("Couldn't create the helper container that carries the copy up.", ConsoleStyle.Error);
                 return 1;
             }
 
             if (await DockerAsync(BuildCopyUpArguments(host, helper, input), cancellationToken).ConfigureAwait(false) != 0)
             {
-                Console.Error.WriteLine("Couldn't copy the backup up to the host.");
+                Console.WriteErrorLine("Couldn't copy the backup up to the host.", ConsoleStyle.Error);
                 return 1;
             }
 
             if (await DockerAsync(BuildRemoteReplaceArguments(host, slug), cancellationToken).ConfigureAwait(false) != 0)
             {
-                Console.Error.WriteLine("Couldn't put the database in place inside the volume.");
+                Console.WriteErrorLine("Couldn't put the database in place inside the volume.", ConsoleStyle.Error);
                 return 1;
             }
 
@@ -362,10 +369,10 @@ internal sealed partial class DbCommand
 
             // Always bring the app back, restored or not: leaving it stopped after a failed restore turns
             // a recoverable problem into an outage.
-            Console.Out.WriteLine($"Starting {slug}…");
+            Console.WriteLine($"Starting {slug}…", ConsoleStyle.Dim);
             if (await DockerAsync(BuildStartArguments(host, slug), CancellationToken.None).ConfigureAwait(false) != 0)
             {
-                Console.Error.WriteLine($"Couldn't start '{slug}' again — start it by hand: docker -H ssh://{host} start {slug}");
+                Console.WriteErrorLine($"Couldn't start '{slug}' again — start it by hand: docker -H ssh://{host} start {slug}", ConsoleStyle.Error);
             }
         }
 
@@ -374,7 +381,7 @@ internal sealed partial class DbCommand
             return 1;
         }
 
-        Console.Out.WriteLine($"Restored {input} to {slug} on {host}.");
+        Console.WriteLine($"Restored {input} to {slug} on {host}.", ConsoleStyle.Success);
         return 0;
     }
 

--- a/src/Rask.Cli/Commands/DbCommand.cs
+++ b/src/Rask.Cli/Commands/DbCommand.cs
@@ -12,8 +12,6 @@ namespace Rask.Cli.Commands;
 internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
     : CliCommand(console)
 {
-    private static readonly string[] Subcommands = ["add", "remove", "list", "update", "drop", "backup", "restore"];
-
     // These two never touch EF: they copy a file through SQLite (locally) or through a container on
     // the host, so they must not pay for a dotnet-ef install, and must work on an app that has none.
     private static readonly string[] FileSubcommands = ["backup", "restore"];
@@ -26,12 +24,12 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
 
     public override string Summary => "Manage EF Core migrations, and back the database up or restore it.";
 
-    public override string Usage =>
-        "rask db <add|remove|list|update|drop|backup|restore> [<name|file>] [--project <path>] [--startup-project <path>] [--context <Name>] [--output <path>] [--remote] [--host <user@host>] [--app <name>] [--force] [-- <ef args>]";
+    // The actions and options are listed in full below; spelling them out here too only gave them a
+    // second place to drift from.
+    public override string Usage => "rask db <action> [<name|file>] [options] [-- <ef args>]";
 
     public override IReadOnlyList<(string Name, string Description)> Arguments =>
     [
-        ("<add|remove|list|update|drop|backup|restore>", "The action to run."),
         ("[<name|file>]", "Migration name for 'add' (e.g. InitialCreate), or the backup file for 'restore'."),
     ];
 
@@ -50,6 +48,13 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
 
     private static ArgumentSchema CreateSchema() =>
         new ArgumentSchema()
+            .Verb("add", "Create a migration from the current model.")
+            .Verb("remove", "Delete the most recent migration.")
+            .Verb("list", "List the migrations and which are applied.")
+            .Verb("update", "Apply pending migrations to the database.")
+            .Verb("drop", "Delete the database and everything in it.")
+            .Verb("backup", "Copy the database to a file.")
+            .Verb("restore", "Replace the database from a backup file.")
             .Option("project", 'p', "path", "Project containing the DbContext (default: found from the current directory).")
             .Option("startup-project", 's', "path", "Startup project (default: same as --project).")
             .Option("context", 'c', "Name", "DbContext to use when the project defines more than one.")
@@ -61,21 +66,11 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
 
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        if (args.Count == 0)
-        {
-            Console.Error.WriteLine($"Specify a migration action: {string.Join(", ", Subcommands)}.");
-            Console.Error.WriteLine($"Usage: {Usage}");
-            return 1;
-        }
-
-        var subcommand = args[0];
-        if (!Subcommands.Contains(subcommand))
-        {
-            Console.Error.WriteLine($"Unknown action '{subcommand}'. Use one of: {string.Join(", ", Subcommands)}.");
-            return 1;
-        }
-
         var schema = CreateSchema();
+        if (!schema.TryResolveVerb(args.FirstOrDefault(), out var subcommand))
+        {
+            return FailUnknownVerb(args.FirstOrDefault(), schema);
+        }
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)
@@ -85,28 +80,24 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
 
         if (parsed.Positionals.Count > 1)
         {
-            Console.Error.WriteLine($"Unexpected argument '{parsed.Positionals[1]}'. Usage: {Usage}");
-            return 1;
+            return Fail($"Unexpected argument '{parsed.Positionals[1]}'.");
         }
 
         var name = parsed.Positionals.FirstOrDefault();
         if (!ValidatePositional(subcommand, name, out var positionalError))
         {
-            Console.Error.WriteLine(positionalError);
-            return 1;
+            return Fail(positionalError!);
         }
 
         var output = parsed.Option("output");
         if (output is not null && subcommand is not ("add" or "backup"))
         {
-            Console.Error.WriteLine("--output only applies to 'rask db add' and 'rask db backup'.");
-            return 1;
+            return Fail("--output only applies to 'rask db add' and 'rask db backup'.");
         }
 
         if (parsed.HasFlag("force") && subcommand is not ("drop" or "restore"))
         {
-            Console.Error.WriteLine("--force only applies to 'rask db drop' and 'rask db restore'.");
-            return 1;
+            return Fail("--force only applies to 'rask db drop' and 'rask db restore'.");
         }
 
         var remote = parsed.HasFlag("remote");
@@ -115,15 +106,13 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
             var supplied = option == "remote" ? remote : parsed.Option(option) is not null;
             if (supplied && !FileSubcommands.Contains(subcommand))
             {
-                Console.Error.WriteLine($"--{option} only applies to 'rask db backup' and 'rask db restore'.");
-                return 1;
+                return Fail($"--{option} only applies to 'rask db backup' and 'rask db restore'.");
             }
         }
 
         if (!remote && (parsed.Option("host") is not null || parsed.Option("app") is not null))
         {
-            Console.Error.WriteLine("--host and --app only apply with --remote.");
-            return 1;
+            return Fail("--host and --app only apply with --remote.");
         }
 
         // An explicit --project wins; otherwise fall back to the single .csproj at or above the CWD. EF
@@ -138,7 +127,9 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
             var located = ProjectLocator.Locate(_fileSystem, _workingDirectory);
             if (located is null && !(remote && FileSubcommands.Contains(subcommand)))
             {
-                Console.Error.WriteLine($"Couldn't find a single .csproj at or above '{_workingDirectory}'. Run this inside a project, or pass --project.");
+                Console.WriteErrorLine(
+                    $"{ProjectLocator.DescribeMissing(_fileSystem, _workingDirectory)} Run this inside a project, or pass --project.",
+                    ConsoleStyle.Error);
                 return 1;
             }
 
@@ -239,11 +230,11 @@ internal sealed partial class DbCommand(IConsole console, IFileSystem fileSystem
             return;
         }
 
-        Console.Out.WriteLine("Adding Microsoft.EntityFrameworkCore.Design to the startup project (required by the EF Core tools)…");
+        Console.WriteLine("Adding Microsoft.EntityFrameworkCore.Design to the startup project (required by the EF Core tools)…", ConsoleStyle.Dim);
         var exit = await _process.RunAsync("dotnet", ["add", csproj, "package", "Microsoft.EntityFrameworkCore.Design"], _workingDirectory, cancellationToken).ConfigureAwait(false);
         if (exit != 0)
         {
-            Console.Error.WriteLine($"  Couldn't add it automatically — add it manually: dotnet add \"{csproj}\" package Microsoft.EntityFrameworkCore.Design");
+            WriteWarning($"  Couldn't add it automatically — add it manually: dotnet add \"{csproj}\" package Microsoft.EntityFrameworkCore.Design");
         }
     }
 

--- a/src/Rask.Cli/Commands/DeployCommand.Ops.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.Ops.cs
@@ -141,8 +141,7 @@ internal sealed partial class DeployCommand
 
         if (!TryResolveTail(parsed.Option("tail"), out var tail, out var tailError))
         {
-            Console.Error.WriteLine(tailError);
-            return 1;
+            return Fail(tailError!);
         }
 
         return await Run(BuildLogsArguments(host, container, tail, parsed.HasFlag("follow")), cancellationToken).ConfigureAwait(false);
@@ -194,7 +193,9 @@ internal sealed partial class DeployCommand
         if (image is null)
         {
             Console.WriteErrorLine($"No previous image for '{slug}' on {HostName(host)} — nothing to roll back to.", ConsoleStyle.Error);
-            Console.Error.WriteLine($"A rollback restores {slug}:{PreviousTag}, which is written by the deploy that replaces it. The first deploy of an app has no predecessor.");
+            Console.WriteErrorLine(
+                $"A rollback restores {slug}:{PreviousTag}, which is written by the deploy that replaces it. The first deploy of an app has no predecessor.",
+                ConsoleStyle.Error);
             return 1;
         }
 

--- a/src/Rask.Cli/Commands/DeployCommand.cs
+++ b/src/Rask.Cli/Commands/DeployCommand.cs
@@ -65,9 +65,6 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
     internal const string PreviousTag = "previous";
 
-    /// <summary>Verbs that operate on an existing deployment. A bare <c>rask deploy</c> deploys.</summary>
-    private static readonly string[] Subcommands = ["status", "logs", "rollback"];
-
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IProcessRunner _process = process;
     private readonly string _workingDirectory = workingDirectory;
@@ -87,13 +84,11 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
     public override IReadOnlyList<(string Name, string Description)> Arguments =>
     [
-        ("[status|logs|rollback]", "Operate on what's already deployed instead of deploying (omit to deploy)."),
+        ("[<action>]", "Operate on what's already deployed instead of deploying (omit to deploy)."),
     ];
 
-    public override string Usage =>
-        "rask deploy [status|logs|rollback] [--host user@box] [--domain app.example.com] [--port <n>] [--container-port <n>] " +
-        "[--project <path>] [--name <slug>] [--dockerfile <path>] [--env KEY=VALUE ...] [--env-file <path>] " +
-        "[--health-path <path>] [--no-health-check] [--setup-host] [--github-actions] [--dry-run]";
+    // The shape only — the actions and options are each listed once below, and --help renders both.
+    public override string Usage => "rask deploy [<action>] [options]";
 
     public override IReadOnlyList<string> Examples =>
     [
@@ -114,7 +109,12 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
     private static ArgumentSchema CreateSchema() =>
         new ArgumentSchema()
-            .Option("host", 'h', "user@box", "SSH target to build and run on (remembered in .rask/deploy.json).")
+            .Verb("status", "Show what is running, and on which color.")
+            .Verb("logs", "Print the deployed app's logs.")
+            .Verb("rollback", "Put the previous image back.")
+            // No short name: '-h' is reserved for --help across the whole CLI, and a command that claimed
+            // it would silently print help instead of running (see CliApplication.RequestsHelp).
+            .Option("host", null, "user@box", "SSH target to build and run on (remembered in .rask/deploy.json).")
             .Option("domain", 'd', "host", "Public domain to serve over HTTPS via Caddy (implies ports 80/443).")
             .Option("port", valueHint: "n", description: "Published port when not using --domain (default: 8080).")
             .Option("container-port", valueHint: "n", description: "Port the app listens on inside the container (default: 8080; remembered).")
@@ -147,24 +147,20 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         }
 
         // A bare `rask deploy` deploys; a verb after it operates on what is already deployed.
-        if (parsed.Positionals.Count > 0 && !Subcommands.Contains(parsed.Positionals[0], StringComparer.Ordinal))
+        if (parsed.Positionals.Count > 0 && !schema.TryResolveVerb(parsed.Positionals[0], out _))
         {
-            Console.Error.WriteLine($"Unknown deploy action '{parsed.Positionals[0]}' — expected one of: {string.Join(", ", Subcommands)}.");
-            Console.Error.WriteLine($"Usage: {Usage}");
-            return 1;
+            return FailUnknownVerb(parsed.Positionals[0], schema);
         }
 
         if (parsed.Positionals.Count > 1)
         {
-            Console.Error.WriteLine($"Unexpected argument '{parsed.Positionals[1]}'. Usage: {Usage}");
-            return 1;
+            return Fail($"Unexpected argument '{parsed.Positionals[1]}'.");
         }
 
         var action = parsed.Positionals.Count > 0 ? parsed.Positionals[0] : null;
         if (!TryRejectMisplacedOptions(parsed, action, out var optionError))
         {
-            Console.Error.WriteLine(optionError);
-            return 1;
+            return Fail(optionError!);
         }
 
         // Flags win over the persisted config; anything unset falls back to .rask/deploy.json.
@@ -176,13 +172,13 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
         if (!TryResolvePort(parsed.Option("port"), config.Port, out var port, out var portError))
         {
-            Console.Error.WriteLine(portError);
+            Console.WriteErrorLine(portError!, ConsoleStyle.Error);
             return 1;
         }
 
         if (!TryResolveContainerPort(parsed.Option("container-port"), config.ContainerPort, out var containerPort, out var containerPortError))
         {
-            Console.Error.WriteLine(containerPortError);
+            Console.WriteErrorLine(containerPortError!, ConsoleStyle.Error);
             return 1;
         }
 
@@ -205,17 +201,14 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         // than silently ignore --port (which also covers a --port passed against a remembered domain).
         if (parsed.Option("port") is not null && domain is not null)
         {
-            Console.Error.WriteLine(parsed.Option("domain") is not null
+            return Fail(parsed.Option("domain") is not null
                 ? "--port doesn't apply with --domain (the app is served over HTTPS on 80/443 via the proxy)."
                 : $"This app is deployed with --domain {domain} (remembered in .rask/deploy.json), so --port doesn't apply. Remove \"domain\" from .rask/deploy.json to switch to a published port.");
-            return 1;
         }
 
         if (host is null)
         {
-            Console.Error.WriteLine("No host to deploy to. Pass --host user@box (it's remembered for next time).");
-            Console.Error.WriteLine($"Usage: {Usage}");
-            return 1;
+            return Fail("No host to deploy to. Pass --host user@box (it's remembered for next time).");
         }
 
         // Validated here, at the boundary, because the host reaches the `ssh` binary as an argument and
@@ -241,7 +234,7 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
         if (action is null && !_fileSystem.FileExists(dockerfile))
         {
-            Console.Error.WriteLine($"No Dockerfile found at '{dockerfile}'.");
+            Console.WriteErrorLine($"No Dockerfile found at '{dockerfile}'.", ConsoleStyle.Error);
             Console.Error.WriteLine("Scaffold one with `rask new <name> --docker`, or point at yours with --dockerfile <path>.");
             return 1;
         }
@@ -249,7 +242,7 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         // Gather runtime env from --env and an optional --env-file (KEY=VALUE lines; # comments allowed).
         if (!TryResolveEnv(parsed.MultiOption("env"), envFile, out var env, out var envError))
         {
-            Console.Error.WriteLine(envError);
+            Console.WriteErrorLine(envError!, ConsoleStyle.Error);
             return 1;
         }
 
@@ -276,8 +269,7 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
         // overrides the path (and re-enables a config-remembered disable). Both are remembered.
         if (parsed.HasFlag("no-health-check") && parsed.Option("health-path") is not null)
         {
-            Console.Error.WriteLine("--health-path doesn't apply with --no-health-check (the HTTP probe is disabled).");
-            return 1;
+            return Fail("--health-path doesn't apply with --no-health-check (the HTTP probe is disabled).");
         }
 
         var healthEnabled = !parsed.HasFlag("no-health-check")
@@ -286,8 +278,7 @@ internal sealed partial class DeployCommand(IConsole console, IFileSystem fileSy
 
         if (!TryResolveSetup(parsed, out var setupMode, out var bootstrapOptions, out var setupError))
         {
-            Console.Error.WriteLine(setupError);
-            return 1;
+            return Fail(setupError!);
         }
 
         // Pure scaffolding — never touches the host, so it works offline and before the box exists.

--- a/src/Rask.Cli/Commands/DevCommand.cs
+++ b/src/Rask.Cli/Commands/DevCommand.cs
@@ -32,7 +32,11 @@ internal sealed class DevCommand(
 
     public override string Summary => "Run the app with hot reload (dotnet watch).";
 
-    public override string Usage => "rask dev [--project <path>] [--open] [-- <args passed to the app>]";
+    // The shape only — the options are listed once, in the schema below, which --help renders directly.
+    public override string Usage => "rask dev [options] [-- <args passed to the app>]";
+
+    public override IReadOnlyList<(string Name, string Description)> Arguments =>
+        [("[-- <args>]", "Everything after '--' is passed to your app, not to rask.")];
 
     public override IReadOnlyList<string> Examples =>
     [
@@ -68,8 +72,9 @@ internal sealed class DevCommand(
         var target = DevTarget.Detect(_fileSystem, _workingDirectory, parsed.Option("project"));
         if (target is null)
         {
-            Console.Error.WriteLine(
-                $"Couldn't find a single .csproj at or above '{_workingDirectory}'. Run this inside a project, or pass --project.");
+            Console.WriteErrorLine(
+                $"{ProjectLocator.DescribeMissing(_fileSystem, _workingDirectory)} Run this inside a project, or pass --project.",
+                ConsoleStyle.Error);
             return 1;
         }
 

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -12,18 +12,6 @@ namespace Rask.Cli.Commands;
 internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, IProcessRunner process, string workingDirectory)
     : CliCommand(console)
 {
-    private static readonly string[] Kinds = ["page", "component", "feature", "job", "email", "cache"];
-
-    private static readonly Dictionary<string, string> KindAliases = new(StringComparer.Ordinal)
-    {
-        ["p"] = "page",
-        ["c"] = "component",
-        ["f"] = "feature",
-        ["j"] = "job",
-        ["e"] = "email",
-        ["ca"] = "cache",
-    };
-
     private readonly IFileSystem _fileSystem = fileSystem;
     private readonly IProcessRunner _process = process;
     private readonly string _workingDirectory = workingDirectory;
@@ -36,12 +24,10 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
     // The shape only — the option list lives in the schema, which --help renders directly. Spelling the
     // flags out here is what let this string go stale before.
-    public override string Usage =>
-        "rask generate <page|component|feature|job|email|cache> <Name> [<field:type> ...] [options]";
+    public override string Usage => "rask generate <artifact> <Name> [<field:type> ...] [options]";
 
     public override IReadOnlyList<(string Name, string Description)> Arguments =>
     [
-        ("<page|component|feature|job|email|cache>", "What to scaffold (aliases: p, c, f, j, e, ca)."),
         ("<Name>", "The type name, e.g. Product or Dashboard."),
         ("[<field:type> ...]", "Fields for a feature, e.g. Name:string Price:decimal."),
     ];
@@ -64,6 +50,12 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
     /// <summary>The flag/option schema — shared by <see cref="ExecuteAsync"/> and <c>--help</c> so they can't drift.</summary>
     private static ArgumentSchema CreateSchema() =>
         new ArgumentSchema()
+            .Verb("page", "A routed page component.", "p")
+            .Verb("component", "A reusable component.", "c")
+            .Verb("feature", "A full CRUD slice: entity, DbContext, commands, and pages.", "f")
+            .Verb("job", "A background job handler.", "j")
+            .Verb("email", "An email message and its send path.", "e")
+            .Verb("cache", "A cached read accessor.", "ca")
             .Option("output", 'o', "dir", "Directory to write into (default: derived from the artifact).")
             .Option("feature", 'F', "Name", "Co-locate under Features/<Name>/ instead of Features/Shared/ (component, job, email).")
             .Flag("force", description: "Overwrite existing files instead of refusing.")
@@ -72,8 +64,8 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             .Option("fields", 'f', "list", "Fields as Name:type,... (or pass them positionally).", FeatureGroup)
             .Option("context", 'c', "Name", "Reuse an existing DbContext instead of generating one.", FeatureGroup)
             .Option("plural", 'p', "Name", "Plural name for the feature folder/route (default: auto-pluralized).", FeatureGroup)
-            .Option("id", valueHint: "guid|int|long", description: "Primary-key type (default: guid).", group: FeatureGroup)
-            .Option("validation", valueHint: "mode", description: "Validation style: valueobjects (default), dataannotations, or fluent.", group: FeatureGroup)
+            .Option("id", valueHint: "type", description: "Primary-key type (default: guid).", group: FeatureGroup, choices: ["guid", "int", "long"])
+            .Option("validation", valueHint: "mode", description: "Validation style (default: valueobjects).", group: FeatureGroup, choices: ["valueobjects", "dataannotations", "fluent"])
             .Flag("bs", description: "Render pages with Rask.Bootstrap (Bs*) components.", group: FeatureGroup)
             .Flag("modal", description: "Fold create/edit into a modal on the list page (implies --bs).", group: FeatureGroup)
             .Flag("soft-delete", description: "Soft-delete rows and add a Restore command.", group: FeatureGroup)
@@ -115,21 +107,11 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
     public override async Task<int> ExecuteAsync(IReadOnlyList<string> args, CancellationToken cancellationToken)
     {
-        if (args.Count == 0)
-        {
-            Console.Error.WriteLine($"Specify what to generate: {string.Join(", ", Kinds)}.");
-            Console.Error.WriteLine($"Usage: {Usage}");
-            return 1;
-        }
-
-        var kind = KindAliases.GetValueOrDefault(args[0], args[0]);
-        if (!Kinds.Contains(kind))
-        {
-            Console.Error.WriteLine($"Unknown artifact '{args[0]}'. Generate one of: {string.Join(", ", Kinds)} (aliases: p, c, f, j, e).");
-            return 1;
-        }
-
         var schema = CreateSchema();
+        if (!schema.TryResolveVerb(args.FirstOrDefault(), out var kind))
+        {
+            return FailUnknownVerb(args.FirstOrDefault(), schema);
+        }
 
         var parsed = schema.Parse(args.Skip(1).ToArray());
         if (parsed.HasErrors)
@@ -140,14 +122,12 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         var name = parsed.Positionals.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(name))
         {
-            Console.Error.WriteLine($"A name is required. Usage: {Usage}");
-            return 1;
+            return Fail($"A name is required, e.g. 'rask generate {kind} Product'.");
         }
 
         if (!Identifiers.IsValidTypeName(name))
         {
-            Console.Error.WriteLine($"'{name}' is not a valid C# type name (letters, digits, and '_'; not starting with a digit).");
-            return 1;
+            return Fail($"'{name}' is not a valid C# type name (letters, digits, and '_'; not starting with a digit).");
         }
 
         var route = parsed.Option("route");
@@ -155,14 +135,12 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         {
             if (kind != "page")
             {
-                Console.Error.WriteLine("--route only applies to 'generate page'.");
-                return 1;
+                return Fail("--route only applies to 'generate page'.");
             }
 
             if (!Identifiers.IsValidRoutePath(route))
             {
-                Console.Error.WriteLine($"'{route}' is not a valid route path (no quotes, backslashes, or control characters).");
-                return 1;
+                return Fail($"'{route}' is not a valid route path (no quotes, backslashes, or control characters).");
             }
         }
 
@@ -176,14 +154,12 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         // expect. Reject the combination rather than silently pick one.
         if (feature is not null && parsed.Option("output") is not null)
         {
-            Console.Error.WriteLine("--output and --feature can't be combined — --output already says where the file goes.");
-            return CliCommand.UsageExitCode;
+            return Fail("--output and --feature can't be combined — --output already says where the file goes.");
         }
 
         if (feature is not null && kind is "page" or "feature")
         {
-            Console.Error.WriteLine("--feature only applies to 'generate component', 'job', or 'email'.");
-            return 1;
+            return Fail("--feature only applies to 'generate component', 'job', or 'email'.");
         }
 
         // Derived from the schema's own grouping rather than a hand-kept list, so a new feature option can't
@@ -198,31 +174,30 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
         if (kind != "feature" && misapplied.Count > 0)
         {
             var verb = misapplied.Count == 1 ? "applies" : "apply";
-            Console.Error.WriteLine($"{Humanize(misapplied)} only {verb} to 'generate feature'.");
-            return 1;
+            return Fail($"{Humanize(misapplied)} only {verb} to 'generate feature'.");
         }
 
         // Positional field specs (Name:type) are how 'generate feature' takes its fields; a page/component
         // has no fields, so extra positionals there are a mistake, not silently ignored.
         if (kind != "feature" && parsed.Positionals.Count > 1)
         {
-            Console.Error.WriteLine($"Unexpected argument '{parsed.Positionals[1]}'. Positional field specs (Name:type) only apply to 'generate feature'.");
-            return 1;
+            return Fail($"Unexpected argument '{parsed.Positionals[1]}'. Positional field specs (Name:type) only apply to 'generate feature'.");
         }
 
         foreach (var (option, value) in new[] { ("context", parsed.Option("context")), ("plural", parsed.Option("plural")), ("feature", feature) })
         {
             if (value is not null && !Identifiers.IsValidTypeName(value))
             {
-                Console.Error.WriteLine($"'{value}' is not a valid C# type name for --{option}.");
-                return 1;
+                return Fail($"'{value}' is not a valid C# type name for --{option}.");
             }
         }
 
         var project = ProjectLocator.Locate(_fileSystem, _workingDirectory);
         if (project is null)
         {
-            Console.Error.WriteLine($"Couldn't find a single .csproj at or above '{_workingDirectory}'. Run this inside a Rask project.");
+            Console.WriteErrorLine(
+                $"{ProjectLocator.DescribeMissing(_fileSystem, _workingDirectory)} Run this inside a Rask project.",
+                ConsoleStyle.Error);
             return 1;
         }
 
@@ -234,16 +209,19 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             var target = Scaffold.TargetDirectory(_workingDirectory, outputOverride);
             if (!Scaffold.IsInside(project.ProjectDirectory, target))
             {
-                Console.WriteErrorLine($"--output '{outputOverride}' resolves outside the project ({target}).", ConsoleStyle.Error);
-                Console.Error.WriteLine($"Generated code is namespaced by its folder, so it has to live under '{project.ProjectDirectory}'.");
-                return CliCommand.UsageExitCode;
+                return Fail(
+                [
+                    $"--output '{outputOverride}' resolves outside the project ({target}).",
+                    $"Generated code is namespaced by its folder, so it has to live under '{project.ProjectDirectory}'.",
+                ]);
             }
         }
 
+        // Everything TryBuild rejects is something in the argument list — a field spec that doesn't parse,
+        // fields given twice, fields missing — so it exits like any other bad command line.
         if (!TryBuild(kind, name, project, parsed, out var result, out var buildError))
         {
-            Console.Error.WriteLine(buildError);
-            return 1;
+            return Fail(buildError!);
         }
 
         // Whether a --tests run needs to wire a *new* test project (vs reuse one an earlier run created) must be
@@ -865,7 +843,10 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
 
             if (existing.Length > 0)
             {
-                Console.Error.WriteLine($"Refusing to overwrite existing file(s): {string.Join(", ", existing)}. Pass --force.");
+                Console.WriteErrorLine(
+                    $"Refusing to overwrite existing file(s): {string.Join(", ", existing)}. "
+                    + "Pass --force to replace them, or --dry-run to see what would be written.",
+                    ConsoleStyle.Error);
                 return 1;
             }
         }

--- a/src/Rask.Cli/Commands/NewCommand.cs
+++ b/src/Rask.Cli/Commands/NewCommand.cs
@@ -17,6 +17,9 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     private readonly IProcessRunner _process = process;
     private readonly string _workingDirectory = workingDirectory;
 
+    /// <summary>The host modes the native template understands (<c>--host</c>).</summary>
+    private static readonly string[] NativeHosts = ["local", "server"];
+
     /// <summary>The opt-in feature flags <c>rask new</c> forwards to a template (as <c>--flag</c>).</summary>
     internal static readonly string[] FeatureFlags =
     [
@@ -29,10 +32,8 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
 
     public override string Summary => "Create a new Rask project from a template.";
 
-    public override string Usage =>
-        "rask new <name> [--template server|wasm|wasm-hosted|native] [--auth] [--pwa] [--cqrs] [--data] "
-        + "[--jobs] [--mail] [--cache] [--outbox] [--push] [--snapshots] [--logs] [--ops] "
-        + "[--all-batteries] [--docker] [--host local|server] [--output <dir>]";
+    // The shape only — the flags are listed once, in the schema below, which --help renders directly.
+    public override string Usage => "rask new <name> [options]";
 
     public override IReadOnlyList<(string Name, string Description)> Arguments =>
         [("<name>", "Name of the project to create (scaffolds ./<name>/).")];
@@ -52,11 +53,11 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
     /// <summary>The flag/option schema — shared by <see cref="ExecuteAsync"/> and <c>--help</c> so they can't drift.</summary>
     private static ArgumentSchema CreateSchema() =>
         new ArgumentSchema()
-            .Option("template", 't', "name", "Template to scaffold: server (default), wasm, wasm-hosted, or native.")
+            .Option("template", 't', "name", "Template to scaffold (default: server).", choices: TemplateCatalog.Keys)
             .Option("output", 'o', "dir", "Directory to create the project in (default: ./<name>).")
             .Option("name", 'n', "name", "Project name, if not given positionally.")
-            .Option("host", valueHint: "local|server", description: "Native host mode: local (default) or server. Native template only.")
-            .Option("database", valueHint: DatabaseCatalog.Keys, description: "Database for --data: sqlite (default, one file, no server) or postgres. Server template only.")
+            .Option("host", valueHint: "mode", description: "Native host mode (default: local). Native template only.", choices: NativeHosts)
+            .Option("database", valueHint: "name", description: "Database for --data (default: sqlite, one file and no server). Server template only.", choices: DatabaseCatalog.Keys)
             .Flag("auth", description: "Add cookie authentication (login + members pages).")
             .Flag("pwa", description: "Add a PWA manifest, icon, and offline page.")
             .Flag("cqrs", description: "Wire up Rask.Cqrs (server template only).")
@@ -99,9 +100,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
                 return await ExecuteAsync(RunWizard(prompt), allowWizard: false, cancellationToken).ConfigureAwait(false);
             }
 
-            Console.Error.WriteLine("A project name is required.");
-            Console.Error.WriteLine($"Usage: {Usage}");
-            return 1;
+            return Fail("A project name is required, e.g. 'rask new Shop'.");
         }
 
         // The name becomes the root namespace and the csproj filename, so an invalid one (a dash, a leading
@@ -109,19 +108,15 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         // rather than writing files the user then has to throw away.
         if (!Identifiers.IsValidNamespaceName(name))
         {
-            Console.Error.WriteLine(
+            return Fail(
                 $"'{name}' isn't a valid project name — it becomes the root namespace, so each dot-separated part must "
                 + "start with a letter or underscore and contain only letters, digits, or underscores (e.g. Shop or Contoso.Shop).");
-            return 1;
         }
 
+        // The schema declares TemplateCatalog.Keys as this option's choices, so the parse already rejected
+        // (and reported) anything else — the lookup here can only succeed.
         var templateKey = parsed.Option("template") ?? TemplateCatalog.Default.Key;
-        if (!TemplateCatalog.TryGet(templateKey, out var template))
-        {
-            var available = string.Join(", ", TemplateCatalog.All.Select(t => t.Key));
-            Console.Error.WriteLine($"Unknown template '{templateKey}'. Available templates: {available}.");
-            return 1;
-        }
+        _ = TemplateCatalog.TryGet(templateKey, out var template);
 
         var requestedFlags = FeatureFlags.Where(parsed.HasFlag).ToArray();
         var unsupported = requestedFlags.Where(flag => !template.SupportedFlags.Contains(flag)).ToArray();
@@ -131,36 +126,29 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
                 ? "(none)"
                 : string.Join(", ", template.SupportedFlags.OrderBy(f => f, StringComparer.Ordinal).Select(f => "--" + f));
             var rejected = string.Join(", ", unsupported.Select(f => "--" + f));
-            Console.Error.WriteLine($"Template '{template.Key}' does not support: {rejected}. Supported flags: {supported}.");
-            return 1;
+            return Fail($"Template '{template.Key}' does not support: {rejected}. Supported flags: {supported}.");
         }
 
         // --database only applies to the server template, which is the only one with a database at all.
         var databaseKey = parsed.Option("database");
         if (databaseKey is not null && template.Key != "server")
         {
-            Console.Error.WriteLine(
+            return Fail(
                 $"Template '{template.Key}' does not support --database. It applies only to the server template, "
                 + "which is the only one that scaffolds a database.");
-            return 1;
         }
 
-        if (!DatabaseCatalog.TryGet(databaseKey ?? DatabaseCatalog.Default.Key, out var database))
-        {
-            var available = string.Join(", ", DatabaseCatalog.All.Select(d => d.Key));
-            Console.Error.WriteLine($"Unknown database '{databaseKey}'. Available databases: {available}.");
-            return 1;
-        }
+        // Declared choices again — the parse rejected any key the catalog doesn't hold.
+        _ = DatabaseCatalog.TryGet(databaseKey ?? DatabaseCatalog.Default.Key, out var database);
 
         // Snapshots copy the database file, so on a client-server database the battery has no meaning.
         // Reject rather than drop it: a backup that silently didn't get wired is discovered too late.
         if (requestedFlags.Contains("snapshots") && !database.IsFileBased)
         {
-            Console.Error.WriteLine(
+            return Fail(
                 $"--snapshots needs a file-based database, but --database {database.Key} is a server. "
                 + $"Scheduled snapshots (and Litestream continuous backup) copy the SQLite file; on "
                 + $"{database.DisplayName} use your provider's backups instead. Drop --snapshots, or use --database sqlite.");
-            return 1;
         }
 
         // --host only applies to the native template (which mode to scaffold). Reject it elsewhere so a
@@ -168,20 +156,14 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
         var host = parsed.Option("host");
         if (host is not null && template.Key != "native")
         {
-            Console.Error.WriteLine($"Template '{template.Key}' does not support --host. It applies only to the native template (--host local|server).");
-            return 1;
+            return Fail($"Template '{template.Key}' does not support --host. It applies only to the native template (--host local|server).");
         }
 
         // Native is generated directly, but with its own shape: a --host choice (local|server), a single
-        // package, and no feature flags.
+        // package, and no feature flags. The value itself is a declared choice, so it is already valid.
         if (template.Key == "native")
         {
             host ??= "local";
-            if (host is not ("local" or "server"))
-            {
-                Console.Error.WriteLine($"Invalid --host '{host}'. The native template supports: local, server.");
-                return 1;
-            }
 
             return await GenerateDirectAsync(
                 template, name, parsed.Option("output"), parsed.HasFlag("dry-run"), parsed.HasFlag("force"), parsed.HasFlag("no-restore"),
@@ -343,7 +325,9 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             if (_fileSystem.FileExists(restoreTarget))
             {
                 var existing = Path.GetFileName(restoreTarget);
-                Console.Error.WriteLine($"A project already exists at '{targetDirectory}' ({existing}). Choose another name, --output, or pass --force.");
+                Console.WriteErrorLine(
+                    $"A project already exists at '{targetDirectory}' ({existing}). Choose another name, --output, or pass --force.",
+                    ConsoleStyle.Error);
                 return 1;
             }
 
@@ -361,7 +345,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
                     Console.Error.WriteLine($"  …and {(clashes.Length - 5).ToString(CultureInfo.InvariantCulture)} more");
                 }
 
-                Console.Error.WriteLine("Choose another name or --output, or pass --force to overwrite.");
+                Console.WriteErrorLine("Choose another name or --output, or pass --force to overwrite.", ConsoleStyle.Error);
                 return 1;
             }
         }
@@ -406,7 +390,7 @@ internal sealed class NewCommand(IConsole console, IFileSystem fileSystem, IProc
             Console.WriteErrorLine(
                 $"The project was written to '{targetDirectory}', but restoring its packages failed — it won't build until that succeeds.",
                 ConsoleStyle.Error);
-            Console.Error.WriteLine("Run 'dotnet restore' there once you're online, or re-run with --no-restore to skip this step.");
+            Console.WriteErrorLine("Run 'dotnet restore' there once you're online, or re-run with --no-restore to skip this step.", ConsoleStyle.Error);
             return 1;
         }
 

--- a/src/Rask.Cli/Scaffolding/DatabaseCatalog.cs
+++ b/src/Rask.Cli/Scaffolding/DatabaseCatalog.cs
@@ -105,8 +105,8 @@ internal static class DatabaseCatalog
     /// <summary>The default when <c>--database</c> is omitted — SQLite, and deliberately so.</summary>
     public static DatabaseInfo Default => All[0];
 
-    /// <summary>The accepted <c>--database</c> values, for help text and error messages.</summary>
-    public static string Keys => string.Join("|", All.Select(database => database.Key));
+    /// <summary>The accepted <c>--database</c> values, for the schema's choice list, help, and completion.</summary>
+    public static IReadOnlyList<string> Keys { get; } = [.. All.Select(database => database.Key)];
 
     public static DatabaseInfo For(DatabaseProvider provider)
         => All.First(database => database.Provider == provider);

--- a/src/Rask.Cli/Scaffolding/ProjectContext.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectContext.cs
@@ -90,6 +90,35 @@ internal sealed partial class ProjectContext(
 /// <summary>Locates the .NET project that owns a directory by walking up to the nearest single <c>*.csproj</c>.</summary>
 internal static class ProjectLocator
 {
+    /// <summary>
+    /// Why <see cref="Locate"/> came back empty, as a sentence to print. Worth distinguishing: the walk
+    /// stops on a directory holding <em>several</em> projects just as it does on finding none, and telling
+    /// someone standing in a two-project folder that nothing was found sends them looking for the wrong
+    /// problem. Callers append their own way out, which differs by command.
+    /// </summary>
+    public static string DescribeMissing(IFileSystem fileSystem, string startDirectory)
+    {
+        var directory = Path.GetFullPath(startDirectory);
+
+        while (!string.IsNullOrEmpty(directory))
+        {
+            if (fileSystem.ListFiles(directory, "*.csproj").Count > 1)
+            {
+                return $"Found more than one .csproj in '{directory}', so it's ambiguous which project to use.";
+            }
+
+            var parent = Path.GetDirectoryName(directory);
+            if (parent == directory)
+            {
+                break;
+            }
+
+            directory = parent!;
+        }
+
+        return $"Couldn't find a .csproj at or above '{startDirectory}'.";
+    }
+
     public static ProjectContext? Locate(IFileSystem fileSystem, string startDirectory)
     {
         var directory = Path.GetFullPath(startDirectory);

--- a/src/Rask.Cli/Suggest.cs
+++ b/src/Rask.Cli/Suggest.cs
@@ -1,0 +1,111 @@
+namespace Rask.Cli;
+
+/// <summary>
+/// Finds the nearest spelling of a word the user got wrong — the "did you mean 'generate'?" behind every
+/// unknown command, option, action, and off-list option value. Deliberately conservative: it offers a
+/// correction only when one candidate is clearly closest, because a confidently wrong suggestion costs
+/// the reader more than no suggestion at all.
+/// </summary>
+internal static class Suggest
+{
+    /// <summary>
+    /// The nearest candidate to <paramref name="input"/>, or <c>null</c> when nothing is close enough.
+    /// Matching is case-insensitive and tolerates a transposition ("srever" → "server"); an unambiguous
+    /// prefix ("gen" → "generate") also counts, since an abbreviation is a guess, not a typo.
+    /// </summary>
+    public static string? Closest(string? input, IEnumerable<string> candidates)
+    {
+        if (string.IsNullOrEmpty(input))
+        {
+            return null;
+        }
+
+        // A short word can only afford one edit before the "correction" is really a different word;
+        // longer ones can absorb two. Anything further apart is left uncorrected on purpose.
+        var budget = input.Length <= 3 ? 1 : 2;
+
+        string? best = null;
+        var bestDistance = int.MaxValue;
+        string? onlyPrefixMatch = null;
+        var prefixMatches = 0;
+
+        foreach (var candidate in candidates)
+        {
+            if (candidate.Equals(input, StringComparison.OrdinalIgnoreCase))
+            {
+                return candidate;
+            }
+
+            // Two or more candidates share the prefix, so it identifies nothing — drop the prefix route.
+            if (input.Length >= 3 && candidate.StartsWith(input, StringComparison.OrdinalIgnoreCase))
+            {
+                prefixMatches++;
+                onlyPrefixMatch = candidate;
+            }
+
+            var distance = Distance(input, candidate, budget);
+            if (distance <= budget && distance < bestDistance)
+            {
+                best = candidate;
+                bestDistance = distance;
+            }
+        }
+
+        // A lone prefix match wins over the nearest edit: "dep" is one substitution from "dev", but
+        // someone who typed it was spelling "deploy" and stopped.
+        return prefixMatches == 1 ? onlyPrefixMatch : best;
+    }
+
+    /// <summary>
+    /// Optimal string alignment distance (Levenshtein plus adjacent transposition), case-insensitive and
+    /// abandoned early once every cell in a row exceeds <paramref name="budget"/> — the answer is only ever
+    /// compared against that budget, so the exact value beyond it is never needed.
+    /// </summary>
+    private static int Distance(string a, string b, int budget)
+    {
+        if (Math.Abs(a.Length - b.Length) > budget)
+        {
+            return int.MaxValue;
+        }
+
+        var previousPrevious = new int[b.Length + 1];
+        var previous = new int[b.Length + 1];
+        var current = new int[b.Length + 1];
+
+        for (var j = 0; j <= b.Length; j++)
+        {
+            previous[j] = j;
+        }
+
+        for (var i = 1; i <= a.Length; i++)
+        {
+            current[0] = i;
+            var rowBest = current[0];
+
+            for (var j = 1; j <= b.Length; j++)
+            {
+                var cost = char.ToLowerInvariant(a[i - 1]) == char.ToLowerInvariant(b[j - 1]) ? 0 : 1;
+                var value = Math.Min(Math.Min(current[j - 1] + 1, previous[j] + 1), previous[j - 1] + cost);
+
+                if (i > 1 && j > 1
+                    && char.ToLowerInvariant(a[i - 1]) == char.ToLowerInvariant(b[j - 2])
+                    && char.ToLowerInvariant(a[i - 2]) == char.ToLowerInvariant(b[j - 1]))
+                {
+                    value = Math.Min(value, previousPrevious[j - 2] + 1);
+                }
+
+                current[j] = value;
+                rowBest = Math.Min(rowBest, value);
+            }
+
+            if (rowBest > budget)
+            {
+                return int.MaxValue;
+            }
+
+            (previousPrevious, previous, current) = (previous, current, previousPrevious);
+        }
+
+        return previous[b.Length];
+    }
+}

--- a/src/Rask.Cli/Templates/TemplateCatalog.cs
+++ b/src/Rask.Cli/Templates/TemplateCatalog.cs
@@ -40,6 +40,9 @@ internal static class TemplateCatalog
     /// <summary>The default template when none is specified — a server-rendered app.</summary>
     public static TemplateInfo Default => All[0];
 
+    /// <summary>The accepted <c>--template</c> values, for the schema's choice list, help, and completion.</summary>
+    public static IReadOnlyList<string> Keys { get; } = [.. All.Select(template => template.Key)];
+
     public static bool TryGet(string key, out TemplateInfo template)
     {
         foreach (var candidate in All)

--- a/tests/Rask.Cli.Tests/ArgumentSchemaTests.cs
+++ b/tests/Rask.Cli.Tests/ArgumentSchemaTests.cs
@@ -127,4 +127,87 @@ public sealed class ArgumentSchemaTests
         Assert.True(auth.IsFlag);
         Assert.Equal("Extras", auth.Group);
     }
+
+    private static ArgumentSchema WithChoices() =>
+        new ArgumentSchema().Option("template", 't', choices: ["server", "wasm", "wasm-hosted"]);
+
+    [Fact]
+    public void A_declared_choice_is_accepted()
+    {
+        var parsed = WithChoices().Parse(["--template", "wasm"]);
+
+        Assert.False(parsed.HasErrors);
+        Assert.Equal("wasm", parsed.Option("template"));
+    }
+
+    [Fact]
+    public void A_choice_is_normalized_to_its_declared_spelling()
+    {
+        // Everything downstream compares ordinally, so the command must never see "SERVER".
+        var parsed = WithChoices().Parse(["--template", "SERVER"]);
+
+        Assert.False(parsed.HasErrors);
+        Assert.Equal("server", parsed.Option("template"));
+    }
+
+    [Fact]
+    public void An_off_list_choice_is_rejected_with_the_set_and_the_nearest_match()
+    {
+        var parsed = WithChoices().Parse(["--template", "srever"]);
+
+        var error = Assert.Single(parsed.Errors);
+        Assert.Equal(
+            "Option '--template' does not accept 'srever'. Did you mean 'server'? Choose one of: server, wasm, wasm-hosted.",
+            error);
+        Assert.Null(parsed.Option("template"));
+    }
+
+    [Fact]
+    public void An_off_list_choice_with_no_near_match_still_lists_the_set()
+    {
+        var parsed = WithChoices().Parse(["--template", "svelte"]);
+
+        Assert.Equal(
+            "Option '--template' does not accept 'svelte'. Choose one of: server, wasm, wasm-hosted.",
+            Assert.Single(parsed.Errors));
+    }
+
+    [Fact]
+    public void An_unknown_long_option_suggests_the_nearest_declared_one() =>
+        Assert.Equal(
+            "Unknown option '--tempate'. Did you mean '--template'?",
+            Assert.Single(WithChoices().Parse(["--tempate", "wasm"]).Errors));
+
+    [Fact]
+    public void An_unknown_short_option_is_not_guessed_at() =>
+        Assert.Equal("Unknown option '-z'.", Assert.Single(WithChoices().Parse(["-z", "wasm"]).Errors));
+
+    [Fact]
+    public void Verbs_resolve_by_name_and_by_alias()
+    {
+        var schema = new ArgumentSchema()
+            .Verb("feature", "A CRUD slice.", "f")
+            .Verb("cache", "A cached read.", "ca");
+
+        Assert.True(schema.TryResolveVerb("feature", out var byName));
+        Assert.Equal("feature", byName);
+
+        Assert.True(schema.TryResolveVerb("ca", out var byAlias));
+        Assert.Equal("cache", byAlias);
+
+        Assert.False(schema.TryResolveVerb("controller", out _));
+        Assert.False(schema.TryResolveVerb(null, out _));
+    }
+
+    [Fact]
+    public void Verbs_keep_their_declaration_order_and_descriptions()
+    {
+        var schema = new ArgumentSchema()
+            .Verb("add", "Create a migration.")
+            .Verb("drop", "Delete the database.", "d");
+
+        Assert.Equal(["add", "drop"], schema.Verbs.Select(v => v.Name));
+        Assert.Equal("Create a migration.", schema.Verbs[0].Description);
+        Assert.Equal(["d"], schema.Verbs[1].Aliases);
+    }
 }

--- a/tests/Rask.Cli.Tests/CliApplicationTests.cs
+++ b/tests/Rask.Cli.Tests/CliApplicationTests.cs
@@ -93,8 +93,8 @@ public sealed class CliApplicationTests
         // `rask g` with no artifact reaches GenerateCommand, which asks what to generate.
         var exit = await app.RunAsync(["g"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
-        Assert.Contains("Specify what to generate", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Specify a 'rask generate' action", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -104,7 +104,7 @@ public sealed class CliApplicationTests
 
         var exit = await app.RunAsync(["bogus"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("Unknown command 'bogus'", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -117,5 +117,72 @@ public sealed class CliApplicationTests
 
         Assert.Equal(0, exit);
         Assert.Contains("Rask CLI", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("genrate", "generate")]
+    [InlineData("deloy", "deploy")]
+    [InlineData("nwe", "new")]
+    public async Task A_mistyped_command_names_the_one_you_meant(string typed, string meant)
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync([typed], CancellationToken.None);
+
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains($"Unknown command '{typed}'. Did you mean '{meant}'?", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_mistyped_alias_suggests_the_command_it_stands_for()
+    {
+        var (console, app) = Build();
+
+        // 'g' is generate's alias; the suggestion has to name the command, not the alias.
+        var exit = await app.RunAsync(["gg"], CancellationToken.None);
+
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Did you mean 'generate'?", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void No_command_may_claim_the_short_h()
+    {
+        // The router resolves -h to help before a command's own parser runs, so a command declaring it
+        // (deploy's --host once did) would silently print help instead of running. Keep it reserved.
+        var app = CliApplication.CreateDefault(new StringConsole(), new FakeProcessRunner(), new FakeFileSystem());
+
+        foreach (var command in app.Commands)
+        {
+            var claimed = command.OptionSchema?.Declared.FirstOrDefault(o => o.ShortName == 'h');
+            Assert.True(
+                claimed is null,
+                $"'rask {command.Name}' declares -h for --{claimed?.LongName}, which the router takes as --help.");
+        }
+    }
+
+    [Theory]
+    [InlineData("-h")]
+    [InlineData("--help")]
+    public async Task Either_help_token_shows_a_commands_help(string token)
+    {
+        var (console, app) = Build();
+
+        var exit = await app.RunAsync(["deploy", token], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.Contains("Usage: rask deploy", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Help_after_a_passthrough_separator_belongs_to_the_app()
+    {
+        var (console, app) = Build();
+
+        // `rask dev -- --help` asks the *app* for help; the CLI must not intercept it.
+        var exit = await app.RunAsync(["dev", "--", "--help"], CancellationToken.None);
+
+        Assert.NotEqual(0, exit);
+        Assert.DoesNotContain("Usage: rask dev", console.OutText, StringComparison.Ordinal);
     }
 }

--- a/tests/Rask.Cli.Tests/CommandHelpTests.cs
+++ b/tests/Rask.Cli.Tests/CommandHelpTests.cs
@@ -88,4 +88,51 @@ public sealed class CommandHelpTests
         Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("Run 'rask new --help' for details.", console.ErrorText, StringComparison.Ordinal);
     }
+
+    [Fact]
+    public async Task Command_help_lists_the_actions_it_dispatches()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["db", "--help"], CancellationToken.None);
+
+        var text = console.OutText;
+        Assert.Contains("Actions:", text, StringComparison.Ordinal);
+        foreach (var action in new[] { "add", "remove", "list", "update", "drop", "backup", "restore" })
+        {
+            Assert.Contains(action, text, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public async Task An_actions_aliases_are_documented_beside_it()
+    {
+        var (console, app) = Build();
+
+        // 'ca' → cache was reachable but named nowhere, in help or in the unknown-action error.
+        await app.RunAsync(["generate", "--help"], CancellationToken.None);
+
+        Assert.Contains("cache (ca)", console.OutText, StringComparison.Ordinal);
+        Assert.Contains("feature (f)", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task An_options_closed_set_is_listed_in_help()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["new", "--help"], CancellationToken.None);
+
+        Assert.Contains("[server|wasm|wasm-hosted|native]", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_command_with_no_actions_has_no_actions_section()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["dev", "--help"], CancellationToken.None);
+
+        Assert.DoesNotContain("Actions:", console.OutText, StringComparison.Ordinal);
+    }
 }

--- a/tests/Rask.Cli.Tests/CompletionCommandTests.cs
+++ b/tests/Rask.Cli.Tests/CompletionCommandTests.cs
@@ -33,8 +33,9 @@ public sealed class CompletionCommandTests
 
         var exit = await app.RunAsync(["completion"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
-        Assert.Contains("Specify a shell", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Specify a 'rask completion' action: bash, zsh, fish.", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Run 'rask completion --help' for details.", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -44,8 +45,9 @@ public sealed class CompletionCommandTests
 
         var exit = await app.RunAsync(["completion", "powershell"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
-        Assert.Contains("Specify a shell", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Unknown 'rask completion' action 'powershell'.", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Choose one of: bash, zsh, fish.", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -56,5 +58,54 @@ public sealed class CompletionCommandTests
         await app.RunAsync([], CancellationToken.None);
 
         Assert.Contains("completion", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("bash")]
+    [InlineData("zsh")]
+    [InlineData("fish")]
+    public async Task Subcommands_are_completable_too(string shell)
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["completion", shell], CancellationToken.None);
+
+        var script = console.OutText;
+        foreach (var verb in new[] { "backup", "restore", "rollback", "component" })
+        {
+            Assert.Contains(verb, script, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [InlineData("bash")]
+    [InlineData("zsh")]
+    [InlineData("fish")]
+    public async Task An_options_closed_set_completes_its_values(string shell)
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["completion", shell], CancellationToken.None);
+
+        // The values of `new --template`, which only the schema knows.
+        Assert.Contains("wasm-hosted", console.OutText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Bash_completes_values_per_command_not_globally()
+    {
+        var (console, app) = Build();
+
+        await app.RunAsync(["completion", "bash"], CancellationToken.None);
+
+        // `--host` names a closed set under `new` and a free-form SSH target under `deploy`; the value
+        // completion has to sit inside the command's own branch or deploy would offer local/server.
+        var script = console.OutText;
+        var newBranch = script.IndexOf("    new)", StringComparison.Ordinal);
+        var hostChoices = script.IndexOf("\"$prev\" = \"--host\"", StringComparison.Ordinal);
+        var deployBranch = script.IndexOf("    deploy)", StringComparison.Ordinal);
+
+        Assert.True(newBranch >= 0 && hostChoices > newBranch, "the --host value list belongs to `new`'s branch");
+        Assert.True(deployBranch > hostChoices, "and must not leak into `deploy`'s");
     }
 }

--- a/tests/Rask.Cli.Tests/DatabaseCatalogTests.cs
+++ b/tests/Rask.Cli.Tests/DatabaseCatalogTests.cs
@@ -48,7 +48,7 @@ public sealed class DatabaseCatalogTests
     [Fact]
     public void Keys_lists_every_database_for_help_text()
     {
-        Assert.Equal("sqlite|postgres|sqlserver", DatabaseCatalog.Keys);
+        Assert.Equal(["sqlite", "postgres", "sqlserver"], DatabaseCatalog.Keys);
     }
 
     [Fact]

--- a/tests/Rask.Cli.Tests/DbCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DbCommandTests.cs
@@ -141,7 +141,7 @@ public sealed class DbCommandTests
 
         var exit = await command.ExecuteAsync([], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("add, remove, list, update, drop", console.ErrorText);
     }
@@ -153,7 +153,7 @@ public sealed class DbCommandTests
 
         var exit = await command.ExecuteAsync(["migrate"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
     }
 
@@ -164,7 +164,7 @@ public sealed class DbCommandTests
 
         var exit = await command.ExecuteAsync(["add"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("needs a migration name", console.ErrorText);
     }
@@ -176,7 +176,7 @@ public sealed class DbCommandTests
 
         var exit = await command.ExecuteAsync(["remove", "Oops"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
     }
 
@@ -201,7 +201,7 @@ public sealed class DbCommandTests
 
         var exit = await command.ExecuteAsync(["list", "--output", "Migrations"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("--output only applies", console.ErrorText);
     }
@@ -213,7 +213,7 @@ public sealed class DbCommandTests
 
         var exit = await command.ExecuteAsync(["update", "--force"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("--force only applies", console.ErrorText);
     }

--- a/tests/Rask.Cli.Tests/DeployCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DeployCommandTests.cs
@@ -225,7 +225,7 @@ public sealed class DeployCommandTests
 
         var exit = await command.ExecuteAsync([], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("--host", console.ErrorText);
     }
@@ -375,7 +375,7 @@ public sealed class DeployCommandTests
 
         var exit = await command.ExecuteAsync(["--host", "deploy@box", "--domain", "app.example.com", "--port", "9000"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("--port doesn't apply with --domain", console.ErrorText);
     }
@@ -390,7 +390,7 @@ public sealed class DeployCommandTests
 
         var exit = await command.ExecuteAsync(["--port", "9000"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains(".rask/deploy.json", console.ErrorText);
     }
 
@@ -641,7 +641,7 @@ public sealed class DeployCommandTests
 
         var exit = await command.ExecuteAsync(["--host", "deploy@box", "--name", "shop", "--no-health-check", "--health-path", "/ready"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--health-path doesn't apply", console.ErrorText);
     }
 
@@ -1089,7 +1089,7 @@ public sealed class DeployCommandTests
 
         var exit = await command.ExecuteAsync([.. new[] { "--host", "root@box", "--name", "shop" }, .. flags], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains(expected, console.ErrorText, StringComparison.Ordinal);
         Assert.Empty(runner.Invocations); // nothing reached the network
     }

--- a/tests/Rask.Cli.Tests/DeployOpsTests.cs
+++ b/tests/Rask.Cli.Tests/DeployOpsTests.cs
@@ -163,7 +163,7 @@ public sealed class DeployOpsTests
 
         var exit = await command.ExecuteAsync(["logs", "--host", "deploy@box", "--name", "shop", "--tail", value], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--tail must be", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -219,8 +219,8 @@ public sealed class DeployOpsTests
 
         var exit = await command.ExecuteAsync(["restart"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
-        Assert.Contains("Unknown deploy action 'restart'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Unknown 'rask deploy' action 'restart'.", console.ErrorText, StringComparison.Ordinal);
         Assert.Contains("status, logs, rollback", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -237,7 +237,7 @@ public sealed class DeployOpsTests
 
         var exit = await command.ExecuteAsync([.. args, "--host", "deploy@box"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains(option, console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -249,7 +249,7 @@ public sealed class DeployOpsTests
 
         var exit = await command.ExecuteAsync(["--host", "deploy@box", "--follow"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("only apply to `rask deploy logs`", console.ErrorText, StringComparison.Ordinal);
     }
 }

--- a/tests/Rask.Cli.Tests/DevCommandTests.cs
+++ b/tests/Rask.Cli.Tests/DevCommandTests.cs
@@ -178,7 +178,7 @@ public sealed class DevCommandTests
         var exit = await command.ExecuteAsync([], CancellationToken.None);
 
         Assert.Equal(1, exit);
-        Assert.Contains("Couldn't find a single .csproj", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Couldn't find a .csproj", console.ErrorText, StringComparison.Ordinal);
     }
 
     // ---- native refusal ----

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -52,7 +52,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page", "Products", "--feature", "Orders"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--feature only applies", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -234,7 +234,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["job", "Cleanup", "--route", "/x"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--route only applies to 'generate page'", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -283,7 +283,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["component", "2Cool"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.DoesNotContain(fs.Files, f => f.Value.Contains("class", StringComparison.Ordinal));
         Assert.Contains("not a valid C# type name", console.ErrorText, StringComparison.Ordinal);
     }
@@ -587,7 +587,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["feature", "Product"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(fs.Files.Where(f => f.Key.EndsWith("Product.cs", StringComparison.Ordinal)).ToArray());
         Assert.Contains("needs fields", console.ErrorText, StringComparison.Ordinal);
     }
@@ -615,7 +615,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["feature", "Product", "Name:string", "--fields", "Price:decimal"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.DoesNotContain(fs.Files, f => f.Key.EndsWith("CreateProduct.cs", StringComparison.Ordinal));
         Assert.Contains("not both", console.ErrorText, StringComparison.Ordinal);
     }
@@ -627,7 +627,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page", "Home", "Name:string"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("Unexpected argument 'Name:string'", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -638,7 +638,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:blob"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("Unknown field type 'blob'", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -660,7 +660,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Product:string"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.DoesNotContain(fs.Files, f => f.Key.EndsWith("Product.cs", StringComparison.Ordinal));
         Assert.Contains("can't share the entity's name", console.ErrorText, StringComparison.Ordinal);
     }
@@ -672,7 +672,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string", "--context", "App-Db Context"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(fs.Files.Where(f => f.Key.EndsWith("Product.cs", StringComparison.Ordinal)).ToArray());
         Assert.Contains("not a valid C# type name for --context", console.ErrorText, StringComparison.Ordinal);
     }
@@ -695,7 +695,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page", "Products", "--fields", "Name:string"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--fields only applies to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -717,7 +717,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page", "Dashboard", "--no-restore"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--no-restore only applies to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -781,8 +781,9 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["feature", "Product", "--fields", "Name:string", "--id", "ulid"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
-        Assert.Contains("--id must be", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Option '--id' does not accept 'ulid'.", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Choose one of: guid, int, long.", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -792,8 +793,9 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["controller", "Products"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
-        Assert.Contains("Unknown artifact 'controller'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
+        Assert.Contains("Unknown 'rask generate' action 'controller'.", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Choose one of: page, component, feature, job, email, cache.", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -803,7 +805,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("A name is required", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -814,7 +816,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page", "Reports", "--route", "a\"b"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.DoesNotContain(fs.Files, f => f.Key.EndsWith("ReportsPage.cs", StringComparison.Ordinal));
         Assert.Contains("not a valid route path", console.ErrorText, StringComparison.Ordinal);
     }
@@ -826,7 +828,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["component", "class"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.DoesNotContain(fs.Files, f => f.Value.Contains("class class", StringComparison.Ordinal));
         Assert.Contains("not a valid C# type name", console.ErrorText, StringComparison.Ordinal);
     }
@@ -838,7 +840,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["component", "PriceTag", "--route", "/x"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--route only applies", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -851,8 +853,24 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["component", "PriceTag"], CancellationToken.None);
 
+        // 1, not the usage code: the command line was fine, the directory it ran in wasn't.
         Assert.Equal(1, exit);
-        Assert.Contains("Couldn't find a single .csproj", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Couldn't find a .csproj", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Two_projects_says_so_rather_than_claiming_it_found_none()
+    {
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        fs.Seed(Path.Combine(ProjectDir, "One.csproj"), "<Project />");
+        fs.Seed(Path.Combine(ProjectDir, "Two.csproj"), "<Project />");
+        var command = new GenerateCommand(console, fs, new FakeProcessRunner(), ProjectDir);
+
+        var exit = await command.ExecuteAsync(["component", "PriceTag"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("Found more than one .csproj", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -893,7 +911,7 @@ public sealed class GenerateCommandTests
 
         var exit = await command.ExecuteAsync(["page", "Dashboard", "--save-defaults"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("--save-defaults only applies to 'generate feature'", console.ErrorText, StringComparison.Ordinal);
     }
 

--- a/tests/Rask.Cli.Tests/NewCommandTests.cs
+++ b/tests/Rask.Cli.Tests/NewCommandTests.cs
@@ -67,7 +67,7 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["Spa", "--template", "wasm", "--data"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("does not support: --data", console.ErrorText, StringComparison.Ordinal);
     }
@@ -100,7 +100,7 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync([name], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations); // never even restored
         Assert.Contains("isn't a valid project name", console.ErrorText, StringComparison.Ordinal);
         Assert.False(fs.FileExists($"/proj/{name}/{name}.csproj"));
@@ -175,9 +175,10 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["MobileApp", "--template", "native", "--host", "cloud"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
-        Assert.Contains("Invalid --host 'cloud'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Option '--host' does not accept 'cloud'.", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Choose one of: local, server.", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -187,7 +188,7 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["MyApp", "--template", "server", "--host", "local"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("does not support --host", console.ErrorText, StringComparison.Ordinal);
     }
@@ -232,7 +233,7 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync([], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("name is required", console.ErrorText, StringComparison.Ordinal);
     }
@@ -244,9 +245,10 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["MyApp", "--template", "svelte"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
-        Assert.Contains("Unknown template 'svelte'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Option '--template' does not accept 'svelte'.", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Choose one of: server, wasm, wasm-hosted, native.", console.ErrorText, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -256,7 +258,7 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["MyApp", "--template", "wasm", "--cqrs"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("does not support: --cqrs", console.ErrorText, StringComparison.Ordinal);
     }
@@ -374,7 +376,7 @@ public sealed class NewCommandTests
         // StringConsole defaults to redirected stdin (non-interactive) — the wizard must not run.
         var exit = await command.ExecuteAsync([], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Contains("name is required", console.ErrorText, StringComparison.Ordinal);
         Assert.Empty(runner.Invocations);
     }
@@ -386,9 +388,9 @@ public sealed class NewCommandTests
 
         var exit = await command.ExecuteAsync(["MyApp", "--data", "--database", "mongo"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
-        Assert.Contains("Unknown database 'mongo'", console.ErrorText, StringComparison.Ordinal);
+        Assert.Contains("Option '--database' does not accept 'mongo'.", console.ErrorText, StringComparison.Ordinal);
         Assert.Contains("sqlite, postgres", console.ErrorText, StringComparison.Ordinal);
     }
 
@@ -403,7 +405,7 @@ public sealed class NewCommandTests
         var exit = await command.ExecuteAsync(
             ["MyApp", "--template", template, "--database", "postgres"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("does not support --database", console.ErrorText, StringComparison.Ordinal);
     }
@@ -418,7 +420,7 @@ public sealed class NewCommandTests
         var exit = await command.ExecuteAsync(
             ["MyApp", "--data", "--database", "postgres", "--snapshots"], CancellationToken.None);
 
-        Assert.Equal(1, exit);
+        Assert.Equal(CliCommand.UsageExitCode, exit);
         Assert.Empty(runner.Invocations);
         Assert.Contains("--snapshots needs a file-based database", console.ErrorText, StringComparison.Ordinal);
     }

--- a/tests/Rask.Cli.Tests/SuggestTests.cs
+++ b/tests/Rask.Cli.Tests/SuggestTests.cs
@@ -1,0 +1,63 @@
+namespace Rask.Cli.Tests;
+
+public sealed class SuggestTests
+{
+    private static readonly string[] Commands = ["new", "dev", "generate", "db", "deploy", "info", "completion"];
+
+    [Theory]
+    [InlineData("genrate", "generate")]   // transposition
+    [InlineData("generat", "generate")]   // dropped letter
+    [InlineData("generatee", "generate")] // doubled letter
+    [InlineData("Deploy", "deploy")]      // case
+    [InlineData("dpeloy", "deploy")]
+    public void Finds_the_intended_word(string typed, string expected) =>
+        Assert.Equal(expected, Suggest.Closest(typed, Commands));
+
+    [Theory]
+    [InlineData("kubernetes")]
+    [InlineData("publish")]
+    [InlineData("")]
+    [InlineData(null)]
+    public void Offers_nothing_when_nothing_is_close(string? typed) =>
+        Assert.Null(Suggest.Closest(typed, Commands));
+
+    [Fact]
+    public void A_short_word_gets_a_smaller_budget()
+    {
+        // "db" and "dev" are both two edits from "dxy"; correcting a three-letter word that far is a
+        // guess, not a suggestion.
+        Assert.Null(Suggest.Closest("dxy", Commands));
+        Assert.Equal("db", Suggest.Closest("dn", Commands));
+    }
+
+    [Fact]
+    public void An_unambiguous_prefix_counts_as_a_match() =>
+        Assert.Equal("generate", Suggest.Closest("gene", Commands));
+
+    [Fact]
+    public void An_unambiguous_prefix_beats_a_nearer_edit()
+    {
+        // "dep" is a single substitution from "dev", but only "deploy" starts with it — an abbreviation
+        // says more about the intent than the edit count does.
+        Assert.Equal("deploy", Suggest.Closest("dep", ["dev", "deploy"]));
+    }
+
+    [Fact]
+    public void An_ambiguous_prefix_is_not_a_match()
+    {
+        // Both start with "sna", so the prefix identifies neither, and neither is within an edit budget.
+        Assert.Null(Suggest.Closest("sna", ["snapshots", "snake"]));
+    }
+
+    [Fact]
+    public void Prefers_the_closest_of_several_candidates() =>
+        Assert.Equal("page", Suggest.Closest("pag", ["page", "cache", "job"]));
+
+    [Fact]
+    public void An_exact_match_returns_itself() =>
+        Assert.Equal("deploy", Suggest.Closest("deploy", Commands));
+
+    [Fact]
+    public void No_candidates_is_not_an_error() =>
+        Assert.Null(Suggest.Closest("anything", []));
+}


### PR DESCRIPTION
## Summary

The CLI already had the pieces for a good error: a styled console, a self-documenting `ArgumentSchema`,
and a `--help` renderer that can't drift from what parses. The **error** path had never been wired
through any of them, so ~40 hand-written validations each printed their own phrasing, unstyled, and
returned the wrong exit code. This routes all of them through one path and turns the schema into the
single source of truth for values and subcommands too.

```console
$ rask genrate
Unknown command 'genrate'. Did you mean 'generate'?

$ rask new Shop --template srever
Option '--template' does not accept 'srever'. Did you mean 'server'? Choose one of: server, wasm, wasm-hosted, native.
Usage: rask new <name> [options]
Run 'rask new --help' for details.

$ rask db bakcup
Unknown 'rask db' action 'bakcup'. Did you mean 'backup'? Choose one of: add, remove, list, update, drop, backup, restore.
```

- **One failure path.** `CliCommand.Fail(string)` / `FailUnknownVerb` — message in red, usage line,
  `Run 'rask <cmd> --help' for details.` The "no verb given" and "unknown verb" cases used to bypass
  `Fail` entirely, so the *worse* mistake got the *less* helpful message.
- **Suggestions** (new `Suggest.cs`: bounded OSA distance + unambiguous-prefix) for commands, options,
  actions and option values. Deliberately conservative — an unrecognizable word gets no guess rather
  than a confident wrong one.
- **Closed sets are declared, not hand-checked.** `--template`, `--database`, `--host`, `--id`,
  `--validation` name their values in the schema: one phrasing for a bad one, the set printed in
  `--help`, the values offered by tab completion, and `--template SERVER` now accepted and normalized
  instead of mysteriously rejected. Six bespoke phrasings deleted.
- **Subcommands are declared too.** `rask db --help` gains an **Actions:** section, an unknown action
  lists them back, and `rask db <tab>` completes them in bash/zsh/fish. This finally surfaces
  `generate`'s `ca` → `cache` alias, which was reachable but named nowhere.
- **`Couldn't find a single .csproj`** now distinguishes "found none" from "found several", instead of
  sending someone standing in a two-project folder to look for the wrong problem.

## Behaviour changes

- **Exit code `2` now means what `docs/cli.md` always said it meant.** A wrong command line exits `2`;
  only work that was attempted and failed exits `1`. Previously *two* paths in the whole CLI returned
  `2`, so a script couldn't tell a typo from a failed deploy. The rule, now documented: decidable from
  the arguments alone → `2`; depends on `.rask/*.json`, the disk, the network or the host → `1`.
- **`-h` is `--help`, everywhere.** `rask deploy -h box` used to print help and never deploy, silently
  — the router resolves `-h` before a command parses its own arguments, and `deploy` had claimed it for
  `--host`. `--host` keeps its long form and loses the short one; a contract test holds `-h` reserved
  so the collision can't come back. (`-h` appeared in no doc, example or test.)

## Testing

- `scripts/run-unit-local.sh` — build + `dotnet format` + full unit suite green.
- `dotnet build Rask.slnx -warnaserror` — clean.
- **Rask.Cli.Tests: 899 → 942.** New `SuggestTests`; choice/verb coverage in `ArgumentSchemaTests`;
  suggestion + `-h`-reservation + `--` passthrough guards in `CliApplicationTests`; Actions/choices
  rendering in `CommandHelpTests`; verb/value completion in `CompletionCommandTests` (including that
  `new --host`'s value list can't leak into `deploy`'s). 48 exit-code assertions moved to the named
  `CliCommand.UsageExitCode`, with guards that a *runtime* failure still returns `1`.
- **Real CLI**, via the `run-rask-cli` smoke script (36/36): every case above driven end to end, exit
  codes included. Also fixed a stale assertion there (`App.cs` moved under `Features/Shared/` in #498).
- **Generated completion scripts**: `bash -n` / `zsh -n` clean, and the bash function driven directly —
  `rask db <tab>` → verbs+options, `rask new --template <tab>` → the four templates, `rask deploy
  --host <tab>` → no leak. Fish isn't installed here, so its output was reviewed but not executed.
- **Pre-push gate**: CLI build gate + the deploy gate (9 real Docker/SSH tests) green.
- Colour verified on a real TTY (red error, `NO_COLOR=1` and piped output plain).

No benchmarks: CLI-only, nothing on the render or live-runtime hot path.

## Docs

`docs/cli.md` (a "when you get it wrong" section, the `1`/`2` rule, `-h` reserved), `docs/cheatsheet.md`
(adds the four shipped-but-unlisted surfaces: `generate cache`/`ca`, the full `db` verb list, `deploy
status|logs|rollback`, `completion`), CHANGELOG `[Unreleased]`.

## Not in scope

Filed separately rather than widening this: `rask doctor` (the probes already exist), `--json` for
`info`/`deploy status`/`db list`, `--dry-run` for `db`/`dev`, and the `-o`/`-f`/`-p` short-flag
collisions across sibling commands.
