### PR TITLE
feat(native): give IPermissions a native backend so it reads the OS, not the WebView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,44 @@ them until tagged releases begin.
   and shutdown is drained from `pagehide` — in reverse start order, and not for a back/forward-cache
   suspend where the page can be restored still running — which the browser does not wait for, so it
   is an optimisation rather than a guarantee.
+- **`IPermissions` now has a native backend, so on iOS/Android it answers about the OS permission the
+  other native backends actually gate on.** It was the only wrapper in its family without one — the 14
+  interfaces beside it (`IGeolocation`, `INotifications`, `IClipboard`, …) resolve to native backends, and
+  the one you reach for *first*, to decide whether you are about to prompt, still answered from the
+  WebView. That made it wrong twice over on a native head. It barely answered at all:
+  `navigator.permissions.query` throws `NotSupportedError` for `Geolocation`/`Notifications` on WebKit and
+  `TypeError` for the clipboard and persistent-storage names, so five of the seven typed `PermissionName`
+  values faulted the awaited task on iOS — including the two the interface's own docs tell you to pair it
+  with. And where it did answer, it described a different system: those native backends are gated by the
+  **OS app permission** (`Info.plist`/manifest + the system prompt), which the WebView's Permissions API
+  cannot see — so you could ask the WebView, get `granted`, and call `IGeolocation`, which reads
+  `CLLocationManager`. Each name is now answered from **the gate the caller will actually meet**: iOS
+  `CLLocationManager` / `UNUserNotificationCenter`, Android `Activity.CheckSelfPermission` plus
+  `AreNotificationsEnabled` (which also catches a user who switched notifications off below API 33, where
+  there is no runtime permission to check). Wired by `ApplePlatform`/`AndroidPlatform` like every other
+  native backend, so an app needs no new code.
+  Three answers are deliberately *not* the OS grant. **`Camera` and `Microphone` stay with the WebView** —
+  nothing on a native head consumes the app's capture grant (`IMediaDevices` is WASM-only, so capture goes
+  through the WebView, which gates it on its own permission on top of the app's), and they are also the
+  only two names WebKit answers, so deferring is both the accurate and the well-supported choice.
+  **`ClipboardRead` reports `Prompt` on iOS**, because since iOS 16 the programmatic `UIPasteboard` read
+  the native `IClipboard` performs can raise the system "Allow Paste?" alert. `ClipboardWrite` and
+  `PersistentStorage` report `Granted`, which is accurate rather than a stand-in for "don't know".
+  **Caveat, and it is deliberate:** Android's `CheckSelfPermission` reports only granted/denied and cannot
+  separate "never asked" from "denied permanently" (`ShouldShowRequestPermissionRationale` doesn't close
+  the gap — it is `false` both before the first ask and after a permanent denial), so anything not granted
+  that it could still request reports `Prompt`. Read that as "not granted", **not** as a promise that a
+  dialog will appear: a permission missing from the manifest is refused with no dialog at all. Claiming
+  `Denied` would mislead on first run, which is the common case. iOS has the real tri-state and reports it.
+  Named `NativePermissionQuery`, not `NativePermissions`: that name already belongs to the public
+  runtime-*request* bridge the scaffolded heads forward `OnRequestPermissionsResult` to, and renaming it
+  would break every scaffolded app. The two are companions — one asks, one requests.
+- **`-p:RaskNativeHeads=ios` builds just the iOS head**, the mirror of the existing `android` value. Only
+  `android` had a one-head switch (it exists so an Ubuntu job can build the APK without the iOS workload,
+  which Linux can't install), which left the opposite case — a macOS dev with only the ios workload —
+  unable to compile `Platforms/iOS/**` at all, so half of every native change was CI-only by construction.
+  Set on `Rask.Native` and both native samples together; a value present on one and missing from another
+  still fails on the workload the other head needs.
 
 ### Changed
 - **BREAKING — a short flag now means the same option on every `rask` command.** The same two

--- a/docs/apis/permissions.md
+++ b/docs/apis/permissions.md
@@ -5,8 +5,51 @@
 - **Wraps:** Permissions API
 - **Home:** `Rask.Core.Browser` (all hosts)
 - **Shape:** one-shot
-- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
-- **Native backend:** — (WebView JS)
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅ ★
+- **Native backend:** OS authorization status (iOS `CLLocationManager`/`UNUserNotificationCenter`/`AVCaptureDevice`) · `Activity.CheckSelfPermission` (Android)
+
+## In the browser, support is patchy
+
+`navigator.permissions.query` answers for different names in different engines. WebKit (Safari, and any
+iOS WebView) answers only for `camera` and `microphone` — verified against `WKWebView`; `geolocation` and
+`notifications` throw `NotSupportedError`, and the clipboard/persistent-storage names throw `TypeError`. An
+unrecognised name faults the awaited task with a `JSException`, so gate accordingly — or catch and treat a
+fault as "unknown".
+
+## On Native it answers about whatever you're actually about to use
+
+This is the wrapper's sharpest edge, and why it has a native backend. In the [native shell](../native.md),
+`IGeolocation`, `INotifications` and `IClipboard` resolve to **native backends gated by the OS app
+permission** — the `Info.plist`/manifest grant and the system prompt. The WebView's Permissions API cannot
+see that: it describes the WebView's own grants, a different system from the one those backends use.
+
+So on Native each name is answered from the gate the caller will actually meet, and all seven answer:
+
+| `PermissionName` | iOS | Android |
+|---|---|---|
+| `Geolocation` | `CLLocationManager.AuthorizationStatus` | `CheckSelfPermission(ACCESS_FINE_LOCATION)` |
+| `Notifications` | `UNUserNotificationCenter` settings | `AreNotificationsEnabled` + `POST_NOTIFICATIONS` (API 33+) |
+| `Camera` / `Microphone` | **the WebView** — see below | **the WebView** — see below |
+| `ClipboardRead` | `Prompt` — iOS 16+ can raise "Allow Paste?" | `Granted` — `ClipboardManager` needs no grant |
+| `ClipboardWrite` | `Granted` — writing never prompts | `Granted` — `ClipboardManager` needs no grant |
+| `PersistentStorage` | `Granted` — app storage is never evicted | `Granted` — app storage is never evicted |
+
+> **`Camera`/`Microphone` deliberately stay with the WebView.** Nothing on a native head consumes the app's
+> camera/mic grant — `IMediaDevices` is WASM-only, so capture goes through the WebView, which gates it on its
+> *own* permission (`WKWebView`'s per-origin decision, Android's `WebChromeClient.OnPermissionRequest`) on
+> top of the app's. Answering from `AVCaptureDevice`/`CheckSelfPermission` would report `Granted` for a
+> capture the WebView is still going to gate. These are also the only two names WebKit answers well, so
+> deferring is both the accurate and the well-supported choice.
+
+> **Android reports `Prompt`, never `Denied`, for a permission it can request.** `Prompt` there means
+> exactly *"not granted — asking is still worth a try"*, not a promise that a dialog will appear: a
+> permanently-denied permission and one that was never requested look identical to `CheckSelfPermission`,
+> and a permission missing from the manifest is refused with no dialog at all.
+> `ShouldShowRequestPermissionRationale` doesn't close the gap either, being `false` both before the first
+> ask and after a permanent denial. Claiming `Denied` instead would be wrong on first run, which is the
+> common case — so the OS decides whether a dialog appears, and you should be ready for it not to.
+> `Notifications` is the exception: it *can* report `Denied`, because `AreNotificationsEnabled` sees a user
+> who switched notifications off. iOS has the real tri-state throughout and reports it.
 
 ## See also
 

--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -15,7 +15,7 @@ Native column marks an API with a native C# backend (the rest run through the We
 | [`ICookies`](apis/cookies.md) | ✅ | ✅ | ✅ | — |
 | [`IClipboard`](apis/clipboard.md) | ✅ | ✅ | ✅&nbsp;★ | UIPasteboard / ClipboardManager |
 | [`IGeolocation`](apis/geolocation.md) | ✅ | ✅ | ✅&nbsp;★ | CLLocationManager / LocationManager |
-| [`IPermissions`](apis/permissions.md) | ✅ | ✅ | ✅ | — |
+| [`IPermissions`](apis/permissions.md) | ✅ | ✅ | ✅&nbsp;★ | OS authorization status / CheckSelfPermission (camera+mic stay on the WebView) |
 | [`IVibration`](apis/vibration.md) | ✅ | ✅ | ✅&nbsp;★ | AudioToolbox / Vibrator |
 | [`IPageVisibility`](apis/page-visibility.md) | ✅ | ✅ | ✅ | — |
 | [`INavigatorInfo`](apis/navigator-info.md) | ✅ | ✅ | ✅ | — |

--- a/docs/native-devices.md
+++ b/docs/native-devices.md
@@ -84,6 +84,7 @@ The shipped native backends (both platforms):
 | `IDeviceMotion` | CoreMotion (`CMMotionManager`) | `SensorManager` (accelerometer + gyroscope) |
 | `INotifications` | `UNUserNotificationCenter` | `NotificationManager` (+ channel) |
 | `IBadge` | `UNUserNotificationCenter.SetBadgeCount` | badge notification (`setNumber`) |
+| `IPermissions` | `CLLocationManager` / `UNUserNotificationCenter` / `AVCaptureDevice` status | `Activity.CheckSelfPermission` |
 
 So `await geolocation.GetCurrentPositionAsync()` returns a native fix (real permission prompt +
 `CLLocationManager` / `LocationManager` accuracy) instead of `navigator.geolocation`, `clipboard.WriteTextAsync`
@@ -91,6 +92,12 @@ hits `UIPasteboard` / `ClipboardManager` (no WebView gesture gate), `notificatio
 OS notification where a WebView has no `Notification` API at all, and so on. Some backends need platform
 permissions — add `ACCESS_FINE_LOCATION` / `ACCESS_NETWORK_STATE` / `POST_NOTIFICATIONS` (Android) and
 `NSLocationWhenInUseUsageDescription` (iOS), and the head requests the location and notification runtime grants.
+
+`IPermissions` is the one to reach for *before* any of those: it reports on the **OS app permission** the
+backends above gate on, not the WebView's own grants, so asking it and then calling `IGeolocation` are
+questions and answers about the same system. Note the tri-state is only real on iOS — Android's
+`CheckSelfPermission` cannot tell "never asked" from "denied permanently", so anything not granted reports
+`Prompt`. See [`IPermissions`](apis/permissions.md).
 
 The **declarative** `Shareable` still reaches the native share sheet through the **capability bridge**: the
 native client advertises `window.__raskNative.capabilities` and an `invoke(name, data)` that posts a

--- a/docs/native.md
+++ b/docs/native.md
@@ -11,8 +11,10 @@ unchanged.
 > `WKWebView` and Android `WebView` app heads), and the native client runtime **ship and run
 > end-to-end on both platforms** — a scaffolded app boots, renders the component tree over the native
 > bridge, routes, and updates live (see [Roadmap](#roadmap) for the verification detail). It's still
-> pre-1.0: APIs may shift. **Native device *backends*** ship for share, geolocation, clipboard, vibration,
-> wake lock, and network info — one `host.UsePlatform(new ApplePlatform(…))` / `new AndroidPlatform(this)`
+> pre-1.0: APIs may shift. **Native device *backends*** ship for fifteen interfaces — share, geolocation,
+> clipboard, vibration, wake lock, network info, battery, speech synthesis/recognition, screen info, device
+> orientation/motion, notifications, badge, and permissions — one
+> `host.UsePlatform(new ApplePlatform(…))` / `new AndroidPlatform(this)`
 > wires them all, and the framework resolves each native-first over the WebView's JS (see
 > [Native device backends](native-devices.md#native-device-backends)) — with biometrics/push still to come. The native client
 > now shares the

--- a/samples/Rask.Example.Native.Server/Rask.Example.Native.Server.csproj
+++ b/samples/Rask.Example.Native.Server/Rask.Example.Native.Server.csproj
@@ -17,6 +17,9 @@
   -->
   <PropertyGroup>
     <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
+    <!-- Same one-head switches as Rask.Native / Rask.Example.Native: build the half whose workload you have. -->
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'android'">net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'ios'">net10.0-ios</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/samples/Rask.Example.Native/Rask.Example.Native.csproj
+++ b/samples/Rask.Example.Native/Rask.Example.Native.csproj
@@ -21,8 +21,11 @@
   <PropertyGroup>
     <TargetFrameworks>net10.0-ios;net10.0-android</TargetFrameworks>
     <!-- -p:RaskNativeHeads=android drops the iOS TFM so the app builds on Linux (no iOS workload), which
-         the Ubuntu+KVM native-appium CI job needs. Matches the same switch on Rask.Native. -->
+         the Ubuntu+KVM native-appium CI job needs. `ios` is the mirror image, for a macOS dev who has only
+         the ios workload. Both match the same switch on Rask.Native — keep the three in step, or a value
+         that builds the library still fails here on the workload the other head needs. -->
     <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'android'">net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'ios'">net10.0-ios</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Rask.Core/Browser/IPermissions.cs
+++ b/src/Rask.Core/Browser/IPermissions.cs
@@ -46,13 +46,30 @@ public enum PermissionState
 ///     whether a feature is granted, denied, or will prompt, <em>before</em> triggering it. Pairs with
 ///     <see cref="IClipboard" /> and <see cref="IGeolocation" /> to avoid surprising the user with a
 ///     prompt. Inject it through a component constructor and call from an event handler or lifecycle hook.
+///     <para>
+///         <b>In the browser, engines answer for different names.</b> WebKit (Safari, and any iOS WebView)
+///         answers only for <see cref="PermissionName.Camera" /> and <see cref="PermissionName.Microphone" />;
+///         the rest fault — see <see cref="QueryAsync" />. In the native shell there is a real backend and
+///         every name answers, each from the gate the caller will actually meet: the OS app permission that
+///         the native <see cref="IGeolocation" />/<see cref="INotifications" />/<see cref="IClipboard" />
+///         backends gate on, rather than the WebView's own grants (a different system). Camera and microphone
+///         are the exception and stay with the WebView, because capture on a native head goes through it.
+///         Android reports <see cref="PermissionState.Prompt" /> rather than
+///         <see cref="PermissionState.Denied" /> for anything not granted that it could still request, since
+///         the platform can't distinguish "never asked" from a permanent denial — read it as "not granted",
+///         not as a promise of a dialog. See <c>docs/apis/permissions.md</c>.
+///     </para>
 /// </summary>
 public interface IPermissions
 {
     /// <summary>
-    ///     Queries the current state of <paramref name="name" /> (<c>navigator.permissions.query</c>).
+    ///     Queries the current state of <paramref name="name" /> (<c>navigator.permissions.query</c>, or the
+    ///     OS authorization status in the native shell).
     ///     A browser that doesn't recognise the permission faults the awaited task with a
-    ///     <see cref="JSException" />.
+    ///     <see cref="JSException" /> — WebKit does this for every name except
+    ///     <see cref="PermissionName.Camera" /> and <see cref="PermissionName.Microphone" />, so catch it if
+    ///     you target Safari. The native backend answers for all of them, and faults the task with an
+    ///     <see cref="ArgumentOutOfRangeException" /> only for a value outside the enum.
     /// </summary>
     ValueTask<PermissionState> QueryAsync(PermissionName name);
 }

--- a/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
+++ b/src/Rask.Native/Platforms/Android/AndroidPlatform.cs
@@ -1,6 +1,7 @@
 using Android.App;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.JSInterop;
 using Rask.Client.Browser;
 using Rask.Core.Browser;
 
@@ -14,7 +15,8 @@ namespace Rask.Native;
 ///     <c>IBattery</c> (BatteryManager), <c>ISpeechSynthesis</c> (TextToSpeech),
 ///     <c>ISpeechRecognition</c> (SpeechRecognizer), <c>IScreenInfo</c> (DisplayMetrics),
 ///     <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (SensorManager), <c>INotifications</c>
-///     (NotificationManager), and <c>IBadge</c> (a badge notification) — so injecting any of them resolves the
+///     (NotificationManager), <c>IBadge</c> (a badge notification), and <c>IPermissions</c> (the OS app
+///     permission the backends above actually gate on) — so injecting any of them resolves the
 ///     native implementation and every other interface falls back to the
 ///     WebView's JS. The app writes one line (<c>host.UsePlatform(new AndroidPlatform(this))</c>) instead of
 ///     registering each backend by hand. Geolocation needs <c>ACCESS_FINE_LOCATION</c>, network info needs
@@ -42,5 +44,9 @@ public sealed class AndroidPlatform(Activity activity) : INativePlatform
         services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion(activity));
         services.TryAddSingleton<INotifications>(_ => new NativeNotifications(activity));
         services.TryAddSingleton<IBadge>(_ => new NativeBadge(activity));
+        // Camera/Microphone defer to the WebView's own Permissions API (see NativePermissionQuery), so this
+        // one needs it. Built directly rather than resolved as IPermissions — that would resolve to this.
+        services.TryAddSingleton<IPermissions>(sp =>
+            new NativePermissionQuery(activity, new Permissions(sp.GetRequiredService<IJSRuntime>())));
     }
 }

--- a/src/Rask.Native/Platforms/Android/NativePermissionQuery.cs
+++ b/src/Rask.Native/Platforms/Android/NativePermissionQuery.cs
@@ -1,0 +1,75 @@
+using Android.App;
+using Android.Content.PM;
+using Rask.Core.Browser;
+
+namespace Rask.Native;
+
+// Native Android backend for IPermissions — the OS app permission instead of navigator.permissions, for the
+// names that HAVE a native backend behind them.
+//
+// The WebView's Permissions API describes the WEBVIEW's grants, but IGeolocation/INotifications/IClipboard
+// resolve to native backends gated by the OS app permission (manifest + runtime grant) — a different system,
+// so a WebView answer is about something the caller isn't going to use. This reads the same source those
+// backends do: Activity.CheckSelfPermission, exactly what NativeGeolocation.HasPermission checks.
+//
+// Camera and Microphone are deliberately NOT answered from the OS grant — see QueryAsync. Registered by
+// AndroidPlatform.
+//
+// Named for what it does rather than Native+interface: NativePermissions is already taken by the public
+// runtime-request bridge (heads forward OnRequestPermissionsResult to it, and the CLI scaffolds that call),
+// so renaming it would break every scaffolded app. The two are companions — this one asks, that one requests.
+internal sealed class NativePermissionQuery(Activity activity, IPermissions webView) : IPermissions
+{
+    public ValueTask<PermissionState> QueryAsync(PermissionName name) => name switch
+    {
+        PermissionName.Geolocation => new(Check(Android.Manifest.Permission.AccessFineLocation)),
+
+        PermissionName.Notifications => new(NotificationState()),
+
+        // NOT the OS grant. Nothing on a native head consumes CAMERA/RECORD_AUDIO: IMediaDevices is
+        // WASM-only, so capture goes through the WebView, which gates it on its OWN permission
+        // (WebChromeClient.OnPermissionRequest) rather than on the app's. Answering "granted" because the
+        // app holds the OS grant would tell a caller it can capture without prompting when the WebView is
+        // the gate it will actually meet. These are also the two names the WebView answers well, so
+        // deferring costs nothing.
+        PermissionName.Camera or PermissionName.Microphone => webView.QueryAsync(name),
+
+        // ClipboardManager (what the native IClipboard uses) needs no permission to read or write in the
+        // foreground, and app-internal storage is never evicted — which is what persistent-storage asks
+        // about. Granted is accurate here, not a placeholder for "don't know".
+        PermissionName.ClipboardRead or PermissionName.ClipboardWrite => new(PermissionState.Granted),
+        PermissionName.PersistentStorage => new(PermissionState.Granted),
+
+        // Faulted rather than thrown, so an unknown value behaves the same on both platforms (iOS's
+        // QueryAsync is async and could only fault) and a caller awaiting inside a try catches it either way.
+        _ => ValueTask.FromException<PermissionState>(
+            new ArgumentOutOfRangeException(nameof(name), name, "Unknown permission name."))
+    };
+
+    // POST_NOTIFICATIONS only exists on API 33+. Below it there is no runtime permission — but the user can
+    // still switch the app's notifications off in Settings, and then a posted notification simply never
+    // appears. AreNotificationsEnabled covers both eras, so this reports on what the user would actually see
+    // rather than on whether a permission string is held.
+    private PermissionState NotificationState()
+    {
+        if (!AndroidNotifications.Manager(activity).AreNotificationsEnabled())
+        {
+            return PermissionState.Denied;
+        }
+
+        return !OperatingSystem.IsAndroidVersionAtLeast(33)
+            ? PermissionState.Granted
+            : Check(Android.Manifest.Permission.PostNotifications);
+    }
+
+    // CheckSelfPermission reports Granted or Denied and nothing else — it cannot separate "never asked" from
+    // "denied permanently", and ShouldShowRequestPermissionRationale doesn't close the gap either (it is
+    // false BOTH before the first ask and after "Don't allow" twice). So anything not granted reports Prompt,
+    // which here means exactly "not granted, asking is still worth a try" — NOT a promise that a dialog will
+    // appear. Reporting Denied instead would tell callers a first-run permission is permanently blocked,
+    // which is wrong more often. iOS has the real tri-state and reports it.
+    private PermissionState Check(string permission) =>
+        activity.CheckSelfPermission(permission) == Permission.Granted
+            ? PermissionState.Granted
+            : PermissionState.Prompt;
+}

--- a/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
+++ b/src/Rask.Native/Platforms/iOS/ApplePlatform.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.JSInterop;
 using Rask.Client.Browser;
 using Rask.Core.Browser;
 using UIKit;
@@ -13,7 +14,8 @@ namespace Rask.Native;
 ///     <c>IWakeLock</c>, <c>INetworkInfo</c> (NWPathMonitor), <c>IBattery</c> (UIDevice battery monitoring),
 ///     <c>ISpeechSynthesis</c> (AVSpeechSynthesizer), <c>ISpeechRecognition</c> (SFSpeechRecognizer),
 ///     <c>IScreenInfo</c> (UIScreen), <c>IDeviceOrientation</c>/<c>IDeviceMotion</c> (CoreMotion),
-///     <c>INotifications</c> (UNUserNotificationCenter), and <c>IBadge</c> (the app-icon badge) — so
+///     <c>INotifications</c> (UNUserNotificationCenter), <c>IBadge</c> (the app-icon badge), and
+///     <c>IPermissions</c> (the OS authorization status the backends above actually gate on) — so
 ///     injecting any of them resolves the native implementation, and every other interface falls back to the
 ///     WebView's JS. The app writes one line
 ///     (<c>host.UsePlatform(new ApplePlatform(() =&gt; Window?.RootViewController))</c>) instead of
@@ -45,5 +47,9 @@ public sealed class ApplePlatform(Func<UIViewController?> presenter) : INativePl
         services.TryAddSingleton<IDeviceMotion>(_ => new NativeDeviceMotion());
         services.TryAddSingleton<INotifications>(_ => new NativeNotifications());
         services.TryAddSingleton<IBadge>(_ => new NativeBadge());
+        // Camera/Microphone defer to the WebView's own Permissions API (see NativePermissionQuery), so this
+        // one needs it. Built directly rather than resolved as IPermissions — that would resolve to this.
+        services.TryAddSingleton<IPermissions>(sp =>
+            new NativePermissionQuery(new Permissions(sp.GetRequiredService<IJSRuntime>())));
     }
 }

--- a/src/Rask.Native/Platforms/iOS/NativePermissionQuery.cs
+++ b/src/Rask.Native/Platforms/iOS/NativePermissionQuery.cs
@@ -1,0 +1,91 @@
+using CoreLocation;
+using Rask.Core.Browser;
+using UIKit;
+using UserNotifications;
+
+namespace Rask.Native;
+
+// Native iOS backend for IPermissions — the OS authorization status instead of navigator.permissions, for
+// the names that HAVE a native backend behind them.
+//
+// Two reasons this exists. (1) WKWebView's Permissions API answers for almost nothing: query() throws
+// NotSupportedError for "geolocation"/"notifications" and TypeError for the clipboard/persistent-storage
+// names — verified against WKWebView, which answers only "camera" and "microphone" — so five of
+// IPermissions' seven typed names faulted the awaited task on the native shell, including the two its own
+// docs recommend pairing it with. (2) Even where it answers, it answers about the wrong system:
+// IGeolocation/INotifications resolve to native backends gated by the OS app permission (Info.plist + the
+// system prompt), which navigator.permissions cannot see. Registered by ApplePlatform.
+//
+// Named for what it does rather than Native+interface, because Android's public NativePermissions (the
+// runtime-request bridge that heads forward OnRequestPermissionsResult to) already owns that name and is
+// part of the scaffolded head's API. Kept identical on both platforms so the pair reads as one thing.
+internal sealed class NativePermissionQuery(IPermissions webView) : IPermissions
+{
+    // One manager for the backend's lifetime. IPermissions is a singleton and is meant to be asked before
+    // every gated action, so allocating a CLLocationManager per query would leave one NSObject peer (and its
+    // CoreLocation registration) behind on each call.
+    private CLLocationManager? _location;
+
+    public async ValueTask<PermissionState> QueryAsync(PermissionName name) => name switch
+    {
+        PermissionName.Geolocation =>
+            await MainThreadAsync(() => Map((_location ??= new CLLocationManager()).AuthorizationStatus))
+                .ConfigureAwait(false),
+
+        PermissionName.Notifications => Map((await UNUserNotificationCenter.Current
+            .GetNotificationSettingsAsync().ConfigureAwait(false)).AuthorizationStatus),
+
+        // NOT AVCaptureDevice. Nothing on a native head consumes the app's camera/mic grant: IMediaDevices
+        // is WASM-only, so capture goes through WKWebView, which gates it on its OWN per-origin permission
+        // on top of the app's. Answering "granted" because the app holds the OS grant would tell a caller it
+        // can capture without prompting when the WebView is the gate it will actually meet. These are also
+        // the only two names WKWebView answers correctly, so deferring to it costs nothing and is the more
+        // accurate source for exactly these.
+        PermissionName.Camera or PermissionName.Microphone =>
+            await webView.QueryAsync(name).ConfigureAwait(false),
+
+        // Since iOS 16 a programmatic UIPasteboard read (what the native IClipboard does — see
+        // NativeClipboard) raises the system "Allow Paste?" alert unless the user has already allowed that
+        // source, so a read really can prompt. Writing never does, and app-sandbox storage is never evicted,
+        // which is exactly what persistent-storage asks about.
+        PermissionName.ClipboardRead => PermissionState.Prompt,
+        PermissionName.ClipboardWrite => PermissionState.Granted,
+        PermissionName.PersistentStorage => PermissionState.Granted,
+
+        _ => throw new ArgumentOutOfRangeException(nameof(name), name, "Unknown permission name.")
+    };
+
+    // CLLocationManager wants to be constructed on a thread with a run loop.
+    private static Task<PermissionState> MainThreadAsync(Func<PermissionState> read)
+    {
+        var tcs = new TaskCompletionSource<PermissionState>();
+        UIApplication.SharedApplication.InvokeOnMainThread(() =>
+        {
+            try
+            {
+                tcs.SetResult(read());
+            }
+            catch (Exception ex)
+            {
+                tcs.SetException(ex);
+            }
+        });
+        return tcs.Task;
+    }
+
+    private static PermissionState Map(CLAuthorizationStatus status) => status switch
+    {
+        CLAuthorizationStatus.AuthorizedAlways or CLAuthorizationStatus.AuthorizedWhenInUse => PermissionState.Granted,
+        CLAuthorizationStatus.NotDetermined => PermissionState.Prompt,
+        // Restricted (parental controls / MDM) can't be granted by prompting, so it reads as Denied.
+        _ => PermissionState.Denied
+    };
+
+    private static PermissionState Map(UNAuthorizationStatus status) => status switch
+    {
+        UNAuthorizationStatus.Authorized or UNAuthorizationStatus.Provisional or UNAuthorizationStatus.Ephemeral
+            => PermissionState.Granted,
+        UNAuthorizationStatus.NotDetermined => PermissionState.Prompt,
+        _ => PermissionState.Denied
+    };
+}

--- a/src/Rask.Native/Rask.Native.csproj
+++ b/src/Rask.Native/Rask.Native.csproj
@@ -19,9 +19,15 @@
   <PropertyGroup>
     <!-- RaskNativeHeads: unset = plain net10.0 (CI/unit); `true` = all heads (macOS, needs ios+android
          workloads); `android` = just the Android head (so an Ubuntu/KVM job can build the APK without the
-         iOS workload, which Linux can't install). -->
-    <TargetFramework Condition="'$(RaskNativeHeads)' != 'true' AND '$(RaskNativeHeads)' != 'android'">net10.0</TargetFramework>
+         iOS workload, which Linux can't install); `ios` = just the iOS head, the mirror image — it lets a
+         macOS dev compile Platforms/iOS/** without installing the android workload too, which is the only
+         way to check that half locally.
+         Every value except unset must be listed in the TargetFramework condition below: leaving one out
+         sets the SINGULAR TargetFramework as well, and that silently wins over TargetFrameworks — so the
+         build reports success having compiled only net10.0, where Platforms/** is excluded. -->
+    <TargetFramework Condition="'$(RaskNativeHeads)' != 'true' AND '$(RaskNativeHeads)' != 'android' AND '$(RaskNativeHeads)' != 'ios'">net10.0</TargetFramework>
     <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'true'">net10.0;net10.0-ios;net10.0-android</TargetFrameworks>
+    <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'ios'">net10.0;net10.0-ios</TargetFrameworks>
     <TargetFrameworks Condition="'$(RaskNativeHeads)' == 'android'">net10.0;net10.0-android</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tests/Rask.Native.Tests/Session/NativePermissionsRegistrationTests.cs
+++ b/tests/Rask.Native.Tests/Session/NativePermissionsRegistrationTests.cs
@@ -1,0 +1,78 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.JSInterop;
+using Rask.Core.Browser;
+using Rask.Core.Live;
+using Rask.Native.Tests.Infrastructure;
+
+namespace Rask.Native.Tests.Session;
+
+// IPermissions is the API you reach for BEFORE calling IGeolocation/INotifications/IClipboard, to decide
+// whether you are about to prompt. On a native head those three resolve to backends gated by the OS app
+// permission, so IPermissions has to resolve to the native backend too — answering from the WebView would
+// be a question about one system answered by another, and it would look authoritative while doing it.
+//
+// The real modules (ApplePlatform / AndroidPlatform) need the iOS/Android workloads and don't build here,
+// so this pins the wiring contract they depend on: a platform-registered IPermissions must survive the
+// browser-API fallbacks the host wires afterwards. That is the failure mode worth a test — the backend
+// silently shadowed by the JS default, with everything still compiling and running.
+[Collection("NativeSession")]
+public sealed class NativePermissionsRegistrationTests() : ResettingTestBase(LiveDiffMode.Auto)
+{
+    [Fact]
+    public async Task NativeHost_WithNoPlatform_FallsBackToTheJsBackedDefault()
+    {
+        var (app, _, _) = await NativeSessionHarness.NewSessionAsync();
+
+        // A head that registers no platform still gets an IPermissions — the WebView one. That is the
+        // documented fallback, and the state issue #639 described as the whole surface.
+        Assert.IsType<Permissions>(app.Services.GetService<IPermissions>());
+    }
+
+    [Fact]
+    public async Task UsePlatform_NativeBackend_WinsOverTheJsDefault()
+    {
+        var host = NativeAppHost.CreateDefault();
+        host.UsePlatform(new FakePlatform());
+        var webView = new FakeNativeWebView();
+
+        var app = await host.RunLocalAsync<NativeStubApp>(webView);
+        await webView.PostAsync("""{"type":"ready"}""");
+
+        var resolved = Assert.IsType<FakeNativePermissions>(app.Services.GetService<IPermissions>());
+        Assert.NotNull(resolved.Js);
+    }
+
+    [Fact]
+    public async Task AppRegistration_BeforeRun_WinsOverTheJsDefault()
+    {
+        var (app, _, _) = await NativeSessionHarness.NewSessionAsync(
+            configure: s => s.AddSingleton<IPermissions>(
+                sp => new FakeNativePermissions(sp.GetRequiredService<IJSRuntime>())));
+
+        Assert.IsType<FakeNativePermissions>(app.Services.GetService<IPermissions>());
+    }
+
+    // Stand-in for ApplePlatform / AndroidPlatform, registering IPermissions the way they do: TryAdd (so it
+    // wins over the JS fallback the host wires afterward) from a factory that resolves IJSRuntime.
+    //
+    // That resolve is the part worth pinning. The real backends answer Camera/Microphone by delegating to
+    // the WebView's own Permissions API, so they need an IJSRuntime at construction — and a platform's
+    // Register runs BEFORE the host has finished wiring. It works only because the factory defers to first
+    // resolve; registering IJSRuntime any later, or constructing eagerly, breaks every native head at
+    // startup with a resolution failure that no unit test would otherwise see.
+    private sealed class FakePlatform : INativePlatform
+    {
+        public void Register(IServiceCollection services) =>
+            services.TryAddSingleton<IPermissions>(sp =>
+                new FakeNativePermissions(sp.GetRequiredService<IJSRuntime>()));
+    }
+
+    private sealed class FakeNativePermissions(IJSRuntime js) : IPermissions
+    {
+        public IJSRuntime Js { get; } = js;
+
+        public ValueTask<PermissionState> QueryAsync(PermissionName name) =>
+            ValueTask.FromResult(PermissionState.Granted);
+    }
+}


### PR DESCRIPTION
## Summary

`IPermissions` was the only wrapper in its family without a native backend. The 14 interfaces beside it
(`IGeolocation`, `INotifications`, `IClipboard`, …) resolve to native C# implementations, and the one you
reach for *first* — to decide whether you are about to prompt — still answered from the WebView. That made
it wrong twice over on a native head, and wrong in a way that looked authoritative.

**It barely answered.** Probed against a real `WKWebView` (script + output below): it answers only for
`camera` and `microphone`. Five of the seven typed `PermissionName` values faulted the awaited task on iOS
— including the two the interface's own docs tell you to pair it with.

**And where it did answer, it described a different system.** `IGeolocation`, `INotifications` and
`IClipboard` are gated by the **OS app permission** (`Info.plist`/manifest + the system prompt), which the
WebView's Permissions API cannot see. You could ask the WebView, get `granted`, and call `IGeolocation`,
which reads `CLLocationManager`.

Each name is now answered from **the gate the caller will actually meet**.

## Where I diverged from the issue's suggested mapping

Issue #639 sketched a mapping and asked for a deliberate decision on the names with no OS analogue. Three
answers are deliberately *not* the OS grant, each for a verified reason:

| | answer | why |
|---|---|---|
| `Camera` / `Microphone` | **the WebView** | Nothing on a native head consumes the app's capture grant — `IMediaDevices` is WASM-only, so capture goes through the WebView, which gates it on its *own* permission on top of the app's, and **neither head wires that up** (no `requestMediaCapturePermissionFor`, no `OnPermissionRequest`). Answering from `AVCaptureDevice` would report `Granted` for a capture the WebView is still going to gate. These are also the only two names WebKit answers, so deferring is both the accurate and the well-supported choice. |
| `ClipboardRead` | `Prompt` | Since iOS 16 the programmatic `UIPasteboard` read that `NativeClipboard` performs can raise the system "Allow Paste?" alert. `Granted` would defeat the interface's stated purpose. |
| `ClipboardWrite`, `PersistentStorage` | `Granted` | Accurate on a native app, not a stand-in for "don't know". |

`Notifications` on Android also uses `AreNotificationsEnabled` in addition to `POST_NOTIFICATIONS`, so it
catches a user who switched notifications off below API 33 — where there is no runtime permission to check
and the old mapping would have said `Granted` while nothing ever appeared.

**Android reports `Prompt`, not `Denied`,** for anything not granted it could still request:
`CheckSelfPermission` can't separate "never asked" from a permanent denial. Read it as *"not granted"*, not
as a promise of a dialog — a permission missing from the manifest is refused with no dialog at all. Claiming
`Denied` would mislead on first run, the common case. iOS has the real tri-state and reports it. The docs
say this plainly rather than leaving `PermissionState.Prompt`'s contract to imply otherwise.

## Verification

**WebKit support, probed rather than recalled** (`swift PermProbe.swift`, a `WKURLSchemeHandler` page —
custom-scheme origins are a secure context; the last line is a negative control proving the probe is honest):

```
secureContext=true
geolocation        => THREW NotSupportedError
notifications      => THREW NotSupportedError
camera             => prompt
microphone         => prompt
clipboard-read     => THREW TypeError
clipboard-write    => THREW TypeError
persistent-storage => THREW TypeError
rask-not-a-real-permission => THREW TypeError
```

- **iOS compiles clean, warnings-as-errors** — and so do **both native sample app bundles** (full Xcode
  link, not compile-only), via the new `-p:RaskNativeHeads=ios`.
- **Android is CI-gated**, per the repo's practice. Every Android API used is already used verbatim by
  `NativeGeolocation` (`CheckSelfPermission` + `AccessFineLocation`) and `NativeNotifications`
  (`IsAndroidVersionAtLeast(33)` + `PostNotifications`, `AndroidNotifications.Manager`), which CI compiles
  today; only the `Camera`/`RecordAudio` constants are new, and those two names no longer reach the OS grant.
- `dotnet format` clean; `CI=true dotnet build Rask.slnx -warnaserror -m:1` clean; full unit suite green;
  browser E2E **57/57**.
- New `NativePermissionsRegistrationTests` (3): the JS default resolves with no platform, a platform-registered
  backend wins over it, and an app registration wins too. The `FakePlatform` resolves `IJSRuntime` from the
  factory exactly as the real platforms now do — that ordering is the new dependency this change introduces
  (a platform's `Register` runs *before* the host finishes wiring), and it only works because the factory
  defers to first resolve.

## Also

`-p:RaskNativeHeads=ios`, the mirror of the existing `android` value. Only `android` had a one-head switch
(so an Ubuntu job can build the APK without the iOS workload), which left the opposite case — a macOS dev
with only the ios workload — unable to compile `Platforms/iOS/**` at all, making half of every native change
CI-only by construction. Set on `Rask.Native` and both native samples together, with a comment on why the
three must stay in step.

## Not covered

On-device Appium (`tests/Rask.Native.Appium.Tests`) needs a booted emulator/simulator and is not part of any
automated gate — so the runtime behaviour on a real device is unverified, as it is for every native change
here.

Closes #639.
