### PR TITLE
fix(core): stop hot reload announcing an edit that never reached the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -280,6 +280,17 @@ them until tagged releases begin.
     test read as though the component had ignored the value. Unconfigured still returns `default` (that is
     deliberate and documented); configured-with-the-wrong-type now throws and names both types.
 
+### Fixed
+- **Hot reload stops claiming success for an edit that never reached the page.** The green
+  "Hot reload applied" pill is driven by the coordinator's `Applied` signal, and the repaint is the whole
+  of what a developer can see — so announcing it after a failed repaint told them the opposite of the
+  truth, with the only evidence on the server's stderr. `RerenderAllForHotReloadAsync` catches per session
+  (one faulting tree must not stop the others repainting) but it was also *swallowing*: it reported
+  success upward whatever happened. It now reports the fault as a diagnostic naming the consequence
+  ("its page still shows the previous render"), returns whether every session repainted, and the
+  coordinator announces only when they did. A missing pill is the honest signal — nothing visibly changed,
+  because nothing did. Partially addresses #603.
+
 ## [0.20.0] - 2026-08-06
 
 ### Fixed

--- a/src/Rask.Core/HotReload/RaskHotReload.cs
+++ b/src/Rask.Core/HotReload/RaskHotReload.cs
@@ -96,17 +96,28 @@ internal static class RaskHotReload
         // on the hot-reload agent's thread and a render can await application code.
         _ = Task.Run(async () =>
         {
+            bool repainted;
             try
             {
-                await LiveSessionBase.RerenderAllForHotReloadAsync().ConfigureAwait(false);
+                repainted = await LiveSessionBase.RerenderAllForHotReloadAsync().ConfigureAwait(false);
             }
             catch (Exception ex)
             {
+                // Defence in depth: RerenderAllForHotReloadAsync catches per session and does not throw,
+                // so this is the "it started to" case rather than a session fault.
                 RaskDiagnostics.Report(
                     RaskLogLevel.Warning, "Rask.HotReload", "Rask: hot-reload rerender failed", ex);
+                repainted = false;
             }
 
-            RaiseApplied();
+            // Applied drives the browser's green "Hot reload applied" pill, and the repaint is the whole
+            // of what the developer can see. Announcing it for an edit that never reached the page told
+            // them the opposite of the truth, with the only evidence on the server's stderr (#603). A
+            // missing pill is the honest signal: nothing visibly changed, because nothing did.
+            if (repainted)
+            {
+                RaiseApplied();
+            }
         });
     }
 

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -2,6 +2,7 @@ using System.Buffers;
 using System.Reflection.Metadata;
 using Microsoft.Extensions.DependencyInjection;
 using Rask.Core.Authentication;
+using Rask.Core.Diagnostics;
 using Rask.Core.Routing;
 
 namespace Rask.Core.Live;
@@ -128,7 +129,18 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     ///         <c>dotnet watch</c>.
     ///     </para>
     /// </summary>
-    internal static async Task RerenderAllForHotReloadAsync()
+    /// <summary>
+    ///     Repaints every live session after a hot-reload edit. Returns <c>false</c> when at least one
+    ///     session failed to repaint.
+    /// </summary>
+    /// <remarks>
+    ///     Hot reload must never throw — a faulting session cannot be allowed to take down the reload for
+    ///     every other one — so a fault is caught per session. But swallowing it and reporting success up
+    ///     the stack is what made the coordinator announce "Hot reload applied" for an edit that never
+    ///     reached the page: the developer got the green pill while the browser still showed the previous
+    ///     render, with the only evidence on the server's stderr (#603). Caught, and reported.
+    /// </remarks>
+    internal static async Task<bool> RerenderAllForHotReloadAsync()
     {
         List<LiveSessionBase> alive = new();
         lock (_hotReloadLock)
@@ -146,6 +158,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
             }
         }
 
+        var allRepainted = true;
         foreach (var session in alive)
         {
             try
@@ -153,11 +166,21 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
                 Component.MarkSubtreeDirtyForHotReload(session.View);
                 await session.RequestRenderAsync().ConfigureAwait(false);
             }
-            catch
+            catch (Exception ex)
             {
-                // Hot reload must never throw; skip a session whose tree walk / render faults.
+                // Skip the session — one faulting tree must not stop the others repainting — but say so,
+                // and remember it, so the caller does not announce a success that did not happen.
+                allRepainted = false;
+                RaskDiagnostics.Report(
+                    RaskLogLevel.Error,
+                    "Rask.HotReload",
+                    "A live session failed to repaint after a hot-reload edit; its page still shows the "
+                    + "previous render. Reload it to pick the edit up.",
+                    ex);
             }
         }
+
+        return allRepainted;
     }
 
     public Component View { get; }

--- a/tests/Rask.Core.Tests/HotReload/HotReloadPhaseTests.cs
+++ b/tests/Rask.Core.Tests/HotReload/HotReloadPhaseTests.cs
@@ -116,6 +116,51 @@ public class HotReloadPhaseTests
         GC.KeepAlive(session);
     }
 
+    /// <summary>
+    ///     A session whose repaint faults must not be announced as applied.
+    /// </summary>
+    /// <remarks>
+    ///     <c>Applied</c> drives the browser's green "Hot reload applied" pill, and the repaint is the
+    ///     whole of what the developer can see — so announcing it for an edit that never reached the page
+    ///     told them the opposite of the truth, with the only evidence on the server's stderr (#603). The
+    ///     per-session catch is still there and still right (one faulting tree must not stop the others),
+    ///     but it now reports rather than swallows, and the coordinator withholds the announcement.
+    /// </remarks>
+    [Fact]
+    public async Task ASessionThatFailsToRepaint_IsNotAnnouncedAsApplied()
+    {
+        // The fault is switched off in the finally, and that is load-bearing rather than tidiness:
+        // RegisterForHotReload puts the session in a process-global weak list that prunes only on
+        // collection, so a session left throwing would fault every LATER test's repaint too — and those
+        // tests would then time out waiting for an announcement this fix correctly withholds.
+        var fail = true;
+        var session = new RecordingSession(
+            new Widget(), RenderHarness.EmptyServices(),
+            onRender: () => { if (fail) throw new InvalidOperationException("boom"); });
+        session.RegisterForHotReload();
+
+        var applied = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        void OnApplied() => applied.TrySetResult();
+
+        RaskHotReload.Applied += OnApplied;
+        try
+        {
+            RaskHotReload.RunPhases(_thisAssembly, null);
+
+            // Asserting an absence needs a wait; the alternative is asserting on a race.
+            var announced = await Task.WhenAny(applied.Task, Task.Delay(TimeSpan.FromSeconds(2)));
+            Assert.NotSame(applied.Task, announced);
+        }
+        finally
+        {
+            fail = false;
+            RaskHotReload.Applied -= OnApplied;
+        }
+
+        Assert.Equal(1, session.RenderRequests);
+        GC.KeepAlive(session);
+    }
+
     [Fact]
     public async Task AThrowingRefreshTarget_StillClosesTheStagingWindow()
     {


### PR DESCRIPTION
Partially addresses #603 — the "smaller, related" half of it. **#603 stays open**; see the bottom.

## What was wrong

The green **"Hot reload applied"** pill is driven by the coordinator's `Applied` signal, and the repaint
is the whole of what a developer can see. So announcing it after a *failed* repaint told them the opposite
of the truth: the pill said the edit had landed while the page in front of them still showed the previous
render, and the only evidence was one line on the server's stderr.

## The issue pointed at the wrong line, and that turned out to matter

> `RaskHotReload.RunPhases` catches a failed re-render, reports `"Rask: hot-reload rerender failed"` to
> stderr — and then still calls `RaiseApplied()`.

That catch is **unreachable**. `RerenderAllForHotReloadAsync` already catches per session and does not
throw, so `RunPhases` never sees a fault and the "rerender failed" line never prints. The real mechanism
was one level down, and it had **no report at all**.

Catching per session is right and stays — one faulting tree must not stop the others repainting. What was
wrong is that it also **swallowed**: it reported success upward whatever happened. Now it:

- reports the fault as a diagnostic naming the consequence — *"its page still shows the previous render.
  Reload it to pick the edit up."*
- returns whether **every** session repainted, and the coordinator announces only when they did.

`RunPhases` keeps its catch as defence in depth, and now says why it's there.

A missing pill is the honest signal: nothing visibly changed, because nothing did.

## A note on the test

It switches its faulting session off in a `finally`, and that's load-bearing rather than tidiness.
`RegisterForHotReload` puts the session in a **process-global weak list** that prunes only on collection —
so a session left throwing faults every *later* test's repaint, and those tests then time out waiting for
the announcement this fix correctly withholds. I found that by writing it the obvious way first and
watching an unrelated test go red.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full unit suite across the solution — green
- Benchmarks (`RenderRoundTrip`, from the worktree dir): **`Allocated` byte-identical** —
  80.67 / 150.98 / 73.66 / 71.53 / 35.31 KB, unchanged. Expected: the changed code is the dev-only
  hot-reload path, which the render hot path never enters.

## What #603 still wants, and why it isn't here

The build-error overlay. I stopped short of it deliberately, because the obvious design doesn't work:

**When the rebuild fails, the app process is down** — which is exactly *why* the browser reports a network
problem. So there is no server left to broadcast an out-of-band frame from. The existing `hotReload` and
`shutdown` frames are broadcast **by the app**, so they are not the primitive this needs; what it needs is
a channel that outlives the app — a side server `rask dev` owns, or a client that can tell "down because
building" from "down" some other way.

That's a design decision for the live protocol, which is a documented contract, and **#607's dev overlay
shares it** — so both should be settled together, once, rather than improvised at the end of a long
session. This PR takes the part that is contained, correct and testable today.
