### PR TITLE
fix(client): report a multi-select's whole selection, sync it on morph, stop logging payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -142,6 +142,51 @@ them until tagged releases begin.
   hot-reloads` and the Local-vs-Server section now all draw the same line.
 
 ### Fixed
+- **The WASM client no longer logs every event payload to the browser console.** `send()` opened with
+  `console.log("[Rask] send", payload)` — behind no flag, in production builds, on a path the comment
+  directly above it documents as firing ~60×/sec while someone types. `payload` carries the event's
+  value, so everything a user typed into a form was written to a place nobody expects data to land, and
+  the console was useless at 60 lines/sec for the debugging it was there to serve. Two quieter traces
+  (`setExports`, `navlink click`) went with it; the boot one is now an `error` raised only when the .NET
+  dispatch export is *unreachable*, which is a dead app and worth saying. The Server client had zero
+  `console.log` all along, which is the standard the others now meet — pinned by a test over all six
+  shipped `.js` files, including `Browser/rask.wasm.js`, the committed build artifact the browser
+  actually downloads and the copy most able to drift unnoticed. `console.warn` / `console.error` stay:
+  they report a fault rather than narrating the happy path.
+- **A full reply now moves a `<select>`'s live selection, not just its `selected` attributes.**
+  `morph()` synced the IDL properties that attributes can't reach for `INPUT` and `TEXTAREA` only, so a
+  reconnect, a scoped-CSS full reply, the WASM boot/navigation morph and the redeploy reload all moved a
+  select through its `selected` **attribute** alone. Per the HTML spec an option carries a *dirtiness*
+  flag, and once set the content attribute stops driving selectedness — so the server's answer was
+  silently ignored. Measured in Chromium rather than argued from the spec, and the result is narrower
+  and stranger than expected, which is why it survived: an attribute-only move is **not** broken by user
+  interaction as such. Dirtiness blocks the attribute only on the option that is dirty, so a move onto a
+  *pristine* option still lands, and a single-select is rescued again by the spec's "ask for a reset".
+  What actually failed: a single-select whose target the user had already touched (the box simply
+  ignored the server), and multi-selects, which get no reset — a user-picked option the incoming render
+  did not mark could not be cleared, so the control accumulated selections neither side ever chose. The
+  new `SELECT` arm applies the selection through the select, and consults the #588 lagging-frame guard
+  first, because making full replies start moving selects would otherwise let a reconnect clobber a
+  just-made pick — trading one bug for its mirror image. A select whose render marks nothing shows its
+  first enabled option, which is what a fresh parse of the same markup shows, rather than blanking.
+- **A `<select multiple>` reports every option the user picked, not just the first.** The change
+  dispatch sent `el.value`, and for a multiple select that is *the first selected option, or `""` when
+  none* — the DOM has no multi-value `value`. So picking three reported one and the server's model
+  converged on that one: correctly, from a report that was the wrong shape rather than merely late,
+  which is why #588's lagging-frame guard could not help. The frame now carries a `values` array
+  alongside `value`; `value` keeps its exact meaning, and `values` is omitted entirely for every other
+  control, so no existing payload grows a byte. `Select<T>(Bind: …, Multiple: true)` binds the whole
+  selection when `T` is a string collection (`string[]`, `List<string>`, `HashSet<string>`, or the
+  read-only/mutable collection interfaces), marking every picked option on render and *replacing* the
+  collection on each change rather than editing membership — the report is absolute, so a replace
+  re-syncs even when an intermediate render was coalesced, which a snapshot-based add/remove cannot.
+  `Multiple: true` over a scalar keeps the single-value binding: that model can hold one answer, and
+  widening it silently would be the more surprising change. The element type is deliberately `string` —
+  the reflective version needs `MakeGenericType`/`Array.CreateInstance`, both `RequiresDynamicCode`, and
+  the WASM sample has to publish with zero trim warnings. All three hosts now build the change frame
+  through one shared helper rather than three hand-copied copies, which is the drift that produced this
+  bug and #588 before it; a contract test holds them to it, and the frame-shape guard from #592 knows
+  `values` rides on `change` alone, so an `input` frame can't collapse a selection to one value.
 - **A `<select>` no longer snaps back to the old option when a lagging re-render lands.** `value` and
   `checked` each had a guard against a frame the server computed *before* the user's edit reached it;
   `selected` — the third property the diff codec mirrors onto its IDL twin — had none, so it was applied

--- a/docs/forms-advanced.md
+++ b/docs/forms-advanced.md
@@ -152,6 +152,30 @@ option renderings. The single-value twin is `BsSelect<T>`: same data-driven API 
 `OptionLabel`) and custom `.dropdown-menu` listbox (zero-JS, keyboard + ARIA `combobox`/`listbox`),
 binding one `TItem`; `Native: true` falls back to the plain OS `<select>`.
 
+**A plain `<select multiple>` bound to a collection.** `Select<T>(Bind: …, Multiple: true)` binds the
+whole selection when `T` is a string collection — `string[]`, `List<string>`, `HashSet<string>`, or the
+`IReadOnlyList<string>` / `IList<string>` / `ICollection<string>` / `IEnumerable<string>` interfaces:
+
+```csharp
+Select(() => model.Tags, Multiple: true)[
+    Option("news"), Option("sport"), Option("weather")
+]
+```
+
+Every picked option is marked on render, and each change replaces the collection rather than editing its
+membership — the browser reports the *absolute* selection every time, so a replace re-syncs the model
+even if an intermediate render was coalesced.
+
+Two limits worth knowing:
+
+- **The element type is `string`.** The reflective version that would accept any parsable element needs
+  `MakeGenericType` and `Array.CreateInstance`, both of which are AOT-hostile — and
+  `samples/Rask.Example.Wasm` has to publish with zero trim warnings. Bind `string[]` and convert.
+- **`Multiple: true` over a scalar property keeps the single-value binding.** That is a model which can
+  only hold one answer; widening it silently would be the more surprising behaviour.
+
+<!-- demo:multi-select-native -->
+
 <!-- demo:multi-select -->
 
 <!-- demo:multi-select-controlled -->

--- a/samples/Rask.Example.Shared/Features/MultiSelect/NativeMultiSelectDemo.cs
+++ b/samples/Rask.Example.Shared/Features/MultiSelect/NativeMultiSelectDemo.cs
@@ -1,0 +1,42 @@
+namespace Rask.Example.Shared.Features;
+
+// A plain OS <select multiple> bound to a model collection — the same binding BsMultiSelect offers, but
+// on the native control, which is what MultiSelect(Native: true) and mobile browsers fall back to.
+//
+// The control reports its WHOLE selection: `select.value` is only the first selected option (the DOM has
+// no multi-value `value`), so the client sends a `values` array alongside it and the binding replaces the
+// collection on every change. Nothing here is StateHasChanged-driven — picking re-renders the owner, so
+// the summary below updates as you select.
+public sealed class NativeMultiSelectDemo : Component
+{
+    private static readonly string[] AllRegions =
+        ["Europe", "North America", "South America", "Asia", "Africa", "Oceania"];
+
+    private readonly Shipping _shipping = new();
+
+    protected override Component? Render() =>
+    [
+        Form(_shipping, Class: "vstack gap-3")[
+            Div()[
+                Label(Class: "form-label fw-semibold", For: "native-regions")["Ship to"],
+                Select(() => _shipping.Regions, Multiple: true, Id: "native-regions",
+                    Class: "form-select", Size: 6)[
+                    AllRegions.Select(r => Option(r, Key: r)[r])
+                ],
+                Div(Class: "form-text")["Hold ⌘ (or Ctrl) to pick more than one."]
+            ]
+        ],
+        BsAlert(Color: BsColor.Secondary, Class: "small mt-3 mb-0", Id: "native-regions-summary")[
+            _shipping.Regions.Count == 0
+                ? "No regions selected."
+                : $"{_shipping.Regions.Count} selected: {string.Join(", ", _shipping.Regions)}"
+        ]
+    ];
+
+    private sealed class Shipping
+    {
+        // Get-only on purpose: this is how a collection property is usually declared, and the binding
+        // refills it in place rather than assigning over it.
+        public List<string> Regions { get; } = [];
+    }
+}

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -191,6 +191,7 @@ public static class DemoRegistry
             ["multi-select-controlled"] = () => CodeSample(["MultiSelectControlledDemo.cs"], Result: MultiSelectControlledDemo()),
             ["multi-select-checkbox"] = () => CodeSample(["MultiSelectCheckboxDemo.cs"], Result: MultiSelectCheckboxDemo()),
             ["multi-select-radio"] = () => CodeSample(["MultiSelectRadioDemo.cs"], Result: MultiSelectRadioDemo()),
+            ["multi-select-native"] = () => CodeSample(["NativeMultiSelectDemo.cs"], Result: NativeMultiSelectDemo()),
 
             // --- Composition guide: context, callbacks, virtualize, keyed lists, drag & drop, error
             //     boundaries (their standalone example pages folded into docs/composition.md). ---

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -1418,6 +1418,14 @@ public abstract class Component
                     await InvokeWithRenderingAsync(() => f(s)).ConfigureAwait(false);
                     owner.Live.StateDirty = true;
                     return true;
+                case Action<IReadOnlyList<string>> a:
+                    a(ExtractStringList(payload));
+                    return true;
+                case Func<IReadOnlyList<string>, Task> f:
+                    var values = ExtractStringList(payload);
+                    await InvokeWithRenderingAsync(() => f(values)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
                 case Action<FormData> a:
                     a(FormData.FromJson(payload));
                     return true;
@@ -1473,6 +1481,9 @@ public abstract class Component
                 case Callback<string> c:
                     c(ExtractString(payload, "value"));
                     return true;
+                case Callback<IReadOnlyList<string>> c:
+                    c(ExtractStringList(payload));
+                    return true;
                 case Callback<FormData> c:
                     c(FormData.FromJson(payload));
                     return true;
@@ -1505,6 +1516,13 @@ public abstract class Component
                 {
                     var value = ExtractString(payload, "value");
                     await InvokeWithRenderingAsync(() => c(value)).ConfigureAwait(false);
+                    owner.Live.StateDirty = true;
+                    return true;
+                }
+                case CallbackAsync<IReadOnlyList<string>> c:
+                {
+                    var picked = ExtractStringList(payload);
+                    await InvokeWithRenderingAsync(() => c(picked)).ConfigureAwait(false);
                     owner.Live.StateDirty = true;
                     return true;
                 }
@@ -2014,6 +2032,42 @@ public abstract class Component
         }
 
         return v.ValueKind == JsonValueKind.String ? v.GetString() ?? string.Empty : string.Empty;
+    }
+
+    /// <summary>
+    ///     The whole selection a <c>&lt;select multiple&gt;</c> reported, from the frame's <c>values</c>
+    ///     array. Falls back to the single <c>value</c> so the handler still sees the user's pick when
+    ///     the array is absent — a single-value control wired to a list handler, or a browser holding a
+    ///     cached client from a deploy that predates the array.
+    /// </summary>
+    private static IReadOnlyList<string> ExtractStringList(JsonElement payload)
+    {
+        if (payload.ValueKind == JsonValueKind.Object
+            && payload.TryGetProperty("values", out var v)
+            && v.ValueKind == JsonValueKind.Array)
+        {
+            var length = v.GetArrayLength();
+            if (length == 0)
+            {
+                return [];
+            }
+
+            var picked = new string[length];
+            var i = 0;
+            foreach (var item in v.EnumerateArray())
+            {
+                picked[i++] = item.ValueKind == JsonValueKind.String
+                    ? item.GetString() ?? string.Empty
+                    : string.Empty;
+            }
+
+            return picked;
+        }
+
+        var single = ExtractString(payload, "value");
+        // "" is what an empty select reports, and it is not a selection — reporting it as one option
+        // named "" would make "nothing picked" indistinguishable from "picked the blank option".
+        return single.Length == 0 ? [] : new[] { single };
     }
 
     private static MouseModifiers ExtractModifiers(JsonElement payload) =>

--- a/src/Rask.Core/Components/Select.cs
+++ b/src/Rask.Core/Components/Select.cs
@@ -17,6 +17,10 @@ public sealed class Select<T> : Element, IFormControl<T>
     private bool _bound;
     private string _selectedValue = "";
 
+    // Non-null only for a multi-select bound to a collection, where the render has to mark every picked
+    // option rather than the one _selectedValue names.
+    private IReadOnlySet<string>? _selectedValues;
+
     protected override string TagName => "select";
 
     public string? Name { get; set; }
@@ -44,13 +48,13 @@ public sealed class Select<T> : Element, IFormControl<T>
     {
         if (_bound && Children is not null)
         {
-            Children = MarkSelected(Children, _selectedValue);
+            Children = MarkSelected(Children, new Selection(_selectedValue, _selectedValues));
         }
 
         return base.EnterChildrenScope();
     }
 
-    private static IEnumerable<Component?> MarkSelected(IEnumerable<Component?> children, string current)
+    private static IEnumerable<Component?> MarkSelected(IEnumerable<Component?> children, Selection current)
     {
         var list = new List<Component?>();
         foreach (var c in children)
@@ -74,9 +78,18 @@ public sealed class Select<T> : Element, IFormControl<T>
         return list.ToArray();
     }
 
-    private static Option MarkOption(Option opt, string current)
+    // Which option values the render should mark. A single-value select carries just the formatted
+    // value; a multi-select bound to a collection carries the set. A struct with a null set keeps the
+    // single-value path — by far the common one — allocation-free.
+    private readonly struct Selection(string single, IReadOnlySet<string>? many)
     {
-        if (opt.Selected is true || opt.Value != current)
+        public bool Matches(string? value) =>
+            many is null ? value == single : value is not null && many.Contains(value);
+    }
+
+    private static Option MarkOption(Option opt, Selection current)
+    {
+        if (opt.Selected is true || !current.Matches(opt.Value))
         {
             return opt;
         }
@@ -101,7 +114,7 @@ public sealed class Select<T> : Element, IFormControl<T>
         };
     }
 
-    private static Optgroup MarkOptgroup(Optgroup og, string current)
+    private static Optgroup MarkOptgroup(Optgroup og, Selection current)
     {
         if (og.Children is null)
         {
@@ -124,6 +137,27 @@ public sealed class Select<T> : Element, IFormControl<T>
         };
     }
 
+    // The picked values a multi-select bound to a collection should mark, or null for every other shape —
+    // which keeps the single-value path on its existing string compare.
+    private IReadOnlySet<string>? SelectionSet(object? bound)
+    {
+        if (Multiple is not true || !BindingHelpers.IsBindableSelectionType<T>())
+        {
+            return null;
+        }
+
+        var picked = new HashSet<string>(StringComparer.Ordinal);
+        if (bound is IEnumerable<string> values)
+        {
+            foreach (var v in values)
+            {
+                picked.Add(v);
+            }
+        }
+
+        return picked;
+    }
+
     protected override void WriteAttributes(StringBuilder sb)
     {
         base.WriteAttributes(sb);
@@ -138,11 +172,13 @@ public sealed class Select<T> : Element, IFormControl<T>
             fid = acc.Field;
             _bound = true;
             _selectedValue = BindingHelpers.FormatValue(acc.Getter());
+            _selectedValues = SelectionSet(acc.Getter());
         }
         else if (Value is not null)
         {
             _bound = true;
             _selectedValue = BindingHelpers.FormatValue(Value);
+            _selectedValues = SelectionSet(Value);
         }
 
         var name = Name ?? acc?.PropertyName;
@@ -195,8 +231,15 @@ public sealed class Select<T> : Element, IFormControl<T>
         {
             var afterBind = BindingHelpers.BuildAfterBind(acc, AfterBind, AfterBindAsync);
             ((IFormControl<T>)this).RegisterValidator(acc, bindCtx);
-            AppendAttr(sb, "data-rask-on-change",
-                ctx.RegisterHandler(BindingHelpers.TouchAndValidateHandler(acc, bindCtx, fid, true, afterBind)));
+            // A multi-select bound to a collection takes the whole selection the client now reports
+            // (`values`), not the single `value` the DOM exposes — which is only the FIRST selected
+            // option, so binding it converged the model on one option out of however many were picked.
+            // A multi-select bound to a scalar keeps the single-value handler: that is a control whose
+            // model can hold one answer, and silently widening it would be the more surprising change.
+            var handler = Multiple is true && BindingHelpers.IsBindableSelectionType<T>()
+                ? BindingHelpers.MultiSelectSetHandler<T>(acc, bindCtx, fid, afterBind)
+                : (Delegate)BindingHelpers.TouchAndValidateHandler(acc, bindCtx, fid, true, afterBind);
+            AppendAttr(sb, "data-rask-on-change", ctx.RegisterHandler(handler));
         }
         else
         {

--- a/src/Rask.Core/Forms/BindingHelpers.cs
+++ b/src/Rask.Core/Forms/BindingHelpers.cs
@@ -279,6 +279,118 @@ public static class BindingHelpers
             }
         };
 
+    /// <summary>
+    ///     The bound handler for a <c>&lt;select multiple&gt;</c> — the sibling of
+    ///     <see cref="TouchAndValidateHandler" /> for a control that reports a whole selection rather
+    ///     than one value.
+    /// </summary>
+    /// <remarks>
+    ///     Set, never toggle, for the same reason <see cref="BoolSetHandler" /> sets: every change frame
+    ///     carries the absolute selection, so the model re-syncs even if an intermediate render was
+    ///     coalesced or missed. A membership edit built from a render-time snapshot cannot recover from a
+    ///     one-step desync — see the note on that method.
+    /// </remarks>
+    public static CallbackAsync<IReadOnlyList<string>> MultiSelectSetHandler<T>(
+        ExpressionAccessor.Accessor acc, EditContext? ctx, FieldIdentifier fid,
+        Func<Task>? afterBind = null) =>
+        async picked =>
+        {
+            var didBind = false;
+            if (TrySetSelection<T>(acc, picked))
+            {
+                ctx?.NotifyFieldChanged(fid);
+                didBind = true;
+            }
+
+            if (didBind && afterBind is not null)
+            {
+                await afterBind().ConfigureAwait(false);
+            }
+
+            ctx?.NotifyFieldTouched(fid);
+            if (ctx is not null)
+            {
+                if (ctx.HasAsyncValidators)
+                {
+                    await ctx.ValidateFieldAsync(fid).ConfigureAwait(false);
+                }
+                else
+                {
+                    ctx.ValidateField(fid);
+                }
+            }
+        };
+
+    /// <summary>
+    ///     Whether <typeparamref name="T" /> is a shape a bound <c>&lt;select multiple&gt;</c> can write.
+    /// </summary>
+    /// <remarks>
+    ///     Deliberately a closed list of string collections rather than "any <c>IEnumerable&lt;E&gt;</c>
+    ///     reached by reflection". The reflective version needs <c>MakeGenericType</c> and
+    ///     <c>Array.CreateInstance</c>, both <c>RequiresDynamicCode</c> — they are IL3050 sites, and
+    ///     <c>samples/Rask.Example.Wasm</c> has to publish with zero trim/AOT warnings. Every instantiation
+    ///     below is written literally, so the AOT compiler can see all of them. A model that wants typed
+    ///     elements binds <c>string[]</c> and converts, which is one line and stays trimmable.
+    /// </remarks>
+    public static bool IsBindableSelectionType<T>() =>
+        typeof(T) == typeof(string[])
+        || typeof(T) == typeof(List<string>)
+        || typeof(T) == typeof(IReadOnlyList<string>)
+        || typeof(T) == typeof(IReadOnlyCollection<string>)
+        || typeof(T) == typeof(IList<string>)
+        || typeof(T) == typeof(ICollection<string>)
+        || typeof(T) == typeof(IEnumerable<string>)
+        || typeof(T) == typeof(HashSet<string>);
+
+    // Replace the bound collection wholesale rather than editing membership: every change frame carries
+    // the absolute selection, so a replace is self-correcting where an add/remove built from a render-time
+    // snapshot cannot recover from a one-step desync (the same reasoning as BoolSetHandler).
+    private static bool TrySetSelection<T>(ExpressionAccessor.Accessor acc, IReadOnlyList<string> picked)
+    {
+        if (!IsBindableSelectionType<T>())
+        {
+            return false;
+        }
+
+        // `public List<string> Tags { get; } = [];` is the ordinary way to declare one of these, and it
+        // has no setter — so refill the collection the model already owns. Checked first, not as a
+        // fallback, because assigning over a settable property is fine either way while calling a
+        // missing setter is not.
+        if (acc.Property.SetMethod is null)
+        {
+            if (acc.Getter() is not ICollection<string> existing || existing.IsReadOnly)
+            {
+                return false;
+            }
+
+            existing.Clear();
+            foreach (var v in picked)
+            {
+                existing.Add(v);
+            }
+
+            return true;
+        }
+
+        object value;
+        if (typeof(T) == typeof(List<string>))
+        {
+            value = new List<string>(picked);
+        }
+        else if (typeof(T) == typeof(HashSet<string>))
+        {
+            value = new HashSet<string>(picked, StringComparer.Ordinal);
+        }
+        else
+        {
+            // Everything else in the supported set is satisfied by an array.
+            value = picked.ToArray();
+        }
+
+        acc.Setter(value);
+        return true;
+    }
+
     // Checkbox binding sets the model to the checkbox's actual checked state reported by
     // the client (rask.js sends "true"/"false" for type=checkbox), rather than flipping a
     // state captured at render time. Setting (not toggling) makes the binding self-

--- a/src/Rask.Core/Live/HandlerFrameShape.cs
+++ b/src/Rask.Core/Live/HandlerFrameShape.cs
@@ -32,6 +32,7 @@ internal static class HandlerFrameShape
         None = 0,
         Modifiers,
         Value,
+        Values,
         Form,
         Files,
         Scroll,
@@ -67,6 +68,9 @@ internal static class HandlerFrameShape
         new[] { "click"u8.ToArray() },
         // Value — the string payload.
         new[] { "input"u8.ToArray(), "change"u8.ToArray(), "beforeinput"u8.ToArray() },
+        // Values — the whole selection of a <select multiple>. Only `change` carries it: the clients add
+        // `values` on the change dispatch alone, so an `input` frame could never feed this shape.
+        new[] { "change"u8.ToArray() },
         // Form — FormData.
         new[] { "submit"u8.ToArray() },
         // Files — the uploaded-file metadata.
@@ -178,6 +182,12 @@ internal static class HandlerFrameShape
         Callback<TouchEventArgs> or CallbackAsync<TouchEventArgs> => Shape.Touch,
         Callback<ClipboardEventArgs> or CallbackAsync<ClipboardEventArgs> => Shape.Clipboard,
         Callback<MediaEventArgs> or CallbackAsync<MediaEventArgs> => Shape.Media,
+        // Last on purpose. This switch is a linear sequence of type tests, so an arm's position is a
+        // cost paid by every arm below it — and measurably: placed next to its Shape.Value sibling, the
+        // four patterns here cost the scroll path ~1.7ns (+6%) on every frame. A multi-select change
+        // happens at human speed; scroll, pointer and mouse frames do not.
+        Action<IReadOnlyList<string>> or Func<IReadOnlyList<string>, Task>
+            or Callback<IReadOnlyList<string>> or CallbackAsync<IReadOnlyList<string>> => Shape.Values,
         _ => Shape.None
     };
 }

--- a/src/Rask.Core/Resources/rask-morph.js
+++ b/src/Rask.Core/Resources/rask-morph.js
@@ -165,6 +165,75 @@ function raskShouldSuppressSelected(el, incoming) {
     return false;
 }
 
+// The group form of the guard above, for a full morph. The diff codec moves one option at a time and
+// can decide one at a time; a morph reconciles the whole control at once and needs a single answer,
+// because applying half a lagging frame would leave the select in a state neither side rendered.
+//
+// A lagging frame is one that carries the pre-pick state of EVERY guarded option — that is exactly what
+// raskNotePendingSelected recorded on dispatch. If even one guarded option differs, the frame knows
+// something the user's pick didn't, so it is authoritative: release the whole group and apply.
+function raskShouldSuppressSelectGroup(select, desired) {
+    const map = _raskPendingSelected();
+    const options = select.options;
+    let guarded = 0, stale = 0;
+    for (let i = 0; i < options.length; i++) {
+        if (!map.has(options[i])) continue;
+        guarded++;
+        if (map.get(options[i]) === !!desired[i]) stale++;
+    }
+    if (guarded === 0) return false;
+    if (guarded === stale) return true;
+    for (let i = 0; i < options.length; i++) map.delete(options[i]);
+    return false;
+}
+
+// Move a select's live selection to what the incoming render marked, writing through the IDL rather
+// than trusting the `selected` ATTRIBUTES morph() has just copied.
+//
+// The attributes alone are not enough, and the reason is the option "dirtiness" flag: once an option's
+// selectedness has been set by the user or by the `.selected` setter (which the diff codec's
+// applySelected uses), its content attribute stops driving it. Measured in Chromium — a single-select
+// whose morph target the user had already touched does not move, and a multi-select is worse, because
+// the "ask for a reset" behaviour that quietly rescues most single-select cases does not apply to it:
+// a user-picked option that the incoming render does NOT mark stays selected, so the control
+// accumulates selections it was never rendered with.
+function raskApplySelectSelection(select, desired) {
+    const options = select.options;
+    if (select.multiple) {
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected !== desired[i]) options[i].selected = desired[i];
+        }
+        return;
+    }
+    // Single select: one write by index, for the same reason applySelected takes that path — poking
+    // each option leaves the control momentarily showing its first option between the deselect and the
+    // select, and an index can't be redirected by duplicate option values.
+    let idx = -1;
+    for (let i = 0; i < desired.length; i++) {
+        if (desired[i]) { idx = i; break; }
+    }
+    if (idx < 0) {
+        // The render marked nothing. On a freshly parsed single-select that shows the first enabled
+        // option, not a blank — mirror the browser's own reset rather than inventing selectedIndex -1,
+        // which would make a re-render look different from a first load of the same markup.
+        idx = 0;
+        while (idx < options.length && options[idx].disabled) idx++;
+        if (idx >= options.length) idx = -1;
+    }
+    if (select.selectedIndex !== idx) select.selectedIndex = idx;
+}
+
+// Called once per <select> at the end of morph(), after its options have been reconciled — so the
+// `selected` attributes read here are the incoming render's, and the option list is final.
+function raskSyncSelectSelection(select) {
+    const options = select.options;
+    if (!options) return;
+    const desired = [];
+    for (let i = 0; i < options.length; i++) desired.push(options[i].hasAttribute("selected"));
+    if (raskShouldSuppressSelectGroup(select, desired)) return;
+    raskApplySelectSelection(select, desired);
+}
+
 // User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
 // the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
 // saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
@@ -279,6 +348,42 @@ function raskNotePendingFormState(el) {
             }
         }
     }
+}
+
+// What a `change` frame reports for a control, in one place for all three hosts — same reasoning as the
+// recorder above, which exists because each host carried its own hand-copied copy and they drifted.
+//
+// `value` keeps exactly the meaning it had, so nothing downstream changes shape. `values` is added only
+// for a <select multiple>: the DOM has no multi-value `value`, so `select.value` is the FIRST selected
+// option (or "" when none), and reporting it alone told the server one option out of however many the
+// user had picked — the model then converged on that one, correctly, from a wrong report.
+function raskChangeFrameValue(el) {
+    const tag = el.tagName;
+    // For a checkbox the meaningful state is el.checked, not el.value (the static "on" default). Report
+    // it as "true"/"false" so a bound checkbox sets the model to the actual state (self-correcting)
+    // rather than relying on a server-side toggle. Radios keep sending el.value — a radio's value IS
+    // the selected option.
+    if (tag === "INPUT" && el.type === "checkbox") return el.checked ? "true" : "false";
+    return el.value == null ? "" : String(el.value);
+}
+
+// The whole selection of a <select multiple>, or null for every other control — null rather than an
+// empty array so the frame simply omits the field and no existing payload grows a byte.
+function raskChangeFrameValues(el) {
+    if (el.tagName !== "SELECT" || !el.multiple) return null;
+    const picked = el.selectedOptions;
+    const values = [];
+    if (picked) {
+        for (let i = 0; i < picked.length; i++) values.push(picked[i].value);
+    } else {
+        // selectedOptions is universally supported, but the fallback costs three lines and keeps the
+        // shared module honest against a stub DOM that models only `options`.
+        const opts = el.options || [];
+        for (let i = 0; i < opts.length; i++) {
+            if (opts[i].selected) values.push(opts[i].value);
+        }
+    }
+    return values;
 }
 
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
@@ -483,6 +588,7 @@ function morph(from, to) {
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
         if (isDocHead) _raskDiscardFrameworkHeadMutations();
+        if (tag === "SELECT") raskSyncSelectSelection(from);
         return;
     }
 
@@ -495,4 +601,7 @@ function morph(from, to) {
         else morph(src, dst);
     }
     if (isDocHead) _raskDiscardFrameworkHeadMutations();
+    // After the options are reconciled, never before: the selection is read off the incoming
+    // `selected` attributes, and until the child walk above has run they are still the old render's.
+    if (tag === "SELECT") raskSyncSelectSelection(from);
 }

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -2356,6 +2356,75 @@ function raskShouldSuppressSelected(el, incoming) {
     return false;
 }
 
+// The group form of the guard above, for a full morph. The diff codec moves one option at a time and
+// can decide one at a time; a morph reconciles the whole control at once and needs a single answer,
+// because applying half a lagging frame would leave the select in a state neither side rendered.
+//
+// A lagging frame is one that carries the pre-pick state of EVERY guarded option — that is exactly what
+// raskNotePendingSelected recorded on dispatch. If even one guarded option differs, the frame knows
+// something the user's pick didn't, so it is authoritative: release the whole group and apply.
+function raskShouldSuppressSelectGroup(select, desired) {
+    const map = _raskPendingSelected();
+    const options = select.options;
+    let guarded = 0, stale = 0;
+    for (let i = 0; i < options.length; i++) {
+        if (!map.has(options[i])) continue;
+        guarded++;
+        if (map.get(options[i]) === !!desired[i]) stale++;
+    }
+    if (guarded === 0) return false;
+    if (guarded === stale) return true;
+    for (let i = 0; i < options.length; i++) map.delete(options[i]);
+    return false;
+}
+
+// Move a select's live selection to what the incoming render marked, writing through the IDL rather
+// than trusting the `selected` ATTRIBUTES morph() has just copied.
+//
+// The attributes alone are not enough, and the reason is the option "dirtiness" flag: once an option's
+// selectedness has been set by the user or by the `.selected` setter (which the diff codec's
+// applySelected uses), its content attribute stops driving it. Measured in Chromium — a single-select
+// whose morph target the user had already touched does not move, and a multi-select is worse, because
+// the "ask for a reset" behaviour that quietly rescues most single-select cases does not apply to it:
+// a user-picked option that the incoming render does NOT mark stays selected, so the control
+// accumulates selections it was never rendered with.
+function raskApplySelectSelection(select, desired) {
+    const options = select.options;
+    if (select.multiple) {
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected !== desired[i]) options[i].selected = desired[i];
+        }
+        return;
+    }
+    // Single select: one write by index, for the same reason applySelected takes that path — poking
+    // each option leaves the control momentarily showing its first option between the deselect and the
+    // select, and an index can't be redirected by duplicate option values.
+    let idx = -1;
+    for (let i = 0; i < desired.length; i++) {
+        if (desired[i]) { idx = i; break; }
+    }
+    if (idx < 0) {
+        // The render marked nothing. On a freshly parsed single-select that shows the first enabled
+        // option, not a blank — mirror the browser's own reset rather than inventing selectedIndex -1,
+        // which would make a re-render look different from a first load of the same markup.
+        idx = 0;
+        while (idx < options.length && options[idx].disabled) idx++;
+        if (idx >= options.length) idx = -1;
+    }
+    if (select.selectedIndex !== idx) select.selectedIndex = idx;
+}
+
+// Called once per <select> at the end of morph(), after its options have been reconciled — so the
+// `selected` attributes read here are the incoming render's, and the option list is final.
+function raskSyncSelectSelection(select) {
+    const options = select.options;
+    if (!options) return;
+    const desired = [];
+    for (let i = 0; i < options.length; i++) desired.push(options[i].hasAttribute("selected"));
+    if (raskShouldSuppressSelectGroup(select, desired)) return;
+    raskApplySelectSelection(select, desired);
+}
+
 // User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
 // the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
 // saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
@@ -2470,6 +2539,42 @@ function raskNotePendingFormState(el) {
             }
         }
     }
+}
+
+// What a `change` frame reports for a control, in one place for all three hosts — same reasoning as the
+// recorder above, which exists because each host carried its own hand-copied copy and they drifted.
+//
+// `value` keeps exactly the meaning it had, so nothing downstream changes shape. `values` is added only
+// for a <select multiple>: the DOM has no multi-value `value`, so `select.value` is the FIRST selected
+// option (or "" when none), and reporting it alone told the server one option out of however many the
+// user had picked — the model then converged on that one, correctly, from a wrong report.
+function raskChangeFrameValue(el) {
+    const tag = el.tagName;
+    // For a checkbox the meaningful state is el.checked, not el.value (the static "on" default). Report
+    // it as "true"/"false" so a bound checkbox sets the model to the actual state (self-correcting)
+    // rather than relying on a server-side toggle. Radios keep sending el.value — a radio's value IS
+    // the selected option.
+    if (tag === "INPUT" && el.type === "checkbox") return el.checked ? "true" : "false";
+    return el.value == null ? "" : String(el.value);
+}
+
+// The whole selection of a <select multiple>, or null for every other control — null rather than an
+// empty array so the frame simply omits the field and no existing payload grows a byte.
+function raskChangeFrameValues(el) {
+    if (el.tagName !== "SELECT" || !el.multiple) return null;
+    const picked = el.selectedOptions;
+    const values = [];
+    if (picked) {
+        for (let i = 0; i < picked.length; i++) values.push(picked[i].value);
+    } else {
+        // selectedOptions is universally supported, but the fallback costs three lines and keeps the
+        // shared module honest against a stub DOM that models only `options`.
+        const opts = el.options || [];
+        for (let i = 0; i < opts.length; i++) {
+            if (opts[i].selected) values.push(opts[i].value);
+        }
+    }
+    return values;
 }
 
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
@@ -2674,6 +2779,7 @@ function morph(from, to) {
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
         if (isDocHead) _raskDiscardFrameworkHeadMutations();
+        if (tag === "SELECT") raskSyncSelectSelection(from);
         return;
     }
 
@@ -2686,6 +2792,9 @@ function morph(from, to) {
         else morph(src, dst);
     }
     if (isDocHead) _raskDiscardFrameworkHeadMutations();
+    // After the options are reconciled, never before: the selection is read off the incoming
+    // `selected` attributes, and until the child walk above has run they are still the old render's.
+    if (tag === "SELECT") raskSyncSelectSelection(from);
 }
 
 
@@ -3349,17 +3458,20 @@ document.addEventListener("scroll", (e) => {
 
 // Change — report the control's value (checkbox → checked). Flush any pending coalesced input first
 // so a change-triggered validator reads the freshly-typed value, not the pre-flush one.
-function valueOf(el) {
-    if (el.type === "checkbox") return el.checked ? "true" : "false";
-    return el.value == null ? "" : String(el.value);
-}
 document.addEventListener("change", function (e) {
     const el = e.target;
     if (!el || !el.getAttribute) return;
     const id = el.getAttribute("data-rask-on-change");
     if (!id || !inRoot(el)) return;
     if (typeof flushInputsNow === "function") flushInputsNow();
-    send({ id: id, type: "change", value: valueOf(el) });
+    // Through the shared module (rask-morph.js, spliced above at @@RASK_MORPH@@) rather than a local
+    // valueOf — this host had its own copy, which is exactly the drift that left <select> unguarded.
+    // `values` is null for everything except a <select multiple>, whose `.value` is only its FIRST
+    // selected option.
+    const frame = { id: id, type: "change", value: raskChangeFrameValue(el) };
+    const values = raskChangeFrameValues(el);
+    if (values !== null) frame.values = values;
+    send(frame);
 });
 
 // Submit — serialize the form fields into a flat { name: value } bag.

--- a/src/Rask.Native/Resources/rask.native.js
+++ b/src/Rask.Native/Resources/rask.native.js
@@ -218,17 +218,20 @@ window.addEventListener("popstate", function () {
 
 // Change — report the control's value (checkbox → checked). Flush any pending coalesced input first
 // so a change-triggered validator reads the freshly-typed value, not the pre-flush one.
-function valueOf(el) {
-    if (el.type === "checkbox") return el.checked ? "true" : "false";
-    return el.value == null ? "" : String(el.value);
-}
 document.addEventListener("change", function (e) {
     const el = e.target;
     if (!el || !el.getAttribute) return;
     const id = el.getAttribute("data-rask-on-change");
     if (!id || !inRoot(el)) return;
     if (typeof flushInputsNow === "function") flushInputsNow();
-    send({ id: id, type: "change", value: valueOf(el) });
+    // Through the shared module (rask-morph.js, spliced above at @@RASK_MORPH@@) rather than a local
+    // valueOf — this host had its own copy, which is exactly the drift that left <select> unguarded.
+    // `values` is null for everything except a <select multiple>, whose `.value` is only its FIRST
+    // selected option.
+    const frame = { id: id, type: "change", value: raskChangeFrameValue(el) };
+    const values = raskChangeFrameValues(el);
+    if (values !== null) frame.values = values;
+    send(frame);
 });
 
 // Submit — serialize the form fields into a flat { name: value } bag.

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -1513,20 +1513,22 @@
             // a change-only control (checkbox, radio, date, number) reaches this without rask-input.js
             // having already noted it; noting twice is a no-op, since the first edit owns the base.
             raskNoteDirtyField(t);
-            // For a checkbox the meaningful state is el.checked, not el.value (which is the
-            // static "on" default). Report it as "true"/"false" so bound checkboxes set the
-            // model to the actual state (self-correcting) instead of relying on a server-side
-            // toggle. Radios and text inputs keep sending el.value (a radio's value IS the
-            // selected option).
-            const changeVal = (t.tagName === "INPUT" && t.type === "checkbox")
-                ? (t.checked ? "true" : "false")
-                : t.value;
+            // What the frame reports, from the shared module (rask-morph.js) rather than computed
+            // here — the hosts each carried their own copy and drifted, which is how <select> ended up
+            // with no lagging-frame guard. `values` is null for everything except a <select multiple>,
+            // whose `.value` is only its FIRST selected option.
+            const changeVal = raskChangeFrameValue(t);
+            const changeVals = raskChangeFrameValues(t);
             // Record what a lagging re-render would have to carry to be stale — the pre-edit value,
             // the pre-click checked (whole radio group), the pre-pick selected (whole select) — so the
             // apply paths can tell "the frame that predates the user's action" from "the server's
             // authoritative answer to it". Shared with the WASM runtime, in rask-morph.js.
             raskNotePendingFormState(t);
-            send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
+            const changeFrame = {
+                id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal
+            };
+            if (changeVals !== null) changeFrame.values = changeVals;
+            send(changeFrame);
         }
     });
 

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2446,7 +2446,13 @@ export function setExports(exports) {
     root = document.querySelector("[data-rask-root]") || document.body;
     const ok = !!(exports && exports.Rask && exports.Rask.Wasm
         && exports.Rask.Wasm.JSInterop && typeof exports.Rask.Wasm.JSInterop.Dispatch === "function");
-    console.log("[Rask] setExports — Dispatch reachable:", ok, "root:", root && root.tagName);
+    // Report the boot only when it went wrong. A success line here is one per session and told nobody
+    // anything; an unreachable Dispatch is a dead app, and without this the first symptom is a click
+    // that silently does nothing.
+    if (!ok) {
+        console.error("[Rask] setExports: the .NET Dispatch export is unreachable — no event will "
+            + "reach the app. Exports:", exports);
+    }
     // Initial sweep for Head-declared external assets emitted by the browser's
     // index.html (and any subsequent applyRender will re-sweep so morph-added
     // assets get picked up too — see applyDom in handle()).
@@ -2755,6 +2761,75 @@ function raskShouldSuppressSelected(el, incoming) {
     return false;
 }
 
+// The group form of the guard above, for a full morph. The diff codec moves one option at a time and
+// can decide one at a time; a morph reconciles the whole control at once and needs a single answer,
+// because applying half a lagging frame would leave the select in a state neither side rendered.
+//
+// A lagging frame is one that carries the pre-pick state of EVERY guarded option — that is exactly what
+// raskNotePendingSelected recorded on dispatch. If even one guarded option differs, the frame knows
+// something the user's pick didn't, so it is authoritative: release the whole group and apply.
+function raskShouldSuppressSelectGroup(select, desired) {
+    const map = _raskPendingSelected();
+    const options = select.options;
+    let guarded = 0, stale = 0;
+    for (let i = 0; i < options.length; i++) {
+        if (!map.has(options[i])) continue;
+        guarded++;
+        if (map.get(options[i]) === !!desired[i]) stale++;
+    }
+    if (guarded === 0) return false;
+    if (guarded === stale) return true;
+    for (let i = 0; i < options.length; i++) map.delete(options[i]);
+    return false;
+}
+
+// Move a select's live selection to what the incoming render marked, writing through the IDL rather
+// than trusting the `selected` ATTRIBUTES morph() has just copied.
+//
+// The attributes alone are not enough, and the reason is the option "dirtiness" flag: once an option's
+// selectedness has been set by the user or by the `.selected` setter (which the diff codec's
+// applySelected uses), its content attribute stops driving it. Measured in Chromium — a single-select
+// whose morph target the user had already touched does not move, and a multi-select is worse, because
+// the "ask for a reset" behaviour that quietly rescues most single-select cases does not apply to it:
+// a user-picked option that the incoming render does NOT mark stays selected, so the control
+// accumulates selections it was never rendered with.
+function raskApplySelectSelection(select, desired) {
+    const options = select.options;
+    if (select.multiple) {
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].selected !== desired[i]) options[i].selected = desired[i];
+        }
+        return;
+    }
+    // Single select: one write by index, for the same reason applySelected takes that path — poking
+    // each option leaves the control momentarily showing its first option between the deselect and the
+    // select, and an index can't be redirected by duplicate option values.
+    let idx = -1;
+    for (let i = 0; i < desired.length; i++) {
+        if (desired[i]) { idx = i; break; }
+    }
+    if (idx < 0) {
+        // The render marked nothing. On a freshly parsed single-select that shows the first enabled
+        // option, not a blank — mirror the browser's own reset rather than inventing selectedIndex -1,
+        // which would make a re-render look different from a first load of the same markup.
+        idx = 0;
+        while (idx < options.length && options[idx].disabled) idx++;
+        if (idx >= options.length) idx = -1;
+    }
+    if (select.selectedIndex !== idx) select.selectedIndex = idx;
+}
+
+// Called once per <select> at the end of morph(), after its options have been reconciled — so the
+// `selected` attributes read here are the incoming render's, and the option list is final.
+function raskSyncSelectSelection(select) {
+    const options = select.options;
+    if (!options) return;
+    const desired = [];
+    for (let i = 0; i < options.length; i++) desired.push(options[i].hasAttribute("selected"));
+    if (raskShouldSuppressSelectGroup(select, desired)) return;
+    raskApplySelectSelection(select, desired);
+}
+
 // User-edit provenance for the redeploy restore. When a replacement server can't carry a session over,
 // the page reloads, and the Server runtime re-applies the fields the user had actually edited (see
 // saveRestoreFields / applyRestoreFields in rask.js). It re-applies one only when the REPLACEMENT
@@ -2869,6 +2944,42 @@ function raskNotePendingFormState(el) {
             }
         }
     }
+}
+
+// What a `change` frame reports for a control, in one place for all three hosts — same reasoning as the
+// recorder above, which exists because each host carried its own hand-copied copy and they drifted.
+//
+// `value` keeps exactly the meaning it had, so nothing downstream changes shape. `values` is added only
+// for a <select multiple>: the DOM has no multi-value `value`, so `select.value` is the FIRST selected
+// option (or "" when none), and reporting it alone told the server one option out of however many the
+// user had picked — the model then converged on that one, correctly, from a wrong report.
+function raskChangeFrameValue(el) {
+    const tag = el.tagName;
+    // For a checkbox the meaningful state is el.checked, not el.value (the static "on" default). Report
+    // it as "true"/"false" so a bound checkbox sets the model to the actual state (self-correcting)
+    // rather than relying on a server-side toggle. Radios keep sending el.value — a radio's value IS
+    // the selected option.
+    if (tag === "INPUT" && el.type === "checkbox") return el.checked ? "true" : "false";
+    return el.value == null ? "" : String(el.value);
+}
+
+// The whole selection of a <select multiple>, or null for every other control — null rather than an
+// empty array so the frame simply omits the field and no existing payload grows a byte.
+function raskChangeFrameValues(el) {
+    if (el.tagName !== "SELECT" || !el.multiple) return null;
+    const picked = el.selectedOptions;
+    const values = [];
+    if (picked) {
+        for (let i = 0; i < picked.length; i++) values.push(picked[i].value);
+    } else {
+        // selectedOptions is universally supported, but the fallback costs three lines and keeps the
+        // shared module honest against a stub DOM that models only `options`.
+        const opts = el.options || [];
+        for (let i = 0; i < opts.length; i++) {
+            if (opts[i].selected) values.push(opts[i].value);
+        }
+    }
+    return values;
 }
 
 // Third-party <head> preservation. Libraries routinely inject <style>/<link>/<script> into <head> at
@@ -3073,6 +3184,7 @@ function morph(from, to) {
             if (leftover.parentNode === from) _raskRemoveChild(from, leftover);
         }
         if (isDocHead) _raskDiscardFrameworkHeadMutations();
+        if (tag === "SELECT") raskSyncSelectSelection(from);
         return;
     }
 
@@ -3085,6 +3197,9 @@ function morph(from, to) {
         else morph(src, dst);
     }
     if (isDocHead) _raskDiscardFrameworkHeadMutations();
+    // After the options are reconciled, never before: the selection is read off the incoming
+    // `selected` attributes, and until the child walk above has run they are still the old render's.
+    if (tag === "SELECT") raskSyncSelectSelection(from);
 }
 
 
@@ -4003,7 +4118,9 @@ function applyFullReply(reply) {
 const _sendEncoder = new TextEncoder();
 
 async function send(payload) {
-    console.log("[Rask] send", payload);
+    // Deliberately not traced. `payload` carries the event's value — everything the user types — and
+    // this runs ~60×/sec via the rAF coalescing path, so a log here writes form input to the console
+    // of every production build. Debug a dispatch with a breakpoint, not by shipping one.
     if (!dotnetExports) {
         console.warn("[Rask] send: dotnetExports not set");
         return;
@@ -4030,7 +4147,6 @@ document.addEventListener("click", (e) => {
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     const a = e.target.closest("a[data-rask-nav]");
     if (!a) return;
-    console.log("[Rask] navlink click", a.getAttribute("href"));
     if (a.getAttribute("target") === "_blank") return;
     const href = a.getAttribute("href");
     if (!href) return;
@@ -4192,18 +4308,22 @@ document.addEventListener("change", (e) => {
         return;
     }
     if (t.hasAttribute("data-rask-on-change")) {
-        // For a checkbox the meaningful state is el.checked, not el.value (the static "on"
-        // default). Report it as "true"/"false" so bound checkboxes set the model to the
-        // actual state (self-correcting). Radios/text keep sending el.value.
-        const changeVal = (t.tagName === "INPUT" && t.type === "checkbox")
-            ? (t.checked ? "true" : "false")
-            : t.value;
+        // What the frame reports, from the shared module (rask-morph.js) rather than computed here —
+        // the hosts each carried their own copy and drifted, which is how <select> ended up with no
+        // lagging-frame guard. `values` is null for everything except a <select multiple>, whose
+        // `.value` is only its FIRST selected option.
+        const changeVal = raskChangeFrameValue(t);
+        const changeVals = raskChangeFrameValues(t);
         // Record what a lagging re-render would have to carry to be stale — the pre-edit value, the
         // pre-click checked (whole radio group), the pre-pick selected (whole select) — so the apply
         // paths can tell "the frame that predates the user's action" from "the server's authoritative
         // answer to it". Shared with the Server runtime, in rask-morph.js.
         raskNotePendingFormState(t);
-        send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
+        const changeFrame = {
+            id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal
+        };
+        if (changeVals !== null) changeFrame.values = changeVals;
+        send(changeFrame);
     }
 });
 

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -281,7 +281,13 @@ export function setExports(exports) {
     root = document.querySelector("[data-rask-root]") || document.body;
     const ok = !!(exports && exports.Rask && exports.Rask.Wasm
         && exports.Rask.Wasm.JSInterop && typeof exports.Rask.Wasm.JSInterop.Dispatch === "function");
-    console.log("[Rask] setExports — Dispatch reachable:", ok, "root:", root && root.tagName);
+    // Report the boot only when it went wrong. A success line here is one per session and told nobody
+    // anything; an unreachable Dispatch is a dead app, and without this the first symptom is a click
+    // that silently does nothing.
+    if (!ok) {
+        console.error("[Rask] setExports: the .NET Dispatch export is unreachable — no event will "
+            + "reach the app. Exports:", exports);
+    }
     // Initial sweep for Head-declared external assets emitted by the browser's
     // index.html (and any subsequent applyRender will re-sweep so morph-added
     // assets get picked up too — see applyDom in handle()).
@@ -572,7 +578,9 @@ function applyFullReply(reply) {
 const _sendEncoder = new TextEncoder();
 
 async function send(payload) {
-    console.log("[Rask] send", payload);
+    // Deliberately not traced. `payload` carries the event's value — everything the user types — and
+    // this runs ~60×/sec via the rAF coalescing path, so a log here writes form input to the console
+    // of every production build. Debug a dispatch with a breakpoint, not by shipping one.
     if (!dotnetExports) {
         console.warn("[Rask] send: dotnetExports not set");
         return;
@@ -599,7 +607,6 @@ document.addEventListener("click", (e) => {
     if (e.button !== 0 || e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
     const a = e.target.closest("a[data-rask-nav]");
     if (!a) return;
-    console.log("[Rask] navlink click", a.getAttribute("href"));
     if (a.getAttribute("target") === "_blank") return;
     const href = a.getAttribute("href");
     if (!href) return;
@@ -661,18 +668,22 @@ document.addEventListener("change", (e) => {
         return;
     }
     if (t.hasAttribute("data-rask-on-change")) {
-        // For a checkbox the meaningful state is el.checked, not el.value (the static "on"
-        // default). Report it as "true"/"false" so bound checkboxes set the model to the
-        // actual state (self-correcting). Radios/text keep sending el.value.
-        const changeVal = (t.tagName === "INPUT" && t.type === "checkbox")
-            ? (t.checked ? "true" : "false")
-            : t.value;
+        // What the frame reports, from the shared module (rask-morph.js) rather than computed here —
+        // the hosts each carried their own copy and drifted, which is how <select> ended up with no
+        // lagging-frame guard. `values` is null for everything except a <select multiple>, whose
+        // `.value` is only its FIRST selected option.
+        const changeVal = raskChangeFrameValue(t);
+        const changeVals = raskChangeFrameValues(t);
         // Record what a lagging re-render would have to carry to be stale — the pre-edit value, the
         // pre-click checked (whole radio group), the pre-pick selected (whole select) — so the apply
         // paths can tell "the frame that predates the user's action" from "the server's authoritative
         // answer to it". Shared with the Server runtime, in rask-morph.js.
         raskNotePendingFormState(t);
-        send({id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal});
+        const changeFrame = {
+            id: t.getAttribute("data-rask-on-change"), type: "change", value: changeVal
+        };
+        if (changeVals !== null) changeFrame.values = changeVals;
+        send(changeFrame);
     }
 });
 

--- a/tests/Rask.Core.Tests/Components/SelectTests.cs
+++ b/tests/Rask.Core.Tests/Components/SelectTests.cs
@@ -247,9 +247,149 @@ public class SelectTests
             view.RenderAsLiveRoot());
     }
 
+    // #595 — a <select multiple> reports its whole selection through the frame's `values` array.
+    // `select.value` is only the FIRST selected option (the DOM has no multi-value `value`), so the model
+    // used to converge on one option out of however many the user picked, from a report that was the
+    // wrong shape rather than merely late.
+
+    [Fact]
+    public async Task BoundMultiSelect_Change_BindsEveryReportedOption()
+    {
+        var model = new TagsModel { Tags = [] };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b"), Option("c")]
+        ]);
+        var html = view.RenderAsLiveRoot();
+
+        var changeId = Markup.Attr(html, "data-rask-on-change");
+        using var doc = JsonDocument.Parse("{\"value\":\"a\",\"values\":[\"a\",\"c\"]}");
+        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.True(ok);
+        Assert.Equal(["a", "c"], model.Tags);
+    }
+
+    [Fact]
+    public async Task BoundMultiSelect_Change_ReplacesRatherThanMerges()
+    {
+        // Set, never merge: every change frame carries the absolute selection, so a replace re-syncs the
+        // model even when an intermediate render was coalesced. A membership edit could not.
+        var model = new TagsModel { Tags = ["a", "b"] };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b"), Option("c")]
+        ]);
+        var html = view.RenderAsLiveRoot();
+
+        var changeId = Markup.Attr(html, "data-rask-on-change");
+        using var doc = JsonDocument.Parse("{\"value\":\"c\",\"values\":[\"c\"]}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Equal(["c"], model.Tags);
+    }
+
+    [Fact]
+    public async Task BoundMultiSelect_EmptySelection_ClearsTheModel()
+    {
+        var model = new TagsModel { Tags = ["a"] };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b")]
+        ]);
+        var html = view.RenderAsLiveRoot();
+
+        var changeId = Markup.Attr(html, "data-rask-on-change");
+        using var doc = JsonDocument.Parse("{\"value\":\"\",\"values\":[]}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Empty(model.Tags);
+    }
+
+    [Fact]
+    public void BoundMultiSelect_PreselectsEveryBoundOption()
+    {
+        // The render half. A single-value select marks the one option matching its formatted value;
+        // a multi-select has to mark each member of the bound collection.
+        var model = new TagsModel { Tags = ["a", "c"] };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b"), Option("c")]
+        ]);
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.Contains("<option value=\"a\" selected>", html);
+        Assert.Contains("<option value=\"c\" selected>", html);
+        Assert.DoesNotContain("<option value=\"b\" selected>", html);
+    }
+
+    [Fact]
+    public async Task BoundMultiSelect_WithoutTheValuesArray_FallsBackToTheSingleValue()
+    {
+        // A browser holding a client cached from a deploy that predates the array still sends `value`
+        // alone. Reporting one option is wrong, but dropping the user's pick entirely is worse.
+        var model = new TagsModel { Tags = [] };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b")]
+        ]);
+        var html = view.RenderAsLiveRoot();
+
+        var changeId = Markup.Attr(html, "data-rask-on-change");
+        using var doc = JsonDocument.Parse("{\"value\":\"b\"}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Equal(["b"], model.Tags);
+    }
+
+    [Fact]
+    public async Task BoundMultiSelect_GetOnlyCollection_IsRefilledInPlace()
+    {
+        // `public List<string> Tags { get; } = [];` is the ordinary way to declare one of these, and it
+        // has no setter — the shape the existing MultiSelect sample uses. Assigning would throw; the
+        // model's own collection is refilled instead.
+        var model = new OwnedTagsModel();
+        model.Tags.Add("a");
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b"), Option("c")]
+        ]);
+        var html = view.RenderAsLiveRoot();
+
+        var changeId = Markup.Attr(html, "data-rask-on-change");
+        using var doc = JsonDocument.Parse("{\"value\":\"b\",\"values\":[\"b\",\"c\"]}");
+        var ok = await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.True(ok);
+        Assert.Equal(["b", "c"], model.Tags);
+    }
+
+    [Fact]
+    public async Task BoundMultiSelect_OverAScalar_KeepsTheSingleValueHandler()
+    {
+        // Multiple:true on a model that can only hold one answer. Silently widening it would be the
+        // more surprising change, so this stays on the single-value path.
+        var model = new ColorPicker { Color = null };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Color, Multiple: true)[Option("red"), Option("blue")]
+        ]);
+        var html = view.RenderAsLiveRoot();
+
+        var changeId = Markup.Attr(html, "data-rask-on-change");
+        using var doc = JsonDocument.Parse("{\"value\":\"red\",\"values\":[\"red\",\"blue\"]}");
+        await view.TryInvokeHandlerAsync(changeId!, doc.RootElement);
+
+        Assert.Equal("red", model.Color);
+    }
+
     private sealed class ColorPicker
     {
         public string? Color { get; set; }
+    }
+
+    private sealed class TagsModel
+    {
+        public string[] Tags { get; set; } = [];
+    }
+
+    private sealed class OwnedTagsModel
+    {
+        public List<string> Tags { get; } = [];
     }
 
     private sealed class ChoiceModel

--- a/tests/Rask.Core.Tests/Live/HandlerFrameTypeTests.cs
+++ b/tests/Rask.Core.Tests/Live/HandlerFrameTypeTests.cs
@@ -103,6 +103,47 @@ public class HandlerFrameTypeTests
     }
 
     [Fact]
+    public async Task A_change_frame_fires_a_selection_handler()
+    {
+        // #595's shape. Only `change` carries `values` — the clients add it on the change dispatch
+        // alone — so this is the one frame type that may feed a whole-selection handler.
+        var model = new TagsModel();
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b"), Option("c")]
+        ]);
+        var id = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change")!;
+
+        var ok = await view.TryInvokeHandlerAsync(
+            id, Frame($$"""{"id":"{{id}}","type":"change","value":"a","values":["a","c"]}"""));
+
+        Assert.True(ok);
+        Assert.Equal(["a", "c"], model.Tags);
+    }
+
+    [Fact]
+    public async Task An_input_frame_does_not_fire_a_selection_handler()
+    {
+        // `input` never carries `values`, so feeding one would silently collapse the user's whole
+        // selection to the single `value` the frame does carry.
+        var model = new TagsModel { Tags = ["b"] };
+        var view = new StubComponent(() => Form(model)[
+            Select(() => model.Tags, Multiple: true)[Option("a"), Option("b")]
+        ]);
+        var id = Markup.Attr(view.RenderAsLiveRoot(), "data-rask-on-change")!;
+
+        var ok = await view.TryInvokeHandlerAsync(
+            id, Frame($$"""{"id":"{{id}}","type":"input","value":"a"}"""));
+
+        Assert.False(ok);
+        Assert.Equal(["b"], model.Tags);
+    }
+
+    private sealed class TagsModel
+    {
+        public string[] Tags { get; set; } = [];
+    }
+
+    [Fact]
     public async Task A_focus_frame_fires_a_parameterless_handler()
     {
         // Same shape, different event: both carry nothing, so this one still dispatches. Telling them

--- a/tests/Rask.Core.Tests/Resources/ClientConsoleContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/ClientConsoleContractTests.cs
@@ -1,0 +1,70 @@
+namespace Rask.Core.Tests.Resources;
+
+/// <summary>
+///     Source-level contract that no shipped client traces to <c>console.log</c>. Structural assertions
+///     over the <c>.js</c> for the same reason as <see cref="FormGuardClientContractTests" />: these files
+///     boot against a live document and still carry unsubstituted <c>@@RASK_*@@</c> splice markers, so
+///     they cannot be executed in Node.
+/// </summary>
+/// <remarks>
+///     The WASM client logged every event payload — form input included — on a path the comment above it
+///     documents as running ~60×/sec while someone types, behind no flag, in production builds. That is a
+///     place data lands where nobody expects it, and it also made the console useless for the debugging it
+///     was there to serve. <c>console.warn</c> / <c>console.error</c> are deliberately still allowed: they
+///     report a fault, they don't narrate the happy path.
+/// </remarks>
+public class ClientConsoleContractTests
+{
+    private static readonly string _repoRoot = LocateRepoRoot();
+
+    public static TheoryData<string, string[]> ShippedClients => new()
+    {
+        { "Rask.Server", ["src", "Rask.Server", "Resources", "rask.js"] },
+        { "Rask.Wasm (source)", ["src", "Rask.Wasm", "Resources", "rask.wasm.js"] },
+        // The committed build artifact. It is spliced from the source above by _RaskSpliceClientJs and
+        // checked in, so it can drift silently — and it is the copy the browser actually downloads.
+        { "Rask.Wasm (committed artifact)", ["src", "Rask.Wasm", "Browser", "rask.wasm.js"] },
+        { "Rask.Native", ["src", "Rask.Native", "Resources", "rask.native.js"] },
+        // The native host's committed spliced artifact, for the same reason as the WASM one above.
+        { "Rask.Native (committed artifact)", ["src", "Rask.Native", "Assets", "rask.native.js"] },
+        { "shared: rask-morph.js", ["src", "Rask.Core", "Resources", "rask-morph.js"] },
+        { "shared: rask-dom.js", ["src", "Rask.Core", "Resources", "rask-dom.js"] },
+    };
+
+    [Theory]
+    [MemberData(nameof(ShippedClients))]
+    public void No_shipped_client_traces_to_the_console(string label, string[] path)
+    {
+        var js = File.ReadAllText(Path.Combine([_repoRoot, .. path]));
+
+        var lines = js.Split('\n');
+        var offenders = lines
+            .Select((text, i) => (Line: i + 1, Text: text))
+            .Where(l => l.Text.Contains("console.log", StringComparison.Ordinal))
+            .Select(l => $"  {label}:{l.Line}: {l.Text.Trim()}")
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            $"{label} traces to console.log, which ships to production:\n{string.Join("\n", offenders)}\n"
+            + "Use console.warn/console.error for a fault, or a breakpoint for a trace. Never log a "
+            + "payload: it carries whatever the user typed.");
+    }
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Core.Tests/Resources/FormGuardClientContractTests.cs
+++ b/tests/Rask.Core.Tests/Resources/FormGuardClientContractTests.cs
@@ -38,14 +38,67 @@ public class FormGuardClientContractTests
         }
     }
 
+    [Fact]
+    public void Every_host_reports_the_change_value_through_the_shared_helper()
+    {
+        // #595's half of the same invariant. Each host computed the change frame's `value` itself, and
+        // all three got <select multiple> wrong in the same way — `select.value` is the FIRST selected
+        // option, so picking three reported one. The fix has to live in one place or the next control
+        // with a non-obvious "current value" repeats it.
+        var native = Read("src", "Rask.Native", "Resources", "rask.native.js");
+        foreach (var js in new[] { ServerJs, WasmJs, native })
+        {
+            var dispatch = ChangeDispatch(js);
+            Assert.Contains("raskChangeFrameValue(", dispatch, StringComparison.Ordinal);
+            Assert.Contains("raskChangeFrameValues(", dispatch, StringComparison.Ordinal);
+
+            // And no host may go back to reading the property directly, which is what it did before.
+            Assert.DoesNotContain("t.checked ? \"true\" : \"false\"", dispatch, StringComparison.Ordinal);
+            Assert.DoesNotContain("el.checked ? \"true\" : \"false\"", dispatch, StringComparison.Ordinal);
+        }
+    }
+
+    [Fact]
+    public void The_shared_helper_reports_the_whole_selection_of_a_multiple_select()
+    {
+        var js = MorphJs;
+        var fn = js[js.IndexOf("function raskChangeFrameValues", StringComparison.Ordinal)..];
+        var body = fn[..fn.IndexOf("\n}", StringComparison.Ordinal)];
+
+        // The point of the function: every picked option, not el.value.
+        Assert.Contains("selectedOptions", body, StringComparison.Ordinal);
+        Assert.Contains("multiple", body, StringComparison.Ordinal);
+    }
+
     // The change listener, up to the message it sends — the window in which a guard has to be armed,
     // because after the send the server's answer is already on its way.
+    // The whole body of the `change` listener. Brace-matched rather than cut at a marker: the frame is
+    // now assembled over several statements instead of inline in the send call, and every marker that
+    // would delimit it (the send's argument shape, `type: "change"`) pins a spelling rather than the
+    // invariant — and the listener's file-upload branch has a send of its own that comes first.
     private static string ChangeDispatch(string js)
     {
-        var listener = js[js.IndexOf("addEventListener(\"change\"", StringComparison.Ordinal)..];
-        var end = listener.IndexOf("data-rask-on-change\"), type: \"change\"", StringComparison.Ordinal);
-        Assert.True(end > 0, "could not find the change dispatch's send in this client");
-        return listener[..end];
+        var at = js.IndexOf("addEventListener(\"change\"", StringComparison.Ordinal);
+        Assert.True(at > 0, "could not find the change listener in this client");
+
+        var open = js.IndexOf('{', at);
+        Assert.True(open > 0, "could not find the change listener's body");
+
+        var depth = 0;
+        for (var i = open; i < js.Length; i++)
+        {
+            if (js[i] == '{')
+            {
+                depth++;
+            }
+            else if (js[i] == '}' && --depth == 0)
+            {
+                return js[open..i];
+            }
+        }
+
+        Assert.Fail("the change listener's body is unbalanced");
+        return string.Empty;
     }
 
     [Fact]

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -5791,6 +5791,35 @@ button .align-items-center .d-flex .dropdown-item .gap-2
 input .form-check-input .m-0 .pe-none
 p .mb-0 .small .text-secondary
 
+=== multi-select-native ===
+div .border-0 .card .mb-4 .sample-card .shadow-sm
+div .sample-code-col
+div .sample-code-header
+span .dot-r .sample-dot
+span .dot-y .sample-dot
+span .dot-g .sample-dot
+span .ms-2 .sample-code-label
+button .sample-copy
+i .bi .bi-clipboard .me-1
+span .sample-copy-text
+pre .m-0 .sample-code
+code .language-csharp
+div .p-4 .sample-result-col
+div .sample-result-label
+div .sample-result-body
+form .gap-3 .vstack
+div
+label .form-label .fw-semibold
+select .form-select
+option
+option
+option
+option
+option
+option
+div .form-text
+div .alert .alert-secondary .mb-0 .mt-3 .small
+
 === multi-select-radio ===
 div .border-0 .card .mb-4 .sample-card .shadow-sm
 div .sample-code-col

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppCollections.cs
@@ -93,3 +93,14 @@ public sealed class ShopExampleCollection
 {
     public const string Name = "ShopExample";
 }
+
+/// <summary>
+///     A real browser and nothing else — no app, no host, no port. For the shared client modules whose
+///     behaviour depends on DOM semantics a stub DOM cannot model (form-control dirtiness, in
+///     particular), where standing an app up would only add a dependency the assertion never uses.
+/// </summary>
+[CollectionDefinition(Name)]
+public sealed class BrowserOnlyCollection : ICollectionFixture<PlaywrightFixture>
+{
+    public const string Name = "BrowserOnly";
+}

--- a/tests/Rask.Examples.E2E.Tests/MorphSelectSelectionTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/MorphSelectSelectionTests.cs
@@ -1,0 +1,193 @@
+using Microsoft.Playwright;
+using Rask.Examples.E2E.Tests.Infrastructure;
+
+namespace Rask.Examples.E2E.Tests;
+
+/// <summary>
+///     A full morph must move a <c>&lt;select&gt;</c>'s live selection, not just its <c>selected</c>
+///     attributes (#596). Runs the production <c>rask-morph.js</c> + <c>rask-dom.js</c> in a real
+///     browser against a hand-built incoming tree — no app, because the assertion is about DOM
+///     semantics rather than about anything an app does.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Why this cannot be a stub-DOM test like <c>MorphSelectedGuardTests</c>: the bug lives in the
+///         HTML spec's option <em>dirtiness</em> flag. Once an option's selectedness has been set by the
+///         user, or by the <c>.selected</c> setter the diff codec's <c>applySelected</c> uses, its
+///         <c>selected</c> content attribute stops driving it — and a stub DOM that models attributes and
+///         properties as independent fields reproduces neither half.
+///     </para>
+///     <para>
+///         Worth recording, because it is the opposite of what it looks like: an attribute-only move is
+///         <em>not</em> broken by any user interaction. Dirtiness blocks the attribute only on the option
+///         that is dirty, so a move whose target is pristine still lands, and a single-select is rescued
+///         again by "ask for a reset". The cases below are the ones that actually fail — a single-select
+///         whose target the user has already touched, and multi-selects, which get no reset and so
+///         accumulate selections no render ever asked for.
+///     </para>
+///     <para>
+///         Frames that morph rather than diff: a reconnect, a scoped-CSS full reply, the WASM
+///         full-document morph on boot and navigation, and the redeploy reload.
+///     </para>
+/// </remarks>
+[Collection(BrowserOnlyCollection.Name)]
+public sealed class MorphSelectSelectionTests(PlaywrightFixture playwright)
+{
+    // No whitespace between the options, deliberately. HtmlSerializer emits none, and a stray text node
+    // between elements is a real difference to morph(): it pairs positionally, so the text node would be
+    // matched against an <option>, replaced, and the trailing option dropped and re-created — which
+    // resets the selection through the browser rather than through anything under test here.
+    private const string SingleHtml = "<!doctype html><html><body><select id=\"s\">"
+        + "<option value=\"a\">A</option><option value=\"b\" selected>B</option>"
+        + "<option value=\"c\">C</option></select></body></html>";
+
+    private const string MultiHtml = "<!doctype html><html><body><select id=\"s\" multiple>"
+        + "<option value=\"a\" selected>A</option><option value=\"b\">B</option>"
+        + "<option value=\"c\">C</option></select></body></html>";
+
+    [Fact]
+    public async Task A_morph_moves_a_single_select_even_onto_an_option_the_user_already_touched()
+    {
+        // The user lands on C having passed through A, so A is dirty. The server then says A. Before
+        // the SELECT arm, the `selected` attribute could not move a dirty option and the box stayed
+        // on C — the server's answer silently ignored.
+        await using var page = await OpenAsync(SingleHtml);
+        await page.SelectOptionAsync("#s", "a");
+        await page.SelectOptionAsync("#s", "c");
+
+        await MorphAsync(page, [0], multiple: false);
+
+        Assert.Equal("a", await SelectionAsync(page));
+    }
+
+    [Fact]
+    public async Task A_morph_deselects_a_multi_select_option_the_render_no_longer_marks()
+    {
+        // The sharpest case. The user picks B; the server renders A and C. The removeAttribute half of
+        // the morph cannot clear B (dirty), so B survived on top of the incoming selection and the
+        // control showed A, B and C — a state neither the user nor the server ever chose.
+        await using var page = await OpenAsync(MultiHtml);
+        await page.SelectOptionAsync("#s", new[] { "b" });
+
+        await MorphAsync(page, [0, 2], multiple: true);
+
+        Assert.Equal("a,c", await SelectionAsync(page));
+    }
+
+    [Fact]
+    public async Task A_diff_applied_selection_does_not_stick_across_a_later_morph()
+    {
+        // Dirtiness is not only set by the user: syncFormProperty writes `.selected` directly, so any
+        // select the diff codec has already moved is dirty from then on — which is how a reconnect
+        // could show a selection the reconnecting server had long since changed.
+        await using var page = await OpenAsync(MultiHtml);
+        await page.EvaluateAsync("() => { document.getElementById('s').options[1].selected = true; }");
+
+        await MorphAsync(page, [2], multiple: true);
+
+        Assert.Equal("c", await SelectionAsync(page));
+    }
+
+    [Theory]
+    [InlineData(false, new[] { 2 }, "c")]
+    [InlineData(true, new[] { 1, 2 }, "b,c")]
+    public async Task A_morph_still_applies_to_a_pristine_select(bool multiple, int[] marked, string want)
+    {
+        await using var page = await OpenAsync(multiple ? MultiHtml : SingleHtml);
+
+        await MorphAsync(page, marked, multiple);
+
+        Assert.Equal(want, await SelectionAsync(page));
+    }
+
+    [Fact]
+    public async Task A_single_select_whose_render_marks_nothing_shows_its_first_option()
+    {
+        // What a fresh parse of the same markup shows. Writing selectedIndex -1 here would blank the
+        // control, making a re-render look unlike a first load of the identical HTML.
+        await using var page = await OpenAsync(SingleHtml);
+        await page.SelectOptionAsync("#s", "c");
+
+        await MorphAsync(page, [], multiple: false);
+
+        Assert.Equal("a", await SelectionAsync(page));
+    }
+
+    [Fact]
+    public async Task The_lagging_frame_guard_still_refuses_a_frame_that_predates_the_pick()
+    {
+        // The SELECT arm makes a full reply start moving selects it previously left alone, so #588's
+        // guard has to be consulted here too — otherwise a reconnect would clobber a just-made pick,
+        // trading one bug for its mirror image.
+        await using var page = await OpenAsync(SingleHtml);
+        await page.EvaluateAsync("() => window.__raskNote(document.getElementById('s'))");
+        await page.SelectOptionAsync("#s", "c");
+
+        await MorphAsync(page, [1], multiple: false);       // the pre-pick state — a lagging frame
+        Assert.Equal("c", await SelectionAsync(page));
+
+        await MorphAsync(page, [0], multiple: false);       // differs, so it is authoritative
+        Assert.Equal("a", await SelectionAsync(page));
+    }
+
+    private async Task<IPage> OpenAsync(string html)
+    {
+        var page = await playwright.Browser.NewPageAsync();
+        await page.SetContentAsync(html);
+
+        // Load the shipped modules the way the hosts' splice does. They are not ES modules and carry
+        // unsubstituted @@RASK_*@@ markers, so they are evaluated as a function body — the same trick
+        // MorphSelectedGuardFixture.mjs uses to run them under Node.
+        var root = LocateRepoRoot();
+        var morph = await File.ReadAllTextAsync(Path.Combine(root, "src/Rask.Core/Resources/rask-morph.js"));
+        var dom = await File.ReadAllTextAsync(Path.Combine(root, "src/Rask.Core/Resources/rask-dom.js"));
+        await page.EvaluateAsync(
+            "([m, d]) => new Function(m + '\\n' + d + '\\n'"
+            + " + 'window.__raskMorph = morph; window.__raskNote = raskNotePendingFormState;')()",
+            new[] { morph, dom });
+
+        return page;
+    }
+
+    // Build the incoming render as a detached tree and morph the live select against it — the shape a
+    // full reply takes. The id is carried because morph removes any attribute the incoming tree lacks.
+    private static Task MorphAsync(IPage page, int[] marked, bool multiple) =>
+        page.EvaluateAsync(
+            """
+            ([marked, multiple]) => {
+              const from = document.getElementById('s');
+              const to = document.createElement('select');
+              to.setAttribute('id', 's');
+              if (multiple) to.setAttribute('multiple', '');
+              ['a', 'b', 'c'].forEach((v, i) => {
+                const o = document.createElement('option');
+                o.setAttribute('value', v);
+                o.textContent = v.toUpperCase();
+                if (marked.includes(i)) o.setAttribute('selected', '');
+                to.appendChild(o);
+              });
+              window.__raskMorph(from, to);
+            }
+            """,
+            new object[] { marked, multiple });
+
+    private static Task<string> SelectionAsync(IPage page) => page.EvalOnSelectorAsync<string>(
+        "#s", "s => [...s.selectedOptions].map(o => o.value).join(',') || '(none)'");
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}


### PR DESCRIPTION
Three issues about what the client reports and what a full reply applies. They share a root cause worth
naming: each host runtime carried its own hand-copied copy of "what is this control's current value",
and the copies drifted. That is the same drift that left `<select>` with no lagging-frame guard until
#588. All three hosts now go through one shared helper, held there by a contract test.

Closes #604. Closes #596. Closes #595.

## #604 — the WASM client logged every event payload to the console

`send()` opened with `console.log("[Rask] send", payload)`, behind no flag, in production builds — on a
path whose own comment directly above documents it as firing **~60×/sec while someone types**.
`payload` carries the event's value, so everything a user typed into a form was written to the browser
console. Two problems, in the issue's order: data landing where nobody expects it, and a console that is
useless for debugging at 60 lines/sec.

Removed, along with two quieter traces. The boot one is now an `error` raised **only** when the .NET
dispatch export is unreachable — that is a dead app, and without it the first symptom is a click that
silently does nothing.

`console.warn`/`console.error` deliberately stay: they report a fault rather than narrating the happy
path. `src/Rask.Wasm/Browser/rask.wasm.js` (the committed build artifact, and the copy the browser
actually downloads) was regenerated with `_RaskSpliceClientJs`. A new contract test asserts no
`console.log` in any of the **six** shipped `.js` files, the artifact included — it is the one most able
to drift unnoticed.

## #596 — a full morph never synced a select's live selection

`morph()` synced the IDL properties attributes can't reach for `INPUT`/`TEXTAREA` only, so a reconnect,
a scoped-CSS full reply, the WASM boot/navigation morph and the redeploy reload all moved a select
through its `selected` **attribute** alone.

**The issue asked for this to be confirmed in a browser before fixing, because the dirtiness half was
spec reasoning over a stub-DOM probe. It was — and the mechanism turned out to be narrower and stranger
than stated, which is why it survived so long.** An attribute-only move is *not* broken by user
interaction as such:

| scenario | attribute-only move |
| --- | --- |
| single-select, pristine | ✅ works |
| single-select, user picked, **target pristine** | ✅ works — rescued by "ask for a reset" |
| single-select, user picked, **target already touched** | ❌ ignored |
| multi-select, user picked | ❌ picked option can't be cleared → `a,b,c` |
| multi-select, after a diff-style `.selected` write | ❌ same |

Dirtiness blocks the content attribute only on the option that *is* dirty. So a move onto a pristine
option still lands, and single-selects are usually saved by the spec's reset. Multi-selects get no
reset, so they accumulate selections neither the user nor the server ever chose.

The new `SELECT` arm applies the selection through the select and **consults #588's guard first** —
making full replies start moving selects would otherwise let a reconnect clobber a just-made pick,
trading one bug for its mirror image. A select whose render marks nothing shows its first enabled
option, which is what a fresh parse of the same markup shows, rather than blanking.

Tested in a real browser (a new `BrowserOnly` collection — no app, no host, no port, because the
assertion is about DOM semantics). A stub DOM cannot reach this: it models attributes and properties as
independent fields and so reproduces neither half of dirtiness. **4 of the 7 cases fail with the arm
disabled** — verified, not assumed.

## #595 — a `<select multiple>` reported only its first option

The change dispatch sent `el.value`, and for a multiple select that is *the first selected option, or
`""` when none* — the DOM has no multi-value `value`. Picking three reported one, and the server's model
converged on that one **correctly, from a report that was the wrong shape** rather than merely late,
which is exactly why #588's guard could not help.

- **Wire.** The frame carries a `values` array alongside `value`. `value` keeps its exact meaning, and
  `values` is omitted for every other control, so no existing payload grows a byte.
- **Dispatch.** A new `Values` shape in `HandlerFrameShape`, fed by `change` alone — the clients add the
  array on the change dispatch only, so an `input` frame can't collapse a selection to one value.
- **Binding.** `Select<T>(Bind: …, Multiple: true)` binds the whole selection when `T` is a string
  collection. Every picked option is marked on render, and each change **replaces** the collection
  rather than editing membership: the report is absolute, so a replace re-syncs even when an
  intermediate render was coalesced — a snapshot-based add/remove cannot.

Two deliberate limits, both load-bearing:

- **The element type is `string`.** My first version accepted any parsable element type and failed the
  build with four IL2070/IL3050 errors: it needs `MakeGenericType` and `Array.CreateInstance`, both
  `RequiresDynamicCode`, and `samples/Rask.Example.Wasm` has to publish with zero trim warnings. The
  shipped version writes every instantiation literally. Documented in `docs/forms-advanced.md`.
- **`Multiple: true` over a scalar keeps the single-value binding.** That model can hold one answer;
  widening it silently would be the more surprising change.

One shape worth calling out: `public List<string> Tags { get; } = [];` — how a collection property is
normally declared, and what the existing `MultiSelectDemo` uses — has **no setter**. The binding refills
the model's own collection in place rather than assigning over it. Covered by its own test.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — green (`Rask.Core.Tests` 2084)
- `scripts/run-e2e-local.sh` — see below
- New: 7 browser tests for the morph arm, 6 contract tests over the shipped clients, 8 multi-select
  binding tests, 2 frame-shape tests

## Benchmarks

`HandlerFrameShapeBenchmarks` (the guard runs on **every** frame, so this is the path that matters).
Measured against `origin/main` by reverting only `HandlerFrameShape.cs` + `Component.cs`, not from a
remembered number:

| Method | main | first attempt | shipped |
| --- | ---: | ---: | ---: |
| ClickOnParameterless | 14.49 ns | 14.49 ns | **14.51 ns** |
| ScrollOnScroll | 26.54 ns | 28.19 ns *(+6%)* | **26.93 ns** *(+1.5%)* |
| InputOnParameterless | 94.49 ns | 96.41 ns | **92.90 ns** |
| UnknownTypeOnParameterless | 211.49 ns | 225.99 ns *(+7%)* | **217.89 ns** *(+3%)* |

**Allocated: zero on every row, before and after.**

The middle column is why the measurement was worth taking. `ShapeOf` is a linear sequence of type tests,
so an arm's position is a cost paid by every arm below it — placing the new one next to its
`Shape.Value` sibling charged the scroll path ~1.7 ns on every frame. It is last now: a multi-select
change happens at human speed, scroll/pointer/mouse frames do not. The residual +3% is the refusal path
scanning one more `Feeders` row, which is irreducible — the row has to exist — and only runs for a frame
type this build doesn't recognise.

## Docs & sample

- `docs/forms-advanced.md` — the bound `<select multiple>`, the supported collection shapes, and both limits
- New `NativeMultiSelectDemo` (registry key `multi-select-native`, surfaced by the doc marker), showing
  the plain OS control bound to a get-only `List<string>`
