### PR TITLE
fix(gates): make the local unit and E2E gates fail only for the change under test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -195,6 +195,37 @@ them until tagged releases begin.
   publish directory that the fixture reuses — so the second run found two start-up lines and failed with a
   match-count error that reads like a UI bug. It now asserts what it means (a start-up line reached the
   store), which is what makes the gate survive a re-run after fixing something else.
+- **The static-host E2E fixtures take a port from the OS, so a second run — or a second worktree — no
+  longer fails as "address already in use".** Each fixture declared a hard-coded port and a comment
+  explaining that the parallel collections need distinct ones. True as far as it went, but every *copy*
+  of the suite on the machine claimed the same numbers, and this repo's workflow puts several checkouts
+  side by side — so a straggler host, a concurrent suite or another worktree produced a bare
+  `HttpListenerException` in one of two shapes, neither of which names a port: a run where all 41 tests
+  passed and the *run* still failed (xUnit reports a collection-cleanup throw as a failed run, and
+  `DisposeAsync` guarded `Stop()` but not the `Close()` that throws), or a host that never came up and
+  twelve `ERR_CONNECTION_REFUSED` tests that read like a broken app. Both are now gone: the OS assigns
+  the port, `Close()` is guarded like its siblings, and a genuinely unbindable machine gets a message
+  naming the fixture and what to look for instead of a bare listener exception.
+  - The obvious fix does not work, which is worth recording: **`HttpListener` rejects a `:0` prefix**
+    ("Invalid port in prefix") and cannot report an assigned port back. So the port is taken from a
+    throwaway `TcpListener` and `HttpListener.Start()` is the authoritative test — a clash costs another
+    candidate rather than the run. The probe binds the family `localhost` actually resolves to: a
+    `localhost` prefix holds **`[::1]` only** where IPv6 is available, which is why a port can look free
+    on `127.0.0.1` and still refuse to bind, and the explicit `http://[::1]:port/` form that would let
+    us bind both is itself rejected as an invalid prefix.
+  - It also removes a collision that was assumed not to exist: `SiteWasmAppFixture` and
+    `WasmWatchAppFixture` both hard-coded **5101**, in different collections, which xUnit runs in
+    parallel. The fixtures that launch a real `dotnet` process keep their fixed ports — they have to
+    tell a child process where to listen, and they already fail fast on a busy one — so that half is
+    tracked separately rather than folded in here.
+- **A logging test no longer passes by winning a race.** `NoDrainRunsWhenTheTimeoutIsZero` wrote an
+  entry to a started writer and asserted the store stayed empty, on the grounds that a zero
+  `ShutdownDrainTimeout` drops it. But the writer's loop drains on its first cycle and nothing held it
+  back, so the entry only survived to shutdown if the test got there first; on a loaded machine the loop
+  won and appended it — which is not a bug, since draining an entry claimed before shutdown is exactly
+  right. It now asserts what the option actually governs — that `StopAsync` runs no drain — with the
+  loop deliberately not started, so the drain branch is the only code that can reach the store, and a
+  new sibling pins the positive direction. No timing, no scheduler dependency.
 - **The style pass is part of the local gate again, and the "spurious CS1503" that kept it out is
   root-caused.** `dotnet format Rask.slnx` failed on `main` with `error IMPORTS: Fix imports ordering` in
   `RaskEndpointExtensions.cs` — a `using` that drifted out of order and stayed there, because nothing ran

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,23 @@ them until tagged releases begin.
   event name carried per live handler, which costs a reference per handler in every session and buys
   nothing for two empty payloads. The check reads the frame's raw UTF-8 through `JsonElement.ValueEquals`
   — 14 ns and **zero allocation** on the accepted path, on a path that already parses JSON.
+- **The browser E2E gate can pass again — it had been red on `main` since #470.** The playground journey
+  waits for `.pg-ide.is-ready` to know the in-browser Roslyn workspace has its references, and the
+  dark-first design overhaul rewrote the readiness pill into a `BsBadge`, dropping the `is-ready` /
+  `is-off` / `is-loading` classes in favour of a Bootstrap colour. The selector matched nothing from then
+  on. What kept it alive is *how* it failed: an unresolvable Playwright locator fails by **timing out**,
+  and this one sits right after the multi-megabyte reference download — so the report looked like a slow
+  network rather than a missing class, and the whole suite got waved through with `RASK_SKIP_E2E=1`, which
+  is the same habit that would wave a real regression through. The pill carries its state as a class
+  again (`IdeBadgeState`), and the mapping is pinned by unit tests that read both the view and the E2E's
+  own source: the exact edit #470 made now fails the **fast** gate in under a millisecond with a message
+  naming the cause, instead of three minutes into a suite people have learned to skip. Swept the
+  playground's other E2E selectors (`pg-run`, `pg-preview`, `pg-example`, `pg-code-host`) while in there —
+  `pg-ide` was the only casualty. And the suite can now pass **twice**: the shop's stored-log journey
+  asserted on `GetByText("Application started")` strictly, while the log store is a file in the sample's
+  publish directory that the fixture reuses — so the second run found two start-up lines and failed with a
+  match-count error that reads like a UI bug. It now asserts what it means (a start-up line reached the
+  store), which is what makes the gate survive a re-run after fixing something else.
 - **The style pass is part of the local gate again, and the "spurious CS1503" that kept it out is
   root-caused.** `dotnet format Rask.slnx` failed on `main` with `error IMPORTS: Fix imports ordering` in
   `RaskEndpointExtensions.cs` — a `using` that drifted out of order and stayed there, because nothing ran

--- a/samples/Rask.Example.Playground/IdeBadgeState.cs
+++ b/samples/Rask.Example.Playground/IdeBadgeState.cs
@@ -1,0 +1,45 @@
+namespace Rask.Example.Playground;
+
+/// <summary>Where the in-browser Roslyn workspace has got to, as shown by the readiness pill.</summary>
+internal enum IdeState
+{
+    Loading,
+    Ready,
+    Unavailable
+}
+
+/// <summary>
+///     The class that carries <see cref="IdeState" /> into the DOM, so the pill's state is readable from
+///     the markup and not only from its colour and its label.
+/// </summary>
+/// <remarks>
+///     This exists as its own type because it is a <b>test contract</b>, not decoration. The E2E waits for
+///     <c>.pg-ide.is-ready</c> to know the workspace has finished pulling its references — and #470, which
+///     turned the pill into a <c>BsBadge</c>, dropped these classes in favour of a Bootstrap colour. The
+///     selector then matched nothing, and the browser gate was red on <c>main</c> for weeks (#593): a
+///     Playwright locator that never resolves fails by <i>timing out</i>, so the report blamed the step
+///     that downloads the reference assemblies rather than the missing class.
+///     <para>
+///         Keeping the mapping here lets <c>Rask.Example.Playground.Tests</c> link this one file and pin
+///         it, so the next redesign that drops a state hook fails the fast unit gate with a message that
+///         says so, instead of a 180-second timeout in a suite people have learned to skip. The same
+///         reasoning as <c>.pg-run</c>, which <c>PlaygroundView.css</c> already documents as a class kept
+///         purely as a hook.
+///     </para>
+/// </remarks>
+internal static class IdeBadgeState
+{
+    public const string Loading = "is-loading";
+    public const string Ready = "is-ready";
+    public const string Unavailable = "is-off";
+
+    /// <summary>Every state class the pill can render — what a selector has to be one of to resolve.</summary>
+    public static readonly string[] All = [Loading, Ready, Unavailable];
+
+    public static string ClassFor(IdeState state) => state switch
+    {
+        IdeState.Ready => Ready,
+        IdeState.Unavailable => Unavailable,
+        _ => Loading
+    };
+}

--- a/samples/Rask.Example.Playground/PlaygroundView.cs
+++ b/samples/Rask.Example.Playground/PlaygroundView.cs
@@ -54,13 +54,6 @@ public sealed class PlaygroundView : Component
         _services = services;
     }
 
-    private enum IdeState
-    {
-        Loading,
-        Ready,
-        Unavailable
-    }
-
     // The Rask brand mark (violet-gradient bolt), matching the marketing site + docs. Inlined here
     // because RaskLogo lives in Rask.Example.Shared, which the isolated playground doesn't reference.
     private const string BoltSvg =
@@ -209,7 +202,11 @@ public sealed class PlaygroundView : Component
             _ => (BsColor.Secondary, "Loading IntelliSense…")
         };
 
-        return BsBadge(Color: color, Pill: true, Class: "pg-ide")[text];
+        // The state rides a class as well as the colour and the label: it is what the E2E waits on to know
+        // the workspace has its references, and a colour is not a thing a locator can wait for. See
+        // IdeBadgeState — the mapping is pinned by a unit test precisely because losing it fails as a
+        // three-minute Playwright timeout rather than as anything that names the cause (#593).
+        return BsBadge(Color: color, Pill: true, Class: $"pg-ide {IdeBadgeState.ClassFor(_ide)}")[text];
     }
 
     private Component PreviewBody()

--- a/samples/Rask.Example.Playground/PlaygroundView.css
+++ b/samples/Rask.Example.Playground/PlaygroundView.css
@@ -54,7 +54,9 @@
 /* Reset / Run / Docs / GitHub / theme-toggle are Bs* buttons (BsButton / BsLink) — Bootstrap styles
    them via the shared --bs-* token bridge, so there are no bespoke .pg-run / .pg-reset rules. The
    .pg-run class stays purely as a hook for the Ctrl/Cmd+Enter shortcut + the E2E. The IntelliSense
-   readiness pill is a BsBadge (.pg-ide is just a positioning hook). */
+   readiness pill is a BsBadge: .pg-ide is a positioning hook, and the .is-ready / .is-off / .is-loading
+   beside it are the state hook the browser E2E waits on — deliberately unstyled, since the colour comes
+   from the badge. Don't drop them for looking unused; that is exactly how #593 happened. */
 .pg-ide {
     font-weight: 600;
 }

--- a/tests/Rask.Example.Playground.Tests/IdeBadgeStateTests.cs
+++ b/tests/Rask.Example.Playground.Tests/IdeBadgeStateTests.cs
@@ -1,0 +1,105 @@
+using System.Text.RegularExpressions;
+using Rask.Example.Playground;
+
+namespace Rask.Example.Playground.Tests;
+
+/// <summary>
+///     Keeps the browser E2E's readiness selector and the markup the playground actually renders in step.
+/// </summary>
+/// <remarks>
+///     #593: <c>PlaygroundExampleTests</c> waits for <c>.pg-ide.is-ready</c> to know the in-browser Roslyn
+///     workspace has finished pulling its references. #470 turned the pill into a <c>BsBadge</c> and
+///     dropped the state classes, so the selector matched nothing and the browser gate was red on
+///     <c>main</c> from then on — and because an unresolvable locator fails by <i>timing out</i>, the
+///     report pointed at the reference download rather than at the missing class, so it read as a sandbox
+///     network problem and got waved through with <c>RASK_SKIP_E2E=1</c>.
+///     <para>
+///         The point of these tests is <b>where they fail</b>: in the fast unit gate, naming the cause,
+///         rather than three minutes into a suite people have learned to skip.
+///     </para>
+/// </remarks>
+public class IdeBadgeStateTests
+{
+    private static readonly string _repoRoot = LocateRepoRoot();
+
+    [Fact]
+    public void Every_state_renders_a_distinct_class()
+    {
+        Assert.Equal("is-loading", IdeBadgeState.ClassFor(IdeState.Loading));
+        Assert.Equal("is-ready", IdeBadgeState.ClassFor(IdeState.Ready));
+        Assert.Equal("is-off", IdeBadgeState.ClassFor(IdeState.Unavailable));
+
+        // Distinct, or a selector can't tell two states apart — "ready" matching "loading" would make the
+        // E2E pass before the workspace is usable, which is worse than failing.
+        var rendered = Enum.GetValues<IdeState>().Select(IdeBadgeState.ClassFor).ToArray();
+        Assert.Equal(rendered.Length, rendered.Distinct().Count());
+
+        // And every state the enum can hold is covered by All, which is what the selector check below
+        // measures against — a new state added without a class would otherwise be invisible here.
+        Assert.Equal(rendered.OrderBy(c => c), IdeBadgeState.All.OrderBy(c => c));
+    }
+
+    [Fact]
+    public void The_badge_renders_the_state_class_beside_its_positioning_hook()
+    {
+        // THE regression assertion — this is the edit #470 made, reduced to what it broke. Checking the
+        // constants alone would not catch it: they stayed correct while the view stopped using them.
+        var view = File.ReadAllText(Path.Combine(
+            _repoRoot, "samples", "Rask.Example.Playground", "PlaygroundView.cs"));
+
+        Assert.True(
+            view.Contains("IdeBadgeState.ClassFor(", StringComparison.Ordinal),
+            "The readiness pill no longer composes its class from IdeBadgeState, so `.pg-ide.is-*` "
+            + "resolves to nothing and the browser E2E waits three minutes to tell you (#593). Keep the "
+            + "state in the class, whatever the pill is styled with.");
+
+        // The `.pg-ide` half is the positioning hook PlaygroundView.css styles, and the other half of
+        // every selector the E2E uses.
+        Assert.Contains("\"pg-ide {IdeBadgeState.ClassFor(", view, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_pill_classes_the_E2E_waits_on_are_ones_the_app_can_render()
+    {
+        // The other direction: the E2E may not wait on a class no state produces. Catches the mirror
+        // mistake — a test updated to a selector nobody renders — which fails the same slow, silent way.
+        var e2e = File.ReadAllText(Path.Combine(
+            _repoRoot, "tests", "Rask.Examples.E2E.Tests", "PlaygroundExampleTests.cs"));
+
+        var selectors = Regex.Matches(e2e, @"\.pg-ide\.([A-Za-z0-9_-]+)")
+            .Select(m => m.Groups[1].Value)
+            .Distinct()
+            .ToArray();
+
+        // And it has to still be waiting on readiness at all: deleting the wait would "fix" the red by
+        // no longer checking that the IDE ever comes up, which is the failure mode worth guarding.
+        Assert.NotEmpty(selectors);
+
+        foreach (var selector in selectors)
+        {
+            Assert.True(
+                IdeBadgeState.All.Contains(selector),
+                $"PlaygroundExampleTests waits for '.pg-ide.{selector}', which the readiness pill never "
+                + $"renders. It renders one of: {string.Join(", ", IdeBadgeState.All)}. Either the badge "
+                + "lost a state class (see IdeBadgeState) or the test is waiting for the wrong one — "
+                + "which is #593, and it costs a three-minute timeout in the browser gate to discover.");
+        }
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Example.Playground.Tests/Rask.Example.Playground.Tests.csproj
+++ b/tests/Rask.Example.Playground.Tests/Rask.Example.Playground.Tests.csproj
@@ -37,6 +37,11 @@
              LinkBase="Compiler"/>
     <Compile Include="..\..\samples\Rask.Example.Playground\PlaygroundSamples.cs"
              LinkBase="Samples"/>
+    <!-- The readiness pill's state → class mapping, linked so the selector the browser E2E waits on is
+         pinned by THIS gate. It lives in its own file for exactly that reason (see IdeBadgeState): the
+         view itself can't be linked here, since it pulls in the browser host and Rask.Bootstrap. -->
+    <Compile Include="..\..\samples\Rask.Example.Playground\IdeBadgeState.cs"
+             LinkBase="Samples"/>
   </ItemGroup>
 
 </Project>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/PlaygroundAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/PlaygroundAppFixture.cs
@@ -10,10 +10,6 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 /// </summary>
 public sealed class PlaygroundAppFixture : StaticWwwrootHostFixture
 {
-    // Unique among the static-host fixtures (Standalone 5096, SubPath 5097) so parallel collections don't
-    // bind-clash.
-    protected override int Port => 5100;
-
     protected override string ProjectRelativePath => "samples/Rask.Example.Playground";
 
     protected override string MissingBundleMessage(string wwwroot) =>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/SiteWasmAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/SiteWasmAppFixture.cs
@@ -8,8 +8,6 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 /// </summary>
 public sealed class SiteWasmAppFixture : StaticWwwrootHostFixture
 {
-    protected override int Port => 5101;
-
     protected override string ProjectRelativePath => "samples/Rask.Example.Site";
 
     protected override string MissingBundleMessage(string wwwroot) =>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/StandaloneWasmAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/StandaloneWasmAppFixture.cs
@@ -16,8 +16,6 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 /// </summary>
 public sealed class StandaloneWasmAppFixture : StaticWwwrootHostFixture
 {
-    protected override int Port => 5096;
-
     protected override string ProjectRelativePath => "samples/Rask.Example.Wasm";
 
     protected override string MissingBundleMessage(string wwwroot) =>

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/StaticWwwrootHostFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/StaticWwwrootHostFixture.cs
@@ -1,12 +1,14 @@
 using System.Net;
+using System.Net.Sockets;
 
 namespace Rask.Examples.E2E.Tests.Infrastructure;
 
 /// <summary>
 ///     Serves a <em>published</em> WASM AppBundle's <c>wwwroot</c> from a tiny in-process static-file host
 ///     — the "any static host" (GitHub Pages / CDN) scenario, with no Rask runtime in front of it. Shared
-///     by every static-host fixture; a subclass only supplies its published-project path and a unique port
-///     (and may hook <see cref="OnBundleLocated" /> for extra checks). Build-free: it relies on the bundle
+///     by every static-host fixture; a subclass only supplies its published-project path (and may hook
+///     <see cref="OnBundleLocated" /> for extra checks) — the port is assigned by the OS, so nothing has to
+///     be kept unique by hand and two runs cannot collide. Build-free: it relies on the bundle
 ///     having been published to the default output path first, so publishing in-fixture (a concurrent
 ///     MSBuild under the full parallel suite) is avoided.
 ///     <para>A non-file GET falls back to <c>index.html</c> so client-side deep links resolve.</para>
@@ -51,10 +53,10 @@ public abstract class StaticWwwrootHostFixture : IAsyncLifetime
     protected abstract string ProjectRelativePath { get; }
 
     /// <summary>
-    ///     A port unique to this fixture — the static-host collections run in parallel, so a shared port
-    ///     would bind-clash and crash both hosts.
+    ///     The loopback port this fixture's host is listening on, assigned by the OS at
+    ///     <see cref="InitializeAsync" /> — see <see cref="BindEphemeral" /> for why it is not a constant.
     /// </summary>
-    protected abstract int Port { get; }
+    protected int Port { get; private set; }
 
     protected string Wwwroot { get; private set; } = string.Empty;
 
@@ -75,9 +77,8 @@ public abstract class StaticWwwrootHostFixture : IAsyncLifetime
         OnBundleLocated(Wwwroot);
 
         _cts = new CancellationTokenSource();
-        _listener = new HttpListener();
-        _listener.Prefixes.Add($"http://localhost:{Port}/");
-        _listener.Start();
+        (_listener, var port) = BindEphemeral(GetType().Name);
+        Port = port;
         _ = Task.Run(() => ServeLoopAsync(_listener, Wwwroot, _cts.Token));
 
         await WaitForReadyAsync(TimeSpan.FromSeconds(30));
@@ -97,9 +98,75 @@ public abstract class StaticWwwrootHostFixture : IAsyncLifetime
             /* ignore */
         }
 
-        _listener?.Close();
+        // Guarded like its siblings: xUnit reports a collection-cleanup throw as a failed *run*, so an
+        // unguarded teardown could fail a suite in which every test passed and name no test as the cause.
+        try { _listener?.Close(); }
+        catch
+        {
+            /* ignore */
+        }
+
         _cts?.Dispose();
         await Task.CompletedTask;
+    }
+
+    /// <summary>
+    ///     Starts a listener on an OS-assigned loopback port, so two runs of the suite — or two worktrees
+    ///     of this repo, which is the ordinary way to work here — cannot collide.
+    /// </summary>
+    /// <remarks>
+    ///     <para>
+    ///         Each fixture used to declare a hard-coded port. Unique <em>within</em> a run, which is all the
+    ///         comment claimed, but every copy of the suite on the machine claimed the same ten, so a
+    ///         straggler host or a second checkout produced a bare <c>HttpListenerException</c> — reported
+    ///         either as a green run that "failed", or as a dozen <c>ERR_CONNECTION_REFUSED</c> tests that
+    ///         read like a broken app rather than a taken port.
+    ///     </para>
+    ///     <para>
+    ///         <c>HttpListener</c> rejects a <c>:0</c> prefix outright ("Invalid port in prefix"), and it
+    ///         cannot report an assigned port back, so the OS is asked for an ephemeral port through a
+    ///         throwaway <see cref="TcpListener" /> and <c>HttpListener.Start()</c> is then the
+    ///         authoritative test. Releasing the probe before binding leaves a window, so a clash simply
+    ///         costs another candidate rather than the run.
+    ///     </para>
+    ///     <para>
+    ///         The probe binds the family <c>localhost</c> will resolve to: a <c>localhost</c> prefix holds
+    ///         <c>[::1]</c> only where IPv6 is available (measured — which is also why a port can look free
+    ///         on <c>127.0.0.1</c> and still refuse to bind), and the explicit <c>http://[::1]:port/</c>
+    ///         form that would let us bind both is itself rejected as an invalid prefix.
+    ///     </para>
+    /// </remarks>
+    private static (HttpListener Listener, int Port) BindEphemeral(string fixture, int attempts = 20)
+    {
+        var loopback = Socket.OSSupportsIPv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
+        HttpListenerException? last = null;
+
+        for (var attempt = 0; attempt < attempts; attempt++)
+        {
+            var probe = new TcpListener(loopback, 0);
+            probe.Start();
+            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+            probe.Stop();
+
+            var listener = new HttpListener();
+            listener.Prefixes.Add($"http://localhost:{port}/");
+            try
+            {
+                listener.Start();
+                return (listener, port);
+            }
+            catch (HttpListenerException ex)
+            {
+                last = ex;
+                listener.Close();
+            }
+        }
+
+        throw new InvalidOperationException(
+            $"{fixture} could not bind a loopback port for its static host: {attempts} OS-assigned " +
+            $"candidates were all refused. Something on this machine is claiming ports as fast as they " +
+            $"are handed out — check for stragglers from an earlier run ('lsof -nP -iTCP -sTCP:LISTEN').",
+            last);
     }
 
     /// <summary>The message thrown when the published bundle is missing — subclasses tailor the fix hint.</summary>

--- a/tests/Rask.Examples.E2E.Tests/ShopExampleTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/ShopExampleTests.cs
@@ -233,7 +233,12 @@ public sealed class ShopExampleTests(ShopExampleAppFixture app, PlaywrightFixtur
         // sees an entry, which is why an app on `"Default": "Warning"` alone stores nothing at all.
         await Assertions.Expect(_page.Locator("table tbody tr").First).ToBeVisibleAsync(
             new() { Timeout = 15_000 });
-        await Assertions.Expect(_page.GetByText("Application started")).ToBeVisibleAsync();
+        // `.First`, because the claim is "a start-up line reached the store", not "exactly one did". The
+        // store is a file in the sample's publish directory and the fixture reuses that directory, so the
+        // SECOND run of this suite finds two — and a strict locator then fails with a match-count error
+        // that reads like a UI bug. Which made the gate pass once and fail on the re-run, i.e. exactly
+        // when someone re-runs it after fixing something else.
+        await Assertions.Expect(_page.GetByText("Application started").First).ToBeVisibleAsync();
 
         // The live tail is still there beside it, reading nothing from disk.
         await _page.ClickAsync("a.nav-link:has-text('Live')");

--- a/tests/Rask.Logging.Tests/LogWriterResilienceTests.cs
+++ b/tests/Rask.Logging.Tests/LogWriterResilienceTests.cs
@@ -77,6 +77,18 @@ public sealed class LogWriterResilienceTests
             "the shutdown drain must give up rather than wait on an unreachable store");
     }
 
+    /// <summary>
+    /// <see cref="RaskLoggingOptions.ShutdownDrainTimeout"/> governs exactly one thing: whether
+    /// <c>StopAsync</c> runs a final flush. These two cases assert that, and nothing else.
+    /// </summary>
+    /// <remarks>
+    /// The writer's own loop is deliberately never started. It is not scenery: the loop drains on its
+    /// first cycle, so a started writer races the test for the same entry and a loaded machine lets the
+    /// loop win — which is not a bug in the writer, since draining an entry claimed before shutdown is
+    /// exactly right. Asserting on the store while both paths can reach it therefore tests the scheduler
+    /// (see #594). With no loop, the drain branch is the only code that can append, so the pair below
+    /// pins the option's effect in both directions with no timing at all.
+    /// </remarks>
     [Fact]
     public async Task NoDrainRunsWhenTheTimeoutIsZero()
     {
@@ -87,11 +99,28 @@ public sealed class LogWriterResilienceTests
             ShutdownDrainTimeout = TimeSpan.Zero,
         });
 
-        await writer.StartAsync(CancellationToken.None);
-        channel.Write(Entry("dropped on shutdown"));
+        channel.Write(Entry("pending at shutdown"));
         await writer.StopAsync(CancellationToken.None);
 
         Assert.Empty(store.Appended);
+        Assert.Equal(0, store.Attempts);
+    }
+
+    /// <inheritdoc cref="NoDrainRunsWhenTheTimeoutIsZero"/>
+    [Fact]
+    public async Task TheDrainRunsWhenTheTimeoutIsPositive()
+    {
+        var store = new FaultyLogStore();
+        using var writer = Build(store, out var channel, new RaskLoggingOptions
+        {
+            FlushInterval = TimeSpan.FromMinutes(5),
+            ShutdownDrainTimeout = TimeSpan.FromSeconds(5),
+        });
+
+        channel.Write(Entry("pending at shutdown"));
+        await writer.StopAsync(CancellationToken.None);
+
+        Assert.Equal("pending at shutdown", Assert.Single(store.Appended).Message);
     }
 
     private static LogWriter Build(ILogStore store, out LogChannel channel, RaskLoggingOptions options)


### PR DESCRIPTION
Three of the ways the local gates went red for reasons unrelated to the change being made. They
matter together rather than separately: each one teaches the same lesson (`RASK_SKIP_E2E=1`,
`--no-verify`), and the gate only has value if a red result means something.

Closes #593. Closes #594. Closes #612.

## #593 — the E2E gate could not pass on `main`

`PlaygroundExampleTests` waited for `.pg-ide.is-ready`. #470 (the dark-first design overhaul)
rewrote `IdeBadge()` into a `BsBadge`, so the class stopped being rendered and the selector matched
nothing from then on. What kept it alive is *how* it failed: an unresolvable Playwright locator fails
by **timing out**, and this one sits right after the multi-megabyte Roslyn reference download — so the
report looked like a slow network rather than a missing class.

The pill carries its state as a class again (`IdeBadgeState`), and the mapping is pinned by unit tests
that read both the view and the E2E's own source: the exact edit #470 made now fails the **fast** gate
in under a millisecond with a message naming the cause, instead of three minutes into a suite people
have learned to skip.

**Selector sweep.** The issue asked for a check on whether #470 stranded others. All 47 app-specific
classes the E2E suite locates on were resolved against `src/` and `samples/`: every one has a live
definition. `pg-ide` was the only casualty.

## #612 — a second run on one machine failed as "address already in use"

Each static-host fixture declared a hard-coded port, with a comment explaining that the parallel
collections need distinct ones. True as far as it went — but every *copy* of the suite on the machine
claimed the same numbers, and this repo's workflow puts several worktrees side by side. The result was
a bare `HttpListenerException` in one of two shapes, neither of which names a port: a run where all 41
tests passed and the *run* still failed (xUnit reports a collection-cleanup throw as a failed run, and
`DisposeAsync` guarded `Stop()` but not the `Close()` that throws), or a host that never came up and
twelve `ERR_CONNECTION_REFUSED` tests that read like a broken app.

**The suggested fix does not work, and measuring why shaped the one that does.** I probed it before
building on it, as the issue asked:

| probe | result |
| --- | --- |
| `HttpListener` on `http://localhost:0/` | ❌ `HttpListenerException: Invalid port in prefix` |
| `HttpListener` on `http://[::1]:{port}/` | ❌ `Invalid port in prefix` (bracketed IPv6 form is rejected) |
| `HttpListener` on `http://127.0.0.1:{port}/` | ✅ |
| `HttpListener` on `http://localhost:{port}/` | ✅ — but holds **`[::1]` only**; `127.0.0.1` stays free |
| second bind of a held port | ✅ throws at `Start()` with a clear message |

So `HttpListener` can neither take port 0 nor report an assigned port back, and the explicit
dual-family bind that would sidestep the resolution question is itself an invalid prefix. The fourth
row is also the answer to the issue's own puzzled observation that 5096 was held on `[::1]` only —
that is simply what a `localhost` prefix does here, and it is why a port can look free on `127.0.0.1`
and still refuse to bind.

The fixture therefore takes a candidate port from a throwaway `TcpListener` **on the family
`localhost` will resolve to**, and lets `HttpListener.Start()` be the authoritative test — a clash
costs another candidate rather than the run. `Close()` is now guarded like its siblings, and an
genuinely unbindable machine gets a message naming the fixture and what to look for.

⚠️ The issue warned that the naive `try { Close(); } catch { }` was tried alone and the next run was
worse. That is respected: the swallow ships only *with* the ephemeral port, so there is no fixed port
left to leak.

**A collision the issue explicitly ruled out.** `SiteWasmAppFixture` and `WasmWatchAppFixture` both
hard-coded **5101**, in different collections — which xUnit runs in parallel. This removes it.

**Scope.** Only `StaticWwwrootHostFixture` (3 subclasses) changes — the two failures in the issue both
trace to it (`InitializeAsync:80`, `DisposeAsync:100`). The fixtures that launch a real `dotnet`
process keep their fixed ports: they have to tell a child process where to listen, and they already
fail fast on a busy one. Tracked separately.

## #594 — a unit test that passed by winning a race

`NoDrainRunsWhenTheTimeoutIsZero` wrote an entry to a started writer and asserted the store stayed
empty. But the writer's loop drains on its first cycle and nothing held it back, so the entry only
survived to shutdown if the test got there first; on a loaded machine the loop won and appended it —
which is not a bug in the writer, since draining an entry claimed before shutdown is exactly right.

It now asserts what `ShutdownDrainTimeout` actually governs — that `StopAsync` runs no drain — with
the writer's loop deliberately not started, so the drain branch is the only code that can reach the
store. A new sibling, `TheDrainRunsWhenTheTimeoutIsPositive`, pins the other direction, so the pair
holds the option's effect both ways with no timing at all. Swept the sibling cases: the remaining ones
assert bounds with wide margins rather than racing two paths.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — **312/312**
- `scripts/run-e2e-local.sh` — **41/41, twice back to back on one machine**, which is the acceptance
  test #612 asks for
- Port strategy proved separately before implementing: 12 concurrent fixtures bound and served over
  `localhost`, two rounds, plus a squatter test confirming the retry picks a different port

No framework code changed, so no benchmarks.

## Changelog

`[Unreleased]` → `Fixed`, one entry per issue.
