### PR TITLE
feat(generators): end the six diagnostics that predict a runtime failure with how to prevent it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,25 @@ them until tagged releases begin.
     same machine and commit, back to back. Traces now record snapshots only — `TestArtifacts` already
     writes a full-page PNG per test, and what a stuck journey needs is the DOM.
 
+- **The six diagnostics that told you production would break, without telling you how to stop it, now
+  say.** #275 gave the route family an actionable fix clause but only reached the descriptors in
+  `RoutesGenerator`; the two that deserved it most were in other files and were missed.
+  - **RASK029** (a CQRS handler) and **RASK035** (a job or outbox event) are *Warnings* announcing a
+    guaranteed runtime failure — the type is skipped, so dispatching it throws or a queued message
+    dead-letters — and they stopped at the bare phrase (`is abstract`, `is a file-local type`, `is not
+    accessible from generated code`). A warning you can miss, telling you a crash is coming and not how to
+    avoid it, is the worst shape a diagnostic has. Each reason now arrives with its remedy from a single
+    switch in `SymbolRegistration`, so the two halves cannot drift.
+  - **RASK003** was the one route diagnostic #275 skipped, in the file it edited: it named the offending
+    segment and never showed a correct one. Each of the four parse failures now shows the template you
+    meant (`/users/{id:int}`, `/files/{folder}/{name}`, a parameter in its own segment).
+  - **RASK011** stated the constraint and stopped. The remedy was only in `docs/diagnostics.md`, which is
+    not where you are at 2am; it now names both escapes — a parsable type, or take it as `string` and
+    convert inside the page.
+  - **RASK015 / RASK017** were purely descriptive, so the `RaskScopedCssAutoInclude` /
+    `RaskScopedJsAutoInclude` opt-out — the right answer whenever the orphan file is a deliberate global
+    one — was undiscoverable from the error that fired.
+
 ## [0.20.0] - 2026-08-06
 
 ### Fixed

--- a/src/Rask.Cqrs.Generators/CqrsDispatchGenerator.cs
+++ b/src/Rask.Cqrs.Generators/CqrsDispatchGenerator.cs
@@ -34,7 +34,7 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask029 = new(
         "RASK029",
         "Handler cannot be registered",
-        "Handler '{0}' {1}; it is skipped, so dispatching its request will throw at runtime",
+        "Handler '{0}' {1}; it is skipped, so dispatching its request will throw at runtime — {2}",
         "Rask.Generators",
         DiagnosticSeverity.Warning,
         true,
@@ -107,13 +107,15 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
                 _ => string.Empty,
             };
 
+            var registerability = DescribeRegisterability(symbol, args);
             handlers.Add(new HandlerModel(
                 kind.Value,
                 Fqn(symbol),
                 requestFqn,
                 resultFqn,
                 Fqn(iface),
-                DescribeRegisterability(symbol, args)));
+                registerability?.Problem,
+                registerability?.Remedy));
         }
 
         if (handlers.Count == 0)
@@ -134,28 +136,38 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
     // typeof(...) operands and generic arguments. That check is defensive rather than a known break:
     // C# already rejects a handler that exposes a less-accessible request through its public
     // HandleAsync (CS0051), so in practice an unnameable request comes with an unnameable handler.
-    private static string? DescribeRegisterability(INamedTypeSymbol symbol, ImmutableArray<ITypeSymbol> typeArguments)
+    //
+    // Each reason comes back with what to do about it. RASK029 is a *Warning* announcing a guaranteed
+    // production failure — the handler is skipped, so dispatching its request throws — and a warning you
+    // can miss, telling you a crash is coming and not how to avoid it, is the worst shape a diagnostic
+    // has (#608).
+    private static (string Problem, string Remedy)? DescribeRegisterability(
+        INamedTypeSymbol symbol,
+        ImmutableArray<ITypeSymbol> typeArguments)
     {
         if (symbol.IsGenericType)
         {
-            return "is an open generic type";
+            return ("is an open generic type",
+                "close its type parameters, or register the handler by hand");
         }
 
         if (!symbol.InstanceConstructors.Any(c => c.DeclaredAccessibility == Accessibility.Public))
         {
-            return "has no public constructor";
+            return ("has no public constructor",
+                "give it a public constructor — the DI container has to be able to build it");
         }
 
-        if (SymbolRegistration.DescribeUnnameable(symbol) is { } handlerProblem)
+        if (SymbolRegistration.DescribeUnnameableWithRemedy(symbol) is { } handlerProblem)
         {
             return handlerProblem;
         }
 
         foreach (var argument in typeArguments)
         {
-            if (SymbolRegistration.DescribeUnnameable(argument) is { } argumentProblem)
+            if (SymbolRegistration.DescribeUnnameableWithRemedy(argument) is { } argumentProblem)
             {
-                return $"handles '{argument.ToDisplayString()}', which {argumentProblem}";
+                return ($"handles '{argument.ToDisplayString()}', which {argumentProblem.Problem}",
+                    $"for '{argument.ToDisplayString()}', {argumentProblem.Remedy}");
             }
         }
 
@@ -193,7 +205,11 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
             if (entry.Model.RegisterabilityProblem is { } problem)
             {
                 spc.ReportDiagnostic(Diagnostic.Create(
-                    Rask029, entry.Location?.ToLocation(), entry.Model.HandlerTypeFqn, problem));
+                    Rask029,
+                    entry.Location?.ToLocation(),
+                    entry.Model.HandlerTypeFqn,
+                    problem,
+                    entry.Model.RegisterabilityRemedy));
                 continue;
             }
 
@@ -432,7 +448,8 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
         string RequestTypeFqn,
         string ResultTypeFqn,
         string ServiceInterfaceFqn,
-        string? RegisterabilityProblem) : IEquatable<HandlerModel>;
+        string? RegisterabilityProblem,
+        string? RegisterabilityRemedy) : IEquatable<HandlerModel>;
 
     private sealed record Candidate(EquatableArray<HandlerModel> Handlers, LocationInfo? Location);
 

--- a/src/Rask.Generators.Shared/RegistryGeneratorBase.cs
+++ b/src/Rask.Generators.Shared/RegistryGeneratorBase.cs
@@ -26,7 +26,7 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask035 = new(
         "RASK035",
         "Job or outbox event type cannot be registered",
-        "{0} type '{1}' {2}; it is skipped, so it will fail to deserialize and dead-letter at runtime",
+        "{0} type '{1}' {2}; it is skipped, so it will fail to deserialize and dead-letter at runtime — {3}",
         "Rask.Generators",
         DiagnosticSeverity.Warning,
         true,
@@ -98,13 +98,13 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
             return null;
         }
 
-        var problem = SymbolRegistration.DescribeUnregisterable(symbol);
-        if (problem is not null)
+        if (SymbolRegistration.DescribeUnregisterableWithRemedy(symbol) is { } unregisterable)
         {
             return new Candidate(
                 Key: null,
                 TypeExpression: null,
-                Problem: problem,
+                Problem: unregisterable.Problem,
+                Remedy: unregisterable.Remedy,
                 DisplayName: SymbolRegistration.RuntimeName(symbol),
                 Noun: noun,
                 Location: SymbolLocation.From(symbol));
@@ -114,6 +114,7 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
             Key: SymbolRegistration.RuntimeName(symbol),
             TypeExpression: SymbolRegistration.TypeExpression(symbol),
             Problem: null,
+            Remedy: null,
             DisplayName: SymbolRegistration.RuntimeName(symbol),
             Noun: noun,
             Location: null);
@@ -139,7 +140,8 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
                     candidate.Location?.ToLocation(),
                     candidate.Noun,
                     candidate.DisplayName,
-                    candidate.Problem));
+                    candidate.Problem,
+                    candidate.Remedy));
             }
         }
 
@@ -202,6 +204,7 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
         string? Key,
         string? TypeExpression,
         string? Problem,
+        string? Remedy,
         string DisplayName,
         string Noun,
         SymbolLocation? Location);

--- a/src/Rask.Generators.Shared/SymbolRegistration.cs
+++ b/src/Rask.Generators.Shared/SymbolRegistration.cs
@@ -65,22 +65,31 @@ internal static class SymbolRegistration
     /// <c>Outer&lt;T&gt;.Inner</c> leaks <c>T</c> into the generated file), a file-local type, or anything
     /// private or protected at any level of its containing chain.
     /// </remarks>
-    public static string? DescribeUnnameable(ITypeSymbol symbol)
+    public static string? DescribeUnnameable(ITypeSymbol symbol) =>
+        DescribeUnnameableWithRemedy(symbol)?.Problem;
+
+    /// <inheritdoc cref="DescribeUnnameable" />
+    /// <remarks>
+    /// Paired with its remedy for the same reason as
+    /// <see cref="DescribeUnregisterableWithRemedy" /> — see there.
+    /// </remarks>
+    public static (string Problem, string Remedy)? DescribeUnnameableWithRemedy(ITypeSymbol symbol)
     {
         switch (symbol)
         {
             case ITypeParameterSymbol:
-                return "refers to an unsubstituted type parameter";
+                return ("refers to an unsubstituted type parameter",
+                    "use a closed type — generated code cannot name a type parameter it has no value for");
 
             case IArrayTypeSymbol array:
-                return DescribeUnnameable(array.ElementType);
+                return DescribeUnnameableWithRemedy(array.ElementType);
 
             case INamedTypeSymbol named:
                 // A file-local type is invisible outside its own file, so the generated registry can't
                 // name it — and its FullName carries a synthesized "<file>F0__" segment anyway.
                 if (named.IsFileLocal)
                 {
-                    return "is a file-local type";
+                    return ("is a file-local type", "remove the 'file' modifier");
                 }
 
                 for (INamedTypeSymbol? type = named; type is not null; type = type.ContainingType)
@@ -92,17 +101,19 @@ internal static class SymbolRegistration
                         or Accessibility.ProtectedOrInternal))
                     {
                         return ReferenceEquals(type, named)
-                            ? "is not accessible from generated code"
-                            : $"is nested inside the inaccessible type '{RuntimeName(type)}'";
+                            ? ("is not accessible from generated code", "make it public or internal")
+                            : ($"is nested inside the inaccessible type '{RuntimeName(type)}'",
+                                $"make '{RuntimeName(type)}' public or internal, or move it out of it");
                     }
 
                     foreach (var argument in type.TypeArguments)
                     {
-                        if (DescribeUnnameable(argument) is { } reason)
+                        if (DescribeUnnameableWithRemedy(argument) is { } reason)
                         {
                             return ReferenceEquals(type, named)
                                 ? reason
-                                : $"is nested inside the generic type '{RuntimeName(type)}'";
+                                : ($"is nested inside the generic type '{RuntimeName(type)}'",
+                                    $"move it out of '{RuntimeName(type)}' to a non-generic scope");
                         }
                     }
                 }
@@ -126,21 +137,39 @@ internal static class SymbolRegistration
     /// <see cref="INamedTypeSymbol.IsGenericType"/> only so the reported reason is accurate:
     /// <c>IsGenericType</c> conflates "has type parameters" with "is nested in something that does".
     /// </remarks>
-    public static string? DescribeUnregisterable(INamedTypeSymbol symbol)
+    public static string? DescribeUnregisterable(INamedTypeSymbol symbol) =>
+        DescribeUnregisterableWithRemedy(symbol)?.Problem;
+
+    /// <summary>
+    /// The reason <paramref name="symbol"/> cannot be put in a name-keyed generated registry paired with
+    /// what to do about it, or <see langword="null"/> when it can.
+    /// </summary>
+    /// <remarks>
+    /// Both halves come from one <c>switch</c> so they cannot drift: every diagnostic that reports one of
+    /// these phrases (RASK029, RASK035) is a <i>Warning</i> announcing a guaranteed production failure —
+    /// the type is skipped, so dispatching or deserializing it throws — and a warning you can miss, telling
+    /// you a crash is coming and not how to avoid it, is the worst shape a diagnostic has. The generator
+    /// already knows the remedy in every case; it just wasn't saying it (#608).
+    /// <para>
+    /// <see cref="DescribeUnregisterable"/> stays as the problem-only accessor because existing tests and
+    /// message formats are written against those exact phrases.
+    /// </para>
+    /// </remarks>
+    public static (string Problem, string Remedy)? DescribeUnregisterableWithRemedy(INamedTypeSymbol symbol)
     {
         if (symbol.IsAbstract)
         {
-            return "is abstract";
+            return ("is abstract", "make it a concrete type, or register the concrete subtype instead");
         }
 
         if (symbol.IsStatic)
         {
-            return "is a static type";
+            return ("is a static type", "make it a non-static class");
         }
 
         if (symbol.TypeKind is not (TypeKind.Class or TypeKind.Struct))
         {
-            return "is not a class or struct";
+            return ("is not a class or struct", "declare it as a class or a struct");
         }
 
         for (INamedTypeSymbol? type = symbol; type is not null; type = type.ContainingType)
@@ -148,12 +177,15 @@ internal static class SymbolRegistration
             if (type.Arity > 0)
             {
                 return ReferenceEquals(type, symbol)
-                    ? "is a generic type"
-                    : $"is nested inside the generic type '{RuntimeName(type)}'";
+                    ? ("is a generic type",
+                        "make it non-generic — a registry is keyed by name, and a closed generic's runtime "
+                        + "name carries assembly-qualified type arguments no key can match")
+                    : ($"is nested inside the generic type '{RuntimeName(type)}'",
+                        $"move it out of '{RuntimeName(type)}' to a non-generic scope");
             }
         }
 
-        return DescribeUnnameable(symbol);
+        return DescribeUnnameableWithRemedy(symbol);
     }
 
     /// <summary>True when <paramref name="symbol"/> can be put in a name-keyed generated registry.</summary>

--- a/src/Rask.Generators/ComponentScopedCssGenerator.cs
+++ b/src/Rask.Generators/ComponentScopedCssGenerator.cs
@@ -25,7 +25,9 @@ public sealed class ComponentScopedCssGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask015 = new(
         "RASK015",
         "Orphan scoped-CSS file",
-        "Scoped-CSS file '{0}' has no matching component class. Expected a Component subclass named '{1}' in the same folder.",
+        "Scoped-CSS file '{0}' has no matching component class — add a Component subclass named '{1}' in the "
+        + "same folder, rename the file to match one, or set "
+        + "<RaskScopedCssAutoInclude>false</RaskScopedCssAutoInclude> if it is a global stylesheet",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,

--- a/src/Rask.Generators/ComponentScopedJsGenerator.cs
+++ b/src/Rask.Generators/ComponentScopedJsGenerator.cs
@@ -26,7 +26,9 @@ public sealed class ComponentScopedJsGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask017 = new(
         "RASK017",
         "Orphan scoped-JS file",
-        "Scoped-JS file '{0}' has no matching component class. Expected a Component subclass named '{1}' in the same folder.",
+        "Scoped-JS file '{0}' has no matching component class — add a Component subclass named '{1}' in the "
+        + "same folder, rename the file to match one, or set "
+        + "<RaskScopedJsAutoInclude>false</RaskScopedJsAutoInclude> if it is a plain wwwroot script",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -108,7 +108,9 @@ public sealed class RoutesGenerator : IIncrementalGenerator
     private static readonly DiagnosticDescriptor Rask011 = new(
         "RASK011",
         "Route/query param type must implement IParsable<T>",
-        "Property '{0}.{1}' of type '{2}' must be 'string' or implement 'System.IParsable<{2}>' to be bound by [RouteParam]/[QueryParam]",
+        "Property '{0}.{1}' of type '{2}' must be 'string' or implement 'System.IParsable<{2}>' to be bound "
+        + "by [RouteParam]/[QueryParam] — use a parsable type (int, Guid, DateOnly, an enum, your own "
+        + "IParsable<T>), or accept it as 'string' and convert inside the page",
         "Rask.Generators",
         DiagnosticSeverity.Error,
         true,
@@ -1261,7 +1263,7 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         {
             if (seg.Length == 0)
             {
-                error = "empty segment";
+                error = "empty segment — remove the doubled '/', e.g. \"/users/{id:int}\"";
                 return false;
             }
 
@@ -1270,7 +1272,7 @@ public sealed class RoutesGenerator : IIncrementalGenerator
                 var inner = seg.Substring(1, seg.Length - 2);
                 if (inner.StartsWith("**", StringComparison.Ordinal))
                 {
-                    error = "catch-all '{**...}' segments are not supported in typed routes";
+                    error = "catch-all '{**...}' segments are not supported in typed routes — name the segments you need, e.g. \"/files/{folder}/{name}\", or match the rest inside the page";
                     return false;
                 }
 
@@ -1296,7 +1298,7 @@ public sealed class RoutesGenerator : IIncrementalGenerator
 
                 if (name.Length == 0)
                 {
-                    error = "param has no name";
+                    error = "param has no name — name it, e.g. \"/users/{id}\" or \"/users/{id:guid?}\"";
                     return false;
                 }
 
@@ -1304,7 +1306,7 @@ public sealed class RoutesGenerator : IIncrementalGenerator
             }
             else if (seg.IndexOf('{') >= 0 || seg.IndexOf('}') >= 0)
             {
-                error = "mixed literal/param segments are not supported";
+                error = "mixed literal/param segments are not supported — give the parameter its own segment, e.g. \"/order/{id}\" rather than \"/order-{id}\"";
                 return false;
             }
             else

--- a/tests/Rask.Cqrs.Generators.Tests/CqrsDispatchGeneratorTests.cs
+++ b/tests/Rask.Cqrs.Generators.Tests/CqrsDispatchGeneratorTests.cs
@@ -101,6 +101,50 @@ public sealed class CqrsDispatchGeneratorTests
         Assert.Contains(run.Diagnostics, d => d.Id == "RASK029");
     }
 
+    /// <summary>
+    ///     RASK029 is a <em>Warning</em> that says production will throw: the handler is skipped, so
+    ///     dispatching its request fails at runtime. A warning you can miss, announcing a crash and not how
+    ///     to avoid it, is the worst shape a diagnostic has — so the remedy is part of the contract (#608).
+    /// </summary>
+    [Theory]
+    // reason under test                              // the remedy it must carry
+    [InlineData("private PrivateHandler() { }", "public constructor")]
+    public void RASK029_says_how_to_fix_it(string body, string remedy)
+    {
+        var run = CqrsGeneratorFixture.Run(Preamble + $$"""
+            public sealed record GetValue : IQuery<int>;
+            public sealed class PrivateHandler : IQueryHandler<GetValue, int>
+            {
+                {{body}}
+                public Task<int> HandleAsync(GetValue query, CancellationToken ct) => Task.FromResult(1);
+            }
+            """);
+
+        var message = run.Diagnostics.First(d => d.Id == "RASK029").GetMessage();
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        Assert.Contains(remedy, message, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc cref="RASK029_says_how_to_fix_it" />
+    [Fact]
+    public void RASK029_on_an_inaccessible_handler_says_how_to_fix_it()
+    {
+        var run = CqrsGeneratorFixture.Run(Preamble + """
+            public sealed record GetValue : IQuery<string>;
+            public class Outer
+            {
+                private sealed class Handler : IQueryHandler<GetValue, string>
+                {
+                    public Task<string> HandleAsync(GetValue query, CancellationToken ct) => Task.FromResult("v");
+                }
+            }
+            """);
+
+        var message = run.Diagnostics.First(d => d.Id == "RASK029").GetMessage();
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        Assert.Contains("public or internal", message, StringComparison.Ordinal);
+    }
+
     [Fact]
     public void Discovers_a_record_handler()
     {

--- a/tests/Rask.Generators.Tests/ActionableDiagnosticMessageTests.cs
+++ b/tests/Rask.Generators.Tests/ActionableDiagnosticMessageTests.cs
@@ -1,0 +1,103 @@
+using Microsoft.CodeAnalysis;
+
+namespace Rask.Generators.Tests;
+
+/// <summary>
+///     Every diagnostic here announces a failure the developer cannot yet see: a build that will not
+///     compile, or — worse, because you can miss a Warning — a registration that is silently skipped so the
+///     thing throws in production. #275 gave the route diagnostics a fix clause and #608 finished the job;
+///     these pin it, because "the message stopped saying what to do" is a regression no other test notices.
+/// </summary>
+/// <remarks>
+///     Each case asserts the em-dash separator (the house shape: problem — remedy) plus a substring of the
+///     remedy itself. Asserting only the dash would pass on an empty clause; asserting the whole sentence
+///     would fail on any rewording. The substring is the imperative verb, which is the part that has to
+///     survive.
+/// </remarks>
+public class ActionableDiagnosticMessageTests
+{
+    [Theory]
+    // Each reason TryParseTemplate can produce, and the correct template it should show you.
+    [InlineData("/users//{id}", "empty segment", "/users/{id:int}")]
+    [InlineData("/files/{**rest}", "catch-all", "/files/{folder}/{name}")]
+    [InlineData("/users/{}", "no name", "/users/{id}")]
+    [InlineData("/order-{id}", "mixed literal/param", "its own segment")]
+    public void Rask003_ShowsACorrectTemplate(string template, string problem, string remedy)
+    {
+        var message = MessageFor("RASK003", $$"""
+                                              using Rask.Core;
+                                              using Rask.Core.Routing;
+                                              namespace Demo;
+                                              [Route("{{template}}")]
+                                              public sealed class P : Component
+                                              {
+                                                  public string? Id { get; set; }
+                                                  public override Component? Render() => this;
+                                              }
+                                              """);
+
+        Assert.Contains(problem, message, StringComparison.Ordinal);
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        Assert.Contains(remedy, message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Rask011_NamesTheWayOut_NotJustTheConstraint()
+    {
+        var message = MessageFor("RASK011", """
+                                            using Rask.Core;
+                                            using Rask.Core.Routing;
+                                            namespace Demo;
+                                            public sealed class NotParsable { }
+                                            [Route("/thing")]
+                                            public sealed class P : Component
+                                            {
+                                                [QueryParam] public NotParsable? Value { get; set; }
+                                                public override Component? Render() => this;
+                                            }
+                                            """);
+
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        // Both escapes, because which one applies depends on whether the type is yours to change.
+        Assert.Contains("use a parsable type", message, StringComparison.Ordinal);
+        Assert.Contains("convert inside the page", message, StringComparison.Ordinal);
+    }
+
+    // The opt-out is the point: an orphan stylesheet is very often a deliberate global one, and until now
+    // the only way to learn that the escape hatch existed was to read docs/diagnostics.md.
+    [Fact]
+    public void Rask015_MentionsTheAutoIncludeOptOut()
+    {
+        var run = GeneratorDriverFixture.Run(
+            [("/proj/Widgets/Unrelated.cs", "namespace Demo; public sealed class Unrelated { }")],
+            new ComponentScopedCssGenerator(),
+            [("/proj/Widgets/Orphan.css", ".a{color:red}")]);
+
+        var message = run.Diagnostics.First(d => d.Id == "RASK015").GetMessage();
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        Assert.Contains("RaskScopedCssAutoInclude", message, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc cref="Rask015_MentionsTheAutoIncludeOptOut" />
+    [Fact]
+    public void Rask017_MentionsTheAutoIncludeOptOut()
+    {
+        var run = GeneratorDriverFixture.Run(
+            [("/proj/Widgets/Unrelated.cs", "namespace Demo; public sealed class Unrelated { }")],
+            new ComponentScopedJsGenerator(),
+            [("/proj/Widgets/Orphan.js", "export function go() {}")]);
+
+        var message = run.Diagnostics.First(d => d.Id == "RASK017").GetMessage();
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        Assert.Contains("RaskScopedJsAutoInclude", message, StringComparison.Ordinal);
+    }
+
+    private static string MessageFor(string id, string source)
+    {
+        var run = GeneratorDriverFixture.RunRoutes(source);
+        var diagnostic = run.Diagnostics.FirstOrDefault(d => d.Id == id);
+        Assert.True(diagnostic is not null,
+            $"expected {id}, got: {string.Join(", ", run.Diagnostics.Select(d => d.Id).Distinct())}");
+        return diagnostic!.GetMessage();
+    }
+}

--- a/tests/Rask.Jobs.Generators.Tests/JobRegistryGeneratorTests.cs
+++ b/tests/Rask.Jobs.Generators.Tests/JobRegistryGeneratorTests.cs
@@ -113,6 +113,28 @@ public class JobRegistryGeneratorTests
 
         var diagnostic = Assert.Single(run.Diagnostics, d => d.Id == "RASK035");
         Assert.Contains("nested inside the generic type 'Demo.Outer'", diagnostic.GetMessage(), StringComparison.Ordinal);
+
+        // RASK035 is a Warning that says production will break — the type is skipped, so a queued job of
+        // it fails to deserialize and dead-letters. Announcing that and not how to avoid it is the worst
+        // shape a diagnostic has, so the remedy is part of the contract (#608).
+        Assert.Contains(" — ", diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.Contains("move it out of 'Demo.Outer'", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc cref="A_job_nested_in_a_generic_type_is_skipped_with_RASK035" />
+    [Fact]
+    public void RASK035_on_a_file_local_job_says_how_to_fix_it()
+    {
+        var run = Run("""
+            using Rask.Jobs;
+            namespace Demo;
+            file sealed record RequestReview(int OrderId) : IJob;
+            """);
+
+        var message = Assert.Single(run.Diagnostics, d => d.Id == "RASK035").GetMessage();
+        Assert.Contains("file-local", message, StringComparison.Ordinal);
+        Assert.Contains(" — ", message, StringComparison.Ordinal);
+        Assert.Contains("remove the 'file' modifier", message, StringComparison.Ordinal);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #608.

Message text only. IDs, severities, argument counts and `docs/diagnostics.md`'s **Fix:** paragraphs are
unchanged — the docs already said the right thing, which is exactly the problem: they are not where you
are at 2am.

## The two that mattered most

**RASK029** (a CQRS handler) and **RASK035** (a job or outbox event type) are **Warnings** that announce a
guaranteed production failure — the type is skipped, so dispatching its request throws, or a queued
message fails to deserialize and dead-letters. And they stopped at a bare phrase:

> `Handler 'Foo' is not accessible from generated code; it is skipped, so dispatching its request will
> throw at runtime`

A latent crash, in a warning you can miss entirely, with no instruction. Every one of those phrases —
`is abstract`, `is a static type`, `is a generic type`, `is a file-local type`, `is nested inside the
generic type 'X'` — has an obvious remedy the generator already knows.

**Each reason now comes back with its remedy from one `switch`**, as a `(Problem, Remedy)` pair, so the
two halves cannot drift apart. `DescribeUnregisterable` / `DescribeUnnameable` stay as problem-only
accessors, because existing tests and message formats are written against those exact phrases — the
issue flagged that trap and it's real.

## The other four

- **RASK003** — the one route diagnostic #275 skipped, in the very file it edited. It echoed the offending
  segment and never showed a correct one, so *"Route template '/order-{id}' on 'X' is malformed: mixed
  literal/param segments are not supported"* left you to guess the shape. All four parse failures now show
  the template you meant.
- **RASK011** stated the constraint and stopped. It now names both escapes — a parsable type, or take it
  as `string` and convert inside the page — because which one applies depends on whether the type is yours
  to change.
- **RASK015 / RASK017** were purely descriptive while their immediate neighbour RASK016 already ended
  *"Move one to disambiguate."* The asymmetry is the small part. The real cost: an orphan `.css`/`.js` is
  very often a **deliberate** global file, and the `RaskScopedCssAutoInclude` / `RaskScopedJsAutoInclude`
  opt-out that makes it legal was discoverable only by going and reading the docs for an error you were
  already staring at.

## Tests

Each case asserts the em-dash separator (the house shape `problem — remedy`, set by #275) **plus a
substring of the remedy**. The dash alone would pass on an empty clause; the whole sentence would fail on
any rewording; the imperative verb is the part that has to survive.

**RASK035 had no message-level coverage at all before this** — the issue noted there is no test project
for `Rask.Generators.Shared`, so it's covered through `Rask.Jobs.Generators.Tests`, which is where the
descriptor is actually reached from.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full unit suite across the solution (39 assemblies) — green
- New: 7 route/scoped-asset message tests, 2 RASK029 tests, 1 RASK035 test; 1 existing RASK035 test
  extended

No runtime code changed, so no benchmarks and no E2E impact.
