### PR TITLE
fix(cli): refuse to scaffold a background job into an app that can never run it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ them until tagged releases begin.
 
 ## [Unreleased]
 
+### Fixed
+- **`rask generate job` no longer scaffolds a job into a browser app that could never run it.** The
+  generator wasn't gated on project kind, so running it inside a WASM app produced an `IJob` + handler
+  and printed next steps written for a server: register `AddRaskJobs<AppDbContext>()`, point EF at
+  `Data Source=app.db`, then `rask db add && rask db update`. Every line of that is wrong there —
+  `rask db` drives `dotnet-ef` against a design-time database a browser bundle doesn't have, and the
+  connection string names a file in the WASM runtime's **in-memory** filesystem that disappears on
+  reload. Worse than either: `AddRaskJobs` registers the processor as a **hosted service**, and
+  `WasmHostBuilder.RunAsync` never starts those — so the queue would have had no runner at all. The
+  scaffolded code compiled, enqueued, and silently did nothing.
+  The CLI now recognises a browser project (a `-browser` target framework, `<RaskWasm>`, or a
+  `Rask.Wasm` reference) and refuses, saying why and where the job belongs — in a hosted-WASM solution,
+  the Server half: `rask generate job SendWelcomeEmail --project ../MyApp.Server`. It exits 1 rather
+  than as a usage error, because the command line was fine; `--help` has nothing to say about it. Every
+  other generator still runs in a WASM app, and `Rask.Wasm.Hosting` (referenced by the *server* half of
+  a hosted solution) deliberately doesn't read as "browser".
+
 ### Added
 - **`Mount` — give a component you built yourself the lifecycle it was missing.** A component normally
   enters the tree through its generated factory, and that factory is what registers the instance with its

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -206,7 +206,7 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 |----------|-------|-------------------|
 | `page <Name>` | `Features/<Name>/<Name>Page.cs` — a routed page `Component` with a `Head` title | `<Name>Page` in `<Root>.Features.<Name>` |
 | `component <Name>` | `Features/Shared/<Name>.cs` — a plain `Component` (or `Features/<Feature>/` with `--feature`) | `<Name>` in `<Root>.Features.Shared` |
-| `job <Name>` | `Features/Shared/<Name>.cs` — a background job: an `IJob` record + its `ICommandHandler` (adds the `Rask.Jobs` / `Rask.Cqrs` packages). `--feature` co-locates it in a slice. Alias: `rask g j` | `<Name>` in `<Root>.Features.Shared` |
+| `job <Name>` | `Features/Shared/<Name>.cs` — a background job: an `IJob` record + its `ICommandHandler` (adds the `Rask.Jobs` / `Rask.Cqrs` packages). `--feature` co-locates it in a slice. **Refused in a browser (WASM) project** — see below. Alias: `rask g j` | `<Name>` in `<Root>.Features.Shared` |
 | `email <Name>` | `Features/Shared/<Name>.cs` — an email-body component rendered to HTML by `Email.Body(...)` (adds the `Rask.Mail` package). **Auto-wires** into your `DbContext` — registers `AddRaskMail<Ctx>` in `Program.cs` and maps the mail table in `OnModelCreating` — when it finds a single one (or `--context <Name>`); otherwise prints the steps. `--feature` co-locates it in a slice. Alias: `rask g e` | `<Name>` in `<Root>.Features.Shared` |
 | `cache <Name>` | `Features/Shared/<Name>.cs` — a read-through cache accessor that owns its key and its invalidation in one place (adds the `Rask.Cache` package). `--feature` co-locates it in a slice. Alias: `rask g ca` | `<Name>` in `<Root>.Features.Shared` |
 | `feature <Name> <field:type> …` | `Features/<Plural>/` — an encapsulated entity (`Create`/`Update`, Guid id) with **value objects** for required strings (built-in validation), an EF `IEntityTypeConfiguration` mapped by the app's one `DbContext` (found in the project, or written to `Features/Shared/AppDbContext.cs` when there is none), **CQRS** create/update/delete commands + list/get queries with handlers, and list / create / edit pages that dispatch via `IDispatcher` | in `<Root>.Features.<Plural>` |
@@ -235,6 +235,14 @@ folder path, the C# convention), and **refuses to overwrite an existing file** u
 | `--force` | Overwrite existing file(s). |
 | `--dry-run` | Print the file(s) that would be written, and write nothing. |
 | `--save-defaults` | `feature` only: remember this run's feature flags in `.rask/generate.json` (see below). |
+
+**`generate job` is refused in a browser (WASM) project.** Not a limitation of the scaffolder — there is
+nothing for it to scaffold *into*. `AddRaskJobs` registers the processor as a **hosted service**, and the
+WASM host never starts those, so the job would compile, enqueue, and never run; the queue also needs a
+database that survives a reload, which the browser's in-memory file is not. Rather than emit next steps
+you can't follow, the CLI stops and points at a server project — in a hosted-WASM solution, the Server
+half: `rask generate job SendWelcomeEmail --project ../MyApp.Server`. (Consistently, `rask new --wasm`
+doesn't offer the `--jobs` battery either.) Every other generator runs in a WASM app as usual.
 
 **Team defaults (`.rask/generate.json`).** So a project doesn't retype the same feature flags every
 time, `rask generate feature` reads defaults from `.rask/generate.json` at the project root — e.g.

--- a/src/Rask.Cli/Commands/GenerateCommand.cs
+++ b/src/Rask.Cli/Commands/GenerateCommand.cs
@@ -223,6 +223,27 @@ internal sealed class GenerateCommand(IConsole console, IFileSystem fileSystem, 
             return 1;
         }
 
+        // Background jobs have no working shape in the browser, so refuse rather than scaffold dead code.
+        // Not a usage error (the command line is fine), so it reports and exits 1 like the no-project case
+        // above rather than printing usage — help has nothing to say about this.
+        if (kind == "job" && project.IsBrowser)
+        {
+            Console.WriteErrorLine(
+                "Background jobs don't run in a browser app, so 'rask generate job' won't scaffold one here.",
+                ConsoleStyle.Error);
+            Console.Error.WriteLine(
+                "  AddRaskJobs registers the processor as a hosted service, and the WASM host never starts");
+            Console.Error.WriteLine(
+                "  those — the job would compile and enqueue, and nothing would ever run it. The queue also");
+            Console.Error.WriteLine(
+                "  needs a database that survives a reload, which the browser's in-memory file isn't.");
+            Console.Error.WriteLine(
+                "  Generate it in a server project instead (in a hosted-WASM solution, the Server one):");
+            Console.Error.WriteLine(
+                $"      rask generate job {name} --project <path-to-server-project>");
+            return 1;
+        }
+
         // --output names a folder INSIDE the project: the namespace is derived from its path, so a folder
         // outside can't produce a coherent one. It used to be accepted — files were written outside the
         // project and quietly given the root namespace instead of failing.

--- a/src/Rask.Cli/Scaffolding/ProjectContext.cs
+++ b/src/Rask.Cli/Scaffolding/ProjectContext.cs
@@ -10,11 +10,20 @@ namespace Rask.Cli.Scaffolding;
 internal sealed partial class ProjectContext(
     string projectDirectory,
     string rootNamespace,
-    DatabaseProvider provider = DatabaseProvider.Sqlite)
+    DatabaseProvider provider = DatabaseProvider.Sqlite,
+    bool isBrowser = false)
 {
     public string ProjectDirectory { get; } = projectDirectory;
 
     public string RootNamespace { get; } = rootNamespace;
+
+    /// <summary>
+    /// Whether this project runs in the browser (a WASM app), read off its project file the same way
+    /// <see cref="Provider"/> is. Scaffolding that depends on a host-side facility has to know: the
+    /// browser has no hosted services, no design-time database and no durable file by default, so a
+    /// generator that assumes a server would emit something that compiles and then quietly does nothing.
+    /// </summary>
+    public bool IsBrowser { get; } = isBrowser;
 
     /// <summary>
     /// The database this project is wired to, read off its package references rather than asked for again.
@@ -64,6 +73,24 @@ internal sealed partial class ProjectContext(
 
     [GeneratedRegex(@"<RootNamespace>\s*(.+?)\s*</RootNamespace>", RegexOptions.IgnoreCase)]
     private static partial Regex RootNamespaceRegex();
+
+    // A browser TFM on either the singular or plural element — net10.0-browser today, but matched by the
+    // "-browser" suffix rather than the version so a framework bump doesn't silently stop detecting it.
+    [GeneratedRegex(@"<TargetFrameworks?>[^<]*-browser", RegexOptions.IgnoreCase)]
+    private static partial Regex BrowserTargetFrameworkRegex();
+
+    /// <summary>Whether <paramref name="csprojText"/> describes a project that runs in the browser.</summary>
+    internal static bool DetectBrowser(string csprojText)
+    {
+        ArgumentNullException.ThrowIfNull(csprojText);
+
+        // Any one of the three is conclusive, and a hand-edited project may carry only one of them.
+        // The package check keeps its closing quote so it does NOT match Rask.Wasm.Hosting — that is
+        // referenced by the SERVER half of a hosted-WASM solution, which is the opposite answer.
+        return BrowserTargetFrameworkRegex().IsMatch(csprojText)
+            || csprojText.Contains("<RaskWasm>true</RaskWasm>", StringComparison.OrdinalIgnoreCase)
+            || csprojText.Contains("Include=\"Rask.Wasm\"", StringComparison.OrdinalIgnoreCase);
+    }
 
     internal static string ReadRootNamespace(IFileSystem fileSystem, string csprojPath)
     {
@@ -128,10 +155,12 @@ internal static class ProjectLocator
             var projects = fileSystem.ListFiles(directory, "*.csproj");
             if (projects.Count == 1)
             {
+                var csproj = fileSystem.ReadAllText(projects[0]);
                 return new ProjectContext(
                     directory,
                     ProjectContext.ReadRootNamespace(fileSystem, projects[0]),
-                    DatabaseCatalog.DetectProvider(fileSystem.ReadAllText(projects[0])));
+                    DatabaseCatalog.DetectProvider(csproj),
+                    ProjectContext.DetectBrowser(csproj));
             }
 
             if (projects.Count > 1)

--- a/tests/Rask.Cli.Tests/GenerateCommandTests.cs
+++ b/tests/Rask.Cli.Tests/GenerateCommandTests.cs
@@ -75,6 +75,86 @@ public sealed class GenerateCommandTests
         Assert.Contains("AddRaskJobs", console.OutText, StringComparison.Ordinal);
     }
 
+    // ── Jobs in a browser app (issue #646) ──────────────────────────────────────────────────────────
+    //
+    // `rask generate job` isn't gated on project kind, so it ran happily inside a WASM app and printed
+    // server-only next steps. The deeper problem is that there is no working shape to point at: AddRaskJobs
+    // registers the processor as a hosted service and WasmHostBuilder.RunAsync never starts those, so a
+    // scaffolded job compiles, enqueues, and is never run — silently. Refuse instead of scaffolding it.
+
+    [Theory]
+    // Any one signal is enough: a hand-edited project may carry only one of the three.
+    [InlineData("<Project><PropertyGroup><TargetFramework>net10.0-browser</TargetFramework></PropertyGroup></Project>")]
+    [InlineData("<Project><PropertyGroup><RaskWasm>true</RaskWasm></PropertyGroup></Project>")]
+    [InlineData("""<Project><ItemGroup><PackageReference Include="Rask.Wasm" Version="1.0.0"/></ItemGroup></Project>""")]
+    public async Task Job_in_a_browser_project_is_refused_with_the_reason(string csproj)
+    {
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/MyApp.csproj", csproj);
+        var command = new GenerateCommand(console, fs, new FakeProcessRunner(), ProjectDir);
+
+        var exit = await command.ExecuteAsync(["job", "SendWelcomeEmail"], CancellationToken.None);
+
+        // 1, not UsageExitCode: the command line was fine, the project just can't host the thing.
+        Assert.Equal(1, exit);
+        Assert.False(fs.Files.ContainsKey(Path.GetFullPath("/proj/Features/Shared/SendWelcomeEmail.cs")));
+        Assert.Contains("don't run in a browser app", console.ErrorText, StringComparison.Ordinal);
+        // The way out has to be in the message — the reason alone leaves you stuck.
+        Assert.Contains("--project", console.ErrorText, StringComparison.Ordinal);
+        // And no usage block: `rask generate --help` has nothing to say about this.
+        Assert.DoesNotContain("Run 'rask generate --help'", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Job_alias_j_is_refused_in_a_browser_project_too()
+    {
+        // The check keys off the resolved verb, so the alias must land on it as well — `rask g j` is how
+        // most people actually type this.
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/MyApp.csproj", "<Project><PropertyGroup><RaskWasm>true</RaskWasm></PropertyGroup></Project>");
+        var command = new GenerateCommand(console, fs, new FakeProcessRunner(), ProjectDir);
+
+        var exit = await command.ExecuteAsync(["j", "SendWelcomeEmail"], CancellationToken.None);
+
+        Assert.Equal(1, exit);
+        Assert.Contains("don't run in a browser app", console.ErrorText, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Job_in_the_server_half_of_a_hosted_wasm_solution_is_still_scaffolded()
+    {
+        // Rask.Wasm.Hosting is referenced by the SERVER project, and it must not read as "browser" —
+        // that project is exactly where the job belongs.
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        fs.Seed(
+            "/proj/MyApp.csproj",
+            """<Project><ItemGroup><PackageReference Include="Rask.Wasm.Hosting" Version="1.0.0"/></ItemGroup></Project>""");
+        var command = new GenerateCommand(console, fs, new FakeProcessRunner(), ProjectDir);
+
+        var exit = await command.ExecuteAsync(["job", "SendWelcomeEmail"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.True(fs.Files.ContainsKey(Path.GetFullPath("/proj/Features/Shared/SendWelcomeEmail.cs")));
+    }
+
+    [Fact]
+    public async Task Other_generators_still_run_in_a_browser_project()
+    {
+        // The refusal is specific to jobs — pages and components are perfectly at home in a WASM app.
+        var console = new StringConsole();
+        var fs = new FakeFileSystem();
+        fs.Seed("/proj/MyApp.csproj", "<Project><PropertyGroup><RaskWasm>true</RaskWasm></PropertyGroup></Project>");
+        var command = new GenerateCommand(console, fs, new FakeProcessRunner(), ProjectDir);
+
+        var exit = await command.ExecuteAsync(["page", "Products"], CancellationToken.None);
+
+        Assert.Equal(0, exit);
+        Assert.True(fs.Files.ContainsKey(Path.GetFullPath("/proj/Features/Products/ProductsPage.cs")));
+    }
+
     [Fact]
     public async Task Job_alias_j_scaffolds_a_job()
     {


### PR DESCRIPTION
## Summary

`rask generate job` wasn't gated on project kind, so it ran inside a WASM app and printed next steps
written for a server — `AddRaskJobs<AppDbContext>()`, `Data Source=app.db`, then
`rask db add && rask db update`. Every line is wrong there: `rask db` drives `dotnet-ef` against a
design-time database a browser bundle doesn't have, and the connection string names a file in the WASM
runtime's **in-memory** filesystem that disappears on reload.

## I diverged from the issue's proposed fix, and here's why

#646 proposed branching `Notes` on browser-ness and describing the browser wiring. Two things it didn't
have:

1. **There is no working shape to point at.** `AddRaskJobs` registers the processor as a **hosted
   service** (`RaskJobsServiceCollectionExtensions.cs:32` → `JobProcessor<T> : BackgroundService`), and
   `WasmHostBuilder.RunAsync` builds the provider and **never starts hosted services**. So the queue has
   no runner at all in a browser app — a deeper failure than the persistence one the issue describes.
2. **`AddRaskBrowserSqlite` doesn't exist on main.** It's part of the in-flight #642 epic. Writing next
   steps around it would ship instructions for an API that isn't there — the same defect class the issue
   objects to, just aimed at the future.

So rather than reword the notes, the CLI **refuses**. That was checked with you before implementing.

## What changed

- `ProjectContext` learns `IsBrowser`, read off the project file the way `Provider` already is: a
  `-browser` target framework, `<RaskWasm>`, or a `Rask.Wasm` package reference. The package check keeps
  its closing quote, so **`Rask.Wasm.Hosting` deliberately doesn't match** — that's referenced by the
  *server* half of a hosted-WASM solution, which is exactly where the job belongs.
- `generate job` stops in a browser project and says why, and where to put it:

```
Background jobs don't run in a browser app, so 'rask generate job' won't scaffold one here.
  AddRaskJobs registers the processor as a hosted service, and the WASM host never starts
  those — the job would compile and enqueue, and nothing would ever run it. The queue also
  needs a database that survives a reload, which the browser's in-memory file isn't.
  Generate it in a server project instead (in a hosted-WASM solution, the Server one):
      rask generate job SendWelcomeEmail --project <path-to-server-project>
```

- **Exits 1, not the usage code.** The command line was fine; `rask generate --help` has nothing to say
  about this, so printing usage would send you looking in the wrong place. This matches the existing
  "no project found" branch rather than the argument-validation ones.
- Every other generator still runs in a WASM app.

## Testing

- 6 new cases in `GenerateCommandTests`: the refusal via each of the three detection signals (theory),
  the `rask g j` **alias** (the check keys off the resolved verb, and the alias is how people actually
  type it), `Rask.Wasm.Hosting` still scaffolding, and `generate page` still working in a WASM app.
  They assert the exit code, that **nothing was written**, that the way out is in the message, and that
  no usage block is printed.
- **Verified on the real CLI**, not just the fake filesystem: `rask new -t wasm` → `rask g j` exits 1 and
  writes nothing; the same command in a scaffolded server app exits 0 and writes
  `Features/Shared/SendWelcomeEmail.cs` with its packages added.
- `dotnet format` clean, `CI=true dotnet build Rask.slnx -warnaserror -m:1` clean, full unit suite green,
  browser E2E 57/57.
- Docs: `docs/cli.md` marks the verb refused in WASM and explains it under the generate table.

Closes #646.
