### PR TITLE
chore(release): v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-06
+
 ### Fixed
 - **`Rask.Postgres` and `Rask.SqlServer` are actually published now.** Both had everything a shipped
   package has — `IsPackable`, a `PackageId`, a description, their own `NUGET.md`, tests — except a


### PR DESCRIPTION
Promotes `[Unreleased]` to `## [0.20.0] - 2026-08-06` and opens a fresh empty `[Unreleased]` above it.
No other change — versioning is MinVer-from-tags, so the tag pushed after this merges *is* the version.

**0.20.0, not 1.0.0 or 0.19.1.** 75 commits since `v0.19.0` (2026-07-20), including three breaking ones
(`feat!` #534, `fix(cli)!` #515, `fix(cli)!` #505) and the exit-code change in #598. Pre-1.0 those still
ride a minor bump, the way v0.16.0–v0.19.0 were cut.

What's in it, in short: session resume across a redeploy (#559) and graceful drain (#560/#566/#570); the
operator dashboard (#529/#531) and `Rask.Logging` (#554); PostgreSQL, SQL Server and Redis as opt-in
stores with leased claiming (#574) — now actually packed (#620); hot reload for Server and WASM
(#534/#569); form-field restore across a redeploy reload (#591); and the CLI error-surface overhaul
(#598).

## Testing

Ship gate run on `main` at the commit this branches from: `dotnet format --verify-no-changes` clean,
`dotnet build Rask.slnx -warnaserror` 0 warnings, full local unit gate green, local browser E2E 41/41
(green again on this branch, through the pre-push hook).
