### PR TITLE
feat(core): add IOriginPrivateFileSystem and let an app ask for eviction-proof storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -387,6 +387,31 @@ them until tagged releases begin.
     stack trace can reach a browser even if a call site forgot to check, and the client requires the
     `data-rask-dev` flag as a second, independent gate.
 
+### Added
+- **`IOriginPrivateFileSystem` — a private, persistent file tree the app owns outright (#642).** The two
+  storage wrappers Rask shipped both stop short of a file an app writes to repeatedly and reopens on the
+  next visit: `IIndexedDb` is a key/value store, and `IFileSystemAccess` is a *picker* — it needs a user
+  gesture and models a document the user chose, not storage the app manages. OPFS is the missing third
+  case, and the one a local database file needs.
+  - **Reads and writes take a byte offset**, so a large file is worked in chunks and the payload crossing
+    the interop boundary is bounded by the range asked for, not the size of the file. A ranged write
+    leaves the rest intact; writing past the end extends the file, zero-filling the gap.
+    `ReadAllBytesAsync`/`WriteAllBytesAsync` are the single-round-trip convenience over the same store.
+  - **Paths, not handles.** The tree is app-owned and persistent, so the same path is reopened every
+    session — there is nothing to pick and nothing to keep alive between calls. Parent directories are
+    created on write.
+  - **A missing path returns `null` rather than throwing**, matching `IKeyValueStore.GetAsync`, and a
+    ranged read past the end returns the bytes that were there — an ordinary short read, not an error.
+  - Works on both transports, but every call is a round trip: under the Server transport that crosses the
+    WebSocket, so the local-database scenario this exists for is in practice a WASM one.
+- **`IStorageEstimator` can now ask for storage to survive eviction.** `IsPersistedAsync` and
+  `RequestPersistAsync` wrap `navigator.storage.persisted()`/`persist()` — the same object `estimate()`
+  already came from. Without this, OPFS is persistent but still reclaimable under storage pressure, which
+  is the difference between a cache and a database. Both resolve `false` where unsupported, so an app can
+  treat "not persisted" and "cannot be persisted" the same way: writes are evictable either way.
+  Chromium grants from engagement heuristics without prompting; Firefox prompts, so call it from a
+  gesture handler.
+
 ## [0.20.0] - 2026-08-06
 
 ### Fixed

--- a/docs/apis/origin-private-file-system.md
+++ b/docs/apis/origin-private-file-system.md
@@ -1,0 +1,71 @@
+# IOriginPrivateFileSystem
+
+> A private, persistent file tree the app owns — for a local database or any large blob.
+
+- **Wraps:** `navigator.storage.getDirectory` (OPFS)
+- **Home:** `Rask.Core.Browser` (all hosts)
+- **Shape:** one-shot
+- **Availability:** Web/Server ✅ · PWA/WASM ✅ · Native ✅
+- **Native backend:** — (WebView JS)
+
+Unlike [`IFileSystemAccess`](file-system-access.md) there is no picker and no user gesture. The app
+addresses files by path and reopens the same paths on every visit, which is what makes OPFS — not
+`IIndexedDb` — the right home for a SQLite file or a downloaded bundle.
+
+```csharp
+public sealed class Notes(IOriginPrivateFileSystem fs) : Component
+{
+    private async Task Save(byte[] page)
+    {
+        // Parent directories are created on write; nothing has to be made explicitly.
+        await fs.WriteAsync("db/app.sqlite", offset: 4096, page);
+    }
+
+    private async Task<byte[]?> Load() => await fs.ReadAsync("db/app.sqlite", 4096, 4096);
+}
+```
+
+## Ranges, not whole files
+
+Reads and writes take a byte offset, so a large file is worked in chunks and the payload crossing the
+interop boundary is bounded by the range you ask for. `ReadAllBytesAsync` / `WriteAllBytesAsync` are the
+single-round-trip convenience over the same store — prefer the ranged calls once a file grows past a few
+megabytes.
+
+A ranged write leaves the rest of the file intact. Writing past the current end extends the file,
+zero-filling the gap; `TruncateAsync` resizes in either direction.
+
+## Missing paths return null
+
+Reading a path that does not exist returns `null` rather than throwing, matching
+`IKeyValueStore.GetAsync`. A ranged read that runs past the end of the file returns the bytes that were
+available — an ordinary short read, not an error.
+
+## Durability
+
+OPFS is persistent but not automatically exempt from eviction: a browser may reclaim it under storage
+pressure. Ask for an exemption through [`IStorageEstimator`](storage-estimator.md), and treat unsynced
+writes as at risk until it reports `true`.
+
+```csharp
+if (!await storage.IsPersistedAsync())
+{
+    await storage.RequestPersistAsync();
+}
+```
+
+Chromium decides from engagement heuristics without prompting; Firefox shows a permission prompt, so
+call it from a user-gesture handler.
+
+## Transports
+
+Works on both, but every call is a round trip — under the Server transport that round trip crosses the
+WebSocket. The local-database scenario this API exists for is in practice a WASM one.
+
+## See also
+
+- Source: [`IOriginPrivateFileSystem.cs`](../../src/Rask.Core/Browser/IOriginPrivateFileSystem.cs)
+- [`IFileSystemAccess`](file-system-access.md) — the user-facing picker, for files outside the app
+- [`IStorageEstimator`](storage-estimator.md) — quota, usage, and the eviction exemption
+- [Capability matrix](../browser-capabilities.md)
+- [Browser APIs — the narrative map](../browser-apis.md)

--- a/docs/browser-apis-reference.md
+++ b/docs/browser-apis-reference.md
@@ -131,6 +131,10 @@ The push pattern above, one element at a time.
 
 <!-- demo:browser-file-system -->
 
+**`IOriginPrivateFileSystem`** — a private, persistent file tree the app owns: no picker, addressed by path, written in byte ranges. The right home for a local database file.
+
+<!-- demo:browser-opfs -->
+
 **`IWebAuthn`** — register and sign in with a passkey instead of a password.
 
 <!-- demo:browser-webauthn -->

--- a/docs/browser-capabilities.md
+++ b/docs/browser-capabilities.md
@@ -34,6 +34,7 @@ Native column marks an API with a native C# backend (the rest run through the We
 | [`IPerformance`](apis/performance.md) | ✅ | ✅ | ✅ | — |
 | [`IIndexedDb`](apis/indexeddb.md) | ✅ | ✅ | ✅ | — |
 | [`IFileSystemAccess`](apis/file-system-access.md) | ✅ | ✅ | ⬜ | — |
+| [`IOriginPrivateFileSystem`](apis/origin-private-file-system.md) | ✅ | ✅ | ✅ | — |
 | [`IWebAuthn`](apis/webauthn.md) | ✅ | ✅ | ✅ | — |
 | [`IWebLocks`](apis/web-locks.md) | ✅ | ✅ | ✅ | — |
 | [`IBroadcastChannel`](apis/broadcast-channel.md) | ✅ | ✅ | ✅ | — |

--- a/samples/Rask.Example.Shared/Features/Browser/OriginPrivateFileSystemDemo.cs
+++ b/samples/Rask.Example.Shared/Features/Browser/OriginPrivateFileSystemDemo.cs
@@ -1,0 +1,95 @@
+using System.Text;
+using Rask.Core.Browser;
+
+namespace Rask.Example.Shared.Features;
+
+/// <summary>
+///     <see cref="IOriginPrivateFileSystem" /> — write a byte range into an app-owned file, read it back,
+///     and ask for the origin's storage to survive eviction.
+/// </summary>
+public sealed class OriginPrivateFileSystemDemo(
+    IOriginPrivateFileSystem fs,
+    IStorageEstimator storage) : Component
+{
+    private const string Path = "demo/notes.bin";
+    private const long Offset = 4096;
+
+    private string? _content;
+    private string? _size;
+    private string? _status;
+
+    protected override Component? Render() =>
+        BsCard(Class: Bs.Join(Shadow.Sm, Border.None))[
+            BsCardBody()[
+                Div(Class: "d-flex flex-wrap gap-2 mb-2")[
+                    BsButton(Color: BsColor.Primary, Outline: true, Size: BsSize.Sm, Id: "opfs-write", OnClickAsync: Write)[
+                        "Write at 4096"],
+                    BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "opfs-read", OnClickAsync: Read)[
+                        "Read back"],
+                    BsButton(Color: BsColor.Secondary, Outline: true, Size: BsSize.Sm, Id: "opfs-persist", OnClickAsync: Persist)[
+                        "Request persistence"]
+                ],
+                Div(Class: "small text-secondary")["Content: ", Code(Id: "opfs-content")[_content ?? "(not read)"]],
+                Div(Class: "small text-secondary")["File size: ", Code(Id: "opfs-size")[_size ?? "(unknown)"]],
+                Div(Class: "small text-secondary")["Status: ", Code(Id: "opfs-status")[_status ?? "(idle)"]]
+            ]
+        ];
+
+    // Writing at an offset leaves everything outside the range intact and zero-fills the gap up to it, so
+    // the file ends up larger than the bytes written — that's the point of a ranged write.
+    private async Task Write()
+    {
+        if (!await Supported())
+        {
+            return;
+        }
+
+        try
+        {
+            await fs.WriteAsync(Path, Offset, Encoding.UTF8.GetBytes("hello from OPFS"));
+            _size = await fs.GetSizeAsync(Path) is { } size ? $"{size} bytes" : "(missing)";
+            _status = "Wrote 15 bytes at offset 4096";
+        }
+        catch (Exception ex) { _status = "Write failed: " + ex.Message; }
+    }
+
+    private async Task Read()
+    {
+        if (!await Supported())
+        {
+            return;
+        }
+
+        try
+        {
+            var bytes = await fs.ReadAsync(Path, Offset, 15);
+            _content = bytes is null ? "(file does not exist)" : Encoding.UTF8.GetString(bytes);
+            _status = "Read 15 bytes at offset 4096";
+        }
+        catch (Exception ex) { _status = "Read failed: " + ex.Message; }
+    }
+
+    // OPFS is persistent but still evictable under storage pressure until the origin is exempted.
+    private async Task Persist()
+    {
+        try
+        {
+            var persisted = await storage.IsPersistedAsync() || await storage.RequestPersistAsync();
+            _status = persisted
+                ? "Storage is exempt from eviction"
+                : "Storage is still evictable (declined or unsupported)";
+        }
+        catch (Exception ex) { _status = "Persist request failed: " + ex.Message; }
+    }
+
+    private async Task<bool> Supported()
+    {
+        if (await fs.IsSupportedAsync())
+        {
+            return true;
+        }
+
+        _status = "OPFS unavailable in this browser";
+        return false;
+    }
+}

--- a/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
+++ b/samples/Rask.Example.Shared/Features/Guides/GuideCatalog.cs
@@ -220,6 +220,7 @@ public static class GuideCatalog
         new("navigator-info", "INavigatorInfo", "Typed browser API: INavigatorInfo.", "bi-plug", "Browser API reference", "apis/navigator-info.md"),
         new("network-info", "INetworkInfo", "Typed browser API: INetworkInfo.", "bi-plug", "Browser API reference", "apis/network-info.md"),
         new("notifications", "INotifications", "Typed browser API: INotifications.", "bi-plug", "Browser API reference", "apis/notifications.md"),
+        new("origin-private-file-system", "IOriginPrivateFileSystem", "Typed browser API: IOriginPrivateFileSystem.", "bi-plug", "Browser API reference", "apis/origin-private-file-system.md"),
         new("page-visibility", "IPageVisibility", "Typed browser API: IPageVisibility.", "bi-plug", "Browser API reference", "apis/page-visibility.md"),
         new("performance", "IPerformance", "Typed browser API: IPerformance.", "bi-plug", "Browser API reference", "apis/performance.md"),
         new("permissions", "IPermissions", "Typed browser API: IPermissions.", "bi-plug", "Browser API reference", "apis/permissions.md"),

--- a/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
+++ b/samples/Rask.Example.Shared/Shared/DemoRegistry.cs
@@ -123,6 +123,7 @@ public static class DemoRegistry
             ["browser-media-session"] = () => CodeSample(["MediaSessionDemo.cs"], Result: MediaSessionDemo()),
             ["browser-crypto"] = () => CodeSample(["CryptoDemo.cs"], Result: CryptoDemo()),
             ["browser-file-system"] = () => CodeSample(["FileSystemAccessDemo.cs"], Result: FileSystemAccessDemo()),
+            ["browser-opfs"] = () => CodeSample(["OriginPrivateFileSystemDemo.cs"], Result: OriginPrivateFileSystemDemo()),
             ["browser-webauthn"] = () => CodeSample(["WebAuthnDemo.cs"], Result: WebAuthnDemo()),
             ["browser-broadcast-channel"] = () => CodeSample(["BroadcastChannelDemo.cs"], Result: BroadcastChannelDemo()),
             ["browser-web-locks"] = () => CodeSample(["WebLocksDemo.cs"], Result: WebLocksDemo()),

--- a/src/Rask.Core/Browser/IOriginPrivateFileSystem.cs
+++ b/src/Rask.Core/Browser/IOriginPrivateFileSystem.cs
@@ -1,0 +1,179 @@
+using Microsoft.JSInterop;
+
+namespace Rask.Core.Browser;
+
+/// <summary>
+///     Typed access to the Origin Private File System
+///     (<see href="https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system" />) —
+///     a private, persistent, origin-scoped file tree the app owns outright. Unlike
+///     <see cref="IFileSystemAccess" /> there is no picker and no user gesture: the app addresses files by
+///     path and reopens the same paths on every visit, which is what makes it the right home for a local
+///     database file, a downloaded bundle, or any blob too large for <see cref="IIndexedDb" />. Inject it
+///     through a component constructor.
+/// </summary>
+/// <remarks>
+///     <para>
+///         Paths are <c>/</c>-separated and relative to the origin's private root (<c>"db/app.sqlite"</c>).
+///         Parent directories are created on write and never have to be made explicitly. Nothing here is
+///         visible to the user's real file system, and nothing is shared with another origin.
+///     </para>
+///     <para>
+///         Reads and writes take a byte <b>offset</b> so a large file can be worked in chunks without ever
+///         materialising the whole thing — the payload crossing the interop boundary is bounded by the range
+///         you ask for. <see cref="ReadAllBytesAsync" /> / <see cref="WriteAllBytesAsync" /> are the
+///         single-round-trip convenience over the same store; prefer the ranged calls once a file grows past
+///         a few megabytes.
+///     </para>
+///     <para>
+///         Reading a path that does not exist returns <c>null</c> rather than throwing, matching
+///         <see cref="IKeyValueStore.GetAsync" />. A ranged read that runs past the end of the file returns
+///         the bytes that were available (a short read), exactly as an ordinary file read would.
+///     </para>
+///     <para>
+///         Works on <b>both transports</b>, but every call is a round trip: under the Server transport that
+///         round trip crosses the WebSocket, so the local-database scenario this API exists for is in
+///         practice a WASM one. Requires a secure context; gate on <see cref="IsSupportedAsync" />.
+///     </para>
+///     <para>
+///         <b>Durability.</b> OPFS is persistent but not automatically exempt from eviction — a browser may
+///         reclaim it under storage pressure. Call
+///         <see cref="IStorageEstimator.RequestPersistAsync" /> to ask for the origin to be exempted, and
+///         treat unsynced writes as at risk until it reports <c>true</c>.
+///     </para>
+/// </remarks>
+public interface IOriginPrivateFileSystem
+{
+    /// <summary>Whether the browser exposes OPFS (<c>navigator.storage.getDirectory</c>).</summary>
+    ValueTask<bool> IsSupportedAsync();
+
+    /// <summary>Whether a file exists at <paramref name="path" />.</summary>
+    ValueTask<bool> ExistsAsync(string path);
+
+    /// <summary>The size of the file at <paramref name="path" /> in bytes, or <c>null</c> if it does not exist.</summary>
+    ValueTask<long?> GetSizeAsync(string path);
+
+    /// <summary>
+    ///     Reads up to <paramref name="count" /> bytes starting at <paramref name="offset" />, or <c>null</c>
+    ///     if the file does not exist. Returns fewer bytes than asked for when the range runs past the end.
+    /// </summary>
+    ValueTask<byte[]?> ReadAsync(string path, long offset, int count);
+
+    /// <summary>
+    ///     Writes <paramref name="bytes" /> at <paramref name="offset" />, leaving the rest of the file
+    ///     intact, and creating the file (and any parent directories) if needed. Writing past the current end
+    ///     extends the file, zero-filling the gap.
+    /// </summary>
+    ValueTask WriteAsync(string path, long offset, byte[] bytes);
+
+    /// <summary>
+    ///     Resizes the file at <paramref name="path" /> to <paramref name="size" /> bytes — truncating it, or
+    ///     extending it with zeroes. Creates the file if it does not exist.
+    /// </summary>
+    ValueTask TruncateAsync(string path, long size);
+
+    /// <summary>Reads the whole file, or <c>null</c> if it does not exist.</summary>
+    ValueTask<byte[]?> ReadAllBytesAsync(string path);
+
+    /// <summary>Replaces the whole file with <paramref name="bytes" />, creating it (and parents) if needed.</summary>
+    ValueTask WriteAllBytesAsync(string path, byte[] bytes);
+
+    /// <summary>
+    ///     Removes the file or directory at <paramref name="path" /> (a no-op if absent). A non-empty
+    ///     directory needs <paramref name="recursive" />.
+    /// </summary>
+    ValueTask DeleteAsync(string path, bool recursive = false);
+
+    /// <summary>
+    ///     The entry names directly inside <paramref name="path" /> (the private root when omitted), or an
+    ///     empty array if that directory does not exist.
+    /// </summary>
+    ValueTask<string[]> ListAsync(string path = "");
+}
+
+/// <summary>
+///     Default <see cref="IOriginPrivateFileSystem" />, backed by the unified <see cref="IJSRuntime" />.
+///     OPFS handles are opaque and cannot cross the interop boundary, and every operation needs the path
+///     walked from the private root, so all access goes through the framework's <c>__raskOpfs</c> helper.
+///     Bytes ride the boundary base64-encoded, as they do for <see cref="IFileSystemAccess" />.
+/// </summary>
+public sealed class OriginPrivateFileSystem(IJSRuntime js) : IOriginPrivateFileSystem
+{
+    /// <inheritdoc />
+    public ValueTask<bool> IsSupportedAsync() => js.InvokeAsync<bool>("__raskOpfs.isSupported");
+
+    /// <inheritdoc />
+    public ValueTask<bool> ExistsAsync(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        return js.InvokeAsync<bool>("__raskOpfs.exists", path);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<long?> GetSizeAsync(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        return js.InvokeAsync<long?>("__raskOpfs.size", path);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]?> ReadAsync(string path, long offset, int count)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentOutOfRangeException.ThrowIfNegative(count);
+
+        var base64 = await js.InvokeAsync<string?>("__raskOpfs.read", path, offset, count);
+        return base64 is null ? null : Convert.FromBase64String(base64);
+    }
+
+    /// <inheritdoc />
+    public ValueTask WriteAsync(string path, long offset, byte[] bytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentOutOfRangeException.ThrowIfNegative(offset);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        return js.InvokeVoidAsync("__raskOpfs.write", path, offset, Convert.ToBase64String(bytes));
+    }
+
+    /// <inheritdoc />
+    public ValueTask TruncateAsync(string path, long size)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentOutOfRangeException.ThrowIfNegative(size);
+
+        return js.InvokeVoidAsync("__raskOpfs.truncate", path, size);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<byte[]?> ReadAllBytesAsync(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var base64 = await js.InvokeAsync<string?>("__raskOpfs.readAll", path);
+        return base64 is null ? null : Convert.FromBase64String(base64);
+    }
+
+    /// <inheritdoc />
+    public ValueTask WriteAllBytesAsync(string path, byte[] bytes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        ArgumentNullException.ThrowIfNull(bytes);
+
+        return js.InvokeVoidAsync("__raskOpfs.writeAll", path, Convert.ToBase64String(bytes));
+    }
+
+    /// <inheritdoc />
+    public ValueTask DeleteAsync(string path, bool recursive = false)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+        return js.InvokeVoidAsync("__raskOpfs.delete", path, recursive);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<string[]> ListAsync(string path = "")
+    {
+        ArgumentNullException.ThrowIfNull(path);
+        return js.InvokeAsync<string[]>("__raskOpfs.list", path);
+    }
+}

--- a/src/Rask.Core/Browser/IStorageEstimator.cs
+++ b/src/Rask.Core/Browser/IStorageEstimator.cs
@@ -15,9 +15,10 @@ public sealed record StorageEstimate(long Quota, long Usage)
 ///     Typed access to the Storage API's quota estimate
 ///     (<see href="https://developer.mozilla.org/en-US/docs/Web/API/StorageManager/estimate" />) — how much
 ///     on-device storage the origin may use and how much it already uses, e.g. to budget a cache or warn
-///     before filling up. Pairs with <see cref="IBrowserStorage" /> and the offline/PWA story. Works on
-///     <b>both transports</b>; inject it through a component constructor and read from an event handler or
-///     lifecycle hook.
+///     before filling up — plus the same object's <b>persistence</b> knob, which asks for that storage to be
+///     exempt from eviction. Pairs with <see cref="IBrowserStorage" />,
+///     <see cref="IOriginPrivateFileSystem" />, and the offline/PWA story. Works on <b>both transports</b>;
+///     inject it through a component constructor and read from an event handler or lifecycle hook.
 /// </summary>
 /// <remarks>
 ///     Requires a secure context; support is partial — gate on <see cref="IsSupportedAsync" />,
@@ -31,6 +32,20 @@ public interface IStorageEstimator
 
     /// <summary>Reads the current <see cref="StorageEstimate" />, or <c>null</c> when unsupported.</summary>
     ValueTask<StorageEstimate?> EstimateAsync();
+
+    /// <summary>
+    ///     Whether the origin's storage is already exempt from eviction
+    ///     (<c>navigator.storage.persisted()</c>). <c>false</c> where unsupported.
+    /// </summary>
+    ValueTask<bool> IsPersistedAsync();
+
+    /// <summary>
+    ///     Asks for the origin's storage to be exempted from eviction, returning whether it now is
+    ///     (<c>navigator.storage.persist()</c>). Chromium decides from engagement heuristics without
+    ///     prompting; Firefox shows a permission prompt, so call this from a user-gesture handler. Already
+    ///     being persisted resolves <c>true</c> without re-asking, and <c>false</c> where unsupported.
+    /// </summary>
+    ValueTask<bool> RequestPersistAsync();
 }
 
 /// <summary>
@@ -47,4 +62,10 @@ public sealed class StorageEstimator(IJSRuntime js) : IStorageEstimator
     /// <inheritdoc />
     public ValueTask<StorageEstimate?> EstimateAsync() =>
         js.InvokeAsync<StorageEstimate?>("__raskApi.storageEstimate");
+
+    /// <inheritdoc />
+    public ValueTask<bool> IsPersistedAsync() => js.InvokeAsync<bool>("__raskApi.storagePersisted");
+
+    /// <inheritdoc />
+    public ValueTask<bool> RequestPersistAsync() => js.InvokeAsync<bool>("__raskApi.storagePersist");
 }

--- a/src/Rask.Core/Browser/RaskBrowserApis.cs
+++ b/src/Rask.Core/Browser/RaskBrowserApis.cs
@@ -67,6 +67,7 @@ public static class RaskBrowserApis
         services.AddBrowserApi<IPerformance, Performance>(lifetime);
         services.AddBrowserApi<IIndexedDb, IndexedDb>(lifetime);
         services.AddBrowserApi<IFileSystemAccess, FileSystemAccess>(lifetime);
+        services.AddBrowserApi<IOriginPrivateFileSystem, OriginPrivateFileSystem>(lifetime);
         services.AddBrowserApi<IWebAuthn, WebAuthn>(lifetime);
         services.AddBrowserApi<ICookies, Cookies>(lifetime);
         services.AddBrowserApi<IPermissions, Permissions>(lifetime);

--- a/src/Rask.Core/Resources/rask-api.js
+++ b/src/Rask.Core/Resources/rask-api.js
@@ -104,6 +104,22 @@ window.__raskApi = window.__raskApi || {
         return {quota: e.quota || 0, usage: e.usage || 0};
     },
 
+    // Storage persistence (driven by IStorageEstimator): whether the origin is exempt from eviction, and a
+    // request to become so. persist() is a one-shot grant — Chromium decides from engagement heuristics
+    // without prompting, Firefox shows a permission prompt. Both resolve false where unsupported.
+    storagePersisted: async () => {
+        if (!(navigator.storage && navigator.storage.persisted)) {
+            return false;
+        }
+        return await navigator.storage.persisted();
+    },
+    storagePersist: async () => {
+        if (!(navigator.storage && navigator.storage.persist)) {
+            return false;
+        }
+        return await navigator.storage.persist();
+    },
+
     // Visual viewport (driven by IVisualViewport): window.visualViewport is a live object — return a plain
     // snapshot (mapped to VisualViewport in C#), or null when unsupported.
     visualViewportSupported: () => !!window.visualViewport,
@@ -885,6 +901,179 @@ window.__raskFs = window.__raskFs || (() => {
         },
         release: (id) => {
             handles.delete(id);
+        }
+    };
+})();
+
+// Origin Private File System (driven by IOriginPrivateFileSystem). OPFS handles are opaque and can't cross
+// the interop boundary, and every call needs the path walked from the private root, so this helper resolves
+// "db/app.sqlite" itself per operation rather than holding handles under an id the way __raskFs does — the
+// tree is app-owned and persistent, so there is nothing to keep alive between calls. Bytes ride the boundary
+// base64-encoded. A missing path resolves to null / false / [] rather than throwing.
+window.__raskOpfs = window.__raskOpfs || (() => {
+    // A path segment that isn't there, or is a directory where a file was expected.
+    const isMissing = (e) => e && (e.name === "NotFoundError" || e.name === "TypeMismatchError");
+
+    // Splits on "/" via split rather than a regex: the framework's JS minifier reads a bare /.../ as
+    // division, which would break the spliced bundle.
+    const segments = (path) => (path || "").split("/").filter((s) => s.length > 0);
+
+    // "db/app.sqlite" -> { dir: <handle for "db">, name: "app.sqlite" }.
+    const parent = async (path, create) => {
+        const parts = segments(path);
+        if (parts.length === 0) {
+            return null;
+        }
+        const name = parts.pop();
+        let dir = await navigator.storage.getDirectory();
+        for (let i = 0; i < parts.length; i++) {
+            dir = await dir.getDirectoryHandle(parts[i], {create: !!create});
+        }
+        return {dir: dir, name: name};
+    };
+
+    const fileHandle = async (path, create) => {
+        const at = await parent(path, create);
+        if (!at) {
+            return null;
+        }
+        return await at.dir.getFileHandle(at.name, {create: !!create});
+    };
+
+    const directory = async (path) => {
+        let dir = await navigator.storage.getDirectory();
+        const parts = segments(path);
+        for (let i = 0; i < parts.length; i++) {
+            dir = await dir.getDirectoryHandle(parts[i], {create: false});
+        }
+        return dir;
+    };
+
+    const toBase64 = (buffer) => {
+        const bytes = new Uint8Array(buffer);
+        let binary = "";
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        return btoa(binary);
+    };
+
+    const fromBase64 = (base64) => {
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+    };
+
+    return {
+        isSupported: () => !!(navigator.storage && navigator.storage.getDirectory),
+        exists: async (path) => {
+            try {
+                return !!(await fileHandle(path, false));
+            } catch (e) {
+                if (isMissing(e)) {
+                    return false;
+                }
+                throw e;
+            }
+        },
+        size: async (path) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                return (await handle.getFile()).size;
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        // Blob.slice() reads only the requested range, so a chunked read never materialises the whole file.
+        // A range past the end yields the bytes that were there, matching an ordinary short read.
+        read: async (path, offset, count) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                const file = await handle.getFile();
+                return toBase64(await file.slice(offset, offset + count).arrayBuffer());
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        readAll: async (path) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                return toBase64(await (await handle.getFile()).arrayBuffer());
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        // keepExistingData is load-bearing: without it createWritable() starts from an empty file, so a
+        // ranged write would discard every byte outside the range it wrote. Writing past the end zero-fills
+        // the gap rather than failing — File System Standard, write() step 9 — which is what lets a growing
+        // database write a page beyond its current size.
+        write: async (path, offset, base64) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable({keepExistingData: true});
+            await writable.write({type: "write", position: offset, data: fromBase64(base64)});
+            await writable.close();
+        },
+        // Whole-file replace, so the default (start empty) is what we want here.
+        writeAll: async (path, base64) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable();
+            await writable.write(fromBase64(base64));
+            await writable.close();
+        },
+        truncate: async (path, size) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable({keepExistingData: true});
+            await writable.truncate(size);
+            await writable.close();
+        },
+        delete: async (path, recursive) => {
+            try {
+                const at = await parent(path, false);
+                if (!at) {
+                    return;
+                }
+                await at.dir.removeEntry(at.name, {recursive: !!recursive});
+            } catch (e) {
+                if (isMissing(e)) {
+                    return;
+                }
+                throw e;
+            }
+        },
+        list: async (path) => {
+            try {
+                const names = [];
+                for await (const name of (await directory(path)).keys()) {
+                    names.push(name);
+                }
+                return names;
+            } catch (e) {
+                if (isMissing(e)) {
+                    return [];
+                }
+                throw e;
+            }
         }
     };
 })();

--- a/src/Rask.Native/Assets/rask.native.js
+++ b/src/Rask.Native/Assets/rask.native.js
@@ -130,6 +130,22 @@ window.__raskApi = window.__raskApi || {
         return {quota: e.quota || 0, usage: e.usage || 0};
     },
 
+    // Storage persistence (driven by IStorageEstimator): whether the origin is exempt from eviction, and a
+    // request to become so. persist() is a one-shot grant — Chromium decides from engagement heuristics
+    // without prompting, Firefox shows a permission prompt. Both resolve false where unsupported.
+    storagePersisted: async () => {
+        if (!(navigator.storage && navigator.storage.persisted)) {
+            return false;
+        }
+        return await navigator.storage.persisted();
+    },
+    storagePersist: async () => {
+        if (!(navigator.storage && navigator.storage.persist)) {
+            return false;
+        }
+        return await navigator.storage.persist();
+    },
+
     // Visual viewport (driven by IVisualViewport): window.visualViewport is a live object — return a plain
     // snapshot (mapped to VisualViewport in C#), or null when unsupported.
     visualViewportSupported: () => !!window.visualViewport,
@@ -911,6 +927,179 @@ window.__raskFs = window.__raskFs || (() => {
         },
         release: (id) => {
             handles.delete(id);
+        }
+    };
+})();
+
+// Origin Private File System (driven by IOriginPrivateFileSystem). OPFS handles are opaque and can't cross
+// the interop boundary, and every call needs the path walked from the private root, so this helper resolves
+// "db/app.sqlite" itself per operation rather than holding handles under an id the way __raskFs does — the
+// tree is app-owned and persistent, so there is nothing to keep alive between calls. Bytes ride the boundary
+// base64-encoded. A missing path resolves to null / false / [] rather than throwing.
+window.__raskOpfs = window.__raskOpfs || (() => {
+    // A path segment that isn't there, or is a directory where a file was expected.
+    const isMissing = (e) => e && (e.name === "NotFoundError" || e.name === "TypeMismatchError");
+
+    // Splits on "/" via split rather than a regex: the framework's JS minifier reads a bare /.../ as
+    // division, which would break the spliced bundle.
+    const segments = (path) => (path || "").split("/").filter((s) => s.length > 0);
+
+    // "db/app.sqlite" -> { dir: <handle for "db">, name: "app.sqlite" }.
+    const parent = async (path, create) => {
+        const parts = segments(path);
+        if (parts.length === 0) {
+            return null;
+        }
+        const name = parts.pop();
+        let dir = await navigator.storage.getDirectory();
+        for (let i = 0; i < parts.length; i++) {
+            dir = await dir.getDirectoryHandle(parts[i], {create: !!create});
+        }
+        return {dir: dir, name: name};
+    };
+
+    const fileHandle = async (path, create) => {
+        const at = await parent(path, create);
+        if (!at) {
+            return null;
+        }
+        return await at.dir.getFileHandle(at.name, {create: !!create});
+    };
+
+    const directory = async (path) => {
+        let dir = await navigator.storage.getDirectory();
+        const parts = segments(path);
+        for (let i = 0; i < parts.length; i++) {
+            dir = await dir.getDirectoryHandle(parts[i], {create: false});
+        }
+        return dir;
+    };
+
+    const toBase64 = (buffer) => {
+        const bytes = new Uint8Array(buffer);
+        let binary = "";
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        return btoa(binary);
+    };
+
+    const fromBase64 = (base64) => {
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+    };
+
+    return {
+        isSupported: () => !!(navigator.storage && navigator.storage.getDirectory),
+        exists: async (path) => {
+            try {
+                return !!(await fileHandle(path, false));
+            } catch (e) {
+                if (isMissing(e)) {
+                    return false;
+                }
+                throw e;
+            }
+        },
+        size: async (path) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                return (await handle.getFile()).size;
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        // Blob.slice() reads only the requested range, so a chunked read never materialises the whole file.
+        // A range past the end yields the bytes that were there, matching an ordinary short read.
+        read: async (path, offset, count) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                const file = await handle.getFile();
+                return toBase64(await file.slice(offset, offset + count).arrayBuffer());
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        readAll: async (path) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                return toBase64(await (await handle.getFile()).arrayBuffer());
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        // keepExistingData is load-bearing: without it createWritable() starts from an empty file, so a
+        // ranged write would discard every byte outside the range it wrote. Writing past the end zero-fills
+        // the gap rather than failing — File System Standard, write() step 9 — which is what lets a growing
+        // database write a page beyond its current size.
+        write: async (path, offset, base64) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable({keepExistingData: true});
+            await writable.write({type: "write", position: offset, data: fromBase64(base64)});
+            await writable.close();
+        },
+        // Whole-file replace, so the default (start empty) is what we want here.
+        writeAll: async (path, base64) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable();
+            await writable.write(fromBase64(base64));
+            await writable.close();
+        },
+        truncate: async (path, size) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable({keepExistingData: true});
+            await writable.truncate(size);
+            await writable.close();
+        },
+        delete: async (path, recursive) => {
+            try {
+                const at = await parent(path, false);
+                if (!at) {
+                    return;
+                }
+                await at.dir.removeEntry(at.name, {recursive: !!recursive});
+            } catch (e) {
+                if (isMissing(e)) {
+                    return;
+                }
+                throw e;
+            }
+        },
+        list: async (path) => {
+            try {
+                const names = [];
+                for await (const name of (await directory(path)).keys()) {
+                    names.push(name);
+                }
+                return names;
+            } catch (e) {
+                if (isMissing(e)) {
+                    return [];
+                }
+                throw e;
+            }
         }
     };
 })();

--- a/src/Rask.Wasm/Browser/rask.wasm.js
+++ b/src/Rask.Wasm/Browser/rask.wasm.js
@@ -114,6 +114,22 @@ window.__raskApi = window.__raskApi || {
         return {quota: e.quota || 0, usage: e.usage || 0};
     },
 
+    // Storage persistence (driven by IStorageEstimator): whether the origin is exempt from eviction, and a
+    // request to become so. persist() is a one-shot grant — Chromium decides from engagement heuristics
+    // without prompting, Firefox shows a permission prompt. Both resolve false where unsupported.
+    storagePersisted: async () => {
+        if (!(navigator.storage && navigator.storage.persisted)) {
+            return false;
+        }
+        return await navigator.storage.persisted();
+    },
+    storagePersist: async () => {
+        if (!(navigator.storage && navigator.storage.persist)) {
+            return false;
+        }
+        return await navigator.storage.persist();
+    },
+
     // Visual viewport (driven by IVisualViewport): window.visualViewport is a live object — return a plain
     // snapshot (mapped to VisualViewport in C#), or null when unsupported.
     visualViewportSupported: () => !!window.visualViewport,
@@ -895,6 +911,179 @@ window.__raskFs = window.__raskFs || (() => {
         },
         release: (id) => {
             handles.delete(id);
+        }
+    };
+})();
+
+// Origin Private File System (driven by IOriginPrivateFileSystem). OPFS handles are opaque and can't cross
+// the interop boundary, and every call needs the path walked from the private root, so this helper resolves
+// "db/app.sqlite" itself per operation rather than holding handles under an id the way __raskFs does — the
+// tree is app-owned and persistent, so there is nothing to keep alive between calls. Bytes ride the boundary
+// base64-encoded. A missing path resolves to null / false / [] rather than throwing.
+window.__raskOpfs = window.__raskOpfs || (() => {
+    // A path segment that isn't there, or is a directory where a file was expected.
+    const isMissing = (e) => e && (e.name === "NotFoundError" || e.name === "TypeMismatchError");
+
+    // Splits on "/" via split rather than a regex: the framework's JS minifier reads a bare /.../ as
+    // division, which would break the spliced bundle.
+    const segments = (path) => (path || "").split("/").filter((s) => s.length > 0);
+
+    // "db/app.sqlite" -> { dir: <handle for "db">, name: "app.sqlite" }.
+    const parent = async (path, create) => {
+        const parts = segments(path);
+        if (parts.length === 0) {
+            return null;
+        }
+        const name = parts.pop();
+        let dir = await navigator.storage.getDirectory();
+        for (let i = 0; i < parts.length; i++) {
+            dir = await dir.getDirectoryHandle(parts[i], {create: !!create});
+        }
+        return {dir: dir, name: name};
+    };
+
+    const fileHandle = async (path, create) => {
+        const at = await parent(path, create);
+        if (!at) {
+            return null;
+        }
+        return await at.dir.getFileHandle(at.name, {create: !!create});
+    };
+
+    const directory = async (path) => {
+        let dir = await navigator.storage.getDirectory();
+        const parts = segments(path);
+        for (let i = 0; i < parts.length; i++) {
+            dir = await dir.getDirectoryHandle(parts[i], {create: false});
+        }
+        return dir;
+    };
+
+    const toBase64 = (buffer) => {
+        const bytes = new Uint8Array(buffer);
+        let binary = "";
+        for (let i = 0; i < bytes.length; i++) {
+            binary += String.fromCharCode(bytes[i]);
+        }
+        return btoa(binary);
+    };
+
+    const fromBase64 = (base64) => {
+        const binary = atob(base64);
+        const bytes = new Uint8Array(binary.length);
+        for (let i = 0; i < binary.length; i++) {
+            bytes[i] = binary.charCodeAt(i);
+        }
+        return bytes;
+    };
+
+    return {
+        isSupported: () => !!(navigator.storage && navigator.storage.getDirectory),
+        exists: async (path) => {
+            try {
+                return !!(await fileHandle(path, false));
+            } catch (e) {
+                if (isMissing(e)) {
+                    return false;
+                }
+                throw e;
+            }
+        },
+        size: async (path) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                return (await handle.getFile()).size;
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        // Blob.slice() reads only the requested range, so a chunked read never materialises the whole file.
+        // A range past the end yields the bytes that were there, matching an ordinary short read.
+        read: async (path, offset, count) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                const file = await handle.getFile();
+                return toBase64(await file.slice(offset, offset + count).arrayBuffer());
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        readAll: async (path) => {
+            try {
+                const handle = await fileHandle(path, false);
+                if (!handle) {
+                    return null;
+                }
+                return toBase64(await (await handle.getFile()).arrayBuffer());
+            } catch (e) {
+                if (isMissing(e)) {
+                    return null;
+                }
+                throw e;
+            }
+        },
+        // keepExistingData is load-bearing: without it createWritable() starts from an empty file, so a
+        // ranged write would discard every byte outside the range it wrote. Writing past the end zero-fills
+        // the gap rather than failing — File System Standard, write() step 9 — which is what lets a growing
+        // database write a page beyond its current size.
+        write: async (path, offset, base64) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable({keepExistingData: true});
+            await writable.write({type: "write", position: offset, data: fromBase64(base64)});
+            await writable.close();
+        },
+        // Whole-file replace, so the default (start empty) is what we want here.
+        writeAll: async (path, base64) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable();
+            await writable.write(fromBase64(base64));
+            await writable.close();
+        },
+        truncate: async (path, size) => {
+            const handle = await fileHandle(path, true);
+            const writable = await handle.createWritable({keepExistingData: true});
+            await writable.truncate(size);
+            await writable.close();
+        },
+        delete: async (path, recursive) => {
+            try {
+                const at = await parent(path, false);
+                if (!at) {
+                    return;
+                }
+                await at.dir.removeEntry(at.name, {recursive: !!recursive});
+            } catch (e) {
+                if (isMissing(e)) {
+                    return;
+                }
+                throw e;
+            }
+        },
+        list: async (path) => {
+            try {
+                const names = [];
+                for await (const name of (await directory(path)).keys()) {
+                    names.push(name);
+                }
+                return names;
+            } catch (e) {
+                if (isMissing(e)) {
+                    return [];
+                }
+                throw e;
+            }
         }
     };
 })();

--- a/tests/Rask.Core.Tests/Browser/RaskBrowserApisTests.cs
+++ b/tests/Rask.Core.Tests/Browser/RaskBrowserApisTests.cs
@@ -9,7 +9,7 @@ namespace Rask.Core.Tests.Browser;
 // native platform or the app) wins and the JS-backed wrapper is only the fallback.
 public class RaskBrowserApisTests
 {
-    // The 34 transport-agnostic wrappers AddCoreBrowserApis must register — service type → default impl.
+    // The 35 transport-agnostic wrappers AddCoreBrowserApis must register — service type → default impl.
     // Keep in sync with the registrar; AddCoreBrowserApis_RegistersNothingBeyondThePinnedSet enforces it.
     private static readonly (Type Service, Type Impl)[] CoreApis =
     [
@@ -36,6 +36,7 @@ public class RaskBrowserApisTests
         (typeof(IPerformance), typeof(Rask.Core.Browser.Performance)),
         (typeof(IIndexedDb), typeof(IndexedDb)),
         (typeof(IFileSystemAccess), typeof(FileSystemAccess)),
+        (typeof(IOriginPrivateFileSystem), typeof(OriginPrivateFileSystem)),
         (typeof(IWebAuthn), typeof(WebAuthn)),
         (typeof(ICookies), typeof(Cookies)),
         (typeof(IPermissions), typeof(Permissions)),

--- a/tests/Rask.Core.Tests/Interop/OriginPrivateFileSystemTests.cs
+++ b/tests/Rask.Core.Tests/Interop/OriginPrivateFileSystemTests.cs
@@ -1,0 +1,179 @@
+using System.Text;
+using Rask.Core.Browser;
+
+namespace Rask.Core.Tests.Interop;
+
+// OPFS is the durable home for a local database file, so these pin the exact identifiers and argument
+// shapes the __raskOpfs helper is written against — particularly that bytes cross the boundary base64-encoded
+// and that a missing path resolves to null rather than throwing.
+public class OriginPrivateFileSystemTests
+{
+    [Fact]
+    public async Task IsSupported_CallsHelper()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskOpfs.isSupported", true);
+
+        Assert.True(await new OriginPrivateFileSystem(js).IsSupportedAsync());
+    }
+
+    [Fact]
+    public async Task Exists_PassesPath()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskOpfs.exists", true);
+
+        Assert.True(await new OriginPrivateFileSystem(js).ExistsAsync("db/app.sqlite"));
+        Assert.Equal(["db/app.sqlite"], js.ArgsFor("__raskOpfs.exists"));
+    }
+
+    [Fact]
+    public async Task GetSize_ReturnsNull_WhenFileMissing()
+    {
+        var js = new FakeJsRuntime();
+
+        Assert.Null(await new OriginPrivateFileSystem(js).GetSizeAsync("nope.db"));
+    }
+
+    [Fact]
+    public async Task GetSize_ReturnsSize()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskOpfs.size", (long?)4096);
+
+        Assert.Equal(4096, await new OriginPrivateFileSystem(js).GetSizeAsync("db/app.sqlite"));
+    }
+
+    [Fact]
+    public async Task Read_PassesRange_AndDecodesBase64()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskOpfs.read", Convert.ToBase64String("page"u8.ToArray()));
+
+        var bytes = await new OriginPrivateFileSystem(js).ReadAsync("db/app.sqlite", 8192, 4096);
+
+        Assert.Equal("page", Encoding.UTF8.GetString(bytes!));
+        Assert.Equal(["db/app.sqlite", 8192L, 4096], js.ArgsFor("__raskOpfs.read"));
+    }
+
+    [Fact]
+    public async Task Read_ReturnsNull_WhenFileMissing()
+    {
+        var js = new FakeJsRuntime();
+
+        Assert.Null(await new OriginPrivateFileSystem(js).ReadAsync("nope.db", 0, 16));
+    }
+
+    [Fact]
+    public async Task Write_EncodesBytes_AtOffset()
+    {
+        var js = new FakeJsRuntime();
+
+        await new OriginPrivateFileSystem(js).WriteAsync("db/app.sqlite", 4096, "page"u8.ToArray());
+
+        Assert.Equal(
+            ["db/app.sqlite", 4096L, Convert.ToBase64String("page"u8.ToArray())],
+            js.ArgsFor("__raskOpfs.write"));
+    }
+
+    [Fact]
+    public async Task ReadAllBytes_DecodesBase64()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskOpfs.readAll", Convert.ToBase64String("whole"u8.ToArray()));
+
+        var bytes = await new OriginPrivateFileSystem(js).ReadAllBytesAsync("notes.txt");
+
+        Assert.Equal("whole", Encoding.UTF8.GetString(bytes!));
+    }
+
+    [Fact]
+    public async Task ReadAllBytes_ReturnsNull_WhenFileMissing()
+    {
+        var js = new FakeJsRuntime();
+
+        Assert.Null(await new OriginPrivateFileSystem(js).ReadAllBytesAsync("nope.txt"));
+    }
+
+    [Fact]
+    public async Task WriteAllBytes_EncodesBytes()
+    {
+        var js = new FakeJsRuntime();
+
+        await new OriginPrivateFileSystem(js).WriteAllBytesAsync("notes.txt", "whole"u8.ToArray());
+
+        Assert.Equal(
+            ["notes.txt", Convert.ToBase64String("whole"u8.ToArray())],
+            js.ArgsFor("__raskOpfs.writeAll"));
+    }
+
+    [Fact]
+    public async Task Truncate_PassesSize()
+    {
+        var js = new FakeJsRuntime();
+
+        await new OriginPrivateFileSystem(js).TruncateAsync("db/app.sqlite", 0);
+
+        Assert.Equal(["db/app.sqlite", 0L], js.ArgsFor("__raskOpfs.truncate"));
+    }
+
+    [Fact]
+    public async Task Delete_DefaultsToNonRecursive()
+    {
+        var js = new FakeJsRuntime();
+
+        await new OriginPrivateFileSystem(js).DeleteAsync("db/app.sqlite");
+
+        Assert.Equal(["db/app.sqlite", false], js.ArgsFor("__raskOpfs.delete"));
+    }
+
+    [Fact]
+    public async Task Delete_PassesRecursive()
+    {
+        var js = new FakeJsRuntime();
+
+        await new OriginPrivateFileSystem(js).DeleteAsync("db", recursive: true);
+
+        Assert.Equal(["db", true], js.ArgsFor("__raskOpfs.delete"));
+    }
+
+    [Fact]
+    public async Task List_DefaultsToRoot()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskOpfs.list", new[] { "db", "notes.txt" });
+
+        Assert.Equal(["db", "notes.txt"], await new OriginPrivateFileSystem(js).ListAsync());
+        Assert.Equal([""], js.ArgsFor("__raskOpfs.list"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public async Task Read_Rejects_EmptyPath(string? path)
+    {
+        var js = new FakeJsRuntime();
+
+        await Assert.ThrowsAnyAsync<ArgumentException>(
+            async () => await new OriginPrivateFileSystem(js).ReadAsync(path!, 0, 1));
+    }
+
+    [Fact]
+    public async Task Read_Rejects_NegativeOffset()
+    {
+        var js = new FakeJsRuntime();
+
+        await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+            async () => await new OriginPrivateFileSystem(js).ReadAsync("db", -1, 1));
+    }
+
+    [Fact]
+    public async Task Write_Rejects_NullBytes()
+    {
+        var js = new FakeJsRuntime();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            async () => await new OriginPrivateFileSystem(js).WriteAsync("db", 0, null!));
+    }
+}

--- a/tests/Rask.Core.Tests/Interop/StorageEstimatorTests.cs
+++ b/tests/Rask.Core.Tests/Interop/StorageEstimatorTests.cs
@@ -40,4 +40,33 @@ public class StorageEstimatorTests
 
         Assert.Null(await new StorageEstimator(js).EstimateAsync());
     }
+
+    [Fact]
+    public async Task IsPersisted_CallsHelper()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskApi.storagePersisted", true);
+
+        Assert.True(await new StorageEstimator(js).IsPersistedAsync());
+    }
+
+    [Fact]
+    public async Task RequestPersist_CallsHelper()
+    {
+        var js = new FakeJsRuntime();
+        js.SetResponse("__raskApi.storagePersist", true);
+
+        Assert.True(await new StorageEstimator(js).RequestPersistAsync());
+    }
+
+    // The helper resolves false rather than throwing where navigator.storage.persist is absent, so an app
+    // can treat "not persisted" and "can't be persisted" the same way: writes are evictable either way.
+    [Fact]
+    public async Task Persistence_ReportsFalse_WhenUnsupported()
+    {
+        var js = new FakeJsRuntime();
+
+        Assert.False(await new StorageEstimator(js).IsPersistedAsync());
+        Assert.False(await new StorageEstimator(js).RequestPersistAsync());
+    }
 }

--- a/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
+++ b/tests/Rask.Example.Shared.Tests/Guides/DemoMarkup.golden.txt
@@ -2797,6 +2797,35 @@ button .btn .btn-outline-danger .btn-sm
 div .small .text-secondary
 code
 
+=== browser-opfs ===
+div .border-0 .card .mb-4 .sample-card .shadow-sm
+div .sample-code-col
+div .sample-code-header
+span .dot-r .sample-dot
+span .dot-y .sample-dot
+span .dot-g .sample-dot
+span .ms-2 .sample-code-label
+button .sample-copy
+i .bi .bi-clipboard .me-1
+span .sample-copy-text
+pre .m-0 .sample-code
+code .language-csharp
+div .p-4 .sample-result-col
+div .sample-result-label
+div .sample-result-body
+div .border-0 .card .shadow-sm
+div .card-body
+div .d-flex .flex-wrap .gap-2 .mb-2
+button .btn .btn-outline-primary .btn-sm
+button .btn .btn-outline-secondary .btn-sm
+button .btn .btn-outline-secondary .btn-sm
+div .small .text-secondary
+code
+div .small .text-secondary
+code
+div .small .text-secondary
+code
+
 === browser-page-visibility ===
 div .border-0 .card .mb-4 .sample-card .shadow-sm
 div .sample-code-col


### PR DESCRIPTION
First item of #642.

## Why

The two storage wrappers Rask shipped both stop short of a file an app writes to repeatedly and reopens on the next visit. `IIndexedDb` is a key/value store. `IFileSystemAccess` is a *picker* — it needs a user gesture and models a document the user chose, not storage the app manages. OPFS is the missing third case, and the one a local database file needs.

## `IOriginPrivateFileSystem`

In `Rask.Core.Browser`, registered by `AddCoreBrowserApis`, works on both transports.

- **Ranged primitives, whole-file convenience.** `ReadAsync`/`WriteAsync`/`TruncateAsync` take a byte offset, so a large file is worked in chunks and the payload crossing the interop boundary is bounded by the range asked for, not the size of the file. `ReadAllBytesAsync`/`WriteAllBytesAsync` are single-round-trip helpers over the same store.
- **Paths, not handles.** The tree is app-owned and persistent, so the same path is reopened every session — there is nothing to pick and nothing to keep alive between calls. Parent directories are created on write.
- **Missing paths return `null`**, matching `IKeyValueStore.GetAsync`; a ranged read past the end returns the bytes that were there. Those two cases stay distinguishable, which is what a restore path depends on.
- **Writing past the end zero-fills the gap** rather than failing. A growing database does this constantly, so the behaviour is stated in the contract rather than inherited — verified against the File System Standard (`write()` step 9, and `truncate()` step 5.1 in the growing direction) rather than assumed.

## `IStorageEstimator` gains persistence

`IsPersistedAsync` / `RequestPersistAsync` wrap `navigator.storage.persisted()`/`persist()` — the same object `estimate()` already came from. Without them OPFS is persistent but still reclaimable under storage pressure, which is the difference between a cache and a database. Both resolve `false` where unsupported, so "not persisted" and "cannot be persisted" collapse into one branch for a caller: writes are evictable either way.

Adding members to a shipped public interface is technically breaking for an external implementer; nothing in the repo implements `IStorageEstimator` besides `StorageEstimator`, and the alternative (a 47th wrapper for two methods) splits one browser object across two interfaces for no gain.

## Two things worth reviewing closely

- **`createWritable({keepExistingData: true})` on ranged writes is load-bearing.** Without it OPFS starts from an empty file, so a 4 KB write at an offset silently discards the rest of the file. This is the failure mode that would corrupt a database rather than error.
- **Path splitting uses `split("/")`, not a regex.** The Server build's minifier mis-parses a bare regex literal as division and corrupts the entire bundle. The minified Release `rask.js` `node --check`s clean.

## Testing

- 17 new unit tests for `IOriginPrivateFileSystem` and 3 for the persistence pair, pinning the exact dotted identifiers and argument shapes the JS helpers are written against, plus the base64 seam and the null-for-missing contract.
- Registration test updated (34 → 35 wrappers).
- Full local unit gate green (`scripts/run-unit-local.sh`), `dotnet format --verify-no-changes` clean, solution builds `-warnaserror` clean.
- Browser E2E gate green.
- Both committed spliced bundles (`rask.wasm.js`, `rask.native.js`) regenerated; `ResourcesSpliceTests` green, and both bundles plus the minified Release server bundle `node --check` clean.

## Payload cost

The shared `rask-api.js` ships on every page, so this is not free: the spliced WASM bundle grows 242,798 → 250,170 bytes uncompressed, **+1,518 bytes gzipped (+2.2%)**. The Server bundle is minified before shipping and costs less. No render or live-runtime hot path is touched, so no benchmark run applies.

## Docs & sample

New `docs/apis/origin-private-file-system.md`, a row in the capability matrix, a `GuideCatalog` entry, and a runnable showcase demo (ranged write, read-back, persistence request) wired through `DemoRegistry` with its marker in `browser-apis-reference.md`. Markup golden regenerated — the diff is a pure addition, no existing demo perturbed.

## Scope note

Local persistence of a live browser SQLite database is handled by `Rask.SQLite.Browser`; this PR does not duplicate it. `IOriginPrivateFileSystem` is the substrate #642 needs for the remote half — getting bytes off the device — and is useful on its own regardless of where that lands.
