### PR TITLE
feat(generators)!: one diagnostic category, a tooltip on all 35, and quick fixes for the mechanical three

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -216,6 +216,32 @@ them until tagged releases begin.
   - **RASK015 / RASK017** were purely descriptive, so the `RaskScopedCssAutoInclude` /
     `RaskScopedJsAutoInclude` opt-out — the right answer whenever the orphan file is a deliberate global
     one — was undiscoverable from the error that fired.
+- **BREAKING — every RASK diagnostic reports under one category, `Rask`.** There used to be two, split by
+  what produced the diagnostic: generators used `Rask.Generators`, analyzers used `Usage`. That is an
+  implementation detail of this repo, and it leaked to the consumer — a category is what an
+  `.editorconfig` rule or an IDE's group-by keys on, so
+  `dotnet_analyzer_diagnostic.category-Rask.severity = …` silently covered 22 of the 35 and quietly
+  ignored the other 13. **If you have a rule keyed on `Usage` or `Rask.Generators`, point it at `Rask`**;
+  one line now covers the family. A test fails the build if a descriptor drifts out of it.
+- **Quick fixes for the three most-hit mechanical diagnostics.** `Rask.Generators.CodeFixes` shipped two
+  providers; the highest-value candidate wasn't among them.
+  - **RASK014** — `new Widget()` → the generated `Widget()` factory. It is an **Error**, so it stops the
+    build, and it is the first thing a Blazor or plain-C# migrant hits, because `new` is simply what you
+    reach for. **Deliberately withheld when the construction has arguments or an object initializer**: the
+    factory's parameters are generated from the component's public properties in an order that is not the
+    constructor's, so carrying positional arguments across would compile and mean something *else*, and an
+    object initializer is only legal after `new`. A quick fix that silently changes meaning is worse than
+    none — in those cases the error stands with its message, which already names the factory.
+  - **RASK026** — deletes the redundant `StateHasChanged()` statement, which is what its message says to
+    do. Offered only when the call is the whole statement, so it can't change what an expression-bodied
+    lambda returns.
+  - **RASK027** — removes the `OnXAsync` argument and keeps the sync one. The diagnostic is already
+    anchored on the exact argument, so there is nothing to infer.
+- **All 35 diagnostics now carry a `description`, so the IDE's expanded tooltip says something.** Only 9
+  did; the other 26 included *every* build-breaking Error (003, 014, 019, 021, 032), where the reader's
+  only route to more detail was clicking through to the docs — not something you do mid-keystroke. Each
+  description explains the consequence and the surprising part rather than restating the message, which is
+  already on screen.
 
 ## [0.20.0] - 2026-08-06
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -7,9 +7,31 @@ These come from the Rask source generator and analyzers (`Rask.Generators`). The
 factories don't exist until a build runs, so if an ID below isn't recognised by your IDE yet,
 build once.
 
-Some diagnostics ship an **IDE quick-fix** (the lightbulb / `Ctrl`+`.`): **RASK001** adds the
-`required` modifier, **RASK023** inserts `Alt: ""`. These are delivered by `Rask.Generators.CodeFixes`,
-packed alongside the analyzers in the `Rask.Server` / `Rask.Wasm` packages — no extra reference needed.
+Some diagnostics ship an **IDE quick-fix** (the lightbulb / `Ctrl`+`.`):
+
+| ID | What the lightbulb does |
+|----|-------------------------|
+| **RASK001** | adds the `required` modifier |
+| **RASK014** | rewrites `new Widget()` into the generated `Widget()` factory call |
+| **RASK023** | inserts `Alt: ""` |
+| **RASK026** | deletes the redundant `StateHasChanged()` statement |
+| **RASK027** | removes the `OnXAsync` argument, keeping the sync one |
+
+These are delivered by `Rask.Generators.CodeFixes`, packed alongside the analyzers in the
+`Rask.Server` / `Rask.Wasm` packages — no extra reference needed.
+
+A fix is offered only when the rewrite means exactly what you wrote. **RASK014's is withheld when the
+construction has arguments or an object initializer**: the factory's parameters are generated from the
+component's public properties in an order that is not the constructor's, so moving positional arguments
+across would compile and mean something else — and an object initializer is only legal after `new`. In
+those cases the error stands with its message, which already names the factory to call.
+
+Every RASK diagnostic reports under the single category **`Rask`**, so one `.editorconfig` line covers
+the family:
+
+```ini
+dotnet_analyzer_diagnostic.category-Rask.severity = warning
+```
 
 | ID | Severity | Summary |
 |----|----------|---------|

--- a/src/Rask.Cqrs.Generators/CqrsDispatchGenerator.cs
+++ b/src/Rask.Cqrs.Generators/CqrsDispatchGenerator.cs
@@ -26,18 +26,24 @@ public sealed class CqrsDispatchGenerator : IIncrementalGenerator
         "RASK028",
         "Ambiguous request handler",
         "Request type '{0}' is handled by more than one handler; a query or command must have exactly one handler",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "The dispatcher maps each request type to exactly one handler, so two handlers for the same query "
+                     + "or command would make dispatch non-deterministic. Reported on each competing handler. "
+                     + "Notifications are exempt: an INotification may have any number of handlers.",
         helpLinkUri: DiagnosticHelp.Link("RASK028"));
 
     private static readonly DiagnosticDescriptor Rask029 = new(
         "RASK029",
         "Handler cannot be registered",
         "Handler '{0}' {1}; it is skipped, so dispatching its request will throw at runtime — {2}",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
+        description: "A Warning rather than an Error because the rest of the assembly still builds — but the handler "
+                     + "is left out of the generated dispatch table, so the first dispatch of its request throws at "
+                     + "runtime. It is worth not ignoring.",
         helpLinkUri: DiagnosticHelp.Link("RASK029"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/src/Rask.Cqrs.Generators/DiagnosticHelp.cs
+++ b/src/Rask.Cqrs.Generators/DiagnosticHelp.cs
@@ -5,6 +5,16 @@ namespace Rask.Cqrs.Generators;
 // Mirrors DiagnosticHelp in Rask.Generators; duplicated so Rask.Cqrs.Generators stays self-contained.
 internal static class DiagnosticHelp
 {
+    // The single category every RASKxxx descriptor reports under.
+    //
+    // There used to be two, split by which kind of thing produced the diagnostic: the incremental
+    // generators used "Rask.Generators" and the analyzers used "Usage". That is an implementation
+    // detail of this repo, and it leaked all the way out to the consumer — a category is what an
+    // .editorconfig rule or an IDE's "group by category" keys on, so any attempt to treat the family
+    // as a family (`dotnet_analyzer_diagnostic.category-Rask.severity = …`) silently caught half of
+    // it (#609). One family, one category.
+    public const string Category = "Rask";
+
     private const string DocBase = "https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md";
 
     // GitHub lowercases heading anchors, and the docs use "## RASKxxx" headings → "#raskxxx".

--- a/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/ComponentConstructionCodeFixProvider.cs
@@ -1,0 +1,73 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
+
+namespace Rask.Generators.CodeFixes;
+
+/// <summary>
+///     RASK014 — rewrite <c>new Widget()</c> into the generated <c>Widget()</c> factory call.
+/// </summary>
+/// <remarks>
+///     <para>
+///         The highest-value fix in the set: RASK014 is an <b>Error</b>, so it stops the build, and it is
+///         the first thing a Blazor or plain-C# migrant hits, because <c>new</c> is simply what you reach
+///         for. The diagnostic message already computes the exact replacement, so nothing is inferred here.
+///     </para>
+///     <para>
+///         <b>Deliberately withheld for anything but an argument-free, initializer-free construction.</b>
+///         A constructor call and a factory call are not the same shape: the factory's parameters are
+///         generated from the component's public properties in a defined order, which is not the
+///         constructor's, so carrying positional arguments across would compile and mean something else.
+///         And an object initializer is only legal after <c>new</c>, so it cannot ride along either. In
+///         both cases the error stands with its message, which names the factory to call — a quick fix
+///         that silently changes meaning is worse than none.
+///     </para>
+/// </remarks>
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(ComponentConstructionCodeFixProvider))]
+[Shared]
+public sealed class ComponentConstructionCodeFixProvider : RaskCodeFixProvider<ObjectCreationExpressionSyntax>
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ["RASK014"];
+
+    protected override string Title => "Use the generated factory";
+
+    protected override string EquivalenceKey => "RASK014_UseFactory";
+
+    protected override Task<bool> CanFixAsync(CodeFixContext context, ObjectCreationExpressionSyntax node) =>
+        Task.FromResult(
+            node.Initializer is null
+            && (node.ArgumentList is null || node.ArgumentList.Arguments.Count == 0)
+            && FactoryName(node) is not null);
+
+    protected override async Task<Document> FixAsync(
+        Document document,
+        ObjectCreationExpressionSyntax node,
+        CancellationToken cancellationToken)
+    {
+        if (FactoryName(node) is not { } name)
+        {
+            return document;
+        }
+
+        return await ReplaceNodeAsync(
+            document,
+            node,
+            InvocationExpression(IdentifierName(name)).WithTriviaFrom(node),
+            cancellationToken).ConfigureAwait(false);
+    }
+
+    // The factory is a static method named after the type, in scope project-wide through the generator's
+    // `global using static …Generated`. So the bare type name IS the call: carrying a qualified name over
+    // would name a type where a method has to go.
+    private static string? FactoryName(ObjectCreationExpressionSyntax node) => node.Type switch
+    {
+        QualifiedNameSyntax qualified => qualified.Right.Identifier.Text,
+        SimpleNameSyntax simple => simple.Identifier.Text,
+        _ => null,
+    };
+}

--- a/src/Rask.Generators.CodeFixes/RedundantStateHasChangedCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/RedundantStateHasChangedCodeFixProvider.cs
@@ -1,0 +1,52 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Rask.Generators.CodeFixes;
+
+// Quick-fix for RASK026 (a StateHasChanged() the framework already does for you inside a callback the
+// factory wraps): delete the statement. The message ends "remove the call", so this is that, mechanically.
+//
+// Only offered when the call IS the whole statement. `var x = StateHasChanged()` doesn't compile and
+// can't occur, but a call used as an expression — the body of an expression-bodied lambda, say — has a
+// value position to fill, and deleting it there would change what the lambda returns rather than just
+// removing a no-op.
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(RedundantStateHasChangedCodeFixProvider))]
+[Shared]
+public sealed class RedundantStateHasChangedCodeFixProvider : RaskCodeFixProvider<InvocationExpressionSyntax>
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ["RASK026"];
+
+    protected override string Title => "Remove the redundant StateHasChanged() call";
+
+    protected override string EquivalenceKey => "RASK026_RemoveCall";
+
+    protected override Task<bool> CanFixAsync(CodeFixContext context, InvocationExpressionSyntax node) =>
+        Task.FromResult(node.Parent is ExpressionStatementSyntax { Parent: BlockSyntax });
+
+    protected override async Task<Document> FixAsync(
+        Document document,
+        InvocationExpressionSyntax node,
+        CancellationToken cancellationToken)
+    {
+        if (node.Parent is not ExpressionStatementSyntax statement)
+        {
+            return document;
+        }
+
+        var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+        if (root is null)
+        {
+            return document;
+        }
+
+        // KeepNoTrivia: the statement's own leading trivia is its indentation and any comment attached to
+        // it, which goes with it. Keeping it would leave a blank, indented line behind.
+        var updated = root.RemoveNode(statement, SyntaxRemoveOptions.KeepNoTrivia);
+        return updated is null ? document : document.WithSyntaxRoot(updated);
+    }
+}

--- a/src/Rask.Generators.CodeFixes/SyncAsyncHandlerCodeFixProvider.cs
+++ b/src/Rask.Generators.CodeFixes/SyncAsyncHandlerCodeFixProvider.cs
@@ -1,0 +1,48 @@
+using System.Collections.Immutable;
+using System.Composition;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace Rask.Generators.CodeFixes;
+
+// Quick-fix for RASK027 (both OnX and OnXAsync passed to one factory call): drop the async one.
+//
+// The diagnostic is anchored on the async argument itself, so this is a single-node deletion with
+// nothing to infer. Which of the two to drop is a real choice — but the analyzer already made it by
+// pointing at the async sibling, and the title says which one goes, so the lightbulb preview shows the
+// author exactly what they are agreeing to. Keeping the sync one is also the reversible direction: the
+// async handler's body is one edit away from being moved into the sync one, where the reverse loses a
+// signature.
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SyncAsyncHandlerCodeFixProvider))]
+[Shared]
+public sealed class SyncAsyncHandlerCodeFixProvider : RaskCodeFixProvider<ArgumentSyntax>
+{
+    public override ImmutableArray<string> FixableDiagnosticIds { get; } = ["RASK027"];
+
+    protected override string Title => "Remove the async handler argument";
+
+    protected override string EquivalenceKey => "RASK027_RemoveAsyncArgument";
+
+    protected override Task<bool> CanFixAsync(CodeFixContext context, ArgumentSyntax node) =>
+        Task.FromResult(node is { NameColon: not null, Parent: ArgumentListSyntax });
+
+    protected override async Task<Document> FixAsync(
+        Document document,
+        ArgumentSyntax node,
+        CancellationToken cancellationToken)
+    {
+        if (node.Parent is not ArgumentListSyntax list)
+        {
+            return document;
+        }
+
+        return await ReplaceNodeAsync(
+            document,
+            list,
+            list.WithArguments(list.Arguments.Remove(node)),
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/src/Rask.Generators.Shared/DiagnosticHelp.cs
+++ b/src/Rask.Generators.Shared/DiagnosticHelp.cs
@@ -6,6 +6,16 @@ namespace Rask.Generators.Shared;
 // they ship as independent analyzers.
 internal static class DiagnosticHelp
 {
+    // The single category every RASKxxx descriptor reports under.
+    //
+    // There used to be two, split by which kind of thing produced the diagnostic: the incremental
+    // generators used "Rask.Generators" and the analyzers used "Usage". That is an implementation
+    // detail of this repo, and it leaked all the way out to the consumer — a category is what an
+    // .editorconfig rule or an IDE's "group by category" keys on, so any attempt to treat the family
+    // as a family (`dotnet_analyzer_diagnostic.category-Rask.severity = …`) silently caught half of
+    // it (#609). One family, one category.
+    public const string Category = "Rask";
+
     private const string DocBase = "https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md";
 
     // GitHub lowercases heading anchors, and the docs use "## RASKxxx" headings → "#raskxxx".

--- a/src/Rask.Generators.Shared/RegistryGeneratorBase.cs
+++ b/src/Rask.Generators.Shared/RegistryGeneratorBase.cs
@@ -27,9 +27,13 @@ public abstract class RegistryGeneratorBase : IIncrementalGenerator
         "RASK035",
         "Job or outbox event type cannot be registered",
         "{0} type '{1}' {2}; it is skipped, so it will fail to deserialize and dead-letter at runtime — {3}",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
+        description: "A Warning rather than an Error because the rest of the assembly still builds — but the type is "
+                     + "left out of the generated registry, so enqueuing it writes a row the processor cannot rehydrate: "
+                     + "it retries until MaxAttempts and then dead-letters. Before this existed the type was skipped "
+                     + "silently, which is what made the failure hard to place.",
         helpLinkUri: DiagnosticHelp.Link("RASK035"));
 
     /// <summary>Fully-qualified marker interface a type must implement, e.g. <c>Rask.Jobs.IJob</c>.</summary>

--- a/src/Rask.Generators/Analyzers/AuthBeforeRaskAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/AuthBeforeRaskAnalyzer.cs
@@ -28,7 +28,7 @@ public sealed class AuthBeforeRaskAnalyzer : DiagnosticAnalyzer
         "UseAuthentication must precede UseRask",
         "UseAuthentication() is called after UseRask<{0}>() — move it before UseRask so HttpContext.User is "
         + "populated on the GET render and the WebSocket upgrade; otherwise every [Authorize] page challenges",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "Rask seeds the live session from HttpContext.User during the initial GET and the WS upgrade. If the "

--- a/src/Rask.Generators/Analyzers/ComponentConstructionAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/ComponentConstructionAnalyzer.cs
@@ -17,9 +17,13 @@ public sealed class ComponentConstructionAnalyzer : DiagnosticAnalyzer
         "RASK014",
         "Components must be created via factory methods",
         "Do not instantiate '{0}' with 'new'; use the generated {1}Components.{0}(...) factory instead",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "The generated factories are how a component gets its key, its children and its injected "
+                     + "services; 'new' skips all three and produces an instance the runtime cannot reconcile. In a test "
+                     + "file that deliberately constructs components, opt out per file with '#pragma warning disable "
+                     + "RASK014'.",
         helpLinkUri: DiagnosticHelp.Link("RASK014"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =

--- a/src/Rask.Generators/Analyzers/DataGridColumnFieldAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/DataGridColumnFieldAnalyzer.cs
@@ -34,7 +34,7 @@ public sealed class DataGridColumnFieldAnalyzer : DiagnosticAnalyzer
         "Column has no Field for the chooser",
         "This column sets no Field, so the BsDataGrid column chooser can't show/hide or reorder it — "
         + "add Field = r => r.X to name it, or opt it out with Hideable = false and Reorderable = false",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "The column chooser and ColumnOrder address a column by the token read off its Field expression. A "

--- a/src/Rask.Generators/Analyzers/HeadChildrenAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/HeadChildrenAnalyzer.cs
@@ -27,9 +27,13 @@ public sealed class HeadChildrenAnalyzer : DiagnosticAnalyzer
         "RASK019",
         "<head> is a framework-managed slot — declare contents via Component.Head",
         "Do not pass children to '<head>'; declare head content by overriding the 'Component? Head' property on any component instead. The framework collects, dedupes, and splices contributions automatically.",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "Rask owns <head>: it collects each component's 'Head' contribution, dedupes it, and splices the "
+                     + "result in, so the element itself takes no children. Contribute by overriding 'protected override "
+                     + "Component? Head => …' on any component in the tree — that is what makes a page's title and meta "
+                     + "composable with the shell's.",
         helpLinkUri: DiagnosticHelp.Link("RASK019"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =

--- a/src/Rask.Generators/Analyzers/ImgMissingAltAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/ImgMissingAltAnalyzer.cs
@@ -25,7 +25,7 @@ public sealed class ImgMissingAltAnalyzer : DiagnosticAnalyzer
         "Img is missing Alt text",
         "Img is created without Alt — set Alt: to a text alternative, or Alt: \"\" for a decorative "
         + "image, so screen readers don't announce the file name (WCAG 1.1.1)",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "Every informative image needs a text alternative. Pass a meaningful Alt:, or the empty "

--- a/src/Rask.Generators/Analyzers/InputTypeMismatchAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/InputTypeMismatchAnalyzer.cs
@@ -32,7 +32,7 @@ public sealed class InputTypeMismatchAnalyzer : DiagnosticAnalyzer
         "Input type conflicts with the bound value type",
         "Input<{0}> derives its HTML type from {0}; the string-only InputType.{1} can't apply — drop Type "
         + "(it is inferred from {0}) or bind a string",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "A non-string Input<T> (e.g. Input<int>, Input<bool>, Input<DateOnly>) renders a type derived from "

--- a/src/Rask.Generators/Analyzers/InternalRouteStringAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/InternalRouteStringAnalyzer.cs
@@ -33,7 +33,7 @@ public sealed class InternalRouteStringAnalyzer : DiagnosticAnalyzer
         "Prefer the generated route URL over a hardcoded path",
         "Navigate with the generated 'Routes.{0}()' instead of the string \"{1}\" — a renamed or removed "
         + "[Route] then becomes a compile error, not a silent dead link",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "Rask generates a type-safe RouteUrl factory ('Routes.<Page>()') for every page's primary [Route]. "

--- a/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/MissingKeyAnalyzer.cs
@@ -29,7 +29,7 @@ public sealed class MissingKeyAnalyzer : DiagnosticAnalyzer
         "List item is missing a Key",
         "'{0}' is rendered in a list without a Key — set Key: so the diff codec reconciles it by "
         + "identity (trusted keyed structural ops) instead of by position",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "Elements/components produced in a .Select(...) projection or added to a component collection "

--- a/src/Rask.Generators/Analyzers/NativeChromeInHtmlAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/NativeChromeInHtmlAnalyzer.cs
@@ -27,9 +27,13 @@ public sealed class NativeChromeInHtmlAnalyzer : DiagnosticAnalyzer
         "RASK032",
         "Native components cannot appear in the HTML tree",
         "'{0}' is a native chrome component and cannot appear inside the HTML tree; compose it at the native layout level (a sibling of NativeWebView), not as an element child",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "Native chrome components describe real platform bars for the Rask.Native host, not HTML. They "
+                     + "are composed at the native page's layout level, as siblings of a NativeWebView — nested inside "
+                     + "the HTML tree one would serialize to nothing, so it is caught at build time rather than as an "
+                     + "invisible bar on a device.",
         helpLinkUri: DiagnosticHelp.Link("RASK032"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =

--- a/src/Rask.Generators/Analyzers/PreferNamedArgsAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/PreferNamedArgsAnalyzer.cs
@@ -34,7 +34,7 @@ public sealed class PreferNamedArgsAnalyzer : DiagnosticAnalyzer
         "'{0}' is called with {1} positional arguments — name them ('Prop: value') so the call is readable "
         + "and doesn't rebind silently if the generated parameter order shifts (a base-class property "
         + "added, a partial file renamed)",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Hidden,
         true,
         "Rask orders factory parameters by inheritance depth then file ordinal + span, so a call with "

--- a/src/Rask.Generators/Analyzers/RedundantStateHasChangedAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/RedundantStateHasChangedAnalyzer.cs
@@ -27,7 +27,7 @@ public sealed class RedundantStateHasChangedAnalyzer : DiagnosticAnalyzer
         "Redundant StateHasChanged in a Rask callback",
         "StateHasChanged is redundant here — Rask re-renders this component automatically after its '{0}' "
         + "callback runs; remove the call",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
         "Rask wraps event callbacks (OnChange/OnClick/OnInput/OnSubmit/…) and binding hooks "

--- a/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/RootShellAnalyzer.cs
@@ -45,9 +45,13 @@ public sealed class RootShellAnalyzer : DiagnosticAnalyzer
         "RASK021",
         "Root component must render a complete page shell",
         "The Rask root component '{0}' does not render a complete page shell; missing: {1}. A root Render() should produce Doctype(), Html(...)[Head(), Body()[...]].",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
+        description: "The root component renders the whole document, so it must produce the shell itself: Doctype(), "
+                     + "then Html(…)[ Head(), Body()[ … ] ]. A runtime backstop enforces the same thing, so a shell that "
+                     + "slips past this analyzer fails at render instead. Do not add the runtime <script> — it is "
+                     + "appended to <body> automatically.",
         helpLinkUri: DiagnosticHelp.Link("RASK021"));
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =

--- a/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
+++ b/src/Rask.Generators/Analyzers/SyncAsyncHandlerAnalyzer.cs
@@ -27,7 +27,7 @@ public sealed class SyncAsyncHandlerAnalyzer : DiagnosticAnalyzer
         "'{0}' and '{1}' are both set on this component — wire only one handler per event. When both "
         + "are supplied the async '{1}' is ignored at runtime (the sync '{0}' wins); pass just one, or "
         + "`null` for the sibling you don't use.",
-        "Usage",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
         "Each DOM event has a single handler slot. Supplying both the sync `OnX` and the async "

--- a/src/Rask.Generators/ComponentFactoryGenerator.cs
+++ b/src/Rask.Generators/ComponentFactoryGenerator.cs
@@ -33,18 +33,27 @@ public sealed class ComponentFactoryGenerator : IIncrementalGenerator
         "RASK001",
         "Property is treated as a required factory parameter",
         "Property '{0}.{1}' is treated as a required factory parameter; consider also marking it 'required' for language-level enforcement",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Hidden,
         true,
+        description: "The generated factory emits a non-nullable property with no initializer as a REQUIRED parameter, "
+                     + "so callers must pass it. Marking the property 'required' gets you the same guarantee from the "
+                     + "language, at the declaration, instead of only from the generated signature. Declare it nullable "
+                     + "instead if the value really is optional.",
         helpLinkUri: DiagnosticHelp.Link("RASK001"));
 
     private static readonly DiagnosticDescriptor Rask002 = new(
         "RASK002",
         "'required' property cannot be honored by the generated factory",
         "Property '{0}.{1}' is marked 'required', but the generated factory for '{0}' cannot set it: '{0}' has a dependency-injected constructor and the property is either excluded from the factory parameters (it has a member initializer) or only reachable via ActivatorUtilities.CreateInstance (no parameterless constructor). Adding a parameterless constructor does not help while the DI constructor remains — the factory then builds '{0}' with 'new {0}()' and the DI constructor never runs, leaving injected services null. Remove 'required', move the value to a constructor parameter (with no initializer), or drop the DI constructor.",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
+        description: "Fires in exactly one shape: the component has both a DI constructor AND a parameterless one, and "
+                     + "the required property carries a member initializer. The factory then builds it with 'new C() { … "
+                     + "}', but an initializer-carrying property is excluded from the factory parameters — so nothing "
+                     + "assigns it and the consumer's build fails with CS9035. A DI constructor with no parameterless "
+                     + "sibling is fine and does not trip this.",
         helpLinkUri: DiagnosticHelp.Link("RASK002"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/src/Rask.Generators/ComponentScopedCssGenerator.cs
+++ b/src/Rask.Generators/ComponentScopedCssGenerator.cs
@@ -28,18 +28,23 @@ public sealed class ComponentScopedCssGenerator : IIncrementalGenerator
         "Scoped-CSS file '{0}' has no matching component class — add a Component subclass named '{1}' in the "
         + "same folder, rename the file to match one, or set "
         + "<RaskScopedCssAutoInclude>false</RaskScopedCssAutoInclude> if it is a global stylesheet",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "Scoped CSS is matched to its component by file name and folder, so a stylesheet with no "
+                     + "component of that name beside it is scoped to nothing and would never be served. A global "
+                     + "stylesheet belongs under wwwroot/ (already excluded) or opts out via RaskScopedCssAutoInclude.",
         helpLinkUri: DiagnosticHelp.Link("RASK015"));
 
     private static readonly DiagnosticDescriptor Rask016 = new(
         "RASK016",
         "Ambiguous scoped-CSS match",
         "Scoped-CSS file '{0}' matches multiple component classes named '{1}': {2}. Move one to disambiguate.",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "The scope is keyed on the component the file matches, so two candidates make the pairing "
+                     + "arbitrary — and the wrong one would silently take the styles.",
         helpLinkUri: DiagnosticHelp.Link("RASK016"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/src/Rask.Generators/ComponentScopedJsGenerator.cs
+++ b/src/Rask.Generators/ComponentScopedJsGenerator.cs
@@ -29,27 +29,35 @@ public sealed class ComponentScopedJsGenerator : IIncrementalGenerator
         "Scoped-JS file '{0}' has no matching component class — add a Component subclass named '{1}' in the "
         + "same folder, rename the file to match one, or set "
         + "<RaskScopedJsAutoInclude>false</RaskScopedJsAutoInclude> if it is a plain wwwroot script",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "As RASK015, for a '{Name}.js' sibling: scoped JS is matched by file name and folder, so a script "
+                     + "with no component of that name beside it is registered against nothing.",
         helpLinkUri: DiagnosticHelp.Link("RASK017"));
 
     private static readonly DiagnosticDescriptor Rask018 = new(
         "RASK018",
         "Ambiguous scoped-JS match",
         "Scoped-JS file '{0}' matches multiple component classes named '{1}': {2}. Move one to disambiguate.",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "As RASK016, for scoped JS: two components of the same name in one folder make the pairing "
+                     + "arbitrary.",
         helpLinkUri: DiagnosticHelp.Link("RASK018"));
 
     private static readonly DiagnosticDescriptor Rask020 = new(
         "RASK020",
         "Scoped-JS simple-name collision",
         "Two or more components with scoped JS share the simple type name '{0}': {1}. The browser-side namespace key window.Rask[\"{0}\"] is shared by all of them and the last registration silently wins. Rename one, move it to a differently-named sibling, or expose your exports under a sub-namespace inside the JS file. Promote to error in csproj with <WarningsAsErrors>RASK020</WarningsAsErrors>.",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Warning,
         true,
+        description: "Scoped JS is exposed to the browser as window.Rask['Name'], keyed on the component's SIMPLE name "
+                     + "— so two components of the same name in different namespaces share one key and the last one "
+                     + "registered wins, silently. Promote to an error with "
+                     + "<WarningsAsErrors>RASK020</WarningsAsErrors>.",
         helpLinkUri: DiagnosticHelp.Link("RASK020"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/src/Rask.Generators/DiagnosticHelp.cs
+++ b/src/Rask.Generators/DiagnosticHelp.cs
@@ -5,6 +5,16 @@ namespace Rask.Generators;
 // Single source of truth for the docs base URL across all generators/analyzers.
 internal static class DiagnosticHelp
 {
+    // The single category every RASKxxx descriptor reports under.
+    //
+    // There used to be two, split by which kind of thing produced the diagnostic: the incremental
+    // generators used "Rask.Generators" and the analyzers used "Usage". That is an implementation
+    // detail of this repo, and it leaked all the way out to the consumer — a category is what an
+    // .editorconfig rule or an IDE's "group by category" keys on, so any attempt to treat the family
+    // as a family (`dotnet_analyzer_diagnostic.category-Rask.severity = …`) silently caught half of
+    // it (#609). One family, one category.
+    public const string Category = "Rask";
+
     private const string DocBase = "https://github.com/pal-tamas/rask/blob/main/docs/diagnostics.md";
 
     // GitHub lowercases heading anchors, and the docs use "## RASKxxx" headings → "#raskxxx".

--- a/src/Rask.Generators/RoutesGenerator.cs
+++ b/src/Rask.Generators/RoutesGenerator.cs
@@ -29,9 +29,13 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "RASK003",
         "Malformed route template",
         "Route template '{0}' on '{1}' is malformed: {2}",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "The template is parsed at build time so a broken route fails here rather than at the first "
+                     + "request. Typed routes support literal segments and single-parameter segments with an optional "
+                     + "':constraint' and trailing '?'; they do not support catch-alls or a segment that mixes literal "
+                     + "text with a parameter.",
         helpLinkUri: DiagnosticHelp.Link("RASK003"));
 
     private static readonly DiagnosticDescriptor Rask004 = new(
@@ -39,9 +43,12 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Route segment has no matching property",
         "Route segment '{{{0}}}' on '{1}' has no matching public settable property — add a public "
         + "settable property named '{0}' to '{1}', or remove '{{{0}}}' from the route template",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "Route parameters bind by name onto public settable properties. A segment with nothing to bind to "
+                     + "would silently discard part of the URL, so it is a build error rather than a value that quietly "
+                     + "never arrives.",
         helpLinkUri: DiagnosticHelp.Link("RASK004"));
 
     private static readonly DiagnosticDescriptor Rask005 = new(
@@ -49,9 +56,12 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property type does not match route constraint",
         "Property '{0}.{1}' has type '{2}', incompatible with route constraint '{3}' — change the property "
         + "type to one the '{3}' constraint accepts, or adjust the constraint in the route template",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "The constraint in the template and the property's CLR type are two statements of the same thing, "
+                     + "and the router trusts the constraint. If they disagree, a URL the router accepted would fail to "
+                     + "bind at request time.",
         helpLinkUri: DiagnosticHelp.Link("RASK005"));
 
     private static readonly DiagnosticDescriptor Rask006 = new(
@@ -60,9 +70,11 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' has [QueryParam] but is also bound by path segment '{{{2}}}' — a value can't "
         + "come from both; remove [QueryParam] to bind it from the path, or rename the property or segment "
         + "so they don't collide",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "A value comes from the path or from the query string, never both. Marking a path-bound property "
+                     + "[QueryParam] describes a binding that cannot happen.",
         helpLinkUri: DiagnosticHelp.Link("RASK006"));
 
     private static readonly DiagnosticDescriptor Rask007 = new(
@@ -70,9 +82,11 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "[ParentRoute] cycle",
         "[ParentRoute] forms a cycle starting at '{0}' — break the cycle so the [ParentRoute] chain ends "
         + "at a page with no parent",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "[ParentRoute] composes a page's template onto its parent's, so the chain has to terminate at a "
+                     + "page with no parent. A cycle has no root to compose from and would not terminate.",
         helpLinkUri: DiagnosticHelp.Link("RASK007"));
 
     private static readonly DiagnosticDescriptor Rask008 = new(
@@ -80,9 +94,12 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "[RouteParam] without matching path segment",
         "Property '{0}.{1}' has [RouteParam] but no path segment matches '{2}' — add a '{{{2}}}' segment "
         + "to the route template, or remove [RouteParam] from the property",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "[RouteParam] says 'bind me from the path', so a property carrying it with no matching segment — "
+                     + "in this template or an ancestor's, via [ParentRoute] — would never be set. Names are matched "
+                     + "exactly.",
         helpLinkUri: DiagnosticHelp.Link("RASK008"));
 
     private static readonly DiagnosticDescriptor Rask009 = new(
@@ -90,9 +107,12 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "[RouteParam] on a non-routed class",
         "Property '{0}.{1}' has [RouteParam] but '{0}' is not a valid route target ({2}) — mark '{0}' with "
         + "[Route] (a concrete Component subclass), or remove [RouteParam]",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "Route binding only runs for pages the router can reach. On a class with no [Route] and no "
+                     + "[ParentRoute] chain to one, the attribute describes binding that never happens, so the property "
+                     + "silently keeps its default.",
         helpLinkUri: DiagnosticHelp.Link("RASK009"));
 
     private static readonly DiagnosticDescriptor Rask010 = new(
@@ -100,9 +120,11 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "[QueryParam] on a non-routed class",
         "Property '{0}.{1}' has [QueryParam] but '{0}' is not a valid route target ({2}) — mark '{0}' with "
         + "[Route] (a concrete Component subclass), or remove [QueryParam]",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "As RASK009, for [QueryParam]: query binding is part of routing a page, so it does nothing on a "
+                     + "class the router never instantiates.",
         helpLinkUri: DiagnosticHelp.Link("RASK010"));
 
     private static readonly DiagnosticDescriptor Rask011 = new(
@@ -111,9 +133,12 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Property '{0}.{1}' of type '{2}' must be 'string' or implement 'System.IParsable<{2}>' to be bound "
         + "by [RouteParam]/[QueryParam] — use a parsable type (int, Guid, DateOnly, an enum, your own "
         + "IParsable<T>), or accept it as 'string' and convert inside the page",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "A URL segment is text, so binding it needs a way to parse it. 'string' is taken verbatim; "
+                     + "anything else must implement System.IParsable<T> — which every built-in numeric, Guid, "
+                     + "DateOnly/DateTime, bool and enum already does.",
         helpLinkUri: DiagnosticHelp.Link("RASK011"));
 
     private static readonly DiagnosticDescriptor Rask012 = new(
@@ -121,9 +146,11 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Multiple [NotFound] components",
         "Multiple [NotFound] components found in this assembly; only one is allowed ('{0}' is a duplicate) "
         + "— remove [NotFound] from all but one component",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "[NotFound] marks the single catch-all page for an assembly. With two, which one answers an "
+                     + "unmatched URL would depend on registration order.",
         helpLinkUri: DiagnosticHelp.Link("RASK012"));
 
     private static readonly DiagnosticDescriptor Rask031 = new(
@@ -131,20 +158,27 @@ public sealed class RoutesGenerator : IIncrementalGenerator
         "Duplicate route template",
         "Route template '{0}' matches the same URL as another page ('{1}') — which one renders is "
         + "arbitrary; give this page a distinct route",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         // Warning, not Error: a route collision is a real bug, but promoting it to Error would hard-break
         // apps that compile today the moment they upgrade (and the app still runs, just picks arbitrarily).
         DiagnosticSeverity.Warning,
         true,
+        description: "Templates are compared the way the runtime router matches them, not as strings: literals match "
+                     + "case-insensitively, surrounding slashes are trimmed, and parameter names and ':constraints' are "
+                     + "ignored. So '/Products' collides with '/products', and '/item/{id:int}' with '/item/{slug}'. "
+                     + "Only pages without a [ParentRoute] are compared — the check under-reports rather than risk a "
+                     + "false positive on a composed path.",
         helpLinkUri: DiagnosticHelp.Link("RASK031"));
 
     private static readonly DiagnosticDescriptor Rask013 = new(
         "RASK013",
         "[NotFound] cannot be combined with [Route]",
         "Class '{0}' has both [NotFound] and [Route]; remove [Route] (NotFound is the catch-all)",
-        "Rask.Generators",
+        DiagnosticHelp.Category,
         DiagnosticSeverity.Error,
         true,
+        description: "[NotFound] IS the fallback — it answers whatever no other route matched. Giving it a [Route] as "
+                     + "well asks it to be both a specific path and the catch-all for every other one.",
         helpLinkUri: DiagnosticHelp.Link("RASK013"));
 
     public void Initialize(IncrementalGeneratorInitializationContext context)

--- a/tests/Rask.Generators.Tests/CodeFixHarness.cs
+++ b/tests/Rask.Generators.Tests/CodeFixHarness.cs
@@ -25,6 +25,20 @@ internal static class CodeFixHarness
         return await ApplyAsync(provider, document, FirstOf(diagnostics, diagnosticId));
     }
 
+    // True when the provider offers a fix for an analyzer diagnostic. The counterpart of the generator
+    // version below, and the more used of the two now: RASK014's fix is deliberately withheld for
+    // anything but an argument-free construction, which is a claim only this can test.
+    public static async Task<bool> IsAnalyzerFixOfferedAsync(
+        DiagnosticAnalyzer analyzer, CodeFixProvider provider, string diagnosticId, string source)
+    {
+        var document = CreateDocument(source);
+        var compilation = (CSharpCompilation)(await document.Project.GetCompilationAsync())!;
+        var diagnostics = await compilation
+            .WithAnalyzers(ImmutableArray.Create(analyzer))
+            .GetAnalyzerDiagnosticsAsync();
+        return (await CollectActionsAsync(provider, document, FirstOf(diagnostics, diagnosticId))).Count > 0;
+    }
+
     // Applies the fix for a source-generator-produced diagnostic (e.g. RASK001).
     public static async Task<string> ApplyGeneratorFixAsync(
         IIncrementalGenerator generator, CodeFixProvider provider, string diagnosticId, string source)

--- a/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
+++ b/tests/Rask.Generators.Tests/CodeFixProviderTests.cs
@@ -104,4 +104,118 @@ public class CodeFixProviderTests
             new ComponentFactoryGenerator(), new RequiredFactoryParamCodeFixProvider(), "RASK001", source);
         Assert.True(offered);
     }
+
+    // ---- RASK014: `new Widget()` -> the generated factory ----
+    //
+    // A user component rather than a built-in tag: inside a `using static …Generated` scope a tag name
+    // binds to the generated factory METHOD, so `new Div()` doesn't resolve to the type there at all.
+
+    private static string Caller(string body) => $$"""
+        using Rask.Core;
+        namespace Demo;
+        public sealed class Widget : Component
+        {
+            public Widget() { }
+            public Widget(string label) { }
+            public string? Id { get; set; }
+            public override Component? Render() => this;
+        }
+        class Caller { void M() { {{body}} } }
+        """;
+
+    [Fact]
+    public async Task Rask014_RewritesArgumentlessNew_ToTheFactoryCall()
+    {
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
+            Caller("var x = new Widget();"));
+        Assert.Contains("var x = Widget();", fixhed);
+        Assert.DoesNotContain("new Widget()", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask014_DropsTheQualifier_BecauseTheFactoryIsAMethodNotAType()
+    {
+        // `new Demo.Widget()` must become `Widget()`, not `Demo.Widget()` — the latter names a type where
+        // a method has to go, and would not compile.
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
+            Caller("var x = new Demo.Widget();"));
+        Assert.Contains("var x = Widget();", fixhed);
+    }
+
+    [Fact]
+    public async Task Rask014_Withheld_WhenTheConstructionHasArguments()
+    {
+        // The factory's parameters are generated from the component's public properties, in an order that
+        // is not the constructor's. Carrying positional arguments across would compile and mean something
+        // else — worse than leaving the error standing with its (already actionable) message.
+        var offered = await CodeFixHarness.IsAnalyzerFixOfferedAsync(
+            new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
+            Caller("var x = new Widget(\"hi\");"));
+        Assert.False(offered);
+    }
+
+    [Fact]
+    public async Task Rask014_Withheld_WhenAnObjectInitializerIsPresent()
+    {
+        // An object initializer is only legal after `new`, so it cannot ride along onto a factory call.
+        var offered = await CodeFixHarness.IsAnalyzerFixOfferedAsync(
+            new ComponentConstructionAnalyzer(), new ComponentConstructionCodeFixProvider(), "RASK014",
+            Caller("var x = new Widget { Id = \"a\" };"));
+        Assert.False(offered);
+    }
+
+    // ---- RASK026: a StateHasChanged() the framework already does -> delete the statement ----
+
+    [Fact]
+    public async Task Rask026_DeletesTheRedundantCall()
+    {
+        var source = """
+            using Rask.Core;
+            using static Rask.Core.Components.Generated;
+            namespace Demo;
+            public sealed class App : Component
+            {
+                private int _n;
+                protected override Component? Render() =>
+                    Button(OnClick: () =>
+                    {
+                        _n++;
+                        StateHasChanged();
+                    })["+"];
+            }
+            """;
+
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new RedundantStateHasChangedAnalyzer(), new RedundantStateHasChangedCodeFixProvider(),
+            "RASK026", source);
+
+        Assert.DoesNotContain("StateHasChanged();", fixhed);
+        Assert.Contains("_n++;", fixhed);
+    }
+
+    // ---- RASK027: both OnX and OnXAsync passed -> drop the async one ----
+
+    [Fact]
+    public async Task Rask027_RemovesTheAsyncArgument_AndKeepsTheSyncOne()
+    {
+        var source = """
+            using System.Threading.Tasks;
+            using Rask.Core;
+            using static Rask.Core.Components.Generated;
+            namespace Demo;
+            public sealed class App : Component
+            {
+                protected override Component? Render() =>
+                    Button(OnClick: () => {}, OnClickAsync: async () => await Task.Yield())["x"];
+            }
+            """;
+
+        var fixhed = await CodeFixHarness.ApplyAnalyzerFixAsync(
+            new SyncAsyncHandlerAnalyzer(), new SyncAsyncHandlerCodeFixProvider(), "RASK027", source);
+
+        Assert.DoesNotContain("OnClickAsync", fixhed);
+        Assert.Contains("OnClick: () => {}", fixhed);
+    }
 }

--- a/tests/Rask.Generators.Tests/DiagnosticDescriptorTests.cs
+++ b/tests/Rask.Generators.Tests/DiagnosticDescriptorTests.cs
@@ -1,0 +1,122 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Rask.Generators.Tests;
+
+/// <summary>
+///     Invariants across the whole RASKxxx family rather than any one member of it, so a new diagnostic
+///     inherits them by existing instead of by someone remembering.
+/// </summary>
+public class DiagnosticDescriptorTests
+{
+    // Every descriptor declared by every analyzer and generator in the three analyzer assemblies. Read by
+    // reflection because that is the only way to enumerate the ones generators hold in private statics —
+    // and generator descriptors are exactly the half a per-analyzer check would miss.
+    private static IReadOnlyList<DiagnosticDescriptor> AllDescriptors()
+    {
+        var found = new Dictionary<string, DiagnosticDescriptor>(StringComparer.Ordinal);
+
+        foreach (var assembly in new[]
+                 {
+                     typeof(RoutesGenerator).Assembly,
+                     typeof(Rask.Cqrs.Generators.CqrsDispatchGenerator).Assembly,
+                     typeof(Rask.Jobs.Generators.JobRegistryGenerator).Assembly,
+                 })
+        {
+            foreach (var type in assembly.GetTypes())
+            {
+                // Analyzers expose theirs through SupportedDiagnostics; generators keep them in private
+                // static fields, which is where RASK001-013, 015-018, 020, 028, 029, 031 and 035 live.
+                if (typeof(DiagnosticAnalyzer).IsAssignableFrom(type) && !type.IsAbstract
+                    && Activator.CreateInstance(type) is DiagnosticAnalyzer analyzer)
+                {
+                    Add(analyzer.SupportedDiagnostics);
+                }
+
+                foreach (var field in type.GetFields(BindingFlags.Static | BindingFlags.NonPublic
+                                                     | BindingFlags.Public))
+                {
+                    if (field.GetValue(null) is DiagnosticDescriptor descriptor)
+                    {
+                        Add([descriptor]);
+                    }
+                }
+            }
+        }
+
+        return found.Values.OrderBy(d => d.Id, StringComparer.Ordinal).ToList();
+
+        void Add(ImmutableArray<DiagnosticDescriptor> descriptors)
+        {
+            foreach (var d in descriptors)
+            {
+                found[d.Id] = d;
+            }
+        }
+    }
+
+    private static IReadOnlyList<DiagnosticDescriptor> RaskDescriptors() =>
+        AllDescriptors().Where(d => d.Id.StartsWith("RASK", StringComparison.Ordinal)).ToList();
+
+    [Fact]
+    public void The_family_is_discoverable_at_all()
+    {
+        // Guards the reflection above: if it silently found nothing, every other test here would pass
+        // vacuously and the invariants would stop being enforced without anything going red.
+        Assert.True(RaskDescriptors().Count >= 30,
+            $"expected the whole RASK family, found {RaskDescriptors().Count}");
+    }
+
+    /// <summary>
+    ///     One family, one category. There used to be two — generators reported under
+    ///     <c>Rask.Generators</c> and analyzers under <c>Usage</c> — which is an implementation detail of
+    ///     this repo that leaked to the consumer: a category is what an <c>.editorconfig</c> rule or an
+    ///     IDE's group-by keys on, so `dotnet_analyzer_diagnostic.category-Rask.severity = …` caught half
+    ///     the family and silently ignored the rest (#609).
+    /// </summary>
+    [Fact]
+    public void Every_diagnostic_reports_under_one_category()
+    {
+        var categories = RaskDescriptors()
+            .Select(d => d.Category)
+            .Distinct(StringComparer.Ordinal)
+            .Order(StringComparer.Ordinal)
+            .ToList();
+
+        Assert.Equal(["Rask"], categories);
+    }
+
+    /// <summary>
+    ///     The one-line title is what an IDE shows in the squiggle; <c>Description</c> is the expanded
+    ///     tooltip and the hover card. 26 of 35 left it null — including every build-breaking Error — so
+    ///     the reader's only way to more detail was to click through to the docs, which is not something
+    ///     you do mid-keystroke.
+    /// </summary>
+    [Fact]
+    public void Every_diagnostic_carries_a_description()
+    {
+        var silent = RaskDescriptors()
+            .Where(d => string.IsNullOrWhiteSpace(d.Description.ToString()))
+            .Select(d => d.Id)
+            .ToList();
+
+        Assert.True(silent.Count == 0,
+            "These diagnostics pass no `description:`, so the IDE's expanded tooltip shows nothing beyond "
+            + "the one-line title:\n  " + string.Join("\n  ", silent));
+    }
+
+    [Fact]
+    public void Every_diagnostic_links_to_its_documentation()
+    {
+        var unlinked = RaskDescriptors()
+            .Where(d => string.IsNullOrWhiteSpace(d.HelpLinkUri)
+                        || !d.HelpLinkUri.EndsWith(d.Id.ToLowerInvariant(), StringComparison.Ordinal))
+            .Select(d => $"{d.Id} -> '{d.HelpLinkUri}'")
+            .ToList();
+
+        Assert.True(unlinked.Count == 0,
+            "These diagnostics don't link to their own docs anchor:\n  " + string.Join("\n  ", unlinked));
+    }
+}

--- a/tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj
+++ b/tests/Rask.Generators.Tests/Rask.Generators.Tests.csproj
@@ -33,6 +33,12 @@
          components (NativeHeaderBar, NativeTabBar, …); the spine's internal ctors preclude defining a
          NativeComponent subclass in the test source. -->
     <ProjectReference Include="..\..\src\Rask.Native\Rask.Native.csproj"/>
+    <!-- The other two analyzer assemblies, referenced as plain libraries (not as analyzers) so
+         DiagnosticDescriptorTests can enumerate the WHOLE RASK family by reflection. RASK028/029 live in
+         Rask.Cqrs.Generators and RASK035 in Rask.Generators.Shared via Rask.Jobs.Generators; a
+         family-wide invariant that skipped them would be checking two thirds of a rule. -->
+    <ProjectReference Include="..\..\src\Rask.Cqrs.Generators\Rask.Cqrs.Generators.csproj"/>
+    <ProjectReference Include="..\..\src\Rask.Jobs.Generators\Rask.Jobs.Generators.csproj"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #609.

## ⚠️ Breaking: one category for the family

Every RASK diagnostic now reports under **`Rask`**. There used to be two, split by what *produced* the
diagnostic — generators used `Rask.Generators`, analyzers used `Usage`.

That split is an implementation detail of this repo, and it leaked all the way out to the consumer. A
category is what an `.editorconfig` rule or an IDE's group-by keys on, so this:

```ini
dotnet_analyzer_diagnostic.category-Rask.severity = warning
```

covered **22 of the 35** and silently ignored the other 13 — which is worse than not working, because it
looks like it worked.

**If you have a rule keyed on `Usage` or `Rask.Generators`, point it at `Rask`.** A test fails the build
if a descriptor ever drifts back out.

## Quick fixes

`Rask.Generators.CodeFixes` shipped two providers, and the highest-value candidate wasn't among them.

**RASK014** — `new Widget()` → the generated `Widget()` factory. It's an **Error**, so it stops the build,
and it's the first thing a Blazor or plain-C# migrant hits, because `new` is simply what you reach for.

> **Deliberately withheld** when the construction has arguments or an object initializer. The factory's
> parameters are generated from the component's public properties in an order that is **not** the
> constructor's, so carrying positional arguments across would compile and mean something *else*. And an
> object initializer is only legal after `new`, so it can't ride along. A quick fix that silently changes
> meaning is worse than no quick fix — there, the error stands with its message, which already names the
> factory to call. Two of the five tests exist to pin that refusal.

**RASK026** — deletes the redundant `StateHasChanged()` statement, which is exactly what its message tells
you to do. Offered only when the call *is* the whole statement, so it can't change what an
expression-bodied lambda returns.

**RASK027** — removes the `OnXAsync` argument and keeps the sync one. The diagnostic is already anchored
on that exact argument, so there's nothing to infer; keeping the sync handler is also the reversible
direction, since moving an async body into a sync one is an edit away and the reverse loses a signature.

## A tooltip on all 35

Only **9 of 35** passed a `description`, and the 26 without included **every build-breaking Error** (003,
014, 019, 021, 032). So for exactly the diagnostics that stop your build, the IDE's expanded tooltip
showed nothing beyond the one-line title, and the only route to more was clicking through to the docs —
which is not something you do mid-keystroke.

Each description explains the **consequence** and the surprising part, rather than restating the message,
which is already on screen. RASK002's, for instance, says which single shape it fires in and why the
consumer's build then fails with `CS9035` — and that a DI constructor without a parameterless sibling is
fine and does *not* trip it.

## The invariants are tests now

Three checks enumerate every descriptor by reflection across all three analyzer assemblies — one
category, a description, a docs link matching the id — plus **a fourth asserting the enumeration found the
family at all**, so they can't quietly start passing vacuously. `Rask.Generators.Tests` gains plain
library references to `Rask.Cqrs.Generators` and `Rask.Jobs.Generators` for this; a family-wide rule that
skipped RASK028/029/035 would be checking two thirds of a rule.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full unit suite across the solution — green
- New: 4 family invariants, 5 code-fix tests, and `IsAnalyzerFixOfferedAsync` on the harness (which had
  only the generator-side counterpart)
- `docs/diagnostics.md` gains the quick-fix table, the withheld-fix rule, and the one-line
  `.editorconfig` recipe the unified category makes possible

## Not in this PR

The issue also listed RASK033, RASK013, RASK012 and RASK030 as fix candidates. RASK012 I'd leave alone
until someone checks what its reported location actually points at — the issue flags that it reports at
`RouteAttrLocation` while telling you to remove `[NotFound]`, and building a fix on that without checking
is how you ship one that deletes the wrong attribute. The other three are straightforward and worth a
follow-up; this PR takes the ones that are hit most and that I could pin properly.
