### PR TITLE
perf(core): give a handler an id that belongs to its component, not to the page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,38 @@ them until tagged releases begin.
 ## [Unreleased]
 
 ### Changed
+- **An event handler's id now belongs to the component that renders it, so one component gaining a
+  handler no longer renumbers the rest of the page.** Ids came from a single counter reset to zero on
+  every root render and handed out `h0, h1, …` in walk order, so a conditional button appearing
+  anywhere pushed every later handler on the page up by one. Two things fell out of that. The diff
+  rewrote `data-rask-on-*` on elements whose markup had not changed — on a 100-row list of buttons with
+  one conditional action above it, an update shipped **3,205 bytes across 101 edit ops; it now ships 94
+  bytes in 1** (new gated `HandlerShiftAboveList100` scenario in `payload-bytes`; the five existing
+  scenarios are byte-identical). And the clean-subtree cache had to refuse any snapshot whose baked-in
+  ids the shifted counter had invalidated, so an interactive list re-walked itself whenever anything
+  above it changed shape: on the `session-churn` handler-shift pass that is **−60% allocation per
+  update at 200 rows (252,097 → 100,124 B) and −64% at 1,000 (1,220,549 → 438,170 B)**, which brings
+  the cost of an update that moves the handler count down to within ~2% of one that does not.
+  Ids are now assigned per (component, local slot) and held for that component's lifetime, anchored to
+  the component whose subtree the element serializes in rather than to the delegate's target — so a
+  callback passed down into a composite wrapper cannot shift the wrapper's own ids either. Renumbering
+  is *bounded to one component*, not eliminated: an element passed into a wrapper as children takes a
+  slot on that wrapper, so a conditional sibling there still shifts the ones after it — within that
+  wrapper, rather than to the end of the page. A number is never handed to a **second component**: when
+  one unmounts its ids simply stop being registered, so a click a user sent a moment before a row
+  vanished resolves to nothing and no-ops instead of being redirected onto whichever component
+  inherited a recycled number. (Within a single component a slot is still reused when its handler set
+  shrinks — unchanged from the counter this replaces, and still narrowed by the frame-shape guard.)
+  The number space
+  therefore tracks cumulative rather than concurrent handler slots — but each id string is minted once
+  and cached on its slot, so steady-state re-render allocation is **unchanged to the byte**
+  (`LiveRenderRoundTrip`'s marginal cost per re-render is 70.31 KB before and after). The costs, both
+  one-off: a component's first render allocates one small state object (a 1,000-row interactive grid
+  retains **+1.5%**, 7,381,092 → 7,493,300 B/session), and a single component that registers many
+  handlers in its own render allocates one array for slots 1.. (`Register1000`, the pathological
+  one-component-owns-1,000-handlers shape, 128.82 → 145.1 KB on the render that builds it).
+  Nothing changes on the wire or in any API: a first render still emits `h0, h1, …` in document order,
+  and ids stay opaque to the client, which echoes them back verbatim.
 - **BREAKING — a short flag now means the same option on every `rask` command.** The same two
   keystrokes used to do different things depending on where you were, and the two worst cases failed
   *silently* rather than erroring, which is what made this worth breaking for:

--- a/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
+++ b/benchmarks/Rask.Benchmarks/Baselines/payload-bytes.csv
@@ -4,3 +4,4 @@ KeyedList100Reorder,6691,47,1
 TextNodeUpdate,66721,54,1
 AppendRowToList100,6759,112,1
 RawGuidePage,1770,661,1
+HandlerShiftAboveList100,15133,94,1

--- a/benchmarks/Rask.Benchmarks/HandlerRegistrationBenchmarks.cs
+++ b/benchmarks/Rask.Benchmarks/HandlerRegistrationBenchmarks.cs
@@ -4,10 +4,18 @@ using B = Rask.Benchmarks.Generated;
 
 namespace Rask.Benchmarks;
 
-// Stresses Component.RegisterHandler in isolation — the interning array (_smallHandlerIds
-// covers h0..h255) is the win to measure. Past 256 handlers, the path falls back to a
-// "h" + n concat which allocates a string per call. Two benchmarks: well-under and
-// well-over the intern threshold, so a regression in either branch shows up.
+// Stresses Component.RegisterHandler in isolation. The prebuilt id table (_smallHandlerIds covers
+// h0..h1023) is the win to measure; past it, minting a slot's id falls back to a formatted string.
+// Three benchmarks straddling that threshold so a regression in either branch shows up.
+//
+// All three measure a component's FIRST render: IterationSetup builds a fresh host, so each one pays
+// the one-off cost of that component's slot table (slot 0 is a scalar; slots 1.. share one array grown
+// geometrically). A re-render reuses both and mints nothing, which is why this benchmark deliberately
+// does not describe steady state — LiveRenderRoundTrip's RenderTenTimes does.
+//
+// Numbers are cumulative rather than concurrent (an id is never reused once issued, so a stale event
+// for a removed element cannot be redirected onto a live handler), which is what makes the
+// past-the-table path reachable on a long-lived churny page rather than merely theoretical.
 [MemoryDiagnoser]
 public class HandlerRegistrationBenchmarks
 {
@@ -17,34 +25,30 @@ public class HandlerRegistrationBenchmarks
     [GlobalSetup]
     public void GlobalSetup() => _action = () => { };
 
-    // Fresh host per iteration: avoids needing private-field reset access on Component
-    // and keeps each [Benchmark] starting from _nextHandlerId == 0. The allocation is
-    // outside the measured region. Construction goes through the generated factory so
-    // RASK014 is satisfied.
+    // Fresh host per iteration: avoids needing private-field reset access on Component and keeps each
+    // [Benchmark] starting from an empty slot table. The allocation is outside the measured region.
+    // Construction goes through the generated factory so RASK014 is satisfied.
     [IterationSetup]
     public void IterationSetup() => _host = (RegHost)B.RegHost();
 
     [Benchmark]
-    public string Register200()
-    {
-        // 200 fits well inside the intern table — represents a typical complex page.
-        // No string-concat allocations on this path; the dictionary insert dominates.
-        string? last = null;
-        for (var i = 0; i < 200; i++)
-        {
-            last = _host.RegisterHandler(_action);
-        }
+    public string Register200() => RegisterMany(200);
 
-        return last!;
-    }
-
+    // 1000 still fits inside the prebuilt table, so this is the same branch as Register200 at 5x the
+    // slot-array growth — it isolates the array from the id minting.
     [Benchmark]
-    public string Register1000()
+    public string Register1000() => RegisterMany(1000);
+
+    // 2000 runs ~1000 registrations past the end of the prebuilt table, so roughly half of them format
+    // their id instead of reading it out. Each such string is minted once and then cached on its slot,
+    // so this is the worst case for a component's first render and costs nothing on its later ones.
+    [Benchmark]
+    public string Register2000() => RegisterMany(2000);
+
+    private string RegisterMany(int count)
     {
-        // 1000 exceeds the 256-slot intern table; the 744 over-the-line registrations
-        // hit the "h" + n concat path. Captures both phases in one number.
         string? last = null;
-        for (var i = 0; i < 1000; i++)
+        for (var i = 0; i < count; i++)
         {
             last = _host.RegisterHandler(_action);
         }

--- a/benchmarks/Rask.Benchmarks/Infrastructure/FootprintApp.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/FootprintApp.cs
@@ -13,20 +13,29 @@ namespace Rask.Benchmarks.Infrastructure;
 ///         shape too, a change in bytes-per-session couldn't be attributed to page size.
 ///     </para>
 ///     <para>
-///         The rows are keyed and interactive on purpose: that is what a real data grid looks like, and it
-///         is the shape the clean-subtree cache cannot help with. A component is only eligible for that
-///         cache — which snapshots its subtree as a compact ~24 B/node <c>LeanFrame</c> span and releases
-///         the Element object graph — when it has no nested user component, no handler, and no
-///         <c>Key</c> (<c>Component.TryCacheCleanSubtree</c>). Since RASK022 pushes every list item toward
-///         a <c>Key</c>, the pages where retained memory matters most are exactly the pages that keep their
-///         Element graph for the session's lifetime. Measuring a keyless, handler-free table instead would
-///         report a best case that few real pages hit.
+///         The rows are keyed and interactive on purpose: that is what a real data grid looks like, and
+///         what the clean-subtree cache has to earn its keep on. A component is eligible for that cache —
+///         which snapshots its subtree as a compact ~24 B/node <c>LeanFrame</c> span and releases the
+///         Element object graph — when it has no nested user component and no indexer children
+///         (<c>Component.TryCacheCleanSubtree</c>); a <c>Key</c> and event handlers were each once
+///         disqualifying and are no longer, so this shape does cache. Since RASK022 pushes every list
+///         item toward a <c>Key</c>, measuring a keyless, handler-free table instead would report a best
+///         case that few real pages hit.
 ///     </para>
 /// </summary>
 public sealed class FootprintApp : Component
 {
     /// <summary>Counter rendered into the header. Bumped to make a render differ from the last one.</summary>
     public int Counter;
+
+    /// <summary>
+    ///     When set, the header carries one extra button — i.e. one extra event handler, rendered
+    ///     <i>above</i> every row's own. Toggling it is how <c>session-churn</c>'s handler-shift pass makes
+    ///     the page's upstream handler count move between renders, which is the case the clean-subtree
+    ///     cache has to survive. Left false by every other report, and it emits nothing when false, so the
+    ///     rest of the sweep measures exactly the page it measured before.
+    /// </summary>
+    public bool ShowExtraAction;
 
     // Non-nullable, no initializer → a required factory parameter (RASK001). Public so the generator
     // emits it; the reports build the page via B.FootprintApp(RowCount: n).
@@ -41,6 +50,16 @@ public sealed class FootprintApp : Component
     ///     its payload buffers and would report a footprint that no real session has.
     /// </summary>
     public void Bump() => Counter++;
+
+    /// <summary>
+    ///     Bump the counter <i>and</i> flip the extra header button, so the render differs from the last
+    ///     one in the usual way AND the page's handler count changes by one above the rows.
+    /// </summary>
+    public void BumpWithHandlerShift()
+    {
+        Counter++;
+        ShowExtraAction = !ShowExtraAction;
+    }
 
     protected override Component? Render()
     {
@@ -57,7 +76,10 @@ public sealed class FootprintApp : Component
                 C.Head(),
                 C.Body()[
                     C.Div(Class: "container", Id: "root")[
-                        C.Div(Class: "header")[C.Span()[$"rows={RowCount} counter={Counter}"]],
+                        C.Div(Class: "header")[
+                            C.Span()[$"rows={RowCount} counter={Counter}"],
+                            ShowExtraAction ? C.Button(OnClick: () => { })["extra"] : null
+                        ],
                         C.Table(Class: "table")[C.Tbody()[rows]]
                     ]
                 ]

--- a/benchmarks/Rask.Benchmarks/Infrastructure/HandlerShiftPage.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/HandlerShiftPage.cs
@@ -1,0 +1,52 @@
+using Rask.Core;
+using B = Rask.Benchmarks.Infrastructure.Generated;
+using C = Rask.Core.Components.Generated;
+
+namespace Rask.Benchmarks.Infrastructure;
+
+/// <summary>
+///     A list of keyed, interactive rows with ONE conditional action above them. Toggling
+///     <see cref="ShowToolbarAction" /> changes how many event handlers are registered before the walk
+///     reaches the rows, while leaving every row's own markup untouched.
+///     <para>
+///         That is the shape behind the <c>HandlerShiftAboveList100</c> payload-bytes scenario. A toolbar
+///         button that appears once something is selected, a "clear filter" affordance, a conditional row
+///         control — all of them move the page's upstream handler count, and the question the scenario asks
+///         is what the rows below cost when they do. The rows are <see cref="FootprintRow" />, the same
+///         keyed handler-bearing row the session reports measure, so the two reports describe one page.
+///     </para>
+/// </summary>
+public sealed class HandlerShiftPage : Component
+{
+    /// <summary>Set to render one extra button — one extra handler — above the rows.</summary>
+    public bool ShowToolbarAction;
+
+    // Non-nullable, no initializer → a required factory parameter (RASK001).
+    public int RowCount { get; set; }
+
+    protected override Component? Render()
+    {
+        var rows = new List<Component>(RowCount);
+        for (var i = 0; i < RowCount; i++)
+        {
+            rows.Add(B.FootprintRow(Index: i, Key: i));
+        }
+
+        return
+        [
+            C.Doctype(),
+            C.Html()[
+                C.Head(),
+                C.Body()[
+                    C.Div(Class: "container", Id: "root")[
+                        C.Div(Class: "toolbar")[
+                            C.Span()["Rows"],
+                            ShowToolbarAction ? C.Button(OnClick: () => { })["clear"] : null
+                        ],
+                        C.Table(Class: "table")[C.Tbody()[rows]]
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/benchmarks/Rask.Benchmarks/Infrastructure/SessionHarness.cs
+++ b/benchmarks/Rask.Benchmarks/Infrastructure/SessionHarness.cs
@@ -91,6 +91,21 @@ internal static class SessionHarness
     }
 
     /// <summary>
+    ///     As <see cref="Drive" />, but each update also flips the header's extra button, so the number of
+    ///     handlers registered above the rows changes on every render. Drives the case a page hits whenever
+    ///     a conditional action appears — and the one that decides whether the rows' cached subtrees can be
+    ///     replayed or have to be re-walked.
+    /// </summary>
+    public static void DriveWithHandlerShift(LiveSession session, FootprintApp app, int updates)
+    {
+        for (var i = 0; i < updates; i++)
+        {
+            app.BumpWithHandlerShift();
+            session.RequestRenderAsync().GetAwaiter().GetResult();
+        }
+    }
+
+    /// <summary>
     ///     Three forced blocking gen-2 collections, then the live bytes.
     ///     <para>
     ///         Deliberately NOT the same technique as the vs-Blazor <c>mem-footprint</c> report, which

--- a/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
+++ b/benchmarks/Rask.Benchmarks/PayloadBytesReport.cs
@@ -1,8 +1,10 @@
 using System.Buffers;
 using System.Globalization;
 using System.Text;
+using Rask.Benchmarks.Infrastructure;
 using Rask.Core;
 using Rask.Core.Live;
+using B = Rask.Benchmarks.Infrastructure.Generated;
 using C = Rask.Core.Components.Generated;
 
 namespace Rask.Benchmarks;
@@ -56,7 +58,15 @@ internal static class PayloadBytesReport
             // drops from full-page to one subtree.
             Report("RawGuidePage", writer,
                 BuildGuideDocument(1),
-                BuildGuideDocument(2))
+                BuildGuideDocument(2)),
+            // Handler-count shift: a 100-row list of buttons with one conditional button ABOVE it, toggled
+            // between the two renders. The rows themselves do not change at all — only the toolbar does —
+            // so the ideal diff touches the toolbar and nothing else. This is the one scenario rendered
+            // through the LIVE root (the others serialize without a live context, which registers no
+            // handlers at all), because handler ids only exist on that path.
+            ReportLive("HandlerShiftAboveList100", writer,
+                B.HandlerShiftPage(RowCount: 100),
+                page => page.ShowToolbarAction = true)
         };
 
         return check ? CheckAgainstBaseline(rows) : 0;
@@ -156,12 +166,6 @@ internal static class PayloadBytesReport
         Component before,
         Component after)
     {
-        // Full-HTML payload size — what the server ships TODAY for every state change.
-        var fullHtml = after.RenderAsLiveRoot();
-        writer.ResetWrittenCount();
-        LivePayload.BuildPayloadUtf8WithRoot(writer, fullHtml, "session-bench", null, false);
-        var fullBytes = writer.WrittenCount;
-
         // Diff payload size — build the previous- and current-render frame streams, diff them, and
         // serialize as the diff wire format. The frames' HtmlStart/HtmlEnd offsets index into the SAME
         // serialized string (afterHtml) they were captured against, so that string — not the injected
@@ -169,6 +173,47 @@ internal static class PayloadBytesReport
         // mirroring how the live session pairs its frames with its render HTML.
         var (beforeFrames, _) = CaptureFrames(before);
         var (afterFrames, afterHtml) = CaptureFrames(after);
+
+        // Full-HTML size is measured from the live-root render (runtime script and all) — what the
+        // server would ship without the diff codec — while the diff is sliced from the bare serialize
+        // the frames were captured against.
+        return Emit(name, writer, beforeFrames, afterFrames, afterHtml, after.RenderAsLiveRoot());
+    }
+
+    /// <summary>
+    ///     Diff cost for one state change on a PERSISTENT root, rendered through <c>RenderAsLiveRoot</c> so
+    ///     the live render context exists and event handlers are actually registered. <see cref="Report" />
+    ///     builds two independent trees and serializes them bare, which is right for markup-shaped
+    ///     scenarios but registers no handlers — so it can't see anything handler ids do.
+    /// </summary>
+    private static Row ReportLive<T>(
+        string name,
+        ArrayBufferWriter<byte> writer,
+        T page,
+        Action<T> mutate)
+        where T : Component
+    {
+        var (beforeFrames, _) = CaptureLiveFrames(page);
+        mutate(page);
+        // Here the live-root render IS what the frames were captured against, so one string serves both.
+        var (afterFrames, afterHtml) = CaptureLiveFrames(page);
+        return Emit(name, writer, beforeFrames, afterFrames, afterHtml, afterHtml);
+    }
+
+    // Shared tail: size the full payload and the diff for one before/after frame pair, print the CSV
+    // row, and hand it back for the baseline check.
+    private static Row Emit(
+        string name,
+        ArrayBufferWriter<byte> writer,
+        RenderFrame[] beforeFrames,
+        RenderFrame[] afterFrames,
+        string afterHtml,
+        string fullHtml)
+    {
+        writer.ResetWrittenCount();
+        LivePayload.BuildPayloadUtf8WithRoot(writer, fullHtml, "session-bench", null, false);
+        var fullBytes = writer.WrittenCount;
+
         var ops = new List<EditOp>();
         FrameDiffer.Diff(beforeFrames, afterFrames, ops, afterHtml);
 
@@ -182,6 +227,18 @@ internal static class PayloadBytesReport
             name, fullBytes, diffBytes, ops.Count));
 
         return new Row(name, fullBytes, diffBytes, ops.Count);
+    }
+
+    private static (RenderFrame[] Frames, string Html) CaptureLiveFrames(Component root)
+    {
+        var fw = new FrameWriter();
+        string html;
+        using (FrameSinkScope.Push(fw))
+        {
+            html = root.RenderAsLiveRoot();
+        }
+
+        return (fw.WrittenSpan.ToArray(), html);
     }
 
     private static (RenderFrame[] Frames, string Html) CaptureFrames(Component tree)

--- a/benchmarks/Rask.Benchmarks/SessionChurnReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionChurnReport.cs
@@ -69,6 +69,8 @@ internal static class SessionChurnReport
         Console.WriteLine();
         UpdateCost();
         Console.WriteLine();
+        UpdateCostWithHandlerShift();
+        Console.WriteLine();
         Churn();
         return 0;
     }
@@ -145,6 +147,42 @@ internal static class SessionChurnReport
             var before = GC.GetAllocatedBytesForCurrentThread();
             var sw = Stopwatch.StartNew();
             SessionHarness.Drive(handle.Session, handle.App, UpdateSamples);
+            sw.Stop();
+
+            Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0},{1},{2:0.0}",
+                rows, (GC.GetAllocatedBytesForCurrentThread() - before) / UpdateSamples,
+                sw.Elapsed.TotalMicroseconds / UpdateSamples));
+            GC.KeepAlive(store);
+            GC.KeepAlive(services);
+        }
+    }
+
+    // ---- Update cost when the page's handler count moves ------------------------------
+
+    // The pass above holds the handler count constant, which is the cache's easy case. This one flips one
+    // extra header button on and off, so the number of handlers registered ABOVE the rows changes on every
+    // single update — the shape a page takes whenever a toolbar action, a "selected" affordance or a
+    // conditional row control appears. It is the honest worst case for the clean-subtree cache and the
+    // reason to read it next to UpdateCost: the gap between the two IS the cost of an upstream handler
+    // count moving. Same rows, same warmup, same sample count, so only the toggle differs.
+    private static void UpdateCostWithHandlerShift()
+    {
+        Console.WriteLine("# Update cost with a HANDLER-COUNT SHIFT — same page and sample count as the pass");
+        Console.WriteLine("# above, but each update also toggles one extra header button, so the handler count");
+        Console.WriteLine("# above the rows changes every render. Read the delta against UpdateCost.");
+        Console.WriteLine("Rows,AllocBytesPerUpdate,MicrosecondsPerUpdate");
+
+        foreach (var rows in UpdateCostRows)
+        {
+            var services = SessionHarness.NewHost();
+            var store = services.GetRequiredService<LiveSessionStore>();
+            var handle = SessionHarness.Create(store, rows, connected: true);
+            SessionHarness.EnsureReachedSteadyState(handle);
+            SessionHarness.DriveWithHandlerShift(handle.Session, handle.App, UpdateWarmup);
+
+            var before = GC.GetAllocatedBytesForCurrentThread();
+            var sw = Stopwatch.StartNew();
+            SessionHarness.DriveWithHandlerShift(handle.Session, handle.App, UpdateSamples);
             sw.Stop();
 
             Console.WriteLine(string.Format(CultureInfo.InvariantCulture, "{0},{1},{2:0.0}",

--- a/benchmarks/Rask.Benchmarks/SessionFootprintReport.cs
+++ b/benchmarks/Rask.Benchmarks/SessionFootprintReport.cs
@@ -27,13 +27,13 @@ namespace Rask.Benchmarks;
 ///         high-water mark.
 ///     </para>
 ///     <para>
-///         <b>On the page shape.</b> Rows are keyed and each owns a handler, i.e. a real data grid. That is
-///         deliberately the shape the clean-subtree cache cannot help: <c>TryCacheCleanSubtree</c> rejects
-///         any component carrying a <c>Key</c>, and RASK022 pushes every list item toward one — so the
-///         pages where retained memory actually matters are exactly the pages that keep their Element
-///         graph. A keyless, handler-free variant was measured during development and did not come out
-///         materially cheaper per byte of page, so the sweep reports the realistic shape only rather than
-///         an axis whose arms differ in page size as well as in shape.
+///         <b>On the page shape.</b> Rows are keyed and each owns a handler, i.e. a real data grid — the
+///         shape the clean-subtree cache has to earn its keep on, and RASK022 pushes every list item
+///         toward a <c>Key</c>. Both a <c>Key</c> and a handler were once outright disqualifying for
+///         <c>TryCacheCleanSubtree</c>; neither is now, so these rows hold a compact frame snapshot rather
+///         than an Element graph. A keyless, handler-free variant was measured during development and did
+///         not come out materially cheaper per byte of page, so the sweep reports the realistic shape only
+///         rather than an axis whose arms differ in page size as well as in shape.
 ///     </para>
 ///     <para>
 ///         <b>What this excludes.</b> The transport (a real socket plus Kestrel's ~32 KB of per-connection
@@ -68,7 +68,7 @@ internal static class SessionFootprintReport
         Console.WriteLine(string.Format(CultureInfo.InvariantCulture,
             "# {0} sessions retained per row; SessionsPer1GiB = 1GiB / BytesPerSession.", sessions));
         Console.WriteLine("# Page shape: a keyed data-table row owning one event handler — a real data grid,");
-        Console.WriteLine("# and the shape the clean-subtree cache cannot help (a Key alone disqualifies it).");
+        Console.WriteLine("# the shape the clean-subtree cache has to earn its keep on (it caches both now).");
         Console.WriteLine("# State: Unconnected = GET'd, socket never attached (still holds a MaxSessions slot);");
         Console.WriteLine("#        Connected = socket attached + updates driven (buffers at high-water).");
         Console.WriteLine("Page,PageHtmlBytes,State,BytesPerSession,SessionsPer1GiB");

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,8 +74,9 @@ public async Task Clicking_increments()
 - **`.Instance`** — the component object you passed to `Render(component)`, so you can assert its own state
   rather than parsing it back out of the markup. It stays the same object for the handle's lifetime.
 - **`.HandlerId(domEvent)`** / **`.Attr(name)`** — read a handler id / attribute off the current `Html`.
-  Handler ids are reissued every render, so read one from the current `Html` right before invoking rather
-  than reusing a captured id.
+  A handler id belongs to the component that rendered it and survives a re-render, but not that element
+  leaving the tree or its component rendering a different set of handlers — so read one from the current
+  `Html` right before invoking rather than reusing a captured id.
 - **`.HandlerIds(domEvent)`** / **`.Attrs(name)`** — every match, in document order. This is how you target
   one of several same-event elements — a grid's sort headers, a list's row buttons:
 
@@ -246,8 +247,9 @@ Payload shapes by event:
 
 `TryInvokeHandlerAsync` returns `false` when no handler matches the id — and, when the payload carries
 the client's `"type"` field, when that event cannot feed the handler the id resolved to (an `"input"`
-frame landing on a parameterless `OnClick`). Handler ids are positional per render, so a frame that
-outlived its render would otherwise run whatever now occupies that slot. A payload with no `"type"` — the
+frame landing on a parameterless `OnClick`). A component reuses its own handler slots when it renders a
+different set of handlers, so a frame that outlived its render could otherwise run whatever now occupies
+one. A payload with no `"type"` — the
 shape these examples use — makes no claim, so it dispatches on the id alone as before.
 
 ---

--- a/src/Rask.Core/Component.cs
+++ b/src/Rask.Core/Component.cs
@@ -21,10 +21,17 @@ namespace Rask.Core;
 [CollectionBuilder(typeof(Component), "__Fragment")]
 public abstract class Component
 {
-    // Pre-built "h0".."h255" so handler registration in the common case (small forms,
-    // typical pages) doesn't pay a string-concat allocation per call. Overflow above
-    // 256 handlers per render falls back to the concat path.
+    // Pre-built "h0".."h1023" so minting a handler slot's id in the common case (small forms, typical
+    // pages) doesn't pay a string allocation. A slot past the table falls back to CreateLargeHandlerId
+    // — once, because the id string is then cached on the slot for the component's lifetime.
     private static readonly string[] _smallHandlerIds = BuildSmallHandlerIds(1024);
+
+    // Process-wide source for HandlerState.Generation. Renders are serialized per session but NOT
+    // across sessions, so a per-root counter would hand two concurrently-rendering roots the same
+    // generation numbers. A shared monotonic source makes a generation globally unique, so a component
+    // can never read a stale stamp as "already reset this frame". long, so it cannot wrap in any
+    // realistic uptime.
+    private static long _renderGenerationSource;
 
     // Static empty dict for PersistedChildren exposed via the public-internal accessor —
     // saves callers from null checks while keeping the per-instance allocation lazy.
@@ -882,23 +889,12 @@ public abstract class Component
             return false;
         }
 
-        // Handler ids are positional and reissued from zero on every root render, so the ids baked into
-        // this span are only the ids a walk would issue now if the counter has arrived back at exactly
-        // the value it held when we captured. It hasn't when anything upstream changed how many handlers
-        // it registers, and replaying then would emit ids that collide with a sibling's. Fall through to
-        // a walk, which reissues correct ids and re-captures under them.
-        //
-        // A miss is not free — we released the Element graph at capture, so the walk re-runs Render() —
-        // but it is exactly what every render costs today, and it only happens when an upstream handler
-        // count actually moves.
-        if (cached.Handlers is { } handlers)
+        // Without a live context there is nowhere to put this subtree's registrations back, and the
+        // root's map is cleared every render — replaying would leave its buttons silently dead. So a
+        // handler-bearing snapshot needs one; fall through to a walk when there is none.
+        if (cached.Handlers is not null && liveCtx is null)
         {
-            if (liveCtx is null || liveCtx.PeekNextHandlerId != cached.HandlerStartId)
-            {
-                return false;
-            }
-
-            liveCtx.ReplayHandlerRun(cached.HandlerStartId, handlers);
+            return false;
         }
 
         // The captured frames carry a baked-in data-rask-key: this component's own Key forwarded onto
@@ -921,6 +917,19 @@ public abstract class Component
             return false;
         }
 
+        // Past every bail-out, so the map is only written once the replay is certain to happen — a
+        // rejected replay must leave the root's handler state exactly as it found it, or the walk that
+        // follows would run against registrations it did not make.
+        //
+        // The ids to re-register under are this component's own slot ids: settled for its lifetime, and
+        // therefore still exactly the ids a walk would issue now no matter what the rest of the page did
+        // this frame. That is the whole reason ids are per (component, slot) — there is no page-wide
+        // counter left to arrive back at, so an upstream handler count moving no longer costs a re-walk.
+        if (cached.Handlers is { } handlers)
+        {
+            liveCtx!.ReplayHandlerRun(this, handlers);
+        }
+
         // Re-emit the HTML and re-write the full frame stream (with fresh offsets) into the active
         // writer in one pass — the replayed frames are identical to a fresh walk's, so the diff sees
         // no change, and no Element object graph is touched.
@@ -940,8 +949,6 @@ public abstract class Component
     // from the full element tree to a compact frame array. Safety requires:
     //   * no nested user component (a nested component could go dirty independently; replaying the
     //     parent's frames would skip its re-render and show stale content — <paramref name="hadNested" />),
-    //   * no event handlers (Rask reissues handler ids positionally each render, so a baked-in id in a
-    //     replayed span could collide with a sibling's — deferred to a stable-id follow-up),
     //   * no indexer Children, no Head contribution (would be dropped on replay), not collecting native
     //     chrome, and cache-eligible (no bypass / ambient-state read) — everything that would make a
     //     frame replay diverge from a walk.
@@ -967,17 +974,15 @@ public abstract class Component
     // component's first element adopts an ancestor's forwarded key, baking someone else's identity into
     // our span — not covered by our own-Key check, and stale-replaying it was a live bug.
     //
-    // Event handlers no longer disqualify either. They used to, because ids are positional and reissued
-    // from zero every root render (RenderAsLiveRootCore clears the map): a replay skips the walk, so it
-    // would neither re-register its handlers — leaving the id absent from the freshly-cleared map, i.e.
-    // a dead button — nor advance the counter, shifting every later sibling's ids into collisions. So
-    // the snapshot records the handler run instead (<paramref name="handlerStartId" /> is the counter
-    // read BEFORE the walk), and a replay re-registers it and advances the counter by its length,
-    // reproducing exactly what the walk did. TryReplayCleanSubtree refuses when the counter no longer
-    // lines up.
+    // Event handlers do not disqualify. RenderAsLiveRootCore clears the root's map every render, so a
+    // replay that skipped the walk would leave its ids absent from the map — a silently dead button —
+    // which is why the snapshot records the handler run and a replay re-registers it. What it does NOT
+    // have to reproduce is a position in a page-wide counter: ids belong to (component, slot) and hold
+    // for the component's lifetime, so the run goes back under the same ids it came from and nothing
+    // upstream can invalidate it.
     internal void TryCacheCleanSubtree(
         FrameWriter frames, int frameStart, bool hadNested, bool collectsNativeChrome,
-        string? forwardedKeyAtCapture, int handlerStartId, LiveRenderContext? liveCtx)
+        string? forwardedKeyAtCapture, LiveRenderContext? liveCtx)
     {
         var count = frames.Count - frameStart;
         if (hadNested
@@ -1037,9 +1042,8 @@ public abstract class Component
         // by now our first element has consumed it, so the live slot no longer holds it.
         cached.KeyIdentity = Key ?? (object?)forwardedKeyAtCapture;
         // Snapshot the handler run this walk registered (empty run → null, so a handler-free subtree
-        // pays nothing and its replay skips the counter check entirely).
-        cached.HandlerStartId = handlerStartId;
-        cached.Handlers = liveCtx?.CaptureHandlerRun(handlerStartId);
+        // pays nothing and its replay skips re-registration entirely).
+        cached.Handlers = liveCtx?.CaptureHandlerRun(this);
         // Drop the Element object graph: a clean re-render now replays the frame span above.
         Live.CachedRenderResult = null;
     }
@@ -1262,25 +1266,126 @@ public abstract class Component
     internal string RegisterHandler(Delegate handler) =>
         RegisterHandler(handler, this);
 
+    /// <summary>
+    ///     Open a new handler-slot generation on this render root, telling every component to restart
+    ///     its own slot numbering the next time it registers. Called once per live render pass, from
+    ///     <see cref="LiveRenderContext" />'s constructor.
+    /// </summary>
+    internal void BeginHandlerGeneration() =>
+        (Live.HandlerState ??= new HandlerState()).Generation =
+            Interlocked.Increment(ref _renderGenerationSource);
+
     internal string RegisterHandler(Delegate handler, Component owner)
     {
-        // For lambdas / method groups that close over `this` inside a Component subclass
-        // (e.g., `() => _field++` or `OnSubmit: SubmitHandler`), the originating component is
-        // the right owner to dirty-mark after invocation — it sidesteps the case where an
-        // element with a handler is built in ComponentA.Render() but rendered inside
-        // ComponentB's subtree (passed as a child of a composite wrapper). DelegateOwner also
-        // unwraps a closure that captured `this` alongside a local (e.g. `() => _active = index`),
-        // so wrapping an interactive element in a composite never steals its re-render.
-        if (DelegateOwner.Resolve(handler) is { } target)
+        // Two roles, kept deliberately separate:
+        //
+        //  * slotComponent — CurrentParent, i.e. the component whose SUBTREE this element is being
+        //    serialized in. It anchors the numbering: each component numbers the handlers appearing in
+        //    its own subtree 0, 1, 2… in walk order, so nothing outside that subtree can renumber them.
+        //    Note "serialized in", not "rendered by": an element built in a parent's Render() and passed
+        //    into a wrapper as indexer children serializes inside the WRAPPER's scope and takes a slot
+        //    there. So `Card()[cond ? Button(a) : null, Button(b)]` still renumbers Button(b) when the
+        //    condition flips — the renumbering is bounded to that one wrapper rather than running to the
+        //    end of the page, which is the guarantee, and it is what CleanSubtreeCache relies on.
+        //  * dispatchOwner — the component to dirty-mark after the handler runs. For lambdas / method
+        //    groups that close over `this` inside a Component subclass (`() => _field++`,
+        //    `OnSubmit: SubmitHandler`), DelegateOwner resolves the component that owns the state, so
+        //    an element built in ComponentA.Render() but rendered inside ComponentB's subtree (passed
+        //    as a child of a composite wrapper) still re-renders A. It also unwraps a closure that
+        //    captured `this` alongside a local (`() => _active = index`).
+        //
+        // Anchoring the SLOT to that resolved target instead would undo the whole point: a callback
+        // passed down into a wrapper would consume a slot on the component it was passed FROM, and so
+        // shift that component's own ids from outside its own render.
+        var slotComponent = owner;
+        var dispatchOwner = DelegateOwner.Resolve(handler) is { } target ? target : owner;
+
+        // `this` is always the render root — LiveRenderContext.RegisterHandler dispatches to _root — so
+        // the id source, the generation and the handler map all live on one node.
+        var rootState = Live.HandlerState ??= new HandlerState();
+        var map = Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
+
+        var slotState = slotComponent.Live.HandlerState ??= new HandlerState();
+
+        // Slot ids are drawn from ONE root's sequence, so a component that arrives under a different
+        // root has to re-mint: handing back an id the new root never issued would let the number it
+        // does issue next collide, wiring two elements to a single entry in the map. Reachable through
+        // ordinary API — rendering the same instance a second time builds a fresh root.
+        if (!ReferenceEquals(slotState.MintedUnder, rootState))
         {
-            owner = target;
+            slotState.MintedUnder = rootState;
+            slotState.Slot0Id = null;
+            slotState.RestIds = null;
+            slotState.Stamp = 0;
         }
 
-        Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
-        var id = HandlerId(Live.NextHandlerId++);
-        Live.Handlers[id] = (owner, handler);
+        // Per-component slot index, reset the first time this component registers in a given root
+        // render. The generation stamp (rather than a "reset me" call at scope entry) is what keeps a
+        // component that somehow gets walked twice in one frame numbering forward instead of reusing
+        // its own slots.
+        if (slotState.Stamp != rootState.Generation)
+        {
+            slotState.Stamp = rootState.Generation;
+            slotState.LocalCount = 0;
+        }
+
+        var id = SlotId(slotState, rootState, slotState.LocalCount++);
+        map[id] = (dispatchOwner, handler);
         return id;
     }
+
+    // The id for one of a component's slots: minted the first time a render reaches that slot, then
+    // held for the component's lifetime. Existing slots never renumber, which is the invariant the
+    // clean-subtree cache rests on — an unchanged component's baked-in ids are still exactly the ids a
+    // walk would issue now, no matter what the rest of the page did.
+    //
+    // A number is never handed to a SECOND COMPONENT. When a component unmounts, its ids simply stop
+    // being re-registered, so a stale in-flight event for a removed element resolves to nothing and
+    // safely no-ops; a free-list would instead redirect that click to whichever component took the
+    // number. The number space therefore grows with CUMULATIVE rather than concurrent slots — but the
+    // id STRING is cached per slot, so a steady-state re-render allocates nothing however large the
+    // numbers get, and only a brand-new slot past the interned table costs a one-off string.
+    //
+    // WITHIN one component a slot is still reused: a component that renders [Cancel, Delete] while
+    // editing and [Delete] otherwise gives Delete slot 0 — Cancel's — once editing ends, so an
+    // in-flight click on Cancel can land on Delete. That is unchanged from the page-wide counter this
+    // replaced (which reassigned far more aggressively), and HandlerFrameShape.Accepts is what narrows
+    // it: a frame can only run a handler it can actually feed. Closing it completely would mean keying
+    // slots on something stabler than emission order, which is a separate change.
+    //
+    // Slot 0 is a scalar, so the common single-handler component never allocates an array; slots 1..
+    // share one geometrically grown array, allocated only when a second handler appears.
+    private static string SlotId(HandlerState slotState, HandlerState rootState, int slot)
+    {
+        if (slot == 0)
+        {
+            return slotState.Slot0Id ??= HandlerId(rootState.NextNumber++);
+        }
+
+        var index = slot - 1;
+        var rest = slotState.RestIds;
+        if (rest is null || index >= rest.Length)
+        {
+            // Double (or jump straight to the needed size) so a component registering many handlers
+            // pays O(n) total array allocation, not O(n²). New entries default to null = unassigned.
+            var grown = new string[Math.Max(index + 1, Math.Max(2, (rest?.Length ?? 0) * 2))];
+            if (rest is { Length: > 0 })
+            {
+                Array.Copy(rest, grown, rest.Length);
+            }
+
+            slotState.RestIds = rest = grown;
+        }
+
+        return rest[index] ??= HandlerId(rootState.NextNumber++);
+    }
+
+    // The id already issued for a slot, or null when that slot has never been reached. Capture and
+    // replay read through this so neither can mint a number as a side effect.
+    private static string? IssuedSlotId(HandlerState state, int slot) =>
+        slot == 0
+            ? state.Slot0Id
+            : state.RestIds is { } rest && slot - 1 < rest.Length ? rest[slot - 1] : null;
 
     private static string[] BuildSmallHandlerIds(int n)
     {
@@ -1306,33 +1411,40 @@ public abstract class Component
             : "h" + n;
     }
 
-    // ---- Clean-subtree handler round-trip (root-scoped; see CachedSubtree.Handlers) ----------------
+    // ---- Clean-subtree handler round-trip (see CachedSubtree.Handlers) -----------------------------
     //
-    // These exist so a replayed subtree can reproduce the walk's effect on handler state. They are only
-    // ever called on the live-render ROOT (LiveRenderContext holds it), which is where the id counter
-    // and the map live.
-
-    /// <summary>The next handler id this render will issue — the replay's staleness check.</summary>
-    internal int NextHandlerIdInternal => Live.NextHandlerId;
+    // These exist so a replayed subtree can reproduce the walk's effect on handler state: the root's
+    // map is cleared every render, so a replay that re-emitted a handler's id without re-registering it
+    // would leave a silently dead button. Called on the SLOT component (the one being cached), with the
+    // root passed in because that is where the map lives.
 
     /// <summary>
-    ///     The (owner, delegate) pairs registered from <paramref name="startId" /> to the current
-    ///     counter, in id order, or <c>null</c> for an empty run. The ids of one subtree's walk are
-    ///     contiguous — a cached subtree contains no nested user component, so nothing interleaves its
-    ///     own registrations — which is what lets the run be described by a start and a length.
+    ///     The (owner, delegate) pairs this component registered during the walk that just finished, in
+    ///     slot order, or <c>null</c> when it registered none. A cacheable subtree contains no nested
+    ///     user component, so every handler inside it was registered under THIS component's slots —
+    ///     which is what lets the run be described by a slot count rather than by a position in some
+    ///     page-wide sequence that anything upstream could move.
     /// </summary>
-    internal (Component Owner, Delegate Handler)[]? CaptureHandlerRun(int startId)
+    internal (Component Owner, Delegate Handler)[]? CaptureHandlerRun(Component root)
     {
-        var count = Live.NextHandlerId - startId;
-        if (count <= 0 || Live.Handlers is not { } map)
+        var state = _live?.HandlerState;
+        var rootState = root._live?.HandlerState;
+
+        // A stale stamp means this component registered nothing this render, so LocalCount still
+        // belongs to an older generation and must not be read as a count.
+        if (state is null
+            || rootState is null
+            || state.Stamp != rootState.Generation
+            || state.LocalCount <= 0
+            || root.Live.Handlers is not { } map)
         {
             return null;
         }
 
-        var run = new (Component, Delegate)[count];
-        for (var i = 0; i < count; i++)
+        var run = new (Component, Delegate)[state.LocalCount];
+        for (var i = 0; i < run.Length; i++)
         {
-            if (!map.TryGetValue(HandlerId(startId + i), out var entry))
+            if (IssuedSlotId(state, i) is not { } id || !map.TryGetValue(id, out var entry))
             {
                 // The run isn't what we assumed it was; caching it would risk a dead handler on replay.
                 return null;
@@ -1345,23 +1457,28 @@ public abstract class Component
     }
 
     /// <summary>
-    ///     Re-register a captured run under the ids it was captured with and advance the counter past it,
-    ///     leaving the root's handler state exactly as the skipped walk would have.
+    ///     Re-register a captured run under this component's own slot ids, leaving the root's handler
+    ///     map exactly as the skipped walk would have. The ids belong to the component rather than to a
+    ///     page-wide sequence, so there is nothing upstream that could have invalidated them.
     /// </summary>
-    internal void ReplayHandlerRun(int startId, (Component Owner, Delegate Handler)[] run)
+    internal void ReplayHandlerRun(Component root, (Component Owner, Delegate Handler)[] run)
     {
-        var map = Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
+        var state = _live!.HandlerState!;
+        var map = root.Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
         for (var i = 0; i < run.Length; i++)
         {
-            map[HandlerId(startId + i)] = run[i];
+            // Non-null by construction: CaptureHandlerRun refuses a run whose slots weren't all issued,
+            // and a slot id is never surrendered once minted.
+            map[IssuedSlotId(state, i)!] = run[i];
         }
-
-        Live.NextHandlerId = startId + run.Length;
     }
 
-    // The id for counter value n. Shared by issue / capture / replay so all three agree by construction.
+    // The id for slot number n. Shared by issue / capture / replay so all three agree by construction.
+    // Unsigned compare so a wrapped (negative) number falls to the format path and yields "h-1" rather
+    // than indexing the table out of bounds. Numbers now accumulate over a session's whole life instead
+    // of resetting each render, so overflow is reachable in principle — 2^31 slots — where it was not.
     private static string HandlerId(int n) =>
-        n < _smallHandlerIds.Length ? _smallHandlerIds[n] : CreateLargeHandlerId(n);
+        (uint)n < (uint)_smallHandlerIds.Length ? _smallHandlerIds[n] : CreateLargeHandlerId(n);
 
     internal ValueTask<bool> TryInvokeHandlerAsync(string id, JsonElement payload)
         => TryInvokeHandlerAsync(id, payload, null);
@@ -1376,11 +1493,12 @@ public abstract class Component
 
         var (owner, handler) = entry;
 
-        // The id said WHICH handler; the frame's own `type` says what it is carrying. Ids are positional
-        // per render, so a frame that outlived its render resolves to whatever now occupies that slot —
-        // and running it because the id happened to resolve is how an `input` message ends up invoking a
-        // parameterless callback. A frame that cannot feed the handler it landed on is a stale id, and is
-        // answered exactly like one.
+        // The id said WHICH handler; the frame's own `type` says what it is carrying. An id names a
+        // component's slot for that component's lifetime, so a frame that outlived its render usually
+        // resolves to the same handler or to nothing at all — but a component that swapped what its
+        // slot 0 renders (an input handler this frame, a click handler the next) still lands a stale
+        // `input` message on a parameterless callback. A frame that cannot feed the handler it landed
+        // on is a stale id by definition, and is answered exactly like one.
         if (!HandlerFrameShape.Accepts(payload, handler))
         {
             return false;
@@ -1748,12 +1866,18 @@ public abstract class Component
     // copied into it instead and null is returned (the caller reads sink.Current).
     private string? RenderAsLiveRootCore(IServiceProvider? services, bool publishOnly, RenderedHtmlBuffers? sink)
     {
-        // Reuse the handler dictionary across renders — IDs are reissued from 0 every
-        // root render, so the prior frame's contents are irrelevant. Lazy-init only on
-        // the very first render of this component as a root.
+        // Reuse the handler map across renders, but clear it: a component that left the tree must not
+        // keep a live registration, and every component still in it re-registers during the walk (or,
+        // for a replayed subtree, via ReplayHandlerRun). Lazy-init only on the very first render of
+        // this component as a root.
+        //
+        // The IDS are not reset. They belong to (component, slot) and stick for the component's
+        // lifetime, so a component that renders unchanged re-registers under exactly the ids already
+        // baked into the page — which is what lets the diff leave its data-rask-on-* attributes alone
+        // and lets its cached subtree replay. What restarts each component's own slot numbering is the
+        // generation, stamped by LiveRenderContext's constructor a few lines below.
         Live.Handlers ??= new Dictionary<string, (Component, Delegate)>();
         Live.Handlers.Clear();
-        Live.NextHandlerId = 0;
         // Lazily init on first root render — non-root Component instances (the 99% case for
         // leaf Elements in a page) never touch this field and stay allocation-free.
         var previousEditContexts =
@@ -2151,20 +2275,72 @@ public abstract class Component
 
         /// <summary>
         ///     The subtree's event handlers in the order the walk registered them, or <c>null</c> when it
-        ///     has none. Ids are NOT stored: the walk issues them from a contiguous counter run starting
-        ///     at <see cref="HandlerStartId" />, so id <c>i</c> is recomputable — one less reference per
-        ///     entry. Retaining the delegates is not new retention: the released Element graph held these
-        ///     very instances.
+        ///     has none. Ids are NOT stored: a cached subtree has no nested user component, so entry
+        ///     <c>i</c> is this component's own slot <c>i</c> and its id is read back off the slot table
+        ///     — one less reference per entry, and the id is settled for the component's lifetime so
+        ///     there is nothing to go stale. Retaining the delegates is not new retention: the released
+        ///     Element graph held these very instances.
         /// </summary>
         public (Component Owner, Delegate Handler)[]? Handlers;
+    }
+
+    /// <summary>
+    ///     Handler-id bookkeeping, hung off <see cref="LiveState.HandlerState" /> so a component that
+    ///     renders no handler pays one null reference rather than a field per role. The render root
+    ///     uses the first two members (it owns the id source); a component that renders handlers uses
+    ///     the rest (its own slot table). See <see cref="RegisterHandler(Delegate, Component)" />.
+    ///     <para>
+    ///         A slot id means something only within the sequence that minted it, so a component that
+    ///         turns up under a different root drops its table and re-mints — see
+    ///         <see cref="MintedUnder" />. Its ids are not stable across that move, which is correct:
+    ///         they were never ids the new root had issued.
+    ///     </para>
+    /// </summary>
+    private sealed class HandlerState
+    {
+        // ---- render root ----
 
         /// <summary>
-        ///     The root's handler counter as it stood when <see cref="Frames" /> were captured, i.e. the
-        ///     first id this subtree baked in. Handler ids are positional and reissued from zero every
-        ///     root render, so a replay is only sound when the counter has arrived back at this exact
-        ///     value — otherwise the baked ids are not the ones a walk would now issue.
+        ///     The next number this root will hand out. Monotonic for the root's whole life: numbers are
+        ///     never reset and never reused, so a stale in-flight event cannot be redirected onto a
+        ///     component that took a freed number.
         /// </summary>
-        public int HandlerStartId;
+        public int NextNumber;
+
+        /// <summary>
+        ///     Identifies the current root render, so each component resets its slot counter exactly
+        ///     once per frame. Drawn from a process-wide source rather than counted per root, because a
+        ///     component reached from two different roots must never mistake one root's generation for
+        ///     the other's and skip its reset.
+        /// </summary>
+        public long Generation;
+
+        // ---- a component that renders handlers ----
+
+        /// <summary>
+        ///     The <see cref="HandlerState" /> of the root whose sequence minted this component's slot
+        ///     ids. Compared by reference on every registration: a component that turns up under a
+        ///     different root re-mints, because ids from one root's sequence mean nothing in another's.
+        /// </summary>
+        public HandlerState? MintedUnder;
+
+        /// <summary>The generation in which <see cref="LocalCount" /> was last reset.</summary>
+        public long Stamp;
+
+        /// <summary>Slots this component has used so far in the generation named by <see cref="Stamp" />.</summary>
+        public int LocalCount;
+
+        /// <summary>
+        ///     The id for slot 0 — a scalar, so the common single-handler component never allocates an
+        ///     array. Minted on first use and then held for the component's lifetime.
+        /// </summary>
+        public string? Slot0Id;
+
+        /// <summary>
+        ///     Ids for slots 1.. (index <c>i</c> → slot <c>i+1</c>), grown geometrically and allocated
+        ///     only when a second handler appears. A null entry is a slot never yet reached.
+        /// </summary>
+        public string[]? RestIds;
     }
 
     // The hoisted state — class so it stays out-of-band from each Component instance.
@@ -2200,7 +2376,7 @@ public abstract class Component
         public bool HasRenderedOnce;
         public bool IsDisposed;
         public bool IsUnmounted;
-        public int NextHandlerId;
+        public HandlerState? HandlerState;
         public Dictionary<Component, Component>? ParentMap;
         public Dictionary<LiveRenderContext.ObjectKey, EditContext>? PersistedEditContexts;
         public Dictionary<(Type, int), Component>? PreviousChildren;

--- a/src/Rask.Core/HtmlSerializer.cs
+++ b/src/Rask.Core/HtmlSerializer.cs
@@ -474,10 +474,6 @@ internal static class HtmlSerializer
                 // consumed — and the snapshot needs to know which identity it was captured under.
                 var forwardedKeyAtCapture = KeyForwardScope.Peek();
 
-                // Likewise the handler-id counter: the walk about to run issues this subtree's ids
-                // starting here, and the snapshot has to know where its run began to replay it.
-                var handlerStartId = liveCtx?.PeekNextHandlerId ?? 0;
-
                 using (LiveRenderContext.PushScopeOrNone(liveCtx, component))
                 using (LiveRenderContext.EnterParentScopeOrNone(liveCtx, component))
                 using (component.EnterChildrenScopeInternal())
@@ -511,7 +507,7 @@ internal static class HtmlSerializer
                 {
                     component.TryCacheCleanSubtree(
                         frames, frameStart, hadNested, liveCtx?.CollectsNativeChrome ?? false,
-                        forwardedKeyAtCapture, handlerStartId, liveCtx);
+                        forwardedKeyAtCapture, liveCtx);
                 }
 
                 // Mark that our parent's subtree now contains a user component (us).
@@ -543,5 +539,17 @@ internal static class HtmlSerializer
                 Serialize(boundary.RenderForLive(), sb);
             }
         }
+
+        // Mark that our parent's subtree now contains a nested component, exactly as the user-component
+        // arm does — an ErrorBoundary IS one, and both reasons that flag exists apply to it:
+        //
+        //  * It re-renders independently. Trip() swaps the body for the fallback without dirtying the
+        //    enclosing component, so replaying that component's frames would re-emit the subtree that
+        //    just threw.
+        //  * It becomes CurrentParent while its children serialize, so handlers the enclosing component
+        //    wrote and passed through as children take slots on the BOUNDARY. The enclosing component's
+        //    capture reads only its own slots, so replaying it would drop those registrations from the
+        //    freshly-cleared map and leave the buttons dead.
+        _sawNestedComponent = true;
     }
 }

--- a/src/Rask.Core/Live/HandlerFrameShape.cs
+++ b/src/Rask.Core/Live/HandlerFrameShape.cs
@@ -6,13 +6,14 @@ namespace Rask.Core.Live;
 // Cross-checks the `type` a client frame declares against the argument shape the handler its `id`
 // resolved to actually demands.
 //
-// Handler ids are POSITIONAL per render (Component.HandlerId over Live.NextHandlerId), so the same id
-// names a different handler after the tree changes. Dispatch used to key on the id alone: a frame that
-// outlived the render it was issued against resolved to whatever now sits in that slot and ran it, with
-// no complaint — `{"id":"h37","type":"input","value":"…"}` arriving at a page where h37 is now a
+// A handler id names one component's slot (Component.RegisterHandler), so the same id can still name a
+// different handler after that component changes what it renders into that slot. Dispatch used to key
+// on the id alone: a frame that outlived the render it was issued against ran whatever now sits there,
+// with no complaint — `{"id":"h37","type":"input","value":"…"}` arriving at a page where h37 is now a
 // parameterless Callback invoked that callback. Not a cross-origin hole (the socket is same-origin and
-// session-bound), but positional ids make the collision ordinary rather than exotic, and the silence is
-// what makes it bad: nothing says the wrong thing ran.
+// session-bound), and per-component ids make it far rarer than the page-wide counter that preceded them
+// did — a slot is no longer reassigned just because something upstream changed. The silence is what
+// makes the remainder bad: nothing says the wrong thing ran.
 //
 // The check is the frame's own claim about what it carries, versus what the delegate needs to be fed. A
 // mismatch is a stale id by definition, so it is answered exactly like one — `false`, no render.

--- a/src/Rask.Core/Live/LiveRenderContext.cs
+++ b/src/Rask.Core/Live/LiveRenderContext.cs
@@ -58,6 +58,11 @@ public sealed class LiveRenderContext : IDisposable
         // read, not a virtual interface call — keeps the render hot path allocation- and dispatch-free on the
         // non-native hosts, which never collect chrome.
         _collectsNativeChrome = _handle?.CollectsNativeChrome ?? false;
+        // One context IS one render pass, and a pass is exactly the scope over which each component
+        // numbers its handler slots from 0. Stamping the generation here rather than in
+        // RenderAsLiveRootCore covers every path that can register a handler — Begin is public, and a
+        // caller driving a root through it repeatedly would otherwise never see its slot counters reset.
+        root.BeginHandlerGeneration();
         _previous = _current.Value;
         _previousSync = _syncCurrent;
         _current.Value = this;
@@ -225,20 +230,17 @@ public sealed class LiveRenderContext : IDisposable
         // owner association is what lets the post-handler dirty-mark land on the right node.
         _root.RegisterHandler(handler, CurrentParent);
 
-    // Handler ids and their map live on the root; the clean-subtree frame cache needs to read the
-    // counter and re-establish a skipped walk's registrations, and only this context knows the root.
-    // See Component.CachedSubtree.Handlers.
+    // The handler map lives on the root; the clean-subtree frame cache has to re-establish a skipped
+    // walk's registrations in it, and only this context knows which root that is. The slot ids come
+    // from the cached component itself. See Component.CachedSubtree.Handlers.
 
-    /// <summary>The next handler id this render will issue.</summary>
-    internal int PeekNextHandlerId => _root.NextHandlerIdInternal;
+    /// <summary>Snapshot the run <paramref name="component" /> just registered (null if it registered none).</summary>
+    internal (Component Owner, Delegate Handler)[]? CaptureHandlerRun(Component component) =>
+        component.CaptureHandlerRun(_root);
 
-    /// <summary>Snapshot the handler run registered since <paramref name="startId" /> (null if empty).</summary>
-    internal (Component Owner, Delegate Handler)[]? CaptureHandlerRun(int startId) =>
-        _root.CaptureHandlerRun(startId);
-
-    /// <summary>Re-register a captured run and advance the counter past it, as the skipped walk would.</summary>
-    internal void ReplayHandlerRun(int startId, (Component Owner, Delegate Handler)[] run) =>
-        _root.ReplayHandlerRun(startId, run);
+    /// <summary>Re-register a captured run under its component's own slot ids, as the skipped walk would.</summary>
+    internal void ReplayHandlerRun(Component component, (Component Owner, Delegate Handler)[] run) =>
+        component.ReplayHandlerRun(_root, run);
 
     public T GetOrCreate<T>(Func<IServiceProvider, T> factory) where T : Component
     {

--- a/src/Rask.Core/Live/RenderFrame.cs
+++ b/src/Rask.Core/Live/RenderFrame.cs
@@ -114,7 +114,7 @@ public struct RenderFrame
 ///     <c>HtmlStart</c>/<c>HtmlEnd</c> (offsets into one render's HTML, regenerated on replay) — so a
 ///     mounted page retains ~24 bytes per node instead of the full frame's ~40. The live
 ///     <see cref="RenderFrame" /> stream that <see cref="FrameDiffer" /> walks is unchanged; only the
-///     per-component <c>CachedFrames</c> snapshot uses this leaner shape. On replay,
+///     per-component clean-subtree snapshot uses this leaner shape. On replay,
 ///     <see cref="HtmlSerializer" /> re-emits the HTML AND writes full frames (with fresh offsets) back
 ///     into the active <see cref="FrameWriter" /> in one pass.
 /// </summary>

--- a/src/Rask.Testing/RenderedComponent.cs
+++ b/src/Rask.Testing/RenderedComponent.cs
@@ -157,9 +157,10 @@ public class RenderedComponent : IRenderHandle
     /// <summary>
     ///     The handler id for the <b>first</b> element wired to <paramref name="domEvent" /> (e.g.
     ///     <c>"click"</c>, <c>"input"</c>, <c>"change"</c>, <c>"submit"</c>), or <c>null</c> if none is
-    ///     present. Handler ids are reissued from scratch on every render, so an id is valid only for the
-    ///     <see cref="Html" /> it was read from — re-query after any re-render rather than reusing a
-    ///     captured id. When several elements are wired to the same event, use <see cref="HandlerIds" />;
+    ///     present. An id belongs to the component that rendered it and survives a re-render, but not
+    ///     that element leaving the tree or its component rendering a different set of handlers — so
+    ///     treat an id as valid only for the <see cref="Html" /> it was read from and re-query after a
+    ///     re-render. When several elements are wired to the same event, use <see cref="HandlerIds" />;
     ///     the event helpers below always target the first match.
     /// </summary>
     public string? HandlerId(string domEvent) => Attr("data-rask-on-" + domEvent);
@@ -168,7 +169,7 @@ public class RenderedComponent : IRenderHandle
     ///     The handler ids for <b>every</b> element wired to <paramref name="domEvent" />, in document order
     ///     — index the one under test when a component wires several (a grid's sort headers, a list's row
     ///     buttons): <c>await page.InvokeAsync(page.HandlerIds("click")[2])</c>. Like <see cref="HandlerId" />,
-    ///     these are only valid for the render they were read from, so re-read them after every re-render.
+    ///     treat these as valid only for the render they were read from, so re-read after every re-render.
     /// </summary>
     public IReadOnlyList<string> HandlerIds(string domEvent) => Attrs("data-rask-on-" + domEvent);
 
@@ -384,8 +385,10 @@ public class RenderedComponent : IRenderHandle
         if (!await DispatchAsync(handlerId, jsonPayload).ConfigureAwait(false))
         {
             throw new InvalidOperationException(
-                $"No handler with id '{handlerId}' is registered in the current render. Handler ids are "
-                + "reissued every render — read the id from the current Html (HandlerId(\"click\") / "
+                $"No handler with id '{handlerId}' is registered in the current render. A handler id "
+                + "belongs to the component that rendered it, so it survives a re-render but not the "
+                + "element leaving the tree or that component rendering a different set of handlers — "
+                + "read the id from the current Html (HandlerId(\"click\") / "
                 + "Attr(\"data-rask-on-...\")) immediately before invoking.");
         }
 

--- a/tests/Rask.Bootstrap.Tests/BsDataGridColumnsTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridColumnsTests.cs
@@ -57,8 +57,8 @@ public class BsDataGridColumnsTests
     private static string Handler(string html, string kind, int index = 0) =>
         Regex.Matches(html, $"data-rask-on-{kind}=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ElementAt(index);
 
-    // The handler id of the button carrying this aria-label. Read from the current markup because ids are
-    // reissued every render.
+    // The handler id of the button carrying this aria-label. Read from the current markup rather than
+    // captured: an id only holds while its component keeps rendering that same handler.
     private static string ClickFor(string html, string label)
     {
         var m = Regex.Match(html,

--- a/tests/Rask.Bootstrap.Tests/BsDataGridGroupPanelTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridGroupPanelTests.cs
@@ -257,8 +257,8 @@ public class BsDataGridGroupPanelTests
         Assert.Contains("No rows.", html, StringComparison.Ordinal);
     }
 
-    // The handler id of the button carrying this aria-label. Ids are reissued every render, so it is read from
-    // the current markup rather than captured.
+    // The handler id of the button carrying this aria-label. Read from the current markup rather than
+    // captured: an id only holds while its component keeps rendering that same handler.
     private static string ClickFor(string html, string label)
     {
         var m = Regex.Match(html,

--- a/tests/Rask.Bootstrap.Tests/BsDataGridRowTests.cs
+++ b/tests/Rask.Bootstrap.Tests/BsDataGridRowTests.cs
@@ -18,8 +18,9 @@ public class BsDataGridRowTests
         new BsColumn<Row> { Title = "Qty", Value = r => r.Qty },
     ];
 
-    // Handler ids are reissued every render, so read them fresh in document order and index the one under
-    // test — the same approach BsDataGridInteractionTests uses.
+    // Read fresh in document order and index the one under test, rather than assuming an id — the grid
+    // decides which handlers it renders, and an id only holds while it keeps rendering that one. Same
+    // approach BsDataGridInteractionTests uses.
     private static string[] ClickHandlers(string html) =>
         Regex.Matches(html, "data-rask-on-click=\"([^\"]+)\"").Select(m => m.Groups[1].Value).ToArray();
 

--- a/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
+++ b/tests/Rask.Core.Tests/Live/CleanSubtreeReplayTests.cs
@@ -136,10 +136,10 @@ public class CleanSubtreeReplayTests
 
     // ---- Handler-bearing subtrees ----------------------------------------------------------
     //
-    // Handler ids are positional and reissued from zero on every ROOT render, so these go through
-    // RenderAsLiveRoot rather than HtmlSerializer.Serialize: only the real root path clears the map and
-    // resets the counter, which is exactly the state a replay has to reproduce. The component under test
-    // is a nested child (the root itself is never cacheable — it contains a user component).
+    // The root's handler map is cleared on every ROOT render, so these go through RenderAsLiveRoot
+    // rather than HtmlSerializer.Serialize: only the real root path clears it and opens a new slot
+    // generation, which is exactly the state a replay has to reproduce. The component under test is a
+    // nested child (the root itself is never cacheable — it contains a user component).
 
     private static JsonElement EmptyPayload => JsonDocument.Parse("{}").RootElement;
 
@@ -233,9 +233,10 @@ public class CleanSubtreeReplayTests
     }
 
     [Fact]
-    public async Task ReplayedSubtree_AdvancesTheHandlerCounter()
+    public async Task ReplayedSiblings_KeepDistinctHandlerRegistrations()
     {
-        // A replay that didn't advance the counter would hand the SECOND row the first row's id.
+        // Two replayed siblings must each re-register under their OWN slot ids. A replay that wrote
+        // both runs into the same ids would leave the second row's button wired to the first's.
         var a = new StubComponent(() => Div(Class: "a", OnClick: () => { })["a"]);
         var b = new StubComponent(() => Div(Class: "b", OnClick: () => { })["b"]);
         var root = new StubComponent(() => Div(Class: "page")[a, b]);
@@ -253,16 +254,56 @@ public class CleanSubtreeReplayTests
     }
 
     [Fact]
-    public async Task HandlerIdsShiftUpstream_FallsBackToWalk()
+    public async Task HandlerInsideAnErrorBoundary_SurvivesTheEnclosingComponentsReplay()
     {
-        // A handler appearing BEFORE a cached sibling shifts every later id by one. The sibling's baked
-        // ids are then not what a walk would issue, so it must re-walk under the corrected ids rather
-        // than replay a colliding span.
+        // An ErrorBoundary becomes CurrentParent while its children serialize, so handlers written by
+        // the ENCLOSING component but passed through the boundary as children land on the boundary's
+        // slot table, not the enclosing one's. A capture that reads only the cached component's own
+        // slots would miss them, and since the root's map is cleared every render the replay would
+        // leave a button that resolves to nothing — dead for the rest of the session, silently.
+        //
+        // A boundary is also a component that can re-render independently (it trips into its fallback
+        // without dirtying its parent), which is the same reason a nested user component disqualifies
+        // the enclosing subtree from caching. So it disqualifies too, and the walk keeps the button live.
+        var clicks = 0;
+        var page = new StubComponent(() =>
+            Div(Class: "page")[ErrorBoundary()[Div(Class: "btn", OnClick: () => clicks++)["go"]]]);
+        var root = new StubComponent(() => Div(Class: "shell")[page]);
+        var cache = new SessionRenderCache();
+        var ops = new List<EditOp>();
+
+        var first = RenderRoot(cache, root, ops);
+        Assert.Contains("data-rask-on-click", first);
+
+        var second = RenderRoot(cache, root, ops);
+        Assert.Equal(first, second);
+
+        var id = HandlerIdIn(second);
+        Assert.True(await root.TryInvokeHandlerAsync(id, EmptyPayload), "the button must still resolve");
+        Assert.Equal(1, clicks);
+    }
+
+    [Fact]
+    public async Task HandlerAppearingUpstream_LeavesACachedSiblingReplayable()
+    {
+        // A handler appearing BEFORE a cached sibling used to shift every later id by one, so the
+        // sibling's baked ids were no longer what a walk would issue and it had to be re-walked under
+        // corrected ids. Ids are now per (component, slot), so the header growing one costs the header
+        // and nothing else: the row's ids are still exactly what a walk would issue, and its snapshot
+        // replays. This is the whole point of stable ids — the cache stops missing on a change that
+        // never touched the cached subtree.
         var headerHandler = false;
         var rowClicks = 0;
-        var row = new StubComponent(() => Div(Class: "row", OnClick: () => rowClicks++)["row"]);
+        var rowRenders = 0;
+        var row = new StubComponent(() =>
+        {
+            rowRenders++;
+            return Div(Class: "row", OnClick: () => rowClicks++)["row"];
+        });
         var root = new StubComponent(() => Div(Class: "page")[
-            headerHandler ? Div(Class: "hdr", OnClick: () => { })["hdr"] : Div(Class: "hdr")["hdr"],
+            // The wrapper stays put so only the HANDLER COUNT moves — the row keeps its position in
+            // the tree and its identity, and the render below is a pure cache question.
+            Div(Class: "hdr")[headerHandler ? Div(Class: "act", OnClick: () => { })["act"] : null],
             row
         ]);
         var cache = new SessionRenderCache();
@@ -271,15 +312,18 @@ public class CleanSubtreeReplayTests
         var first = RenderRoot(cache, root, ops);
         var rowIdBefore = HandlerIdIn(first);
         Assert.True(row.IsCleanSubtreeCachedForTest);
+        Assert.Equal(1, rowRenders);
 
-        // The header grows a handler and takes the row's old id.
         headerHandler = true;
         var second = RenderRoot(cache, root, ops);
         var headerId = HandlerIdIn(second, 0);
         var rowIdAfter = HandlerIdIn(second, 1);
 
-        Assert.Equal(rowIdBefore, headerId);       // the header claimed the id the row used to hold
-        Assert.NotEqual(rowIdAfter, headerId);     // the row moved rather than colliding
+        Assert.Equal(rowIdBefore, rowIdAfter);     // the row did not move
+        Assert.NotEqual(rowIdAfter, headerId);     // and the header drew a number of its own
+        Assert.Equal(1, rowRenders);               // ...so the row replayed rather than re-rendering
+        Assert.True(row.IsCleanSubtreeCachedForTest);
+
         Assert.True(await root.TryInvokeHandlerAsync(rowIdAfter, EmptyPayload));
         Assert.Equal(1, rowClicks);                // and it is still the ROW's handler behind it
     }

--- a/tests/Rask.Core.Tests/Live/StableHandlerIdTests.cs
+++ b/tests/Rask.Core.Tests/Live/StableHandlerIdTests.cs
@@ -1,0 +1,350 @@
+using System.Globalization;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+
+#pragma warning disable RASK014 // test-defined component subclasses have no generated factories
+
+namespace Rask.Core.Tests.Live;
+
+// Handler ids are assigned per (rendering component, local slot) and stick for that component's
+// lifetime. The invariant every test here defends: WHAT ONE COMPONENT RENDERS CANNOT RENUMBER
+// ANOTHER'S HANDLERS. Before this, ids came from a single per-render counter reset to 0 each frame,
+// so one component gaining a handler shifted every later handler on the page — rewriting
+// data-rask-on-* on untouched elements, and forcing the clean-subtree cache to re-walk them.
+//
+// Each case asserts the id AND that dispatch still lands on the right delegate, because a stable id
+// that resolves to the wrong handler is worse than an unstable one.
+public class StableHandlerIdTests
+{
+    private static JsonElement EmptyPayload => JsonDocument.Parse("{}").RootElement;
+
+    // The handler id on the element carrying `cls`. Attribute order puts class before the
+    // data-rask-on-* hooks (Element.WriteAttributes), so this stays anchored to the right element.
+    private static string IdOn(string html, string cls)
+    {
+        var m = Regex.Match(html, $"class=\"{cls}\"[^>]*?data-rask-on-[a-z]+=\"([^\"]+)\"");
+        Assert.True(m.Success, $"no handler hook on .{cls} in: {html}");
+        return m.Groups[1].Value;
+    }
+
+    private static int NumberOf(string handlerId) =>
+        int.Parse(handlerId.AsSpan(1), CultureInfo.InvariantCulture);
+
+    // ---- One component gaining a handler must not renumber another's -----------------------------
+
+    private sealed class Toggler : Component
+    {
+        public int ExtraClicks;
+        public int OwnClicks;
+        private bool _expanded;
+
+        public void Expand()
+        {
+            _expanded = true;
+            StateHasChanged();
+        }
+
+        protected override Component? Render() => _expanded
+            ? Div(Class: "t-wrap")[
+                Div(Class: "t-extra", OnClick: () => ExtraClicks++)["extra"],
+                Div(Class: "t-own", OnClick: () => OwnClicks++)["own"]
+            ]
+            : Div(Class: "t-wrap")[Div(Class: "t-own", OnClick: () => OwnClicks++)["own"]];
+    }
+
+    private sealed class Steady : Component
+    {
+        public int Clicks;
+
+        protected override Component? Render() =>
+            Div(Class: "steady", OnClick: () => Clicks++)["steady"];
+    }
+
+    [Fact]
+    public async Task UnchangedComponentKeepsItsId_WhenAnotherComponentGainsAHandler()
+    {
+        var toggler = new Toggler();
+        var steady = new Steady();
+        var root = new StubComponent(() => Div(Class: "page")[toggler, steady]);
+
+        var before = root.RenderAsLiveRoot();
+        var steadyId = IdOn(before, "steady");
+
+        // The toggler now renders one MORE handler, and renders it BEFORE `steady` in walk order —
+        // the exact shape that used to push every later id up by one.
+        toggler.Expand();
+        var after = root.RenderAsLiveRoot();
+
+        Assert.Equal(steadyId, IdOn(after, "steady"));
+        Assert.True(await root.TryInvokeHandlerAsync(steadyId, EmptyPayload), "the unshifted id must resolve");
+        Assert.Equal(1, steady.Clicks);
+        Assert.Equal(0, toggler.ExtraClicks);
+
+        // ...and the handler the toggler gained is live too, on an id of its own.
+        var extraId = IdOn(after, "t-extra");
+        Assert.NotEqual(steadyId, extraId);
+        Assert.True(await root.TryInvokeHandlerAsync(extraId, EmptyPayload));
+        Assert.Equal(1, toggler.ExtraClicks);
+    }
+
+    // ---- A component's own slots stay put across its own re-renders ------------------------------
+
+    private sealed class ThreeHandlers : Component
+    {
+        public int A;
+        public int B;
+        public int C;
+        public int Version;
+
+        public void Touch()
+        {
+            Version++;
+            StateHasChanged();
+        }
+
+        protected override Component? Render() =>
+            Div(Class: "three")[
+                Div(Class: "h-a", OnClick: () => A++)[$"a{Version}"],
+                Div(Class: "h-b", OnClick: () => B++)["b"],
+                Div(Class: "h-c", OnClick: () => C++)["c"]
+            ];
+    }
+
+    [Fact]
+    public async Task MultiHandlerComponent_KeepsEverySlotId_AcrossRenders_AndEachStillDispatches()
+    {
+        var three = new ThreeHandlers();
+        var root = new StubComponent(() => Div(Class: "page")[three]);
+
+        var before = root.RenderAsLiveRoot();
+        var (a, b, c) = (IdOn(before, "h-a"), IdOn(before, "h-b"), IdOn(before, "h-c"));
+        Assert.Equal(3, new HashSet<string> { a, b, c }.Count);
+
+        three.Touch();
+        var after = root.RenderAsLiveRoot();
+
+        Assert.Equal(a, IdOn(after, "h-a"));
+        Assert.Equal(b, IdOn(after, "h-b"));
+        Assert.Equal(c, IdOn(after, "h-c"));
+
+        // Every slot resolves to ITS OWN delegate — the failure mode of a slot table that drifts is a
+        // stable-looking id wired to the neighbouring handler.
+        Assert.True(await root.TryInvokeHandlerAsync(a, EmptyPayload));
+        Assert.True(await root.TryInvokeHandlerAsync(b, EmptyPayload));
+        Assert.True(await root.TryInvokeHandlerAsync(c, EmptyPayload));
+        Assert.Equal((1, 1, 1), (three.A, three.B, three.C));
+    }
+
+    // ---- Numbering follows the RENDERING component, not the delegate's target --------------------
+
+    private sealed class Callee : Component
+    {
+        public int External;
+        public int Own;
+
+        public void OnExternal() => External++;
+
+        protected override Component? Render() =>
+            Div(Class: "callee", OnClick: () => Own++)["callee"];
+    }
+
+    private sealed class Caller : Component
+    {
+        public Callee? Target;
+        private bool _wired;
+
+        public void Wire()
+        {
+            _wired = true;
+            StateHasChanged();
+        }
+
+        protected override Component? Render() => _wired
+            ? Div(Class: "caller-wrap")[
+                Div(Class: "to-callee", OnClick: Target!.OnExternal)["call out"],
+                Div(Class: "caller", OnClick: () => { })["caller"]
+            ]
+            : Div(Class: "caller-wrap")[Div(Class: "caller", OnClick: () => { })["caller"]];
+    }
+
+    [Fact]
+    public async Task HandlerTargetingAnotherComponent_DoesNotShiftThatComponentsOwnIds()
+    {
+        // The delegate's target is `callee`, but it is REGISTERED during `caller`'s render. Slot
+        // numbering is anchored to the component whose Render() emitted the element (CurrentParent), so
+        // this consumes one of the CALLER's slots — a callee that renders nothing new keeps its own id.
+        // Anchoring to the delegate target instead would let a callback passed into a wrapper renumber
+        // the component it was passed from.
+        var callee = new Callee();
+        var caller = new Caller { Target = callee };
+        var root = new StubComponent(() => Div(Class: "page")[caller, callee]);
+
+        var before = root.RenderAsLiveRoot();
+        var calleeId = IdOn(before, "callee");
+
+        caller.Wire();
+        var after = root.RenderAsLiveRoot();
+
+        Assert.Equal(calleeId, IdOn(after, "callee"));
+
+        // The cross-component handler fires on its own id, and dirty-marking still follows the delegate
+        // target (Callee), not the slot anchor — the two roles stay separate.
+        var crossId = IdOn(after, "to-callee");
+        Assert.NotEqual(calleeId, crossId);
+        Assert.True(await root.TryInvokeHandlerAsync(crossId, EmptyPayload));
+        Assert.Equal(1, callee.External);
+        Assert.Equal(0, callee.Own);
+
+        Assert.True(await root.TryInvokeHandlerAsync(calleeId, EmptyPayload));
+        Assert.Equal(1, callee.Own);
+    }
+
+    // ---- A number is never handed to a second component --------------------------------------------
+
+    private sealed class LeafA : Component
+    {
+        public int Clicks;
+
+        protected override Component? Render() => Div(Class: "leaf-a", OnClick: () => Clicks++)["a"];
+    }
+
+    private sealed class LeafB : Component
+    {
+        public int Clicks;
+
+        protected override Component? Render() => Div(Class: "leaf-b", OnClick: () => Clicks++)["b"];
+    }
+
+    [Fact]
+    public async Task UnmountedHandlerId_NoOps_AndIsNotReusedByTheComponentThatReplacesIt()
+    {
+        // Recycling a freed number is what makes a stale in-flight event dangerous: the click a user
+        // sent a moment before the row vanished would resolve to whatever took the number. Numbers are
+        // therefore issued once and never reissued — the stale id resolves to nothing and no-ops.
+        var showA = true;
+        var leafA = new LeafA();
+        var leafB = new LeafB();
+        var root = new StubComponent(() => showA
+            ? Div(Class: "page")[leafA]
+            : Div(Class: "page")[leafB]);
+
+        var before = root.RenderAsLiveRoot();
+        var idA = IdOn(before, "leaf-a");
+
+        showA = false;
+        var after = root.RenderAsLiveRoot();
+        var idB = IdOn(after, "leaf-b");
+
+        Assert.NotEqual(idA, idB);
+        Assert.False(await root.TryInvokeHandlerAsync(idA, EmptyPayload), "a departed id must not resolve");
+        Assert.Equal(0, leafA.Clicks);
+        Assert.Equal(0, leafB.Clicks);
+
+        Assert.True(await root.TryInvokeHandlerAsync(idB, EmptyPayload));
+        Assert.Equal(1, leafB.Clicks);
+    }
+
+    private sealed class Row : Component
+    {
+        public int Clicks;
+        public int Index;
+
+        protected override Component? Render() =>
+            Div(Class: $"row-{Index}", OnClick: () => Clicks++)[$"row {Index}"];
+    }
+
+    [Fact]
+    public void GrowingList_KeepsEveryExistingRowsId_AndDrawsAFreshNumberForEachNewRow()
+    {
+        // The payload win in one test. A list that grows by one used to renumber every row after the
+        // insertion point, so the diff rewrote data-rask-on-click on rows whose markup was identical.
+        // Now an existing row's id is settled for its lifetime and only the new row draws a number.
+        // Held across renders, the way a generated factory's GetOrCreate hands back the same persisted
+        // instance for a given list position — constructing fresh rows every render would instead be
+        // testing a page that remounts its whole list, which has no ids to keep.
+        var rows = new List<Component>();
+        var root = new StubComponent(() => Div(Class: "page")[rows]);
+
+        var settled = new Dictionary<int, string>();
+        var issued = new HashSet<int>();
+
+        for (var count = 3; count <= 8; count++)
+        {
+            while (rows.Count < count)
+            {
+                rows.Add(new Row { Index = rows.Count });
+            }
+
+            var html = root.RenderAsLiveRoot();
+            for (var i = 0; i < count; i++)
+            {
+                var id = IdOn(html, $"row-{i}");
+                if (settled.TryGetValue(i, out var previous))
+                {
+                    Assert.Equal(previous, id);
+                    continue;
+                }
+
+                Assert.True(issued.Add(NumberOf(id)), $"row {i} was handed the reissued number {id}");
+                settled[i] = id;
+            }
+        }
+
+        Assert.Equal(8, settled.Count);
+    }
+
+    [Fact]
+    public async Task ComponentRenderedUnderASecondRoot_DoesNotCollideWithThatRootsOwnIds()
+    {
+        // A slot id is minted from whichever root was rendering and then cached on the component. If a
+        // component is later reached from a DIFFERENT root, handing back the id minted under the first
+        // would hand the second root an id it never issued — and the number it does issue next then
+        // collides, wiring two elements to one entry in the map. Reachable through ordinary API: a
+        // second Render of the same instance builds a fresh root. So a component that changes root
+        // re-mints its slots from the new root's sequence.
+        var shared = new Steady();
+        var firstRoot = new StubComponent(() => Div(Class: "page")[shared]);
+        var firstHtml = firstRoot.RenderAsLiveRoot();
+        var idUnderFirst = IdOn(firstHtml, "steady");
+
+        // The second root renders a handler of its own BEFORE the shared component, so if the shared
+        // one keeps its old id the two collide on the number the new root issues first.
+        var native = new Steady();
+        var secondRoot = new StubComponent(() => Div(Class: "page")[native, shared]);
+        var secondHtml = secondRoot.RenderAsLiveRoot();
+
+        var nativeId = IdOn(secondHtml, "steady");
+        var sharedId = Regex.Matches(secondHtml, "class=\"steady\"[^>]*?data-rask-on-[a-z]+=\"([^\"]+)\"")
+            .Select(m => m.Groups[1].Value).Last();
+
+        Assert.NotEqual(nativeId, sharedId);
+        Assert.True(await secondRoot.TryInvokeHandlerAsync(sharedId, EmptyPayload));
+        Assert.Equal(1, shared.Clicks);
+        Assert.Equal(0, native.Clicks);
+
+        Assert.True(await secondRoot.TryInvokeHandlerAsync(nativeId, EmptyPayload));
+        Assert.Equal(1, native.Clicks);
+        Assert.Equal(1, shared.Clicks);
+        _ = idUnderFirst;
+    }
+
+    [Fact]
+    public void FirstRenderStillNumbersInWalkOrder_FromZero()
+    {
+        // The scheme draws a number the first time it reaches a slot, and the first render reaches
+        // them in walk order — so an initial page is byte-identical to what the positional counter
+        // produced. This is what keeps the change invisible to the client and to every existing
+        // expected-HTML test.
+        var root = new StubComponent(() => Div(Class: "page")[
+            Div(Class: "one", OnClick: () => { })["1"],
+            Div(Class: "two", OnClick: () => { })["2"],
+            Div(Class: "three", OnClick: () => { })["3"]
+        ]);
+
+        var html = root.RenderAsLiveRoot();
+
+        Assert.Equal("h0", IdOn(html, "one"));
+        Assert.Equal("h1", IdOn(html, "two"));
+        Assert.Equal("h2", IdOn(html, "three"));
+    }
+}


### PR DESCRIPTION
## Summary

Handler ids came from a single counter reset to zero on every root render, handed out `h0, h1, …` in
walk order. A conditional button appearing anywhere pushed **every later handler on the page** up by
one. Two costs fell out of that:

1. The diff rewrote `data-rask-on-*` on elements whose markup had not changed.
2. The clean-subtree cache had to refuse any snapshot whose baked-in ids the shifted counter had
   invalidated — so an interactive list re-walked itself whenever anything above it changed shape.

Ids are now assigned per **(component, slot)** and held for the component's lifetime, anchored to the
component whose subtree the element serializes in rather than to the delegate's target — so a callback
passed down into a composite wrapper cannot shift the wrapper's own ids either. That let the
`HandlerStartId` counter-equality workaround go entirely, so a handler-bearing subtree replays whenever
it is clean.

A number is never handed to a **second component**: when one unmounts its ids simply stop being
registered, so a click a user sent a moment before a row vanished resolves to nothing and no-ops
instead of being redirected onto whichever component inherited a recycled number.

**No wire or API change.** A first render still emits `h0, h1, …` in document order, and ids stay
opaque to the client, which echoes them back verbatim.

> **On the issue text:** #640 says this "blocks P4 (subtree short-circuit)". P4 already shipped —
> `TryCacheCleanSubtree` / `TryReplayCleanSubtree` are on `main`, and handler-bearing subtrees were made
> cacheable by *adding* the counter-equality workaround rather than by fixing the numbering. This
> removes that workaround. The prior-art branch `worktree-p4-cached-subtree` predates the whole cache
> apparatus, so this is a fresh implementation of its (corrected, no-recycling) design rather than a
> rebase.

## What this does not claim

Renumbering is **bounded to one component**, not eliminated. An element built in a parent's `Render()`
and passed into a wrapper as indexer children serializes inside the *wrapper's* scope and takes a slot
there, so a conditional sibling still shifts the ones after it — within that wrapper, rather than to the
end of the page. Likewise, within a single component a slot is reused when its handler set shrinks;
that is unchanged from the counter it replaces, and still narrowed by `HandlerFrameShape.Accepts`.
Both limits are documented at the code, not just here.

## Benchmarks

Run from the worktree directory (`benchmarks/Rask.Benchmarks`). Allocation is the headline — it is
deterministic; timings are directional.

| | before | after |
|---|---|---|
| **New gated** `HandlerShiftAboveList100` | 3,205 B / **101 ops** | 94 B / **1 op** |
| `session-churn` handler-shift, 200 rows | 252,097 B/update | **100,124** (−60%) |
| `session-churn` handler-shift, 1,000 rows | 1,220,549 B/update | **438,170** (−64%) |
| `session-churn` no shift, 200 / 1,000 rows | 98,072 / 436,176 | 98,084 / 436,176 (unchanged) |
| Steady-state re-render, marginal cost | 70.31 KB | **70.31 KB** |
| Retained, 1,000-row grid | 7,381,092 B | 7,493,300 (+1.5%) |
| `Register1000` (first render) | 128.82 KB | 145.1 KB |

An update that moves the handler count now costs within ~2% of one that does not (it was 2.6–2.8×).
The two costs are one-off: one small state object per component's first render, and one array for a
component that registers many handlers in its own render. Steady-state re-render allocation is
unchanged to the byte.

The five existing `payload-bytes` scenarios are byte-identical; `payload-bytes.csv` is refreshed with
the new gated row.

**Benchmarks added** (the existing suite could not see this — `FootprintApp` holds its handler count
constant, so the cache already hit): a `session-churn` handler-shift pass, a gated `payload-bytes`
scenario rendered through the live root (the others serialize bare and register no handlers at all),
and `Register2000` to cover the past-the-interned-table path, which cumulative numbering makes
reachable where the per-render reset did not.

## Fixes found by review

The high-effort review caught a regression this introduced, plus a latent one:

- **Handlers inside an `ErrorBoundary` went permanently dead.** A boundary becomes `CurrentParent`
  without marking the enclosing subtree as containing a nested component, so its handlers landed on the
  boundary's slot table and the enclosing component's capture missed them. Fixed, with a regression
  test. This also closes a **pre-existing** bug: a boundary can trip into its fallback without dirtying
  its parent, so a parent whose span contains one should never have been caching in the first place.
- **Cross-root id collision**, reachable through public API — two elements emitting `h0`. A component
  now re-mints its slots when it turns up under a different root.
- Replay no longer writes into the handler map before a check that can still reject it.
- `HandlerId` is bounds-safe against a wrapped counter (cumulative numbering makes overflow reachable
  in principle where the per-render reset did not).

## Testing

- `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` clean.
- Full unit suite green. New `StableHandlerIdTests` (7 cases): an unchanged component keeps its id when
  another gains a handler; multi-slot stability with per-slot dispatch integrity; a delegate targeting
  another component does not shift that component's ids; an unmounted id no-ops and is not reused; a
  growing list keeps every existing row's id; a component under a second root does not collide; first
  render still numbers in walk order.
- `CleanSubtreeReplayTests` gains the `ErrorBoundary` regression test, and the test that pinned the old
  positional behaviour now pins the new one — including that the cached row **replays** (render count
  stays 1) instead of re-walking.
- Browser E2E: **57/57**, including both full journeys and the session-resume tests — the real proof the
  wire contract held, since ids are baked into every page and echoed by both client dialects.

Closes #640.
