### PR TITLE
test(e2e): take the font CDN out of the browser gate, and stop the trace hiding the bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -162,6 +162,20 @@ them until tagged releases begin.
   how `LiveTicker` walked past it. The new check holds one instance and reads it again after its timers have
   fired, and names the line that moved. It found two offenders on its first run: the ticker, and the
   `ToHtml()` corruption above.
+- **The browser gate no longer depends on Google's font CDN, which is what #625 turned out to be.** The
+  showcase shell links three font families with `display=swap`. Swap means paint with the fallback now and
+  **reflow** when each webfont lands — several files, over the public internet, on a page the journey
+  throttles to Slow-3G. Every arrival moves the text and therefore the bounding box of everything below it,
+  and Playwright's actionability check requires a box that is identical across two consecutive animation
+  frames. Hence a 30s `element is not stable` on whichever guide page the walk had reached, on all three
+  hosts (they share the shell), with the text assertions on the very same subtree passing — `innerText`
+  does not care what font it is in. The journey now aborts requests to `fonts.googleapis.com` /
+  `fonts.gstatic.com`, so the page renders in the fallback immediately and settles once. No assertion is
+  about typography, and "the browser gate is green" no longer includes "a third-party CDN was fast today".
+  - **The gate had also been green for the wrong reason.** Capturing a Playwright screenshot on every
+    action was settling the page: with screenshots on the suite ran 3/3 green and with them off 4/4 red,
+    same machine and commit, back to back. Traces now record snapshots only — `TestArtifacts` already
+    writes a full-page PNG per test, and what a stuck journey needs is the DOM.
 
 ## [0.20.0] - 2026-08-06
 

--- a/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
+++ b/tests/Rask.Examples.E2E.Tests/SharedSmokeTests.cs
@@ -43,15 +43,41 @@ public abstract partial class SharedSmokeTests : IAsyncLifetime
         // the element and nothing about what was moving. A trace's DOM snapshots do name it.
         //
         // Always-on rather than behind a flag, deliberately: the failure this is for did not reproduce on
-        // demand, so the only trace worth having is the one from the run that happened to fail. Screenshots
-        // are included because a moving box is a thing you can see; Sources are not, since the C# stack is
+        // demand, so the only trace worth having is the one from the run that happened to fail.
+        //
+        // Snapshots only, and the reason is the whole of #625. Capturing a screenshot on every action puts
+        // a small pause and a rendering-pipeline flush in front of each one, which was quietly settling the
+        // page — with screenshots on this suite ran 3/3 green and with them off 4/4 red, same machine, same
+        // commit, back to back. That is a gate passing for a reason unrelated to the code under test, which
+        // is worse than a gate that fails: the page really was unstable (see the font routing below), and
+        // the harness was hiding it. Turning them off is what made the failure reproducible enough to fix.
+        //
+        // Nothing is lost. TestArtifacts already writes a full-page PNG for every test, and what a stuck
+        // journey needs is the DOM, which is what a snapshot is. Sources are off too: the C# stack is
         // already in the test output.
         await _ctx.Tracing.StartAsync(new TracingStartOptions
         {
-            Screenshots = true,
+            Screenshots = false,
             Snapshots = true,
             Sources = false
         });
+
+        // Serve the showcase's web fonts from nowhere, so the gate does not depend on a CDN.
+        //
+        // App.cs links three Google Font families with `display=swap`. Swap means: paint with the fallback
+        // now, and REFLOW when each webfont lands — three families, several weights, over the public
+        // internet, on a page the journey throttles to Slow-3G. Every arrival moves the text and therefore
+        // the bounding box of everything below it, and Playwright's actionability check requires a box that
+        // is identical across two consecutive animation frames. That is #625: "element is not stable" for
+        // the full 30s, on whichever guide page the walk had reached, on all three hosts (they share this
+        // shell), with the text assertions on the very same subtree passing because innerText does not care
+        // what font it is in.
+        //
+        // Aborting the requests makes the page render in the fallback font immediately and settle once.
+        // It costs the gate nothing — no assertion is about typography — and it removes a third-party CDN
+        // from the definition of "the browser gate is green".
+        await _ctx.RouteAsync("**://fonts.googleapis.com/**", route => route.AbortAsync());
+        await _ctx.RouteAsync("**://fonts.gstatic.com/**", route => route.AbortAsync());
 
         Page = await _ctx.NewPageAsync();
         // Capture the browser console + uncaught page errors so a failing test can surface


### PR DESCRIPTION
Closes #625.

Two lines of browser setup. The reason they're the right two lines is the rest of this.

## What it is

`samples/Rask.Example.Shared/App.cs` links three Google Font families from the CDN with `display=swap`:

```csharp
Link(Rel: "preconnect", Href: "https://fonts.gstatic.com", CrossOrigin: "anonymous"),
Link(Rel: "stylesheet", Href: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700"
    + "&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap"),
```

**Swap** means: paint with the fallback now, and **reflow** when each webfont lands. Several files, over
the public internet, on a page the journey deliberately throttles to Slow-3G. Every arrival changes text
metrics, which moves the bounding box of everything below it — and Playwright's actionability check
requires a box that is *identical across two consecutive animation frames* before it will click.

That is the whole of #625, and it accounts for every detail the issue recorded:

| the issue observed | why |
| --- | --- |
| `element is not stable`, never "not found" or "not visible" | the element is there and hittable; only its geometry keeps moving |
| a different demo each run — `.guide-demo` "Success", "Toggle theme", the double-click pad, `#component-tiers` | whichever page the walk had reached when a font landed. Nothing to do with those demos |
| Server **and** both WASM hosts | they share this shell |
| text assertions on the very same subtree pass, then the first click hangs | `innerText` does not care what font it is in |
| load-correlated, "reproduced then vanished" | it depends on CDN latency and machine load, neither of which is in the repo |

Aborting the two font hosts makes the page render in the fallback immediately and settle once. It costs
the gate nothing — no assertion is about typography — and it removes a third-party CDN from the definition
of "the browser gate is green".

## The gate was also green for the wrong reason

Worth its own heading, because it is the more uncomfortable half.

#626 added always-on Playwright tracing with `Screenshots = true`. Capturing a screenshot on every action
puts a small pause and a rendering-pipeline flush in front of each one — which was **settling the page**.
Same machine, same commit, back to back:

| trace screenshots | CDN fonts | full-suite runs |
| --- | --- | --- |
| on | allowed | **0/3 fail** |
| off | allowed | **4/4 fail** — `element is not stable` |
| off | **blocked** | **0/4 fail** |

So the suite was passing for a reason unrelated to the code under test, and my own diagnostic tooling was
the thing hiding the bug it was added to diagnose. Turning screenshots off is what made #625 reproducible
enough to fix, and they stay off: `TestArtifacts` already writes a full-page PNG per test, and what a
stuck journey needs is the DOM, which is what a snapshot is.

## How it was found

The trace from #626 did its job. `trace.network` in a failing run listed the resource loads, and three
`fonts.gstatic.com` woff2 files were sitting in there among otherwise-local URLs — the only entries in the
whole journey that leave the machine.

Everything else had already been ruled out and is recorded on the issue: not #615's sync-on-morph
(mechanically cannot loop), not `.guide-demo` CSS (one `margin` rule; the only `infinite` animation is a
`box-shadow` on a `::before`), not #623/#624 (neither touches client JS, CSS or the showcase), not a stale
published bundle (verified the nested publish does re-run), not client-side highlighting (it is
server-side C#).

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full browser E2E ×3 on this branch — green
- Plus the before/after table above: 11 full-suite runs in one sitting, on one machine, to establish the
  causal direction rather than assert it.

No framework code changed, so no benchmarks.

## What this does not do

It does not change what the samples ship — the showcase still uses the CDN fonts in a browser, which is
the right thing for a demo site. If you'd rather the samples self-hosted their fonts (one fewer external
dependency, no FOUT for real visitors), that's a separate call and a separate PR.
