### PR TITLE
fix(core): stop a nested ToHtml() corrupting the page, and unflake three load-sensitive tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,47 @@ them until tagged releases begin.
   with DOM snapshots throughout and keeps it only on failure, printing the path and the command that opens
   it. Always on rather than behind a flag, because the run worth tracing is the one that unexpectedly failed.
 
+### Fixed
+- **A component that calls `ToHtml()` on a tree containing a `<head>` no longer corrupts the page around
+  it.** `HeadSentinelIndex` is a byte offset into whichever builder is being serialized, and `ToHtml()`
+  serializes into a private one whose string is handed straight back — so a nested call published an offset
+  that meant nothing to the render owning the context, and the live root then spliced the scoped-CSS/JS
+  block *there*: into the middle of an unrelated opening tag, cutting it in half and losing its attributes.
+  Recording is first-wins, so a page with its own `<head>` was safe by accident (the shell's head goes
+  first) while a render without one — every `RaskTest.Render`, so every unit test, in a shipped package —
+  was not. `ToHtml()` now saves and restores the offset; its output never goes through the splice, so it
+  had no use for it. Found by the new demo-markup timer guard below, which caught it corrupting a demo that
+  had been snapshotting the damage as normal.
+
+### Changed
+- **Three tests that went red under load rather than on merit.** Each one taught `--no-verify`.
+  - **The persisted-state budget diagnostic** asserted `Assert.Single` over everything the process-global
+    `RaskDiagnostics.Sink` saw while it was swapped in — which is really "no other test in the assembly
+    reported anything in this millisecond", true almost always and so failing rarely and confusingly. It
+    now asserts on the events its own call site produces, and moved into the serialised collection that
+    already owns that global: two tests swapping the sink concurrently lose it entirely, since both save
+    `previous`, the second saves the first's capturing delegate, and restoring in that order leaves the
+    sink pointing at a list nobody reads.
+  - **The log-writer shutdown-drain test** started the writer's loop, on the belief that a five-minute
+    `FlushInterval` meant nothing could reach disk on the timer. `ExecuteAsync` is a `do/while` over a
+    `PeriodicTimer`, so its first cycle runs *before* the first tick — and under load that cycle can pull
+    the entry out of the channel and still be inside `AppendAsync` when shutdown cancels the token, at
+    which point the entry is gone for good and the drain finds nothing. The loop is no longer started, so
+    the drain is the only code that can append and the test's premise is true by construction.
+  - **The demo-markup golden** captured `LiveTicker` mid-race. Fixed at the source rather than by
+    regenerating, which would only have moved the flake to the other state — see below.
+- **`LiveTicker` renders one layout, not two.** The headline price switched class list (`fs-3 text-secondary`
+  → `fs-2 fw-bold`) and the chart swapped a `<p>` placeholder for its `<svg>` when the first tick landed
+  50 ms after mount — so the number resized and the chart appeared, shoving the page around, and the demo's
+  golden markup became a race against machine load. The price span now keeps one class list and changes only
+  its text, and the `<svg>` is always emitted (`Sparkline` already draws a labelled empty frame for an empty
+  series, so the placeholder was a second, worse answer to the same question).
+- **A new guard catches the next demo that does this.** `EveryDemoSkeleton_IsReproducible` renders twice
+  back-to-back, so both renders land on the same side of any mount-time timer and agree — which is exactly
+  how `LiveTicker` walked past it. The new check holds one instance and reads it again after its timers have
+  fired, and names the line that moved. It found two offenders on its first run: the ticker, and the
+  `ToHtml()` corruption above.
+
 ## [0.20.0] - 2026-08-06
 
 ### Fixed

--- a/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
+++ b/samples/Rask.Example.Shared/Features/LiveTicker/LiveTicker.cs
@@ -204,10 +204,15 @@ public sealed class LiveTicker : Component
                         $"poll {IntervalMs} ms · {_history.Count}/{HistoryCapacity} pts"]
                 ],
                 BsStack(Gap: 3, Align: BsAlign.Baseline, Class: Margin.Bottom(3))[
-                    _history.Count == 0
-                        ? Span(Class: "fs-3 text-secondary", Id: "ticker-price")["Waiting for first tick…"]
-                        : Span(Class: "fs-2 fw-bold", Id: "ticker-price")[
-                            $"${current.ToString("N2", CultureInfo.InvariantCulture)}"],
+                    // One element, one class list, whichever state we're in — the price *text* changes,
+                    // the box doesn't. Two spellings (fs-3 text-secondary → fs-2 fw-bold) meant the first
+                    // tick resized and re-weighted the headline number 50 ms after mount, shoving the chart
+                    // below it; and because the difference lived in a class attribute, it also made this
+                    // demo's golden markup a race against the wall clock (#618).
+                    Span(Class: "fs-2 fw-bold", Id: "ticker-price")[
+                        _history.Count == 0
+                            ? "Waiting for first tick…"
+                            : $"${current.ToString("N2", CultureInfo.InvariantCulture)}"],
                     _history.Count > 1
                         ? Span(Class: $"fs-6 fw-semibold {changeClass}", Id: "ticker-change")[
                             $"{changeSign}{change.ToString("F2", CultureInfo.InvariantCulture)}% since first sample"]
@@ -223,11 +228,13 @@ public sealed class LiveTicker : Component
                 // <svg> a known box to fill.
                 Div(Class: "ticker-chart-container", Id: "ticker-chart",
                     Style: "position: relative; height: 160px;")[
-                    _history.Count == 0
-                        ? P(Class: "text-secondary small mb-0")["Waiting for first tick…"]
-                        : Sparkline(
-                            _history.Select(p => (double)p.PriceUsd).ToList(),
-                            Class: "ticker-chart-svg")
+                    // Always the <svg>. Sparkline already draws an empty labelled frame for an empty
+                    // series, so the <p> placeholder this replaces was a second, worse answer to the same
+                    // question — and swapping <p> for <svg> on the first tick was a tag-name change, which
+                    // is the one thing the demo-markup golden cannot snapshot (#618).
+                    Sparkline(
+                        _history.Select(p => (double)p.PriceUsd).ToList(),
+                        Class: "ticker-chart-svg")
                 ]
             ]
         ];

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -493,6 +493,22 @@ public abstract class Component
         // pool returns it on dispose; oversized buffers (>64 KiB) are discarded so a single
         // huge render doesn't retain an outlier capacity indefinitely.
         var sb = RaskStringBuilderPool.Shared.Get();
+
+        // HeadSentinelIndex is a byte offset into whichever builder is being serialized, and this one is
+        // not the page — it is a private buffer whose string is handed back to the caller, never spliced.
+        // Left unguarded, a component that calls ToHtml() on a tree containing a <head> (the documented
+        // way to demo the document elements, which cannot render live inside a page) publishes an offset
+        // into THIS buffer, and RenderAsLiveRoot then splices the head-asset block there — into the middle
+        // of whatever the real page had at that position. A page with its own <head> is safe by accident,
+        // since recording is first-wins and the shell's head goes first; a render without one — every
+        // RaskTest.Render, so every unit test — is not. See #627.
+        // CurrentSync, not Current: it is the accessor HtmlSerializer writes HeadSentinelIndex through
+        // (HtmlSerializer.cs, the <head> branch), so it names exactly the context at risk — and it is the
+        // cheap ThreadStatic rather than an AsyncLocal read, which matters because HeadAssetRegistry.Add
+        // routes every head contribution through ToHtml() during the render walk.
+        var live = LiveRenderContext.CurrentSync;
+        var savedSentinel = live?.HeadSentinelIndex ?? -1;
+
         try
         {
             HtmlSerializer.Serialize(this, sb);
@@ -500,6 +516,11 @@ public abstract class Component
         }
         finally
         {
+            if (live is not null)
+            {
+                live.HeadSentinelIndex = savedSentinel;
+            }
+
             RaskStringBuilderPool.Shared.Return(sb);
         }
     }

--- a/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
+++ b/tests/Rask.Core.Tests/HeadAssets/HeadAssetRenderTests.cs
@@ -98,6 +98,43 @@ public class HeadAssetRenderTests
         Assert.Equal(1, CountOccurrences(third, "/a.css"));
     }
 
+    // #627. HeadSentinelIndex is an offset into whichever builder is being serialized, and ToHtml()
+    // serializes into a private one whose string is handed straight to the caller. A component that calls
+    // ToHtml() on a tree containing a <head> — the documented way to demo the document elements, which
+    // cannot render live inside a page — used to publish an offset into that private buffer, and the live
+    // root then spliced the head-asset block there: into the middle of whatever the real page had at that
+    // position, cutting an opening tag in half and losing its attributes.
+    //
+    // Rendered without an enclosing shell, which is the case that broke: recording is first-wins, so a
+    // page with its own <head> was safe by accident while every RaskTest.Render was not.
+    // Asserts on the RAW sentinel throughout: the serialized shell that ToHtml() hands back is rendered as
+    // text, so the page legitimately contains an HTML-ENCODED copy (&lt;!--__rask_head_assets__--&gt;) —
+    // that is the demo showing its own output, not a leak.
+    [Fact]
+    public void NestedToHtmlOverAHead_DoesNotSpliceIntoTheOuterRender()
+    {
+        var html = new SerializesAShell().RenderAsLiveRoot();
+
+        // The marker tag must survive intact — the bug cut it after "<span cla" and dropped its class.
+        Assert.Contains("<span class=\"marker\"", html);
+        Assert.DoesNotContain("<span cla<", html);
+    }
+
+    // The counterpart: a page that has its own <head> still splices there, and the nested ToHtml() has not
+    // moved the target. Without this, "don't record from ToHtml" could be satisfied by not splicing at all.
+    [Fact]
+    public void NestedToHtmlOverAHead_LeavesTheRealHeadSpliceAlone()
+    {
+        var html = new PageShell(new SerializesAShell()).RenderAsLiveRoot();
+
+        // The shell's own sentinel is consumed …
+        Assert.DoesNotContain("<!--__rask_head_assets__-->", html);
+        // … in <head>, not wherever the nested call happened to point.
+        var sentinelWasHere = html.IndexOf("<body", StringComparison.Ordinal);
+        Assert.True(sentinelWasHere > 0);
+        Assert.Contains("<span class=\"marker\"", html);
+    }
+
     // ----- helpers -----
 
     private static int CountOccurrences(string haystack, string needle)
@@ -161,6 +198,19 @@ public class HeadAssetRenderTests
     {
         protected override Component? Render() => Div()["plain body"];
     }
+
+    // Mirrors ElementsMetadataDemo: composes a real document shell and shows its serialized HTML as text.
+    // The <span class="marker"> after it is what the misplaced splice used to cut in half.
+#pragma warning disable RASK019 // composing Head() children directly is the point here
+    private sealed class SerializesAShell : Component
+    {
+        protected override Component? Render() =>
+        [
+            Pre()[Code()[Html("en")[Head()[Title()["Inner"]], Body()[P()["hi"]]].ToHtml()]],
+            Span(Class: "marker")["after"]
+        ];
+    }
+#pragma warning restore RASK019
 
     private sealed class ContributesLink : Component
     {

--- a/tests/Rask.Core.Tests/Lifecycle/ConsoleRedirectCollection.cs
+++ b/tests/Rask.Core.Tests/Lifecycle/ConsoleRedirectCollection.cs
@@ -1,10 +1,19 @@
 namespace Rask.Core.Tests.Lifecycle;
 
-// Test classes that redirect Console.Error / Console.Out via Console.SetError / SetOut
-// share global static state — running them in parallel produces a flake where one test
-// captures the other's output (or nothing at all). Group them under one collection so
-// xUnit serialises them. Add this collection's [Collection] attribute to any new test
-// class that calls Console.SetError / Console.SetOut.
+// Test classes that mutate the framework's process-global observability state: Console.Error /
+// Console.Out via Console.SetError / SetOut, and RaskDiagnostics.Sink (plus the ReportedOnce dedup set
+// behind ReportOnce). Running two of those in parallel produces a flake where one captures the other's
+// output, or — worse and silently — loses the sink entirely: both save `previous`, the second saves the
+// FIRST one's capturing delegate, and restoring in that order leaves Sink pointing at a list nobody
+// reads. Group them under one collection so xUnit serialises them.
+//
+// Add this collection's [Collection] attribute to any new test class that calls Console.SetError /
+// Console.SetOut, assigns RaskDiagnostics.Sink, or calls ResetReportOnceForTests.
+//
+// Note what this does NOT buy: xUnit serialises members of a collection against each other, not against
+// the rest of the assembly. Other collections still run in parallel and their diagnostics still land in
+// whatever sink is installed — so a test in here must assert on the events IT provoked rather than on
+// the whole capture. See PersistentStateDiagnosticTests for the shape.
 [CollectionDefinition("ConsoleRedirect", DisableParallelization = true)]
 public class ConsoleRedirectCollection
 {

--- a/tests/Rask.Core.Tests/Live/PersistentStateDiagnosticTests.cs
+++ b/tests/Rask.Core.Tests/Live/PersistentStateDiagnosticTests.cs
@@ -1,0 +1,62 @@
+using Rask.Core.Diagnostics;
+using Rask.Core.Live;
+
+namespace Rask.Core.Tests.Live;
+
+/// <summary>
+///     Split out of <see cref="PersistentStateTests" /> because this is the one test in that file which
+///     touches process-global state, and xUnit binds collections per class.
+/// </summary>
+/// <remarks>
+///     Two globals are in play, and only one of them is fixed by joining a serialised collection:
+///     <list type="bullet">
+///         <item>
+///             <c>RaskDiagnostics.Sink</c> — two tests swapping it concurrently lose it entirely (both
+///             save <c>previous</c>, the second saves the first's capturing delegate, and restoring in
+///             that order leaves the sink pointing at a list nobody reads). The collection prevents that.
+///         </item>
+///         <item>
+///             The <c>ReportedOnce</c> dedup set behind <c>ReportOnce</c>, which is why the reset is
+///             needed on the way in: another test may already have burned this call site's key, and the
+///             overflow would then be suppressed and the capture empty.
+///         </item>
+///     </list>
+///     What the collection does <em>not</em> buy is isolation from the rest of the assembly — xUnit runs
+///     other collections in parallel, and every diagnostic any of them emits lands in the sink installed
+///     here. Asserting <c>Assert.Single</c> over the whole capture therefore asserted "no other test in
+///     Rask.Core.Tests reported anything in this millisecond", which is true almost always and so failed
+///     rarely and confusingly (#617). The assertion is scoped to the events this call site produces
+///     instead — and stays strict about those, so a second report from the budget check still fails.
+/// </remarks>
+[Collection("ConsoleRedirect")]
+public class PersistentStateDiagnosticTests
+{
+    /// <summary>The overflow is reported to the developer, not swallowed — it explains a reload they'd otherwise chase.</summary>
+    [Fact]
+    public void Exceeding_the_budget_reports_a_diagnostic()
+    {
+        var captured = new List<RaskDiagnosticEvent>();
+        var previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.ResetReportOnceForTests();
+        RaskDiagnostics.Sink = captured.Add;
+        try
+        {
+            var state = new PersistentState { MaxBytes = 32 };
+            state.Persist("big", new string('x', 256));
+        }
+        finally
+        {
+            RaskDiagnostics.Sink = previous;
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+
+        var overflow = captured
+            .Where(e => e.Category == "Rask.Live"
+                        && e.Message.Contains("budget", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        var warning = Assert.Single(overflow);
+        Assert.Equal(RaskLogLevel.Warning, warning.Level);
+        Assert.Contains("resumable", warning.Message, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/tests/Rask.Core.Tests/Live/PersistentStateTests.cs
+++ b/tests/Rask.Core.Tests/Live/PersistentStateTests.cs
@@ -2,7 +2,6 @@ using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
-using Rask.Core.Diagnostics;
 using Rask.Core.Live;
 
 namespace Rask.Core.Tests.Live;
@@ -212,29 +211,9 @@ public sealed partial class PersistentStateTests
         Assert.True(state.Overflowed);
     }
 
-    /// <summary>The overflow is reported to the developer, not swallowed — it explains a reload they'd otherwise chase.</summary>
-    [Fact]
-    public void Exceeding_the_budget_reports_a_diagnostic()
-    {
-        var captured = new List<RaskDiagnosticEvent>();
-        var previous = RaskDiagnostics.Sink;
-        RaskDiagnostics.ResetReportOnceForTests();
-        RaskDiagnostics.Sink = captured.Add;
-        try
-        {
-            var state = new PersistentState { MaxBytes = 32 };
-            state.Persist("big", new string('x', 256));
-        }
-        finally
-        {
-            RaskDiagnostics.Sink = previous;
-            RaskDiagnostics.ResetReportOnceForTests();
-        }
-
-        var warning = Assert.Single(captured);
-        Assert.Equal(RaskLogLevel.Warning, warning.Level);
-        Assert.Contains("resumable", warning.Message, StringComparison.OrdinalIgnoreCase);
-    }
+    // The matching "…reports a diagnostic" test lives in PersistentStateDiagnosticTests: it swaps the
+    // process-global RaskDiagnostics.Sink, so it belongs in the serialised collection, and xUnit binds
+    // collections per class rather than per test.
 
     [Fact]
     public void Overwriting_a_key_replaces_rather_than_accumulates()

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -4566,8 +4566,7 @@ div .sample-code-header
 span .dot-r .sample-dot
 span .dot-y .sample-dot
 span .dot-g .sample-dot
-span
-script
+span .ms-2 .sample-code-label
 button .sample-copy
 i .bi .bi-clipboard .me-1
 span .sample-copy-text
@@ -5481,9 +5480,9 @@ div .align-items-baseline .d-flex .justify-content-between .mb-3
 h3 .fw-semibold .h4 .mb-0
 span .small .text-secondary
 div .align-items-baseline .d-flex .gap-3 .mb-3
-span .fs-3 .text-secondary
+span .fs-2 .fw-bold
 div .ticker-chart-container
-p .mb-0 .small .text-secondary
+svg .ticker-chart-svg
 div .col-lg-5
 div .bg-light .border-0 .card .h-100
 div .card-body

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkupGoldenTests.cs
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkupGoldenTests.cs
@@ -51,6 +51,18 @@ public sealed class DemoMarkupGoldenTests
         "(<code[^>]*class=\"[^\"]*language-[^\"]*\"[^>]*>).*?</code>",
         RegexOptions.Compiled | RegexOptions.Singleline);
 
+    // The second legitimate exception, and the counterpart to the one below: a chart's *contents* are its
+    // data. LiveTicker polls on a 50 ms simulated latency, so the Sparkline it draws holds no points on the
+    // first render and one shortly after — and an empty series renders a labelled <text>No data</text>
+    // frame where a populated one renders <line>/<polyline>/<circle>. That is a tag-name change on a timer,
+    // which no snapshot can hold; it made this golden a race against machine load and failed unrelated PRs
+    // (#618). The <svg> element itself is kept — LiveTicker always emits it, so "is the chart there, in the
+    // right place, with the right classes" is still asserted — and only its body is dropped. What the chart
+    // draws is Sparkline's contract and has its own tests in Rask.Example.Shared.Tests.
+    private static readonly Regex LiveChartBody = new(
+        "(<svg[^>]*class=\"[^\"]*ticker-chart-svg[^\"]*\"[^>]*>).*?</svg>",
+        RegexOptions.Compiled | RegexOptions.Singleline);
+
     // The one legitimate exception to "moving parts never live in a class attribute": a calendar day cell
     // (BsDatePicker/BsDateTimePicker) tags itself with which day is *today* (bs-cal-today), which days spill
     // in from an adjacent month (bs-cal-muted), which is selected/cursored (active / bs-cal-focus), and which
@@ -99,6 +111,43 @@ public sealed class DemoMarkupGoldenTests
             + string.Join("\n  ", offenders));
     }
 
+    // The half the pair above cannot see, and the half #618 actually needed. Two back-to-back renders each
+    // mount a FRESH instance and capture it immediately, so both land on the same side of any mount-time
+    // timer and agree — which is exactly why LiveTicker's 50 ms simulated poll latency walked straight
+    // through that check and failed the golden instead, on whichever unrelated PR happened to run on a busy
+    // machine.
+    //
+    // So hold one instance and read it again after its timers have had time to fire. A demo may of course
+    // CHANGE when it ticks — that is the point of a live demo — but the change has to live in text, an id
+    // or a data-* attribute, which is the contract this file has always stated. A tag name or a class that
+    // moves on a timer cannot be snapshotted by anyone.
+    [Fact]
+    public async Task NoDemoSkeleton_ChangesOnATimer()
+    {
+        var offenders = new List<string>();
+
+        foreach (var key in DemoRegistry.Keys)
+        {
+            var page = RaskTest.Render(() => DemoRegistry.Build(key), TestServices.Default());
+            var before = SkeletonOf(page.Html);
+
+            // Comfortably past LiveTicker's 50 ms poll and LiveTickerDemo's 50 ms deferred re-render — the
+            // two mount-time timers in the set — without waiting on the 1 s inter-tick interval.
+            await Task.Delay(250);
+
+            var after = SkeletonOf(page.Render());
+            if (!string.Equals(before, after, StringComparison.Ordinal))
+            {
+                offenders.Add($"{key}: {FirstDifference(before, after)}");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "These demos' markup skeletons changed on their own after mount, so their golden entry is a "
+            + "race against the wall clock. Move the moving part into text, an id or a data-* attribute — "
+            + "never a tag name or a class:\n  " + string.Join("\n  ", offenders));
+    }
+
     private static string RenderAll()
     {
         var sb = new StringBuilder();
@@ -113,11 +162,32 @@ public sealed class DemoMarkupGoldenTests
         return sb.ToString();
     }
 
-    private static string Skeleton(string key)
+    // "lifecycle-ticker" on its own sends you reading a 300-line component; naming the line that moved
+    // sends you to the element.
+    private static string FirstDifference(string before, string after)
     {
-        var html = HighlightedSource.Replace(
-            RaskTest.Render(() => DemoRegistry.Build(key), TestServices.Default()).Html,
-            "$1</code>");
+        var a = before.Split('\n');
+        var b = after.Split('\n');
+
+        for (var i = 0; i < Math.Max(a.Length, b.Length); i++)
+        {
+            var left = i < a.Length ? a[i] : "(end)";
+            var right = i < b.Length ? b[i] : "(end)";
+            if (!string.Equals(left, right, StringComparison.Ordinal))
+            {
+                return $"line {i + 1}: `{left}` became `{right}`";
+            }
+        }
+
+        return "(no line differs — trailing whitespace?)";
+    }
+
+    private static string Skeleton(string key) =>
+        SkeletonOf(RaskTest.Render(() => DemoRegistry.Build(key), TestServices.Default()).Html);
+
+    private static string SkeletonOf(string rendered)
+    {
+        var html = LiveChartBody.Replace(HighlightedSource.Replace(rendered, "$1</code>"), "$1</svg>");
 
         var sb = new StringBuilder();
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.Journey.cs
@@ -1462,6 +1462,12 @@ public abstract partial class SharedSmokeTests
             new LocatorAssertionsToHaveTextOptions { Timeout = 30_000 });
         await Expect(Page.Locator("#ticker-chart svg")).ToBeVisibleAsync(
             new LocatorAssertionsToBeVisibleOptions { Timeout = 10_000 });
+        // The <svg> is now emitted from the first render (Sparkline draws its own empty frame, so the
+        // chart no longer swaps a <p> placeholder for an <svg> when data arrives — #618), which means the
+        // assertion above no longer proves a tick landed. The price does: it reads "Waiting for first
+        // tick…" until one has, and "$…" after.
+        await Expect(Page.Locator("#ticker-price")).ToContainTextAsync("$",
+            new LocatorAssertionsToContainTextOptions { Timeout = 30_000 });
         await Page.Locator("#ticker-switch-ETH").ClickAsync();
         await Expect(Page.Locator("#ticker-symbol")).ToHaveTextAsync("ETH",
             new LocatorAssertionsToHaveTextOptions { Timeout = 10_000 });

--- a/tests/Rask.Logging.Tests/LogCaptureTests.cs
+++ b/tests/Rask.Logging.Tests/LogCaptureTests.cs
@@ -122,14 +122,26 @@ public sealed class LogCaptureTests
     /// The lines written in the seconds before a shutdown are the ones most worth keeping, so the writer
     /// drains what is buffered instead of exiting with it in memory.
     /// </summary>
+    /// <remarks>
+    /// The writer's loop is deliberately never started, which is the fix for #617's sibling #619 and the
+    /// same lesson #594 landed. A long <c>FlushInterval</c> does <em>not</em> mean "nothing reaches disk on
+    /// the timer" — <c>ExecuteAsync</c> is a <c>do/while</c> over <c>PeriodicTimer</c>, so its first cycle
+    /// runs immediately, before the first tick. Under load that cycle can pull the entry out of the channel
+    /// and still be inside <c>store.AppendAsync</c> when <c>StopAsync</c> cancels the stopping token — at
+    /// which point the entry is gone for good (already out of the buffer, counted dropped, never re-queued)
+    /// and the drain finds nothing. The test then failed on an empty collection, for a reason that had
+    /// nothing to do with the behaviour it names.
+    /// <para>
+    /// With no loop, the shutdown drain is the only code that can append, so "anything stored can only have
+    /// come from the drain" is true by construction rather than by scheduling. The pipeline under test is
+    /// unchanged: the entry still goes through the real <c>ILogger</c> → channel → store path.
+    /// </para>
+    /// </remarks>
     [Fact]
     public async Task FlushesBufferedEntriesOnShutdown()
     {
         await using var harness = new LoggingHarness(o => o.FlushInterval = TimeSpan.FromMinutes(5));
 
-        // A flush interval far longer than the test: nothing reaches disk on the timer, so anything stored
-        // afterwards can only have come from the shutdown drain.
-        await harness.Writer.StartAsync(CancellationToken.None);
         harness.Logger().LogWarning("the last thing that happened");
         await harness.Writer.StopAsync(CancellationToken.None);
 

--- a/tests/Rask.Logging.Tests/LoggingHarness.cs
+++ b/tests/Rask.Logging.Tests/LoggingHarness.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
@@ -77,14 +78,23 @@ public sealed class LoggingHarness : IAsyncDisposable
     public Task RunUntilStoredAsync(int count, TimeSpan? timeout = null) =>
         RunUntilAsync(async () => await Store.CountAsync() >= count, timeout);
 
-    public async Task WaitUntilAsync(Func<Task<bool>> condition, TimeSpan? timeout = null)
+    /// <summary>
+    ///     Polls <paramref name="condition"/> until it holds. The timeout names the predicate it gave up on
+    ///     (the principle #589 landed in <c>JobsHarness</c>): "Condition not met in time" tells you a wait
+    ///     expired and nothing about which one, on a harness whose callers all wait for different things.
+    /// </summary>
+    public async Task WaitUntilAsync(
+        Func<Task<bool>> condition,
+        TimeSpan? timeout = null,
+        [CallerArgumentExpression(nameof(condition))] string? description = null)
     {
-        var deadline = DateTime.UtcNow + (timeout ?? TimeSpan.FromSeconds(10));
+        var budget = timeout ?? TimeSpan.FromSeconds(10);
+        var deadline = DateTime.UtcNow + budget;
         while (!await condition())
         {
             if (DateTime.UtcNow > deadline)
             {
-                throw new TimeoutException("Condition not met in time.");
+                throw new TimeoutException($"`{description}` was still false after {budget}.");
             }
 
             await Task.Delay(20);


### PR DESCRIPTION
Closes #617. Closes #618. Closes #619. Closes #627.

Three tests that went red under load rather than on merit — each one teaches `--no-verify`, which is the
real cost — plus the framework bug that fixing the third one uncovered.

## #617 — an assertion that was really about the scheduler

The persisted-state budget test asserted `Assert.Single` over **everything** the process-global
`RaskDiagnostics.Sink` saw while it was swapped in. That is not "the budget reported one diagnostic", it
is *"no other test in this assembly reported anything in this millisecond"* — true almost always, so it
failed rarely and confusingly.

It now asserts on the events its own call site produced, and moved into the serialised collection that
already owns that global (xUnit binds collections per class, so it needed its own).

Worth being precise about what the collection does and doesn't buy, because the issue proposed it as the
whole fix:

- It does **not** isolate from the assembly. Other collections still run in parallel and their diagnostics
  still land in whatever sink is installed. The scoped assertion is the load-bearing half.
- It does prevent two tests swapping the sink at once, which **loses it outright**: both save `previous`,
  the second saves the first's capturing delegate, and restoring in that order leaves `Sink` pointing at a
  list nobody reads.

## #619 — the mechanism the issue couldn't pin down

The issue recorded the symptom and deliberately declined to guess. It's the loop.

`LogWriter.ExecuteAsync` is a `do/while` over a `PeriodicTimer`, so **its first cycle runs before the
first tick** — a five-minute `FlushInterval` does not mean "nothing reaches disk on the timer", which is
exactly what the test's comment claimed. Under load that cycle can pull the entry out of the channel and
still be inside `store.AppendAsync` when `StopAsync` cancels the stopping token, at which point the entry
is gone for good: already out of the buffer, counted dropped, never re-queued. The drain then finds
nothing.

So of the issue's two candidate shapes it is **zero entries**, not two — the harness is not the leaky
part. Fixed the way #594 established: don't start the loop, and the shutdown drain becomes the only code
that can append. `LoggingHarness.WaitUntilAsync` also gets the `CallerArgumentExpression` message #589
added elsewhere; it still threw a bare `"Condition not met in time."`.

## #618 — fixed at the source, because regenerating would move the flake, not remove it

`LiveTicker` polls 50 ms after mount. Two things changed on that tick: the headline price switched class
list (`fs-3 text-secondary` → `fs-2 fw-bold`) and the chart swapped a `<p>` placeholder for its `<svg>`.

That is worse UI on its own terms — the number resized and re-weighted and the chart appeared, shoving the
page around 50 ms in — and a tag name and a class that move on a timer are precisely the two things
`DemoMarkupGoldenTests` says up front that it cannot snapshot.

- The price span keeps one class list and changes only its text.
- The `<svg>` is always emitted. `Sparkline` already draws a labelled empty frame for an empty series, so
  the placeholder was a second, worse answer to the same question.
- The chart's *contents* are its data, so the golden drops the `<svg>` body the same way it already drops
  a `CodeSample`'s highlighted source — keeping the element, its position and its classes. What the chart
  draws is `Sparkline`'s contract and has its own tests.
- The E2E's `#ticker-chart svg` assertion no longer proves a tick landed, so it now waits on the price.

**`EveryDemoSkeleton_IsReproducible` could not have caught this**: two back-to-back renders each mount a
fresh instance and capture it immediately, so both land on the same side of a mount-time timer and agree.
The new `NoDemoSkeleton_ChangesOnATimer` holds one instance and reads it again after its timers have
fired, and names the line that moved.

## #627 — which that new guard found on its first run

It reported two offenders, and the second was not a demo problem.

`LiveRenderContext.HeadSentinelIndex` is a byte offset into whichever builder is being serialized, and
`Component.ToHtml()` serializes into a **private** one whose string is handed straight back to the caller.
So a component calling `ToHtml()` on a tree containing a `<head>` — the documented way to demo the
document elements, which cannot render live inside a page — published an offset that meant nothing to the
render owning the context, and the live root then spliced the scoped-CSS/JS block **there**: into the
middle of an unrelated opening tag, cutting it in half and losing its `class`.

```html
<span clas<link rel="stylesheet" …><script src="…" defer></script>data-r-a91b79fb>ElementsMetadataDemo.cs</span>
```

Recording is first-wins, so a page with its own `<head>` was safe by accident — the shell's head goes
first — while a render **without** one was not. That is every `RaskTest.Render`, i.e. every unit test, in a
shipped package. The committed golden had been recording the damage as normal (`span` with no classes,
followed by a stray `script`) for as long as the demo has existed.

`ToHtml()` now saves and restores the offset; its output never goes through the splice, so it had no use
for it. Read through `CurrentSync` rather than `Current`: it names exactly the context `HtmlSerializer`
writes through, and it is the ThreadStatic rather than an AsyncLocal — which matters because
`HeadAssetRegistry.Add` routes every head contribution through `ToHtml()` during the render walk.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full unit suite across the solution — green
- Full browser E2E — **57/57**
- Benchmarks (`RenderRoundTrip`, run from the worktree dir): **`Allocated` byte-identical on all five** —
  80.67 / 150.98 / 73.66 / 71.53 / 35.31 KB before and after. `RenderAndBuildPayload` (the low-noise one)
  7.582 → 7.617 µs, inside its own StdDev.

One caveat recorded rather than hidden: a single `Rask.Core.Tests` failure appeared in one full parallel
run and I never captured its name. It did not recur in three further full runs, ten isolated runs of that
assembly under a concurrent rebuild, or the isolated suite. Unexplained, so said out loud.

**#625 is not in here.** It is solved — reproduced 4/4 and fixed 0/4 — but the change is one line of
browser setup with a long story, so it goes in its own PR rather than riding along with this one.
