### PR TITLE
docs: make the pages that ship inside every package describe what actually ships

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,10 @@ GitHub is the source of truth — keep docs, examples, and these guides up to da
 ## Repo workflows (`.claude/skills/`)
 Apply the matching playbook automatically:
 - **rask-ship** — definition-of-done gate before any commit/PR.
-- **add-html-tag** / **add-diagnostic** — scaffolding. **run-benchmarks** — hot-path Allocated delta.
+- **add-html-tag** / **add-diagnostic** / **add-codefix** — scaffolding (component+test / RASK0xx+docs+test /
+  IDE quick-fix+test). **run-benchmarks** — hot-path Allocated delta.
+- **run-rask** / **run-rask-wasm** / **run-rask-cli** — build, launch and drive the real thing (Server
+  showcase, WASM showcase, the `rask` CLI) when a test passing isn't the same as it working.
 - **rask-review** — security/perf/memory/best-practices. **open-pr** — Conventional-Commit PR, no AI footers.
 - **cut-release** — tag `vX.Y.Z`. **check-nuget-updates** — dependency hygiene.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,27 @@ them until tagged releases begin.
     action was settling the page: with screenshots on the suite ran 3/3 green and with them off 4/4 red,
     same machine and commit, back to back. Traces now record snapshots only — `TestArtifacts` already
     writes a full-page PNG per test, and what a stuck journey needs is the DOM.
+- **The docs that ship inside every package now describe what actually ships.** `NUGET.md` is packed into
+  all 24 packages via `Directory.Build.props`, which makes it the most-read page the project publishes and
+  the one nobody edits — it listed **7**. Missing: every battery (Jobs, Mail, Cache, Outbox, Data, Logging,
+  Dashboard), both SQLite satellites, both alternative database providers, and `Rask.Testing`. It also
+  showed only `rask new`, though `generate`, `db`, `dev` and `deploy` have shipped since, and still led
+  with the pre-OPF tagline the README and `llms.txt` had moved on from. Rewritten by role — pick a host,
+  add the batteries you want, pick a database — and **a test now fails the build if a packable project is
+  not named there**, next to the existing guard that catches one missing from the pack workflow.
+- **`CONTRIBUTING.md` no longer contradicts itself about CI.** It said tests don't run in CI and then, 20
+  lines later, that CI runs them; it credited a CodeQL workflow this repo doesn't have; it gave the
+  diagnostic range as RASK001–029 twice when it is 001–035; and it opened with bare `dotnet test`, which
+  pulls in the Playwright suite the rest of the page tells you to avoid. It now says what `ci.yml`
+  contains, and points at the two gate scripts the hooks actually run.
+- **`llms.txt`** framed deployment as "opt-in `--docker`" when `rask deploy` — SSH, blue-green, health-gated
+  cutover, Caddy auto-HTTPS, bare-VPS provisioning — has shipped, and its battery list stopped at four.
+- **`AGENTS.md`** listed 8 of the 12 committed skills, omitting `add-codefix` and all three
+  "drive the real app" playbooks — the ones an agent needs precisely when a passing test isn't proof.
+- **`docs/getting-started.md`** said three templates and listed three; there are four (`native` was
+  missing). It called `--docker` a template when it is a flag, and its "see the README's *Sub-path hosting*
+  section" pointed at a section that does not exist — the README's only mention pointed back at
+  getting-started, so the reader went in a circle. It now points at the pages that cover it.
 
 ## [0.20.0] - 2026-08-06
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,14 +17,18 @@ or send a pull request (fork → branch → PR). Review and merge are handled by
 ## Build & test loop
 
 ```bash
-dotnet build
-dotnet test
+dotnet build Rask.slnx
 
-# Faster inner loop — skip the heavy Playwright E2E suite:
-dotnet test --filter "FullyQualifiedName!~Rask.Examples.E2E"
+# The inner loop. Bare `dotnet test` pulls in the Playwright browser suite, which needs published
+# samples and takes minutes — this is what you want while you work:
+dotnet test Rask.slnx --filter "FullyQualifiedName!~Rask.Examples.E2E"
 
 # A single class:
-dotnet test --filter FullyQualifiedName~SessionUploadStoreTests
+dotnet test Rask.slnx --filter FullyQualifiedName~SessionUploadStoreTests
+
+# The two gates, as the hooks run them (see "Commits & pull requests" below):
+scripts/run-unit-local.sh      # format + everything except the browser E2E
+scripts/run-e2e-local.sh       # build, publish the samples, then the browser journeys
 
 # Run a sample app:
 dotnet run --project samples/Rask.Example.Server
@@ -48,7 +52,7 @@ a `[DynamicallyAccessedMembers]` annotation or a justified `[UnconditionalSuppre
 | Path | What lives there |
 |------|------------------|
 | `src/Rask.Core/` | Rendering, live diff codec, routing, lifecycle, scoped CSS/JS, primitives. |
-| `src/Rask.Generators/` | Roslyn factory/route generators and analyzers (RASK001–029). |
+| `src/Rask.Generators/` | Roslyn factory/route generators and analyzers (RASK001–034; RASK035 is in `src/Rask.Generators.Shared/`). |
 | `src/Rask.Server/`, `src/Rask.Wasm/`, `src/Rask.Wasm.Hosting/` | The three hosts. |
 | `src/Rask.Cli/` | The `rask` CLI — scaffolds every project via `rask new` (server, wasm, wasm-hosted, native). |
 | `samples/` | Runnable feature showcases. | 
@@ -65,7 +69,7 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   `tests/Rask.Core.Tests/Components/{Tag}Tests.cs` asserting exact attribute order
   (id, class, style, data-*, then tag-specific). The factory is generated automatically.
 - **Don't `new` a `Component`** outside `Rask.Core` — use the generated factory (RASK014).
-- Diagnostics RASK001–029 are documented in [docs/diagnostics.md](docs/diagnostics.md);
+- Diagnostics RASK001–035 are documented in [docs/diagnostics.md](docs/diagnostics.md);
   the analyzer descriptors are the source of truth.
 
 ## Commits & pull requests
@@ -83,8 +87,9 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   **E2E** gate (see below). Hooks are advisory — bypass any with the git no-verify flag,
   `RASK_SKIP_UNIT=1`, or `RASK_SKIP_E2E=1`.
 - **Tests run locally, not in CI.** The unit/integration suite and both E2E suites were moved out of the
-  CI pipeline; CI keeps only the deterministic benchmark byte-gates, the native compile gate, commitlint,
-  and CodeQL.
+  CI pipeline. `.github/workflows/ci.yml` has exactly two jobs — the deterministic benchmark byte-gates
+  and the native compile gate — alongside commitlint and GitHub's default CodeQL setup. No workflow in
+  this repo runs `dotnet test`, so **nothing but your machine will tell you a test broke.**
 - **Format + unit tests — `pre-commit`.** The `pre-commit` hook runs `scripts/run-unit-local.sh` when a
   commit stages code (`src/`, `tests/`, `benchmarks/`, `Rask.slnx`, `Directory.*`); docs-only commits skip
   it. The script builds once, runs the full `dotnet format Rask.slnx --verify-no-changes` (whitespace +
@@ -101,8 +106,7 @@ Most `src/` projects have a sibling `+ Tests` project. Deeper rationale lives in
   pipeline. Run the browser gate with `scripts/run-e2e-local.sh` (the `pre-push` hook runs it for you on
   `git push`; bypass a docs-only push with `git push --no-verify` or `RASK_SKIP_E2E=1`). The on-device
   native suite needs a booted emulator/simulator + Appium — run it manually before shipping native
-  changes (see [docs/native.md](docs/native.md)). CI still runs unit/integration tests, the deterministic
-  benchmark byte-gates, and a native compile gate.
+  changes (see [docs/native.md](docs/native.md)).
 - **Do not** append `Co-Authored-By` or `Generated-with` footers to commits or PR descriptions.
 - Add a note to [`CHANGELOG.md`](CHANGELOG.md) under `[Unreleased]` for user-visible changes.
 - User-facing changes must update a sample under `samples/` and the relevant docs

--- a/NUGET.md
+++ b/NUGET.md
@@ -2,7 +2,7 @@
 
 <img alt="Rask" src="https://raw.githubusercontent.com/pal-tamas/rask/main/assets/rask-logo.svg" width="280">
 
-### Live apps in C#. One codebase — server-rendered over WebSockets, client-side in the browser via WebAssembly, or a native iOS/Android app.
+### The .NET One Person Framework — build, run, and ship a whole product solo, in C#, on one server.
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/pal-tamas/rask/blob/main/LICENSE)
 ![.NET](https://img.shields.io/badge/.NET-10-512BD4)
@@ -35,20 +35,55 @@ public sealed class Counter : Component
 > (`dotnet workload install ios android`) for the native template.
 
 ```bash
-dotnet tool install -g Rask.Cli          # the rask CLI (scaffolding)
+dotnet tool install -g Rask.Cli          # the rask CLI — scaffold, migrate, run, deploy
 rask new MyApp                            # or: --template wasm | wasm-hosted | native
+rask generate feature Product Name:string Price:decimal   # CQRS + EF CRUD, pages included
+rask db add Initial && rask db update     # migrations, via dotnet-ef
+rask dev                                  # run with hot reload
+rask deploy --host you@box --domain app.example.com       # build + run on one box, over SSH
 ```
 
-Or add to an existing project:
+Or add to an existing project. **Pick a host:**
 
 ```bash
 dotnet add package Rask.Server            # server-rendered over WebSockets
 dotnet add package Rask.Wasm              # client-side WebAssembly
 dotnet add package Rask.Wasm.Hosting      # host a published WASM bundle on ASP.NET
 dotnet add package Rask.Native            # native iOS/Android app head (WebView hybrid, preview)
-dotnet add package Rask.Bootstrap          # optional: typed Bootstrap 5.3 components
-dotnet add package Rask.WebPush           # send Web Push notifications from the backend
+```
+
+**Then the batteries you want** — each is opt-in, and every one is a `AddRaskX<AppDbContext>()` call plus
+a `modelBuilder.AddRaskX()` schema line:
+
+```bash
+dotnet add package Rask.Data              # base entity + EF interceptors (soft delete, concurrency, events)
 dotnet add package Rask.Cqrs              # source-generated CQRS/mediator (queries, commands, notifications)
+dotnet add package Rask.Jobs              # durable background jobs
+dotnet add package Rask.Mail              # transactional email queue
+dotnet add package Rask.Cache             # read-through cache
+dotnet add package Rask.Outbox            # transactional outbox for domain events
+dotnet add package Rask.Logging           # durable log store (its own SQLite file)
+dotnet add package Rask.Dashboard         # the /_ops operator dashboard over every pillar
+dotnet add package Rask.WebPush           # send Web Push notifications from the backend
+```
+
+**Database** — SQLite is the production default; Postgres and SQL Server are drop-in alternatives:
+
+```bash
+dotnet add package Rask.SQLite                        # production pragmas (WAL, busy_timeout) via UseRaskSqlite
+dotnet add package Rask.SQLite.EntityFrameworkCore    # the EF Core provider glue
+dotnet add package Rask.SQLite.Litestream             # managed continuous replication
+dotnet add package Rask.SQLite.Snapshots              # scheduled Online-Backup-API copies
+dotnet add package Rask.Postgres                      # or Postgres
+dotnet add package Rask.SqlServer                     # or SQL Server
+```
+
+**UI and testing:**
+
+```bash
+dotnet add package Rask.Bootstrap                     # typed Bootstrap 5.3 components
+dotnet add package Rask.Validation.DataAnnotations    # or Rask.Validation.FluentValidation
+dotnet add package Rask.Testing                       # render + drive components in unit tests
 ```
 
 ## Why Rask

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -44,19 +44,21 @@ dotnet tool install -g Rask.Cli      # one-time: install the rask CLI
 rask new MyApp                       # create a server app in ./MyApp (server is the default)
 ```
 
-`rask new` ships three templates, one per host model:
+`rask new` ships four templates, one per host model:
 
 | `--template`        | What you get                                                                                  |
 |---------------------|-----------------------------------------------------------------------------------------------|
 | `server` (default)  | One ASP.NET project. Components render on the server; live updates ship over a WebSocket. **Best default.** |
 | `wasm`              | One `net10.0-browser` project that publishes to a static `wwwroot/` you can host anywhere (GitHub Pages, S3, nginx). Bring your own API. |
 | `wasm-hosted`       | Three projects: `MyApp.Client` (the WASM SPA), `MyApp.Server` (the ASP.NET host that serves the bundle and your own `/api/...` endpoints), and `MyApp.Shared` (a class library both reference). |
+| `native`            | A native iOS/Android app head (WebView hybrid, preview) running the same components — see [native](native.md). Needs the `ios android` workloads. |
 
-All three emit the same starter pages, so the rest of this guide applies whichever you chose. Each also
+They emit the same starter pages, so the rest of this guide applies whichever you chose. Each also
 accepts a `--auth` switch that scaffolds a working login flow — see [authentication](authentication.md)
 when you need it. The `server` template additionally accepts `--cqrs`, which scaffolds the
-[Rask.Cqrs](cqrs.md) mediator (a sample query + handler and a `/greeting` page that dispatches it), and
-`--pwa`, which makes it an installable [PWA](pwa.md).
+[Rask.Cqrs](cqrs.md) mediator (a sample query + handler and a `/greeting` page that dispatches it),
+`--pwa`, which makes it an installable [PWA](pwa.md), and `--docker` — a flag, not a template, which adds
+a Dockerfile for [`rask deploy`](cli.md). The full flag list is in [the CLI reference](cli.md).
 
 ## 2. Run it
 
@@ -330,8 +332,10 @@ The snags you're most likely to hit on a fresh project:
   (`RASK015`–`RASK018`) — check the build output.
 
 - **Blank page or 404s on `/_rask/...` assets behind a reverse proxy or sub-path.** The app is running
-  under a URL prefix the framework doesn't know about — set `PathBase` (see the README's
-  *Sub-path hosting* section).
+  under a URL prefix the framework doesn't know about — set `PathBase` ([configuration](configuration.md)),
+  and build any hand-written asset URL as `LiveOptions.PathBase + "/…"` ([JS interop](js-interop.md)).
+  For a WASM bundle published under a prefix (GitHub Pages project sites), publish with
+  `-p:RaskPathBase=/my-repo` — see [Deploying to a sub-path](pwa.md#deploying-github-pages--sub-paths).
 
 ## Next steps
 

--- a/llms.txt
+++ b/llms.txt
@@ -7,7 +7,9 @@
 > over WebSockets, client-side on WebAssembly, or native iOS/Android (Rask.Native); markup uses generated
 > factory methods + a children indexer (`Div()[Span(), "hi"]`). Batteries: the `rask` CLI, a
 > `generate feature` CQRS+EF CRUD scaffolder, Rask.Cqrs, Rask.Data, production SQLite (pragmas + backup),
-> auth, and `--docker` deploy.
+> auth, background jobs, transactional email, cache, outbox, a durable log store and an operator
+> dashboard — and `rask deploy`, which builds and runs the app on one box over SSH with zero-downtime
+> blue-green releases, a health-gated cutover, auto-HTTPS via Caddy, and bare-VPS provisioning.
 
 This file helps AI coding assistants build apps with Rask. Start with the repo-root AGENTS.md
 (the AI guidance shipped alongside this file) for app-authoring conventions, then the docs below.

--- a/tests/Rask.Generators.Tests/PackageDependencyTests.cs
+++ b/tests/Rask.Generators.Tests/PackageDependencyTests.cs
@@ -100,6 +100,44 @@ public class PackageDependencyTests
             + string.Join("\n  ", missing));
     }
 
+    // NUGET.md is packed into EVERY package (Directory.Build.props), so it is the most-read page the project
+    // ships and the one nobody edits — it listed 7 packages while the repo built 24, missing every battery
+    // (Jobs/Mail/Cache/Outbox/Data/Dashboard/Logging), both SQLite satellites, both alternative database
+    // providers and Rask.Testing (#602). A package that exists and is documented nowhere is one a reader can
+    // only find by reading the source, which defeats the point of shipping it.
+    //
+    // Matching on the PackageId is deliberate: the id is what a reader types into `dotnet add package`, so
+    // naming it is the minimum bar. This does not check that what NUGET.md SAYS about a package is right —
+    // nothing can — only that the package is not silently absent.
+    [Fact]
+    public void Every_packable_project_is_named_in_the_packed_readme()
+    {
+        var readme = File.ReadAllText(Path.Combine(RepoRoot(), "NUGET.md"));
+
+        var missing = SourceProjects()
+            .Where(p => IsPackable(p.Value))
+            .Select(p => PackageId(p.Value))
+            .Where(id => id is not null && !readme.Contains(id, StringComparison.Ordinal))
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            "These packages ship but NUGET.md — which is packed into every one of them — never names them, so "
+            + "the most-read page the project publishes does not admit they exist:\n  "
+            + string.Join("\n  ", missing));
+    }
+
+    // The <PackageId> a project publishes under, or its file name when it doesn't override one.
+    private static string? PackageId(string csprojPath)
+    {
+        var doc = XDocument.Load(csprojPath);
+        var declared = doc.Descendants("PackageId").FirstOrDefault()?.Value.Trim();
+        return string.IsNullOrEmpty(declared) || declared.Contains('$', StringComparison.Ordinal)
+            ? Path.GetFileNameWithoutExtension(csprojPath)
+            : declared;
+    }
+
     // Every project under src/, packable or not, keyed by its file name. Both invariants above need the whole set:
     // one to tell a reference to an unpackable project from a reference to a shipped one, the other to pick the
     // packable ones out.


### PR DESCRIPTION
Closes #602.

Every claim in the issue verified against the tree, and every one was true.

## `NUGET.md` — the most-read page nobody edits

It is packed into **all 24 packages** via `Directory.Build.props`, so it is what a reader sees on
nuget.org for every one of them. It listed **seven**.

Missing: every battery (`Rask.Jobs`, `Rask.Mail`, `Rask.Cache`, `Rask.Outbox`, `Rask.Data`,
`Rask.Logging`, `Rask.Dashboard`), both SQLite satellites, both alternative database providers
(`Rask.Postgres` / `Rask.SqlServer`, added only last week by #620), and `Rask.Testing`. It also showed
only `rask new` — `generate`, `db`, `dev` and `deploy` have all shipped since — and still led with the
pre-OPF tagline that `README.md` and `llms.txt` had already moved on from.

Rewritten **by role** rather than as a flat list: pick a host, add the batteries you want, pick a
database, plus UI and testing. That way it is something a reader acts on instead of a set someone has to
keep in sync by hand.

**And a test now fails the build if a packable project isn't named there.** It sits directly beside the
existing guard that catches a project missing from the pack workflow — the same failure one step
earlier. A package that exists and is documented nowhere can only be found by reading the source, which
defeats the point of shipping it.

## `CONTRIBUTING.md` — contradicted itself within twenty lines

> **Tests run locally, not in CI.** … CI keeps only the deterministic benchmark byte-gates, the native
> compile gate, commitlint, and CodeQL.

> … **CI still runs unit/integration tests**, the deterministic benchmark byte-gates, and a native
> compile gate.

Reality is neither. `ci.yml` has exactly two jobs (`benchmarks`, `native`) and **no workflow in this repo
runs `dotnet test` at all** — worth saying plainly, because it means nothing but your own machine will
tell you a test broke. Also fixed: the CodeQL *workflow* it credits doesn't exist (that's GitHub's
default setup); the diagnostic range was given as RASK001–029 twice when it is 001–035, and RASK035
lives in `Rask.Generators.Shared`, not `Rask.Generators`; and the build loop opened with bare
`dotnet test`, which pulls in the Playwright suite the rest of the same page tells you to avoid. It now
names the two gate scripts the hooks actually run.

## The rest

- **`llms.txt`** framed deployment as "opt-in `--docker` deploy" when `rask deploy` — SSH, blue-green,
  health-gated cutover, Caddy auto-HTTPS, bare-VPS provisioning — has shipped; its battery list stopped
  at four of them.
- **`AGENTS.md`** listed 8 of the 12 committed skills. The four missing were `add-codefix` and all three
  *drive the real app* playbooks — which is exactly the set an agent needs when a passing test is not the
  same as the thing working.
- **`docs/getting-started.md`** said `rask new` ships three templates and listed three; there are four,
  and `native` was the absent one. It called `--docker` a template when it's a flag. And its
  *"see the README's Sub-path hosting section"* pointed at a section that does not exist — the README's
  only mention points back at getting-started, so a reader chasing `PathBase` went in a circle. It now
  points at `configuration.md`, `js-interop.md` and the PWA sub-path section, which really do cover it.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- `scripts/run-unit-local.sh` — green, including the new `NUGET.md` guard (which I checked fails as
  intended before the rewrite)
- Every link target in the changed pages confirmed to exist, including the `#deploying-github-pages--sub-paths`
  anchor

Docs and one test only — no framework code, so no benchmarks and no E2E impact.
