### PR TITLE
feat(core): show a development fault over the running app instead of replacing it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -291,6 +291,28 @@ them until tagged releases begin.
   coordinator announces only when they did. A missing pill is the honest signal — nothing visibly changed,
   because nothing did. Partially addresses #603.
 
+### Added
+- **In development, a fault the tree survived is shown *over* the app instead of replacing it (#607).** The
+  full-document swap is right in production and wrong in development, where a handler that throws is the
+  common case rather than the exceptional one: it takes the scroll position, the form input, the expanded
+  panels and the route with it, at the moment you most want to look at the state that produced the bug.
+  The app now stays mounted and live behind a dismissible panel carrying the exception type, the message
+  and a collapsible stack — the shape React's and Next's dev overlays settled on, and for the same reason.
+  - **Only for a fault the tree survived.** A *render* fault still replaces the page, in development as in
+    production: re-rendering the subtree that just threw would only throw again. `ErrorBoundary` now
+    records whether it was tripped by a render, a handler or an async lifecycle hook, which is what makes
+    that distinction possible at all.
+  - **It rides inside the render payload**, not a new frame — the same reasoning as `resume`, `history`
+    and `auth`. The frame stream is a documented contract, and an extra frame is observable in ways an
+    extra field is not. Its bytes are discounted from the diff-vs-full comparison for the same reason the
+    resume record's are: it sits on both sides, so counting it only against the diff would ship the whole
+    body precisely when a minimal frame is most readable.
+  - **Both dedup gates now let it through.** A click whose only effect was the exception renders
+    byte-identical HTML, so without this the overlay would never arrive in the simplest case of all.
+  - Production is unchanged and cannot leak: `DevErrorInfo.From` returns `null` outside development, so no
+    stack trace can reach a browser even if a call site forgot to check, and the client requires the
+    `data-rask-dev` flag as a second, independent gate.
+
 ## [0.20.0] - 2026-08-06
 
 ### Fixed

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -796,7 +796,7 @@ public abstract class Component
         var boundary = comp.Boundary;
         if (boundary is not null)
         {
-            boundary.Trip(actual);
+            boundary.Trip(actual, ErrorSource.Lifecycle);
             return;
         }
 
@@ -1678,7 +1678,7 @@ public abstract class Component
             // higher. For non-boundary owners (regular components), fall back to their
             // ancestor boundary. Without a boundary the exception bubbles so the dispatcher's
             // catch-and-log still fires.
-            ResolveHandlerBoundary(owner)!.Trip(ex);
+            ResolveHandlerBoundary(owner)!.Trip(ex, ErrorSource.Handler);
             return true;
         }
     }

--- a/src/Rask.Core/Components/ErrorBoundary.cs
+++ b/src/Rask.Core/Components/ErrorBoundary.cs
@@ -1,10 +1,33 @@
 namespace Rask.Core.Components;
 
+/// <summary>Where the exception a boundary caught came from.</summary>
+/// <remarks>
+///     The distinction is load-bearing for the development error overlay: after a <see cref="Handler" />
+///     or <see cref="Lifecycle" /> fault the component tree is intact and the next render succeeds, so the
+///     app can stay on screen with the error painted over it. After a <see cref="Render" /> fault it is
+///     not — re-rendering the subtree that just threw would only throw again — so the fallback must
+///     replace the page, in development as in production.
+/// </remarks>
+internal enum ErrorSource
+{
+    /// <summary>Thrown while rendering. The tree cannot be re-rendered as it stands.</summary>
+    Render,
+
+    /// <summary>Thrown by an event handler. The tree is intact.</summary>
+    Handler,
+
+    /// <summary>Thrown by an async lifecycle hook, off the dispatch's call stack. The tree is intact.</summary>
+    Lifecycle,
+}
+
 public sealed class ErrorBoundary : Component
 {
     public Func<Exception, Callback, Component>? Fallback { get; set; }
 
     internal Exception? Error { get; private set; }
+
+    /// <summary>Where <see cref="Error" /> came from. Meaningless when <see cref="Error" /> is null.</summary>
+    internal ErrorSource Source { get; private set; }
 
     // Boundary state (Error) lives outside the framework's prop/state diff, so the cached
     // render result would never reflect a Trip(). BypassRenderCache forces Render() to run
@@ -21,11 +44,19 @@ public sealed class ErrorBoundary : Component
         Fallback = fallback;
     }
 
-    internal void Trip(Exception ex)
+    internal void Trip(Exception ex, ErrorSource source = ErrorSource.Render)
     {
         Error = ex;
+        Source = source;
         StateHasChanged();
     }
+
+    /// <summary>
+    ///     Clears the error <b>without</b> asking for a render — for a caller already inside the render
+    ///     that is about to display the app anyway (the development overlay). <see cref="Recover" /> is the
+    ///     one to use from a handler.
+    /// </summary>
+    internal void ClearErrorInRender() => Error = null;
 
     internal void SetParentBoundary(ErrorBoundary? parent)
     {

--- a/src/Rask.Core/Live/DevErrorInfo.cs
+++ b/src/Rask.Core/Live/DevErrorInfo.cs
@@ -1,0 +1,65 @@
+namespace Rask.Core.Live;
+
+/// <summary>
+///     A fault to show the developer <em>over</em> the running app, rather than instead of it.
+/// </summary>
+/// <param name="Kind">
+///     What produced it — <c>"handler"</c> or <c>"lifecycle"</c> for an app fault, <c>"build"</c> for a
+///     compile failure reported by <c>rask dev</c>. The client uses it for the overlay's heading, so the
+///     reader knows whether to look at their last click or their last save.
+/// </param>
+/// <param name="Title">The exception type name, or the build tool's summary line.</param>
+/// <param name="Message">The exception message, or the first compiler error.</param>
+/// <param name="Detail">The stack trace or the full error list. May be long; the overlay scrolls it.</param>
+/// <remarks>
+///     <para>
+///         <b>Development only.</b> It carries a stack trace, so it must never be built on a host that
+///         reports Production — the call sites gate on <see cref="LiveOptions.IsDevelopment" />, which
+///         since #605 reflects the host's real environment rather than only an environment variable.
+///     </para>
+///     <para>
+///         Deliberately four strings rather than the exception: the payload is JSON on a wire, the client
+///         renders text, and anything richer would be inventing a serialization format for exceptions that
+///         nothing needs.
+///     </para>
+/// </remarks>
+public sealed record DevErrorInfo(string Kind, string Title, string Message, string Detail)
+{
+    /// <summary>The overlay's cap on <see cref="Detail" />. A stack that long is already unreadable.</summary>
+    private const int MaxDetail = 8 * 1024;
+
+    /// <summary>
+    ///     Builds the record from a caught exception. Returns <c>null</c> outside development, so a caller
+    ///     cannot leak a stack trace by forgetting the gate.
+    /// </summary>
+    public static DevErrorInfo? From(Exception ex, string kind)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+
+        // The same decision the development error page makes, from the same resolver, so the two can
+        // never disagree about whether this host is in development (#605).
+        if (!Components.DefaultErrorPage.ResolveIsDevelopment(
+                LiveOptions.IsDevelopment,
+                Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT"),
+                Environment.GetEnvironmentVariable("DOTNET_ENVIRONMENT")))
+        {
+            return null;
+        }
+
+        // The innermost exception is the one the developer wrote; the outer ones are the framework's
+        // call stack getting it here. Show that one and let the detail carry the rest.
+        var innermost = ex;
+        while (innermost.InnerException is { } inner)
+        {
+            innermost = inner;
+        }
+
+        var detail = ex.ToString();
+        if (detail.Length > MaxDetail)
+        {
+            detail = detail[..MaxDetail] + "\n… (truncated)";
+        }
+
+        return new DevErrorInfo(kind, innermost.GetType().Name, innermost.Message, detail);
+    }
+}

--- a/src/Rask.Core/Live/IRenderHandle.cs
+++ b/src/Rask.Core/Live/IRenderHandle.cs
@@ -19,6 +19,23 @@ public interface IRenderHandle
 
     internal Task RenderInScopeAsync() => Task.CompletedTask;
 
+    /// <summary>
+    ///     Records a development fault to paint <em>over</em> the app, reported by
+    ///     <c>RootErrorBoundary</c> during the render walk that follows it.
+    /// </summary>
+    /// <remarks>
+    ///     It goes to the handle rather than staying on the <see cref="LiveRenderContext" /> because the
+    ///     context is disposed when the walk ends, and the frame is built afterwards — a session reading
+    ///     it from the context would find nothing. The session holds it until it writes the payload.
+    ///     <para>
+    ///         Defaulted to a no-op so the interface stays non-breaking, and so the non-session
+    ///         implementations (the unit-test render handle) simply don't have an overlay.
+    ///     </para>
+    /// </remarks>
+    internal void ReportDevError(DevErrorInfo error)
+    {
+    }
+
     // Host-awareness axes surfaced to components during render (via LiveRenderContext → Component.HostShell/…).
     // Defaulted here so the interface stays non-breaking; concrete sessions override with their own facts.
     internal RenderShell Shell => RenderShell.Web;

--- a/src/Rask.Core/Live/LivePayload.cs
+++ b/src/Rask.Core/Live/LivePayload.cs
@@ -169,10 +169,11 @@ public static class LivePayload
         AuthInstruction? auth = null,
         PendingDownload? download = null,
         IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
     {
         using var writer = new Utf8JsonWriter(output, DiffWriterOptions);
-        WriteJson(writer, html, historyUrl, replace, auth, download, jsInvokes, resume);
+        WriteJson(writer, html, historyUrl, replace, auth, download, jsInvokes, resume, devError);
     }
 
     /// <summary>
@@ -256,9 +257,10 @@ public static class LivePayload
         AuthInstruction? auth = null,
         PendingDownload? download = null,
         IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
         => BuildPayloadUtf8Spliced(output, html, sessionId, false,
-            historyUrl, replace, auth, download, jsInvokes, resume);
+            historyUrl, replace, auth, download, jsInvokes, resume, devError);
 
     /// <summary>
     ///     Diff-mode payload: writes <c>{ "kind": "diff", "ops": [...] }</c> directly
@@ -308,7 +310,8 @@ public static class LivePayload
         IReadOnlyList<PendingJsInvoke>? jsInvokes = null,
         string? headHtml = null,
         ReadOnlySpan<char> newHtml = default,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
     {
         // Pass 1: build the attribute-name symbol table. Intern when the name appears
         // 3+ times — break-even with the table overhead lands around there for typical
@@ -523,7 +526,8 @@ public static class LivePayload
         AuthInstruction? auth,
         PendingDownload? download,
         IReadOnlyList<PendingJsInvoke>? jsInvokes,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
     {
         // Find <body> bounds on the UTF-16 source. The prior implementation
         // rented + encoded the entire html to UTF-8 first, scanned the byte span,
@@ -601,7 +605,8 @@ public static class LivePayload
             // not embedded into HTML, so the default HTML-safe escaping inflates the "html"
             // field's `<` / `>` 5× for no security benefit. Shaves ~3-5 KB off a 10 KB page.
             using var writer = new Utf8JsonWriter(output, DiffWriterOptions);
-            WriteJsonUtf8Body(writer, span[..cursor], historyUrl, replace, auth, download, jsInvokes, resume);
+            WriteJsonUtf8Body(writer, span[..cursor], historyUrl, replace, auth, download, jsInvokes, resume,
+                devError);
         }
         finally
         {
@@ -645,11 +650,12 @@ public static class LivePayload
         AuthInstruction? auth,
         PendingDownload? download,
         IReadOnlyList<PendingJsInvoke>? jsInvokes,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
     {
         writer.WriteStartObject();
         writer.WriteString("html", html);
-        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes, resume);
+        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes, resume, devError);
     }
 
     /// <summary>
@@ -670,6 +676,33 @@ public static class LivePayload
         }
     }
 
+    /// <summary>
+    ///     Writes the development error overlay record when a handler or async lifecycle hook threw.
+    /// </summary>
+    /// <remarks>
+    ///     Rides inside the render payload for the same reason <see cref="WriteResume" /> does — the frame
+    ///     stream is a contract, and an extra frame is observable in ways an extra field is not. It is also
+    ///     exact here: the overlay only ever appears alongside the render that follows the fault.
+    ///     <para>
+    ///         Never written outside development: <see cref="DevErrorInfo.From" /> returns <c>null</c> there,
+    ///         so a production payload cannot carry a stack trace even if a call site forgot to check.
+    ///     </para>
+    /// </remarks>
+    private static void WriteDevError(Utf8JsonWriter writer, DevErrorInfo? devError)
+    {
+        if (devError is null)
+        {
+            return;
+        }
+
+        writer.WriteStartObject("devError");
+        writer.WriteString("kind", devError.Kind);
+        writer.WriteString("title", devError.Title);
+        writer.WriteString("message", devError.Message);
+        writer.WriteString("detail", devError.Detail);
+        writer.WriteEndObject();
+    }
+
     private static void WriteJsonUtf8Body(
         Utf8JsonWriter writer,
         ReadOnlySpan<byte> htmlUtf8,
@@ -678,11 +711,12 @@ public static class LivePayload
         AuthInstruction? auth,
         PendingDownload? download,
         IReadOnlyList<PendingJsInvoke>? jsInvokes,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
     {
         writer.WriteStartObject();
         writer.WriteString("html", htmlUtf8);
-        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes, resume);
+        WriteJsonTail(writer, historyUrl, replace, auth, download, jsInvokes, resume, devError);
     }
 
     private static void WriteJsonTail(
@@ -692,9 +726,11 @@ public static class LivePayload
         AuthInstruction? auth,
         PendingDownload? download,
         IReadOnlyList<PendingJsInvoke>? jsInvokes,
-        string? resume = null)
+        string? resume = null,
+        DevErrorInfo? devError = null)
     {
         WriteResume(writer, resume);
+        WriteDevError(writer, devError);
         WriteJsInvokesArray(writer, jsInvokes);
 
         if (historyUrl is not null)

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -126,6 +126,19 @@ public sealed class LiveRenderContext : IDisposable
     internal int HeadSentinelIndex { get; set; } = -1;
 
     /// <summary>
+    ///     Hands a development-only error to the session, to paint <em>over</em> the app. Called during
+    ///     the render walk by <see cref="RootErrorBoundary" /> when a handler or async lifecycle hook threw.
+    /// </summary>
+    /// <remarks>
+    ///     It goes to the handle rather than being held here because this context is disposed when the
+    ///     walk ends and the frame is built afterwards. The session then rides it inside the render
+    ///     payload rather than sending its own control frame — the same reasoning as <c>resume</c>,
+    ///     <c>history</c> and <c>auth</c>: the frame stream is a contract, and an extra frame is
+    ///     observable in ways an extra field is not.
+    /// </remarks>
+    internal void ReportDevError(DevErrorInfo error) => _handle?.ReportDevError(error);
+
+    /// <summary>
     ///     Every user-component type observed during this render walk. Populated
     ///     unconditionally by <see cref="PushScope" /> on each component entry — covers
     ///     components with scoped CSS, scoped JS, both, and neither. Read by

--- a/src/Rask.Core/Live/LiveSessionBase.cs
+++ b/src/Rask.Core/Live/LiveSessionBase.cs
@@ -295,6 +295,37 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
     /// <summary>Bytes the <c>"resume":"…"</c> field name, quotes and separator add around the record itself.</summary>
     private const int ResumeFieldOverhead = 12;
 
+    /// <summary>Bytes the <c>devError</c> object's own field names, braces, quotes and separators add.</summary>
+    private const int DevErrorFieldOverhead = 64;
+
+    private DevErrorInfo? _pendingDevError;
+
+    /// <inheritdoc cref="IRenderHandle.ReportDevError" />
+    void IRenderHandle.ReportDevError(DevErrorInfo error) => _pendingDevError = error;
+
+    /// <summary>
+    ///     True when the walk just finished recorded a development fault. Read by the host's HTML-level
+    ///     dedup, which would otherwise drop the whole frame: a handler that threw and changed nothing
+    ///     renders byte-identical HTML, so the overlay would never reach the browser precisely in the
+    ///     simplest case — a click whose only effect was the exception.
+    /// </summary>
+    protected bool HasPendingDevError => _pendingDevError is not null;
+
+    /// <summary>
+    ///     Takes the development error the render walk recorded, if any, clearing it so the overlay is
+    ///     shown once rather than on every subsequent frame.
+    /// </summary>
+    private DevErrorInfo? TakeDevError()
+    {
+        var error = _pendingDevError;
+        _pendingDevError = null;
+        return error;
+    }
+
+    private static int DevErrorCost(DevErrorInfo error) =>
+        error.Kind.Length + error.Title.Length + error.Message.Length + error.Detail.Length
+        + DevErrorFieldOverhead;
+
     /// <summary>
     ///     Decide diff-vs-full for the just-rendered <paramref name="html" /> and write the frame
     ///     into <see cref="_writeBuffer" />. Identical on both hosts; the seams are parameters:
@@ -314,6 +345,11 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
         // record and a frame that ends up discarded on size doesn't consume it twice. Null on every host
         // but the ASP.NET one, which is the only place a session can outlive the process holding it.
         var resume = TakeResumeToken();
+
+        // A development error to paint over the app, recorded by RootErrorBoundary during the walk that
+        // produced `html`. Taken once, for the same reason the resume record is: both paths must carry
+        // the same one, and a frame discarded on size must not consume it.
+        var devError = TakeDevError();
 
         // Out-of-band side effects (auth, download) and structural ops route to the full-HTML morph
         // path; in-place state changes ship a diff. Head changes (per-route <title>, a scoped-asset
@@ -337,7 +373,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
             {
                 var headHtml = headChanged ? LiveDiffGate.ExtractHead(html.Span) : null;
                 LivePayload.BuildPayloadUtf8Diff(_writeBuffer, _diffOps, historyUrl, replace, jsInvokes,
-                    headHtml, html.Span, resume);
+                    headHtml, html.Span, resume, devError);
 
                 // Ship the diff whenever it isn't larger than re-sending the body, or unconditionally
                 // under Forced. Only the pathological case (nearly every node changed on a tiny page,
@@ -348,8 +384,15 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
                 // letting it count only against the diff would flip small pages to full HTML purely
                 // because a record happened to be due — a page whose diff is a few hundred bytes would
                 // start shipping its whole body every time the declared state moved.
+                // The dev-error record is discounted for exactly the reason the resume record is: the
+                // full-HTML payload carries the identical record, so it sits on both sides of this
+                // comparison. Letting it count only against the diff would flip a page to full HTML
+                // purely because a handler threw — shipping the whole body at the moment the developer
+                // most wants a minimal, legible frame.
                 var resumeCost = resume is null ? 0 : resume.Length + ResumeFieldOverhead;
-                if (DiffMode == LiveDiffMode.Forced || _writeBuffer.WrittenCount - resumeCost < html.Length)
+                var devErrorCost = devError is null ? 0 : DevErrorCost(devError);
+                if (DiffMode == LiveDiffMode.Forced
+                    || _writeBuffer.WrittenCount - resumeCost - devErrorCost < html.Length)
                 {
                     usedDiff = true;
                 }
@@ -365,7 +408,7 @@ internal abstract class LiveSessionBase : IRenderHandle, ILiveJsHost
             // Full-HTML path (first render, structural change, out-of-band side effect, size fallback):
             // this ships the whole body anyway, so materialising it as a string here is not wasted.
             LivePayload.BuildPayloadUtf8WithRoot(_writeBuffer, new string(html.Span), sessionId, historyUrl,
-                replace, auth, download, jsInvokes, resume);
+                replace, auth, download, jsInvokes, resume, devError);
             // Keep the cache in lockstep with the client even when shipping full HTML: promote
             // current → previous so the NEXT diff's baseline matches what the client received. Skip
             // when TryComputeDiff already rotated (diffPathEntered), or when the caller defers the

--- a/src/Rask.Core/Live/RootErrorBoundary.cs
+++ b/src/Rask.Core/Live/RootErrorBoundary.cs
@@ -67,9 +67,39 @@ internal sealed class RootErrorBoundary : Component
         // because the common fault is a handler that threw rather than a render that cannot succeed, so
         // the tree is intact and recovering keeps the session, the state and the scroll position that a
         // reload throws away.
+        // The boundary is resolved explicitly rather than through the generated factory because the
+        // fallback needs to ask it HOW it was tripped (see below), and the factory's delegate only
+        // receives the exception and Recover. Same positional identity either way: GetOrCreate keys on
+        // (type, position) and this is the second and last GetOrCreate in this method, every render.
+        var boundary = (ErrorBoundary)ctx.GetOrCreate(typeof(ErrorBoundary), static _ => new ErrorBoundary());
+
         RenderedFallback = false;
-        return F.ErrorBoundary((ex, recover) =>
+        boundary.SetProps([inner], (ex, recover) =>
         {
+            // In development, a fault the tree survived is shown OVER the app instead of replacing it.
+            //
+            // The full-document swap is right in production and wrong in development, where a handler
+            // that throws is the common case rather than the exceptional one: it takes the scroll
+            // position, the form input, the expanded panels and the route with it, so the developer
+            // loses the state that produced the bug at the moment they most want to look at it. React's
+            // and Next's dev overlays leave the app mounted for exactly this reason.
+            //
+            // Only for a fault the tree SURVIVED. After a render fault, re-rendering the subtree that
+            // just threw would only throw again — so a render fault still replaces the page, in
+            // development as in production, which is the honest outcome.
+            if (boundary is { Source: not ErrorSource.Render }
+                && DevErrorInfo.From(ex, boundary.Source == ErrorSource.Handler ? "handler" : "lifecycle")
+                    is { } devError)
+            {
+                ctx.ReportDevError(devError);
+
+                // Clear without asking for a render: this render is already in flight and is about to
+                // show the app. Recover() would signal one, and the signal would land while the walk
+                // that set it is still running.
+                boundary.ClearErrorInRender();
+                return inner;
+            }
+
             RenderedFallback = true;
             return F.Fragment()[
                 F.Doctype(),
@@ -82,6 +112,8 @@ internal sealed class RootErrorBoundary : Component
                     F.Body()[new DefaultErrorPage(ex, recover)]
                 ]
             ];
-        })[inner];
+        });
+
+        return boundary;
     }
 }

--- a/src/Rask.Core/Resources/rask-deverror.js
+++ b/src/Rask.Core/Resources/rask-deverror.js
@@ -1,0 +1,170 @@
+// Development error overlay — the panel that says what broke, *over* the running app.
+//
+// Spliced (at "// @@RASK_DEVERROR@@") into the Server runtime (rask.js) and the WASM runtime
+// (rask.wasm.js), so both hosts show the same thing. Written in the Server dialect (var/function, no
+// arrows, no template literals) because that file is ES5; the WASM module is a superset, so one source
+// serves both.
+//
+// WHY A SECOND OVERLAY RATHER THAN THE RECONNECT ONE. They mean opposite things. The reconnect overlay
+// blocks: it makes the document inert because nothing you click can reach a server that isn't there.
+// This one must NOT block — the whole point is that the app is still running and still yours to poke at,
+// which is what makes it useful for finding the bug. So it is a corner panel with pointer events only on
+// itself, and the app behind it stays live (#607).
+//
+// Never shown outside development. The server only ever puts `devError` on a payload in development
+// (DevErrorInfo.From returns null otherwise), and the client checks the document flag as well — two
+// independent gates, because this renders a stack trace.
+
+var devErrorPanel = null;
+var devErrorCount = 0;
+
+// The dev gate, read from the document rather than from a host-local variable, so this one source works
+// in all three runtimes. The Server stamps `data-rask-dev` onto <body> per request (LivePayload
+// .InjectRootAttr); the WASM and Native runtimes set it at boot from their host's own answer, because
+// they render client-side and no server ever touches their <body>.
+function devErrorEnabled() {
+    var b = document.body;
+    return !!(b && b.hasAttribute("data-rask-dev"));
+}
+
+function installDevErrorStyles() {
+    var style = document.createElement("style");
+    style.setAttribute("data-rask-managed", "");
+    style.setAttribute("data-rask-dev-error-style", "");
+    style.textContent =
+        ".rask-deverr{position:fixed;left:12px;right:12px;bottom:12px;max-width:760px;margin:0 auto;" +
+        "z-index:2147483646;font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;" +
+        "background:#1b1114;color:#ffe9ec;border:1px solid #7f1d2b;border-radius:10px;" +
+        "box-shadow:0 12px 40px rgba(0,0,0,.45);overflow:hidden;}" +
+        ".rask-deverr[hidden]{display:none;}" +
+        ".rask-deverr__bar{display:flex;align-items:center;gap:10px;padding:10px 12px;" +
+        "background:#7f1d2b;color:#fff;}" +
+        ".rask-deverr__kind{font-weight:600;letter-spacing:.02em;}" +
+        ".rask-deverr__count{background:rgba(255,255,255,.22);border-radius:999px;padding:1px 8px;" +
+        "font-size:11px;}" +
+        ".rask-deverr__spacer{flex:1;}" +
+        ".rask-deverr__btn{border:1px solid rgba(255,255,255,.45);background:rgba(255,255,255,.12);" +
+        "color:#fff;border-radius:6px;padding:3px 10px;font:inherit;font-size:12px;cursor:pointer;}" +
+        ".rask-deverr__btn:hover{background:rgba(255,255,255,.24);}" +
+        ".rask-deverr__body{padding:12px;}" +
+        ".rask-deverr__title{font-weight:600;margin:0 0 4px;}" +
+        ".rask-deverr__msg{margin:0 0 10px;white-space:pre-wrap;word-break:break-word;}" +
+        ".rask-deverr__detail{margin:0;max-height:38vh;overflow:auto;white-space:pre-wrap;" +
+        "word-break:break-word;font-size:12px;color:#f0b8c0;background:#140c0e;border-radius:6px;" +
+        "padding:10px;}" +
+        ".rask-deverr__detail[hidden]{display:none;}";
+    document.head.appendChild(style);
+}
+
+function installDevErrorPanel() {
+    installDevErrorStyles();
+
+    var el = document.createElement("div");
+    el.className = "rask-deverr";
+    // data-rask-managed keeps the morph from trimming a node the server never rendered — the same
+    // contract the reconnect overlay relies on.
+    el.setAttribute("data-rask-managed", "");
+    el.setAttribute("data-rask-dev-error", "");
+    el.setAttribute("role", "alert");
+    el.hidden = true;
+
+    var bar = document.createElement("div");
+    bar.className = "rask-deverr__bar";
+
+    var kind = document.createElement("span");
+    kind.className = "rask-deverr__kind";
+
+    var count = document.createElement("span");
+    count.className = "rask-deverr__count";
+    count.hidden = true;
+
+    var spacer = document.createElement("span");
+    spacer.className = "rask-deverr__spacer";
+
+    var toggle = document.createElement("button");
+    toggle.className = "rask-deverr__btn";
+    toggle.type = "button";
+    toggle.textContent = "Stack";
+
+    var dismiss = document.createElement("button");
+    dismiss.className = "rask-deverr__btn";
+    dismiss.type = "button";
+    dismiss.textContent = "Dismiss";
+
+    var body = document.createElement("div");
+    body.className = "rask-deverr__body";
+
+    var title = document.createElement("p");
+    title.className = "rask-deverr__title";
+
+    var msg = document.createElement("p");
+    msg.className = "rask-deverr__msg";
+
+    var detail = document.createElement("pre");
+    detail.className = "rask-deverr__detail";
+    detail.hidden = true;
+
+    toggle.addEventListener("click", function () {
+        detail.hidden = !detail.hidden;
+        toggle.textContent = detail.hidden ? "Stack" : "Hide stack";
+    });
+    dismiss.addEventListener("click", function () { hideDevError(); });
+
+    bar.appendChild(kind);
+    bar.appendChild(count);
+    bar.appendChild(spacer);
+    bar.appendChild(toggle);
+    bar.appendChild(dismiss);
+    body.appendChild(title);
+    body.appendChild(msg);
+    body.appendChild(detail);
+    el.appendChild(bar);
+    el.appendChild(body);
+    document.documentElement.appendChild(el);
+    return el;
+}
+
+function devErrorHeading(kind) {
+    if (kind === "handler") return "Unhandled exception in an event handler";
+    if (kind === "lifecycle") return "Unhandled exception in an async lifecycle hook";
+    if (kind === "build") return "Build failed";
+    return "Unhandled exception";
+}
+
+// Shows (or updates) the panel. `info` is the payload's devError object: {kind,title,message,detail}.
+function showDevError(info) {
+    if (!devErrorEnabled() || !info || typeof info !== "object") return;
+    if (!devErrorPanel) devErrorPanel = installDevErrorPanel();
+
+    devErrorCount++;
+    var countEl = devErrorPanel.querySelector(".rask-deverr__count");
+    countEl.textContent = String(devErrorCount);
+    countEl.hidden = devErrorCount < 2;
+
+    devErrorPanel.querySelector(".rask-deverr__kind").textContent = devErrorHeading(info.kind);
+    devErrorPanel.querySelector(".rask-deverr__title").textContent = info.title || "";
+    devErrorPanel.querySelector(".rask-deverr__msg").textContent = info.message || "";
+
+    var detail = devErrorPanel.querySelector(".rask-deverr__detail");
+    detail.textContent = info.detail || "";
+    // Collapsed on arrival: the message is what you read first, and a stack that opened itself would
+    // cover the app this panel exists to keep visible.
+    detail.hidden = true;
+    devErrorPanel.querySelector(".rask-deverr__btn").textContent = "Stack";
+
+    devErrorPanel.hidden = false;
+
+    // Also to the console, where a developer's own breakpoints and filters already live — and where it
+    // survives dismissing the panel.
+    if (typeof console !== "undefined" && console.error) {
+        console.error("[Rask] " + devErrorHeading(info.kind) + ": " + (info.title || "") +
+            (info.message ? ": " + info.message : ""), info.detail || "");
+    }
+}
+
+function hideDevError() {
+    if (!devErrorPanel) return;
+    devErrorPanel.hidden = true;
+    devErrorCount = 0;
+    devErrorPanel.querySelector(".rask-deverr__count").hidden = true;
+}

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -1417,6 +1417,179 @@ window.__raskWakeLock = window.__raskWakeLock || (() => {
 })();
 
 
+// The development error panel (showDevError / hideDevError), shared with the Server runtime.
+// Development error overlay — the panel that says what broke, *over* the running app.
+//
+// Spliced (at "// @@RASK_DEVERROR@@") into the Server runtime (rask.js) and the WASM runtime
+// (rask.wasm.js), so both hosts show the same thing. Written in the Server dialect (var/function, no
+// arrows, no template literals) because that file is ES5; the WASM module is a superset, so one source
+// serves both.
+//
+// WHY A SECOND OVERLAY RATHER THAN THE RECONNECT ONE. They mean opposite things. The reconnect overlay
+// blocks: it makes the document inert because nothing you click can reach a server that isn't there.
+// This one must NOT block — the whole point is that the app is still running and still yours to poke at,
+// which is what makes it useful for finding the bug. So it is a corner panel with pointer events only on
+// itself, and the app behind it stays live (#607).
+//
+// Never shown outside development. The server only ever puts `devError` on a payload in development
+// (DevErrorInfo.From returns null otherwise), and the client checks the document flag as well — two
+// independent gates, because this renders a stack trace.
+
+var devErrorPanel = null;
+var devErrorCount = 0;
+
+// The dev gate, read from the document rather than from a host-local variable, so this one source works
+// in all three runtimes. The Server stamps `data-rask-dev` onto <body> per request (LivePayload
+// .InjectRootAttr); the WASM and Native runtimes set it at boot from their host's own answer, because
+// they render client-side and no server ever touches their <body>.
+function devErrorEnabled() {
+    var b = document.body;
+    return !!(b && b.hasAttribute("data-rask-dev"));
+}
+
+function installDevErrorStyles() {
+    var style = document.createElement("style");
+    style.setAttribute("data-rask-managed", "");
+    style.setAttribute("data-rask-dev-error-style", "");
+    style.textContent =
+        ".rask-deverr{position:fixed;left:12px;right:12px;bottom:12px;max-width:760px;margin:0 auto;" +
+        "z-index:2147483646;font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;" +
+        "background:#1b1114;color:#ffe9ec;border:1px solid #7f1d2b;border-radius:10px;" +
+        "box-shadow:0 12px 40px rgba(0,0,0,.45);overflow:hidden;}" +
+        ".rask-deverr[hidden]{display:none;}" +
+        ".rask-deverr__bar{display:flex;align-items:center;gap:10px;padding:10px 12px;" +
+        "background:#7f1d2b;color:#fff;}" +
+        ".rask-deverr__kind{font-weight:600;letter-spacing:.02em;}" +
+        ".rask-deverr__count{background:rgba(255,255,255,.22);border-radius:999px;padding:1px 8px;" +
+        "font-size:11px;}" +
+        ".rask-deverr__spacer{flex:1;}" +
+        ".rask-deverr__btn{border:1px solid rgba(255,255,255,.45);background:rgba(255,255,255,.12);" +
+        "color:#fff;border-radius:6px;padding:3px 10px;font:inherit;font-size:12px;cursor:pointer;}" +
+        ".rask-deverr__btn:hover{background:rgba(255,255,255,.24);}" +
+        ".rask-deverr__body{padding:12px;}" +
+        ".rask-deverr__title{font-weight:600;margin:0 0 4px;}" +
+        ".rask-deverr__msg{margin:0 0 10px;white-space:pre-wrap;word-break:break-word;}" +
+        ".rask-deverr__detail{margin:0;max-height:38vh;overflow:auto;white-space:pre-wrap;" +
+        "word-break:break-word;font-size:12px;color:#f0b8c0;background:#140c0e;border-radius:6px;" +
+        "padding:10px;}" +
+        ".rask-deverr__detail[hidden]{display:none;}";
+    document.head.appendChild(style);
+}
+
+function installDevErrorPanel() {
+    installDevErrorStyles();
+
+    var el = document.createElement("div");
+    el.className = "rask-deverr";
+    // data-rask-managed keeps the morph from trimming a node the server never rendered — the same
+    // contract the reconnect overlay relies on.
+    el.setAttribute("data-rask-managed", "");
+    el.setAttribute("data-rask-dev-error", "");
+    el.setAttribute("role", "alert");
+    el.hidden = true;
+
+    var bar = document.createElement("div");
+    bar.className = "rask-deverr__bar";
+
+    var kind = document.createElement("span");
+    kind.className = "rask-deverr__kind";
+
+    var count = document.createElement("span");
+    count.className = "rask-deverr__count";
+    count.hidden = true;
+
+    var spacer = document.createElement("span");
+    spacer.className = "rask-deverr__spacer";
+
+    var toggle = document.createElement("button");
+    toggle.className = "rask-deverr__btn";
+    toggle.type = "button";
+    toggle.textContent = "Stack";
+
+    var dismiss = document.createElement("button");
+    dismiss.className = "rask-deverr__btn";
+    dismiss.type = "button";
+    dismiss.textContent = "Dismiss";
+
+    var body = document.createElement("div");
+    body.className = "rask-deverr__body";
+
+    var title = document.createElement("p");
+    title.className = "rask-deverr__title";
+
+    var msg = document.createElement("p");
+    msg.className = "rask-deverr__msg";
+
+    var detail = document.createElement("pre");
+    detail.className = "rask-deverr__detail";
+    detail.hidden = true;
+
+    toggle.addEventListener("click", function () {
+        detail.hidden = !detail.hidden;
+        toggle.textContent = detail.hidden ? "Stack" : "Hide stack";
+    });
+    dismiss.addEventListener("click", function () { hideDevError(); });
+
+    bar.appendChild(kind);
+    bar.appendChild(count);
+    bar.appendChild(spacer);
+    bar.appendChild(toggle);
+    bar.appendChild(dismiss);
+    body.appendChild(title);
+    body.appendChild(msg);
+    body.appendChild(detail);
+    el.appendChild(bar);
+    el.appendChild(body);
+    document.documentElement.appendChild(el);
+    return el;
+}
+
+function devErrorHeading(kind) {
+    if (kind === "handler") return "Unhandled exception in an event handler";
+    if (kind === "lifecycle") return "Unhandled exception in an async lifecycle hook";
+    if (kind === "build") return "Build failed";
+    return "Unhandled exception";
+}
+
+// Shows (or updates) the panel. `info` is the payload's devError object: {kind,title,message,detail}.
+function showDevError(info) {
+    if (!devErrorEnabled() || !info || typeof info !== "object") return;
+    if (!devErrorPanel) devErrorPanel = installDevErrorPanel();
+
+    devErrorCount++;
+    var countEl = devErrorPanel.querySelector(".rask-deverr__count");
+    countEl.textContent = String(devErrorCount);
+    countEl.hidden = devErrorCount < 2;
+
+    devErrorPanel.querySelector(".rask-deverr__kind").textContent = devErrorHeading(info.kind);
+    devErrorPanel.querySelector(".rask-deverr__title").textContent = info.title || "";
+    devErrorPanel.querySelector(".rask-deverr__msg").textContent = info.message || "";
+
+    var detail = devErrorPanel.querySelector(".rask-deverr__detail");
+    detail.textContent = info.detail || "";
+    // Collapsed on arrival: the message is what you read first, and a stack that opened itself would
+    // cover the app this panel exists to keep visible.
+    detail.hidden = true;
+    devErrorPanel.querySelector(".rask-deverr__btn").textContent = "Stack";
+
+    devErrorPanel.hidden = false;
+
+    // Also to the console, where a developer's own breakpoints and filters already live — and where it
+    // survives dismissing the panel.
+    if (typeof console !== "undefined" && console.error) {
+        console.error("[Rask] " + devErrorHeading(info.kind) + ": " + (info.title || "") +
+            (info.message ? ": " + info.message : ""), info.detail || "");
+    }
+}
+
+function hideDevError() {
+    if (!devErrorPanel) return;
+    devErrorPanel.hidden = true;
+    devErrorCount = 0;
+    devErrorPanel.querySelector(".rask-deverr__count").hidden = true;
+}
+
+
 // ----- The diff codec: applyDiff(ops, names) + applyFrameInvokes(reply, dispatchOne) — rask-dom.js -----
 // Shared diff-codec interpreter consumed by both rask.js (Server) and
 // rask.wasm.js (WASM). Concatenated into each runtime at build time — see the

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -171,7 +171,8 @@
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
       <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
-      <_RaskNativeJs>$(_RaskNativeTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)'))</_RaskNativeJs>
+      <_RaskDevErrorBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-deverror.js'))</_RaskDevErrorBody>
+      <_RaskNativeJs>$(_RaskNativeTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)'))</_RaskNativeJs>
     </PropertyGroup>
     <MakeDir Directories="Assets"/>
     <WriteLinesToFile File="Assets\rask.native.js" Lines="$(_RaskNativeJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>

--- a/src/Rask.Native/Resources/rask.native.js
+++ b/src/Rask.Native/Resources/rask.native.js
@@ -35,6 +35,9 @@ let root = null;
 // build, where hot reload is unsupported and nothing ever calls it — see #565.
 // @@RASK_HOTRELOAD@@
 
+// The development error panel (showDevError / hideDevError), shared with the Server runtime.
+// @@RASK_DEVERROR@@
+
 // ----- The diff codec: applyDiff(ops, names) + applyFrameInvokes(reply, dispatchOne) — rask-dom.js -----
 // @@RASK_DOM@@
 

--- a/src/Rask.Server/LiveSession.cs
+++ b/src/Rask.Server/LiveSession.cs
@@ -636,14 +636,21 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             // baseline) and there's nothing out-of-band to flow, the payload would be byte-identical
             // to the last send — skip before building. Preserves JS-applied DOM state (hljs's `.hljs`
             // class) across noop publish-renders, and lets a fresh socket dedup against the GET HTML.
+            // HasPendingDevError defeats this deliberately: a handler that threw and changed nothing
+            // renders byte-identical HTML, so without it the overlay would never reach the browser in
+            // exactly the simplest case — a click whose only effect was the exception.
             if (jsInvokes is null
                 && historyUrl is null && auth is null && download is null
+                && !HasPendingDevError
                 && _htmlBuffers.CurrentEqualsPrevious())
             {
                 return;
             }
 
             var renderStarted = Stopwatch.GetTimestamp();
+
+            // Read before WritePayload consumes it — the byte-level dedup below needs to know too.
+            var devErrorPending = HasPendingDevError;
 
             WritePayload(html, frameWriter, download, jsInvokes, historyUrl, replace,
                 commitCache: true, auth, Id);
@@ -656,7 +663,8 @@ internal sealed class LiveSession : LiveSessionBase, IDisposable, IAsyncDisposab
             // reset one. Measuring it there silently records zero for every frame.
             var payloadBytes = _writeBuffer.WrittenCount;
 
-            var force = historyUrl is not null || auth is not null || download is not null;
+            var force = historyUrl is not null || auth is not null || download is not null
+                        || devErrorPending;
             bool sent;
             try
             {

--- a/src/Rask.Server/Rask.Server.csproj
+++ b/src/Rask.Server/Rask.Server.csproj
@@ -69,7 +69,8 @@
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
       <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
-      <_RaskClientJs>$(_RaskClientTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)'))</_RaskClientJs>
+      <_RaskDevErrorBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-deverror.js'))</_RaskDevErrorBody>
+      <_RaskClientJs>$(_RaskClientTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)'))</_RaskClientJs>
     </PropertyGroup>
     <MakeDir Directories="$(IntermediateOutputPath)"/>
     <WriteLinesToFile File="$(IntermediateOutputPath)rask.js" Lines="$(_RaskClientJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>

--- a/src/Rask.Server/Resources/rask.js
+++ b/src/Rask.Server/Resources/rask.js
@@ -319,6 +319,13 @@
             // pure bookkeeping, changes nothing on screen, and must not wait on the render queue —
             // a drop between now and the paint should still leave us holding the newer record.
             if (typeof data.resume === "string") rememberResumeToken(data.resume);
+            // A development fault the app survived. Like `resume` it rides the render payload rather
+            // than arriving as its own frame, and like it, it is applied here rather than inside either
+            // render path: the panel is a sibling of the app, so it must not wait on the render queue —
+            // and showing it before the repaint is right, since the repaint is what puts the app back on
+            // screen underneath it. Dev-gated twice: the server only sends it in development, and
+            // devMode is read off the document (#607).
+            if (data.devError) showDevError(data.devError);
             // Diff-mode payload (kind:"diff"): apply ops directly against the live DOM.
             // Both render paths chain through _renderQueue so a diff that defers its body
             // for a scoped-CSS load (see applyDiffReply) can't be overtaken by the next
@@ -754,6 +761,10 @@
     // window.__raskHotReloadPill; only the way the notification *arrives* differs per transport (here,
     // the hotReload frame branch above).
     // @@RASK_HOTRELOAD@@
+
+    // The development error panel (showDevError / hideDevError). Shared with the WASM runtime so both
+    // hosts render the same thing from one source.
+    // @@RASK_DEVERROR@@
 
     // Toggle the overlay's manual action button. Pass a label to show it, or null to hide it. A single
     // click handler routes to retryNow(), which reloads when the session has expired and otherwise

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -2112,6 +2112,179 @@ window.__raskBluetooth = window.__raskBluetooth || (() => {
 })();
 
 
+// The development error panel (showDevError / hideDevError), shared with the Server runtime.
+// Development error overlay — the panel that says what broke, *over* the running app.
+//
+// Spliced (at "// @@RASK_DEVERROR@@") into the Server runtime (rask.js) and the WASM runtime
+// (rask.wasm.js), so both hosts show the same thing. Written in the Server dialect (var/function, no
+// arrows, no template literals) because that file is ES5; the WASM module is a superset, so one source
+// serves both.
+//
+// WHY A SECOND OVERLAY RATHER THAN THE RECONNECT ONE. They mean opposite things. The reconnect overlay
+// blocks: it makes the document inert because nothing you click can reach a server that isn't there.
+// This one must NOT block — the whole point is that the app is still running and still yours to poke at,
+// which is what makes it useful for finding the bug. So it is a corner panel with pointer events only on
+// itself, and the app behind it stays live (#607).
+//
+// Never shown outside development. The server only ever puts `devError` on a payload in development
+// (DevErrorInfo.From returns null otherwise), and the client checks the document flag as well — two
+// independent gates, because this renders a stack trace.
+
+var devErrorPanel = null;
+var devErrorCount = 0;
+
+// The dev gate, read from the document rather than from a host-local variable, so this one source works
+// in all three runtimes. The Server stamps `data-rask-dev` onto <body> per request (LivePayload
+// .InjectRootAttr); the WASM and Native runtimes set it at boot from their host's own answer, because
+// they render client-side and no server ever touches their <body>.
+function devErrorEnabled() {
+    var b = document.body;
+    return !!(b && b.hasAttribute("data-rask-dev"));
+}
+
+function installDevErrorStyles() {
+    var style = document.createElement("style");
+    style.setAttribute("data-rask-managed", "");
+    style.setAttribute("data-rask-dev-error-style", "");
+    style.textContent =
+        ".rask-deverr{position:fixed;left:12px;right:12px;bottom:12px;max-width:760px;margin:0 auto;" +
+        "z-index:2147483646;font:13px/1.5 ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;" +
+        "background:#1b1114;color:#ffe9ec;border:1px solid #7f1d2b;border-radius:10px;" +
+        "box-shadow:0 12px 40px rgba(0,0,0,.45);overflow:hidden;}" +
+        ".rask-deverr[hidden]{display:none;}" +
+        ".rask-deverr__bar{display:flex;align-items:center;gap:10px;padding:10px 12px;" +
+        "background:#7f1d2b;color:#fff;}" +
+        ".rask-deverr__kind{font-weight:600;letter-spacing:.02em;}" +
+        ".rask-deverr__count{background:rgba(255,255,255,.22);border-radius:999px;padding:1px 8px;" +
+        "font-size:11px;}" +
+        ".rask-deverr__spacer{flex:1;}" +
+        ".rask-deverr__btn{border:1px solid rgba(255,255,255,.45);background:rgba(255,255,255,.12);" +
+        "color:#fff;border-radius:6px;padding:3px 10px;font:inherit;font-size:12px;cursor:pointer;}" +
+        ".rask-deverr__btn:hover{background:rgba(255,255,255,.24);}" +
+        ".rask-deverr__body{padding:12px;}" +
+        ".rask-deverr__title{font-weight:600;margin:0 0 4px;}" +
+        ".rask-deverr__msg{margin:0 0 10px;white-space:pre-wrap;word-break:break-word;}" +
+        ".rask-deverr__detail{margin:0;max-height:38vh;overflow:auto;white-space:pre-wrap;" +
+        "word-break:break-word;font-size:12px;color:#f0b8c0;background:#140c0e;border-radius:6px;" +
+        "padding:10px;}" +
+        ".rask-deverr__detail[hidden]{display:none;}";
+    document.head.appendChild(style);
+}
+
+function installDevErrorPanel() {
+    installDevErrorStyles();
+
+    var el = document.createElement("div");
+    el.className = "rask-deverr";
+    // data-rask-managed keeps the morph from trimming a node the server never rendered — the same
+    // contract the reconnect overlay relies on.
+    el.setAttribute("data-rask-managed", "");
+    el.setAttribute("data-rask-dev-error", "");
+    el.setAttribute("role", "alert");
+    el.hidden = true;
+
+    var bar = document.createElement("div");
+    bar.className = "rask-deverr__bar";
+
+    var kind = document.createElement("span");
+    kind.className = "rask-deverr__kind";
+
+    var count = document.createElement("span");
+    count.className = "rask-deverr__count";
+    count.hidden = true;
+
+    var spacer = document.createElement("span");
+    spacer.className = "rask-deverr__spacer";
+
+    var toggle = document.createElement("button");
+    toggle.className = "rask-deverr__btn";
+    toggle.type = "button";
+    toggle.textContent = "Stack";
+
+    var dismiss = document.createElement("button");
+    dismiss.className = "rask-deverr__btn";
+    dismiss.type = "button";
+    dismiss.textContent = "Dismiss";
+
+    var body = document.createElement("div");
+    body.className = "rask-deverr__body";
+
+    var title = document.createElement("p");
+    title.className = "rask-deverr__title";
+
+    var msg = document.createElement("p");
+    msg.className = "rask-deverr__msg";
+
+    var detail = document.createElement("pre");
+    detail.className = "rask-deverr__detail";
+    detail.hidden = true;
+
+    toggle.addEventListener("click", function () {
+        detail.hidden = !detail.hidden;
+        toggle.textContent = detail.hidden ? "Stack" : "Hide stack";
+    });
+    dismiss.addEventListener("click", function () { hideDevError(); });
+
+    bar.appendChild(kind);
+    bar.appendChild(count);
+    bar.appendChild(spacer);
+    bar.appendChild(toggle);
+    bar.appendChild(dismiss);
+    body.appendChild(title);
+    body.appendChild(msg);
+    body.appendChild(detail);
+    el.appendChild(bar);
+    el.appendChild(body);
+    document.documentElement.appendChild(el);
+    return el;
+}
+
+function devErrorHeading(kind) {
+    if (kind === "handler") return "Unhandled exception in an event handler";
+    if (kind === "lifecycle") return "Unhandled exception in an async lifecycle hook";
+    if (kind === "build") return "Build failed";
+    return "Unhandled exception";
+}
+
+// Shows (or updates) the panel. `info` is the payload's devError object: {kind,title,message,detail}.
+function showDevError(info) {
+    if (!devErrorEnabled() || !info || typeof info !== "object") return;
+    if (!devErrorPanel) devErrorPanel = installDevErrorPanel();
+
+    devErrorCount++;
+    var countEl = devErrorPanel.querySelector(".rask-deverr__count");
+    countEl.textContent = String(devErrorCount);
+    countEl.hidden = devErrorCount < 2;
+
+    devErrorPanel.querySelector(".rask-deverr__kind").textContent = devErrorHeading(info.kind);
+    devErrorPanel.querySelector(".rask-deverr__title").textContent = info.title || "";
+    devErrorPanel.querySelector(".rask-deverr__msg").textContent = info.message || "";
+
+    var detail = devErrorPanel.querySelector(".rask-deverr__detail");
+    detail.textContent = info.detail || "";
+    // Collapsed on arrival: the message is what you read first, and a stack that opened itself would
+    // cover the app this panel exists to keep visible.
+    detail.hidden = true;
+    devErrorPanel.querySelector(".rask-deverr__btn").textContent = "Stack";
+
+    devErrorPanel.hidden = false;
+
+    // Also to the console, where a developer's own breakpoints and filters already live — and where it
+    // survives dismissing the panel.
+    if (typeof console !== "undefined" && console.error) {
+        console.error("[Rask] " + devErrorHeading(info.kind) + ": " + (info.title || "") +
+            (info.message ? ": " + info.message : ""), info.detail || "");
+    }
+}
+
+function hideDevError() {
+    if (!devErrorPanel) return;
+    devErrorPanel.hidden = true;
+    devErrorCount = 0;
+    devErrorPanel.querySelector(".rask-deverr__count").hidden = true;
+}
+
+
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
 // preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could
@@ -4014,6 +4187,10 @@ function applyFrameInvokes(reply, dispatchOne) {
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
+    // A development fault the app survived, riding the render payload (see the Server runtime for why
+    // it is a field rather than a frame). Applied before either render path: the panel is a sibling of
+    // the app, so it must not wait on the render queue.
+    if (reply.devError) showDevError(reply.devError);
     // Diff-mode payload: apply ops directly against the live DOM. Both paths chain
     // through _renderQueue so a diff that defers its body for a CSS load can't be
     // overtaken by the next payload (see _renderQueue).

--- a/src/Rask.Wasm/Rask.Wasm.csproj
+++ b/src/Rask.Wasm/Rask.Wasm.csproj
@@ -115,7 +115,8 @@
       <_RaskInputBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-input.js'))</_RaskInputBody>
       <_RaskScopedBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-scoped.js'))</_RaskScopedBody>
       <_RaskHotReloadBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-hotreload.js'))</_RaskHotReloadBody>
-      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)'))</_RaskWasmJs>
+      <_RaskDevErrorBody>$([System.IO.File]::ReadAllText('$(MSBuildProjectDirectory)\..\Rask.Core\Resources\rask-deverror.js'))</_RaskDevErrorBody>
+      <_RaskWasmJs>$(_RaskWasmTemplate.Replace('// @@RASK_DOM@@', '$(_RaskDomBody)').Replace('// @@RASK_MORPH@@', '$(_RaskMorphBody)').Replace('// @@RASK_API@@', '$(_RaskApiBody)').Replace('// @@RASK_EVENTS@@', '$(_RaskEventsBody)').Replace('// @@RASK_PWA@@', '$(_RaskPwaBody)').Replace('// @@RASK_WASM_API@@', '$(_RaskWasmApiBody)').Replace('// @@RASK_INPUT@@', '$(_RaskInputBody)').Replace('// @@RASK_SCOPED@@', '$(_RaskScopedBody)').Replace('// @@RASK_HOTRELOAD@@', '$(_RaskHotReloadBody)').Replace('// @@RASK_DEVERROR@@', '$(_RaskDevErrorBody)'))</_RaskWasmJs>
     </PropertyGroup>
     <WriteLinesToFile File="Browser\rask.wasm.js" Lines="$(_RaskWasmJs)" Overwrite="true" WriteOnlyWhenDifferent="true"/>
   </Target>

--- a/src/Rask.Wasm/Resources/rask.wasm.js
+++ b/src/Rask.Wasm/Resources/rask.wasm.js
@@ -25,6 +25,9 @@ let basePath = null;
 // a WASM app has no Rask server to push it a frame.
 // @@RASK_HOTRELOAD@@
 
+// The development error panel (showDevError / hideDevError), shared with the Server runtime.
+// @@RASK_DEVERROR@@
+
 // Serializes render application across payloads. A navigation diff/full reply may defer
 // its body swap until the new page's scoped CSS applies (waitForUnappliedHeadCss /
 // preloadNewHeadStylesheets), opening a microtask/timer gap during which .NET could
@@ -474,6 +477,10 @@ function applyNavScroll(history) {
 
 function handle(reply) {
     if (!reply || typeof reply !== "object") return;
+    // A development fault the app survived, riding the render payload (see the Server runtime for why
+    // it is a field rather than a frame). Applied before either render path: the panel is a sibling of
+    // the app, so it must not wait on the render queue.
+    if (reply.devError) showDevError(reply.devError);
     // Diff-mode payload: apply ops directly against the live DOM. Both paths chain
     // through _renderQueue so a diff that defers its body for a CSS load can't be
     // overtaken by the next payload (see _renderQueue).

--- a/tests/Rask.Native.Tests/NativeClientSpliceTests.cs
+++ b/tests/Rask.Native.Tests/NativeClientSpliceTests.cs
@@ -21,6 +21,7 @@ public sealed class NativeClientSpliceTests
         var input = File.ReadAllText(Path.Combine(core, "rask-input.js"));
         var scoped = File.ReadAllText(Path.Combine(core, "rask-scoped.js"));
         var hotReload = File.ReadAllText(Path.Combine(core, "rask-hotreload.js"));
+        var devError = File.ReadAllText(Path.Combine(core, "rask-deverror.js"));
         var committed = File.ReadAllText(Path.Combine(repoRoot, "src", "Rask.Native", "Assets", "rask.native.js"));
 
         // Mirror the marker splice order in _RaskSpliceNativeClientJs (Rask.Native.csproj).
@@ -32,7 +33,8 @@ public sealed class NativeClientSpliceTests
             .Replace("// @@RASK_PWA@@", pwa)
             .Replace("// @@RASK_INPUT@@", input)
             .Replace("// @@RASK_SCOPED@@", scoped)
-            .Replace("// @@RASK_HOTRELOAD@@", hotReload);
+            .Replace("// @@RASK_HOTRELOAD@@", hotReload)
+            .Replace("// @@RASK_DEVERROR@@", devError);
 
         Assert.True(
             spliced == committed,

--- a/tests/Rask.Server.Tests/Infrastructure/HostEnvironmentCollection.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/HostEnvironmentCollection.cs
@@ -1,0 +1,17 @@
+namespace Rask.Server.Tests.Infrastructure;
+
+// Test classes that build a host with an explicit environment, and so decide the value of the
+// process-global LiveOptions.IsDevelopment for as long as that host lives.
+//
+// UseRask claims it with `??=` — first host in the process wins and it is never revised — so two hosts
+// disagreeing about their environment is not a thing the product has to handle, but it IS a thing a test
+// run produces. RaskTestHost.Dispose now clears it, which makes each host claim it fresh; running these
+// classes in parallel would still let one host's answer land while another's dev-gated assertion reads
+// it. Serialise them.
+//
+// Add this collection's [Collection] attribute to any new test class that passes `environment:` to
+// RaskTestHost.Create.
+[CollectionDefinition("HostEnvironment", DisableParallelization = true)]
+public class HostEnvironmentCollection
+{
+}

--- a/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
+++ b/tests/Rask.Server.Tests/Infrastructure/RaskTestHost.cs
@@ -43,6 +43,12 @@ internal sealed class RaskTestHost : IDisposable
         // into subsequent tests in the same AppDomain. Cheap; matches the
         // existing Diff-mode reset convention.
         LiveOptions.PathBase = string.Empty;
+
+        // Same reason, and sharper: UseRask sets IsDevelopment with `??=`, so it is claimed by the FIRST
+        // host in the process and never revised. Left set, one host built with environment "Development"
+        // would decide what every later host in the run reports — and the dev-only behaviour gated on it
+        // (the error overlay, the dev error page) would then be tested against somebody else's answer.
+        LiveOptions.IsDevelopment = null;
     }
 
     public static RaskTestHost Create<TApp>(

--- a/tests/Rask.Server.Tests/WebSockets/DevErrorOverlayTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/DevErrorOverlayTests.cs
@@ -1,0 +1,119 @@
+using System.Text.RegularExpressions;
+using Rask.Core.Live;
+using Rask.Server.Tests.Infrastructure;
+
+namespace Rask.Server.Tests.WebSockets;
+
+/// <summary>
+///     The development error overlay: in Development a fault the tree survived is reported <em>over</em>
+///     the app instead of replacing it (#607).
+/// </summary>
+/// <remarks>
+///     The behaviour under test is a whole-payload property — "the app is still there AND the error came
+///     with it" — so these drive the real WebSocket round trip rather than a rendered component. That is
+///     also the only place the two halves meet: the boundary decides, the payload carries.
+/// </remarks>
+[Collection("HostEnvironment")]
+public sealed class DevErrorOverlayTests
+{
+    [Fact]
+    public async Task In_development_a_handler_fault_keeps_the_app_and_reports_the_error_beside_it()
+    {
+        using var host = RaskTestHost.Create<ThrowingApp>(
+            diffMode: LiveDiffMode.DisabledFull, environment: "Development");
+
+        var payload = await FaultAsync(host);
+
+        // The app is still on screen — this is the whole point. The full-document swap takes the scroll
+        // position, the form input and the expanded panels with it, at the moment the developer most
+        // wants to look at the state that produced the bug.
+        Assert.Contains("count=", payload, StringComparison.Ordinal);
+        Assert.DoesNotContain("Something went wrong", payload, StringComparison.Ordinal);
+
+        // …and the error rides the same payload, rather than arriving as its own frame.
+        Assert.Contains("\"devError\"", payload, StringComparison.Ordinal);
+        Assert.Contains("\"kind\":\"handler\"", payload, StringComparison.Ordinal);
+        Assert.Contains("InvalidOperationException", payload, StringComparison.Ordinal);
+        Assert.Contains("boom", payload, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task In_production_the_same_fault_still_replaces_the_page_and_carries_no_stack()
+    {
+        // Unchanged behaviour, deliberately: an end user gets the styled error page, and the payload must
+        // not carry a stack trace to a browser that isn't a developer's.
+        using var host = RaskTestHost.Create<ThrowingApp>(
+            diffMode: LiveDiffMode.DisabledFull, environment: "Production");
+
+        var payload = await FaultAsync(host);
+
+        Assert.Contains("Something went wrong", payload, StringComparison.Ordinal);
+        // The production error page names the exception type by design, so the claim here is narrower
+        // and exact: no devError record, which is what would carry the stack trace.
+        Assert.DoesNotContain("devError", payload, StringComparison.Ordinal);
+        Assert.DoesNotContain("   at ", payload, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task A_render_fault_still_replaces_the_page_even_in_development()
+    {
+        // The one case the overlay must NOT take: the tree cannot be re-rendered as it stands, so keeping
+        // the app on screen would mean re-running the render that just threw. Replacing the page is the
+        // honest outcome, and it is what the issue's own note says.
+        using var host = RaskTestHost.Create<ThrowingOnRenderApp>(
+            diffMode: LiveDiffMode.DisabledFull, environment: "Development");
+
+        var html = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+
+        Assert.Contains("Something went wrong", html, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task The_overlay_is_shown_once_not_on_every_later_frame()
+    {
+        // The record is taken and cleared while the frame is built. Left in place it would ride every
+        // subsequent payload, so an error you dismissed would reappear on the next click for the rest of
+        // the session.
+        using var host = RaskTestHost.Create<ThrowingApp>(
+            diffMode: LiveDiffMode.DisabledFull, environment: "Development");
+
+        var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = MarkupAssert.SessionId(initialHtml);
+        var handlers = Regex.Matches(initialHtml, "data-rask-on-click=\"(h\\d+)\"")
+            .Select(m => m.Groups[1].Value)
+            .ToArray();
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        await ws.SendJsonAsync(new { id = handlers[0] });   // throw
+        var faulted = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.Contains("\"devError\"", faulted!, StringComparison.Ordinal);
+
+        await ws.SendJsonAsync(new { id = handlers[1] });   // bump — an ordinary click
+        var next = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        Assert.NotNull(next);
+        Assert.DoesNotContain("devError", next, StringComparison.Ordinal);
+    }
+
+    // Connects, clicks the throwing button, and returns the payload that came back.
+    private static async Task<string> FaultAsync(RaskTestHost host)
+    {
+        var initialHtml = await (await host.Http.GetAsync("/start")).Content.ReadAsStringAsync();
+        var sessionId = MarkupAssert.SessionId(initialHtml);
+        var throwingId = Regex.Matches(initialHtml, "data-rask-on-click=\"(h\\d+)\"")
+            .Select(m => m.Groups[1].Value)
+            .First();
+
+        using var ws = await host.WebSockets.ConnectAsync(host.WebSocketUri, CancellationToken.None);
+        await ws.SendJsonAsync(new { type = "hello", session = sessionId });
+        _ = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+
+        await ws.SendJsonAsync(new { id = throwingId });
+        var payload = await ws.TryReceiveTextAsync(TimeSpan.FromSeconds(2));
+        Assert.NotNull(payload);
+        return payload!;
+    }
+}

--- a/tests/Rask.Server.Tests/WebSockets/HotReloadMessageTests.cs
+++ b/tests/Rask.Server.Tests/WebSockets/HotReloadMessageTests.cs
@@ -9,6 +9,7 @@ namespace Rask.Server.Tests.WebSockets;
 ///     The dev-only "hot reload applied" channel: its exact wire text, and the two independent gates
 ///     that keep it out of production.
 /// </summary>
+[Collection("HostEnvironment")]
 public class HotReloadMessageTests
 {
     [Fact]

--- a/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
+++ b/tests/Rask.Wasm.Tests/ResourcesSpliceTests.cs
@@ -16,6 +16,7 @@ public sealed class ResourcesSpliceTests
         var inputPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-input.js");
         var scopedPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-scoped.js");
         var hotReloadPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-hotreload.js");
+        var devErrorPath = Path.Combine(repoRoot, "src", "Rask.Core", "Resources", "rask-deverror.js");
         var browserPath = Path.Combine(repoRoot, "src", "Rask.Wasm", "Browser", "rask.wasm.js");
 
         var template = File.ReadAllText(templatePath);
@@ -28,6 +29,7 @@ public sealed class ResourcesSpliceTests
         var input = File.ReadAllText(inputPath);
         var scoped = File.ReadAllText(scopedPath);
         var hotReload = File.ReadAllText(hotReloadPath);
+        var devError = File.ReadAllText(devErrorPath);
         var committed = File.ReadAllText(browserPath);
 
         // Mirror the marker splice order in _RaskSpliceClientJs (Rask.Wasm.csproj): the diff codec
@@ -46,7 +48,8 @@ public sealed class ResourcesSpliceTests
             .Replace("// @@RASK_WASM_API@@", wasmApi)
             .Replace("// @@RASK_INPUT@@", input)
             .Replace("// @@RASK_SCOPED@@", scoped)
-            .Replace("// @@RASK_HOTRELOAD@@", hotReload);
+            .Replace("// @@RASK_HOTRELOAD@@", hotReload)
+            .Replace("// @@RASK_DEVERROR@@", devError);
 
         Assert.True(
             spliced == committed,


### PR DESCRIPTION
Closes #607. **#603 stays open** — see the bottom, and the commit's own note.

## What changed

A handler that throws used to morph the entire live document away — scroll position, form input,
expanded panels, route. In production that's right: an end user gets a styled error page. In development
it's exactly backwards, because a handler that throws is the **common** case there, and the swap destroys
the state that produced the bug at the moment you most want to look at it.

The app now stays mounted and live behind a dismissible panel with the exception type, the message and a
collapsible stack.

**Not a blocking overlay.** The reconnect overlay makes the document `inert` because nothing you click can
reach a server that isn't there. This one means the opposite — the app is still running and still yours to
poke at, which is what makes it useful — so it's a corner panel with pointer events only on itself.

## Only for a fault the tree survived

A **render** fault still replaces the page, in development as in production. Re-rendering the subtree that
just threw would only throw again — which is what the issue's own note says, and it's why #622 stopped
short here.

Making that distinction possible is the one structural change: `ErrorBoundary` now records *where* its
exception came from (`Render` / `Handler` / `Lifecycle`). The trip sites already knew; they just weren't
saying.

## It rides inside the render payload

Not a new frame. Same reasoning as `resume`, `history` and `auth`: the frame stream is a documented
contract, an extra frame is observable in ways an extra field is not, and this is exact anyway — the
overlay only ever appears alongside the render that follows the fault.

Its bytes are **discounted from the diff-vs-full comparison**, for the same reason the resume record's
are: it sits on both sides, so counting it only against the diff would ship the whole body precisely when
a minimal, legible frame matters most.

> **Both dedup gates had to let it through, and finding that was the interesting part.** A click whose
> only effect was the exception re-renders byte-identical HTML — so the HTML-level early-out and the
> byte-level frame dedup each dropped the entire frame, and the overlay never arrived in the simplest case
> there is. A test caught it, which is the argument for driving this through the real socket rather than a
> rendered component.

The record reaches the session through `IRenderHandle`, not `LiveRenderContext`: the context is disposed
when the walk ends and the frame is built afterwards, so a session reading it off the context finds
nothing. I wrote it the obvious way first and the test found that too.

## Production cannot leak

`DevErrorInfo.From` returns `null` outside development — via the **same resolver** the dev error page uses
(#605's), so the two can never disagree about the host's environment — and the client requires the
`data-rask-dev` flag as a second, independent gate. A test asserts both directions: in Production the same
click still gets the replacement page, with no `devError` record and no stack.

## Hosts

The panel is one shared module spliced into all three runtimes, so Server, WASM and Native render the same
thing. **It is live on the Server host today**, which is where `rask dev` runs and where the issue's
scenario lives. The WASM host has no environment concept at all, so `DevErrorInfo.From` returns `null`
there and the plumbing sits inert until it gains one — worth stating rather than implying.

## A global that was quietly deciding test outcomes

`RaskTestHost` now clears `LiveOptions.IsDevelopment` on dispose, and the two classes that build hosts
with an explicit environment share a non-parallel collection.

`UseRask` sets that global with `??=`, so the **first** host in the process claimed it and never revised
it — one test's `"Development"` decided what every later host reported, and every dev-gated assertion
after it was testing somebody else's answer. Same class of problem as #617, found the same way.

## Testing

- `dotnet format Rask.slnx --verify-no-changes` — clean
- `CI=true dotnet build Rask.slnx -warnaserror -m:1` — 0 warnings, 0 errors
- Full unit suite across the solution — green. Four new round-trip tests (dev keeps the app + carries the
  error; production replaces it and carries no stack; a render fault still replaces; the overlay is shown
  once, not on every later frame), and both splice guards taught about the new module.
- Benchmarks (`RenderRoundTrip`, from the worktree dir): **`Allocated` byte-identical** —
  80.67 / 150.98 / 73.66 / 71.53 / 35.31 KB, including `RenderAndBuildPayload`, which is the payload
  builder this actually touches.

## Why #603 isn't closed

Its overlay needs this same panel — already built here, and it already renders a **"Build failed"**
heading — but a different **transport**. When a rebuild fails the app process is *down*, so there is no
server left to put a field on a payload. That's not incidental; it's why the browser reports a network
problem in the first place.

What it needs is a channel that outlives the app: a status endpoint `rask dev` owns and the client polls
when its socket drops. That's a CLI change rather than a live-protocol one, and it's the last piece. The
[analysis is on #603](https://github.com/pal-tamas/rask/issues/603#issuecomment-5216237716); the shared
half — the thing I said needed designing once — is what this PR builds.
