### PR TITLE
fix(build): pin AssemblyVersion so hot reload can apply an edit in this repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,23 @@ them until tagged releases begin.
   "element is not stable" naming the element and nothing about what was moving. The journey records a trace
   with DOM snapshots throughout and keeps it only on failure, printing the path and the command that opens
   it. Always on rather than behind a flag, because the run worth tracing is the one that unexpectedly failed.
+- **Hot reload can apply an edit in this repo again.** Every save under `rask dev` on any sample failed
+  with `error CS7038: … Changing the version of an assembly reference is not allowed during debugging:
+  'Rask.Bootstrap, Version=0.0.0.0' changed version to '1.0.0.0'`, so the edit never reached the running
+  app — for a one-character change to a `Render()` body, the most hot-reloadable thing there is.
+  - MinVer sets `AssemblyVersion` from a **target**; hot reload never runs targets, because Roslyn's EnC
+    service compiles in-process from the project's **evaluated** properties, where MinVer has not run and
+    the SDK falls back to `Version 1.0.0` → `AssemblyVersion 1.0.0.0`. Every emit therefore disagreed with
+    the assembly already loaded. `Directory.Build.props` now pins `<AssemblyVersion>0.0.0.0</AssemblyVersion>`
+    at evaluation time — the same value MinVer's target produces on the `0.x` line, so nothing about the
+    shipped binaries changes and the real version keeps riding on `FileVersion`/`InformationalVersion`.
+  - **It only affected the packable projects**, which is why it went unnoticed: MinVer is referenced under
+    `Condition=" '$(IsPackable)' != 'false' "`, so `Rask.Core` read `1.0.0.0` on both sides and agreed by
+    accident. That is also why `AssemblyVersionStabilityTests` asserts against a packable assembly — a
+    guard reading `Rask.Core` would pass with the pin removed.
+  - It would equally have hit **any app that project-references a Rask project**, and it quietly devalued
+    the hot-reload work in #534/#569: all of it behaves correctly, and none of it could be demonstrated on
+    this repo's own samples.
 - **A build that fails under `rask dev` is reported as a build failure, not as a lost connection.** Saving
   a file that didn't compile took the app down, and the browser — which only knows that its socket closed —
   said "Reconnecting…", then "Still trying to reconnect…" with a **Retry now** button that could not

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,6 +22,33 @@
     <Deterministic>true</Deterministic>
     <ContinuousIntegrationBuild Condition=" '$(GITHUB_ACTIONS)' == 'true' ">true</ContinuousIntegrationBuild>
     <MinVerTagPrefix>v</MinVerTagPrefix>
+    <!--
+      Pinned at evaluation time, deliberately, and NOT left to MinVer.
+
+      MinVer sets AssemblyVersion from a TARGET (to $(MinVerMajor).0.0.0 — 0.0.0.0 for our 0.x line).
+      Hot reload does not run targets: Roslyn's EnC service compiles in-process from the project's
+      EVALUATED properties, where MinVer has not run and the SDK falls back to Version 1.0.0 →
+      AssemblyVersion 1.0.0.0. So every hot-reload emit disagreed with the assembly already loaded and
+      Roslyn refused it outright:
+
+        error CS7038: Failed to emit module 'X': Changing the version of an assembly reference is not
+        allowed during debugging: 'Rask.Bootstrap, Version=0.0.0.0' changed version to '1.0.0.0'
+
+      That made the FIRST save of every `rask dev` session on this repo's own samples fail for a reason
+      that had nothing to do with the edit — and it would hit any app that project-references Rask.
+      Pinning it here makes evaluation and target agree. AssemblyVersion is the binary-compat identity
+      and is meant to be stable anyway; the real version still rides on FileVersion/InformationalVersion,
+      which MinVer keeps stamping.
+
+      It only ever bit the PACKABLE projects, which is why it survived so long: MinVer is referenced
+      under `Condition=" '$(IsPackable)' != 'false' "` below, so an unpackable project reads 1.0.0.0
+      both on disk and under EnC and never mismatches. The error named Rask.Bootstrap, never Rask.Core —
+      and anyone investigating via Rask.Core sees nothing wrong.
+
+      0.0.0.0 is right only while the major is 0. AssemblyVersionStabilityTests fails when the shipped
+      major leaves 0.x, so this gets moved rather than silently understating compatibility at v1.0.0.
+    -->
+    <AssemblyVersion>0.0.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <!--

--- a/src/Rask.Cli/Dev/DevBuildWatcher.cs
+++ b/src/Rask.Cli/Dev/DevBuildWatcher.cs
@@ -53,6 +53,17 @@ internal sealed class DevBuildWatcher
     // colour) — and equally deliberately stripped here, because the panel renders text, not a terminal.
     private static readonly Regex AnsiEscape = new(@"\x1B\[[0-9;]*[A-Za-z]", RegexOptions.Compiled);
 
+    // Watch's own byline — `dotnet watch ❌ `, `dotnet watch ⌚ ` — which it puts in front of everything,
+    // including a diagnostic that already has a file location:
+    //
+    //   dotnet watch ❌ /app/Pages/Home.cs(12,9): error CS0103: The name 'x' does not exist…
+    //
+    // The location-ends-in-a-colon rule below cannot drop it there, because the byline is *part* of the
+    // prefix that ends in a colon. Stripped up front instead. The character class stops at the first
+    // letter, digit or path character, so it eats the emoji and the spaces and nothing else — and it
+    // leaves the line alone when DOTNET_WATCH_SUPPRESS_EMOJIS removed the symbol already.
+    private static readonly Regex WatchByline = new(@"^dotnet watch[^\p{L}\p{N}/\\._]*", RegexOptions.Compiled);
+
     // Watch announces a rebuild before it starts one. Matched loosely (contains, case-insensitive) because
     // the surrounding decoration varies; a miss only costs a slightly late transition to Building, which
     // no one sees, where a false positive would clear a real failure. "file updated" is what .NET 10's
@@ -63,13 +74,14 @@ internal sealed class DevBuildWatcher
     ];
 
     // …and what it prints when one has finished cleanly. Taken from what .NET 10's watch actually emits —
-    // MSBuild's "Build succeeded.", watch's "Hot reload of changes succeeded." and its "No managed code
-    // changes to apply." (which is what a save that only reverts a broken edit produces). Without these
+    // MSBuild's "Build succeeded.", watch's "C# and Razor changes applied in 456ms." / "Hot reload of
+    // changes succeeded." and its "No managed code changes to apply." (what a save reverting a broken edit
+    // produces). All observed, not guessed — the applied-form is the one a working edit emits. Without these
     // the machine would sit on Building forever after a recovery: harmless for the client, which only
     // acts on "failed", but a state nobody could explain.
     private static readonly string[] SuccessMarkers =
     [
-        "build succeeded", "changes succeeded", "no managed code changes", "started",
+        "build succeeded", "changes succeeded", "changes applied", "no managed code changes", "started",
     ];
 
     // What watch prints when it has given up and is idling — "Waiting for a file to change before
@@ -119,7 +131,7 @@ internal sealed class DevBuildWatcher
             return;
         }
 
-        var clean = AnsiEscape.Replace(line, string.Empty).Trim();
+        var clean = WatchByline.Replace(AnsiEscape.Replace(line, string.Empty).Trim(), string.Empty).Trim();
         if (clean.Length == 0)
         {
             return;

--- a/tests/Rask.Cli.Tests/DevBuildWatcherTests.cs
+++ b/tests/Rask.Cli.Tests/DevBuildWatcherTests.cs
@@ -113,6 +113,7 @@ public sealed class DevBuildWatcherTests
     [InlineData("Build succeeded.")]
     [InlineData("dotnet watch 🔥 Hot reload of changes succeeded.")]
     [InlineData("dotnet watch ⌚ No managed code changes to apply.")]
+    [InlineData("dotnet watch 🔥 C# and Razor changes applied in 456ms.")]
     public void A_build_that_finished_cleanly_settles_to_ok(string line)
     {
         // Every one of these is something .NET 10's watch (or MSBuild under it) actually prints on the
@@ -151,6 +152,21 @@ public sealed class DevBuildWatcherTests
         Assert.Equal(DevBuildState.Failed, watcher.State);
         // Watch's decoration is dropped; a real file location is not.
         Assert.Equal("error CS7038: Failed to emit module 'App'.", Assert.Single(watcher.Errors));
+    }
+
+    [Fact]
+    public void Watchs_byline_is_dropped_even_when_it_precedes_a_real_file_location()
+    {
+        // The shape a genuine compile error actually arrives in under watch: its byline sits in FRONT of
+        // the path, so the "keep the prefix when it ends in a colon" rule would otherwise keep the emoji
+        // too and put `dotnet watch ❌ /Users/…` in the panel.
+        var watcher = new DevBuildWatcher();
+
+        watcher.Observe("dotnet watch ❌ /app/A.cs(12,26): error CS0103: The name 'x' does not exist");
+
+        Assert.Equal(
+            "/app/A.cs(12,26): error CS0103: The name 'x' does not exist",
+            Assert.Single(watcher.Errors));
     }
 
     [Fact]

--- a/tests/Rask.Core.Tests/HotReload/AssemblyVersionStabilityTests.cs
+++ b/tests/Rask.Core.Tests/HotReload/AssemblyVersionStabilityTests.cs
@@ -1,0 +1,88 @@
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+namespace Rask.Core.Tests.HotReload;
+
+/// <summary>
+///     Guards the one build property that decides whether hot reload can apply anything at all in this
+///     repo (#637).
+///     <para>
+///         MinVer sets <c>AssemblyVersion</c> from a <b>target</b>. Hot reload never runs targets —
+///         Roslyn's EnC service compiles in-process from the project's <b>evaluated</b> properties, where
+///         MinVer has not run and the SDK falls back to <c>Version 1.0.0</c>. Without an evaluation-time
+///         pin the two disagree, and every edit comes back as <c>error CS7038: … Changing the version of
+///         an assembly reference is not allowed during debugging</c>. Silent in the way that matters: the
+///         build is green, the tests pass, the packages are right, and only someone sitting in front of
+///         <c>rask dev</c> ever finds out.
+///     </para>
+///     <para>
+///         <b>It only ever bit the packable projects</b>, which is why it hid so long. MinVer is
+///         referenced under <c>Condition=" '$(IsPackable)' != 'false' "</c>, so an unpackable project like
+///         <c>Rask.Core</c> reads <c>1.0.0.0</c> from disk <i>and</i> under EnC and never mismatches — the
+///         error named <c>Rask.Bootstrap</c>. Assert on a packable assembly or this proves nothing.
+///     </para>
+/// </summary>
+public class AssemblyVersionStabilityTests
+{
+    /// <summary>A <b>packable</b> Rask assembly — the only kind MinVer stamps, so the only kind at risk.</summary>
+    private static readonly Assembly Packable = typeof(Rask.Server.RaskEndpointExtensions).Assembly;
+
+    private static string Informational =>
+        Packable.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? string.Empty;
+
+    /// <summary>
+    ///     Whether MinVer actually ran for this build. <c>scripts/run-unit-local.sh</c> passes
+    ///     <c>-p:MinVerSkip=true</c> for speed, and then there is no stamped version to compare anything
+    ///     against — but the pin below must hold either way, which is the point of pinning it.
+    /// </summary>
+    private static bool MinVerRan => !Informational.StartsWith("1.0.0", StringComparison.Ordinal);
+
+    [Fact]
+    public void The_assembly_version_of_a_packable_project_is_pinned_and_not_left_to_a_target()
+    {
+        // The load-bearing one, and true in every build mode. 1.0.0.0 is the SDK's fallback when Version
+        // was never set — exactly what an evaluation-time read produces once the pin is gone. Seeing it
+        // here means Directory.Build.props lost the pin and hot reload is broken again.
+        Assert.Equal(new Version(0, 0, 0, 0), Packable.GetName().Version);
+    }
+
+    [Fact]
+    public void The_pinned_version_matches_what_MinVer_would_stamp_for_the_major_being_shipped()
+    {
+        if (!MinVerRan)
+        {
+            // Not a silent pass: state what this build is, and re-assert the invariant that still applies.
+            Assert.StartsWith("1.0.0", Informational, StringComparison.Ordinal);
+            Assert.Equal(new Version(0, 0, 0, 0), Packable.GetName().Version);
+            return;
+        }
+
+        // The pin is only correct while the major is 0: MinVer stamps $(MinVerMajor).0.0.0, so at v1.0.0 a
+        // pinned 0.0.0.0 would understate the binary-compatibility identity. This speaks up on that day
+        // rather than letting the pin quietly become wrong.
+        var major = int.Parse(Regex.Match(Informational, @"^\d+").Value);
+
+        Assert.True(
+            major == 0,
+            $"Rask now ships major version {major}, so <AssemblyVersion> in Directory.Build.props must "
+            + $"become {major}.0.0.0 (what MinVer's target stamps) — and this test updated with it. "
+            + "Leaving it at 0.0.0.0 keeps hot reload working but misstates binary compatibility; "
+            + "removing it altogether breaks hot reload again (#637).");
+    }
+
+    [Fact]
+    public void Pinning_the_assembly_version_does_not_cost_the_real_version()
+    {
+        // Pinning must not swallow the actual version: it moves to FileVersion and InformationalVersion,
+        // which MinVer keeps stamping — what `rask info`, the packages and every bug report read.
+        if (!MinVerRan)
+        {
+            Assert.StartsWith("1.0.0", Informational, StringComparison.Ordinal);
+            return;
+        }
+
+        Assert.False(string.IsNullOrWhiteSpace(Informational));
+        Assert.Matches(@"^\d+\.\d+\.\d+", Informational);
+    }
+}


### PR DESCRIPTION
fix(build): pin AssemblyVersion so hot reload can apply an edit in this repo

Closes #637.

Every save under `rask dev` on any sample in this repo failed, and the edit never reached the running app:

    dotnet watch 🔥 Unable to apply changes due to compilation errors.
    dotnet watch ❌ error CS7038: Failed to emit module 'Rask.Example.Shared': Changing the version of an
    assembly reference is not allowed during debugging: 'Rask.Bootstrap, Version=0.0.0.0' changed version
    to '1.0.0.0'.

Not the edit's fault: it happened for a one-character change to a `Render()` body, the most
hot-reloadable thing there is.

MinVer sets `AssemblyVersion` from a TARGET. Hot reload never runs targets -- Roslyn's EnC service
compiles in-process from the project's EVALUATED properties, where MinVer has not run and the SDK falls
back to `Version 1.0.0` -> `AssemblyVersion 1.0.0.0`. So every hot-reload emit disagreed with the
assembly already loaded, and Roslyn refused it outright. Reproducible without a browser or a watcher:

    dotnet msbuild src/Rask.Bootstrap/Rask.Bootstrap.csproj -getProperty:AssemblyVersion       # ""  -> 1.0.0.0
    dotnet msbuild src/Rask.Bootstrap/Rask.Bootstrap.csproj -t:Build -getProperty:AssemblyVersion  # 0.0.0.0

IT ONLY EVER BIT THE PACKABLE PROJECTS, which is why it survived this long -- and why my first
investigation found nothing. MinVer is referenced under `Condition=" '$(IsPackable)' != 'false' "`, so an
unpackable project like Rask.Core reads 1.0.0.0 on disk AND under EnC and agrees by accident. The error
names Rask.Bootstrap and never Rask.Core; probing Rask.Core to diagnose it shows a perfectly healthy
build. The regression guard therefore asserts against a PACKABLE assembly -- one reading
`typeof(Component).Assembly` would pass with the pin removed.

Pinning `<AssemblyVersion>0.0.0.0</AssemblyVersion>` at evaluation time makes both reads agree. It is the
same value MinVer's target produces on our 0.x line, so nothing about the shipped binaries changes;
AssemblyVersion is the binary-compat identity and is meant to be stable anyway, and the real version keeps
riding on FileVersion/InformationalVersion (verified: FileVersion 0.20.1.0, Version 0.20.1-alpha.0.14).

The pin is only right while the major is 0 -- at v1.0.0 MinVer would stamp 1.0.0.0 and a pinned 0.0.0.0
would understate compatibility. `AssemblyVersionStabilityTests` fails on that day with instructions,
rather than letting the pin quietly become wrong. It also handles `-p:MinVerSkip=true` (which
`scripts/run-unit-local.sh` passes for speed) explicitly instead of vacuously: with no stamped version to
compare, it re-asserts the pin, which is the invariant that holds in every build mode.

Also folds in three watcher corrections found by running this: `dotnet watch` reports a working edit as
"C# and Razor changes applied in 456ms" (a success marker the state machine was missing, so it sat on
Building forever), and it puts its byline in FRONT of a located diagnostic --
`dotnet watch ❌ /app/A.cs(12,26): error CS0103: …` -- which the keep-the-prefix-if-it-ends-in-a-colon
rule kept verbatim, emoji and all.

Verified on samples/Rask.Example.Server, before and after:

  - before: every save -> CS7038, nothing applied.
  - after:  `dotnet watch 🔥 C# and Razor changes applied in 456ms.`, and the edited text is served by
    the running process with no restart.
  - a genuinely broken file now reports the real error -- `BindingManualDemo.cs(12,26): error CS0103: The
    name 'titel_typo_that_does_not_exist' does not exist in the current context` -- where before it was
    masked by CS7038.

This also quietly devalued shipped work: the hot-reload epic (#534) and the WASM hot-reload work (#569)
both behave correctly, and neither could be demonstrated on this repo's own samples.
