### PR TITLE
feat(testing): let Rask.Testing read structure, target elements by name, and fake what a page needs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -243,6 +243,43 @@ them until tagged releases begin.
   description explains the consequence and the surprising part rather than restating the message, which is
   already on screen.
 
+- **`Rask.Testing` can read structure, not just attributes.** Its scan had no notion of elements or
+  nesting — it said so in its own remarks — so every structural assertion in a consumer's test degraded to
+  `Assert.Contains("<span class=\"badge\">3</span>", page.Html)`, brittle against exactly the
+  attribute-order invariant this framework's own suite goes to lengths to pin.
+  - **`Find` / `FindAll` / `Exists` / `TextOf` / `TestId`** over a parsed tree. `Find` throws both when
+    nothing matches *and* when several do — a test that silently took the first of several keeps passing
+    after somebody adds a second — and a failure names the near miss (`'#items' matches 1, so the rest of
+    the selector is what fails`) and the path of each candidate.
+  - The **selector is a documented subset** (`tag`, `*`, `#id`, `.class`, `[attr]`, `[attr="v"]` and the
+    `^= $= *=` variants, `:has-text("…")`, descendant and `>`), and **anything outside it throws**. A
+    selector that quietly matched nothing because `:nth-child` was ignored would turn a green test into a
+    lie. The parser is ~200 lines rather than a dependency: `Rask.Testing` is a shipped package, so a
+    parser dependency lands in every consumer's test project, and Rask's own serializer emits the markup —
+    always double-quoted, always encoded — which is what makes a small reader correct here.
+  - **`page.On("#save").ClickAsync()`** targets an element by name. `HandlerId` returns the *first* match
+    in the document and `HandlerIds` is indexed by position, so adding an unrelated button above the one
+    under test silently re-points every such assertion and the test keeps passing. A handle rather than a
+    `ClickAsync(selector)` overload, because `ClickAsync` already takes a `string` — the JSON payload.
+  - **`TestDownloadSink`.** `Navigator.Download` refuses to run without an `IDownloadSink` and its message
+    says *"If you're in a unit test, register a fake"* — while the testing package shipped none, so
+    everyone wrote the same twenty lines.
+  - **Event dispatch now enters the `Navigator`'s handler scope**, as a live session does. Without it
+    `NavigateTo` / `Download` / `SetQuery` all refused with "can only be used from event handlers" —
+    true of the harness, not of the component — so a page that navigates or exports on click could not be
+    unit-tested at all, only through Playwright.
+  - **`TestRoute.At("/search?q=hello%20world")`** seeds a `RouteState` with its query string parsed,
+    decoded and repeated keys kept. Seeding a path was already a one-liner; seeding a query meant building
+    an `IQueryCollection` by hand, so most tests simply didn't.
+  - **`CapturingDiagnostics`** captures framework diagnostics, so an app author can finally assert that a
+    swallowed fault happened — or that none did. A public wrapper rather than a public `RaskDiagnostics`:
+    `Rask.Testing` is already on Core's `InternalsVisibleTo` list, and a public seam is irreversible where
+    a wrapper is not.
+  - **`TestJSRuntime` stops failing silently on a type mismatch.** `SetResponse("getCount", 1)` against a
+    component calling `InvokeAsync<long>` returned `0` — indistinguishable from "not configured", so the
+    test read as though the component had ignored the value. Unconfigured still returns `default` (that is
+    deliberate and documented); configured-with-the-wrong-type now throws and names both types.
+
 ## [0.20.0] - 2026-08-06
 
 ### Fixed

--- a/src/Rask.Testing/CapturingDiagnostics.cs
+++ b/src/Rask.Testing/CapturingDiagnostics.cs
@@ -1,0 +1,127 @@
+using Rask.Core.Diagnostics;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     Captures the framework diagnostics raised while it is installed, so a test can assert that
+///     something was reported — or that nothing was.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Swallow-and-log is the framework's primary failure mode for the faults it must not let escape:
+///         a navigate that threw, a JS dispatch that faulted, a malformed frame, a lifecycle hook with no
+///         boundary above it. Those go to <c>RaskDiagnostics</c>, which is <c>internal</c>, so an app
+///         author had no supported way to assert on any of them — the fault was reported to stderr and
+///         the test saw nothing.
+///     </para>
+///     <para>
+///         This is a public wrapper rather than a public <c>RaskDiagnostics</c>: <c>Rask.Testing</c> is on
+///         <c>Rask.Core</c>'s <c>InternalsVisibleTo</c> list, so the capability needs no new public seam
+///         on the framework — and a public seam is an irreversible commitment where this is not.
+///     </para>
+///     <para>
+///         <b>The sink is process-global</b>, so this serializes on a lock and restores the previous sink
+///         on <see cref="Dispose" />. Two of these live at once in parallel tests would still interleave —
+///         if a test asserts on a <em>count</em>, filter to the events it provoked (<see cref="OfCategory" />)
+///         rather than asserting over everything captured.
+///     </para>
+///     <code>
+///     using var diagnostics = CapturingDiagnostics.Install();
+///     await page.ClickAsync("#save");
+///     Assert.Empty(diagnostics.Errors);
+///     </code>
+/// </remarks>
+public sealed class CapturingDiagnostics : IDisposable
+{
+    private static readonly Lock InstallGate = new();
+
+    private readonly Lock _gate = new();
+    private readonly List<CapturedDiagnostic> _captured = [];
+    private readonly Action<RaskDiagnosticEvent>? _previous;
+    private bool _disposed;
+
+    private CapturingDiagnostics()
+    {
+        _previous = RaskDiagnostics.Sink;
+        RaskDiagnostics.ResetReportOnceForTests();
+        RaskDiagnostics.Sink = Capture;
+    }
+
+    /// <summary>Installs a capturing sink. Dispose to restore the previous one.</summary>
+    public static CapturingDiagnostics Install()
+    {
+        lock (InstallGate)
+        {
+            return new CapturingDiagnostics();
+        }
+    }
+
+    /// <summary>Everything captured so far, oldest first.</summary>
+    public IReadOnlyList<CapturedDiagnostic> Captured
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _captured.ToArray();
+            }
+        }
+    }
+
+    /// <summary>Captured events at error level — the ones that mean something was swallowed.</summary>
+    public IReadOnlyList<CapturedDiagnostic> Errors =>
+        Captured.Where(e => e.Level == DiagnosticLevel.Error).ToArray();
+
+    /// <summary>Captured events from one subsystem, e.g. <c>"Rask.Lifecycle"</c> or <c>"Rask.JsInvoke"</c>.</summary>
+    public IReadOnlyList<CapturedDiagnostic> OfCategory(string category) =>
+        Captured.Where(e => string.Equals(e.Category, category, StringComparison.Ordinal)).ToArray();
+
+    /// <summary>Restores the sink that was installed before this one.</summary>
+    public void Dispose()
+    {
+        lock (InstallGate)
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+            RaskDiagnostics.Sink = _previous;
+            RaskDiagnostics.ResetReportOnceForTests();
+        }
+    }
+
+    private void Capture(RaskDiagnosticEvent e)
+    {
+        lock (_gate)
+        {
+            _captured.Add(new CapturedDiagnostic(
+                (DiagnosticLevel)e.Level, e.Category, e.Message, e.Exception));
+        }
+    }
+}
+
+/// <summary>Severity of a captured framework diagnostic.</summary>
+public enum DiagnosticLevel
+{
+    /// <summary>Something worth knowing that is not a fault.</summary>
+    Information,
+
+    /// <summary>A degradation the app survives — a budget exceeded, a feature falling back.</summary>
+    Warning,
+
+    /// <summary>A fault the framework caught and did not let escape.</summary>
+    Error,
+}
+
+/// <summary>One framework diagnostic, as captured by <see cref="CapturingDiagnostics" />.</summary>
+/// <param name="Level">Severity.</param>
+/// <param name="Category">The subsystem that raised it, e.g. <c>Rask.Lifecycle</c>.</param>
+/// <param name="Message">The human-readable message, without the exception text appended.</param>
+/// <param name="Exception">The associated exception, or <c>null</c> for a message-only diagnostic.</param>
+public sealed record CapturedDiagnostic(
+    DiagnosticLevel Level,
+    string Category,
+    string Message,
+    Exception? Exception);

--- a/src/Rask.Testing/HtmlNode.cs
+++ b/src/Rask.Testing/HtmlNode.cs
@@ -1,0 +1,136 @@
+using System.Diagnostics;
+using System.Net;
+using System.Text;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     One element in a rendered tree: its tag, its attributes, its children, and the text under it.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Deliberately small. This exists so an assertion can say <em>which element</em> a match came
+///         from — the one thing <see cref="Markup" />'s attribute scan cannot do — not to be a DOM. There
+///         is no mutation, no live collection, and no parent pointer beyond <see cref="Parent" />.
+///     </para>
+///     <para>
+///         Text is exposed as <see cref="Text" /> (this element's own text, decoded) and
+///         <see cref="TextContent" /> (that plus every descendant's, which is what an assertion about
+///         "what the user reads" usually means).
+///     </para>
+/// </remarks>
+[DebuggerDisplay("{Tag,nq} {DebugAttributes,nq}")]
+public sealed class HtmlNode
+{
+    // Content in document order: each item is either a text run (string) or a child element. Keeping the
+    // order matters — `<li><span>7</span> shipped</li>` reads "7 shipped", and a model that buffered all
+    // of an element's own text separately from its children would render that as "shipped7".
+    private readonly List<object> _content = [];
+    private readonly Dictionary<string, string> _attributes = new(StringComparer.OrdinalIgnoreCase);
+
+    internal HtmlNode(string tag) => Tag = tag;
+
+    /// <summary>Lower-case tag name (<c>div</c>, <c>button</c>, …). <c>#root</c> for the synthetic root.</summary>
+    public string Tag { get; }
+
+    /// <summary>This element's parent, or <c>null</c> for the synthetic root.</summary>
+    public HtmlNode? Parent { get; private set; }
+
+    /// <summary>Child elements, in document order.</summary>
+    public IReadOnlyList<HtmlNode> Children => _content.OfType<HtmlNode>().ToArray();
+
+    /// <summary>Attributes, values HTML-decoded. Names are matched case-insensitively.</summary>
+    public IReadOnlyDictionary<string, string> Attributes => _attributes;
+
+    /// <summary>The <c>id</c> attribute, or <c>null</c>.</summary>
+    public string? Id => Attribute("id");
+
+    /// <summary>The <c>class</c> attribute split on whitespace. Empty when there is no class.</summary>
+    public IReadOnlyList<string> Classes =>
+        Attribute("class")?.Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries) ?? [];
+
+    /// <summary>This element's own text runs, excluding descendants'. HTML-decoded.</summary>
+    public string Text => string.Concat(_content.OfType<string>());
+
+    /// <summary>This element's text plus every descendant's, in document order. HTML-decoded.</summary>
+    public string TextContent
+    {
+        get
+        {
+            var sb = new StringBuilder();
+            Collect(this, sb);
+            return sb.ToString();
+
+            static void Collect(HtmlNode node, StringBuilder into)
+            {
+                foreach (var item in node._content)
+                {
+                    if (item is HtmlNode child)
+                    {
+                        Collect(child, into);
+                    }
+                    else
+                    {
+                        into.Append((string)item);
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>The value of <paramref name="name" />, or <c>null</c> when the attribute is absent.</summary>
+    public string? Attribute(string name) => _attributes.GetValueOrDefault(name);
+
+    /// <summary>True when <c>class</c> contains <paramref name="name" /> as a whole token.</summary>
+    public bool HasClass(string name) =>
+        Classes.Contains(name, StringComparer.Ordinal);
+
+    /// <summary>This element and every descendant, in document order.</summary>
+    public IEnumerable<HtmlNode> DescendantsAndSelf()
+    {
+        yield return this;
+        foreach (var child in _content.OfType<HtmlNode>())
+        {
+            foreach (var node in child.DescendantsAndSelf())
+            {
+                yield return node;
+            }
+        }
+    }
+
+    /// <summary>A short path from the root — what a failing assertion prints so you can find the element.</summary>
+    public string Path()
+    {
+        var parts = new List<string>();
+        for (var node = this; node is not null && node.Parent is not null; node = node.Parent)
+        {
+            var part = node.Tag;
+            if (node.Id is { Length: > 0 } id)
+            {
+                part += "#" + id;
+            }
+            else if (node.Classes.Count > 0)
+            {
+                part += "." + string.Join(".", node.Classes);
+            }
+
+            parts.Insert(0, part);
+        }
+
+        return parts.Count == 0 ? Tag : string.Join(" > ", parts);
+    }
+
+    internal void Add(HtmlNode child)
+    {
+        child.Parent = this;
+        _content.Add(child);
+    }
+
+    internal void SetAttribute(string name, string value) =>
+        _attributes[name] = WebUtility.HtmlDecode(value);
+
+    internal void AppendText(string raw) => _content.Add(WebUtility.HtmlDecode(raw));
+
+    private string DebugAttributes =>
+        string.Join(" ", _attributes.Select(a => $"{a.Key}=\"{a.Value}\""));
+}

--- a/src/Rask.Testing/HtmlSelector.cs
+++ b/src/Rask.Testing/HtmlSelector.cs
@@ -1,0 +1,342 @@
+using System.Text;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     A deliberately small CSS-selector subset, matched against a parsed <see cref="HtmlNode" /> tree.
+/// </summary>
+/// <remarks>
+///     <para><b>Supported:</b></para>
+///     <list type="bullet">
+///         <item><description><c>tag</c>, <c>*</c></description></item>
+///         <item><description><c>#id</c></description></item>
+///         <item><description><c>.class</c> (whole-token match, repeatable: <c>.btn.btn-primary</c>)</description></item>
+///         <item><description><c>[attr]</c>, <c>[attr="value"]</c>, <c>[attr^="v"]</c>, <c>[attr$="v"]</c>, <c>[attr*="v"]</c></description></item>
+///         <item><description>descendant (<c>ul li</c>) and child (<c>ul &gt; li</c>) combinators</description></item>
+///         <item><description><c>:has-text("…")</c> — the element's text content contains this, case-insensitively</description></item>
+///     </list>
+///     <para>
+///         <b>Anything else throws</b>, with the offending selector in the message. That is the whole point
+///         of writing a subset rather than a partial implementation: a selector that silently matched
+///         nothing because <c>:nth-child</c> was quietly ignored would turn a green test into a lie. If
+///         you need more than this, the element is reachable by id or data-attribute — which is also what
+///         makes the test readable.
+///     </para>
+/// </remarks>
+internal static class HtmlSelector
+{
+    public static IReadOnlyList<HtmlNode> Select(HtmlNode root, string selector)
+    {
+        var steps = Parse(selector);
+        IEnumerable<HtmlNode> current = [root];
+
+        foreach (var step in steps)
+        {
+            current = step.Child
+                ? current.SelectMany(n => n.Children).Where(step.Simple.Matches)
+                : current.SelectMany(n => n.DescendantsAndSelf().Skip(1)).Where(step.Simple.Matches);
+
+            // Distinct: overlapping descendant sets would otherwise report an element more than once.
+            current = current.Distinct();
+        }
+
+        return current.ToList();
+    }
+
+    private static List<Step> Parse(string selector)
+    {
+        if (string.IsNullOrWhiteSpace(selector))
+        {
+            throw new ArgumentException("A selector cannot be empty.", nameof(selector));
+        }
+
+        var steps = new List<Step>();
+        var child = false;
+        var i = 0;
+
+        while (i < selector.Length)
+        {
+            while (i < selector.Length && char.IsWhiteSpace(selector[i]))
+            {
+                i++;
+            }
+
+            if (i >= selector.Length)
+            {
+                break;
+            }
+
+            if (selector[i] == '>')
+            {
+                if (steps.Count == 0)
+                {
+                    throw Unsupported(selector, "a '>' combinator with nothing before it");
+                }
+
+                child = true;
+                i++;
+                continue;
+            }
+
+            steps.Add(new Step(ParseSimple(selector, ref i), child));
+            child = false;
+        }
+
+        if (steps.Count == 0)
+        {
+            throw Unsupported(selector, "no selector at all");
+        }
+
+        return steps;
+    }
+
+    private static Simple ParseSimple(string selector, ref int i)
+    {
+        var simple = new Simple();
+        var read = false;
+
+        while (i < selector.Length)
+        {
+            var c = selector[i];
+            if (char.IsWhiteSpace(c) || c == '>')
+            {
+                break;
+            }
+
+            switch (c)
+            {
+                case '*':
+                    i++;
+                    read = true;
+                    break;
+
+                case '#':
+                    i++;
+                    simple.Id = ReadIdentifier(selector, ref i);
+                    read = true;
+                    break;
+
+                case '.':
+                    i++;
+                    simple.Classes.Add(ReadIdentifier(selector, ref i));
+                    read = true;
+                    break;
+
+                case '[':
+                    simple.Attributes.Add(ReadAttribute(selector, ref i));
+                    read = true;
+                    break;
+
+                case ':':
+                    simple.HasText = ReadHasText(selector, ref i);
+                    read = true;
+                    break;
+
+                default:
+                    if (!char.IsLetter(c))
+                    {
+                        throw Unsupported(selector, $"the character '{c}'");
+                    }
+
+                    simple.Tag = ReadIdentifier(selector, ref i).ToLowerInvariant();
+                    read = true;
+                    break;
+            }
+        }
+
+        if (!read)
+        {
+            throw Unsupported(selector, "an empty step");
+        }
+
+        return simple;
+    }
+
+    private static string ReadIdentifier(string selector, ref int i)
+    {
+        var start = i;
+        while (i < selector.Length && (char.IsLetterOrDigit(selector[i]) || selector[i] is '-' or '_'))
+        {
+            i++;
+        }
+
+        if (i == start)
+        {
+            throw Unsupported(selector, "an empty name");
+        }
+
+        return selector[start..i];
+    }
+
+    private static AttributeMatch ReadAttribute(string selector, ref int i)
+    {
+        i++; // '['
+        var name = ReadIdentifier(selector, ref i);
+
+        if (i < selector.Length && selector[i] == ']')
+        {
+            i++;
+            return new AttributeMatch(name, null, AttributeOperator.Present);
+        }
+
+        var op = i < selector.Length
+            ? selector[i] switch
+            {
+                '=' => AttributeOperator.Equals,
+                '^' => AttributeOperator.StartsWith,
+                '$' => AttributeOperator.EndsWith,
+                '*' => AttributeOperator.Contains,
+                _ => throw Unsupported(selector, $"the attribute operator '{selector[i]}'"),
+            }
+            : throw Unsupported(selector, "an unterminated '['");
+
+        i += op == AttributeOperator.Equals ? 1 : 2;
+        var value = ReadQuoted(selector, ref i);
+
+        if (i >= selector.Length || selector[i] != ']')
+        {
+            throw Unsupported(selector, "an unterminated '['");
+        }
+
+        i++;
+        return new AttributeMatch(name, value, op);
+    }
+
+    private static string ReadHasText(string selector, ref int i)
+    {
+        const string token = ":has-text(";
+        if (!selector.AsSpan(i).StartsWith(token, StringComparison.Ordinal))
+        {
+            var end = selector.IndexOfAny([' ', '>', '['], i);
+            var pseudo = end < 0 ? selector[i..] : selector[i..end];
+            throw Unsupported(selector, $"the pseudo-class '{pseudo}'");
+        }
+
+        i += token.Length;
+        var text = ReadQuoted(selector, ref i);
+        if (i >= selector.Length || selector[i] != ')')
+        {
+            throw Unsupported(selector, "an unterminated ':has-text('");
+        }
+
+        i++;
+        return text;
+    }
+
+    private static string ReadQuoted(string selector, ref int i)
+    {
+        if (i >= selector.Length)
+        {
+            throw Unsupported(selector, "a value that ends the selector");
+        }
+
+        var quote = selector[i];
+        if (quote is not ('"' or '\''))
+        {
+            // Unquoted values are legal CSS but ambiguous to read; require quotes so the selector says
+            // plainly where the value ends.
+            throw Unsupported(selector, "an unquoted value — write [attr=\"value\"]");
+        }
+
+        i++;
+        var sb = new StringBuilder();
+        while (i < selector.Length && selector[i] != quote)
+        {
+            if (selector[i] == '\\' && i + 1 < selector.Length)
+            {
+                i++;
+            }
+
+            sb.Append(selector[i]);
+            i++;
+        }
+
+        if (i >= selector.Length)
+        {
+            throw Unsupported(selector, "an unterminated quote");
+        }
+
+        i++;
+        return sb.ToString();
+    }
+
+    private static ArgumentException Unsupported(string selector, string what) =>
+        new($"Selector '{selector}' contains {what}, which Rask.Testing's selector subset does not "
+            + "support. Supported: tag, *, #id, .class, [attr], [attr=\"v\"], [attr^=\"v\"], "
+            + "[attr$=\"v\"], [attr*=\"v\"], ':has-text(\"…\")', and the descendant and '>' combinators. "
+            + "For anything else, give the element an id or a data-* attribute and select on that — the "
+            + "test reads better for it too.");
+
+    private readonly record struct Step(Simple Simple, bool Child);
+
+    private enum AttributeOperator
+    {
+        Present,
+        Equals,
+        StartsWith,
+        EndsWith,
+        Contains,
+    }
+
+    private readonly record struct AttributeMatch(string Name, string? Value, AttributeOperator Operator)
+    {
+        public bool Matches(HtmlNode node)
+        {
+            if (node.Attribute(Name) is not { } actual)
+            {
+                return false;
+            }
+
+            return Operator switch
+            {
+                AttributeOperator.Present => true,
+                AttributeOperator.Equals => string.Equals(actual, Value, StringComparison.Ordinal),
+                AttributeOperator.StartsWith => actual.StartsWith(Value!, StringComparison.Ordinal),
+                AttributeOperator.EndsWith => actual.EndsWith(Value!, StringComparison.Ordinal),
+                AttributeOperator.Contains => actual.Contains(Value!, StringComparison.Ordinal),
+                _ => false,
+            };
+        }
+    }
+
+    private sealed class Simple
+    {
+        public string? Tag { get; set; }
+        public string? Id { get; set; }
+        public List<string> Classes { get; } = [];
+        public List<AttributeMatch> Attributes { get; } = [];
+        public string? HasText { get; set; }
+
+        public bool Matches(HtmlNode node)
+        {
+            if (Tag is not null && !string.Equals(node.Tag, Tag, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+
+            if (Id is not null && !string.Equals(node.Id, Id, StringComparison.Ordinal))
+            {
+                return false;
+            }
+
+            foreach (var cls in Classes)
+            {
+                if (!node.HasClass(cls))
+                {
+                    return false;
+                }
+            }
+
+            foreach (var attribute in Attributes)
+            {
+                if (!attribute.Matches(node))
+                {
+                    return false;
+                }
+            }
+
+            return HasText is null
+                   || node.TextContent.Contains(HasText, StringComparison.OrdinalIgnoreCase);
+        }
+    }
+}

--- a/src/Rask.Testing/HtmlTree.cs
+++ b/src/Rask.Testing/HtmlTree.cs
@@ -1,0 +1,304 @@
+using System.Text;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     Parses the markup Rask's own serializer produced into a small <see cref="HtmlNode" /> tree.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <b>Not a general-purpose HTML parser, and shouldn't be pointed at one's output.</b> It reads
+///         what <c>HtmlSerializer</c> emits, and that is a narrow, known shape: attributes are always
+///         double-quoted, values always encode <c>&lt;</c>, <c>&gt;</c> and <c>"</c>, void elements are
+///         written self-closing, and every non-void element gets its closing tag. Those guarantees are
+///         what make a ~200-line reader correct here and what let <c>Rask.Testing</c> keep its single
+///         dependency instead of taking one on a full parser — a testing package's dependencies land in
+///         every consumer's test project.
+///     </para>
+///     <para>
+///         Mis-nesting is tolerated rather than diagnosed: a stray close tag that matches no open element
+///         is ignored, and anything still open at the end is closed implicitly. The serializer does not
+///         produce either, so treating them as errors would only turn a framework bug into a confusing
+///         parser exception in somebody's test.
+///     </para>
+/// </remarks>
+internal static class HtmlTree
+{
+    // Elements HTML says never have a closing tag. The serializer writes these self-closed, but a
+    // hand-written fixture (or a Raw()) may not, so treat the name as authoritative either way.
+    private static readonly HashSet<string> VoidElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    };
+
+    // Content is CDATA-ish: '<' inside does not open a tag, so scan to the matching close tag instead.
+    private static readonly HashSet<string> RawTextElements = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "script", "style",
+    };
+
+    public static HtmlNode Parse(string html)
+    {
+        var root = new HtmlNode("#root");
+        var open = new Stack<HtmlNode>();
+        open.Push(root);
+
+        var i = 0;
+        while (i < html.Length)
+        {
+            var lt = html.IndexOf('<', i);
+            if (lt < 0)
+            {
+                AppendText(open.Peek(), html, i, html.Length);
+                break;
+            }
+
+            AppendText(open.Peek(), html, i, lt);
+
+            // <!-- comment -->, <!doctype …>, <?…> — skipped whole; none of them carry assertable content.
+            if (lt + 1 < html.Length && (html[lt + 1] == '!' || html[lt + 1] == '?'))
+            {
+                i = SkipBogus(html, lt);
+                continue;
+            }
+
+            if (lt + 1 < html.Length && html[lt + 1] == '/')
+            {
+                var close = html.IndexOf('>', lt);
+                if (close < 0)
+                {
+                    break;
+                }
+
+                var name = html[(lt + 2)..close].Trim();
+                CloseTo(open, name, root);
+                i = close + 1;
+                continue;
+            }
+
+            if (!TryReadStartTag(html, lt, out var tag, out var attributes, out var selfClosing, out var after))
+            {
+                // A '<' that starts no tag is text — the serializer encodes those, but a Raw() need not.
+                AppendText(open.Peek(), html, lt, lt + 1);
+                i = lt + 1;
+                continue;
+            }
+
+            var node = new HtmlNode(tag);
+            foreach (var (name, value) in attributes)
+            {
+                node.SetAttribute(name, value);
+            }
+
+            open.Peek().Add(node);
+
+            if (selfClosing || VoidElements.Contains(tag))
+            {
+                i = after;
+                continue;
+            }
+
+            if (RawTextElements.Contains(tag))
+            {
+                var end = html.IndexOf($"</{tag}", after, StringComparison.OrdinalIgnoreCase);
+                if (end < 0)
+                {
+                    node.AppendText(html[after..]);
+                    break;
+                }
+
+                node.AppendText(html[after..end]);
+                var gt = html.IndexOf('>', end);
+                i = gt < 0 ? html.Length : gt + 1;
+                continue;
+            }
+
+            open.Push(node);
+            i = after;
+        }
+
+        return root;
+    }
+
+    private static void AppendText(HtmlNode into, string html, int start, int end)
+    {
+        if (end > start)
+        {
+            into.AppendText(html[start..end]);
+        }
+    }
+
+    // Pops to and including the nearest matching open element. A close tag matching nothing is ignored —
+    // popping blindly would reparent everything after it under the wrong element, which is worse.
+    private static void CloseTo(Stack<HtmlNode> open, string name, HtmlNode root)
+    {
+        if (!open.Any(n => string.Equals(n.Tag, name, StringComparison.OrdinalIgnoreCase)))
+        {
+            return;
+        }
+
+        while (open.Count > 1)
+        {
+            var node = open.Pop();
+            if (string.Equals(node.Tag, name, StringComparison.OrdinalIgnoreCase))
+            {
+                return;
+            }
+        }
+
+        _ = root;
+    }
+
+    private static int SkipBogus(string html, int lt)
+    {
+        if (html.AsSpan(lt).StartsWith("<!--", StringComparison.Ordinal))
+        {
+            var end = html.IndexOf("-->", lt, StringComparison.Ordinal);
+            return end < 0 ? html.Length : end + 3;
+        }
+
+        var gt = html.IndexOf('>', lt);
+        return gt < 0 ? html.Length : gt + 1;
+    }
+
+    private static bool TryReadStartTag(
+        string html,
+        int lt,
+        out string tag,
+        out List<(string Name, string Value)> attributes,
+        out bool selfClosing,
+        out int after)
+    {
+        tag = string.Empty;
+        attributes = [];
+        selfClosing = false;
+        after = lt + 1;
+
+        var i = lt + 1;
+        var nameStart = i;
+        while (i < html.Length && !char.IsWhiteSpace(html[i]) && html[i] is not ('>' or '/'))
+        {
+            i++;
+        }
+
+        if (i == nameStart)
+        {
+            return false;
+        }
+
+        tag = html[nameStart..i].ToLowerInvariant();
+        if (tag.Length == 0 || !char.IsLetter(tag[0]))
+        {
+            return false;
+        }
+
+        while (i < html.Length)
+        {
+            while (i < html.Length && char.IsWhiteSpace(html[i]))
+            {
+                i++;
+            }
+
+            if (i >= html.Length)
+            {
+                break;
+            }
+
+            if (html[i] == '>')
+            {
+                after = i + 1;
+                return true;
+            }
+
+            if (html[i] == '/')
+            {
+                selfClosing = true;
+                i++;
+                continue;
+            }
+
+            var attrStart = i;
+            while (i < html.Length && !char.IsWhiteSpace(html[i]) && html[i] is not ('=' or '>' or '/'))
+            {
+                i++;
+            }
+
+            var name = html[attrStart..i];
+            if (name.Length == 0)
+            {
+                i++;
+                continue;
+            }
+
+            while (i < html.Length && char.IsWhiteSpace(html[i]))
+            {
+                i++;
+            }
+
+            if (i < html.Length && html[i] == '=')
+            {
+                i++;
+                while (i < html.Length && char.IsWhiteSpace(html[i]))
+                {
+                    i++;
+                }
+
+                attributes.Add((name, ReadValue(html, ref i)));
+            }
+            else
+            {
+                // A bare attribute (`defer`, `disabled`) — HTML says its value is its own name.
+                attributes.Add((name, name));
+            }
+        }
+
+        after = html.Length;
+        return true;
+    }
+
+    private static string ReadValue(string html, ref int i)
+    {
+        if (i >= html.Length)
+        {
+            return string.Empty;
+        }
+
+        var quote = html[i];
+        if (quote is '"' or '\'')
+        {
+            i++;
+            var end = html.IndexOf(quote, i);
+            if (end < 0)
+            {
+                var rest = html[i..];
+                i = html.Length;
+                return rest;
+            }
+
+            var value = html[i..end];
+            i = end + 1;
+            return value;
+        }
+
+        var start = i;
+        while (i < html.Length && !char.IsWhiteSpace(html[i]) && html[i] != '>')
+        {
+            i++;
+        }
+
+        return html[start..i];
+    }
+
+    // Only used by the debugger display; kept here so HtmlNode stays about shape rather than formatting.
+    internal static string Describe(HtmlNode node)
+    {
+        var sb = new StringBuilder("<").Append(node.Tag);
+        foreach (var (name, value) in node.Attributes)
+        {
+            sb.Append(' ').Append(name).Append("=\"").Append(value).Append('"');
+        }
+
+        return sb.Append('>').ToString();
+    }
+}

--- a/src/Rask.Testing/NUGET.md
+++ b/src/Rask.Testing/NUGET.md
@@ -44,13 +44,66 @@ public async Task Clicking_increments()
 - **`.HandlerIds(domEvent)`** / **`.Attrs(name)`** — every match, in document order. Index these to target
   one of several same-event elements: `await page.InvokeAsync(page.HandlerIds("click")[1])`.
 - **`Markup.Attr(html, name)`** / **`Markup.Attrs(html, name)`** — the same lookups over any HTML string.
+
+### Finding elements
+
+`.Find(selector)` returns the element, so an assertion can say *which one* rather than substring-matching
+the whole page — which is brittle against exactly the attribute-order invariant the framework pins.
+
+```csharp
+var badge = page.Find("#items li.selected .badge");
+Assert.Equal("7", badge.TextContent);
+
+Assert.Equal(["3", "7"], page.FindAll(".badge").Select(b => b.TextContent));
+Assert.Equal("7 shipped", page.TextOf("#items li.selected"));   // whitespace collapsed
+page.TestId("refresh");                                          // [data-testid="refresh"]
+```
+
+`.Find` throws when there is **no** match *and* when there is **more than one** — a test that silently
+took the first of several keeps passing after somebody adds a second. Use `.FindAll` when several are the
+point, and `.Exists(selector)` for presence.
+
+**The selector is a documented subset**, and anything outside it throws rather than quietly matching
+nothing: `tag`, `*`, `#id`, `.class`, `[attr]`, `[attr="v"]`, `[attr^="v"]`, `[attr$="v"]`, `[attr*="v"]`,
+`:has-text("…")`, and the descendant and `>` combinators. For anything else, give the element an id or a
+`data-*` attribute — the test reads better for it too.
+
+### Driving one element
+
+```csharp
+await page.On("#save").ClickAsync();
+await page.On("#name").InputAsync("Ada");
+await page.On("form#signup").SubmitAsync();
+```
+
+`.HandlerId(domEvent)` returns the **first** match in the document and `.HandlerIds` is indexed by
+position — so adding an unrelated button above the one under test silently re-points the assertion and the
+test keeps passing. `.On(selector)` names the element instead. (It's a handle rather than a
+`ClickAsync(selector)` overload because `ClickAsync` already takes a `string`, the JSON payload.)
+
+### Fakes for the things a component needs
+
+- **`TestDownloadSink`** — an `IDownloadSink` that records what a component staged. `Navigator.Download`
+  refuses to run without one and tells you to "register a fake"; this is that fake. Assert on
+  `.Staged` (`FileName`, `ContentType`, `Bytes`, `.Text`).
+- **`TestRoute.At("/search?q=hello%20world")`** — a `RouteState` at a URL, query string parsed and
+  decoded, repeated keys kept. `TestRoute.NavigatorFor(state, downloads)` wires the `Navigator`.
+  Register the `Navigator` in the provider and event dispatch enters its handler scope, so a component
+  that navigates or downloads on click can be unit-tested at all.
+- **`CapturingDiagnostics.Install()`** — captures the framework diagnostics raised while it is installed,
+  so you can assert that a swallowed fault happened (or that none did). Swallow-and-log is the framework's
+  designed behaviour for navigate faults, JS dispatch faults and faulted async lifecycle hooks, and
+  without this there is no supported way to see them.
 - **`.TryInvokeAsync(handlerId, json?)`** — dispatch only if the id is still live; returns `false` rather
   than throwing, so you can assert a handler is gone.
 - **`.Instance`** — the component object you passed in, for asserting its state directly.
 - **`.Render()`** — re-render after mutating external state the component reads.
 - **`TestJSRuntime`** — an `IJSRuntime` that records calls and returns canned values, for components that
   inject `IJSRuntime`. Register it in the provider, then assert with `.ArgsFor(id)` / `.Calls` /
-  `.CallCount(id)`; configure with `.SetResponse(id, value)` / `.SetException(id, ex)`.
+  `.CallCount(id)`; configure with `.SetResponse(id, value)` / `.SetException(id, ex)`. An unconfigured
+  call returns `default`; a call configured with the **wrong type** now throws and names both types,
+  rather than also returning `default` — `SetResponse("getCount", 1)` against `InvokeAsync<long>` used to
+  hand back `0`, indistinguishable from "not configured".
 - **`RaskTest.EditContextProbe(capture)`** — placed inside a `Form`'s children, hands you the form's
   `EditContext` so you can assert validation state (`GetValidationMessages`, `IsModified`, `IsValidating`)
   that never appears in the markup.

--- a/src/Rask.Testing/RenderedComponent.cs
+++ b/src/Rask.Testing/RenderedComponent.cs
@@ -2,12 +2,13 @@ using System.Diagnostics;
 using System.Text.Json;
 using Rask.Core;
 using Rask.Core.Live;
+using Rask.Core.Routing;
 
 namespace Rask.Testing;
 
 /// <summary>
 ///     A rendered component under test. <see cref="Html" /> is the current markup; invoke a handler
-///     (<see cref="InvokeAsync" />, <see cref="ClickAsync" />) to simulate an event, which dispatches it
+///     (<see cref="InvokeAsync(string, string?)" />, <see cref="ClickAsync(string?)" />) to simulate an event, which dispatches it
 ///     and re-renders, or call <see cref="Render" /> to re-render after mutating external state.
 /// </summary>
 public class RenderedComponent : IRenderHandle
@@ -41,6 +42,12 @@ public class RenderedComponent : IRenderHandle
 
     /// <summary>The current rendered HTML, reflecting the component's state as of the last render.</summary>
     public string Html { get; private set; } = string.Empty;
+
+    // The parsed view of Html, rebuilt lazily and only when the markup actually changed. Keyed on
+    // reference rather than value: Render() always produces a fresh string, so a reference match means
+    // "this is literally the markup we parsed", with no comparison over a page-sized string.
+    private HtmlNode? _parsed;
+    private string? _parsedFrom;
 
     /// <summary>Re-renders the component (e.g. after mutating state it reads) and refreshes <see cref="Html" />.</summary>
     public string Render()
@@ -165,6 +172,204 @@ public class RenderedComponent : IRenderHandle
     /// </summary>
     public IReadOnlyList<string> HandlerIds(string domEvent) => Attrs("data-rask-on-" + domEvent);
 
+    // ---- structure ----
+
+    /// <summary>
+    ///     The single element matching <paramref name="selector" /> in the current render.
+    /// </summary>
+    /// <remarks>
+    ///     Throws when there is no match, and when there is more than one. Both are deliberate: a test that
+    ///     silently took the first of several is one that keeps passing after somebody adds a second, and a
+    ///     test that silently found nothing is one that asserts about an element that isn't there. The
+    ///     message names what was found so the fix is obvious. Use <see cref="FindAll" /> when several
+    ///     matches are the point.
+    /// </remarks>
+    /// <exception cref="ArgumentException"><paramref name="selector" /> is outside the supported subset.</exception>
+    /// <exception cref="InvalidOperationException">There is not exactly one match.</exception>
+    public HtmlNode Find(string selector)
+    {
+        var matches = FindAll(selector);
+        return matches.Count switch
+        {
+            1 => matches[0],
+            0 => throw new InvalidOperationException(
+                $"No element matches '{selector}'.{NearMiss(selector)}\n\n{Html}"),
+            _ => throw new InvalidOperationException(
+                $"{matches.Count} elements match '{selector}', so Find cannot pick one — use FindAll, or "
+                + "narrow the selector:\n  "
+                + string.Join("\n  ", matches.Take(10).Select(m => m.Path()))),
+        };
+    }
+
+    /// <summary>
+    ///     Every element matching <paramref name="selector" />, in document order. Empty when none match.
+    /// </summary>
+    /// <exception cref="ArgumentException"><paramref name="selector" /> is outside the supported subset.</exception>
+    public IReadOnlyList<HtmlNode> FindAll(string selector) =>
+        HtmlSelector.Select(Root, selector);
+
+    /// <summary>True when at least one element matches <paramref name="selector" />.</summary>
+    /// <exception cref="ArgumentException"><paramref name="selector" /> is outside the supported subset.</exception>
+    public bool Exists(string selector) => FindAll(selector).Count > 0;
+
+    /// <summary>
+    ///     The element carrying <c>data-testid="<paramref name="id" />"</c> — the stable hook to reach for
+    ///     when an element has no id of its own and you don't want the test coupled to its classes.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">There is not exactly one such element.</exception>
+    public HtmlNode TestId(string id) => Find($"[data-testid=\"{id}\"]");
+
+    /// <summary>
+    ///     The text under the single element matching <paramref name="selector" />, HTML-decoded and with
+    ///     runs of whitespace collapsed — what a reader would see, not what the serializer wrote.
+    /// </summary>
+    /// <exception cref="InvalidOperationException">There is not exactly one match.</exception>
+    public string TextOf(string selector) => Normalize(Find(selector).TextContent);
+
+    /// <summary>
+    ///     The parsed tree for the current <see cref="Html" />. Reparsed whenever the markup changes, so it
+    ///     always reflects the latest render.
+    /// </summary>
+    public HtmlNode Root
+    {
+        get
+        {
+            var html = Html;
+            if (!ReferenceEquals(_parsedFrom, html))
+            {
+                _parsed = HtmlTree.Parse(html);
+                _parsedFrom = html;
+            }
+
+            return _parsed!;
+        }
+    }
+
+    // ---- targeting a handler by what it says, not by where it happens to sit ----
+
+    /// <summary>
+    ///     The handler id for <paramref name="domEvent" /> on the single element matching
+    ///     <paramref name="selector" />.
+    /// </summary>
+    /// <remarks>
+    ///     The reason this exists: <see cref="HandlerId(string)" /> returns the <em>first</em> match in the
+    ///     document, and <see cref="HandlerIds(string)" /> is indexed by position — so adding an unrelated
+    ///     button above the one under test silently re-points every such assertion at the wrong element,
+    ///     and the test keeps passing. Naming the element instead makes the test say what it means.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">
+    ///     There is not exactly one match, or the matched element is not wired to <paramref name="domEvent" />.
+    /// </exception>
+    public string HandlerIdFor(string selector, string domEvent)
+    {
+        var node = Find(selector);
+        return node.Attribute("data-rask-on-" + domEvent)
+               ?? throw new InvalidOperationException(
+                   $"'{node.Path()}' matches '{selector}' but has no {domEvent} handler. Wired here: "
+                   + Describe(node.Attributes.Keys
+                       .Where(k => k.StartsWith("data-rask-on-", StringComparison.Ordinal))
+                       .Select(k => k["data-rask-on-".Length..])));
+    }
+
+    /// <summary>
+    ///     The events of the single element matching <paramref name="selector" />:
+    ///     <c>await page.On("#save").ClickAsync()</c>.
+    /// </summary>
+    /// <remarks>
+    ///     A handle rather than <c>ClickAsync(selector)</c> overloads, because the existing
+    ///     <see cref="ClickAsync(string?)" /> already takes a <see cref="string" /> — the JSON payload — so a
+    ///     selector overload would be chosen by argument count and quietly send "#save" as event args. Two
+    ///     meanings for one parameter type is exactly the trap this API is meant to remove.
+    /// </remarks>
+    /// <exception cref="InvalidOperationException">There is not exactly one match.</exception>
+    public ElementActions On(string selector) => new(this, selector);
+
+    /// <summary>The events of one element, resolved by selector. Obtained from <see cref="On" />.</summary>
+    /// <param name="page">The rendered component the element belongs to.</param>
+    /// <param name="selector">The selector that names it — re-resolved on each call, so it survives re-renders.</param>
+    public readonly struct ElementActions(RenderedComponent page, string selector)
+    {
+        /// <summary>Dispatches this element's <c>click</c> handler, then re-renders.</summary>
+        public Task<string> ClickAsync(string? jsonPayload = null) => Raise("click", jsonPayload);
+
+        /// <summary>Raises <c>input</c> with <paramref name="value" /> as the event's value.</summary>
+        public Task<string> InputAsync(string value) => Raise("input", JsonValuePayload(value));
+
+        /// <summary>Raises <c>change</c> with <paramref name="value" /> as the event's value.</summary>
+        public Task<string> ChangeAsync(string value) => Raise("change", JsonValuePayload(value));
+
+        /// <summary>Dispatches this element's <c>submit</c> handler, then re-renders.</summary>
+        public Task<string> SubmitAsync(string? jsonPayload = null) => Raise("submit", jsonPayload);
+
+        /// <summary>Dispatches an arbitrary DOM event by name, for anything without a helper above.</summary>
+        public Task<string> RaiseAsync(string domEvent, string? jsonPayload = null) =>
+            Raise(domEvent, jsonPayload);
+
+        /// <summary>The element itself, re-resolved from the current render.</summary>
+        public HtmlNode Element => page.Find(selector);
+
+        // Resolved per call, not captured: a handler re-renders, and the node from the previous render is
+        // then stale. Re-resolving means `var save = page.On("#save")` keeps working across renders.
+        private Task<string> Raise(string domEvent, string? jsonPayload) =>
+            page.InvokeAsync(page.HandlerIdFor(selector, domEvent), jsonPayload);
+
+        private static string JsonValuePayload(string value) =>
+            "{\"value\":" + System.Text.Json.JsonSerializer.Serialize(value) + "}";
+    }
+
+    private static string Describe(IEnumerable<string> values)
+    {
+        var list = values.ToList();
+        return list.Count == 0 ? "nothing" : string.Join(", ", list);
+    }
+
+    // A selector that matches nothing is nearly always a typo or a stale expectation, and the two read very
+    // differently. Saying which part of it does match turns "no element matches" into a pointer.
+    private string NearMiss(string selector)
+    {
+        var head = selector.Split([' ', '>'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (head is null || head == selector)
+        {
+            return string.Empty;
+        }
+
+        try
+        {
+            var partial = FindAll(head);
+            return partial.Count == 0
+                ? $" Nor does '{head}'."
+                : $" '{head}' matches {partial.Count}, so the rest of the selector is what fails.";
+        }
+        catch (ArgumentException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private static string Normalize(string text)
+    {
+        var sb = new System.Text.StringBuilder(text.Length);
+        var space = false;
+        foreach (var c in text)
+        {
+            if (char.IsWhiteSpace(c))
+            {
+                space = sb.Length > 0;
+                continue;
+            }
+
+            if (space)
+            {
+                sb.Append(' ');
+                space = false;
+            }
+
+            sb.Append(c);
+        }
+
+        return sb.ToString();
+    }
+
     /// <summary>
     ///     Dispatches the handler registered under <paramref name="handlerId" /> with an optional JSON event
     ///     payload (e.g. <c>"{\"value\":\"hi\"}"</c> for an input event), then re-renders and returns the new
@@ -225,6 +430,13 @@ public class RenderedComponent : IRenderHandle
 
         using (doc)
         {
+            // Enter the Navigator's handler scope for the dispatch, exactly as a live session does.
+            // Without it, Navigator.NavigateTo / Download / SetQuery all refuse — "can only be used from
+            // event handlers" — which was true of the harness and not of the component: a page that
+            // navigates or exports on click could not be unit-tested at all, only through Playwright.
+            // No Navigator registered (the common case for a leaf component) means nothing to scope.
+            using var scope = (_services.GetService(typeof(Navigator)) as Navigator)?.EnterHandler();
+
             return await _root.TryInvokeHandlerAsync(handlerId, doc.RootElement, _services)
                 .ConfigureAwait(false);
         }

--- a/src/Rask.Testing/TestDownloadSink.cs
+++ b/src/Rask.Testing/TestDownloadSink.cs
@@ -1,0 +1,116 @@
+using Rask.Core.Routing;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     An <see cref="IDownloadSink" /> that records what a component staged, instead of handing it to a
+///     browser.
+/// </summary>
+/// <remarks>
+///     <para>
+///         <c>Navigator.Download</c> refuses to run without a sink, and its message says <em>"If you're in
+///         a unit test, register a fake."</em> — while the testing package shipped none, so everyone wrote
+///         the same twenty lines. This is those twenty lines, once.
+///     </para>
+///     <para>
+///         <see cref="Staged" /> is the assertion surface: it keeps every download in order, so a test can
+///         check the file name, the content type and the bytes. <c>TryConsume</c> hands them back the way
+///         a real sink does, so a component that stages and then consumes behaves the same here.
+///     </para>
+///     <code>
+///     var downloads = new TestDownloadSink();
+///     var page = RaskTest.Render(new ExportPage(new Navigator(new RouteState(), downloads)));
+///     await page.ClickAsync("#export");
+///
+///     var file = Assert.Single(downloads.Staged);
+///     Assert.Equal("orders.csv", file.FileName);
+///     Assert.StartsWith("Id,Total", Encoding.UTF8.GetString(file.Bytes));
+///     </code>
+/// </remarks>
+public sealed class TestDownloadSink : IDownloadSink
+{
+    private readonly Lock _gate = new();
+    private readonly List<StagedDownload> _staged = [];
+    private readonly Queue<PendingDownload> _pending = new();
+
+    /// <summary>Every download staged so far, oldest first. Consuming one does not remove it from here.</summary>
+    public IReadOnlyList<StagedDownload> Staged
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _staged.ToArray();
+            }
+        }
+    }
+
+    /// <summary>The most recent staged download, or <c>null</c> when nothing has been staged.</summary>
+    public StagedDownload? Last
+    {
+        get
+        {
+            lock (_gate)
+            {
+                return _staged.Count == 0 ? null : _staged[^1];
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    public void Stage(string fileName, byte[] bytes, string? contentType)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(bytes);
+        Record(fileName, bytes, contentType);
+    }
+
+    /// <inheritdoc />
+    public void Stage(string fileName, Stream content, string? contentType)
+    {
+        ArgumentNullException.ThrowIfNull(fileName);
+        ArgumentNullException.ThrowIfNull(content);
+
+        // Read it here rather than storing the stream: the component may dispose it as soon as Stage
+        // returns, and a test that asserted on it later would then read from a disposed stream — a
+        // failure about the harness rather than about the code under test.
+        using var buffer = new MemoryStream();
+        content.CopyTo(buffer);
+        Record(fileName, buffer.ToArray(), contentType);
+    }
+
+    /// <inheritdoc />
+    public bool TryConsume(out PendingDownload? download)
+    {
+        lock (_gate)
+        {
+            if (_pending.Count == 0)
+            {
+                download = null;
+                return false;
+            }
+
+            download = _pending.Dequeue();
+            return true;
+        }
+    }
+
+    private void Record(string fileName, byte[] bytes, string? contentType)
+    {
+        lock (_gate)
+        {
+            _staged.Add(new StagedDownload(fileName, bytes, contentType));
+            _pending.Enqueue(new PendingDownload(fileName, contentType, Url: null, bytes));
+        }
+    }
+}
+
+/// <summary>One download a component handed to <see cref="TestDownloadSink" />.</summary>
+/// <param name="FileName">The name the component asked the browser to save it as.</param>
+/// <param name="Bytes">The content, materialized — safe to assert on after the component disposed its source.</param>
+/// <param name="ContentType">The MIME type, or <c>null</c> when the component left it to the host.</param>
+public sealed record StagedDownload(string FileName, byte[] Bytes, string? ContentType)
+{
+    /// <summary>The content decoded as UTF-8 — the common case for a CSV, JSON or text export.</summary>
+    public string Text => System.Text.Encoding.UTF8.GetString(Bytes);
+}

--- a/src/Rask.Testing/TestJSRuntime.cs
+++ b/src/Rask.Testing/TestJSRuntime.cs
@@ -57,10 +57,32 @@ public sealed class TestJSRuntime : IJSRuntime
             return ValueTask.FromException<TValue>(failure);
         }
 
-        return hasCanned && canned is TValue typed
-            ? ValueTask.FromResult(typed)
-            : ValueTask.FromResult<TValue>(default!);
+        if (!hasCanned)
+        {
+            // Unconfigured returns default. Deliberate and documented: most calls in a component are
+            // fire-and-forget, and making every one of them require a canned response would be noise.
+            return ValueTask.FromResult<TValue>(default!);
+        }
+
+        if (canned is TValue typed)
+        {
+            return ValueTask.FromResult(typed);
+        }
+
+        // Configured, but not with a TValue. This used to fall into the same `default!` path as
+        // unconfigured, which made the two indistinguishable — SetResponse("getCount", 1) against a
+        // component calling InvokeAsync<long> returned 0, and the test read as "the component ignored
+        // the value" rather than "the harness dropped it". A boxed int is not a long, and nothing in the
+        // signature says so, so say it here.
+        return ValueTask.FromException<TValue>(new InvalidOperationException(
+            $"The response configured for '{identifier}' is a {Describe(canned)}, but the component asked "
+            + $"for {typeof(TValue).Name}. SetResponse stores the value as-is and hands it back only when "
+            + "the types match exactly — a boxed int is not a long, and 1 is not 1.0. Configure it as the "
+            + $"type the component reads: SetResponse(\"{identifier}\", ({typeof(TValue).Name})…)."));
     }
+
+    private static string Describe(object? value) =>
+        value is null ? "null" : value.GetType().Name;
 
     /// <inheritdoc />
     public ValueTask<TValue> InvokeAsync<TValue>(

--- a/src/Rask.Testing/TestRoute.cs
+++ b/src/Rask.Testing/TestRoute.cs
@@ -1,0 +1,80 @@
+using Microsoft.Extensions.Primitives;
+using Rask.Core.Routing;
+
+namespace Rask.Testing;
+
+/// <summary>
+///     Builds the routing state a page under test reads: a <see cref="RouteState" /> at a given URL, and a
+///     <see cref="Navigator" /> over it.
+/// </summary>
+/// <remarks>
+///     Seeding a path was already a one-liner (<c>new RouteState { Path = "/orders" }</c>) and is done that
+///     way in a dozen places. Seeding a <em>query string</em> was not: <c>RouteState.Query</c> takes an
+///     <c>IQueryCollection</c>, which nothing wrapped — so testing a <c>[QueryParam]</c>-bound page meant
+///     building one by hand, and most tests simply didn't.
+/// </remarks>
+public static class TestRoute
+{
+    /// <summary>
+    ///     A <see cref="RouteState" /> at <paramref name="url" />. The query string, if present, is parsed
+    ///     and decoded, so <c>"/search?q=hello%20world&amp;page=2"</c> arrives as the page will read it.
+    /// </summary>
+    /// <param name="url">A path, optionally with a query string. A leading <c>/</c> is added if missing.</param>
+    public static RouteState At(string url)
+    {
+        ArgumentNullException.ThrowIfNull(url);
+
+        var split = url.IndexOf('?');
+        var path = split < 0 ? url : url[..split];
+        var query = split < 0 ? string.Empty : url[(split + 1)..];
+
+        if (path.Length == 0 || path[0] != '/')
+        {
+            path = "/" + path;
+        }
+
+        var state = new RouteState { Path = path };
+        if (query.Length > 0)
+        {
+            state.Query = ParseQuery(query);
+        }
+
+        return state;
+    }
+
+    // Repeated keys accumulate rather than overwrite, because that is what a real query collection does and
+    // what a multi-select or a checkbox group produces: "?tag=a&tag=b" is two values, not the last one.
+    private static QueryCollection ParseQuery(string query)
+    {
+        var store = new Dictionary<string, StringValues>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var pair in query.Split('&', StringSplitOptions.RemoveEmptyEntries))
+        {
+            var eq = pair.IndexOf('=');
+            var key = Uri.UnescapeDataString((eq < 0 ? pair : pair[..eq]).Replace('+', ' '));
+            var value = eq < 0 ? string.Empty : Uri.UnescapeDataString(pair[(eq + 1)..].Replace('+', ' '));
+
+            if (key.Length == 0)
+            {
+                continue;
+            }
+
+            store[key] = store.TryGetValue(key, out var existing)
+                ? StringValues.Concat(existing, value)
+                : new StringValues(value);
+        }
+
+        return new QueryCollection(store);
+    }
+
+    /// <summary>
+    ///     A <see cref="Navigator" /> over <paramref name="state" />, wired to <paramref name="downloads" />
+    ///     so <c>Navigator.Download</c> works instead of throwing. Pass a <see cref="TestDownloadSink" />
+    ///     when the page under test exports anything.
+    /// </summary>
+    public static Navigator NavigatorFor(RouteState state, IDownloadSink? downloads = null)
+    {
+        ArgumentNullException.ThrowIfNull(state);
+        return new Navigator(state, downloads);
+    }
+}

--- a/tests/Rask.Testing.Tests/StructuralQueryTests.cs
+++ b/tests/Rask.Testing.Tests/StructuralQueryTests.cs
@@ -1,0 +1,131 @@
+#pragma warning disable RASK014 // test-local components have no generated factories
+
+using Rask.Core;
+
+namespace Rask.Testing.Tests;
+
+/// <summary>
+///     The structural surface #610 asked for: find an element, say which one, and assert on what it holds
+///     — rather than <c>Assert.Contains("&lt;span class=\"badge\"&gt;3&lt;/span&gt;", page.Html)</c>, which is brittle
+///     against the very attribute-order invariant this framework's own suite goes to lengths to pin.
+/// </summary>
+public class StructuralQueryTests
+{
+    private sealed class Card : Component
+    {
+        protected override Component? Render() =>
+            Div(Class: "card shadow-sm")[
+                H2(Class: "title")["Orders"],
+                Ul(Id: "items")[
+                    Li(Class: "item")[Span(Class: "badge")["3"], " pending"],
+                    Li(Class: "item selected")[Span(Class: "badge")["7"], " shipped"]
+                ],
+                Button(Class: "btn", Data: new Dictionary<string, string?> { ["testid"] = "refresh" })["Refresh"]
+            ];
+    }
+
+    private static RenderedComponent<Card> Page() => RaskTest.Render(new Card());
+
+    [Fact]
+    public void Find_ReturnsTheElement_NotJustAnAttribute()
+    {
+        var badge = Page().Find("#items li.selected .badge");
+
+        Assert.Equal("span", badge.Tag);
+        Assert.Equal("7", badge.TextContent);
+        Assert.True(badge.HasClass("badge"));
+    }
+
+    [Fact]
+    public void FindAll_IsInDocumentOrder()
+    {
+        var badges = Page().FindAll(".badge");
+
+        Assert.Equal(["3", "7"], badges.Select(b => b.TextContent));
+    }
+
+    // Both halves of Find's contract, and the reason it isn't "first match wins": a test that silently
+    // took the first of several keeps passing after somebody adds a second.
+    [Fact]
+    public void Find_RefusesToPickBetweenSeveralMatches()
+    {
+        var error = Assert.Throws<InvalidOperationException>(() => Page().Find("li"));
+
+        Assert.Contains("2 elements match", error.Message, StringComparison.Ordinal);
+        Assert.Contains("FindAll", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Find_SaysWhichPartOfTheSelectorFailed()
+    {
+        var error = Assert.Throws<InvalidOperationException>(() => Page().Find("#items .missing"));
+
+        // The near-miss is the useful half: "#items matches 1, so the rest is what fails" points at the
+        // typo, where "no element matches" only says you were wrong somewhere.
+        Assert.Contains("#items", error.Message, StringComparison.Ordinal);
+        Assert.Contains("matches 1", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TextOf_JoinsTheChildrenAsAReaderSeesThem()
+    {
+        // The <li> is a <span> plus a text node; TextOf reads the whole subtree, which is what an
+        // assertion about "the row says 7 shipped" actually means.
+        Assert.Equal("7 shipped", Page().TextOf("#items li.selected"));
+    }
+
+    [Fact]
+    public void TextOf_CollapsesWhitespace_ToWhatAReaderSees()
+    {
+        var page = RaskTest.Render(new Spaced());
+
+        Assert.Equal("Total 42 items", page.TextOf("#t"));
+    }
+
+    private sealed class Spaced : Component
+    {
+        protected override Component? Render() =>
+            P(Id: "t")["  Total\n\n  ", Span()["42"], "   items  "];
+    }
+
+    [Fact]
+    public void TestId_FindsTheStableHook()
+    {
+        Assert.Equal("Refresh", Page().TestId("refresh").TextContent);
+    }
+
+    [Fact]
+    public void Path_NamesTheElement_SoAFailureIsFindable()
+    {
+        Assert.Equal("div.card.shadow-sm > ul#items > li.item.selected", Page().Find("li.selected").Path());
+    }
+
+    [Theory]
+    [InlineData("li:nth-child(2)", "the pseudo-class ':nth-child(2)'")]
+    [InlineData("li + li", "the character '+'")]
+    [InlineData("[data-testid=refresh]", "an unquoted value")]
+    public void AnUnsupportedSelector_Throws_RatherThanQuietlyMatchingNothing(string selector, string expected)
+    {
+        // The whole justification for a subset instead of a partial implementation: a selector that
+        // silently matched nothing because ':nth-child' was ignored would turn a green test into a lie.
+        var error = Assert.Throws<ArgumentException>(() => Page().FindAll(selector));
+
+        Assert.Contains(expected, error.Message, StringComparison.Ordinal);
+        Assert.Contains("does not support", error.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Attributes_AreDecoded_NotAsTheSerializerWroteThem()
+    {
+        var page = RaskTest.Render(new Quoted());
+
+        Assert.Equal("a \"quoted\" & <angled> title", page.Find("#t").Attribute("title"));
+        Assert.Equal("3 < 5 & 5 > 3", page.TextOf("#t"));
+    }
+
+    private sealed class Quoted : Component
+    {
+        protected override Component? Render() =>
+            Div(Id: "t", Title: "a \"quoted\" & <angled> title")["3 < 5 & 5 > 3"];
+    }
+}

--- a/tests/Rask.Testing.Tests/TestingSurfaceTests.cs
+++ b/tests/Rask.Testing.Tests/TestingSurfaceTests.cs
@@ -1,0 +1,204 @@
+#pragma warning disable RASK014 // test-local components have no generated factories
+
+using Microsoft.Extensions.DependencyInjection;
+using Rask.Core;
+using Rask.Core.Routing;
+
+namespace Rask.Testing.Tests;
+
+/// <summary>
+///     The four ergonomic gaps #610 listed alongside the structural one: targeting a handler by what it
+///     says rather than where it sits, a download sink, route/query seeding, and a JS runtime that fails
+///     loudly on a type mismatch.
+/// </summary>
+public class TestingSurfaceTests
+{
+    // ---- targeting a handler by what it is, not by its position ----
+
+    private sealed class Toolbar : Component
+    {
+        public int Saves { get; private set; }
+        public int Cancels { get; private set; }
+
+        protected override Component? Render() =>
+            Div()[
+                Button(Id: "cancel", OnClick: () => Cancels++)["Cancel"],
+                Button(Id: "save", OnClick: () => Saves++)["Save"]
+            ];
+    }
+
+    [Fact]
+    public async Task ClickAsync_TargetsTheNamedElement_NotTheFirstHandlerInTheDocument()
+    {
+        var page = RaskTest.Render(new Toolbar());
+
+        await page.On("#save").ClickAsync();
+
+        // The point of the whole helper: "Save" is the SECOND click handler, so HandlerIds("click")[1]
+        // would work today and silently re-point at something else the moment a button is added above it.
+        Assert.Equal(1, page.Instance.Saves);
+        Assert.Equal(0, page.Instance.Cancels);
+    }
+
+    [Fact]
+    public void HandlerIdFor_SaysWhatTheElementIsActuallyWiredTo()
+    {
+        var page = RaskTest.Render(new Toolbar());
+
+        var error = Assert.Throws<InvalidOperationException>(() => page.HandlerIdFor("#save", "input"));
+
+        Assert.Contains("no input handler", error.Message, StringComparison.Ordinal);
+        Assert.Contains("click", error.Message, StringComparison.Ordinal);
+    }
+
+    // ---- a download sink, so Navigator.Download stops throwing in a unit test ----
+
+    private sealed class ExportPage(Navigator navigator) : Component
+    {
+        protected override Component? Render() =>
+            Button(Id: "export", OnClick: () =>
+                navigator.Download("orders.csv", "Id,Total\n1,9.99"u8.ToArray(), "text/csv"))["Export"];
+    }
+
+    [Fact]
+    public async Task TestDownloadSink_RecordsWhatTheComponentStaged()
+    {
+        var downloads = new TestDownloadSink();
+        var navigator = TestRoute.NavigatorFor(TestRoute.At("/orders"), downloads);
+        var services = new ServiceCollection().AddSingleton(navigator).BuildServiceProvider();
+
+        var page = RaskTest.Render(new ExportPage(navigator), services);
+        await page.On("#export").ClickAsync();
+
+        var file = Assert.Single(downloads.Staged);
+        Assert.Equal("orders.csv", file.FileName);
+        Assert.Equal("text/csv", file.ContentType);
+        Assert.StartsWith("Id,Total", file.Text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TestDownloadSink_HandsThemBackTheWayARealSinkDoes()
+    {
+        var sink = new TestDownloadSink();
+        sink.Stage("a.txt", "one"u8.ToArray(), "text/plain");
+        sink.Stage("b.txt", "two"u8.ToArray(), "text/plain");
+
+        Assert.True(sink.TryConsume(out var first));
+        Assert.Equal("a.txt", first!.Filename);
+        Assert.True(sink.TryConsume(out _));
+        Assert.False(sink.TryConsume(out _));
+
+        // Consuming empties the queue but not the record — the assertion surface outlives the handoff.
+        Assert.Equal(2, sink.Staged.Count);
+    }
+
+    // ---- route + query seeding ----
+
+    [Fact]
+    public void TestRoute_ParsesAndDecodesTheQueryString()
+    {
+        var state = TestRoute.At("/search?q=hello%20world&page=2");
+
+        Assert.Equal("/search", state.Path);
+        Assert.Equal("hello world", state.Query["q"].ToString());
+        Assert.Equal("2", state.Query["page"].ToString());
+    }
+
+    [Fact]
+    public void TestRoute_KeepsEveryValueOfARepeatedKey()
+    {
+        // What a multi-select or a checkbox group produces. Overwriting would make a page that reads all
+        // of them look broken in a test and fine in a browser.
+        var state = TestRoute.At("/filter?tag=a&tag=b");
+
+        Assert.Equal(["a", "b"], state.Query["tag"].ToArray().Select(v => v ?? string.Empty));
+    }
+
+    [Fact]
+    public void TestRoute_AddsTheLeadingSlash_SoBothSpellingsWork()
+    {
+        Assert.Equal("/orders", TestRoute.At("orders").Path);
+    }
+
+    // ---- a JS runtime that says when it dropped your value ----
+
+    [Fact]
+    public async Task TestJSRuntime_StillReturnsDefault_WhenNothingIsConfigured()
+    {
+        var js = new TestJSRuntime();
+
+        Assert.Equal(0, await js.InvokeAsync<int>("getCount", args: null));
+    }
+
+    [Fact]
+    public async Task TestJSRuntime_ThrowsWhenTheCannedValueIsTheWrongType()
+    {
+        // The trap #610 named: SetResponse stores the value boxed, and a boxed int is not a long — so this
+        // used to return 0, indistinguishable from "not configured", and the test read as though the
+        // component had ignored the value.
+        var js = new TestJSRuntime();
+        js.SetResponse("getCount", 1);
+
+        var error = await Assert.ThrowsAsync<InvalidOperationException>(
+            async () => await js.InvokeAsync<long>("getCount", args: null));
+
+        Assert.Contains("Int32", error.Message, StringComparison.Ordinal);
+        Assert.Contains("Int64", error.Message, StringComparison.Ordinal);
+    }
+
+    // ---- diagnostics capture ----
+
+    // A faulted async lifecycle hook: the framework's canonical swallow-and-log path. The continuation
+    // runs off the dispatch's call stack, so there is nobody to throw to — it reports and carries on,
+    // which is exactly the class of fault an app author had no supported way to assert on.
+    private sealed class FaultsInMountAsync : Component
+    {
+        protected override async Task OnMountAsync()
+        {
+            await Task.Yield();
+            throw new InvalidOperationException("boom");
+        }
+
+        protected override Component? Render() => Div()["x"];
+    }
+
+    [Fact]
+    public async Task CapturingDiagnostics_SeesAFaultTheFrameworkSwallowed()
+    {
+        using var diagnostics = CapturingDiagnostics.Install();
+
+        _ = RaskTest.Render(new FaultsInMountAsync(), new ServiceCollection().BuildServiceProvider());
+
+        // Swallow-and-log is the framework's designed behaviour here; without a capture there is no
+        // supported way for an app author to assert that it happened, or that it didn't.
+        await WaitForCaptureAsync(diagnostics);
+
+        Assert.Contains(diagnostics.Captured, e =>
+            e.Level == DiagnosticLevel.Error && e.Exception?.Message == "boom");
+    }
+
+    [Fact]
+    public async Task CapturingDiagnostics_RestoresThePreviousSinkOnDispose()
+    {
+        var before = CapturingDiagnostics.Install();
+        before.Dispose();
+
+        // Nothing observable to assert on directly — the sink is internal — so assert the property that
+        // matters: a second install/dispose cycle still captures, which it wouldn't if the first had left
+        // the global pointing at its own dead list.
+        using var after = CapturingDiagnostics.Install();
+        _ = RaskTest.Render(new FaultsInMountAsync(), new ServiceCollection().BuildServiceProvider());
+        await WaitForCaptureAsync(after);
+
+        Assert.NotEmpty(after.Captured);
+    }
+
+    // The hook faults on a thread-pool continuation, so the report lands after Render() returns.
+    private static async Task WaitForCaptureAsync(CapturingDiagnostics diagnostics)
+    {
+        for (var i = 0; i < 200 && diagnostics.Captured.Count == 0; i++)
+        {
+            await Task.Delay(10);
+        }
+    }
+}


### PR DESCRIPTION
Closes #610.

`Markup`'s own remarks were the clearest statement of the problem:

> It reads attributes, not structure — it has no notion of elements or nesting, so it cannot tell you
> which element a match came from.

So every structural assertion in a consumer's test degraded to
`Assert.Contains("<span class=\"badge\">3</span>", page.Html)` — brittle against exactly the
attribute-order invariant this framework's own suite goes to great lengths to pin.

## Finding elements

```csharp
var badge = page.Find("#items li.selected .badge");
Assert.Equal("7", badge.TextContent);

Assert.Equal(["3", "7"], page.FindAll(".badge").Select(b => b.TextContent));
Assert.Equal("7 shipped", page.TextOf("#items li.selected"));   // whitespace collapsed
page.TestId("refresh");
```

`Find` throws when **nothing** matches *and* when **several** do. Both are deliberate: a test that
silently took the first of several keeps passing after somebody adds a second, and one that silently
found nothing asserts about an element that isn't there. A failure names the near miss —
`'#items' matches 1, so the rest of the selector is what fails` — and the path of each candidate.

**The selector is a documented subset and anything outside it throws**: `tag`, `*`, `#id`, `.class`,
`[attr]`, `[attr="v"]` with the `^= $= *=` variants, `:has-text("…")`, descendant and `>`. That refusal
*is* the design — a selector that quietly matched nothing because `:nth-child` was ignored would turn a
green test into a lie.

**The parser is ~200 lines rather than a dependency.** `Rask.Testing` is a shipped package with exactly
one package reference today, so a parser dependency lands in every consumer's test project — and Rask's
own serializer emits the markup it reads (always double-quoted attributes, always encoding `<`, `>`, `"`),
which is the guarantee that makes a small reader correct here and would not hold for HTML in general. It
says so at the top of the file, so nobody points it at arbitrary HTML.

## Driving one element

```csharp
await page.On("#save").ClickAsync();
await page.On("#name").InputAsync("Ada");
```

`HandlerId` returns the **first** match in the document and `HandlerIds` is indexed by position — so
adding an unrelated button above the one under test silently re-points every such assertion, and the test
keeps passing.

A handle rather than a `ClickAsync(selector)` overload, and that's not cosmetic: `ClickAsync` already
takes a `string` (the JSON payload), so an overload would be picked by argument count and send `"#save"`
as event args. I wrote it that way first and the test caught it. Two meanings for one parameter type is
the trap this API exists to remove.

## Event dispatch now enters the Navigator's handler scope

The one I didn't expect. `Navigator.NavigateTo` / `Download` / `SetQuery` all refuse outside a handler
scope, and the test harness never entered one — so they failed with *"can only be used from event
handlers"*, which was true of the harness and not of the component.

**A page that navigates or exports on click could not be unit-tested at all**, only through Playwright.
That is also the real reason `Navigator.Download`'s *"If you're in a unit test, register a fake"* went
nowhere: the fake was missing *and* so was the scope. `RaskTest` is on Core's `InternalsVisibleTo` list,
so the dispatch now enters `Navigator.EnterHandler()` exactly as a live session does.

## The rest

- **`TestDownloadSink`** — the fake that message asks for. Two hand-rolled copies already existed in this
  repo's own test tree.
- **`TestRoute.At("/search?q=hello%20world")`** — a `RouteState` with its query parsed, decoded, and
  repeated keys kept (what a multi-select produces). Seeding a *path* was already a one-liner; seeding a
  *query* meant building an `IQueryCollection` by hand, so most tests simply didn't.
- **`CapturingDiagnostics`** — assert that a swallowed fault happened, or that none did. A public
  **wrapper** rather than a public `RaskDiagnostics`: `Rask.Testing` is already on Core's IVT list, so no
  new public seam is needed on the framework — and a public seam is irreversible where a wrapper isn't.
- **`TestJSRuntime` stops failing silently on a type mismatch.** `SetResponse("getCount", 1)` against a
  component calling `InvokeAsync<long>` returned `0`, indistinguishable from "not configured", so the test
  read as though the component had ignored the value. Unconfigured still returns `default` — deliberate
  and documented — but configured-with-the-wrong-type throws and names both types.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full unit suite across the solution — green
- `Rask.Testing.Tests` — **71/71**, and that project deliberately sits **off** Core's `InternalsVisibleTo`
  list, so all of this is exercised through the public surface only. Kept that way.

No framework runtime code changed, so no benchmarks.

## Not included

Moving `RaskTestHost` into a package. It forces `Microsoft.AspNetCore.TestHost` and the ASP.NET Core web
SDK onto a package that has one dependency, so it needs a separate `Rask.Testing.Server` — a packaging
decision, not a testing-ergonomics one, and the issue says as much. `docs/testing.md` still documents the
split accurately.
