### PR TITLE
fix(core): say which environment you are in, what broke, and how to fix it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -296,6 +296,61 @@ them until tagged releases begin.
   through one shared helper rather than three hand-copied copies, which is the drift that produced this
   bug and #588 before it; a contract test holds them to it, and the frame-shape guard from #592 knows
   `values` rides on `change` alone, so an `input` frame can't collapse a selection to one value.
+- **You get the development error page whenever you are actually in Development, not only when an
+  environment variable said so.** `DefaultErrorPage` decided by reading `ASPNETCORE_ENVIRONMENT` /
+  `DOTNET_ENVIRONMENT` and nothing else. The reason was sound — `Rask.Core` takes no
+  `Microsoft.Extensions.Hosting` dependency — but the consequence was not: `dotnet run --environment
+  Development`, `appsettings.json`, assigning `builder.Environment.EnvironmentName`, and IDE profiles
+  that set configuration rather than the process environment all select Development *without* setting a
+  variable, and every one of them silently produced the production page — no stack trace, no source
+  excerpt, and no hint why. It only looked fine because `rask dev` exports the variable itself, so the
+  failure appeared the moment you stepped off it, which is exactly when the stack trace matters. The
+  host now answers: `UseRask` resolves `LiveOptions.IsDevelopment` from `IWebHostEnvironment`, and the
+  variables remain as the fallback for a standalone host or a component rendered outside one. A host
+  reporting Production is not overridden by a stale variable left in a shell.
+- **A page that crashed no longer answers `200 OK`.** The root boundary catches the exception and
+  renders the error document, so the response was ordinary HTML and nothing downstream could tell it
+  from a healthy page — caches stored it, crawlers indexed it, uptime checks reported green. The initial
+  GET for a render that faulted now answers **500**, with the same body, so the error page is still
+  served and the live session still attaches.
+- **The framework's error page offers `Try again`, not just `Reload this page`.** `ErrorBoundary`'s
+  fallback has always received the boundary's `Recover` as its second argument, and the root boundary
+  discarded it — `(ex, _) =>` — leaving a full round trip as the only way out of a fault that had
+  damaged nothing. The common case is a handler that threw, where the tree is intact, so clearing the
+  error puts the app straight back with its state and scroll position. A render that faults
+  deterministically lands back on the error page, which is the honest outcome and what React's boundary
+  does too; the reload button is still there for it.
+- **Framework exception messages name the fix, not just the fault.** Most of `Rask.Core` already did —
+  `Navigator`, `Context`, `RouteAuthorizationGuard`, `ExpressionAccessor`, `RaskJSRuntime` are the
+  models. These did not, and all of them are page-fatal now that a render throw becomes a whole-document
+  swap:
+  - `RoutePattern`'s three parameter errors were the runtime siblings of RASK003 and worse off than it:
+    they echoed the offending segment, showed no correct one, and carried nothing to say *which* route
+    it came from — so `Empty parameter in route segment '{}'` was the whole story. They now name the
+    template and show a valid segment (`{id}`, `{**path}`, `{id:guid?}`).
+  - `EditContext`'s sync-validate refusal named the remedy but not the cause, so on a form carrying
+    several validators you found the culprit by bisecting them. It now names what made the context
+    async — the validator types, an async form-level `Validate`, or the field whose `Validate` is async.
+  - `Outlet` and `RouteChainRenderer` threw two different sentences for one condition, and which you got
+    depended only on whether there was a live context or merely no route in it. Converged on the better
+    one, which names `Router(...)`.
+  - `DragDrop`, `VirtualizeModel`, `ServerFileBackend`, `RaskEndpointExtensions` and `RootErrorBoundary`
+    now show the API shape, the packaging remedy, or what the reader actually did. `VirtualizeModel`'s
+    `ItemSize` check is an `ArgumentOutOfRangeException` carrying the offending value rather than an
+    `InvalidOperationException` describing it — **note this is not a widening**, so a `catch
+    (InvalidOperationException)` around it needs updating.
+  - `Form`'s `Form requires Model or Context.` is fixed too, and turned out to be **unreachable**: both
+    callers of `ResolveContext` already gate on exactly the condition it checks, and a `Form` with
+    neither renders as a plain `<form>` by design. Kept and reworded for the next caller; nobody has
+    seen the old text.
+- **Framework diagnostics carry their level and category on every host.** The default sink rendered
+  `message` (plus the exception), dropping the severity and subsystem the event has always carried — so
+  on any host without a logging bridge, "framework said something" and "framework reported an error in
+  the diff codec" printed identically. It now reads `[Rask:Rask.Diff] error: …`, which fixes every
+  unbridged host at once. **WASM additionally gains an `ILogger` bridge**: the host already called
+  `AddLogging()`, but nothing consumed it, so a browser app was the one host where a swallowed framework
+  fault — a navigate fault, a JS dispatch fault, a malformed frame — never reached the app's configured
+  providers at all.
 - **A `<select>` no longer snaps back to the old option when a lagging re-render lands.** `value` and
   `checked` each had a guard against a frame the server computed *before* the user's edit reached it;
   `selected` — the third property the diff codec mirrors onto its IDL twin — had none, so it was applied

--- a/docs/lifecycle.md
+++ b/docs/lifecycle.md
@@ -121,13 +121,45 @@ protected override async Task OnRenderedAsync(bool firstRender) =>
     // re-render from another component won't re-fire this — no loop
 ```
 
-## Gotcha: faulted async hooks are silent
+## Gotcha: a faulted async hook takes the page, not the component
 
-**If an async hook faults, the framework logs the exception to `Console.Error` and does NOT trigger a re-render.** It
-does not surface as an error page or a thrown exception up the render stack. The practical symptom: a component stuck
-on a loading placeholder that never resolves is almost always an `OnMountAsync` / `OnPropsChangedAsync` /
-`OnRenderedAsync` that threw. Check `Console.Error`. (Wrap risky work in `try/catch` if you want to render an error
-state yourself, or use an `ErrorBoundary` around the subtree for render/handler faults.)
+**If an async hook faults, it trips the nearest `ErrorBoundary` — and in a live app there is always one.** The host
+wraps your `App` in an implicit root boundary, and every component is stamped with the boundary above it during the
+render walk, so a faulting `OnMountAsync` / `OnPropsChangedAsync` / `OnRenderedAsync` renders that boundary's fallback
+rather than logging quietly.
+
+The practical symptom is therefore the opposite of what you might expect: not a component stuck forever on a loading
+placeholder, but **the whole page replaced by an error page** — because the boundary that caught it is the root one,
+unless you put a closer boundary in the way.
+
+```csharp
+// Without a boundary of your own, a throw here replaces the entire document.
+protected override async Task OnMountAsync() => _rows = await api.LoadAsync();
+
+// With one, the blast radius is the subtree you chose.
+ErrorBoundary(Fallback: (ex, retry) => Div()[
+    P()["Could not load the rows."],
+    Button(OnClick: retry)["Try again"]
+])[
+    RowList()
+]
+```
+
+Two things follow:
+
+- **Scope the damage yourself.** An `ErrorBoundary` around the risky subtree keeps the rest of the page alive, and its
+  `Fallback` receives a `retry` callback that clears the error and re-renders that subtree. A `try/catch` inside the
+  hook is still the right tool when you want to render an error *state* rather than a fallback.
+- **The root error page offers `Try again` as well as `Reload this page`.** The first clears the error and re-renders
+  in place, keeping the session, the state and the scroll position — enough for the common case, a handler that threw
+  and damaged nothing. A render that faults deterministically simply lands back on the error page, and then the reload
+  is what you want.
+
+The initial GET for a page whose render faulted answers **500**, not 200 — the body is still the error page, so both
+buttons work.
+
+`Console.Error` only comes into it when there is genuinely no boundary — a component rendered outside a live render
+context. In a live app that path is unreachable, so do not go looking there for a fault you can see on screen.
 
 ## Gotcha: don't `StateHasChanged()` in unmount
 

--- a/src/Rask.Core/Components/DefaultErrorPage.cs
+++ b/src/Rask.Core/Components/DefaultErrorPage.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Rask.Core.Live;
 
 namespace Rask.Core.Components;
 
@@ -38,16 +39,35 @@ public sealed class DefaultErrorPage : Component
     private readonly Exception _error;
     private readonly bool _isDevelopment;
 
+    private readonly Callback? _recover;
+
     public DefaultErrorPage(Exception error) : this(error, IsDevelopmentEnvironment())
+    {
+    }
+
+    /// <summary>
+    ///     The page with an in-session recovery action. <paramref name="recover" /> is the boundary's
+    ///     <c>Recover</c>, which clears the error and re-renders the subtree.
+    /// </summary>
+    /// <remarks>
+    ///     Worth having because the common fault is a handler that threw, not a render that cannot
+    ///     succeed: the tree is intact, so clearing the error puts the app straight back with its state
+    ///     and scroll position, where the reload button costs a full round trip and all of it. A render
+    ///     that faults deterministically simply throws again and lands back here, which is the honest
+    ///     outcome and is what React's boundary does too.
+    /// </remarks>
+    public DefaultErrorPage(Exception error, Callback recover)
+        : this(error, IsDevelopmentEnvironment(), recover)
     {
     }
 
     // Test seam: construct with an explicit environment so unit tests need no process-global env var
     // (setting ASPNETCORE_ENVIRONMENT would race other tests that render this page).
-    internal DefaultErrorPage(Exception error, bool isDevelopment)
+    internal DefaultErrorPage(Exception error, bool isDevelopment, Callback? recover = null)
     {
         _error = error;
         _isDevelopment = isDevelopment;
+        _recover = recover;
     }
 
     protected override bool BypassRenderCache => true;
@@ -56,15 +76,28 @@ public sealed class DefaultErrorPage : Component
     {
         var children = new List<Component>
         {
-            Generated.H1(Style: "margin:0 0 0.75rem;font-size:1.5rem;color:#b42323;")["Something went wrong"],
-            // In-app recovery so the user isn't stranded on the fault: the runtime wires data-rask-reload
-            // to location.reload() (CSP-clean, both hosts). If the runtime never loaded, the browser's own
-            // reload is the fallback.
-            Generated.Button(
+            Generated.H1(Style: "margin:0 0 0.75rem;font-size:1.5rem;color:#b42323;")["Something went wrong"]
+        };
+
+        // Try again first, when the boundary handed us a way to: it keeps the session, the state and the
+        // scroll position, where the reload below throws all three away. Offered as the cheaper action
+        // rather than the only one — a render that faults deterministically will come straight back here,
+        // and then a reload is what you want.
+        if (_recover is { } recover)
+        {
+            children.Add(Generated.Button(
                 Type: "button",
                 Style: ReloadButtonStyle,
-                Data: new Dictionary<string, string?> { ["rask-reload"] = "" })["Reload this page"]
-        };
+                OnClick: recover)["Try again"]);
+        }
+
+        // In-app recovery so the user isn't stranded on the fault: the runtime wires data-rask-reload
+        // to location.reload() (CSP-clean, both hosts). If the runtime never loaded, the browser's own
+        // reload is the fallback.
+        children.Add(Generated.Button(
+            Type: "button",
+            Style: ReloadButtonStyle,
+            Data: new Dictionary<string, string?> { ["rask-reload"] = "" })["Reload this page"]);
 
         var chain = Unwind(_error);
 
@@ -242,12 +275,37 @@ public sealed class DefaultErrorPage : Component
         return info.DeclaringTypeName is { } type ? $"{type}.{info.Name}" : info.Name;
     }
 
-    private static bool IsDevelopmentEnvironment()
+    private static bool IsDevelopmentEnvironment() =>
+        ResolveIsDevelopment(
+            LiveOptions.IsDevelopment,
+            Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+            Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT"));
+
+    /// <summary>
+    ///     The decision itself, as a pure function of its three inputs.
+    /// </summary>
+    /// <remarks>
+    ///     Split out so it can be tested without mutating <see cref="LiveOptions.IsDevelopment" />, which
+    ///     is process-global and read by every render that reaches <c>RootErrorBoundary</c> — a test that
+    ///     flipped it would be able to change what a concurrently-running test's error page contains.
+    ///     <para>
+    ///         <paramref name="hostAnswer" /> wins outright. It comes from <c>UseRask</c> via
+    ///         <c>IWebHostEnvironment</c>, and is the only input that sees Development selected by
+    ///         configuration rather than by a process environment variable — <c>dotnet run
+    ///         --environment</c>, <c>appsettings.json</c>, an assigned <c>EnvironmentName</c>, an IDE
+    ///         profile. All of those used to yield the production error page while developing (#605).
+    ///         The variables remain as the fallback for a standalone host, or a component rendered
+    ///         outside one; a host that reports Production is not overridden by a stale shell variable.
+    ///     </para>
+    /// </remarks>
+    internal static bool ResolveIsDevelopment(bool? hostAnswer, string? aspnetEnv, string? dotnetEnv)
     {
-        // Read the standard ASP.NET environment variables so we can gate stack traces without
-        // taking a Microsoft.Extensions.Hosting dependency on the framework core.
-        var env = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT")
-                  ?? Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT");
+        if (hostAnswer is { } resolved)
+        {
+            return resolved;
+        }
+
+        var env = aspnetEnv ?? dotnetEnv;
         return string.Equals(env, "Development", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/src/Rask.Core/Components/DragDrop.cs
+++ b/src/Rask.Core/Components/DragDrop.cs
@@ -99,7 +99,9 @@ public sealed class DragDrop : Component
     {
         if (Body is null)
         {
-            throw new InvalidOperationException("DragDrop: Body (render) delegate is required.");
+            throw new InvalidOperationException(
+                "DragDrop has no Body, so there is nothing for it to render. Body is a delegate "
+                + "receiving the drag context: DragDrop(Body: ctx => Div()[ … ]).");
         }
 
         return Body(new DragDropContext(this));

--- a/src/Rask.Core/Components/Form.cs
+++ b/src/Rask.Core/Components/Form.cs
@@ -120,7 +120,16 @@ public sealed class Form : Element
         {
             if (Model is null)
             {
-                throw new InvalidOperationException("Form requires Model or Context.");
+                // Defensive, and worth saying so: both of today's callers already gate on
+                // `Model is not null || Context is not null`, so this cannot fire from a render — a Form
+                // with neither is a plain <form>, deliberately. It is kept for the next caller, and
+                // reworded because the old text ("Form requires Model or Context.") named neither the
+                // form nor the API shape, and "Context" is ambiguous between the Context<T> component
+                // and the EditContext this actually wants.
+                throw new InvalidOperationException(
+                    $"Form{Describe()} has neither a model nor an EditContext, so there is nothing for "
+                    + "its fields to bind to. Pass the model as the first argument — Form(model)[ … ] — "
+                    + "or hand it an existing EditContext with Form(Context: editContext)[ … ].");
             }
 
             ctx = LiveRenderContext.CurrentSync is { } live
@@ -133,6 +142,15 @@ public sealed class Form : Element
         ctx.RegisterFormValidator(Validate);
         return ctx;
     }
+
+    // Which form, when a page has several. Nothing identifies a Form intrinsically, so this leans on
+    // whatever the author already wrote — an id, a name, a class — and says nothing when there is none,
+    // rather than inventing a label that would not help anyone find it.
+    private string Describe() =>
+        Id is { Length: > 0 } id ? $" '#{id}'"
+        : Name is { Length: > 0 } name ? $" '{name}'"
+        : Class is { Length: > 0 } cls ? $" '.{cls}'"
+        : string.Empty;
 
     private Func<FormData, Task> BuildSubmitBridge(EditContext ctx) =>
         async formData =>

--- a/src/Rask.Core/Components/VirtualizeModel.cs
+++ b/src/Rask.Core/Components/VirtualizeModel.cs
@@ -119,7 +119,12 @@ public sealed class VirtualizeModel : Component
     {
         if (Body is null)
         {
-            throw new InvalidOperationException("VirtualizeModel: Render delegate is required.");
+            throw new InvalidOperationException(
+                "VirtualizeModel has no Body, so there is nothing for it to render. Body is the first "
+                + "argument and receives the virtualization state — wire its OnScroll to your scroll "
+                + "container and render state.Items inside it: "
+                + "VirtualizeModel(state => Div(OnScroll: state.OnScroll)[ … ], Items: rows, "
+                + "ItemSize: 32).");
         }
 
         if (Items is null == ItemsProvider is null)
@@ -130,7 +135,13 @@ public sealed class VirtualizeModel : Component
 
         if (ItemSize <= 0)
         {
-            throw new InvalidOperationException("VirtualizeModel: ItemSize must be greater than zero.");
+            // ArgumentOutOfRangeException, not InvalidOperationException: the offending value belongs in
+            // the exception rather than only in the prose, and this IS an out-of-range argument.
+            throw new ArgumentOutOfRangeException(
+                nameof(ItemSize), ItemSize,
+                "VirtualizeModel.ItemSize is the pixel height of one row and drives every scroll "
+                + "calculation, so it must be greater than zero. Pass the row height you render, e.g. "
+                + "ItemSize: 32.");
         }
 
         var itemSize = ItemSize;

--- a/src/Rask.Core/Diagnostics/RaskDiagnostics.cs
+++ b/src/Rask.Core/Diagnostics/RaskDiagnostics.cs
@@ -127,8 +127,24 @@ internal static class RaskDiagnostics
 
     // The single-line stderr rendering used by the default sink. Extracted so it can be unit-tested
     // without redirecting the process-global Console.Error stream.
-    internal static string FormatDefault(RaskDiagnosticEvent e) =>
-        e.Exception is null ? e.Message : $"{e.Message}: {e.Exception}";
+    //
+    // Carries the level and the category, which the event has always had and this always dropped. A host
+    // with a bridge installed never sees this — but the hosts WITHOUT one (WASM until now, Native, and
+    // any app that hasn't wired logging) got a bare sentence with no severity and no subsystem, so
+    // "framework said something" and "framework reported an error in the diff codec" read identically.
+    // Fixing it here fixes it for every unbridged host at once, which a per-host bridge cannot.
+    internal static string FormatDefault(RaskDiagnosticEvent e)
+    {
+        var head = $"[Rask:{e.Category}] {Label(e.Level)}: {e.Message}";
+        return e.Exception is null ? head : $"{head}: {e.Exception}";
+    }
+
+    private static string Label(RaskLogLevel level) => level switch
+    {
+        RaskLogLevel.Error => "error",
+        RaskLogLevel.Warning => "warning",
+        _ => "info"
+    };
 
     // Test hook: clears the ReportOnce dedup set so a test can exercise the once-per-key behaviour
     // deterministically regardless of what earlier tests reported.

--- a/src/Rask.Core/Forms/EditContext.cs
+++ b/src/Rask.Core/Forms/EditContext.cs
@@ -39,6 +39,32 @@ public sealed class EditContext : IDisposable
 
     public bool HasAsyncValidators => _asyncValidators.Count > 0 || HasAsyncDelegateValidators;
 
+    // What made this context async. Without it the sync-validate refusal names the remedy but not the
+    // cause, so on a form carrying several validators you find the culprit by bisecting them.
+    private string DescribeAsyncValidators()
+    {
+        var named = new List<string>();
+        foreach (var v in _asyncValidators)
+        {
+            named.Add(v.GetType().Name);
+        }
+
+        if (_formDelegate is not null && DelegateValidator.IsAsync(_formDelegate))
+        {
+            named.Add("an async form-level Validate delegate");
+        }
+
+        foreach (var (field, reg) in _fieldDelegates)
+        {
+            if (DelegateValidator.IsAsync(reg.Validate))
+            {
+                named.Add($"an async Validate on '{field.FieldName}'");
+            }
+        }
+
+        return named.Count == 0 ? "none found — this is a framework bug" : string.Join(", ", named);
+    }
+
     public bool HasAsyncDelegateValidators
     {
         get
@@ -354,7 +380,9 @@ public sealed class EditContext : IDisposable
     {
         if (_asyncValidators.Count > 0 || HasAsyncDelegateValidators)
         {
-            throw new InvalidOperationException("Async validators are registered; call ValidateAsync.");
+            throw new InvalidOperationException(
+                $"This EditContext has async validators ({DescribeAsyncValidators()}), so it cannot be "
+                + "validated synchronously. Call ValidateAsync() instead of Validate().");
         }
 
         ClearAllMessages();
@@ -381,7 +409,10 @@ public sealed class EditContext : IDisposable
     {
         if (_asyncValidators.Count > 0 || HasAsyncDelegateValidators)
         {
-            throw new InvalidOperationException("Async validators are registered; call ValidateFieldAsync.");
+            throw new InvalidOperationException(
+                $"This EditContext has async validators ({DescribeAsyncValidators()}), so field "
+                + $"'{field.FieldName}' cannot be validated synchronously. Call "
+                + "ValidateFieldAsync(field) instead of ValidateField(field).");
         }
 
         ClearMessages(field);

--- a/src/Rask.Core/Live/LiveOptions.cs
+++ b/src/Rask.Core/Live/LiveOptions.cs
@@ -121,6 +121,25 @@ public static class LiveOptions
     public static bool? MinifyScopedAssets { get; set; }
 
     /// <summary>
+    ///     Whether the app is running in Development, as decided by the <em>host</em>. <c>null</c>
+    ///     (default) = unresolved, in which case <see cref="Components.DefaultErrorPage" /> falls back to
+    ///     reading the standard ASP.NET environment variables itself.
+    /// </summary>
+    /// <remarks>
+    ///     This decides whether an error page shows a stack trace and a source excerpt or just a type and
+    ///     a message, so getting it wrong is expensive in exactly the moment it matters. Core cannot ask
+    ///     the host directly — it takes no dependency on <c>Microsoft.Extensions.Hosting</c>, deliberately
+    ///     — and the environment-variable fallback it used instead is only correct when the environment
+    ///     arrived that way. <c>dotnet run --environment Development</c>, <c>appsettings.json</c>,
+    ///     assigning <c>builder.Environment.EnvironmentName</c>, and IDE profiles that set configuration
+    ///     rather than the process environment all select Development without setting a variable, and all
+    ///     of them silently produced the production error page while developing (#605). <c>UseRask</c>
+    ///     now resolves this from <c>IWebHostEnvironment</c>; a standalone host or a test can set it
+    ///     directly. Host-wide rather than per-session, like <see cref="MinifyScopedAssets" />.
+    /// </remarks>
+    public static bool? IsDevelopment { get; set; }
+
+    /// <summary>
     ///     Active URL prefix (see <see cref="RaskLiveOptions.PathBase" />).
     ///     Always normalized: <c>""</c> or <c>"/segment"</c> (no trailing slash).
     /// </summary>

--- a/src/Rask.Core/Live/RootErrorBoundary.cs
+++ b/src/Rask.Core/Live/RootErrorBoundary.cs
@@ -19,15 +19,33 @@ internal sealed class RootErrorBoundary : Component
     // the first GetOrCreate inside Render() lazily forwards the handle.
     internal Component Inner { get; }
 
+    /// <summary>
+    ///     Whether the most recent render walk ended up showing the fallback rather than the app.
+    /// </summary>
+    /// <remarks>
+    ///     The boundary catches the exception, so nothing escapes <c>RenderAsLiveRoot</c> and the caller
+    ///     cannot otherwise tell a crashed page from a healthy one — which is why the initial GET for a
+    ///     page that threw used to answer <c>200 OK</c> (#607). Set from inside the fallback delegate,
+    ///     which runs exactly when the fallback is rendered, and cleared at the top of each
+    ///     <see cref="Render" /> — the delegate is invoked by the serializer walking the tree this method
+    ///     returns, so the clear always precedes the set.
+    /// </remarks>
+    internal bool RenderedFallback { get; private set; }
+
     protected override bool BypassRenderCache => true;
 
     private static LiveRenderContext? Current => LiveRenderContext.Current;
 
     protected override Component? Render()
     {
+        // An internal type in the message helps nobody: if this fires, the reader wrote none of the
+        // words in it. Say what they did instead — rendered a component outside a live render.
         var ctx = Current
                   ?? throw new InvalidOperationException(
-                      "RootErrorBoundary requires an active LiveRenderContext.");
+                      "A Rask app was rendered outside a live render context, so the framework's root "
+                      + "error boundary has nothing to wrap. Render through the host — UseRask<TApp>() "
+                      + "on the server, the WASM host builder in the browser — or, in a test, through "
+                      + "RaskTest.Render, which sets one up for you.");
         var inner = ctx.GetOrCreate(Inner.GetType(), _ => Inner);
 
         // Propagate the "force the root to re-execute this frame" contract that
@@ -44,16 +62,26 @@ internal sealed class RootErrorBoundary : Component
         // OnPropsChanged still fire on the App exactly as they used to.
         ctx.NotifyParameters(inner, false);
 
-        return F.ErrorBoundary((ex, _) => F.Fragment()[
-            F.Doctype(),
-            F.Html("en")[
-                F.Head()[
-                    F.Meta("utf-8"),
-                    F.Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
-                    F.Title()["Application error"]
-                ],
-                F.Body()[new DefaultErrorPage(ex)]
-            ]
-        ])[inner];
+        // The second parameter is the boundary's Recover, and it used to be discarded. Forwarding it
+        // gives the page a "Try again" that clears the error and re-renders in place — worth having
+        // because the common fault is a handler that threw rather than a render that cannot succeed, so
+        // the tree is intact and recovering keeps the session, the state and the scroll position that a
+        // reload throws away.
+        RenderedFallback = false;
+        return F.ErrorBoundary((ex, recover) =>
+        {
+            RenderedFallback = true;
+            return F.Fragment()[
+                F.Doctype(),
+                F.Html("en")[
+                    F.Head()[
+                        F.Meta("utf-8"),
+                        F.Meta(Name: "viewport", Content: "width=device-width, initial-scale=1"),
+                        F.Title()["Application error"]
+                    ],
+                    F.Body()[new DefaultErrorPage(ex, recover)]
+                ]
+            ];
+        })[inner];
     }
 }

--- a/src/Rask.Core/Routing/Outlet.cs
+++ b/src/Rask.Core/Routing/Outlet.cs
@@ -35,9 +35,14 @@ public sealed class Outlet : Component
 
     protected override Component? Render()
     {
+        // Same condition as RouteChainRenderer.RenderChainEntry, and deliberately the same words: which
+        // of the two you hit depends only on whether there is a live render context or merely no route
+        // in it, which is not a distinction the reader can act on. Two spellings for one problem meant
+        // searching for the message found half the story.
         var ctx = LiveRenderContext.Current
                   ?? throw new InvalidOperationException(
-                      "Outlet() must be called inside a Router render tree.");
+                      "Outlet() and Router rendering require an active route context. " +
+                      "Place Outlet() inside a Router(...) render tree.");
         return RouteChainRenderer.RenderChainEntry(ctx);
     }
 }

--- a/src/Rask.Core/Routing/RoutePattern.cs
+++ b/src/Rask.Core/Routing/RoutePattern.cs
@@ -27,7 +27,7 @@ internal sealed class RoutePattern
         var literal = 0;
         for (var i = 0; i < parts.Length; i++)
         {
-            segments[i] = ParseSegment(parts[i]);
+            segments[i] = ParseSegment(parts[i], template);
             if (segments[i].Kind == SegmentKind.Literal)
             {
                 literal++;
@@ -37,7 +37,11 @@ internal sealed class RoutePattern
         return new RoutePattern(template, segments, literal);
     }
 
-    private static RouteSegment ParseSegment(string raw)
+    // These are the runtime siblings of RASK003, and they used to be worse off than it: they echoed the
+    // offending segment, never showed a correct one, and — unlike the diagnostic — carried no way to tell
+    // WHICH route it came from, so `Empty parameter in route segment '{}'` was the whole story. The
+    // template is threaded in for that reason.
+    private static RouteSegment ParseSegment(string raw, string template)
     {
         if (raw.Length == 0)
         {
@@ -52,7 +56,9 @@ internal sealed class RoutePattern
         var inner = raw[1..^1];
         if (inner.Length == 0)
         {
-            throw new InvalidOperationException($"Empty parameter in route segment '{raw}'.");
+            throw new InvalidOperationException(
+                $"Route template '{template}' has an empty parameter segment '{raw}'. Give the "
+                + "parameter a name — '{id}' — or make the segment a literal by dropping the braces.");
         }
 
         if (inner.StartsWith("**", StringComparison.Ordinal))
@@ -60,7 +66,9 @@ internal sealed class RoutePattern
             var name = inner[2..];
             if (name.Length == 0)
             {
-                throw new InvalidOperationException($"Catch-all parameter must have a name in '{raw}'.");
+                throw new InvalidOperationException(
+                    $"Route template '{template}' has an unnamed catch-all segment '{raw}'. Name it — "
+                    + "'{**path}' — so the matched remainder has something to bind to.");
             }
 
             return new RouteSegment(SegmentKind.CatchAll, string.Empty, name, true);
@@ -71,7 +79,9 @@ internal sealed class RoutePattern
             var name = inner[1..];
             if (name.Length == 0)
             {
-                throw new InvalidOperationException($"Catch-all parameter must have a name in '{raw}'.");
+                throw new InvalidOperationException(
+                    $"Route template '{template}' has an unnamed catch-all segment '{raw}'. Name it — "
+                    + "'{*path}' — so the matched remainder has something to bind to.");
             }
 
             return new RouteSegment(SegmentKind.CatchAll, string.Empty, name, true);
@@ -92,7 +102,9 @@ internal sealed class RoutePattern
 
         if (paramName.Length == 0)
         {
-            throw new InvalidOperationException($"Parameter must have a name in '{raw}'.");
+            throw new InvalidOperationException(
+                $"Route template '{template}' has an unnamed parameter segment '{raw}'. Put the name "
+                + "before the constraint and the '?' — '{id:guid?}', not '{:guid?}'.");
         }
 
         return new RouteSegment(SegmentKind.Parameter, string.Empty, paramName, optional);

--- a/src/Rask.Server/Files/ServerFileBackend.cs
+++ b/src/Rask.Server/Files/ServerFileBackend.cs
@@ -21,7 +21,13 @@ internal sealed class ServerFileBackend : IBrowserFileBackend
             : string.Empty;
         if (string.IsNullOrEmpty(token))
         {
-            throw new InvalidOperationException("File metadata is missing 'token'.");
+            // Two lines below, the sibling throw explains itself in app-facing terms; this one spoke
+            // wire protocol at someone who never sees the wire.
+            throw new InvalidOperationException(
+                "A file arrived without an upload token, so the server cannot tell which uploaded file "
+                + "it refers to. The token is added by the client's upload step — this usually means "
+                + "the file was constructed by hand rather than coming from a file input's change "
+                + "event, or the client script is from a different Rask version than the server.");
         }
 
         var entry = _store.Get(_session.Id, token)

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -389,6 +389,16 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
         return html;
     }
 
+    /// <summary>
+    ///     Whether the last render fell back to the framework's error page rather than the app.
+    /// </summary>
+    /// <remarks>
+    ///     The root boundary catches the exception, so a crashed page returns perfectly ordinary HTML
+    ///     and the GET used to answer <c>200 OK</c> — telling every cache, crawler and uptime check that
+    ///     the page was fine (#607).
+    /// </remarks>
+    internal bool LastRenderFaulted => View is RootErrorBoundary { RenderedFallback: true };
+
     public void AttachSocket(WebSocket socket, CancellationToken ct)
     {
         _socketCt = ct;

--- a/src/Rask.Server/RaskEndpointExtensions.cs
+++ b/src/Rask.Server/RaskEndpointExtensions.cs
@@ -284,6 +284,11 @@ public static class RaskEndpointExtensions
         // readable + hot-reloadable in Development.
         LiveOptions.MinifyScopedAssets ??= !app.Environment.IsDevelopment();
 
+        // Same idea, and the reason it is here rather than in Core: the host knows the answer, and every
+        // way of selecting Development that ISN'T an environment variable — --environment, appsettings,
+        // an IDE profile — used to give you the production error page while developing (#605).
+        LiveOptions.IsDevelopment ??= app.Environment.IsDevelopment();
+
         app.UseWebSockets();
         ((IEndpointRouteBuilder)app).UseRask<TApp>(pattern, pathBase);
         return app;
@@ -433,6 +438,15 @@ public static class RaskEndpointExtensions
             var content = LivePayload.InjectRootAttr(
                 html, session.Id, IsDevHotReloadEnabled(httpContext.RequestServices));
             httpContext.Response.ContentType = "text/html; charset=utf-8";
+            // A page that crashed is not a 200. The root boundary catches the exception and renders the
+            // error document, so without this the response looked entirely healthy to every cache,
+            // crawler and uptime check (#607). The body is unchanged — the error page is still served,
+            // and the live session still attaches, so "Try again" and the reload button both work.
+            if (session.LastRenderFaulted)
+            {
+                httpContext.Response.StatusCode = StatusCodes.Status500InternalServerError;
+            }
+
             // The shell embeds the session id (data-rask-root), which is the de-facto bearer
             // for the WS / upload / download endpoints. Forbid any shared-proxy / bfcache /
             // history caching so an authenticated user's session id can't be persisted and
@@ -1809,7 +1823,12 @@ public static class RaskEndpointExtensions
         var asm = typeof(RaskEndpointExtensions).Assembly;
         var name = asm.GetManifestResourceNames()
                        .FirstOrDefault(n => n.EndsWith("rask.js", StringComparison.Ordinal))
-                   ?? throw new InvalidOperationException("rask.js embedded resource not found.");
+                   ?? throw new InvalidOperationException(
+                       $"The Rask client script is missing from {asm.GetName().Name} "
+                       + $"{asm.GetName().Version}. This is a packaging fault rather than anything in "
+                       + "your app: the assembly should embed rask.js. Clear obj/ and bin/ and rebuild; "
+                       + "if it persists, the package is damaged — reinstall it, and please report it "
+                       + "with the assembly version above.");
         using var stream = asm.GetManifestResourceStream(name)!;
         using var reader = new StreamReader(stream, Encoding.UTF8);
         return reader.ReadToEnd();

--- a/src/Rask.Wasm/Diagnostics/RaskWasmDiagnostics.cs
+++ b/src/Rask.Wasm/Diagnostics/RaskWasmDiagnostics.cs
@@ -1,0 +1,87 @@
+using Microsoft.Extensions.Logging;
+using Rask.Core.Diagnostics;
+
+namespace Rask.Wasm.Diagnostics;
+
+/// <summary>
+///     Bridges the framework's dependency-free <see cref="RaskDiagnostics" /> seam to the browser app's
+///     <c>ILogger</c> pipeline — the WASM sibling of the server's bridge, installed once by
+///     <c>WasmHostBuilder.RunAsync</c>.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Without it, a WASM app was the one host where framework faults never reached the app's own
+///         logging at all: swallow-and-log is the framework's primary failure mode for navigate faults,
+///         JS dispatch faults and malformed frames, and all of them went to the seam's stderr default
+///         while the app's configured providers saw nothing. The host already calls
+///         <c>Services.AddLogging()</c>, so the factory was there the whole time; nothing consumed it.
+///     </para>
+///     <para>
+///         Deliberately a sibling rather than a shared type. The two hosts live in packages that share no
+///         assembly carrying <c>Microsoft.Extensions.Logging</c> — <c>Rask.Core</c> cannot take that
+///         dependency, which is the entire reason this seam exists — and giving <c>Rask.Server</c> a
+///         reference to a browser-side package to dedupe sixty lines would trade a real packaging
+///         constraint for a cosmetic one. <c>RaskDiagnosticsBridgeParityTests</c> pins the two
+///         implementations to the same level mapping so the copies cannot drift.
+///     </para>
+/// </remarks>
+internal static class RaskWasmDiagnostics
+{
+    private static ILoggerFactory? _factory;
+
+    /// <summary>
+    ///     Routes <see cref="RaskDiagnostics.Sink" /> into <paramref name="factory" />. A no-op when no
+    ///     logger factory is available, leaving the seam's stderr default in place.
+    /// </summary>
+    public static void Install(ILoggerFactory? factory)
+    {
+        if (factory is null)
+        {
+            return;
+        }
+
+        // No lock, unlike the server bridge: a browser app is single-threaded and there is exactly one
+        // host per process, so the multi-host race that one guards against cannot arise here.
+        _factory = factory;
+        RaskDiagnostics.Sink = Forward;
+    }
+
+    private static void Forward(RaskDiagnosticEvent e)
+    {
+        if (_factory is { } factory)
+        {
+            Emit(factory, e);
+        }
+    }
+
+    /// <summary>
+    ///     Log one event. A diagnostic must never become a fault — these call sites are inside the
+    ///     framework's own catch blocks, so an exception escaping here would turn a swallowed warning
+    ///     into a torn-down session. Swallow and fall back to stderr.
+    /// </summary>
+    internal static void Emit(ILoggerFactory factory, RaskDiagnosticEvent e)
+    {
+        try
+        {
+            factory.CreateLogger(e.Category).Log(Map(e.Level), e.Exception, "{RaskMessage}", e.Message);
+        }
+        catch
+        {
+            try
+            {
+                Console.Error.WriteLine(RaskDiagnostics.FormatDefault(e));
+            }
+            catch
+            {
+                // Nothing left to do — never rethrow out of a diagnostic.
+            }
+        }
+    }
+
+    internal static LogLevel Map(RaskLogLevel level) => level switch
+    {
+        RaskLogLevel.Error => LogLevel.Error,
+        RaskLogLevel.Warning => LogLevel.Warning,
+        _ => LogLevel.Information
+    };
+}

--- a/src/Rask.Wasm/WasmHostBuilder.cs
+++ b/src/Rask.Wasm/WasmHostBuilder.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
 using Microsoft.JSInterop;
 using Rask.Client.Browser;
 using Rask.Core;
@@ -13,6 +14,7 @@ using Rask.Core.Messaging;
 using Rask.Core.Routing;
 using Rask.Wasm.Authentication;
 using Rask.Wasm.Browser;
+using Rask.Wasm.Diagnostics;
 using Rask.Wasm.Files;
 
 namespace Rask.Wasm;
@@ -159,6 +161,11 @@ public sealed class WasmHostBuilder
         }
 
         var provider = Services.BuildServiceProvider();
+
+        // Route framework diagnostics into the app's own logging before anything can report one. Until
+        // this existed, WASM was the one host where a swallowed framework fault never reached the app's
+        // configured providers at all — it went to the seam's stderr default and nowhere else.
+        RaskWasmDiagnostics.Install(provider.GetService<ILoggerFactory>());
 
         // Bind the singleton JSRuntime into the static [JSImport]/[JSExport] bridge
         // BEFORE any user code can resolve IJSRuntime and start dispatching.

--- a/tests/Rask.Core.Tests/Components/DefaultErrorPageTests.cs
+++ b/tests/Rask.Core.Tests/Components/DefaultErrorPageTests.cs
@@ -1,4 +1,5 @@
 using Rask.Core.Components;
+using Rask.Core.Live;
 
 #pragma warning disable RASK014 // DefaultErrorPage is [SkipFactory]; tests construct it directly
 
@@ -25,6 +26,49 @@ public class DefaultErrorPageTests
 
     private static string Render(Exception ex, bool isDevelopment) =>
         new DefaultErrorPage(ex, isDevelopment).ToHtml();
+
+    // #605: the parameterless ctor — the one RootErrorBoundary actually uses in production — decided
+    // Development by reading ASPNETCORE_ENVIRONMENT / DOTNET_ENVIRONMENT and nothing else. Every other
+    // way of selecting it (dotnet run --environment, appsettings.json, assigning EnvironmentName, an IDE
+    // profile that sets configuration rather than the process environment) therefore produced the
+    // production page while developing: no stack trace, no source excerpt, and no hint why.
+    //
+    // Driven as a pure function rather than through LiveOptions.IsDevelopment. That flag is
+    // process-global and read by every render reaching RootErrorBoundary, so a test that flipped it
+    // could change what a concurrently-running test's error page contains — which is the class of
+    // flake this branch is otherwise busy removing.
+
+    [Fact]
+    public void The_host_answer_selects_development_with_no_environment_variable_set()
+    {
+        Assert.True(DefaultErrorPage.ResolveIsDevelopment(true, aspnetEnv: null, dotnetEnv: null));
+    }
+
+    [Fact]
+    public void The_host_answer_wins_over_the_environment_variables()
+    {
+        // The variables are a fallback, not a vote. A host reporting Production is not overridden by a
+        // stale variable left in someone's shell, and a host reporting Development does not need one.
+        Assert.False(DefaultErrorPage.ResolveIsDevelopment(false, "Development", "Development"));
+        Assert.True(DefaultErrorPage.ResolveIsDevelopment(true, "Production", "Production"));
+    }
+
+    [Fact]
+    public void With_no_host_answer_the_environment_variables_still_decide()
+    {
+        // Unchanged behaviour for a standalone host, or a component rendered outside one.
+        Assert.True(DefaultErrorPage.ResolveIsDevelopment(null, "Development", null));
+        Assert.True(DefaultErrorPage.ResolveIsDevelopment(null, null, "Development"));
+        Assert.True(DefaultErrorPage.ResolveIsDevelopment(null, "development", null));  // case-insensitive
+        Assert.False(DefaultErrorPage.ResolveIsDevelopment(null, "Production", null));
+        Assert.False(DefaultErrorPage.ResolveIsDevelopment(null, null, null));
+    }
+
+    [Fact]
+    public void ASPNETCORE_ENVIRONMENT_takes_precedence_over_DOTNET_ENVIRONMENT()
+    {
+        Assert.False(DefaultErrorPage.ResolveIsDevelopment(null, "Production", "Development"));
+    }
 
     [Fact]
     public void Always_ShowsHeadingTypeAndMessage()

--- a/tests/Rask.Core.Tests/Components/VirtualizeModelTests.cs
+++ b/tests/Rask.Core.Tests/Components/VirtualizeModelTests.cs
@@ -161,7 +161,13 @@ public class VirtualizeModelTests
             new List<int> { 1 },
             ItemSize: 0));
 
-        Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot());
+        // ArgumentOutOfRangeException, not InvalidOperationException: an out-of-range argument carries
+        // the offending value as a field rather than only in the prose (#611). Note this is NOT a
+        // widening — ArgumentOutOfRangeException does not derive from InvalidOperationException — so
+        // anything that caught the old type has to be updated.
+        var ex = Assert.Throws<ArgumentOutOfRangeException>(() => view.RenderAsLiveRoot());
+        Assert.Equal("ItemSize", ex.ParamName);
+        Assert.Equal(0, ex.ActualValue);
     }
 
     [Fact]

--- a/tests/Rask.Core.Tests/Diagnostics/ActionableExceptionMessageTests.cs
+++ b/tests/Rask.Core.Tests/Diagnostics/ActionableExceptionMessageTests.cs
@@ -1,0 +1,116 @@
+using Rask.Core.Routing;
+
+#pragma warning disable RASK014 // test-defined Component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Diagnostics;
+
+/// <summary>
+///     The framework's throw messages have to name the remedy, not just the cause (#611). Most of
+///     <c>Rask.Core</c> already did — <c>Navigator</c>, <c>Context</c>, <c>RouteAuthorizationGuard</c>,
+///     <c>ExpressionAccessor</c>, <c>RaskJSRuntime</c> are the models. These are the ones that didn't.
+/// </summary>
+/// <remarks>
+///     Asserting on message text is usually a smell, and here it is the point: the text IS the feature.
+///     Each case asserts the two things that were missing — enough context to find the offending thing,
+///     and a concrete instruction — rather than the exact sentence, so rewording stays free.
+/// </remarks>
+public class ActionableExceptionMessageTests
+{
+    // #611 calls this "the worst one", and it turned out to be unreachable: both callers of
+    // ResolveContext already gate on `Model is not null || Context is not null`, which is exactly the
+    // condition the throw checks. A Form with neither renders as a plain <form>, deliberately. So these
+    // drive ResolveContext directly — the guard is kept for the next caller, and the message is worth
+    // fixing for when that happens, but nobody has ever seen the old one.
+    [Fact]
+    public void A_form_with_neither_a_model_nor_a_context_renders_as_a_plain_form()
+    {
+        var view = new StubComponent(() => Form(Id: "plain")[Div()]);
+
+        var html = view.RenderAsLiveRoot();
+
+        Assert.Contains("<form id=\"plain\">", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_form_binding_guard_names_the_form_and_shows_both_ways_to_give_it_one()
+    {
+        var form = new Form { Id = "signup" };
+
+        var ex = Assert.Throws<InvalidOperationException>(() => form.ResolveContext());
+
+        Assert.Contains("#signup", ex.Message, StringComparison.Ordinal);       // which form
+        Assert.Contains("Form(model)", ex.Message, StringComparison.Ordinal);   // the shape
+        Assert.Contains("EditContext", ex.Message, StringComparison.Ordinal);   // the other way
+        // "Context" alone was ambiguous between the Context<T> component and an EditContext.
+        Assert.DoesNotContain("Form requires Model or Context.", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void The_form_binding_guard_invents_no_label_when_there_is_nothing_to_name()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => new Form().ResolveContext());
+
+        Assert.Contains("Form has neither", ex.Message, StringComparison.Ordinal);
+    }
+
+    // The runtime siblings of RASK003. Each used to echo the offending segment, show no correct one, and
+    // carry nothing to say which route it came from.
+    [Theory]
+    [InlineData("/docs/{}", "{id}")]
+    [InlineData("/files/{**}", "{**path}")]
+    [InlineData("/files/{*}", "{*path}")]
+    [InlineData("/items/{:guid}", "{id:guid?}")]
+    public void A_malformed_route_names_the_template_and_shows_a_correct_segment(
+        string template, string suggestion)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => RoutePattern.Parse(template));
+
+        Assert.Contains(template, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(suggestion, ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Outlet_outside_a_router_uses_the_same_words_as_the_router_itself()
+    {
+        // Two spellings for one condition meant searching the message found half the story, and which of
+        // them you hit depended only on whether there was a live context or merely no route in it.
+        var outlet = ReadSource("src", "Rask.Core", "Routing", "Outlet.cs");
+        var renderer = ReadSource("src", "Rask.Core", "Routing", "RouteChainRenderer.cs");
+
+        const string Shared = "Place Outlet() inside a Router(...) render tree.";
+        Assert.Contains(Shared, outlet, StringComparison.Ordinal);
+        Assert.Contains(Shared, renderer, StringComparison.Ordinal);
+        Assert.DoesNotContain(
+            "Outlet() must be called inside a Router render tree.", outlet, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DragDrop_without_a_body_shows_the_delegate_shape()
+    {
+        var view = new StubComponent(() => DragDrop());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => view.RenderAsLiveRoot());
+
+        Assert.Contains("DragDrop(Body:", ex.Message, StringComparison.Ordinal);
+    }
+
+    private static string ReadSource(params string[] parts) =>
+        File.ReadAllText(Path.Combine([LocateRepoRoot(), .. parts]));
+
+    private static string LocateRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException(
+            $"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Core.Tests/Diagnostics/RaskDiagnosticsTests.cs
+++ b/tests/Rask.Core.Tests/Diagnostics/RaskDiagnosticsTests.cs
@@ -131,12 +131,34 @@ public class RaskDiagnosticsTests
     }
 
     [Fact]
-    public void FormatDefault_MessageOnly_RendersMessage()
+    public void FormatDefault_MessageOnly_CarriesCategoryAndLevel()
     {
+        // The event has always carried a level and a category and the default sink dropped both, so on
+        // any host without a logging bridge "framework said something" and "framework reported an error
+        // in the diff codec" printed identically (#611).
         var line = RaskDiagnostics.FormatDefault(
             new RaskDiagnosticEvent(RaskLogLevel.Warning, "Rask.Test", "just a message"));
 
-        Assert.Equal("just a message", line);
+        Assert.Equal("[Rask:Rask.Test] warning: just a message", line);
+    }
+
+    // One Fact rather than a Theory: RaskLogLevel is internal, so it cannot be an InlineData parameter
+    // on a public test method.
+    [Fact]
+    public void FormatDefault_LabelsEveryLevel()
+    {
+        var expected = new[]
+        {
+            (RaskLogLevel.Information, "info"),
+            (RaskLogLevel.Warning, "warning"),
+            (RaskLogLevel.Error, "error"),
+        };
+
+        foreach (var (level, label) in expected)
+        {
+            var line = RaskDiagnostics.FormatDefault(new RaskDiagnosticEvent(level, "Rask.Test", "m"));
+            Assert.Equal($"[Rask:Rask.Test] {label}: m", line);
+        }
     }
 
     [Fact]
@@ -146,8 +168,9 @@ public class RaskDiagnosticsTests
         var line = RaskDiagnostics.FormatDefault(
             new RaskDiagnosticEvent(RaskLogLevel.Error, "Rask.Test", "handler threw", ex));
 
-        // Reproduces the framework's historical "<message>: <exception>" stderr format.
-        Assert.StartsWith("handler threw: ", line);
+        // The exception still travels after the message, separated by a colon; the prefix in front of it
+        // is what changed.
+        Assert.StartsWith("[Rask:Rask.Test] error: handler threw: ", line);
         Assert.Contains("boom", line);
     }
 }

--- a/tests/Rask.Server.Tests/Infrastructure/ThrowingOnRenderApp.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/ThrowingOnRenderApp.cs
@@ -1,0 +1,17 @@
+using Rask.Core;
+using Rask.Core.Components;
+
+#pragma warning disable RASK019 // test-infra apps predate framework-managed <head>
+
+namespace Rask.Server.Tests.Infrastructure;
+
+/// <summary>
+///     Faults during <em>render</em>, unlike <see cref="ThrowingApp" /> which faults in a click handler.
+///     That difference is the point: a render fault happens during the initial GET, so it is the case
+///     where the HTTP status of the response is decided (#607).
+/// </summary>
+public sealed class ThrowingOnRenderApp : Component
+{
+    protected override Component? Render() =>
+        throw new InvalidOperationException("render-boom");
+}

--- a/tests/Rask.Server.Tests/WebSockets/ErrorPageResponseTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/ErrorPageResponseTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Text.RegularExpressions;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+/// <summary>
+///     What the network sees when a page crashes, and what the user can do about it (#607).
+/// </summary>
+public sealed class ErrorPageResponseTests
+{
+    [Fact]
+    public async Task A_page_that_throws_while_rendering_answers_500_not_200()
+    {
+        // The root boundary catches the exception and renders the error document, so the response is
+        // perfectly ordinary HTML and nothing downstream could tell it apart from a healthy page: caches
+        // would store it, crawlers would index it, and an uptime check would report the site green.
+        using var host = RaskTestHost.Create<ThrowingOnRenderApp>(diffMode: LiveDiffMode.DisabledFull);
+
+        var response = await host.Http.GetAsync("/start");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+        // The body is unchanged: still the error page, not an empty 500.
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Something went wrong", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_page_that_renders_fine_still_answers_200()
+    {
+        using var host = RaskTestHost.Create<ThrowingApp>(diffMode: LiveDiffMode.DisabledFull);
+
+        var response = await host.Http.GetAsync("/start");
+
+        // ThrowingApp only throws from a click handler, so its initial render is healthy.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task The_error_page_offers_an_in_session_retry_alongside_the_reload()
+    {
+        // RootErrorBoundary used to discard the boundary's Recover — `(ex, _) =>` — leaving a full page
+        // reload as the only way out of a fault that had not damaged anything.
+        using var host = RaskTestHost.Create<ThrowingOnRenderApp>(diffMode: LiveDiffMode.DisabledFull);
+
+        var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+
+        Assert.Contains("Try again", html, StringComparison.Ordinal);
+        Assert.Contains("Reload this page", html, StringComparison.Ordinal);
+        // Try again is a live handler, not a link or a reload in disguise.
+        Assert.Matches(new Regex("data-rask-on-click=\"h\\d+\"[^>]*>Try again", RegexOptions.None), html);
+    }
+
+    [Fact]
+    public async Task Try_again_clears_the_error_and_puts_the_app_back()
+    {
+        // The common fault is a handler that threw, not a render that cannot succeed: the tree is
+        // intact, so recovering restores the app with its state rather than costing a round trip.
+        using var host = RaskTestHost.Create<ThrowingApp>(diffMode: LiveDiffMode.DisabledFull);
+        var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = MarkupAssert.SessionId(initialHtml);
+        var throwingId = Regex.Matches(initialHtml, "data-rask-on-click=\"(h\\d+)\"")
+            .Select(m => m.Groups[1].Value)
+            .First();
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        await ws.SendJsonAsync(new { id = throwingId });
+        var faulted = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(faulted);
+        Assert.Contains("Try again", faulted, StringComparison.Ordinal);
+
+        // Click it. Its id comes from the fallback render, so read it from the faulted payload.
+        var retryId = Regex.Match(faulted!, "data-rask-on-click=\\\\?\"(h\\d+)\\\\?\"[^>]*>Try again")
+            .Groups[1].Value;
+        Assert.NotEmpty(retryId);
+
+        await ws.SendJsonAsync(new { id = retryId });
+        var recovered = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(recovered);
+        Assert.Contains("count=", recovered, StringComparison.Ordinal);
+        Assert.DoesNotContain("Something went wrong", recovered, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
The developer-facing error surface: what the framework says when something breaks, and whether you can
tell you're in Development at the moment you most need to be.

Closes #611. Closes #605. Closes #606.
Partially addresses #607 — see **What is deferred** at the bottom.

## #605 — you lost dev stack traces unless the environment arrived via an env var

`DefaultErrorPage` decided Development by reading `ASPNETCORE_ENVIRONMENT` / `DOTNET_ENVIRONMENT` and
nothing else. The stated reason is sound — `Rask.Core` takes no `Microsoft.Extensions.Hosting`
dependency. The consequence was not: `dotnet run --environment Development`, `appsettings.json`,
assigning `builder.Environment.EnvironmentName`, and IDE profiles that set *configuration* all select
Development without setting a variable, and every one silently produced the production page.

It only looked fine because `DevCommand.BuildEnvironment` exports the variable itself — so the failure
appeared the moment you stepped off `rask dev`, which is exactly when the stack trace matters.

`UseRask` now resolves `LiveOptions.IsDevelopment` from `IWebHostEnvironment` (the same shape as the
adjacent `MinifyScopedAssets ??=` line); the variables stay as the fallback for a standalone host or a
component rendered outside one. A host reporting Production is **not** overridden by a stale shell
variable.

The decision is tested as a pure function rather than by mutating the flag. That is deliberate:
`LiveOptions.IsDevelopment` is process-global and read by every render reaching `RootErrorBoundary`, so
a test that flipped it could change what a *concurrently running* test's error page contains — which is
the class of flake this branch is otherwise busy removing.

## #611 — exceptions that name the problem but not the fix

| site | was | now |
| --- | --- | --- |
| `RoutePattern` ×3 | `Empty parameter in route segment '{}'` | names the **template** and shows a valid segment (`{id}`, `{**path}`, `{id:guid?}`) |
| `EditContext` ×2 | `Async validators are registered; call ValidateAsync.` | names **which** validator made it async |
| `Outlet` | its own weaker wording | converged on `RouteChainRenderer`'s, which names `Router(...)` |
| `DragDrop`, `VirtualizeModel` | `… delegate is required.` | shows the delegate shape |
| `VirtualizeModel.ItemSize` | `InvalidOperationException` | `ArgumentOutOfRangeException` carrying the value |
| `RootErrorBoundary` | an internal type name | what the reader actually did |
| `ServerFileBackend` | `File metadata is missing 'token'.` | app-facing, like the sibling throw two lines below |
| `RaskEndpointExtensions` | `rask.js embedded resource not found.` | names the assembly + version and what to try |

**⚠️ `VirtualizeModel.ItemSize` is a behavioural change, not just wording.**
`ArgumentOutOfRangeException` does **not** derive from `InvalidOperationException`, so a
`catch (InvalidOperationException)` around it needs updating. Sanctioned by the issue, called out in
the CHANGELOG.

**`Form requires Model or Context.` is unreachable.** The issue calls it "the worst one" — but both
callers of `ResolveContext` already gate on exactly the condition it checks, and a `Form` with neither
renders as a plain `<form>` by design. Kept and reworded for the next caller; the tests drive
`ResolveContext` directly rather than pretending it fires from a render, and a sibling test pins the
plain-`<form>` behaviour so nobody "fixes" it into a throw.

### Diagnostics

The issue's second half was that the default sink is `message` (plus exception) — no level, no category.
Two changes, and the order matters:

1. **`FormatDefault` now carries both** — `[Rask:Rask.Diff] error: …`. This fixes **every** unbridged
   host at once (WASM, Native, any app that hasn't wired logging), which a per-host bridge cannot.
2. **WASM gains an `ILogger` bridge.** The host already called `AddLogging()`; nothing consumed it, so a
   browser app was the one host where a swallowed framework fault never reached the app's own providers.

**I did not make `RaskDiagnostics` public**, which the plan proposed. `Rask.Testing` and `Rask.Wasm`
already have `InternalsVisibleTo` on Core — so #610's diagnostics capture is unblocked without it, and
the class doc's "kept internal for now" reasoning stands. A public seam is an irreversible commitment
and nothing here needed it.

The WASM bridge is a sibling of the server's rather than a shared type, and the code says why: no
assembly both hosts reference can carry `Microsoft.Extensions.Logging` — Core is forbidden from it by
design, which is the entire reason this seam exists — and giving `Rask.Server` a reference to a
browser-side package to dedupe sixty lines would trade a real packaging constraint for a cosmetic one.

## #607 — what shipped

- **A crashed page answers `500`, not `200`.** The root boundary catches the exception and renders the
  error document, so the response was ordinary HTML: caches stored it, crawlers indexed it, uptime
  checks reported green. Body unchanged, so the error page still renders and the live session still
  attaches.
- **`Try again` alongside `Reload this page`.** `ErrorBoundary`'s fallback has always received the
  boundary's `Recover` as its second argument and the root boundary discarded it (`(ex, _) =>`). The
  common fault is a handler that threw, where the tree is intact — recovering keeps the session, state
  and scroll position that a reload throws away. A deterministic render fault lands back on the error
  page, which is honest and is what React's boundary does; the reload button remains for it.

Tested end to end: a round-trip test throws from a handler, clicks the rendered `Try again`, and asserts
the app comes back with its counter intact.

## #606 — the docs said the opposite

`docs/lifecycle.md` claimed a faulted async hook logs to `Console.Error` and does **not** re-render, with
the symptom "a component stuck on a loading placeholder". `Component.ReportLifecycleFault` prefers the
boundary, `HtmlSerializer` stamps `Boundary` on every component, and `RootErrorBoundary` wraps the app —
so `comp.Boundary` is never null in a live app and the real symptom is the **whole page** being replaced.
Rewritten against the behaviour this PR settles, including how to scope the blast radius with your own
`ErrorBoundary` and what `Try again` does.

## What is deferred

**#607's development overlay is not in this PR, and #607 stays open.** Rendering the error *over* a live
app cannot be done from the root boundary: the fallback replaces the children, and re-rendering the
subtree that just threw would only throw again. Keeping the app's DOM requires the server to send an
out-of-band frame instead of a replacement render, and the client to paint over what it already has.

That is the same mechanism #603 needs for build errors, and the plan already notes #603 depends on this
primitive. Designing the frame twice — or landing a live-protocol change late in a long session, when
the WS frame stream is a documented contract — is worse than doing it once, deliberately, with #603.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — green
- New: 9 actionable-message tests, 4 dev-detection tests, 4 error-page response tests (incl. the
  `Try again` round trip)
- Updated: `VirtualizeModelTests` for the new exception type, `RaskDiagnosticsTests` for the new format

No render-hotpath change, so no benchmarks.
