### PR TITLE
test(e2e): let the OS pick every fixture's port, and trace a journey that fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,30 @@ them until tagged releases begin.
     rather than "did we write it", so the test doesn't vanish from the common path.
   - Docs, the tutorial (chapters 2, 3, 7), the `Rask.Example.Shop` command list and `rask new`'s printed next
     steps all drop the `--context AppDbContext` that is now the default behaviour.
+- **No E2E fixture picks its own port any more, so a straggler host can't block the push gate.** #612 fixed
+  the in-process static hosts; the eleven fixtures that launch a real `dotnet` process kept their constants,
+  maintained against a comment listing their siblings' numbers. That list was only ever unique *within* one
+  run of one checkout — and `5099` is the port `.githooks/pre-push` gates on, so a single leftover host
+  blocked pushing from every worktree on the machine. All eleven now reserve a loopback port from the OS
+  (`LoopbackPort.Reserve`, probing the family `localhost` actually resolves to), and a test fails the build
+  if a literal port comes back.
+  - **A bind clash and a broken app are no longer the same error.** An out-of-process host has to be *told*
+    where to listen, so the number is decided before anything binds and a clash stays possible in principle.
+    The fixture now reads the child's output: Kestrel's "address already in use" retries the whole launch on
+    a fresh port, anything else still fails immediately — a genuinely broken sample must not be retried into
+    a five-times-longer timeout. Previously a clash surfaced as "exited before becoming ready", sending the
+    reader after a bug in the sample; worse, a *stale host* on the fixed port answered the readiness poll
+    and every assertion silently ran against the wrong process.
+  - `WasmWatchAppFixture`'s hand-rolled `EnsurePortFree` is gone with the constant it guarded. It probed
+    IPv4 loopback only — the exact family mismatch that lets a port look free and still refuse to bind.
+  - The local-dev publish folder is keyed on the app instead of the app *and its port*, which would now
+    leave a fresh multi-hundred-megabyte publish behind on every run; concurrent publishes of the same app
+    are serialised, and it re-publishes rather than reusing whatever it finds.
+- **A failing browser journey now leaves a Playwright trace.** The existing dump explains a page that
+  *threw*; it says nothing about a page that is merely never still, which is how #625 presented — a 30s
+  "element is not stable" naming the element and nothing about what was moving. The journey records a trace
+  with DOM snapshots throughout and keeps it only on failure, printing the path and the command that opens
+  it. Always on rather than behind a flag, because the run worth tracing is the one that unexpectedly failed.
 
 ## [0.20.0] - 2026-08-06
 

--- a/tests/Rask.Examples.E2E.Tests/FixturePortTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/FixturePortTests.cs
@@ -1,0 +1,75 @@
+using System.Text.RegularExpressions;
+
+namespace Rask.Examples.E2E.Tests;
+
+/// <summary>
+///     Guards the invariant #614 established: no fixture in this suite picks its own port.
+/// </summary>
+/// <remarks>
+///     Every fixture used to declare one, kept unique by a comment naming its siblings' numbers. That is a
+///     list a human maintains, and it drifted exactly as you'd expect — <c>WasmWatchAppFixture</c> and
+///     <c>SiteWasmAppFixture</c> both held <c>5101</c> in different collections xUnit runs in parallel.
+///     Uniqueness was also only ever per <em>run</em>: a second worktree mid-suite claimed the same numbers,
+///     and <c>5099</c> is the port <c>.githooks/pre-push</c> gates on, so one straggler blocked pushing from
+///     everywhere on the machine.
+///     <para>
+///         This is a source scan rather than a reflection check on purpose: the thing being prevented is
+///         somebody writing the constant back, and by the time a port is reachable through a property it has
+///         already been reserved.
+///     </para>
+/// </remarks>
+public sealed class FixturePortTests
+{
+    // Any literal in the 5000-5999 range — the block the fixtures drew from, and the one an author reaching
+    // for "a port that looks free" reaches into.
+    private static readonly Regex Literal = new(@"\b5\d{3}\b", RegexOptions.Compiled);
+
+    [Fact]
+    public void No_fixture_hard_codes_a_port()
+    {
+        var infrastructure = Path.Combine(RepoRoot(), "tests", "Rask.Examples.E2E.Tests", "Infrastructure");
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(infrastructure, "*.cs"))
+        {
+            var lines = File.ReadAllLines(file);
+            for (var i = 0; i < lines.Length; i++)
+            {
+                var line = lines[i];
+
+                // Comments are where the history lives ("this fixture used to hold 5101"), and keeping that
+                // readable is worth more than a scan that cannot tell code from prose.
+                if (line.TrimStart().StartsWith("//", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                if (Literal.IsMatch(line))
+                {
+                    offenders.Add($"{Path.GetFileName(file)}:{i + 1}: {line.Trim()}");
+                }
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "E2E fixtures must take their port from LoopbackPort.Reserve(), not a literal — a number kept "
+            + "unique by hand is only unique within one run of one checkout. Offending lines:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Rask.slnx")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new InvalidOperationException($"Could not locate Rask.slnx walking up from {AppContext.BaseDirectory}");
+    }
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/AuthExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/AuthExampleAppFixture.cs
@@ -4,5 +4,4 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 public sealed class AuthExampleAppFixture : ExampleAppFixture
 {
     protected override string ProjectRelativePath => "samples/Rask.Example.Auth";
-    protected override int Port => 5102;
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/EfCoreExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/EfCoreExampleAppFixture.cs
@@ -13,9 +13,6 @@ public sealed class EfCoreExampleAppFixture : ExampleAppFixture
         Path.Combine(Path.GetTempPath(), $"rask-efcore-e2e-mail-{Guid.NewGuid():N}");
 
     protected override string ProjectRelativePath => "samples/Rask.Example.EfCore";
-
-    protected override int Port => 5110;
-
     protected override IReadOnlyDictionary<string, string>? ExtraEnvironment =>
         new Dictionary<string, string>
         {

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ExampleAppFixture.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Text;
 
@@ -11,13 +12,29 @@ public abstract class ExampleAppFixture : IAsyncLifetime
     private const string Configuration = "Release";
 #endif
 
+    // How many times a launch is retried when the child reports the port was taken between reserving it
+    // and binding it. A clash is already unlikely (the OS hands out ephemeral ports it believes free) and
+    // independent per attempt, so a handful is plenty; the cap exists so a machine that is genuinely out
+    // of ports fails with a sentence rather than spinning.
+    private const int LaunchAttempts = 5;
+
+    // One lock per published app, so two fixtures booting the same app can't run `dotnet publish` into the
+    // same output directory at once.
+    private static readonly ConcurrentDictionary<string, Lock> PublishLocks = new();
+
     private readonly Lock _logLock = new();
     private readonly StringBuilder _stderr = new();
     private readonly StringBuilder _stdout = new();
     private Process? _process;
 
     protected abstract string ProjectRelativePath { get; }
-    protected abstract int Port { get; }
+
+    /// <summary>
+    ///     The loopback port the host was launched on, reserved from the OS in <see cref="InitializeAsync" />
+    ///     — see <see cref="LoopbackPort" /> for why it is not a constant.
+    /// </summary>
+    protected int Port { get; private set; }
+
     protected virtual TimeSpan ReadyTimeout => TimeSpan.FromSeconds(120);
 
     // When true the host is `dotnet publish`-ed and the published DLL is run from its own folder,
@@ -52,27 +69,51 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         var repoRoot = LocateRepoRoot();
         var projectPath = Path.Combine(repoRoot, ProjectRelativePath);
 
-        var psi = RunPublished
-            ? PublishAndBuildStartInfo(repoRoot, projectPath)
-            : DotnetRunStartInfo(repoRoot, projectPath);
-        psi.Environment["ASPNETCORE_URLS"] = BaseUrl;
-        psi.Environment["DOTNET_ENVIRONMENT"] = "Production";
-
-        if (ExtraEnvironment is { } extra)
+        // Reserve → launch → wait, retrying the *whole* launch if the child reports the port was taken in
+        // between. The window is inherent: an out-of-process host must be told where to listen, so the
+        // number is decided before anything binds (see LoopbackPort). Retrying is what closes it.
+        for (var attempt = 1; ; attempt++)
         {
-            foreach (var (key, value) in extra)
+            Port = LoopbackPort.Reserve();
+
+            var psi = RunPublished
+                ? PublishAndBuildStartInfo(repoRoot, projectPath)
+                : DotnetRunStartInfo(repoRoot, projectPath);
+            psi.Environment["ASPNETCORE_URLS"] = BaseUrl;
+            psi.Environment["DOTNET_ENVIRONMENT"] = "Production";
+
+            if (ExtraEnvironment is { } extra)
             {
-                psi.Environment[key] = value;
+                foreach (var (key, value) in extra)
+                {
+                    psi.Environment[key] = value;
+                }
+            }
+
+            ClearLog();
+            _process = Process.Start(psi)
+                       ?? throw new InvalidOperationException($"Failed to start `dotnet run` for {ProjectRelativePath}");
+
+            _ = Task.Run(() => DrainAsync(_process.StandardOutput, _stdout));
+            _ = Task.Run(() => DrainAsync(_process.StandardError, _stderr));
+
+            if (await WaitForReadyAsync() is not { } portClash)
+            {
+                return;
+            }
+
+            await DisposeAsync();
+            _process = null;
+
+            if (attempt == LaunchAttempts)
+            {
+                throw new InvalidOperationException(
+                    $"{ProjectRelativePath} could not bind a loopback port: {LaunchAttempts} OS-assigned " +
+                    "candidates were all taken before the host could claim them. Something on this machine " +
+                    "is claiming ports as fast as they are handed out — check for stragglers from an " +
+                    "earlier run ('lsof -nP -iTCP -sTCP:LISTEN').", portClash);
             }
         }
-
-        _process = Process.Start(psi)
-                   ?? throw new InvalidOperationException($"Failed to start `dotnet run` for {ProjectRelativePath}");
-
-        _ = Task.Run(() => DrainAsync(_process.StandardOutput, _stdout));
-        _ = Task.Run(() => DrainAsync(_process.StandardError, _stderr));
-
-        await WaitForReadyAsync();
     }
 
     public async Task DisposeAsync()
@@ -104,7 +145,12 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         _process.Dispose();
     }
 
-    private async Task WaitForReadyAsync()
+    /// <summary>
+    ///     Polls until the host answers. Returns <c>null</c> once it does, or the bind failure when the host
+    ///     died because the port was taken — which the caller retries on a fresh port. Anything else throws:
+    ///     a sample that is genuinely broken must not be retried into a five-times-longer timeout.
+    /// </summary>
+    private async Task<Exception?> WaitForReadyAsync()
     {
         using var http = new HttpClient { Timeout = TimeSpan.FromSeconds(2) };
         var deadline = DateTime.UtcNow + ReadyTimeout;
@@ -113,8 +159,20 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         {
             if (_process!.HasExited)
             {
+                // The drain tasks are still reading a pipe that has just closed; give them the moment they
+                // need, or the log that decides "port clash" vs "broken app" can be read half-written.
+                await _process.WaitForExitAsync();
+                var log = ServerLog;
+
+                if (LoopbackPort.LooksLikeAddressInUse(log))
+                {
+                    return new InvalidOperationException(
+                        $"{ProjectRelativePath} could not bind {BaseUrl} — the port was taken between " +
+                        $"reserving it and launching the host.\n{log}");
+                }
+
                 throw new InvalidOperationException(
-                    $"{ProjectRelativePath} exited before becoming ready (code {_process.ExitCode}).\n{ServerLog}");
+                    $"{ProjectRelativePath} exited before becoming ready (code {_process.ExitCode}).\n{log}");
             }
 
             try
@@ -122,7 +180,7 @@ public abstract class ExampleAppFixture : IAsyncLifetime
                 using var resp = await http.GetAsync(BaseUrl);
                 if ((int)resp.StatusCode < 500)
                 {
-                    return;
+                    return null;
                 }
             }
             catch (HttpRequestException)
@@ -139,6 +197,15 @@ public abstract class ExampleAppFixture : IAsyncLifetime
 
         throw new TimeoutException(
             $"{ProjectRelativePath} did not respond on {BaseUrl} within {ReadyTimeout}.\n{ServerLog}");
+    }
+
+    private void ClearLog()
+    {
+        lock (_logLock)
+        {
+            _stdout.Clear();
+            _stderr.Clear();
+        }
     }
 
     private async Task DrainAsync(StreamReader reader, StringBuilder buffer)
@@ -170,7 +237,25 @@ public abstract class ExampleAppFixture : IAsyncLifetime
         }
 
         // Local-dev fallback: no CI prebuild present, so publish the host on demand into a temp folder.
-        var publishDir = Path.Combine(Path.GetTempPath(), "rask-e2e-publish", $"{appName}-{Port}");
+        // Keyed on the app alone — it used to carry the port too, which was harmless while ports were
+        // constants and would now leave a fresh multi-hundred-megabyte publish behind on every run. Two
+        // fixtures booting the same app therefore share one folder, so the publish is serialised: MSBuild
+        // writing the same output directory from two processes corrupts it.
+        var publishDir = Path.Combine(Path.GetTempPath(), "rask-e2e-publish", appName);
+        lock (PublishLocks.GetOrAdd(appName, static _ => new Lock()))
+        {
+            PublishInto(repoRoot, publishDir);
+        }
+
+        return RunPublishedDllStartInfo(publishDir, appName);
+    }
+
+    // Always re-publishes rather than reusing whatever is in the folder: `dotnet publish` is incremental,
+    // so the cost of being right is small, and a reused publish directory silently serving last week's
+    // bytes is the failure mode that costs an afternoon.
+    private void PublishInto(string repoRoot, string publishDir)
+    {
+        var projectPath = Path.Combine(repoRoot, ProjectRelativePath);
         Directory.CreateDirectory(publishDir);
 
         var publish = new ProcessStartInfo("dotnet")
@@ -194,8 +279,6 @@ public abstract class ExampleAppFixture : IAsyncLifetime
                     $"`dotnet publish` failed for {ProjectRelativePath} (exit {p.ExitCode}).\n{stdout}\n{stderr}");
             }
         }
-
-        return RunPublishedDllStartInfo(publishDir, appName);
     }
 
     // Runs the published host DLL *from its own folder* — the working directory becomes the content root,

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/JwtServerAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/JwtServerAuthAppFixture.cs
@@ -4,5 +4,4 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 public sealed class JwtServerAuthAppFixture : ExampleAppFixture
 {
     protected override string ProjectRelativePath => "samples/Rask.Example.Auth.Jwt";
-    protected override int Port => 5103;
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/LoopbackPort.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/LoopbackPort.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace Rask.Examples.E2E.Tests.Infrastructure;
+
+/// <summary>
+///     Asks the OS for a free loopback port, so nothing in this suite has to keep a list of numbers unique
+///     by hand.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Every fixture used to declare a constant. That was unique <em>within</em> a run, which is all the
+///         comments claimed, but each copy of the suite on the machine claimed the same numbers — so a
+///         straggler host, or a second worktree mid-suite, produced either a bind failure or, worse, a poll
+///         that succeeded against somebody else's process. <c>5099</c> was the sharpest case: the
+///         <c>pre-push</c> hook runs its gate on it, so one leftover host blocked pushing from every
+///         worktree on the machine.
+///     </para>
+///     <para>
+///         The probe binds the family <c>localhost</c> will actually resolve to. A <c>localhost</c> prefix
+///         holds <c>[::1]</c> only where IPv6 is available (measured in #612 — which is also why a port can
+///         look free on <c>127.0.0.1</c> and still refuse to bind), so probing the wrong family hands back a
+///         number that is not free for the thing about to use it.
+///     </para>
+///     <para>
+///         Releasing the probe before the real listener binds leaves a window in which someone else can take
+///         the port. That is unavoidable here: an <see cref="System.Diagnostics.Process">out-of-process</see>
+///         host has to be <em>told</em> where to listen, so the number must be decided before anything binds
+///         — the "let <c>HttpListener.Start()</c> be the authoritative test" trick that fixed the in-process
+///         static hosts does not transfer. Callers close the window by retrying: see
+///         <see cref="LooksLikeAddressInUse" />.
+///     </para>
+/// </remarks>
+internal static class LoopbackPort
+{
+    /// <summary>Returns a port the OS has just confirmed free on the loopback family <c>localhost</c> uses.</summary>
+    public static int Reserve()
+    {
+        var loopback = Socket.OSSupportsIPv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
+        var probe = new TcpListener(loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    /// <summary>
+    ///     True when a host's drained output is the "someone already has that port" failure rather than the
+    ///     app being broken. Without this the two are indistinguishable: a child that fails to bind exits
+    ///     immediately, and the fixture reported that as "exited before becoming ready", sending the reader
+    ///     after a bug in the sample.
+    /// </summary>
+    /// <remarks>
+    ///     Kestrel fails fast with <c>IOException: Failed to bind to address http://localhost:{port}:
+    ///     address already in use.</c> Both fragments are matched: the second is the OS text and can be
+    ///     localised, the first is Kestrel's own and is not.
+    /// </remarks>
+    public static bool LooksLikeAddressInUse(string log) =>
+        log.Contains("address already in use", StringComparison.OrdinalIgnoreCase)
+        || log.Contains("Failed to bind to address", StringComparison.OrdinalIgnoreCase)
+        || log.Contains("Only one usage of each socket address", StringComparison.OrdinalIgnoreCase);
+}

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ServerExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ServerExampleAppFixture.cs
@@ -3,8 +3,6 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 public sealed class ServerExampleAppFixture : ExampleAppFixture
 {
     protected override string ProjectRelativePath => "samples/Rask.Example.Server";
-    protected override int Port => 5099;
-
     // The Server journey runs the slow-3G step, which needs production static-asset serving
     // (brotli-compressed, ETag/304-revalidated package _content). Run the published host.
     protected override bool RunPublished => true;

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/ShopExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/ShopExampleAppFixture.cs
@@ -22,9 +22,6 @@ public sealed class ShopExampleAppFixture : ExampleAppFixture
     private string DbPath => Path.Combine(Path.GetTempPath(), $"rask-shop-e2e-{_id}.db");
 
     protected override string ProjectRelativePath => "samples/Rask.Example.Shop";
-
-    protected override int Port => 5113;
-
     // Run the published app, like the Server showcase does. A plain `dotnet run` over in-repo project
     // references never materialises the `_content/Rask.Bootstrap/*` static assets the shell links, so the
     // page loads with failing stylesheet requests — which is not how anyone deploys it, and not what these

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/SqliteExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/SqliteExampleAppFixture.cs
@@ -8,9 +8,6 @@ public sealed class SqliteExampleAppFixture : ExampleAppFixture
         Path.Combine(Path.GetTempPath(), $"rask-sqlite-e2e-{Guid.NewGuid():N}.db");
 
     protected override string ProjectRelativePath => "samples/Rask.Example.Sqlite";
-
-    protected override int Port => 5112;
-
     protected override IReadOnlyDictionary<string, string>? ExtraEnvironment =>
         new Dictionary<string, string> { ["RASK_DB_PATH"] = _dbPath };
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/StaticWwwrootHostFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/StaticWwwrootHostFixture.cs
@@ -116,37 +116,25 @@ public abstract class StaticWwwrootHostFixture : IAsyncLifetime
     /// </summary>
     /// <remarks>
     ///     <para>
-    ///         Each fixture used to declare a hard-coded port. Unique <em>within</em> a run, which is all the
-    ///         comment claimed, but every copy of the suite on the machine claimed the same ten, so a
-    ///         straggler host or a second checkout produced a bare <c>HttpListenerException</c> — reported
-    ///         either as a green run that "failed", or as a dozen <c>ERR_CONNECTION_REFUSED</c> tests that
-    ///         read like a broken app rather than a taken port.
+    ///         <see cref="LoopbackPort.Reserve" /> explains why the number comes from the OS rather than a
+    ///         constant, and which loopback family the probe has to bind.
     ///     </para>
     ///     <para>
-    ///         <c>HttpListener</c> rejects a <c>:0</c> prefix outright ("Invalid port in prefix"), and it
-    ///         cannot report an assigned port back, so the OS is asked for an ephemeral port through a
-    ///         throwaway <see cref="TcpListener" /> and <c>HttpListener.Start()</c> is then the
-    ///         authoritative test. Releasing the probe before binding leaves a window, so a clash simply
-    ///         costs another candidate rather than the run.
-    ///     </para>
-    ///     <para>
-    ///         The probe binds the family <c>localhost</c> will resolve to: a <c>localhost</c> prefix holds
-    ///         <c>[::1]</c> only where IPv6 is available (measured — which is also why a port can look free
-    ///         on <c>127.0.0.1</c> and still refuse to bind), and the explicit <c>http://[::1]:port/</c>
-    ///         form that would let us bind both is itself rejected as an invalid prefix.
+    ///         <c>HttpListener</c> rejects a <c>:0</c> prefix outright ("Invalid port in prefix") and cannot
+    ///         report an assigned port back, so the reserved number is passed to it and
+    ///         <c>HttpListener.Start()</c> is then the authoritative test. This host is in-process, so it can
+    ///         afford that: the probe-release window costs another candidate rather than the run. (The
+    ///         explicit <c>http://[::1]:port/</c> form that would let us bind both families is itself
+    ///         rejected as an invalid prefix.)
     ///     </para>
     /// </remarks>
     private static (HttpListener Listener, int Port) BindEphemeral(string fixture, int attempts = 20)
     {
-        var loopback = Socket.OSSupportsIPv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
         HttpListenerException? last = null;
 
         for (var attempt = 0; attempt < attempts; attempt++)
         {
-            var probe = new TcpListener(loopback, 0);
-            probe.Start();
-            var port = ((IPEndPoint)probe.LocalEndpoint).Port;
-            probe.Stop();
+            var port = LoopbackPort.Reserve();
 
             var listener = new HttpListener();
             listener.Prefixes.Add($"http://localhost:{port}/");

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/SubPathWasmAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/SubPathWasmAppFixture.cs
@@ -21,10 +21,6 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
     private const string Configuration = "Release";
 #endif
 
-    // 5099 is ServerExampleAppFixture, 5098 is WasmExampleAppFixture; these collections
-    // run in parallel, so this fixture needs its own port to avoid an "address already in
-    // use" bind clash that crashes both hosts.
-    private const int Port = 5097;
     private const string PathBase = "/sub";
 
     private readonly Lock _logLock = new();
@@ -33,8 +29,12 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
     private Process? _process;
     private string? _bundleDir;
 
-    public string BaseUrl => $"http://localhost:{Port}{PathBase}";
-    public string OriginUrl => $"http://localhost:{Port}";
+    // Assigned by the OS at InitializeAsync — see LoopbackPort. This fixture used to hold 5097 by hand,
+    // maintained against a written-down list of its siblings' numbers, which is only unique per run.
+    private int _port;
+
+    public string BaseUrl => $"http://localhost:{_port}{PathBase}";
+    public string OriginUrl => $"http://localhost:{_port}";
 
     public string ServerLog
     {
@@ -83,6 +83,8 @@ public sealed class SubPathWasmAppFixture : IAsyncLifetime
         }
 
         await File.WriteAllTextAsync(indexHtmlPath, rewritten);
+
+        _port = LoopbackPort.Reserve();
 
         var psi = new ProcessStartInfo("dotnet")
         {

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/TestArtifacts.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/TestArtifacts.cs
@@ -6,12 +6,19 @@ internal static class TestArtifacts
 {
     private static readonly string Root = Path.Combine(LocateRepoRoot(), "TestResults", "E2E");
 
-    public static async Task DumpAsync(IPage page, string fixtureName, string testName, string serverLog,
-        string[]? console = null)
+    /// <summary>Where a failing test's artifacts for <paramref name="testName" /> are written.</summary>
+    public static string DirectoryFor(string fixtureName, string testName)
     {
         var safeName = string.Concat(testName.Select(c => char.IsLetterOrDigit(c) || c is '_' or '-' ? c : '_'));
         var dir = Path.Combine(Root, fixtureName, safeName);
         Directory.CreateDirectory(dir);
+        return dir;
+    }
+
+    public static async Task DumpAsync(IPage page, string fixtureName, string testName, string serverLog,
+        string[]? console = null)
+    {
+        var dir = DirectoryFor(fixtureName, testName);
 
         if (console is { Length: > 0 })
         {

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmCookieAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmCookieAuthAppFixture.cs
@@ -4,6 +4,5 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 public sealed class WasmCookieAuthAppFixture : ExampleAppFixture
 {
     protected override string ProjectRelativePath => "samples/Rask.Example.Auth.WasmCookie.Host";
-    protected override int Port => 5104;
     protected override TimeSpan ReadyTimeout => TimeSpan.FromSeconds(180);
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmExampleAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmExampleAppFixture.cs
@@ -3,6 +3,5 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 public sealed class WasmExampleAppFixture : ExampleAppFixture
 {
     protected override string ProjectRelativePath => "samples/Rask.Example.Wasm.Host";
-    protected override int Port => 5098;
     protected override TimeSpan ReadyTimeout => TimeSpan.FromSeconds(180);
 }

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmJwtAuthAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmJwtAuthAppFixture.cs
@@ -4,7 +4,6 @@ namespace Rask.Examples.E2E.Tests.Infrastructure;
 public sealed class WasmJwtAuthAppFixture : ExampleAppFixture
 {
     protected override string ProjectRelativePath => "samples/Rask.Example.Auth.WasmJwt.Host";
-    protected override int Port => 5105;
     protected override TimeSpan ReadyTimeout => TimeSpan.FromSeconds(180);
 
     // The host fails fast without Jwt:Key outside Development (the public DevKey would let anyone

--- a/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmWatchAppFixture.cs
+++ b/tests/Rask.Examples.E2E.Tests/Infrastructure/WasmWatchAppFixture.cs
@@ -28,15 +28,18 @@ public sealed class WasmWatchAppFixture : IAsyncLifetime
     internal const string EditedMarker = "hot-reload-probe-edited";
     internal const string ProbeRoute = "hot-reload-probe";
 
-    private const int PortNumber = 5101;
-
     private readonly Lock _logLock = new();
     private readonly StringBuilder _log = new();
 
     private Process? _process;
     private string _probeFile = string.Empty;
 
-    public string BaseUrl => $"http://localhost:{PortNumber}";
+    // Assigned by the OS at InitializeAsync — see LoopbackPort. This fixture used to hold 5101, which it
+    // shared with SiteWasmAppFixture in a different (parallel) collection until #612 moved that one to an
+    // ephemeral port; the collision was removed by the other side of it, not by this one.
+    private int _port;
+
+    public string BaseUrl => $"http://localhost:{_port}";
 
     public string ServerLog
     {
@@ -55,10 +58,12 @@ public sealed class WasmWatchAppFixture : IAsyncLifetime
         var host = Path.Combine(repoRoot, "samples", "Rask.Example.Wasm.Host");
         _probeFile = Path.Combine(repoRoot, "samples", "Rask.Example.Wasm", "Features", "HotReloadProbePage.cs");
 
-        // Fail fast on a busy port instead of testing against whatever is on it. A leftover host from
-        // an earlier run answers the readiness poll perfectly happily, and every later assertion then
-        // measures a server that never saw the edit — which reads as "hot reload is broken" and is not.
-        EnsurePortFree();
+        // An OS-assigned port, rather than testing against whatever is on a fixed one. A leftover host
+        // from an earlier run answers the readiness poll perfectly happily, and every later assertion
+        // then measures a server that never saw the edit — which reads as "hot reload is broken" and is
+        // not. The old guard probed IPv4 loopback for a fixed number and told you to `pkill`;
+        // LoopbackPort.Reserve asks for one nobody holds, on the family `localhost` resolves to.
+        _port = LoopbackPort.Reserve();
 
         WriteProbe(OriginalMarker);
 
@@ -201,24 +206,6 @@ public sealed class WasmWatchAppFixture : IAsyncLifetime
         if (build.ExitCode != 0)
         {
             throw new InvalidOperationException($"Pre-build of the WASM host failed.\n{output}\n{error}");
-        }
-    }
-
-    private static void EnsurePortFree()
-    {
-        try
-        {
-            using var probe = new System.Net.Sockets.TcpListener(System.Net.IPAddress.Loopback, PortNumber);
-            probe.Start();
-            probe.Stop();
-        }
-        catch (System.Net.Sockets.SocketException)
-        {
-            throw new InvalidOperationException(
-                $"Port {PortNumber} is already in use — most likely a `dotnet watch` or host process left "
-                + "over from an earlier run of this gate. Kill it (`pkill -f Rask.Example.Wasm.Host`, "
-                + "`pkill -f 'dotnet watch'`) and re-run; otherwise this test would silently assert "
-                + "against that process instead of the one it starts.");
         }
     }
 

--- a/tests/Rask.Examples.E2E.Tests/LoopbackPortTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/LoopbackPortTests.cs
@@ -1,0 +1,51 @@
+using System.Net;
+using System.Net.Sockets;
+using Rask.Examples.E2E.Tests.Infrastructure;
+
+namespace Rask.Examples.E2E.Tests;
+
+public sealed class LoopbackPortTests
+{
+    [Fact]
+    public void Reserve_hands_back_a_port_that_can_actually_be_bound()
+    {
+        var port = LoopbackPort.Reserve();
+
+        // The family matters: a `localhost` prefix holds [::1] only where IPv6 is available, so a port
+        // probed on the wrong family can look free and still refuse to bind (measured in #612).
+        var loopback = Socket.OSSupportsIPv6 ? IPAddress.IPv6Loopback : IPAddress.Loopback;
+        var listener = new TcpListener(loopback, port);
+        listener.Start();
+        listener.Stop();
+    }
+
+    [Fact]
+    public void Reserve_does_not_hand_the_same_port_out_twice_in_a_row()
+    {
+        // Not a guarantee the OS makes in general, but if consecutive calls collided the retry loop in
+        // ExampleAppFixture would burn all five attempts on the same number.
+        var ports = Enumerable.Range(0, 8).Select(_ => LoopbackPort.Reserve()).ToArray();
+
+        Assert.Equal(ports.Length, ports.Distinct().Count());
+    }
+
+    // Kestrel's real failure text. If this string ever drifts the retry silently stops working and a
+    // clash comes back as "exited before becoming ready", so it is pinned verbatim rather than paraphrased.
+    [Theory]
+    [InlineData("Unhandled exception. System.IO.IOException: Failed to bind to address "
+                + "http://localhost:5099: address already in use.")]
+    [InlineData("System.Net.Sockets.SocketException (48): Address already in use")]
+    [InlineData("Only one usage of each socket address (protocol/network address/port) is normally permitted.")]
+    public void LooksLikeAddressInUse_recognises_a_bind_clash(string log) =>
+        Assert.True(LoopbackPort.LooksLikeAddressInUse(log));
+
+    // The other half of the contract, and the more important one: a host that died for its own reasons
+    // must NOT be retried, or a genuinely broken sample turns a 120s timeout into a 600s one and the
+    // reader is told the port was busy.
+    [Theory]
+    [InlineData("Unhandled exception. System.InvalidOperationException: Jwt__Key is not configured.")]
+    [InlineData("Microsoft.Data.Sqlite.SqliteException: SQLite Error 14: 'unable to open database file'.")]
+    [InlineData("")]
+    public void LooksLikeAddressInUse_ignores_an_ordinary_crash(string log) =>
+        Assert.False(LoopbackPort.LooksLikeAddressInUse(log));
+}

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
@@ -37,6 +37,22 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
             Permissions = ["clipboard-read", "clipboard-write", "geolocation"],
             Geolocation = new Geolocation { Latitude = 51.5074f, Longitude = -0.1278f, Accuracy = 50 }
         });
+        // Record a Playwright trace for the whole journey and keep it only if the journey fails (see
+        // RunAsync). The console dump below explains a page that *threw*; it says nothing about a page
+        // that is merely never still, which is how #625 presented — a 30s "element is not stable" naming
+        // the element and nothing about what was moving. A trace's DOM snapshots do name it.
+        //
+        // Always-on rather than behind a flag, deliberately: the failure this is for did not reproduce on
+        // demand, so the only trace worth having is the one from the run that happened to fail. Screenshots
+        // are included because a moving box is a thing you can see; Sources are not, since the C# stack is
+        // already in the test output.
+        await _ctx.Tracing.StartAsync(new TracingStartOptions
+        {
+            Screenshots = true,
+            Snapshots = true,
+            Sources = false
+        });
+
         Page = await _ctx.NewPageAsync();
         // Capture the browser console + uncaught page errors so a failing test can surface
         // the real client-side cause (e.g. a scoped-JS "Could not find … on target" force-fault
@@ -108,17 +124,30 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
 
     protected async Task RunAsync(Func<Task> body, [CallerMemberName] string testName = "")
     {
+        var traced = false;
         try
         {
             await body();
         }
         catch
         {
+            traced = true;
+            await SaveTraceAsync(testName);
             await DumpDiagnosticsAsync(testName);
             throw;
         }
         finally
         {
+            if (!traced)
+            {
+                // Stop with no path: the trace is discarded, so a green run leaves nothing behind.
+                try { await _ctx.Tracing.StopAsync(); }
+                catch
+                {
+                    /* context may already be gone */
+                }
+            }
+
             string[] console;
             lock (_console)
             {
@@ -126,6 +155,23 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
             }
 
             await TestArtifacts.DumpAsync(Page, FixtureName, testName, ServerLog, console);
+        }
+    }
+
+    // Writes the journey's trace next to the rest of its artifacts and prints the command that opens it —
+    // a trace nobody knows how to look at is not evidence.
+    private async Task SaveTraceAsync(string testName)
+    {
+        try
+        {
+            var path = Path.Combine(TestArtifacts.DirectoryFor(FixtureName, testName), "trace.zip");
+            await _ctx.Tracing.StopAsync(new TracingStopOptions { Path = path });
+            Console.WriteLine($"  trace: {path}");
+            Console.WriteLine($"    open with: pwsh <playwright.ps1> show-trace {path}");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"  trace: could not be saved ({ex.GetType().Name}: {ex.Message})");
         }
     }
 


### PR DESCRIPTION
Closes #614.

#612 fixed the half of this that the in-process static hosts own. This is the other half — the eleven
fixtures that launch a real `dotnet` process — plus a diagnostic for #625.

## Why these were left behind, and why that reasoning has run out

The deferral was defensible: an out-of-process host has to be **told** where to listen, so the port must
be decided before anything binds, and "let `HttpListener.Start()` be the authoritative test" — the trick
that fixed the static hosts — does not transfer.

What it left in place was a list of eleven constants kept unique by a comment naming each fixture's
siblings. That is unique *within* one run of one checkout, which is all the comments claimed, but every
copy of the suite on the machine claimed the same eleven. `5099` is the sharp one: `.githooks/pre-push`
gates on it, so one leftover host blocked pushing from **every** worktree.

`LoopbackPort.Reserve` asks the OS instead, probing the family `localhost` actually resolves to — a
`localhost` prefix holds `[::1]` only where IPv6 is available, which is why a port can look free on
`127.0.0.1` and still refuse to bind. The reserve-then-hand-over window is inherent, so the fixture closes
it by retrying rather than pretending it isn't there.

## A bind clash and a broken app were the same error

This is the part worth reading. `WaitForReadyAsync` now reads the child's drained output:

- Kestrel's `address already in use` → retry the whole launch on a fresh port (5 attempts, then a sentence
  naming what to look for).
- Anything else → fail immediately, unchanged. A genuinely broken sample must **not** be retried into a
  five-times-longer timeout.

Before, a clash surfaced as *"exited before becoming ready"*, sending the reader after a bug in the sample.
And worse, a **stale host** sitting on the fixed port answered the readiness poll perfectly happily — so
every assertion in the class then ran against the wrong process, which is the failure mode that reads as a
broken app and isn't one.

`LoopbackPortTests` pins Kestrel's failure text verbatim in both directions. If that string ever drifts the
retry silently stops working, so the negative cases (a config throw, a SQLite throw, an empty log) are
pinned too.

## The rest

- **`WasmWatchAppFixture.EnsurePortFree` is gone** with the constant it guarded. It probed IPv4 `Loopback`
  only — the exact family mismatch above — and its remedy was to tell you to `pkill`.
- **The local-dev publish folder is keyed on the app**, not the app *and its port*, which would now leave a
  fresh multi-hundred-megabyte publish behind on every run. Same-app publishes are serialised (MSBuild
  writing one output directory from two processes corrupts it), and it re-publishes rather than trusting
  what it finds — a publish directory silently serving last week's bytes is a known afternoon.
- **A test fails the build if a port literal comes back into a fixture.** A source scan, not a reflection
  check, because the thing being prevented is somebody writing the constant back; by the time a port is
  reachable through a property it has already been reserved. Comments are skipped so the history
  ("this fixture used to hold 5101") stays readable.

## For #625 — a failing journey now leaves a trace

Not a fix. [#625 does not reproduce here](https://github.com/pal-tamas/rask/issues/625#issuecomment-5212607012)
and I'm not closing it or loosening an assertion to make the symptom go away.

But the existing failure dump explains a page that **threw** and says nothing about a page that is merely
never still, which is exactly how #625 presented: a 30s `element is not stable` naming the element and
nothing about what was moving. The journey now records a Playwright trace with DOM snapshots throughout,
keeps it **only on failure**, and prints the path plus the command that opens it. Always on rather than
behind a flag — the run worth tracing is the one that unexpectedly failed, and that one can't be asked for
in advance. Cost measured at ~10% of journey wall time (2:32 → 2:46 for the full suite).

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — 316/316
- Full browser E2E — **49/49**
- **The headline case, directly:** held `[::1]:5099` with a foreign listener and ran the whole
  `ServerExampleTests` class — **4/4 pass**, where before every one of them would have died on the bind.

No framework code changed, so no benchmarks.
